### PR TITLE
pkg/trace: Add release note for sampler change

### DIFF
--- a/releasenotes/notes/apm-max-tps-0-value-0c5b09dfb820c6dd.yaml
+++ b/releasenotes/notes/apm-max-tps-0-value-0c5b09dfb820c6dd.yaml
@@ -10,4 +10,4 @@ upgrade:
   - |
     APM Breaking change: The `default head based sampling mechanism <https://docs.datadoghq.com/tracing/trace_ingestion/mechanisms?tab=environmentvariables#head-based-default-mechanism>`_
     settings `apm_config.max_traces_per_second` or `DD_APM_MAX_TPS`, when set to 0, will be sending 
-    0% of traces to Datadog, instead of 100% in previous agent versions. 
+    0% of traces to Datadog, instead of 100% in previous Agent versions. 

--- a/releasenotes/notes/apm-max-tps-0-value-0c5b09dfb820c6dd.yaml
+++ b/releasenotes/notes/apm-max-tps-0-value-0c5b09dfb820c6dd.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+upgrade:
+  - |
+    APM Breaking change: The `default head based sampling mechanism <https://docs.datadoghq.com/tracing/trace_ingestion/mechanisms?tab=environmentvariables#head-based-default-mechanism>`_
+    settings `apm_config.max_traces_per_second` or `DD_APM_MAX_TPS` when set to 0 will result in 
+    rates of 0% instead of 100% on head based sampling. 

--- a/releasenotes/notes/apm-max-tps-0-value-0c5b09dfb820c6dd.yaml
+++ b/releasenotes/notes/apm-max-tps-0-value-0c5b09dfb820c6dd.yaml
@@ -9,5 +9,5 @@
 upgrade:
   - |
     APM Breaking change: The `default head based sampling mechanism <https://docs.datadoghq.com/tracing/trace_ingestion/mechanisms?tab=environmentvariables#head-based-default-mechanism>`_
-    settings `apm_config.max_traces_per_second` or `DD_APM_MAX_TPS` when set to 0 will result in 
-    rates of 0% instead of 100% on head based sampling. 
+    settings `apm_config.max_traces_per_second` or `DD_APM_MAX_TPS`, when set to 0, will be sending 
+    0% of traces to Datadog, instead of 100% in previous agent versions. 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

https://github.com/DataDog/datadog-agent/pull/10958 introduces a breaking change on the settings `apm_config.max_traces_per_second` and `DD_APM_MAX_TPS`. A value of 0 would previously result in sampling rates of 100%. Now a value of 0 results in sampling rates of 0%

We make this breaking change as the 100% was unintended and isn't expected.
This new default will match the ERROR_TPS behavior


### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
