### PR TITLE
[CWS] improve speed of btfhub archive constant builder script

### DIFF
--- a/pkg/security/probe/constantfetch/btfhub/main.go
+++ b/pkg/security/probe/constantfetch/btfhub/main.go
@@ -74,7 +74,7 @@ type treeWalkCollector struct {
 func newTreeWalkCollector() *treeWalkCollector {
 	return &treeWalkCollector{
 		counter: 0,
-		sem:     semaphore.NewWeighted(int64(runtime.NumCPU())),
+		sem:     semaphore.NewWeighted(int64(runtime.NumCPU() * 2)),
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR allows the script to extract multiple constant sets in parallel.
The concurrency is limited to `2 * NCPUs` because you can easily go over the limit in opened file descriptor.

Before:
```
Executed in  208.30 secs    fish           external
   usr time  196.47 secs  805.00 micros  196.47 secs
   sys time   63.45 secs    0.00 micros   63.45 secs
```
After:
```
Executed in   74.87 secs    fish           external
   usr time  172.61 secs    0.00 micros  172.61 secs
   sys time   11.13 secs  376.00 micros   11.13 secs
```

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
