### PR TITLE
[corechecks/helm] Add event collection

### DIFF
--- a/pkg/collector/corechecks/cluster/helm/events.go
+++ b/pkg/collector/corechecks/cluster/helm/events.go
@@ -1,0 +1,112 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+// +build kubeapiserver
+
+package helm
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	coreMetrics "github.com/DataDog/datadog-agent/pkg/metrics"
+)
+
+const (
+	eventTitle = "Event on Helm release"
+)
+
+type eventsManager struct {
+	events      []coreMetrics.Event
+	eventsMutex sync.Mutex
+}
+
+func (em *eventsManager) addEventForNewRelease(rel *release, storage helmStorage) {
+	event := eventForRelease(rel, storage, textForAddEvent(rel), false)
+	em.storeEvent(event)
+}
+
+func (em *eventsManager) addEventForDeletedRelease(rel *release, storage helmStorage) {
+	event := eventForRelease(rel, storage, textForDeleteEvent(rel), true)
+	em.storeEvent(event)
+}
+
+func (em *eventsManager) addEventForUpdatedRelease(old *release, updated *release, storage helmStorage) {
+	// nil Info should not happen, so let's ignore those at least for now.
+	if (old.Info == nil || updated.Info == nil) || (old.Info.Status == updated.Info.Status) {
+		return
+	}
+
+	event := eventForRelease(updated, storage, textForChangedStatus(old.Info.Status, updated), false)
+	em.storeEvent(event)
+}
+
+func (em *eventsManager) sendEvents(sender aggregator.Sender) {
+	em.eventsMutex.Lock()
+	eventsToSend := em.events
+	em.events = nil
+	em.eventsMutex.Unlock()
+
+	for _, event := range eventsToSend {
+		sender.Event(event)
+	}
+}
+
+func (em *eventsManager) storeEvent(event coreMetrics.Event) {
+	em.eventsMutex.Lock()
+	defer em.eventsMutex.Unlock()
+	em.events = append(em.events, event)
+}
+
+func eventForRelease(rel *release, storage helmStorage, text string, isDelete bool) coreMetrics.Event {
+	return coreMetrics.Event{
+		Title:          eventTitle,
+		Text:           text,
+		Ts:             time.Now().Unix(),
+		Priority:       coreMetrics.EventPriorityNormal,
+		SourceTypeName: checkName,
+		EventType:      checkName,
+		AggregationKey: fmt.Sprintf("helm_release:%s", rel.namespacedName()),
+
+		// The revision tag is not included in delete events, because we generate a single event for all the revisions.
+		Tags: helmTags(rel, storage, !isDelete),
+	}
+}
+
+func textForAddEvent(rel *release) string {
+	status := ""
+	if rel.Info != nil {
+		status = rel.Info.Status
+	}
+
+	if rel.Version == 1 {
+		return fmt.Sprintf("New Helm release %q has been deployed in %q namespace. Its status is %q.",
+			rel.Name,
+			rel.Namespace,
+			status)
+	}
+
+	return fmt.Sprintf("Helm release %q in %q namespace upgraded to revision %d. Its status is %q.",
+		rel.Name,
+		rel.Namespace,
+		rel.Version,
+		status)
+}
+
+func textForDeleteEvent(rel *release) string {
+	return fmt.Sprintf("Helm release %q in %q namespace has been deleted.", rel.Name, rel.Namespace)
+}
+
+func textForChangedStatus(previousRelStatus string, updatedRelease *release) string {
+	return fmt.Sprintf("Helm release %q (revision %d) in %q namespace changed its status from %q to %q.",
+		updatedRelease.Name,
+		updatedRelease.Version,
+		updatedRelease.Namespace,
+		previousRelStatus,
+		updatedRelease.Info.Status)
+}

