### PR TITLE
Introduce 'bare configs' from AD scheduler, for services with no config

### DIFF
--- a/pkg/autodiscovery/README.md
+++ b/pkg/autodiscovery/README.md
@@ -78,7 +78,9 @@ It can notify in three circumstances:
 
 1. When a config provider detects a non-template configuration, that is published immediately by the metascheduler.
 2. Whenever template configurations or services change, these are reconciled by matching AD identifiers, any new or removed configs are published by the metascheduler.
-3. For every service, a "service config" -- one with no provider and no configuration -- is published by the metascheduler.
+3. For services that have no matching template, a "bare config" is published.
+   Such configs can be identified by `Provider: "bare"`, and can be used for "automatic" behavior such as logging all containers.
+4. For every service, a "service config" -- one with no provider and no configuration -- is published by the metascheduler.
    Only service configs have an entity defined.
 
 ## Resolving Templates

--- a/pkg/autodiscovery/integration/config.go
+++ b/pkg/autodiscovery/integration/config.go
@@ -74,7 +74,7 @@ type Config struct {
 	// for service configs)
 	ServiceID string `json:"-"` // (include in digest: true)
 
-	// TaggerEntity is the tagger entity ID
+	// TaggerEntity is the tagger entity ID, set only for service configs
 	TaggerEntity string `json:"-"` // (include in digest: false)
 
 	// ClusterCheck is cluster-check configuration flag
@@ -183,6 +183,11 @@ func (c *Config) IsCheckConfig() bool {
 // IsLogConfig returns true if config contains a logs config.
 func (c *Config) IsLogConfig() bool {
 	return c.LogsConfig != nil
+}
+
+// IsBareConfig returns true if this is a bare config
+func (c *Config) IsBareConfig() bool {
+	return c.Provider == "bare"
 }
 
 // HasFilter returns true if metrics or logs collection must be disabled for this config.

--- a/pkg/autodiscovery/integration/config_test.go
+++ b/pkg/autodiscovery/integration/config_test.go
@@ -66,6 +66,13 @@ func TestIsLogConfig(t *testing.T) {
 	assert.True(t, config.IsLogConfig())
 }
 
+func TestIsBareConfig(t *testing.T) {
+	config := &Config{}
+	assert.False(t, config.IsBareConfig())
+	config.Provider = "bare"
+	assert.True(t, config.IsBareConfig())
+}
+
 func TestIsCheckConfig(t *testing.T) {
 	config := &Config{}
 	assert.False(t, config.IsCheckConfig())

--- a/pkg/autodiscovery/store.go
+++ b/pkg/autodiscovery/store.go
@@ -63,6 +63,14 @@ func (s *store) addConfigForService(serviceEntity string, config integration.Con
 	}
 }
 
+// getConfigsForService returns the slice of integration.Config's for the given
+// service, or nil if there are none.  This value must not be modified.
+func (s *store) getConfigsForService(serviceEntity string) []integration.Config {
+	s.m.RLock()
+	defer s.m.RUnlock()
+	return s.serviceToConfigs[serviceEntity]
+}
+
 // removeConfigsForTemplate removes all configs for a specified template, returning
 // those configs
 func (s *store) removeConfigsForTemplate(templateDigest string) []integration.Config {


### PR DESCRIPTION
All existing AD schedulers will ignore such configs, so this will have
no effect:

 * pareConfig.IsLogsConfig() is false, so the logs agent will ignore them
   (pkg/logs/schedulers/ad/scheduler.go)
 * bareConfig.IsCheckConfig() is false, so the check collector will ignore them
   (pkg/collector/scheduler.go)
 * bareConfig.ClusterCheck is false, so the cluster agent will ignore them.
   (pkg/clusteragent/clusterchecks/dispatcher_main.go)

### Motivation

AD currently sends "regular" configs and "service" configs, where regular configs are sent for anything with a config template, and service configs are sent for every service.  This leaves components wishing to react to services without config templates juggling race conditions to exclude services that _do_ have config.  The logs agent currently does this two different ways, depending on the configuration `logs_config.k8s_container_use_file` (!!):

 * (kubernetes launcher) Listen only for service configs and parse container and pod AD annotations directly, ignoring any template reconciliation in AD.
 * (docker launcher) Listen for services and regular configs, reconciling them together and logging only when both are present.  To detect services with no templates, this launcher waits until AD has run once (a hack of its own!) and then adds a "fake" regular config to which any service config may be matched.  The matching uses a "scoring" process to prefer regular configs for a service when those are present, but this depends on delivery order of service configs and regular configs from AD.  The MetaScheduler _does_ deliver them in order (regular configs before service configs), but they are split into two channels in the logs agent between which delivery order is not guaranteed.

So, yeah, this is a mess.

With this change in place, the plan is to refactor the logs agent so that it listens for bare configs to learn about services with no templates.

Once that's done, we can remove support for service configs, as logs-agent is the only thing that consumes them.

### Additional Notes

This PR shows the external behavior of AD that I'm proposing.  So, I'd like feedback on that -- is the "bare" Provider field OK?  Any other issues there?

I'd like _separate_ feedback on the implementation, which is probably terrible -- it just "adopts" the same race conditions currently being solved by the logs agent, hoping that after 30 seconds any config pollers have found the relevant templates. 
 How else might this be implemented?

Finally, please confirm that this will have no effect -- the bare configs will be ignored by all consumers.  If that's questionable, then we should verify in QA.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
