### PR TITLE
Use RWMutexes to remove contention between clients

### DIFF
--- a/pkg/config/remote/service/clients.go
+++ b/pkg/config/remote/service/clients.go
@@ -23,7 +23,7 @@ func (c *client) expired(clock clock.Clock, ttl time.Duration) bool {
 }
 
 type clients struct {
-	mutex sync.RWMutex
+	mutex sync.Mutex
 	clock clock.Clock
 
 	clientsTTL time.Duration
@@ -52,8 +52,8 @@ func (c *clients) seen(pbClient *pbgo.Client) {
 
 // activeClients returns the list of active clients
 func (c *clients) activeClients() []*pbgo.Client {
-	c.mutex.RLock()
-	defer c.mutex.RUnlock()
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
 	var activeClients []*pbgo.Client
 	for id, client := range c.clients {
 		if client.expired(c.clock, c.clientsTTL) {

--- a/pkg/config/remote/uptane/client_state.go
+++ b/pkg/config/remote/uptane/client_state.go
@@ -64,8 +64,8 @@ type TUFVersions struct {
 
 // TUFVersionState TODO <remote-config>
 func (c *Client) TUFVersionState() (TUFVersions, error) {
-	c.Lock()
-	defer c.Unlock()
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
 
 	drv, err := c.directorLocalStore.GetMetaVersion(metaRoot)
 	if err != nil {
@@ -97,9 +97,8 @@ func (c *Client) TUFVersionState() (TUFVersions, error) {
 
 // State returns the state of the uptane client
 func (c *Client) State() (State, error) {
-	c.Lock()
-	defer c.Unlock()
-
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
 	s := State{
 		ConfigState:     map[string]MetaState{},
 		DirectorState:   map[string]MetaState{},


### PR DESCRIPTION
Reduce contention in remote-config by using RWLocks

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
