### PR TITLE
[tasks] Enabling copyrights linting in CI pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,6 +154,15 @@ jobs:
           name: run license linting
           command: inv -e lint-licenses
 
+  copyrights_linting:
+    <<: *job_template
+    steps:
+      - restore_cache: *restore_source
+      - restore_cache: *restore_deps
+      - run:
+          name: run copyrights linting
+          command: inv -e lint-copyrights
+
   filename_linting:
     <<: *job_template
     steps:

--- a/cmd/agent/gui/gui.go
+++ b/cmd/agent/gui/gui.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package gui
 
 import (

--- a/cmd/process-agent/app/status_test.go
+++ b/cmd/process-agent/app/status_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package app
 
 import (

--- a/cmd/process-agent/app/version.go
+++ b/cmd/process-agent/app/version.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package app
 
 import (

--- a/cmd/process-agent/app/version_test.go
+++ b/cmd/process-agent/app/version_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package app
 
 import (

--- a/cmd/system-probe/utils/limiter.go
+++ b/cmd/system-probe/utils/limiter.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021-present Datadog, Inc.
+
 package utils
 
 import (

--- a/cmd/system-probe/utils/limiter_test.go
+++ b/cmd/system-probe/utils/limiter_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021-present Datadog, Inc.
+
 package utils
 
 import (

--- a/internal/patch/logr/funcr/internal/wrapper/wrapper.go
+++ b/internal/patch/logr/funcr/internal/wrapper/wrapper.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package wrapper
 
 import (

--- a/internal/tools/modparser/main.go
+++ b/internal/tools/modparser/main.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package main
 
 import (

--- a/internal/tools/modparser/main_test.go
+++ b/internal/tools/modparser/main_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package main
 
 import (

--- a/pkg/autodiscovery/common/utils/container_labels.go
+++ b/pkg/autodiscovery/common/utils/container_labels.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package utils
 
 import (

--- a/pkg/autodiscovery/common/utils/container_labels_test.go
+++ b/pkg/autodiscovery/common/utils/container_labels_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package utils
 
 import (

--- a/pkg/autodiscovery/common/utils/pod_annotations.go
+++ b/pkg/autodiscovery/common/utils/pod_annotations.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package utils
 
 import (

--- a/pkg/autodiscovery/common/utils/pod_annotations_test.go
+++ b/pkg/autodiscovery/common/utils/pod_annotations_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package utils
 
 import (

--- a/pkg/collector/corechecks/snmp/internal/report/report_format_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_format_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package report
 
 import (

--- a/pkg/collector/corechecks/snmp/internal/valuestore/value_utils.go
+++ b/pkg/collector/corechecks/snmp/internal/valuestore/value_utils.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package valuestore
 
 var strippableSpecialChars = map[byte]bool{'\r': true, '\n': true, '\t': true}

--- a/pkg/config/remote/client.go
+++ b/pkg/config/remote/client.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package remote
 
 import (

--- a/pkg/config/remote/client_test.go
+++ b/pkg/config/remote/client_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package remote
 
 import (

--- a/pkg/config/remote/data/file.go
+++ b/pkg/config/remote/data/file.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package data
 
 import (

--- a/pkg/config/remote/data/file_test.go
+++ b/pkg/config/remote/data/file_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package data
 
 import (

--- a/pkg/config/remote/data/product.go
+++ b/pkg/config/remote/data/product.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package data
 
 // Product is a remote configuration product

--- a/pkg/config/remote/service/clients.go
+++ b/pkg/config/remote/service/clients.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package service
 
 import (

--- a/pkg/config/remote/service/clients_test.go
+++ b/pkg/config/remote/service/clients_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package service
 
 import (

--- a/pkg/config/remote/service/service_test.go
+++ b/pkg/config/remote/service/service_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package service
 
 import (

--- a/pkg/config/remote/service/util_test.go
+++ b/pkg/config/remote/service/util_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package service
 
 import (

--- a/pkg/config/remote/uptane/client_state.go
+++ b/pkg/config/remote/uptane/client_state.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package uptane
 
 // State represents the state of an uptane client

--- a/pkg/config/remote/uptane/local_store_test.go
+++ b/pkg/config/remote/uptane/local_store_test.go
@@ -1,9 +1,9 @@
-package uptane
-
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-present Datadog, Inc.
+// Copyright 2021-present Datadog, Inc.
+
+package uptane
 
 import (
 	"encoding/json"

--- a/pkg/ebpf/bytecode/runtime/runtime_compilation_helpers.go
+++ b/pkg/ebpf/bytecode/runtime/runtime_compilation_helpers.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 //go:build linux_bpf
 // +build linux_bpf
 

--- a/pkg/logs/schedulers/cca/scheduler_test.go
+++ b/pkg/logs/schedulers/cca/scheduler_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package cca
 
 import (

--- a/pkg/logs/sender/destination_sender.go
+++ b/pkg/logs/sender/destination_sender.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package sender
 
 import (

--- a/pkg/logs/sender/destination_sender_test.go
+++ b/pkg/logs/sender/destination_sender_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package sender
 
 import (

--- a/pkg/network/driver/driver_test.go
+++ b/pkg/network/driver/driver_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 //go:build windows && npm
 // +build windows,npm
 

--- a/pkg/process/util/status.go
+++ b/pkg/process/util/status.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package util
 
 import (

--- a/pkg/process/util/status_test.go
+++ b/pkg/process/util/status_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package util
 
 import (

--- a/pkg/proto/msgpgo/key.go
+++ b/pkg/proto/msgpgo/key.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package msgpgo
 
 // RemoteConfigKey is a RemoteConfigKey

--- a/pkg/remoteconfig/client/client.go
+++ b/pkg/remoteconfig/client/client.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package client
 
 import (

--- a/pkg/remoteconfig/client/config.go
+++ b/pkg/remoteconfig/client/config.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package client
 
 import (

--- a/pkg/remoteconfig/client/internal/uptane/partial_client_test.go
+++ b/pkg/remoteconfig/client/internal/uptane/partial_client_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package uptane
 
 import (

--- a/pkg/remoteconfig/client/internal/uptane/tuf_test.go
+++ b/pkg/remoteconfig/client/internal/uptane/tuf_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package uptane
 
 import (

--- a/pkg/remoteconfig/client/path.go
+++ b/pkg/remoteconfig/client/path.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package client
 
 import (

--- a/pkg/remoteconfig/client/path_test.go
+++ b/pkg/remoteconfig/client/path_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package client
 
 import (

--- a/pkg/remoteconfig/client/products.go
+++ b/pkg/remoteconfig/client/products.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package client
 
 import (

--- a/pkg/remoteconfig/client/products/apmsampling/remote_rates.go
+++ b/pkg/remoteconfig/client/products/apmsampling/remote_rates.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package apmsampling
 
 // SamplingMechanism is the source of the sampling rates.

--- a/pkg/security/probe/constantfetch/available.go
+++ b/pkg/security/probe/constantfetch/available.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 //go:build linux && linux_bpf
 // +build linux,linux_bpf
 

--- a/pkg/security/probe/constantfetch/available_unsupported.go
+++ b/pkg/security/probe/constantfetch/available_unsupported.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 //go:build linux && !linux_bpf
 // +build linux,!linux_bpf
 

--- a/pkg/security/secl/compiler/generators/accessors/resolver/fields_resolver.go
+++ b/pkg/security/secl/compiler/generators/accessors/resolver/fields_resolver.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package resolver
 
 import (

--- a/pkg/serverless/daemon/routes.go
+++ b/pkg/serverless/daemon/routes.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package daemon
 
 import (

--- a/pkg/serverless/invocationlifecycle/rand.go
+++ b/pkg/serverless/invocationlifecycle/rand.go
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016 Datadog, Inc.
+// Copyright 2022-present Datadog, Inc.
 
 package invocationlifecycle
 

--- a/pkg/serverless/trace/inferredspan/inferred_span.go
+++ b/pkg/serverless/trace/inferredspan/inferred_span.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package inferredspan
 
 import (

--- a/pkg/snmp/constants.go
+++ b/pkg/snmp/constants.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package snmp
 
 // DeviceReachableGetNextOid is used in getNext call to check if the device is reachable

--- a/pkg/snmp/traps/oid_resolver.go
+++ b/pkg/snmp/traps/oid_resolver.go
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2022-present Datadog, Inc.package traps
+// Copyright 2022-present Datadog, Inc.
 
 package traps
 

--- a/pkg/trace/api/telemetry.go
+++ b/pkg/trace/api/telemetry.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package api
 
 import (

--- a/pkg/trace/api/telemetry_test.go
+++ b/pkg/trace/api/telemetry_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package api
 
 import (

--- a/pkg/trace/sampler/env.go
+++ b/pkg/trace/sampler/env.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package sampler
 
 // tracers with an env value of "" or agentEnv share

--- a/pkg/trace/testutil/otlp.go
+++ b/pkg/trace/testutil/otlp.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package testutil
 
 import (

--- a/pkg/trace/testutil/otlp_test.go
+++ b/pkg/trace/testutil/otlp_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package testutil
 
 import (

--- a/pkg/util/static_tags.go
+++ b/pkg/util/static_tags.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package util
 
 import (

--- a/pkg/util/static_tags_test.go
+++ b/pkg/util/static_tags_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package util
 
 import (

--- a/pkg/workloadmeta/cached_entity.go
+++ b/pkg/workloadmeta/cached_entity.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package workloadmeta
 
 import (

--- a/pkg/workloadmeta/store_example_test.go
+++ b/pkg/workloadmeta/store_example_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package workloadmeta
 
 import "fmt"

--- a/pkg/workloadmeta/types_example_test.go
+++ b/pkg/workloadmeta/types_example_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package workloadmeta
 
 import "fmt"

--- a/tasks/libs/copyright.py
+++ b/tasks/libs/copyright.py
@@ -25,13 +25,22 @@ COPYRIGHT_REGEX = [
 # These path patterns are excluded from checks
 PATH_EXCLUSION_REGEX = [
     # These are auto-generated files but without headers to indicate it
+    '/pkg/remoteconfig/client/products/apmsampling/.*_gen(_test){,1}.go',
+    '/pkg/proto/msgpgo/.*_gen(_test){,1}.go',
     '/pkg/security/probe/accessors.go',
+    '/pkg/security/probe/activity_dump_gen_linux.go',
     '/pkg/security/probe/custom_events_easyjson.go',
+    '/pkg/security/probe/fields_resolver.go',
     '/pkg/security/probe/serializers_easyjson.go',
+    '/pkg/security/secl/model/.*_gen(_test){,1}.go',
     '/pkg/security/secl/model/accessors.go',
+    '/pkg/trace/pb/.*_gen(_test){,1}.go',
     # These are files that we should not add our copyright to
-    '/third_party/golang/',
-    '/third_party/kubernetes/',
+    '/internal/patch/grpc-go-insecure/',
+    '/internal/patch/logr/funcr/funcr(_test){,1}.go',
+    '/internal/patch/logr/funcr/internal/logr/',
+    '/internal/third_party/golang/',
+    '/internal/third_party/kubernetes/',
 ]
 
 # These header matchers skip enforcement of the rules if found in the first


### PR DESCRIPTION
### What does this PR do?

This PR enables the linter that checks all files have the correct header/copyright. The PR also adds the copyright to the files that had it missing as well.

### Motivation

Automation of copyright header linting.

### Additional Notes

I've excluded some auto generated files from the linter.

### Possible Drawbacks / Trade-offs

Due to the merge freeze this might cause some builds to break once merged.

### Describe how to test/QA your changes

```sh-session
$ inv lint-copyrights
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
