### PR TITLE
Update 7.35 branch to windows NPM driver 1.3.2

### DIFF
--- a/release.json
+++ b/release.json
@@ -12,8 +12,8 @@
         "JMXFETCH_HASH": "3c41c0660e9c53451dfb51e8dad33bc87b03be1abc1fcd3c856ea81e6b0894ee",
         "MACOS_BUILD_VERSION": "master",
         "WINDOWS_DDNPM_DRIVER": "release-signed",
-        "WINDOWS_DDNPM_VERSION": "1.3.1",
-        "WINDOWS_DDNPM_SHASUM": "a14514beb952f3aaa09de4df43c5e439044a90aaddf05b1ade459778c1d255d3",
+        "WINDOWS_DDNPM_VERSION": "1.3.2",
+        "WINDOWS_DDNPM_SHASUM": "1f65d40519bc307d652c64183b2cac2a36da9839c21d64f9823aa158ff6336bb",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "nightly-a7": {
@@ -24,8 +24,8 @@
         "JMXFETCH_HASH": "3c41c0660e9c53451dfb51e8dad33bc87b03be1abc1fcd3c856ea81e6b0894ee",
         "MACOS_BUILD_VERSION": "master",
         "WINDOWS_DDNPM_DRIVER": "release-signed",
-        "WINDOWS_DDNPM_VERSION": "1.3.1",
-        "WINDOWS_DDNPM_SHASUM": "a14514beb952f3aaa09de4df43c5e439044a90aaddf05b1ade459778c1d255d3",
+        "WINDOWS_DDNPM_VERSION": "1.3.2",
+        "WINDOWS_DDNPM_SHASUM": "1f65d40519bc307d652c64183b2cac2a36da9839c21d64f9823aa158ff6336bb",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "release-a6": {

--- a/releasenotes/notes/npm132for735-cfa91640efd6a8ea.yaml
+++ b/releasenotes/notes/npm132for735-cfa91640efd6a8ea.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    For Windows, includes NPM driver 1.3.2, which has a fix for a BSOD on system probe shutdown.


### PR DESCRIPTION
### What does this PR do?

Updates NPM driver to 1.3.2, which contains a BSOD fix.

### Motivation

Customer issue
### Additional Notes

### Possible Drawbacks / Trade-offs


### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
