### PR TITLE
Fix AD port name interpolation by properly merging slices in workloadmeta

### DIFF
--- a/pkg/workloadmeta/merge.go
+++ b/pkg/workloadmeta/merge.go
@@ -7,35 +7,90 @@ package workloadmeta
 
 import (
 	"reflect"
+	"strconv"
 	"time"
 
 	"github.com/imdario/mergo"
 )
 
-type timeMerger struct{}
-
-var (
-	timeType           = reflect.TypeOf(time.Time{})
-	timeMergerInstance = timeMerger{}
+type (
+	merger struct{}
 )
 
-func (tm timeMerger) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
-	if typ != timeType {
+var (
+	timeType       = reflect.TypeOf(time.Time{})
+	portSliceType  = reflect.TypeOf([]ContainerPort{})
+	mergerInstance = merger{}
+)
+
+func (merger) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
+	switch typ {
+	case timeType:
+		return timeMerge
+	case portSliceType:
+		return portSliceMerge
+	}
+
+	return nil
+}
+
+func timeMerge(dst, src reflect.Value) error {
+	if !dst.CanSet() {
 		return nil
 	}
 
-	return func(dst, src reflect.Value) error {
-		if dst.CanSet() {
-			isZero := src.MethodByName("IsZero")
-			result := isZero.Call([]reflect.Value{})
-			if !result[0].Bool() {
-				dst.Set(src)
-			}
-		}
+	isZero := src.MethodByName("IsZero")
+	result := isZero.Call([]reflect.Value{})
+	if !result[0].Bool() {
+		dst.Set(src)
+	}
+	return nil
+}
+
+func portSliceMerge(dst, src reflect.Value) error {
+	if !dst.CanSet() {
 		return nil
+	}
+
+	srcSlice := src.Interface().([]ContainerPort)
+	dstSlice := dst.Interface().([]ContainerPort)
+
+	// Not allocation the map if nothing to do
+	if len(srcSlice) == 0 || len(dstSlice) == 0 {
+		return nil
+	}
+
+	mergeMap := make(map[string]ContainerPort, len(srcSlice)+len(dstSlice))
+	for _, port := range dstSlice {
+		mergeContainerPort(mergeMap, port)
+	}
+
+	for _, port := range srcSlice {
+		mergeContainerPort(mergeMap, port)
+	}
+
+	dstSlice = make([]ContainerPort, 0, len(mergeMap))
+	for _, port := range mergeMap {
+		dstSlice = append(dstSlice, port)
+	}
+	dst.Set(reflect.ValueOf(dstSlice))
+
+	return nil
+}
+
+func mergeContainerPort(mergeMap map[string]ContainerPort, port ContainerPort) {
+	portKey := strconv.Itoa(port.Port) + port.Protocol
+	existingPort, found := mergeMap[portKey]
+
+	if found {
+		if existingPort.Name == "" && port.Name != "" {
+			mergeMap[portKey] = port
+		}
+	} else {
+		mergeMap[portKey] = port
 	}
 }
 
 func merge(dst, src interface{}) error {
-	return mergo.Merge(dst, src, mergo.WithTransformers(timeMergerInstance))
+	return mergo.Merge(dst, src, mergo.WithAppendSlice, mergo.WithTransformers(mergerInstance))
 }

--- a/pkg/workloadmeta/merge_test.go
+++ b/pkg/workloadmeta/merge_test.go
@@ -13,10 +13,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestMerge(t *testing.T) {
-	testTime := time.Now()
-
-	fromSource1 := Container{
+func container1(testTime time.Time) Container {
+	return Container{
 		EntityID: EntityID{
 			Kind: KindContainer,
 			ID:   "foo1",
@@ -24,6 +22,20 @@ func TestMerge(t *testing.T) {
 		EntityMeta: EntityMeta{
 			Name:      "foo1-name",
 			Namespace: "",
+		},
+		Ports: []ContainerPort{
+			{
+				Name:     "port1",
+				Port:     42000,
+				Protocol: "tcp",
+			},
+			{
+				Port:     42001,
+				Protocol: "udp",
+			},
+			{
+				Port: 42002,
+			},
 		},
 		State: ContainerState{
 			Running:    true,
@@ -31,9 +43,12 @@ func TestMerge(t *testing.T) {
 			StartedAt:  testTime,
 			FinishedAt: time.Time{},
 		},
+		CollectorTags: []string{"tag1", "tag2"},
 	}
+}
 
-	fromSource2 := Container{
+func container2(testTime time.Time) Container {
+	return Container{
 		EntityID: EntityID{
 			Kind: KindContainer,
 			ID:   "foo1",
@@ -42,13 +57,35 @@ func TestMerge(t *testing.T) {
 			Name:      "foo1-name",
 			Namespace: "",
 		},
+		Ports: []ContainerPort{
+			{
+				Port:     42000,
+				Protocol: "tcp",
+			},
+			{
+				Port:     42001,
+				Protocol: "udp",
+			},
+			{
+				Port:     42002,
+				Protocol: "tcp",
+			},
+			{
+				Port: 42003,
+			},
+		},
 		State: ContainerState{
 			CreatedAt:  time.Time{},
 			StartedAt:  time.Time{},
 			FinishedAt: time.Time{},
 			ExitCode:   pointer.UInt32Ptr(100),
 		},
+		CollectorTags: []string{"tag3"},
 	}
+}
+
+func TestMerge(t *testing.T) {
+	testTime := time.Now()
 
 	expectedContainer := Container{
 		EntityID: EntityID{
@@ -68,12 +105,63 @@ func TestMerge(t *testing.T) {
 		},
 	}
 
+	expectedPorts := []ContainerPort{
+		{
+			Name:     "port1",
+			Port:     42000,
+			Protocol: "tcp",
+		},
+		{
+			Port:     42001,
+			Protocol: "udp",
+		},
+		{
+			Port: 42002,
+		},
+		{
+			Port:     42002,
+			Protocol: "tcp",
+		},
+		{
+			Port: 42003,
+		},
+	}
+
+	expectedTags := []string{"tag1", "tag2", "tag3"}
+
 	// Test merging both ways
+	fromSource1 := container1(testTime)
+	fromSource2 := container2(testTime)
 	err := merge(&fromSource1, &fromSource2)
 	assert.NoError(t, err)
+	assert.ElementsMatch(t, expectedPorts, fromSource1.Ports)
+	assert.ElementsMatch(t, expectedTags, fromSource1.CollectorTags)
+	fromSource1.Ports = nil
+	fromSource1.CollectorTags = nil
 	assert.Equal(t, expectedContainer, fromSource1)
 
+	fromSource1 = container1(testTime)
+	fromSource2 = container2(testTime)
 	err = merge(&fromSource2, &fromSource1)
 	assert.NoError(t, err)
+	assert.ElementsMatch(t, expectedPorts, fromSource2.Ports)
+	assert.ElementsMatch(t, expectedTags, fromSource2.CollectorTags)
+	fromSource2.Ports = nil
+	fromSource2.CollectorTags = nil
 	assert.Equal(t, expectedContainer, fromSource2)
+
+	// Test merging nil slice in src/dst
+	fromSource1 = container1(testTime)
+	fromSource2 = container2(testTime)
+	fromSource2.Ports = nil
+	err = merge(&fromSource1, &fromSource2)
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, container1(testTime).Ports, fromSource1.Ports)
+
+	fromSource1 = container1(testTime)
+	fromSource2 = container2(testTime)
+	fromSource2.Ports = nil
+	err = merge(&fromSource2, &fromSource1)
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, container1(testTime).Ports, fromSource2.Ports)
 }

--- a/releasenotes/notes/fix-ad-port-name-872d0839b789a1f8.yaml
+++ b/releasenotes/notes/fix-ad-port-name-872d0839b789a1f8.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix a bug introduced in 7.33 that could prevent autodiscovery variable %%port_<name>%% to not be resolved properly.


### PR DESCRIPTION
### What does this PR do?

Fix AD port name interpolation by properly merging slices in workloadmeta.
Depending on the merging order (e.g. collector name), the port name (later used in autodiscovery) might be overridden.
Notably it happens when the port is reported by Docker collector and Kubelet collector.

### Motivation

Bugfix.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Deploy the Agent on Kubernetes with Docker.
Deploy a target component with a port exposed in the Dockerfile (like [nginx][https://github.com/DataDog/k8s-testing-resources/blob/master/nginx/nginx-ad-deployment.yml]).
Make sure to give a port name to the `80` and `81` ports in your deployment:
```
ports:
  - name: http
     containerPort: 80
     protocol: TCP
  - name: status
     containerPort: 81
     protocol: TCP
```

Reference these ports in the AD annotation using `%%port_http%%` instead of `80`

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
