### PR TITLE
[windows] fix npm upgrade bug

### DIFF
--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -79,6 +79,7 @@
     <Property Id="APIKEY" Hidden="yes" />
     <Property Id="SITE" Value="datadoghq.com" />
     <Property Id="FinalizeInstall" Hidden="yes" />
+    <Property Id="NPMFEATURESTATE" />
      <PropertyRef Id="WIX_ACCOUNT_ADMINISTRATORS" />
      <PropertyRef Id="WIX_ACCOUNT_LOCALSYSTEM" />
      <PropertyRef Id="WIX_ACCOUNT_USERS" />
@@ -101,7 +102,9 @@
     <SetProperty Id="PROJECTLOCATIONONCMDLINESLASH" Value="[PROJECTLOCATION]\" Before="AppSearch">PROJECTLOCATION </SetProperty>
     <SetProperty Id="CONFDIRONCOMMANDLINE" Value="[APPLICATIONDATADIRECTORY]" Before="AppSearch">APPLICATIONDATADIRECTORY </SetProperty>
     <SetProperty Id="CONFDIRONCOMMANDLINESLASH" Value="[APPLICATIONDATADIRECTORY]\" Before="AppSearch">APPLICATIONDATADIRECTORY </SetProperty>
-
+    
+    <SetProperty Action="SetNPMOff" Id="NPMFEATURESTATE" Before="SetFinalizeProperty" Value="off" Sequence="execute"><![CDATA[not (&NPM = 3)]]></SetProperty>
+    <SetProperty Action="SetNPMOn"  Id="NPMFEATURESTATE" Before="SetFinalizeProperty" Value="on"  Sequence="execute"><![CDATA[(&NPM = 3)]]></SetProperty>
     <!-- This condition allows the install if
         1) the user didn't supply the binary directory on the command line
         2) this is NOT an upgrade
@@ -651,6 +654,7 @@
       This does not affect the final artefact, as it seems to affects only the base string, not the expanded one.
       At runtime this limitation doesn\'t seem to apply.
     -->
+    
     <CustomAction Id='SetFinalizeProperty' Return='check' Property='FinalizeInstall'
         Value='
             UILevel=[UILevel]
@@ -659,6 +663,7 @@
             DDAGENTUSER_NAME=[DDAGENTUSER_NAME]
             DDAGENTUSER_PASSWORD=[DDAGENTUSER_PASSWORD]
             SYSPROBE_PRESENT=[SYSPROBE_PRESENT]
+            NPMFEATURE=[NPMFEATURESTATE]
             ADDLOCAL=[ADDLOCAL]
             APIKEY=[APIKEY]
             TAGS=[TAGS]

--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -103,6 +103,19 @@
     <SetProperty Id="CONFDIRONCOMMANDLINE" Value="[APPLICATIONDATADIRECTORY]" Before="AppSearch">APPLICATIONDATADIRECTORY </SetProperty>
     <SetProperty Id="CONFDIRONCOMMANDLINESLASH" Value="[APPLICATIONDATADIRECTORY]\" Before="AppSearch">APPLICATIONDATADIRECTORY </SetProperty>
     
+    <!--
+      The following sets a property (to be used by the custom action).
+      the "&" indicates the action state of a feature (so &NPM refers to the NPM _feature_ not the NPM property that might be set on the command line)
+      "3" refers to the action state "on the local computer" (which is the only one we support besides "not present", which happens to be "2")
+
+      So, the NPMFEATURESTATE property will be set to "off" if the NPM feature is no installed on the local computer
+      and will be set to "on" if it is used on the local computer.  
+
+      This flag will be used in the custom action to decide what service dependencies need to be set
+
+      For more information on this syntax see
+      https://www.firegiant.com/wix/tutorial/com-expression-syntax-miscellanea/expression-syntax/
+      -->
     <SetProperty Action="SetNPMOff" Id="NPMFEATURESTATE" Before="SetFinalizeProperty" Value="off" Sequence="execute"><![CDATA[not (&NPM = 3)]]></SetProperty>
     <SetProperty Action="SetNPMOn"  Id="NPMFEATURESTATE" Before="SetFinalizeProperty" Value="on"  Sequence="execute"><![CDATA[(&NPM = 3)]]></SetProperty>
     <!-- This condition allows the install if

