### PR TITLE
[Serverless] Remove cobra dependency

### DIFF
--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -6,25 +6,18 @@
 package main
 
 import (
-	_ "expvar"
-	"fmt"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
-	"runtime"
 	"strings"
 	"sync"
 	"syscall"
 	"time"
-
-	"github.com/spf13/cobra"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/logs"
 	logConfig "github.com/DataDog/datadog-agent/pkg/logs/config"
-	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/serverless"
 	"github.com/DataDog/datadog-agent/pkg/serverless/daemon"
 	"github.com/DataDog/datadog-agent/pkg/serverless/flush"
@@ -36,37 +29,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/serverless/trace"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
 var (
-	// serverlessAgentCmd is the root command
-	serverlessAgentCmd = &cobra.Command{
-		Use:   "agent [command]",
-		Short: "Serverless Datadog Agent at your service.",
-		Long: `
-Datadog Serverless Agent accepts custom application metrics points over UDP, aggregates and forwards them to Datadog,
-where they can be graphed on dashboards. The Datadog Serverless Agent implements the StatsD protocol, along with a few extensions for special Datadog features.`,
-	}
-
-	runCmd = &cobra.Command{
-		Use:   "run",
-		Short: "Runs the Serverless Datadog Agent",
-		Long:  `Runs the Serverless Datadog Agent`,
-		RunE:  run,
-	}
-
-	versionCmd = &cobra.Command{
-		Use:   "version",
-		Short: "Print the version number",
-		Long:  ``,
-		Run: func(cmd *cobra.Command, args []string) {
-			av, _ := version.Agent()
-			fmt.Printf("Serverless Datadog Agent %s - Codename: %s - Commit: %s - Serialization version: %s - Go version: %s\n",
-				av.GetNumber(), av.Meta, av.Commit, serializer.AgentPayloadVersion, runtime.Version())
-		},
-	}
-
 	kmsAPIKeyEnvVar            = "DD_KMS_API_KEY"
 	secretsManagerAPIKeyEnvVar = "DD_API_KEY_SECRET_ARN"
 	apiKeyEnvVar               = "DD_API_KEY"
@@ -100,19 +65,15 @@ const (
 	logsAPIMaxItems            = 1000
 )
 
-func init() {
-	// attach the command to the root
-	serverlessAgentCmd.AddCommand(runCmd)
-	serverlessAgentCmd.AddCommand(versionCmd)
-}
-
-func run(cmd *cobra.Command, args []string) error {
+func main() {
+	flavor.SetFlavor(flavor.ServerlessAgent)
 	stopCh := make(chan struct{})
 
 	// run the agent
 	serverlessDaemon, err := runAgent(stopCh)
 	if err != nil {
-		return err
+		log.Error(err)
+		os.Exit(-1)
 	}
 
 	// handle SIGTERM
@@ -120,21 +81,6 @@ func run(cmd *cobra.Command, args []string) error {
 
 	// block here until we receive a stop signal
 	<-stopCh
-	return nil
-}
-
-func main() {
-	flavor.SetFlavor(flavor.ServerlessAgent)
-
-	// if not command has been provided, run the agent
-	if len(os.Args) == 1 {
-		os.Args = append(os.Args, "run")
-	}
-
-	if err := serverlessAgentCmd.Execute(); err != nil {
-		log.Error(err)
-		os.Exit(-1)
-	}
 }
 
 func runAgent(stopCh chan struct{}) (serverlessDaemon *daemon.Daemon, err error) {


### PR DESCRIPTION
### What does this PR do?

I think we can get rid of Cobra as we never use the extension as a CLI + get the version 
The version is logged when the extension is starting

This PR also removes imports from `expvar` and `net/http/pprof` as we do not use them

### Motivation

Cleanup

### Describe how to test/QA your changes

integration tests to make sure that the extension keeps starting

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
