### PR TITLE
Adding support for ibm cloud

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -233,7 +233,7 @@ func InitConfig(config Config) {
 	config.BindEnv("site")
 	config.BindEnv("dd_url", "DD_DD_URL", "DD_URL")
 	config.BindEnvAndSetDefault("app_key", "")
-	config.BindEnvAndSetDefault("cloud_provider_metadata", []string{"aws", "gcp", "azure", "alibaba", "oracle"})
+	config.BindEnvAndSetDefault("cloud_provider_metadata", []string{"aws", "gcp", "azure", "alibaba", "oracle", "ibm"})
 	config.SetDefault("proxy", nil)
 	config.BindEnvAndSetDefault("skip_ssl_validation", false)
 	config.BindEnvAndSetDefault("sslkeylogfile", "")
@@ -659,7 +659,9 @@ func InitConfig(config Config) {
 
 	// Metadata endpoints
 
-	// Defines the maximum size of hostame gathered from EC2, GCE, Azure and Alibabacloud metadata endpoints.
+	// Defines the maximum size of hostame gathered from EC2, GCE, Azure, Alibaba, Oracle and Tencent cloud metadata
+	// endpoints (all cloudprovider except IBM). IBM cloud ignore this setting as their API return a huge JSON with
+	// all the metadata for the VM.
 	// Used internally to protect against configurations where metadata endpoints return incorrect values with 200 status codes.
 	config.BindEnvAndSetDefault("metadata_endpoints_max_hostname_size", 255)
 
@@ -717,6 +719,10 @@ func InitConfig(config Config) {
 
 	// Azure
 	config.BindEnvAndSetDefault("azure_hostname_style", "os")
+
+	// IBM cloud
+	// We use a long timeout here since the metadata and token API can be very slow sometimes.
+	config.BindEnvAndSetDefault("ibm_metadata_timeout", 5) // value in seconds
 
 	// JMXFetch
 	config.BindEnvAndSetDefault("jmx_custom_jars", []string{})

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -321,8 +321,8 @@ api_key:
 ## higher maximum backoff time.
 # forwarder_backoff_max: 64
 
-## @param cloud_provider_metadata - list of strings -  optional - default: ["aws", "gcp", "azure", "alibaba", "oracle"]
-## @env DD_CLOUD_PROVIDER_METADATA - space separated list of strings - optional - default: aws gcp azure alibaba oracle
+## @param cloud_provider_metadata - list of strings -  optional - default: ["aws", "gcp", "azure", "alibaba", "oracle", "ibm"]
+## @env DD_CLOUD_PROVIDER_METADATA - space separated list of strings - optional - default: aws gcp azure alibaba oracle ibm
 ## This option restricts which cloud provider endpoint will be used by the
 ## agent to retrieve metadata. By default the agent will try # AWS, GCP, Azure
 ## and alibaba providers. Some cloud provider are not enabled by default to not
@@ -339,6 +339,7 @@ api_key:
 ## "alibaba" Alibaba
 ## "tencent" Tencent
 ## "oracle"  Oracle Cloud
+## "ibm"     IBM Cloud
 #
 # cloud_provider_metadata:
 #   - "aws"
@@ -346,6 +347,7 @@ api_key:
 #   - "azure"
 #   - "alibaba"
 #   - "oracle"
+#   - "ibm"
 
 ## @param collect_ec2_tags - boolean - optional - default: false
 ## @env DD_COLLECT_EC2_TAGS - boolean - optional - default: false

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -68,7 +68,7 @@ func TestDefaults(t *testing.T) {
 	assert.False(t, config.IsSet("dd_url"))
 	assert.Equal(t, "", config.GetString("site"))
 	assert.Equal(t, "", config.GetString("dd_url"))
-	assert.Equal(t, []string{"aws", "gcp", "azure", "alibaba", "oracle"}, config.GetStringSlice("cloud_provider_metadata"))
+	assert.Equal(t, []string{"aws", "gcp", "azure", "alibaba", "oracle", "ibm"}, config.GetStringSlice("cloud_provider_metadata"))
 
 	// Testing process-agent defaults
 	assert.Equal(t, map[string]interface{}{

--- a/pkg/util/cloudproviders/cloudproviders.go
+++ b/pkg/util/cloudproviders/cloudproviders.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders/azure"
 	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders/cloudfoundry"
 	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders/gce"
+	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders/ibm"
 	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders/kubernetes"
 	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders/oracle"
 	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders/tencent"
@@ -42,6 +43,7 @@ func DetectCloudProvider(ctx context.Context) {
 		{name: alibaba.CloudProviderName, callback: alibaba.IsRunningOn},
 		{name: tencent.CloudProviderName, callback: tencent.IsRunningOn},
 		{name: oracle.CloudProviderName, callback: oracle.IsRunningOn},
+		{name: ibm.CloudProviderName, callback: ibm.IsRunningOn},
 	}
 
 	for _, cloudDetector := range detectors {
@@ -98,6 +100,7 @@ func GetHostAliases(ctx context.Context) []string {
 		{name: "kubelet", callback: kubelet.GetHostAliases},
 		{name: tencent.CloudProviderName, callback: tencent.GetHostAliases},
 		{name: oracle.CloudProviderName, callback: oracle.GetHostAliases},
+		{name: ibm.CloudProviderName, callback: ibm.GetHostAliases},
 		{name: kubernetes.CloudProviderName, callback: kubernetes.GetHostAliases},
 	}
 

--- a/pkg/util/cloudproviders/ibm/diagnosis.go
+++ b/pkg/util/cloudproviders/ibm/diagnosis.go
@@ -1,0 +1,22 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package ibm
+
+import (
+	"context"
+
+	"github.com/DataDog/datadog-agent/pkg/diagnose/diagnosis"
+)
+
+func init() {
+	diagnosis.Register("IBM cloud Metadata availability", diagnose)
+}
+
+// diagnose the IBM cloud metadata API availability
+func diagnose() error {
+	_, err := GetHostAliases(context.TODO())
+	return err
+}

--- a/pkg/util/cloudproviders/ibm/ibm.go
+++ b/pkg/util/cloudproviders/ibm/ibm.go
@@ -1,0 +1,129 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package ibm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/cachedfetch"
+	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// declare these as vars not const to ease testing
+var (
+	metadataURL      = "http://169.254.169.254"
+	tokenEndpoint    = "/instance_identity/v1/token?version=2022-03-08"
+	instanceEndpoint = "/metadata/v1/instance?version=2022-03-08"
+
+	token *httputils.APIToken
+
+	// CloudProviderName contains the inventory name of for EC2
+	CloudProviderName = "IBM"
+)
+
+func init() {
+	token = httputils.NewAPIToken(getToken)
+}
+
+type tokenAnswer struct {
+	Value     string `json:"access_token"`
+	ExpiresAt string `json:"expires_at"`
+}
+
+type instanceAnswer struct {
+	ID string `json:"id"`
+}
+
+func getToken(ctx context.Context) (string, time.Time, error) {
+	res, err := httputils.Put(ctx,
+		metadataURL+tokenEndpoint,
+		map[string]string{
+			"Metadata-Flavor": "ibm",
+		},
+		[]byte("{\"expires_in\": 3600}"),
+		config.Datadog.GetDuration("ibm_metadata_timeout")*time.Second)
+
+	if err != nil {
+		token.ExpirationDate = time.Now()
+		return "", time.Time{}, err
+	}
+
+	data := tokenAnswer{}
+	err = json.Unmarshal([]byte(res), &data)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("could not Unmarshal IBM token answer: %s", err)
+	} else if data.Value == "" {
+		return "", time.Time{}, fmt.Errorf("empty token returned by token API")
+	}
+
+	expiresAt, err := time.Parse(time.RFC3339, data.ExpiresAt)
+	if err != nil {
+		// if we can't parse the expire we expire the token right Now
+		log.Debugf("could not parse token expire date: %s", err)
+		return data.Value, time.Now(), nil
+	}
+	return data.Value, expiresAt, nil
+}
+
+// IsRunningOn returns true if the agent is running on IBM cloud
+func IsRunningOn(ctx context.Context) bool {
+	_, err := GetHostAliases(ctx)
+	log.Debugf("running on IBM cloud: %v (%s)", err == nil, err)
+	return err == nil
+}
+
+var instanceIDFetcher = cachedfetch.Fetcher{
+	Name: "IBM instance name",
+	Attempt: func(ctx context.Context) (interface{}, error) {
+		if !config.IsCloudProviderEnabled(CloudProviderName) {
+			return "", fmt.Errorf("IBM cloud provider is disabled by configuration")
+		}
+
+		t, err := token.Get(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("IBM HostAliases: unable to get a token: %s", err)
+		}
+
+		res, err := httputils.Get(ctx,
+			metadataURL+instanceEndpoint,
+			map[string]string{
+				"Authorization": fmt.Sprintf("Bearer %s", t),
+			},
+			config.Datadog.GetDuration("ibm_metadata_timeout")*time.Second)
+		if err != nil {
+			return nil, fmt.Errorf("IBM HostAliases: unable to query metadata endpoint: %s", err)
+		}
+
+		if res == "" {
+			return nil, fmt.Errorf("IBM '%s' returned empty id", metadataURL)
+		}
+
+		// We do not enforce config "metadata_endpoints_max_hostname_size" since the API returns all the
+		// metadata for the host (around 2k payload).
+
+		data := instanceAnswer{}
+		err = json.Unmarshal([]byte(res), &data)
+		if err != nil {
+			return "", fmt.Errorf("could not Unmarshal IBM metadata answer: %s", err)
+		}
+
+		if data.ID == "" {
+			return nil, fmt.Errorf("IBM cloud metdata endpoint returned an empty 'id'")
+		}
+
+		return []string{data.ID}, nil
+	},
+}
+
+// GetHostAliases returns the VM name from the IBM Metadata api
+func GetHostAliases(ctx context.Context) ([]string, error) {
+	return instanceIDFetcher.FetchStringSlice(ctx)
+}

--- a/pkg/util/cloudproviders/ibm/ibm_test.go
+++ b/pkg/util/cloudproviders/ibm/ibm_test.go
@@ -1,0 +1,105 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package ibm
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	tokenPayload            = "{\"access_token\":\"some data\",\"created_at\":\"2022-03-22T15:35:50.227Z\",\"expires_at\":\"2022-03-22T15:40:50.227Z\",\"expires_in\":3600}"
+	tokenPayloadExpireError = "{\"access_token\":\"some data\",\"created_at\":\"2022-03-22T15:35:50.227Z\",\"expires_at\":\"2022-03-22T15:40\",\"expires_in\":3600}"
+
+	// We only care about the 'id' entry from the metadata endpoint answer.
+	metadataPayload = "{\"id\": \"an ID\"}"
+)
+
+func TestGetToken(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PUT", r.Method)
+		assert.Equal(t, tokenEndpoint, r.RequestURI)
+		assert.Equal(t, "ibm", r.Header.Get("Metadata-Flavor"))
+
+		body, _ := io.ReadAll(r.Body)
+		assert.Equal(t, "{\"expires_in\": 3600}", string(body))
+
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		io.WriteString(w, tokenPayload)
+	}))
+	defer ts.Close()
+
+	defer func(url string) { metadataURL = url }(metadataURL)
+	metadataURL = ts.URL
+
+	value, expiresAt, err := getToken(context.Background())
+	require.Nil(t, err)
+	assert.Equal(t, "some data", value)
+
+	expectedExpiresAt, _ := time.Parse(time.RFC3339, "2022-03-22T15:40:50.227Z")
+	assert.Equal(t, expectedExpiresAt, expiresAt)
+}
+
+func TestGetTokenError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		io.WriteString(w, "{}")
+	}))
+	defer ts.Close()
+
+	defer func(url string) { metadataURL = url }(metadataURL)
+	metadataURL = ts.URL
+
+	_, _, err := getToken(context.Background())
+	require.NotNil(t, err)
+}
+
+func TestGetTokenErrorParsingDate(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		io.WriteString(w, tokenPayloadExpireError)
+	}))
+	defer ts.Close()
+
+	defer func(url string) { metadataURL = url }(metadataURL)
+	metadataURL = ts.URL
+
+	value, expiresAt, err := getToken(context.Background())
+	require.Nil(t, err)
+	assert.Equal(t, "some data", value)
+
+	assert.True(t, time.Now().After(expiresAt))
+}
+
+func TestGetHostAliases(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "PUT":
+			assert.Equal(t, tokenEndpoint, r.RequestURI)
+			w.Header().Set("Content-Type", "application/json; charset=utf-8")
+			io.WriteString(w, tokenPayload)
+		case "GET":
+			assert.Equal(t, instanceEndpoint, r.RequestURI)
+			w.Header().Set("Content-Type", "application/json; charset=utf-8")
+			io.WriteString(w, metadataPayload)
+		}
+	}))
+	defer ts.Close()
+
+	defer func(url string) { metadataURL = url }(metadataURL)
+	metadataURL = ts.URL
+
+	aliases, err := GetHostAliases(context.Background())
+	require.Nil(t, err)
+	assert.Equal(t, []string{"an ID"}, aliases)
+}

