### PR TITLE
[windows] Fix aws invocation in omnibus builds

### DIFF
--- a/tasks/ssm.py
+++ b/tasks/ssm.py
@@ -4,7 +4,7 @@ import json
 import os
 import tempfile
 
-ssm_command = "aws.exe ssm get-parameter --name {} --with-decryption --region us-east-1"
+ssm_command = "aws ssm get-parameter --name {} --with-decryption --region us-east-1"
 ssm_param_password = "keygen.dd_win_agent_codesign.password"
 ssm_param_pfx_part1 = "keygen.dd_win_agent_codesign.pfx_b64_0"
 ssm_param_pfx_part2 = "keygen.dd_win_agent_codesign.pfx_b64_1"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

In Windows omnibus builds, call `aws` instead of `aws.exe`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

`aws` works with the current build image, and `aws.exe` won't work once we start installing `awscli` with pip on Windows (see [this PR comment](https://github.com/DataDog/datadog-agent-buildimages/pull/209#issuecomment-1066673377)).

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Check Windows Agent build, make sure it is properly signed.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
