### PR TITLE
Fix pipeline dependencies when building only A6 or A7

### DIFF
--- a/.gitlab/binary_build/windows.yml
+++ b/.gitlab/binary_build/windows.yml
@@ -2,7 +2,6 @@
 # Entrypoint for the Windows Docker image
 build_windows_container_entrypoint:
   rules:
-    !reference [.on_a7]
   stage: binary_build
   tags: ["runner:windows-docker", "windowsversion:1809"]
   needs: ["tests_windows-x64"]

--- a/.gitlab/kitchen_deploy.yml
+++ b/.gitlab/kitchen_deploy.yml
@@ -67,7 +67,7 @@ deploy_deb_testing-a6_arm64:
     !reference [.on_all_kitchen_builds_a6]
   extends:
     - .deploy_deb_testing-a6
-  needs: ["agent_deb-arm64-a6", "tests_deb-arm64-py2", "tests_deb-arm64-py3"]
+  needs: ["agent_deb-arm64-a6", "tests_deb-arm64-py2"]
   script:
     - *setup_apt_signing_key
     - set +x  # make sure we don't output the creds to the build log
@@ -108,7 +108,7 @@ deploy_deb_testing-a7_arm64:
     !reference [.on_all_kitchen_builds_a7]
   extends:
     - .deploy_deb_testing-a7
-  needs: ["agent_deb-arm64-a7", "tests_deb-arm64-py2", "tests_deb-arm64-py3"]
+  needs: ["agent_deb-arm64-a7", "tests_deb-arm64-py3"]
   script:
     - *setup_apt_signing_key
     - set +x  # make sure we don't output the creds to the build log


### PR DESCRIPTION
### What does this PR do?

Fixes the following errors on pipelines triggered with `--major-versions 7`:

- 'docker_build_agent6_windows1809_core' job needs 'build_windows_container_entrypoint' job, but it was not added to the pipeline
- 'docker_build_agent6_windows1909_core' job needs 'build_windows_container_entrypoint' job, but it was not added to the pipeline
- 'docker_build_agent6_windows2004_core' job needs 'build_windows_container_entrypoint' job, but it was not added to the pipeline
- 'docker_build_agent6_windows20h2_core' job needs 'build_windows_container_entrypoint' job, but it was not added to the pipeline
- 'docker_build_agent6_windows2022_core' job needs 'build_windows_container_entrypoint' job, but it was not added to the pipeline

Fixes the following errors on pipelines triggered with `--major-versions 6`:
- 'deploy_deb_testing-a7_arm64' job needs 'tests_deb-arm64-py2' job, but it was not added to the pipeline
