### PR TITLE
Trigger 'mod tidy' action automatically on dependabot PRs

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -146,10 +146,11 @@ updates:
     directory: /internal/tools
     labels:
       - dependencies
-      # NOTE: We don't want to add the label dependencies-go here, because that
-      # label triggers a github action with write access to the repo that runs
-      # some go tools from this package. A malicious dependency could push a new
-      # release that exploits that we run it automatically after it updates.
+      - dependencies-go
+      - dependencies-go-tools # This makes the go_mod_tidy Github Action not run go tools from this
+                              # package on Dependabot PRs. Otherwise, a malicious dependency could
+                              # publish a new version exploiting that it runs automatically after it
+                              # is updated to write to our repo.
       - dev/tooling
       - team/agent-platform
       - changelog/no-changelog

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,6 +4,7 @@ updates:
     directory: /
     labels:
       - dependencies
+      - dependencies-go
       - team/agent-platform
       - changelog/no-changelog
     milestone: 22
@@ -36,6 +37,7 @@ updates:
     directory: /pkg/otlp/model
     labels:
       - dependencies
+      - dependencies-go
       - team/agent-platform
       - changelog/no-changelog
     milestone: 22
@@ -48,6 +50,7 @@ updates:
     directory: /pkg/trace
     labels:
       - dependencies
+      - dependencies-go
       - team/agent-apm
       - changelog/no-changelog
     milestone: 22
@@ -62,6 +65,7 @@ updates:
     directory: /pkg/obfuscate
     labels:
       - dependencies
+      - dependencies-go
       - team/agent-apm
       - changelog/no-changelog
     milestone: 22
@@ -76,6 +80,7 @@ updates:
     directory: /pkg/quantile
     labels:
       - dependencies
+      - dependencies-go
       - team/metrics-aggregation
       - changelog/no-changelog
     milestone: 22
@@ -88,6 +93,7 @@ updates:
     directory: /pkg/util/log
     labels:
       - dependencies
+      - dependencies-go
       - team/agent-platform
       - changelog/no-changelog
     milestone: 22
@@ -101,6 +107,7 @@ updates:
     directory: /pkg/util/scrubber
     labels:
       - dependencies
+      - dependencies-go
       - team/agent-core
       - changelog/no-changelog
     milestone: 22
@@ -113,6 +120,7 @@ updates:
     directory: /pkg/util/winutil
     labels:
       - dependencies
+      - dependencies-go
       - team/agent-platform
       - changelog/no-changelog
     milestone: 22
@@ -125,6 +133,7 @@ updates:
     directory: /pkg/security/secl
     labels:
       - dependencies
+      - dependencies-go
       - team/agent-security
       - changelog/no-changelog
     milestone: 22
@@ -137,6 +146,10 @@ updates:
     directory: /internal/tools
     labels:
       - dependencies
+      # NOTE: We don't want to add the label dependencies-go here, because that
+      # label triggers a github action with write access to the repo that runs
+      # some go tools from this package. A malicious dependency could push a new
+      # release that exploits that we run it automatically after it updates.
       - dev/tooling
       - team/agent-platform
       - changelog/no-changelog

--- a/.github/workflows/go_mod_tidy.yml
+++ b/.github/workflows/go_mod_tidy.yml
@@ -31,11 +31,14 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: '3.8.10'
+    - name: Install python requirements.txt
+      run: python3 -m pip install -r requirements.txt
     - name: Go mod tidy
+      run: inv -e tidy-all
+    - name: Update LICENSE-3rdparty.csv
+      if: ${{ github.event_name == 'workflow_dispatch' || !contains(github.event.pull_request.labels.*.name, 'dependencies-go-tools') }}
       run: |
-        python3 -m pip install -r requirements.txt
         inv -e install-tools
-        inv -e tidy-all
         inv -e generate-licenses
     - uses: stefanzweifel/git-auto-commit-action@v4
       id: autocommit

--- a/.github/workflows/go_mod_tidy.yml
+++ b/.github/workflows/go_mod_tidy.yml
@@ -1,17 +1,25 @@
 name: "Run Go Mod Tidy And Generate Licenses"
 on:
+  pull_request:
+    types:
+      - labeled
   workflow_dispatch:
     inputs:
       pr_number:
-        description: 'PR number'     
+        description: 'PR number'
         required: true
         type: number
+permissions:
+  contents: write
 jobs:
+  if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.actor == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'dependencies-go')) }}
   mod_tidy_and_generate_licenses:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Checkout PR
+      # run only if triggered manually, otherwise we are already on the right branch and we won't have `pr_number`
+      if: ${{ github.event_name == 'workflow_dispatch' }}
       run: gh pr checkout ${{ github.event.inputs.pr_number }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### What does this PR do?

On Dependabot PRs, automatically triggers the Github Action that regenerates `go.sum` with `-compat=1.17` and the `LICENSE-3rdparty.csv` file.

### Motivation

Dependabot doesn't pass `-compat=1.17` when running `go mod tidy`, which makes the CI detect a difference and fail.

### Additional Notes

This only triggers the Action when the Dependabot PRs didn't update dependencies that would be called as part of the Action itself, for security reasons.

### Describe how to test/QA your changes

Can only be tested after merging :(
