### PR TITLE
[tagger] Add task_* and static tags to OrchestratorScopeEntityID

### DIFF
--- a/pkg/otlp/internal/serializerexporter/consumer.go
+++ b/pkg/otlp/internal/serializerexporter/consumer.go
@@ -42,7 +42,7 @@ func (c *serializerConsumer) enrichedTags(dimensions *translator.Dimensions) []s
 		enrichedTags = append(enrichedTags, entityTags...)
 	}
 
-	orchestratorTags, err := tagger.OrchestratorScopeTag()
+	orchestratorTags, err := tagger.OrchestratorScopeTag(c.cardinality)
 	if err != nil {
 		log.Trace(err.Error())
 	} else {

--- a/pkg/otlp/internal/serializerexporter/consumer.go
+++ b/pkg/otlp/internal/serializerexporter/consumer.go
@@ -42,11 +42,11 @@ func (c *serializerConsumer) enrichedTags(dimensions *translator.Dimensions) []s
 		enrichedTags = append(enrichedTags, entityTags...)
 	}
 
-	orchestratorTags, err := tagger.OrchestratorScopeTag(c.cardinality)
+	globalTags, err := tagger.GlobalTags(c.cardinality)
 	if err != nil {
 		log.Trace(err.Error())
 	} else {
-		enrichedTags = append(enrichedTags, orchestratorTags...)
+		enrichedTags = append(enrichedTags, globalTags...)
 	}
 
 	return enrichedTags

--- a/pkg/tagger/collectors/workloadmeta_extract.go
+++ b/pkg/tagger/collectors/workloadmeta_extract.go
@@ -222,11 +222,6 @@ func (c *WorkloadMetaCollector) handleContainer(ev workloadmeta.Event) []*TagInf
 		utils.AddMetadataAsTags(envName, envValue, c.containerEnvAsTags, c.globContainerEnvLabels, tags)
 	}
 
