### PR TITLE
[tasks] Updated check_logger in worker to log check end correctly

### DIFF
--- a/pkg/collector/worker/check_logger_test.go
+++ b/pkg/collector/worker/check_logger_test.go
@@ -54,14 +54,22 @@ func TestShouldLogNewCheck(t *testing.T) {
 func TestShouldLogLastVerboseLog(t *testing.T) {
 	setUp()
 
-	for idx := 0; idx < 10; idx++ {
+	for idx := 1; idx < 10; idx++ {
 		testCheck := newTestCheck(fmt.Sprintf("testcheck %d", idx))
 
-		for logIdx := 1; logIdx < 10; logIdx++ {
+		for logIdx := 0; logIdx < 61; logIdx++ {
+			// Given a CheckLogger
+			checkLogger := CheckLogger{Check: testCheck}
+			// When I start the check
+			checkLogger.CheckStarted()
+			// And increment the CheckStats
 			addExpvarsCheckStats(testCheck)
+			// And the check finishes
+			checkLogger.CheckFinished()
 
-			_, lastVerboseLog := shouldLogCheck(testCheck.ID())
+			lastVerboseLog := checkLogger.lastVerboseLog
 
+			// Then lastVerboseLog should be true for 5th run
 			// initialCheckLoggingSeriesLimit should be 5
 			if logIdx == 5 {
 				assert.True(t, lastVerboseLog, fmt.Sprintf("Loop idx: %d", logIdx))
@@ -79,10 +87,18 @@ func TestShouldLogInitialCheckLoggingSeries(t *testing.T) {
 		testCheck := newTestCheck(fmt.Sprintf("testcheck %d", idx))
 
 		for logIdx := 1; logIdx < 61; logIdx++ {
+			// Given a CheckLogger
+			checkLogger := CheckLogger{Check: testCheck}
+			// When I start the check
+			checkLogger.CheckStarted()
+			// And increment the CheckStats
 			addExpvarsCheckStats(testCheck)
+			// And the check finishes
+			checkLogger.CheckFinished()
 
-			shouldLog, _ := shouldLogCheck(testCheck.ID())
+			shouldLog := checkLogger.shouldLog
 
+			// Then shouldLog should be true for first five runs and every 20th run
 			// initialCheckLoggingSeriesLimit is 5 and we use 20 as our log limit config value in tests
 			if logIdx <= 5 || logIdx%20 == 0 {
 				assert.True(t, shouldLog, fmt.Sprintf("Loop idx: %d", logIdx))

--- a/releasenotes/notes/worker-now-logs-checks-start-and-end-checks-correctly-56cb730ac408f75e.yaml
+++ b/releasenotes/notes/worker-now-logs-checks-start-and-end-checks-correctly-56cb730ac408f75e.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Previously, the Agent could not log the start or end of a check properly after the first five check runs. The Agent now can log the start or end of a check correctly.


### PR DESCRIPTION
### What does this PR do?

This PR now fixes the issue where the Agent would incorrectly log start and finish messages. The Agent now correctly counts the number of checks that have run as well.

### Motivation

This PR fixes #10917.

### Additional Notes

N/A

### Possible Drawbacks / Trade-offs

None

### Describe how to test/QA your changes

Start the agent and tail the logs to see that the check messages have a start and matching end message.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
