### PR TITLE
[CWS] Add IP and CIDR secl types

### DIFF
--- a/docs/cloud-workload-security/agent_expressions.md
+++ b/docs/cloud-workload-security/agent_expressions.md
@@ -150,12 +150,14 @@ The *file.rights* attribute can now be used in addition to *file.mode*. *file.mo
 | -------- | ---- | ---------- |
 | `container.id` | string | ID of the container |
 | `container.tags` | string | Tags of the container |
+| `network.destination.ip` | net.IP | IP address |
 | `network.destination.port` | int | Port number |
 | `network.device.ifindex` | int | interface ifindex |
 | `network.device.ifname` | string | interface ifname |
 | `network.l3_protocol` | int | l3 protocol of the network packet |
 | `network.l4_protocol` | int | l4 protocol of the network packet |
 | `network.size` | int | size in bytes of the network packet |
+| `network.source.ip` | net.IP | IP address |
 | `network.source.port` | int | Port number |
 | `process.ancestors.args` | string | Arguments of the process (as a string) |
 | `process.ancestors.args_flags` | string | Arguments of the process (as an array) |

--- a/docs/cloud-workload-security/secl.json
+++ b/docs/cloud-workload-security/secl.json
@@ -18,6 +18,11 @@
           "definition": "Tags of the container"
         },
         {
+          "name": "network.destination.ip",
+          "type": "net.IP",
+          "definition": "IP address"
+        },
+        {
           "name": "network.destination.port",
           "type": "int",
           "definition": "Port number"
@@ -46,6 +51,11 @@
           "name": "network.size",
           "type": "int",
           "definition": "size in bytes of the network packet"
+        },
+        {
+          "name": "network.source.ip",
+          "type": "net.IP",
+          "definition": "IP address"
         },
         {
           "name": "network.source.port",

--- a/go.mod
+++ b/go.mod
@@ -416,6 +416,10 @@ require (
 	google.golang.org/grpc/credentials/insecure v0.0.0 // indirect
 )
 
+require github.com/docker/libnetwork v0.5.6
+
+require github.com/Sirupsen/logrus v1.0.6 // indirect
+
 // Fixing a CVE on a transitive dep of k8s/etcd, should be cleaned-up once k8s.io/apiserver dep is removed (but double-check with `go mod why` that no other dep pulls it)
 replace github.com/dgrijalva/jwt-go => github.com/golang-jwt/jwt v3.2.1+incompatible
 

--- a/go.sum
+++ b/go.sum
@@ -211,6 +211,8 @@ github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/Shopify/sarama v1.22.0/go.mod h1:lm3THZ8reqBDBQKQyb5HB3sY1lKp3grEbQ81aWSgPp4=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
+github.com/Sirupsen/logrus v1.0.6 h1:HCAGQRk48dRVPA5Y+Yh0qdCSTzPOyU1tBJ7Q9YzotII=
+github.com/Sirupsen/logrus v1.0.6/go.mod h1:rmk17hk6i8ZSAJkSDa7nOxamrG+SP4P0mm+DAvExv4U=
 github.com/StackExchange/wmi v0.0.0-20181212234831-e0a55b97c705/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
@@ -518,6 +520,8 @@ github.com/docker/go-metrics v0.0.1/go.mod h1:cG1hvH2utMXtqgqqYE9plW6lDxS3/5ayHz
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/docker/libnetwork v0.5.6 h1:hnGiypBsZR6PW1I8lqaBHh06U6LCJbI3IhOvfsZiymY=
+github.com/docker/libnetwork v0.5.6/go.mod h1:93m0aTqz6z+g32wla4l4WxTrdtvBRmVzYRkYvasA5Z8=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dsnet/compress v0.0.1/go.mod h1:Aw8dCMJ7RioblQeTqt88akK31OvO8Dhf5JflhBbQEHo=
@@ -2486,6 +2490,7 @@ gopkg.in/DataDog/dd-trace-go.v1 v1.37.0 h1:V485ujNZdVc9pBQgpalgSpTRlr3PdxcX5v60Y
 gopkg.in/DataDog/dd-trace-go.v1 v1.37.0/go.mod h1:HMpV5TQ38YAfRJ8OlM7UfLyGg6D01MPNHRFwsnrGMB0=
 gopkg.in/Knetic/govaluate.v3 v3.0.0 h1:18mUyIt4ZlRlFZAAfVetz4/rzlJs9yhN+U02F4u1AOc=
 gopkg.in/Knetic/govaluate.v3 v3.0.0/go.mod h1:csKLBORsPbafmSCGTEh3U7Ozmsuq8ZSIlKk1bcqph0E=
+gopkg.in/airbrake/gobrake.v2 v2.0.9 h1:7z2uVWwn7oVeeugY1DtlPAy5H+KYgB1KeKTnqjNatLo=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d/go.mod h1:cuepJuh7vyXfUyUwEgHQXw849cJrilpS5NeIjOWESAw=
@@ -2499,6 +2504,7 @@ gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qS
 gopkg.in/cheggaaa/pb.v1 v1.0.28/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
+gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2 h1:OAj3g0cR6Dx/R07QgQe8wkA9RNjB2u4i700xBkIT4e0=
 gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKWaSkCsqBpgog8nAV2xsGOxlo=
 gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8bDuhia5mkpMnE=
 gopkg.in/go-playground/validator.v8 v8.18.2/go.mod h1:RX2a/7Ha8BgOhfk7j780h4/u/RRjR0eouCJSH80/M2Y=

--- a/pkg/security/probe/accessors.go
+++ b/pkg/security/probe/accessors.go
@@ -21779,6 +21779,8 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.NetworkContext.Destination.IP = v
 
+		return nil
+
 	case "network.destination.port":
 
 		var ok bool
@@ -21853,6 +21855,8 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "NetworkContext.Source.IP"}
 		}
 		e.NetworkContext.Source.IP = v
+
+		return nil
 
 	case "network.source.port":
 

