### PR TITLE
Revert "Make the DEB package datadog-signing-keys a hard dependency"

### DIFF
--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -53,7 +53,7 @@ else
   end
 
   if debian?
-    runtime_dependency 'datadog-signing-keys'
+    runtime_recommended_dependency 'datadog-signing-keys'
   end
 
   if osx?

--- a/omnibus/config/projects/dogstatsd.rb
+++ b/omnibus/config/projects/dogstatsd.rb
@@ -44,7 +44,7 @@ else
   end
 
   if debian?
-    runtime_dependency 'datadog-signing-keys'
+    runtime_recommended_dependency 'datadog-signing-keys'
   end
 end
 

--- a/omnibus/config/projects/iot-agent.rb
+++ b/omnibus/config/projects/iot-agent.rb
@@ -46,7 +46,7 @@ else
   end
 
   if debian?
-    runtime_dependency 'datadog-signing-keys'
+    runtime_recommended_dependency 'datadog-signing-keys'
   end
 end
 

--- a/releasenotes/notes/signing-keys-deb-strong-dep-fd8d8e605d88d9d9.yaml
+++ b/releasenotes/notes/signing-keys-deb-strong-dep-fd8d8e605d88d9d9.yaml
@@ -1,4 +1,0 @@
----
-upgrade:
-  - |
-    The DEB package now depends on the datadog-signing-keys package. This package contains the latest signing keys used to sign the packages and repo metadata.


### PR DESCRIPTION
Reverts DataDog/datadog-agent#11141

We realized we don't need to do this because:
- Users installing from our repos are already getting the keys package even if it's a soft dependency.
- Users not installing from our repos don't need the keys package.