### PR TITLE
[Process Agent] Add user friendly output to check command

### DIFF
--- a/cmd/process-agent/app/check.go
+++ b/cmd/process-agent/app/check.go
@@ -202,8 +202,6 @@ func runCheckAsRealTime(cfg *config.AgentConfig, ch checks.CheckWithRealTime, st
 
 	time.Sleep(1 * time.Second)
 
-	printResultsBanner(ch.RealTimeName())
-
 	start := time.Now()
 	run, err := ch.RunWithOptions(cfg, nextGroupID, options)
 	stats.Runtime = time.Since(start)

--- a/cmd/process-agent/flags/flags_common.go
+++ b/cmd/process-agent/flags/flags_common.go
@@ -10,4 +10,6 @@ const (
 	CfgPath = "cfgpath"
 	// SysProbeConfig defines the sysprobe-config flag
 	SysProbeConfig = "sysprobe-config"
+	// JSONFlag defines the json flag for the check command
+	JSONFlag = "json"
 )

--- a/pkg/process/checks/stats.go
+++ b/pkg/process/checks/stats.go
@@ -1,0 +1,24 @@
+package checks
+
+import "time"
+
+type Stats struct {
+	CheckName         string
+	CheckConfigSource string
+	Runtime           time.Duration
+	IsRealtime        bool
+}
+
+func NewStats(c Check) *Stats {
+	return &Stats{
+		CheckName:  c.Name(),
+		IsRealtime: false,
+	}
+}
+
+func NewStatsRealtime(c CheckWithRealTime) *Stats {
+	return &Stats{
+		CheckName:  c.RealTimeName(),
+		IsRealtime: true,
+	}
+}

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -25,6 +25,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/logs"
 	"github.com/DataDog/datadog-agent/pkg/metadata/host"
+	procCheck "github.com/DataDog/datadog-agent/pkg/process/checks"
 	"github.com/DataDog/datadog-agent/pkg/snmp/traps"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
@@ -149,6 +150,10 @@ func GetCheckStatus(c check.Check, cs *check.Stats) ([]byte, error) {
 	}
 
 	return []byte(st), nil
+}
+
+func GetProcessCheckStatus(c procCheck.Check, cs *procCheck.Stats) ([]byte, error) {
+	panic("implement me!")
 }
 
 // GetDCAStatus grabs the status from expvar and puts it into a map


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

This PR adds a human readable output to the `process-agent check` command. The user can bring back the machine readable output by using the `--json` flag.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Run `process-agent check` with the `process`, `rtprocess` flags. Make sure that the output is human readable and seems accurate.

Next, try this again with adding the `--json` flag, and make sure that proper json is outputted to stdout.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
