### PR TITLE
[process-agent] Collect process agent profile in flare

### DIFF
--- a/cmd/agent/app/flare.go
+++ b/cmd/agent/app/flare.go
@@ -88,6 +88,7 @@ var flareCmd = &cobra.Command{
 }
 
 type profileCollector func(prefix, debugURL string, cpusec int, target *flare.ProfileData) error
+type agentProfileCollector func(pdata *flare.ProfileData, seconds int, c profileCollector) error
 
 func readProfileData(pdata *flare.ProfileData, seconds int, collector profileCollector) error {
 	prevSettings, err := setRuntimeProfilingSettings()
@@ -98,7 +99,7 @@ func readProfileData(pdata *flare.ProfileData, seconds int, collector profileCol
 
 	agentCollectors := []struct {
 		name string
-		fn   func(pdata *flare.ProfileData, seconds int, c profileCollector) error
+		fn   agentProfileCollector
 	}{
 		{
 			name: "core",

--- a/cmd/agent/app/flare.go
+++ b/cmd/agent/app/flare.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
@@ -88,58 +87,73 @@ var flareCmd = &cobra.Command{
 	},
 }
 
-func readProfileData(pdata *flare.ProfileData) error {
+type profileCollector func(prefix, debugURL string, cpusec int, target *flare.ProfileData) error
+
+func readProfileData(pdata *flare.ProfileData, seconds int, collector profileCollector) error {
 	prevSettings, err := setRuntimeProfilingSettings()
 	if err != nil {
 		return err
 	}
 	defer resetRuntimeProfilingSettings(prevSettings)
 
+	agentCollectors := []struct {
+		name string
+		fn   func(pdata *flare.ProfileData, seconds int, c profileCollector) error
+	}{
+		{
+			name: "core",
+			fn:   readCoreAgentProfileData,
+		},
+		{
+			name: "trace",
+			fn:   readTraceAgentProfileData,
+		},
+		{
+			name: "process",
+			fn:   readProcessAgentProfileData,
+		},
+	}
+
 	var errs error
-	if err := readCoreAgentProfileData(pdata); err != nil {
-		errs = multierror.Append(errs, errors.Wrap(err, "error collecting core agent profile"))
+	for _, c := range agentCollectors {
+		if err := c.fn(pdata, seconds, collector); err != nil {
+			errs = multierror.Append(errs, fmt.Errorf("error collecting %s agent profile: %v", c.name, err))
+		}
 	}
 
-	if err := readTraceAgentProfileData(pdata); err != nil {
-		errs = multierror.Append(errs, errors.Wrap(err, "error collecting trace agent profile"))
-	}
-
-	if err := readProcessAgentProfileData(pdata); err != nil {
-		errs = multierror.Append(errs, errors.Wrap(err, "error collecting process agent profile"))
-	}
 	return errs
 }
 
-func readCoreAgentProfileData(pdata *flare.ProfileData) error {
+func readCoreAgentProfileData(pdata *flare.ProfileData, seconds int, collector profileCollector) error {
 	fmt.Fprintln(color.Output, color.BlueString("Getting a %ds profile snapshot from core.", profiling))
 	coreDebugURL := fmt.Sprintf("http://127.0.0.1:%s/debug/pprof", config.Datadog.GetString("expvar_port"))
-	return flare.CreatePerformanceProfile("core", coreDebugURL, profiling, pdata)
+	return collector("core", coreDebugURL, seconds, pdata)
 }
 
-func readTraceAgentProfileData(pdata *flare.ProfileData) error {
+func readTraceAgentProfileData(pdata *flare.ProfileData, seconds int, collector profileCollector) error {
 	if k := "apm_config.enabled"; config.Datadog.IsSet(k) && !config.Datadog.GetBool(k) {
 		return nil
 	}
 	traceDebugURL := fmt.Sprintf("http://127.0.0.1:%d/debug/pprof", config.Datadog.GetInt("apm_config.receiver_port"))
 	cpusec := 4 // 5s is the default maximum connection timeout on the trace-agent HTTP server
 	if v := config.Datadog.GetInt("apm_config.receiver_timeout"); v > 0 {
-		if v > profiling {
+		if v > seconds {
 			// do not exceed requested duration
-			cpusec = profiling
+			cpusec = seconds
 		} else {
 			// fit within set limit
 			cpusec = v - 1
 		}
 	}
 	fmt.Fprintln(color.Output, color.BlueString("Getting a %ds profile snapshot from trace.", cpusec))
-	return flare.CreatePerformanceProfile("trace", traceDebugURL, cpusec, pdata)
+	return collector("trace", traceDebugURL, cpusec, pdata)
 }
 
-func readProcessAgentProfileData(pdata *flare.ProfileData) error {
+func readProcessAgentProfileData(pdata *flare.ProfileData, seconds int, collector profileCollector) error {
 	// We are unconditionally collecting process agent profile in the flare as best effort
 	processDebugURL := fmt.Sprintf("http://127.0.0.1:%d/debug/pprof", config.Datadog.GetInt("process_config.expvar_port"))
 	fmt.Fprintln(color.Output, color.BlueString("Getting a %ds profile snapshot from process.", profiling))
-	return flare.CreatePerformanceProfile("process", processDebugURL, profiling, pdata)
+	return collector("process", processDebugURL, seconds, pdata)
 }
 
 func makeFlare(caseID string) error {
@@ -157,7 +171,7 @@ func makeFlare(caseID string) error {
 		err     error
 	)
 	if profiling >= 30 {
-		if err := readProfileData(&profile); err != nil {
+		if err := readProfileData(&profile, profiling, flare.CreatePerformanceProfile); err != nil {
 			fmt.Fprintln(color.Output, color.YellowString(fmt.Sprintf("Could not collect performance profile data: %s", err)))
 		}
 	} else if profiling != -1 {

--- a/cmd/agent/app/flare_test.go
+++ b/cmd/agent/app/flare_test.go
@@ -1,0 +1,91 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package app
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/flare"
+)
+
+type mockProfileCollector struct {
+	mock.Mock
+}
+
+func (m *mockProfileCollector) CreatePerformanceProfile(prefix, debugURL string, cpusec int, target *flare.ProfileData) error {
+	args := m.Called(prefix, debugURL, cpusec, target)
+	return args.Error(0)
+}
+
+func TestReadProfileData(t *testing.T) {
+	m := &mockProfileCollector{}
+	defer m.AssertExpectations(t)
+
+	mockConfig := config.Mock()
+	mockConfig.Set("expvar_port", "1001")
+	mockConfig.Set("apm_config.enabled", true)
+	mockConfig.Set("apm_config.receiver_port", "1002")
+	mockConfig.Set("apm_config.receiver_timeout", "10")
+	mockConfig.Set("process_config.expvar_port", "1003")
+
+	pdata := &flare.ProfileData{}
+
+	m.On("CreatePerformanceProfile", "core", "http://127.0.0.1:1001/debug/pprof", 30, pdata).Return(nil)
+	m.On("CreatePerformanceProfile", "trace", "http://127.0.0.1:1002/debug/pprof", 9, pdata).Return(nil)
+	m.On("CreatePerformanceProfile", "process", "http://127.0.0.1:1003/debug/pprof", 30, pdata).Return(nil)
+
+	err := readProfileData(pdata, 30, m.CreatePerformanceProfile)
+	assert.NoError(t, err)
+}
+
+func TestReadProfileDataNoTraceAgent(t *testing.T) {
+	m := &mockProfileCollector{}
+	defer m.AssertExpectations(t)
+
+	mockConfig := config.Mock()
+	mockConfig.Set("expvar_port", "1001")
+	mockConfig.Set("apm_config.enabled", false)
+	mockConfig.Set("process_config.expvar_port", "1003")
+
+	pdata := &flare.ProfileData{}
+
+	m.On("CreatePerformanceProfile", "core", "http://127.0.0.1:1001/debug/pprof", 30, pdata).Return(nil)
+	m.On("CreatePerformanceProfile", "process", "http://127.0.0.1:1003/debug/pprof", 30, pdata).Return(nil)
+
+	err := readProfileData(pdata, 30, m.CreatePerformanceProfile)
+	assert.NoError(t, err)
+}
+
+func TestReadProfileDataErrors(t *testing.T) {
+	m := &mockProfileCollector{}
+	defer m.AssertExpectations(t)
+
+	mockConfig := config.Mock()
+	mockConfig.Set("expvar_port", "1001")
+	mockConfig.Set("apm_config.enabled", true)
+	mockConfig.Set("apm_config.receiver_port", "1002")
+	mockConfig.Set("apm_config.receiver_timeout", "10")
+	mockConfig.Set("process_config.expvar_port", "1003")
+
+	pdata := &flare.ProfileData{}
+
+	m.On("CreatePerformanceProfile", "core", "http://127.0.0.1:1001/debug/pprof", 30, pdata).Return(errors.New("can't connect to core agent"))
+	m.On("CreatePerformanceProfile", "trace", "http://127.0.0.1:1002/debug/pprof", 9, pdata).Return(errors.New("can't connect to trace agent"))
+	m.On("CreatePerformanceProfile", "process", "http://127.0.0.1:1003/debug/pprof", 30, pdata).Return(nil)
+
+	err := readProfileData(pdata, 30, m.CreatePerformanceProfile)
+	const expectError = `2 errors occurred:
+	* error collecting core agent profile: can't connect to core agent
+	* error collecting trace agent profile: can't connect to trace agent
+
+`
+	assert.EqualError(t, err, expectError)
+}

--- a/releasenotes/notes/process-agent-profile-in-flare-dacd155ccd635f05.yaml
+++ b/releasenotes/notes/process-agent-profile-in-flare-dacd155ccd635f05.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   - |
-    Agent flare command now collects Process Agent performance profile data in the flare bundle (when ``--profile`` flag is used).
+    The Agent flare command now collects Process Agent performance profile data in the flare bundle when the ``--profile`` flag is used.

--- a/releasenotes/notes/process-agent-profile-in-flare-dacd155ccd635f05.yaml
+++ b/releasenotes/notes/process-agent-profile-in-flare-dacd155ccd635f05.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Agent flare command now collects Process Agent performance profile data in the flare bundle (when ``--profile`` flag is used).


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

- Collect Process Agent profile in the flare when `--profile` flag is used.
- Errors in collection of profiles in individual agents do not prevent the overall flare bundle from being collected.

Note: there is currently no conditional check before we attempt to collect Process Agent's profile, this is on purpose - with `process_discovery` check enabled by default Process Agent should be running in default configuration unless disabled explicitly.

### Motivation

Improve flare collection

### Describe how to test/QA your changes

With these changes we support profile collection from the core agent, trace agent and process agent. 

Happy path testing should result in observing profile data from these agents in the flare.

Failure to collect individual profiles should not prevent collecting the flare bundle. This should help in cases when a particular agent fails to start but we still would like to collect profile data. When these errors occur the output should clarify the issue as follows:

```
Getting a 30s profile snapshot from core.
Getting a 4s profile snapshot from trace.
Getting a 30s profile snapshot from process.
Could not collect performance profile data: 1 error occurred:
        * error collecting core agent profile: Get "http://127.0.0.1:5000/debug/pprof/heap": dial tcp 127.0.0.1:5000: connect: connection refused
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
