### PR TITLE
Add Datadog registry entries in flare

### DIFF
--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -336,6 +336,10 @@ func createArchive(confSearchPaths SearchPaths, local bool, zipFilePath string, 
 	if err != nil {
 		log.Errorf("Could not export Windows driver status: %s", err)
 	}
+	err = zipDatadogRegistry(tempDir, hostname)
+	if err != nil {
+		log.Errorf("Could not export Windows Datadog Registry: %s", err)
+	}
 
 	// force a log flush before zipping them
 	log.Flush()

--- a/pkg/flare/archive_nix.go
+++ b/pkg/flare/archive_nix.go
@@ -36,6 +36,9 @@ func zipWindowsEventLogs(tempDir, hostname string) error {
 func zipServiceStatus(tempDir, hostname string) error {
 	return nil
 }
+func zipDatadogRegistry(tempDir, hostname string) error {
+	return nil
+}
 
 // Add puts the given filepath in the map
 // of files to process later during the commit phase.

--- a/releasenotes/notes/add-registry-to-flare-bb2b806f374633e8.yaml
+++ b/releasenotes/notes/add-registry-to-flare-bb2b806f374633e8.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Windows: Add Datadog registry to flare..

--- a/releasenotes/notes/add-registry-to-flare-bb2b806f374633e8.yaml
+++ b/releasenotes/notes/add-registry-to-flare-bb2b806f374633e8.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    Windows: Add Datadog registry to flare..
+    Windows: Add Datadog registry to Flare.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Adds datadog.reg file to the Flare's package on Windows. The file content is exported SOFTWARE\Datadog registry key.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
* PR added a code which invokes built in Windows command`reg export HKLM\Software\Datadog  <file path\datadog.reg> /y`

### Motivation
Troubleshooting assistance.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->


### Additional Notes
No unit or kitchen tests had been provided due to ...
* ... very simple implementation
* ... not much value from decoupling code from concrete registry path
* ... no similar flare artifacts had been tested in unit tests
* ... flare is not tested in kitchen tests

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
There are two ways to implement this functionality with its own pros and cons.
#### Using Registry API calls
One would use [Registry API ](https://pkg.go.dev/golang.org/x/sys/windows/registry) to recursively enumerate and  dump Keys and Values. While the solution guarantees high performance (perhaps handful of microseconds) interpreting  Registry value to be saved as text requires relatively big effort to handle [all nearly a dozen types of Registry values](https://docs.microsoft.com/en-us/windows/win32/sysinfo/registry-value-types). Consider a relatively trivial example of various registry value types
```
[HKEY_LOCAL_MACHINE\Software\Datadog\Len-Test]
"str"="asdfasdf"
"bin"=hex:ad,fd,fa,a0
"dword"=dword:00000000
"multi-str"=hex(7):61,00,73,00,64,00,66,00,61,00,73,00,64,00,66,00,00,00,61,00,73,\
  00,64,00,66,00,61,00,73,00,64,00,66,00,66,00,66,00,66,00,66,00,66,00,00,00,\
  73,00,73,00,73,00,73,00,00,00,73,00,73,00,73,00,00,00,00,00
"expand-str"=hex(2):25,00,61,00,70,00,70,00,64,00,61,00,74,00,61,00,25,00,00,00

```
#### Spawning Windows built-in reg.exe command
Starting [reg.exe](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/reg) process had a relatively large overhead of small executable start but fast otherwise (perhaps in order of few milliseconds). However, zero coding is needed to capture Datadog all registry key and values in the proper format directly in the file. Because the file is saved in the protected Flare's directory (where only datadog user can access it) solution is secure.

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Run flare command on Windows. Observe the presence of datadog.reg file in the flare package.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a release note.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
