### PR TITLE
[tasks] Invoke agent.run now calls "agent run"

### DIFF
--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -257,6 +257,7 @@ def run(
     build_exclude=None,
     flavor=AgentFlavor.base.name,
     skip_build=False,
+    config_path=None,
 ):
     """
     Execute the agent binary.
@@ -267,7 +268,9 @@ def run(
     if not skip_build:
         build(ctx, rebuild, race, build_include, build_exclude, flavor)
 
-    ctx.run(os.path.join(BIN_PATH, bin_name("agent")))
+    agent_bin = os.path.join(BIN_PATH, bin_name("agent"))
+    config_path = os.path.join(BIN_PATH, "dist", "datadog.yaml") if not config_path else config_path
+    ctx.run(f"{agent_bin} run -c {config_path}")
 
 
 @task


### PR DESCRIPTION

### What does this PR do?

Currently running `invoke agent.run` only executes `./bin/agent/agent`, which only lists the available commands. This is technically correct as the agent binary is executed. For some people, the expected behaviour would be for the agent to run and collect data.

### Motivation

While working on building and running the agent I found I had to chain `invoke agent.build` with `./bin/agent/agent run -c datadog.yaml`. I expected `invoke agent.run` to do all of that for us. This should lead to less mistakes being made when making changes and testing a build as the user doesn't have to remember to rebuild first.

### Additional Notes

Added a flag `--config-path` so that the default config used can be overridden. 

### Possible Drawbacks / Trade-offs

This might not be expected behaviour for `invoke agent.run`.

### Describe how to test/QA your changes

Run `invoke agent.run` with a valid configuration file in `dev/dist/datadog.yaml`. The agent will start up, begin to collect data and send it back.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
