### PR TITLE
Add support for IPv6 support

### DIFF
--- a/pkg/autodiscovery/autoconfig_test.go
+++ b/pkg/autodiscovery/autoconfig_test.go
@@ -426,9 +426,9 @@ func TestDecryptConfig(t *testing.T) {
 			returnedError:  nil,
 		},
 		{
-			expectedData:   []byte("param1: ENC[foo]"),
+			expectedData:   []byte("param1: ENC[foo]\n"),
 			expectedOrigin: "cpu",
-			returnedData:   []byte("param1: foo"),
+			returnedData:   []byte("param1: foo\n"),
 			returnedError:  nil,
 		},
 	}}
@@ -449,7 +449,7 @@ func TestDecryptConfig(t *testing.T) {
 	resolved := integration.Config{
 		Name:          "cpu",
 		ADIdentifiers: []string{"redis"},
-		InitConfig:    []byte("param1: foo"),
+		InitConfig:    []byte("param1: foo\n"),
 		Instances:     []integration.Data{},
 		MetricConfig:  integration.Data{},
 		LogsConfig:    integration.Data{},

--- a/pkg/autodiscovery/common_test.go
+++ b/pkg/autodiscovery/common_test.go
@@ -78,6 +78,6 @@ func (s *dummyService) HasFilter(filter containers.FilterType) bool {
 }
 
 // GetExtraConfig isn't supported
-func (s *dummyService) GetExtraConfig(key []byte) ([]byte, error) {
-	return []byte{}, nil
+func (s *dummyService) GetExtraConfig(key string) (string, error) {
+	return "", nil
 }

--- a/pkg/autodiscovery/configmgr_test.go
+++ b/pkg/autodiscovery/configmgr_test.go
@@ -116,12 +116,12 @@ func (suite *ConfigManagerSuite) TestNewTemplateBeforeService_ConfigRemovedFirst
 	assertConfigsMatch(suite.T(), changes.unschedule)
 
 	changes = suite.cm.processNewService(myService.ADIdentifiers, myService)
-	assertConfigsMatch(suite.T(), changes.schedule, matchAll(matchName("template"), matchLogsConfig("source: myhost")))
+	assertConfigsMatch(suite.T(), changes.schedule, matchAll(matchName("template"), matchLogsConfig("source: myhost\n")))
 	assertConfigsMatch(suite.T(), changes.unschedule)
 
 	changes = suite.cm.processDelConfigs([]integration.Config{templateConfig})
 	assertConfigsMatch(suite.T(), changes.schedule)
-	assertConfigsMatch(suite.T(), changes.unschedule, matchAll(matchName("template"), matchLogsConfig("source: myhost")))
+	assertConfigsMatch(suite.T(), changes.unschedule, matchAll(matchName("template"), matchLogsConfig("source: myhost\n")))
 
 	changes = suite.cm.processDelService(myService)
 	assertConfigsMatch(suite.T(), changes.schedule)
@@ -137,12 +137,12 @@ func (suite *ConfigManagerSuite) TestNewTemplateBeforeService_ServiceRemovedFirs
 	assertConfigsMatch(suite.T(), changes.unschedule)
 
 	changes = suite.cm.processNewService(myService.ADIdentifiers, myService)
-	assertConfigsMatch(suite.T(), changes.schedule, matchAll(matchName("template"), matchLogsConfig("source: myhost")))
+	assertConfigsMatch(suite.T(), changes.schedule, matchAll(matchName("template"), matchLogsConfig("source: myhost\n")))
 	assertConfigsMatch(suite.T(), changes.unschedule)
 
 	changes = suite.cm.processDelService(myService)
 	assertConfigsMatch(suite.T(), changes.schedule)
-	assertConfigsMatch(suite.T(), changes.unschedule, matchAll(matchName("template"), matchLogsConfig("source: myhost")))
+	assertConfigsMatch(suite.T(), changes.unschedule, matchAll(matchName("template"), matchLogsConfig("source: myhost\n")))
 
 	changes = suite.cm.processDelConfigs([]integration.Config{templateConfig})
 	assertConfigsMatch(suite.T(), changes.schedule)
@@ -158,12 +158,12 @@ func (suite *ConfigManagerSuite) TestNewServiceBeforeTemplate_ConfigRemovedFirst
 	assertConfigsMatch(suite.T(), changes.unschedule)
 
 	changes = suite.cm.processNewConfig(templateConfig)
-	assertConfigsMatch(suite.T(), changes.schedule, matchAll(matchName("template"), matchLogsConfig("source: myhost")))
+	assertConfigsMatch(suite.T(), changes.schedule, matchAll(matchName("template"), matchLogsConfig("source: myhost\n")))
 	assertConfigsMatch(suite.T(), changes.unschedule)
 
 	changes = suite.cm.processDelConfigs([]integration.Config{templateConfig})
 	assertConfigsMatch(suite.T(), changes.schedule)
-	assertConfigsMatch(suite.T(), changes.unschedule, matchAll(matchName("template"), matchLogsConfig("source: myhost")))
+	assertConfigsMatch(suite.T(), changes.unschedule, matchAll(matchName("template"), matchLogsConfig("source: myhost\n")))
 
 	changes = suite.cm.processDelService(myService)
 	assertConfigsMatch(suite.T(), changes.schedule)
@@ -179,12 +179,12 @@ func (suite *ConfigManagerSuite) TestNewServiceBeforeTemplate_ServiceRemovedFirs
 	assertConfigsMatch(suite.T(), changes.unschedule)
 
 	changes = suite.cm.processNewConfig(templateConfig)
-	assertConfigsMatch(suite.T(), changes.schedule, matchAll(matchName("template"), matchLogsConfig("source: myhost")))
+	assertConfigsMatch(suite.T(), changes.schedule, matchAll(matchName("template"), matchLogsConfig("source: myhost\n")))
 	assertConfigsMatch(suite.T(), changes.unschedule)
 
 	changes = suite.cm.processDelService(myService)
 	assertConfigsMatch(suite.T(), changes.schedule)
-	assertConfigsMatch(suite.T(), changes.unschedule, matchAll(matchName("template"), matchLogsConfig("source: myhost")))
+	assertConfigsMatch(suite.T(), changes.unschedule, matchAll(matchName("template"), matchLogsConfig("source: myhost\n")))
 
 	changes = suite.cm.processDelConfigs([]integration.Config{templateConfig})
 	assertConfigsMatch(suite.T(), changes.schedule)

--- a/pkg/autodiscovery/configresolver/configresolver.go
+++ b/pkg/autodiscovery/configresolver/configresolver.go
@@ -6,28 +6,31 @@
 package configresolver
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/listeners"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers/names"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/datadog-agent/pkg/util/tmplvar"
+
+	yaml "gopkg.in/yaml.v2"
 )
 
-type variableGetter func(ctx context.Context, key []byte, svc listeners.Service) ([]byte, error)
+type variableGetter func(ctx context.Context, key string, svc listeners.Service) (string, error)
 
 var templateVariables = map[string]variableGetter{
 	"host":     getHost,
 	"pid":      getPid,
 	"port":     getPort,
 	"hostname": getHostname,
+	"env":      getEnvvar,
 	"extra":    getAdditionalTplVariables,
 	"kube":     getAdditionalTplVariables,
 }
@@ -37,17 +40,7 @@ var templateVariables = map[string]variableGetter{
 // When there is an error, it continues replacing. When there are multiple
 // errors, the one returned is the one that happened first.
 func SubstituteTemplateEnvVars(config *integration.Config) error {
-	var retErr error
-
-	for _, toResolve := range dataToResolve(config) {
-		var err error
-		*toResolve, err = resolveDataWithEnvs(*toResolve)
-		if err != nil && retErr == nil {
-			retErr = err
-		}
-	}
-
-	return retErr
+	return substituteTemplateVariables(context.Background(), config, nil, nil)
 }
 
 // Resolve takes a template and a service and generates a config with
@@ -97,24 +90,19 @@ func Resolve(tpl integration.Config, svc listeners.Service) (integration.Config,
 		return resolvedConfig, errors.New("unable to resolve, service not ready")
 	}
 
-	if err := substituteTemplateVariables(ctx, &resolvedConfig, svc); err != nil {
-		return resolvedConfig, err
-	}
-
-	if err := SubstituteTemplateEnvVars(&resolvedConfig); err != nil {
-		// We add the service name to the error here, since SubstituteTemplateEnvVars doesn't know about that
-		return resolvedConfig, fmt.Errorf("%w, skipping service %s", err, svc.GetServiceID())
-	}
-
 	tags, err := svc.GetTags()
 	if err != nil {
 		return resolvedConfig, fmt.Errorf("couldn't get tags for service '%s', err: %w", svc.GetServiceID(), err)
 	}
 
+	var postProcessor func(interface{}) error
+
 	if !tpl.IgnoreAutodiscoveryTags {
-		if err := addServiceTags(&resolvedConfig, tags); err != nil {
-			return resolvedConfig, fmt.Errorf("unable to add tags for service '%s', err: %w", svc.GetServiceID(), err)
-		}
+		postProcessor = tagsAdder(tags)
+	}
+
+	if err := substituteTemplateVariables(ctx, &resolvedConfig, svc, postProcessor); err != nil {
+		return resolvedConfig, err
 	}
 
 	return resolvedConfig, nil
@@ -123,11 +111,15 @@ func Resolve(tpl integration.Config, svc listeners.Service) (integration.Config,
 // substituteTemplateVariables replaces %%VARIABLES%% in the config init,
 // instances, and logs config.
 // When there is an error, it stops processing.
-func substituteTemplateVariables(ctx context.Context, config *integration.Config, svc listeners.Service) error {
+func substituteTemplateVariables(ctx context.Context, config *integration.Config, svc listeners.Service, postProcessor func(interface{}) error) error {
 	var err error
 
-	for _, toResolve := range dataToResolve(config) {
-		*toResolve, err = resolveDataWithTemplateVars(ctx, *toResolve, svc)
+	for _, toResolve := range listDataToResolve(config) {
+		var pp func(interface{}) error
+		if toResolve.dtype == dataInstance {
+			pp = postProcessor
+		}
+		*toResolve.data, err = resolveDataWithTemplateVars(ctx, *toResolve.data, svc, pp)
 		if err != nil {
 			return err
 		}
@@ -136,91 +128,229 @@ func substituteTemplateVariables(ctx context.Context, config *integration.Config
 	return nil
 }
 
-func dataToResolve(config *integration.Config) []*integration.Data {
-	res := []*integration.Data{&config.InitConfig}
+type dataType int
+
+const (
+	dataInit dataType = iota
+	dataInstance
+	dataLogs
+)
+
+type dataToResolve struct {
+	data  *integration.Data
+	dtype dataType
+}
+
+func listDataToResolve(config *integration.Config) []dataToResolve {
+	res := []dataToResolve{
+		{
+			data:  &config.InitConfig,
+			dtype: dataInit,
+		},
+	}
 
 	for i := 0; i < len(config.Instances); i++ {
-		res = append(res, &config.Instances[i])
+		res = append(res, dataToResolve{
+			data:  &config.Instances[i],
+			dtype: dataInstance,
+		})
 	}
 
 	if config.IsLogConfig() {
-		res = append(res, &config.LogsConfig)
+		res = append(res, dataToResolve{
+			data:  &config.LogsConfig,
+			dtype: dataLogs,
+		})
 	}
 
 	return res
 }
 
-func resolveDataWithTemplateVars(ctx context.Context, data integration.Data, svc listeners.Service) ([]byte, error) {
-	res := append([]byte(nil), data...)
+func resolveDataWithTemplateVars(ctx context.Context, data integration.Data, svc listeners.Service, postProcessor func(interface{}) error) ([]byte, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
 
-	templateVars := tmplvar.Parse(data)
-	for _, tVar := range templateVars {
-		if f, found := templateVariables[string(tVar.Name)]; found {
-			resolvedVar, err := f(ctx, tVar.Key, svc)
-			if err != nil {
-				return res, err
+	var treeIn interface{}
+
+	// Percent character is not allowed in unquoted yaml strings.
+	data2 := strings.ReplaceAll(string(data), "%%", "‰")
+	if err := yaml.Unmarshal([]byte(data2), &treeIn); err != nil {
+		return data, err
+	}
+
+	treeOut, err := visitInterface(ctx, treeIn, svc)
+	if err != nil {
+		return data, err
+	}
+
+	if postProcessor != nil {
+		if err := postProcessor(treeOut); err != nil {
+			return data, err
+		}
+	}
+
+	return yaml.Marshal(&treeOut)
+}
+
+func visitInterface(ctx context.Context, in interface{}, svc listeners.Service) (interface{}, error) {
+	switch e := in.(type) {
+	case map[interface{}]interface{}:
+		return visitMap(ctx, e, svc)
+	case []interface{}:
+		return visitList(ctx, e, svc)
+	case string:
+		return visitString(ctx, e, svc)
+	case int:
+		return in, nil
+	default:
+		log.Errorf("I don't know about type %T.\n", e)
+		return in, nil
+	}
+	return nil, nil
+}
+
+func visitMap(ctx context.Context, in map[interface{}]interface{}, svc listeners.Service) (out map[interface{}]interface{}, err error) {
+	out = make(map[interface{}]interface{})
+	for k, v := range in {
+		visitedK, e := visitInterface(ctx, k, svc)
+		if e != nil {
+			err = e
+		}
+		visitedV, e := visitInterface(ctx, v, svc)
+		if e != nil {
+			err = e
+		}
+		out[visitedK] = visitedV
+	}
+	return
+}
+
+func visitList(ctx context.Context, in []interface{}, svc listeners.Service) (out []interface{}, err error) {
+	out = make([]interface{}, len(in))
+	for i, v := range in {
+		visited, e := visitInterface(ctx, v, svc)
+		if e != nil {
+			err = e
+		}
+		out[i] = visited
+	}
+	return
+}
+
+var varPattern = regexp.MustCompile(`‰(.+?)(?:_(.+?))?‰`)
+
+func visitString(ctx context.Context, in string, svc listeners.Service) (out interface{}, err error) {
+	varIndexes := varPattern.FindAllStringSubmatchIndex(in, -1)
+
+	if len(varIndexes) == 0 {
+		return in, nil
+	}
+
+	var sb strings.Builder
+
+	sb.WriteString(in[:varIndexes[0][0]])
+	for i := range varIndexes {
+		if i != 0 {
+			sb.WriteString(in[varIndexes[i-1][1]:varIndexes[i][0]])
+		}
+
+		varName := in[varIndexes[i][2]:varIndexes[i][3]]
+		varKey := ""
+		if varIndexes[i][4] != -1 {
+			varKey = in[varIndexes[i][4]:varIndexes[i][5]]
+		}
+
+		if f, found := templateVariables[varName]; found {
+			resolvedVar, e := f(ctx, varKey, svc)
+			if e != nil {
+				err = e
 			}
-			res = bytes.Replace(res, tVar.Raw, resolvedVar, -1)
-		}
-	}
-
-	return res, nil
-}
-
-func resolveDataWithEnvs(data integration.Data) ([]byte, error) {
-	var retErr error
-	res := append([]byte(nil), data...)
-
-	templateVars := tmplvar.Parse(data)
-	for _, tVar := range templateVars {
-		if "env" == string(tVar.Name) {
-			resolvedVar, err := getEnvvar(tVar.Key)
-			if err != nil {
-				log.Warnf("variable not replaced: %s", err)
-				if retErr == nil {
-					retErr = err
-				}
-				continue
+			sb.WriteString(resolvedVar)
+		} else {
+			endTagIdx := varIndexes[i][5]
+			if endTagIdx == -1 {
+				endTagIdx = varIndexes[i][3]
 			}
-			res = bytes.Replace(res, tVar.Raw, resolvedVar, -1)
+			err := fmt.Errorf("invalid %%%%%s%%%% tag", in[varIndexes[i][2]:endTagIdx])
+			if svc != nil {
+				err = fmt.Errorf("unable to add tags for service '%s', err: %w", svc.GetServiceID(), err)
+			}
+			return out, err
+		}
+	}
+	sb.WriteString(in[varIndexes[len(varIndexes)-1][1]:])
+
+	out = sb.String()
+
+	if len(varIndexes) == 1 &&
+		varIndexes[0][0] == 0 &&
+		varIndexes[0][1] == len(in) {
+
+		if i, e := strconv.ParseInt(out.(string), 0, 64); e == nil {
+			return i, err
+		}
+		if b, e := strconv.ParseBool(out.(string)); e == nil {
+			return b, err
 		}
 	}
 
-	return res, retErr
+	return
 }
 
-func addServiceTags(resolvedConfig *integration.Config, tags []string) error {
-	for i := 0; i < len(resolvedConfig.Instances); i++ {
-		if err := resolvedConfig.Instances[i].MergeAdditionalTags(tags); err != nil {
-			return err
+func tagsAdder(tags []string) func(interface{}) error {
+	return func(tree interface{}) error {
+		if len(tags) == 0 {
+			return nil
 		}
+
+		if typedTree, ok := tree.(map[interface{}]interface{}); ok {
+			tagList, _ := typedTree["tags"].([]string)
+			// Use a set to remove duplicates
+			tagSet := make(map[string]struct{})
+			for _, t := range tagList {
+				tagSet[t] = struct{}{}
+			}
+			for _, t := range tags {
+				tagSet[t] = struct{}{}
+			}
+			typedTree["tags"] = make([]string, len(tagSet))
+			i := 0
+			for k := range tagSet {
+				typedTree["tags"].([]string)[i] = k
+				i++
+			}
+		}
+		return nil
 	}
-	return nil
 }
 
-func getHost(ctx context.Context, tplVar []byte, svc listeners.Service) ([]byte, error) {
+func getHost(ctx context.Context, tplVar string, svc listeners.Service) (string, error) {
+	if svc == nil {
+		return "", fmt.Errorf("No service. %%%%host%%%% is not allowed")
+	}
+
 	hosts, err := svc.GetHosts(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to extract IP address for container %s, ignoring it. Source error: %s", svc.GetServiceID(), err)
+		return "", fmt.Errorf("failed to extract IP address for container %s, ignoring it. Source error: %s", svc.GetServiceID(), err)
 	}
 	if len(hosts) == 0 {
-		return nil, fmt.Errorf("no network found for container %s, ignoring it", svc.GetServiceID())
+		return "", fmt.Errorf("no network found for container %s, ignoring it", svc.GetServiceID())
 	}
 
 	// a network was specified
-	tplVarStr := string(tplVar)
-	if ip, ok := hosts[tplVarStr]; ok {
-		return []byte(ip), nil
+	if ip, ok := hosts[tplVar]; ok {
+		return ip, nil
 	}
-	log.Debugf("Network %q not found, trying bridge IP instead", tplVarStr)
+	log.Debugf("Network %q not found, trying bridge IP instead", tplVar)
 
 	// otherwise use fallback policy
 	ip, err := getFallbackHost(hosts)
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve IP address for container %s, ignoring it. Source error: %s", svc.GetServiceID(), err)
+		return "", fmt.Errorf("failed to resolve IP address for container %s, ignoring it. Source error: %s", svc.GetServiceID(), err)
 	}
 
-	return []byte(ip), nil
+	return ip, nil
 }
 
 // getFallbackHost implements the fallback strategy to get a service's IP address
@@ -244,51 +374,63 @@ func getFallbackHost(hosts map[string]string) (string, error) {
 }
 
 // getPort returns ports of the service
-func getPort(ctx context.Context, tplVar []byte, svc listeners.Service) ([]byte, error) {
+func getPort(ctx context.Context, tplVar string, svc listeners.Service) (string, error) {
+	if svc == nil {
+		return "", fmt.Errorf("No service. %%%%port%%%% is not allowed")
+	}
+
 	ports, err := svc.GetPorts(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to extract port list for container %s, ignoring it. Source error: %s", svc.GetServiceID(), err)
+		return "", fmt.Errorf("failed to extract port list for container %s, ignoring it. Source error: %s", svc.GetServiceID(), err)
 	} else if len(ports) == 0 {
-		return nil, fmt.Errorf("no port found for container %s - ignoring it", svc.GetServiceID())
+		return "", fmt.Errorf("no port found for container %s - ignoring it", svc.GetServiceID())
 	}
 
 	if len(tplVar) == 0 {
-		return []byte(strconv.Itoa(ports[len(ports)-1].Port)), nil
+		return strconv.Itoa(ports[len(ports)-1].Port), nil
 	}
 
-	idx, err := strconv.Atoi(string(tplVar))
+	idx, err := strconv.Atoi(tplVar)
 	if err != nil {
 		// The template variable is not an index so try to lookup port by name.
 		for _, port := range ports {
-			if port.Name == string(tplVar) {
-				return []byte(strconv.Itoa(port.Port)), nil
+			if port.Name == tplVar {
+				return strconv.Itoa(port.Port), nil
 			}
 		}
-		return nil, fmt.Errorf("port %s not found, skipping container %s", string(tplVar), svc.GetServiceID())
+		return "", fmt.Errorf("port %s not found, skipping container %s", tplVar, svc.GetServiceID())
 	}
 	if len(ports) <= idx {
-		return nil, fmt.Errorf("index given for the port template var is too big, skipping container %s", svc.GetServiceID())
+		return "", fmt.Errorf("index given for the port template var is too big, skipping container %s", svc.GetServiceID())
 	}
-	return []byte(strconv.Itoa(ports[idx].Port)), nil
+	return strconv.Itoa(ports[idx].Port), nil
 }
 
 // getPid returns the process identifier of the service
-func getPid(ctx context.Context, _ []byte, svc listeners.Service) ([]byte, error) {
+func getPid(ctx context.Context, _ string, svc listeners.Service) (string, error) {
+	if svc == nil {
+		return "", fmt.Errorf("No service. %%%%pid%%%% is not allowed")
+	}
+
 	pid, err := svc.GetPid(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get pid for service %s, skipping config - %s", svc.GetServiceID(), err)
+		return "", fmt.Errorf("failed to get pid for service %s, skipping config - %s", svc.GetServiceID(), err)
 	}
-	return []byte(strconv.Itoa(pid)), nil
+	return strconv.Itoa(pid), nil
 }
 
 // getHostname returns the hostname of the service, to be used
 // when the IP is unavailable or erroneous
-func getHostname(ctx context.Context, tplVar []byte, svc listeners.Service) ([]byte, error) {
+func getHostname(ctx context.Context, _ string, svc listeners.Service) (string, error) {
+	if svc == nil {
+		return "", fmt.Errorf("No service. %%%%hostname%%%% is not allowed")
+	}
+
 	name, err := svc.GetHostname(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get hostname for service %s, skipping config - %s", svc.GetServiceID(), err)
+		return "", fmt.Errorf("failed to get hostname for service %s, skipping config - %s", svc.GetServiceID(), err)
 	}
-	return []byte(name), nil
+	return name, nil
 }
 
 // getAdditionalTplVariables returns listener-specific template variables.
@@ -296,22 +438,32 @@ func getHostname(ctx context.Context, tplVar []byte, svc listeners.Service) ([]b
 // Even though it gets the data from the same listener method GetExtraConfig, the kube_ and extra_
 // prefixes are customer facing, we support both of them for a better user experience depending on
 // the AD listener and what the template variable represents.
-func getAdditionalTplVariables(_ context.Context, tplVar []byte, svc listeners.Service) ([]byte, error) {
+func getAdditionalTplVariables(_ context.Context, tplVar string, svc listeners.Service) (string, error) {
+	if svc == nil {
+		return "", fmt.Errorf("No service. %%%%extra_*%%%% or %%%%kube_*%%%% are not allowed")
+	}
+
 	value, err := svc.GetExtraConfig(tplVar)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get extra info for service %s, skipping config - %s", svc.GetServiceID(), err)
+		return "", fmt.Errorf("failed to get extra info for service %s, skipping config - %s", svc.GetServiceID(), err)
 	}
 	return value, nil
 }
 
 // getEnvvar returns a system environment variable if found
-func getEnvvar(envVar []byte) ([]byte, error) {
+func getEnvvar(_ context.Context, envVar string, svc listeners.Service) (string, error) {
 	if len(envVar) == 0 {
-		return nil, fmt.Errorf("envvar name is missing")
+		if svc != nil {
+			return "", fmt.Errorf("envvar name is missing, skipping service %s", svc.GetServiceID())
+		}
+		return "", fmt.Errorf("envvar name is missing")
 	}
-	value, found := os.LookupEnv(string(envVar))
+	value, found := os.LookupEnv(envVar)
 	if !found {
-		return nil, fmt.Errorf("failed to retrieve envvar %s", envVar)
+		if svc != nil {
+			return "", fmt.Errorf("failed to retrieve envvar %s, skipping service %s", envVar, svc.GetServiceID())
+		}
+		return "", fmt.Errorf("failed to retrieve envvar %s", envVar)
 	}
-	return []byte(value), nil
+	return value, nil
 }

--- a/pkg/autodiscovery/configresolver/configresolver_test.go
+++ b/pkg/autodiscovery/configresolver/configresolver_test.go
@@ -700,6 +700,26 @@ func TestResolve(t *testing.T) {
 				ServiceID:     "a5901276aed1",
 			},
 		},
+		{
+			testName: "IPv6 %%host%%",
+			svc: &dummyService{
+				ID:            "a5901276aed1",
+				ADIdentifiers: []string{"redis"},
+				Hosts:         map[string]string{"ipv4": "192.168.0.1", "ipv6": "fd::1"},
+				Ports:         newFakeContainerPorts(),
+			},
+			tpl: integration.Config{
+				Name:          "cpu",
+				ADIdentifiers: []string{"redis"},
+				Instances:     []integration.Data{integration.Data("host_ipv4: %%host_ipv4%%\nhost_ipv6: %%host_ipv6%%\nurl_ipv4: http://%%host_ipv4%%:%%port%%/data\nurl_ipv6: http://%%host_ipv6%%:%%port%%/data")},
+			},
+			out: integration.Config{
+				Name:          "cpu",
+				ADIdentifiers: []string{"redis"},
+				Instances:     []integration.Data{integration.Data("host_ipv4: 192.168.0.1\nhost_ipv6: fd::1\ntags:\n- foo:bar\nurl_ipv4: http://192.168.0.1:3/data\nurl_ipv6: http://[fd::1]:3/data\n")},
+				ServiceID:     "a5901276aed1",
+			},
+		},
 	}
 
 	for i, tc := range testCases {

--- a/pkg/autodiscovery/listeners/cloudfoundry.go
+++ b/pkg/autodiscovery/listeners/cloudfoundry.go
@@ -251,6 +251,6 @@ func (s *CloudFoundryService) HasFilter(filter containers.FilterType) bool {
 }
 
 // GetExtraConfig isn't supported
-func (s *CloudFoundryService) GetExtraConfig(key []byte) ([]byte, error) {
-	return []byte{}, ErrNotSupported
+func (s *CloudFoundryService) GetExtraConfig(key string) (string, error) {
+	return "", ErrNotSupported
 }

--- a/pkg/autodiscovery/listeners/environment.go
+++ b/pkg/autodiscovery/listeners/environment.go
@@ -130,6 +130,6 @@ func (s *EnvironmentService) HasFilter(filter containers.FilterType) bool {
 }
 
 // GetExtraConfig is not supported
-func (s *EnvironmentService) GetExtraConfig(key []byte) ([]byte, error) {
-	return []byte{}, ErrNotSupported
+func (s *EnvironmentService) GetExtraConfig(key string) (string, error) {
+	return "", ErrNotSupported
 }

--- a/pkg/autodiscovery/listeners/kube_endpoints.go
+++ b/pkg/autodiscovery/listeners/kube_endpoints.go
@@ -445,6 +445,6 @@ func (s *KubeEndpointService) HasFilter(filter containers.FilterType) bool {
 }
 
 // GetExtraConfig isn't supported
-func (s *KubeEndpointService) GetExtraConfig(key []byte) ([]byte, error) {
-	return []byte{}, ErrNotSupported
+func (s *KubeEndpointService) GetExtraConfig(key string) (string, error) {
+	return "", ErrNotSupported
 }

--- a/pkg/autodiscovery/listeners/kube_services.go
+++ b/pkg/autodiscovery/listeners/kube_services.go
@@ -340,6 +340,6 @@ func (s *KubeServiceService) HasFilter(filter containers.FilterType) bool {
 }
 
 // GetExtraConfig isn't supported
-func (s *KubeServiceService) GetExtraConfig(key []byte) ([]byte, error) {
-	return []byte{}, ErrNotSupported
+func (s *KubeServiceService) GetExtraConfig(key string) (string, error) {
+	return "", ErrNotSupported
 }

--- a/pkg/autodiscovery/listeners/service.go
+++ b/pkg/autodiscovery/listeners/service.go
@@ -117,13 +117,13 @@ func (s *service) HasFilter(filter containers.FilterType) bool {
 }
 
 // GetExtraConfig returns extra configuration associated with the service.
-func (s *service) GetExtraConfig(key []byte) ([]byte, error) {
-	result, found := s.extraConfig[string(key)]
+func (s *service) GetExtraConfig(key string) (string, error) {
+	result, found := s.extraConfig[key]
 	if !found {
-		return []byte{}, fmt.Errorf("extra config %q is not supported", key)
+		return "", fmt.Errorf("extra config %q is not supported", key)
 	}
 
-	return []byte(result), nil
+	return result, nil
 }
 
 // svcEqual checks that two Services are equal to each other by doing a deep

--- a/pkg/autodiscovery/listeners/snmp.go
+++ b/pkg/autodiscovery/listeners/snmp.go
@@ -377,48 +377,48 @@ func (s *SNMPService) HasFilter(filter containers.FilterType) bool {
 }
 
 // GetExtraConfig returns data from configuration
-func (s *SNMPService) GetExtraConfig(key []byte) ([]byte, error) {
-	switch string(key) {
+func (s *SNMPService) GetExtraConfig(key string) (string, error) {
+	switch key {
 	case "version":
-		return []byte(s.config.Version), nil
+		return s.config.Version, nil
 	case "timeout":
-		return []byte(fmt.Sprintf("%d", s.config.Timeout)), nil
+		return fmt.Sprintf("%d", s.config.Timeout), nil
 	case "retries":
-		return []byte(fmt.Sprintf("%d", s.config.Retries)), nil
+		return fmt.Sprintf("%d", s.config.Retries), nil
 	case "oid_batch_size":
-		return []byte(fmt.Sprintf("%d", s.config.OidBatchSize)), nil
+		return fmt.Sprintf("%d", s.config.OidBatchSize), nil
 	case "community":
-		return []byte(s.config.Community), nil
+		return s.config.Community, nil
 	case "user":
-		return []byte(s.config.User), nil
+		return s.config.User, nil
 	case "auth_key":
-		return []byte(s.config.AuthKey), nil
+		return s.config.AuthKey, nil
 	case "auth_protocol":
-		return []byte(s.config.AuthProtocol), nil
+		return s.config.AuthProtocol, nil
 	case "priv_key":
-		return []byte(s.config.PrivKey), nil
+		return s.config.PrivKey, nil
 	case "priv_protocol":
-		return []byte(s.config.PrivProtocol), nil
+		return s.config.PrivProtocol, nil
 	case "context_engine_id":
-		return []byte(s.config.ContextEngineID), nil
+		return s.config.ContextEngineID, nil
 	case "context_name":
-		return []byte(s.config.ContextName), nil
+		return s.config.ContextName, nil
 	case "autodiscovery_subnet":
-		return []byte(s.config.Network), nil
+		return s.config.Network, nil
 	case "loader":
-		return []byte(s.config.Loader), nil
+		return s.config.Loader, nil
 	case "namespace":
-		return []byte(s.config.Namespace), nil
+		return s.config.Namespace, nil
 	case "collect_device_metadata":
-		return []byte(strconv.FormatBool(s.config.CollectDeviceMetadata)), nil
+		return strconv.FormatBool(s.config.CollectDeviceMetadata), nil
 	case "use_device_id_as_hostname":
-		return []byte(strconv.FormatBool(s.config.UseDeviceIDAsHostname)), nil
+		return strconv.FormatBool(s.config.UseDeviceIDAsHostname), nil
 	case "tags":
-		return []byte(convertToCommaSepTags(s.config.Tags)), nil
+		return convertToCommaSepTags(s.config.Tags), nil
 	case "min_collection_interval":
-		return []byte(fmt.Sprintf("%d", s.config.MinCollectionInterval)), nil
+		return fmt.Sprintf("%d", s.config.MinCollectionInterval), nil
 	}
-	return []byte{}, ErrNotSupported
+	return "", ErrNotSupported
 }
 
 func convertToCommaSepTags(tags []string) string {

--- a/pkg/autodiscovery/listeners/snmp_test.go
+++ b/pkg/autodiscovery/listeners/snmp_test.go
@@ -172,61 +172,61 @@ func TestExtraConfig(t *testing.T) {
 		config:       snmpConfig,
 	}
 
-	info, err := svc.GetExtraConfig([]byte("autodiscovery_subnet"))
+	info, err := svc.GetExtraConfig("autodiscovery_subnet")
 	assert.Equal(t, nil, err)
-	assert.Equal(t, "192.168.0.0/24", string(info))
+	assert.Equal(t, "192.168.0.0/24", info)
 
-	info, err = svc.GetExtraConfig([]byte("community"))
+	info, err = svc.GetExtraConfig("community")
 	assert.Equal(t, nil, err)
-	assert.Equal(t, "public", string(info))
+	assert.Equal(t, "public", info)
 
-	info, err = svc.GetExtraConfig([]byte("timeout"))
+	info, err = svc.GetExtraConfig("timeout")
 	assert.Equal(t, nil, err)
-	assert.Equal(t, "5", string(info))
+	assert.Equal(t, "5", info)
 
-	info, err = svc.GetExtraConfig([]byte("retries"))
+	info, err = svc.GetExtraConfig("retries")
 	assert.Equal(t, nil, err)
-	assert.Equal(t, "2", string(info))
+	assert.Equal(t, "2", info)
 
-	info, err = svc.GetExtraConfig([]byte("oid_batch_size"))
+	info, err = svc.GetExtraConfig("oid_batch_size")
 	assert.Equal(t, nil, err)
-	assert.Equal(t, "10", string(info))
+	assert.Equal(t, "10", info)
 
-	info, err = svc.GetExtraConfig([]byte("tags"))
+	info, err = svc.GetExtraConfig("tags")
 	assert.Equal(t, nil, err)
-	assert.Equal(t, "", string(info))
+	assert.Equal(t, "", info)
 
-	info, err = svc.GetExtraConfig([]byte("collect_device_metadata"))
+	info, err = svc.GetExtraConfig("collect_device_metadata")
 	assert.Equal(t, nil, err)
-	assert.Equal(t, "false", string(info))
+	assert.Equal(t, "false", info)
 
 	svc.config.CollectDeviceMetadata = true
-	info, err = svc.GetExtraConfig([]byte("collect_device_metadata"))
+	info, err = svc.GetExtraConfig("collect_device_metadata")
 	assert.Equal(t, nil, err)
-	assert.Equal(t, "true", string(info))
+	assert.Equal(t, "true", info)
 
 	svc.config.CollectDeviceMetadata = false
-	info, err = svc.GetExtraConfig([]byte("collect_device_metadata"))
+	info, err = svc.GetExtraConfig("collect_device_metadata")
 	assert.Equal(t, nil, err)
-	assert.Equal(t, "false", string(info))
+	assert.Equal(t, "false", info)
 
-	info, err = svc.GetExtraConfig([]byte("min_collection_interval"))
+	info, err = svc.GetExtraConfig("min_collection_interval")
 	assert.Equal(t, nil, err)
-	assert.Equal(t, "0", string(info))
+	assert.Equal(t, "0", info)
 
 	svc.config.UseDeviceIDAsHostname = false
-	info, err = svc.GetExtraConfig([]byte("use_device_id_as_hostname"))
+	info, err = svc.GetExtraConfig("use_device_id_as_hostname")
 	assert.Equal(t, nil, err)
-	assert.Equal(t, "false", string(info))
+	assert.Equal(t, "false", info)
 
 	svc.config.MinCollectionInterval = 60
-	info, err = svc.GetExtraConfig([]byte("min_collection_interval"))
+	info, err = svc.GetExtraConfig("min_collection_interval")
 	assert.Equal(t, nil, err)
-	assert.Equal(t, "60", string(info))
+	assert.Equal(t, "60", info)
 
-	info, err = svc.GetExtraConfig([]byte("namespace"))
+	info, err = svc.GetExtraConfig("namespace")
 	assert.Equal(t, nil, err)
-	assert.Equal(t, "my-ns", string(info))
+	assert.Equal(t, "my-ns", info)
 }
 
 func TestExtraConfigExtraTags(t *testing.T) {
@@ -248,9 +248,9 @@ func TestExtraConfigExtraTags(t *testing.T) {
 		config:       snmpConfig,
 	}
 
-	info, err := svc.GetExtraConfig([]byte("tags"))
+	info, err := svc.GetExtraConfig("tags")
 	assert.Equal(t, nil, err)
-	assert.Equal(t, "tag1:val_1_2,tag2:val_2", string(info))
+	assert.Equal(t, "tag1:val_1_2,tag2:val_2", info)
 }
 
 func TestExtraConfigv3(t *testing.T) {
@@ -271,27 +271,27 @@ func TestExtraConfigv3(t *testing.T) {
 		config:       snmpConfig,
 	}
 
-	info, err := svc.GetExtraConfig([]byte("user"))
+	info, err := svc.GetExtraConfig("user")
 	assert.Equal(t, nil, err)
-	assert.Equal(t, "admin", string(info))
+	assert.Equal(t, "admin", info)
 
-	info, err = svc.GetExtraConfig([]byte("auth_key"))
+	info, err = svc.GetExtraConfig("auth_key")
 	assert.Equal(t, nil, err)
-	assert.Equal(t, "secret", string(info))
+	assert.Equal(t, "secret", info)
 
-	info, err = svc.GetExtraConfig([]byte("auth_protocol"))
+	info, err = svc.GetExtraConfig("auth_protocol")
 	assert.Equal(t, nil, err)
-	assert.Equal(t, "SHA", string(info))
+	assert.Equal(t, "SHA", info)
 
-	info, err = svc.GetExtraConfig([]byte("priv_key"))
+	info, err = svc.GetExtraConfig("priv_key")
 	assert.Equal(t, nil, err)
-	assert.Equal(t, "private", string(info))
+	assert.Equal(t, "private", info)
 
-	info, err = svc.GetExtraConfig([]byte("priv_protocol"))
+	info, err = svc.GetExtraConfig("priv_protocol")
 	assert.Equal(t, nil, err)
-	assert.Equal(t, "DES", string(info))
+	assert.Equal(t, "DES", info)
 
-	info, err = svc.GetExtraConfig([]byte("loader"))
+	info, err = svc.GetExtraConfig("loader")
 	assert.Equal(t, nil, err)
-	assert.Equal(t, "core", string(info))
+	assert.Equal(t, "core", info)
 }

--- a/pkg/autodiscovery/listeners/types.go
+++ b/pkg/autodiscovery/listeners/types.go
@@ -34,7 +34,7 @@ type Service interface {
 	IsReady(context.Context) bool                        // is the service ready
 	GetCheckNames(context.Context) []string              // slice of check names defined in kubernetes annotations or container labels
 	HasFilter(containers.FilterType) bool                // whether the service is excluded by metrics or logs exclusion config
-	GetExtraConfig([]byte) ([]byte, error)               // Extra configuration values
+	GetExtraConfig(string) (string, error)               // Extra configuration values
 }
 
 // ServiceListener monitors running services and triggers check (un)scheduling

--- a/releasenotes/notes/ipv6-f5895a1f5d804eac.yaml
+++ b/releasenotes/notes/ipv6-f5895a1f5d804eac.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Partial support of IPv6 on EKS clusters
+    * Fix the kubelet client when the IP of the host is IPv6.
+    * Fix the substitution of `%%host%%` patterns inside the auto-discovery annotations:
+      If the concerned pod has an IPv6 and the `%%host%%` pattern appears inside an URL context, then the IPv6 is surrounded by square brackets.


### PR DESCRIPTION
### What does this PR do?

Add support for IPv6.

A specificity of IPv6 compared to IPv4 that was affecting the agent is the requirement to use square brackets in URL.
This is needed to distinguish the colons that are part of the IPv6 from the port separator.
Ex: `http://[::1]:80/`

This PR adds those square brackets around IPv6 in URL contexts.
* in the kubelet client
* when substituting the `%%host%%` pattern in the auto-discovery annotations.

### Motivation

Support [IPv6 on AWS EKS](https://docs.aws.amazon.com/eks/latest/userguide/cni-ipv6.html).

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Spawn an EKS cluster with IPv6 enabled ([script to create such an environment](https://github.com/DataDog/container-agent-envs-doc/blob/main/create_test_env/1_cluster_management/eks/create_ipv6.sh))
* Check that auto-discovery works.
* Check that the `kubelet` check works.

For ex., a pod with [these annotations](https://github.com/DataDog/container-agent-envs-doc/blob/047812be3230cb25bc8a810de3e4a7957442ec9f/create_test_env/3_dummy_app_management/k8s/manifests/nginx/deployment-nginx.yaml#L20):
```yaml
        ad.datadoghq.com/nginx.instances: '[{"nginx_status_url": "http://%%host%%/nginx_status"}]'
```

should show up like this in the output of `agent configcheck`:
```plain
=== nginx check ===
Configuration provider: kubernetes
Configuration source: kubelet:containerd://1b4370b4e8bbecc7c7206b0fea69fb67cb1da5af5aa6e30026c1a7c6b1895f4c
Instance ID: nginx:dc356e1b62c031e4
nginx_status_url: http://[2600:1f18:5b0:b803:6857::c]/nginx_status
[…]
```

Note the automatically added square brackets `[` `]`

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
