### PR TITLE
[DCA][Admission Controller] Use ReinvocationPolicy `IfNeeded` + make it configurable

### DIFF
--- a/pkg/clusteragent/admission/controllers/webhook/config.go
+++ b/pkg/clusteragent/admission/controllers/webhook/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	svcPort                  int32
 	timeout                  int32
 	failurePolicy            string
+	reinvocationPolicy       string
 }
 
 // NewConfig creates a webhook controller configuration
@@ -42,19 +43,21 @@ func NewConfig(admissionV1Enabled, namespaceSelectorEnabled bool) Config {
 		svcPort:                  int32(443),
 		timeout:                  config.Datadog.GetInt32("admission_controller.timeout_seconds"),
 		failurePolicy:            config.Datadog.GetString("admission_controller.failure_policy"),
+		reinvocationPolicy:       config.Datadog.GetString("admission_controller.reinvocation_policy"),
 	}
 }
 
-func (w *Config) getWebhookName() string     { return w.webhookName }
-func (w *Config) getSecretName() string      { return w.secretName }
-func (w *Config) getSecretNs() string        { return w.namespace }
-func (w *Config) useAdmissionV1() bool       { return w.admissionV1Enabled }
-func (w *Config) useNamespaceSelector() bool { return w.namespaceSelectorEnabled }
-func (w *Config) getServiceNs() string       { return w.namespace }
-func (w *Config) getServiceName() string     { return w.svcName }
-func (w *Config) getServicePort() int32      { return w.svcPort }
-func (w *Config) getTimeout() int32          { return w.timeout }
-func (w *Config) getFailurePolicy() string   { return w.failurePolicy }
+func (w *Config) getWebhookName() string        { return w.webhookName }
+func (w *Config) getSecretName() string         { return w.secretName }
+func (w *Config) getSecretNs() string           { return w.namespace }
+func (w *Config) useAdmissionV1() bool          { return w.admissionV1Enabled }
+func (w *Config) useNamespaceSelector() bool    { return w.namespaceSelectorEnabled }
+func (w *Config) getServiceNs() string          { return w.namespace }
+func (w *Config) getServiceName() string        { return w.svcName }
+func (w *Config) getServicePort() int32         { return w.svcPort }
+func (w *Config) getTimeout() int32             { return w.timeout }
+func (w *Config) getFailurePolicy() string      { return w.failurePolicy }
+func (w *Config) getReinvocationPolicy() string { return w.reinvocationPolicy }
 func (w *Config) configName(suffix string) string {
 	return strings.ReplaceAll(fmt.Sprintf("%s.%s", w.webhookName, suffix), "-", ".")
 }

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
@@ -204,6 +204,7 @@ func (c *ControllerV1) getWebhookSkeleton(nameSuffix, path string) admiv1.Mutati
 	port := c.config.getServicePort()
 	timeout := c.config.getTimeout()
 	failurePolicy := c.getAdmiV1FailurePolicy()
+	reinvocationPolicy := c.getReinvocationPolicy()
 	webhook := admiv1.MutatingWebhook{
 		Name: c.config.configName(nameSuffix),
 		ClientConfig: admiv1.WebhookClientConfig{
@@ -226,6 +227,7 @@ func (c *ControllerV1) getWebhookSkeleton(nameSuffix, path string) admiv1.Mutati
 				},
 			},
 		},
+		ReinvocationPolicy:      &reinvocationPolicy,
 		FailurePolicy:           &failurePolicy,
 		MatchPolicy:             &matchPolicy,
 		SideEffects:             &sideEffects,
@@ -254,5 +256,18 @@ func (c *ControllerV1) getAdmiV1FailurePolicy() admiv1.FailurePolicyType {
 	default:
 		_ = log.Warnf("Unknown failure policy %s - defaulting to 'Ignore'", policy)
 		return admiv1.Ignore
+	}
+}
+
+func (c *ControllerV1) getReinvocationPolicy() admiv1.ReinvocationPolicyType {
+	policy := strings.ToLower(c.config.getReinvocationPolicy())
+	switch policy {
+	case "ifneeded":
+		return admiv1.IfNeededReinvocationPolicy
+	case "never":
+		return admiv1.NeverReinvocationPolicy
+	default:
+		log.Warnf("Unknown reinvocation policy %q - defaulting to %q", policy, admiv1.IfNeededReinvocationPolicy)
+		return admiv1.IfNeededReinvocationPolicy
 	}
 }

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
@@ -267,7 +267,7 @@ func (c *ControllerV1) getReinvocationPolicy() admiv1.ReinvocationPolicyType {
 	case "never":
 		return admiv1.NeverReinvocationPolicy
 	default:
-		log.Warnf("Unknown reinvocation policy %q - defaulting to %q", policy, admiv1.IfNeededReinvocationPolicy)
+		log.Warnf("Unknown reinvocation policy %q - defaulting to %q", c.config.getReinvocationPolicy(), admiv1.IfNeededReinvocationPolicy)
 		return admiv1.IfNeededReinvocationPolicy
 	}
 }

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
@@ -267,7 +267,7 @@ func (c *ControllerV1beta1) getReinvocationPolicy() admiv1beta1.ReinvocationPoli
 	case "never":
 		return admiv1beta1.NeverReinvocationPolicy
 	default:
