### PR TITLE
pkg/trace/api: ensure TagStats.Stats fields are not nil

### DIFF
--- a/cmd/trace-agent/test/agent.go
+++ b/cmd/trace-agent/test/agent.go
@@ -48,7 +48,7 @@ func newAgentRunner(ddAddr string, verbose bool) (*agentRunner, error) {
 	}
 	// TODO(gbbr): find a way to re-use the same binary within a whole run
 	// instead of creating new ones on each test creating a new runner.
-	err = exec.Command("go", "build", "-o", binpath, "github.com/DataDog/datadog-agent/cmd/trace-agent").Run()
+	err = exec.Command("go", "build", "-tags", "otlp", "-o", binpath, "github.com/DataDog/datadog-agent/cmd/trace-agent").Run()
 	if err != nil {
 		if verbose {
 			log.Printf("error installing trace-agent: %v", err)
@@ -195,11 +195,7 @@ func (s *agentRunner) createConfigFile(conf []byte) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	dir, err := ioutil.TempDir("", "agent-conf-")
-	if err != nil {
-		return "", err
-	}
-	f, err := os.Create(filepath.Join(dir, "datadog.yaml"))
+	f, err := os.Create(filepath.Join(s.bindir, "datadog.yaml"))
 	if err != nil {
 		return "", err
 	}

--- a/cmd/trace-agent/test/testsuite/otlp_test.go
+++ b/cmd/trace-agent/test/testsuite/otlp_test.go
@@ -1,0 +1,199 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package testsuite
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/cmd/trace-agent/test"
+	"github.com/DataDog/datadog-agent/pkg/trace/pb"
+	"github.com/DataDog/datadog-agent/pkg/trace/pb/otlppb"
+	"github.com/DataDog/datadog-agent/pkg/trace/testutil"
+	"github.com/stretchr/testify/assert"
+
+	"google.golang.org/grpc"
+)
+
+var otlpTestID128 = []byte{0x72, 0xdf, 0x52, 0xa, 0xf2, 0xbd, 0xe7, 0xa5, 0x24, 0x0, 0x31, 0xea, 0xd7, 0x50, 0xe5, 0xf3}
+
+func makeOTLPTestSpan(start uint64) *otlppb.Span {
+	return &otlppb.Span{
+		TraceId:           otlpTestID128,
+		SpanId:            otlpTestID128,
+		TraceState:        "state",
+		ParentSpanId:      []byte{0},
+		Name:              "/path",
+		Kind:              otlppb.Span_SPAN_KIND_SERVER,
+		StartTimeUnixNano: start,
+		EndTimeUnixNano:   start + 200000000,
+		Attributes: []*otlppb.KeyValue{
+			{Key: "name", Value: &otlppb.AnyValue{Value: &otlppb.AnyValue_StringValue{StringValue: "john"}}},
+			{Key: "name", Value: &otlppb.AnyValue{Value: &otlppb.AnyValue_DoubleValue{DoubleValue: 1.2}}},
+			{Key: "count", Value: &otlppb.AnyValue{Value: &otlppb.AnyValue_IntValue{IntValue: 2}}},
+		},
+		DroppedAttributesCount: 0,
+		Events: []*otlppb.Span_Event{
+			{
+				TimeUnixNano: 123,
+				Name:         "boom",
+				Attributes: []*otlppb.KeyValue{
+					{Key: "message", Value: &otlppb.AnyValue{Value: &otlppb.AnyValue_StringValue{StringValue: "Out of memory"}}},
+					{Key: "accuracy", Value: &otlppb.AnyValue{Value: &otlppb.AnyValue_DoubleValue{DoubleValue: 2.4}}},
+				},
+				DroppedAttributesCount: 2,
+			},
+			{
+				TimeUnixNano: 456,
+				Name:         "exception",
+				Attributes: []*otlppb.KeyValue{
+					{Key: "exception.message", Value: &otlppb.AnyValue{Value: &otlppb.AnyValue_StringValue{StringValue: "Out of memory"}}},
+					{Key: "exception.type", Value: &otlppb.AnyValue{Value: &otlppb.AnyValue_StringValue{StringValue: "mem"}}},
+					{Key: "exception.stacktrace", Value: &otlppb.AnyValue{Value: &otlppb.AnyValue_StringValue{StringValue: "1/2/3"}}},
+				},
+				DroppedAttributesCount: 2,
+			},
+		},
+		DroppedEventsCount: 0,
+		Links:              nil,
+		DroppedLinksCount:  0,
+		Status: &otlppb.Status{
+			Message: "Error",
+			Code:    otlppb.Status_STATUS_CODE_ERROR,
+		},
+	}
+}
+
+func TestOTLPIngest(t *testing.T) {
+	var r test.Runner
+	if err := r.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := r.Shutdown(time.Second); err != nil {
+			t.Log("shutdown: ", err)
+		}
+	}()
+
+	t.Run("passthrough", func(t *testing.T) {
+		port := testutil.FreeTCPPort(t)
+		c := fmt.Sprintf(`
+otlp_config:
+  traces:
+    internal_port: %d
+  receiver:
+    grpc:
+      endpoint: 0.0.0.0:5111
+apm_config:
+  env: my-env
+`, port)
+		if err := r.RunAgent([]byte(c)); err != nil {
+			t.Fatal(err)
+		}
+		defer r.KillAgent()
+
+		conn, err := grpc.Dial(fmt.Sprintf("localhost:%d", port), grpc.WithBlock(), grpc.WithInsecure())
+		if err != nil {
+			log.Fatal("Error dialing: ", err)
+		}
+		client := otlppb.NewTraceServiceClient(conn)
+		pack := otlppb.ExportTraceServiceRequest{
+			ResourceSpans: []*otlppb.ResourceSpans{
+				{
+					Resource: &otlppb.Resource{
+						Attributes: []*otlppb.KeyValue{
+							{Key: "service.name", Value: &otlppb.AnyValue{Value: &otlppb.AnyValue_StringValue{StringValue: "pylons"}}},
+						},
+					},
+					InstrumentationLibrarySpans: []*otlppb.InstrumentationLibrarySpans{
+						{
+							InstrumentationLibrary: &otlppb.InstrumentationLibrary{Name: "test", Version: "0.1t"},
+							Spans:                  []*otlppb.Span{makeOTLPTestSpan(uint64(time.Now().UnixNano()))},
+						},
+					},
+				},
+			},
+		}
+		_, err = client.Export(context.Background(), &pack)
+		if err != nil {
+			log.Fatal("Error calling: ", err)
+		}
+		waitForTrace(t, &r, func(p pb.AgentPayload) {
+			assert := assert.New(t)
+			assert.Equal(p.Env, "my-env")
+			assert.Len(p.TracerPayloads, 1)
+			assert.Len(p.TracerPayloads[0].Chunks, 1)
+			assert.Len(p.TracerPayloads[0].Chunks[0].Spans, 1)
+			assert.Equal(p.TracerPayloads[0].Chunks[0].Spans[0].Meta["name"], "john")
+		})
+	})
+
+	// regression test for DataDog/datadog-agent#11297
+	t.Run("duplicate-spanID", func(t *testing.T) {
+		port := testutil.FreeTCPPort(t)
+		c := fmt.Sprintf(`
+otlp_config:
+  traces:
+    internal_port: %d
+  receiver:
+    grpc:
+      endpoint: 0.0.0.0:5111
+apm_config:
+  env: my-env
+`, port)
+		if err := r.RunAgent([]byte(c)); err != nil {
+			t.Fatal(err)
+		}
+		defer r.KillAgent()
+
+		conn, err := grpc.Dial(fmt.Sprintf("localhost:%d", port), grpc.WithBlock(), grpc.WithInsecure())
+		if err != nil {
+			log.Fatal("Error dialing: ", err)
+		}
+		client := otlppb.NewTraceServiceClient(conn)
+		pack := otlppb.ExportTraceServiceRequest{
+			ResourceSpans: []*otlppb.ResourceSpans{
+				{
+					Resource: &otlppb.Resource{
+						Attributes: []*otlppb.KeyValue{
+							{Key: "service.name", Value: &otlppb.AnyValue{Value: &otlppb.AnyValue_StringValue{StringValue: "pylons"}}},
+						},
+					},
+					InstrumentationLibrarySpans: []*otlppb.InstrumentationLibrarySpans{
+						{
+							InstrumentationLibrary: &otlppb.InstrumentationLibrary{Name: "test", Version: "0.1t"},
+							Spans: []*otlppb.Span{
+								makeOTLPTestSpan(uint64(time.Now().UnixNano())),
+								makeOTLPTestSpan(uint64(time.Now().UnixNano())),
+							},
+						},
+					},
+				},
+			},
+		}
+		_, err = client.Export(context.Background(), &pack)
+		if err != nil {
+			log.Fatal("Error calling: ", err)
+		}
+		timeout := time.After(1 * time.Second)
+	loop:
+		for {
+			select {
+			case <-timeout:
+				t.Fatal("Timed out waiting for duplicate SpanID warning.")
+			default:
+				time.Sleep(10 * time.Millisecond)
+				if strings.Contains(r.AgentLog(), `Found malformed trace with duplicate span ID (reason:duplicate_span_id): service:"pylons"`) {
+					break loop
+				}
+			}
+		}
+	})
+}

