### PR TITLE
Serverless serialize in parallel

### DIFF
--- a/pkg/aggregator/demultiplexer.go
+++ b/pkg/aggregator/demultiplexer.go
@@ -513,14 +513,11 @@ func (d *AgentDemultiplexer) flushToSerializer(start time.Time, waitForSerialize
 	var done chan struct{}
 
 	if d.aggregator.flushAndSerializeInParallel.enabled {
-		seriesSink = metrics.NewIterableSeries(func(se *metrics.Serie) {
-			if logPayloads {
-				log.Debugf("Flushing serie: %s", se)
-			}
-			tagsetTlm.updateHugeSerieTelemetry(se)
-		}, d.aggregator.flushAndSerializeInParallel.bufferSize, d.aggregator.flushAndSerializeInParallel.channelSize)
-		done = make(chan struct{})
-		go d.sendIterableSeries(start, seriesSink, done)
+		seriesSink, done = startSendingIterableSeries(
+			d.sharedSerializer,
+			&d.aggregator.flushAndSerializeInParallel,
+			logPayloads,
+			start)
 	}
 
 	// flush DogStatsD pipelines (statsd/time samplers)
@@ -562,8 +559,7 @@ func (d *AgentDemultiplexer) flushToSerializer(start time.Time, waitForSerialize
 	}
 
 	if d.aggregator.flushAndSerializeInParallel.enabled {
-		seriesSink.SenderStopped()
-		<-done
+		stopIterableSeries(seriesSink, done)
 	}
 
 	// collect the series and sketches that the multiple samplers may have reported
@@ -617,13 +613,34 @@ func (d *AgentDemultiplexer) flushToSerializer(start time.Time, waitForSerialize
 	aggregatorNumberOfFlush.Add(1)
 }
 
+func startSendingIterableSeries(
+	serializer serializer.MetricSerializer,
+	flushAndSerializeInParallel *flushAndSerializeInParallel,
+	logPayloads bool,
+	start time.Time) (*metrics.IterableSeries, chan struct{}) {
+	seriesSink := metrics.NewIterableSeries(func(se *metrics.Serie) {
+		if logPayloads {
+			log.Debugf("Flushing serie: %s", se)
+		}
+		tagsetTlm.updateHugeSerieTelemetry(se)
+	}, flushAndSerializeInParallel.bufferSize, flushAndSerializeInParallel.channelSize)
+	done := make(chan struct{})
+	go sendIterableSeries(serializer, start, seriesSink, done)
+	return seriesSink, done
+}
+
+func stopIterableSeries(seriesSink *metrics.IterableSeries, done chan struct{}) {
+	seriesSink.SenderStopped()
+	<-done
+}
+
 // sendIterableSeries is continuously sending series to the serializer, until another routine calls SenderStopped on the
 // series sink.
 // Mainly meant to be executed in its own routine, sendIterableSeries is closing the `done` channel once it has returned
 // from SendIterableSeries (because the SenderStopped methods has been called on the sink).
-func (d *AgentDemultiplexer) sendIterableSeries(start time.Time, series *metrics.IterableSeries, done chan<- struct{}) {
+func sendIterableSeries(serializer serializer.MetricSerializer, start time.Time, series *metrics.IterableSeries, done chan<- struct{}) {
 	log.Debug("Demultiplexer: sendIterableSeries: start sending iterable series to the serializer")
-	err := d.sharedSerializer.SendIterableSeries(series)
+	err := serializer.SendIterableSeries(series)
 	// if err == nil, SenderStopped was called and it is safe to read the number of series.
 	count := series.SeriesCount()
 	addFlushCount("Series", int64(count))

--- a/pkg/aggregator/demultiplexer.go
+++ b/pkg/aggregator/demultiplexer.go
@@ -512,10 +512,10 @@ func (d *AgentDemultiplexer) flushToSerializer(start time.Time, waitForSerialize
 	var seriesSink *metrics.IterableSeries
 	var done chan struct{}
 
-	if d.aggregator.flushAndSerializeInParallel.enabled {
+	if d.aggregator.flushAndSerializeInParallel.Enabled {
 		seriesSink, done = startSendingIterableSeries(
 			d.sharedSerializer,
-			&d.aggregator.flushAndSerializeInParallel,
+			d.aggregator.flushAndSerializeInParallel,
 			logPayloads,
 			start)
 	}
@@ -558,7 +558,7 @@ func (d *AgentDemultiplexer) flushToSerializer(start time.Time, waitForSerialize
 		<-t.trigger.blockChan
 	}
 
-	if d.aggregator.flushAndSerializeInParallel.enabled {
+	if d.aggregator.flushAndSerializeInParallel.Enabled {
 		stopIterableSeries(seriesSink, done)
 	}
 
@@ -615,7 +615,7 @@ func (d *AgentDemultiplexer) flushToSerializer(start time.Time, waitForSerialize
 
 func startSendingIterableSeries(
 	serializer serializer.MetricSerializer,
-	flushAndSerializeInParallel *flushAndSerializeInParallel,
+	flushAndSerializeInParallel FlushAndSerializeInParallel,
 	logPayloads bool,
 	start time.Time) (*metrics.IterableSeries, chan struct{}) {
 	seriesSink := metrics.NewIterableSeries(func(se *metrics.Serie) {
@@ -623,7 +623,7 @@ func startSendingIterableSeries(
 			log.Debugf("Flushing serie: %s", se)
 		}
 		tagsetTlm.updateHugeSerieTelemetry(se)
-	}, flushAndSerializeInParallel.bufferSize, flushAndSerializeInParallel.channelSize)
+	}, flushAndSerializeInParallel.BufferSize, flushAndSerializeInParallel.ChannelSize)
 	done := make(chan struct{})
 	go sendIterableSeries(serializer, start, seriesSink, done)
 	return seriesSink, done
@@ -797,7 +797,7 @@ func InitAndStartServerlessDemultiplexer(domainResolvers map[string]resolver.Dom
 	tagsStore := tags.NewStore(config.Datadog.GetBool("aggregator_use_tags_store"), "timesampler")
 
 	statsdSampler := NewTimeSampler(TimeSamplerID(0), bucketSize, tagsStore)
-	statsdWorker := newTimeSamplerWorker(statsdSampler, DefaultFlushInterval, bufferSize, metricSamplePool, flushAndSerializeInParallel{enabled: false}, tagsStore)
+	statsdWorker := newTimeSamplerWorker(statsdSampler, DefaultFlushInterval, bufferSize, metricSamplePool, FlushAndSerializeInParallel{Enabled: false}, tagsStore)
 
 	demux := &ServerlessDemultiplexer{
 		forwarder:        forwarder,

--- a/pkg/aggregator/time_sampler_worker.go
+++ b/pkg/aggregator/time_sampler_worker.go
@@ -27,7 +27,7 @@ type timeSamplerWorker struct {
 	flushInterval time.Duration
 
 	// parallel serialization configuration
-	parallelSerialization flushAndSerializeInParallel
+	parallelSerialization FlushAndSerializeInParallel
 
 	// samplesChan is used to communicate between from the processLoop receiving the
 	// samples and the TimeSampler.
@@ -43,7 +43,7 @@ type timeSamplerWorker struct {
 
 func newTimeSamplerWorker(sampler *TimeSampler, flushInterval time.Duration, bufferSize int,
 	metricSamplePool *metrics.MetricSamplePool,
-	parallelSerialization flushAndSerializeInParallel, tagsStore *tags.Store) *timeSamplerWorker {
+	parallelSerialization FlushAndSerializeInParallel, tagsStore *tags.Store) *timeSamplerWorker {
 	return &timeSamplerWorker{
 		sampler: sampler,
 
@@ -91,7 +91,7 @@ func (w *timeSamplerWorker) stop() {
 }
 
 func (w *timeSamplerWorker) triggerFlush(trigger flushTrigger) {
-	if w.parallelSerialization.enabled {
+	if w.parallelSerialization.Enabled {
 		sketches := w.sampler.flush(float64(trigger.time.Unix()), trigger.seriesSink)
 		if len(sketches) > 0 {
 			*trigger.flushedSketches = append(*trigger.flushedSketches, sketches)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR adds the support of the parallel serialization for ServerlessDemultiplexer.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Having ServerlessDemultiplexer behaves the same as AgentDemultiplexer makes future development easier.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

https://github.com/DataDog/datadog-agent/pull/11113 was reverted by https://github.com/DataDog/datadog-agent/pull/11376
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Check series can be sent with the serverless agent.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
