### PR TITLE
Fix deadlock in destination sender

### DIFF
--- a/pkg/logs/sender/destination_sender_test.go
+++ b/pkg/logs/sender/destination_sender_test.go
@@ -102,7 +102,7 @@ func TestDestinationSenderDeadlock(t *testing.T) {
 		for range dest.input {
 		}
 	}()
-	
+
 	syn := make(chan struct{})
 	wg := sync.WaitGroup{}
 	wg.Add(2)

--- a/pkg/logs/sender/destination_sender_test.go
+++ b/pkg/logs/sender/destination_sender_test.go
@@ -1,6 +1,7 @@
 package sender
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
@@ -90,4 +91,39 @@ func TestDestinationSenderStopsRetrying(t *testing.T) {
 	}
 
 	<-gotPayload
+}
+
+func TestDestinationSenderDeadlock(t *testing.T) {
+	output := make(chan *message.Payload)
+	dest := &mockDestination{}
+	d := NewDestinationSender(dest, output, 100)
+
+	go func() {
+		for range dest.input {
+		}
+	}()
+	
+	syn := make(chan struct{})
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+
+	go func() {
+		<-syn
+		for i := 0; i < 1000; i++ {
+			dest.isRetrying <- false
+		}
+		wg.Done()
+	}()
+
+	go func() {
+		<-syn
+		for i := 0; i < 1000; i++ {
+			d.Send(&message.Payload{})
+		}
+		wg.Done()
+	}()
+
+	close(syn)
+	wg.Wait()
+	close(dest.input)
 }

--- a/releasenotes/notes/destination-sender-deadlock-b4329079cb4df157.yaml
+++ b/releasenotes/notes/destination-sender-deadlock-b4329079cb4df157.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Fixed a deadlock in the logs agent.

--- a/releasenotes/notes/destination-sender-deadlock-b4329079cb4df157.yaml
+++ b/releasenotes/notes/destination-sender-deadlock-b4329079cb4df157.yaml
@@ -1,3 +1,3 @@
 fixes:
   - |
-    Fixed a deadlock in the logs agent.
+    Fixed a deadlock in the Logs Agent.


### PR DESCRIPTION
### What does this PR do?

Deadlock happens between startRetryReader and Send. startRetryReader
can block on a write to an unbuffered channel cancelSendChan while
holding the retryLock. If this happens after cancelSendChan is
checked, Send will block trying to acquire retryLock too, deadlocking
two goroutines.

Use non-blocking send in startRetryReader so it will never block while
holding the lock. Mark the channel buffered, so non-blocking send will
always succeed if the channel is empty (Send is still executing and
can be cancelled).

### Motivation

Bugfix

### Describe how to test/QA your changes

Run the logs agent in both TCP and HTTP, make sure logs are flowing.

A more targeted unit test is also included.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
