### PR TITLE
Make DEB packages depend on datadog-signing-keys >= 1.1.0

### DIFF
--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -53,7 +53,7 @@ else
   end
 
   if debian?
-    runtime_recommended_dependency 'datadog-signing-keys'
+    runtime_recommended_dependency 'datadog-signing-keys (>= 1.1.0)'
   end
 
   if osx?

--- a/omnibus/config/projects/dogstatsd.rb
+++ b/omnibus/config/projects/dogstatsd.rb
@@ -44,7 +44,7 @@ else
   end
 
   if debian?
-    runtime_recommended_dependency 'datadog-signing-keys'
+    runtime_recommended_dependency 'datadog-signing-keys (>= 1.1.0)'
   end
 end
 

--- a/omnibus/config/projects/iot-agent.rb
+++ b/omnibus/config/projects/iot-agent.rb
@@ -46,7 +46,7 @@ else
   end
 
   if debian?
-    runtime_recommended_dependency 'datadog-signing-keys'
+    runtime_recommended_dependency 'datadog-signing-keys (>= 1.1.0)'
   end
 end
 

--- a/releasenotes/notes/signing-keys-1.1.0-ba7238dad735d1b2.yaml
+++ b/releasenotes/notes/signing-keys-1.1.0-ba7238dad735d1b2.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The datadog-agent, datadog-iot-agent and datadog-dogstatsd deb packages
+    now have versioned weak dependency on the datadog-signing-keys package
+    version 1.1.0, instead of unversioned weak dependency.

--- a/releasenotes/notes/signing-keys-1.1.0-ba7238dad735d1b2.yaml
+++ b/releasenotes/notes/signing-keys-1.1.0-ba7238dad735d1b2.yaml
@@ -9,5 +9,5 @@
 enhancements:
   - |
     The datadog-agent, datadog-iot-agent and datadog-dogstatsd deb packages
-    now have versioned weak dependency on the datadog-signing-keys package
-    version 1.1.0, instead of unversioned weak dependency.
+    now have a versioned weak dependency on the datadog-signing-keys package
+    version 1.1.0, instead of an unversioned weak dependency.


### PR DESCRIPTION
### What does this PR do?

Make DEB packages depend on the recently released datadog-signing-keys >= 1.1.0 because of a fix: https://github.com/DataDog/datadog-signing-keys/blob/master/CHANGELOG.md#110--2022-03-22

Backport of https://github.com/DataDog/datadog-agent/pull/11447

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Download the built DEB file and test following scenarios:
* On a system with datadog-signing-keys not installed, running `dpkg -i ./datadog-agent_<...>.deb` installs agent correctly.
* On a system with datadog-signing-keys not installed and a datadog source list file not configured, running `apt install ./datadog-agent_<...>.deb` installs agent correctly.
* On a system with earlier datadog-signing-keys version (e.g. 1.0.1) and a datadog source list file not configured, running `apt install ./datadog-agent_<...>.deb` installs agent correctly and doesn't touch the datadog-signing-keys package.
* On a system with no datadog-signing-keys package and a datadog source list file configured, running `apt install ./datadog-agent_<...>.deb` installs agent correctly along datadog-signing-keys 1.1.0.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
