### PR TITLE
[corechecks/helm] Add "release_state" service check

### DIFF
--- a/pkg/collector/corechecks/cluster/helm/events.go
+++ b/pkg/collector/corechecks/cluster/helm/events.go
@@ -74,7 +74,7 @@ func eventForRelease(rel *release, storage helmStorage, text string, isDelete bo
 		AggregationKey: fmt.Sprintf("helm_release:%s", rel.namespacedName()),
 
 		// The revision tag is not included in delete events, because we generate a single event for all the revisions.
-		Tags: helmTags(rel, storage, !isDelete),
+		Tags: tagsForMetricsAndEvents(rel, storage, !isDelete),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/helm/events_test.go
+++ b/pkg/collector/corechecks/cluster/helm/events_test.go
@@ -52,7 +52,7 @@ func TestAddEventForNewRelease(t *testing.T) {
 			SourceTypeName: "helm",
 			EventType:      "helm",
 			AggregationKey: "helm_release:default/my_datadog",
-			Tags:           helmTags(&rel, k8sSecrets, true),
+			Tags:           tagsForMetricsAndEvents(&rel, k8sSecrets, true),
 		},
 		storedEvent,
 	)
@@ -72,7 +72,7 @@ func TestAddEventForNewRelease(t *testing.T) {
 			SourceTypeName: "helm",
 			EventType:      "helm",
 			AggregationKey: "helm_release:default/my_datadog",
-			Tags:           helmTags(&rel, k8sSecrets, true),
+			Tags:           tagsForMetricsAndEvents(&rel, k8sSecrets, true),
 		},
 		storedEvent,
 	)
@@ -111,7 +111,7 @@ func TestAddEventForDeletedRelease(t *testing.T) {
 			SourceTypeName: "helm",
 			EventType:      "helm",
 			AggregationKey: "helm_release:default/my_datadog",
-			Tags:           helmTags(&rel, k8sSecrets, false),
+			Tags:           tagsForMetricsAndEvents(&rel, k8sSecrets, false),
 		},
 		storedEvent,
 	)
@@ -182,7 +182,7 @@ func TestAddEventForUpdatedRelease(t *testing.T) {
 				SourceTypeName: "helm",
 				EventType:      "helm",
 				AggregationKey: "helm_release:default/my_datadog",
-				Tags:           helmTags(&exampleReleaseWithFailedStatus, k8sSecrets, true),
+				Tags:           tagsForMetricsAndEvents(&exampleReleaseWithFailedStatus, k8sSecrets, true),
 			},
 		},
 		{
@@ -257,7 +257,7 @@ func TestSendEvents(t *testing.T) {
 			SourceTypeName: "helm",
 			EventType:      "helm",
 			AggregationKey: "helm_release:default/my_datadog",
-			Tags:           helmTags(&rel, k8sSecrets, true),
+			Tags:           tagsForMetricsAndEvents(&rel, k8sSecrets, true),
 		},
 		10*time.Second,
 	)

--- a/pkg/collector/corechecks/cluster/helm/helm.go
+++ b/pkg/collector/corechecks/cluster/helm/helm.go
@@ -21,17 +21,20 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	coreMetrics "github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (
 	checkName               = "helm"
+	serviceCheckName        = "helm.release_state"
 	maximumWaitForAPIServer = 10 * time.Second
 	informerSyncTimeout     = 60 * time.Second
 	labelSelector           = "owner=helm"
@@ -149,13 +152,15 @@ func (hc *HelmCheck) Run() error {
 
 	for _, storageDriver := range []helmStorage{k8sConfigmaps, k8sSecrets} {
 		for _, rel := range hc.store.getAll(storageDriver) {
-			sender.Gauge("helm.release", 1, "", helmTags(rel, storageDriver, true))
+			sender.Gauge("helm.release", 1, "", tagsForMetricsAndEvents(rel, storageDriver, true))
 		}
 	}
 
 	if hc.instance.CollectEvents {
 		hc.eventsManager.sendEvents(sender)
 	}
+
+	hc.sendServiceCheck(sender)
 
 	return nil
 }
