### PR TITLE
Update docs for the LogSources type

### DIFF
--- a/pkg/logs/config/sources.go
+++ b/pkg/logs/config/sources.go
@@ -34,7 +34,7 @@ func NewLogSources() *LogSources {
 
 // AddSource adds a new source.
 //
-// Any subscribers registered for this source's type (src.Config.Type) will be
+// One of the subscribers registered for this source's type (src.Config.Type) will be
 // notified.
 func (s *LogSources) AddSource(source *LogSource) {
 	s.mu.Lock()
@@ -53,7 +53,7 @@ func (s *LogSources) AddSource(source *LogSource) {
 
 // RemoveSource removes a source.
 //
-// Any subscribers registered for this source's type (src.Config.Type) will be
+// One of the subscribers registered for this source's type (src.Config.Type) will be
 // notified of its removal.
 func (s *LogSources) RemoveSource(source *LogSource) {
 	s.mu.Lock()


### PR DESCRIPTION
..having worked on this a while, I was still surprised by the behavior
when there is more than one subscriber per type.  That behavior is now
documented, and can be changed if it becomes problematic.


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