-	// static tags for ECS and EKS Fargate containers
-	for tag, value := range c.staticTags {
-		tags.AddLow(tag, value)
-	}
-
 	low, orch, high, standard := tags.Compute()
 	return []*TagInfo{
 		{
@@ -278,11 +273,6 @@ func (c *WorkloadMetaCollector) handleKubePod(ev workloadmeta.Event) []*TagInfo 
 		tags.AddOrchestrator(kubernetes.OwnerRefNameTagName, owner.Name)
 
 		c.extractTagsFromPodOwner(pod, owner, tags)
-	}
-
-	// static tags for EKS Fargate pods
-	for tag, value := range c.staticTags {
-		tags.AddLow(tag, value)
 	}
 
 	low, orch, high, standard := tags.Compute()
@@ -366,15 +356,7 @@ func (c *WorkloadMetaCollector) handleECSTask(ev workloadmeta.Event) []*TagInfo 
 	}
 
 	if task.LaunchType == workloadmeta.ECSLaunchTypeFargate {
-		tags := taskTags.Copy()
-
-		// add static tags only to OrchestratorScopeEntityID since
-		// they'll be added to the containers by handleContainer
-		for tag, value := range c.staticTags {
-			tags.AddLow(tag, value)
-		}
-
-		low, orch, high, standard := tags.Compute()
+		low, orch, high, standard := taskTags.Compute()
 		tagInfos = append(tagInfos, &TagInfo{
 			Source:               taskSource,
 			Entity:               GlobalEntityID,

--- a/pkg/tagger/collectors/workloadmeta_extract.go
+++ b/pkg/tagger/collectors/workloadmeta_extract.go
@@ -313,6 +313,31 @@ func (c *WorkloadMetaCollector) handleKubePod(ev workloadmeta.Event) []*TagInfo 
 func (c *WorkloadMetaCollector) handleECSTask(ev workloadmeta.Event) []*TagInfo {
 	task := ev.Entity.(*workloadmeta.ECSTask)
 
+	taskTags := utils.NewTagList()
+
+	// as of Agent 7.33, tasks have a name internally, but before that
+	// task_name already was task.Family, so we keep it for backwards
+	// compatibility
+	taskTags.AddLow("task_name", task.Family)
+	taskTags.AddLow("task_family", task.Family)
+	taskTags.AddLow("task_version", task.Version)
+	taskTags.AddOrchestrator("task_arn", task.ID)
+
+	if task.ClusterName != "" {
+		if !config.Datadog.GetBool("disable_cluster_name_tag_key") {
+			taskTags.AddLow("cluster_name", task.ClusterName)
+		}
+		taskTags.AddLow("ecs_cluster_name", task.ClusterName)
+	}
+
+	if task.LaunchType == workloadmeta.ECSLaunchTypeFargate {
+		taskTags.AddLow("region", task.Region)
+		taskTags.AddLow("availability_zone", task.AvailabilityZone)
+	} else if c.collectEC2ResourceTags {
+		addResourceTags(taskTags, task.ContainerInstanceTags)
+		addResourceTags(taskTags, task.Tags)
+	}
+
 	tagInfos := make([]*TagInfo, 0, len(task.Containers))
 	for _, taskContainer := range task.Containers {
 		container, err := c.store.GetContainer(taskContainer.ID)
@@ -323,32 +348,9 @@ func (c *WorkloadMetaCollector) handleECSTask(ev workloadmeta.Event) []*TagInfo 
 
 		c.registerChild(task.EntityID, container.EntityID)
 
-		tags := utils.NewTagList()
-
-		// as of Agent 7.33, tasks have a name internally, but before that
-		// task_name already was task.Family, so we keep it for backwards
-		// compatibility
-		tags.AddLow("task_name", task.Family)
-		tags.AddLow("task_family", task.Family)
-		tags.AddLow("task_version", task.Version)
-		tags.AddOrchestrator("task_arn", task.ID)
+		tags := taskTags.Copy()
 
 		tags.AddLow("ecs_container_name", taskContainer.Name)
-
-		if task.ClusterName != "" {
-			if !config.Datadog.GetBool("disable_cluster_name_tag_key") {
-				tags.AddLow("cluster_name", task.ClusterName)
-			}
-			tags.AddLow("ecs_cluster_name", task.ClusterName)
-		}
-
-		if task.LaunchType == workloadmeta.ECSLaunchTypeFargate {
-			tags.AddLow("region", task.Region)
-			tags.AddLow("availability_zone", task.AvailabilityZone)
-		} else if c.collectEC2ResourceTags {
-			addResourceTags(tags, task.ContainerInstanceTags)
-			addResourceTags(tags, task.Tags)
-		}
 
 		low, orch, high, standard := tags.Compute()
 		tagInfos = append(tagInfos, &TagInfo{
@@ -364,9 +366,13 @@ func (c *WorkloadMetaCollector) handleECSTask(ev workloadmeta.Event) []*TagInfo 
 	}
 
 	if task.LaunchType == workloadmeta.ECSLaunchTypeFargate {
-		tags := utils.NewTagList()
+		tags := taskTags.Copy()
 
-		tags.AddOrchestrator("task_arn", task.ID)
+		// add static tags only to OrchestratorScopeEntityID since
+		// they'll be added to the containers by handleContainer
+		for tag, value := range c.staticTags {
+			tags.AddLow(tag, value)
+		}
 
 		low, orch, high, standard := tags.Compute()
 		tagInfos = append(tagInfos, &TagInfo{

--- a/pkg/tagger/collectors/workloadmeta_extract.go
+++ b/pkg/tagger/collectors/workloadmeta_extract.go
@@ -21,8 +21,8 @@ import (
 )
 
 const (
-	// OrchestratorScopeEntityID defines the orchestrator scope entity ID
-	OrchestratorScopeEntityID = "internal://orchestrator-scope-entity-id"
+	// GlobalEntityID defines the entity ID that holds global tags
+	GlobalEntityID = "internal://global-entity-id"
 
 	podAnnotationPrefix              = "ad.datadoghq.com/"
 	podContainerTagsAnnotationFormat = podAnnotationPrefix + "%s.tags"
@@ -377,7 +377,7 @@ func (c *WorkloadMetaCollector) handleECSTask(ev workloadmeta.Event) []*TagInfo 
 		low, orch, high, standard := tags.Compute()
 		tagInfos = append(tagInfos, &TagInfo{
 			Source:               taskSource,
-			Entity:               OrchestratorScopeEntityID,
+			Entity:               GlobalEntityID,
 			HighCardTags:         high,
 			OrchestratorCardTags: orch,
 			LowCardTags:          low,

--- a/pkg/tagger/collectors/workloadmeta_test.go
+++ b/pkg/tagger/collectors/workloadmeta_test.go
@@ -533,7 +533,7 @@ func TestHandleECSTask(t *testing.T) {
 				},
 				{
 					Source:       taskSource,
-					Entity:       OrchestratorScopeEntityID,
+					Entity:       GlobalEntityID,
 					HighCardTags: []string{},
 					OrchestratorCardTags: []string{
 						"task_arn:foobar",

--- a/pkg/tagger/global.go
+++ b/pkg/tagger/global.go
@@ -183,10 +183,10 @@ func AgentTags(cardinality collectors.TagCardinality) ([]string, error) {
 }
 
 // OrchestratorScopeTag queries tags for orchestrator scope (e.g. task_arn in ECS Fargate)
-func OrchestratorScopeTag() ([]string, error) {
+func OrchestratorScopeTag(cardinality collectors.TagCardinality) ([]string, error) {
 	mux.RLock()
 	if captureTagger != nil {
-		tags, err := captureTagger.Tag(collectors.OrchestratorScopeEntityID, collectors.OrchestratorCardinality)
+		tags, err := captureTagger.Tag(collectors.OrchestratorScopeEntityID, cardinality)
 		if err == nil && len(tags) > 0 {
 			mux.RUnlock()
 			return tags, nil
@@ -194,15 +194,15 @@ func OrchestratorScopeTag() ([]string, error) {
 	}
 	mux.RUnlock()
 
-	return defaultTagger.Tag(collectors.OrchestratorScopeEntityID, collectors.OrchestratorCardinality)
+	return defaultTagger.Tag(collectors.OrchestratorScopeEntityID, cardinality)
 }
 
 // OrchestratorScopeTagBuilder queries tags for orchestrator scope (e.g.
 // task_arn in ECS Fargate) and appends them to the TagAccumulator
-func OrchestratorScopeTagBuilder(tb tagset.TagAccumulator) error {
+func OrchestratorScopeTagBuilder(cardinality collectors.TagCardinality, tb tagset.TagAccumulator) error {
 	mux.RLock()
 	if captureTagger != nil {
-		err := captureTagger.AccumulateTagsFor(collectors.OrchestratorScopeEntityID, collectors.OrchestratorCardinality, tb)
+		err := captureTagger.AccumulateTagsFor(collectors.OrchestratorScopeEntityID, cardinality, tb)
 
 		if err == nil {
 			mux.RUnlock()
@@ -211,7 +211,7 @@ func OrchestratorScopeTagBuilder(tb tagset.TagAccumulator) error {
 	}
 	mux.RUnlock()
 
-	return defaultTagger.AccumulateTagsFor(collectors.OrchestratorScopeEntityID, collectors.OrchestratorCardinality, tb)
+	return defaultTagger.AccumulateTagsFor(collectors.OrchestratorScopeEntityID, cardinality, tb)
 }
 
 // Stop queues a stop signal to the defaultTagger
@@ -272,7 +272,7 @@ func EnrichTags(tb tagset.TagAccumulator, udsOrigin string, clientOrigin string,
 
 	// Include orchestrator scope tags if the cardinality is set to orchestrator
 	if cardinality == collectors.OrchestratorCardinality {
-		if err := OrchestratorScopeTagBuilder(tb); err != nil {
+		if err := OrchestratorScopeTagBuilder(cardinality, tb); err != nil {
 			log.Error(err.Error())
 		}
 	}

--- a/pkg/tagger/global.go
+++ b/pkg/tagger/global.go
@@ -182,11 +182,12 @@ func AgentTags(cardinality collectors.TagCardinality) ([]string, error) {
 	return Tag(entityID, cardinality)
 }
 
-// OrchestratorScopeTag queries tags for orchestrator scope (e.g. task_arn in ECS Fargate)
-func OrchestratorScopeTag(cardinality collectors.TagCardinality) ([]string, error) {
+// GlobalTags queries global tags that should apply to all data coming from the
+// agent.
+func GlobalTags(cardinality collectors.TagCardinality) ([]string, error) {
 	mux.RLock()
 	if captureTagger != nil {
-		tags, err := captureTagger.Tag(collectors.OrchestratorScopeEntityID, cardinality)
+		tags, err := captureTagger.Tag(collectors.GlobalEntityID, cardinality)
 		if err == nil && len(tags) > 0 {
 			mux.RUnlock()
 			return tags, nil
@@ -194,15 +195,15 @@ func OrchestratorScopeTag(cardinality collectors.TagCardinality) ([]string, erro
 	}
 	mux.RUnlock()
 
-	return defaultTagger.Tag(collectors.OrchestratorScopeEntityID, cardinality)
+	return defaultTagger.Tag(collectors.GlobalEntityID, cardinality)
 }
 
-// OrchestratorScopeTagBuilder queries tags for orchestrator scope (e.g.
-// task_arn in ECS Fargate) and appends them to the TagAccumulator
-func OrchestratorScopeTagBuilder(cardinality collectors.TagCardinality, tb tagset.TagAccumulator) error {
+// globalTagBuilder queries global tags that should apply to all data coming
+// from the agent and appends them to the TagAccumulator
+func globalTagBuilder(cardinality collectors.TagCardinality, tb tagset.TagAccumulator) error {
 	mux.RLock()
 	if captureTagger != nil {
-		err := captureTagger.AccumulateTagsFor(collectors.OrchestratorScopeEntityID, cardinality, tb)
+		err := captureTagger.AccumulateTagsFor(collectors.GlobalEntityID, cardinality, tb)
 
 		if err == nil {
 			mux.RUnlock()
@@ -211,7 +212,7 @@ func OrchestratorScopeTagBuilder(cardinality collectors.TagCardinality, tb tagse
 	}
 	mux.RUnlock()
 
-	return defaultTagger.AccumulateTagsFor(collectors.OrchestratorScopeEntityID, cardinality, tb)
+	return defaultTagger.AccumulateTagsFor(collectors.GlobalEntityID, cardinality, tb)
 }
 
 // Stop queues a stop signal to the defaultTagger
@@ -270,11 +271,8 @@ func EnrichTags(tb tagset.TagAccumulator, udsOrigin string, clientOrigin string,
 		}
 	}
 
-	// Include orchestrator scope tags if the cardinality is set to orchestrator
-	if cardinality == collectors.OrchestratorCardinality {
-		if err := OrchestratorScopeTagBuilder(cardinality, tb); err != nil {
-			log.Error(err.Error())
-		}
+	if err := globalTagBuilder(cardinality, tb); err != nil {
+		log.Error(err.Error())
 	}
 
 	if clientOrigin != "" {

--- a/pkg/tagger/local/tagger.go
+++ b/pkg/tagger/local/tagger.go
@@ -58,7 +58,7 @@ func (t *Tagger) Init(ctx context.Context) error {
 	)
 
 	go t.tagStore.Run(t.ctx)
-	go t.collector.Stream(t.ctx)
+	go t.collector.Run(t.ctx)
 
 	return nil
 }

--- a/pkg/tagger/local/tagger.go
+++ b/pkg/tagger/local/tagger.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/tagset"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/api/response"
@@ -106,21 +105,7 @@ func (t *Tagger) Standard(entity string) ([]string, error) {
 		return nil, fmt.Errorf("empty entity ID")
 	}
 
-	tags, err := t.tagStore.LookupStandard(entity)
-	if err == tagstore.ErrNotFound {
-		// entity not found yet in the tagger
-		// trigger tagger fetch operations
-		log.Debugf("Entity '%s' not found in tagger cache, will try to fetch it", entity)
-		_, _ = t.Tag(entity, collectors.LowCardinality)
-
-		return t.tagStore.LookupStandard(entity)
-	}
-
-	if err != nil {
-		return nil, fmt.Errorf("Entity %q not found: %w", entity, err)
-	}
-
-	return tags, nil
+	return t.tagStore.LookupStandard(entity)
 }
 
 // GetEntity returns the entity corresponding to the specified id and an error

--- a/releasenotes/notes/ecs-fargate-tags-7e50a4ab3d114e32.yaml
+++ b/releasenotes/notes/ecs-fargate-tags-7e50a4ab3d114e32.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixes an issue where some data coming from the Agent when running in ECS
+    Fargate did not have task_*, ecs_cluster_name, region, and
+    availability_zone tags.


### PR DESCRIPTION
### What does this PR do?

This fixes missing static (aka DD_TAGS) and ECS-related tags in ECS
Fargate environments when using dogstatsd metrics and origin detection,
by fixing a regression introduced by #9557 in 7.33 where the removal of
the `static` tagger collector stopped adding these tags to
OrchestratorScopeEntityID (but not any of the containers).

### Describe how to test/QA your changes

Both in ECS Fargate and EKS Fargate, check that there is a `internal://global-entity-id` entity in the output of `agent tagger-list`, containing the tags described in this comment: https://github.com/DataDog/datadog-agent/pull/11293#issuecomment-1070804891 -- you'll also need to set up `DD_TAGS` and check that they're also in that output (as the `workloadmeta-static` source)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
