### PR TITLE
[CWS] Generate fields resolver function

### DIFF
--- a/pkg/security/probe/fields_resolver.go
+++ b/pkg/security/probe/fields_resolver.go
@@ -1,0 +1,220 @@
+//go:build linux
+// +build linux
+
+// Code generated - DO NOT EDIT.
+
+package probe
+
+// ResolveFields resolves all the fields associate to the event type. Context fields are automatically resolved.
+func (ev *Event) ResolveFields() {
+	// resolve context fields that are not related to any event type
+	_ = ev.ResolveContainerID(&ev.ContainerContext)
+	_ = ev.ResolveContainerTags(&ev.ContainerContext)
+	_ = ev.ResolveProcessArgs(&ev.ProcessContext.Process)
+	_ = ev.ResolveProcessArgsTruncated(&ev.ProcessContext.Process)
+	_ = ev.ResolveProcessArgv(&ev.ProcessContext.Process)
+	_ = ev.ResolveProcessArgv0(&ev.ProcessContext.Process)
+	_ = ev.ResolveProcessCreatedAt(&ev.ProcessContext.Process)
+	_ = ev.ResolveProcessEnvp(&ev.ProcessContext.Process)
+	_ = ev.ResolveProcessEnvs(&ev.ProcessContext.Process)
+	_ = ev.ResolveProcessEnvsTruncated(&ev.ProcessContext.Process)
+	_ = ev.ResolveFileFieldsGroup(&ev.ProcessContext.Process.FileFields)
+	_ = ev.ResolveFileFieldsInUpperLayer(&ev.ProcessContext.Process.FileFields)
+	_ = ev.ResolveFileFieldsUser(&ev.ProcessContext.Process.FileFields)
+
+	// resolve event specific fields
+	switch ev.GetEventType().String() {
+
+	case "bpf":
+		_ = ev.ResolveHelpers(&ev.BPF.Program)
+
+	case "capset":
+
+	case "chmod":
+		_ = ev.ResolveFileFieldsUser(&ev.Chmod.File.FileFields)
+		_ = ev.ResolveFileFieldsGroup(&ev.Chmod.File.FileFields)
+		_ = ev.ResolveFileFieldsInUpperLayer(&ev.Chmod.File.FileFields)
+		_ = ev.ResolveFilePath(&ev.Chmod.File)
+		_ = ev.ResolveFileBasename(&ev.Chmod.File)
+		_ = ev.ResolveFileFilesystem(&ev.Chmod.File)
+
+	case "chown":
+		_ = ev.ResolveFileFieldsUser(&ev.Chown.File.FileFields)
+		_ = ev.ResolveFileFieldsGroup(&ev.Chown.File.FileFields)
+		_ = ev.ResolveFileFieldsInUpperLayer(&ev.Chown.File.FileFields)
+		_ = ev.ResolveFilePath(&ev.Chown.File)
+		_ = ev.ResolveFileBasename(&ev.Chown.File)
+		_ = ev.ResolveFileFilesystem(&ev.Chown.File)
+		_ = ev.ResolveChownUID(&ev.Chown)
+		_ = ev.ResolveChownGID(&ev.Chown)
+
+	case "exec":
+		_ = ev.ResolveFileFieldsUser(&ev.Exec.Process.FileFields)
+		_ = ev.ResolveFileFieldsGroup(&ev.Exec.Process.FileFields)
+		_ = ev.ResolveFileFieldsInUpperLayer(&ev.Exec.Process.FileFields)
+		_ = ev.ResolveProcessCreatedAt(&ev.Exec.Process)
+		_ = ev.ResolveProcessArgv0(&ev.Exec.Process)
+		_ = ev.ResolveProcessArgs(&ev.Exec.Process)
+		_ = ev.ResolveProcessArgv(&ev.Exec.Process)
+		_ = ev.ResolveProcessArgsTruncated(&ev.Exec.Process)
+		_ = ev.ResolveProcessEnvs(&ev.Exec.Process)
+		_ = ev.ResolveProcessEnvp(&ev.Exec.Process)
+		_ = ev.ResolveProcessEnvsTruncated(&ev.Exec.Process)
+
+	case "link":
+		_ = ev.ResolveFileFieldsUser(&ev.Link.Source.FileFields)
+		_ = ev.ResolveFileFieldsGroup(&ev.Link.Source.FileFields)
+		_ = ev.ResolveFileFieldsInUpperLayer(&ev.Link.Source.FileFields)
+		_ = ev.ResolveFilePath(&ev.Link.Source)
+		_ = ev.ResolveFileBasename(&ev.Link.Source)
+		_ = ev.ResolveFileFilesystem(&ev.Link.Source)
+		_ = ev.ResolveFileFieldsUser(&ev.Link.Target.FileFields)
+		_ = ev.ResolveFileFieldsGroup(&ev.Link.Target.FileFields)
+		_ = ev.ResolveFileFieldsInUpperLayer(&ev.Link.Target.FileFields)
+		_ = ev.ResolveFilePath(&ev.Link.Target)
+		_ = ev.ResolveFileBasename(&ev.Link.Target)
+		_ = ev.ResolveFileFilesystem(&ev.Link.Target)
+
+	case "load_module":
+		_ = ev.ResolveFileFieldsUser(&ev.LoadModule.File.FileFields)
+		_ = ev.ResolveFileFieldsGroup(&ev.LoadModule.File.FileFields)
+		_ = ev.ResolveFileFieldsInUpperLayer(&ev.LoadModule.File.FileFields)
+		_ = ev.ResolveFilePath(&ev.LoadModule.File)
+		_ = ev.ResolveFileBasename(&ev.LoadModule.File)
+		_ = ev.ResolveFileFilesystem(&ev.LoadModule.File)
+
+	case "mkdir":
+		_ = ev.ResolveFileFieldsUser(&ev.Mkdir.File.FileFields)
+		_ = ev.ResolveFileFieldsGroup(&ev.Mkdir.File.FileFields)
+		_ = ev.ResolveFileFieldsInUpperLayer(&ev.Mkdir.File.FileFields)
+		_ = ev.ResolveFilePath(&ev.Mkdir.File)
+		_ = ev.ResolveFileBasename(&ev.Mkdir.File)
+		_ = ev.ResolveFileFilesystem(&ev.Mkdir.File)
+
+	case "mmap":
+		_ = ev.ResolveFileFieldsUser(&ev.MMap.File.FileFields)
+		_ = ev.ResolveFileFieldsGroup(&ev.MMap.File.FileFields)
+		_ = ev.ResolveFileFieldsInUpperLayer(&ev.MMap.File.FileFields)
+		_ = ev.ResolveFilePath(&ev.MMap.File)
+		_ = ev.ResolveFileBasename(&ev.MMap.File)
+		_ = ev.ResolveFileFilesystem(&ev.MMap.File)
+
+	case "mprotect":
+
+	case "open":
+		_ = ev.ResolveFileFieldsUser(&ev.Open.File.FileFields)
+		_ = ev.ResolveFileFieldsGroup(&ev.Open.File.FileFields)
+		_ = ev.ResolveFileFieldsInUpperLayer(&ev.Open.File.FileFields)
+		_ = ev.ResolveFilePath(&ev.Open.File)
+		_ = ev.ResolveFileBasename(&ev.Open.File)
+		_ = ev.ResolveFileFilesystem(&ev.Open.File)
+
+	case "ptrace":
+		_ = ev.ResolveFileFieldsUser(&ev.PTrace.Tracee.Process.FileFields)
+		_ = ev.ResolveFileFieldsGroup(&ev.PTrace.Tracee.Process.FileFields)
+		_ = ev.ResolveFileFieldsInUpperLayer(&ev.PTrace.Tracee.Process.FileFields)
+		_ = ev.ResolveProcessCreatedAt(&ev.PTrace.Tracee.Process)
+		_ = ev.ResolveProcessArgv0(&ev.PTrace.Tracee.Process)
+		_ = ev.ResolveProcessArgs(&ev.PTrace.Tracee.Process)
+		_ = ev.ResolveProcessArgv(&ev.PTrace.Tracee.Process)
+		_ = ev.ResolveProcessArgsTruncated(&ev.PTrace.Tracee.Process)
+		_ = ev.ResolveProcessEnvs(&ev.PTrace.Tracee.Process)
+		_ = ev.ResolveProcessEnvp(&ev.PTrace.Tracee.Process)
+		_ = ev.ResolveProcessEnvsTruncated(&ev.PTrace.Tracee.Process)
+
+	case "removexattr":
+		_ = ev.ResolveFileFieldsUser(&ev.RemoveXAttr.File.FileFields)
+		_ = ev.ResolveFileFieldsGroup(&ev.RemoveXAttr.File.FileFields)
+		_ = ev.ResolveFileFieldsInUpperLayer(&ev.RemoveXAttr.File.FileFields)
+		_ = ev.ResolveFilePath(&ev.RemoveXAttr.File)
+		_ = ev.ResolveFileBasename(&ev.RemoveXAttr.File)
+		_ = ev.ResolveFileFilesystem(&ev.RemoveXAttr.File)
+		_ = ev.ResolveXAttrNamespace(&ev.RemoveXAttr)
+		_ = ev.ResolveXAttrName(&ev.RemoveXAttr)
+
+	case "rename":
+		_ = ev.ResolveFileFieldsUser(&ev.Rename.Old.FileFields)
+		_ = ev.ResolveFileFieldsGroup(&ev.Rename.Old.FileFields)
+		_ = ev.ResolveFileFieldsInUpperLayer(&ev.Rename.Old.FileFields)
+		_ = ev.ResolveFilePath(&ev.Rename.Old)
+		_ = ev.ResolveFileBasename(&ev.Rename.Old)
+		_ = ev.ResolveFileFilesystem(&ev.Rename.Old)
+		_ = ev.ResolveFileFieldsUser(&ev.Rename.New.FileFields)
+		_ = ev.ResolveFileFieldsGroup(&ev.Rename.New.FileFields)
+		_ = ev.ResolveFileFieldsInUpperLayer(&ev.Rename.New.FileFields)
+		_ = ev.ResolveFilePath(&ev.Rename.New)
+		_ = ev.ResolveFileBasename(&ev.Rename.New)
+		_ = ev.ResolveFileFilesystem(&ev.Rename.New)
+
+	case "rmdir":
+		_ = ev.ResolveFileFieldsUser(&ev.Rmdir.File.FileFields)
+		_ = ev.ResolveFileFieldsGroup(&ev.Rmdir.File.FileFields)
+		_ = ev.ResolveFileFieldsInUpperLayer(&ev.Rmdir.File.FileFields)
+		_ = ev.ResolveFilePath(&ev.Rmdir.File)
+		_ = ev.ResolveFileBasename(&ev.Rmdir.File)
+		_ = ev.ResolveFileFilesystem(&ev.Rmdir.File)
+
+	case "selinux":
+		_ = ev.ResolveSELinuxBoolName(&ev.SELinux)
+
+	case "setgid":
+		_ = ev.ResolveSetgidGroup(&ev.SetGID)
+		_ = ev.ResolveSetgidEGroup(&ev.SetGID)
+		_ = ev.ResolveSetgidFSGroup(&ev.SetGID)
+
+	case "setuid":
+		_ = ev.ResolveSetuidUser(&ev.SetUID)
+		_ = ev.ResolveSetuidEUser(&ev.SetUID)
+		_ = ev.ResolveSetuidFSUser(&ev.SetUID)
+
+	case "setxattr":
+		_ = ev.ResolveFileFieldsUser(&ev.SetXAttr.File.FileFields)
+		_ = ev.ResolveFileFieldsGroup(&ev.SetXAttr.File.FileFields)
+		_ = ev.ResolveFileFieldsInUpperLayer(&ev.SetXAttr.File.FileFields)
+		_ = ev.ResolveFilePath(&ev.SetXAttr.File)
+		_ = ev.ResolveFileBasename(&ev.SetXAttr.File)
+		_ = ev.ResolveFileFilesystem(&ev.SetXAttr.File)
+		_ = ev.ResolveXAttrNamespace(&ev.SetXAttr)
+		_ = ev.ResolveXAttrName(&ev.SetXAttr)
+
+	case "signal":
+		_ = ev.ResolveFileFieldsUser(&ev.Signal.Target.Process.FileFields)
+		_ = ev.ResolveFileFieldsGroup(&ev.Signal.Target.Process.FileFields)
+		_ = ev.ResolveFileFieldsInUpperLayer(&ev.Signal.Target.Process.FileFields)
+		_ = ev.ResolveProcessCreatedAt(&ev.Signal.Target.Process)
+		_ = ev.ResolveProcessArgv0(&ev.Signal.Target.Process)
+		_ = ev.ResolveProcessArgs(&ev.Signal.Target.Process)
+		_ = ev.ResolveProcessArgv(&ev.Signal.Target.Process)
+		_ = ev.ResolveProcessArgsTruncated(&ev.Signal.Target.Process)
+		_ = ev.ResolveProcessEnvs(&ev.Signal.Target.Process)
+		_ = ev.ResolveProcessEnvp(&ev.Signal.Target.Process)
+		_ = ev.ResolveProcessEnvsTruncated(&ev.Signal.Target.Process)
+
+	case "splice":
+		_ = ev.ResolveFileFieldsUser(&ev.Splice.File.FileFields)
+		_ = ev.ResolveFileFieldsGroup(&ev.Splice.File.FileFields)
+		_ = ev.ResolveFileFieldsInUpperLayer(&ev.Splice.File.FileFields)
+		_ = ev.ResolveFilePath(&ev.Splice.File)
+		_ = ev.ResolveFileBasename(&ev.Splice.File)
+		_ = ev.ResolveFileFilesystem(&ev.Splice.File)
+
+	case "unlink":
+		_ = ev.ResolveFileFieldsUser(&ev.Unlink.File.FileFields)
+		_ = ev.ResolveFileFieldsGroup(&ev.Unlink.File.FileFields)
+		_ = ev.ResolveFileFieldsInUpperLayer(&ev.Unlink.File.FileFields)
+		_ = ev.ResolveFilePath(&ev.Unlink.File)
+		_ = ev.ResolveFileBasename(&ev.Unlink.File)
+		_ = ev.ResolveFileFilesystem(&ev.Unlink.File)
+
+	case "unload_module":
+
+	case "utimes":
+		_ = ev.ResolveFileFieldsUser(&ev.Utimes.File.FileFields)
+		_ = ev.ResolveFileFieldsGroup(&ev.Utimes.File.FileFields)
+		_ = ev.ResolveFileFieldsInUpperLayer(&ev.Utimes.File.FileFields)
+		_ = ev.ResolveFilePath(&ev.Utimes.File)
+		_ = ev.ResolveFileBasename(&ev.Utimes.File)
+		_ = ev.ResolveFileFilesystem(&ev.Utimes.File)
+
+	}
+}

