### PR TITLE
[7.35] Fix panic in cgroup CPU CFS parsing (#11421)

### DIFF
--- a/pkg/util/cgroups/cgroupv1_cpu.go
+++ b/pkg/util/cgroups/cgroupv1_cpu.go
@@ -64,14 +64,16 @@ func (c *cgroupV1) parseCPUController(stats *CPUStats) {
 	}
 
 	if err := parseSingleUnsignedStat(c.fr, c.pathFor("cpu", "cpu.cfs_period_us"), &stats.SchedulerPeriod); err == nil {
-		stats.SchedulerPeriod = uint64Ptr(*stats.SchedulerPeriod * uint64(time.Microsecond))
+		if stats.SchedulerPeriod != nil {
+			stats.SchedulerPeriod = uint64Ptr(*stats.SchedulerPeriod * uint64(time.Microsecond))
+		}
 	} else {
 		reportError(err)
 	}
 
 	var tempValue *int64
 	if err := parseSingleSignedStat(c.fr, c.pathFor("cpu", "cpu.cfs_quota_us"), &tempValue); err == nil {
-		if *tempValue != -1 {
+		if tempValue != nil && *tempValue != -1 {
 			stats.SchedulerQuota = uint64Ptr(uint64(*tempValue) * uint64(time.Microsecond))
 		}
 	} else {

--- a/pkg/util/cgroups/cgroupv1_cpu_test.go
+++ b/pkg/util/cgroups/cgroupv1_cpu_test.go
@@ -82,6 +82,9 @@ func TestCgroupV1CPUStats(t *testing.T) {
 	// Test reading files in CPU controllers, all files present except 1 (cpu.shares)
 	tr.reset()
 	cfs.deleteCgroupV1File(cgFoo1, "cpu", "cpu.shares")
+	// Set empty period and quota, make sure we don't panic
+	cfs.setCgroupV1File(cgFoo1, "cpu", "cpu.cfs_period_us", "")
+	cfs.setCgroupV1File(cgFoo1, "cpu", "cpu.cfs_quota_us", "")
 	stats = &CPUStats{}
 	err = cgFoo1.GetCPUStats(stats)
 	assert.NoError(t, err)
@@ -94,7 +97,7 @@ func TestCgroupV1CPUStats(t *testing.T) {
 		ElapsedPeriods:   uint64Ptr(421),
 		ThrottledPeriods: uint64Ptr(0),
 		ThrottledTime:    uint64Ptr(0),
-		SchedulerPeriod:  uint64Ptr(100000 * uint64(time.Microsecond)),
+		SchedulerPeriod:  nil,
 		SchedulerQuota:   nil,
 		CPUCount:         uint64Ptr(8),
 	}, *stats))


### PR DESCRIPTION
### What does this PR do?

Backport #11421 

### Motivation

Bugfix

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

See #11421 

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
