### PR TITLE
Add DD_URL environment variable to set Datadog server host value in configuration

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -22,10 +22,12 @@ api_key:
 
 ## @param dd_url - string - optional - default: https://app.datadoghq.com
 ## @env DD_DD_URL - string - optional - default: https://app.datadoghq.com
+## @env DD_URL - string - optional - default: https://app.datadoghq.com
 ## The host of the Datadog intake server to send metrics to, only set this option
 ## if you need the Agent to send metrics to a custom URL, it overrides the site
 ## setting defined in "site". It does not affect APM, Logs or Live Process intake which have their
 ## own "*_dd_url" settings.
+## If DD_DD_URL and DD_URL are both set, DD_DD_URL is used in priority.
 #
 # dd_url: https://app.datadoghq.com
 

--- a/releasenotes/notes/add-DD_URL-env-var-c2cacb4783c13bb0.yaml
+++ b/releasenotes/notes/add-DD_URL-env-var-c2cacb4783c13bb0.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    DD_URL environment variable can now set Datadog server host just like
+    DD_DD_URL.
+    DD_DD_URL is used in priotity if DD_URL and DD_DD_URL variables are set.
+   


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR allows users to use the `DD_URL` environment variable to set the Datadog server host value the same way we use `DD_DD_URL` variable. If `DD_URL` and `DD_DD_URL` both exist, `DD_DD_URL` value is used for the server host.

### Motivation

Allowing users to override the 'dd_url' value in the configuration file by a much more intuitive name. 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Run the agent with `DD_URL` and `DD_DD_URL` environment variables and use command like status or config to find the value of the server host.

Server host must be equal to `DD_DD_URL` value when `DD_DD_URL` is defined.
Server host must be equal to `DD_URL` value when `DD_URL` is defined and `DD_DD_URL` is not defined.
Otherwise, server host takes the value of 'dd_url' key in the configuration file, if presents.


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
