### PR TITLE
pkg/config/remote: Handles multiple APM Remote Config files

### DIFF
--- a/pkg/config/remote/client_test.go
+++ b/pkg/config/remote/client_test.go
@@ -152,9 +152,11 @@ func TestClientValidResponse(t *testing.T) {
 	apmUpdate := <-apmUpdates
 	assert.Equal(t, APMSamplingUpdate{
 		Config: &APMSamplingConfig{
-			Config: Config{
-				ID:      "id",
-				Version: 5,
+			Configs: map[string]Config{
+				"id": {
+					ID:      "id",
+					Version: 5,
+				},
 			},
 			Rates: []pb.APMSampling{apmConfig},
 		},

--- a/pkg/config/remote/configs.go
+++ b/pkg/config/remote/configs.go
@@ -72,10 +72,12 @@ func (c *configs) update(products []data.Product, files configFiles) update {
 func (c *configs) state() []*pbgo.Config {
 	var configs []*pbgo.Config
 	if c.apmSampling.config != nil {
-		configs = append(configs, &pbgo.Config{
-			Id:      c.apmSampling.config.ID,
-			Version: c.apmSampling.config.Version,
-		})
+		for _, config := range c.apmSampling.config.Configs {
+			configs = append(configs, &pbgo.Config{
+				Id:      config.ID,
+				Version: config.Version,
+			})
+		}
 	}
 	return configs
 }

--- a/pkg/config/remote/configs_apm_sampling.go
+++ b/pkg/config/remote/configs_apm_sampling.go
@@ -8,8 +8,8 @@ import (
 
 // APMSamplingConfig is an apm sampling config
 type APMSamplingConfig struct {
-	Config
-	Rates []pb.APMSampling
+	Configs map[string]Config
+	Rates   []pb.APMSampling
 }
 
 // APMSamplingUpdate is an apm sampling config update
@@ -26,20 +26,18 @@ func newApmSamplingConfigs() *apmSamplingConfigs {
 }
 
 func (c *apmSamplingConfigs) update(configFiles map[string]configFiles) (*APMSamplingUpdate, error) {
-	if len(configFiles) > 1 {
-		return nil, fmt.Errorf("apm sampling expects one config max. %d received", len(configFiles))
+	if !c.shouldUpdate(configFiles) {
+		return nil, nil
+	}
+	update := &APMSamplingUpdate{
+		Config: &APMSamplingConfig{
+			Configs: make(map[string]Config, len(configFiles)),
+		},
 	}
 	for configID, files := range configFiles {
-		if c.config != nil && c.config.ID == configID && c.config.Version >= files.version() {
-			return nil, nil
-		}
-		update := &APMSamplingUpdate{
-			Config: &APMSamplingConfig{
-				Config: Config{
-					ID:      configID,
-					Version: files.version(),
-				},
-			},
+		update.Config.Configs[configID] = Config{
+			ID:      configID,
+			Version: files.version(),
 		}
 		for _, file := range files {
 			var mpconfig pb.APMSampling
@@ -53,4 +51,16 @@ func (c *apmSamplingConfigs) update(configFiles map[string]configFiles) (*APMSam
 		return update, nil
 	}
 	return nil, nil
+}
+
+func (c *apmSamplingConfigs) shouldUpdate(configFiles map[string]configFiles) bool {
+	if c.config == nil || len(c.config.Configs) != len(configFiles) {
+		return true
+	}
+	for configID, files := range configFiles {
+		if config, ok := c.config.Configs[configID]; !ok || config.Version < files.version() {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/config/remote/configs_apm_sampling.go
+++ b/pkg/config/remote/configs_apm_sampling.go
@@ -48,9 +48,8 @@ func (c *apmSamplingConfigs) update(configFiles map[string]configFiles) (*APMSam
 			update.Config.Rates = append(update.Config.Rates, mpconfig)
 		}
 		c.config = update.Config
-		return update, nil
 	}
-	return nil, nil
+	return update, nil
 }
 
 func (c *apmSamplingConfigs) shouldUpdate(configFiles map[string]configFiles) bool {

--- a/pkg/config/remote/configs_test.go
+++ b/pkg/config/remote/configs_test.go
@@ -39,9 +39,11 @@ func TestConfigsAPMSamplingUpdates(t *testing.T) {
 		},
 	})
 	expectedConfig1 := &APMSamplingConfig{
-		Config: Config{
-			ID:      "config_id1",
-			Version: 1,
+		Configs: map[string]Config{
+			"config_id1": {
+				ID:      "config_id1",
+				Version: 1,
+			},
 		},
 		Rates: []pb.APMSampling{samplingFile1},
 	}
@@ -75,9 +77,11 @@ func TestConfigsAPMSamplingUpdates(t *testing.T) {
 		},
 	})
 	expectedConfig2 := &APMSamplingConfig{
-		Config: Config{
-			ID:      "config_id2",
-			Version: 2,
+		Configs: map[string]Config{
+			"config_id2": {
+				ID:      "config_id2",
+				Version: 2,
+			},
 		},
 		Rates: []pb.APMSampling{samplingFile2},
 	}

--- a/pkg/config/remote/configs_test.go
+++ b/pkg/config/remote/configs_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestConfigsAPMSamplingUpdates(t *testing.T) {
 	configs := newConfigs()
-	samplingFile1 := pb.APMSampling{
+	samplingFile1a := pb.APMSampling{
 		TargetTPS: []pb.TargetTPS{
 			{
 				Env:     "env1",
@@ -21,10 +21,33 @@ func TestConfigsAPMSamplingUpdates(t *testing.T) {
 				Env:     "env2",
 				Service: "service2",
 				Value:   2,
+				Rank:    2,
 			},
 		},
 	}
-	samplingFile1Content, err := samplingFile1.MarshalMsg(nil)
+	samplingFile1b := pb.APMSampling{
+		TargetTPS: []pb.TargetTPS{
+			{
+				Env:     "env1",
+				Service: "service1",
+				Value:   4.7,
+				Rank:    2,
+			},
+			{
+				Env:     "env2",
+				Service: "service2",
+				Value:   2,
+			},
+			{
+				Env:     "env3",
+				Service: "service3",
+				Value:   7,
+			},
+		},
+	}
+	samplingFile1Content1, err := samplingFile1a.MarshalMsg(nil)
+	assert.NoError(t, err)
+	samplingFile1Content2, err := samplingFile1b.MarshalMsg(nil)
 	assert.NoError(t, err)
 
 	update1 := configs.update([]data.Product{data.ProductAPMSampling}, configFiles{
@@ -35,7 +58,16 @@ func TestConfigsAPMSamplingUpdates(t *testing.T) {
 				Name:     "target_tps1",
 			},
 			version: 1,
-			raw:     samplingFile1Content,
+			raw:     samplingFile1Content1,
+		},
+		{
+			pathMeta: data.PathMeta{
+				Product:  data.ProductAPMSampling,
+				ConfigID: "config_id2",
+				Name:     "target_tps2",
+			},
+			version: 2,
+			raw:     samplingFile1Content2,
 		},
 	})
 	expectedConfig1 := &APMSamplingConfig{
@@ -44,8 +76,12 @@ func TestConfigsAPMSamplingUpdates(t *testing.T) {
 				ID:      "config_id1",
 				Version: 1,
 			},
+			"config_id2": {
+				ID:      "config_id2",
+				Version: 2,
+			},
 		},
-		Rates: []pb.APMSampling{samplingFile1},
+		Rates: []pb.APMSampling{samplingFile1a, samplingFile1b},
 	}
 	assert.Equal(t, update{apmSamplingUpdate: &APMSamplingUpdate{Config: expectedConfig1}}, update1)
 
@@ -86,4 +122,48 @@ func TestConfigsAPMSamplingUpdates(t *testing.T) {
 		Rates: []pb.APMSampling{samplingFile2},
 	}
 	assert.Equal(t, update{apmSamplingUpdate: &APMSamplingUpdate{Config: expectedConfig2}}, update2)
+}
+
+func TestShouldUpdate(t *testing.T) {
+	c := newApmSamplingConfigs()
+	assert.True(t, c.shouldUpdate(nil))
+	assert.True(t, c.shouldUpdate(map[string]configFiles{}))
+	assert.True(t, c.shouldUpdate(map[string]configFiles{
+		"": {},
+	}))
+
+	c.config = &APMSamplingConfig{
+		Configs: map[string]Config{
+			"id1": {
+				ID:      "id1",
+				Version: 1,
+			},
+			"id2": {
+				ID:      "id2",
+				Version: 2,
+			},
+		},
+	}
+	assert.True(t, c.shouldUpdate(nil))
+	assert.True(t, c.shouldUpdate(map[string]configFiles{}))
+	assert.True(t, c.shouldUpdate(map[string]configFiles{
+		"": {},
+	}))
+	assert.False(t, c.shouldUpdate(map[string]configFiles{
+		"id1": {{version: 1}},
+		"id2": {{version: 1}},
+	}))
+	assert.False(t, c.shouldUpdate(map[string]configFiles{
+		"id1": {{version: 1}},
+		"id2": {{version: 2}},
+	}))
+	assert.True(t, c.shouldUpdate(map[string]configFiles{
+		"id1": {{version: 1}},
+		"id2": {{version: 2}},
+		"id3": {{version: 1}},
+	}))
+	assert.True(t, c.shouldUpdate(map[string]configFiles{
+		"id1": {{version: 1}},
+		"id2": {{version: 3}},
+	}))
 }

--- a/pkg/trace/sampler/remote_rates.go
+++ b/pkg/trace/sampler/remote_rates.go
@@ -67,7 +67,15 @@ func newRemoteRates(maxTPS float64) *RemoteRates {
 }
 
 func (r *RemoteRates) onUpdate(update remote.APMSamplingUpdate) error {
-	log.Debugf("fetched config version %d from remote config management", update.Config.Version)
+	// TODO: We don't have a version per product, yet. But, we will have it in the next version.
+	// In the meantime we will just use a version of one of the config files.
+	var version uint64
+	for _, c := range update.Config.Configs {
+		version = c.Version
+		break
+	}
+
+	log.Debugf("fetched config version %d from remote config management", version)
 	tpsTargets := make(map[Signature]pb.TargetTPS, len(r.tpsTargets))
 	for _, rates := range update.Config.Rates {
 		for _, targetTPS := range rates.TargetTPS {
@@ -81,7 +89,7 @@ func (r *RemoteRates) onUpdate(update remote.APMSamplingUpdate) error {
 		}
 	}
 	r.updateTPS(tpsTargets)
-	atomic.StoreUint64(&r.tpsVersion, update.Config.Version)
+	atomic.StoreUint64(&r.tpsVersion, version)
 	return nil
 }
 

--- a/pkg/trace/sampler/remote_rates_test.go
+++ b/pkg/trace/sampler/remote_rates_test.go
@@ -42,9 +42,11 @@ func newTestRemoteRates() *RemoteRates {
 func configGenerator(version uint64, rates pb.APMSampling) remote.APMSamplingUpdate {
 	return remote.APMSamplingUpdate{
 		Config: &remote.APMSamplingConfig{
-			Config: remote.Config{
-				ID:      "testid",
-				Version: version,
+			Configs: map[string]remote.Config{
+				"testid": {
+					ID:      "testid",
+					Version: version,
+				},
 			},
 			Rates: []pb.APMSampling{rates},
 		},


### PR DESCRIPTION
### What does this PR do?
It allows APM to send multiple config files to the agent.

![Screenshot 2022-02-22 at 00 35 57](https://user-images.githubusercontent.com/1836721/155038600-64108001-84d8-47cc-a178-93345ba659f8.png)

### Motivation
APM remote configs can be generated from multiple sources, and each source has its own config id. They can enabled/disabled independently by their config id.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