--- a/pkg/collector/corechecks/cluster/helm/events_test.go
+++ b/pkg/collector/corechecks/cluster/helm/events_test.go
@@ -1,0 +1,264 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+// +build kubeapiserver
+
+package helm
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	coreMetrics "github.com/DataDog/datadog-agent/pkg/metrics"
+)
+
+func TestAddEventForNewRelease(t *testing.T) {
+	events := eventsManager{}
+
+	rel := release{
+		Name: "my_datadog",
+		Info: &info{
+			Status: "deployed",
+		},
+		Chart: &chart{
+			Metadata: &metadata{
+				Name:       "datadog",
+				Version:    "2.30.5",
+				AppVersion: "7",
+			},
+		},
+		Version:   1,
+		Namespace: "default",
+	}
+
+	events.addEventForNewRelease(&rel, k8sSecrets)
+
+	// Test new release with revision 1.
+	storedEvent := events.events[0]
+	storedEvent.Ts = 0 // Can't control it, so don't check.
+	assert.Equal(
+		t,
+		coreMetrics.Event{
+			Title:          "Event on Helm release",
+			Text:           "New Helm release \"my_datadog\" has been deployed in \"default\" namespace. Its status is \"deployed\".",
+			Ts:             0,
+			Priority:       coreMetrics.EventPriorityNormal,
+			SourceTypeName: "helm",
+			EventType:      "helm",
+			AggregationKey: "helm_release:default/my_datadog",
+			Tags:           helmTags(&rel, k8sSecrets, true),
+		},
+		storedEvent,
+	)
+
+	// Test release with upgraded revision (Notice that the text of the events is different).
+	rel.Version = 2
+	events.addEventForNewRelease(&rel, k8sSecrets)
+	storedEvent = events.events[1]
+	storedEvent.Ts = 0 // Can't control it, so don't check.
+	assert.Equal(
+		t,
+		coreMetrics.Event{
+			Title:          "Event on Helm release",
+			Text:           "Helm release \"my_datadog\" in \"default\" namespace upgraded to revision 2. Its status is \"deployed\".",
+			Ts:             0,
+			Priority:       coreMetrics.EventPriorityNormal,
+			SourceTypeName: "helm",
+			EventType:      "helm",
+			AggregationKey: "helm_release:default/my_datadog",
+			Tags:           helmTags(&rel, k8sSecrets, true),
+		},
+		storedEvent,
+	)
+}
+
+func TestAddEventForDeletedRelease(t *testing.T) {
+	events := eventsManager{}
+
+	rel := release{
+		Name: "my_datadog",
+		Info: &info{
+			Status: "deployed",
+		},
+		Chart: &chart{
+			Metadata: &metadata{
+				Name:       "datadog",
+				Version:    "2.30.5",
+				AppVersion: "7",
+			},
+		},
+		Version:   1,
+		Namespace: "default",
+	}
+
+	events.addEventForDeletedRelease(&rel, k8sSecrets)
+
+	storedEvent := events.events[0]
+	storedEvent.Ts = 0 // Can't control it, so don't check.
+	assert.Equal(
+		t,
+		coreMetrics.Event{
+			Title:          "Event on Helm release",
+			Text:           "Helm release \"my_datadog\" in \"default\" namespace has been deleted.",
+			Ts:             0,
+			Priority:       coreMetrics.EventPriorityNormal,
+			SourceTypeName: "helm",
+			EventType:      "helm",
+			AggregationKey: "helm_release:default/my_datadog",
+			Tags:           helmTags(&rel, k8sSecrets, false),
+		},
+		storedEvent,
+	)
+}
+
+func TestAddEventForUpdatedRelease(t *testing.T) {
+	exampleRelease := release{
+		Name: "my_datadog",
+		Info: &info{
+			Status: "deployed",
+		},
+		Chart: &chart{
+			Metadata: &metadata{
+				Name:       "datadog",
+				Version:    "2.30.5",
+				AppVersion: "7",
+			},
+		},
+		Version:   1,
+		Namespace: "default",
+	}
+
+	exampleReleaseWithFailedStatus := release{
+		Name: "my_datadog",
+		Info: &info{
+			Status: "failed",
+		},
+		Chart: &chart{
+			Metadata: &metadata{
+				Name:       "datadog",
+				Version:    "2.30.5",
+				AppVersion: "7",
+			},
+		},
+		Version:   1,
+		Namespace: "default",
+	}
+
+	releaseWithoutInfo := release{
+		Name: "my_datadog",
+		Info: nil,
+		Chart: &chart{
+			Metadata: &metadata{
+				Name:       "datadog",
+				Version:    "2.30.5",
+				AppVersion: "7",
+			},
+		},
+		Version:   1,
+		Namespace: "default",
+	}
+
+	tests := []struct {
+		name           string
+		oldRelease     *release
+		updatedRelease *release
+		expectedEvent  *coreMetrics.Event
+	}{
+		{
+			name:           "The status changed",
+			oldRelease:     &exampleRelease,
+			updatedRelease: &exampleReleaseWithFailedStatus,
+			expectedEvent: &coreMetrics.Event{
+				Title:          "Event on Helm release",
+				Text:           "Helm release \"my_datadog\" (revision 1) in \"default\" namespace changed its status from \"deployed\" to \"failed\".",
+				Ts:             0,
+				Priority:       coreMetrics.EventPriorityNormal,
+				SourceTypeName: "helm",
+				EventType:      "helm",
+				AggregationKey: "helm_release:default/my_datadog",
+				Tags:           helmTags(&exampleReleaseWithFailedStatus, k8sSecrets, true),
+			},
+		},
+		{
+			name:           "The status didn't change",
+			oldRelease:     &exampleRelease,
+			updatedRelease: &exampleRelease,
+			expectedEvent:  nil,
+		},
+		{
+			name:           "There's no info in the old release",
+			oldRelease:     &releaseWithoutInfo,
+			updatedRelease: &exampleRelease,
+			expectedEvent:  nil,
+		},
+		{
+			name:           "There's no info in the updated release",
+			oldRelease:     &exampleRelease,
+			updatedRelease: &releaseWithoutInfo,
+			expectedEvent:  nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			events := eventsManager{}
+
+			events.addEventForUpdatedRelease(test.oldRelease, test.updatedRelease, k8sSecrets)
+
+			if test.expectedEvent == nil {
+				assert.Empty(t, events.events)
+			} else {
+				storedEvent := events.events[0]
+				storedEvent.Ts = 0 // Can't control it, so don't check.
+				assert.Equal(t, test.expectedEvent, &storedEvent)
+			}
+		})
+	}
+}
+
+func TestSendEvents(t *testing.T) {
+	events := eventsManager{}
+
+	rel := release{
+		Name: "my_datadog",
+		Info: &info{
+			Status: "deployed",
+		},
+		Chart: &chart{
+			Metadata: &metadata{
+				Name:       "datadog",
+				Version:    "2.30.5",
+				AppVersion: "7",
+			},
+		},
+		Version:   1,
+		Namespace: "default",
+	}
+
+	events.addEventForNewRelease(&rel, k8sSecrets)
+
+	sender := mocksender.NewMockSender("1")
+	sender.SetupAcceptAll()
+	events.sendEvents(sender)
+
+	sender.AssertEvent(
+		t,
+		coreMetrics.Event{
+			Title:          "Event on Helm release",
+			Text:           "New Helm release \"my_datadog\" has been deployed in \"default\" namespace. Its status is \"deployed\".",
+			Ts:             time.Now().Unix(),
+			Priority:       coreMetrics.EventPriorityNormal,
+			SourceTypeName: "helm",
+			EventType:      "helm",
+			AggregationKey: "helm_release:default/my_datadog",
+			Tags:           helmTags(&rel, k8sSecrets, true),
+		},
+		10*time.Second,
+	)
+}

