### PR TITLE
[snmp] Use GETNEXT 1 for device reachable state for SNMP Listener and corecheck

### DIFF
--- a/pkg/autodiscovery/listeners/snmp.go
+++ b/pkg/autodiscovery/listeners/snmp.go
@@ -156,10 +156,9 @@ func (l *SNMPListener) checkDevice(job snmpJob) {
 	} else {
 		defer params.Conn.Close()
 
-		oids := []string{"1.3.6.1.2.1.1.2.0"}
 		// Since `params<GoSNMP>.ContextEngineID` is empty
-		// `params.Get` might lead to multiple SNMP GET calls when using SNMP v3
-		value, err := params.Get(oids)
+		// `params.GetNext` might lead to multiple SNMP GET calls when using SNMP v3
+		value, err := params.GetNext([]string{snmp.DeviceReachableGetNextOid})
 		if err != nil {
 			log.Debugf("SNMP get to %s error: %v", deviceIP, err)
 			l.deleteService(entityID, job.subnet)

--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metadata/externalhost"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
+	coresnmp "github.com/DataDog/datadog-agent/pkg/snmp"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
@@ -33,8 +34,6 @@ const (
 	snmpLoaderTag        = "loader:core"
 	serviceCheckName     = "snmp.can_check"
 	deviceHostnamePrefix = "device:"
-	// 1.3 (iso.org) is the OID used for getNext call to check if the device is reachable
-	deviceReachableGetNextOid = "1.3"
 )
 
 // DeviceCheck hold info necessary to collect info for a single device
@@ -154,7 +153,7 @@ func (d *DeviceCheck) getValuesAndTags(staticTags []string) (bool, []string, *va
 	}()
 
 	// Check if the device is reachable
-	getNextValue, err := d.session.GetNext([]string{deviceReachableGetNextOid})
+	getNextValue, err := d.session.GetNext([]string{coresnmp.DeviceReachableGetNextOid})
 	if err != nil {
 		deviceReachable = false
 		checkErrors = append(checkErrors, fmt.Sprintf("check device reachable: failed: %s", err))

--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck_test.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck_test.go
@@ -245,7 +245,7 @@ profiles:
 		},
 	}
 
-	sess.On("GetNext", []string{"1"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
+	sess.On("GetNext", []string{"1.0"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
 	sess.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).Return(&sysObjectIDPacket, nil)
 	sess.On("Get", []string{
 		"1.2.3.4.5",

--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck_test.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck_test.go
@@ -245,7 +245,7 @@ profiles:
 		},
 	}
 
-	sess.On("GetNext", []string{"1.3"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
+	sess.On("GetNext", []string{"1"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
 	sess.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).Return(&sysObjectIDPacket, nil)
 	sess.On("Get", []string{
 		"1.2.3.4.5",

--- a/pkg/collector/corechecks/snmp/profile_test.go
+++ b/pkg/collector/corechecks/snmp/profile_test.go
@@ -263,7 +263,7 @@ profiles:
 		},
 	}
 
-	sess.On("GetNext", []string{"1"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
+	sess.On("GetNext", []string{"1.0"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
 	sess.On("Get", []string{
 		"1.3.6.1.2.1.1.1.0",
 		"1.3.6.1.2.1.1.2.0",

--- a/pkg/collector/corechecks/snmp/profile_test.go
+++ b/pkg/collector/corechecks/snmp/profile_test.go
@@ -263,7 +263,7 @@ profiles:
 		},
 	}
 
-	sess.On("GetNext", []string{"1.3"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
+	sess.On("GetNext", []string{"1"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
 	sess.On("Get", []string{
 		"1.3.6.1.2.1.1.1.0",
 		"1.3.6.1.2.1.1.2.0",

--- a/pkg/collector/corechecks/snmp/snmp_test.go
+++ b/pkg/collector/corechecks/snmp/snmp_test.go
@@ -257,7 +257,7 @@ tags:
 		},
 	}
 
-	sess.On("GetNext", []string{"1"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
+	sess.On("GetNext", []string{"1.0"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
 	sess.On("Get", mock.Anything).Return(&packet, nil)
 	sess.On("Get", mock.Anything).Return(&packet, nil)
 	sess.On("GetBulk", []string{"1.3.6.1.2.1.2.2.1.14", "1.3.6.1.2.1.2.2.1.2", "1.3.6.1.2.1.2.2.1.20", "1.3.6.1.2.1.2.2.1.6", "1.3.6.1.2.1.2.2.1.7"}, checkconfig.DefaultBulkMaxRepetitions).Return(&bulkBatch1Packet1, nil)
@@ -349,7 +349,7 @@ metrics:
 		},
 	}
 
-	sess.On("GetNext", []string{"1"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
+	sess.On("GetNext", []string{"1.0"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
 	sess.On("Get", mock.Anything).Return(&packet, nil)
 
 	err = chk.Run()
@@ -563,7 +563,7 @@ profiles:
 		},
 	}
 
-	sess.On("GetNext", []string{"1"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
+	sess.On("GetNext", []string{"1.0"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
 	sess.On("Get", []string{
 		"1.2.3.4.5",
 		"1.3.6.1.2.1.1.1.0",
@@ -948,7 +948,7 @@ namespace: '%s'
 
 			mocksender.SetSender(sender, chk.ID())
 
-			sess.On("GetNext", []string{"1"}).Return(&tt.reachableValuesPacket, tt.reachableGetNextError)
+			sess.On("GetNext", []string{"1.0"}).Return(&tt.reachableValuesPacket, tt.reachableGetNextError)
 			sess.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).Return(&tt.sysObjectIDPacket, tt.sysObjectIDError)
 			sess.On("Get", []string{"1.2.3.4.5", "1.3.6.1.2.1.1.3.0", "1.3.6.1.2.1.1.5.0", "1.3.6.1.4.1.3375.2.1.1.2.1.44.0", "1.3.6.1.4.1.3375.2.1.1.2.1.44.999"}).Return(&tt.valuesPacket, tt.valuesError)
 			sess.On("Get", []string{"1.3.6.1.2.1.1.3.0"}).Return(&tt.valuesPacket, tt.valuesError)
@@ -1011,7 +1011,7 @@ metrics:
 	packet := gosnmp.SnmpPacket{
 		Variables: []gosnmp.SnmpPDU{},
 	}
-	sess.On("GetNext", []string{"1"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
+	sess.On("GetNext", []string{"1.0"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
 	sess.On("Get", []string{"1.2.3", "1.3.6.1.2.1.1.3.0"}).Return(&packet, nil)
 	sender.SetupAcceptAll()
 
@@ -1184,7 +1184,7 @@ tags:
 			},
 		},
 	}
-	sess.On("GetNext", []string{"1"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
+	sess.On("GetNext", []string{"1.0"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
 	var sysObjectIDPacket *gosnmp.SnmpPacket
 	sess.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).Return(sysObjectIDPacket, fmt.Errorf("no value"))
 
@@ -1310,7 +1310,7 @@ tags:
 	sender.On("Commit").Return()
 
 	var nilPacket *gosnmp.SnmpPacket
-	sess.On("GetNext", []string{"1"}).Return(nilPacket, fmt.Errorf("no value for GetNext"))
+	sess.On("GetNext", []string{"1.0"}).Return(nilPacket, fmt.Errorf("no value for GetNext"))
 	sess.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).Return(nilPacket, fmt.Errorf("no value"))
 
 	sess.On("Get", []string{
@@ -1404,7 +1404,7 @@ metric_tags:
 		},
 	}
 
-	sess.On("GetNext", []string{"1"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
+	sess.On("GetNext", []string{"1.0"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
 	sess.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).Return(&discoveryPacket, nil)
 
 	err := chk.Configure(rawInstanceConfig, []byte(``), "test")
@@ -1691,7 +1691,7 @@ metric_tags:
 		},
 	}
 
-	sess.On("GetNext", []string{"1"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
+	sess.On("GetNext", []string{"1.0"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
 	sess.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).Return(&discoveryPacket, nil)
 
 	err = chk.Configure(rawInstanceConfig, []byte(``), "test")
@@ -1769,7 +1769,7 @@ use_device_id_as_hostname: true
 	sender.On("EventPlatformEvent", mock.Anything, mock.Anything).Return()
 	sender.On("Commit").Return()
 
-	sess.On("GetNext", []string{"1"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
+	sess.On("GetNext", []string{"1.0"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
 
 	packet := gosnmp.SnmpPacket{
 		Variables: []gosnmp.SnmpPDU{
@@ -1926,7 +1926,7 @@ metrics:
   - symboltag2:2
 `)
 
-	sess.On("GetNext", []string{"1"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
+	sess.On("GetNext", []string{"1.0"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
 
 	discoveryPacket := gosnmp.SnmpPacket{
 		Variables: []gosnmp.SnmpPDU{

--- a/pkg/collector/corechecks/snmp/snmp_test.go
+++ b/pkg/collector/corechecks/snmp/snmp_test.go
@@ -257,7 +257,7 @@ tags:
 		},
 	}
 
-	sess.On("GetNext", []string{"1.3"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
+	sess.On("GetNext", []string{"1"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
 	sess.On("Get", mock.Anything).Return(&packet, nil)
 	sess.On("Get", mock.Anything).Return(&packet, nil)
 	sess.On("GetBulk", []string{"1.3.6.1.2.1.2.2.1.14", "1.3.6.1.2.1.2.2.1.2", "1.3.6.1.2.1.2.2.1.20", "1.3.6.1.2.1.2.2.1.6", "1.3.6.1.2.1.2.2.1.7"}, checkconfig.DefaultBulkMaxRepetitions).Return(&bulkBatch1Packet1, nil)
@@ -349,7 +349,7 @@ metrics:
 		},
 	}
 
-	sess.On("GetNext", []string{"1.3"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
+	sess.On("GetNext", []string{"1"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
 	sess.On("Get", mock.Anything).Return(&packet, nil)
 
 	err = chk.Run()
@@ -563,7 +563,7 @@ profiles:
 		},
 	}
 
-	sess.On("GetNext", []string{"1.3"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
+	sess.On("GetNext", []string{"1"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
 	sess.On("Get", []string{
 		"1.2.3.4.5",
 		"1.3.6.1.2.1.1.1.0",
@@ -948,7 +948,7 @@ namespace: '%s'
 
 			mocksender.SetSender(sender, chk.ID())
 
-			sess.On("GetNext", []string{"1.3"}).Return(&tt.reachableValuesPacket, tt.reachableGetNextError)
+			sess.On("GetNext", []string{"1"}).Return(&tt.reachableValuesPacket, tt.reachableGetNextError)
 			sess.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).Return(&tt.sysObjectIDPacket, tt.sysObjectIDError)
 			sess.On("Get", []string{"1.2.3.4.5", "1.3.6.1.2.1.1.3.0", "1.3.6.1.2.1.1.5.0", "1.3.6.1.4.1.3375.2.1.1.2.1.44.0", "1.3.6.1.4.1.3375.2.1.1.2.1.44.999"}).Return(&tt.valuesPacket, tt.valuesError)
 			sess.On("Get", []string{"1.3.6.1.2.1.1.3.0"}).Return(&tt.valuesPacket, tt.valuesError)
@@ -1011,7 +1011,7 @@ metrics:
 	packet := gosnmp.SnmpPacket{
 		Variables: []gosnmp.SnmpPDU{},
 	}
-	sess.On("GetNext", []string{"1.3"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
+	sess.On("GetNext", []string{"1"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
 	sess.On("Get", []string{"1.2.3", "1.3.6.1.2.1.1.3.0"}).Return(&packet, nil)
 	sender.SetupAcceptAll()
 
@@ -1184,7 +1184,7 @@ tags:
 			},
 		},
 	}
-	sess.On("GetNext", []string{"1.3"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
+	sess.On("GetNext", []string{"1"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
 	var sysObjectIDPacket *gosnmp.SnmpPacket
 	sess.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).Return(sysObjectIDPacket, fmt.Errorf("no value"))
 
@@ -1310,7 +1310,7 @@ tags:
 	sender.On("Commit").Return()
 
 	var nilPacket *gosnmp.SnmpPacket
-	sess.On("GetNext", []string{"1.3"}).Return(nilPacket, fmt.Errorf("no value for GetNext"))
+	sess.On("GetNext", []string{"1"}).Return(nilPacket, fmt.Errorf("no value for GetNext"))
 	sess.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).Return(nilPacket, fmt.Errorf("no value"))
 
 	sess.On("Get", []string{
@@ -1404,7 +1404,7 @@ metric_tags:
 		},
 	}
 
-	sess.On("GetNext", []string{"1.3"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
+	sess.On("GetNext", []string{"1"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
 	sess.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).Return(&discoveryPacket, nil)
 
 	err := chk.Configure(rawInstanceConfig, []byte(``), "test")
@@ -1691,7 +1691,7 @@ metric_tags:
 		},
 	}
 
-	sess.On("GetNext", []string{"1.3"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
+	sess.On("GetNext", []string{"1"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
 	sess.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).Return(&discoveryPacket, nil)
 
 	err = chk.Configure(rawInstanceConfig, []byte(``), "test")
@@ -1769,7 +1769,7 @@ use_device_id_as_hostname: true
 	sender.On("EventPlatformEvent", mock.Anything, mock.Anything).Return()
 	sender.On("Commit").Return()
 
-	sess.On("GetNext", []string{"1.3"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
+	sess.On("GetNext", []string{"1"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
 
 	packet := gosnmp.SnmpPacket{
 		Variables: []gosnmp.SnmpPDU{
@@ -1926,7 +1926,7 @@ metrics:
   - symboltag2:2
 `)
 
-	sess.On("GetNext", []string{"1.3"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
+	sess.On("GetNext", []string{"1"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
 
 	discoveryPacket := gosnmp.SnmpPacket{
 		Variables: []gosnmp.SnmpPDU{

--- a/pkg/snmp/constants.go
+++ b/pkg/snmp/constants.go
@@ -1,4 +1,4 @@
 package snmp
 
 // DeviceReachableGetNextOid is used in getNext call to check if the device is reachable
-const DeviceReachableGetNextOid = "1"
+const DeviceReachableGetNextOid = "1.0"

--- a/pkg/snmp/constants.go
+++ b/pkg/snmp/constants.go
@@ -1,0 +1,4 @@
+package snmp
+
+// DeviceReachableGetNextOid is used in getNext call to check if the device is reachable
+const DeviceReachableGetNextOid = "1"

--- a/pkg/snmp/constants.go
+++ b/pkg/snmp/constants.go
@@ -1,4 +1,8 @@
 package snmp
 
 // DeviceReachableGetNextOid is used in getNext call to check if the device is reachable
+// GETNEXT 1.0 should be able to fetch the first available SNMP OID.
+// There is no need to handle top node other than iso(1) since it the only valid SNMP tree starting point.
+// Other top nodes like ccitt(0) and joint(2) do not pertain to SNMP.
+// Source: https://docstore.mik.ua/orelly/networking_2ndEd/snmp/ch02_03.htm
 const DeviceReachableGetNextOid = "1.0"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

[snmp] Use GETNEXT 1 to check device reachable state

Additional change:
- Use OID `1.0` instead of `1.3`: a device can be reachable with OID outside of 1.3 tree. For example [1.0.8802.1.1.2.1.1.1.0](https://oidref.com/1.0.8802.1.1.2.1.1.1.0)


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Even if a device doesn't have sysObjectID, we want it to be discovered by SNMP Listener to give visibility to users (a user can see a device is not reachable in NDM UI and fix it).

Currently if a device is reachable but doesn't return a valid sysObjectID 1.3.6.1.2.1.1.2.0 , the device cannot be discovered by SNMP Listener / SNMP Agent Autodiscovery.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

- Test SNMP autodiscovery works for devices with valid sysObjectID
- Test SNMP autodiscovery works for devices without sysObjectID but has at leat one OID under `1.*` tree
- Test SNMP corecheck reachable state report OK for devices with that has 1.3.* OID
- Test SNMP corecheck reachable state report OK for devices with that has 1.0.* OID

**QA Tips**

You can add `qa.snmprec` like this:
```
1.0.8802.1.1.2.1.1.1.0|2|10
```
to `integrations-core/snmp/tests/compose/data` folder

Then, for SNMP Listener:

1/ `ddev env start snmp py38-snmplistener`
2/ ssh into the docker image and change SNMP Listener config to `community_string` to `qa` in datadog.yaml
3/ Restart agent docker image
4/ `ddev env check snmp py38-snmplistener` to verify the reachable status is OK

Then, for SNMP Corecheck:

1/ `ddev env start snmp py38`
2/ ssh into the docker image and change SNMP Listener config to `community_string` to `qa` in /etc/datadog-agent/conf.d/snmp.d/snmp.yaml
3/ Restart agent docker image
4/ `ddev env check snmp py38` to verify the reachable status is OK


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
