### PR TITLE
fix: rename daemonset.updated metrics source

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
@@ -50,7 +50,7 @@ var (
 		"kube_daemonset_status_desired_number_scheduled":                                           "daemonset.desired",
 		"kube_daemonset_status_number_misscheduled":                                                "daemonset.misscheduled",
 		"kube_daemonset_status_number_ready":                                                       "daemonset.ready",
-		"kube_daemonset_updated_number_scheduled":                                                  "daemonset.updated",
+		"kube_daemonset_status_updated_number_scheduled":                                           "daemonset.updated",
 		"kube_deployment_spec_paused":                                                              "deployment.paused",
 		"kube_deployment_spec_replicas":                                                            "deployment.replicas_desired",
 		"kube_deployment_spec_strategy_rollingupdate_max_unavailable":                              "deployment.rollingupdate.max_unavailable",


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

The kube-state-metrics metric `kube_daemonset_updated_number_scheduled` was renamed to `kube_daemonset_status_updated_number_scheduled` in a late v2.0.0 alpha version (see: https://github.com/kubernetes/kube-state-metrics/pull/1181)

our check was still using the old name so the `daemonset.updated` metrics was not generated.

### Motivation

Fix bug reported on the `kubernetes_state.daemonset.updated` metrics.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
