### PR TITLE
add histogram buckets stats in status page, expvars and telemetry

### DIFF
--- a/cmd/agent/gui/views/templates/collectorStatus.tmpl
+++ b/cmd/agent/gui/views/templates/collectorStatus.tmpl
@@ -34,6 +34,7 @@
                 {{ $k }}: Last Run: {{humanize (index $instance.EventPlatformEvents $k) }}, Total: {{humanize $v}}<br>
                 {{- end -}}
                 Service Checks: {{humanize .ServiceChecks}}, Total: {{humanize .TotalServiceChecks}}<br>
+                Histogram Buckets: {{humanize .HistogramBuckets}}, Total: {{humanize .TotalHistogramBuckets}}<br>
                 Average Execution Time : {{humanizeDuration .AverageExecutionTime "ms"}}<br>
                 Last Execution Date : {{formatUnixTime .UpdateTimestamp}}<br>
                 Last Successful Execution Date : {{ if .LastSuccessDate }}{{formatUnixTime .LastSuccessDate}}{{ else }}Never{{ end }}<br>

--- a/cmd/agent/gui/views/templates/collectorStatus.tmpl
+++ b/cmd/agent/gui/views/templates/collectorStatus.tmpl
@@ -34,7 +34,9 @@
                 {{ $k }}: Last Run: {{humanize (index $instance.EventPlatformEvents $k) }}, Total: {{humanize $v}}<br>
                 {{- end -}}
                 Service Checks: {{humanize .ServiceChecks}}, Total: {{humanize .TotalServiceChecks}}<br>
+                {{- if .TotalHistogramBuckets}}
                 Histogram Buckets: {{humanize .HistogramBuckets}}, Total: {{humanize .TotalHistogramBuckets}}<br>
+                {{- end -}}
                 Average Execution Time : {{humanizeDuration .AverageExecutionTime "ms"}}<br>
                 Last Execution Date : {{formatUnixTime .UpdateTimestamp}}<br>
                 Last Successful Execution Date : {{ if .LastSuccessDate }}{{formatUnixTime .LastSuccessDate}}{{ else }}Never{{ end }}<br>

--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -436,6 +436,9 @@
         {{- if .SketchesFlushErrors}}
           Sketches Flush Errors: {{.SketchesFlushErrors}}<br>
         {{- end -}}
+        {{- if .ChecksHistogramBucketMetricSample}}
+          Checks Histogram Bucket Metric Sample: {{.ChecksHistogramBucketMetricSample}}<br>
+        {{- end -}}
         {{- if .EventPlatformEvents }}
         {{- range $k, $v := .EventPlatformEvents }}
           {{ $k }}: {{humanize $v}}

--- a/cmd/agent/gui/views/templates/singleCheck.tmpl
+++ b/cmd/agent/gui/views/templates/singleCheck.tmpl
@@ -8,6 +8,7 @@
         Metric Samples: {{humanize .MetricSamples}}, Total: {{humanize .TotalMetricSamples}}<br>
         Events: {{humanize .Events}}, Total: {{humanize .TotalEvents}}<br>
         Service Checks: {{humanize .ServiceChecks}}, Total: {{humanize .TotalServiceChecks}}<br>
+        Histogram Buckets: {{humanize .HistogramBuckets}}, Total: {{humanize .TotalHistogramBuckets}}<br>
         Last Execution Date : {{formatUnixTime .UpdateTimestamp}}<br>
         Last Successful Execution Date : {{ if .LastSuccessDate }}{{formatUnixTime .LastSuccessDate}}{{ else }}Never{{ end }}<br>
       {{- if .LastError}}

--- a/cmd/agent/gui/views/templates/singleCheck.tmpl
+++ b/cmd/agent/gui/views/templates/singleCheck.tmpl
@@ -8,7 +8,9 @@
         Metric Samples: {{humanize .MetricSamples}}, Total: {{humanize .TotalMetricSamples}}<br>
         Events: {{humanize .Events}}, Total: {{humanize .TotalEvents}}<br>
         Service Checks: {{humanize .ServiceChecks}}, Total: {{humanize .TotalServiceChecks}}<br>
+        {{- if .TotalHistogramBuckets}}
         Histogram Buckets: {{humanize .HistogramBuckets}}, Total: {{humanize .TotalHistogramBuckets}}<br>
