### PR TITLE
Create a new dedicated call to get count of openfiles for a set of PIDs

### DIFF
--- a/pkg/collector/corechecks/containers/containerd/check_metrics_extension.go
+++ b/pkg/collector/corechecks/containers/containerd/check_metrics_extension.go
@@ -31,7 +31,7 @@ func (cext *containerdCustomMetricsExtension) PreProcess(sender generic.SenderFu
 
 func (cext *containerdCustomMetricsExtension) Process(tags []string, container *workloadmeta.Container, collector provider.Collector, cacheValidity time.Duration) {
 	// Duplicate call with generic.Processor, but cache should allow for a fast response.
-	containerStats, err := collector.GetContainerStats(container.ID, cacheValidity)
+	containerStats, err := collector.GetContainerStats(container.Namespace, container.ID, cacheValidity)
 	if err != nil {
 		log.Debugf("Gathering container metrics for container: %v failed, metrics may be missing, err: %v", container, err)
 		return

--- a/pkg/collector/corechecks/containers/docker/check_metrics_extension.go
+++ b/pkg/collector/corechecks/containers/docker/check_metrics_extension.go
@@ -31,7 +31,7 @@ func (dn *dockerCustomMetricsExtension) PreProcess(sender generic.SenderFunc, ag
 func (dn *dockerCustomMetricsExtension) Process(tags []string, container *workloadmeta.Container, collector provider.Collector, cacheValidity time.Duration) {
 	// Duplicate call with generic.Processor, but cache should allow for a fast response.
 	// We only need it for PIDs
-	containerStats, err := collector.GetContainerStats(container.ID, cacheValidity)
+	containerStats, err := collector.GetContainerStats(container.Namespace, container.ID, cacheValidity)
 	if err != nil {
 		log.Debugf("Gathering container metrics for container: %v failed, metrics may be missing, err: %v", container, err)
 		return

--- a/pkg/collector/corechecks/containers/docker/check_network.go
+++ b/pkg/collector/corechecks/containers/docker/check_network.go
@@ -79,13 +79,13 @@ func (dn *dockerNetworkExtension) PreProcess(sender generic.SenderFunc, aggSende
 func (dn *dockerNetworkExtension) Process(tags []string, container *workloadmeta.Container, collector provider.Collector, cacheValidity time.Duration) {
 	// Duplicate call with generic.Processor, but cache should allow for a fast response.
 	// We only need it for PIDs
-	containerStats, err := collector.GetContainerStats(container.ID, cacheValidity)
+	containerStats, err := collector.GetContainerStats(container.Namespace, container.ID, cacheValidity)
 	if err != nil {
 		log.Debugf("Gathering container metrics for container: %v failed, metrics may be missing, err: %v", container, err)
 		return
 	}
 
-	containerNetworkStats, err := collector.GetContainerNetworkStats(container.ID, cacheValidity)
+	containerNetworkStats, err := collector.GetContainerNetworkStats(container.Namespace, container.ID, cacheValidity)
 	if err != nil {
 		log.Debugf("Gathering network metrics for container: %v failed, metrics may be missing, err: %v", container, err)
 		return

--- a/pkg/collector/corechecks/containers/generic/processor.go
+++ b/pkg/collector/corechecks/containers/generic/processor.go
@@ -102,7 +102,7 @@ func (p *Processor) Run(sender aggregator.Sender, cacheValidity time.Duration) e
 			continue
 		}
 
-		containerStats, err := collector.GetContainerStats(container.ID, cacheValidity)
+		containerStats, err := collector.GetContainerStats(container.Namespace, container.ID, cacheValidity)
 		if err != nil {
 			log.Debugf("Container stats for: %v not available through collector %q, err: %v", container, collector.ID(), err)
 			continue
@@ -111,6 +111,13 @@ func (p *Processor) Run(sender aggregator.Sender, cacheValidity time.Duration) e
 		if err := p.processContainer(sender, tags, container, containerStats); err != nil {
 			log.Debugf("Generating metrics for container: %v failed, metrics may be missing, err: %v", container, err)
 			continue
+		}
+
+		openFiles, err := collector.GetContainerOpenFilesCount(container.Namespace, container.ID, cacheValidity)
+		if err == nil {
+			p.sendMetric(sender.Gauge, "container.pid.open_files", pointer.UIntPtrToFloatPtr(openFiles), tags)
+		} else {
+			log.Debugf("OpenFiles count for: %v not available through collector %q, err: %v", container, collector.ID(), err)
 		}
 
 		// TODO: Implement container stats. We currently don't have enough information from Metadata service to do it.
@@ -181,7 +188,6 @@ func (p *Processor) processContainer(sender aggregator.Sender, tags []string, co
 	if containerStats.PID != nil {
 		p.sendMetric(sender.Gauge, "container.pid.thread_count", containerStats.PID.ThreadCount, tags)
 		p.sendMetric(sender.Gauge, "container.pid.thread_limit", containerStats.PID.ThreadLimit, tags)
-		p.sendMetric(sender.Gauge, "container.pid.open_files", containerStats.PID.OpenFiles, tags)
 	}
 
 	return nil

--- a/pkg/collector/corechecks/containers/generic/processor_network.go
+++ b/pkg/collector/corechecks/containers/generic/processor_network.go
@@ -46,7 +46,7 @@ func (pn *ProcessorNetwork) PreProcess(sender SenderFunc, aggSender aggregator.S
 
 // Process stores each container in relevant network group
 func (pn *ProcessorNetwork) Process(tags []string, container *workloadmeta.Container, collector provider.Collector, cacheValidity time.Duration) {
-	containerNetworkStats, err := collector.GetContainerNetworkStats(container.ID, cacheValidity)
+	containerNetworkStats, err := collector.GetContainerNetworkStats(container.Namespace, container.ID, cacheValidity)
 	if err != nil {
 		log.Debugf("Gathering network metrics for container: %v failed, metrics may be missing, err: %v", container, err)
 		return

--- a/pkg/process/util/containers.go
+++ b/pkg/process/util/containers.go
@@ -151,7 +151,7 @@ func (p *containerProvider) GetContainers(cacheValidity time.Duration, previousC
 			continue
 		}
 
-		containerStats, err := collector.GetContainerStats(container.ID, cacheValidity)
+		containerStats, err := collector.GetContainerStats(container.Namespace, container.ID, cacheValidity)
 		if err != nil || containerStats == nil {
 			log.Debugf("Container stats for: %+v not available through collector %q, err: %v", container, collector.ID(), err)
 			// If main container stats are missing, we skip the container
@@ -166,7 +166,7 @@ func (p *containerProvider) GetContainers(cacheValidity time.Duration, previousC
 			}
 		}
 
-		containerNetworkStats, err := collector.GetContainerNetworkStats(container.ID, cacheValidity)
+		containerNetworkStats, err := collector.GetContainerNetworkStats(container.Namespace, container.ID, cacheValidity)
 		if err != nil {
 			log.Debugf("Container network stats for: %+v not available through collector %q, err: %v", container, collector.ID(), err)
 		}

--- a/pkg/util/containers/v2/metrics/containerd/collector.go
+++ b/pkg/util/containers/v2/metrics/containerd/collector.go
@@ -71,13 +71,9 @@ func (c *containerdCollector) ID() string {
 }
 
 // GetContainerStats returns stats by container ID.
-func (c *containerdCollector) GetContainerStats(containerID string, cacheValidity time.Duration) (*provider.ContainerStats, error) {
-	namespace, err := c.containerNamespace(containerID)
-	if err != nil {
-		return nil, err
-	}
-	c.client.SetCurrentNamespace(namespace)
-
+func (c *containerdCollector) GetContainerStats(containerNS, containerID string, cacheValidity time.Duration) (*provider.ContainerStats, error) {
+	// TODO: Relying on `SetCurrentNamespace` is not correct as the collector is supposed to allow for concurrent calls
+	c.client.SetCurrentNamespace(containerNS)
 	metrics, err := c.getContainerdMetrics(containerID)
 	if err != nil {
 		return nil, err
@@ -124,13 +120,16 @@ func (c *containerdCollector) GetContainerStats(containerID string, cacheValidit
 	return containerStats, nil
 }
 
+// GetContainerOpenFilesCount returns open files count by container ID.
+func (c *containerdCollector) GetContainerOpenFilesCount(containerNS, containerID string, cacheValidity time.Duration) (*uint64, error) {
+	// Not available
+	return nil, nil
+}
+
 // GetContainerNetworkStats returns network stats by container ID.
-func (c *containerdCollector) GetContainerNetworkStats(containerID string, cacheValidity time.Duration) (*provider.ContainerNetworkStats, error) {
-	namespace, err := c.containerNamespace(containerID)
-	if err != nil {
-		return nil, err
-	}
-	c.client.SetCurrentNamespace(namespace)
+func (c *containerdCollector) GetContainerNetworkStats(containerNS, containerID string, cacheValidity time.Duration) (*provider.ContainerNetworkStats, error) {
+	// TODO: Relying on `SetCurrentNamespace` is not correct as the collector is supposed to allow for concurrent calls
+	c.client.SetCurrentNamespace(containerNS)
 
 	metrics, err := c.getContainerdMetrics(containerID)
 	if err != nil {
@@ -220,13 +219,4 @@ func (c *containerdCollector) refreshPIDCache(currentTime time.Time, cacheValidi
 
 	c.pidCache.Store(currentTime, pidCacheFullRefreshKey, struct{}{}, nil)
 	return nil
-}
-
-func (c *containerdCollector) containerNamespace(containerID string) (string, error) {
-	container, err := c.workloadmetaStore.GetContainer(containerID)
-	if err != nil {
-		return "", err
-	}
-
-	return container.Namespace, nil
 }

--- a/pkg/util/containers/v2/metrics/containerd/collector_linux_test.go
+++ b/pkg/util/containers/v2/metrics/containerd/collector_linux_test.go
@@ -273,7 +273,7 @@ func TestGetContainerStats_Containerd(t *testing.T) {
 			}
 
 			// ID and cache TTL not relevant for these tests
-			result, err := collector.GetContainerStats(containerID, 10*time.Second)
+			result, err := collector.GetContainerStats("", containerID, 10*time.Second)
 			assert.NoError(t, err)
 
 			result.CPU.Limit = nil         // Don't check this field. It's complex to calculate. Needs separate tests.
@@ -363,7 +363,7 @@ func TestGetContainerNetworkStats_Containerd(t *testing.T) {
 			}
 
 			// ID and cache TTL not relevant for these tests
-			result, err := collector.GetContainerNetworkStats(containerID, 10*time.Second)
+			result, err := collector.GetContainerNetworkStats("", containerID, 10*time.Second)
 			result.Timestamp = time.Time{} // We have no control over it, so set it to avoid checking it.
 
 			assert.NoError(t, err)

--- a/pkg/util/containers/v2/metrics/containerd/collector_windows_test.go
+++ b/pkg/util/containers/v2/metrics/containerd/collector_windows_test.go
@@ -112,7 +112,7 @@ func TestGetContainerStats_Containerd(t *testing.T) {
 			}
 
 			// ID and cache TTL not relevant for these tests
-			result, err := collector.GetContainerStats(containerID, 10*time.Second)
+			result, err := collector.GetContainerStats("test-namespace", containerID, 10*time.Second)
 			assert.NoError(t, err)
 
 			result.CPU.Limit = nil         // Don't check this field. It's complex to calculate. Needs separate tests.
@@ -170,7 +170,7 @@ func TestGetContainerNetworkStats_Containerd(t *testing.T) {
 			}
 
 			// ID and cache TTL not relevant for these tests
-			result, err := collector.GetContainerNetworkStats(containerID, 10*time.Second)
+			result, err := collector.GetContainerNetworkStats("test-namespace", containerID, 10*time.Second)
 
 			assert.NoError(t, err)
 			assert.Empty(t, cmp.Diff(test.expectedNetworkStats, result))

--- a/pkg/util/containers/v2/metrics/cri/collector.go
+++ b/pkg/util/containers/v2/metrics/cri/collector.go
@@ -58,7 +58,7 @@ func (collector *criCollector) ID() string {
 }
 
 // GetContainerStats returns stats by container ID.
-func (collector *criCollector) GetContainerStats(containerID string, cacheValidity time.Duration) (*provider.ContainerStats, error) {
+func (collector *criCollector) GetContainerStats(containerNS, containerID string, cacheValidity time.Duration) (*provider.ContainerStats, error) {
 	stats, err := collector.getCriContainerStats(containerID)
 	if err != nil {
 		return nil, err
@@ -75,8 +75,14 @@ func (collector *criCollector) GetContainerStats(containerID string, cacheValidi
 	}, nil
 }
 
+// GetContainerOpenFilesCount returns open files count by container ID.
+func (collector *criCollector) GetContainerOpenFilesCount(containerNS, containerID string, cacheValidity time.Duration) (*uint64, error) {
+	// Not available
+	return nil, nil
+}
+
 // GetContainerNetworkStats returns network stats by container ID.
-func (collector *criCollector) GetContainerNetworkStats(containerID string, cacheValidity time.Duration) (*provider.ContainerNetworkStats, error) {
+func (collector *criCollector) GetContainerNetworkStats(containerNS, containerID string, cacheValidity time.Duration) (*provider.ContainerNetworkStats, error) {
 	// Not available
 	return nil, nil
 }

--- a/pkg/util/containers/v2/metrics/cri/collector_test.go
+++ b/pkg/util/containers/v2/metrics/cri/collector_test.go
@@ -46,7 +46,7 @@ func TestGetContainerStats(t *testing.T) {
 		client: mockedCriClient,
 	}
 
-	stats, err := collector.GetContainerStats(containerID, 10*time.Second)
+	stats, err := collector.GetContainerStats("", containerID, 10*time.Second)
 	assert.NoError(t, err)
 
 	assert.Equal(t, pointer.UIntToFloatPtr(1000), stats.CPU.Total)
@@ -55,7 +55,7 @@ func TestGetContainerStats(t *testing.T) {
 
 func TestGetContainerNetworkStats(t *testing.T) {
 	collector := criCollector{}
-	stats, err := collector.GetContainerNetworkStats("123", time.Second)
+	stats, err := collector.GetContainerNetworkStats("", "123", time.Second)
 	assert.NoError(t, err)
 	assert.Nil(t, stats) // The CRI collector does not return any network data
 }

--- a/pkg/util/containers/v2/metrics/docker/collector.go
+++ b/pkg/util/containers/v2/metrics/docker/collector.go
@@ -74,7 +74,7 @@ func (d *dockerCollector) ID() string {
 }
 
 // GetContainerStats returns stats by container ID.
-func (d *dockerCollector) GetContainerStats(containerID string, cacheValidity time.Duration) (*provider.ContainerStats, error) {
+func (d *dockerCollector) GetContainerStats(containerNS, containerID string, cacheValidity time.Duration) (*provider.ContainerStats, error) {
 	stats, err := d.stats(containerID)
 	if err != nil {
 		return nil, err
@@ -91,8 +91,14 @@ func (d *dockerCollector) GetContainerStats(containerID string, cacheValidity ti
 	return outStats, nil
 }
 
+// GetContainerOpenFilesCount returns open files count by container ID.
+func (d *dockerCollector) GetContainerOpenFilesCount(containerNS, containerID string, cacheValidity time.Duration) (*uint64, error) {
+	// Not available
+	return nil, nil
+}
+
 // GetContainerNetworkStats returns network stats by container ID.
-func (d *dockerCollector) GetContainerNetworkStats(containerID string, cacheValidity time.Duration) (*provider.ContainerNetworkStats, error) {
+func (d *dockerCollector) GetContainerNetworkStats(containerNS, containerID string, cacheValidity time.Duration) (*provider.ContainerNetworkStats, error) {
 	stats, err := d.stats(containerID)
 	if err != nil {
 		return nil, err

--- a/pkg/util/containers/v2/metrics/ecsfargate/collector.go
+++ b/pkg/util/containers/v2/metrics/ecsfargate/collector.go
@@ -69,7 +69,7 @@ func newEcsFargateCollector() (*ecsFargateCollector, error) {
 func (e *ecsFargateCollector) ID() string { return ecsFargateCollectorID }
 
 // GetContainerStats returns stats by container ID.
-func (e *ecsFargateCollector) GetContainerStats(containerID string, cacheValidity time.Duration) (*provider.ContainerStats, error) {
+func (e *ecsFargateCollector) GetContainerStats(containerNS, containerID string, cacheValidity time.Duration) (*provider.ContainerStats, error) {
 	stats, err := e.stats(containerID)
 	if err != nil {
 		return nil, err
@@ -86,8 +86,20 @@ func (e *ecsFargateCollector) GetContainerStats(containerID string, cacheValidit
 	return containerStats, nil
 }
 
+// GetContainerPIDStats returns pid stats by container ID.
+func (e *ecsFargateCollector) GetContainerPIDStats(containerNS, containerID string, cacheValidity time.Duration) (*provider.ContainerPIDStats, error) {
+	// Not available
+	return nil, nil
+}
+
+// GetContainerOpenFilesCount returns open files count by container ID.
+func (e *ecsFargateCollector) GetContainerOpenFilesCount(containerNS, containerID string, cacheValidity time.Duration) (*uint64, error) {
+	// Not available
+	return nil, nil
+}
+
 // GetContainerNetworkStats returns network stats by container ID.
-func (e *ecsFargateCollector) GetContainerNetworkStats(containerID string, cacheValidity time.Duration) (*provider.ContainerNetworkStats, error) {
+func (e *ecsFargateCollector) GetContainerNetworkStats(containerNS, containerID string, cacheValidity time.Duration) (*provider.ContainerNetworkStats, error) {
 	stats, err := e.stats(containerID)
 	if err != nil {
 		return nil, err

--- a/pkg/util/containers/v2/metrics/kubelet/collector.go
+++ b/pkg/util/containers/v2/metrics/kubelet/collector.go
@@ -91,7 +91,7 @@ func (kc *kubeletCollector) GetSelfContainerID() (string, error) {
 }
 
 // GetContainerStats returns stats by container ID.
-func (kc *kubeletCollector) GetContainerStats(containerID string, cacheValidity time.Duration) (*provider.ContainerStats, error) {
+func (kc *kubeletCollector) GetContainerStats(containerNS, containerID string, cacheValidity time.Duration) (*provider.ContainerStats, error) {
 	currentTime := time.Now()
 
 	containerStats, found, err := kc.statsCache.Get(currentTime, contStatsCachePrefix+containerID, cacheValidity)
@@ -118,8 +118,20 @@ func (kc *kubeletCollector) GetContainerStats(containerID string, cacheValidity 
 	return nil, nil
 }
 
+// GetContainerPIDStats returns pid stats by container ID.
+func (kc *kubeletCollector) GetContainerPIDStats(containerNS, containerID string, cacheValidity time.Duration) (*provider.ContainerPIDStats, error) {
+	// Not available
+	return nil, nil
+}
+
+// GetContainerOpenFilesCount returns open files count by container ID.
+func (kc *kubeletCollector) GetContainerOpenFilesCount(containerNS, containerID string, cacheValidity time.Duration) (*uint64, error) {
+	// Not available
+	return nil, nil
+}
+
 // GetContainerNetworkStats returns network stats by container ID.
-func (kc *kubeletCollector) GetContainerNetworkStats(containerID string, cacheValidity time.Duration) (*provider.ContainerNetworkStats, error) {
+func (kc *kubeletCollector) GetContainerNetworkStats(containerNS, containerID string, cacheValidity time.Duration) (*provider.ContainerNetworkStats, error) {
 	currentTime := time.Now()
 
 	containerNetworkStats, found, err := kc.statsCache.Get(currentTime, contNetStatsCachePrefix+containerID, cacheValidity)

--- a/pkg/util/containers/v2/metrics/kubelet/collector_test.go
+++ b/pkg/util/containers/v2/metrics/kubelet/collector_test.go
@@ -58,10 +58,10 @@ func TestKubeletCollectorLinux(t *testing.T) {
 		metadataStore: metadataStore,
 	}
 
-	// On first `GetContainerStats`, the full data is read and cache is filled
+	// On first `GetCoreContainerStats`, the full data is read and cache is filled
 	expectedTime, _ := time.Parse(time.RFC3339, "2019-11-20T13:13:13Z")
 	expectedTime = expectedTime.Local()
-	cID1Stats, err := kubeletCollector.GetContainerStats("cID1", time.Minute)
+	cID1Stats, err := kubeletCollector.GetContainerStats("", "cID1", time.Minute)
 	// Removing content from kubeletMock to make sure anything we hit is from cache
 	clearFakeStatsSummary(kubeletMock)
 
@@ -79,7 +79,7 @@ func TestKubeletCollectorLinux(t *testing.T) {
 
 	expectedTime, _ = time.Parse(time.RFC3339, "2019-11-20T13:13:09Z")
 	expectedTime = expectedTime.Local()
-	cID2Stats, err := kubeletCollector.GetContainerStats("cID2", time.Minute)
+	cID2Stats, err := kubeletCollector.GetContainerStats("", "cID2", time.Minute)
 	assert.NoError(t, err)
 	assert.Equal(t, &provider.ContainerStats{
 		Timestamp: expectedTime,
@@ -94,7 +94,7 @@ func TestKubeletCollectorLinux(t *testing.T) {
 
 	expectedTime, _ = time.Parse(time.RFC3339, "2019-11-20T13:13:16Z")
 	expectedTime = expectedTime.Local()
-	cID3Stats, err := kubeletCollector.GetContainerStats("cID3", time.Minute)
+	cID3Stats, err := kubeletCollector.GetContainerStats("", "cID3", time.Minute)
 	assert.NoError(t, err)
 	assert.Equal(t, &provider.ContainerStats{
 		Timestamp: expectedTime,
@@ -121,21 +121,21 @@ func TestKubeletCollectorLinux(t *testing.T) {
 		NetworkIsolationGroupID: pointer.UInt64Ptr(17659160645723176180),
 	}
 
-	cID3NetworkStats, err := kubeletCollector.GetContainerNetworkStats("cID3", time.Minute)
+	cID3NetworkStats, err := kubeletCollector.GetContainerNetworkStats("", "cID3", time.Minute)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedPodNetworkStats, cID3NetworkStats)
 
-	cID2NetworkStats, err := kubeletCollector.GetContainerNetworkStats("cID2", time.Minute)
+	cID2NetworkStats, err := kubeletCollector.GetContainerNetworkStats("", "cID2", time.Minute)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedPodNetworkStats, cID2NetworkStats)
 
 	// Test getting stats for an unknown container, should answer without data but without error (no API call triggered)
-	cID4Stats, err := kubeletCollector.GetContainerStats("cID4", time.Minute)
+	cID4Stats, err := kubeletCollector.GetContainerStats("", "cID4", time.Minute)
 	assert.NoError(t, err)
 	assert.Nil(t, cID4Stats)
 
 	// Forcing a refresh, will trigger a Kubelet call (which will answer with 404 Not found)
-	cID1Stats, err = kubeletCollector.GetContainerStats("cID1", 0)
+	cID1Stats, err = kubeletCollector.GetContainerStats("", "cID1", 0)
 	assert.Equal(t, err.Error(), "Unable to fetch stats summary from Kubelet, rc: 404")
 	assert.Nil(t, cID1Stats)
 }
@@ -169,10 +169,10 @@ func TestKubeletCollectorWindows(t *testing.T) {
 		metadataStore: metadataStore,
 	}
 
-	// On first `GetContainerStats`, the full data is read and cache is filled
+	// On first `GetCoreContainerStats`, the full data is read and cache is filled
 	expectedTime, _ := time.Parse(time.RFC3339, "2020-04-24T15:54:14Z")
 	expectedTime = expectedTime.Local()
-	cID1Stats, err := kubeletCollector.GetContainerStats("cID1", time.Minute)
+	cID1Stats, err := kubeletCollector.GetContainerStats("", "cID1", time.Minute)
 	assert.NoError(t, err)
 	assert.Equal(t, &provider.ContainerStats{
 		Timestamp: expectedTime,

--- a/pkg/util/containers/v2/metrics/mock/mock.go
+++ b/pkg/util/containers/v2/metrics/mock/mock.go
@@ -66,6 +66,7 @@ func (mp *MetricsProvider) Clear() {
 type ContainerEntry struct {
 	ContainerStats provider.ContainerStats
 	NetworkStats   provider.ContainerNetworkStats
+	OpenFiles      *uint64
 	Error          error
 }
 
@@ -104,7 +105,7 @@ func (mp *Collector) Clear() {
 }
 
 // GetContainerStats returns stats from MockContainerEntry
-func (mp *Collector) GetContainerStats(containerID string, cacheValidity time.Duration) (*provider.ContainerStats, error) {
+func (mp *Collector) GetContainerStats(containerNS, containerID string, cacheValidity time.Duration) (*provider.ContainerStats, error) {
 	if entry, found := mp.containers[containerID]; found {
 		return &entry.ContainerStats, entry.Error
 	}
@@ -112,8 +113,17 @@ func (mp *Collector) GetContainerStats(containerID string, cacheValidity time.Du
 	return nil, fmt.Errorf("container not found")
 }
 
+// GetContainerOpenFilesCount returns stats from MockContainerEntry
+func (mp *Collector) GetContainerOpenFilesCount(containerNS, containerID string, cacheValidity time.Duration) (*uint64, error) {
+	if entry, found := mp.containers[containerID]; found {
+		return entry.OpenFiles, entry.Error
+	}
+
+	return nil, fmt.Errorf("container not found")
+}
+
 // GetContainerNetworkStats returns stats from MockContainerEntry
-func (mp *Collector) GetContainerNetworkStats(containerID string, cacheValidity time.Duration) (*provider.ContainerNetworkStats, error) {
+func (mp *Collector) GetContainerNetworkStats(containerNS, containerID string, cacheValidity time.Duration) (*provider.ContainerNetworkStats, error) {
 	if entry, found := mp.containers[containerID]; found {
 		return &entry.NetworkStats, entry.Error
 	}

--- a/pkg/util/containers/v2/metrics/mock/mock_samples.go
+++ b/pkg/util/containers/v2/metrics/mock/mock_samples.go
@@ -74,8 +74,8 @@ func GetFullSampleContainerEntry() ContainerEntry {
 				PIDs:        []int{4, 2},
 				ThreadCount: pointer.Float64Ptr(10),
 				ThreadLimit: pointer.Float64Ptr(20),
-				OpenFiles:   pointer.Float64Ptr(200),
 			},
 		},
+		OpenFiles: pointer.UInt64Ptr(200),
 	}
 }

--- a/pkg/util/containers/v2/metrics/provider/collector.go
+++ b/pkg/util/containers/v2/metrics/provider/collector.go
@@ -11,7 +11,9 @@ import "time"
 // All implementations should allow for concurrent access.
 type Collector interface {
 	ID() string
-	GetContainerStats(containerID string, cacheValidity time.Duration) (*ContainerStats, error)
-	GetContainerNetworkStats(containerID string, cacheValidity time.Duration) (*ContainerNetworkStats, error)
+	GetContainerStats(containerNS, containerID string, cacheValidity time.Duration) (*ContainerStats, error)
+	GetContainerNetworkStats(containerNS, containerID string, cacheValidity time.Duration) (*ContainerNetworkStats, error)
+	// OpenFiles count has been splitted of as it incurs a high performance penalty on Linux
+	GetContainerOpenFilesCount(containerNS, containerID string, cacheValidity time.Duration) (*uint64, error)
 	MetaCollector
 }

--- a/pkg/util/containers/v2/metrics/provider/collector_cache_test.go
+++ b/pkg/util/containers/v2/metrics/provider/collector_cache_test.go
@@ -46,19 +46,19 @@ func TestCollectorCache(t *testing.T) {
 	collectorCache := NewCollectorCache(actualCollector)
 	assert.Equal(t, collectorCache.ID(), actualCollector.ID())
 
-	cStats, err := collectorCache.GetContainerStats("cID1", time.Minute)
+	cStats, err := collectorCache.GetContainerStats("", "cID1", time.Minute)
 	assert.NoError(t, err)
 	assert.Equal(t, 100.0, *cStats.CPU.Total)
 
-	ncStats, err := collectorCache.GetContainerNetworkStats("cID1", time.Minute)
+	ncStats, err := collectorCache.GetContainerNetworkStats("", "cID1", time.Minute)
 	assert.NoError(t, err)
 	assert.Equal(t, 110.0, *ncStats.BytesSent)
 
-	cStats2, err := collectorCache.GetContainerStats("cID2", time.Minute)
+	cStats2, err := collectorCache.GetContainerStats("", "cID2", time.Minute)
 	assert.NoError(t, err)
 	assert.Equal(t, 200.0, *cStats2.CPU.Total)
 
-	ncStats2, err := collectorCache.GetContainerNetworkStats("cID2", time.Minute)
+	ncStats2, err := collectorCache.GetContainerNetworkStats("", "cID2", time.Minute)
 	assert.NoError(t, err)
 	assert.Equal(t, 210.0, *ncStats2.BytesSent)
 
@@ -86,16 +86,16 @@ func TestCollectorCache(t *testing.T) {
 	}
 	actualCollector.cIDForPID[2] = "cID22"
 
-	cStats, err = collectorCache.GetContainerStats("cID1", time.Minute)
+	cStats, err = collectorCache.GetContainerStats("", "cID1", time.Minute)
 	assert.NoError(t, err)
 	assert.Equal(t, 100.0, *cStats.CPU.Total)
 
-	ncStats, err = collectorCache.GetContainerNetworkStats("cID1", time.Minute)
+	ncStats, err = collectorCache.GetContainerNetworkStats("", "cID1", time.Minute)
 	assert.NoError(t, err)
 	assert.Equal(t, 110.0, *ncStats.BytesSent)
 
 	// Force refresh
-	cStats2, err = collectorCache.GetContainerStats("cID2", 0)
+	cStats2, err = collectorCache.GetContainerStats("", "cID2", 0)
 	assert.NoError(t, err)
 	assert.Equal(t, 250.0, *cStats2.CPU.Total)
 
@@ -104,7 +104,7 @@ func TestCollectorCache(t *testing.T) {
 	assert.Equal(t, "cID22", cID2)
 
 	// Verify networkStats was not refreshed
-	ncStats2, err = collectorCache.GetContainerNetworkStats("cID2", time.Minute)
+	ncStats2, err = collectorCache.GetContainerNetworkStats("", "cID2", time.Minute)
 	assert.NoError(t, err)
 	assert.Equal(t, 210.0, *ncStats2.BytesSent)
 

--- a/pkg/util/containers/v2/metrics/provider/mock.go
+++ b/pkg/util/containers/v2/metrics/provider/mock.go
@@ -12,6 +12,8 @@ import (
 type dummyCollector struct {
 	id              string
 	cStats          map[string]*ContainerStats
+	cPIDStats       map[string]*ContainerPIDStats
+	cOpenFilesCount map[string]*uint64
 	cNetStats       map[string]*ContainerNetworkStats
 	cIDForPID       map[int]string
 	selfContainerID string
@@ -22,12 +24,20 @@ func (d dummyCollector) ID() string {
 	return d.id
 }
 
-func (d dummyCollector) GetContainerStats(containerID string, cacheValidity time.Duration) (*ContainerStats, error) {
-	return d.cStats[containerID], d.err
+func (d dummyCollector) GetContainerStats(containerNS, containerID string, cacheValidity time.Duration) (*ContainerStats, error) {
+	return d.cStats[containerNS+containerID], d.err
 }
 
-func (d dummyCollector) GetContainerNetworkStats(containerID string, cacheValidity time.Duration) (*ContainerNetworkStats, error) {
-	return d.cNetStats[containerID], d.err
+func (d dummyCollector) GetContainerPIDStats(containerNS, containerID string, cacheValidity time.Duration) (*ContainerPIDStats, error) {
+	return d.cPIDStats[containerNS+containerID], d.err
+}
+
+func (d dummyCollector) GetContainerOpenFilesCount(containerNS, containerID string, cacheValidity time.Duration) (*uint64, error) {
+	return d.cOpenFilesCount[containerNS+containerID], d.err
+}
+
+func (d dummyCollector) GetContainerNetworkStats(containerNS, containerID string, cacheValidity time.Duration) (*ContainerNetworkStats, error) {
+	return d.cNetStats[containerNS+containerID], d.err
 }
 
 func (d dummyCollector) GetContainerIDForPID(pid int, cacheValidity time.Duration) (string, error) {

--- a/pkg/util/containers/v2/metrics/provider/types.go
+++ b/pkg/util/containers/v2/metrics/provider/types.go
@@ -73,7 +73,6 @@ type ContainerPIDStats struct {
 	PIDs        []int
 	ThreadCount *float64
 	ThreadLimit *float64
-	OpenFiles   *float64
 }
 
 // InterfaceNetStats stores network statistics about a network interface

--- a/pkg/util/containers/v2/metrics/system/collector_linux.go
+++ b/pkg/util/containers/v2/metrics/system/collector_linux.go
@@ -87,7 +87,7 @@ func (c *systemCollector) ID() string {
 	return systemCollectorID
 }
 
-func (c *systemCollector) GetContainerStats(containerID string, cacheValidity time.Duration) (*provider.ContainerStats, error) {
+func (c *systemCollector) GetContainerStats(containerNS, containerID string, cacheValidity time.Duration) (*provider.ContainerStats, error) {
 	cg, err := c.getCgroup(containerID, cacheValidity)
 	if err != nil {
 		return nil, err
@@ -96,7 +96,27 @@ func (c *systemCollector) GetContainerStats(containerID string, cacheValidity ti
 	return c.buildContainerMetrics(cg, cacheValidity)
 }
 
-func (c *systemCollector) GetContainerNetworkStats(containerID string, cacheValidity time.Duration) (*provider.ContainerNetworkStats, error) {
+func (c *systemCollector) GetContainerOpenFilesCount(containerNS, containerID string, cacheValidity time.Duration) (*uint64, error) {
+	cg, err := c.getCgroup(containerID, cacheValidity)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get PIDs
+	pids, err := cg.GetPIDs(cacheValidity)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get PIDs for cgroup id: %s. Unable to get count of open files", cg.Identifier())
+	}
+
+	ofCount, allFailed := systemutils.CountProcessesFileDescriptors(c.procPath, pids)
+	if allFailed {
+		return nil, fmt.Errorf("unable to read any PID open FDs for cgroup id: %s. Unable to get count of open files", cg.Identifier())
+	}
+
+	return &ofCount, nil
+}
+
+func (c *systemCollector) GetContainerNetworkStats(containerNS, containerID string, cacheValidity time.Duration) (*provider.ContainerNetworkStats, error) {
 	cg, err := c.getCgroup(containerID, cacheValidity)
 	if err != nil {
 		return nil, err
@@ -160,12 +180,6 @@ func (c *systemCollector) buildContainerMetrics(cg cgroups.Cgroup, cacheValidity
 	cs.PID.PIDs, err = cg.GetPIDs(cacheValidity)
 	if err != nil {
 		log.Debugf("Unable to get PIDs for cgroup id: %s. Metrics will be missing", cg.Identifier())
-	}
-
-	// Get OpenFDs
-	count, allFailed := systemutils.CountProcessesFileDescriptors(c.procPath, cs.PID.PIDs)
-	if !allFailed {
-		convertField(&count, &cs.PID.OpenFiles)
 	}
 
 	return cs, nil


### PR DESCRIPTION
### What does this PR do?

Create a new dedicated call to get count of openfiles for a set of PIDs. Remove the performance penalty introduced by the (useless) retrieval of the count of openfiles in `process-agent`

### Motivation

Performance.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Performance improvement compared to `7.35` in `process-agent` on nodes with a lot of PIDs.
Make sure the `container.pid.open_files` metric is still emitted correctly.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
