### PR TITLE
[tasks] Added `force_use_<transport>` configs for logs agent

### DIFF
--- a/cmd/agent/dist/conf.d/myapp.d/conf.yaml
+++ b/cmd/agent/dist/conf.d/myapp.d/conf.yaml
@@ -1,0 +1,5 @@
+logs:
+  - type: tcp
+    port: 10518
+    service: test_app
+    source: local_osx

--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -318,7 +318,7 @@
       {{- end }}
       {{- if and (eq .use_http false) (.is_running) }}
 
-        You are currently sending Logs to Datadog through TCP (either because logs_config.use_tcp or logs_config.socks5_proxy_address is set or the HTTP connectivity test has failed). To benefit from increased reliability and better network performances, we strongly encourage switching over to compressed HTTPS which is now the default protocol.</br>
+        You are currently sending Logs to Datadog through TCP (either because logs_config.force_use_tcp or logs_config.socks5_proxy_address is set or the HTTP connectivity test has failed). To benefit from increased reliability and better network performances, we strongly encourage switching over to compressed HTTPS which is now the default protocol.</br>
       {{- end }}
       {{- if .metrics }}
 
@@ -373,7 +373,7 @@
             24h Average Latency (ms): {{ .recent_avg_latency }}</br>
             Peak Latency (ms): {{ .all_time_peak_latency }}</br>
             24h Peak Latency (ms): {{ .recent_peak_latency }}</br>
-            {{- if .info }} 
+            {{- if .info }}
             {{- range $key, $value := .info }} {{ $len := len $value }} {{ if eq $len 1 }}
             {{$key}}: {{index $value 0}}</br> {{ else }}
             {{$key}}:</br>

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -790,8 +790,12 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("logs_config.docker_client_read_timeout", 30)
 	// Internal Use Only: avoid modifying those configuration parameters, this could lead to unexpected results.
 	config.BindEnvAndSetDefault("logs_config.run_path", defaultRunPath)
+	// DEPRECATED in favor of `logs_config.force_use_http`.
 	config.BindEnvAndSetDefault("logs_config.use_http", false)
+	config.BindEnvAndSetDefault("logs_config.force_use_http", false)
+	// DEPRECATED in favor of `logs_config.force_use_tcp`.
 	config.BindEnvAndSetDefault("logs_config.use_tcp", false)
+	config.BindEnvAndSetDefault("logs_config.force_use_tcp", false)
 
 	bindEnvAndSetLogsConfigKeys(config, "logs_config.")
 	bindEnvAndSetLogsConfigKeys(config, "database_monitoring.samples.")

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -958,21 +958,21 @@ api_key:
   #     name: <RULE_NAME>
   #     pattern: <RULE_PATTERN>
 
-  ## @param use_http - boolean - optional - default: false
-  ## @env DD_LOGS_CONFIG_USE_HTTP - boolean - optional - default: false
+  ## @param force_use_http - boolean - optional - default: false
+  ## @env DD_LOGS_CONFIG_FORCE_USE_HTTP - boolean - optional - default: false
   ## By default, the Agent sends logs in HTTPS batches to port 443 if HTTPS connectivity can
   ## be established at Agent startup, and falls back to TCP otherwise. Set this parameter to `true` to
   ## always send logs with HTTPS (recommended).
   #
-  # use_http: true
+  # force_use_http: true
 
-  ## @param use_tcp - boolean - optional - default: false
-  ## @env DD_USE_TCP - boolean - optional - default: false
+  ## @param force_use_tcp - boolean - optional - default: false
+  ## @env DD_LOGS_FORCE_USE_TCP - boolean - optional - default: false
   ## By default, logs are sent through HTTPS if possible, set this parameter
   ## to `true` to always send logs via TCP. If `use_http` is set to `true`, this parameter
   ## is ignored.
   #
-  # use_tcp: true
+  # force_use_tcp: true
 
   ## @param use_compression - boolean - optional - default: false
   ## @env DD_LOGS_CONFIG_USE_COMPRESSION - boolean - optional - default: false

--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -119,7 +119,7 @@ func BuildEndpointsWithConfig(logsConfig *LogsConfigKeys, endpointPrefix string,
 	log.Warnf("You are currently sending Logs to Datadog through TCP (either because %s or %s is set or the HTTP connectivity test has failed) "+
 		"To benefit from increased reliability and better network performances, "+
 		"we strongly encourage switching over to compressed HTTPS which is now the default protocol.",
-		logsConfig.getConfigKey("use_tcp"), logsConfig.getConfigKey("socks5_proxy_address"))
+		logsConfig.getConfigKey("force_use_tcp"), logsConfig.getConfigKey("socks5_proxy_address"))
 	return buildTCPEndpoints(logsConfig)
 }
 

