### PR TITLE
Stop checks before workloadmeta

### DIFF
--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -476,9 +476,6 @@ func StopAgent() {
 		log.Warnf("Some components were unhealthy: %v", health.Unhealthy)
 	}
 
-	// gracefully shut down any component
-	common.MainCtxCancel()
-
 	if common.DSD != nil {
 		common.DSD.Stop()
 	}
@@ -505,6 +502,10 @@ func StopAgent() {
 	profiler.Stop()
 
 	os.Remove(pidfilePath)
+
+	// gracefully shut down any component
+	common.MainCtxCancel()
+
 	log.Info("See ya!")
 	log.Flush()
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Stop autodiscovery/scheduler/collector before canceling the main agent context (`common.MainCtx`) 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Use-case: a check relying on workloadmeta should stop before workloadmeta (same for the tagger).

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

This ordering issue was discovered while working on https://github.com/DataDog/datadog-agent/pull/11278 - the ordering fixes this panic

```
2022-03-14 12:57:09 UTC | CORE | INFO | (pkg/workloadmeta/store.go:145 in func2) | stopped workloadmeta store
2022-03-14 12:57:09 UTC | CORE | WARN | (pkg/workloadmeta/collectors/internal/docker/docker.go:119 in stream) | error unsubscribbing from container events: not subscribed
panic: close of nil channel

goroutine 361 [running]:
github.com/DataDog/datadog-agent/pkg/collector/corechecks/containerlifecycle.(*processor).processEvents(0xc000de3a20, {{0x0, 0x0, 0x0}, 0x0})
	/git/datadog-agent/pkg/collector/corechecks/containerlifecycle/processor.go:39 +0x59
github.com/DataDog/datadog-agent/pkg/collector/corechecks/containerlifecycle.(*Check).Run(0xc000703880)
	/git/datadog-agent/pkg/collector/corechecks/containerlifecycle/check.go:120 +0x713
github.com/DataDog/datadog-agent/pkg/collector/worker.(*Worker).Run(0xc000790b40)
	/git/datadog-agent/pkg/collector/worker/worker.go:147 +0x525
github.com/DataDog/datadog-agent/pkg/collector/runner.(*Runner).newWorker.func1()
	/git/datadog-agent/pkg/collector/runner/runner.go:131 +0xc5
created by github.com/DataDog/datadog-agent/pkg/collector/runner.(*Runner).newWorker
	/git/datadog-agent/pkg/collector/runner/runner.go:128 +0x325
```

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

The agent shouldn't panic when it's stopped (with container lifecycle events enabled)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