-		log.Warnf("Unknown reinvocation policy %q - defaulting to %q", policy, admiv1beta1.IfNeededReinvocationPolicy)
+		log.Warnf("Unknown reinvocation policy %q - defaulting to %q", c.config.getReinvocationPolicy(), admiv1beta1.IfNeededReinvocationPolicy)
 		return admiv1beta1.IfNeededReinvocationPolicy
 	}
 }

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
@@ -204,6 +204,7 @@ func (c *ControllerV1beta1) getWebhookSkeleton(nameSuffix, path string) admiv1be
 	port := c.config.getServicePort()
 	timeout := c.config.getTimeout()
 	failurePolicy := c.getAdmiV1Beta1FailurePolicy()
+	reinvocationPolicy := c.getReinvocationPolicy()
 	webhook := admiv1beta1.MutatingWebhook{
 		Name: c.config.configName(nameSuffix),
 		ClientConfig: admiv1beta1.WebhookClientConfig{
@@ -226,6 +227,7 @@ func (c *ControllerV1beta1) getWebhookSkeleton(nameSuffix, path string) admiv1be
 				},
 			},
 		},
+		ReinvocationPolicy:      &reinvocationPolicy,
 		FailurePolicy:           &failurePolicy,
 		MatchPolicy:             &matchPolicy,
 		SideEffects:             &sideEffects,
@@ -254,5 +256,18 @@ func (c *ControllerV1beta1) getAdmiV1Beta1FailurePolicy() admiv1beta1.FailurePol
 	default:
 		_ = log.Warnf("Unknown failure policy %s - defaulting to 'Ignore'", policy)
 		return admiv1beta1.Ignore
+	}
+}
+
+func (c *ControllerV1beta1) getReinvocationPolicy() admiv1beta1.ReinvocationPolicyType {
+	policy := strings.ToLower(c.config.getReinvocationPolicy())
+	switch policy {
+	case "ifneeded":
+		return admiv1beta1.IfNeededReinvocationPolicy
+	case "never":
+		return admiv1beta1.NeverReinvocationPolicy
+	default:
+		log.Warnf("Unknown reinvocation policy %q - defaulting to %q", policy, admiv1beta1.IfNeededReinvocationPolicy)
+		return admiv1beta1.IfNeededReinvocationPolicy
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -911,6 +911,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("admission_controller.pod_owners_cache_validity", 10) // in minutes
 	config.BindEnvAndSetDefault("admission_controller.namespace_selector_fallback", false)
 	config.BindEnvAndSetDefault("admission_controller.failure_policy", "Ignore")
+	config.BindEnvAndSetDefault("admission_controller.reinvocation_policy", "IfNeeded")
 
 	// Telemetry
 	// Enable telemetry metrics on the internals of the Agent.

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2441,6 +2441,13 @@ api_key:
   ## Setting to Fail will require the admission controller to be present and pods to be injected before they are allowed to run.
   #
   # failure_policy: Ignore
+
+  ## @param reinvocation_policy - string - optional - default: IfNeeded
+  ## @env DD_ADMISSION_CONTROLLER_REINVOCATION_POLICY - string - optional - default: IfNeeded
+  ## Set the reinvocation policy for dynamic admission control.
+  ## See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#reinvocation-policy
+  #
+  # reinvocation_policy: IfNeeded
 {{ end -}}
 {{- if .DockerTagging }}
 

--- a/releasenotes-dca/notes/adm-reinvocation-e1435102b435f1d1.yaml
+++ b/releasenotes-dca/notes/adm-reinvocation-e1435102b435f1d1.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    The admission controller's reinvocation policy is now set to ``IfNeeded`` by default.
+    It can be changed using the ``admission_controller.reinvocation_policy`` parameter.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

- Set the Reinvocation Policy to `IfNeeded` by default
- Make it configurable

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

The admission controller is idempotent, it makes sense to set the Reinvocation Policy to `IfNeeded`.

Fixes:
- https://github.com/DataDog/datadog-agent/issues/8350
- https://github.com/DataDog/datadog-agent/pull/8351

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#reinvocation-policy

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Deploy the admission controller
- The `ReinvocationPolicy` field in the `datadog-webhook` object should be set to `IfNeeded` by default.
- `DD_ADMISSION_CONTROLLER_REINVOCATION_POLICY=Never` should change that.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
