### PR TITLE
[system-probe] add register feature to system-probe

### DIFF
--- a/cmd/system-probe/modules/network_tracer.go
+++ b/cmd/system-probe/modules/network_tracer.go
@@ -91,6 +91,18 @@ func (nt *networkTracer) Register(httpMux *module.Router) error {
 		logRequests(id, count, len(cs.Conns), start)
 	}))
 
+	httpMux.HandleFunc("/register", utils.WithConcurrencyLimit(utils.DefaultMaxConcurrentRequests, func(w http.ResponseWriter, req *http.Request) {
+		id := getClientID(req)
+		err := nt.tracer.RegisterClient(id)
+		log.Debugf("Got request on /register?client_id=%s", id)
+		if err != nil {
+			log.Errorf("unable to register client: %s", err)
+			w.WriteHeader(http.StatusInternalServerError)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+
 	httpMux.HandleFunc("/debug/net_maps", func(w http.ResponseWriter, req *http.Request) {
 		cs, err := nt.tracer.DebugNetworkMaps()
 		if err != nil {

--- a/cmd/system-probe/modules/network_tracer.go
+++ b/cmd/system-probe/modules/network_tracer.go
@@ -91,10 +91,10 @@ func (nt *networkTracer) Register(httpMux *module.Router) error {
 		logRequests(id, count, len(cs.Conns), start)
 	}))
 
-	httpMux.HandleFunc("/register", utils.WithConcurrencyLimit(utils.DefaultMaxConcurrentRequests, func(w http.ResponseWriter, req *http.Request) {
+	httpMux.HandleFunc("/network_tracer/register", utils.WithConcurrencyLimit(utils.DefaultMaxConcurrentRequests, func(w http.ResponseWriter, req *http.Request) {
 		id := getClientID(req)
 		err := nt.tracer.RegisterClient(id)
-		log.Debugf("Got request on /register?client_id=%s", id)
+		log.Debugf("Got request on /network_tracer/register?client_id=%s", id)
 		if err != nil {
 			log.Errorf("unable to register client: %s", err)
 			w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/network/state.go
+++ b/pkg/network/state.go
@@ -242,6 +242,8 @@ func (ns *networkState) GetDelta(
 	}
 }
 
+// saveTelemetry saves the non-monotonic telemetry data for each registered clients.
+// It does so by accumulating values per telemetry point.
 func (ns *networkState) saveTelemetry(telemetry map[ConnTelemetryType]int64) {
 	for _, cl := range ns.clients {
 		for _, telType := range ConnTelemetryTypes {

--- a/pkg/network/state.go
+++ b/pkg/network/state.go
@@ -46,6 +46,7 @@ type State interface {
 		http map[http.Key]http.RequestStats,
 	) Delta
 
+	// GetTelemetryDelta returns the telemetry delta since last time the given client requested telemetry data.
 	GetTelemetryDelta(
 		id string,
 		telemetry map[ConnTelemetryType]int64,
@@ -182,6 +183,9 @@ func (ns *networkState) getClients() []string {
 	return clients
 }
 
+// GetTelemetryDelta returns the telemetry delta for a given client.
+// As for now, this only keeps track of monotonic telemetry, as the
+// other ones are already relative to the last time they were fetched.
 func (ns *networkState) GetTelemetryDelta(
 	id string,
 	telemetry map[ConnTelemetryType]int64,

--- a/pkg/network/state_test.go
+++ b/pkg/network/state_test.go
@@ -363,7 +363,6 @@ func TestLastStatsForClosedConnection(t *testing.T) {
 	conn2.MonotonicRecvBytes += dRecv
 	conn2.MonotonicRetransmits += dRetransmits
 
-	// Let's register our client first
 	state.RegisterClient(clientID)
 
 	// First get, we should not have any connections stored

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -323,7 +323,7 @@ func (t *Tracer) GetActiveConnections(clientID string) (*network.Connections, er
 		ips = append(ips, conn.Source, conn.Dest)
 	}
 	names := t.reverseDNS.Resolve(ips)
-	ctm := t.getConnTelemetry(len(active))
+	ctm := t.state.GetTelemetryDelta(clientID, t.getConnTelemetry(len(active)))
 	rctm := t.getRuntimeCompilationTelemetry()
 
 	return &network.Connections{

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -336,6 +336,11 @@ func (t *Tracer) GetActiveConnections(clientID string) (*network.Connections, er
 	}, nil
 }
 
+func (t *Tracer) RegisterClient(clientID string) error {
+	t.state.RegisterClient(clientID)
+	return nil
+}
+
 func (t *Tracer) getConnTelemetry(mapSize int) map[network.ConnTelemetryType]int64 {
 	kprobeStats := ddebpf.GetProbeTotals()
 	tm := map[network.ConnTelemetryType]int64{

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -195,6 +195,8 @@ func TestTCPSendAndReceive(t *testing.T) {
 	err = wg.Wait()
 	require.NoError(t, err)
 
+	initTracerState(t, tr)
+
 	// Iterate through active connections until we find connection created above, and confirm send + recv counts
 	connections := getConnections(t, tr)
 
@@ -247,6 +249,7 @@ func TestPreexistingConnectionDirection(t *testing.T) {
 	r := bufio.NewReader(c)
 	_, _ = r.ReadBytes(byte('\n'))
 
+	initTracerState(t, tr)
 	connections := getConnections(t, tr)
 
 	conn, ok := findConnection(c.LocalAddr(), c.RemoteAddr(), connections)
@@ -272,8 +275,7 @@ func TestTCPShortlived(t *testing.T) {
 	}
 	defer tr.Stop()
 
-	// Simulate registering by calling get one time
-	getConnections(t, tr)
+	initTracerState(t, tr)
 
 	// Create TCP Server which sends back serverMessageSize bytes
 	server := NewTCPServer(func(c net.Conn) {
@@ -372,6 +374,7 @@ func TestTCPOverIPv6(t *testing.T) {
 	r := bufio.NewReader(c)
 	r.ReadBytes(byte('\n'))
 
+	initTracerState(t, tr)
 	connections := getConnections(t, tr)
 
 	conn, ok := findConnection(c.LocalAddr(), c.RemoteAddr(), connections)
@@ -424,6 +427,7 @@ func TestTCPCollectionDisabled(t *testing.T) {
 	r := bufio.NewReader(c)
 	r.ReadBytes(byte('\n'))
 
+	initTracerState(t, tr)
 	connections := getConnections(t, tr)
 
 	// Confirm that we could not find connection created above
@@ -461,6 +465,7 @@ func TestUDPSendAndReceive(t *testing.T) {
 	_, err = c.Read(make([]byte, serverMessageSize))
 	require.NoError(t, err)
 
+	initTracerState(t, tr)
 	// Iterate through active connections until we find connection created above, and confirm send + recv counts
 	connections := getConnections(t, tr)
 
@@ -517,6 +522,7 @@ func TestUDPDisabled(t *testing.T) {
 
 	c.Read(make([]byte, serverMessageSize))
 
+	initTracerState(t, tr)
 	// Iterate through active connections until we find connection created above, and confirm send + recv counts
 	connections := getConnections(t, tr)
 
@@ -545,6 +551,8 @@ func TestLocalDNSCollectionDisabled(t *testing.T) {
 	// Write anything
 	_, err = cn.Write([]byte("test"))
 	assert.NoError(t, err)
+
+	initTracerState(t, tr)
 
 	// Iterate through active connections making sure there are no local DNS calls
 	for _, c := range getConnections(t, tr).Conns {
@@ -577,6 +585,9 @@ func TestLocalDNSCollectionEnabled(t *testing.T) {
 	assert.NoError(t, err)
 
 	found := false
+
+	initTracerState(t, tr)
+
 	// Iterate through active connections making sure theres at least one connection
 	for _, c := range getConnections(t, tr).Conns {
 		found = found || isLocalDNS(c)
@@ -612,6 +623,8 @@ func TestShouldSkipExcludedConnection(t *testing.T) {
 	// Write anything
 	_, err = cn.Write([]byte("test"))
 	assert.NoError(t, err)
+
+	initTracerState(t, tr)
 
 	// Make sure we're not picking up 127.0.0.1:80
 	for _, c := range getConnections(t, tr).Conns {
@@ -989,6 +1002,11 @@ func addrPort(addr string) int {
 	return p
 }
 
+func initTracerState(t *testing.T, tr *Tracer) {
+	err := tr.RegisterClient("1")
+	require.NoError(t, err)
+}
+
 func getConnections(t *testing.T, tr *Tracer) *network.Connections {
 	// Iterate through active connections until we find connection created above, and confirm send + recv counts
 	connections, err := tr.GetActiveConnections("1")
@@ -1035,6 +1053,8 @@ func testDNSStats(t *testing.T, domain string, success int, failure int, timeout
 
 	// Allow the DNS reply to be processed in the snooper
 	time.Sleep(time.Millisecond * 500)
+
+	initTracerState(t, tr)
 
 	// Iterate through active connections until we find connection created above, and confirm send + recv counts
 	connections := getConnections(t, tr)
@@ -1093,8 +1113,7 @@ func TestTCPEstablished(t *testing.T) {
 	require.NoError(t, err)
 	defer tr.Stop()
 
-	// Warm-up state
-	getConnections(t, tr)
+	initTracerState(t, tr)
 
 	server := NewTCPServer(func(c net.Conn) {
 		io.Copy(ioutil.Discard, c)
@@ -1151,8 +1170,7 @@ func TestTCPEstablishedPreExistingConn(t *testing.T) {
 	require.NoError(t, err)
 	defer tr.Stop()
 
-	// Warm-up state
-	getConnections(t, tr)
+	initTracerState(t, tr)
 
 	c.Write([]byte("hello"))
 	c.Close()
@@ -1182,6 +1200,7 @@ func TestUnconnectedUDPSendIPv4(t *testing.T) {
 	bytesSent, err := conn.WriteTo(message, remoteAddr)
 	require.NoError(t, err)
 
+	initTracerState(t, tr)
 	connections := getConnections(t, tr)
 	outgoing := searchConnections(connections, func(cs network.ConnectionStats) bool {
 		return cs.DPort == uint16(remotePort)
@@ -1211,6 +1230,7 @@ func TestConnectedUDPSendIPv6(t *testing.T) {
 	bytesSent, err := conn.Write(message)
 	require.NoError(t, err)
 
+	initTracerState(t, tr)
 	connections := getConnections(t, tr)
 	outgoing := searchConnections(connections, func(cs network.ConnectionStats) bool {
 		return cs.DPort == uint16(remotePort)
@@ -1297,6 +1317,7 @@ func TestConnectionClobber(t *testing.T) {
 	time.Sleep(2 * time.Second)
 
 	preCap := tr.activeBuffer.Capacity()
+	initTracerState(t, tr)
 	connections := getConnections(t, tr)
 	require.NotEmpty(t, connections)
 	src := connections.Conns[0].SPort
@@ -1333,8 +1354,7 @@ func TestTCPDirection(t *testing.T) {
 	require.NoError(t, err)
 	defer tr.Stop()
 
-	// Warm-up tracer state
-	_ = getConnections(t, tr)
+	initTracerState(t, tr)
 
 	// Start an HTTP server on localhost:8080
 	serverAddr := "127.0.0.1:8080"
@@ -1418,8 +1438,7 @@ func TestTCPDirectionWithPreexistingConnection(t *testing.T) {
 	require.NoError(t, err)
 	defer tr.Stop()
 
-	// Warm-up tracer state
-	_ = getConnections(t, tr)
+	initTracerState(t, tr)
 
 	// open and close another client connection to force port binding delete
 	wg.Add(1)
@@ -1472,8 +1491,7 @@ func TestHTTPStats(t *testing.T) {
 	require.NoError(t, err)
 	defer tr.Stop()
 
-	// Warm-up tracer state
-	_ = getConnections(t, tr)
+	initTracerState(t, tr)
 
 	// Start an HTTP server on localhost:8080
 	serverAddr := "127.0.0.1:8080"

--- a/pkg/network/tracer/tracer_unsupported.go
+++ b/pkg/network/tracer/tracer_unsupported.go
@@ -30,6 +30,11 @@ func (t *Tracer) GetActiveConnections(_ string) (*network.Connections, error) {
 	return nil, ebpf.ErrNotImplemented
 }
 
+// RegisterClient registers the client
+func (t *Tracer) RegisterClient(clientID string) error {
+	return ebpf.ErrNotImplemented
+}
+
 // GetStats is not implemented on this OS for Tracer
 func (t *Tracer) GetStats() (map[string]interface{}, error) {
 	return nil, ebpf.ErrNotImplemented

--- a/pkg/network/tracer/tracer_windows.go
+++ b/pkg/network/tracer/tracer_windows.go
@@ -141,6 +141,12 @@ func (t *Tracer) GetActiveConnections(clientID string) (*network.Connections, er
 	}, nil
 }
 
+// RegisterClient registers the client
+func (t *Tracer) RegisterClient(clientID string) error {
+	t.state.RegisterClient(clientID)
+	return nil
+}
+
 func (t *Tracer) getConnTelemetry() map[network.ConnTelemetryType]int64 {
 	tm := map[network.ConnTelemetryType]int64{}
 

--- a/pkg/network/tracer/tracer_windows.go
+++ b/pkg/network/tracer/tracer_windows.go
@@ -133,11 +133,12 @@ func (t *Tracer) GetActiveConnections(clientID string) (*network.Connections, er
 		ips = append(ips, conn.Source, conn.Dest)
 	}
 	names := t.reverseDNS.Resolve(ips)
+	telemetryDelta := t.state.GetTelemetryDelta(clientID, t.getConnTelemetry())
 	return &network.Connections{
 		BufferedData:  delta.BufferedData,
 		DNS:           names,
 		DNSStats:      delta.DNSStats,
-		ConnTelemetry: t.getConnTelemetry(),
+		ConnTelemetry: telemetryDelta,
 	}, nil
 }
 

--- a/pkg/process/checks/net.go
+++ b/pkg/process/checks/net.go
@@ -36,7 +36,6 @@ var (
 	ErrTracerStillNotInitialized = errors.New("remote tracer is still not initialized")
 
 	// ProcessAgentClientID process-agent unique ID
-	// FIXME: what should this be?
 	ProcessAgentClientID = "process-agent-unique-id"
 )
 

--- a/pkg/process/net/common.go
+++ b/pkg/process/net/common.go
@@ -193,6 +193,23 @@ func (r *RemoteSysProbeUtil) GetStats() (map[string]interface{}, error) {
 	return stats, nil
 }
 
+// Register registers the client to system probe
+func (r *RemoteSysProbeUtil) Register(clientID string) error {
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s?client_id=%s", registerURL, clientID), nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := r.httpClient.Do(req)
+	if err != nil {
+		return err
+	} else if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("conn request failed: Path %s, url: %s, status code: %d", r.path, statsURL, resp.StatusCode)
+	}
+
+	return nil
+}
+
 func newSystemProbe() *RemoteSysProbeUtil {
 	return &RemoteSysProbeUtil{
 		path: globalSocketPath,

--- a/pkg/process/net/common_linux.go
+++ b/pkg/process/net/common_linux.go
@@ -17,6 +17,7 @@ const (
 	connectionsURL = "http://unix/connections"
 	statsURL       = "http://unix/debug/stats"
 	procStatsURL   = "http://unix/proc/stats"
+	registerURL    = "http://unix/register"
 	netType        = "unix"
 )
 

--- a/pkg/process/net/common_linux.go
+++ b/pkg/process/net/common_linux.go
@@ -17,7 +17,7 @@ const (
 	connectionsURL = "http://unix/connections"
 	statsURL       = "http://unix/debug/stats"
 	procStatsURL   = "http://unix/proc/stats"
-	registerURL    = "http://unix/register"
+	registerURL    = "http://unix/network_tracer/register"
 	netType        = "unix"
 )
 

--- a/pkg/process/net/common_unsupported.go
+++ b/pkg/process/net/common_unsupported.go
@@ -45,3 +45,8 @@ func (r *RemoteSysProbeUtil) GetStats() (map[string]interface{}, error) {
 func (r *RemoteSysProbeUtil) GetProcStats(pids []int32) (*model.ProcStatsWithPermByPID, error) {
 	return nil, ebpf.ErrNotImplemented
 }
+
+// Register is not supported
+func (r *RemoteSysProbeUtil) Register(clientID string) error {
+	return ebpf.ErrNotImplemented
+}

--- a/pkg/process/net/common_windows.go
+++ b/pkg/process/net/common_windows.go
@@ -15,7 +15,7 @@ const (
 	statsURL       = "http://localhost:3333/debug/stats"
 	// procStatsURL is not used in windows, the value is added to avoid compilation error in windows
 	procStatsURL = "http://localhost:3333/proc/stats"
-	registerURL  = "http://localhost:3333/register"
+	registerURL  = "http://localhost:3333/network_tracer/register"
 	netType      = "tcp"
 )
 

--- a/pkg/process/net/common_windows.go
+++ b/pkg/process/net/common_windows.go
@@ -15,6 +15,7 @@ const (
 	statsURL       = "http://localhost:3333/debug/stats"
 	// procStatsURL is not used in windows, the value is added to avoid compilation error in windows
 	procStatsURL = "http://localhost:3333/proc/stats"
+	registerURL  = "http://localhost:3333/register"
 	netType      = "tcp"
 )
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR adds the 'register' api endpoint to _system-probe_.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Although not strictly necessary, some clients (like `process-agent`) like to first init and then start gathering data. With this scenario in mind, there was no way to correctly register the client without making the call to `/connections`, which would result in actually **getting data**. 
 
As a result of this, `process-agent` was throwing away the first gathered data, which doesn't really make sense either.

Adding this API permits those users to have a better workflow for this scenario.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

Hopefully, this doesn't really bring any breaking changes, as adding this new endpoint is only about registering a client, nothing more. The current behaviour still works (which is calling `/connections` without prior calls to `/register`).

This also permits to remove special handling part of this mentioned behaviour (dropping first batch) in `system-probe`, so it's a win on that side.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Interestingly, the behaviour seemed to already been tested (the fact that we were throwing the first batch), so adapting those tests actually shows that both behaviour are working as expected here.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
