### PR TITLE
[CWS] use lower case operator override for dns name

### DIFF
--- a/pkg/security/probe/accessors.go
+++ b/pkg/security/probe/accessors.go
@@ -609,6 +609,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "dns.question.name":
 		return &eval.StringEvaluator{
+			OpOverrides: LowerCaseCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).DNS.Name

--- a/pkg/security/probe/oo_lower_case.go
+++ b/pkg/security/probe/oo_lower_case.go
@@ -1,0 +1,130 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+// +build linux
+
+package probe
+
+import (
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
+)
+
+func toLowerStringEvaluator(evaluator *eval.StringEvaluator) (*eval.StringEvaluator, error) {
+	if evaluator.IsScalar() {
+		evaluator.Value = strings.ToLower(evaluator.Value)
+		switch evaluator.ValueType {
+		case eval.PatternValueType, eval.RegexpValueType:
+			evaluator.Value = strings.ToLower(evaluator.Value)
+			if err := evaluator.Compile(); err != nil {
+				return nil, err
+			}
+		}
+
+		return evaluator, nil
+	}
+
+	return &eval.StringEvaluator{
+		EvalFnc: func(ctx *eval.Context) string {
+			return strings.ToLower(evaluator.EvalFnc(ctx))
+		},
+	}, nil
+}
+
+func toLowerStringArrayEvaluator(evaluator *eval.StringArrayEvaluator) *eval.StringArrayEvaluator {
+	if evaluator.IsScalar() {
+		var values []string
+		for _, value := range evaluator.Values {
+			values = append(values, strings.ToLower(value))
+		}
+		evaluator.Values = values
+
+		return evaluator
+	}
+	return &eval.StringArrayEvaluator{
+		EvalFnc: func(ctx *eval.Context) []string {
+			values := evaluator.EvalFnc(ctx)
+			for _, value := range evaluator.Values {
+				values = append(values, strings.ToLower(value))
+			}
+			return values
+		},
+	}
+}
+
+func toLowerStringValues(values *eval.StringValues) *eval.StringValues {
+	var lowerValues eval.StringValues
+
+	for _, value := range values.GetFieldValues() {
+		if str, ok := value.Value.(string); ok {
+			value.Value = strings.ToLower(str)
+		}
+		lowerValues.AppendFieldValue(value)
+	}
+	return &lowerValues
+}
+
+func toLowerStringValuesEvaluator(evaluator *eval.StringValuesEvaluator) *eval.StringValuesEvaluator {
+	if evaluator.IsScalar() {
+		values := toLowerStringValues(&evaluator.Values)
+		evaluator.Values = *values
+
+		return evaluator
+	}
+	return &eval.StringValuesEvaluator{
+		EvalFnc: func(ctx *eval.Context) *eval.StringValues {
+			return toLowerStringValues(evaluator.EvalFnc(ctx))
+		},
+	}
+}
+
+var (
+	// LowerCaseCmp lower case values before comparing. Important : this operator override doesn't support approvers
+	LowerCaseCmp = &eval.OpOverrides{
+		StringEquals: func(a *eval.StringEvaluator, b *eval.StringEvaluator, opts *eval.Opts, state *eval.State) (*eval.BoolEvaluator, error) {
+			var err error
+
+			if a, err = toLowerStringEvaluator(a); err != nil {
+				return nil, err
+			}
+
+			if b, err = toLowerStringEvaluator(b); err != nil {
+				return nil, err
+			}
+
+			return eval.StringEquals(a, b, opts, state)
+		},
+		StringValuesContains: func(a *eval.StringEvaluator, b *eval.StringValuesEvaluator, opts *eval.Opts, state *eval.State) (*eval.BoolEvaluator, error) {
+			var err error
+
+			if a, err = toLowerStringEvaluator(a); err != nil {
+				return nil, err
+			}
+
+			b = toLowerStringValuesEvaluator(b)
+
+			return eval.StringValuesContains(a, b, opts, state)
+		},
+		StringArrayContains: func(a *eval.StringEvaluator, b *eval.StringArrayEvaluator, opts *eval.Opts, state *eval.State) (*eval.BoolEvaluator, error) {
+			var err error
+
+			if a, err = toLowerStringEvaluator(a); err != nil {
+				return nil, err
+			}
+
+			b = toLowerStringArrayEvaluator(b)
+
+			return eval.StringArrayContains(a, b, opts, state)
+		},
+		StringArrayMatches: func(a *eval.StringArrayEvaluator, b *eval.StringValuesEvaluator, opts *eval.Opts, state *eval.State) (*eval.BoolEvaluator, error) {
+			a = toLowerStringArrayEvaluator(a)
+			b = toLowerStringValuesEvaluator(b)
+
+			return eval.StringArrayMatches(a, b, opts, state)
+		},
+	}
+)

