### PR TITLE
Change Cluster Agent API to be served only with TLS 1.3 by default

### DIFF
--- a/cmd/cluster-agent/api/server.go
+++ b/cmd/cluster-agent/api/server.go
@@ -85,10 +85,11 @@ func StartServer() error {
 
 	tlsConfig := tls.Config{
 		Certificates: []tls.Certificate{rootTLSCert},
+		MinVersion:   tls.VersionTLS13,
 	}
 
-	if config.Datadog.GetBool("force_tls_12") {
-		tlsConfig.MinVersion = tls.VersionTLS12
+	if config.Datadog.GetBool("cluster_agent.allow_legacy_tls") {
+		tlsConfig.MinVersion = tls.VersionTLS10
 	}
 
 	srv := &http.Server{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -646,6 +646,7 @@ func InitConfig(config Config) {
 
 	// Datadog cluster agent
 	config.BindEnvAndSetDefault("cluster_agent.enabled", false)
+	config.BindEnvAndSetDefault("cluster_agent.allow_legacy_tls", false)
 	config.BindEnvAndSetDefault("cluster_agent.auth_token", "")
 	config.BindEnvAndSetDefault("cluster_agent.url", "")
 	config.BindEnvAndSetDefault("cluster_agent.kubernetes_service_name", "datadog-cluster-agent")
@@ -1370,7 +1371,6 @@ func getMainInfraEndpointWithConfig(config Config) string {
 
 // GetMainEndpointWithConfig implements the logic to extract the DD URL from a config, based on `site` and ddURLKey
 func GetMainEndpointWithConfig(config Config, prefix string, ddURLKey string) (resolvedDDURL string) {
-
 	if envVarAreSetAndNotEqual(config, "DD_DD_URL", "DD_URL") {
 		log.Warnf("'DD_URL' and 'DD_DD_URL' variables are both set in environment. URL key is set to 'DD_DD_URL' value")
 	}
@@ -1388,7 +1388,6 @@ func GetMainEndpointWithConfig(config Config, prefix string, ddURLKey string) (r
 
 // envVarAreSetAndNotEqual returns true if two given variables are set in environment and are not equal.
 func envVarAreSetAndNotEqual(config Config, lhsName string, rhsName string) bool {
-
 	lhsValue, lhsIsSet := os.LookupEnv(lhsName)
 	rhsValue, rhsIsSet := os.LookupEnv(rhsName)
 

--- a/releasenotes-dca/notes/min-tls-13-4ea49e60e2378c37.yaml
+++ b/releasenotes-dca/notes/min-tls-13-4ea49e60e2378c37.yaml
@@ -1,0 +1,3 @@
+security:
+  - |
+    Cluster Agent API (only used by Node Agents) is now only server with TLS >= 1.3 by default. Setting "cluster_agent.allow_legacy_tls" to true allows to fallback to TLS 1.0.


### PR DESCRIPTION
### What does this PR do?

Change Cluster Agent API to be served only with TLS 1.3 by default.

### Motivation

Security. Even though Agents should connects with TLS 1.3 already, it makes sure we'll never serve over insecure TLS version/ciphers.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Deploy the Cluster Agent with an old Datadog Agent version (like 7.26.0 which is roughly ~1 year old) and make sure the Agent is still able to connect to Cluster Agent (`agent status`)

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
