### PR TITLE
[pkg/otlp] Add unit tests for literal `null` on config

### DIFF
--- a/pkg/otlp/config_test.go
+++ b/pkg/otlp/config_test.go
@@ -30,11 +30,13 @@ func TestIsEnabled(t *testing.T) {
 		{path: "experimental/receiver/noprotocols.yaml", enabled: true},
 		{path: "experimental/receiver/portandreceiver.yaml", enabled: true},
 		{path: "experimental/receiver/simple.yaml", enabled: true},
+		{path: "experimental/receiver/null.yaml", enabled: true},
 		{path: "experimental/receiver/advanced.yaml", enabled: true},
 
 		{path: "stable/invalid_port_based.yaml", enabled: false},
 		{path: "stable/receiver/noprotocols.yaml", enabled: true},
 		{path: "stable/receiver/simple.yaml", enabled: true},
+		{path: "stable/receiver/null.yaml", enabled: true},
 		{path: "stable/receiver/advanced.yaml", enabled: true},
 	}
 
@@ -139,6 +141,24 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 			},
 		},
 		{
+			path: "experimental/receiver/null.yaml",
+			cfg: PipelineConfig{
+				OTLPReceiverConfig: map[string]interface{}{
+					"protocols": map[string]interface{}{
+						"grpc": nil,
+						"http": nil,
+					},
+				},
+				TracePort:      5003,
+				MetricsEnabled: true,
+				TracesEnabled:  true,
+				Metrics: map[string]interface{}{
+					"enabled":         true,
+					"tag_cardinality": "low",
+				},
+			},
+		},
+		{
 			path: "experimental/receiver/advanced.yaml",
 			cfg: PipelineConfig{
 				OTLPReceiverConfig: map[string]interface{}{
@@ -186,6 +206,24 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 		},
 		{
 			path: "stable/receiver/simple.yaml",
+			cfg: PipelineConfig{
+				OTLPReceiverConfig: map[string]interface{}{
+					"protocols": map[string]interface{}{
+						"grpc": nil,
+						"http": nil,
+					},
+				},
+				TracePort:      5003,
+				MetricsEnabled: true,
+				TracesEnabled:  true,
+				Metrics: map[string]interface{}{
+					"enabled":         true,
+					"tag_cardinality": "low",
+				},
+			},
+		},
+		{
+			path: "stable/receiver/null.yaml",
 			cfg: PipelineConfig{
 				OTLPReceiverConfig: map[string]interface{}{
 					"protocols": map[string]interface{}{

--- a/pkg/otlp/testdata/experimental/receiver/null.yaml
+++ b/pkg/otlp/testdata/experimental/receiver/null.yaml
@@ -1,0 +1,6 @@
+experimental:
+  otlp:
+    receiver:
+      protocols:
+        http: null
+        grpc: null

--- a/pkg/otlp/testdata/stable/receiver/null.yaml
+++ b/pkg/otlp/testdata/stable/receiver/null.yaml
@@ -1,0 +1,5 @@
+otlp_config:
+  receiver:
+    protocols:
+      http: null
+      grpc: null


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Add unit tests for configuration that includes a literal `null`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

While this configuration would (usually) not be written by a human, things like Helm charts' `toYaml` function does explicitly print the `null`s.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

This works, but since it's a bit of an edge case I want to add it so that we don't introduce a bug if changing unmarshaling in some way, and to help in debugging an internal issue.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