--- a/pkg/security/probe/oo_lower_case_test.go
+++ b/pkg/security/probe/oo_lower_case_test.go
@@ -1,0 +1,308 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+// +build linux
+
+package probe
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
+)
+
+func TestLowerCaseEquals(t *testing.T) {
+	t.Run("no-match", func(t *testing.T) {
+		a := &eval.StringEvaluator{
+			Value:     "BAR",
+			ValueType: eval.ScalarValueType,
+		}
+
+		b := &eval.StringEvaluator{
+			Field: "field",
+			EvalFnc: func(ctx *eval.Context) string {
+				return "foo"
+			},
+		}
+
+		var ctx eval.Context
+		var state eval.State
+
+		e, err := LowerCaseCmp.StringEquals(a, b, nil, &state)
+		assert.Empty(t, err)
+		assert.False(t, e.Eval(&ctx).(bool))
+
+		e, err = LowerCaseCmp.StringEquals(b, a, nil, &state)
+		assert.Empty(t, err)
+		assert.False(t, e.Eval(&ctx).(bool))
+	})
+
+	t.Run("scalar", func(t *testing.T) {
+		a := &eval.StringEvaluator{
+			Value:     "FOO",
+			ValueType: eval.ScalarValueType,
+		}
+
+		b := &eval.StringEvaluator{
+			Field: "field",
+			EvalFnc: func(ctx *eval.Context) string {
+				return "foo"
+			},
+		}
+
+		var ctx eval.Context
+		var state eval.State
+
+		e, err := LowerCaseCmp.StringEquals(a, b, nil, &state)
+		assert.Empty(t, err)
+		assert.True(t, e.Eval(&ctx).(bool))
+
+		e, err = LowerCaseCmp.StringEquals(b, a, nil, &state)
+		assert.Empty(t, err)
+		assert.True(t, e.Eval(&ctx).(bool))
+	})
+
+	t.Run("pattern", func(t *testing.T) {
+		a := &eval.StringEvaluator{
+			Value:     "FO*",
+			ValueType: eval.PatternValueType,
+		}
+		_ = a.Compile()
+
+		b := &eval.StringEvaluator{
+			Field: "field",
+			EvalFnc: func(ctx *eval.Context) string {
+				return "foo"
+			},
+		}
+
+		var ctx eval.Context
+		var state eval.State
+
+		e, err := LowerCaseCmp.StringEquals(a, b, nil, &state)
+		assert.Empty(t, err)
+		assert.True(t, e.Eval(&ctx).(bool))
+
+		e, err = LowerCaseCmp.StringEquals(b, a, nil, &state)
+		assert.Empty(t, err)
+		assert.True(t, e.Eval(&ctx).(bool))
+	})
+
+	t.Run("regex", func(t *testing.T) {
+		a := &eval.StringEvaluator{
+			Value:     "FO.*",
+			ValueType: eval.RegexpValueType,
+		}
+		_ = a.Compile()
+
+		b := &eval.StringEvaluator{
+			Field: "field",
+			EvalFnc: func(ctx *eval.Context) string {
+				return "foo"
+			},
+		}
+
+		var ctx eval.Context
+		var state eval.State
+
+		e, err := LowerCaseCmp.StringEquals(a, b, nil, &state)
+		assert.Empty(t, err)
+		assert.True(t, e.Eval(&ctx).(bool))
+
+		e, err = LowerCaseCmp.StringEquals(b, a, nil, &state)
+		assert.Empty(t, err)
+		assert.True(t, e.Eval(&ctx).(bool))
+	})
+}
+
+func TestLowerCaseContains(t *testing.T) {
+	t.Run("no-match", func(t *testing.T) {
+		a := &eval.StringEvaluator{
+			Field: "field",
+			EvalFnc: func(ctx *eval.Context) string {
+				return "BAR"
+			},
+		}
+
+		var values eval.StringValues
+		values.AppendFieldValue(eval.FieldValue{Value: "aaa", Type: eval.ScalarValueType})
+		values.AppendFieldValue(eval.FieldValue{Value: "foo", Type: eval.ScalarValueType})
+
+		b := &eval.StringValuesEvaluator{
+			Values: values,
+		}
+
+		var ctx eval.Context
+		var state eval.State
+
+		e, err := LowerCaseCmp.StringValuesContains(a, b, nil, &state)
+		assert.Empty(t, err)
+		assert.False(t, e.Eval(&ctx).(bool))
+	})
+
+	t.Run("scalar", func(t *testing.T) {
+		a := &eval.StringEvaluator{
+			Field: "field",
+			EvalFnc: func(ctx *eval.Context) string {
+				return "FOO"
+			},
+		}
+
+		var values eval.StringValues
+		values.AppendFieldValue(eval.FieldValue{Value: "aaa", Type: eval.ScalarValueType})
+		values.AppendFieldValue(eval.FieldValue{Value: "foo", Type: eval.ScalarValueType})
+
+		b := &eval.StringValuesEvaluator{
+			Values: values,
+		}
+
+		var ctx eval.Context
+		var state eval.State
+
+		e, err := LowerCaseCmp.StringValuesContains(a, b, nil, &state)
+		assert.Empty(t, err)
+		assert.True(t, e.Eval(&ctx).(bool))
+	})
+
+	t.Run("pattern", func(t *testing.T) {
+		a := &eval.StringEvaluator{
+			Field: "field",
+			EvalFnc: func(ctx *eval.Context) string {
+				return "foo"
+			},
+		}
+
+		var values eval.StringValues
+		values.AppendFieldValue(eval.FieldValue{Value: "aaa", Type: eval.ScalarValueType})
+		values.AppendFieldValue(eval.FieldValue{Value: "FOO*", Type: eval.PatternValueType})
+
+		b := &eval.StringValuesEvaluator{
+			Values: values,
+		}
+
+		var ctx eval.Context
+		var state eval.State
+
+		e, err := LowerCaseCmp.StringValuesContains(a, b, nil, &state)
+		assert.Empty(t, err)
+		assert.True(t, e.Eval(&ctx).(bool))
+	})
+
+	t.Run("regex", func(t *testing.T) {
+		a := &eval.StringEvaluator{
+			Field: "field",
+			EvalFnc: func(ctx *eval.Context) string {
+				return "foo"
+			},
+		}
+
+		var values eval.StringValues
+		values.AppendFieldValue(eval.FieldValue{Value: "aaa", Type: eval.ScalarValueType})
+		values.AppendFieldValue(eval.FieldValue{Value: "FOO.*", Type: eval.RegexpValueType})
+
+		b := &eval.StringValuesEvaluator{
+			Values: values,
+		}
+
+		var ctx eval.Context
+		var state eval.State
+
+		e, err := LowerCaseCmp.StringValuesContains(a, b, nil, &state)
+		assert.Empty(t, err)
+		assert.True(t, e.Eval(&ctx).(bool))
+	})
+
+	t.Run("eval", func(t *testing.T) {
+		a := &eval.StringEvaluator{
+			Field: "field",
+			EvalFnc: func(ctx *eval.Context) string {
+				return "FOO"
+			},
+		}
+
+		b := &eval.StringValuesEvaluator{
+			EvalFnc: func(ctx *eval.Context) *eval.StringValues {
+				var values eval.StringValues
+				values.AppendFieldValue(eval.FieldValue{Value: "aaa", Type: eval.ScalarValueType})
+				values.AppendFieldValue(eval.FieldValue{Value: "fo*", Type: eval.PatternValueType})
+				return &values
+			},
+		}
+
+		var ctx eval.Context
+		var state eval.State
+
+		e, err := LowerCaseCmp.StringValuesContains(a, b, nil, &state)
+		assert.Empty(t, err)
+		assert.True(t, e.Eval(&ctx).(bool))
+	})
+}
+
+func TestLowerCaseArrayContains(t *testing.T) {
+	t.Run("no-match", func(t *testing.T) {
+		a := &eval.StringEvaluator{
+			Field: "field",
+			EvalFnc: func(ctx *eval.Context) string {
+				return "BAR"
+			},
+		}
+
+		b := &eval.StringArrayEvaluator{
+			Values: []string{"aaa", "bbb"},
+		}
+
+		var ctx eval.Context
+		var state eval.State
+
+		e, err := LowerCaseCmp.StringArrayContains(a, b, nil, &state)
+		assert.Empty(t, err)
+		assert.False(t, e.Eval(&ctx).(bool))
+	})
+
+	t.Run("scalar", func(t *testing.T) {
+		a := &eval.StringEvaluator{
+			Field: "field",
+			EvalFnc: func(ctx *eval.Context) string {
+				return "FOO"
+			},
+		}
+
+		b := &eval.StringArrayEvaluator{
+			Values: []string{"aaa", "foo"},
+		}
+
+		var ctx eval.Context
+		var state eval.State
+
+		e, err := LowerCaseCmp.StringArrayContains(a, b, nil, &state)
+		assert.Empty(t, err)
+		assert.True(t, e.Eval(&ctx).(bool))
+	})
+
+	t.Run("eval", func(t *testing.T) {
+		a := &eval.StringEvaluator{
+			Field: "field",
+			EvalFnc: func(ctx *eval.Context) string {
+				return "foo"
+			},
+		}
+		b := &eval.StringArrayEvaluator{
+			Field: "array",
+			EvalFnc: func(ctx *eval.Context) []string {
+				return []string{"aaa", "foo"}
+			},
+		}
+
+		var ctx eval.Context
+		var state eval.State
+
+		e, err := LowerCaseCmp.StringArrayContains(a, b, nil, &state)
+		assert.Empty(t, err)
+		assert.True(t, e.Eval(&ctx).(bool))
+	})
+}

