### PR TITLE
[corechecks/helm] Add "failed_releases" service check

### DIFF
--- a/pkg/collector/corechecks/cluster/helm/releases_store_test.go
+++ b/pkg/collector/corechecks/cluster/helm/releases_store_test.go
@@ -153,3 +153,112 @@ func TestDelete(t *testing.T) {
 	// Should return false when it doesn't exist
 	assert.False(t, store.delete(releases[1], k8sSecrets))
 }
+
+func TestGetLatestRevisions(t *testing.T) {
+	tests := []struct {
+		name    string
+		storage helmStorage
+	}{
+		{
+			name:    "using secrets storage",
+			storage: k8sSecrets,
+		},
+		{
+			name:    "using configmaps storage",
+			storage: k8sConfigmaps,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store := newReleasesStore()
+
+			// Start with a release with revisions 1 and 2, and another one with
+			// revision 10. 10 is just an example to verify that the code does
+			// not assume that revisions will always start from 1.
+			releases := map[string]map[revision]*release{
+				"my_datadog": {
+					revision(1): {
+						Name: "my_datadog",
+						Info: &info{
+							Status: "superseded",
+						},
+						Chart: &chart{
+							Metadata: &metadata{
+								Name:       "datadog",
+								Version:    "2.30.5",
+								AppVersion: "7",
+							},
+						},
+						Version:   1,
+						Namespace: "default",
+					},
+					revision(2): {
+						Name: "my_datadog",
+						Info: &info{
+							Status: "deployed",
+						},
+						Chart: &chart{
+							Metadata: &metadata{
+								Name:       "datadog",
+								Version:    "2.30.5",
+								AppVersion: "7",
+							},
+						},
+						Version:   2,
+						Namespace: "default",
+					},
+				},
+				"my_proxy": {
+					revision(10): {
+						Name: "my_proxy",
+						Info: &info{
+							Status: "deployed",
+						},
+						Chart: &chart{
+							Metadata: &metadata{
+								Name:       "nginx",
+								Version:    "1.0.0",
+								AppVersion: "1",
+							},
+						},
+						Version:   10,
+						Namespace: "default",
+					},
+				},
+			}
+
+			for _, releasesByRevision := range releases {
+				for _, rel := range releasesByRevision {
+					store.add(rel, test.storage)
+				}
+			}
+
+			// First we should get revision 2 for the "my_datadog" release (the
+			// other revision is 1) and revision 10 for the "my_proxy" release.
+			assert.ElementsMatch(
+				t,
+				[]*release{releases["my_datadog"][revision(2)], releases["my_proxy"][revision(10)]},
+				store.getLatestRevisions(test.storage),
+			)
+
+			// After deleting revision 2 of "my_datadog", the only remaining
+			// revision of "my_datadog" is 1, so we should get that one.
+			store.delete(releases["my_datadog"][revision(2)], test.storage)
+			assert.ElementsMatch(
+				t,
+				[]*release{releases["my_datadog"][revision(1)], releases["my_proxy"][revision(10)]},
+				store.getLatestRevisions(test.storage),
+			)
+
+			// Here we delete the last remaining revision of "my_datadog", so it
+			// shouldn't appear in the result anymore.
+			store.delete(releases["my_datadog"][revision(1)], test.storage)
+			assert.ElementsMatch(
+				t,
+				[]*release{releases["my_proxy"][revision(10)]},
+				store.getLatestRevisions(test.storage),
+			)
+		})
+	}
+}

--- a/releasenotes/notes/helm-service-check-fd1f003c0d032dcb.yaml
+++ b/releasenotes/notes/helm-service-check-fd1f003c0d032dcb.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Adds a service check for the Helm check. The service check fails if there's
+    at least one release for which its latest revision is on failed state.


### PR DESCRIPTION
### What does this PR do?

Adds a service check (`helm.failed_releases`) for the Helm check.

The service check reports an error when there's at least one release for which its latest revision is on "failed" state.

### Describe how to test/QA your changes

Deploy on Kubernetes with the helm check enabled. Check in the UI or with `agent check helm` (in the runner or DCA where the check is scheduled) that the service check `helm.failed_releases` reports OK or CRITICAL as expected.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
