### PR TITLE
Add a workflow to run mod tidy on an existing PR

### DIFF
--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -1,11 +1,10 @@
-name: Dependabot-Tidier
+name: Dependabot-Tidy
 on:
   pull_request:
-    types: [ labeled ]
-
+    types: [ milestoned ]
 jobs:
-  mod_tidier:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'dependencies') }}
+  go_mod_tidy:
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'dependencies') && github.event.pull_request.milestone.title != 'Triage' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -1,7 +1,7 @@
 name: Dependabot-Tidier
 on:
   pull_request:
-    types: [ labeled ]
+    types: [ milestoned ]
 jobs:
   mod_tidier:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'dependencies') }}

--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -1,9 +1,9 @@
-name: Dependabot-Tidy
+name: Dependabot-Tidier
 on:
   pull_request:
     types: [ labeled ]
 jobs:
-  go_mod_tidy:
+  mod_tidier:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'dependencies') }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -1,6 +1,6 @@
 name: Dependabot-Tidier
 on:
-  pull_request:
+  issues:
     types: [ milestoned ]
 jobs:
   mod_tidier:

--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -1,7 +1,7 @@
 name: Dependabot-Tidy
 on:
   pull_request:
-    types: [ milestoned ]
+    types: [ labeled ]
 jobs:
   go_mod_tidy:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'dependencies') && github.event.pull_request.milestone.title != 'Triage' }}

--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -1,7 +1,7 @@
 name: Dependabot-Tidy
 on:
   pull_request:
-    types: [ milestoned ]
+    types: [ labeled ]
 jobs:
   go_mod_tidy:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'dependencies') }}

--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -1,10 +1,10 @@
 name: Dependabot-Tidy
 on:
   pull_request:
-    types: [ labeled ]
+    types: [ milestoned ]
 jobs:
   go_mod_tidy:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'dependencies') && github.event.pull_request.milestone.title != 'Triage' }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'dependencies') }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/go_mod_tidy.yml
+++ b/.github/workflows/go_mod_tidy.yml
@@ -1,14 +1,18 @@
 name: "Run Go Mod Tidy And Generate Licenses"
 on:
   workflow_dispatch:
-    inputs: {}
+    inputs:
+      pr_id:
+        description: 'PR number'     
+        required: true
+        type: number
 jobs:
   mod_tidy_and_generate_licenses:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v2
       with:
-        ref: ${{ github.head_ref }}
+        ref: pull/${{ inputs.pr_id }}/head
     - name: Install go
       uses: actions/setup-go@v2
       with:

--- a/.github/workflows/go_mod_tidy.yml
+++ b/.github/workflows/go_mod_tidy.yml
@@ -1,10 +1,9 @@
-name: Dependabot-Tidier
+name: "Run Go Mod Tidy And Generate Licenses"
 on:
-  issues:
-    types: [ milestoned ]
+  workflow_dispatch:
+    inputs: {}
 jobs:
-  mod_tidier:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'dependencies') }}
+  mod_tidy_and_generate_licenses:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
### What does this PR do?

This is a more manual version of https://github.com/DataDog/datadog-agent/pull/11208

### Motivation

We want to run `go-mod-tidy` on dependabot PRs, but we need it to be a manual process because a malicious dependency pulled by dependabot could abuse this to push to master if our Action code runs the dependency code after it's been updated (eg: `invoke` tasks' dependencies, `modvendor` and `license-detector` in this case could be used as a backdoor).

That's the reason my previous PR didn't work is because Github already though about this and [Dependabot PRs run with a read-only `GITHUB_TOKEN`](https://github.blog/changelog/2021-10-06-github-actions-workflows-triggered-by-dependabot-prs-will-respect-permissions-key-in-workflows/). This made [git-auto-commit-action](https://github.com/stefanzweifel/git-auto-commit-action) fail, like in #11258.

### Possible Drawbacks / Trade-offs

Security implications: we should check the dependencies manually before triggering the action for the reasons mentioned above.
