### PR TITLE
[system-probe] add missing namespaces to config command

### DIFF
--- a/cmd/system-probe/api/config.go
+++ b/cmd/system-probe/api/config.go
@@ -7,14 +7,25 @@ package api
 
 import (
 	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	"github.com/DataDog/datadog-agent/cmd/system-probe/modules"
 	settingshttp "github.com/DataDog/datadog-agent/pkg/config/settings/http"
 	"github.com/gorilla/mux"
 )
 
 // setupConfigHandlers adds the specific handlers for /config endpoints
 func setupConfigHandlers(r *mux.Router) {
-	r.HandleFunc("/config", settingshttp.Server.GetFull(config.Namespace)).Methods("GET")
+	r.HandleFunc("/config", settingshttp.Server.GetFull(getAggregatedNamespaces()...)).Methods("GET")
 	r.HandleFunc("/config/list-runtime", settingshttp.Server.ListConfigurable).Methods("GET")
 	r.HandleFunc("/config/{setting}", settingshttp.Server.GetValue).Methods("GET")
 	r.HandleFunc("/config/{setting}", settingshttp.Server.SetValue).Methods("POST")
+}
+
+func getAggregatedNamespaces() []string {
+	namespaces := []string{
+		config.Namespace,
+	}
+	for _, m := range modules.All {
+		namespaces = append(namespaces, m.ConfigNamespaces...)
+	}
+	return namespaces
 }

--- a/cmd/system-probe/api/module/common.go
+++ b/cmd/system-probe/api/module/common.go
@@ -17,8 +17,9 @@ var ErrNotEnabled = errors.New("module is not enabled")
 
 // Factory encapsulates the initialization of a Module
 type Factory struct {
-	Name config.ModuleName
-	Fn   func(cfg *config.Config) (Module, error)
+	Name             config.ModuleName
+	ConfigNamespaces []string
+	Fn               func(cfg *config.Config) (Module, error)
 }
 
 // Module defines the common API implemented by every System Probe Module

