### PR TITLE
[Serverless] Fix EOF while submitting metrics

### DIFF
--- a/pkg/aggregator/demultiplexer.go
+++ b/pkg/aggregator/demultiplexer.go
@@ -774,7 +774,7 @@ type ServerlessDemultiplexer struct {
 // InitAndStartServerlessDemultiplexer creates and starts new Demultiplexer for the serverless agent.
 func InitAndStartServerlessDemultiplexer(domainResolvers map[string]resolver.DomainResolver, hostname string, forwarderTimeout time.Duration) *ServerlessDemultiplexer {
 	bufferSize := config.Datadog.GetInt("aggregator_buffer_size")
-	forwarder := forwarder.NewSyncForwarder(domainResolvers, forwarderTimeout)
+	forwarder := forwarder.NewSyncForwarder(domainResolvers, forwarderTimeout, true)
 	serializer := serializer.NewSerializer(forwarder, nil, nil)
 	metricSamplePool := metrics.NewMetricSamplePool(MetricSamplePoolBatchSize)
 	tagsStore := tags.NewStore(config.Datadog.GetBool("aggregator_use_tags_store"), "timesampler")

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -104,7 +104,7 @@ type Options struct {
 	DomainResolvers                map[string]resolver.DomainResolver
 	ConnectionResetInterval        time.Duration
 	CompletionHandler              transaction.HTTPCompletionHandler
-	ServerlessMode                 bool
+	CloseConnections               bool
 }
 
 // SetFeature sets forwarder features in a feature set
@@ -197,7 +197,7 @@ type DefaultForwarder struct {
 	NumberOfWorkers int
 
 	// ServerlessMode tells whether or not  the agent is running in a serverless mode
-	ServerlessMode bool
+	CloseConnections bool
 
 	domainForwarders map[string]*domainForwarder
 	domainResolvers  map[string]resolver.DomainResolver
@@ -227,7 +227,7 @@ func NewDefaultForwarder(options *Options) *DefaultForwarder {
 		},
 		completionHandler: options.CompletionHandler,
 		agentName:         agentName,
-		ServerlessMode:    options.ServerlessMode,
+		CloseConnections:  options.CloseConnections,
 	}
 	var optionalRemovalPolicy *retry.FileRemovalPolicy
 	storageMaxSize := config.Datadog.GetInt64("forwarder_storage_max_size_in_bytes")
@@ -433,7 +433,7 @@ func (f *DefaultForwarder) createAdvancedHTTPTransactions(endpoint transaction.E
 		for domain, dr := range f.domainResolvers {
 			for _, apiKey := range dr.GetAPIKeys() {
 				t := transaction.NewHTTPTransaction()
-				t.CloseAfterCreation = f.ServerlessMode
+				t.Close = f.CloseConnections
 				t.Domain, _ = dr.Resolve(endpoint)
 				t.Endpoint = endpoint
 				if apiKeyInQueryString {

--- a/pkg/forwarder/internal/retry/http_transactions_serializer_test.go
+++ b/pkg/forwarder/internal/retry/http_transactions_serializer_test.go
@@ -103,7 +103,7 @@ func TestHTTPTransactionSerializerMissingAPIKey(t *testing.T) {
 func TestHTTPTransactionFieldsCount(t *testing.T) {
 	tr := transaction.HTTPTransaction{}
 	transactionType := reflect.TypeOf(tr)
-	assert.Equalf(t, 11, transactionType.NumField(),
+	assert.Equalf(t, 12, transactionType.NumField(),
 		"A field was added or remove from HTTPTransaction. "+
 			"You probably need to update the implementation of "+
 			"HTTPTransactionsSerializer and then adjust this unit test.")

--- a/pkg/forwarder/transaction/transaction.go
+++ b/pkg/forwarder/transaction/transaction.go
@@ -167,7 +167,7 @@ const (
 type contextKey string
 
 const (
-	// ContextKeyRetry is the key set to the context to indicates whether or not we're currently retrying a failed transcation
+	// ContextKeyRetry is the key set to the context to indicates whether or not we're currently retrying a failed transaction
 	ContextKeyRetry contextKey = "retry"
 )
 
@@ -200,8 +200,8 @@ type HTTPTransaction struct {
 
 	Priority Priority
 
-	// In Serverless mode, requests should not be reused on failure retries
-	CloseAfterCreation bool
+	// Close in Serverless mode, connections should not be reused on failure retries
+	Close bool
 }
 
 // TransactionsSerializer serializes Transaction instances.
@@ -308,7 +308,7 @@ func (t *HTTPTransaction) createRequest(ctx context.Context) (*http.Request, err
 		return nil, err
 	}
 	req = req.WithContext(ctx)
-	req.Close = t.CloseAfterCreation && getRetryValueFromContext(ctx)
+	req.Close = t.Close && getRetryValueFromContext(ctx)
 	req.Header = t.Headers
 	return req, nil
 }

--- a/pkg/forwarder/transaction/transaction.go
+++ b/pkg/forwarder/transaction/transaction.go
@@ -164,10 +164,11 @@ const (
 	TransactionPriorityHigh Priority = iota
 )
 
-type ContextKey string
+type contextKey string
 
 const (
-	ContextKeyRetry ContextKey = "retry"
+	// ContextKeyRetry is the key set to the context to indicates whether or not we're currently retrying a failed transcation
+	ContextKeyRetry contextKey = "retry"
 )
 
 // HTTPTransaction represents one Payload for one Endpoint on one Domain.

--- a/pkg/forwarder/transaction/transaction_test.go
+++ b/pkg/forwarder/transaction/transaction_test.go
@@ -200,7 +200,7 @@ func TestCreateRequestServerlessNoRetry(t *testing.T) {
 	transaction.Payload = &payload
 	transaction.Domain = "example.com"
 	transaction.Endpoint.Route = "/endpoint/test"
-	transaction.CloseAfterCreation = true
+	transaction.Close = true
 	req, err := transaction.createRequest(context.TODO())
 	assert.NotNil(t, req)
 	assert.Nil(t, err)
@@ -213,7 +213,7 @@ func TestCreateRequestServerlessRetry(t *testing.T) {
 	transaction.Payload = &payload
 	transaction.Domain = "example.com"
 	transaction.Endpoint.Route = "/endpoint/test"
-	transaction.CloseAfterCreation = true
+	transaction.Close = true
 	testContext := context.WithValue(context.TODO(), ContextKeyRetry, true)
 	req, err := transaction.createRequest(testContext)
 	assert.NotNil(t, req)


### PR DESCRIPTION
### What does this PR do?

For some metric flushes, in serverless mode, we've found that an error was thrown
`2022-03-23 19:02:40 UTC | DD_EXTENSION | ERROR | SyncForwarder.sendHTTPTransactions final attempt: error while sending transaction, rescheduling it: Post "https://6-0-0-app.agent.datadoghq.com/api/v1/check_run?api_key=***************************4b490": EOF`

This EOF error was not only for `/check_run` but for all endpoints

This error was here because we're not `closing` http request which leads to tcp re-use (which is bad in a serverless context where the runtime environment could have been frozen during invocations)

Taken from the doc : 
```
// Close indicates whether to close the connection after
// replying to this request (for servers) or after sending this
// request and reading its response (for clients).
//
// For server requests, the HTTP server handles this automatically
// and this field is not needed by Handlers.
//
// For client requests, setting this field prevents re-use of
// TCP connections between requests to the same hosts, as if
// Transport.DisableKeepAlives were set.
Close bool
```

So in this PR we : 
- modify the retry process by setting `.Close` to `true` if serverless + retry mode 
- propagate a `ServerlessMode` boolean in the synchronizer
- use the context to set a retry boolean mode to avoid changing the signature of the `Process` and `internalProcess` functions
- add a method to create the request (easier to test)
- add unit tests
- change back the final failure warn log to error level

Note : we don't want to close all requests since it could have an impact on performance, but only those which are flaged as `in retry mode + serverless

![Screen Shot 2022-03-23 at 3 16 00 PM](https://user-images.githubusercontent.com/864493/159778700-d81306b1-3286-4d55-9bd9-643c210cc9ac.png)


### Motivation

Fix an important issue (data loss)

### Describe how to test/QA your changes

Unit test + integration testing

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