--- a/pkg/security/secl/compiler/eval/operators.go
+++ b/pkg/security/secl/compiler/eval/operators.go
@@ -13,7 +13,7 @@ type OpOverrides struct {
 	StringArrayMatches   func(a *StringArrayEvaluator, b *StringValuesEvaluator, opts *Opts, state *State) (*BoolEvaluator, error)
 }
 
-// return whether a arithmetic operation is deterministic
+// return whether an arithmetic operation is deterministic
 func isArithmDeterministic(a Evaluator, b Evaluator, state *State) bool {
 	isDc := a.IsDeterministicFor(state.field) || b.IsDeterministicFor(state.field)
 
@@ -56,18 +56,18 @@ func IntNot(a *IntEvaluator, opts *Opts, state *State) *IntEvaluator {
 func StringEquals(a *StringEvaluator, b *StringEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
 
-	var arrayOp func(a string, b string) bool
+	var op func(a string, b string) bool
 
 	if a.stringMatcher != nil {
-		arrayOp = func(as string, bs string) bool {
+		op = func(as string, bs string) bool {
 			return a.stringMatcher.Matches(bs)
 		}
 	} else if b.stringMatcher != nil {
-		arrayOp = func(as string, bs string) bool {
+		op = func(as string, bs string) bool {
 			return b.stringMatcher.Matches(as)
 		}
 	} else {
-		arrayOp = func(as string, bs string) bool {
+		op = func(as string, bs string) bool {
 			return as == bs
 		}
 	}
@@ -76,7 +76,7 @@ func StringEquals(a *StringEvaluator, b *StringEvaluator, opts *Opts, state *Sta
 		ea, eb := a.EvalFnc, b.EvalFnc
 
 		evalFnc := func(ctx *Context) bool {
-			return arrayOp(ea(ctx), eb(ctx))
+			return op(ea(ctx), eb(ctx))
 		}
 
 		return &BoolEvaluator{
@@ -90,7 +90,7 @@ func StringEquals(a *StringEvaluator, b *StringEvaluator, opts *Opts, state *Sta
 		ea, eb := a.Value, b.Value
 
 		return &BoolEvaluator{
-			Value:           arrayOp(ea, eb),
+			Value:           op(ea, eb),
 			Weight:          a.Weight + InArrayWeight*len(eb),
 			isDeterministic: isDc,
 		}, nil
@@ -106,7 +106,7 @@ func StringEquals(a *StringEvaluator, b *StringEvaluator, opts *Opts, state *Sta
 		}
 
 		evalFnc := func(ctx *Context) bool {
-			return arrayOp(ea(ctx), eb)
+			return op(ea(ctx), eb)
 		}
 
 		return &BoolEvaluator{
@@ -125,7 +125,7 @@ func StringEquals(a *StringEvaluator, b *StringEvaluator, opts *Opts, state *Sta
 	}
 
 	evalFnc := func(ctx *Context) bool {
-		return arrayOp(ea, eb(ctx))
+		return op(ea, eb(ctx))
 	}
 
 	return &BoolEvaluator{

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -775,11 +775,11 @@ type NetworkContext struct {
 //msgp:ignore DNSEvent
 type DNSEvent struct {
 	ID    uint16 `field:"-"`
-	Name  string `field:"question.name"`  // the queried domain name
-	Type  uint16 `field:"question.type"`  // a two octet code which specifies the DNS question type
-	Class uint16 `field:"question.class"` // the class looked up by the DNS question
-	Size  uint16 `field:"question.size"`  // the total DNS request size in bytes
-	Count uint16 `field:"question.count"` // the total count of questions in the DNS request
+	Name  string `field:"question.name" op_override:"LowerCaseCmp"` // the queried domain name
+	Type  uint16 `field:"question.type"`                            // a two octet code which specifies the DNS question type
+	Class uint16 `field:"question.class"`                           // the class looked up by the DNS question
+	Size  uint16 `field:"question.size"`                            // the total DNS request size in bytes
+	Count uint16 `field:"question.count"`                           // the total count of questions in the DNS request
 }
 
 // NetDevice represents a network device

--- a/pkg/security/tests/dns_test.go
+++ b/pkg/security/tests/dns_test.go
@@ -63,4 +63,21 @@ func TestDNS(t *testing.T) {
 			}
 		})
 	})
+
+	t.Run("dns-case", func(t *testing.T) {
+		test.WaitSignal(t, func() error {
+			_, err = net.LookupIP("GOOGLE.COM")
+			if err != nil {
+				return err
+			}
+			return nil
+		}, func(event *sprobe.Event, rule *rules.Rule) {
+			assert.Equal(t, "dns", event.GetType(), "wrong event type")
+			assert.Equal(t, "GOOGLE.COM", event.DNS.Name, "wrong domain name")
+
+			if !validateDNSSchema(t, event) {
+				t.Error(event.String())
+			}
+		})
+	})
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This allow to write insensitive  case rule  matching `foo.com` or `FOO.com`:

```
dns.question.name == "foo.com"
or
dns.question.name == "FOO.com"
```


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
