### PR TITLE
Add `--service` to `stream-logs`

### DIFF
--- a/cmd/agent/app/stream_logs.go
+++ b/cmd/agent/app/stream_logs.go
@@ -29,6 +29,7 @@ func init() {
 	troubleshootLogsCmd.Flags().StringVar(&filters.Name, "name", "", "Filter by name")
 	troubleshootLogsCmd.Flags().StringVar(&filters.Type, "type", "", "Filter by type")
 	troubleshootLogsCmd.Flags().StringVar(&filters.Source, "source", "", "Filter by source")
+	troubleshootLogsCmd.Flags().StringVar(&filters.Service, "service", "", "Filter by service")
 }
 
 var troubleshootLogsCmd = &cobra.Command{

--- a/pkg/logs/diagnostic/message_receiver.go
+++ b/pkg/logs/diagnostic/message_receiver.go
@@ -35,9 +35,10 @@ type BufferedMessageReceiver struct {
 
 // Filters for processing log messages
 type Filters struct {
-	Name   string `json:"name"`
-	Type   string `json:"type"`
-	Source string `json:"source"`
+	Name    string `json:"name"`
+	Type    string `json:"type"`
+	Source  string `json:"source"`
+	Service string `json:"service"`
 }
 
 // NewBufferedMessageReceiver creates a new MessageReceiver
@@ -132,6 +133,10 @@ func shouldHandleMessage(m *message.Message, filters *Filters) bool {
 
 	if filters.Source != "" {
 		shouldHandle = shouldHandle && filters.Source == m.Origin.Source()
+	}
+
+	if filters.Service != "" {
+		shouldHandle = shouldHandle && filters.Service == m.Origin.Service()
 	}
 
 	return shouldHandle

--- a/pkg/logs/diagnostic/message_receiver_test.go
+++ b/pkg/logs/diagnostic/message_receiver_test.go
@@ -17,7 +17,7 @@ func TestEnableDisable(t *testing.T) {
 	assert.True(t, b.SetEnabled(true))
 	assert.False(t, b.SetEnabled(true))
 
-	b.HandleMessage(newMessage("", "", ""), []byte("a"))
+	b.HandleMessage(newMessage("", "", "", ""), []byte("a"))
 
 	done := make(chan struct{})
 	defer close(done)
@@ -34,7 +34,7 @@ func TestEnableDisable(t *testing.T) {
 	default:
 	}
 
-	b.HandleMessage(newMessage("", "", ""), []byte("a"))
+	b.HandleMessage(newMessage("", "", "", ""), []byte("a"))
 
 	select {
 	case <-lineChan:
@@ -50,15 +50,16 @@ func TestFilterAll(t *testing.T) {
 	b.SetEnabled(true)
 
 	for i := 0; i < 5; i++ {
-		b.HandleMessage(newMessage("test1", "a", "b"), []byte("a"))
-		b.HandleMessage(newMessage("test1", "1", "2"), []byte("a"))
-		b.HandleMessage(newMessage("test2", "a", "b"), []byte("a"))
+		b.HandleMessage(newMessage("test1", "a", "b", "service_a"), []byte("a"))
+		b.HandleMessage(newMessage("test1", "1", "2", "service_b"), []byte("a"))
+		b.HandleMessage(newMessage("test2", "a", "b", "service_c"), []byte("a"))
 	}
 
 	filters := Filters{
-		Name:   "test1",
-		Type:   "a",
-		Source: "b",
+		Name:    "test1",
+		Type:    "a",
+		Source:  "b",
+		Service: "service_a",
 	}
 	readFilteredLines(t, b, &filters, 5)
 }
@@ -69,13 +70,49 @@ func TestFilterTypeAndSource(t *testing.T) {
 	b.SetEnabled(true)
 
 	for i := 0; i < 5; i++ {
-		b.HandleMessage(newMessage("test", "a", "b"), []byte("a"))
-		b.HandleMessage(newMessage("test", "1", "2"), []byte("a"))
+		b.HandleMessage(newMessage("test", "a", "b", "service_a"), []byte("a"))
+		b.HandleMessage(newMessage("test", "1", "2", "service_b"), []byte("a"))
 	}
 
 	filters := Filters{
 		Type:   "a",
 		Source: "b",
+	}
+
+	readFilteredLines(t, b, &filters, 5)
+}
+
+func TestFilterTypeAndService(t *testing.T) {
+
+	b := NewBufferedMessageReceiver()
+	b.SetEnabled(true)
+
+	for i := 0; i < 5; i++ {
+		b.HandleMessage(newMessage("test", "a", "b", "service_a"), []byte("a"))
+		b.HandleMessage(newMessage("test", "1", "2", "service_b"), []byte("a"))
+	}
+
+	filters := Filters{
+		Type:    "a",
+		Service: "service_a",
+	}
+
+	readFilteredLines(t, b, &filters, 5)
+}
+
+func TestFilterSourceAndService(t *testing.T) {
+
+	b := NewBufferedMessageReceiver()
+	b.SetEnabled(true)
+
+	for i := 0; i < 5; i++ {
+		b.HandleMessage(newMessage("test", "a", "b", "service_a"), []byte("a"))
+		b.HandleMessage(newMessage("test", "1", "2", "service_b"), []byte("a"))
+	}
+
+	filters := Filters{
+		Source:  "b",
+		Service: "service_a",
 	}
 
 	readFilteredLines(t, b, &filters, 5)
@@ -87,9 +124,9 @@ func TestFilterName(t *testing.T) {
 	b.SetEnabled(true)
 
 	for i := 0; i < 5; i++ {
-		b.HandleMessage(newMessage("test1", "a", "b"), []byte("a"))
-		b.HandleMessage(newMessage("test2", "a", "2"), []byte("a"))
-		b.HandleMessage(newMessage("test2", "b", "2"), []byte("a"))
+		b.HandleMessage(newMessage("test1", "a", "b", "service_a"), []byte("a"))
+		b.HandleMessage(newMessage("test2", "a", "2", "service_b"), []byte("a"))
+		b.HandleMessage(newMessage("test2", "b", "2", "service_c"), []byte("a"))
 	}
 
 	filters := Filters{
@@ -105,9 +142,9 @@ func TestFilterSource(t *testing.T) {
 	b.SetEnabled(true)
 
 	for i := 0; i < 5; i++ {
-		b.HandleMessage(newMessage("test", "a", "b"), []byte("a"))
-		b.HandleMessage(newMessage("test", "a", "2"), []byte("a"))
-		b.HandleMessage(newMessage("test", "b", "2"), []byte("a"))
+		b.HandleMessage(newMessage("test", "a", "b", "service_a"), []byte("a"))
+		b.HandleMessage(newMessage("test", "a", "2", "service_b"), []byte("a"))
+		b.HandleMessage(newMessage("test", "b", "2", "service_c"), []byte("a"))
 	}
 
 	filters := Filters{
@@ -123,9 +160,9 @@ func TestFilterType(t *testing.T) {
 	b.SetEnabled(true)
 
 	for i := 0; i < 5; i++ {
-		b.HandleMessage(newMessage("test", "a", "b"), []byte("a"))
-		b.HandleMessage(newMessage("test", "a", "2"), []byte("a"))
-		b.HandleMessage(newMessage("test", "b", "2"), []byte("a"))
+		b.HandleMessage(newMessage("test", "a", "b", "service_a"), []byte("a"))
+		b.HandleMessage(newMessage("test", "a", "2", "service_b"), []byte("a"))
+		b.HandleMessage(newMessage("test", "b", "2", "service_c"), []byte("a"))
 	}
 
 	filters := Filters{
@@ -135,32 +172,53 @@ func TestFilterType(t *testing.T) {
 	readFilteredLines(t, b, &filters, 10)
 }
 
+func TestFilterService(t *testing.T) {
+
+	b := NewBufferedMessageReceiver()
+	b.SetEnabled(true)
+
+	for i := 0; i < 5; i++ {
+		b.HandleMessage(newMessage("test", "a", "b", "service_a"), []byte("a"))
+		b.HandleMessage(newMessage("test", "a", "2", "service_b"), []byte("a"))
+		b.HandleMessage(newMessage("test", "b", "2", "service_c"), []byte("a"))
+	}
+
+	filters := Filters{
+		Service: "service_a",
+	}
+
+	readFilteredLines(t, b, &filters, 5)
+}
+
 func TestNoFilters(t *testing.T) {
 
 	b := NewBufferedMessageReceiver()
 	b.SetEnabled(true)
 
 	for i := 0; i < 5; i++ {
-		b.HandleMessage(newMessage("test", "a", "b"), []byte("a"))
-		b.HandleMessage(newMessage("test", "a", "2"), []byte("a"))
-		b.HandleMessage(newMessage("test", "b", "2"), []byte("a"))
+		b.HandleMessage(newMessage("test", "a", "b", "service_a"), []byte("a"))
+		b.HandleMessage(newMessage("test", "a", "2", "service_b"), []byte("a"))
+		b.HandleMessage(newMessage("test", "b", "2", "service_c"), []byte("a"))
 	}
 
 	filters := Filters{
-		Type:   "",
-		Source: "",
+		Name:    "",
+		Type:    "",
+		Source:  "",
+		Service: "",
 	}
 
 	readFilteredLines(t, b, &filters, 15)
 }
 
-func newMessage(n string, t string, s string) message.Message {
+func newMessage(name, typ, source, service string) message.Message {
 	cfg := &config.LogsConfig{
-		Type:   t,
-		Source: s,
+		Type:    typ,
+		Source:  source,
+		Service: service,
 	}
-	source := config.NewLogSource(n, cfg)
-	origin := message.NewOrigin(source)
+	src := config.NewLogSource(name, cfg)
+	origin := message.NewOrigin(src)
 	return *message.NewMessage([]byte("a"), origin, "", 0)
 }
 

--- a/releasenotes/notes/add-service-flag-to-stream-logs-command-6968b5a0277fa018.yaml
+++ b/releasenotes/notes/add-service-flag-to-stream-logs-command-6968b5a0277fa018.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add `--service` flag to `stream-logs` command to filter
+    streamed logs in detail.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Add `--service` flag to `stream-logs` command.

### Motivation

Because I want to filter the logs in more detail.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

1 ) Build the Agent at [this branch](https://github.com/keisku/datadog-agent/tree/add_service_steram-logs_filter) according to https://github.com/DataDog/datadog-agent#getting-started

2 ) Confirm the `Flags`

I can see `--service string   Filter by service`.

![1  keisuke_umegaki_datadoghq_com@keisuke-vm-201 _gosrcgithub comkeiskudatadog-agent 2022-03-17 at 10 23 18 PM](https://user-images.githubusercontent.com/41987730/158817857-ddb9bd9e-95a6-4500-9c2c-fc9667c2d0c5.jpg)

3 ) Create the log config for test.

```bash
touch ~/test.log
```

Write the configuration in `/bin/agent/dist/conf.d/tttttest.d/conf.yaml`.

```yaml
logs:
 - type: file
   path: /home/keisuke_umegaki_datadoghq_com/test.log
   source: test_log
   service: test_log
```

4 ) Run the Agent

```bash
sudo ./bin/agent/agent run -c ./bin/agent/dist/datadog.yaml > /dev/null 2>&1 &
```

5 ) Write logs to `~/test.log`

```bash
while true; do echo "hello at $(date)" >> ~/test.log; sleep 2; done &
```

6 ) See streamed logs

```bash
sudo ./bin/agent/agent stream-logs --service=test_log -c ./bin/agent/dist/datadog.yaml
```

![Screen Recording 2022-03-17 at 10 28 37 PM](https://user-images.githubusercontent.com/41987730/158818916-e63a58ff-e744-4dfa-aca2-0d9896b163d0.gif)


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
