### PR TITLE
[ksm] make time based metrics comparable.

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
@@ -11,6 +11,7 @@ package ksm
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
@@ -252,7 +253,7 @@ func TestProcessMetrics(t *testing.T) {
 			},
 			metricsToGet: []ksmstore.DDMetricsFam{},
 			metricTransformers: map[string]metricTransformerFunc{
-				"kube_pod_status_phase": func(s aggregator.Sender, n string, m ksmstore.DDMetric, h string, t []string) {
+				"kube_pod_status_phase": func(s aggregator.Sender, n string, m ksmstore.DDMetric, h string, t []string, c time.Time) {
 					s.Gauge("kube_pod_status_phase_transformed", 1, "", []string{"transformed:tag"})
 				},
 			},
@@ -457,7 +458,7 @@ func TestProcessMetrics(t *testing.T) {
 		for _, metricFam := range test.metricsToGet {
 			labelJoiner.insertFamily(metricFam)
 		}
-		kubeStateMetricsSCheck.processMetrics(mocked, test.metricsToProcess, labelJoiner)
+		kubeStateMetricsSCheck.processMetrics(mocked, test.metricsToProcess, labelJoiner, time.Now())
 		t.Run(test.name, func(t *testing.T) {
 			for _, expectMetric := range test.expected {
 				mocked.AssertMetric(t, "Gauge", expectMetric.name, expectMetric.val, expectMetric.hostname, expectMetric.tags)

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers.go
@@ -22,7 +22,7 @@ import (
 
 // metricTransformerFunc is used to tweak or generate new metrics from a given KSM metric
 // For name translation only please use metricNamesMapper instead
-type metricTransformerFunc = func(aggregator.Sender, string, ksmstore.DDMetric, string, []string)
+type metricTransformerFunc = func(aggregator.Sender, string, ksmstore.DDMetric, string, []string, time.Time)
 
 var (
 	// metricTransformers contains KSM metric names and their corresponding transformer functions
@@ -54,12 +54,9 @@ var (
 	}
 )
 
-// now allows testing
-var now = time.Now
-
 // nodeConditionTransformer generates service checks based on the metric kube_node_status_condition
 // It also submit the metric kubernetes_state.node.by_condition
-func nodeConditionTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string) {
+func nodeConditionTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string, _ time.Time) {
 	if metric.Val != 1.0 {
 		// Only consider active metrics
 		return
@@ -139,7 +136,7 @@ func statusForCondition(status string, positiveEvent bool) metrics.ServiceCheckS
 
 // nodeUnschedulableTransformer reports whether a node can schedule new pods
 // It adds a tag 'status' that can be either 'schedulable' or 'unschedulable' and always report the metric value '1'
-func nodeUnschedulableTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string) {
+func nodeUnschedulableTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string, _ time.Time) {
 	status := ""
 	switch metric.Val {
 	case 0.0:
@@ -156,27 +153,27 @@ func nodeUnschedulableTransformer(s aggregator.Sender, name string, metric ksmst
 
 // submitAge generates a resource age or uptime metric based on a given timestamp
 // The metric value must correspond to a timestamp
-func submitAge(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string) {
-	s.Gauge(name, float64(now().Unix())-metric.Val, hostname, tags)
+func submitAge(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string, currentTime time.Time) {
+	s.Gauge(name, float64(currentTime.Unix())-metric.Val, hostname, tags)
 }
 
 // nodeCreationTransformer generates the node age metric based on the creation timestamp
-func nodeCreationTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string) {
-	submitAge(s, ksmMetricPrefix+"node.age", metric, hostname, tags)
+func nodeCreationTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string, currentTime time.Time) {
+	submitAge(s, ksmMetricPrefix+"node.age", metric, hostname, tags, currentTime)
 }
 
 // podCreationTransformer generates the pod age metric based on the creation timestamp
-func podCreationTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string) {
-	submitAge(s, ksmMetricPrefix+"pod.age", metric, hostname, tags)
+func podCreationTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string, currentTime time.Time) {
+	submitAge(s, ksmMetricPrefix+"pod.age", metric, hostname, tags, currentTime)
 }
 
 // podStartTimeTransformer generates the pod uptime metric based on the start time timestamp
-func podStartTimeTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string) {
-	submitAge(s, ksmMetricPrefix+"pod.uptime", metric, hostname, tags)
+func podStartTimeTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string, currentTime time.Time) {
+	submitAge(s, ksmMetricPrefix+"pod.uptime", metric, hostname, tags, currentTime)
 }
 
 // podPhaseTransformer sends status phase metrics for pods, the tag phase has the pod status
-func podPhaseTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string) {
+func podPhaseTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string, _ time.Time) {
 	submitActiveMetric(s, ksmMetricPrefix+"pod.status_phase", metric, hostname, tags)
 }
 
@@ -188,7 +185,7 @@ var allowedWaitingReasons = map[string]struct{}{
 }
 
 // containerWaitingReasonTransformer validates the container waiting reasons for metric kube_pod_container_status_waiting_reason
-func containerWaitingReasonTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string) {
+func containerWaitingReasonTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string, _ time.Time) {
 	if reason, found := metric.Labels["reason"]; found {
 		// Filtering according to the reason here is paramount to limit cardinality
 		if _, allowed := allowedWaitingReasons[strings.ToLower(reason)]; allowed {
@@ -204,7 +201,7 @@ var allowedTerminatedReasons = map[string]struct{}{
 }
 
 // containerTerminatedReasonTransformer validates the container waiting reasons for metric kube_pod_container_status_terminated_reason
-func containerTerminatedReasonTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string) {
+func containerTerminatedReasonTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string, _ time.Time) {
 	if reason, found := metric.Labels["reason"]; found {
 		// Filtering according to the reason here is paramount to limit cardinality
 		if _, allowed := allowedTerminatedReasons[strings.ToLower(reason)]; allowed {
@@ -214,12 +211,12 @@ func containerTerminatedReasonTransformer(s aggregator.Sender, name string, metr
 }
 
 // containerResourceRequestsTransformer transforms the generic ksm resource request metrics into resource-specific metrics
-func containerResourceRequestsTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string) {
+func containerResourceRequestsTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string, _ time.Time) {
 	submitContainerResourceMetric(s, name, metric, hostname, tags, "requested")
 }
 
 // containerResourceLimitsTransformer transforms the generic ksm resource limit metrics into resource-specific metrics
-func containerResourceLimitsTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string) {
+func containerResourceLimitsTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string, _ time.Time) {
 	submitContainerResourceMetric(s, name, metric, hostname, tags, "limit")
 }
 
@@ -245,12 +242,12 @@ func submitContainerResourceMetric(s aggregator.Sender, name string, metric ksms
 }
 
 // nodeAllocatableTransformer transforms the generic ksm node allocatable metrics into resource-specific metrics
-func nodeAllocatableTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string) {
+func nodeAllocatableTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string, _ time.Time) {
 	submitNodeResourceMetric(s, name, metric, hostname, tags, "allocatable")
 }
 
 // nodeCapacityTransformer transforms the generic ksm node capacity metrics into resource-specific metrics
-func nodeCapacityTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string) {
+func nodeCapacityTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string, _ time.Time) {
 	submitNodeResourceMetric(s, name, metric, hostname, tags, "capacity")
 }
 
@@ -282,10 +279,10 @@ func submitNodeResourceMetric(s aggregator.Sender, name string, metric ksmstore.
 }
 
 // cronJobNextScheduleTransformer sends a service check to alert if the cronjob's next schedule is in the past
-func cronJobNextScheduleTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string) {
+func cronJobNextScheduleTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string, currentTime time.Time) {
 	message := ""
 	var status metrics.ServiceCheckStatus
-	timeDiff := int64(metric.Val) - now().Unix()
+	timeDiff := int64(metric.Val) - currentTime.Unix()
 	if timeDiff >= 0 {
 		status = metrics.ServiceCheckOK
 	} else {
@@ -296,12 +293,12 @@ func cronJobNextScheduleTransformer(s aggregator.Sender, name string, metric ksm
 }
 
 // cronJobLastScheduleTransformer sends the duration since the last time the cronjob was scheduled
-func cronJobLastScheduleTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string) {
-	s.Gauge(ksmMetricPrefix+"cronjob.duration_since_last_schedule", float64(now().Unix())-metric.Val, hostname, tags)
+func cronJobLastScheduleTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string, currentTime time.Time) {
+	s.Gauge(ksmMetricPrefix+"cronjob.duration_since_last_schedule", float64(currentTime.Unix())-metric.Val, hostname, tags)
 }
 
 // jobCompleteTransformer sends a metric and a service check based on kube_job_complete
-func jobCompleteTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string) {
+func jobCompleteTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string, _ time.Time) {
 	for i, tag := range tags {
 		if tag == "condition:true" {
 			jobMetric(s, metric, ksmMetricPrefix+"job.completion.succeeded", hostname, append(tags[:i], tags[i+1:]...))
@@ -312,7 +309,7 @@ func jobCompleteTransformer(s aggregator.Sender, name string, metric ksmstore.DD
 }
 
 // jobFailedTransformer sends a metric and a service check based on kube_job_failed
-func jobFailedTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string) {
+func jobFailedTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string, _ time.Time) {
 	for i, tag := range tags {
 		if tag == "condition:true" {
 			jobMetric(s, metric, ksmMetricPrefix+"job.completion.failed", hostname, append(tags[:i], tags[i+1:]...))
@@ -363,7 +360,7 @@ func jobServiceCheck(s aggregator.Sender, metric ksmstore.DDMetric, status metri
 }
 
 // jobStatusSucceededTransformer sends a metric based on kube_job_status_succeeded
-func jobStatusSucceededTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string) {
+func jobStatusSucceededTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string, _ time.Time) {
 	jobMetric(s, metric, ksmMetricPrefix+"job.succeeded", hostname, tags)
 }
 
@@ -377,7 +374,7 @@ func jobStatusSucceededTransformer(s aggregator.Sender, name string, metric ksms
 //
 // In order to reduce the cardinality, we are here removing the `reason` tag.
 // The resulting datadog metric is 0 if there are no failed pods and 1 otherwise.
-func jobStatusFailedTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string) {
+func jobStatusFailedTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string, _ time.Time) {
 	// Remove the `reason` tag to reduce the cardinality
 	reasonTagIndex := -1
 	for idx, tag := range tags {
@@ -405,7 +402,7 @@ func jobMetric(s aggregator.Sender, metric ksmstore.DDMetric, metricName string,
 }
 
 // resourcequotaTransformer generates dedicated metrics per resource per type from the kube_resourcequota metric
-func resourcequotaTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string) {
+func resourcequotaTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string, _ time.Time) {
 	resource, found := metric.Labels["resource"]
 	if !found {
 		log.Debugf("Couldn't find 'resource' label, ignoring metric '%s'", name)
@@ -433,7 +430,7 @@ var constraintsMapper = map[string]string{
 }
 
 // limitrangeTransformer generates dedicated metrics per resource per type from the kube_limitrange metric
-func limitrangeTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string) {
+func limitrangeTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string, _ time.Time) {
 	constraintLabel, found := metric.Labels["constraint"]
 	if !found {
 		log.Debugf("Couldn't find 'constraint' label, ignoring metric '%s'", name)
@@ -463,11 +460,11 @@ func submitActiveMetric(s aggregator.Sender, metricName string, metric ksmstore.
 }
 
 // pvPhaseTransformer generates metrics per persistentvolume and per phase from the kube_persistentvolume_status_phase metric
-func pvPhaseTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string) {
+func pvPhaseTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string, _ time.Time) {
 	submitActiveMetric(s, ksmMetricPrefix+"persistentvolume.by_phase", metric, hostname, tags)
 }
 
 // serviceTypeTransformer generates metrics per service, namespace, and type from the kube_service_spec_type metric
-func serviceTypeTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string) {
+func serviceTypeTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string, _ time.Time) {
 	submitActiveMetric(s, ksmMetricPrefix+"service.type", metric, hostname, tags)
 }

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers_test.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers_test.go
@@ -118,7 +118,8 @@ func Test_resourcequotaTransformer(t *testing.T) {
 		s := mocksender.NewMockSender("ksm")
 		s.SetupAcceptAll()
 		t.Run(tt.name, func(t *testing.T) {
-			resourcequotaTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags)
+			currentTime := time.Now()
+			resourcequotaTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags, currentTime)
 			if tt.expected != nil {
 				s.AssertMetric(t, "Gauge", tt.expected.name, tt.expected.val, tt.args.hostname, tt.expected.tags)
 				s.AssertNumberOfCalls(t, "Gauge", 1)
@@ -191,8 +192,8 @@ func Test_cronJobNextScheduleTransformer(t *testing.T) {
 		s := mocksender.NewMockSender("ksm")
 		s.SetupAcceptAll()
 		t.Run(tt.name, func(t *testing.T) {
-			now = tt.args.now
-			cronJobNextScheduleTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags)
+			currentTime := tt.args.now()
+			cronJobNextScheduleTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags, currentTime)
 			if tt.expected != nil {
 				s.AssertServiceCheck(t, tt.expected.name, tt.expected.status, tt.args.hostname, tt.args.tags, tt.expected.message)
 				s.AssertNumberOfCalls(t, "ServiceCheck", 1)
@@ -236,8 +237,8 @@ func Test_cronJobLastScheduleTransformer(t *testing.T) {
 		s := mocksender.NewMockSender("ksm")
 		s.SetupAcceptAll()
 		t.Run(tt.name, func(t *testing.T) {
-			now = tt.args.now
-			cronJobLastScheduleTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags)
+			currentTime := tt.args.now()
+			cronJobLastScheduleTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags, currentTime)
 			if tt.expected != nil {
 				s.AssertMetric(t, "Gauge", tt.expected.name, tt.expected.val, tt.args.hostname, tt.expected.tags)
 				s.AssertNumberOfCalls(t, "Gauge", 1)
@@ -312,7 +313,8 @@ func Test_jobCompleteTransformer(t *testing.T) {
 		s := mocksender.NewMockSender("ksm")
 		s.SetupAcceptAll()
 		t.Run(tt.name, func(t *testing.T) {
-			jobCompleteTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags)
+			currentTime := time.Now()
+			jobCompleteTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags, currentTime)
 			if tt.expected != nil {
 				s.AssertServiceCheck(t, tt.expected.name, tt.expected.status, tt.args.hostname, tt.args.tags, "")
 				s.AssertNumberOfCalls(t, "ServiceCheck", 1)
@@ -402,7 +404,8 @@ func Test_jobFailedTransformer(t *testing.T) {
 		s := mocksender.NewMockSender("ksm")
 		s.SetupAcceptAll()
 		t.Run(tt.name, func(t *testing.T) {
-			jobFailedTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags)
+			currentTime := time.Now()
+			jobFailedTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags, currentTime)
 			if tt.expectedServiceCheck != nil {
 				s.AssertServiceCheck(t, tt.expectedServiceCheck.name, tt.expectedServiceCheck.status, tt.args.hostname, tt.expectedServiceCheck.tags, "")
 				s.AssertNumberOfCalls(t, "ServiceCheck", 1)
@@ -483,7 +486,8 @@ func Test_jobStatusSucceededTransformer(t *testing.T) {
 		s := mocksender.NewMockSender("ksm")
 		s.SetupAcceptAll()
 		t.Run(tt.name, func(t *testing.T) {
-			jobStatusSucceededTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags)
+			currentTime := time.Now()
+			jobStatusSucceededTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags, currentTime)
 			if tt.expected != nil {
 				s.AssertMetric(t, "Gauge", tt.expected.name, tt.expected.val, tt.args.hostname, tt.args.tags)
 				s.AssertNumberOfCalls(t, "Gauge", 1)
@@ -580,7 +584,8 @@ func Test_jobStatusFailedTransformer(t *testing.T) {
 		s := mocksender.NewMockSender("ksm")
 		s.SetupAcceptAll()
 		t.Run(tt.name, func(t *testing.T) {
-			jobStatusFailedTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags)
+			currentTime := time.Now()
+			jobStatusFailedTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags, currentTime)
 			if tt.expected != nil {
 				s.AssertMetric(t, "Gauge", tt.expected.name, tt.expected.val, tt.args.hostname, tt.expected.tags)
 				s.AssertNumberOfCalls(t, "Gauge", 1)
@@ -636,7 +641,8 @@ func Test_pvPhaseTransformer(t *testing.T) {
 		s := mocksender.NewMockSender("ksm")
 		s.SetupAcceptAll()
 		t.Run(tt.name, func(t *testing.T) {
-			pvPhaseTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags)
+			currentTime := time.Now()
+			pvPhaseTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags, currentTime)
 			if tt.expected != nil {
 				s.AssertMetric(t, "Gauge", tt.expected.name, tt.expected.val, tt.args.hostname, tt.args.tags)
 				s.AssertNumberOfCalls(t, "Gauge", 1)
@@ -694,7 +700,8 @@ func Test_serviceTypeTransformer(t *testing.T) {
 		s := mocksender.NewMockSender("ksm")
 		s.SetupAcceptAll()
 		t.Run(tt.name, func(t *testing.T) {
-			serviceTypeTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags)
+			currentTime := time.Now()
+			serviceTypeTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags, currentTime)
 			if tt.expected != nil {
 				s.AssertMetric(t, "Gauge", tt.expected.name, tt.expected.val, tt.args.hostname, tt.args.tags)
 				s.AssertNumberOfCalls(t, "Gauge", 1)
@@ -752,7 +759,8 @@ func Test_podPhaseTransformer(t *testing.T) {
 		s := mocksender.NewMockSender("ksm")
 		s.SetupAcceptAll()
 		t.Run(tt.name, func(t *testing.T) {
-			podPhaseTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags)
+			currentTime := time.Now()
+			podPhaseTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags, currentTime)
 			if tt.expected != nil {
 				s.AssertMetric(t, "Gauge", tt.expected.name, tt.expected.val, tt.args.hostname, tt.args.tags)
 				s.AssertNumberOfCalls(t, "Gauge", 1)
@@ -858,7 +866,8 @@ func Test_containerWaitingReasonTransformer(t *testing.T) {
 		s := mocksender.NewMockSender("ksm")
 		s.SetupAcceptAll()
 		t.Run(tt.name, func(t *testing.T) {
-			containerWaitingReasonTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags)
+			currentTime := time.Now()
+			containerWaitingReasonTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags, currentTime)
 			if tt.expected != nil {
 				s.AssertMetric(t, "Gauge", tt.expected.name, tt.expected.val, tt.args.hostname, tt.args.tags)
 				s.AssertNumberOfCalls(t, "Gauge", 1)
@@ -943,7 +952,8 @@ func Test_containerTerminatedReasonTransformer(t *testing.T) {
 		s := mocksender.NewMockSender("ksm")
 		s.SetupAcceptAll()
 		t.Run(tt.name, func(t *testing.T) {
-			containerTerminatedReasonTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags)
+			currentTime := time.Now()
+			containerTerminatedReasonTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags, currentTime)
 			if tt.expected != nil {
 				s.AssertMetric(t, "Gauge", tt.expected.name, tt.expected.val, tt.args.hostname, tt.args.tags)
 				s.AssertNumberOfCalls(t, "Gauge", 1)
@@ -1031,7 +1041,8 @@ func Test_limitrangeTransformer(t *testing.T) {
 		s := mocksender.NewMockSender("ksm")
 		s.SetupAcceptAll()
 		t.Run(tt.name, func(t *testing.T) {
-			limitrangeTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags)
+			currentTime := time.Now()
+			limitrangeTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags, currentTime)
 			if tt.expected != nil {
 				s.AssertMetric(t, "Gauge", tt.expected.name, tt.expected.val, tt.args.hostname, tt.args.tags)
 				s.AssertNumberOfCalls(t, "Gauge", 1)
@@ -1103,7 +1114,8 @@ func Test_nodeUnschedulableTransformer(t *testing.T) {
 		s := mocksender.NewMockSender("ksm")
 		s.SetupAcceptAll()
 		t.Run(tt.name, func(t *testing.T) {
-			nodeUnschedulableTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags)
+			currentTime := time.Now()
+			nodeUnschedulableTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags, currentTime)
 			if tt.expected != nil {
 				s.AssertMetric(t, "Gauge", tt.expected.name, tt.expected.val, tt.args.hostname, tt.args.tags)
 				s.AssertNumberOfCalls(t, "Gauge", 1)
@@ -1434,7 +1446,8 @@ func Test_nodeConditionTransformer(t *testing.T) {
 		s := mocksender.NewMockSender("ksm")
 		s.SetupAcceptAll()
 		t.Run(tt.name, func(t *testing.T) {
-			nodeConditionTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags)
+			currentTime := time.Now()
+			nodeConditionTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags, currentTime)
 			if tt.expectedServiceCheck != nil {
 				s.AssertServiceCheck(t, tt.expectedServiceCheck.name, tt.expectedServiceCheck.status, tt.expectedServiceCheck.hostname, tt.expectedServiceCheck.tags, tt.expectedServiceCheck.message)
 				s.AssertNumberOfCalls(t, "ServiceCheck", 1)
@@ -1572,7 +1585,8 @@ func Test_containerResourceRequestsTransformer(t *testing.T) {
 		s := mocksender.NewMockSender("ksm")
 		s.SetupAcceptAll()
 		t.Run(tt.name, func(t *testing.T) {
-			containerResourceRequestsTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags)
+			currentTime := time.Now()
+			containerResourceRequestsTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags, currentTime)
 			if tt.expected != nil {
 				s.AssertMetric(t, "Gauge", tt.expected.name, tt.expected.val, tt.args.hostname, tt.expected.tags)
 				s.AssertNumberOfCalls(t, "Gauge", 1)
@@ -1651,7 +1665,8 @@ func Test_containerResourceLimitsTransformer(t *testing.T) {
 		s := mocksender.NewMockSender("ksm")
 		s.SetupAcceptAll()
 		t.Run(tt.name, func(t *testing.T) {
-			containerResourceLimitsTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags)
+			currentTime := time.Now()
+			containerResourceLimitsTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags, currentTime)
 			if tt.expected != nil {
 				s.AssertMetric(t, "Gauge", tt.expected.name, tt.expected.val, tt.args.hostname, tt.expected.tags)
 				s.AssertNumberOfCalls(t, "Gauge", 1)
@@ -1772,7 +1787,8 @@ func Test_nodeAllocatableTransformer(t *testing.T) {
 		s := mocksender.NewMockSender("ksm")
 		s.SetupAcceptAll()
 		t.Run(tt.name, func(t *testing.T) {
-			nodeAllocatableTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags)
+			currentTime := time.Now()
+			nodeAllocatableTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags, currentTime)
 			if tt.expected != nil {
 				s.AssertMetric(t, "Gauge", tt.expected.name, tt.expected.val, tt.args.hostname, tt.expected.tags)
 				s.AssertNumberOfCalls(t, "Gauge", 1)
@@ -1893,7 +1909,8 @@ func Test_nodeCapacityTransformer(t *testing.T) {
 		s := mocksender.NewMockSender("ksm")
 		s.SetupAcceptAll()
 		t.Run(tt.name, func(t *testing.T) {
-			nodeCapacityTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags)
+			currentTime := time.Now()
+			nodeCapacityTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags, currentTime)
 			if tt.expected != nil {
 				s.AssertMetric(t, "Gauge", tt.expected.name, tt.expected.val, tt.args.hostname, tt.expected.tags)
 				s.AssertNumberOfCalls(t, "Gauge", 1)
@@ -1946,8 +1963,8 @@ func Test_timestampTransformers(t *testing.T) {
 		s := mocksender.NewMockSender("ksm")
 		s.SetupAcceptAll()
 		t.Run(tt.name, func(t *testing.T) {
-			now = argsTemplate.now
-			tt.transformer(s, tt.name, argsTemplate.metric, argsTemplate.hostname, argsTemplate.tags)
+			currentTime := argsTemplate.now()
+			tt.transformer(s, tt.name, argsTemplate.metric, argsTemplate.hostname, argsTemplate.tags, currentTime)
 			s.AssertMetric(t, "Gauge", tt.newName, expectedTemplate.val, expectedTemplate.hostname, expectedTemplate.tags)
 			s.AssertNumberOfCalls(t, "Gauge", 1)
 		})

--- a/releasenotes-dca/notes/ksm-comparable-metrics-b31f1f1fcbae1753.yaml
+++ b/releasenotes-dca/notes/ksm-comparable-metrics-b31f1f1fcbae1753.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Time-based metrics (e.g `kubernetes_state.pod.age`, `kubernetes_state.pod.uptime`) are now comparable in the Kubernetes state core check.
+    Time-based metrics (for example, `kubernetes_state.pod.age`, `kubernetes_state.pod.uptime`) are now comparable in the Kubernetes state core check.

--- a/releasenotes-dca/notes/ksm-comparable-metrics-b31f1f1fcbae1753.yaml
+++ b/releasenotes-dca/notes/ksm-comparable-metrics-b31f1f1fcbae1753.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Time-based metrics (e.g `kubernetes_state.pod.age`, `kubernetes_state.pod.uptime`) are now comparable in the Kubernetes state core check.

--- a/releasenotes/notes/ksm-comparable-metrics-b31f1f1fcbae1753.yaml
+++ b/releasenotes/notes/ksm-comparable-metrics-b31f1f1fcbae1753.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Time-based metrics (e.g `kubernetes_state.pod.age`, `kubernetes_state.pod.uptime`) are now comparable in the Kubernetes state core check.
+    Time-based metrics (for example, `kubernetes_state.pod.age`, `kubernetes_state.pod.uptime`) are now comparable in the Kubernetes state core check.

--- a/releasenotes/notes/ksm-comparable-metrics-b31f1f1fcbae1753.yaml
+++ b/releasenotes/notes/ksm-comparable-metrics-b31f1f1fcbae1753.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Time-based metrics (e.g `kubernetes_state.pod.age`, `kubernetes_state.pod.uptime`) are now comparable in the Kubernetes state core check.


### PR DESCRIPTION
### What does this PR do?

Prior to this patch the ksm collector would call
`time.Now().Unix.()-metric.Val` at every point a `_time` metric is
computed, this leads to the values collected in the same loop not being
comparable since their values skews based on the value of `time.Now()`
at the time metric was collected.

For an example of the impact of the above, to compute how long it takes a
pod to start after being created we create a function:

```
avg:kubernetes_state.pod.age{pod_name:filebeat-lf6hz} by {pod_name}
- avg:kubernetes_state.pod.uptime{pod_name:filebeat-lf6hz} by {pod_name}
```

When this is plotted on a dashboard we end up with values fluctuating
between negative and positive.

To ensure the values are comparable the `currentTime` is snapshotted at
the start of the Run loop and the value is reused in all places that had
previously called `time.Now()`.

### Motivation

We need to determine how long our pods take from creation to starting, to
measure control plane overhead. The screenshot below depicts the problem
this patch is attempting to solve:

![image](https://user-images.githubusercontent.com/593852/159366482-89b28b27-0268-4ef0-b63a-e6dad360dd44.png)


### Additional Notes

### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes


### Reviewer's Checklist


- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
