### PR TITLE
[CWS] Add dns events in activity dumps

### DIFF
--- a/cmd/security-agent/app/runtime.go
+++ b/cmd/security-agent/app/runtime.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"time"
 
+	ddgostatsd "github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
@@ -43,7 +44,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/startstop"
 	"github.com/DataDog/datadog-agent/pkg/version"
-	ddgostatsd "github.com/DataDog/datadog-go/v5/statsd"
 )
 
 const (
@@ -208,13 +208,13 @@ func init() {
 	activityDumpGenerateDumpCmd.Flags().BoolVar(
 		&activityDumpArgs.withGraph,
 		"graph",
-		false,
+		true,
 		"generate a graph from the generated dump",
 	)
 	activityDumpGenerateDumpCmd.Flags().BoolVar(
 		&activityDumpArgs.differentiateArgs,
 		"differentiate-args",
-		false,
+		true,
 		"add the arguments in the process node merge algorithm",
 	)
 	activityDumpGenerateDumpCmd.Flags().StringVar(

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,10 +21,9 @@ import (
 	yaml "gopkg.in/yaml.v2"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check/defaults"
+	"github.com/DataDog/datadog-agent/pkg/secrets"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname/validate"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-
-	"github.com/DataDog/datadog-agent/pkg/secrets"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
@@ -1046,10 +1045,12 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.cleanup_period", 30)
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.tags_resolution_period", 60)
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.traced_cgroups_count", -1)
-	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.traced_event_types", []string{"exec", "open"})
+	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.traced_event_types", []string{"exec", "open", "dns"})
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.cgroup_dump_timeout", 30)
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.cgroup_wait_list_size", 10)
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.cgroup_output_directory", "")
+	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.cgroup_generate_graph", false)
+	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.cgroup_differentiate_args", true)
 	config.BindEnvAndSetDefault("runtime_security_config.network.enabled", true)
 	config.BindEnvAndSetDefault("runtime_security_config.network.lazy_interface_prefixes", []string{})
 	config.BindEnvAndSetDefault("runtime_security_config.remote_configuration.enabled", false)

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -118,6 +118,11 @@ type Config struct {
 	// ActivityDumpCgroupOutputDirectory defines the output directory for the cgroup activity dumps and graphs. Leave
 	// this field empty to prevent writing any output to disk.
 	ActivityDumpCgroupOutputDirectory string
+	// ActivityDumpCgroupGenerateGraph defines if system-probe should generate a graph for cgroup dumps.
+	ActivityDumpCgroupGenerateGraph bool
+	// ActivityDumpCgroupDifferentiateGraphs defines if system-probe should differentiate process nodes using process
+	// arguments for dumps.
+	ActivityDumpCgroupDifferentiateGraphs bool
 	// RuntimeMonitor defines if the runtime monitor should be enabled
 	RuntimeMonitor bool
 	// NetworkEnabled defines if the network probes should be activated
@@ -189,22 +194,27 @@ func NewConfig(cfg *config.Config) (*Config, error) {
 		LogPatterns:                        aconfig.Datadog.GetStringSlice("runtime_security_config.log_patterns"),
 		LogTags:                            aconfig.Datadog.GetStringSlice("runtime_security_config.log_tags"),
 		SelfTestEnabled:                    aconfig.Datadog.GetBool("runtime_security_config.self_test.enabled"),
-		ActivityDumpEnabled:                aconfig.Datadog.GetBool("runtime_security_config.activity_dump.enabled"),
-		ActivityDumpCleanupPeriod:          time.Duration(aconfig.Datadog.GetInt("runtime_security_config.activity_dump.cleanup_period")) * time.Second,
-		ActivityDumpTagsResolutionPeriod:   time.Duration(aconfig.Datadog.GetInt("runtime_security_config.activity_dump.tags_resolution_period")) * time.Second,
-		ActivityDumpTracedCgroupsCount:     aconfig.Datadog.GetInt("runtime_security_config.activity_dump.traced_cgroups_count"),
-		ActivityDumpTracedEventTypes:       model.ParseEventTypeStringSlice(aconfig.Datadog.GetStringSlice("runtime_security_config.activity_dump.traced_event_types")),
-		ActivityDumpCgroupDumpTimeout:      time.Duration(aconfig.Datadog.GetInt("runtime_security_config.activity_dump.cgroup_dump_timeout")) * time.Minute,
-		ActivityDumpCgroupWaitListSize:     aconfig.Datadog.GetInt("runtime_security_config.activity_dump.cgroup_wait_list_size"),
-		ActivityDumpCgroupOutputDirectory:  aconfig.Datadog.GetString("runtime_security_config.activity_dump.cgroup_output_directory"),
 		RuntimeMonitor:                     aconfig.Datadog.GetBool("runtime_security_config.runtime_monitor.enabled"),
 		NetworkEnabled:                     aconfig.Datadog.GetBool("runtime_security_config.network.enabled"),
 		NetworkLazyInterfacePrefixes:       aconfig.Datadog.GetStringSlice("runtime_security_config.network.lazy_interface_prefixes"),
+		RemoteConfigurationEnabled:         aconfig.Datadog.GetBool("runtime_security_config.remote_configuration.enabled"),
+
 		// runtime compilation
 		RuntimeCompilationEnabled:       aconfig.Datadog.GetBool("runtime_security_config.runtime_compilation.enabled"),
 		RuntimeCompiledConstantsEnabled: aconfig.Datadog.GetBool("runtime_security_config.runtime_compilation.compiled_constants_enabled"),
 		RuntimeCompiledConstantsIsSet:   aconfig.Datadog.IsSet("runtime_security_config.runtime_compilation.compiled_constants_enabled"),
-		RemoteConfigurationEnabled:      aconfig.Datadog.GetBool("runtime_security_config.remote_configuration.enabled"),
+
+		// activity dump
+		ActivityDumpEnabled:                   aconfig.Datadog.GetBool("runtime_security_config.activity_dump.enabled"),
+		ActivityDumpCleanupPeriod:             time.Duration(aconfig.Datadog.GetInt("runtime_security_config.activity_dump.cleanup_period")) * time.Second,
+		ActivityDumpTagsResolutionPeriod:      time.Duration(aconfig.Datadog.GetInt("runtime_security_config.activity_dump.tags_resolution_period")) * time.Second,
+		ActivityDumpTracedCgroupsCount:        aconfig.Datadog.GetInt("runtime_security_config.activity_dump.traced_cgroups_count"),
+		ActivityDumpTracedEventTypes:          model.ParseEventTypeStringSlice(aconfig.Datadog.GetStringSlice("runtime_security_config.activity_dump.traced_event_types")),
+		ActivityDumpCgroupDumpTimeout:         time.Duration(aconfig.Datadog.GetInt("runtime_security_config.activity_dump.cgroup_dump_timeout")) * time.Minute,
+		ActivityDumpCgroupWaitListSize:        aconfig.Datadog.GetInt("runtime_security_config.activity_dump.cgroup_wait_list_size"),
+		ActivityDumpCgroupOutputDirectory:     aconfig.Datadog.GetString("runtime_security_config.activity_dump.cgroup_output_directory"),
+		ActivityDumpCgroupGenerateGraph:       aconfig.Datadog.GetBool("runtime_security_config.activity_dump.cgroup_generate_graph"),
+		ActivityDumpCgroupDifferentiateGraphs: aconfig.Datadog.GetBool("runtime_security_config.activity_dump.cgroup_differentiate_args"),
 	}
 
 	// if runtime is enabled then we force fim

--- a/pkg/security/probe/activity_dump.go
+++ b/pkg/security/probe/activity_dump.go
@@ -343,7 +343,7 @@ func (ad *ActivityDump) Insert(event *Event) (newEntry bool) {
 
 	// check if this event type is traced
 	var traced bool
-	for _, evtType := range ad.adm.tracedEventTypes {
+	for _, evtType := range ad.adm.probe.config.ActivityDumpTracedEventTypes {
 		if evtType == event.GetEventType() {
 			traced = true
 		}
@@ -363,6 +363,8 @@ func (ad *ActivityDump) Insert(event *Event) (newEntry bool) {
 	switch event.GetEventType() {
 	case model.FileOpenEventType:
 		return node.InsertFileEvent(&event.Open.File, event, Runtime)
+	case model.DNSEventType:
+		return node.InsertDNSEvent(&event.DNS)
 	}
 	return false
 }
@@ -468,6 +470,26 @@ func NewProfileRule(expression string, ruleIDPrefix string) ProfileRule {
 	}
 }
 
+func (ad *ActivityDump) generateDNSRule(dns *DNSNode, activityNode *ProcessActivityNode, ancestors []*ProcessActivityNode, ruleIDPrefix string) []ProfileRule {
+	var rules []ProfileRule
+
+	if dns != nil {
+		rule := NewProfileRule(fmt.Sprintf(
+			"dns.question.name == \"%s\" && dns.question.type == \"%s\"",
+			dns.Name,
+			model.QType(dns.Type).String()),
+			ruleIDPrefix,
+		)
+		rule.Expression += fmt.Sprintf(" && process.file.path == \"%s\"", activityNode.Process.FileEvent.PathnameStr)
+		for _, parent := range ancestors {
+			rule.Expression += fmt.Sprintf(" && process.ancestors.file.path == \"%s\"", parent.Process.FileEvent.PathnameStr)
+		}
+		rules = append(rules, rule)
+	}
+
+	return rules
+}
+
 func (ad *ActivityDump) generateFIMRules(file *FileActivityNode, activityNode *ProcessActivityNode, ancestors []*ProcessActivityNode, ruleIDPrefix string) []ProfileRule {
 	var rules []ProfileRule
 
@@ -521,6 +543,12 @@ func (ad *ActivityDump) generateRules(node *ProcessActivityNode, ancestors []*Pr
 	for _, file := range node.Files {
 		fimRules := ad.generateFIMRules(file, node, ancestors, ruleIDPrefix)
 		rules = append(rules, fimRules...)
+	}
+
+	// add DNS rules
+	for _, dns := range node.DNSNames {
+		dnsRules := ad.generateDNSRule(dns, node, ancestors, ruleIDPrefix)
+		rules = append(rules, dnsRules...)
 	}
 
 	// add children rules recursively
@@ -662,6 +690,7 @@ type ProcessActivityNode struct {
 	GenerationType NodeGenerationType `msg:"generation_type"`
 
 	Files    map[string]*FileActivityNode `msg:"files,omitempty"`
+	DNSNames map[string]*DNSNode          `msg:"dns,omitempty"`
 	Children []*ProcessActivityNode       `msg:"children,omitempty"`
 }
 
@@ -679,6 +708,7 @@ func NewProcessActivityNode(entry *model.ProcessCacheEntry, generationType NodeG
 		Process:        entry.Process,
 		GenerationType: generationType,
 		Files:          make(map[string]*FileActivityNode),
+		DNSNames:       make(map[string]*DNSNode),
 	}
 	_ = pan.GetID()
 	pan.retain()
@@ -829,7 +859,7 @@ func (pan *ProcessActivityNode) snapshot(ad *ActivityDump) error {
 		return nil
 	}
 
-	for _, eventType := range ad.adm.tracedEventTypes {
+	for _, eventType := range ad.adm.probe.config.ActivityDumpTracedEventTypes {
 		switch eventType {
 		case model.FileOpenEventType:
 			if err = pan.snapshotFiles(p, ad); err != nil {
@@ -909,6 +939,15 @@ func (pan *ProcessActivityNode) snapshotFiles(p *process.Process, ad *ActivityDu
 		}
 	}
 	return nil
+}
+
+// InsertDNSEvent inserts
+func (pan *ProcessActivityNode) InsertDNSEvent(evt *model.DNSEvent) bool {
+	if _, ok := pan.DNSNames[evt.Name]; ok {
+		return false
+	}
+	pan.DNSNames[evt.Name] = NewDNSNode(evt)
+	return true
 }
 
 // FileActivityNode holds a tree representation of a list of files
@@ -1014,4 +1053,25 @@ func (fan *FileActivityNode) debug(prefix string) {
 	for _, child := range fan.Children {
 		child.debug("\t" + prefix)
 	}
+}
+
+// DNSNode is used to store a DNS node
+type DNSNode struct {
+	model.DNSEvent
+	id string
+}
+
+// NewDNSNode returns a new DNSNode instance
+func NewDNSNode(event *model.DNSEvent) *DNSNode {
+	return &DNSNode{
+		DNSEvent: *event,
+	}
+}
+
+// GetID returns the ID of the current DNS node
+func (n *DNSNode) GetID() string {
+	if len(n.id) == 0 {
+		n.id = eval.RandString(5)
+	}
+	return n.id
 }

--- a/pkg/security/probe/activity_dump_gen_linux.go
+++ b/pkg/security/probe/activity_dump_gen_linux.go
@@ -508,6 +508,113 @@ func (z *ActivityDump) Msgsize() (s int) {
 }
 
 // DecodeMsg implements msgp.Decodable
+func (z *DNSNode) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "DNSEvent":
+			err = z.DNSEvent.DecodeMsg(dc)
+			if err != nil {
+				err = msgp.WrapError(err, "DNSEvent")
+				return
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *DNSNode) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 1
+	// write "DNSEvent"
+	err = en.Append(0x81, 0xa8, 0x44, 0x4e, 0x53, 0x45, 0x76, 0x65, 0x6e, 0x74)
+	if err != nil {
+		return
+	}
+	err = z.DNSEvent.EncodeMsg(en)
+	if err != nil {
+		err = msgp.WrapError(err, "DNSEvent")
+		return
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *DNSNode) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 1
+	// string "DNSEvent"
+	o = append(o, 0x81, 0xa8, 0x44, 0x4e, 0x53, 0x45, 0x76, 0x65, 0x6e, 0x74)
+	o, err = z.DNSEvent.MarshalMsg(o)
+	if err != nil {
+		err = msgp.WrapError(err, "DNSEvent")
+		return
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *DNSNode) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "DNSEvent":
+			bts, err = z.DNSEvent.UnmarshalMsg(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "DNSEvent")
+				return
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *DNSNode) Msgsize() (s int) {
+	s = 1 + 9 + z.DNSEvent.Msgsize()
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
 func (z *FileActivityNode) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field
@@ -1451,33 +1558,98 @@ func (z *ProcessActivityNode) DecodeMsg(dc *msgp.Reader) (err error) {
 				}
 				z.Files[za0001] = za0002
 			}
-		case "children":
+		case "dns":
 			var zb0004 uint32
-			zb0004, err = dc.ReadArrayHeader()
+			zb0004, err = dc.ReadMapHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "DNSNames")
+				return
+			}
+			if z.DNSNames == nil {
+				z.DNSNames = make(map[string]*DNSNode, zb0004)
+			} else if len(z.DNSNames) > 0 {
+				for key := range z.DNSNames {
+					delete(z.DNSNames, key)
+				}
+			}
+			for zb0004 > 0 {
+				zb0004--
+				var za0003 string
+				var za0004 *DNSNode
+				za0003, err = dc.ReadString()
+				if err != nil {
+					err = msgp.WrapError(err, "DNSNames")
+					return
+				}
+				if dc.IsNil() {
+					err = dc.ReadNil()
+					if err != nil {
+						err = msgp.WrapError(err, "DNSNames", za0003)
+						return
+					}
+					za0004 = nil
+				} else {
+					if za0004 == nil {
+						za0004 = new(DNSNode)
+					}
+					var zb0005 uint32
+					zb0005, err = dc.ReadMapHeader()
+					if err != nil {
+						err = msgp.WrapError(err, "DNSNames", za0003)
+						return
+					}
+					for zb0005 > 0 {
+						zb0005--
+						field, err = dc.ReadMapKeyPtr()
+						if err != nil {
+							err = msgp.WrapError(err, "DNSNames", za0003)
+							return
+						}
+						switch msgp.UnsafeString(field) {
+						case "DNSEvent":
+							err = za0004.DNSEvent.DecodeMsg(dc)
+							if err != nil {
+								err = msgp.WrapError(err, "DNSNames", za0003, "DNSEvent")
+								return
+							}
+						default:
+							err = dc.Skip()
+							if err != nil {
+								err = msgp.WrapError(err, "DNSNames", za0003)
+								return
+							}
+						}
+					}
+				}
+				z.DNSNames[za0003] = za0004
+			}
+		case "children":
+			var zb0006 uint32
+			zb0006, err = dc.ReadArrayHeader()
 			if err != nil {
 				err = msgp.WrapError(err, "Children")
 				return
 			}
-			if cap(z.Children) >= int(zb0004) {
-				z.Children = (z.Children)[:zb0004]
+			if cap(z.Children) >= int(zb0006) {
+				z.Children = (z.Children)[:zb0006]
 			} else {
-				z.Children = make([]*ProcessActivityNode, zb0004)
+				z.Children = make([]*ProcessActivityNode, zb0006)
 			}
-			for za0003 := range z.Children {
+			for za0005 := range z.Children {
 				if dc.IsNil() {
 					err = dc.ReadNil()
 					if err != nil {
-						err = msgp.WrapError(err, "Children", za0003)
+						err = msgp.WrapError(err, "Children", za0005)
 						return
 					}
-					z.Children[za0003] = nil
+					z.Children[za0005] = nil
 				} else {
-					if z.Children[za0003] == nil {
-						z.Children[za0003] = new(ProcessActivityNode)
+					if z.Children[za0005] == nil {
+						z.Children[za0005] = new(ProcessActivityNode)
 					}
-					err = z.Children[za0003].DecodeMsg(dc)
+					err = z.Children[za0005].DecodeMsg(dc)
 					if err != nil {
-						err = msgp.WrapError(err, "Children", za0003)
+						err = msgp.WrapError(err, "Children", za0005)
 						return
 					}
 				}
@@ -1496,15 +1668,19 @@ func (z *ProcessActivityNode) DecodeMsg(dc *msgp.Reader) (err error) {
 // EncodeMsg implements msgp.Encodable
 func (z *ProcessActivityNode) EncodeMsg(en *msgp.Writer) (err error) {
 	// omitempty: check for empty values
-	zb0001Len := uint32(4)
-	var zb0001Mask uint8 /* 4 bits */
+	zb0001Len := uint32(5)
+	var zb0001Mask uint8 /* 5 bits */
 	if z.Files == nil {
 		zb0001Len--
 		zb0001Mask |= 0x4
 	}
-	if z.Children == nil {
+	if z.DNSNames == nil {
 		zb0001Len--
 		zb0001Mask |= 0x8
+	}
+	if z.Children == nil {
+		zb0001Len--
+		zb0001Mask |= 0x10
 	}
 	// variable map header, size zb0001Len
 	err = en.Append(0x80 | uint8(zb0001Len))
@@ -1566,6 +1742,43 @@ func (z *ProcessActivityNode) EncodeMsg(en *msgp.Writer) (err error) {
 		}
 	}
 	if (zb0001Mask & 0x8) == 0 { // if not empty
+		// write "dns"
+		err = en.Append(0xa3, 0x64, 0x6e, 0x73)
+		if err != nil {
+			return
+		}
+		err = en.WriteMapHeader(uint32(len(z.DNSNames)))
+		if err != nil {
+			err = msgp.WrapError(err, "DNSNames")
+			return
+		}
+		for za0003, za0004 := range z.DNSNames {
+			err = en.WriteString(za0003)
+			if err != nil {
+				err = msgp.WrapError(err, "DNSNames")
+				return
+			}
+			if za0004 == nil {
+				err = en.WriteNil()
+				if err != nil {
+					return
+				}
+			} else {
+				// map header, size 1
+				// write "DNSEvent"
+				err = en.Append(0x81, 0xa8, 0x44, 0x4e, 0x53, 0x45, 0x76, 0x65, 0x6e, 0x74)
+				if err != nil {
+					return
+				}
+				err = za0004.DNSEvent.EncodeMsg(en)
+				if err != nil {
+					err = msgp.WrapError(err, "DNSNames", za0003, "DNSEvent")
+					return
+				}
+			}
+		}
+	}
+	if (zb0001Mask & 0x10) == 0 { // if not empty
 		// write "children"
 		err = en.Append(0xa8, 0x63, 0x68, 0x69, 0x6c, 0x64, 0x72, 0x65, 0x6e)
 		if err != nil {
@@ -1576,16 +1789,16 @@ func (z *ProcessActivityNode) EncodeMsg(en *msgp.Writer) (err error) {
 			err = msgp.WrapError(err, "Children")
 			return
 		}
-		for za0003 := range z.Children {
-			if z.Children[za0003] == nil {
+		for za0005 := range z.Children {
+			if z.Children[za0005] == nil {
 				err = en.WriteNil()
 				if err != nil {
 					return
 				}
 			} else {
-				err = z.Children[za0003].EncodeMsg(en)
+				err = z.Children[za0005].EncodeMsg(en)
 				if err != nil {
-					err = msgp.WrapError(err, "Children", za0003)
+					err = msgp.WrapError(err, "Children", za0005)
 					return
 				}
 			}
@@ -1598,15 +1811,19 @@ func (z *ProcessActivityNode) EncodeMsg(en *msgp.Writer) (err error) {
 func (z *ProcessActivityNode) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
-	zb0001Len := uint32(4)
-	var zb0001Mask uint8 /* 4 bits */
+	zb0001Len := uint32(5)
+	var zb0001Mask uint8 /* 5 bits */
 	if z.Files == nil {
 		zb0001Len--
 		zb0001Mask |= 0x4
 	}
-	if z.Children == nil {
+	if z.DNSNames == nil {
 		zb0001Len--
 		zb0001Mask |= 0x8
+	}
+	if z.Children == nil {
+		zb0001Len--
+		zb0001Mask |= 0x10
 	}
 	// variable map header, size zb0001Len
 	o = append(o, 0x80|uint8(zb0001Len))
@@ -1641,16 +1858,36 @@ func (z *ProcessActivityNode) MarshalMsg(b []byte) (o []byte, err error) {
 		}
 	}
 	if (zb0001Mask & 0x8) == 0 { // if not empty
+		// string "dns"
+		o = append(o, 0xa3, 0x64, 0x6e, 0x73)
+		o = msgp.AppendMapHeader(o, uint32(len(z.DNSNames)))
+		for za0003, za0004 := range z.DNSNames {
+			o = msgp.AppendString(o, za0003)
+			if za0004 == nil {
+				o = msgp.AppendNil(o)
+			} else {
+				// map header, size 1
+				// string "DNSEvent"
+				o = append(o, 0x81, 0xa8, 0x44, 0x4e, 0x53, 0x45, 0x76, 0x65, 0x6e, 0x74)
+				o, err = za0004.DNSEvent.MarshalMsg(o)
+				if err != nil {
+					err = msgp.WrapError(err, "DNSNames", za0003, "DNSEvent")
+					return
+				}
+			}
+		}
+	}
+	if (zb0001Mask & 0x10) == 0 { // if not empty
 		// string "children"
 		o = append(o, 0xa8, 0x63, 0x68, 0x69, 0x6c, 0x64, 0x72, 0x65, 0x6e)
 		o = msgp.AppendArrayHeader(o, uint32(len(z.Children)))
-		for za0003 := range z.Children {
-			if z.Children[za0003] == nil {
+		for za0005 := range z.Children {
+			if z.Children[za0005] == nil {
 				o = msgp.AppendNil(o)
 			} else {
-				o, err = z.Children[za0003].MarshalMsg(o)
+				o, err = z.Children[za0005].MarshalMsg(o)
 				if err != nil {
-					err = msgp.WrapError(err, "Children", za0003)
+					err = msgp.WrapError(err, "Children", za0005)
 					return
 				}
 			}
@@ -1734,32 +1971,96 @@ func (z *ProcessActivityNode) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				}
 				z.Files[za0001] = za0002
 			}
-		case "children":
+		case "dns":
 			var zb0004 uint32
-			zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
-				err = msgp.WrapError(err, "Children")
+				err = msgp.WrapError(err, "DNSNames")
 				return
 			}
-			if cap(z.Children) >= int(zb0004) {
-				z.Children = (z.Children)[:zb0004]
-			} else {
-				z.Children = make([]*ProcessActivityNode, zb0004)
+			if z.DNSNames == nil {
+				z.DNSNames = make(map[string]*DNSNode, zb0004)
+			} else if len(z.DNSNames) > 0 {
+				for key := range z.DNSNames {
+					delete(z.DNSNames, key)
+				}
 			}
-			for za0003 := range z.Children {
+			for zb0004 > 0 {
+				var za0003 string
+				var za0004 *DNSNode
+				zb0004--
+				za0003, bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "DNSNames")
+					return
+				}
 				if msgp.IsNil(bts) {
 					bts, err = msgp.ReadNilBytes(bts)
 					if err != nil {
 						return
 					}
-					z.Children[za0003] = nil
+					za0004 = nil
 				} else {
-					if z.Children[za0003] == nil {
-						z.Children[za0003] = new(ProcessActivityNode)
+					if za0004 == nil {
+						za0004 = new(DNSNode)
 					}
-					bts, err = z.Children[za0003].UnmarshalMsg(bts)
+					var zb0005 uint32
+					zb0005, bts, err = msgp.ReadMapHeaderBytes(bts)
 					if err != nil {
-						err = msgp.WrapError(err, "Children", za0003)
+						err = msgp.WrapError(err, "DNSNames", za0003)
+						return
+					}
+					for zb0005 > 0 {
+						zb0005--
+						field, bts, err = msgp.ReadMapKeyZC(bts)
+						if err != nil {
+							err = msgp.WrapError(err, "DNSNames", za0003)
+							return
+						}
+						switch msgp.UnsafeString(field) {
+						case "DNSEvent":
+							bts, err = za0004.DNSEvent.UnmarshalMsg(bts)
+							if err != nil {
+								err = msgp.WrapError(err, "DNSNames", za0003, "DNSEvent")
+								return
+							}
+						default:
+							bts, err = msgp.Skip(bts)
+							if err != nil {
+								err = msgp.WrapError(err, "DNSNames", za0003)
+								return
+							}
+						}
+					}
+				}
+				z.DNSNames[za0003] = za0004
+			}
+		case "children":
+			var zb0006 uint32
+			zb0006, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Children")
+				return
+			}
+			if cap(z.Children) >= int(zb0006) {
+				z.Children = (z.Children)[:zb0006]
+			} else {
+				z.Children = make([]*ProcessActivityNode, zb0006)
+			}
+			for za0005 := range z.Children {
+				if msgp.IsNil(bts) {
+					bts, err = msgp.ReadNilBytes(bts)
+					if err != nil {
+						return
+					}
+					z.Children[za0005] = nil
+				} else {
+					if z.Children[za0005] == nil {
+						z.Children[za0005] = new(ProcessActivityNode)
+					}
+					bts, err = z.Children[za0005].UnmarshalMsg(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Children", za0005)
 						return
 					}
 				}
@@ -1790,12 +2091,24 @@ func (z *ProcessActivityNode) Msgsize() (s int) {
 			}
 		}
 	}
+	s += 4 + msgp.MapHeaderSize
+	if z.DNSNames != nil {
+		for za0003, za0004 := range z.DNSNames {
+			_ = za0004
+			s += msgp.StringPrefixSize + len(za0003)
+			if za0004 == nil {
+				s += msgp.NilSize
+			} else {
+				s += 1 + 9 + za0004.DNSEvent.Msgsize()
+			}
+		}
+	}
 	s += 9 + msgp.ArrayHeaderSize
-	for za0003 := range z.Children {
-		if z.Children[za0003] == nil {
+	for za0005 := range z.Children {
+		if z.Children[za0005] == nil {
 			s += msgp.NilSize
 		} else {
-			s += z.Children[za0003].Msgsize()
+			s += z.Children[za0005].Msgsize()
 		}
 	}
 	return

--- a/pkg/security/probe/activity_dump_gen_linux.go
+++ b/pkg/security/probe/activity_dump_gen_linux.go
@@ -525,12 +525,6 @@ func (z *DNSNode) DecodeMsg(dc *msgp.Reader) (err error) {
 			return
 		}
 		switch msgp.UnsafeString(field) {
-		case "DNSEvent":
-			err = z.DNSEvent.DecodeMsg(dc)
-			if err != nil {
-				err = msgp.WrapError(err, "DNSEvent")
-				return
-			}
 		default:
 			err = dc.Skip()
 			if err != nil {
@@ -543,32 +537,20 @@ func (z *DNSNode) DecodeMsg(dc *msgp.Reader) (err error) {
 }
 
 // EncodeMsg implements msgp.Encodable
-func (z *DNSNode) EncodeMsg(en *msgp.Writer) (err error) {
-	// map header, size 1
-	// write "DNSEvent"
-	err = en.Append(0x81, 0xa8, 0x44, 0x4e, 0x53, 0x45, 0x76, 0x65, 0x6e, 0x74)
+func (z DNSNode) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 0
+	err = en.Append(0x80)
 	if err != nil {
-		return
-	}
-	err = z.DNSEvent.EncodeMsg(en)
-	if err != nil {
-		err = msgp.WrapError(err, "DNSEvent")
 		return
 	}
 	return
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *DNSNode) MarshalMsg(b []byte) (o []byte, err error) {
+func (z DNSNode) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
-	// map header, size 1
-	// string "DNSEvent"
-	o = append(o, 0x81, 0xa8, 0x44, 0x4e, 0x53, 0x45, 0x76, 0x65, 0x6e, 0x74)
-	o, err = z.DNSEvent.MarshalMsg(o)
-	if err != nil {
-		err = msgp.WrapError(err, "DNSEvent")
-		return
-	}
+	// map header, size 0
+	o = append(o, 0x80)
 	return
 }
 
@@ -590,12 +572,6 @@ func (z *DNSNode) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			return
 		}
 		switch msgp.UnsafeString(field) {
-		case "DNSEvent":
-			bts, err = z.DNSEvent.UnmarshalMsg(bts)
-			if err != nil {
-				err = msgp.WrapError(err, "DNSEvent")
-				return
-			}
 		default:
 			bts, err = msgp.Skip(bts)
 			if err != nil {
@@ -609,8 +585,8 @@ func (z *DNSNode) UnmarshalMsg(bts []byte) (o []byte, err error) {
 }
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
-func (z *DNSNode) Msgsize() (s int) {
-	s = 1 + 9 + z.DNSEvent.Msgsize()
+func (z DNSNode) Msgsize() (s int) {
+	s = 1
 	return
 }
 
@@ -1606,12 +1582,6 @@ func (z *ProcessActivityNode) DecodeMsg(dc *msgp.Reader) (err error) {
 							return
 						}
 						switch msgp.UnsafeString(field) {
-						case "DNSEvent":
-							err = za0004.DNSEvent.DecodeMsg(dc)
-							if err != nil {
-								err = msgp.WrapError(err, "DNSNames", za0003, "DNSEvent")
-								return
-							}
 						default:
 							err = dc.Skip()
 							if err != nil {
@@ -1764,15 +1734,9 @@ func (z *ProcessActivityNode) EncodeMsg(en *msgp.Writer) (err error) {
 					return
 				}
 			} else {
-				// map header, size 1
-				// write "DNSEvent"
-				err = en.Append(0x81, 0xa8, 0x44, 0x4e, 0x53, 0x45, 0x76, 0x65, 0x6e, 0x74)
+				// map header, size 0
+				err = en.Append(0x80)
 				if err != nil {
-					return
-				}
-				err = za0004.DNSEvent.EncodeMsg(en)
-				if err != nil {
-					err = msgp.WrapError(err, "DNSNames", za0003, "DNSEvent")
 					return
 				}
 			}
@@ -1866,14 +1830,8 @@ func (z *ProcessActivityNode) MarshalMsg(b []byte) (o []byte, err error) {
 			if za0004 == nil {
 				o = msgp.AppendNil(o)
 			} else {
-				// map header, size 1
-				// string "DNSEvent"
-				o = append(o, 0x81, 0xa8, 0x44, 0x4e, 0x53, 0x45, 0x76, 0x65, 0x6e, 0x74)
-				o, err = za0004.DNSEvent.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "DNSNames", za0003, "DNSEvent")
-					return
-				}
+				// map header, size 0
+				o = append(o, 0x80)
 			}
 		}
 	}
@@ -2018,12 +1976,6 @@ func (z *ProcessActivityNode) UnmarshalMsg(bts []byte) (o []byte, err error) {
 							return
 						}
 						switch msgp.UnsafeString(field) {
-						case "DNSEvent":
-							bts, err = za0004.DNSEvent.UnmarshalMsg(bts)
-							if err != nil {
-								err = msgp.WrapError(err, "DNSNames", za0003, "DNSEvent")
-								return
-							}
 						default:
 							bts, err = msgp.Skip(bts)
 							if err != nil {
@@ -2099,7 +2051,7 @@ func (z *ProcessActivityNode) Msgsize() (s int) {
 			if za0004 == nil {
 				s += msgp.NilSize
 			} else {
-				s += 1 + 9 + za0004.DNSEvent.Msgsize()
+				s += 1
 			}
 		}
 	}

--- a/pkg/security/probe/activity_dump_graph.go
+++ b/pkg/security/probe/activity_dump_graph.go
@@ -21,10 +21,16 @@ var (
 	processColor         = "#8fbbff"
 	processRuntimeColor  = "#edf3ff"
 	processSnapshotColor = "white"
+	processShape         = "record"
 
 	fileColor         = "#77bf77"
 	fileRuntimeColor  = "#e9f3e7"
 	fileSnapshotColor = "white"
+	fileShape         = "record"
+
+	dnsColor        = "#ff9800"
+	dnsRuntimeColor = "#ffebcd"
+	dnsShape        = "record"
 )
 
 type node struct {
@@ -33,6 +39,7 @@ type node struct {
 	Size      int
 	Color     string
 	FillColor string
+	Shape     string
 }
 
 type edge struct {
@@ -61,7 +68,7 @@ func (ad *ActivityDump) generateGraph() error {
 		edge [penwidth=2]
 
 		{{ range .Nodes }}
-		{{ .ID }} [label="{{ .Label }}", fontsize={{ .Size }}, shape=record, fontname = "arial", color="{{ .Color }}", fillcolor="{{ .FillColor }}", style="filled"]{{ end }}
+		{{ .ID }} [label="{{ .Label }}", fontsize={{ .Size }}, shape={{ .Shape }}, fontname = "arial", color="{{ .Color }}", fillcolor="{{ .FillColor }}", style="filled"]{{ end }}
 
 		{{ range .Edges }}
 		{{ .Link }} [arrowhead=none, color="{{ .Color }}"]
@@ -100,6 +107,7 @@ func (ad *ActivityDump) prepareProcessActivityNode(p *ProcessActivityNode, data 
 		Label: fmt.Sprintf("%s %s", p.Process.FileEvent.PathnameStr, args),
 		Size:  60,
 		Color: processColor,
+		Shape: processShape,
 	}
 	switch p.GenerationType {
 	case Runtime:
@@ -109,6 +117,13 @@ func (ad *ActivityDump) prepareProcessActivityNode(p *ProcessActivityNode, data 
 	}
 	data.Nodes[p.GetID()] = pan
 
+	for _, n := range p.DNSNames {
+		data.Edges = append(data.Edges, edge{
+			Link:  p.GetID() + " -> " + p.GetID() + n.GetID(),
+			Color: dnsColor,
+		})
+		ad.prepareDNSNode(n, data, p.GetID())
+	}
 	for _, f := range p.Files {
 		data.Edges = append(data.Edges, edge{
 			Link:  p.GetID() + " -> " + p.GetID() + f.GetID(),
@@ -125,6 +140,18 @@ func (ad *ActivityDump) prepareProcessActivityNode(p *ProcessActivityNode, data 
 	}
 }
 
+func (ad *ActivityDump) prepareDNSNode(n *DNSNode, data *graph, processID string) {
+	dnsNode := node{
+		ID:        processID + n.GetID(),
+		Label:     n.Name,
+		Size:      30,
+		Color:     dnsColor,
+		FillColor: dnsRuntimeColor,
+		Shape:     dnsShape,
+	}
+	data.Nodes[dnsNode.ID] = dnsNode
+}
+
 func (ad *ActivityDump) prepareFileNode(f *FileActivityNode, data *graph, prefix string, processID string) {
 	mergedID := processID + f.GetID()
 	fn := node{
@@ -132,6 +159,7 @@ func (ad *ActivityDump) prepareFileNode(f *FileActivityNode, data *graph, prefix
 		Label: f.getNodeLabel(),
 		Size:  30,
 		Color: fileColor,
+		Shape: fileShape,
 	}
 	switch f.GenerationType {
 	case Runtime:

--- a/pkg/security/probe/activity_dump_graph.go
+++ b/pkg/security/probe/activity_dump_graph.go
@@ -15,6 +15,8 @@ import (
 	"text/template"
 
 	"github.com/tinylib/msgp/msgp"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 )
 
 var (
@@ -141,9 +143,19 @@ func (ad *ActivityDump) prepareProcessActivityNode(p *ProcessActivityNode, data 
 }
 
 func (ad *ActivityDump) prepareDNSNode(n *DNSNode, data *graph, processID string) {
+	if len(n.requests) == 0 {
+		// save guard, this should never happen
+		return
+	}
+	name := n.requests[0].Name + " (" + (model.QType(n.requests[0].Type).String())
+	for _, req := range n.requests[1:] {
+		name += ", " + model.QType(req.Type).String()
+	}
+	name += ")"
+
 	dnsNode := node{
 		ID:        processID + n.GetID(),
-		Label:     n.Name,
+		Label:     name,
 		Size:      30,
 		Color:     dnsColor,
 		FillColor: dnsRuntimeColor,

--- a/pkg/security/probe/namespace_resolver_graph.go
+++ b/pkg/security/probe/namespace_resolver_graph.go
@@ -21,10 +21,12 @@ var (
 	namespaceColor        = "#8fbbff"
 	lonelyNamespaceColor  = "#edf3ff"
 	activeNamespacetColor = "white"
+	namespaceShape        = "record"
 
 	deviceColor       = "#77bf77"
 	queuedDeviceColor = "#e9f3e7"
 	activeDeviceColor = "white"
+	deviceShape       = "record"
 )
 
 func (nr *NamespaceResolver) generateGraph(dump []NetworkNamespaceDump, graphFile *os.File) error {
@@ -67,6 +69,7 @@ func (nr *NamespaceResolver) generateGraphDataFromDump(dump []NetworkNamespaceDu
 			ID:    utils.RandString(10),
 			Label: fmt.Sprintf("%v [fd:%d][handle:%v]", netns.NsID, netns.HandleFD, netns.HandlePath),
 			Color: namespaceColor,
+			Shape: namespaceShape,
 			Size:  60,
 		}
 		if netns.LonelyTimeout.Equal(time.Time{}) {
@@ -83,6 +86,7 @@ func (nr *NamespaceResolver) generateGraphDataFromDump(dump []NetworkNamespaceDu
 				Label:     fmt.Sprintf("%s [%d]", dev.IfName, dev.IfIndex),
 				FillColor: activeDeviceColor,
 				Color:     deviceColor,
+				Shape:     deviceShape,
 				Size:      50,
 			}
 			g.Nodes[devNode.ID] = devNode
@@ -99,6 +103,7 @@ func (nr *NamespaceResolver) generateGraphDataFromDump(dump []NetworkNamespaceDu
 				Label:     fmt.Sprintf("%s [%d]", dev.IfName, dev.IfIndex),
 				FillColor: queuedDeviceColor,
 				Color:     deviceColor,
+				Shape:     deviceShape,
 				Size:      50,
 			}
 			g.Nodes[devNode.ID] = devNode

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -803,7 +803,6 @@ type NetworkContext struct {
 }
 
 // DNSEvent represents a DNS event
-//msgp:ignore DNSEvent
 type DNSEvent struct {
 	ID    uint16 `field:"-" msg:"-"`
 	Name  string `field:"question.name" msg:"name" op_override:"eval.DNSNameCmp"` // the queried domain name

--- a/pkg/security/secl/model/model_gen.go
+++ b/pkg/security/secl/model/model_gen.go
@@ -435,6 +435,209 @@ func (z *Credentials) Msgsize() (s int) {
 }
 
 // DecodeMsg implements msgp.Decodable
+func (z *DNSEvent) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "name":
+			z.Name, err = dc.ReadString()
+			if err != nil {
+				err = msgp.WrapError(err, "Name")
+				return
+			}
+		case "type":
+			z.Type, err = dc.ReadUint16()
+			if err != nil {
+				err = msgp.WrapError(err, "Type")
+				return
+			}
+		case "class":
+			z.Class, err = dc.ReadUint16()
+			if err != nil {
+				err = msgp.WrapError(err, "Class")
+				return
+			}
+		case "size":
+			z.Size, err = dc.ReadUint16()
+			if err != nil {
+				err = msgp.WrapError(err, "Size")
+				return
+			}
+		case "count":
+			z.Count, err = dc.ReadUint16()
+			if err != nil {
+				err = msgp.WrapError(err, "Count")
+				return
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *DNSEvent) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 5
+	// write "name"
+	err = en.Append(0x85, 0xa4, 0x6e, 0x61, 0x6d, 0x65)
+	if err != nil {
+		return
+	}
+	err = en.WriteString(z.Name)
+	if err != nil {
+		err = msgp.WrapError(err, "Name")
+		return
+	}
+	// write "type"
+	err = en.Append(0xa4, 0x74, 0x79, 0x70, 0x65)
+	if err != nil {
+		return
+	}
+	err = en.WriteUint16(z.Type)
+	if err != nil {
+		err = msgp.WrapError(err, "Type")
+		return
+	}
+	// write "class"
+	err = en.Append(0xa5, 0x63, 0x6c, 0x61, 0x73, 0x73)
+	if err != nil {
+		return
+	}
+	err = en.WriteUint16(z.Class)
+	if err != nil {
+		err = msgp.WrapError(err, "Class")
+		return
+	}
+	// write "size"
+	err = en.Append(0xa4, 0x73, 0x69, 0x7a, 0x65)
+	if err != nil {
+		return
+	}
+	err = en.WriteUint16(z.Size)
+	if err != nil {
+		err = msgp.WrapError(err, "Size")
+		return
+	}
+	// write "count"
+	err = en.Append(0xa5, 0x63, 0x6f, 0x75, 0x6e, 0x74)
+	if err != nil {
+		return
+	}
+	err = en.WriteUint16(z.Count)
+	if err != nil {
+		err = msgp.WrapError(err, "Count")
+		return
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *DNSEvent) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 5
+	// string "name"
+	o = append(o, 0x85, 0xa4, 0x6e, 0x61, 0x6d, 0x65)
+	o = msgp.AppendString(o, z.Name)
+	// string "type"
+	o = append(o, 0xa4, 0x74, 0x79, 0x70, 0x65)
+	o = msgp.AppendUint16(o, z.Type)
+	// string "class"
+	o = append(o, 0xa5, 0x63, 0x6c, 0x61, 0x73, 0x73)
+	o = msgp.AppendUint16(o, z.Class)
+	// string "size"
+	o = append(o, 0xa4, 0x73, 0x69, 0x7a, 0x65)
+	o = msgp.AppendUint16(o, z.Size)
+	// string "count"
+	o = append(o, 0xa5, 0x63, 0x6f, 0x75, 0x6e, 0x74)
+	o = msgp.AppendUint16(o, z.Count)
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *DNSEvent) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "name":
+			z.Name, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Name")
+				return
+			}
+		case "type":
+			z.Type, bts, err = msgp.ReadUint16Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Type")
+				return
+			}
+		case "class":
+			z.Class, bts, err = msgp.ReadUint16Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Class")
+				return
+			}
+		case "size":
+			z.Size, bts, err = msgp.ReadUint16Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Size")
+				return
+			}
+		case "count":
+			z.Count, bts, err = msgp.ReadUint16Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Count")
+				return
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *DNSEvent) Msgsize() (s int) {
+	s = 1 + 5 + msgp.StringPrefixSize + len(z.Name) + 5 + msgp.Uint16Size + 6 + msgp.Uint16Size + 5 + msgp.Uint16Size + 6 + msgp.Uint16Size
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
 func (z *FileEvent) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

This PR adds the DNS event type in the activity dumps.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Expand the amount of dumped events.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
