### PR TITLE
[pkg/otlp] Deprecate `metrics.report_quantiles` in favor of `metrics.summaries.mode`

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -3144,6 +3144,7 @@ api_key:
 
     ## @param report_quantiles - boolean - optional - default: true
     ## @env DD_OTLP_CONFIG_METRICS_REPORT_QUANTILES - boolean - optional - default: true
+    ## DEPRECATED: [v7.36] Use `summaries.mode` instead. Will be removed in v7.37.
     ## Whether to report quantile metrics for OTLP Summary points.
     ## See https://docs.datadoghq.com/metrics/otlp/?tab=summary for more details.
     #
@@ -3198,6 +3199,18 @@ api_key:
         ## - `raw_value` to report the raw value as a Datadog gauge.
         #
         # cumulative_monotonic_mode: to_delta
+    
+    ## @param summaries - custom object - optional
+    ## Configuration for OTLP Summaries.
+    ## See https://docs.datadoghq.com/metrics/otlp/?tab=summary for more details.
+        ## @param mode - string - optional - default: gauges
+        ## @env DD_OTLP_CONFIG_METRICS_SUMMARIES_MODE - string - optional - default: gauges
+        ## How to report summaries. Valid values are:
+        ##
+        ## - `noquantiles` to no report quantile metrics.
+        ## - `gauges` to report one gauge metric per quantile.
+        #
+        # mode: gauges
 
   ## @param traces - custom object - optional
   ## Traces-specific configuration for OTLP ingest in the Datadog Agent.

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -3144,7 +3144,7 @@ api_key:
 
     ## @param report_quantiles - boolean - optional - default: true
     ## @env DD_OTLP_CONFIG_METRICS_REPORT_QUANTILES - boolean - optional - default: true
-    ## DEPRECATED: [v7.36] Use `summaries.mode` instead. Will be removed in v7.37.
+    ## DEPRECATED: [v7.36 / v6.36] Use `summaries.mode` instead. Will be removed in v7.37 / 6.36.
     ## Whether to report quantile metrics for OTLP Summary points.
     ## See https://docs.datadoghq.com/metrics/otlp/?tab=summary for more details.
     #
@@ -3207,7 +3207,7 @@ api_key:
         ## @env DD_OTLP_CONFIG_METRICS_SUMMARIES_MODE - string - optional - default: gauges
         ## How to report summaries. Valid values are:
         ##
-        ## - `noquantiles` to no report quantile metrics.
+        ## - `noquantiles` to not report quantile metrics.
         ## - `gauges` to report one gauge metric per quantile.
         #
         # mode: gauges

--- a/pkg/config/otlp.go
+++ b/pkg/config/otlp.go
@@ -163,4 +163,5 @@ func setupOTLPEnvironmentVariables(config Config) {
 	config.BindEnv(OTLPSection + ".metrics.histograms.mode")
 	config.BindEnv(OTLPSection + ".metrics.histograms.send_count_sum_metrics")
 	config.BindEnv(OTLPSection + ".metrics.sums.cumulative_monotonic_mode")
+	config.BindEnv(OTLPSection + ".metrics.summaries.mode")
 }

--- a/pkg/otlp/internal/serializerexporter/config.go
+++ b/pkg/otlp/internal/serializerexporter/config.go
@@ -52,6 +52,9 @@ type metricsConfig struct {
 
 	// SumConfig defines the export of OTLP Sums.
 	SumConfig sumConfig `mapstructure:"sums"`
+
+	// SummaryConfig defines the export for OTLP Summaries.
+	SummaryConfig summaryConfig `mapstructure:"summaries"`
 }
 
 // histogramConfig customizes export of OTLP Histograms.
@@ -108,6 +111,42 @@ type sumConfig struct {
 	// The default is 'to_delta'.
 	// See https://docs.datadoghq.com/metrics/otlp/?tab=sum#mapping for details and examples.
 	CumulativeMonotonicMode CumulativeMonotonicSumMode `mapstructure:"cumulative_monotonic_mode"`
+}
+
+// SummaryMode is the export mode for OTLP Summary metrics.
+type SummaryMode string
+
+const (
+	// SummaryModeNoQuantiles sends no `.quantile` metrics. `.sum` and `.count` metrics will still be sent.
+	SummaryModeNoQuantiles SummaryMode = "noquantiles"
+	// SummaryModeGauges sends `.quantile` metrics as gauges tagged by the quantile.
+	SummaryModeGauges SummaryMode = "gauges"
+)
+
+var _ encoding.TextUnmarshaler = (*SummaryMode)(nil)
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+func (sm *SummaryMode) UnmarshalText(in []byte) error {
+	switch mode := SummaryMode(in); mode {
+	case SummaryModeNoQuantiles,
+		SummaryModeGauges:
+		*sm = mode
+		return nil
+	default:
+		return fmt.Errorf("invalid summary mode %q", mode)
+	}
+}
+
+// summaryConfig customizes export of OTLP Summaries.
+type summaryConfig struct {
+	// Mode is the the mode for exporting OTLP Summaries.
+	// Valid values are 'noquantiles' or 'gauges'.
+	//  - 'noquantiles' sends no `.quantile` metrics. `.sum` and `.count` metrics will still be sent.
+	//  - 'gauges' sends `.quantile` metrics as gauges tagged by the quantile.
+	//
+	// The default is 'gauges'.
+	// See https://docs.datadoghq.com/metrics/otlp/?tab=summary#mapping for details and examples.
+	Mode SummaryMode `mapstructure:"mode"`
 }
 
 // metricsExporterConfig provides options for a user to customize the behavior of the

