### PR TITLE
[contlcycle] Flush events when the agent is stopped

### DIFF
--- a/pkg/collector/corechecks/containerlifecycle/processor.go
+++ b/pkg/collector/corechecks/containerlifecycle/processor.go
@@ -6,6 +6,7 @@
 package containerlifecycle
 
 import (
+	"context"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
@@ -29,8 +30,8 @@ func newProcessor(sender aggregator.Sender, chunkSize int) *processor {
 }
 
 // start spawns a go routine to consume event queues
-func (p *processor) start(stop chan struct{}, pollInterval time.Duration) {
-	go p.processQueues(stop, pollInterval)
+func (p *processor) start(ctx context.Context, pollInterval time.Duration) {
+	go p.processQueues(ctx, pollInterval)
 }
 
 // processEvents handles workloadmeta events, supports pods and container unset events.
@@ -109,25 +110,40 @@ func (p *processor) processPod(pod workloadmeta.Entity) error {
 }
 
 // processQueues consumes the data available in the queues
-func (p *processor) processQueues(stop chan struct{}, pollInterval time.Duration) {
+func (p *processor) processQueues(ctx context.Context, pollInterval time.Duration) {
 	ticker := time.NewTicker(pollInterval)
 
 	for {
 		select {
 		case <-ticker.C:
-			if !p.containersQueue.isEmpty() {
-				msgs := p.containersQueue.dump()
-				p.containersQueue.reset()
-				p.sender.ContainerLifecycleEvent(msgs)
-			}
-
-			if !p.podsQueue.isEmpty() {
-				msgs := p.podsQueue.dump()
-				p.podsQueue.reset()
-				p.sender.ContainerLifecycleEvent(msgs)
-			}
-		case <-stop:
+			p.flush()
+		case <-ctx.Done():
+			p.flush()
 			return
 		}
+	}
+}
+
+// flush forwards all queued events to the aggregator
+func (p *processor) flush() {
+	p.flushContainers()
+	p.flushPods()
+}
+
+// flushContainers forwards queued container events to the aggregator
+func (p *processor) flushContainers() {
+	if !p.containersQueue.isEmpty() {
+		msgs := p.containersQueue.dump()
+		p.containersQueue.reset()
+		p.sender.ContainerLifecycleEvent(msgs)
+	}
+}
+
+// flushPods forwards queued pod events to the aggregator
+func (p *processor) flushPods() {
+	if !p.podsQueue.isEmpty() {
+		msgs := p.podsQueue.dump()
+		p.podsQueue.reset()
+		p.sender.ContainerLifecycleEvent(msgs)
 	}
 }

--- a/pkg/collector/corechecks/containerlifecycle/processor_test.go
+++ b/pkg/collector/corechecks/containerlifecycle/processor_test.go
@@ -6,6 +6,7 @@
 package containerlifecycle
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -65,8 +66,10 @@ func TestProcessQueues(t *testing.T) {
 			sender.On("ContainerLifecycleEvent", mock.Anything, mock.Anything).Return()
 			p.sender = sender
 
-			stop := make(chan struct{})
-			go p.processQueues(stop, 500*time.Millisecond)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			go p.processQueues(ctx, 500*time.Millisecond)
 			time.Sleep(1 * time.Second)
 
 			tt.wantFunc(t, sender)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

The container lifecycle events check now flushes the queued events when it's stopped.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Make sure the check forwards every event received

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

The agent should be able to report deletion events when it's stopped, a testing scenario is running `docker stop <other container> <agent container>` the check should be able to report the deletion event.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