--- a/releasenotes/notes/fixnpmupgrade-ef6b42d87c980541.yaml
+++ b/releasenotes/notes/fixnpmupgrade-ef6b42d87c980541.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    For Windows, fixes problem in upgrade wherein NPM driver is not automatically started by system probe.

--- a/tools/windows/install-help/cal/customactiondata.cpp
+++ b/tools/windows/install-help/cal/customactiondata.cpp
@@ -145,6 +145,7 @@ bool CustomActionData::parseSysprobeData()
     std::wstring sysprobePresent;
     std::wstring addlocal;
     std::wstring npm;
+    std::wstring npmFeature;
     this->_doInstallSysprobe = false;
     this->_ddnpmPresent = false;
     if (!this->value(L"SYSPROBE_PRESENT", sysprobePresent))
@@ -172,24 +173,18 @@ bool CustomActionData::parseSysprobeData()
         this->_ddnpmPresent = true;
     }
 
-    // now check to see if we're installing the driver
-    if (!this->value(L"ADDLOCAL", addlocal))
+    
+    if(this->value(L"NPMFEATURE", npmFeature))
     {
-        // should never happen.  But if the addlocalkey isn't there,
-        // don't bother trying
-        WcaLog(LOGMSG_STANDARD, "ADDLOCAL not present");
-
-        return true;
-    }
-    WcaLog(LOGMSG_STANDARD, "ADDLOCAL is (%S)", addlocal.c_str());
-    if (_wcsicmp(addlocal.c_str(), L"ALL") == 0)
-    {
-        // installing all components, do it
-        this->_ddnpmPresent = true;
-        WcaLog(LOGMSG_STANDARD, "ADDLOCAL is ALL");
-    } else if (addlocal.find(L"NPM") != std::wstring::npos) {
-        WcaLog(LOGMSG_STANDARD, "ADDLOCAL contains NPM %S", addlocal.c_str());
-        this->_ddnpmPresent = true;
+        // this property is set to "on" or "off" depending on the desired installed state
+        // of the NPM feature.
+        WcaLog(LOGMSG_STANDARD, "NPMFEATURE key is present and (%S)", npmFeature.c_str());
+        if (_wcsicmp(npmFeature.c_str(), L"on") == 0)
+        {
+            this->_ddnpmPresent = true;
+        }
+    } else {
+        WcaLog(LOGMSG_STANDARD, "NPMFEATURE not present");
     }
 
     return true;

--- a/tools/windows/install-help/cal/customactiondata.cpp
+++ b/tools/windows/install-help/cal/customactiondata.cpp
@@ -174,7 +174,7 @@ bool CustomActionData::parseSysprobeData()
     }
 
     
-    if(this->value(L"NPMFEATURE", npmFeature))
+    if (this->value(L"NPMFEATURE", npmFeature))
     {
         // this property is set to "on" or "off" depending on the desired installed state
         // of the NPM feature.

--- a/tools/windows/install-help/cal/customactiondata.cpp
+++ b/tools/windows/install-help/cal/customactiondata.cpp
@@ -183,7 +183,9 @@ bool CustomActionData::parseSysprobeData()
         {
             this->_ddnpmPresent = true;
         }
-    } else {
+    }
+    else
+    {
         WcaLog(LOGMSG_STANDARD, "NPMFEATURE not present");
     }
 


### PR DESCRIPTION
### What does this PR do?

Fixes problem with upgrade code wherein, upon doing an agent version upgrade, the service dependency is lost and therefore the NPM driver isn't automatically started when the system probe is started.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

#### To view the bug
- Install an old release with the NPM product installed (e.g. 7.34)
- Upgrade to a newer release using no command line arguments to the installer

Expected behavior
 - NPM should still function properly
Actual Behavior:
 - system probe doesn't start
 - npm isn't started
 - checking the dependencies shows that system-probe no longer depends on the npm driver (`sc.exe qc datadog-system-probe`, the npm driver isn't in the list of dependencies)
 
#### to view the fix
- Install an old release with the NPM product installed (e.g. 7.34)
- Upgrade to a newer release which contains this pr using no command line arguments to the installer

Expected behavior
 - NPM should still function properly
 - checking the dependencies shows that system-probe still depends on the npm driver (`sc.exe qc datadog-system-probe`, the npm driver is in the list of dependencies)

 
### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