--- a/pkg/logs/config/config_keys.go
+++ b/pkg/logs/config/config_keys.go
@@ -81,7 +81,8 @@ func (l *LogsConfigKeys) socks5ProxyAddress() string {
 }
 
 func (l *LogsConfigKeys) isForceTCPUse() bool {
-	return l.getConfig().GetBool(l.getConfigKey("use_tcp"))
+	return l.getConfig().GetBool(l.getConfigKey("use_tcp")) ||
+		l.getConfig().GetBool(l.getConfigKey("force_use_tcp"))
 }
 
 func (l *LogsConfigKeys) usePort443() bool {
@@ -89,7 +90,8 @@ func (l *LogsConfigKeys) usePort443() bool {
 }
 
 func (l *LogsConfigKeys) isForceHTTPUse() bool {
-	return l.getConfig().GetBool(l.getConfigKey("use_http"))
+	return l.getConfig().GetBool(l.getConfigKey("use_http")) ||
+		l.getConfig().GetBool(l.getConfigKey("force_use_http"))
 }
 
 func (l *LogsConfigKeys) logsNoSSL() bool {

--- a/pkg/logs/config/config_test.go
+++ b/pkg/logs/config/config_test.go
@@ -40,7 +40,10 @@ func (suite *ConfigTestSuite) TestDefaultDatadogConfig() {
 	suite.Equal(30, suite.config.GetInt("logs_config.stop_grace_period"))
 	suite.Equal(nil, suite.config.Get("logs_config.processing_rules"))
 	suite.Equal("", suite.config.GetString("logs_config.processing_rules"))
+	suite.Equal(false, suite.config.GetBool("logs_config.use_tcp"))
+	suite.Equal(false, suite.config.GetBool("logs_config.force_use_tcp"))
 	suite.Equal(false, suite.config.GetBool("logs_config.use_http"))
+	suite.Equal(false, suite.config.GetBool("logs_config.force_use_http"))
 	suite.Equal(false, suite.config.GetBool("logs_config.k8s_container_use_file"))
 	suite.Equal(true, suite.config.GetBool("logs_config.use_v2_api"))
 }

--- a/pkg/status/templates/logsagent.tmpl
+++ b/pkg/status/templates/logsagent.tmpl
@@ -19,7 +19,7 @@ Logs Agent
 
 {{- if and (eq .use_http false) (eq .is_running true) }}
 
-    You are currently sending Logs to Datadog through TCP (either because logs_config.use_tcp or logs_config.socks5_proxy_address is set or the HTTP connectivity test has failed). To benefit from increased reliability and better network performances, we strongly encourage switching over to compressed HTTPS which is now the default protocol.
+    You are currently sending Logs to Datadog through TCP (either because logs_config.force_use_tcp or logs_config.socks5_proxy_address is set or the HTTP connectivity test has failed). To benefit from increased reliability and better network performances, we strongly encourage switching over to compressed HTTPS which is now the default protocol.
 {{ end }}
 
 {{- if .metrics }}
@@ -71,7 +71,7 @@ Logs Agent
       24h Average Latency (ms): {{ .recent_avg_latency }}
       Peak Latency (ms): {{ .all_time_peak_latency }}
       24h Peak Latency (ms): {{ .recent_peak_latency }}
-      {{- if .info }} 
+      {{- if .info }}
       {{- range $key, $value := .info }} {{ $len := len $value }} {{ if eq $len 1 }}
       {{$key}}: {{index $value 0}} {{ else }}
       {{$key}}:

--- a/releasenotes/notes/logs-config-switch-flag-from-use-to-force_use-78696faf2ea39d56.yaml
+++ b/releasenotes/notes/logs-config-switch-flag-from-use-to-force_use-78696faf2ea39d56.yaml
@@ -1,0 +1,4 @@
+---
+deprecations:
+  - |
+    The logs configuration `use_http` and `use_tcp` flags have been deprecated in favor of `force_use_http` and `force_use_tcp`.


### PR DESCRIPTION
### What does this PR do?

Adds two new config flags, which deprecate previous config flags:

- `logs_config.force_use_http` deprecates `logs_config.use_http`
- `logs_config.force_use_tcp` deprecates `logs_config.use_tcp`

### Motivation

This change has been made so that the language is more consistent with other flags used by the Agent.

### Additional Notes

The old flags are still behave as they did before. This means that it won't break previous Agent configs using it. A PR needs to be raised once the agent is released to reflect the change in flag names.

### Possible Drawbacks / Trade-offs

Having to keep both flags until we can determine that no one is using the old flags. 

### Describe how to test/QA your changes

To test these changes add following to your `datadog.yaml`:

```yaml
logs_enabled: true
logs_config:
  # use_http: false
  # use_tcp: true
  force_use_http: false
  force_use_tcp: true
```
Start the Agent and in another terminal run

- `agent status` to check the status in the terminal
- `agent launch-gui` to check the status in the browser

Both should report back:

> Reliable: Sending uncompressed logs in SSL encrypted TCP to agent-intake.logs.datadoghq.com on port 10516
> You are currently sending Logs to Datadog through TCP (either because logs_config.force_use_tcp...

Switching back to using `use_tcp` will cause the same message above to appear.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