--- a/cmd/system-probe/modules/network_tracer.go
+++ b/cmd/system-probe/modules/network_tracer.go
@@ -38,7 +38,8 @@ const inactivityRestartDuration = 20 * time.Minute
 
 // NetworkTracer is a factory for NPM's tracer
 var NetworkTracer = module.Factory{
-	Name: config.NetworkTracerModule,
+	Name:             config.NetworkTracerModule,
+	ConfigNamespaces: []string{"network_config", "service_monitoring_config"},
 	Fn: func(cfg *config.Config) (module.Module, error) {
 		ncfg := networkconfig.New()
 

--- a/cmd/system-probe/modules/oom_kill_probe.go
+++ b/cmd/system-probe/modules/oom_kill_probe.go
@@ -22,7 +22,8 @@ import (
 
 // OOMKillProbe Factory
 var OOMKillProbe = module.Factory{
-	Name: config.OOMKillProbeModule,
+	Name:             config.OOMKillProbeModule,
+	ConfigNamespaces: []string{},
 	Fn: func(cfg *config.Config) (module.Module, error) {
 		log.Infof("Starting the OOM Kill probe")
 		okp, err := probe.NewOOMKillProbe(ebpf.NewConfig())

--- a/cmd/system-probe/modules/process.go
+++ b/cmd/system-probe/modules/process.go
@@ -30,7 +30,8 @@ var ErrProcessUnsupported = errors.New("process module unsupported")
 
 // Process is a module that fetches process level data
 var Process = module.Factory{
-	Name: config.ProcessModule,
+	Name:             config.ProcessModule,
+	ConfigNamespaces: []string{},
 	Fn: func(cfg *config.Config) (module.Module, error) {
 		log.Infof("Creating process module for: %s", filepath.Base(os.Args[0]))
 

--- a/cmd/system-probe/modules/security_runtime.go
+++ b/cmd/system-probe/modules/security_runtime.go
@@ -24,7 +24,8 @@ const (
 
 // SecurityRuntime - Security runtime Factory
 var SecurityRuntime = module.Factory{
-	Name: config.SecurityRuntimeModule,
+	Name:             config.SecurityRuntimeModule,
+	ConfigNamespaces: []string{"runtime_security_config"},
 	Fn: func(agentConfig *config.Config) (module.Module, error) {
 		config, err := sconfig.NewConfig(agentConfig)
 		if err != nil {

--- a/cmd/system-probe/modules/tcp_queue_tracer.go
+++ b/cmd/system-probe/modules/tcp_queue_tracer.go
@@ -21,7 +21,8 @@ import (
 
 // TCPQueueLength Factory
 var TCPQueueLength = module.Factory{
-	Name: config.TCPQueueLengthTracerModule,
+	Name:             config.TCPQueueLengthTracerModule,
+	ConfigNamespaces: []string{},
 	Fn: func(cfg *config.Config) (module.Module, error) {
 		t, err := probe.NewTCPQueueLengthTracer(ebpf.NewConfig())
 		if err != nil {

--- a/pkg/config/settings/http/server.go
+++ b/pkg/config/settings/http/server.go
@@ -20,7 +20,7 @@ import (
 
 // Server offers functions that implement the standard runtime settings HTTP API
 var Server = struct {
-	GetFull          func(string) http.HandlerFunc
+	GetFull          func(...string) http.HandlerFunc
 	GetValue         http.HandlerFunc
 	SetValue         http.HandlerFunc
 	ListConfigurable http.HandlerFunc
@@ -31,22 +31,41 @@ var Server = struct {
 	ListConfigurable: listConfigurableSettings,
 }
 
-func getFullConfig(namespace string) http.HandlerFunc {
+func getFullConfig(namespaces ...string) http.HandlerFunc {
+	requiresUniqueNs := len(namespaces) == 1 && namespaces[0] != ""
+	requiresAllNamespaces := len(namespaces) == 0
+
+	// We want to create a unique list of namespaces.
+	uniqueNamespaces := map[string]struct{}{}
+	for _, k := range namespaces {
+		uniqueNamespaces[k] = struct{}{}
+		if k == "" {
+			requiresAllNamespaces = true
+			break
+		}
+	}
 	return func(w http.ResponseWriter, _ *http.Request) {
-		var nsSettings interface{}
+		nsSettings := map[string]interface{}{}
 		allSettings := ddconfig.Datadog.AllSettings()
-		if namespace != "" {
-			for k, v := range allSettings {
-				if k == namespace {
-					nsSettings = v
-					break
+		if !requiresAllNamespaces {
+			for ns := range uniqueNamespaces {
+				if val, ok := allSettings[ns]; ok {
+					nsSettings[ns] = val
 				}
 			}
-		} else {
-			nsSettings = allSettings
 		}
 
-		runtimeConfig, err := yaml.Marshal(nsSettings)
+		var runtimeConfig []byte
+		var err error
+		if requiresUniqueNs {
+			// This special case is to respect previous behavior not to display
+			// a yaml root entry with the name of the namespace.
+			runtimeConfig, err = yaml.Marshal(nsSettings[namespaces[0]])
+		} else if requiresAllNamespaces {
+			runtimeConfig, err = yaml.Marshal(allSettings)
+		} else {
+			runtimeConfig, err = yaml.Marshal(nsSettings)
+		}
 		if err != nil {
 			log.Errorf("Unable to marshal runtime config response: %s", err)
 			body, _ := json.Marshal(map[string]string{"error": err.Error()})


### PR DESCRIPTION
### What does this PR do?

Adds potential submodules configuration namespaces to the `system-probe config` command. As for now, only the `system_probe_config` is displayed.

### Motivation

This makes it easier to know what is configurable and what is not.

### Describe how to test/QA your changes

The config subcommands are working correctly locally. The old behaviour of `getFullConfig` has been maintained (which is, when only one namespace is provided, it doesn't show itself at the root level of the yaml output).

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