@@ -228,12 +233,8 @@ func (hc *HelmCheck) addExistingReleases(apiClient *apiserver.APIClient) error {
 	return nil
 }
 
-func helmTags(release *release, storageDriver helmStorage, includeRevision bool) []string {
-	tags := []string{
-		fmt.Sprintf("helm_release:%s", release.Name),
-		fmt.Sprintf("helm_namespace:%s", release.Namespace),
-		fmt.Sprintf("helm_storage:%s", storageDriver),
-	}
+func tagsForMetricsAndEvents(release *release, storageDriver helmStorage, includeRevision bool) []string {
+	tags := tagsForServiceCheck(release, storageDriver)
 
 	if includeRevision {
 		tags = append(tags, fmt.Sprintf("helm_revision:%d", release.Version))
@@ -244,7 +245,6 @@ func helmTags(release *release, storageDriver helmStorage, includeRevision bool)
 	if release.Chart != nil && release.Chart.Metadata != nil {
 		tags = append(
 			tags,
-			fmt.Sprintf("helm_chart_name:%s", release.Chart.Metadata.Name),
 			fmt.Sprintf("helm_chart_version:%s", release.Chart.Metadata.Version),
 			fmt.Sprintf("helm_app_version:%s", release.Chart.Metadata.AppVersion),
 		)
@@ -252,6 +252,22 @@ func helmTags(release *release, storageDriver helmStorage, includeRevision bool)
 
 	if release.Info != nil {
 		tags = append(tags, fmt.Sprintf("helm_status:%s", release.Info.Status))
+	}
+
+	return tags
+}
+
+// tagsForServiceCheck returns the tags needed for the service check which
+// are the ones that don't change between revisions
+func tagsForServiceCheck(release *release, storageDriver helmStorage) []string {
+	tags := []string{
+		fmt.Sprintf("helm_release:%s", release.Name),
+		fmt.Sprintf("helm_namespace:%s", release.Namespace),
+		fmt.Sprintf("helm_storage:%s", storageDriver),
+	}
+
+	if release.Chart != nil && release.Chart.Metadata != nil {
+		tags = append(tags, fmt.Sprintf("helm_chart_name:%s", release.Chart.Metadata.Name))
 	}
 
 	return tags
@@ -377,4 +393,18 @@ func isLeader() (bool, error) {
 	}
 
 	return true, nil
+}
+
+func (hc *HelmCheck) sendServiceCheck(sender aggregator.Sender) {
+	for _, storageDriver := range []helmStorage{k8sConfigmaps, k8sSecrets} {
+		for _, rel := range hc.store.getLatestRevisions(storageDriver) {
+			tags := tagsForServiceCheck(rel, storageDriver)
+
+			if rel.Info != nil && rel.Info.Status == "failed" {
+				sender.ServiceCheck(serviceCheckName, coreMetrics.ServiceCheckCritical, "", tags, "Release in \"failed\" state")
+			} else {
+				sender.ServiceCheck(serviceCheckName, coreMetrics.ServiceCheckOK, "", tags, "")
+			}
+		}
+	}
 }

--- a/pkg/collector/corechecks/cluster/helm/helm_test.go
+++ b/pkg/collector/corechecks/cluster/helm/helm_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	coreMetrics "github.com/DataDog/datadog-agent/pkg/metrics"
 )
 
 func TestRun(t *testing.T) {
@@ -292,6 +293,184 @@ func TestRun_withCollectEvents(t *testing.T) {
 			10*time.Second,
 		)
 	}, 5*time.Second, time.Millisecond*100)
+}
+
+func TestRun_ServiceCheck(t *testing.T) {
+	// Releases used for this test:
+	// - "my_datadog" has 2 revisions without failures.
+	// - "my_app" has 2 revisions but the latest one is not in "failed" state.
+	// - "my_proxy" has 2 revisions and the latest one is in "failed" state.
+	//
+	// Only "my_proxy" should be marked as failed by the service check.
+	releases := []*release{
+		{
+			Name: "my_datadog",
+			Info: &info{
+				Status: "superseded",
+			},
+			Chart: &chart{
+				Metadata: &metadata{
+					Name:       "datadog",
+					Version:    "2.30.5",
+					AppVersion: "7",
+				},
+			},
+			Version:   1,
+			Namespace: "default",
+		},
+		{
+			Name: "my_datadog",
+			Info: &info{
+				Status: "deployed",
+			},
+			Chart: &chart{
+				Metadata: &metadata{
+					Name:       "datadog",
+					Version:    "2.30.5",
+					AppVersion: "7",
+				},
+			},
+			Version:   2,
+			Namespace: "default",
+		},
+		{
+			Name: "my_app",
+			Info: &info{
+				Status: "failed", // Notice that it's failed, but it's not the latest release
+			},
+			Chart: &chart{
+				Metadata: &metadata{
+					Name:       "some_app",
+					Version:    "1.0.0",
+					AppVersion: "1",
+				},
+			},
+			Version:   1,
+			Namespace: "default",
+		},
+		{
+			Name: "my_app",
+			Info: &info{
+				Status: "deployed",
+			},
+			Chart: &chart{
+				Metadata: &metadata{
+					Name:       "some_app",
+					Version:    "1.0.0",
+					AppVersion: "1",
+				},
+			},
+			Version:   2,
+			Namespace: "default",
+		},
+		{
+			Name: "my_proxy",
+			Info: &info{
+				Status: "deployed",
+			},
+			Chart: &chart{
+				Metadata: &metadata{
+					Name:       "nginx",
+					Version:    "1.0.0",
+					AppVersion: "1",
+				},
+			},
+			Version:   10,
+			Namespace: "default",
+		},
+		{
+			Name: "my_proxy",
+			Info: &info{
+				Status: "failed", // Notice that this is the latest release, and it's failed
+			},
+			Chart: &chart{
+				Metadata: &metadata{
+					Name:       "nginx",
+					Version:    "1.0.0",
+					AppVersion: "1",
+				},
+			},
+			Version:   12,
+			Namespace: "default",
+		},
+	}
+
+	tests := []struct {
+		name    string
+		storage helmStorage
+	}{
+		{
+			name:    "using secrets storage",
+			storage: k8sSecrets,
+		},
+		{
+			name:    "using configmaps storage",
+			storage: k8sConfigmaps,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			check := factory().(*HelmCheck)
+			check.runLeaderElection = false
+
+			for _, rel := range releases {
+				check.store.add(rel, test.storage)
+			}
+
+			mockedSender := mocksender.NewMockSender(checkName)
+			mockedSender.SetupAcceptAll()
+
+			err := check.Run()
+			assert.NoError(t, err)
+
+			// "my_datadog" release should report OK.
+			mockedSender.AssertServiceCheck(
+				t,
+				"helm.release_state",
+				coreMetrics.ServiceCheckOK,
+				"",
+				[]string{
+					"helm_release:my_datadog",
+					"helm_namespace:default",
+					fmt.Sprintf("helm_storage:%s", test.storage),
+					"helm_chart_name:datadog",
+				},
+				"",
+			)
+
+			// "my_app" release should report OK.
+			mockedSender.AssertServiceCheck(
+				t,
+				"helm.release_state",
+				coreMetrics.ServiceCheckOK,
+				"",
+				[]string{
+					"helm_release:my_app",
+					"helm_namespace:default",
+					fmt.Sprintf("helm_storage:%s", test.storage),
+					"helm_chart_name:some_app",
+				},
+				"",
+			)
+
+			// "my_proxy" release should report a failure.
+			mockedSender.AssertServiceCheck(
+				t,
+				"helm.release_state",
+				coreMetrics.ServiceCheckCritical,
+				"",
+				[]string{
+					"helm_release:my_proxy",
+					"helm_namespace:default",
+					fmt.Sprintf("helm_storage:%s", test.storage),
+					"helm_chart_name:nginx",
+				},
+				"Release in \"failed\" state",
+			)
+		})
+	}
+
 }
 
 // secretForRelease returns a Kubernetes secret that contains the info of the

