### PR TITLE
[CWS] fix `TestProcessExec` test

### DIFF
--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -347,14 +347,32 @@ func assertFieldEqual(t *testing.T, e *sprobe.Event, field string, value interfa
 }
 
 //nolint:deadcode,unused
-func assertFieldOneOf(t *testing.T, e *sprobe.Event, field string, values []interface{}, msgAndArgs ...interface{}) bool {
+func assertFieldStringArrayNotEmptyIntersection(t *testing.T, e *sprobe.Event, field string, values []string, msgAndArgs ...interface{}) bool {
 	t.Helper()
 	fieldValue, err := e.GetFieldValue(field)
 	if err != nil {
 		t.Errorf("failed to get field '%s': %s", field, err)
 		return false
 	}
-	return assert.Contains(t, values, fieldValue)
+
+	if fieldValues, ok := fieldValue.([]string); ok {
+		notEmptyIntersection := false
+		for _, leftValue := range fieldValues {
+			for _, rightValue := range values {
+				if leftValue == rightValue {
+					notEmptyIntersection = true
+				}
+			}
+		}
+
+		if !notEmptyIntersection {
+			return assert.Fail(t, "intersection not empty", msgAndArgs...)
+		}
+		return true
+	}
+
+	t.Errorf("failed to get field '%s' as an array", field)
+	return false
 }
 
 func setTestConfig(dir string, opts testOpts) (string, error) {

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -347,7 +347,7 @@ func assertFieldEqual(t *testing.T, e *sprobe.Event, field string, value interfa
 }
 
 //nolint:deadcode,unused
-func assertFieldStringArrayNotEmptyIntersection(t *testing.T, e *sprobe.Event, field string, values []string, msgAndArgs ...interface{}) bool {
+func assertFieldStringArrayIndexedOneOf(t *testing.T, e *sprobe.Event, field string, index int, values []string, msgAndArgs ...interface{}) bool {
 	t.Helper()
 	fieldValue, err := e.GetFieldValue(field)
 	if err != nil {
@@ -356,19 +356,7 @@ func assertFieldStringArrayNotEmptyIntersection(t *testing.T, e *sprobe.Event, f
 	}
 
 	if fieldValues, ok := fieldValue.([]string); ok {
-		notEmptyIntersection := false
-		for _, leftValue := range fieldValues {
-			for _, rightValue := range values {
-				if leftValue == rightValue {
-					notEmptyIntersection = true
-				}
-			}
-		}
-
-		if !notEmptyIntersection {
-			return assert.Fail(t, "intersection not empty", msgAndArgs...)
-		}
-		return true
+		return assert.Contains(t, values, fieldValues[index])
 	}
 
 	t.Errorf("failed to get field '%s' as an array", field)

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -746,7 +746,7 @@ func TestProcessExec(t *testing.T) {
 		return cmd.Run()
 	}, func(event *sprobe.Event, rule *rules.Rule) {
 		assertFieldEqual(t, event, "exec.file.path", executable)
-		assertFieldOneOf(t, event, "process.file.name", []interface{}{"sh", "bash", "dash"})
+		assertFieldStringArrayNotEmptyIntersection(t, event, "process.ancestors.file.name", []string{"sh", "bash", "dash"})
 	})
 }
 

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -746,7 +746,8 @@ func TestProcessExec(t *testing.T) {
 		return cmd.Run()
 	}, func(event *sprobe.Event, rule *rules.Rule) {
 		assertFieldEqual(t, event, "exec.file.path", executable)
-		assertFieldStringArrayNotEmptyIntersection(t, event, "process.ancestors.file.name", []string{"sh", "bash", "dash"})
+		// TODO: use `process.ancestors[0].file.name` directly when this feature is reintroduced
+		assertFieldStringArrayIndexedOneOf(t, event, "process.ancestors.file.name", 0, []string{"sh", "bash", "dash"})
 	})
 }
 


### PR DESCRIPTION
### What does this PR do?

Fix `TestProcessExec` test, broken by https://github.com/DataDog/datadog-agent/pull/11215

I'm very open to another name for the test helper function.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