--- a/pkg/util/http/helpers.go
+++ b/pkg/util/http/helpers.go
@@ -6,6 +6,7 @@
 package http
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io/ioutil"
@@ -13,14 +14,28 @@ import (
 	"time"
 )
 
-// Get is a high level helper to query an url and return its body as a string
-func Get(ctx context.Context, url string, headers map[string]string, timeout time.Duration) (string, error) {
+func parseResponse(res *http.Response, method string, URL string) (string, error) {
+	if res.StatusCode != 200 {
+		return "", fmt.Errorf("status code %d trying to %s %s", res.StatusCode, method, URL)
+	}
+
+	defer res.Body.Close()
+	all, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return "", fmt.Errorf("error while reading response from %s: %s", URL, err)
+	}
+
+	return string(all), nil
+}
+
+// Get is a high level helper to query an URL and return its body as a string
+func Get(ctx context.Context, URL string, headers map[string]string, timeout time.Duration) (string, error) {
 	client := http.Client{
 		Transport: CreateHTTPTransport(),
 		Timeout:   timeout,
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, URL, nil)
 	if err != nil {
 		return "", err
 	}
@@ -34,15 +49,29 @@ func Get(ctx context.Context, url string, headers map[string]string, timeout tim
 		return "", err
 	}
 
-	if res.StatusCode != 200 {
-		return "", fmt.Errorf("status code %d trying to GET %s", res.StatusCode, url)
+	return parseResponse(res, "GET", URL)
+}
+
+// Put is a high level helper to query an URL using the PUT method and return its body as a string
+func Put(ctx context.Context, URL string, headers map[string]string, body []byte, timeout time.Duration) (string, error) {
+	client := http.Client{
+		Transport: CreateHTTPTransport(),
+		Timeout:   timeout,
 	}
 
-	defer res.Body.Close()
-	all, err := ioutil.ReadAll(res.Body)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, URL, bytes.NewBuffer(body))
 	if err != nil {
-		return "", fmt.Errorf("error while reading response from oraclecloud metadata endpoint: %s", err)
+		return "", err
 	}
 
-	return string(all), nil
+	for header, value := range headers {
+		req.Header.Add(header, value)
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+
+	return parseResponse(res, "PUT", URL)
 }

--- a/pkg/util/http/token.go
+++ b/pkg/util/http/token.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package http
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// APITokenRenewCallback represents the callback type to fetch a token
+type APITokenRenewCallback func(context.Context) (string, time.Time, error)
+
+// APIToken is an API token with auto renew when expired
+type APIToken struct {
+	Value          string
+	ExpirationDate time.Time
+	renewCallback  APITokenRenewCallback
+
+	sync.RWMutex
+}
+
+// NewAPIToken returns a new APIToken
+func NewAPIToken(cb APITokenRenewCallback) *APIToken {
+	return &APIToken{
+		renewCallback: cb,
+	}
+}
+
+// Get returns the token value
+func (token *APIToken) Get(ctx context.Context) (string, error) {
+	token.RLock()
+	// The token renewal window is open, refreshing the token
+	if time.Now().Before(token.ExpirationDate) {
+		val := token.Value
+		token.RUnlock()
+		return val, nil
+	}
+	token.RUnlock()
+
+	token.Lock()
+	defer token.Unlock()
+	// Token has been refreshed by another caller
+	if time.Now().Before(token.ExpirationDate) {
+		return token.Value, nil
+	}
+
+	value, expirationDate, err := token.renewCallback(ctx)
+	if err != nil {
+		token.ExpirationDate = time.Now()
+		return "", err
+	}
+
+	token.Value = value
+	token.ExpirationDate = expirationDate
+	return token.Value, nil
+}

--- a/pkg/util/http/token_test.go
+++ b/pkg/util/http/token_test.go
@@ -1,0 +1,63 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package http
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewAPIToken(t *testing.T) {
+	cb := func(ctx context.Context) (string, time.Time, error) { return "test", time.Time{}, nil }
+
+	token := NewAPIToken(cb)
+	require.NotNil(t, token)
+
+	val, _, _ := token.renewCallback(context.Background())
+	assert.Equal(t, "test", val)
+
+	assert.True(t, token.ExpirationDate.IsZero())
+	assert.Equal(t, "", token.Value)
+}
+
+func TestGetNewToken(t *testing.T) {
+	nbCbCall := 0
+	tokenReturnValue := "test"
+	expireReturnValue := time.Now().Add(10 * time.Minute)
+
+	cb := func(ctx context.Context) (string, time.Time, error) {
+		nbCbCall++
+		return tokenReturnValue, expireReturnValue, nil
+	}
+
+	token := NewAPIToken(cb)
+	val, err := token.Get(context.Background())
+	require.Nil(t, err)
+	assert.Equal(t, "test", val)
+	assert.Equal(t, expireReturnValue, token.ExpirationDate)
+	assert.Equal(t, 1, nbCbCall)
+
+	// Test expire date
+	tokenReturnValue = "test2"
+
+	val, err = token.Get(context.Background())
+	require.Nil(t, err)
+	assert.Equal(t, "test", val)
+	assert.Equal(t, expireReturnValue, token.ExpirationDate)
+	assert.Equal(t, 1, nbCbCall)
+
+	// expire token
+	token.ExpirationDate = time.Now().Add(-10 * time.Minute)
+	val, err = token.Get(context.Background())
+	require.Nil(t, err)
+	assert.Equal(t, "test2", val)
+	assert.Equal(t, expireReturnValue, token.ExpirationDate)
+	assert.Equal(t, 2, nbCbCall)
+}

--- a/releasenotes/notes/adding-ibm-cloud-support-93803194b1e4aa58.yaml
+++ b/releasenotes/notes/adding-ibm-cloud-support-93803194b1e4aa58.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Adding support for IBM cloud. The agent will now detect that he're running on IBM cloud and collecto host aliased
+    (vm name and ID).


### PR DESCRIPTION
### What does this PR do?

- Adding a token helper to the http package. Multiple services require fetching a token first and refreshing it when
it expires. This is used by EC2 and IBM for now.
- Adding support for IBM cloud. We only support detecting host alias for now.

### Describe how to test/QA your changes

- Run a EC2 instance and check that the host alias are still fetched and that the renewal still works (the `pkg/util/cachedfetch/fetcher.go` will log at debug level if there is an error
- Run a IBM instance and check that the host alias of the box is well fetched   (both VM ID and name).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
