### PR TITLE
[CWS] dentry resolver remove copy config parameters

### DIFF
--- a/pkg/security/probe/dentry_resolver.go
+++ b/pkg/security/probe/dentry_resolver.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 
+	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
@@ -35,22 +36,20 @@ var (
 
 // DentryResolver resolves inode/mountID to full paths
 type DentryResolver struct {
+	config                *config.Config
 	client                *statsd.Client
 	pathnames             *lib.Map
 	erpcStats             [2]*lib.Map
 	bufferSelector        *lib.Map
 	activeERPCStatsBuffer uint32
-	dentryCacheSize       int
 	cache                 map[uint32]*lru.Cache
 	cacheGeneration       uint64
 	erpc                  *ERPC
 	erpcSegment           []byte
 	erpcSegmentSize       int
 	erpcRequest           ERPCRequest
-	erpcEnabled           bool
 	erpcStatsZero         []eRPCStats
 	numCPU                int
-	mapEnabled            bool
 
 	hitsCounters map[string]map[string]*int64
 	missCounters map[string]map[string]*int64
@@ -280,7 +279,7 @@ func (dr *DentryResolver) cacheInode(key PathKey, path *PathEntry) error {
 	if !exists {
 		var err error
 
-		entries, err = lru.NewWithEvict(dr.dentryCacheSize, func(_, value interface{}) {
+		entries, err = lru.NewWithEvict(dr.config.DentryCacheSize, func(_, value interface{}) {
 			dr.pathEntryPool.Put(value)
 		})
 		if err != nil {
@@ -358,10 +357,10 @@ func (dr *DentryResolver) GetNameFromMap(mountID uint32, inode uint64, pathID ui
 // GetName resolves a couple of mountID/inode to a path
 func (dr *DentryResolver) GetName(mountID uint32, inode uint64, pathID uint32) string {
 	name, err := dr.getNameFromCache(mountID, inode)
-	if err != nil && dr.erpcEnabled {
+	if err != nil && dr.config.ERPCDentryResolutionEnabled {
 		name, err = dr.GetNameFromERPC(mountID, inode, pathID)
 	}
-	if err != nil && dr.mapEnabled {
+	if err != nil && dr.config.MapDentryResolutionEnabled {
 		name, err = dr.GetNameFromMap(mountID, inode, pathID)
 	}
 
@@ -667,10 +666,10 @@ func (dr *DentryResolver) ResolveFromERPC(mountID uint32, inode uint64, pathID u
 // Resolve the pathname of a dentry, starting at the pathnameKey in the pathnames table
 func (dr *DentryResolver) Resolve(mountID uint32, inode uint64, pathID uint32, cache bool) (string, error) {
 	path, err := dr.ResolveFromCache(mountID, inode)
-	if err != nil && dr.erpcEnabled {
+	if err != nil && dr.config.ERPCDentryResolutionEnabled {
 		path, err = dr.ResolveFromERPC(mountID, inode, pathID, cache)
 	}
-	if err != nil && err != errTruncatedParentsERPC && dr.mapEnabled {
+	if err != nil && err != errTruncatedParentsERPC && dr.config.MapDentryResolutionEnabled {
 		path, err = dr.ResolveFromMap(mountID, inode, pathID, cache)
 	}
 	return path, err
@@ -732,10 +731,10 @@ func (dr *DentryResolver) resolveParentFromMap(mountID uint32, inode uint64, pat
 // GetParent returns the parent mount_id/inode
 func (dr *DentryResolver) GetParent(mountID uint32, inode uint64, pathID uint32) (uint32, uint64, error) {
 	parentMountID, parentInode, err := dr.resolveParentFromCache(mountID, inode)
-	if err != nil && dr.erpcEnabled {
+	if err != nil && dr.config.ERPCDentryResolutionEnabled {
 		parentMountID, parentInode, err = dr.resolveParentFromERPC(mountID, inode, pathID)
 	}
-	if err != nil && err != errTruncatedParentsERPC && dr.mapEnabled {
+	if err != nil && err != errTruncatedParentsERPC && dr.config.MapDentryResolutionEnabled {
 		parentMountID, parentInode, err = dr.resolveParentFromMap(mountID, inode, pathID)
 	}
 
@@ -875,16 +874,14 @@ func NewDentryResolver(probe *Probe) (*DentryResolver, error) {
 	}
 
 	return &DentryResolver{
+		config:          probe.config,
 		client:          probe.statsdClient,
 		cache:           make(map[uint32]*lru.Cache),
-		dentryCacheSize: probe.config.DentryCacheSize,
 		erpc:            probe.erpc,
 		erpcSegment:     segment,
 		erpcSegmentSize: len(segment),
 		erpcRequest:     ERPCRequest{},
-		erpcEnabled:     probe.config.ERPCDentryResolutionEnabled,
 		erpcStatsZero:   make([]eRPCStats, numCPU),
-		mapEnabled:      probe.config.MapDentryResolutionEnabled,
 		hitsCounters:    hitsCounters,
 		missCounters:    missCounters,
 		numCPU:          numCPU,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Make dentry map fallback working with lockdown. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
