### PR TITLE
[kitchen] Replace stable repo when upgrading the Agent

### DIFF
--- a/test/kitchen/site-cookbooks/dd-agent-upgrade/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-upgrade/recipes/default.rb
@@ -80,9 +80,9 @@ if node['dd-agent-upgrade']['add_new_repo']
   when 'rhel'
     include_recipe 'yum'
 
-    yum_repository 'datadog-update' do
-      name 'datadog-update'
-      description 'datadog-update'
+    yum_repository 'datadog' do
+      name 'datadog'
+      description 'datadog'
       url node['dd-agent-upgrade']['yumrepo']
       action :add
       make_cache true
@@ -110,9 +110,9 @@ if node['dd-agent-upgrade']['add_new_repo']
       action :nothing
     end
 
-    zypper_repository 'datadog-update' do
-      name 'datadog-update'
-      description 'datadog-update'
+    zypper_repository 'datadog' do
+      name 'datadog'
+      description 'datadog'
       baseurl node['dd-agent-upgrade']['yumrepo_suse']
       action :add
       gpgcheck false


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

When creating the repofile for upgrading the Agent to the tested version on `yum` / `zypper` / `dnf` systems, replace the `datadog` repofile instead of adding a new `datadog-update` repofile.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Make sure that the only version of the Agent that can be installed is the tested version. With the previous behavior, if the latest stable version was higher than the tested version, then the Agent would be upgraded to the latest stable version, causing the upgrade test to fail.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Run upgrade kitchen tests with an Agent version that's lower than the latest stable version: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/7276992

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
