### PR TITLE
admission controller: Set failure policy

### DIFF
--- a/pkg/clusteragent/admission/controllers/webhook/config.go
+++ b/pkg/clusteragent/admission/controllers/webhook/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	svcName                  string
 	svcPort                  int32
 	timeout                  int32
+	failurePolicy            string
 }
 
 // NewConfig creates a webhook controller configuration
@@ -40,6 +41,7 @@ func NewConfig(admissionV1Enabled, namespaceSelectorEnabled bool) Config {
 		svcName:                  config.Datadog.GetString("admission_controller.service_name"),
 		svcPort:                  int32(443),
 		timeout:                  config.Datadog.GetInt32("admission_controller.timeout_seconds"),
+		failurePolicy:            config.Datadog.GetString("admission_controller.failure_policy"),
 	}
 }
 
@@ -52,6 +54,7 @@ func (w *Config) getServiceNs() string       { return w.namespace }
 func (w *Config) getServiceName() string     { return w.svcName }
 func (w *Config) getServicePort() int32      { return w.svcPort }
 func (w *Config) getTimeout() int32          { return w.timeout }
+func (w *Config) getFailurePolicy() string   { return w.failurePolicy }
 func (w *Config) configName(suffix string) string {
 	return strings.ReplaceAll(fmt.Sprintf("%s.%s", w.webhookName, suffix), "-", ".")
 }

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
@@ -198,11 +198,11 @@ func (c *ControllerV1) generateTemplates() {
 }
 
 func (c *ControllerV1) getWebhookSkeleton(nameSuffix, path string) admiv1.MutatingWebhook {
-	failurePolicy := admiv1.Ignore
 	matchPolicy := admiv1.Exact
 	sideEffects := admiv1.SideEffectClassNone
 	port := c.config.getServicePort()
 	timeout := c.config.getTimeout()
+	failurePolicy := c.getAdmiV1FailurePolicy()
 	webhook := admiv1.MutatingWebhook{
 		Name: c.config.configName(nameSuffix),
 		ClientConfig: admiv1.WebhookClientConfig{
@@ -241,4 +241,15 @@ func (c *ControllerV1) getWebhookSkeleton(nameSuffix, path string) admiv1.Mutati
 	webhook.ObjectSelector = labelSelector
 
 	return webhook
+}
+
+func (c *ControllerV1) getAdmiV1FailurePolicy() admiv1.FailurePolicyType {
+	switch c.config.getFailurePolicy() {
+	case "ignore":
+		return admiv1.Ignore
+	case "fail":
+		return admiv1.Fail
+	default:
+		return admiv1.Ignore
+	}
 }

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
@@ -10,6 +10,7 @@ package webhook
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -244,12 +245,14 @@ func (c *ControllerV1) getWebhookSkeleton(nameSuffix, path string) admiv1.Mutati
 }
 
 func (c *ControllerV1) getAdmiV1FailurePolicy() admiv1.FailurePolicyType {
-	switch c.config.getFailurePolicy() {
-	case "Ignore", "ignore":
+	policy := strings.ToLower(c.config.getFailurePolicy())
+	switch policy {
+	case "ignore":
 		return admiv1.Ignore
-	case "Fail", "fail":
+	case "fail":
 		return admiv1.Fail
 	default:
+		_ = log.Warnf("Unknown failure policy %s - defaulting to 'Ignore'", policy)
 		return admiv1.Ignore
 	}
 }

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
@@ -245,9 +245,9 @@ func (c *ControllerV1) getWebhookSkeleton(nameSuffix, path string) admiv1.Mutati
 
 func (c *ControllerV1) getAdmiV1FailurePolicy() admiv1.FailurePolicyType {
 	switch c.config.getFailurePolicy() {
-	case "ignore":
+	case "Ignore":
 		return admiv1.Ignore
-	case "fail":
+	case "Fail":
 		return admiv1.Fail
 	default:
 		return admiv1.Ignore

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
@@ -245,9 +245,9 @@ func (c *ControllerV1) getWebhookSkeleton(nameSuffix, path string) admiv1.Mutati
 
 func (c *ControllerV1) getAdmiV1FailurePolicy() admiv1.FailurePolicyType {
 	switch c.config.getFailurePolicy() {
-	case "Ignore":
+	case "Ignore", "ignore":
 		return admiv1.Ignore
-	case "Fail":
+	case "Fail", "fail":
 		return admiv1.Fail
 	default:
 		return admiv1.Ignore

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
@@ -133,6 +133,12 @@ func TestAdmissionControllerFailureModeIgnore(t *testing.T) {
 	webhookSkeleton := c.getWebhookSkeleton("foo", "/bar")
 	assert.Equal(t, admiv1.Ignore, *webhookSkeleton.FailurePolicy)
 
+	config.Datadog.Set("admission_controller.failure_policy", "ignore")
+	c.config = NewConfig(true, false)
+
+	webhookSkeleton = c.getWebhookSkeleton("foo", "/bar")
+	assert.Equal(t, admiv1.Ignore, *webhookSkeleton.FailurePolicy)
+
 	config.Datadog.Set("admission_controller.failure_policy", "BadVal")
 	c.config = NewConfig(true, false)
 
@@ -157,6 +163,12 @@ func TestAdmissionControllerFailureModeFail(t *testing.T) {
 	c.config = NewConfig(true, false)
 
 	webhookSkeleton := c.getWebhookSkeleton("foo", "/bar")
+	assert.Equal(t, admiv1.Fail, *webhookSkeleton.FailurePolicy)
+
+	config.Datadog.Set("admission_controller.failure_policy", "fail")
+	c.config = NewConfig(true, false)
+
+	webhookSkeleton = c.getWebhookSkeleton("foo", "/bar")
 	assert.Equal(t, admiv1.Fail, *webhookSkeleton.FailurePolicy)
 }
 

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
@@ -119,6 +119,47 @@ func TestUpdateOutdatedWebhookV1(t *testing.T) {
 	}
 }
 
+func TestAdmissionControllerFailureModeIgnore(t *testing.T) {
+	f := newFixtureV1(t)
+	c := f.run(t)
+	c.config = NewConfig(true, false)
+
+	holdValue := config.Datadog.Get("admission_controller.failure_policy")
+	defer config.Datadog.Set("admission_controller.failure_policy", holdValue)
+
+	config.Datadog.Set("admission_controller.failure_policy", "ignore")
+	c.config = NewConfig(true, false)
+
+	webhookSkeleton := c.getWebhookSkeleton("foo", "/bar")
+	assert.Equal(t, admiv1.Ignore, *webhookSkeleton.FailurePolicy)
+
+	config.Datadog.Set("admission_controller.failure_policy", "BadVal")
+	c.config = NewConfig(true, false)
+
+	webhookSkeleton = c.getWebhookSkeleton("foo", "/bar")
+	assert.Equal(t, admiv1.Ignore, *webhookSkeleton.FailurePolicy)
+
+	config.Datadog.Set("admission_controller.failure_policy", "")
+	c.config = NewConfig(true, false)
+
+	webhookSkeleton = c.getWebhookSkeleton("foo", "/bar")
+	assert.Equal(t, admiv1.Ignore, *webhookSkeleton.FailurePolicy)
+}
+
+func TestAdmissionControllerFailureModeFail(t *testing.T) {
+	holdValue := config.Datadog.Get("admission_controller.failure_policy")
+	defer config.Datadog.Set("admission_controller.failure_policy", holdValue)
+
+	f := newFixtureV1(t)
+	c := f.run(t)
+
+	config.Datadog.Set("admission_controller.failure_policy", "fail")
+	c.config = NewConfig(true, false)
+
+	webhookSkeleton := c.getWebhookSkeleton("foo", "/bar")
+	assert.Equal(t, admiv1.Fail, *webhookSkeleton.FailurePolicy)
+}
+
 func TestGenerateTemplatesV1(t *testing.T) {
 	mockConfig := config.Mock()
 	failurePolicy := admiv1.Ignore

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
@@ -127,7 +127,7 @@ func TestAdmissionControllerFailureModeIgnore(t *testing.T) {
 	holdValue := config.Datadog.Get("admission_controller.failure_policy")
 	defer config.Datadog.Set("admission_controller.failure_policy", holdValue)
 
-	config.Datadog.Set("admission_controller.failure_policy", "ignore")
+	config.Datadog.Set("admission_controller.failure_policy", "Ignore")
 	c.config = NewConfig(true, false)
 
 	webhookSkeleton := c.getWebhookSkeleton("foo", "/bar")
@@ -153,7 +153,7 @@ func TestAdmissionControllerFailureModeFail(t *testing.T) {
 	f := newFixtureV1(t)
 	c := f.run(t)
 
-	config.Datadog.Set("admission_controller.failure_policy", "fail")
+	config.Datadog.Set("admission_controller.failure_policy", "Fail")
 	c.config = NewConfig(true, false)
 
 	webhookSkeleton := c.getWebhookSkeleton("foo", "/bar")

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
@@ -10,6 +10,7 @@ package webhook
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -244,12 +245,14 @@ func (c *ControllerV1beta1) getWebhookSkeleton(nameSuffix, path string) admiv1be
 }
 
 func (c *ControllerV1beta1) getAdmiV1Beta1FailurePolicy() admiv1beta1.FailurePolicyType {
-	switch c.config.getFailurePolicy() {
-	case "Ignore", "ignore":
+	policy := strings.ToLower(c.config.getFailurePolicy())
+	switch policy {
+	case "ignore":
 		return admiv1beta1.Ignore
-	case "Fail", "fail":
+	case "fail":
 		return admiv1beta1.Fail
 	default:
+		_ = log.Warnf("Unknown failure policy %s - defaulting to 'Ignore'", policy)
 		return admiv1beta1.Ignore
 	}
 }

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
@@ -198,11 +198,11 @@ func (c *ControllerV1beta1) generateTemplates() {
 }
 
 func (c *ControllerV1beta1) getWebhookSkeleton(nameSuffix, path string) admiv1beta1.MutatingWebhook {
-	failurePolicy := admiv1beta1.Ignore
 	matchPolicy := admiv1beta1.Exact
 	sideEffects := admiv1beta1.SideEffectClassNone
 	port := c.config.getServicePort()
 	timeout := c.config.getTimeout()
+	failurePolicy := c.getAdmiV1Beta1FailurePolicy()
 	webhook := admiv1beta1.MutatingWebhook{
 		Name: c.config.configName(nameSuffix),
 		ClientConfig: admiv1beta1.WebhookClientConfig{
@@ -241,4 +241,15 @@ func (c *ControllerV1beta1) getWebhookSkeleton(nameSuffix, path string) admiv1be
 	webhook.ObjectSelector = labelSelector
 
 	return webhook
+}
+
+func (c *ControllerV1beta1) getAdmiV1Beta1FailurePolicy() admiv1beta1.FailurePolicyType {
+	switch c.config.getFailurePolicy() {
+	case "ignore":
+		return admiv1beta1.Ignore
+	case "fail":
+		return admiv1beta1.Fail
+	default:
+		return admiv1beta1.Ignore
+	}
 }

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
@@ -245,9 +245,9 @@ func (c *ControllerV1beta1) getWebhookSkeleton(nameSuffix, path string) admiv1be
 
 func (c *ControllerV1beta1) getAdmiV1Beta1FailurePolicy() admiv1beta1.FailurePolicyType {
 	switch c.config.getFailurePolicy() {
-	case "Ignore":
+	case "Ignore", "ignore":
 		return admiv1beta1.Ignore
-	case "Fail":
+	case "Fail", "fail":
 		return admiv1beta1.Fail
 	default:
 		return admiv1beta1.Ignore

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
@@ -245,9 +245,9 @@ func (c *ControllerV1beta1) getWebhookSkeleton(nameSuffix, path string) admiv1be
 
 func (c *ControllerV1beta1) getAdmiV1Beta1FailurePolicy() admiv1beta1.FailurePolicyType {
 	switch c.config.getFailurePolicy() {
-	case "ignore":
+	case "Ignore":
 		return admiv1beta1.Ignore
-	case "fail":
+	case "Fail":
 		return admiv1beta1.Fail
 	default:
 		return admiv1beta1.Ignore

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
@@ -133,6 +133,12 @@ func TestAdmissionControllerFailureModeIgnoreV1beta1(t *testing.T) {
 	webhookSkeleton := c.getWebhookSkeleton("foo", "/bar")
 	assert.Equal(t, admiv1beta1.Ignore, *webhookSkeleton.FailurePolicy)
 
+	config.Datadog.Set("admission_controller.failure_policy", "ignore")
+	c.config = NewConfig(true, false)
+
+	webhookSkeleton = c.getWebhookSkeleton("foo", "/bar")
+	assert.Equal(t, admiv1beta1.Ignore, *webhookSkeleton.FailurePolicy)
+
 	config.Datadog.Set("admission_controller.failure_policy", "BadVal")
 	c.config = NewConfig(true, false)
 
@@ -157,6 +163,12 @@ func TestAdmissionControllerFailureModeFailV1beta1(t *testing.T) {
 	c.config = NewConfig(true, false)
 
 	webhookSkeleton := c.getWebhookSkeleton("foo", "/bar")
+	assert.Equal(t, admiv1beta1.Fail, *webhookSkeleton.FailurePolicy)
+
+	config.Datadog.Set("admission_controller.failure_policy", "fail")
+	c.config = NewConfig(true, false)
+
+	webhookSkeleton = c.getWebhookSkeleton("foo", "/bar")
 	assert.Equal(t, admiv1beta1.Fail, *webhookSkeleton.FailurePolicy)
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -906,7 +906,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("admission_controller.inject_tags.endpoint", "/injecttags")
 	config.BindEnvAndSetDefault("admission_controller.pod_owners_cache_validity", 10) // in minutes
 	config.BindEnvAndSetDefault("admission_controller.namespace_selector_fallback", false)
-	config.BindEnvAndSetDefault("admission_controller.failure_policy", "ignore")
+	config.BindEnvAndSetDefault("admission_controller.failure_policy", "Ignore")
 
 	// Telemetry
 	// Enable telemetry metrics on the internals of the Agent.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -906,6 +906,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("admission_controller.inject_tags.endpoint", "/injecttags")
 	config.BindEnvAndSetDefault("admission_controller.pod_owners_cache_validity", 10) // in minutes
 	config.BindEnvAndSetDefault("admission_controller.namespace_selector_fallback", false)
+	config.BindEnvAndSetDefault("admission_controller.failure_policy", "ignore")
 
 	// Telemetry
 	// Enable telemetry metrics on the internals of the Agent.

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2433,6 +2433,14 @@ api_key:
     ## Admission controller's endpoint responsible for handling tags injection requests.
     #
     # endpoint: /injecttags
+
+  ## @param failure_policy - string - optional - default: Ignore
+  ## @env DD_ADMISSION_CONTROLLER_FAILURE_POLICY - string - optional - default: Ignore
+  ## Set the failure policy for dynamic admission control.
+  ## The default of Ignore means that pods will still be admitted even if the webhook is unavailable to inject them.
+  ## Setting to Fail will require the admission controller to be present and pods to be injected before they are allowed to run.
+  #
+  # failure_policy: Ignore
 {{ end -}}
 {{- if .DockerTagging }}
 

--- a/releasenotes-dca/notes/add-admission-controller-failure-policy-b147223ae7cfbf88.yaml
+++ b/releasenotes-dca/notes/add-admission-controller-failure-policy-b147223ae7cfbf88.yaml
@@ -1,0 +1,16 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Added a configuration option to admission controller to allow
+    configuration of the failure policy. Defaults to Ignore which
+    was the previous default. The default of Ignore means that pods
+    will still be admitted even if the webhook is unavailable to
+    inject them. Setting to Fail will require the admission controller
+    to be present and pods to be injected before they are allowed to run.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR adds the ability to configure the failure policy for the admission controller.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Fixes: #11426

> Use case: presently, some of my services validate that DD_AGENT_HOST is set upon startup. If those services start before the admission controller is ready, the variable is never injected but kubernetes keeps trying to restart the failed containers, rather than rescheduling the pods. If instead I make the controller fail on error, they will be rescheduled and hence readmitted and can come alive in their own time.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
We also considered using a boolean instead of a string since there are only two options, but decided to go with a string as it seemed more self explanatory.
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
The default value for this config option will remain the same.  There should be no real drawbacks.
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
I've added some tests to ensure the value is set correctly based on several different string values.
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