--- a/pkg/collector/corechecks/cluster/helm/releases_store_test.go
+++ b/pkg/collector/corechecks/cluster/helm/releases_store_test.go
@@ -153,3 +153,112 @@ func TestDelete(t *testing.T) {
 	// Should return false when it doesn't exist
 	assert.False(t, store.delete(releases[1], k8sSecrets))
 }
+
+func TestGetLatestRevisions(t *testing.T) {
+	// Start with a release with revisions 1 and 2, and another one with
+	// revision 10. 10 is just an example to verify that the code does
+	// not assume that revisions will always start from 1.
+	releases := map[string]map[revision]*release{
+		"my_datadog": {
+			revision(1): {
+				Name: "my_datadog",
+				Info: &info{
+					Status: "superseded",
+				},
+				Chart: &chart{
+					Metadata: &metadata{
+						Name:       "datadog",
+						Version:    "2.30.5",
+						AppVersion: "7",
+					},
+				},
+				Version:   1,
+				Namespace: "default",
+			},
+			revision(2): {
+				Name: "my_datadog",
+				Info: &info{
+					Status: "deployed",
+				},
+				Chart: &chart{
+					Metadata: &metadata{
+						Name:       "datadog",
+						Version:    "2.30.5",
+						AppVersion: "7",
+					},
+				},
+				Version:   2,
+				Namespace: "default",
+			},
+		},
+		"my_proxy": {
+			revision(10): {
+				Name: "my_proxy",
+				Info: &info{
+					Status: "deployed",
+				},
+				Chart: &chart{
+					Metadata: &metadata{
+						Name:       "nginx",
+						Version:    "1.0.0",
+						AppVersion: "1",
+					},
+				},
+				Version:   10,
+				Namespace: "default",
+			},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		storage helmStorage
+	}{
+		{
+			name:    "using secrets storage",
+			storage: k8sSecrets,
+		},
+		{
+			name:    "using configmaps storage",
+			storage: k8sConfigmaps,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store := newReleasesStore()
+
+			for _, releasesByRevision := range releases {
+				for _, rel := range releasesByRevision {
+					store.add(rel, test.storage)
+				}
+			}
+
+			// First we should get revision 2 for the "my_datadog" release (the
+			// other revision is 1) and revision 10 for the "my_proxy" release.
+			assert.ElementsMatch(
+				t,
+				[]*release{releases["my_datadog"][revision(2)], releases["my_proxy"][revision(10)]},
+				store.getLatestRevisions(test.storage),
+			)
+
+			// After deleting revision 2 of "my_datadog", the only remaining
+			// revision of "my_datadog" is 1, so we should get that one.
+			store.delete(releases["my_datadog"][revision(2)], test.storage)
+			assert.ElementsMatch(
+				t,
+				[]*release{releases["my_datadog"][revision(1)], releases["my_proxy"][revision(10)]},
+				store.getLatestRevisions(test.storage),
+			)
+
+			// Here we delete the last remaining revision of "my_datadog", so it
+			// shouldn't appear in the result anymore.
+			store.delete(releases["my_datadog"][revision(1)], test.storage)
+			assert.ElementsMatch(
+				t,
+				[]*release{releases["my_proxy"][revision(10)]},
+				store.getLatestRevisions(test.storage),
+			)
+		})
+	}
+}

--- a/releasenotes/notes/helm-service-check-fd1f003c0d032dcb.yaml
+++ b/releasenotes/notes/helm-service-check-fd1f003c0d032dcb.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Adds a service check for the Helm check. The check fails for a release when its latest revision is in "failed" state.


### PR DESCRIPTION

### What does this PR do?

Adds a service check (`helm.release_state`) for the Helm check.

The service check reports an error ("critical") for a release when its latest revision is in "failed" state.

The tags associated to the service check are `helm_chart_name`, `helm_namespace`, `helm_release`, and `helm_storage` plus all the ones that are automatically added (`kube_cluster_name`, etc.).


### Describe how to test/QA your changes

Deploy on Kubernetes with the helm check enabled.

Check in the UI or with agent check helm (in the runner or DCA where the check is scheduled) that the service check `helm.release_state` reports OK or CRITICAL as expected for each of the helm releases deployed in your cluster.

Check also that the tags reported are the ones mentioned above and that they're correct.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
