### PR TITLE
[Process Agent] Add timeout to api server

### DIFF
--- a/cmd/process-agent/api/server.go
+++ b/cmd/process-agent/api/server.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/gorilla/mux"
 
@@ -31,6 +32,8 @@ func StartServer() error {
 	// Set up routes
 	r := mux.NewRouter()
 	setupHandlers(r)
+	timeout := time.Duration(ddconfig.Datadog.GetInt("server_timeout")) * time.Second
+	handler := http.TimeoutHandler(r, timeout, "timed out")
 
 	addr, err := GetAPIAddressPort()
 	if err != nil {
@@ -39,7 +42,7 @@ func StartServer() error {
 	log.Infof("API server listening on %s", addr)
 
 	srv := &http.Server{
-		Handler: r,
+		Handler: handler,
 		Addr:    addr,
 	}
 

--- a/cmd/process-agent/api/server.go
+++ b/cmd/process-agent/api/server.go
@@ -42,8 +42,9 @@ func StartServer() error {
 	log.Infof("API server listening on %s", addr)
 
 	srv := &http.Server{
-		Handler: handler,
-		Addr:    addr,
+		Handler:     handler,
+		Addr:        addr,
+		ReadTimeout: timeout,
 	}
 
 	go func() {

--- a/cmd/process-agent/api/server.go
+++ b/cmd/process-agent/api/server.go
@@ -32,19 +32,19 @@ func StartServer() error {
 	// Set up routes
 	r := mux.NewRouter()
 	setupHandlers(r)
-	timeout := time.Duration(ddconfig.Datadog.GetInt("server_timeout")) * time.Second
-	handler := http.TimeoutHandler(r, timeout, "timed out")
 
 	addr, err := GetAPIAddressPort()
 	if err != nil {
 		return err
 	}
 	log.Infof("API server listening on %s", addr)
-
+	timeout := time.Duration(ddconfig.Datadog.GetInt("server_timeout")) * time.Second
 	srv := &http.Server{
-		Handler:     handler,
-		Addr:        addr,
-		ReadTimeout: timeout,
+		Handler:      r,
+		Addr:         addr,
+		ReadTimeout:  timeout,
+		WriteTimeout: timeout,
+		IdleTimeout:  timeout,
 	}
 
 	go func() {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

This PR adds a timeout to the API server in the process agent. This can be configured with the `server_timeout` config key.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Go timeouts can be a bit confusing. A fantastic guide can be found here: https://blog.cloudflare.com/the-complete-guide-to-golang-net-http-timeouts/

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

You can induce a timeout with the following steps:
1. Run the Process Agent
2. `sudo lsof -i -P -n | grep 6162 | wc -l` should return 1.
3. Run `nc -v localhost 6162`
4. `sudo lsof -i -P -n | grep 6162 | wc -l` should return 3.
5. Wait `server_timeout` seconds (`30` seconds by default)
6. Type `GET /agent/status HTTP/1.1` into stdin
7. You should not get a response because the connection was closed before `nc` could send a payload
8. `sudo lsof -i -P -n | grep 6162 | wc -l` should return 2.

Additionally you can test the timeout after the request is finished with the following:
1. Set `server_timeout` to a large enough value that your connection does not time out while you're typing the request.
2. Run the process agent
3. Run `nc -v localhost 6162`
4. `sudo lsof -i -P -n | grep 6162 | wc -l` should return 3.
5. Type:
```
GET /agent/status HTTP/1.1
Host: localhost
```
6. You should get a json payload back on stdout.
7. `sudo lsof -i -P -n | grep 6162 | wc -l` should still return 3.
9. `sleep 30 && sudo lsof -i -P -n | grep 6162 | wc -l` should return 2.

When you close the process agent and netcat, `sudo lsof -i -P -n | grep 6162 | wc -l` should be 0.



### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