--- a/pkg/trace/api/otlp.go
+++ b/pkg/trace/api/otlp.go
@@ -219,6 +219,7 @@ func (o *OTLPReceiver) processRequest(protocol string, header http.Header, in *o
 				TracerVersion:   fmt.Sprintf("otlp-%s", rattr[string(semconv.AttributeTelemetrySDKVersion)]),
 				EndpointVersion: fmt.Sprintf("opentelemetry_%s_v1", protocol),
 			},
+			Stats: info.NewStats(),
 		}
 		tracesByID := make(map[uint64]pb.Trace)
 		for _, libspans := range rspans.InstrumentationLibrarySpans {

--- a/pkg/trace/info/stats.go
+++ b/pkg/trace/info/stats.go
@@ -124,7 +124,7 @@ type TagStats struct {
 }
 
 func newTagStats(tags Tags) *TagStats {
-	return &TagStats{tags, Stats{TracesDropped: &TracesDropped{}, SpansMalformed: &SpansMalformed{}}}
+	return &TagStats{Tags: tags, Stats: NewStats()}
 }
 
 // AsTags returns all the tags contained in the TagStats.
@@ -332,6 +332,8 @@ func (s *samplingPriorityStats) TagValues() map[string]int64 {
 
 // Stats holds the metrics that will be reported every 10s by the agent.
 // Its fields require to be accessed in an atomic way.
+//
+// Use NewStats to initialise.
 type Stats struct {
 	// TracesReceived is the total number of traces received, including the dropped ones.
 	TracesReceived int64
@@ -365,6 +367,14 @@ type Stats struct {
 	PayloadAccepted int64
 	// PayloadRefused counts the number of payloads that have been rejected by the rate limiter.
 	PayloadRefused int64
+}
+
+// NewStats returns new, ready to use stats.
+func NewStats() Stats {
+	return Stats{
+		TracesDropped:  new(TracesDropped),
+		SpansMalformed: new(SpansMalformed),
+	}
 }
 
 func (s *Stats) update(recent *Stats) {

--- a/pkg/trace/pb/otlppb/trace_service.pb.go
+++ b/pkg/trace/pb/otlppb/trace_service.pb.go
@@ -81,7 +81,7 @@ func NewTraceServiceClient(cc *grpc.ClientConn) TraceServiceClient {
 
 func (c *traceServiceClient) Export(ctx context.Context, in *ExportTraceServiceRequest, opts ...grpc.CallOption) (*ExportTraceServiceResponse, error) {
 	out := new(ExportTraceServiceResponse)
-	err := grpc.Invoke(ctx, "/otlppb.TraceService/Export", in, out, c.cc, opts...)
+	err := grpc.Invoke(ctx, "/opentelemetry.proto.collector.trace.v1.TraceService/Export", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +110,7 @@ func _TraceService_Export_Handler(srv interface{}, ctx context.Context, dec func
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/otlppb.TraceService/Export",
+		FullMethod: "/opentelemetry.proto.collector.trace.v1.TraceService/Export",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(TraceServiceServer).Export(ctx, req.(*ExportTraceServiceRequest))

--- a/releasenotes/notes/apm-otlp-panic-739fb84a9e87605a.yaml
+++ b/releasenotes/notes/apm-otlp-panic-739fb84a9e87605a.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    APM: Fixed an issue which caused a panic when receiving OpenTelemetry traces with invalid data (specifically duplicate SpanIDs).
+    APM: Fixed an issue which caused a panic when receiving OTLP traces with invalid data (specifically duplicate SpanIDs).

--- a/releasenotes/notes/apm-otlp-panic-739fb84a9e87605a.yaml
+++ b/releasenotes/notes/apm-otlp-panic-739fb84a9e87605a.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: Fixed an issue which caused a panic when receiving OpenTelemetry traces with invalid data (specifically duplicate SpanIDs).


### PR DESCRIPTION
This change ensures that TagStats.Stats fields are never nil, resulting
in a panic when invalid data is received.

Closes #11297