### PR TITLE
[CWS] improve arch selection in tasks

### DIFF
--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -1,6 +1,7 @@
 import datetime
 import errno
 import os
+import platform
 import shutil
 import sys
 import tempfile
@@ -47,6 +48,18 @@ def get_go_env(ctx, go_version):
     return goenv
 
 
+arch_mapping = {
+    "amd64": "x64",
+    "x86_64": "x64",
+    "x64": "x64",
+    "i386": "x86",
+    "i686": "x86",
+    "aarch64": "arm64",  # linux
+    "arm64": "arm64",  # darwin
+}
+CURRENT_ARCH = arch_mapping.get(platform.machine(), "x64")
+
+
 @task
 def build(
     ctx,
@@ -56,7 +69,7 @@ def build(
     major_version='7',
     # arch is never used here; we keep it to have a
     # consistent CLI on the build task for all agents.
-    arch="x64",  # noqa: U100
+    arch=CURRENT_ARCH,  # noqa: U100
     go_mod="mod",
     skip_assets=False,
 ):
@@ -241,7 +254,7 @@ def create_dir_if_needed(dir):
 
 
 @task
-def build_embed_syscall_tester(ctx, arch="x64", static=True):
+def build_embed_syscall_tester(ctx, arch=CURRENT_ARCH, static=True):
     build_dir = os.path.join(".", "pkg", "security", "tests", "syscall_tester", "bin")
     go_dir = os.path.join(".", "pkg", "security", "tests", "syscall_tester", "go")
     create_dir_if_needed(build_dir)
@@ -258,7 +271,7 @@ def build_functional_tests(
     ctx,
     output='pkg/security/tests/testsuite',
     go_version=None,
-    arch="x64",
+    arch=CURRENT_ARCH,
     major_version='7',
     build_tags='functionaltests',
     build_flags='',
@@ -319,7 +332,7 @@ def build_stress_tests(
     ctx,
     output='pkg/security/tests/stresssuite',
     go_version=None,
-    arch="x64",
+    arch=CURRENT_ARCH,
     major_version='7',
     bundle_ebpf=True,
     skip_linters=False,
@@ -341,7 +354,7 @@ def stress_tests(
     ctx,
     verbose=False,
     go_version=None,
-    arch="x64",
+    arch=CURRENT_ARCH,
     major_version='7',
     output='pkg/security/tests/stresssuite',
     bundle_ebpf=True,
@@ -371,7 +384,7 @@ def functional_tests(
     ctx,
     verbose=False,
     go_version=None,
-    arch="x64",
+    arch=CURRENT_ARCH,
     major_version='7',
     output='pkg/security/tests/testsuite',
     bundle_ebpf=True,
@@ -401,6 +414,7 @@ def kitchen_functional_tests(
     ctx,
     verbose=False,
     go_version=None,
+    arch=CURRENT_ARCH,
     major_version='7',
     build_tests=False,
     testflags='',
@@ -410,19 +424,9 @@ def kitchen_functional_tests(
             ctx,
             verbose=verbose,
             go_version=go_version,
-            arch="x64",
+            arch=arch,
             major_version=major_version,
             output="test/kitchen/site-cookbooks/dd-security-agent-check/files/testsuite",
-            testflags=testflags,
-        )
-
-        functional_tests(
-            ctx,
-            verbose=verbose,
-            go_version=go_version,
-            major_version=major_version,
-            output="test/kitchen/site-cookbooks/dd-security-agent-check/files/testsuite32",
-            arch="x86",
             testflags=testflags,
         )
 
@@ -440,7 +444,7 @@ def docker_functional_tests(
     ctx,
     verbose=False,
     go_version=None,
-    arch="x64",
+    arch=CURRENT_ARCH,
     major_version='7',
     testflags='',
     static=False,

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -1,7 +1,6 @@
 import datetime
 import errno
 import os
-import platform
 import shutil
 import sys
 import tempfile
@@ -12,7 +11,7 @@ from invoke import task
 from .build_tags import get_default_build_tags
 from .go import golangci_lint, staticcheck, vet
 from .system_probe import CLANG_CMD as CLANG_BPF_CMD
-from .system_probe import get_ebpf_build_flags
+from .system_probe import CURRENT_ARCH, get_ebpf_build_flags
 from .utils import (
     REPO_PATH,
     bin_name,
@@ -46,18 +45,6 @@ def get_go_env(ctx, go_version):
         goenv["PATH"] += ":" + os.environ["PATH"]
 
     return goenv
-
-
-arch_mapping = {
-    "amd64": "x64",
-    "x86_64": "x64",
-    "x64": "x64",
-    "i386": "x86",
-    "i686": "x86",
-    "aarch64": "arm64",  # linux
-    "arm64": "arm64",  # darwin
-}
-CURRENT_ARCH = arch_mapping.get(platform.machine(), "x64")
 
 
 @task

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -52,7 +52,7 @@ def build(
     ctx,
     race=False,
     go_version=None,
-    incremental_build=False,
+    incremental_build=True,
     major_version='7',
     # arch is never used here; we keep it to have a
     # consistent CLI on the build task for all agents.

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -52,7 +52,7 @@ CURRENT_ARCH = arch_mapping.get(platform.machine(), "x64")
 def build(
     ctx,
     race=False,
-    incremental_build=False,
+    incremental_build=True,
     major_version='7',
     python_runtimes='3',
     go_mod="mod",

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -247,7 +247,7 @@ def kitchen_test(ctx, target=None, provider="virtualbox"):
     elif CURRENT_ARCH == "arm64":
         vagrant_arch = "arm64"
     else:
-        raise Exit(f"Unsupported vagrant arch", code=1)
+        raise Exit(f"Unsupported vagrant arch for {CURRENT_ARCH}", code=1)
 
     # Retrieve a list of all available vagrant images
     images = {}

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -234,12 +234,20 @@ def kitchen_prepare(ctx, windows=is_windows):
 
 
 @task
-def kitchen_test(ctx, target=None, vagrant_arch="x86_64", provider="virtualbox"):
+def kitchen_test(ctx, target=None, provider="virtualbox"):
     """
     Run tests (locally) using chef kitchen against an array of different platforms.
     * Make sure to run `inv -e system-probe.kitchen-prepare` using the agent-development VM;
     * Then we recommend to run `inv -e system-probe.kitchen-test` directly from your (macOS) machine;
     """
+
+    vagrant_arch = ""
+    if CURRENT_ARCH == "x64":
+        vagrant_arch = "x86_64"
+    elif CURRENT_ARCH == "arm64":
+        vagrant_arch = "arm64"
+    else:
+        raise Exit(f"Unsupported vagrant arch", code=1)
 
     # Retrieve a list of all available vagrant images
     images = {}


### PR DESCRIPTION
### What does this PR do?

Most build/test functions related to security agent or system probe take a `arch` param that defaults to `x64`. This PR changes this to use the current arch of the machine.

This PR also switch incremental build to true by default on both executables 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
