### PR TITLE
Measure number of contexts per metric type

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -117,6 +117,7 @@ var (
 	aggregatorOrchestratorMetadata             = expvar.Int{}
 	aggregatorOrchestratorMetadataErrors       = expvar.Int{}
 	aggregatorDogstatsdContexts                = expvar.Int{}
+	aggregatorDogstatsdContextsByMtype         = []expvar.Int{}
 	aggregatorEventPlatformEvents              = expvar.Map{}
 	aggregatorEventPlatformEventsErrors        = expvar.Map{}
 	aggregatorContainerLifecycleEvents         = expvar.Int{}
@@ -130,6 +131,8 @@ var (
 		nil, "Count of hostname update")
 	tlmDogstatsdContexts = telemetry.NewGauge("aggregator", "dogstatsd_contexts",
 		nil, "Count the number of dogstatsd contexts in the aggregator")
+	tlmDogstatsdContextsByMtype = telemetry.NewGauge("aggregator", "dogstatsd_contexts_by_mtype",
+		[]string{"metric_type"}, "Count the number of dogstatsd contexts in the aggregator, by metric type")
 
 	// Hold series to be added to aggregated series on each flush
 	recurrentSeries     metrics.Series
@@ -172,6 +175,15 @@ func init() {
 	aggregatorExpvars.Set("EventPlatformEventsErrors", &aggregatorEventPlatformEventsErrors)
 	aggregatorExpvars.Set("ContainerLifecycleEvents", &aggregatorContainerLifecycleEvents)
 	aggregatorExpvars.Set("ContainerLifecycleEventsErrors", &aggregatorContainerLifecycleEventsErrors)
+
+	contextsByMtypeMap := expvar.Map{}
+	aggregatorDogstatsdContextsByMtype = make([]expvar.Int, int(metrics.NumMetricTypes))
+	for i := 0; i < int(metrics.NumMetricTypes); i++ {
+		mtype := metrics.MetricType(i).String()
+		aggregatorDogstatsdContextsByMtype[i] = expvar.Int{}
+		contextsByMtypeMap.Set(mtype, &aggregatorDogstatsdContextsByMtype[i])
+	}
+	aggregatorExpvars.Set("DogstatsdContextsByMtype", &contextsByMtypeMap)
 
 	tagsetTlm = newTagsetTelemetry([]uint64{90, 100})
 

--- a/pkg/aggregator/context_resolver.go
+++ b/pkg/aggregator/context_resolver.go
@@ -134,6 +134,10 @@ func (cr *timestampContextResolver) length() int {
 	return cr.resolver.length()
 }
 
+func (cr *timestampContextResolver) countsByMtype() []uint64 {
+	return cr.resolver.countsByMtype
+}
+
 func (cr *timestampContextResolver) get(key ckey.ContextKey) (*Context, bool) {
 	return cr.resolver.get(key)
 }

--- a/pkg/aggregator/context_resolver_test.go
+++ b/pkg/aggregator/context_resolver_test.go
@@ -72,7 +72,7 @@ func testTrackContext(t *testing.T, store *tags.Store) {
 	mSample3 := metrics.MetricSample{ // same as mSample2, with different Host
 		Name:       "my.metric.name",
 		Value:      1,
-		Mtype:      metrics.GaugeType,
+		Mtype:      metrics.CountType,
 		Tags:       []string{"foo", "bar", "baz"},
 		Host:       "metric-hostname",
 		SampleRate: 1,
@@ -94,6 +94,10 @@ func testTrackContext(t *testing.T, store *tags.Store) {
 
 	context3 := contextResolver.contextsByKey[contextKey3]
 	assertContext(t, context3, mSample3.Name, mSample3.Tags, mSample3.Host)
+
+	assert.Equal(t, uint64(2), contextResolver.countsByMtype[metrics.GaugeType])
+	assert.Equal(t, uint64(1), contextResolver.countsByMtype[metrics.CountType])
+	assert.Equal(t, uint64(0), contextResolver.countsByMtype[metrics.RateType])
 
 	unknownContextKey := ckey.ContextKey(0xffffffffffffffff)
 	_, ok := contextResolver.contextsByKey[unknownContextKey]

--- a/pkg/aggregator/time_sampler.go
+++ b/pkg/aggregator/time_sampler.go
@@ -217,8 +217,17 @@ func (s *TimeSampler) flush(timestamp float64, series metrics.SerieSink) metrics
 	s.contextResolver.expireContexts(timestamp - config.Datadog.GetFloat64("dogstatsd_context_expiry_seconds"))
 	s.lastCutOffTime = cutoffTime
 
-	aggregatorDogstatsdContexts.Set(int64(s.contextResolver.length()))
-	tlmDogstatsdContexts.Set(float64(s.contextResolver.length()))
+	totalContexts := s.contextResolver.length()
+	aggregatorDogstatsdContexts.Set(int64(totalContexts))
+	tlmDogstatsdContexts.Set(float64(totalContexts))
+
+	byMtype := s.contextResolver.countsByMtype()
+	for i, count := range byMtype {
+		mtype := metrics.MetricType(i).String()
+		aggregatorDogstatsdContextsByMtype[i].Set(int64(count))
+		tlmDogstatsdContextsByMtype.Set(float64(count), mtype)
+	}
+
 	return sketches
 }
 

--- a/pkg/metrics/histogram_bucket.go
+++ b/pkg/metrics/histogram_bucket.go
@@ -39,3 +39,8 @@ func (m *HistogramBucket) GetTags(taggerBuffer, metricBuffer *tagset.HashingTags
 	// tags.
 	metricBuffer.Append(m.Tags...)
 }
+
+// GetMetricType implements MetricSampleContext#GetMetricType.
+func (m *HistogramBucket) GetMetricType() MetricType {
+	return HistogramType
+}

--- a/pkg/metrics/metric_sample.go
+++ b/pkg/metrics/metric_sample.go
@@ -24,6 +24,9 @@ const (
 	HistorateType
 	SetType
 	DistributionType
+
+	// NumMetricTypes is the number of metric types; must be the last item here
+	NumMetricTypes
 )
 
 // DistributionMetricTypes contains the MetricTypes that are used for percentiles
@@ -63,12 +66,16 @@ func (m MetricType) String() string {
 type MetricSampleContext interface {
 	GetName() string
 	GetHost() string
+
 	// GetTags extracts metric tags for context tracking.
 	//
 	// Implementations should call `Append` or `AppendHashed` on the provided accumulators.
 	// Tags from origin detection should be appended to taggerBuffer. Client-provided tags
 	// should be appended to the metricBuffer.
 	GetTags(taggerBuffer, metricBuffer *tagset.HashingTagsAccumulator)
+
+	// GetMetricType returns the metric type for this metric.  This is used for telemetry.
+	GetMetricType() MetricType
 }
 
 // MetricSample represents a raw metric sample
@@ -103,6 +110,11 @@ func (m *MetricSample) GetHost() string {
 func (m *MetricSample) GetTags(taggerBuffer, metricBuffer *tagset.HashingTagsAccumulator) {
 	metricBuffer.Append(m.Tags...)
 	tagger.EnrichTags(taggerBuffer, m.OriginFromUDS, m.OriginFromClient, m.Cardinality)
+}
+
+// GetMetricType implements MetricSampleContext#GetMetricType.
+func (m *MetricSample) GetMetricType() MetricType {
+	return m.Mtype
 }
 
 // Copy returns a deep copy of the m MetricSample


### PR DESCRIPTION
### What does this PR do?

Measures the number of contexts in the TimeSampler per metric type.

This is in addition to `datadog.agent.aggregator.dogstatsd_contexts`, which sums all contexts regardless of type.

### Motivation

@olivielpeau:
> useful in particular to evaluate the impact (both in agent and client performance gain, and potential CPU/mem increase on the client side) of enabling client-side aggregation for dist metrics

### Possible Drawbacks / Trade-offs

May have a cost in terms of performance or memory usage, since it adds an additional field to Context.

### Describe how to test/QA your changes

Set up an agent with telemetry enabled and blast it with some dogstatsd metrics (`docker run --rm --name cxgen -v /var/run/datadog:/var/run/datadog -e DD_AGENT_HOST=unix:///var/run/datadog/dsd.sock datadog/agent-dev:cxgenerator ./cxgenerator 10000 10 10`).  15 seconds in, verify the new expvars and that the old one hasn't changed:

```
curl localhost:5000/debug/vars | jq .aggregator.DogstatsdContexts
curl localhost:5000/debug/vars | jq .aggregator.DogstatsdContextsByMtype
```

then verify the telemetry for the host matches, looking at `datadog.agent.aggregator.dogstatsd_contexts` and `datadog.agent.aggregator.dogstatsd_contexts_by_mtype`:

```
$ curl -s http://127.0.0.1:5000/telemetry | grep dogstatsd.*context
# HELP aggregator__dogstatsd_contexts Count the number of dogstatsd contexts in the aggregator
# TYPE aggregator__dogstatsd_contexts gauge
aggregator__dogstatsd_contexts 100019
# HELP aggregator__dogstatsd_contexts_by_mtype Count the number of dogstatsd contexts in the aggregator, by metric type
# TYPE aggregator__dogstatsd_contexts_by_mtype gauge
aggregator__dogstatsd_contexts_by_mtype{metric_type="Count"} 1
aggregator__dogstatsd_contexts_by_mtype{metric_type="Counter"} 18
aggregator__dogstatsd_contexts_by_mtype{metric_type="Distribution"} 0
aggregator__dogstatsd_contexts_by_mtype{metric_type="Gauge"} 100000
aggregator__dogstatsd_contexts_by_mtype{metric_type="Histogram"} 0
aggregator__dogstatsd_contexts_by_mtype{metric_type="Historate"} 0
aggregator__dogstatsd_contexts_by_mtype{metric_type="MonotonicCount"} 0
aggregator__dogstatsd_contexts_by_mtype{metric_type="Rate"} 0
aggregator__dogstatsd_contexts_by_mtype{metric_type="Set"} 0
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
