### PR TITLE
Bump Gohai version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -68,7 +68,7 @@ require (
 	github.com/DataDog/datadog-operator v0.5.0-rc.2.0.20210402083916-25ba9a22e67a
 	github.com/DataDog/ebpf v0.0.0-20220301203322-3fc9ab3b8daf
 	github.com/DataDog/ebpf-manager v0.0.0-20220325092125-b2221d88caf3
-	github.com/DataDog/gohai v0.0.0-20220321112924-fb06c09f7924
+	github.com/DataDog/gohai v0.0.0-20220329101230-3b6a804fdd24
 	github.com/DataDog/gopsutil v0.0.0-20220308095538-d086941833e3
 	github.com/DataDog/nikos v1.7.5
 	github.com/DataDog/sketches-go v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,8 @@ github.com/DataDog/ebpf-manager v0.0.0-20220325092125-b2221d88caf3 h1:QixW0L0iCN
 github.com/DataDog/ebpf-manager v0.0.0-20220325092125-b2221d88caf3/go.mod h1:eOlqnaKvEMqn47uNlK+UMdQHwpnL0xXFJAhxwYgLqT0=
 github.com/DataDog/extendeddaemonset v0.5.1-0.20210315105301-41547d4ff09c h1:a9OMhZzrrB4nd2eAsXZIBkQ061Gb/QT4CI2g+OWWevs=
 github.com/DataDog/extendeddaemonset v0.5.1-0.20210315105301-41547d4ff09c/go.mod h1:lMIXf2EAzxbIv2zEvWu1bdqlaclUWoCtN13MHuPcY5I=
-github.com/DataDog/gohai v0.0.0-20220321112924-fb06c09f7924 h1:oPdBVQvB45hiyDnaYQJ6IBbOpwOVxfDZu3p+1LgIJMs=
-github.com/DataDog/gohai v0.0.0-20220321112924-fb06c09f7924/go.mod h1:uZzedF91i4YWo9OqkpdYKS2V0pR6piGY6kfQZk44JA0=
+github.com/DataDog/gohai v0.0.0-20220329101230-3b6a804fdd24 h1:R8hgt2Rj4j5vED8q/SLVYSqmlA466xpBjRdBe+QOwO0=
+github.com/DataDog/gohai v0.0.0-20220329101230-3b6a804fdd24/go.mod h1:uZzedF91i4YWo9OqkpdYKS2V0pR6piGY6kfQZk44JA0=
 github.com/DataDog/gopsutil v0.0.0-20200624212600-1b53412ef321/go.mod h1:tGQp6XG4XpOyy67WG/YWXVxzOY6LejK35e8KcQhtRIQ=
 github.com/DataDog/gopsutil v0.0.0-20211112180027-9aa392ae181a/go.mod h1:glkxNt/qRu9lnpmUEQwOIAXW+COWDTBOTEAHqbgBPts=
 github.com/DataDog/gopsutil v0.0.0-20220308095538-d086941833e3 h1:TzjzV4FcSe81oI4372DijvtStUuAS5m0uts6cbvueGU=

--- a/releasenotes/notes/gohai-bump-to-8f11139570f7-60a8a8165f350584.yaml
+++ b/releasenotes/notes/gohai-bump-to-8f11139570f7-60a8a8165f350584.yaml
@@ -1,0 +1,11 @@
+---
+fixes:
+  - |
+    Fix Gohai not being able to fetch network information when running on a non-English windows (when the output of
+    commands like `ipconfig` were not in English). `Gohai` no longer relies on system commands but uses Golang `net` package
+    instead (same as Linux hosts).
+    This bug had the side effect of preventing network monitoring data to be linked back to the host.
+other:
+  - |
+    Gohai dependency has been upgraded. This brings a newer version of gopsutil and a fix when fetching network
+    information in non-english Windows (see `fixes` section).


### PR DESCRIPTION
### What does this PR do?

This bump the version of gohai used, bringing 2 new changes:
- Using [gopsutil/v3](https://github.com/DataDog/gohai/pull/91)
- Switching to golang native package instead of `ipconfig` to collect information on windows. This fixes the issue where gohai could not collect network data on non english system. See this [PR](https://github.com/DataDog/gohai/pull/92)

### Describe how to test/QA your changes

`agent-platform` should test the `gopsutil` PR.

`agent-core` the network config PR:
- start a windows host and install the Agent with the network monitoring enabled: https://docs.datadoghq.com/network_monitoring/performance/setup/?tab=agentlinux
- Set the host in japanese:
  + in language add the japanese package and remove the english one
  + in powershell run:
     ```
     Set-WinSystemLocale ja-JP
     Set-WinUserLanguageList ja-JP -Force
     ```
  + Restart the host/VM
- Check on the `infra list` page that for your host the `network`  informations under `Host Info` tab are present. 
- Check on the infra list that the `Network` tab show some data
- Check that the `Infrastructure` > `Network Map` > `Flows` has some data for the host.