--- a/pkg/otlp/internal/serializerexporter/exporter.go
+++ b/pkg/otlp/internal/serializerexporter/exporter.go
@@ -45,6 +45,9 @@ func newDefaultConfig() config.Exporter {
 			SumConfig: sumConfig{
 				CumulativeMonotonicMode: CumulativeMonotonicSumModeToDelta,
 			},
+			SummaryConfig: summaryConfig{
+				Mode: SummaryModeGauges,
+			},
 		},
 	}
 }
@@ -87,7 +90,8 @@ func translatorFromConfig(logger *zap.Logger, cfg *exporterConfig) (*translator.
 		options = append(options, translator.WithCountSumMetrics())
 	}
 
-	if cfg.Metrics.Quantiles {
+	switch cfg.Metrics.SummaryConfig.Mode {
+	case SummaryModeGauges:
 		options = append(options, translator.WithQuantiles())
 	}
 

--- a/pkg/otlp/internal/serializerexporter/warning_deprecated.go
+++ b/pkg/otlp/internal/serializerexporter/warning_deprecated.go
@@ -50,6 +50,18 @@ var renamedSettings = []renameError{
 			}
 		},
 	},
+	{
+		oldName:      "metrics::report_quantiles",
+		newName:      "metrics::summaries::mode",
+		oldRemovedIn: "v7.37",
+		updateFn: func(c *exporterConfig) {
+			if c.Metrics.Quantiles {
+				c.Metrics.SummaryConfig.Mode = SummaryModeGauges
+			} else {
+				c.Metrics.SummaryConfig.Mode = SummaryModeNoQuantiles
+			}
+		},
+	},
 }
 
 // Error implements the error interface.

--- a/releasenotes/notes/otlp-report-quantiles-74692bf1b8066614.yaml
+++ b/releasenotes/notes/otlp-report-quantiles-74692bf1b8066614.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+deprecations:
+  - |
+    OTLP ingest: ``metrics.report_quantiles`` has been deprecated in favor of ``metrics.summaries.mode``. ``metrics.report_quantiles`` will be removed in v7.37.

--- a/releasenotes/notes/otlp-report-quantiles-74692bf1b8066614.yaml
+++ b/releasenotes/notes/otlp-report-quantiles-74692bf1b8066614.yaml
@@ -8,4 +8,4 @@
 ---
 deprecations:
   - |
-    OTLP ingest: ``metrics.report_quantiles`` has been deprecated in favor of ``metrics.summaries.mode``. ``metrics.report_quantiles`` will be removed in v7.37.
+    OTLP ingest: ``metrics.report_quantiles`` has been deprecated in favor of ``metrics.summaries.mode``. ``metrics.report_quantiles`` will be removed in v7.37 / v6.37.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Add a new configuration option, `metrics.summaries.mode` to replace `metrics.report_quantiles`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Counterpart to open-telemetry/opentelemetry-collector-contrib#8846

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

As on #11406, no link to the Collector issue, to avoid confusion

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

#### Test one

Run the OTLP pipeline with `metrics.report_quantiles` set to true or false:

```yaml
otlp_config:
  receiver:
    protocols:
      grpc:
  metrics:
    report_quantiles: true|false
```

Send OTLP Summary metrics. To do this, since Summary metrics are not produced by the SDKs, you will need to use a Collector and produce them with e.g. [the `statsdreceiver`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/statsdreceiver):

```yaml
receivers:
  statsd:
    endpoint: 0.0.0.0:9999 # to not conflict with the Agent
    timer_histogram_mapping:
      - statsd_type: "histogram"
        observer_type: "summary"

exporters:
  otlp:
    endpoint: '0.0.0.0:4317'
    tls:
      insecure: true

service:
  pipelines:
    metrics:
      receivers: [statsd]
      exporters: [otlp]
```

and then send a histogram to the statsd endpoint (`0.0.0.0:9999`) using, for example, the `datadog-go` library.

Check that:

- [ ] Quantiles are reported or not for these summaries depending on the `report_quantiles` value
- [ ] A warning is logged telling users to switch to `metrics.summaries.mode`

#### Test two

Run the OTLP pipeline with `metrics.summaries.mode` set to `noquantiles` or `gauges`.

```yaml
otlp_config:
  receiver:
    protocols:
      grpc:
  metrics:
    summaries:
      mode: noquantiles|gauges
```

Send OTLP summary metrics (see above for details) and check that:

- [ ] Quantiles are reported or not for these summaries depending on the mode, mathing the `report_quantiles` behavior (true -> gauges, false -> noquantiles)
- [ ] No deprecation warning is logged

#### Test three

Run the OTLP pipeline with both `metrics.report_quantiles` and `metrics.summaries.mode`:

```yaml
otlp_config:
  receiver:
    protocols:
      grpc:
  metrics:
    report_quantiles: true|false
    summaries:
      mode: noquantiles|gauges
```

Check that:

- [ ] The OTLP pipeline fails to start with an error indicating that both settings should not be used at the same time

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