--- a/pkg/security/secl/compiler/generators/accessors/common/types.go
+++ b/pkg/security/secl/compiler/generators/accessors/common/types.go
@@ -5,6 +5,19 @@
 
 package common
 
+// EventTypeMetadata is used to iterate over the model from the event types
+type EventTypeMetadata struct {
+	Doc    string
+	Fields []string
+}
+
+// NewEventTypeMetada returns a new EventTypeMetada
+func NewEventTypeMetada(fields ...string) *EventTypeMetadata {
+	return &EventTypeMetadata{
+		Fields: fields,
+	}
+}
+
 // Module represents everything needed to generate the accessors for a specific module (fields, build tags, ...)
 type Module struct {
 	Name            string
@@ -14,27 +27,27 @@ type Module struct {
 	BuildTags       []string
 	Fields          map[string]*StructField
 	Iterators       map[string]*StructField
-	EventTypes      map[string]bool
-	EventTypeDocs   map[string]string
+	EventTypes      map[string]*EventTypeMetadata
 	Mock            bool
 }
 
 // StructField represents a structure field for which an accessor will be generated
 type StructField struct {
-	Name          string
-	Prefix        string
-	Struct        string
-	BasicType     string
-	ReturnType    string
-	IsArray       bool
-	Event         string
-	Handler       string
-	OrigType      string
-	IsOrigTypePtr bool
-	Iterator      *StructField
-	Weight        int64
-	CommentText   string
-	OpOverrides   string
+	Name                string
+	Prefix              string
+	Struct              string
+	BasicType           string
+	ReturnType          string
+	IsArray             bool
+	Event               string
+	Handler             string
+	CachelessResolution bool
+	OrigType            string
+	IsOrigTypePtr       bool
+	Iterator            *StructField
+	Weight              int64
+	CommentText         string
+	OpOverrides         string
 }
 
 // GetEvaluatorType returns the evaluator type name

--- a/pkg/security/secl/compiler/generators/accessors/doc/doc.go
+++ b/pkg/security/secl/compiler/generators/accessors/doc/doc.go
@@ -67,7 +67,7 @@ func GenerateDocJSON(module *common.Module, outputPath string) error {
 			return properties[i].Name < properties[j].Name
 		})
 
