### PR TITLE
Switch default value of `external_metrics_provider.port` to 8443

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -840,7 +840,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("hpa_watcher_gc_period", 60*5) // 5 minutes
 	config.BindEnvAndSetDefault("hpa_configmap_name", "datadog-custom-metrics")
 	config.BindEnvAndSetDefault("external_metrics_provider.enabled", false)
-	config.BindEnvAndSetDefault("external_metrics_provider.port", 443)
+	config.BindEnvAndSetDefault("external_metrics_provider.port", 8443)
 	config.BindEnvAndSetDefault("external_metrics_provider.endpoint", "")                 // Override the Datadog API endpoint to query external metrics from
 	config.BindEnvAndSetDefault("external_metrics_provider.api_key", "")                  // Override the Datadog API Key for external metrics endpoint
 	config.BindEnvAndSetDefault("external_metrics_provider.app_key", "")                  // Override the Datadog APP Key for external metrics endpoint

--- a/releasenotes-dca/notes/external_metrics_provider_8443-670f76a2c0afef73.yaml
+++ b/releasenotes-dca/notes/external_metrics_provider_8443-670f76a2c0afef73.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+other:
+  - |
+    Change the default value of the external metrics provider port from 443 to 8443.
+    This will allow to run the cluster agent with a non-root user for better security.
+    This was already the default value in the Helm chart and in the datadog operator.


### PR DESCRIPTION

### What does this PR do?

Switch the default value of the external metrics provider port (`external_metrics_provider.port`) from `443` to `8443` to remove the need to run the `cluster-agent` as `root`.

### Motivation

In order to improve security, we’d like to run the `cluster-agent` with a non-`root` user.

### Additional Notes

The external metrics server makes sense only on Kubernetes.
And on Kubernetes, `8443` was already the default value
* when deployed with the Helm chart: https://github.com/DataDog/helm-charts/blob/9867710765119c7db862a00598e4673d953e699d/charts/datadog/values.yaml#L657-L658
* when deployed with the datadog operator: https://github.com/DataDog/datadog-operator/blob/22cf9133ecae817586c1ccfd70ad651aa2294e4f/apis/datadoghq/v1alpha1/datadogagent_default.go#L68

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
