### PR TITLE
Fix `containerd_namespace` config defaulting

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -582,7 +582,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("cri_query_timeout", int64(5))      // in seconds
 
 	// Containerd
-	config.BindEnvAndSetDefault("containerd_namespace", "")
+	config.BindEnvAndSetDefault("containerd_namespace", []string{})
 	config.BindEnvAndSetDefault("containerd_namespaces", []string{}) // alias for containerd_namespace
 	config.BindEnvAndSetDefault("container_env_as_tags", map[string]string{})
 	config.BindEnvAndSetDefault("container_labels_as_tags", map[string]string{})

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2474,8 +2474,8 @@ api_key:
 # cri_query_timeout: 5
 
 ## Deprecated - use `containerd_namespaces` instead
-## @param containerd_namespace - list of strings - optional - default: ""
-## @env DD_CONTAINERD_NAMESPACE - space separated list of strings - optional - default: ""
+## @param containerd_namespace - list of strings - optional - default: []
+## @env DD_CONTAINERD_NAMESPACE - space separated list of strings - optional - default: []
 ## Activating the Containerd check also activates the CRI check, as it contains an additional subset of useful metrics.
 ## Defaults to "" which configures the agent to report metrics and events from all the containerd namespaces.
 ## To watch specific namespaces, list them here.

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2477,7 +2477,7 @@ api_key:
 ## @param containerd_namespace - list of strings - optional - default: []
 ## @env DD_CONTAINERD_NAMESPACE - space separated list of strings - optional - default: []
 ## Activating the Containerd check also activates the CRI check, as it contains an additional subset of useful metrics.
-## Defaults to "" which configures the agent to report metrics and events from all the containerd namespaces.
+## Defaults to [] which configures the agent to report metrics and events from all the containerd namespaces.
 ## To watch specific namespaces, list them here.
 ## https://github.com/containerd/cri/blob/release/1.2/pkg/constants/constants.go#L22-L23
 #


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

if the `containerd_namespace` is not set it is default to an empty string.
but with the introduction of `containerd_namespaces` alias, both need to
be a []string{}.

### Motivation
Fix for a bug introduced by: https://github.com/DataDog/datadog-agent/pull/10768
Avoid having the following error:

```
2022-03-18T16:28:56.902-04:00

ERROR 2022/03/18 20:28:56 svType != tvType; key=containerd_namespace, st=string, tt=[]string, sv=, tv=[]
```

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

deployment the agent with a custom configuration containing:
```yaml
containerd_namespace: "foo"
containerd_namespaces:
- "foo"
- "bar"
```

in `agent config` both parameters should contains: `foo` and `bar`


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
