### PR TITLE
Revert "Determine the container runtime from the environment. (#11101)"

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -812,6 +812,11 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line_default_match_timeout", 30) // Seconds
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line_default_match_threshold", 0.48)
 
+	// If true, the agent looks for container logs in the location used by podman, rather
+	// than docker.  This is a temporary configuration parameter to support podman logs until
+	// a more substantial refactor of autodiscovery is made to determine this automatically.
+	config.BindEnvAndSetDefault("logs_config.use_podman_logs", false)
+
 	config.BindEnvAndSetDefault("logs_config.auditor_ttl", DefaultAuditorTTL) // in hours
 	// Timeout in milliseonds used when performing agreggation operations,
 	// including multi-line log processing rules and chunked line reaggregation.

--- a/pkg/logs/config/integration_config.go
+++ b/pkg/logs/config/integration_config.go
@@ -71,11 +71,6 @@ type LogsConfig struct {
 	AutoMultiLine               *bool   `mapstructure:"auto_multi_line_detection" json:"auto_multi_line_detection"`
 	AutoMultiLineSampleSize     int     `mapstructure:"auto_multi_line_sample_size" json:"auto_multi_line_sample_size"`
 	AutoMultiLineMatchThreshold float64 `mapstructure:"auto_multi_line_match_threshold" json:"auto_multi_line_match_threshold"`
-
-	// When logging containers with Type="file", this is set to the current
-	// container runtime, allowing the file launcher to determine how to decode
-	// the on-disk content.
-	ContainerRuntime config.Feature
 }
 
 // TailingMode type

--- a/pkg/logs/internal/decoder/file_decoder.go
+++ b/pkg/logs/internal/decoder/file_decoder.go
@@ -33,11 +33,10 @@ func NewDecoderFromSourceWithPattern(source *config.LogSource, multiLinePattern 
 	case config.KubernetesSourceType:
 		lineParser = kubernetes.New()
 	case config.DockerSourceType:
-		switch source.Config.ContainerRuntime {
-		case coreConfig.Podman:
+		if coreConfig.Datadog.GetBool("logs_config.use_podman_logs") {
 			// podman's on-disk logs are in kubernetes format
 			lineParser = kubernetes.New()
-		default: // default to Docker
+		} else {
 			lineParser = dockerfile.New()
 		}
 	default:

--- a/pkg/logs/internal/launchers/docker/launcher_nix_test.go
+++ b/pkg/logs/internal/launchers/docker/launcher_nix_test.go
@@ -17,16 +17,20 @@ import (
 )
 
 func TestGetPath(t *testing.T) {
-	t.Run("runtime=Docker", func(t *testing.T) {
-		l := &Launcher{runtime: config.Docker}
+	t.Run("use_podman_logs=false", func(t *testing.T) {
+		mockConfig := config.Mock()
+		mockConfig.Set("logs_config.use_podman_logs", false)
+
 		require.Equal(t,
 			filepath.Join(basePath, "123abc/123abc-json.log"),
-			l.getContainerLogfilePath("123abc"))
+			getPath("123abc"))
 	})
-	t.Run("runtime=Podman", func(t *testing.T) {
-		l := &Launcher{runtime: config.Podman}
+	t.Run("use_podman_logs=true", func(t *testing.T) {
+		mockConfig := config.Mock()
+		mockConfig.Set("logs_config.use_podman_logs", true)
+
 		require.Equal(t,
 			"/var/lib/containers/storage/overlay-containers/123abc/userdata/ctr.log",
-			l.getContainerLogfilePath("123abc"))
+			getPath("123abc"))
 	})
 }

--- a/pkg/logs/internal/launchers/docker/launcher_windows.go
+++ b/pkg/logs/internal/launchers/docker/launcher_windows.go
@@ -18,13 +18,13 @@ const (
 	basePath = "c:\\programdata\\docker\\containers"
 )
 
-func (l *Launcher) checkContainerLogfileAccess() error {
+func checkReadAccess() error {
 	// We need read access to the docker folder
 	_, err := ioutil.ReadDir(basePath)
 	return err
 }
 
-// checkContainerLogfileAccess returns the file path of the container log to tail.
-func (l *Launcher) getContainerLogfilePath(id string) string {
+// getPath returns the file path of the container log to tail.
+func getPath(id string) string {
 	return filepath.Join(basePath, id, fmt.Sprintf("%s-json.log", id))
 }

--- a/pkg/logs/internal/launchers/docker/launcher_windows_test.go
+++ b/pkg/logs/internal/launchers/docker/launcher_windows_test.go
@@ -76,8 +76,7 @@ func TestGetFileSourceOnWindows(t *testing.T) {
 }
 
 func TestGetPath(t *testing.T) {
-	l := &Launcher{}
 	require.Equal(t,
 		filepath.Join(basePath, "123abc/123abc-json.log"),
-		l.getContainerLogfilePath("123abc"))
+		getPath("123abc"))
 }


### PR DESCRIPTION
### What does this PR do?

This reverts commit 94cf95cec8b3bfb21f64dd1cf99f72720c8d17de.  This commit has not been released.

### Motivation

#11101 mixes up the older, hacky way of supporting Podman with the newer.  The old way was to run the agent in a podman container and set DOCKER_HOST to the podman socket.  In this arragement, the Agent has no idea Podman is running, which is fine _except_ that the log format is different -- hence the need for `logs_config.use_podman_logs`. But PR #11101 expects the agent to "know" it's running in Podman to set the appropriate feature.

The new (as-yet undocumented) way is to treat podman as a different runtime from docker, meaning that integration.Config's have a ServiceID of the form `podman://<sha>`.  In this circumstance, the features are set correctly, but the logs-agent will create a source with `Config.Type = "podman"` which will not result in any logging.

### Describe how to test/QA your changes

Verify that running the agent in a podman container, with logs and container_collect_all enabled and DD_LOGS_CONFIG_USE_PODMAN_LOGS, appropriately logs the container.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
