### PR TITLE
[Process Agent] Add check output to flare

### DIFF
--- a/cmd/process-agent/api/check.go
+++ b/cmd/process-agent/api/check.go
@@ -13,13 +13,13 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/DataDog/datadog-agent/pkg/process/exports"
+	"github.com/DataDog/datadog-agent/pkg/process/checks"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 func checkHandler(w http.ResponseWriter, req *http.Request) {
 	requestedCheck := mux.Vars(req)["check"]
-	checkOutput, ok := exports.GetCheckOutput(requestedCheck)
+	checkOutput, ok := checks.GetCheckOutput(requestedCheck)
 	if !ok {
 		w.WriteHeader(http.StatusNotFound)
 		_, err := io.WriteString(w, fmt.Sprintf("%s check is not running or has not been scheduled yet\n", requestedCheck))

--- a/cmd/process-agent/api/check.go
+++ b/cmd/process-agent/api/check.go
@@ -1,0 +1,45 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package api
+
+import (
+	"encoding/json"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"net/http"
+
+	"github.com/gorilla/mux"
+
+	"github.com/DataDog/datadog-agent/pkg/process/checks"
+)
+
+func checkHandler(w http.ResponseWriter, req *http.Request) {
+	requestedCheck := mux.Vars(req)["check"]
+	for _, check := range checks.All {
+		if check.Name() == requestedCheck {
+			payload, err := check.Run(nil, 0)
+			if err != nil {
+				writeError(err, http.StatusInternalServerError, w)
+				_ = log.Error(err)
+				return
+			}
+
+			b, err := json.Marshal(&payload)
+			if err != nil {
+				writeError(err, http.StatusInternalServerError, w)
+				_ = log.Error(err)
+				return
+			}
+
+			_, err = w.Write(b)
+			if err != nil {
+				_ = log.Error(err)
+			}
+			return
+		}
+	}
+
+	w.WriteHeader(http.StatusNotFound)
+}

--- a/cmd/process-agent/api/server.go
+++ b/cmd/process-agent/api/server.go
@@ -25,7 +25,7 @@ func setupHandlers(r *mux.Router) {
 	r.HandleFunc("/config/{setting}", settingshttp.Server.GetValue).Methods("GET")
 	r.HandleFunc("/config/{setting}", settingshttp.Server.SetValue).Methods("POST")
 	r.HandleFunc("/agent/status", statusHandler).Methods("GET")
-	r.HandleFunc("/check/{name}", checkHandler).Methods("GET")
+	r.HandleFunc("/check/{check}", checkHandler).Methods("GET")
 }
 
 // StartServer starts the config server

--- a/cmd/process-agent/api/server.go
+++ b/cmd/process-agent/api/server.go
@@ -25,6 +25,7 @@ func setupHandlers(r *mux.Router) {
 	r.HandleFunc("/config/{setting}", settingshttp.Server.GetValue).Methods("GET")
 	r.HandleFunc("/config/{setting}", settingshttp.Server.SetValue).Methods("POST")
 	r.HandleFunc("/agent/status", statusHandler).Methods("GET")
+	r.HandleFunc("/check/{name}", checkHandler).Methods("GET")
 }
 
 // StartServer starts the config server

--- a/cmd/process-agent/api/util.go
+++ b/cmd/process-agent/api/util.go
@@ -1,0 +1,6 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package api

--- a/cmd/process-agent/collector.go
+++ b/cmd/process-agent/collector.go
@@ -7,7 +7,6 @@ package main
 
 import (
 	"fmt"
-	"github.com/DataDog/datadog-agent/pkg/process/exports"
 	"math/rand"
 	"net/http"
 	"strconv"
@@ -157,7 +156,7 @@ func (l *Collector) runCheck(c checks.Check, results *api.WeightedQueue) {
 		log.Errorf("Unable to run check '%s': %s", c.Name(), err)
 		return
 	}
-	exports.StoreCheckOutput(c.Name(), messages)
+	checks.StoreCheckOutput(c.Name(), messages)
 	l.messagesToResults(start, c.Name(), messages, results)
 
 	if !c.RealTime() {
@@ -178,13 +177,13 @@ func (l *Collector) runCheckWithRealTime(c checks.CheckWithRealTime, results, rt
 	}
 	l.messagesToResults(start, c.Name(), run.Standard, results)
 	if options.RunStandard {
-		exports.StoreCheckOutput(c.Name(), run.Standard)
+		checks.StoreCheckOutput(c.Name(), run.Standard)
 		logCheckDuration(c.Name(), start, runCounter)
 	}
 
 	l.messagesToResults(start, c.RealTimeName(), run.RealTime, rtResults)
 	if options.RunRealTime {
-		exports.StoreCheckOutput(c.RealTimeName(), run.RealTime)
+		checks.StoreCheckOutput(c.RealTimeName(), run.RealTime)
 	}
 }
 

--- a/cmd/process-agent/collector.go
+++ b/cmd/process-agent/collector.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/DataDog/datadog-agent/pkg/process/exports"
 	"math/rand"
 	"net/http"
 	"strconv"
@@ -156,6 +157,7 @@ func (l *Collector) runCheck(c checks.Check, results *api.WeightedQueue) {
 		log.Errorf("Unable to run check '%s': %s", c.Name(), err)
 		return
 	}
+	exports.StoreCheckOutput(c.Name(), messages)
 	l.messagesToResults(start, c.Name(), messages, results)
 
 	if !c.RealTime() {
@@ -175,10 +177,14 @@ func (l *Collector) runCheckWithRealTime(c checks.CheckWithRealTime, results, rt
 		return
 	}
 	l.messagesToResults(start, c.Name(), run.Standard, results)
-	l.messagesToResults(start, c.RealTimeName(), run.RealTime, rtResults)
-
 	if options.RunStandard {
+		exports.StoreCheckOutput(c.Name(), run.Standard)
 		logCheckDuration(c.Name(), start, runCounter)
+	}
+
+	l.messagesToResults(start, c.RealTimeName(), run.RealTime, rtResults)
+	if options.RunRealTime {
+		exports.StoreCheckOutput(c.RealTimeName(), run.RealTime)
 	}
 }
 

--- a/pkg/process/checks/exports.go
+++ b/pkg/process/checks/exports.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package exports
+package checks
 
 import (
 	"sync"

--- a/pkg/process/exports/check_outputs.go
+++ b/pkg/process/exports/check_outputs.go
@@ -1,0 +1,31 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package exports
+
+import (
+	"sync"
+
+	procmodel "github.com/DataDog/agent-payload/v5/process"
+)
+
+var checkOutputs sync.Map
+
+// StoreCheckOutput stores the output of a check. We use helpers instead of checkOutputs directly to preserve type safety.
+func StoreCheckOutput(checkName string, message []procmodel.MessageBody) {
+	if message == nil {
+		checkOutputs.Store(checkName, []procmodel.MessageBody{})
+	} else {
+		checkOutputs.Store(checkName, message)
+	}
+}
+
+// GetCheckOutput retrieves the last output of a check. We use helpers instead of checkOutput directly to preserve type safety.
+func GetCheckOutput(checkName string) (value []procmodel.MessageBody, ok bool) {
+	if v, ok := checkOutputs.Load(checkName); ok {
+		return v.([]procmodel.MessageBody), true
+	}
+	return nil, false
+}

--- a/releasenotes/notes/process-agent-add-check-output-1a09261da182cd7e.yaml
+++ b/releasenotes/notes/process-agent-add-check-output-1a09261da182cd7e.yaml
@@ -1,3 +1,3 @@
 ---
 enhancements:
-  - Agent flare now includes output from the `process` and `container` checks
+  - Agent flare now includes output from the `process` and `container` checks.

--- a/releasenotes/notes/process-agent-add-check-output-1a09261da182cd7e.yaml
+++ b/releasenotes/notes/process-agent-add-check-output-1a09261da182cd7e.yaml
@@ -1,3 +1,3 @@
 ---
 enhancements:
-  - The flaire now includes output from the `processes` and `container` checks
+  - Agent flare now includes output from the `process` and `container` checks

--- a/releasenotes/notes/process-agent-add-check-output-1a09261da182cd7e.yaml
+++ b/releasenotes/notes/process-agent-add-check-output-1a09261da182cd7e.yaml
@@ -1,0 +1,3 @@
+---
+enhancements:
+  - The flaire now includes output from the `processes` and `container` checks


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->


Adds the output of the `process` and `container` checks to the flare. The output is put into `process_check_output.json` and `container_check_output.json` at the root of the flare.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Make sure that `process_config.process_collection = true`. Run both the core agent and the process agent. Give the agent some time to run a few checks and populate the cache. Next run, `agent flare` and check to see if `process_check_output.json` is in the flare.

Repeat with the container check and the process_discovery check.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
