### PR TITLE
Fix http stats debug statement that was reporting incorrect events / sec

### DIFF
--- a/pkg/network/http/telemetry.go
+++ b/pkg/network/http/telemetry.go
@@ -76,9 +76,9 @@ func (t *telemetry) report() {
 		t.misses,
 		float64(t.misses)/float64(t.elapsed),
 		t.dropped,
-		float64(t.rejected)/float64(t.elapsed),
-		t.rejected,
 		float64(t.dropped)/float64(t.elapsed),
+		t.rejected,
+		float64(t.rejected)/float64(t.elapsed),
 		t.aggregations,
 	)
 }


### PR DESCRIPTION
### What does this PR do?

Fix http stats summary debug statement so that it provides accurate events / sec counts.

### Motivation

The http stats summary debug statement had `requests_dropped` and `requests_rejected` variables accidentally switched in the (events/s) section of the message. This resulted in incorrect logs like the following:

```
datadog-v4hcv system-probe 2022-03-18 16:20:11 UTC | SYS-PROBE | DEBUG | (pkg/network/http/telemetry.go:72 in report) | http stats summary: requests_processed=51315(1710.50/s) requests_missed=0(0.00/s) requests_dropped=10830(0.00/s) requests_rejected=0(361.00/s) aggregations=15525
```

In the above example, although `10830` requests had been dropped, the events per second displayed was `(0.00/s)`.
Likewise, although `0` requests had been rejected, the events per second displayed was `(361.00/s)`.

The fix was to simply reorder the variables provided to the Debugf statement.

After the fix, the previous debug log would appear as:
```
datadog-v4hcv system-probe 2022-03-18 16:20:11 UTC | SYS-PROBE | DEBUG | (pkg/network/http/telemetry.go:72 in report) | http stats summary: requests_processed=51315(1710.50/s) requests_missed=0(0.00/s) requests_dropped=10830(361.00/s) requests_rejected=0(0.00/s) aggregations=15525
```

### Additional Notes

Because the change was so tiny, I assumed no release note or test changes would be required.

> Commit titles should be prefixed with general area of pull request's change.

What area of the code does this PR qualify as?

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
