### PR TITLE
[process-agent] Add --cfgpath and deprecate --config

### DIFF
--- a/cmd/process-agent/app/status.go
+++ b/cmd/process-agent/app/status.go
@@ -137,7 +137,7 @@ func StatusCmd() *cobra.Command {
 }
 
 func runStatus(cmd *cobra.Command, _ []string) error {
-	err := config.LoadConfigIfExists(cmd.Flag("config").Value.String())
+	err := config.LoadConfigIfExists(cmd.Flag("cfgpath").Value.String())
 	if err != nil {
 		writeError(os.Stdout, err)
 		return err

--- a/cmd/process-agent/main.go
+++ b/cmd/process-agent/main.go
@@ -36,7 +36,7 @@ func main() {
 	rootCmd.PersistentFlags().StringVar(&opts.check, "check", "",
 		"Run a specific check and print the results. Choose from: process, connections, realtime, process_discovery")
 
-	fixDeprecatedFlags()
+	fixDeprecatedFlags(os.Args, os.Stdout)
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(-1)
 	}

--- a/cmd/process-agent/main.go
+++ b/cmd/process-agent/main.go
@@ -24,9 +24,7 @@ func rootCmdRun(cmd *cobra.Command, args []string) {
 }
 
 func main() {
-	ignore := ""
-	rootCmd.PersistentFlags().StringVar(&opts.configPath, "config", flags.DefaultConfPath, "Path to datadog.yaml config")
-	rootCmd.PersistentFlags().StringVar(&ignore, "ddconfig", "", "[deprecated] Path to dd-agent config")
+	rootCmd.PersistentFlags().StringVar(&opts.configPath, "cfgpath", flags.DefaultConfPath, "Path to datadog.yaml config")
 
 	if flags.DefaultSysProbeConfPath != "" {
 		rootCmd.PersistentFlags().StringVar(&opts.sysProbeConfigPath, "sysprobe-config", flags.DefaultSysProbeConfPath, "Path to system-probe.yaml config")

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -109,9 +109,14 @@ func init() {
 func fixDeprecatedFlags() {
 	deprecatedFlags := []string{
 		// Global flags
-		"-config", "-ddconfig", "-sysprobe-config", "-pid", "-info", "-version", "-check",
+		"-config", "--config", "-sysprobe-config", "-pid", "-info", "-version", "-check",
 		// Windows flags
 		"-install-service", "-uninstall-service", "-start-service", "-stop-service", "-foreground",
+	}
+
+	replaceFlags := map[string]string{
+		"-config":  "--cfgpath",
+		"--config": "--cfgpath",
 	}
 
 	for i, arg := range os.Args {
@@ -119,8 +124,15 @@ func fixDeprecatedFlags() {
 			if !strings.HasPrefix(arg, f) {
 				continue
 			}
-			fmt.Printf("WARNING: `%s` argument is deprecated and will be removed in a future version. Please use `-%[1]s` instead.\n", f)
-			os.Args[i] = "-" + os.Args[i]
+			replaceWith := replaceFlags[f]
+			if len(replaceWith) == 0 {
+				os.Args[i] = "-" + f
+				os.Args[i] = "-" + os.Args[i]
+			} else {
+				os.Args[i] = strings.Replace(os.Args[i], f, replaceWith, 1)
+			}
+
+			fmt.Printf("WARNING: `%s` argument is deprecated and will be removed in a future version. Please use `%s` instead.\n", f, replaceWith)
 		}
 	}
 }

--- a/cmd/process-agent/main_common_test.go
+++ b/cmd/process-agent/main_common_test.go
@@ -1,0 +1,127 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFixDeprecatedFlags(t *testing.T) {
+	tests := []struct {
+		cli        string
+		expectArgs []string
+		expectWarn string
+	}{
+		{
+			cli: "-config datadog.yaml",
+			expectArgs: []string{
+				"--cfgpath",
+				"datadog.yaml",
+			},
+			expectWarn: deprecatedFlagWarning("-config", "--cfgpath"),
+		},
+		{
+			cli: "-config=datadog.yaml",
+			expectArgs: []string{
+				"--cfgpath=datadog.yaml",
+			},
+			expectWarn: deprecatedFlagWarning("-config", "--cfgpath"),
+		},
+		{
+			cli: "--cfgpath=datadog.yaml",
+			expectArgs: []string{
+				"--cfgpath=datadog.yaml",
+			},
+		},
+		{
+			cli: "-sysprobe-config system-probe.yaml",
+			expectArgs: []string{
+				"--sysprobe-config",
+				"system-probe.yaml",
+			},
+			expectWarn: deprecatedFlagWarning("-sysprobe-config", "--sysprobe-config"),
+		},
+		{
+			cli: "-pid pidfile",
+			expectArgs: []string{
+				"--pid",
+				"pidfile",
+			},
+			expectWarn: deprecatedFlagWarning("-pid", "--pid"),
+		},
+		{
+			cli: "-info",
+			expectArgs: []string{
+				"--info",
+			},
+			expectWarn: deprecatedFlagWarning("-info", "--info"),
+		},
+		{
+			cli: "-version",
+			expectArgs: []string{
+				"--version",
+			},
+			expectWarn: deprecatedFlagWarning("-version", "--version"),
+		},
+		{
+			cli: "-check process",
+			expectArgs: []string{
+				"--check",
+				"process",
+			},
+			expectWarn: deprecatedFlagWarning("-check", "--check"),
+		},
+		{
+			cli: "-install-service",
+			expectArgs: []string{
+				"--install-service",
+			},
+			expectWarn: deprecatedFlagWarning("-install-service", "--install-service"),
+		},
+		{
+			cli: "-uninstall-service",
+			expectArgs: []string{
+				"--uninstall-service",
+			},
+			expectWarn: deprecatedFlagWarning("-uninstall-service", "--uninstall-service"),
+		},
+		{
+			cli: "-start-service",
+			expectArgs: []string{
+				"--start-service",
+			},
+			expectWarn: deprecatedFlagWarning("-start-service", "--start-service"),
+		},
+		{
+			cli: "-stop-service",
+			expectArgs: []string{
+				"--stop-service",
+			},
+			expectWarn: deprecatedFlagWarning("-stop-service", "--stop-service"),
+		},
+		{
+			cli: "-foreground",
+			expectArgs: []string{
+				"--foreground",
+			},
+			expectWarn: deprecatedFlagWarning("-foreground", "--foreground"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.cli, func(t *testing.T) {
+			w := strings.Builder{}
+			args := strings.Split(tc.cli, " ")
+			fixDeprecatedFlags(args, &w)
+
+			assert.Equal(t, tc.expectArgs, args)
+			assert.Equal(t, tc.expectWarn, w.String())
+		})
+	}
+}

--- a/cmd/process-agent/main_windows.go
+++ b/cmd/process-agent/main_windows.go
@@ -135,7 +135,7 @@ func main() {
 	rootCmd.PersistentFlags().BoolVar(&winopts.foreground, "foreground", false, "Always run foreground instead whether session is interactive or not")
 
 	// Invoke the Agent
-	fixDeprecatedFlags()
+	fixDeprecatedFlags(os.Args, os.Stdout)
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(-1)
 	}

--- a/cmd/process-agent/main_windows.go
+++ b/cmd/process-agent/main_windows.go
@@ -121,10 +121,8 @@ func runService(isDebug bool) {
 
 // main is the main application entry point
 func main() {
-	ignore := ""
-	rootCmd.PersistentFlags().StringVar(&opts.configPath, "config", defaultConfigPath, "Path to datadog.yaml config")
+	rootCmd.PersistentFlags().StringVar(&opts.configPath, "cfgpath", defaultConfigPath, "Path to datadog.yaml config")
 	rootCmd.PersistentFlags().StringVar(&opts.sysProbeConfigPath, "sysprobe-config", defaultSysProbeConfigPath, "Path to system-probe.yaml config")
-	rootCmd.PersistentFlags().StringVar(&ignore, "ddconfig", "", "[deprecated] Path to dd-agent config")
 	rootCmd.PersistentFlags().BoolVarP(&opts.info, "info", "i", false, "Show info about running process agent and exit")
 	rootCmd.PersistentFlags().BoolVarP(&opts.version, "version", "v", false, "Print the version and exit")
 	rootCmd.PersistentFlags().StringVar(&opts.check, "check", "", "Run a specific check and print the results. Choose from: process, connections, realtime, process_discovery")

--- a/releasenotes/notes/process-agent-cfgpath-446137d2fa9c6b12.yaml
+++ b/releasenotes/notes/process-agent-cfgpath-446137d2fa9c6b12.yaml
@@ -1,0 +1,10 @@
+---
+
+enhancements:
+  - |
+    Add the ``--cfgpath`` parameter in the Process Agent replacing ``--config``.
+deprecations:
+  - |
+    Remove the unused ``--ddconfig`` (``-ddconfig``) parameter.
+    Deprecate the ``--config`` (``-config``) parameter (show warning on usage).
+


### PR DESCRIPTION
### What does this PR do?

- Add the `--cfgpath` parameter in the Process Agent replacing `--config`.
- Remove the unused `--ddconfig` (`-ddconfig`) parameter.
- Deprecate the `--config` (`-config`) parameter (show warning on usage).

### Motivation

Consistency with the Core Agent and avoiding possible confusion between this parameter with the `config` subcommand in the Process Agent.

### Describe how to test/QA your changes

The following should be tested in supported OSs (Windows, Linux, MacOS)
- Running with `--cfgpath` should correctly configure the config file to use.
- Running with `-config/--config` should still be supported and work correctly but show a warning.
- Running with `-ddconfig/--ddconfig` should show an error (unsupported parameter).

Since I am also touching `status` command we should test this is still working as expected.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