-		info := extractVersionAndDefinition(module.EventTypeDocs[name])
+		info := extractVersionAndDefinition(module.EventTypes[name])
 		eventTypes = append(eventTypes, eventType{
 			Name:             name,
 			Definition:       info.Definition,
@@ -110,7 +110,11 @@ type eventTypeInfo struct {
 	FromAgentVersion string
 }
 
-func extractVersionAndDefinition(comment string) eventTypeInfo {
+func extractVersionAndDefinition(evtType *common.EventTypeMetadata) eventTypeInfo {
+	var comment string
+	if evtType != nil {
+		comment = evtType.Doc
+	}
 	trimmed := strings.TrimSpace(comment)
 
 	if matches := minVersionRE.FindStringSubmatch(trimmed); matches != nil {

--- a/pkg/security/secl/compiler/generators/accessors/resolver/fields_resolver.go
+++ b/pkg/security/secl/compiler/generators/accessors/resolver/fields_resolver.go
@@ -1,0 +1,49 @@
+package resolver
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"text/template"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/generators/accessors/common"
+)
+
+//go:embed fields_resolver.tmpl
+var fieldsResolverTemplate string
+
+// GenerateFieldsResolver generates the fields resolver file
+func GenerateFieldsResolver(module *common.Module, output string) error {
+	tmpl := template.Must(template.New("tmpl").Parse(fieldsResolverTemplate))
+	_ = os.Remove(output)
+
+	// override module name
+	module.Name = "probe"
+
+	tmpFile, err := os.CreateTemp(path.Dir(output), "fields_resolver")
+	if err != nil {
+		return fmt.Errorf("couldn't create temp fields_resolver file: %w", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	if err = tmpl.Execute(tmpFile, module); err != nil {
+		return fmt.Errorf("failed to execute profile: %w", err)
+	}
+
+	if err = tmpFile.Close(); err != nil {
+		return fmt.Errorf("failed to close temporary fields_resolver file: %w", err)
+	}
+
+	cmd := exec.Command("gofmt", "-s", "-w", tmpFile.Name())
+	if err = cmd.Run(); err != nil {
+		return fmt.Errorf("failed to execute gofmt: %w", err)
+	}
+
+	if err = os.Rename(tmpFile.Name(), output); err != nil {
+		return fmt.Errorf("couldn't rename fields_resolver file: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/security/secl/compiler/generators/accessors/resolver/fields_resolver.tmpl
+++ b/pkg/security/secl/compiler/generators/accessors/resolver/fields_resolver.tmpl
@@ -1,0 +1,42 @@
+{{- range .BuildTags }}// {{.}}{{end}}
+
+// Code generated - DO NOT EDIT.
+
+package {{.Name}}
+
+import (
+
+)
+
+// ResolveFields resolves all the fields associate to the event type. Context fields are automatically resolved.
+func (ev *Event) ResolveFields() {
+    // resolve context fields that are not related to any event type
+{{- range $Key, $Field := .Fields}}
+    {{- if and (eq $Field.Event "*") (ne $Field.Handler "") (not $Field.Iterator) (eq $Field.CachelessResolution false) }}
+        {{- if (eq $Field.Prefix "") }}
+            _ = {{ print "ev." $Field.Handler "(ev)"}}
+        {{- else}}
+            _ = {{ print "ev." $Field.Handler "(&ev." $Field.Prefix ")"}}
+        {{- end}}
+    {{- end -}}
+{{end}}
+
+    // resolve event specific fields
+    switch ev.GetEventType().String() {
+    {{- range $Name, $EventType := .EventTypes}}
+        {{- if (ne $Name "*") }}
+        case "{{$Name}}":
+            {{- range $Key, $FieldName := $EventType.Fields }}
+            {{- $Field := index $.Fields $FieldName }}
+                {{- if and (ne $Field.Handler "") (not $Field.Iterator) (eq $Field.CachelessResolution false) }}
+                    {{- if (eq $Field.Prefix "") }}
+                        _ = {{ print "ev." $Field.Handler "(ev)"}}
+                    {{- else}}
+                        _ = {{ print "ev." $Field.Handler "(&ev." $Field.Prefix ")"}}
+                    {{- end}}
+                {{- end -}}
+            {{end}}
+        {{- end}}
+    {{end}}
+    }
+}

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -4,7 +4,7 @@
 // Copyright 2016-present Datadog, Inc.
 
 //go:generate go run github.com/DataDog/datadog-agent/pkg/security/secl/compiler/generators/accessors -mock -output accessors.go
-//go:generate go run github.com/DataDog/datadog-agent/pkg/security/secl/compiler/generators/accessors -tags linux -output ../../probe/accessors.go -doc ../../../../docs/cloud-workload-security/secl.json
+//go:generate go run github.com/DataDog/datadog-agent/pkg/security/secl/compiler/generators/accessors -tags linux -output ../../probe/accessors.go -doc ../../../../docs/cloud-workload-security/secl.json -fields-resolver ../../probe/fields_resolver.go
 
 package model
 
@@ -284,13 +284,13 @@ type Process struct {
 	EnvsEntry *EnvsEntry `field:"-"`
 
 	// defined to generate accessors, ArgsTruncated and EnvsTruncated are used during by unmarshaller
-	Argv0         string   `field:"argv0,ResolveProcessArgv0:100"`                                                                                         // First argument of the process
-	Args          string   `field:"args,ResolveProcessArgs:100"`                                                                                           // Arguments of the process (as a string)
-	Argv          []string `field:"argv,ResolveProcessArgv:100" field:"args_flags,ResolveProcessArgsFlags" field:"args_options,ResolveProcessArgsOptions"` // Arguments of the process (as an array)
-	ArgsTruncated bool     `field:"args_truncated,ResolveProcessArgsTruncated"`                                                                            // Indicator of arguments truncation
-	Envs          []string `field:"envs,ResolveProcessEnvs:100"`                                                                                           // Environment variable names of the process
-	Envp          []string `field:"envp,ResolveProcessEnvp:100"`                                                                                           // Environment variables of the process
-	EnvsTruncated bool     `field:"envs_truncated,ResolveProcessEnvsTruncated"`                                                                            // Indicator of environment variables truncation
+	Argv0         string   `field:"argv0,ResolveProcessArgv0:100"`                                                                                                                                     // First argument of the process
+	Args          string   `field:"args,ResolveProcessArgs:100"`                                                                                                                                       // Arguments of the process (as a string)
+	Argv          []string `field:"argv,ResolveProcessArgv:100" field:"args_flags,ResolveProcessArgsFlags,,cacheless_resolution" field:"args_options,ResolveProcessArgsOptions,,cacheless_resolution"` // Arguments of the process (as an array)
+	ArgsTruncated bool     `field:"args_truncated,ResolveProcessArgsTruncated"`                                                                                                                        // Indicator of arguments truncation
+	Envs          []string `field:"envs,ResolveProcessEnvs:100"`                                                                                                                                       // Environment variable names of the process
+	Envp          []string `field:"envp,ResolveProcessEnvp:100"`                                                                                                                                       // Environment variables of the process
+	EnvsTruncated bool     `field:"envs_truncated,ResolveProcessEnvsTruncated"`                                                                                                                        // Indicator of environment variables truncation
 
 	// cache version
 	ScrubbedArgvResolved  bool           `field:"-"`
@@ -312,13 +312,13 @@ type ExecEvent struct {
 
 // FileFields holds the information required to identify a file
 type FileFields struct {
-	UID   uint32 `field:"uid"`                               // UID of the file's owner
-	User  string `field:"user,ResolveFileFieldsUser"`        // User of the file's owner
-	GID   uint32 `field:"gid"`                               // GID of the file's owner
-	Group string `field:"group,ResolveFileFieldsGroup"`      // Group of the file's owner
-	Mode  uint16 `field:"mode" field:"rights,ResolveRights"` // Mode/rights of the file
-	CTime uint64 `field:"change_time"`                       // Change time of the file
-	MTime uint64 `field:"modification_time"`                 // Modification time of the file
+	UID   uint32 `field:"uid"`                                                     // UID of the file's owner
+	User  string `field:"user,ResolveFileFieldsUser"`                              // User of the file's owner
+	GID   uint32 `field:"gid"`                                                     // GID of the file's owner
+	Group string `field:"group,ResolveFileFieldsGroup"`                            // Group of the file's owner
+	Mode  uint16 `field:"mode" field:"rights,ResolveRights,,cacheless_resolution"` // Mode/rights of the file
+	CTime uint64 `field:"change_time"`                                             // Change time of the file
+	MTime uint64 `field:"modification_time"`                                       // Modification time of the file
 
 	MountID      uint32 `field:"mount_id"`                                     // Mount ID of the file
 	Inode        uint64 `field:"inode"`                                        // Inode of the file


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

This PR generates the `fields_resolver.go` file from the `model.Event`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Make sure we don't forget to resolve a field when we need to copy parts of a `model.Event` instance.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
