### PR TITLE
[corechecks/helm] Add selector in informers

### DIFF
--- a/pkg/collector/corechecks/cluster/helm/helm_test.go
+++ b/pkg/collector/corechecks/cluster/helm/helm_test.go
@@ -194,9 +194,11 @@ func TestRun(t *testing.T) {
 			check := factory().(*HelmCheck)
 			check.runLeaderElection = false
 
-			k8sClient := fake.NewSimpleClientset(kubeObjects...)
-			sharedK8sInformerFactory := informers.NewSharedInformerFactory(k8sClient, time.Minute)
-			err := check.setupInformers(sharedK8sInformerFactory)
+			check.informerFactory = informers.NewSharedInformerFactory(
+				fake.NewSimpleClientset(kubeObjects...),
+				time.Minute,
+			)
+			err := check.setupInformers()
 			assert.NoError(t, err)
 
 			mockedSender := mocksender.NewMockSender(checkName)
@@ -238,8 +240,8 @@ func TestRun_withCollectEvents(t *testing.T) {
 	assert.NoError(t, err)
 
 	k8sClient := fake.NewSimpleClientset()
-	sharedK8sInformerFactory := informers.NewSharedInformerFactory(k8sClient, time.Minute)
-	err = check.setupInformers(sharedK8sInformerFactory)
+	check.informerFactory = informers.NewSharedInformerFactory(k8sClient, time.Minute)
+	err = check.setupInformers()
 	assert.NoError(t, err)
 
 	mockedSender := mocksender.NewMockSender(checkName)


### PR DESCRIPTION

### What does this PR do?

Adds a label selector in the informers used by the Helm check.


### Describe how to test/QA your changes

The helm check should work without any changes. The memory consumption might be reduced in some environments.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
