### PR TITLE
Prohibit restarting a logs agent

### DIFF
--- a/pkg/logs/agent.go
+++ b/pkg/logs/agent.go
@@ -46,6 +46,9 @@ type Agent struct {
 	inputs                    []restart.Restartable
 	health                    *health.Handle
 	diagnosticMessageReceiver *diagnostic.BufferedMessageReceiver
+
+	// started is true if the agent has ever been started
+	started bool
 }
 
 // NewAgent returns a new Logs Agent
@@ -156,10 +159,16 @@ func NewServerless(sources *config.LogSources, services *service.Services, proce
 // Start starts all the elements of the data pipeline
 // in the right order to prevent data loss
 func (a *Agent) Start() {
+	if a.started {
+		panic("logs agent cannot be started more than once")
+	}
+	a.started = true
+
 	inputs := restart.NewStarter()
 	for _, input := range a.inputs {
 		inputs.Add(input)
 	}
+
 	starter := restart.NewStarter(
 		a.destinationsCtx,
 		a.auditor,

--- a/pkg/logs/agent_test.go
+++ b/pkg/logs/agent_test.go
@@ -110,10 +110,6 @@ func (suite *AgentTestSuite) testAgent(endpoints *config.Endpoints) {
 	assert.Equal(suite.T(), suite.fakeLogs, metrics.LogsProcessed.Value())
 	assert.Equal(suite.T(), suite.fakeLogs, metrics.LogsSent.Value())
 	assert.Equal(suite.T(), zero, metrics.DestinationErrors.Value())
-
-	// Validate that we can restart it without obvious breakages.
-	agent.Start()
-	agent.Stop()
 }
 
 func (suite *AgentTestSuite) TestAgentTcp() {


### PR DESCRIPTION
### What does this PR do?

This functionality appears to be unused, and many components do not
correctly handle being restarted, so let's make that expectation
explicit.

### Motivation

Supporting restart is difficult and, it seems, unnecessary.

### Additional Notes

I made this a panic() because
 * It's a programming error, and [irrecoverable](https://go.dev/doc/effective_go#panic) -- just returning without starting the logs agent would be incorrect
 * I'm quite confident it is not used, and would like to find out early if I'm wrong (either by failing CI or in some QA situation)

Note that until recently, `./pkg/logs.Start(..)` did not return the Agent instance, so the call to `agent.Start()` in `pkg/logs/logs.go` is the only place that this method is called, and it's only called once.  So I'm pretty sure this agent is never restarted.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
