### PR TITLE
[gitlab] Fix notification assignments and silence dev container deploy jobs for now

### DIFF
--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -30,14 +30,23 @@ dca_scan_*_docker_hub*               @DataDog/container-integrations
 # deploy pipelines
 check_already_deployed_version_*     @DataDog/do-not-notify
 
-# Image deploy
-dev_*_docker_hub*                    @DataDog/container-integrations
-dev_*_google_container_repository*   @DataDog/container-integrations
-docker_trigger_internal*             @DataDog/container-integrations
+# Dev container deploy
+# HACK: Silenced for now, uncomment and remove the next section once
+# public-images is fixed.
+# dca_dev_branch*                      @DataDog/container-integrations
+# dev_branch*                          @DataDog/container-integrations
+# dev_master*                          @DataDog/container-integrations
+# dev_nightly*                         @DataDog/container-integrations
+# docker_trigger_internal*             @DataDog/container-integrations
+
+dca_dev_branch*                      @DataDog/do-not-notify
+dev_branch*                          @DataDog/do-not-notify
+dev_master*                          @DataDog/do-not-notify
+dev_nightly*                         @DataDog/do-not-notify
+docker_trigger_internal*             @DataDog/do-not-notify
 
 # Deploy
-deploy_*docker_hub*                  @DataDog/container-integrations
-deploy_*google_container_repository* @DataDog/container-integrations
+deploy_containers*                   @DataDog/container-integrations
 
 # Functional test
 kitchen_*_system_probe*                        @DataDog/agent-network


### PR DESCRIPTION


<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Assign docker publish job to the correct team.
Temporarily silence dev container deploy jobs.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Remove spammy notifications.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
