### PR TITLE
[CWS] small fixes related to btfhub constants generation file name parsing

### DIFF
--- a/pkg/security/probe/constantfetch/btfhub/main.go
+++ b/pkg/security/probe/constantfetch/btfhub/main.go
@@ -123,14 +123,14 @@ func (c *treeWalkCollector) treeWalkerBuilder(prefix string) fs.WalkDirFunc {
 		pathSuffix := strings.TrimPrefix(path, prefix)
 
 		btfParts := strings.Split(pathSuffix, "/")
-		if len(btfParts) != 4 {
-			return fmt.Errorf("file has wront format: %s", pathSuffix)
+		if len(btfParts) < 4 {
+			return fmt.Errorf("file has wrong format: %s", pathSuffix)
 		}
 
-		distribution := btfParts[0]
-		distribVersion := btfParts[1]
-		arch := btfParts[2]
-		unameRelease := strings.TrimSuffix(btfParts[3], ".btf.tar.xz")
+		distribution := btfParts[len(btfParts)-4]
+		distribVersion := btfParts[len(btfParts)-3]
+		arch := btfParts[len(btfParts)-2]
+		unameRelease := strings.TrimSuffix(btfParts[len(btfParts)-1], ".btf.tar.xz")
 
 		fmt.Println(path)
 


### PR DESCRIPTION
### What does this PR do?

In some cases, the path could start with `/` and thus the count of parts would be != 4, thus breaking the algorithm. This PR fixes this by using the last 4 path atoms.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
