### PR TITLE
[process-agent] Add check subcommand and deprecate --check

### DIFF
--- a/cmd/process-agent/app/check.go
+++ b/cmd/process-agent/app/check.go
@@ -92,7 +92,7 @@ func runCheckCmd(cmd *cobra.Command, args []string) error {
 
 	sysInfo, err := checks.CollectSystemInfo(cfg)
 	if err != nil {
-		log.Errorf("failed tp collect system info: %s", err)
+		log.Errorf("failed to collect system info: %s", err)
 	}
 
 	check := args[0]

--- a/cmd/process-agent/app/check.go
+++ b/cmd/process-agent/app/check.go
@@ -31,7 +31,7 @@ import (
 // CheckCmd is a command that runs the process-agent version data
 var CheckCmd = &cobra.Command{
 	Use:          "check",
-	Short:        "Run a specific check and print the results. Choose from: process, connections, realtime, process_discovery",
+	Short:        "Run a specific check and print the results. Choose from: process, rtprocess, container, rtcontainer, connections, process_discovery",
 	Args:         cobra.ExactArgs(1),
 	RunE:         runCheckCmd,
 	SilenceUsage: true,
@@ -46,8 +46,7 @@ func runCheckCmd(cmd *cobra.Command, args []string) error {
 
 	configPath := cmd.Flag(flags.CfgPath).Value.String()
 	sysprobePath := cmd.Flag(flags.SysProbeConfig).Value.String()
-	// `GetContainers` will panic when running in docker if the config hasn't called `DetectFeatures`.
-	// `LoadConfigIfExists` does the job of loading the config and calling `DetectFeatures` so that we can detect containers.
+
 	if err := config.LoadConfigIfExists(configPath); err != nil {
 		return log.Criticalf("Error parsing config: %s", err)
 	}

--- a/cmd/process-agent/app/check.go
+++ b/cmd/process-agent/app/check.go
@@ -1,0 +1,187 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/DataDog/agent-payload/v5/process"
+	"github.com/DataDog/datadog-agent/cmd/process-agent/flags"
+	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/metadata/host"
+	"github.com/DataDog/datadog-agent/pkg/process/checks"
+	"github.com/DataDog/datadog-agent/pkg/process/config"
+	"github.com/DataDog/datadog-agent/pkg/tagger"
+	"github.com/DataDog/datadog-agent/pkg/tagger/local"
+	"github.com/DataDog/datadog-agent/pkg/tagger/remote"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/version"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
+)
+
+// CheckCmd is a command that runs the process-agent version data
+var CheckCmd = &cobra.Command{
+	Use:          "check",
+	Short:        "Run a specific check and print the results. Choose from: process, connections, realtime, process_discovery",
+	Args:         cobra.ExactArgs(1),
+	RunE:         runCheckCmd,
+	SilenceUsage: true,
+}
+
+const loggerName ddconfig.LoggerName = "PROCESS"
+
+func runCheckCmd(cmd *cobra.Command, args []string) error {
+	// We need to load in the system probe environment variables before we load the config, otherwise an
+	// "Unknown environment variable" warning will show up whenever valid system probe environment variables are defined.
+	ddconfig.InitSystemProbeConfig(ddconfig.Datadog)
+
+	configPath := cmd.Flag(flags.CfgPath).Value.String()
+	sysprobePath := cmd.Flag(flags.SysProbeConfig).Value.String()
+	// `GetContainers` will panic when running in docker if the config hasn't called `DetectFeatures`.
+	// `LoadConfigIfExists` does the job of loading the config and calling `DetectFeatures` so that we can detect containers.
+	if err := config.LoadConfigIfExists(configPath); err != nil {
+		return log.Criticalf("Error parsing config: %s", err)
+	}
+
+	// For system probe, there is an additional config file that is shared with the system-probe
+	syscfg, err := sysconfig.Merge(sysprobePath)
+	if err != nil {
+		return log.Critical(err)
+	}
+
+	cfg, err := config.NewAgentConfig(loggerName, configPath, syscfg)
+	if err != nil {
+		return log.Criticalf("Error parsing config: %s", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Now that the logger is configured log host info
+	hostInfo := host.GetStatusInformation()
+	log.Infof("running on platform: %s", hostInfo.Platform)
+	agentVersion, _ := version.Agent()
+	log.Infof("running version: %s", agentVersion.GetNumberAndPre())
+
+	// Start workload metadata store before tagger (used for containerCollection)
+	store := workloadmeta.GetGlobalStore()
+	store.Start(ctx)
+
+	// Tagger must be initialized after agent config has been setup
+	var t tagger.Tagger
+	if ddconfig.Datadog.GetBool("process_config.remote_tagger") {
+		t = remote.NewTagger()
+	} else {
+		t = local.NewTagger(store)
+	}
+	tagger.SetDefaultTagger(t)
+	err = tagger.Init(ctx)
+	if err != nil {
+		log.Errorf("failed to start the tagger: %s", err)
+	}
+	defer tagger.Stop() //nolint:errcheck
+
+	sysInfo, err := checks.CollectSystemInfo(cfg)
+	if err != nil {
+		log.Errorf("failed tp collect system info: %s", err)
+	}
+
+	check := args[0]
+
+	// Connections check requires process-check to have occurred first (for process creation ts),
+	if check == checks.Connections.Name() {
+		checks.Process.Init(cfg, sysInfo)
+		checks.Process.Run(cfg, 0) //nolint:errcheck
+	}
+
+	names := make([]string, 0, len(checks.All))
+	for _, ch := range checks.All {
+		names = append(names, ch.Name())
+
+		if ch.Name() == check {
+			ch.Init(cfg, sysInfo)
+			return runCheck(cfg, ch)
+		}
+
+		withRealTime, ok := ch.(checks.CheckWithRealTime)
+		if ok && withRealTime.RealTimeName() == check {
+			withRealTime.Init(cfg, sysInfo)
+			return runCheckAsRealTime(cfg, withRealTime)
+		}
+	}
+	return log.Errorf("invalid check '%s', choose from: %v", check, names)
+}
+
+func runCheck(cfg *config.AgentConfig, ch checks.Check) error {
+	// Run the check once to prime the cache.
+	if _, err := ch.Run(cfg, 0); err != nil {
+		return fmt.Errorf("collection error: %s", err)
+	}
+
+	time.Sleep(1 * time.Second)
+
+	printResultsBanner(ch.Name())
+
+	msgs, err := ch.Run(cfg, 1)
+	if err != nil {
+		return fmt.Errorf("collection error: %s", err)
+	}
+	return printResults(msgs)
+}
+
+func runCheckAsRealTime(cfg *config.AgentConfig, ch checks.CheckWithRealTime) error {
+	options := checks.RunOptions{
+		RunStandard: true,
+		RunRealTime: true,
+	}
+	var (
+		groupID     int32
+		nextGroupID = func() int32 {
+			groupID++
+			return groupID
+		}
+	)
+
+	// We need to run the check twice in order to initialize the stats
+	// Rate calculations rely on having two datapoints
+	if _, err := ch.RunWithOptions(cfg, nextGroupID, options); err != nil {
+		return fmt.Errorf("collection error: %s", err)
+	}
+
+	time.Sleep(1 * time.Second)
+
+	printResultsBanner(ch.RealTimeName())
+
+	run, err := ch.RunWithOptions(cfg, nextGroupID, options)
+	if err != nil {
+		return fmt.Errorf("collection error: %s", err)
+	}
+
+	return printResults(run.RealTime)
+}
+
+func printResultsBanner(name string) {
+	fmt.Printf("-----------------------------\n\n")
+	fmt.Printf("\nResults for check %s\n", name)
+	fmt.Printf("-----------------------------\n\n")
+}
+
+func printResults(msgs []process.MessageBody) error {
+	for _, m := range msgs {
+		b, err := json.MarshalIndent(m, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshal error: %s", err)
+		}
+		fmt.Println(string(b))
+	}
+	return nil
+}

--- a/cmd/process-agent/app/status.go
+++ b/cmd/process-agent/app/status.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/DataDog/datadog-agent/cmd/process-agent/api"
+	"github.com/DataDog/datadog-agent/cmd/process-agent/flags"
 	apiutil "github.com/DataDog/datadog-agent/pkg/api/util"
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/process/config"
@@ -126,18 +127,16 @@ func getStatusURL() (string, error) {
 	return fmt.Sprintf("http://%s/agent/status", addressPort), nil
 }
 
-// StatusCmd returns a cobra command that prints the current status
-func StatusCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "status",
-		Short: "Print the current status",
-		Long:  ``,
-		RunE:  runStatus,
-	}
+// StatusCmd is a cobra command that prints the current status
+var StatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Print the current status",
+	Long:  ``,
+	RunE:  runStatus,
 }
 
 func runStatus(cmd *cobra.Command, _ []string) error {
-	err := config.LoadConfigIfExists(cmd.Flag("cfgpath").Value.String())
+	err := config.LoadConfigIfExists(cmd.Flag(flags.CfgPath).Value.String())
 	if err != nil {
 		writeError(os.Stdout, err)
 		return err

--- a/cmd/process-agent/flags/flags_common.go
+++ b/cmd/process-agent/flags/flags_common.go
@@ -1,0 +1,13 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package flags
+
+const (
+	// CfgPath defines the cfgpath flag
+	CfgPath = "cfgpath"
+	// SysProbeConfig defines the sysprobe-config flag
+	SysProbeConfig = "sysprobe-config"
+)

--- a/cmd/process-agent/main.go
+++ b/cmd/process-agent/main.go
@@ -24,19 +24,19 @@ func rootCmdRun(cmd *cobra.Command, args []string) {
 }
 
 func main() {
-	rootCmd.PersistentFlags().StringVar(&opts.configPath, "cfgpath", flags.DefaultConfPath, "Path to datadog.yaml config")
+	rootCmd.PersistentFlags().StringVar(&opts.configPath, flags.CfgPath, flags.DefaultConfPath, "Path to datadog.yaml config")
 
 	if flags.DefaultSysProbeConfPath != "" {
-		rootCmd.PersistentFlags().StringVar(&opts.sysProbeConfigPath, "sysprobe-config", flags.DefaultSysProbeConfPath, "Path to system-probe.yaml config")
+		rootCmd.PersistentFlags().StringVar(&opts.sysProbeConfigPath, flags.SysProbeConfig, flags.DefaultSysProbeConfPath, "Path to system-probe.yaml config")
 	}
 
 	rootCmd.PersistentFlags().StringVarP(&opts.pidfilePath, "pid", "p", "", "Path to set pidfile for process")
 	rootCmd.PersistentFlags().BoolVarP(&opts.info, "info", "i", false, "Show info about running process agent and exit")
-	rootCmd.PersistentFlags().BoolVarP(&opts.version, "version", "v", false, "Print the version and exit")
-	rootCmd.PersistentFlags().StringVar(&opts.check, "check", "",
-		"Run a specific check and print the results. Choose from: process, connections, realtime, process_discovery")
+	rootCmd.PersistentFlags().BoolP("version", "v", false, "[deprecated] Print the version and exit")
+	rootCmd.PersistentFlags().String("check", "",
+		"[deprecated] Run a specific check and print the results. Choose from: process, connections, realtime, process_discovery")
 
-	fixDeprecatedFlags(os.Args, os.Stdout)
+	os.Args = fixDeprecatedFlags(os.Args, os.Stdout)
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(-1)
 	}

--- a/cmd/process-agent/main.go
+++ b/cmd/process-agent/main.go
@@ -34,7 +34,7 @@ func main() {
 	rootCmd.PersistentFlags().BoolVarP(&opts.info, "info", "i", false, "Show info about running process agent and exit")
 	rootCmd.PersistentFlags().BoolP("version", "v", false, "[deprecated] Print the version and exit")
 	rootCmd.PersistentFlags().String("check", "",
-		"[deprecated] Run a specific check and print the results. Choose from: process, connections, realtime, process_discovery")
+		"[deprecated] Run a specific check and print the results. Choose from: process, rtprocess, container, rtcontainer, connections, process_discovery")
 
 	os.Args = fixDeprecatedFlags(os.Args, os.Stdout)
 	if err := rootCmd.Execute(); err != nil {

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -224,8 +224,6 @@ func runAgent(exit chan struct{}) {
 	// "Unknown environment variable" warning will show up whenever valid system probe environment variables are defined.
 	ddconfig.InitSystemProbeConfig(ddconfig.Datadog)
 
-	// `GetContainers` will panic when running in docker if the config hasn't called `DetectFeatures`.
-	// `LoadConfigIfExists` does the job of loading the config and calling `DetectFeatures` so that we can detect containers.
 	if err := config.LoadConfigIfExists(opts.configPath); err != nil {
 		_ = log.Criticalf("Error parsing config: %s", err)
 		cleanupAndExit(1)

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -7,7 +7,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -16,10 +15,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
-	"github.com/DataDog/agent-payload/v5/process"
 	cmdconfig "github.com/DataDog/datadog-agent/cmd/agent/common/commands/config"
 	"github.com/DataDog/datadog-agent/cmd/manager"
 	"github.com/DataDog/datadog-agent/cmd/process-agent/api"
@@ -31,7 +28,6 @@ import (
 	settingshttp "github.com/DataDog/datadog-agent/pkg/config/settings/http"
 	"github.com/DataDog/datadog-agent/pkg/metadata/host"
 	"github.com/DataDog/datadog-agent/pkg/pidfile"
-	"github.com/DataDog/datadog-agent/pkg/process/checks"
 	"github.com/DataDog/datadog-agent/pkg/process/config"
 	"github.com/DataDog/datadog-agent/pkg/process/statsd"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
@@ -56,8 +52,6 @@ var opts struct {
 	sysProbeConfigPath string
 	pidfilePath        string
 	debug              bool
-	version            bool
-	check              string
 	info               bool
 }
 
@@ -101,44 +95,100 @@ func getSettingsClient(_ *cobra.Command, _ []string) (settings.Client, error) {
 }
 
 func init() {
-	rootCmd.AddCommand(configCommand, app.StatusCmd(), app.VersionCmd)
+	rootCmd.AddCommand(configCommand, app.StatusCmd, app.VersionCmd, app.CheckCmd)
 }
 
 func deprecatedFlagWarning(deprecated, replaceWith string) string {
 	return fmt.Sprintf("WARNING: `%s` argument is deprecated and will be removed in a future version. Please use `%s` instead.\n", deprecated, replaceWith)
 }
 
-// fixDeprecatedFlags modifies os.Args so that non-posix flags are converted to posix flags
-// it also displays a warning when a non-posix flag is found
-func fixDeprecatedFlags(args []string, w io.Writer) {
-	deprecatedFlags := []string{
-		// Global flags
-		"-config", "--config", "-sysprobe-config", "-pid", "-info", "-version", "-check",
-		// Windows flags
-		"-install-service", "-uninstall-service", "-start-service", "-stop-service", "-foreground",
+type replaceFlag struct {
+	hint string
+	args []string
+}
+
+type replaceFlagFunc func(arg string, flag string) replaceFlag
+
+func replaceFlagPosix(arg string, flag string) replaceFlag {
+	newFlag := "-" + flag
+	return replaceFlag{
+		hint: newFlag,
+		args: []string{
+			strings.Replace(arg, flag, newFlag, 1),
+		},
 	}
+}
 
-	replaceFlags := map[string]string{
-		"-config":  "--cfgpath",
-		"--config": "--cfgpath",
-	}
-
-	for i, arg := range args {
-		for _, f := range deprecatedFlags {
-			if !strings.HasPrefix(arg, f) {
-				continue
-			}
-			replaceWith := replaceFlags[f]
-			if len(replaceWith) == 0 {
-				replaceWith = "-" + f
-				args[i] = "-" + args[i]
-			} else {
-				args[i] = strings.Replace(args[i], f, replaceWith, 1)
-			}
-
-			fmt.Fprint(w, deprecatedFlagWarning(f, replaceWith))
+func replaceFlagExact(replaceWith string) replaceFlagFunc {
+	return func(arg string, flag string) replaceFlag {
+		return replaceFlag{
+			hint: replaceWith,
+			args: []string{strings.Replace(arg, flag, replaceWith, 1)},
 		}
 	}
+}
+
+func replaceFlagSubCommandPosArg(replaceWith string) replaceFlagFunc {
+	return func(arg string, _ string) replaceFlag {
+		parts := strings.SplitN(arg, "=", 2)
+		parts[0] = replaceWith
+		return replaceFlag{
+			hint: replaceWith,
+			args: parts,
+		}
+	}
+}
+
+// fixDeprecatedFlags transforms args so that they are conforming to the new CLI structure:
+// - replace non-posix flags posix flags
+// - replace deprecated flags with their command equivalents
+// - display warnings when deprecated flags are encountered
+func fixDeprecatedFlags(args []string, w io.Writer) []string {
+	var (
+		replaceCfgPath = replaceFlagExact("--cfgpath")
+		replaceVersion = replaceFlagExact("version")
+		replaceCheck   = replaceFlagSubCommandPosArg("check")
+	)
+
+	deprecatedFlags := map[string]replaceFlagFunc{
+		// Global flags
+		"-config":          replaceCfgPath,
+		"--config":         replaceCfgPath,
+		"-sysprobe-config": replaceFlagPosix,
+		"-version":         replaceVersion,
+		"--version":        replaceVersion,
+		"-check":           replaceCheck,
+		"--check":          replaceCheck,
+		"-pid":             replaceFlagPosix,
+		"-info":            replaceFlagPosix,
+		// Windows flags
+		"-install-service":   replaceFlagPosix,
+		"-uninstall-service": replaceFlagPosix,
+		"-start-service":     replaceFlagPosix,
+		"-stop-service":      replaceFlagPosix,
+		"-foreground":        replaceFlagPosix,
+	}
+
+	var newArgs []string
+	for i, arg := range args {
+		var replaced bool
+
+		for f, replacer := range deprecatedFlags {
+			if strings.HasPrefix(arg, f) {
+				replacement := replacer(args[i], f)
+				newArgs = append(newArgs, replacement.args...)
+
+				fmt.Fprint(w, deprecatedFlagWarning(f, replacement.hint))
+				replaced = true
+				break
+			}
+		}
+
+		if !replaced {
+			newArgs = append(newArgs, args[i])
+		}
+	}
+	return newArgs
 }
 
 const (
@@ -152,17 +202,11 @@ Exiting.`
 )
 
 func runAgent(exit chan struct{}) {
-	if opts.version {
-		fmt.Println("WARNING: --version is deprecated and will be removed in a future version. Please use `process-agent version` instead.")
-		_ = app.WriteVersion(color.Output)
-		cleanupAndExit(0)
-	}
-
 	if err := ddutil.SetupCoreDump(); err != nil {
 		log.Warnf("Can't setup core dumps: %v, core dumps might not be available after a crash", err)
 	}
 
-	if opts.check == "" && !opts.info && opts.pidfilePath != "" {
+	if !opts.info && opts.pidfilePath != "" {
 		err := pidfile.WritePID(opts.pidfilePath)
 		if err != nil {
 			log.Errorf("Error while writing PID file, exiting: %v", err)
@@ -239,6 +283,7 @@ func runAgent(exit chan struct{}) {
 		log.Criticalf("Error initializing info: %s", err)
 		cleanupAndExit(1)
 	}
+
 	if err := statsd.Configure(ddconfig.GetBindHost(), ddconfig.Datadog.GetInt("dogstatsd_port")); err != nil {
 		log.Criticalf("Error configuring statsd: %s", err)
 		cleanupAndExit(1)
@@ -246,8 +291,8 @@ func runAgent(exit chan struct{}) {
 
 	enabledChecks := getChecks(syscfg, cfg.Orchestrator, ddconfig.IsAnyContainerFeaturePresent())
 
-	// Exit if agent is not enabled and we're not debugging a check.
-	if len(enabledChecks) == 0 && opts.check == "" {
+	// Exit if agent is not enabled.
+	if len(enabledChecks) == 0 {
 		log.Infof(agent6DisabledMessage)
 
 		// a sleep is necessary to ensure that supervisor registers this process as "STARTED"
@@ -301,16 +346,6 @@ func runAgent(exit chan struct{}) {
 	}
 
 	log.Debug("Running process-agent with DEBUG logging enabled")
-	if opts.check != "" {
-		err := debugCheckResults(cfg, opts.check)
-		if err != nil {
-			fmt.Println(err)
-			cleanupAndExit(1)
-		} else {
-			cleanupAndExit(0)
-		}
-		return
-	}
 
 	expVarPort := ddconfig.Datadog.GetInt("process_config.expvar_port")
 	if expVarPort <= 0 {
@@ -358,101 +393,6 @@ func runAgent(exit chan struct{}) {
 
 	for range exit {
 	}
-}
-
-func debugCheckResults(cfg *config.AgentConfig, check string) error {
-	sysInfo, err := checks.CollectSystemInfo(cfg)
-	if err != nil {
-		return err
-	}
-
-	// Connections check requires process-check to have occurred first (for process creation ts),
-	if check == checks.Connections.Name() {
-		checks.Process.Init(cfg, sysInfo)
-		checks.Process.Run(cfg, 0) //nolint:errcheck
-	}
-
-	names := make([]string, 0, len(checks.All))
-	for _, ch := range checks.All {
-		names = append(names, ch.Name())
-
-		if ch.Name() == check {
-			ch.Init(cfg, sysInfo)
-			return runCheck(cfg, ch)
-		}
-
-		withRealTime, ok := ch.(checks.CheckWithRealTime)
-		if ok && withRealTime.RealTimeName() == check {
-			withRealTime.Init(cfg, sysInfo)
-			return runCheckAsRealTime(cfg, withRealTime)
-		}
-	}
-	return fmt.Errorf("invalid check '%s', choose from: %v", check, names)
-}
-
-func runCheck(cfg *config.AgentConfig, ch checks.Check) error {
-	// Run the check once to prime the cache.
-	if _, err := ch.Run(cfg, 0); err != nil {
-		return fmt.Errorf("collection error: %s", err)
-	}
-
-	time.Sleep(1 * time.Second)
-
-	printResultsBanner(ch.Name())
-
-	msgs, err := ch.Run(cfg, 1)
-	if err != nil {
-		return fmt.Errorf("collection error: %s", err)
-	}
-	return printResults(msgs)
-}
-
-func runCheckAsRealTime(cfg *config.AgentConfig, ch checks.CheckWithRealTime) error {
-	options := checks.RunOptions{
-		RunStandard: true,
-		RunRealTime: true,
-	}
-	var (
-		groupID     int32
-		nextGroupID = func() int32 {
-			groupID++
-			return groupID
-		}
-	)
-
-	// We need to run the check twice in order to initialize the stats
-	// Rate calculations rely on having two datapoints
-	if _, err := ch.RunWithOptions(cfg, nextGroupID, options); err != nil {
-		return fmt.Errorf("collection error: %s", err)
-	}
-
-	time.Sleep(1 * time.Second)
-
-	printResultsBanner(ch.RealTimeName())
-
-	run, err := ch.RunWithOptions(cfg, nextGroupID, options)
-	if err != nil {
-		return fmt.Errorf("collection error: %s", err)
-	}
-
-	return printResults(run.RealTime)
-}
-
-func printResultsBanner(name string) {
-	fmt.Printf("-----------------------------\n\n")
-	fmt.Printf("\nResults for check %s\n", name)
-	fmt.Printf("-----------------------------\n\n")
-}
-
-func printResults(msgs []process.MessageBody) error {
-	for _, m := range msgs {
-		b, err := json.MarshalIndent(m, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal error: %s", err)
-		}
-		fmt.Println(string(b))
-	}
-	return nil
 }
 
 // cleanupAndExit cleans all resources allocated by the agent before calling

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -170,12 +170,12 @@ func fixDeprecatedFlags(args []string, w io.Writer) []string {
 	}
 
 	var newArgs []string
-	for i, arg := range args {
+	for _, arg := range args {
 		var replaced bool
 
 		for f, replacer := range deprecatedFlags {
 			if strings.HasPrefix(arg, f) {
-				replacement := replacer(args[i], f)
+				replacement := replacer(arg, f)
 				newArgs = append(newArgs, replacement.args...)
 
 				fmt.Fprint(w, deprecatedFlagWarning(f, replacement.hint))
@@ -185,7 +185,7 @@ func fixDeprecatedFlags(args []string, w io.Writer) []string {
 		}
 
 		if !replaced {
-			newArgs = append(newArgs, args[i])
+			newArgs = append(newArgs, arg)
 		}
 	}
 	return newArgs

--- a/cmd/process-agent/main_windows.go
+++ b/cmd/process-agent/main_windows.go
@@ -125,7 +125,7 @@ func main() {
 	rootCmd.PersistentFlags().StringVar(&opts.sysProbeConfigPath, flags.SysProbeConfig, defaultSysProbeConfigPath, "Path to system-probe.yaml config")
 	rootCmd.PersistentFlags().BoolVarP(&opts.info, "info", "i", false, "Show info about running process agent and exit")
 	rootCmd.PersistentFlags().BoolP("version", "v", false, "[deprecated] Print the version and exit")
-	rootCmd.PersistentFlags().String("check", "", "[deprecated] Run a specific check and print the results. Choose from: process, connections, realtime, process_discovery")
+	rootCmd.PersistentFlags().String("check", "", "[deprecated] Run a specific check and print the results. Choose from: process, rtprocess, container, rtcontainer, connections, process_discovery")
 
 	// windows-specific options for installing the service, uninstalling the service, etc.
 	rootCmd.PersistentFlags().BoolVar(&winopts.installService, "install-service", false, "Install the process agent to the Service Control Manager")

--- a/cmd/process-agent/main_windows.go
+++ b/cmd/process-agent/main_windows.go
@@ -121,11 +121,11 @@ func runService(isDebug bool) {
 
 // main is the main application entry point
 func main() {
-	rootCmd.PersistentFlags().StringVar(&opts.configPath, "cfgpath", defaultConfigPath, "Path to datadog.yaml config")
-	rootCmd.PersistentFlags().StringVar(&opts.sysProbeConfigPath, "sysprobe-config", defaultSysProbeConfigPath, "Path to system-probe.yaml config")
+	rootCmd.PersistentFlags().StringVar(&opts.configPath, flags.CfgPath, defaultConfigPath, "Path to datadog.yaml config")
+	rootCmd.PersistentFlags().StringVar(&opts.sysProbeConfigPath, flags.SysProbeConfig, defaultSysProbeConfigPath, "Path to system-probe.yaml config")
 	rootCmd.PersistentFlags().BoolVarP(&opts.info, "info", "i", false, "Show info about running process agent and exit")
-	rootCmd.PersistentFlags().BoolVarP(&opts.version, "version", "v", false, "Print the version and exit")
-	rootCmd.PersistentFlags().StringVar(&opts.check, "check", "", "Run a specific check and print the results. Choose from: process, connections, realtime, process_discovery")
+	rootCmd.PersistentFlags().BoolP("version", "v", false, "[deprecated] Print the version and exit")
+	rootCmd.PersistentFlags().String("check", "", "[deprecated] Run a specific check and print the results. Choose from: process, connections, realtime, process_discovery")
 
 	// windows-specific options for installing the service, uninstalling the service, etc.
 	rootCmd.PersistentFlags().BoolVar(&winopts.installService, "install-service", false, "Install the process agent to the Service Control Manager")
@@ -135,7 +135,7 @@ func main() {
 	rootCmd.PersistentFlags().BoolVar(&winopts.foreground, "foreground", false, "Always run foreground instead whether session is interactive or not")
 
 	// Invoke the Agent
-	fixDeprecatedFlags(os.Args, os.Stdout)
+	os.Args = fixDeprecatedFlags(os.Args, os.Stdout)
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(-1)
 	}

--- a/releasenotes/notes/process-agent-check-subcommand-7ba5c4574eecae1f.yaml
+++ b/releasenotes/notes/process-agent-check-subcommand-7ba5c4574eecae1f.yaml
@@ -1,0 +1,8 @@
+---
+enhancements:
+  - |
+    Add the ``check`` subcommand in the Process Agent replacing ``--check`` (``-check``).
+    Only warn once if the ``-version`` flag is used.
+deprecations:
+  - |
+    Deprecate the ``--check`` (``-check``) parameter (show warning on usage).


### PR DESCRIPTION
### What does this PR do?

- Add the `check` subcommand in the Process Agent replacing `--check` (`-check`).
- Only warn once if the `-version` flag is used.
- Deprecate the `--check` (`-check`) parameter (show warning on usage).

### Motivation

Improve consistency with the Core Agent


### Describe how to test/QA your changes

Test that the new `check` subcommand works correctly across supported OSs.

Since this touches the deprecation logic in these flags, they should be validated as well:
- `-config` (`--config`)
- `-sysprobe-config` (`--sysprobe-config`)
- `-version` (`--version`)
- `-check` (`--check`)
- `-pid` (`--pid`)
- `-info` (`--info`)
- `-install-service` (`--install-service`)
- `-uninstall-service` (`--uninstall-service`)
- `-start-service` (`--start-service`)
- `-stop-service` (`--stop-service`)
- `-foreground` (`--foreground`)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