--- a/pkg/collector/corechecks/cluster/helm/helm.go
+++ b/pkg/collector/corechecks/cluster/helm/helm.go
@@ -12,11 +12,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 	"time"
 
+	"gopkg.in/yaml.v2"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 
@@ -53,23 +54,37 @@ const (
 // https://helm.sh/docs/faq/changes_since_helm2/#secrets-as-the-default-storage-driver
 type HelmCheck struct {
 	core.CheckBase
-	releases          map[helmStorage]map[string]*release
-	releasesMutex     sync.Mutex
+	instance          *checkConfig
+	store             *releasesStore
 	runLeaderElection bool
+	eventsManager     *eventsManager
+
+	// existingReleasesStored indicates whether the releases deployed before the
+	// agent was started have already been stored. This is needed to avoid
+	// emitting events for those releases.
+	existingReleasesStored bool
+}
+
+type checkConfig struct {
+	CollectEvents bool `yaml:"collect_events"`
+}
+
+// Parse parses the config and sets default values
+func (cc *checkConfig) Parse(data []byte) error {
+	// default values
+	cc.CollectEvents = false
+
+	return yaml.Unmarshal(data, cc)
 }
 
 func factory() check.Check {
-	helmCheck := &HelmCheck{
+	return &HelmCheck{
 		CheckBase:         core.NewCheckBase(checkName),
-		releases:          make(map[helmStorage]map[string]*release),
+		instance:          &checkConfig{},
+		store:             newReleasesStore(),
 		runLeaderElection: !config.IsCLCRunner(),
+		eventsManager:     &eventsManager{},
 	}
-
-	for _, storageDriver := range []helmStorage{k8sConfigmaps, k8sSecrets} {
-		helmCheck.releases[storageDriver] = make(map[string]*release)
-	}
-
-	return helmCheck
 }
 
 // Configure configures the Helm check
@@ -78,6 +93,10 @@ func (hc *HelmCheck) Configure(config, initConfig integration.Data, source strin
 
 	err := hc.CommonConfigure(config, source)
 	if err != nil {
+		return err
+	}
+
+	if err = hc.instance.Parse(config); err != nil {
 		return err
 	}
 
@@ -91,6 +110,13 @@ func (hc *HelmCheck) Configure(config, initConfig integration.Data, source strin
 
 	apiClient, err := apiserver.WaitForAPIClient(apiCtx)
 	if err != nil {
+		return err
+	}
+
+	// Add the releases present before setting up the informers. This allows us
+	// to avoid emitting events for releases that were deployed before the agent
+	// started.
+	if err = hc.addExistingReleases(apiClient); err != nil {
 		return err
 	}
 
@@ -117,13 +143,14 @@ func (hc *HelmCheck) Run() error {
 		}
 	}
 
-	hc.releasesMutex.Lock()
-	defer hc.releasesMutex.Unlock()
-
 	for _, storageDriver := range []helmStorage{k8sConfigmaps, k8sSecrets} {
-		for _, rel := range hc.releases[storageDriver] {
-			sender.Gauge("helm.release", 1, "", helmTags(rel, storageDriver))
+		for _, rel := range hc.store.getAll(storageDriver) {
+			sender.Gauge("helm.release", 1, "", helmTags(rel, storageDriver, true))
 		}
+	}
+
+	if hc.instance.CollectEvents {
+		hc.eventsManager.sendEvents(sender)
 	}
 
 	return nil
@@ -157,12 +184,45 @@ func (hc *HelmCheck) setupInformers(sharedInformerFactory informers.SharedInform
 	)
 }
 
-func helmTags(release *release, storageDriver helmStorage) []string {
+func (hc *HelmCheck) addExistingReleases(apiClient *apiserver.APIClient) error {
+	selector := labels.Set{"owner": "helm"}.AsSelector()
+
+	initialHelmSecrets, err := apiClient.Cl.CoreV1().Secrets(v1.NamespaceAll).List(
+		context.Background(), metav1.ListOptions{LabelSelector: selector.String()},
+	)
+	if err != nil {
+		return err
+	}
+
+	for _, secret := range initialHelmSecrets.Items {
+		hc.addSecret(&secret)
+	}
+
+	initialHelmConfigMaps, err := apiClient.Cl.CoreV1().ConfigMaps(v1.NamespaceAll).List(
+		context.Background(), metav1.ListOptions{LabelSelector: selector.String()},
+	)
+	if err != nil {
+		return err
+	}
+
+	for _, configMap := range initialHelmConfigMaps.Items {
+		hc.addConfigmap(&configMap)
+	}
+
+	hc.existingReleasesStored = true
+
+	return nil
+}
+
+func helmTags(release *release, storageDriver helmStorage, includeRevision bool) []string {
 	tags := []string{
 		fmt.Sprintf("helm_release:%s", release.Name),
 		fmt.Sprintf("helm_namespace:%s", release.Namespace),
-		fmt.Sprintf("helm_revision:%d", release.Version),
 		fmt.Sprintf("helm_storage:%s", storageDriver),
+	}
+
+	if includeRevision {
+		tags = append(tags, fmt.Sprintf("helm_revision:%d", release.Version))
 	}
 
 	// I've found releases without a chart reference. Not sure if it's due to
@@ -254,9 +314,17 @@ func (hc *HelmCheck) addRelease(encodedRelease string, storageDriver helmStorage
 		return
 	}
 
-	hc.releasesMutex.Lock()
-	defer hc.releasesMutex.Unlock()
-	hc.releases[storageDriver][decodedRelease.ID()] = decodedRelease
+	needToEmitEvent := hc.instance.CollectEvents && hc.existingReleasesStored
+
+	if needToEmitEvent {
+		if previous := hc.store.get(decodedRelease.namespacedName(), decodedRelease.revision(), storageDriver); previous != nil {
+			hc.eventsManager.addEventForUpdatedRelease(previous, decodedRelease, storageDriver)
+		} else {
+			hc.eventsManager.addEventForNewRelease(decodedRelease, storageDriver)
+		}
+	}
+
+	hc.store.add(decodedRelease, storageDriver)
 }
 
 func (hc *HelmCheck) deleteRelease(encodedRelease string, storageDriver helmStorage) {
@@ -266,9 +334,14 @@ func (hc *HelmCheck) deleteRelease(encodedRelease string, storageDriver helmStor
 		return
 	}
 
-	hc.releasesMutex.Lock()
-	defer hc.releasesMutex.Unlock()
-	delete(hc.releases[storageDriver], decodedRelease.ID())
+	wasLastRevision := hc.store.delete(decodedRelease, storageDriver)
+
+	// When a release is deleted, all its revisions are deleted at the same
+	// time. To avoid generating many events with the same info, we just emit
+	// one when the last remaining revision has been deleted.
+	if hc.instance.CollectEvents && wasLastRevision {
+		hc.eventsManager.addEventForDeletedRelease(decodedRelease, storageDriver)
+	}
 }
 
 func isManagedByHelm(object metav1.Object) bool {

--- a/pkg/collector/corechecks/cluster/helm/helm.go
+++ b/pkg/collector/corechecks/cluster/helm/helm.go
@@ -334,12 +334,12 @@ func (hc *HelmCheck) deleteRelease(encodedRelease string, storageDriver helmStor
 		return
 	}
 
-	wasLastRevision := hc.store.delete(decodedRelease, storageDriver)
+	moreRevisionsLeft := hc.store.delete(decodedRelease, storageDriver)
 
 	// When a release is deleted, all its revisions are deleted at the same
 	// time. To avoid generating many events with the same info, we just emit
-	// one when the last remaining revision has been deleted.
-	if hc.instance.CollectEvents && wasLastRevision {
+	// one when there are no more revisions left.
+	if hc.instance.CollectEvents && !moreRevisionsLeft {
 		hc.eventsManager.addEventForDeletedRelease(decodedRelease, storageDriver)
 	}
 }

--- a/pkg/collector/corechecks/cluster/helm/release.go
+++ b/pkg/collector/corechecks/cluster/helm/release.go
@@ -34,8 +34,15 @@ type release struct {
 	Namespace string `json:"namespace,omitempty"`
 }
 
-func (rel *release) ID() string {
-	return fmt.Sprintf("%s/%s/%d", rel.Namespace, rel.Name, rel.Version)
+type namespacedName string
+type revision int
+
+func (rel *release) namespacedName() namespacedName {
+	return namespacedName(fmt.Sprintf("%s/%s", rel.Namespace, rel.Name))
+}
+
+func (rel *release) revision() revision {
+	return revision(rel.Version)
 }
 
 type info struct {

--- a/pkg/collector/corechecks/cluster/helm/releases_store.go
+++ b/pkg/collector/corechecks/cluster/helm/releases_store.go
@@ -1,0 +1,89 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+// +build kubeapiserver
+
+package helm
+
+import "sync"
+
+type releasesStore struct {
+	store      map[helmStorage]map[namespacedName]map[revision]*release
+	storeMutex sync.Mutex
+}
+
+func newReleasesStore() *releasesStore {
+	res := &releasesStore{
+		store: make(map[helmStorage]map[namespacedName]map[revision]*release),
+	}
+
+	for _, storageDriver := range []helmStorage{k8sConfigmaps, k8sSecrets} {
+		res.store[storageDriver] = make(map[namespacedName]map[revision]*release)
+	}
+
+	return res
+}
+
+// add stores a release
+func (rs *releasesStore) add(rel *release, storage helmStorage) {
+	rs.storeMutex.Lock()
+	defer rs.storeMutex.Unlock()
+
+	if rs.store[storage][rel.namespacedName()] == nil {
+		rs.store[storage][rel.namespacedName()] = make(map[revision]*release)
+	}
+
+	rs.store[storage][rel.namespacedName()][rel.revision()] = rel
+}
+
+// get returns the release stored with the given namespacedName, revision and
+// storage. Returns nil when it does not exist.
+func (rs *releasesStore) get(namespacedName namespacedName, revision revision, storage helmStorage) *release {
+	rs.storeMutex.Lock()
+	defer rs.storeMutex.Unlock()
+
+	if rs.store[storage][namespacedName] == nil {
+		return nil
+	}
+
+	return rs.store[storage][namespacedName][revision]
+}
+
+// getAll returns all the releases stored for the given helmStorage
+func (rs *releasesStore) getAll(storage helmStorage) []*release {
+	rs.storeMutex.Lock()
+	defer rs.storeMutex.Unlock()
+
+	var res []*release
+
+	for _, releasesByRevision := range rs.store[storage] {
+		for _, rel := range releasesByRevision {
+			res = append(res, rel)
+		}
+	}
+
+	return res
+}
+
+// delete removes a release. It returns a bool that indicates whether the
+// release deleted was the only existing revision.
+func (rs *releasesStore) delete(rel *release, storage helmStorage) bool {
+	rs.storeMutex.Lock()
+	defer rs.storeMutex.Unlock()
+
+	if rs.store[storage][rel.namespacedName()] == nil {
+		return true
+	}
+
+	delete(rs.store[storage][rel.namespacedName()], rel.revision())
+
+	if len(rs.store[storage][rel.namespacedName()]) == 0 {
+		delete(rs.store[storage], rel.namespacedName())
+		return true
+	}
+
+	return false
+}

--- a/pkg/collector/corechecks/cluster/helm/releases_store.go
+++ b/pkg/collector/corechecks/cluster/helm/releases_store.go
@@ -68,22 +68,22 @@ func (rs *releasesStore) getAll(storage helmStorage) []*release {
 	return res
 }
 
-// delete removes a release. It returns a bool that indicates whether the
-// release deleted was the only existing revision.
+// delete removes a release. It returns a bool that indicates whether there are
+// any revisions left for the release.
 func (rs *releasesStore) delete(rel *release, storage helmStorage) bool {
 	rs.storeMutex.Lock()
 	defer rs.storeMutex.Unlock()
 
 	if rs.store[storage][rel.namespacedName()] == nil {
-		return true
+		return false
 	}
 
 	delete(rs.store[storage][rel.namespacedName()], rel.revision())
 
-	if len(rs.store[storage][rel.namespacedName()]) == 0 {
-		delete(rs.store[storage], rel.namespacedName())
+	if len(rs.store[storage][rel.namespacedName()]) > 0 {
 		return true
 	}
 
+	delete(rs.store[storage], rel.namespacedName())
 	return false
 }

--- a/pkg/collector/corechecks/cluster/helm/releases_store_test.go
+++ b/pkg/collector/corechecks/cluster/helm/releases_store_test.go
@@ -1,0 +1,155 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+// +build kubeapiserver
+
+package helm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAdd(t *testing.T) {
+	store := newReleasesStore()
+
+	rel := release{
+		Name: "my_datadog",
+		Info: &info{
+			Status: "deployed",
+		},
+		Chart: &chart{
+			Metadata: &metadata{
+				Name:       "datadog",
+				Version:    "2.30.5",
+				AppVersion: "7",
+			},
+		},
+		Version:   1,
+		Namespace: "default",
+	}
+
+	store.add(&rel, k8sSecrets)
+	assert.Equal(t, &rel, store.get("default/my_datadog", 1, k8sSecrets))
+	assert.Nil(t, store.get("default/my_datadog", 1, k8sConfigmaps)) // Different storage
+}
+
+func TestGetAll(t *testing.T) {
+	store := newReleasesStore()
+
+	releasesInSecrets := []*release{
+		{
+			Name: "my_datadog",
+			Info: &info{
+				Status: "deployed",
+			},
+			Chart: &chart{
+				Metadata: &metadata{
+					Name:       "datadog",
+					Version:    "2.30.5",
+					AppVersion: "7",
+				},
+			},
+			Version:   1,
+			Namespace: "default",
+		},
+		{
+			Name: "my_proxy",
+			Info: &info{
+				Status: "deployed",
+			},
+			Chart: &chart{
+				Metadata: &metadata{
+					Name:       "nginx",
+					Version:    "1.0.0",
+					AppVersion: "1",
+				},
+			},
+			Version:   2,
+			Namespace: "default",
+		},
+	}
+
+	releasesInConfigMaps := []*release{
+		{
+			Name: "my_app",
+			Info: &info{
+				Status: "deployed",
+			},
+			Chart: &chart{
+				Metadata: &metadata{
+					Name:       "some_app",
+					Version:    "1.1.0",
+					AppVersion: "1",
+				},
+			},
+			Version:   2,
+			Namespace: "app",
+		},
+	}
+
+	for _, rel := range releasesInSecrets {
+		store.add(rel, k8sSecrets)
+	}
+
+	for _, rel := range releasesInConfigMaps {
+		store.add(rel, k8sConfigmaps)
+	}
+
+	assert.ElementsMatch(t, releasesInSecrets, store.getAll(k8sSecrets))
+	assert.ElementsMatch(t, releasesInConfigMaps, store.getAll(k8sConfigmaps))
+}
+
+func TestDelete(t *testing.T) {
+	store := newReleasesStore()
+
+	releases := []*release{
+		{
+			Name: "my_datadog",
+			Info: &info{
+				Status: "superseded",
+			},
+			Chart: &chart{
+				Metadata: &metadata{
+					Name:       "datadog",
+					Version:    "2.30.5",
+					AppVersion: "7",
+				},
+			},
+			Version:   1,
+			Namespace: "default",
+		},
+		{
+			Name: "my_datadog",
+			Info: &info{
+				Status: "deployed",
+			},
+			Chart: &chart{
+				Metadata: &metadata{
+					Name:       "datadog",
+					Version:    "2.30.5",
+					AppVersion: "7",
+				},
+			},
+			Version:   2,
+			Namespace: "default",
+		},
+	}
+
+	for _, rel := range releases {
+		store.add(rel, k8sSecrets)
+	}
+
+	// Should return false when there are more revisions
+	assert.False(t, store.delete(releases[0], k8sSecrets))
+
+	// Should return true when it was the last revision
+	assert.True(t, store.delete(releases[1], k8sSecrets))
+
+	// Should return true when it doesn't exist
+	assert.True(t, store.delete(releases[1], k8sSecrets))
+}

--- a/pkg/collector/corechecks/cluster/helm/releases_store_test.go
+++ b/pkg/collector/corechecks/cluster/helm/releases_store_test.go
@@ -144,12 +144,12 @@ func TestDelete(t *testing.T) {
 		store.add(rel, k8sSecrets)
 	}
 
-	// Should return false when there are more revisions
-	assert.False(t, store.delete(releases[0], k8sSecrets))
+	// Should return true when there are more revisions
+	assert.True(t, store.delete(releases[0], k8sSecrets))
 
-	// Should return true when it was the last revision
-	assert.True(t, store.delete(releases[1], k8sSecrets))
+	// Should return false when it was the last revision
+	assert.False(t, store.delete(releases[1], k8sSecrets))
 
-	// Should return true when it doesn't exist
-	assert.True(t, store.delete(releases[1], k8sSecrets))
+	// Should return false when it doesn't exist
+	assert.False(t, store.delete(releases[1], k8sSecrets))
 }

--- a/releasenotes/notes/helm-check-events-95ad885436481a70.yaml
+++ b/releasenotes/notes/helm-check-events-95ad885436481a70.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Added event collection in the Helm check. The feature is disabled by default. To enable it, set the `collect_events` option to true.


### PR DESCRIPTION
### What does this PR do?

Adds events in the Helm Check.

In particular, it emits an event in the following situations:
- A new release has been deployed.
- A release has been deleted.
- A release has been upgraded (new revision).
- There's a status change (from "deployed" to "superseded"), etc.

This PR adds a new option in the check, `collect_events`, to enable and disable this feature. It's disabled by default.


### Describe how to test/QA your changes

Deploy on Kubernetes. Enable the Helm check and the new `collect_events` option.
This PR adds an option to enable the feature using the helm chart: https://github.com/DataDog/helm-charts/pull/572

Deploy helm charts, upgrade them, delete them, etc. and check in the events explorer view that the events described above are correctly emitted.

This should work both when Helm uses secrets and configmaps as its storage.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