+        {{- end -}}
         Last Execution Date : {{formatUnixTime .UpdateTimestamp}}<br>
         Last Successful Execution Date : {{ if .LastSuccessDate }}{{formatUnixTime .LastSuccessDate}}{{ else }}Never{{ end }}<br>
       {{- if .LastError}}

--- a/pkg/collector/check/stats.go
+++ b/pkg/collector/check/stats.go
@@ -39,6 +39,8 @@ var (
 		[]string{"check_name"}, "Events count")
 	tlmServices = telemetry.NewCounter("checks", "services_checks",
 		[]string{"check_name"}, "Service checks count")
+	tlmHistogramBuckets = telemetry.NewCounter("checks", "histogram_buckets",
+		[]string{"check_name"}, "Histogram buckets count")
 	tlmExecutionTime = telemetry.NewGauge("checks", "execution_time",
 		[]string{"check_name"}, "Check execution time")
 )
@@ -82,9 +84,11 @@ type Stats struct {
 	MetricSamples            int64
 	Events                   int64
 	ServiceChecks            int64
+	HistogramBuckets         int64
 	TotalMetricSamples       uint64
 	TotalEvents              uint64
 	TotalServiceChecks       uint64
+	TotalHistogramBuckets    uint64
 	EventPlatformEvents      map[string]int64
 	TotalEventPlatformEvents map[string]int64
 	ExecutionTimes           [32]int64 // circular buffer of recent run durations, most recent at [(TotalRuns+31) % 32]
@@ -186,6 +190,13 @@ func (cs *Stats) Add(t time.Duration, err error, warnings []error, metricStats S
 		cs.TotalServiceChecks += uint64(metricStats.ServiceChecks)
 		if cs.telemetry {
 			tlmServices.Add(float64(metricStats.ServiceChecks), cs.CheckName)
+		}
+	}
+	if metricStats.HistogramBuckets > 0 {
+		cs.HistogramBuckets = metricStats.HistogramBuckets
+		cs.TotalHistogramBuckets += uint64(metricStats.HistogramBuckets)
+		if cs.telemetry {
+			tlmHistogramBuckets.Add(float64(metricStats.HistogramBuckets), cs.CheckName)
 		}
 	}
 	for k, v := range metricStats.EventPlatformEvents {

--- a/pkg/status/templates/collector.tmpl
+++ b/pkg/status/templates/collector.tmpl
@@ -37,6 +37,7 @@ Collector
       {{ $k }}: Last Run: {{humanize (index $instance.EventPlatformEvents $k) }}, Total: {{humanize $v}}
       {{- end }}
       Service Checks: Last Run: {{humanize .ServiceChecks}}, Total: {{humanize .TotalServiceChecks}}
+      Histogram Buckets: Last Run: {{humanize .HistogramBuckets}}, Total: {{humanize .TotalHistogramBuckets}}
       Average Execution Time : {{humanizeDuration .AverageExecutionTime "ms"}}
       Last Execution Date : {{formatUnixTime .UpdateTimestamp}}
       Last Successful Execution Date : {{ if .LastSuccessDate }}{{formatUnixTime .LastSuccessDate}}{{ else }}Never{{ end }}

--- a/pkg/status/templates/collector.tmpl
+++ b/pkg/status/templates/collector.tmpl
@@ -37,7 +37,9 @@ Collector
       {{ $k }}: Last Run: {{humanize (index $instance.EventPlatformEvents $k) }}, Total: {{humanize $v}}
       {{- end }}
       Service Checks: Last Run: {{humanize .ServiceChecks}}, Total: {{humanize .TotalServiceChecks}}
+      {{- if .TotalHistogramBuckets}}
       Histogram Buckets: Last Run: {{humanize .HistogramBuckets}}, Total: {{humanize .TotalHistogramBuckets}}
+      {{- end }}
       Average Execution Time : {{humanizeDuration .AverageExecutionTime "ms"}}
       Last Execution Date : {{formatUnixTime .UpdateTimestamp}}
       Last Successful Execution Date : {{ if .LastSuccessDate }}{{formatUnixTime .LastSuccessDate}}{{ else }}Never{{ end }}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR adds information about the number of histogram bucket samples submitted per check on status page, expvars and telemetry.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

The goal is to make easier to troubleshoot how many histogram buckets a check submits.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

We need to check modifications in 4 places : 

- CLI status page
- GUI status page
- Expvars
- Telemetry

But first we have to correctly setup the agent to be able to test this PR.

## Setup

Had integration problems when I was using `inv agent.build` to create the agent binary.
Downloading the agent to get all the configuration files and then using this command `inv -e agent.build --exclude-rtloader  --no-development --embedded-path=/opt/datadog-agent/embedded --python-home-2=/opt/datadog-agent/embedded --python-home-3=/opt/datadog-agent/embedded --build-exclude=systemd` worked fine for me. 

#### 1. Send histogram buckets

For testing purpose, we need to send histogram buckets via Prometheus using the following code :

```go
// runner.go
package main

import (
    "fmt"
    "net/http"
    "time"

    "github.com/prometheus/client_golang/prometheus"
    "github.com/prometheus/client_golang/prometheus/promauto"
    "github.com/prometheus/client_golang/prometheus/promhttp"
)

func recordMetrics() {
    i := 2000.0
    for {
        opsProcessed.Observe(i)
        time.Sleep(1 * time.Second)
        i++
        fmt.Printf("Index is now %f\n", i)
    }
}

var (
    opsProcessed = promauto.NewHistogram(prometheus.HistogramOpts{
        Name:        "test_histogram",
        Help:        "The total number of processed events",
        ConstLabels: map[string]string{"tag": "test"},
    })
)

func main() {
    go recordMetrics()

    fmt.Println("Listening...")
    http.Handle("/metrics", promhttp.Handler())
    http.ListenAndServe(":2112", nil)
}
```

You can run this code using `go run runner.go` and should be able to connect to [127.0.0.1:2112/metrics](http://localhost:2112/metrics). You should have a page full of text with the following format : 

```
# HELP var_name description
# TYPE var_name type
<name_and_values>
```

and should find something close to : 

```
# HELP test_histogram The total number of processed events
# TYPE test_histogram histogram
test_histogram_bucket{tag="test",le="0.005"} 0
test_histogram_bucket{tag="test",le="0.01"} 0
test_histogram_bucket{tag="test",le="0.025"} 0
.....
```

#### 2. Agent configuration

Now we need to configure the agent to fetch the Prometheus variables from the endpoint defined in `runner.go`.

- Modify `openmetrics.d/conf.yaml` file in the `conf.d` folder (probably`/opt/datadog-agent/etc/conf.d/`) to configure the Prometheus url : 
Here is an example of a minimal configuration.

```
init_config:

instances:
  - prometheus_url: http://localhost:2112/metrics
    namespace: service
    metrics:
      - test_histogram
    send_distribution_buckets: true
```

- `prometheus_url` must correspond to the endpoint in `runner.go`
- `metrics` must contains the same value as the `Name` field in the `obsProcessed` variable in `runner.go`
- You can find the `conf.d`  folder used by agent with the `config` command and looking for `confd_path` value 

You also need to add those lines to the main config file (`/opt/datadog-agent/etc/datadog.yaml`) :
```
telemetry.enabled: true
telemetry.checks: "*"
```

Launch the agent, check the status page and verify that the `openmetrics` check is correctly running.

## Testing

### 1. Status CLI

With the agent running, launch the `status` command.

You should see a new line (see below) for each check, under the Collector/Running Checks section, that expose this metric: 
`Histogram Buckets: Last Run: 12, Total: 36`.

This line is probably visible only in the `openmetrics` section. 

### 2. Status GUI

With the agent running, launch the `launch-gui` command.

- You should see a new line under the Aggregator section which looks like this :

`Checks Histogram Bucket Metric Sample: 192`

- Also you should have a new line (see below) for each check that expose this metric when clicking on `status` -> `collector`:

`Histogram Buckets: 12, Total: 300`

### 3. Expvars

With the agent running, go to [localhost:5000/debug/vars](http://localhost:5000/debug/vars)

You should see a page with a pretty big json file. Look for the keys `runner` then `checks`. For each check you should
have a new key `TotalHistogramBuckets`.

### 4. Telemetry

With the agent running, go to [localhost:5000/telemetry](http://localhost:5000/telemetry)

You should see a page full of text with the following format : 

```
# HELP var_name description
# TYPE var_name type
<name_and_values>
```

Search for `openmetrics`, you should have new lines which look like :
```
# HELP checks__histogram_buckets Histogram buckets count
# TYPE checks__histogram_buckets counter
checks__histogram_buckets{check_name="openmetrics"} 1032
```

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
