### PR TITLE
[7.35] Remove map allocation from cgroup stats retrieval code path (#11234)

### DIFF
--- a/pkg/util/cgroups/cgroupv1_memory.go
+++ b/pkg/util/cgroups/cgroupv1_memory.go
@@ -11,6 +11,7 @@ package cgroups
 import (
 	"math"
 	"os"
+	"strconv"
 )
 
 // When no memory limit is set, the Kernel returns a maximum value, being computed as:
@@ -26,23 +27,50 @@ func (c *cgroupV1) GetMemoryStats(stats *MemoryStats) error {
 		return &ControllerNotFoundError{Controller: "memory"}
 	}
 
-	if err := parse2ColumnStatsWithMapping(c.fr, c.pathFor("memory", "memory.stat"), 0, 1, map[string]**uint64{
-		"total_cache":               &stats.Cache,
-		"total_swap":                &stats.Swap,
-		"total_rss":                 &stats.RSS,
-		"total_rss_huge":            &stats.RSSHuge,
-		"total_mapped_file":         &stats.MappedFile,
-		"total_pgpgin":              &stats.Pgpgin,
-		"total_pgpgout":             &stats.Pgpgout,
-		"total_pgfault":             &stats.Pgfault,
-		"total_pgmajfault":          &stats.Pgmajfault,
-		"total_inactive_anon":       &stats.InactiveAnon,
-		"total_active_anon":         &stats.ActiveAnon,
-		"total_inactive_file":       &stats.InactiveFile,
-		"total_active_file":         &stats.ActiveFile,
-		"total_unevictable":         &stats.Unevictable,
-		"hierarchical_memory_limit": &stats.Limit,
-		"hierarchical_memsw_limit":  &stats.SwapLimit,
+	if err := parse2ColumnStats(c.fr, c.pathFor("memory", "memory.stat"), 0, 1, func(key, value string) error {
+		intVal, err := strconv.ParseUint(value, 10, 64)
+		if err != nil {
+			reportError(newValueError(value, err))
+			// Dont't stop parsing on a single faulty value
+			return nil
+		}
+
+		switch key {
+		case "total_cache":
+			stats.Cache = &intVal
+		case "total_swap":
+			stats.Swap = &intVal
+		case "total_rss":
+			stats.RSS = &intVal
+		case "total_rss_huge":
+			stats.RSSHuge = &intVal
+		case "total_mapped_file":
+			stats.MappedFile = &intVal
+		case "total_pgpgin":
+			stats.Pgpgin = &intVal
+		case "total_pgpgout":
+			stats.Pgpgout = &intVal
+		case "total_pgfault":
+			stats.Pgfault = &intVal
+		case "total_pgmajfault":
+			stats.Pgmajfault = &intVal
+		case "total_inactive_anon":
+			stats.InactiveAnon = &intVal
+		case "total_active_anon":
+			stats.ActiveAnon = &intVal
+		case "total_inactive_file":
+			stats.InactiveFile = &intVal
+		case "total_active_file":
+			stats.ActiveFile = &intVal
+		case "total_unevictable":
+			stats.Unevictable = &intVal
+		case "hierarchical_memory_limit":
+			stats.Limit = &intVal
+		case "hierarchical_memsw_limit":
+			stats.SwapLimit = &intVal
+		}
+
+		return nil
 	}); err != nil {
 		reportError(err)
 	}

--- a/pkg/util/cgroups/file.go
+++ b/pkg/util/cgroups/file.go
@@ -133,21 +133,6 @@ func parse2ColumnStats(fr fileReader, path string, keyColumn, valueColumn int, v
 	return err
 }
 
-func parse2ColumnStatsWithMapping(fr fileReader, path string, keyColumn, valueColumn int, mapping map[string]**uint64) error {
-	return parse2ColumnStats(fr, path, keyColumn, valueColumn, func(key, value string) error {
-		if storeVal, found := mapping[key]; found {
-			intVal, err := strconv.ParseUint(value, 10, 64)
-			if err != nil {
-				reportError(newValueError(value, err))
-			}
-
-			*storeVal = &intVal
-		}
-
-		return nil
-	})
-}
-
 // format is "some avg10=0.00 avg60=0.00 avg300=0.00 total=0"
 func parsePSI(fr fileReader, path string, somePsi, fullPsi *PSIStats) error {
 	return parseColumnStats(fr, path, func(fields []string) error {


### PR DESCRIPTION
### What does this PR do?

Backport #11234 to 7.35

### Motivation

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

See #11234

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
