### PR TITLE
Fix panic in cgroup CPU CFS parsing

### DIFF
--- a/pkg/util/cgroups/cgroupv1_cpu.go
+++ b/pkg/util/cgroups/cgroupv1_cpu.go
@@ -64,14 +64,16 @@ func (c *cgroupV1) parseCPUController(stats *CPUStats) {
 	}
 
 	if err := parseSingleUnsignedStat(c.fr, c.pathFor("cpu", "cpu.cfs_period_us"), &stats.SchedulerPeriod); err == nil {
-		stats.SchedulerPeriod = uint64Ptr(*stats.SchedulerPeriod * uint64(time.Microsecond))
+		if stats.SchedulerPeriod != nil {
+			stats.SchedulerPeriod = uint64Ptr(*stats.SchedulerPeriod * uint64(time.Microsecond))
+		}
 	} else {
 		reportError(err)
 	}
 
 	var tempValue *int64
 	if err := parseSingleSignedStat(c.fr, c.pathFor("cpu", "cpu.cfs_quota_us"), &tempValue); err == nil {
-		if *tempValue != -1 {
+		if tempValue != nil && *tempValue != -1 {
 			stats.SchedulerQuota = uint64Ptr(uint64(*tempValue) * uint64(time.Microsecond))
 		}
 	} else {

--- a/pkg/util/cgroups/cgroupv1_cpu_test.go
+++ b/pkg/util/cgroups/cgroupv1_cpu_test.go
@@ -82,6 +82,9 @@ func TestCgroupV1CPUStats(t *testing.T) {
 	// Test reading files in CPU controllers, all files present except 1 (cpu.shares)
 	tr.reset()
 	cfs.deleteCgroupV1File(cgFoo1, "cpu", "cpu.shares")
+	// Set empty period and quota, make sure we don't panic
+	cfs.setCgroupV1File(cgFoo1, "cpu", "cpu.cfs_period_us", "")
+	cfs.setCgroupV1File(cgFoo1, "cpu", "cpu.cfs_quota_us", "")
 	stats = &CPUStats{}
 	err = cgFoo1.GetCPUStats(stats)
 	assert.NoError(t, err)
@@ -94,7 +97,7 @@ func TestCgroupV1CPUStats(t *testing.T) {
 		ElapsedPeriods:   uint64Ptr(421),
 		ThrottledPeriods: uint64Ptr(0),
 		ThrottledTime:    uint64Ptr(0),
-		SchedulerPeriod:  uint64Ptr(100000 * uint64(time.Microsecond)),
+		SchedulerPeriod:  nil,
 		SchedulerQuota:   nil,
 		CPUCount:         uint64Ptr(8),
 	}, *stats))


### PR DESCRIPTION
### What does this PR do?

Fix possible panic in cgroup parsing in cgroupv1 when `cpu.cfs_period_us` or `cpu.cfs_quota_us` files are empty.

### Motivation

Bugfix.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

The condition does not happen very often, but it's possible to verify that this panic:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x405dab6]

goroutine 480 [running]:
github.com/DataDog/datadog-agent/pkg/util/cgroups.(*cgroupV1).parseCPUController(0xc001472500, 0xc000593b20)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/util/cgroups/cgroupv1_cpu.go:53 +0x756
github.com/DataDog/datadog-agent/pkg/util/cgroups.(*cgroupV1).GetCPUStats(0xc001472500, 0xc000593b20, 0xc003451930, 0x176d7f8)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/util/cgroups/cgroupv1_cpu.go:29 +0xe5
github.com/DataDog/datadog-agent/pkg/util/cgroups.(*cgroupV1).GetStats(0xc001472500, 0xc0020aee80, 0x40, 0x1bf08eb00)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/util/cgroups/cgroupv1.go:44 +0x57
github.com/DataDog/datadog-agent/pkg/util/containers/v2/metrics/system.(*cgroupCollector).GetContainerStats(0xc0006ef830, 0xc001005380, 0x40, 0x1bf08eb00, 0xc0016f4b40, 0xc001606700, 0x1c)
...
```

is not present anymore internally.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
