### PR TITLE
Run Windows unit tests on PRs from forks

### DIFF
--- a/.github/workflows/windows-unittests.yml
+++ b/.github/workflows/windows-unittests.yml
@@ -1,6 +1,7 @@
 name: "Windows unit tests"
 
-on: [push]
+on:
+  - pull_request
 
 jobs:
   windows-unit-tests:


### PR DESCRIPTION
### What does this PR do?

Changes the unit tests workflow trigger from `push` to [`pull_request`](https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request).

### Motivation
So the workflow runs on PRs from external contributors.

Would have caught the Windows build error added in #11023 and fixed in #11481.