### PR TITLE
[DCA][Admission Controller] Inject local service and socket

### DIFF
--- a/pkg/clusteragent/admission/common/const.go
+++ b/pkg/clusteragent/admission/common/const.go
@@ -8,4 +8,10 @@
 
 package common
 
-const EnabledLabelKey = "admission.datadoghq.com/enabled"
+const (
+	// EnabledLabelKey pod label to disable/enable mutations at the pod level.
+	EnabledLabelKey = "admission.datadoghq.com/enabled"
+
+	// InjectionModeLabelKey pod label to chose the config injection at the pod level.
+	InjectionModeLabelKey = "admission.datadoghq.com/config.mode"
+)

--- a/pkg/clusteragent/admission/mutate/common.go
+++ b/pkg/clusteragent/admission/mutate/common.go
@@ -72,6 +72,24 @@ func injectEnv(pod *corev1.Pod, env corev1.EnvVar) bool {
 	return injected
 }
 
+// injectVolume injects a volume into a pod template if it doesn't exist
+func injectVolume(pod *corev1.Pod, volume corev1.Volume, volumeMount corev1.VolumeMount) bool {
+	podStr := podString(pod)
+	for _, vol := range pod.Spec.Volumes {
+		if vol.Name == volume.Name {
+			log.Debugf("Ignoring pod %q: volume %q already exists", podStr, vol.Name)
+			return false
+		}
+	}
+
+	pod.Spec.Volumes = append(pod.Spec.Volumes, volume)
+	for i := range pod.Spec.Containers {
+		pod.Spec.Containers[i].VolumeMounts = append(pod.Spec.Containers[i].VolumeMounts, volumeMount)
+	}
+
+	return true
+}
+
 // podString returns a string that helps identify the pod
 func podString(pod *corev1.Pod) string {
 	if pod.GetNamespace() == "" || pod.GetName() == "" {

--- a/pkg/clusteragent/admission/mutate/config.go
+++ b/pkg/clusteragent/admission/mutate/config.go
@@ -10,11 +10,14 @@ package mutate
 
 import (
 	"errors"
+	"fmt"
 	"strconv"
+	"strings"
 
-	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
+	admCommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/metrics"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	apiCommon "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	corev1 "k8s.io/api/core/v1"
@@ -22,8 +25,17 @@ import (
 )
 
 const (
+	// Env vars
 	agentHostEnvVarName  = "DD_AGENT_HOST"
 	ddEntityIDEnvVarName = "DD_ENTITY_ID"
+
+	// Config injection modes
+	hostIP  = "hostip"
+	socket  = "socket"
+	service = "service"
+
+	// Volume name
+	datadogVolumeName = "datadog"
 )
 
 var (
@@ -46,6 +58,11 @@ var (
 			},
 		},
 	}
+
+	agentServiceEnvVar = corev1.EnvVar{
+		Name:  agentHostEnvVarName,
+		Value: config.Datadog.GetString("admission_controller.inject_config.local_service_name") + "." + apiCommon.GetMyNamespace() + ".svc.cluster.local",
+	}
 )
 
 // InjectConfig adds the DD_AGENT_HOST and DD_ENTITY_ID env vars to the pod template if they don't exist
@@ -55,9 +72,9 @@ func InjectConfig(rawPod []byte, ns string, dc dynamic.Interface) ([]byte, error
 
 // injectConfig injects DD_AGENT_HOST and DD_ENTITY_ID into a pod template if needed
 func injectConfig(pod *corev1.Pod, _ string, _ dynamic.Interface) error {
-	var injectedHost, injectedEntity bool
+	var injectedConfig, injectedEntity bool
 	defer func() {
-		metrics.MutationAttempts.Inc(metrics.ConfigMutationType, strconv.FormatBool(injectedHost || injectedEntity))
+		metrics.MutationAttempts.Inc(metrics.ConfigMutationType, strconv.FormatBool(injectedConfig || injectedEntity))
 	}()
 
 	if pod == nil {
@@ -65,10 +82,25 @@ func injectConfig(pod *corev1.Pod, _ string, _ dynamic.Interface) error {
 		return errors.New("cannot inject config into nil pod")
 	}
 
-	if shouldInjectConf(pod) {
-		injectedHost = injectEnv(pod, agentHostEnvVar)
-		injectedEntity = injectEnv(pod, ddEntityIDEnvVar)
+	if !shouldInjectConf(pod) {
+		return nil
 	}
+
+	mode := injectionMode(pod, config.Datadog.GetString("admission_controller.inject_config.mode"))
+	switch mode {
+	case hostIP:
+		injectedConfig = injectEnv(pod, agentHostEnvVar)
+	case service:
+		injectedConfig = injectEnv(pod, agentServiceEnvVar)
+	case socket:
+		volume, volumeMount := buildVolume(datadogVolumeName, config.Datadog.GetString("admission_controller.inject_config.socket_path"))
+		injectedConfig = injectVolume(pod, volume, volumeMount)
+	default:
+		metrics.MutationErrors.Inc(metrics.ConfigMutationType, "unknown mode")
+		return fmt.Errorf("invalid injection mode %q", mode)
+	}
+
+	injectedEntity = injectEnv(pod, ddEntityIDEnvVar)
 
 	return nil
 }
@@ -76,16 +108,52 @@ func injectConfig(pod *corev1.Pod, _ string, _ dynamic.Interface) error {
 // shouldInjectConf returns whether the config should be injected
 // based on the pod labels and the cluster agent config
 func shouldInjectConf(pod *corev1.Pod) bool {
-	if val, found := pod.GetLabels()[common.EnabledLabelKey]; found {
+	if val, found := pod.GetLabels()[admCommon.EnabledLabelKey]; found {
 		switch val {
 		case "true":
 			return true
 		case "false":
 			return false
 		default:
-			log.Warnf("Invalid label value '%s=%s' on pod %s should be either 'true' or 'false', ignoring it", common.EnabledLabelKey, val, podString(pod))
+			log.Warnf("Invalid label value '%s=%s' on pod %s should be either 'true' or 'false', ignoring it", admCommon.EnabledLabelKey, val, podString(pod))
 			return false
 		}
 	}
 	return config.Datadog.GetBool("admission_controller.mutate_unlabelled")
+}
+
+// injectionMode returns the injection mode based on the global mode and pod labels
+func injectionMode(pod *corev1.Pod, globalMode string) string {
+	if val, found := pod.GetLabels()[admCommon.InjectionModeLabelKey]; found {
+		mode := strings.ToLower(val)
+		switch mode {
+		case hostIP, service, socket:
+			return mode
+		default:
+			log.Warnf("Invalid label value '%s=%s' on pod %s should be either 'hostip', 'service' or 'socket', defaulting to %q", admCommon.InjectionModeLabelKey, val, podString(pod), globalMode)
+			return globalMode
+		}
+	}
+
+	return globalMode
+}
+
+func buildVolume(volumeName, path string) (corev1.Volume, corev1.VolumeMount) {
+	pathType := corev1.HostPathDirectoryOrCreate
+	volume := corev1.Volume{
+		Name: volumeName,
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: path,
+				Type: &pathType,
+			},
+		},
+	}
+
+	volumeMount := corev1.VolumeMount{
+		Name:      volumeName,
+		MountPath: path,
+	}
+
+	return volume, volumeMount
 }

--- a/pkg/clusteragent/admission/mutate/test_utils.go
+++ b/pkg/clusteragent/admission/mutate/test_utils.go
@@ -62,6 +62,13 @@ func fakePodWithEnv(name, env string) *corev1.Pod {
 	return fakePodWithContainer(name, corev1.Container{Name: name + "-container", Env: []corev1.EnvVar{fakeEnv(env)}})
 }
 
+func fakePodWithVolume(podName, volumeName string) *corev1.Pod {
+	pod := fakePod(podName)
+	pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{Name: volumeName})
+	pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{Name: volumeName})
+	return pod
+}
+
 func fakePod(name string) *corev1.Pod {
 	return fakePodWithContainer(name, corev1.Container{Name: name + "-container"})
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -886,6 +886,9 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("admission_controller.webhook_name", "datadog-webhook")
 	config.BindEnvAndSetDefault("admission_controller.inject_config.enabled", true)
 	config.BindEnvAndSetDefault("admission_controller.inject_config.endpoint", "/injectconfig")
+	config.BindEnvAndSetDefault("admission_controller.inject_config.mode", "hostip") // possible values: hostip / service / socket
+	config.BindEnvAndSetDefault("admission_controller.inject_config.local_service_name", "datadog")
+	config.BindEnvAndSetDefault("admission_controller.inject_config.socket_path", "/var/run/datadog")
 	config.BindEnvAndSetDefault("admission_controller.inject_tags.enabled", true)
 	config.BindEnvAndSetDefault("admission_controller.inject_tags.endpoint", "/injecttags")
 	config.BindEnvAndSetDefault("admission_controller.pod_owners_cache_validity", 10) // in minutes

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2299,10 +2299,10 @@ api_key:
 
 ## @param admission_controller - custom object - optional
 ## Enter specific configurations for your admission controller.
-## The Datadog admission controller is a component of the Datadog Cluster Agent,
+## The Datadog admission controller is a component of the Datadog Cluster Agent.
 ## It has two main functionalities:
-## Inject environment variables (DD_AGENT_HOST and DD_ENTITY_ID) to configure DogStatsD and APM tracer libraries into the user’s application containers.
-## Inject Datadog standard tags (env, service, version) from application labels into the container environment variables.
+## Inject environment variables (DD_AGENT_HOST and DD_ENTITY_ID) to configure DogStatsD and APM tracer libraries into your application containers.
+## Inject Datadog reserved tags (env, service, version) from application labels into the container environment variables.
 ## Uncomment this parameter and the one below to enable it.
 ## See https://docs.datadoghq.com/agent/cluster_agent/admission_controller/
 #
@@ -2353,7 +2353,7 @@ api_key:
   ## @param namespace_selector_fallback - boolean - optional - default: false
   ## @env DD_ADMISSION_CONTROLLER_NAMESPACE_SELECTOR_FALLBACK - boolean - optional - default: false
   ## Use namespace selectors instead of object selectors to watch objects.
-  ## For Kubernetes versions from 1.10 to 1.14 (included)
+  ## For Kubernetes versions from 1.10 to 1.14 (inclusive)
   #
   # namespace_selector_fallback: false
 
@@ -2399,7 +2399,7 @@ api_key:
 
     ## @param mode - string - optional - default: hostip
     ## @env DD_ADMISSION_CONTROLLER_INJECT_CONFIG_MODE - string - optional - default: hostip
-    ## The kind of configuration to be injected, it can be "hostip", "service" or "socket".
+    ## The kind of configuration to be injected, it can be "hostip", "service", or "socket".
     #
     # mode: hostip
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2291,6 +2291,147 @@ api_key:
   # clc_runners_port: 5005
 
 {{ end -}}
+{{- if .AdmissionController }}
+
+########################################
+## Admission controller Configuration ##
+########################################
+
+## @param admission_controller - custom object - optional
+## Enter specific configurations for your admission controller.
+## The Datadog admission controller is a component of the Datadog Cluster Agent,
+## It has two main functionalities:
+## Inject environment variables (DD_AGENT_HOST and DD_ENTITY_ID) to configure DogStatsD and APM tracer libraries into the user’s application containers.
+## Inject Datadog standard tags (env, service, version) from application labels into the container environment variables.
+## Uncomment this parameter and the one below to enable it.
+## See https://docs.datadoghq.com/agent/cluster_agent/admission_controller/
+#
+# admission_controller:
+
+  ## @param enabled - boolean - optional - default: false
+  ## @env DD_ADMISSION_CONTROLLER_ENABLED - boolean - optional - default: false
+  ## Set to true to enable the admission controller in the cluster-agent.
+  #
+  # enabled: false
+
+  ## @param mutate_unlabelled - boolean - optional - default: false
+  ## @env DD_ADMISSION_CONTROLLER_MUTATE_ENABLED - boolean - optional - default: false
+  ## Enable injecting config without having the pod label admission.datadoghq.com/enabled="true".
+  #
+  # mutate_unlabelled: false
+
+  ## @param port - integer - optional - default: 8000
+  ## @env DD_ADMISSION_CONTROLLER_PORT - integer - optional - default: 8000
+  ## The admission controller server port.
+  #
+  # port: 8000
+
+  ## @param timeout_seconds - integer - optional - default: 10
+  ## @env DD_ADMISSION_CONTROLLER_TIMEOUT_SECONDS - integer - optional - default: 10
+  ## The admission controller server timeout in seconds.
+  #
+  # timeout_seconds: 10
+
+  ## @param service_name - string - optional - default: datadog-admission-controller
+  ## @env DD_ADMISSION_CONTROLLER_SERVICE_NAME - string - optional - default: datadog-admission-controller
+  ## The name of the Kubernetes service that exposes the admission controller.
+  #
+  # service_name: datadog-admission-controller
+
+  ## @param webhook_name - string - optional - default: datadog-webhook
+  ## @env DD_ADMISSION_CONTROLLER_WEBHOOK_NAME - string - optional - default: datadog-webhook
+  ## The name of the Kubernetes webhook object.
+  #
+  # webhook_name: datadog-webhook
+
+  ## @param pod_owners_cache_validity - integer - optional - default: 10
+  ## @env DD_ADMISSION_CONTROLLER_POD_OWNERS_CACHE_VALIDITY - integer - optional - default: pod_owners_cache_validity
+  ## The in-memory cache TTL for pod owners in minutes.
+  #
+  # pod_owners_cache_validity: 10
+
+  ## @param namespace_selector_fallback - boolean - optional - default: false
+  ## @env DD_ADMISSION_CONTROLLER_NAMESPACE_SELECTOR_FALLBACK - boolean - optional - default: false
+  ## Use namespace selectors instead of object selectors to watch objects.
+  ## For Kubernetes versions from 1.10 to 1.14 (included)
+  #
+  # namespace_selector_fallback: false
+
+  ## @param certificate - custom object - optional
+  ## The webhook's certificate configuration.
+  #
+  # certificate:
+
+    ## @param validity_bound - integer - optional - default: 8760
+    ## @env DD_ADMISSION_CONTROLLER_CERTIFICATE_VALIDITY_BOUND - integer - optional - default: 8760
+    ## The certificate's validity bound in hours, default 1 year (365*24).
+    #
+    # validity_bound: 8760
+
+    ## @param expiration_threshold - integer - optional - default: 720
+    ## @env DD_ADMISSION_CONTROLLER_CERTIFICATE_EXPIRATION_THRESHOLD - integer - optional - default: 720
+    ## The certificate's refresh threshold in hours, default 1 month (30*24).
+    #
+    # expiration_threshold: 720
+
+    ## @param secret_name - string - optional - default: webhook-certificate
+    ## @env DD_ADMISSION_CONTROLLER_CERTIFICATE_SECRET_NAME - string - optional - default: webhook-certificate
+    ## Name of the Secret object containing the webhook certificate.
+    #
+    # secret_name: webhook-certificate
+
+  ## @param inject_config - custom object - optional
+  ## Configuration injection parameters.
+  #
+  # inject_config:
+
+    ## @param enabled - boolean - optional - default: true
+    ## @env DD_ADMISSION_CONTROLLER_INJECT_CONFIG_ENABLED - boolean - optional - default: true
+    ## Enable configuration injection (configure DogStatsD and APM tracer libraries).
+    #
+    # enabled: true
+
+    ## @param endpoint - string - optional - default: /injectconfig
+    ## @env DD_ADMISSION_CONTROLLER_INJECT_CONFIG_ENDPOINT - string - optional - default: /injectconfig
+    ## Admission controller's endpoint responsible for handling configuration injection requests.
+    #
+    # endpoint: /injectconfig
+
+    ## @param mode - string - optional - default: hostip
+    ## @env DD_ADMISSION_CONTROLLER_INJECT_CONFIG_MODE - string - optional - default: hostip
+    ## The kind of configuration to be injected, it can be "hostip", "service" or "socket".
+    #
+    # mode: hostip
+
+    ## @param local_service_name - string - optional - default: datadog
+    ## @env DD_ADMISSION_CONTROLLER_INJECT_CONFIG_LOCAL_SERVICE_NAME - string - optional - default: datadog
+    ## Configure the local service name that exposes the Datadog Agent. Only applicable in "service" mode.
+    #
+    # local_service_name: datadog
+
+    ## @param socket_path - string - optional - default: /var/run/datadog
+    ## @env DD_ADMISSION_CONTROLLER_INJECT_CONFIG_SOCKET_PATH - string - optional - default: /var/run/datadog
+    ## Configure Datadog Agent's socket path. Only applicable in "socket" mode.
+    #
+    # socket_path: /var/run/datadog
+
+  ## @param inject_tags - custom object - optional
+  ## Tags injection parameters.
+  #
+  # inject_tags:
+
+    ## @param enabled - boolean - optional - default: true
+    ## @env DD_ADMISSION_CONTROLLER_INJECT_TAGS_ENABLED - boolean - optional - default: true
+    ## Enable standard tags injection.
+    #
+    # enabled: true
+
+    ## @param endpoint - string - optional - default: /injecttags
+    ## @env DD_ADMISSION_CONTROLLER_INJECT_TAGS_ENDPOINT - string - optional - default: /injecttags
+    ## Admission controller's endpoint responsible for handling tags injection requests.
+    #
+    # endpoint: /injecttags
+{{ end -}}
 {{- if .DockerTagging }}
 
 #########################

--- a/pkg/config/render_config.go
+++ b/pkg/config/render_config.go
@@ -19,39 +19,40 @@ import (
 
 // context contains the context used to render the config file template
 type context struct {
-	OS                string
-	Common            bool
-	Agent             bool
-	Python            bool // Sub-option of Agent
-	BothPythonPresent bool // Sub-option of Agent - Python
-	Metadata          bool
-	InternalProfiling bool
-	Dogstatsd         bool
-	LogsAgent         bool
-	JMX               bool
-	Autoconfig        bool
-	Logging           bool
-	Autodiscovery     bool
-	DockerTagging     bool
-	Kubelet           bool
-	KubernetesTagging bool
-	ECS               bool
-	Containerd        bool
-	CRI               bool
-	ProcessAgent      bool
-	SystemProbe       bool
-	KubeApiServer     bool
-	TraceAgent        bool
-	ClusterAgent      bool
-	ClusterChecks     bool
-	CloudFoundryBBS   bool
-	CloudFoundryCC    bool
-	Compliance        bool
-	SNMP              bool
-	SecurityModule    bool
-	SecurityAgent     bool
-	NetworkModule     bool // Sub-module of System Probe
-	PrometheusScrape  bool
+	OS                  string
+	Common              bool
+	Agent               bool
+	Python              bool // Sub-option of Agent
+	BothPythonPresent   bool // Sub-option of Agent - Python
+	Metadata            bool
+	InternalProfiling   bool
+	Dogstatsd           bool
+	LogsAgent           bool
+	JMX                 bool
+	Autoconfig          bool
+	Logging             bool
+	Autodiscovery       bool
+	DockerTagging       bool
+	Kubelet             bool
+	KubernetesTagging   bool
+	ECS                 bool
+	Containerd          bool
+	CRI                 bool
+	ProcessAgent        bool
+	SystemProbe         bool
+	KubeApiServer       bool
+	TraceAgent          bool
+	ClusterAgent        bool
+	ClusterChecks       bool
+	AdmissionController bool
+	CloudFoundryBBS     bool
+	CloudFoundryCC      bool
+	Compliance          bool
+	SNMP                bool
+	SecurityModule      bool
+	SecurityAgent       bool
+	NetworkModule       bool // Sub-module of System Probe
+	PrometheusScrape    bool
 }
 
 func mkContext(buildType string) context {
@@ -118,11 +119,12 @@ func mkContext(buildType string) context {
 		}
 	case "dca":
 		return context{
-			ClusterAgent:  true,
-			Common:        true,
-			Logging:       true,
-			KubeApiServer: true,
-			ClusterChecks: true,
+			ClusterAgent:        true,
+			Common:              true,
+			Logging:             true,
+			KubeApiServer:       true,
+			ClusterChecks:       true,
+			AdmissionController: true,
 		}
 	case "dcacf":
 		return context{

--- a/releasenotes-dca/notes/admission-config-modes-f8d680c0a57e4c02.yaml
+++ b/releasenotes-dca/notes/admission-config-modes-f8d680c0a57e4c02.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    The Datadog Admission Controller supports multiple configuration injection
+    modes via the ``admission_controller.inject_config.mode`` parameter
+    or the ``DD_ADMISSION_CONTROLLER_INJECT_CONFIG_MODE`` environment variable:
+    - ``hostip``: Inject the host IP. (default)
+    - ``service``: Inject Datadog's local-service DNS name.
+    - ``socket``: Inject the Datadog socket path.

--- a/releasenotes-dca/notes/admission-config-modes-f8d680c0a57e4c02.yaml
+++ b/releasenotes-dca/notes/admission-config-modes-f8d680c0a57e4c02.yaml
@@ -2,7 +2,7 @@
 features:
   - |
     The Datadog Admission Controller supports multiple configuration injection
-    modes via the ``admission_controller.inject_config.mode`` parameter
+    modes through the ``admission_controller.inject_config.mode`` parameter
     or the ``DD_ADMISSION_CONTROLLER_INJECT_CONFIG_MODE`` environment variable:
     - ``hostip``: Inject the host IP. (default)
     - ``service``: Inject Datadog's local-service DNS name.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Support multiple configuration injection modes:
- `hostip`: Inject the host IP (default)
- `service`: Inject Datadog's local-service DNS name
- `socket`: Inject the Datadog socket path 

The user can also define pod-specific mode using the `admission.datadoghq.com/config.mode=<mode>` pod label.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

As we're moving away from the hostIP config for APM and DSD, this feature allows automating socket volumes and local svc name injection.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

- Try different config combinations for `DD_ADMISSION_CONTROLLER_INJECT_CONFIG_MODE` (`hostip`, `service`, `socket`), make sure the desired config gets injected
- Use the `admission.datadoghq.com/config.mode=<mode>` pod label to override the global config
- Try providing invalid config modes

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