--- a/pkg/security/probe/accessors.go
+++ b/pkg/security/probe/accessors.go
@@ -6,6 +6,7 @@
 package probe
 
 import (
+	"net"
 	"reflect"
 	"unsafe"
 
@@ -1918,6 +1919,15 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
+	case "network.destination.ip":
+		return &eval.CIDREvaluator{
+			EvalFnc: func(ctx *eval.Context) *eval.FieldValue {
+				return eval.NewIPFieldValue((*Event)(ctx.Object).NetworkContext.Destination.IP, nil)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
 	case "network.destination.port":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -1973,6 +1983,15 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) int {
 
 				return int((*Event)(ctx.Object).NetworkContext.Size)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "network.source.ip":
+		return &eval.CIDREvaluator{
+			EvalFnc: func(ctx *eval.Context) *eval.FieldValue {
+				return eval.NewIPFieldValue((*Event)(ctx.Object).NetworkContext.Source.IP, nil)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -9545,6 +9564,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"mprotect.vm_protection",
 
+		"network.destination.ip",
+
 		"network.destination.port",
 
 		"network.device.ifindex",
@@ -9556,6 +9577,8 @@ func (e *Event) GetFields() []eval.Field {
 		"network.l4_protocol",
 
 		"network.size",
+
+		"network.source.ip",
 
 		"network.source.port",
 
@@ -11166,6 +11189,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.MProtect.VMProtection, nil
 
+	case "network.destination.ip":
+
+		return e.NetworkContext.Destination.IP, nil
+
 	case "network.destination.port":
 
 		return int(e.NetworkContext.Destination.Port), nil
@@ -11189,6 +11216,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "network.size":
 
 		return int(e.NetworkContext.Size), nil
+
+	case "network.source.ip":
+
+		return e.NetworkContext.Source.IP, nil
 
 	case "network.source.port":
 
@@ -15918,6 +15949,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "mprotect.vm_protection":
 		return "mprotect", nil
 
+	case "network.destination.ip":
+		return "*", nil
+
 	case "network.destination.port":
 		return "*", nil
 
@@ -15934,6 +15968,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "*", nil
 
 	case "network.size":
+		return "*", nil
+
+	case "network.source.ip":
 		return "*", nil
 
 	case "network.source.port":
@@ -17980,6 +18017,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
+	case "network.destination.ip":
+
+		return reflect.Struct, nil
+
 	case "network.destination.port":
 
 		return reflect.Int, nil
@@ -18003,6 +18044,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "network.size":
 
 		return reflect.Int, nil
+
+	case "network.source.ip":
+
+		return reflect.Struct, nil
 
 	case "network.source.port":
 
@@ -21725,6 +21770,15 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "network.destination.ip":
+
+		var ok bool
+		v, ok := value.(net.IP)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "NetworkContext.Destination.IP"}
+		}
+		e.NetworkContext.Destination.IP = v
+
 	case "network.destination.port":
 
 		var ok bool
@@ -21790,6 +21844,15 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.NetworkContext.Size = uint32(v)
 
 		return nil
+
+	case "network.source.ip":
+
+		var ok bool
+		v, ok := value.(net.IP)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "NetworkContext.Source.IP"}
+		}
+		e.NetworkContext.Source.IP = v
 
 	case "network.source.port":
 

--- a/pkg/security/probe/model_test.go
+++ b/pkg/security/probe/model_test.go
@@ -9,6 +9,7 @@
 package probe
 
 import (
+	"net"
 	"reflect"
 	"sort"
 	"testing"
@@ -38,8 +39,15 @@ func TestSetFieldValue(t *testing.T) {
 			if err = event.SetFieldValue(field, true); err != nil {
 				t.Error(err)
 			}
+		case reflect.Struct:
+			switch field {
+			case "network.destination.ip", "network.source.ip":
+				if err = event.SetFieldValue(field, net.ParseIP("127.0.0.1")); err != nil {
+					t.Error(err)
+				}
+			}
 		default:
-			t.Errorf("type unknown: %v", kind)
+			t.Errorf("type of field %s unknown: %v", field, kind)
 		}
 	}
 }

--- a/pkg/security/secl/compiler/ast/secl.go
+++ b/pkg/security/secl/compiler/ast/secl.go
@@ -18,6 +18,8 @@ import (
 var (
 	seclLexer = lexer.Must(ebnf.New(`
 Comment = ("#" | "//") { "\u0000"…"\uffff"-"\n" } .
+CIDR = IP "/" digit { digit } .
+IP = (ipv4 | ipv6) .
 Variable = "${" (alpha | "_") { "_" | alpha | digit | "." } "}" .
 Duration = digit { digit } ("ms" | "s" | "m" | "h" | "d") .
 Regexp = "r\"" { "\u0000"…"\uffff"-"\""-"\\" | "\\" any } "\"" .
@@ -27,6 +29,9 @@ Pattern = "~\"" { "\u0000"…"\uffff"-"\""-"\\" | "\\" any } "\"" .
 Int = [ "-" | "+" ] digit { digit } .
 Punct = "!"…"/" | ":"…"@" | "["…` + "\"`\"" + ` | "{"…"~" .
 Whitespace = ( " " | "\t" | "\n" ) { " " | "\t" | "\n" } .
+ipv4 = (digit { digit } "." digit { digit } "." digit { digit } "." digit { digit }) .
+ipv6 = ( [hex { hex }] ":" [hex { hex }] ":" [hex { hex }] [":" | "."] [hex { hex }] [":" | "."] [hex { hex }] [":" | "."] [hex { hex }] [":" | "."] [hex { hex }] [":" | "."] [hex { hex }]) .
+hex = "a"…"f" | "A"…"F" | "0"…"9" .
 alpha = "a"…"z" | "A"…"Z" .
 digit = "0"…"9" .
 any = "\u0000"…"\uffff" .
@@ -153,7 +158,7 @@ type ScalarComparison struct {
 type ArrayComparison struct {
 	Pos lexer.Position
 
-	Op    *string `parser:"( @( \"in\" | \"not\" \"in\" )"`
+	Op    *string `parser:"( @( \"in\" | \"not\" \"in\" | \"intersects\" )"`
 	Array *Array  `parser:"@@ )"`
 }
 
@@ -181,6 +186,8 @@ type Primary struct {
 	Pos lexer.Position
 
 	Ident         *string     `parser:"@Ident"`
+	CIDR          *string     `parser:"| @CIDR"`
+	IP            *string     `parser:"| @IP"`
 	Number        *int        `parser:"| @Int"`
 	Variable      *string     `parser:"| @Variable"`
 	String        *string     `parser:"| @String"`
@@ -199,12 +206,22 @@ type StringMember struct {
 	Regexp  *string `parser:"| @Regexp"`
 }
 
+// CIDRMember describes a CIDR based array member
+type CIDRMember struct {
+	Pos lexer.Position
+
+	IP   *string `parser:"@IP"`
+	CIDR *string `parser:"| @CIDR"`
+}
+
 // Array describes an array of values
 type Array struct {
 	Pos lexer.Position
 
-	StringMembers []StringMember `parser:"\"[\" @@ { \",\" @@ } \"]\""`
-	Numbers       []int          `parser:"| \"[\" @Int { \",\" @Int } \"]\""`
+	CIDR          *string        `parser:"@CIDR"`
 	Variable      *string        `parser:"| @Variable"`
 	Ident         *string        `parser:"| @Ident"`
+	StringMembers []StringMember `parser:"| \"[\" @@ { \",\" @@ } \"]\""`
+	CIDRMembers   []CIDRMember   `parser:"| \"[\" @@ { \",\" @@ } \"]\""`
+	Numbers       []int          `parser:"| \"[\" @Int { \",\" @Int } \"]\""`
 }

--- a/pkg/security/secl/compiler/ast/secl_test.go
+++ b/pkg/security/secl/compiler/ast/secl_test.go
@@ -222,3 +222,111 @@ func TestNumberVariable(t *testing.T) {
 
 	print(t, rule)
 }
+
+func TestIPv4(t *testing.T) {
+	rule, err := ParseRule(`network.source.ip == 127.0.0.1`)
+	if err != nil {
+		t.Error(err)
+	}
+
+	print(t, rule)
+}
+
+func TestIPv4Raw(t *testing.T) {
+	rule, err := ParseRule(`127.0.0.2 == 127.0.0.1`)
+	if err != nil {
+		t.Error(err)
+	}
+
+	print(t, rule)
+}
+
+func TestIPv6Localhost(t *testing.T) {
+	rule, err := ParseRule(`network.source.ip == ::1`)
+	if err != nil {
+		t.Error(err)
+	}
+
+	print(t, rule)
+}
+
+func TestIPv6(t *testing.T) {
+	rule, err := ParseRule(`network.source.ip == 2001:0000:0eab:DEAD:0000:00A0:ABCD:004E`)
+	if err != nil {
+		t.Error(err)
+	}
+
+	print(t, rule)
+}
+
+func TestIPv6Short(t *testing.T) {
+	rule, err := ParseRule(`network.source.ip == 2001:0:0eab:dead::a0:abcd:4e`)
+	if err != nil {
+		t.Error(err)
+	}
+
+	print(t, rule)
+}
+
+func TestIPList(t *testing.T) {
+	rule, err := ParseRule(`network.source.ip in [ ::1, 2001:0:0eab:dead::a0:abcd:4e, 127.0.0.1 ]`)
+	if err != nil {
+		t.Error(err)
+	}
+
+	print(t, rule)
+}
+
+func TestIPv4CIDR(t *testing.T) {
+	rule, err := ParseRule(`network.source.ip in 192.168.0.0/24`)
+	if err != nil {
+		t.Error(err)
+	}
+
+	print(t, rule)
+}
+
+func TestIPv6CIDR(t *testing.T) {
+	rule, err := ParseRule(`network.source.ip in ::1/128`)
+	if err != nil {
+		t.Error(err)
+	}
+
+	print(t, rule)
+}
+
+func TestCIDRList(t *testing.T) {
+	rule, err := ParseRule(`network.source.ip in [ ::1/128, 2001:0:0eab:dead::a0:abcd:4e/24, 127.0.0.1/32 ]`)
+	if err != nil {
+		t.Error(err)
+	}
+
+	print(t, rule)
+}
+
+func TestIPAndCIDRList(t *testing.T) {
+	rule, err := ParseRule(`network.source.ip in [ ::1, 2001:0:0eab:dead::a0:abcd:4e, 127.0.0.1, ::1/128, 2001:0:0eab:dead::a0:abcd:4e/24, 127.0.0.1/32 ]`)
+	if err != nil {
+		t.Error(err)
+	}
+
+	print(t, rule)
+}
+
+func TestCIDRMatches(t *testing.T) {
+	rule, err := ParseRule(`network.source.cidr intersects 192.168.0.0/24`)
+	if err != nil {
+		t.Error(err)
+	}
+
+	print(t, rule)
+}
+
+func TestCIDRListMatches(t *testing.T) {
+	rule, err := ParseRule(`network.source.cidr intersects [ 192.168.0.0/24, ::1/128 ]`)
+	if err != nil {
+		t.Error(err)
+	}
+
+	print(t, rule)
+}

--- a/pkg/security/secl/compiler/eval/cidr.go
+++ b/pkg/security/secl/compiler/eval/cidr.go
@@ -188,8 +188,7 @@ func (sipm *SingleIPMatcher) Matches(value IPMatcher) bool {
 
 // CIDRMatcher defines an IPv4/IPv6 CIDR
 type CIDRMatcher struct {
-	net    *net.IPNet
-	lastIP net.IP
+	net *net.IPNet
 }
 
 func (cm *CIDRMatcher) String() string {

--- a/pkg/security/secl/compiler/eval/cidr.go
+++ b/pkg/security/secl/compiler/eval/cidr.go
@@ -1,0 +1,262 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package eval
+
+import (
+	"fmt"
+	"net"
+)
+
+// CIDRValues describes a set of CIDRs, either simple IPs or CIDR
+type CIDRValues struct {
+	matchers []IPMatcher
+
+	// caches
+	fieldValues []FieldValue
+
+	exists map[interface{}]bool
+}
+
+// NewCIDRValues returns a new CIDRValues
+func NewCIDRValues(ips []net.IP, cidrs []*net.IPNet) *CIDRValues {
+	var values CIDRValues
+	for _, ip := range ips {
+		values.AppendIP(ip)
+	}
+	for _, cidr := range cidrs {
+		values.AppendCIDR(cidr)
+	}
+	return &values
+}
+
+// AppendFieldValue append a FieldValue
+func (s *CIDRValues) AppendFieldValue(value FieldValue) error {
+	if s.exists == nil {
+		s.exists = make(map[interface{}]bool)
+	}
+	if s.exists[value.Value] {
+		return nil
+	}
+	s.exists[value.Value] = true
+
+	switch value.Type {
+	case IPValueType, CIDRValueType:
+		if err := value.Compile(); err != nil {
+			return err
+		}
+		s.matchers = append(s.matchers, value.IPMatcher)
+	default:
+		return fmt.Errorf("unknown value type `%v`", value.Type)
+	}
+	s.fieldValues = append(s.fieldValues, value)
+
+	return nil
+}
+
+// AppendIP appends an IP
+func (s *CIDRValues) AppendIP(ip net.IP) {
+	fieldValue := FieldValue{
+		Type: IPValueType,
+		IPMatcher: &SingleIPMatcher{
+			ip: ip,
+		},
+	}
+	s.matchers = append(s.matchers, fieldValue.IPMatcher)
+	s.fieldValues = append(s.fieldValues, fieldValue)
+}
+
+// AppendCIDR appends a CIDR
+func (s *CIDRValues) AppendCIDR(cidr *net.IPNet) {
+	fieldValue := FieldValue{
+		Type: CIDRValueType,
+		IPMatcher: &CIDRMatcher{
+			net: cidr,
+		},
+	}
+	s.matchers = append(s.matchers, fieldValue.IPMatcher)
+	s.fieldValues = append(s.fieldValues, fieldValue)
+}
+
+// GetMatchers return the matchers
+func (s *CIDRValues) GetMatchers() []IPMatcher {
+	return s.matchers
+}
+
+// GetFieldValues returns the list of FieldValues stored in the current CIDRValues
+func (s *CIDRValues) GetFieldValues() []FieldValue {
+	return s.fieldValues
+}
+
+// SetFieldValues apply field values
+func (s *CIDRValues) SetFieldValues(values ...FieldValue) error {
+	// reset internal caches
+	s.matchers = s.matchers[:0]
+	s.exists = nil
+
+	for _, value := range values {
+		if err := s.AppendFieldValue(value); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Matches returns whether the value matches the provided IPMatcher
+func (s *CIDRValues) Matches(value IPMatcher) bool {
+	for _, pm := range s.matchers {
+		if pm.Matches(value) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// MatchesAll returns true if value matches all CIDRValues entries
+func (s *CIDRValues) MatchesAll(value IPMatcher) bool {
+	for _, pm := range s.matchers {
+		if !pm.Matches(value) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// IPMatcher defines an IP matcher
+type IPMatcher interface {
+	Compile(pattern string) error
+	IPMatches(value net.IP) bool
+	Matches(value IPMatcher) bool
+	GetType() FieldValueType
+	String() string
+}
+
+// SingleIPMatcher defines an IPv4/IPv6 matcher
+type SingleIPMatcher struct {
+	ip net.IP
+}
+
+func (sipm *SingleIPMatcher) String() string {
+	return sipm.ip.String()
+}
+
+// Compile the string representation of an IP to a net.IP
+func (sipm *SingleIPMatcher) Compile(pattern string) error {
+	if sipm.ip != nil {
+		return nil
+	}
+
+	ip := net.ParseIP(pattern)
+	if ip == nil {
+		return fmt.Errorf("invalid textual representation of an IP address")
+	}
+	sipm.ip = ip
+
+	return nil
+}
+
+// GetType returns the FieldValueType of the IPMatcher
+func (sipm *SingleIPMatcher) GetType() FieldValueType {
+	return IPValueType
+}
+
+// IPMatches returns true the value matches
+func (sipm *SingleIPMatcher) IPMatches(value net.IP) bool {
+	return sipm.ip.Equal(value)
+}
+
+// Matches matches with an IPMatcher
+func (sipm *SingleIPMatcher) Matches(value IPMatcher) bool {
+	switch value.GetType() {
+	case IPValueType:
+		ipMatcher, ok := value.(*SingleIPMatcher)
+		if ok {
+			return sipm.IPMatches(ipMatcher.ip)
+		}
+		return false
+	case CIDRValueType:
+		return value.IPMatches(sipm.ip)
+	default:
+		return false
+	}
+}
+
+// CIDRMatcher defines an IPv4/IPv6 CIDR
+type CIDRMatcher struct {
+	net    *net.IPNet
+	lastIP net.IP
+}
+
+func (cm *CIDRMatcher) String() string {
+	return cm.net.String()
+}
+
+// Compile the string representation of a CIDR to a net.IPNet
+func (cm *CIDRMatcher) Compile(pattern string) error {
+	if cm.net != nil {
+		return nil
+	}
+
+	_, ipNet, err := net.ParseCIDR(pattern)
+	if err != nil {
+		return fmt.Errorf("invalid textual representation of a CIDR: %v", err)
+	}
+	cm.net = ipNet
+
+	return nil
+}
+
+// GetType returns the FieldValueType of the IPMatcher
+func (cm *CIDRMatcher) GetType() FieldValueType {
+	return CIDRValueType
+}
+
+// IPMatches returns wether the value matches
+func (cm *CIDRMatcher) IPMatches(value net.IP) bool {
+	return cm.net.Contains(value)
+}
+
+// Matches matches with an IPMatcher
+func (cm *CIDRMatcher) Matches(value IPMatcher) bool {
+	switch value.GetType() {
+	case IPValueType:
+		sipm, ok := value.(*SingleIPMatcher)
+		if ok {
+			return cm.IPMatches(sipm.ip)
+		}
+		return false
+	case CIDRValueType:
+		cidrMatcher, ok := value.(*CIDRMatcher)
+		if ok {
+			return cidrMatcher.IPMatches(cm.net.IP) || cm.IPMatches(cidrMatcher.net.IP)
+		}
+		return false
+	default:
+		return false
+	}
+}
+
+// NewIPMatcher returns a new IP matcher
+func NewIPMatcher(kind FieldValueType, pattern string) (IPMatcher, error) {
+	switch kind {
+	case IPValueType:
+		var matcher SingleIPMatcher
+		if err := matcher.Compile(pattern); err != nil {
+			return nil, fmt.Errorf("invalid IP `%s`: %s", pattern, err)
+		}
+		return &matcher, nil
+	case CIDRValueType:
+		var matcher CIDRMatcher
+		if err := matcher.Compile(pattern); err != nil {
+			return nil, fmt.Errorf("invalid CIDR `%s`: %s", pattern, err)
+		}
+		return &matcher, nil
+	}
+
+	return nil, fmt.Errorf("unknown type")
+}

--- a/pkg/security/secl/compiler/eval/errors.go
+++ b/pkg/security/secl/compiler/eval/errors.go
@@ -65,6 +65,11 @@ func NewArrayTypeError(pos lexer.Position, arrayKind reflect.Kind, kind reflect.
 	return NewError(pos, fmt.Sprintf("%s of %s expected", arrayKind, kind))
 }
 
+// NewCIDRTypeError returns a new ErrAstToEval error when an invalid type was used
+func NewCIDRTypeError(pos lexer.Position, arrayKind reflect.Kind, kind interface{}) *ErrAstToEval {
+	return NewError(pos, fmt.Sprintf("%s of %s expected", arrayKind, reflect.TypeOf(kind)))
+}
+
 // NewOpUnknownError returns a new ErrAstToEval error when an unknown operator was used
 func NewOpUnknownError(pos lexer.Position, op string) *ErrAstToEval {
 	return NewError(pos, fmt.Sprintf("operator `%s` unknown", op))

--- a/pkg/security/secl/compiler/eval/eval_test.go
+++ b/pkg/security/secl/compiler/eval/eval_test.go
@@ -8,6 +8,7 @@ package eval
 import (
 	"container/list"
 	"fmt"
+	"net"
 	"os"
 	"runtime"
 	"strings"
@@ -1026,6 +1027,157 @@ func TestDuration(t *testing.T) {
 
 		if result != test.Expected {
 			t.Errorf("expected result `%t` not found, got `%t`\nnow: %v, create_at: %v\n%s", test.Expected, result, time.Now().UnixNano(), event.process.createdAt, test.Expr)
+		}
+	}
+}
+
+func TestIPv4(t *testing.T) {
+	_, cidr, _ := net.ParseCIDR("192.168.0.1/24")
+	var cidrs []*net.IPNet
+	for _, cidrStr := range []string{"192.168.0.1/24", "10.0.0.1/16"} {
+		_, cidrTmp, _ := net.ParseCIDR(cidrStr)
+		cidrs = append(cidrs, cidrTmp)
+	}
+	event := &testEvent{
+		network: testNetwork{
+			ip:    net.ParseIP("192.168.0.1"),
+			ips:   []net.IP{net.ParseIP("192.168.0.1"), net.ParseIP("192.169.0.1")},
+			cidr:  cidr,
+			cidrs: cidrs,
+		},
+	}
+
+	tests := []struct {
+		Expr     string
+		Expected bool
+	}{
+		{Expr: `192.168.0.1 == 192.168.0.1`, Expected: true},
+		{Expr: `192.168.0.1 == 192.168.0.2`, Expected: false},
+		{Expr: `192.168.0.15 in 192.168.0.1/24`, Expected: true},
+		{Expr: `192.168.0.16 not in 192.168.1.1/24`, Expected: true},
+		{Expr: `192.168.0.16/16 in 192.168.1.1/8`, Expected: true},
+		{Expr: `192.168.0.16/16 intersects 192.168.1.1/8`, Expected: true},
+		{Expr: `193.168.0.16/16 in 192.168.1.1/8`, Expected: false},
+		{Expr: `network.ip == 192.168.0.1`, Expected: true},
+		{Expr: `network.ip == 127.0.0.1`, Expected: false},
+		{Expr: `network.ip == ::ffff:192.168.0.1`, Expected: true},
+		{Expr: `network.ip == ::ffff:127.0.0.1`, Expected: false},
+		{Expr: `network.ip in 192.168.0.1/32`, Expected: true},
+		{Expr: `network.ip in 0.0.0.0/0`, Expected: true},
+		{Expr: `network.ip in ::1/0`, Expected: false},
+		{Expr: `network.ip in 192.168.4.0/16`, Expected: true},
+		{Expr: `network.ip in 192.168.4.0/24`, Expected: false},
+		{Expr: `network.ip not in 192.168.4.0/16`, Expected: false},
+		{Expr: `network.ip not in 192.168.4.0/24`, Expected: true},
+		{Expr: `network.ip in ::ffff:192.168.4.0/112`, Expected: true},
+		{Expr: `network.ip in ::ffff:192.168.4.0/120`, Expected: false},
+		{Expr: `network.ip in [ 127.0.0.1, 192.168.0.1, 10.0.0.1 ]`, Expected: true},
+		{Expr: `network.ip in [ 127.0.0.1, 10.0.0.1 ]`, Expected: false},
+		{Expr: `network.ip in [ 192.168.4.1/16, 10.0.0.1/32 ]`, Expected: true},
+		{Expr: `network.ip in [ 10.0.0.1, 127.0.0.1, 192.169.4.1/16 ]`, Expected: false},
+		{Expr: `network.ip in [ 10.0.0.1, 127.0.0.1, 192.169.4.1/16, ::ffff:192.168.0.1/128 ]`, Expected: true},
+		{Expr: `192.168.0.1 in [ 10.0.0.1, 127.0.0.1, 192.169.4.1/16, ::ffff:192.168.0.1/128 ]`, Expected: true},
+		{Expr: `192.168.0.1/24 in [ 10.0.0.1, 127.0.0.1, 192.169.4.1/16, ::ffff:192.168.0.1/120 ]`, Expected: true},
+		{Expr: `192.168.0.1/24 intersects [ 10.0.0.1, 127.0.0.1, 192.169.4.1/16, ::ffff:192.168.0.1/120 ]`, Expected: false},
+
+		{Expr: `network.ips in 192.168.0.0/16`, Expected: true},
+		{Expr: `network.ips not in 192.168.0.0/16`, Expected: false},
+		{Expr: `network.ips intersects 192.168.0.0/16`, Expected: false},
+		{Expr: `network.ips intersects 192.168.0.0/8`, Expected: true},
+		{Expr: `network.ips in [ 192.168.0.0/32, 193.168.0.0/16, ::ffff:192.168.0.1 ]`, Expected: true},
+		{Expr: `network.ips not in [ 192.168.0.0/32, 193.168.0.0/16 ]`, Expected: true},
+		{Expr: `network.ips intersects [ 192.168.0.0/8, 0.0.0.0/0 ]`, Expected: true},
+		{Expr: `network.ips intersects [ 192.168.0.0/8, 1.0.0.0/8 ]`, Expected: false},
+		{Expr: `network.ips intersects [ 192.168.0.0/8, 1.0.0.0/8 ]`, Expected: false},
+		{Expr: `192.0.0.0/8 intersects network.ips`, Expected: true},
+
+		{Expr: `network.cidr in 192.168.0.0/8`, Expected: true},
+		{Expr: `network.cidr in 193.168.0.0/8`, Expected: false},
+		{Expr: `network.cidrs in 10.0.0.1/8`, Expected: true},
+		{Expr: `network.cidrs intersects 10.0.0.1/8`, Expected: false},
+	}
+
+	for _, test := range tests {
+		result, _, err := eval(t, event, test.Expr)
+		if err != nil {
+			t.Fatalf("error while evaluating `%s`: %s", test.Expr, err)
+		}
+
+		if result != test.Expected {
+			t.Errorf("expected result `%v` not found, got `%v`, expression: %s", test.Expected, result, test.Expr)
+		}
+	}
+}
+
+func TestIPv6(t *testing.T) {
+	_, cidr, _ := net.ParseCIDR("2001:0:0eab:dead::a0:abcd:4e/112")
+	var cidrs []*net.IPNet
+	for _, cidrStr := range []string{"2001:0:0eab:dead::a0:abcd:4e/112", "2001:0:0eab:c00f::a0:abcd:4e/64"} {
+		_, cidrTmp, _ := net.ParseCIDR(cidrStr)
+		cidrs = append(cidrs, cidrTmp)
+	}
+	event := &testEvent{
+		network: testNetwork{
+			ip:    net.ParseIP("2001:0:0eab:dead::a0:abcd:4e"),
+			ips:   []net.IP{net.ParseIP("2001:0:0eab:dead::a0:abcd:4e"), net.ParseIP("2001:0:0eab:dead::a0:abce:4e")},
+			cidr:  cidr,
+			cidrs: cidrs,
+		},
+	}
+
+	tests := []struct {
+		Expr     string
+		Expected bool
+	}{
+		{Expr: `2001:0:0eab:dead::a0:abcd:4e == 2001:0:0eab:dead::a0:abcd:4e`, Expected: true},
+		{Expr: `2001:0:0eab:dead::a0:abcd:4e == 2001:0:0eab:dead::a0:abcd:4f`, Expected: false},
+		{Expr: `2001:0:0eab:dead::a0:abcd:4e in 2001:0:0eab:dead::a0:abcd:0/120`, Expected: true},
+		{Expr: `2001:0:0eab:dead::a0:abcd:4e not in 2001:0:0eab:dead::a0:abcd:ab00/120`, Expected: true},
+		{Expr: `2001:0:0eab:dead::a0:abcd:4e/64 in 2001:0:0eab:dead::a0:abcd:1b00/32`, Expected: true},
+		{Expr: `2001:0:0eab:dead::a0:abcd:4e/64 intersects 2001:0:0eab:dead::a0:abcd:1b00/32`, Expected: true},
+		{Expr: `2001:0:0eab:dead::a0:abcd:4e/64 in [ 2001:0:0eab:dead::a0:abcd:1b00/32 ]`, Expected: true},
+		{Expr: `2001:0:0eab:dead::a0:abcd:4e/32 in [ 2001:0:0eab:dead::a0:abcd:1b00/64 ]`, Expected: true},
+		{Expr: `network.ip == 2001:0:0eab:dead::a0:abcd:4e`, Expected: true},
+		{Expr: `network.ip == ::1`, Expected: false},
+		{Expr: `network.ip == 127.0.0.1`, Expected: false},
+		{Expr: `network.ip in 0.0.0.0/0`, Expected: false},
+		{Expr: `network.ip in ::1/0`, Expected: true},
+		{Expr: `network.ip in 2001:0:0eab:dead::a0:abcd:4e/128`, Expected: true},
+		{Expr: `network.ip in 2001:0:0eab:dead::a0:abcd:0/112`, Expected: true},
+		{Expr: `network.ip in 2001:0:0eab:dead::a0:0:0/112`, Expected: false},
+		{Expr: `network.ip not in 2001:0:0eab:dead::a0:0:0/112`, Expected: true},
+		{Expr: `network.ip in [ ::1, 2001:0:0eab:dead::a0:abcd:4e, 2001:0:0eab:dead::a0:abcd:4f ]`, Expected: true},
+		{Expr: `network.ip in [ ::1, 2001:0:0eab:dead::a0:abcd:4f ]`, Expected: false},
+		{Expr: `network.ip in [ 2001:0:0eab:dead::a0:abcd:0/112, 2001:0:0eab:dead::a0:abcd:4f/128 ]`, Expected: true},
+		{Expr: `network.ip in [ ::1, 2001:124:0eab:dead::a0:abcd:4f, 2001:0:0eab:dead::a0:abcd:0/112 ]`, Expected: true},
+		{Expr: `2001:0:0eab:dead::a0:abcd:4e in [ 2001:0:0eab:dead::a0:abcd:4e, ::1, 2002:0:0eab:dead::/64, ::ffff:192.168.0.1/128 ]`, Expected: true},
+		{Expr: `2001:0:0eab:dead::a0:abcd:4e/64 in [ 10.0.0.1, 127.0.0.1, 2001:0:0eab:dead::a0:abcd:1b00/32, ::ffff:192.168.0.1/120 ]`, Expected: true},
+		{Expr: `2001:0:0eab:dead::a0:abcd:4e/64 intersects [ 10.0.0.1, 127.0.0.1, 2001:0:0eab:dead::a0:abcd:1b00/32, ::ffff:192.168.0.1/120 ]`, Expected: false},
+
+		{Expr: `network.ips in 2001:0:0eab:dead::a0:abcd:0/120`, Expected: true},
+		{Expr: `network.ips not in 2001:0:0eab:dead::a0:abcd:0/120`, Expected: false},
+		{Expr: `network.ips intersects 2001:0:0eab:dead::a0:abcd:0/120`, Expected: false},
+		{Expr: `network.ips intersects 2001:0:0eab:dead::a0:abcd:0/104`, Expected: true},
+		{Expr: `network.ips in [ 2001:0:0eab:dead::a0:abcd:0/128, 2001:0:0eab:dead::a0:abcd:0/120, 2001:0:0eab:dead::a0:abce:4e ]`, Expected: true},
+		{Expr: `network.ips not in [ 2001:0:0eab:dead::a0:abcd:0/128, 2001:0:0eab:dead::a0:abcf:4e/120 ]`, Expected: true},
+		{Expr: `network.ips intersects [ 2001:0:0eab:dead::a0:abcd:0/104, 2001::1/16 ]`, Expected: true},
+		{Expr: `network.ips intersects [ 2001:0:0eab:dead::a0:abcd:0/104, 2002::1/16 ]`, Expected: false},
+		{Expr: `2001:0:0eab:dead::a0:abcd:0/104 intersects network.ips`, Expected: true},
+
+		{Expr: `network.cidr in 2001:0:0eab:dead::a0:abcd:4e/112`, Expected: true},
+		{Expr: `network.cidr in 2002:0:0eab:dead::a0:abcd:4e/72`, Expected: false},
+		{Expr: `network.cidrs in 2001:0:0eab:dead::a0:abcd:4e/64`, Expected: true},
+		{Expr: `network.cidrs intersects 2001:0:0eab:dead::a0:abcd:4e/64`, Expected: false},
+	}
+
+	for _, test := range tests {
+		result, _, err := eval(t, event, test.Expr)
+		if err != nil {
+			t.Fatalf("error while evaluating `%s`: %s", test.Expr, err)
+		}
+
+		if result != test.Expected {
+			t.Errorf("expected result `%v` not found, got `%v`, expression: %s", test.Expected, result, test.Expr)
 		}
 	}
 }

--- a/pkg/security/secl/compiler/eval/field.go
+++ b/pkg/security/secl/compiler/eval/field.go
@@ -32,8 +32,7 @@ type FieldValue struct {
 	Value interface{}
 	Type  FieldValueType
 
-	StringMatcher StringMatcher
-	IPMatcher     IPMatcher
+	IPMatcher IPMatcher
 }
 
 // Compile the regular expression or the pattern

--- a/pkg/security/secl/compiler/eval/field.go
+++ b/pkg/security/secl/compiler/eval/field.go
@@ -5,6 +5,11 @@
 
 package eval
 
+import (
+	"fmt"
+	"net"
+)
+
 // Field name
 type Field = string
 
@@ -18,10 +23,53 @@ const (
 	RegexpValueType   FieldValueType = 1 << 2
 	BitmaskValueType  FieldValueType = 1 << 3
 	VariableValueType FieldValueType = 1 << 4
+	IPValueType       FieldValueType = 1 << 5
+	CIDRValueType     FieldValueType = 1 << 6
 )
 
 // FieldValue describes a field value with its type
 type FieldValue struct {
 	Value interface{}
 	Type  FieldValueType
+
+	StringMatcher StringMatcher
+	IPMatcher     IPMatcher
+}
+
+// Compile the regular expression or the pattern
+func (f *FieldValue) Compile() error {
+	switch f.Type {
+	case IPValueType, CIDRValueType:
+		value, ok := f.Value.(string)
+		if !ok {
+			return fmt.Errorf("invalid IP `%v`", f.Value)
+		}
+
+		matcher, err := NewIPMatcher(f.Type, value)
+		if err != nil {
+			return err
+		}
+
+		f.IPMatcher = matcher
+	}
+
+	return nil
+}
+
+// NewIPFieldValue returns a new FieldValue pointer initiailised with the provided IP
+func NewIPFieldValue(ip net.IP, net *net.IPNet) *FieldValue {
+	if net != nil {
+		return &FieldValue{
+			Type: CIDRValueType,
+			IPMatcher: &CIDRMatcher{
+				net: net,
+			},
+		}
+	}
+	return &FieldValue{
+		Type: IPValueType,
+		IPMatcher: &SingleIPMatcher{
+			ip: ip,
+		},
+	}
 }

--- a/pkg/security/secl/compiler/eval/operators.go
+++ b/pkg/security/secl/compiler/eval/operators.go
@@ -611,7 +611,7 @@ func ArrayBoolContains(a *BoolEvaluator, b *BoolArrayEvaluator, opts *Opts, stat
 func CIDREquals(a *CIDREvaluator, b *CIDREvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
 
-	arrayOp := func(as IPMatcher, bs IPMatcher) bool {
+	op := func(as IPMatcher, bs IPMatcher) bool {
 		return as.Matches(bs)
 	}
 
@@ -619,7 +619,7 @@ func CIDREquals(a *CIDREvaluator, b *CIDREvaluator, opts *Opts, state *State) (*
 		ea, eb := a.EvalFnc, b.EvalFnc
 
 		evalFnc := func(ctx *Context) bool {
-			return arrayOp(ea(ctx).IPMatcher, eb(ctx).IPMatcher)
+			return op(ea(ctx).IPMatcher, eb(ctx).IPMatcher)
 		}
 
 		return &BoolEvaluator{
@@ -633,7 +633,7 @@ func CIDREquals(a *CIDREvaluator, b *CIDREvaluator, opts *Opts, state *State) (*
 		ea, eb := a.cidrMatcher, b.cidrMatcher
 
 		return &BoolEvaluator{
-			Value:           arrayOp(ea, eb),
+			Value:           op(ea, eb),
 			Weight:          a.Weight + b.Weight,
 			isDeterministic: isDc,
 		}, nil
@@ -649,7 +649,7 @@ func CIDREquals(a *CIDREvaluator, b *CIDREvaluator, opts *Opts, state *State) (*
 		}
 
 		evalFnc := func(ctx *Context) bool {
-			return arrayOp(ea(ctx).IPMatcher, eb)
+			return op(ea(ctx).IPMatcher, eb)
 		}
 
 		return &BoolEvaluator{
@@ -668,7 +668,7 @@ func CIDREquals(a *CIDREvaluator, b *CIDREvaluator, opts *Opts, state *State) (*
 	}
 
 	evalFnc := func(ctx *Context) bool {
-		return arrayOp(ea, eb(ctx).IPMatcher)
+		return op(ea, eb(ctx).IPMatcher)
 	}
 
 	return &BoolEvaluator{

--- a/pkg/security/secl/compiler/eval/utils.go
+++ b/pkg/security/secl/compiler/eval/utils.go
@@ -6,6 +6,10 @@
 package eval
 
 import (
+	"fmt"
+	"math/big"
+	"net"
+
 	"github.com/pkg/errors"
 )
 
@@ -21,4 +25,29 @@ func NotOfValue(value interface{}) (interface{}, error) {
 	}
 
 	return nil, errors.New("value type unknown")
+}
+
+// IPToInt transforms an IP to a big Int
+func IPToInt(ip net.IP) (*big.Int, int, error) {
+	val := &big.Int{}
+	val.SetBytes(ip)
+	if len(ip) == net.IPv4len {
+		return val, 32, nil
+	} else if len(ip) == net.IPv6len {
+		return val, 128, nil
+	} else {
+		return nil, 0, fmt.Errorf("unsupported address length %d", len(ip))
+	}
+}
+
+// IntToIP transforms a big Int to an IP
+func IntToIP(ipInt *big.Int, bits int) net.IP {
+	ipBytes := ipInt.Bytes()
+	ret := make([]byte, bits/8)
+	// Pack our IP bytes into the end of the return array,
+	// since big.Int.Bytes() removes front zero padding.
+	for i := 1; i <= len(ipBytes); i++ {
+		ret[len(ret)-i] = ipBytes[len(ipBytes)-i]
+	}
+	return ret
 }

--- a/pkg/security/secl/compiler/generators/accessors/accessors.tmpl
+++ b/pkg/security/secl/compiler/generators/accessors/accessors.tmpl
@@ -334,6 +334,7 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
             {{else}}
                 {{$FieldName}} = v
             {{end}}
+			return nil
 		{{end}}
 		{{end}}
 		}

--- a/pkg/security/secl/compiler/generators/accessors/accessors.tmpl
+++ b/pkg/security/secl/compiler/generators/accessors/accessors.tmpl
@@ -5,6 +5,7 @@
 package {{.Name}}
 
 import (
+    "net"
 	"reflect"
 	"unsafe"
 
@@ -102,6 +103,20 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					return results
 				},
+			{{- else if eq $Field.ReturnType "net.IP" }}
+                {{- $Return := $Field.Name | printf "(*Event)(ctx.Object).%s"}}
+                {{- if and (ne $Field.Handler "") (not $Mock)}}
+                    {{- $Return = print "(*Event)(ctx.Object)." $Field.Handler "(&(*Event)(ctx.Object)." $Field.Prefix ")"}}
+                {{end -}}
+			    {{- if $Field.IsArray }}
+                    EvalFnc: func(ctx *eval.Context) *eval.CIDRValues {
+                        return eval.NewCIDRValues({{$Return}}, nil)
+                    },
+                {{- else}}
+                    EvalFnc: func(ctx *eval.Context) *eval.FieldValue {
+                        return eval.NewIPFieldValue({{$Return}}, nil)
+                    },
+                {{end -}}
 			{{- else}}
 				{{- $ReturnType := $Field.ReturnType}}
 				EvalFnc: func(ctx *eval.Context) {{$Field.GetArrayPrefix}}{{$ReturnType}} {
@@ -228,6 +243,8 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 				{{end -}}
 			{{else if eq $Field.ReturnType "bool"}}
 				return {{$Return}}, nil
+            {{else if eq $Field.ReturnType "net.IP"}}
+                return {{$Return}}, nil
 			{{end}}
 		{{end}}
 		{{end}}
@@ -258,6 +275,8 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 			return reflect.Int, nil
 		{{else if eq $Field.ReturnType "bool"}}
 			return reflect.Bool, nil
+        {{else if eq $Field.ReturnType "net.IP"}}
+            return reflect.Struct, nil
 		{{end}}
 		{{end}}
 		}
@@ -305,6 +324,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 				return &eval.ErrValueTypeMismatch{Field: "{{$Field.Name}}"}
 			}
 			return nil
+        {{else if eq $Field.BasicType "net.IP"}}
+            v, ok := value.(net.IP)
+            if !ok {
+                return &eval.ErrValueTypeMismatch{Field: "{{$Field.Name}}"}
+            }
+			{{- if $Field.IsArray}}
+                {{$FieldName}} = append({{$FieldName}}, v)
+            {{else}}
+                {{$FieldName}} = v
+            {{end}}
 		{{end}}
 		{{end}}
 		}

--- a/pkg/security/secl/compiler/generators/accessors/common/types.go
+++ b/pkg/security/secl/compiler/generators/accessors/common/types.go
@@ -63,6 +63,11 @@ func (sf *StructField) GetEvaluatorType() string {
 		if sf.Iterator != nil || sf.IsArray {
 			evaluatorType = "eval.BoolArrayEvaluator"
 		}
+	} else if sf.ReturnType == "net.IP" {
+		evaluatorType = "eval.CIDREvaluator"
+		if sf.IsArray {
+			evaluatorType = "eval.CIDRValuesEvaluator"
+		}
 	} else {
 		evaluatorType = "eval.StringEvaluator"
 		if sf.Iterator != nil || sf.IsArray {

--- a/pkg/security/secl/model/accessors.go
+++ b/pkg/security/secl/model/accessors.go
@@ -20964,6 +20964,8 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.NetworkContext.Destination.IP = v
 
+		return nil
+
 	case "network.destination.port":
 
 		var ok bool
@@ -21038,6 +21040,8 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "NetworkContext.Source.IP"}
 		}
 		e.NetworkContext.Source.IP = v
+
+		return nil
 
 	case "network.source.port":
 

--- a/pkg/security/secl/model/accessors.go
+++ b/pkg/security/secl/model/accessors.go
@@ -3,6 +3,7 @@
 package model
 
 import (
+	"net"
 	"reflect"
 	"unsafe"
 
@@ -1913,6 +1914,15 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
+	case "network.destination.ip":
+		return &eval.CIDREvaluator{
+			EvalFnc: func(ctx *eval.Context) *eval.FieldValue {
+				return eval.NewIPFieldValue((*Event)(ctx.Object).NetworkContext.Destination.IP, nil)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
 	case "network.destination.port":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -1968,6 +1978,15 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) int {
 
 				return int((*Event)(ctx.Object).NetworkContext.Size)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "network.source.ip":
+		return &eval.CIDREvaluator{
+			EvalFnc: func(ctx *eval.Context) *eval.FieldValue {
+				return eval.NewIPFieldValue((*Event)(ctx.Object).NetworkContext.Source.IP, nil)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -8730,6 +8749,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"mprotect.vm_protection",
 
+		"network.destination.ip",
+
 		"network.destination.port",
 
 		"network.device.ifindex",
@@ -8741,6 +8762,8 @@ func (e *Event) GetFields() []eval.Field {
 		"network.l4_protocol",
 
 		"network.size",
+
+		"network.source.ip",
 
 		"network.source.port",
 
@@ -10351,6 +10374,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.MProtect.VMProtection, nil
 
+	case "network.destination.ip":
+
+		return e.NetworkContext.Destination.IP, nil
+
 	case "network.destination.port":
 
 		return int(e.NetworkContext.Destination.Port), nil
@@ -10374,6 +10401,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "network.size":
 
 		return int(e.NetworkContext.Size), nil
+
+	case "network.source.ip":
+
+		return e.NetworkContext.Source.IP, nil
 
 	case "network.source.port":
 
@@ -15103,6 +15134,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "mprotect.vm_protection":
 		return "mprotect", nil
 
+	case "network.destination.ip":
+		return "*", nil
+
 	case "network.destination.port":
 		return "*", nil
 
@@ -15119,6 +15153,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "*", nil
 
 	case "network.size":
+		return "*", nil
+
+	case "network.source.ip":
 		return "*", nil
 
 	case "network.source.port":
@@ -17165,6 +17202,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
+	case "network.destination.ip":
+
+		return reflect.Struct, nil
+
 	case "network.destination.port":
 
 		return reflect.Int, nil
@@ -17188,6 +17229,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "network.size":
 
 		return reflect.Int, nil
+
+	case "network.source.ip":
+
+		return reflect.Struct, nil
 
 	case "network.source.port":
 
@@ -20910,6 +20955,15 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "network.destination.ip":
+
+		var ok bool
+		v, ok := value.(net.IP)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "NetworkContext.Destination.IP"}
+		}
+		e.NetworkContext.Destination.IP = v
+
 	case "network.destination.port":
 
 		var ok bool
@@ -20975,6 +21029,15 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.NetworkContext.Size = uint32(v)
 
 		return nil
+
+	case "network.source.ip":
+
+		var ok bool
+		v, ok := value.(net.IP)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "NetworkContext.Source.IP"}
+		}
+		e.NetworkContext.Source.IP = v
 
 	case "network.source.port":
 

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -131,7 +131,7 @@ type Event struct {
 	ID           string    `field:"-"`
 	Type         uint64    `field:"-"`
 	TimestampRaw uint64    `field:"-"`
-	Timestamp    time.Time `field:"timestamp"` // Timestamp of the event
+	Timestamp    time.Time `field:"-"` // Timestamp of the event
 
 	ProcessContext   ProcessContext   `field:"process" event:"*"`
 	SpanContext      SpanContext      `field:"-"`
@@ -755,7 +755,7 @@ type NetworkDeviceContext struct {
 // IPPortContext is used to hold an IP and Port
 //msgp:ignore IPPortContext
 type IPPortContext struct {
-	IP   net.IP `field:"-"`
+	IP   net.IP `field:"ip"`   // IP address
 	Port uint16 `field:"port"` // Port number
 }
 

--- a/pkg/security/tests/network_test.go
+++ b/pkg/security/tests/network_test.go
@@ -1,0 +1,72 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build functionaltests
+// +build functionaltests
+
+package tests
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/docker/libnetwork/resolvconf"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
+	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
+)
+
+func TestNetworkCIDR(t *testing.T) {
+	checkKernelCompatibility(t, "RHEL, SLES and Oracle kernels", func(kv *kernel.Version) bool {
+		// TODO: Oracle because we are missing offsets
+		return kv.IsRH7Kernel() || kv.IsOracleUEKKernel()
+	})
+
+	if testEnvironment != DockerEnvironment && !config.IsContainerized() {
+		if out, err := loadModule("veth"); err != nil {
+			t.Fatalf("couldn't load 'veth' module: %s, %v", string(out), err)
+		}
+	}
+
+	// write the rules using the local resolv.conf file
+	resolvFile, err := resolvconf.Get()
+	if err != nil {
+		t.Fatal(err)
+	}
+	nameserversCIDR := resolvconf.GetNameserversAsCIDR(resolvFile.Content)
+
+	rule := &rules.RuleDefinition{
+		ID:         "test_rule",
+		Expression: fmt.Sprintf(`dns.question.type == A && dns.question.name == "google.com" && process.file.name == "testsuite" && network.destination.ip in [%s]`, strings.Join(nameserversCIDR, ", ")),
+	}
+
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{enableNetwork: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+
+	t.Run("dns", func(t *testing.T) {
+		test.WaitSignal(t, func() error {
+			_, err = net.LookupIP("google.com")
+			if err != nil {
+				return err
+			}
+			return nil
+		}, func(event *sprobe.Event, rule *rules.Rule) {
+			assert.Equal(t, "dns", event.GetType(), "wrong event type")
+			assert.Equal(t, "google.com", event.DNS.Name, "wrong domain name")
+
+			if !validateDNSSchema(t, event) {
+				t.Error(event.String())
+			}
+		})
+	})
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

This PR introduces the ability to write rules on IP addresses and CIDR ranges. It is now possible to write this kind of rules:
- `dns.question.type == A && dns.question.name == "google.com" && process.file.name == "testsuite" && network.destination.ip in [ 127.0.0.53, 10.0.0.2/24 ]`

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Introduce rules on IP addresses and CIDR ranges.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
