### PR TITLE
[CWS] improve sles/suse kernel detection, enable `TestFallbackConstants` on OpenSUSE

### DIFF
--- a/pkg/security/ebpf/kernel/kernel.go
+++ b/pkg/security/ebpf/kernel/kernel.go
@@ -170,17 +170,22 @@ func (k *Version) IsRH8Kernel() bool {
 
 // IsSuseKernel returns whether the kernel is a suse kernel
 func (k *Version) IsSuseKernel() bool {
-	return k.OsRelease["ID"] == "sles" || k.OsRelease["ID"] == "opensuse-leap"
+	return k.IsSLESKernel() || k.OsRelease["ID"] == "opensuse-leap"
 }
 
-// IsSLES12Kernel returns whether the kernel is a sles 12 kernel
-func (k *Version) IsSLES12Kernel() bool {
+// IsSuse12Kernel returns whether the kernel is a sles 12 kernel
+func (k *Version) IsSuse12Kernel() bool {
 	return k.IsSuseKernel() && strings.HasPrefix(k.OsRelease["VERSION_ID"], "12")
 }
 
-// IsSLES15Kernel returns whether the kernel is a sles 15 kernel
-func (k *Version) IsSLES15Kernel() bool {
+// IsSuse15Kernel returns whether the kernel is a sles 15 kernel
+func (k *Version) IsSuse15Kernel() bool {
 	return k.IsSuseKernel() && strings.HasPrefix(k.OsRelease["VERSION_ID"], "15")
+}
+
+// IsSLESKernel returns whether the kernel is a sles kernel
+func (k *Version) IsSLESKernel() bool {
+	return k.OsRelease["ID"] == "sles"
 }
 
 // IsOracleUEKKernel returns whether the kernel is an oracle uek kernel

--- a/pkg/security/probe/constantfetch/fallback.go
+++ b/pkg/security/probe/constantfetch/fallback.go
@@ -405,7 +405,11 @@ func getBpfProgAuxNameOffset(kv *kernel.Version) uint64 {
 	case kv.IsRH8Kernel():
 		nameOffset = 520
 	case kv.IsSuse15Kernel():
-		nameOffset = 256
+		if kv.IsInRangeCloseOpen(kernel.Kernel5_3, kernel.Kernel5_4) {
+			nameOffset = 424
+		} else {
+			nameOffset = 256
+		}
 	case kv.IsSuse12Kernel():
 		nameOffset = 160
 	case kv.IsCOSKernel() && kv.IsInRangeCloseOpen(kernel.Kernel5_10, kernel.Kernel5_11):
@@ -486,7 +490,11 @@ func getSizeOfUpid(kv *kernel.Version) uint64 {
 	case kv.IsSuse12Kernel():
 		sizeOfUpid = 16
 	case kv.IsSuse15Kernel():
-		sizeOfUpid = 32
+		if kv.IsInRangeCloseOpen(kernel.Kernel5_3, kernel.Kernel5_4) {
+			sizeOfUpid = 16
+		} else {
+			sizeOfUpid = 32
+		}
 	case kv.IsAmazonLinuxKernel() && kv.Code != 0 && kv.Code < kernel.Kernel4_15:
 		sizeOfUpid = 32
 	}

--- a/pkg/security/probe/constantfetch/fallback.go
+++ b/pkg/security/probe/constantfetch/fallback.go
@@ -134,9 +134,9 @@ func getSizeOfStructInode(kv *kernel.Version) uint64 {
 		sizeOf = 584
 	case kv.IsRH8Kernel():
 		sizeOf = 648
-	case kv.IsSLES12Kernel():
+	case kv.IsSuse12Kernel():
 		sizeOf = 560
-	case kv.IsSLES15Kernel():
+	case kv.IsSuse15Kernel():
 		sizeOf = 592
 	case kv.IsOracleUEKKernel():
 		sizeOf = 632
@@ -187,9 +187,9 @@ func getSignalTTYOffset(kv *kernel.Version) uint64 {
 		ttyOffset = 416
 	case kv.IsRH8Kernel():
 		ttyOffset = 392
-	case kv.IsSLES12Kernel():
+	case kv.IsSuse12Kernel():
 		ttyOffset = 376
-	case kv.IsSLES15Kernel():
+	case kv.IsSuse15Kernel():
 		ttyOffset = 408
 	case kv.IsCOSKernel() && kv.IsInRangeCloseOpen(kernel.Kernel4_19, kernel.Kernel4_20):
 		ttyOffset = 416
@@ -293,9 +293,9 @@ func getBpfMapNameOffset(kv *kernel.Version) uint64 {
 		nameOffset = 112
 	case kv.IsRH8Kernel():
 		nameOffset = 80
-	case kv.IsSLES15Kernel():
+	case kv.IsSuse15Kernel():
 		nameOffset = 88
-	case kv.IsSLES12Kernel():
+	case kv.IsSuse12Kernel():
 		nameOffset = 176
 
 	case kv.IsInRangeCloseOpen(kernel.Kernel4_15, kernel.Kernel4_18):
@@ -374,9 +374,9 @@ func getBpfProgAuxIDOffset(kv *kernel.Version) uint64 {
 		idOffset = 8
 	case kv.IsRH8Kernel():
 		idOffset = 32
-	case kv.IsSLES15Kernel():
+	case kv.IsSuse15Kernel():
 		idOffset = 28
-	case kv.IsSLES12Kernel():
+	case kv.IsSuse12Kernel():
 		idOffset = 16
 	case kv.IsAmazonLinuxKernel() && kv.IsInRangeCloseOpen(kernel.Kernel4_14, kernel.Kernel4_15):
 		idOffset = 16
@@ -404,9 +404,9 @@ func getBpfProgAuxNameOffset(kv *kernel.Version) uint64 {
 		nameOffset = 144
 	case kv.IsRH8Kernel():
 		nameOffset = 520
-	case kv.IsSLES15Kernel():
+	case kv.IsSuse15Kernel():
 		nameOffset = 256
-	case kv.IsSLES12Kernel():
+	case kv.IsSuse12Kernel():
 		nameOffset = 160
 	case kv.IsCOSKernel() && kv.IsInRangeCloseOpen(kernel.Kernel5_10, kernel.Kernel5_11):
 		nameOffset = 544
@@ -446,9 +446,9 @@ func getPIDNumbersOffset(kv *kernel.Version) uint64 {
 		pidNumbersOffset = 48
 	case kv.IsRH8Kernel():
 		pidNumbersOffset = 56
-	case kv.IsSLES12Kernel():
+	case kv.IsSuse12Kernel():
 		pidNumbersOffset = 48
-	case kv.IsSLES15Kernel():
+	case kv.IsSuse15Kernel():
 		pidNumbersOffset = 80
 	case kv.IsDebianKernel() && kv.IsInRangeCloseOpen(kernel.Kernel4_19, kernel.Kernel4_20):
 		pidNumbersOffset = 56
@@ -483,9 +483,9 @@ func getSizeOfUpid(kv *kernel.Version) uint64 {
 		sizeOfUpid = 32
 	case kv.IsRH8Kernel():
 		sizeOfUpid = 16
-	case kv.IsSLES12Kernel():
+	case kv.IsSuse12Kernel():
 		sizeOfUpid = 16
-	case kv.IsSLES15Kernel():
+	case kv.IsSuse15Kernel():
 		sizeOfUpid = 32
 	case kv.IsAmazonLinuxKernel() && kv.Code != 0 && kv.Code < kernel.Kernel4_15:
 		sizeOfUpid = 32

--- a/pkg/security/probe/constantfetch/fallback.go
+++ b/pkg/security/probe/constantfetch/fallback.go
@@ -535,9 +535,9 @@ func getNetDeviceIfindexOffset(kv *kernel.Version) uint64 {
 		offset = 192
 	case kv.IsRH8Kernel():
 		offset = 264
-	case kv.IsSLES12Kernel():
+	case kv.IsSuse12Kernel():
 		offset = 264
-	case kv.IsSLES15Kernel():
+	case kv.IsSuse15Kernel():
 		offset = 256
 
 	case kv.Code >= kernel.Kernel4_14 && kv.Code < kernel.Kernel5_8:
@@ -597,9 +597,9 @@ func getSocketSockOffset(kv *kernel.Version) uint64 {
 		offset = 32
 	case kv.IsRH8Kernel():
 		offset = 32
-	case kv.IsSLES12Kernel():
+	case kv.IsSuse12Kernel():
 		offset = 32
-	case kv.IsSLES15Kernel():
+	case kv.IsSuse15Kernel():
 		offset = 24
 
 	case kv.Code >= kernel.Kernel5_3:

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -1366,7 +1366,7 @@ func AppendProbeRequestsToFetcher(constantFetcher constantfetch.ConstantFetcher,
 	constantFetcher.AppendOffsetofRequest("bpf_prog_aux_offset", "struct bpf_prog", "aux", "linux/filter.h")
 	constantFetcher.AppendOffsetofRequest("bpf_prog_type_offset", "struct bpf_prog", "type", "linux/filter.h")
 
-	if kv.Code != 0 && (kv.Code > kernel.Kernel4_16 || kv.IsSLES12Kernel() || kv.IsSLES15Kernel()) {
+	if kv.Code != 0 && (kv.Code > kernel.Kernel4_16 || kv.IsSuse12Kernel() || kv.IsSuse15Kernel()) {
 		constantFetcher.AppendOffsetofRequest("bpf_prog_attach_type_offset", "struct bpf_prog", "expected_attach_type", "linux/filter.h")
 	}
 	// namespace nr offsets

--- a/pkg/security/tests/constants_test.go
+++ b/pkg/security/tests/constants_test.go
@@ -42,7 +42,7 @@ func TestOctogonConstants(t *testing.T) {
 
 	t.Run("rc-vs-fallback", func(t *testing.T) {
 		checkKernelCompatibility(t, "SLES and Oracle kernels", func(kv *kernel.Version) bool {
-			return kv.IsSuseKernel() || kv.IsOracleUEKKernel()
+			return kv.IsSLESKernel() || kv.IsOracleUEKKernel()
 		})
 
 		fallbackFetcher := constantfetch.NewFallbackConstantFetcher(kv)
@@ -53,7 +53,7 @@ func TestOctogonConstants(t *testing.T) {
 
 	t.Run("btfhub-vs-rc", func(t *testing.T) {
 		checkKernelCompatibility(t, "SLES and Oracle kernels", func(kv *kernel.Version) bool {
-			return kv.IsSuseKernel() || kv.IsOracleUEKKernel()
+			return kv.IsSLESKernel() || kv.IsOracleUEKKernel()
 		})
 
 		btfhubFetcher, err := constantfetch.NewBTFHubConstantFetcher(kv)
@@ -82,7 +82,7 @@ func TestOctogonConstants(t *testing.T) {
 
 	t.Run("guesser-vs-rc", func(t *testing.T) {
 		checkKernelCompatibility(t, "SLES and Oracle kernels", func(kv *kernel.Version) bool {
-			return kv.IsSuseKernel() || kv.IsOracleUEKKernel()
+			return kv.IsSLESKernel() || kv.IsOracleUEKKernel()
 		})
 
 		rcFetcher := constantfetch.NewRuntimeCompilationConstantFetcher(&config.Config, nil)

--- a/pkg/security/tests/dns_test.go
+++ b/pkg/security/tests/dns_test.go
@@ -22,8 +22,8 @@ import (
 
 func TestDNS(t *testing.T) {
 	checkKernelCompatibility(t, "RHEL, SLES and Oracle kernels", func(kv *kernel.Version) bool {
-		// TODO: Suse and Oracle because we are missing offsets
-		return kv.IsRH7Kernel() || kv.IsSuseKernel() || kv.IsOracleUEKKernel()
+		// TODO: Oracle because we are missing offsets
+		return kv.IsRH7Kernel() || kv.IsOracleUEKKernel()
 	})
 
 	if testEnvironment != DockerEnvironment && !config.IsContainerized() {

--- a/pkg/security/tests/dns_test.go
+++ b/pkg/security/tests/dns_test.go
@@ -21,14 +21,10 @@ import (
 )
 
 func TestDNS(t *testing.T) {
-	kv, err := kernel.NewKernelVersion()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if kv.IsRH7Kernel() || kv.IsSLES12Kernel() || kv.IsSLES15Kernel() || kv.IsOracleUEKKernel() {
-		t.Skip()
-	}
+	checkKernelCompatibility(t, "RHEL, SLES and Oracle kernels", func(kv *kernel.Version) bool {
+		// TODO: Suse and Oracle because we are missing offsets
+		return kv.IsRH7Kernel() || kv.IsSuseKernel() || kv.IsOracleUEKKernel()
+	})
 
 	if testEnvironment != DockerEnvironment && !config.IsContainerized() {
 		if out, err := loadModule("veth"); err != nil {

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -1255,6 +1255,7 @@ func randStringRunes(n int) string {
 
 //nolint:deadcode,unused
 func checkKernelCompatibility(t *testing.T, why string, skipCheck func(kv *kernel.Version) bool) {
+	t.Helper()
 	kv, err := kernel.NewKernelVersion()
 	if err != nil {
 		t.Errorf("failed to get kernel version: %s", err)

--- a/pkg/security/tests/network_device_test.go
+++ b/pkg/security/tests/network_device_test.go
@@ -28,8 +28,8 @@ import (
 
 func TestNetDevice(t *testing.T) {
 	checkKernelCompatibility(t, "RHEL, SLES and Oracle kernels", func(kv *kernel.Version) bool {
-		// TODO: Suse and Oracle because we are missing offsets
-		return kv.IsRH7Kernel() || kv.IsSuseKernel() || kv.IsOracleUEKKernel()
+		// TODO: Oracle because we are missing offsets
+		return kv.IsRH7Kernel() || kv.IsOracleUEKKernel()
 	})
 
 	if testEnvironment != DockerEnvironment && !config.IsContainerized() {

--- a/pkg/security/tests/network_device_test.go
+++ b/pkg/security/tests/network_device_test.go
@@ -27,14 +27,10 @@ import (
 )
 
 func TestNetDevice(t *testing.T) {
-	kv, err := kernel.NewKernelVersion()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if kv.IsRH7Kernel() || kv.IsSLES12Kernel() || kv.IsSLES15Kernel() || kv.IsOracleUEKKernel() {
-		t.Skip()
-	}
+	checkKernelCompatibility(t, "RHEL, SLES and Oracle kernels", func(kv *kernel.Version) bool {
+		// TODO: Suse and Oracle because we are missing offsets
+		return kv.IsRH7Kernel() || kv.IsSuseKernel() || kv.IsOracleUEKKernel()
+	})
 
 	if testEnvironment != DockerEnvironment && !config.IsContainerized() {
 		if out, err := loadModule("veth"); err != nil {

--- a/pkg/security/tests/overlayfs_test.go
+++ b/pkg/security/tests/overlayfs_test.go
@@ -43,16 +43,9 @@ func createOverlayLayers(t *testing.T, test *testModule) (string, string, string
 }
 
 func TestOverlayFS(t *testing.T) {
-	var sles12 bool
-
-	kv, err := kernel.NewKernelVersion()
-	if err == nil {
-		sles12 = kv.IsSLES12Kernel()
-	}
-
-	if sles12 {
-		t.Skip()
-	}
+	checkKernelCompatibility(t, "Suse 12 kernels", func(kv *kernel.Version) bool {
+		return kv.IsSuse12Kernel()
+	})
 
 	ruleDefs := []*rules.RuleDefinition{
 		{

--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -43,7 +43,7 @@
             "x86_64": {
                 "sles-12": "urn,SUSE:sles-12-sp5-byos:gen1:2022.03.08",
                 "sles-15": "urn,SUSE:sles-15-sp2-byos:gen1:2022.03.09",
-                "opensuse-15-3": "urn,SUSE:opensuse-leap-15-3:gen1:2021.10.12"
+                "opensuse-15-3": "urn,SUSE:opensuse-leap-15-3:gen1:2022.01.28"
             }
         },
         "ec2": {

--- a/test/kitchen/test/integration/security-agent-test/rspec/security-agent-test_spec.rb
+++ b/test/kitchen/test/integration/security-agent-test/rspec/security-agent-test_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 print `cat /etc/os-release`
-print `cat /etc/zypp/repos/*`
+print `cat /etc/zypp/repos.d/*`
 print `uname -a`
 print `uname -r`
 

--- a/test/kitchen/test/integration/security-agent-test/rspec/security-agent-test_spec.rb
+++ b/test/kitchen/test/integration/security-agent-test/rspec/security-agent-test_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 print `cat /etc/os-release`
+print `ls /etc/zypp/repos.d/`
 print `cat /etc/zypp/repos.d/*`
 print `uname -a`
 print `uname -r`

--- a/test/kitchen/test/integration/security-agent-test/rspec/security-agent-test_spec.rb
+++ b/test/kitchen/test/integration/security-agent-test/rspec/security-agent-test_spec.rb
@@ -1,20 +1,7 @@
 require 'spec_helper'
 
 print `cat /etc/os-release`
-print `ls /etc/zypp/repos.d/`
-print `cat /etc/zypp/repos.d/*`
-
-print `ls /etc/yum/vars`
-print `cat /etc/yum/vars/*`
-
-print `ls /etc/dnf/vars`
-print `cat /etc/dnf/vars/*`
-
-print `ls /etc/zypp/vars.d`
-print `cat /etc/zypp/vars.d/*`
-
 print `uname -a`
-print `uname -r`
 
 describe 'successfully run functional test' do
   it 'displays PASS and returns 0' do

--- a/test/kitchen/test/integration/security-agent-test/rspec/security-agent-test_spec.rb
+++ b/test/kitchen/test/integration/security-agent-test/rspec/security-agent-test_spec.rb
@@ -3,6 +3,16 @@ require 'spec_helper'
 print `cat /etc/os-release`
 print `ls /etc/zypp/repos.d/`
 print `cat /etc/zypp/repos.d/*`
+
+print `ls /etc/yum/vars`
+print `cat /etc/yum/vars/*`
+
+print `ls /etc/dnf/vars`
+print `cat /etc/dnf/vars/*`
+
+print `ls /etc/zypp/vars.d`
+print `cat /etc/zypp/vars.d/*`
+
 print `uname -a`
 print `uname -r`
 

--- a/test/kitchen/test/integration/security-agent-test/rspec/security-agent-test_spec.rb
+++ b/test/kitchen/test/integration/security-agent-test/rspec/security-agent-test_spec.rb
@@ -1,7 +1,9 @@
 require 'spec_helper'
 
 print `cat /etc/os-release`
+print `cat /etc/zypp/repos/*`
 print `uname -a`
+print `uname -r`
 
 describe 'successfully run functional test' do
   it 'displays PASS and returns 0' do


### PR DESCRIPTION
### What does this PR do?

This PR cleans up the `Is(Suse|SLES)Kernel` functions and enables the `TestFallbackConstants` on OpenSUSE. This PR also bumps the urn version of OpenSUSE used in the CI to a version where repo are up to date (still OpenSUSE Leap 15.3).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
