### PR TITLE
Re-generate the static kubernetes sample manifests

### DIFF
--- a/Dockerfiles/manifests/agent-only/README.md
+++ b/Dockerfiles/manifests/agent-only/README.md
@@ -1,6 +1,6 @@
 The kubernetes manifests found in this directory have been automatically generated
 from the [helm chart `datadog/datadog`](https://github.com/DataDog/helm-charts/tree/master/charts/datadog)
-version 2.28.13 with the following `values.yaml`:
+version 2.30.16 with the following `values.yaml`:
 
 ```yaml
 datadog:

--- a/Dockerfiles/manifests/agent-only/cluster-agent-deployment.yaml
+++ b/Dockerfiles/manifests/agent-only/cluster-agent-deployment.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: datadog-cluster-agent
       containers:
         - name: cluster-agent
-          image: "gcr.io/datadoghq/cluster-agent:1.16.0"
+          image: "gcr.io/datadoghq/cluster-agent:1.18.0"
           imagePullPolicy: IfNotPresent
           resources: {}
           ports:
@@ -104,13 +104,15 @@ spec:
           configMap:
             name: datadog-installinfo
       affinity:
-        # Force scheduling the cluster agents on different nodes
+        # Prefer scheduling the cluster agents on different nodes
         # to guarantee that the standby instance can immediately take the lead from a leader running of a faulty node.
         podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchLabels:
-                  app: datadog-cluster-agent
-              topologyKey: kubernetes.io/hostname
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 50
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: datadog-cluster-agent
+                topologyKey: kubernetes.io/hostname
       nodeSelector:
         kubernetes.io/os: linux

--- a/Dockerfiles/manifests/agent-only/cluster-agent-rbac.yaml
+++ b/Dockerfiles/manifests/agent-only/cluster-agent-rbac.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app: "datadog"
-    chart: "datadog-2.28.13"
+    chart: "datadog-2.30.16"
     heritage: "Helm"
     release: "datadog"
   name: datadog-cluster-agent
@@ -102,6 +102,16 @@ rules:
       - get
       - update
   - apiGroups:
+      - ""
+    resources:
+      - persistentvolumes
+      - persistentvolumeclaims
+      - serviceaccounts
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
       - "apps"
     resources:
       - deployments
@@ -117,6 +127,25 @@ rules:
     resources:
       - cronjobs
       - jobs
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
+      - "rbac.authorization.k8s.io"
+    resources:
+      - roles
+      - rolebindings
+      - clusterroles
+      - clusterrolebindings
     verbs:
       - list
       - get

--- a/Dockerfiles/manifests/agent-only/daemonset.yaml
+++ b/Dockerfiles/manifests/agent-only/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.32.4"
+          image: "gcr.io/datadoghq/agent:7.34.0"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -69,6 +69,8 @@ spec:
               value: "false"
             - name: DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE
               value: "true"
+            - name: DD_LOGS_CONFIG_AUTO_MULTI_LINE_DETECTION
+              value: "false"
             - name: DD_HEALTH_PORT
               value: "5555"
             - name: DD_DOGSTATSD_SOCKET
@@ -125,7 +127,7 @@ spec:
             timeoutSeconds: 5
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.32.4"
+          image: "gcr.io/datadoghq/agent:7.34.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -135,7 +137,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.32.4"
+          image: "gcr.io/datadoghq/agent:7.34.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:

--- a/Dockerfiles/manifests/all-containers/README.md
+++ b/Dockerfiles/manifests/all-containers/README.md
@@ -1,6 +1,6 @@
 The kubernetes manifests found in this directory have been automatically generated
 from the [helm chart `datadog/datadog`](https://github.com/DataDog/helm-charts/tree/master/charts/datadog)
-version 2.28.13 with the following `values.yaml`:
+version 2.30.16 with the following `values.yaml`:
 
 ```yaml
 datadog:

--- a/Dockerfiles/manifests/all-containers/cluster-agent-deployment.yaml
+++ b/Dockerfiles/manifests/all-containers/cluster-agent-deployment.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: datadog-cluster-agent
       containers:
         - name: cluster-agent
-          image: "gcr.io/datadoghq/cluster-agent:1.16.0"
+          image: "gcr.io/datadoghq/cluster-agent:1.18.0"
           imagePullPolicy: IfNotPresent
           resources: {}
           ports:
@@ -108,13 +108,15 @@ spec:
           configMap:
             name: datadog-installinfo
       affinity:
-        # Force scheduling the cluster agents on different nodes
+        # Prefer scheduling the cluster agents on different nodes
         # to guarantee that the standby instance can immediately take the lead from a leader running of a faulty node.
         podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchLabels:
-                  app: datadog-cluster-agent
-              topologyKey: kubernetes.io/hostname
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 50
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: datadog-cluster-agent
+                topologyKey: kubernetes.io/hostname
       nodeSelector:
         kubernetes.io/os: linux

--- a/Dockerfiles/manifests/all-containers/cluster-agent-rbac.yaml
+++ b/Dockerfiles/manifests/all-containers/cluster-agent-rbac.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app: "datadog"
-    chart: "datadog-2.28.13"
+    chart: "datadog-2.30.16"
     heritage: "Helm"
     release: "datadog"
   name: datadog-cluster-agent
@@ -102,6 +102,16 @@ rules:
       - get
       - update
   - apiGroups:
+      - ""
+    resources:
+      - persistentvolumes
+      - persistentvolumeclaims
+      - serviceaccounts
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
       - "apps"
     resources:
       - deployments
@@ -117,6 +127,25 @@ rules:
     resources:
       - cronjobs
       - jobs
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
+      - "rbac.authorization.k8s.io"
+    resources:
+      - roles
+      - rolebindings
+      - clusterroles
+      - clusterrolebindings
     verbs:
       - list
       - get

--- a/Dockerfiles/manifests/all-containers/daemonset.yaml
+++ b/Dockerfiles/manifests/all-containers/daemonset.yaml
@@ -26,7 +26,7 @@ spec:
       hostPID: true
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.32.4"
+          image: "gcr.io/datadoghq/agent:7.34.0"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -72,6 +72,8 @@ spec:
               value: "false"
             - name: DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE
               value: "true"
+            - name: DD_LOGS_CONFIG_AUTO_MULTI_LINE_DETECTION
+              value: "false"
             - name: DD_HEALTH_PORT
               value: "5555"
             - name: DD_DOGSTATSD_SOCKET
@@ -148,7 +150,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.32.4"
+          image: "gcr.io/datadoghq/agent:7.34.0"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -214,7 +216,7 @@ spec:
               port: 8126
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.32.4"
+          image: "gcr.io/datadoghq/agent:7.34.0"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -287,7 +289,7 @@ spec:
               mountPath: /etc/datadog-agent/system-probe.yaml
               subPath: system-probe.yaml
         - name: system-probe
-          image: "gcr.io/datadoghq/agent:7.32.4"
+          image: "gcr.io/datadoghq/agent:7.34.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -357,7 +359,7 @@ spec:
               mountPropagation: None
               readOnly: true
         - name: security-agent
-          image: "gcr.io/datadoghq/agent:7.32.4"
+          image: "gcr.io/datadoghq/agent:7.34.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -444,7 +446,7 @@ spec:
               subPath: system-probe.yaml
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.32.4"
+          image: "gcr.io/datadoghq/agent:7.34.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -454,7 +456,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.32.4"
+          image: "gcr.io/datadoghq/agent:7.34.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -492,7 +494,7 @@ spec:
               value: "yes"
           resources: {}
         - name: seccomp-setup
-          image: "gcr.io/datadoghq/agent:7.32.4"
+          image: "gcr.io/datadoghq/agent:7.34.0"
           command:
             - cp
             - /etc/config/system-probe-seccomp.json

--- a/Dockerfiles/manifests/all-containers/system-probe-configmap.yaml
+++ b/Dockerfiles/manifests/all-containers/system-probe-configmap.yaml
@@ -32,7 +32,6 @@ data:
       enabled: false
     runtime_security_config:
       enabled: true
-      debug: false
       socket: /var/run/sysprobe/runtime-security.sock
       policies:
         dir: /etc/datadog-agent/runtime-security.d

--- a/Dockerfiles/manifests/cluster-agent-datadogmetrics/README.md
+++ b/Dockerfiles/manifests/cluster-agent-datadogmetrics/README.md
@@ -1,6 +1,6 @@
 The kubernetes manifests found in this directory have been automatically generated
 from the [helm chart `datadog/datadog`](https://github.com/DataDog/helm-charts/tree/master/charts/datadog)
-version 2.28.13 with the following `values.yaml`:
+version 2.30.16 with the following `values.yaml`:
 
 ```yaml
 datadog:

--- a/Dockerfiles/manifests/cluster-agent-datadogmetrics/agent-services.yaml
+++ b/Dockerfiles/manifests/cluster-agent-datadogmetrics/agent-services.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: default
   labels:
     app: "datadog"
-    chart: "datadog-2.28.13"
+    chart: "datadog-2.30.16"
     release: "datadog"
     heritage: "Helm"
 spec:

--- a/Dockerfiles/manifests/cluster-agent-datadogmetrics/cluster-agent-deployment.yaml
+++ b/Dockerfiles/manifests/cluster-agent-datadogmetrics/cluster-agent-deployment.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: datadog-cluster-agent
       containers:
         - name: cluster-agent
-          image: "gcr.io/datadoghq/cluster-agent:1.16.0"
+          image: "gcr.io/datadoghq/cluster-agent:1.18.0"
           imagePullPolicy: IfNotPresent
           resources: {}
           ports:
@@ -122,13 +122,15 @@ spec:
           configMap:
             name: datadog-installinfo
       affinity:
-        # Force scheduling the cluster agents on different nodes
+        # Prefer scheduling the cluster agents on different nodes
         # to guarantee that the standby instance can immediately take the lead from a leader running of a faulty node.
         podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchLabels:
-                  app: datadog-cluster-agent
-              topologyKey: kubernetes.io/hostname
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 50
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: datadog-cluster-agent
+                topologyKey: kubernetes.io/hostname
       nodeSelector:
         kubernetes.io/os: linux

--- a/Dockerfiles/manifests/cluster-agent-datadogmetrics/cluster-agent-rbac.yaml
+++ b/Dockerfiles/manifests/cluster-agent-datadogmetrics/cluster-agent-rbac.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app: "datadog"
-    chart: "datadog-2.28.13"
+    chart: "datadog-2.30.16"
     heritage: "Helm"
     release: "datadog"
   name: datadog-cluster-agent
@@ -113,6 +113,16 @@ rules:
       - get
       - update
   - apiGroups:
+      - ""
+    resources:
+      - persistentvolumes
+      - persistentvolumeclaims
+      - serviceaccounts
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
       - "apps"
     resources:
       - deployments
@@ -128,6 +138,25 @@ rules:
     resources:
       - cronjobs
       - jobs
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
+      - "rbac.authorization.k8s.io"
+    resources:
+      - roles
+      - rolebindings
+      - clusterroles
+      - clusterrolebindings
     verbs:
       - list
       - get
@@ -186,7 +215,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app: "datadog"
-    chart: "datadog-2.28.13"
+    chart: "datadog-2.30.16"
     release: "datadog"
     heritage: "Helm"
   name: datadog-cluster-agent-system-auth-delegator

--- a/Dockerfiles/manifests/cluster-agent-datadogmetrics/daemonset.yaml
+++ b/Dockerfiles/manifests/cluster-agent-datadogmetrics/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.32.4"
+          image: "gcr.io/datadoghq/agent:7.34.0"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -69,6 +69,8 @@ spec:
               value: "false"
             - name: DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE
               value: "true"
+            - name: DD_LOGS_CONFIG_AUTO_MULTI_LINE_DETECTION
+              value: "false"
             - name: DD_HEALTH_PORT
               value: "5555"
             - name: DD_DOGSTATSD_SOCKET
@@ -125,7 +127,7 @@ spec:
             timeoutSeconds: 5
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.32.4"
+          image: "gcr.io/datadoghq/agent:7.34.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -135,7 +137,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.32.4"
+          image: "gcr.io/datadoghq/agent:7.34.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:

--- a/Dockerfiles/manifests/cluster-agent/README.md
+++ b/Dockerfiles/manifests/cluster-agent/README.md
@@ -1,6 +1,6 @@
 The kubernetes manifests found in this directory have been automatically generated
 from the [helm chart `datadog/datadog`](https://github.com/DataDog/helm-charts/tree/master/charts/datadog)
-version 2.28.13 with the following `values.yaml`:
+version 2.30.16 with the following `values.yaml`:
 
 ```yaml
 datadog:

--- a/Dockerfiles/manifests/cluster-agent/agent-services.yaml
+++ b/Dockerfiles/manifests/cluster-agent/agent-services.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: default
   labels:
     app: "datadog"
-    chart: "datadog-2.28.13"
+    chart: "datadog-2.30.16"
     release: "datadog"
     heritage: "Helm"
 spec:

--- a/Dockerfiles/manifests/cluster-agent/cluster-agent-deployment.yaml
+++ b/Dockerfiles/manifests/cluster-agent/cluster-agent-deployment.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: datadog-cluster-agent
       containers:
         - name: cluster-agent
-          image: "gcr.io/datadoghq/cluster-agent:1.16.0"
+          image: "gcr.io/datadoghq/cluster-agent:1.18.0"
           imagePullPolicy: IfNotPresent
           resources: {}
           ports:
@@ -122,13 +122,15 @@ spec:
           configMap:
             name: datadog-installinfo
       affinity:
-        # Force scheduling the cluster agents on different nodes
+        # Prefer scheduling the cluster agents on different nodes
         # to guarantee that the standby instance can immediately take the lead from a leader running of a faulty node.
         podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchLabels:
-                  app: datadog-cluster-agent
-              topologyKey: kubernetes.io/hostname
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 50
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: datadog-cluster-agent
+                topologyKey: kubernetes.io/hostname
       nodeSelector:
         kubernetes.io/os: linux

--- a/Dockerfiles/manifests/cluster-agent/cluster-agent-rbac.yaml
+++ b/Dockerfiles/manifests/cluster-agent/cluster-agent-rbac.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app: "datadog"
-    chart: "datadog-2.28.13"
+    chart: "datadog-2.30.16"
     heritage: "Helm"
     release: "datadog"
   name: datadog-cluster-agent
@@ -113,6 +113,16 @@ rules:
       - get
       - update
   - apiGroups:
+      - ""
+    resources:
+      - persistentvolumes
+      - persistentvolumeclaims
+      - serviceaccounts
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
       - "apps"
     resources:
       - deployments
@@ -128,6 +138,25 @@ rules:
     resources:
       - cronjobs
       - jobs
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
+      - "rbac.authorization.k8s.io"
+    resources:
+      - roles
+      - rolebindings
+      - clusterroles
+      - clusterrolebindings
     verbs:
       - list
       - get
@@ -171,7 +200,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app: "datadog"
-    chart: "datadog-2.28.13"
+    chart: "datadog-2.30.16"
     release: "datadog"
     heritage: "Helm"
   name: datadog-cluster-agent-system-auth-delegator

--- a/Dockerfiles/manifests/cluster-agent/daemonset.yaml
+++ b/Dockerfiles/manifests/cluster-agent/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.32.4"
+          image: "gcr.io/datadoghq/agent:7.34.0"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -69,6 +69,8 @@ spec:
               value: "false"
             - name: DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE
               value: "true"
+            - name: DD_LOGS_CONFIG_AUTO_MULTI_LINE_DETECTION
+              value: "false"
             - name: DD_HEALTH_PORT
               value: "5555"
             - name: DD_DOGSTATSD_SOCKET
@@ -125,7 +127,7 @@ spec:
             timeoutSeconds: 5
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.32.4"
+          image: "gcr.io/datadoghq/agent:7.34.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -135,7 +137,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.32.4"
+          image: "gcr.io/datadoghq/agent:7.34.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:

--- a/Dockerfiles/manifests/cluster-checks-runners/README.md
+++ b/Dockerfiles/manifests/cluster-checks-runners/README.md
@@ -1,6 +1,6 @@
 The kubernetes manifests found in this directory have been automatically generated
 from the [helm chart `datadog/datadog`](https://github.com/DataDog/helm-charts/tree/master/charts/datadog)
-version 2.28.13 with the following `values.yaml`:
+version 2.30.16 with the following `values.yaml`:
 
 ```yaml
 datadog:

--- a/Dockerfiles/manifests/cluster-checks-runners/agent-clusterchecks-deployment.yaml
+++ b/Dockerfiles/manifests/cluster-checks-runners/agent-clusterchecks-deployment.yaml
@@ -31,7 +31,7 @@ spec:
       imagePullSecrets: []
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.32.4"
+          image: "gcr.io/datadoghq/agent:7.34.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -41,7 +41,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.32.4"
+          image: "gcr.io/datadoghq/agent:7.34.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -52,7 +52,7 @@ spec:
           resources: {}
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.32.4"
+          image: "gcr.io/datadoghq/agent:7.34.0"
           command: ["bash", "-c"]
           args:
             - rm -rf /etc/datadog-agent/conf.d && touch /etc/datadog-agent/datadog.yaml && exec agent run

--- a/Dockerfiles/manifests/cluster-checks-runners/agent-clusterchecks-rbac.yaml
+++ b/Dockerfiles/manifests/cluster-checks-runners/agent-clusterchecks-rbac.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app: "datadog"
-    chart: "datadog-2.28.13"
+    chart: "datadog-2.30.16"
     heritage: "Helm"
     release: "datadog"
   name: datadog-cluster-checks

--- a/Dockerfiles/manifests/cluster-checks-runners/agent-services.yaml
+++ b/Dockerfiles/manifests/cluster-checks-runners/agent-services.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: default
   labels:
     app: "datadog"
-    chart: "datadog-2.28.13"
+    chart: "datadog-2.30.16"
     release: "datadog"
     heritage: "Helm"
 spec:

--- a/Dockerfiles/manifests/cluster-checks-runners/cluster-agent-deployment.yaml
+++ b/Dockerfiles/manifests/cluster-checks-runners/cluster-agent-deployment.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: datadog-cluster-agent
       containers:
         - name: cluster-agent
-          image: "gcr.io/datadoghq/cluster-agent:1.16.0"
+          image: "gcr.io/datadoghq/cluster-agent:1.18.0"
           imagePullPolicy: IfNotPresent
           resources: {}
           ports:
@@ -124,13 +124,15 @@ spec:
           configMap:
             name: datadog-installinfo
       affinity:
-        # Force scheduling the cluster agents on different nodes
+        # Prefer scheduling the cluster agents on different nodes
         # to guarantee that the standby instance can immediately take the lead from a leader running of a faulty node.
         podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchLabels:
-                  app: datadog-cluster-agent
-              topologyKey: kubernetes.io/hostname
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 50
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: datadog-cluster-agent
+                topologyKey: kubernetes.io/hostname
       nodeSelector:
         kubernetes.io/os: linux

--- a/Dockerfiles/manifests/cluster-checks-runners/cluster-agent-rbac.yaml
+++ b/Dockerfiles/manifests/cluster-checks-runners/cluster-agent-rbac.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app: "datadog"
-    chart: "datadog-2.28.13"
+    chart: "datadog-2.30.16"
     heritage: "Helm"
     release: "datadog"
   name: datadog-cluster-agent
@@ -113,6 +113,16 @@ rules:
       - get
       - update
   - apiGroups:
+      - ""
+    resources:
+      - persistentvolumes
+      - persistentvolumeclaims
+      - serviceaccounts
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
       - "apps"
     resources:
       - deployments
@@ -128,6 +138,25 @@ rules:
     resources:
       - cronjobs
       - jobs
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
+      - "rbac.authorization.k8s.io"
+    resources:
+      - roles
+      - rolebindings
+      - clusterroles
+      - clusterrolebindings
     verbs:
       - list
       - get
@@ -171,7 +200,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app: "datadog"
-    chart: "datadog-2.28.13"
+    chart: "datadog-2.30.16"
     release: "datadog"
     heritage: "Helm"
   name: datadog-cluster-agent-system-auth-delegator

--- a/Dockerfiles/manifests/cluster-checks-runners/daemonset.yaml
+++ b/Dockerfiles/manifests/cluster-checks-runners/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.32.4"
+          image: "gcr.io/datadoghq/agent:7.34.0"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -69,6 +69,8 @@ spec:
               value: "false"
             - name: DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE
               value: "true"
+            - name: DD_LOGS_CONFIG_AUTO_MULTI_LINE_DETECTION
+              value: "false"
             - name: DD_HEALTH_PORT
               value: "5555"
             - name: DD_DOGSTATSD_SOCKET
@@ -125,7 +127,7 @@ spec:
             timeoutSeconds: 5
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.32.4"
+          image: "gcr.io/datadoghq/agent:7.34.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -135,7 +137,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.32.4"
+          image: "gcr.io/datadoghq/agent:7.34.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:

--- a/Dockerfiles/manifests/kubernetes_state_core/README.md
+++ b/Dockerfiles/manifests/kubernetes_state_core/README.md
@@ -1,6 +1,6 @@
 The kubernetes manifests found in this directory have been automatically generated
 from the [helm chart `datadog/datadog`](https://github.com/DataDog/helm-charts/tree/master/charts/datadog)
-version 2.28.13 with the following `values.yaml`:
+version 2.30.16 with the following `values.yaml`:
 
 ```yaml
 datadog:

--- a/Dockerfiles/manifests/kubernetes_state_core/cluster-agent-deployment.yaml
+++ b/Dockerfiles/manifests/kubernetes_state_core/cluster-agent-deployment.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: datadog-cluster-agent
       containers:
         - name: cluster-agent
-          image: "gcr.io/datadoghq/cluster-agent:1.16.0"
+          image: "gcr.io/datadoghq/cluster-agent:1.18.0"
           imagePullPolicy: IfNotPresent
           resources: {}
           ports:
@@ -113,13 +113,15 @@ spec:
               - key: kubernetes_state_core.yaml.default
                 path: kubernetes_state_core.yaml.default
       affinity:
-        # Force scheduling the cluster agents on different nodes
+        # Prefer scheduling the cluster agents on different nodes
         # to guarantee that the standby instance can immediately take the lead from a leader running of a faulty node.
         podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchLabels:
-                  app: datadog-cluster-agent
-              topologyKey: kubernetes.io/hostname
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 50
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: datadog-cluster-agent
+                topologyKey: kubernetes.io/hostname
       nodeSelector:
         kubernetes.io/os: linux

--- a/Dockerfiles/manifests/kubernetes_state_core/cluster-agent-rbac.yaml
+++ b/Dockerfiles/manifests/kubernetes_state_core/cluster-agent-rbac.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app: "datadog"
-    chart: "datadog-2.28.13"
+    chart: "datadog-2.30.16"
     heritage: "Helm"
     release: "datadog"
   name: datadog-cluster-agent
@@ -102,6 +102,16 @@ rules:
       - get
       - update
   - apiGroups:
+      - ""
+    resources:
+      - persistentvolumes
+      - persistentvolumeclaims
+      - serviceaccounts
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
       - "apps"
     resources:
       - deployments
@@ -117,6 +127,25 @@ rules:
     resources:
       - cronjobs
       - jobs
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
+      - "rbac.authorization.k8s.io"
+    resources:
+      - roles
+      - rolebindings
+      - clusterroles
+      - clusterrolebindings
     verbs:
       - list
       - get

--- a/Dockerfiles/manifests/kubernetes_state_core/daemonset.yaml
+++ b/Dockerfiles/manifests/kubernetes_state_core/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.32.4"
+          image: "gcr.io/datadoghq/agent:7.34.0"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -69,6 +69,8 @@ spec:
               value: "false"
             - name: DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE
               value: "true"
+            - name: DD_LOGS_CONFIG_AUTO_MULTI_LINE_DETECTION
+              value: "false"
             - name: DD_HEALTH_PORT
               value: "5555"
             - name: DD_DOGSTATSD_SOCKET
@@ -126,7 +128,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.32.4"
+          image: "gcr.io/datadoghq/agent:7.34.0"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -192,7 +194,7 @@ spec:
               readOnly: true
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.32.4"
+          image: "gcr.io/datadoghq/agent:7.34.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -202,7 +204,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.32.4"
+          image: "gcr.io/datadoghq/agent:7.34.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:

--- a/Dockerfiles/manifests/orchestrator-explorer/README.md
+++ b/Dockerfiles/manifests/orchestrator-explorer/README.md
@@ -1,6 +1,6 @@
 The kubernetes manifests found in this directory have been automatically generated
 from the [helm chart `datadog/datadog`](https://github.com/DataDog/helm-charts/tree/master/charts/datadog)
-version 2.28.13 with the following `values.yaml`:
+version 2.30.16 with the following `values.yaml`:
 
 ```yaml
 datadog:

--- a/Dockerfiles/manifests/orchestrator-explorer/cluster-agent-deployment.yaml
+++ b/Dockerfiles/manifests/orchestrator-explorer/cluster-agent-deployment.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: datadog-cluster-agent
       containers:
         - name: cluster-agent
-          image: "gcr.io/datadoghq/cluster-agent:1.16.0"
+          image: "gcr.io/datadoghq/cluster-agent:1.18.0"
           imagePullPolicy: IfNotPresent
           resources: {}
           ports:
@@ -104,13 +104,15 @@ spec:
           configMap:
             name: datadog-installinfo
       affinity:
-        # Force scheduling the cluster agents on different nodes
+        # Prefer scheduling the cluster agents on different nodes
         # to guarantee that the standby instance can immediately take the lead from a leader running of a faulty node.
         podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchLabels:
-                  app: datadog-cluster-agent
-              topologyKey: kubernetes.io/hostname
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 50
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: datadog-cluster-agent
+                topologyKey: kubernetes.io/hostname
       nodeSelector:
         kubernetes.io/os: linux

--- a/Dockerfiles/manifests/orchestrator-explorer/cluster-agent-rbac.yaml
+++ b/Dockerfiles/manifests/orchestrator-explorer/cluster-agent-rbac.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app: "datadog"
-    chart: "datadog-2.28.13"
+    chart: "datadog-2.30.16"
     heritage: "Helm"
     release: "datadog"
   name: datadog-cluster-agent
@@ -102,6 +102,16 @@ rules:
       - get
       - update
   - apiGroups:
+      - ""
+    resources:
+      - persistentvolumes
+      - persistentvolumeclaims
+      - serviceaccounts
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
       - "apps"
     resources:
       - deployments
@@ -117,6 +127,25 @@ rules:
     resources:
       - cronjobs
       - jobs
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
+      - "rbac.authorization.k8s.io"
+    resources:
+      - roles
+      - rolebindings
+      - clusterroles
+      - clusterrolebindings
     verbs:
       - list
       - get

--- a/Dockerfiles/manifests/orchestrator-explorer/daemonset.yaml
+++ b/Dockerfiles/manifests/orchestrator-explorer/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.32.4"
+          image: "gcr.io/datadoghq/agent:7.34.0"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -69,6 +69,8 @@ spec:
               value: "false"
             - name: DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE
               value: "true"
+            - name: DD_LOGS_CONFIG_AUTO_MULTI_LINE_DETECTION
+              value: "false"
             - name: DD_HEALTH_PORT
               value: "5555"
             - name: DD_DOGSTATSD_SOCKET
@@ -124,7 +126,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.32.4"
+          image: "gcr.io/datadoghq/agent:7.34.0"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -190,7 +192,7 @@ spec:
               readOnly: true
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.32.4"
+          image: "gcr.io/datadoghq/agent:7.34.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -200,7 +202,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.32.4"
+          image: "gcr.io/datadoghq/agent:7.34.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:

--- a/Dockerfiles/manifests/security-agent/README.md
+++ b/Dockerfiles/manifests/security-agent/README.md
@@ -1,6 +1,6 @@
 The kubernetes manifests found in this directory have been automatically generated
 from the [helm chart `datadog/datadog`](https://github.com/DataDog/helm-charts/tree/master/charts/datadog)
-version 2.28.13 with the following `values.yaml`:
+version 2.30.16 with the following `values.yaml`:
 
 ```yaml
 datadog:

--- a/Dockerfiles/manifests/security-agent/cluster-agent-deployment.yaml
+++ b/Dockerfiles/manifests/security-agent/cluster-agent-deployment.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: datadog-cluster-agent
       containers:
         - name: cluster-agent
-          image: "gcr.io/datadoghq/cluster-agent:1.16.0"
+          image: "gcr.io/datadoghq/cluster-agent:1.18.0"
           imagePullPolicy: IfNotPresent
           resources: {}
           ports:
@@ -108,13 +108,15 @@ spec:
           configMap:
             name: datadog-installinfo
       affinity:
-        # Force scheduling the cluster agents on different nodes
+        # Prefer scheduling the cluster agents on different nodes
         # to guarantee that the standby instance can immediately take the lead from a leader running of a faulty node.
         podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchLabels:
-                  app: datadog-cluster-agent
-              topologyKey: kubernetes.io/hostname
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 50
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: datadog-cluster-agent
+                topologyKey: kubernetes.io/hostname
       nodeSelector:
         kubernetes.io/os: linux

--- a/Dockerfiles/manifests/security-agent/cluster-agent-rbac.yaml
+++ b/Dockerfiles/manifests/security-agent/cluster-agent-rbac.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app: "datadog"
-    chart: "datadog-2.28.13"
+    chart: "datadog-2.30.16"
     heritage: "Helm"
     release: "datadog"
   name: datadog-cluster-agent
@@ -102,6 +102,16 @@ rules:
       - get
       - update
   - apiGroups:
+      - ""
+    resources:
+      - persistentvolumes
+      - persistentvolumeclaims
+      - serviceaccounts
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
       - "apps"
     resources:
       - deployments
@@ -117,6 +127,25 @@ rules:
     resources:
       - cronjobs
       - jobs
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
+      - "rbac.authorization.k8s.io"
+    resources:
+      - roles
+      - rolebindings
+      - clusterroles
+      - clusterrolebindings
     verbs:
       - list
       - get

--- a/Dockerfiles/manifests/security-agent/daemonset.yaml
+++ b/Dockerfiles/manifests/security-agent/daemonset.yaml
@@ -26,7 +26,7 @@ spec:
       hostPID: true
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.32.4"
+          image: "gcr.io/datadoghq/agent:7.34.0"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -72,6 +72,8 @@ spec:
               value: "false"
             - name: DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE
               value: "true"
+            - name: DD_LOGS_CONFIG_AUTO_MULTI_LINE_DETECTION
+              value: "false"
             - name: DD_HEALTH_PORT
               value: "5555"
             - name: DD_DOGSTATSD_SOCKET
@@ -133,7 +135,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.32.4"
+          image: "gcr.io/datadoghq/agent:7.34.0"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -204,7 +206,7 @@ spec:
               mountPath: /etc/datadog-agent/system-probe.yaml
               subPath: system-probe.yaml
         - name: system-probe
-          image: "gcr.io/datadoghq/agent:7.32.4"
+          image: "gcr.io/datadoghq/agent:7.34.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -274,7 +276,7 @@ spec:
               mountPropagation: None
               readOnly: true
         - name: security-agent
-          image: "gcr.io/datadoghq/agent:7.32.4"
+          image: "gcr.io/datadoghq/agent:7.34.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -361,7 +363,7 @@ spec:
               subPath: system-probe.yaml
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.32.4"
+          image: "gcr.io/datadoghq/agent:7.34.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -371,7 +373,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.32.4"
+          image: "gcr.io/datadoghq/agent:7.34.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -409,7 +411,7 @@ spec:
               value: "yes"
           resources: {}
         - name: seccomp-setup
-          image: "gcr.io/datadoghq/agent:7.32.4"
+          image: "gcr.io/datadoghq/agent:7.34.0"
           command:
             - cp
             - /etc/config/system-probe-seccomp.json

--- a/Dockerfiles/manifests/security-agent/system-probe-configmap.yaml
+++ b/Dockerfiles/manifests/security-agent/system-probe-configmap.yaml
@@ -32,7 +32,6 @@ data:
       enabled: false
     runtime_security_config:
       enabled: true
-      debug: false
       socket: /var/run/sysprobe/runtime-security.sock
       policies:
         dir: /etc/datadog-agent/runtime-security.d


### PR DESCRIPTION
### What does this PR do?

Re-generate the static kubernetes sample manifests.

### Motivation

Align them with those in [`documentation`](https://github.com/DataDog/documentation/tree/master/static/resources/yaml) : DataDog/documentation#13414

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
