### PR TITLE
[WIP][process-agent] Add human readable output to real time checks

### DIFF
--- a/pkg/process/checks/format.go
+++ b/pkg/process/checks/format.go
@@ -21,6 +21,7 @@ import (
 )
 
 var (
+	// ErrNoHumanFormat is thrown when a check without human-readable support is passed to the HumanFormat method
 	ErrNoHumanFormat = errors.New("no implementation of human-readable output for this check")
 
 	//go:embed templates/processes.tmpl
@@ -46,6 +47,7 @@ var (
 	}
 )
 
+// HumanFormat takes the messages produced by a check run and outputs them in a human-readable format
 func HumanFormat(check string, msgs []model.MessageBody, w io.Writer) error {
 	switch check {
 	case config.ProcessCheckName:

--- a/pkg/process/checks/format_test.go
+++ b/pkg/process/checks/format_test.go
@@ -278,6 +278,112 @@ func TestHumanFormatContainer(t *testing.T) {
 	assert.Equal(t, expectHumanFormat, w.String())
 }
 
+func TestHumanFormatRealtimeContainer(t *testing.T) {
+	msgs := []model.MessageBody{
+		&model.CollectorContainerRealTime{
+			Stats: []*model.ContainerStat{
+				{
+					Id:          "foo-container-id",
+					CpuLimit:    2.0,
+					MemLimit:    300.0,
+					State:       model.ContainerState_running,
+					Health:      model.ContainerHealth_healthy,
+					Started:     1609733140,
+					TotalPct:    10,
+					SystemPct:   9,
+					UserPct:     1,
+					MemRss:      100,
+					MemCache:    200,
+					Rbps:        10,
+					Wbps:        20,
+					NetRcvdPs:   5,
+					NetSentPs:   10,
+					NetRcvdBps:  100,
+					NetSentBps:  200,
+					ThreadCount: 40,
+					ThreadLimit: 100,
+				},
+				{
+					Id:          "baz-container-id",
+					CpuLimit:    3.0,
+					MemLimit:    200.0,
+					State:       model.ContainerState_running,
+					Health:      model.ContainerHealth_unhealthy,
+					Started:     1609733240,
+					TotalPct:    90,
+					SystemPct:   80,
+					UserPct:     10,
+					MemRss:      10,
+					MemCache:    20,
+					Rbps:        10,
+					Wbps:        20,
+					NetRcvdPs:   5,
+					NetSentPs:   10,
+					NetRcvdBps:  100,
+					NetSentBps:  200,
+					ThreadCount: 40,
+					ThreadLimit: 100,
+				},
+			},
+		},
+	}
+
+	w := &strings.Builder{}
+	err := humanFormatRealtimeContainer(msgs, w)
+	assert.NoError(t, err)
+
+	const expectHumanFormat = `RealTime Containers
+===================
+> ID: baz-container-id
+  CPU Limit:    3
+  Memory Limit: 200
+  State:  running
+  Health: unhealthy
+  Started: 1609733240
+  CPU:
+    Total:  90%
+    System: 80%
+    User:   10%
+  Memory:
+    RSS: 10
+    Cache: 20
+  IO:
+    Read Bytes/s: 10
+    Write Bytes/s: 20
+  Net:
+    Received Ops/s:   5
+    Sent Ops/s:       10
+    Received Bytes/s: 100
+    Sent Bytes/s:     200
+  Thread Count: 40
+  Thread Limit: 100
+> ID: foo-container-id
+  CPU Limit:    2
+  Memory Limit: 300
+  State:  running
+  Health: healthy
+  Started: 1609733140
+  CPU:
+    Total:  10%
+    System: 9%
+    User:   1%
+  Memory:
+    RSS: 100
+    Cache: 200
+  IO:
+    Read Bytes/s: 10
+    Write Bytes/s: 20
+  Net:
+    Received Ops/s:   5
+    Sent Ops/s:       10
+    Received Bytes/s: 100
+    Sent Bytes/s:     200
+  Thread Count: 40
+  Thread Limit: 100
+`
+	assert.Equal(t, expectHumanFormat, w.String())
+}
+
 func TestHumanFormatProcessDiscovery(t *testing.T) {
 	var msgs []model.MessageBody = []model.MessageBody{
 		&model.CollectorProcDiscovery{

--- a/pkg/process/checks/format_test.go
+++ b/pkg/process/checks/format_test.go
@@ -159,9 +159,10 @@ func TestHumanFormatRealTimeProcess(t *testing.T) {
 		&model.CollectorRealTime{
 			Stats: []*model.ProcessStat{
 				{
-					Pid:         2,
-					ContainerId: "foo-container",
-					CreateTime:  1609733040,
+					Pid:          2,
+					ContainerId:  "foo-container",
+					CreateTime:   1609733040,
+					ProcessState: model.ProcessState_R,
 					Memory: &model.MemoryStat{
 						Rss:    100,
 						Vms:    200,
@@ -225,6 +226,7 @@ func TestHumanFormatRealTimeProcess(t *testing.T) {
 > PID: 2
   Container ID: foo-container
   Create Time: 1609733040
+  State: R
   Memory:
     Rss:    100
     Vms:    200

--- a/pkg/process/checks/format_test.go
+++ b/pkg/process/checks/format_test.go
@@ -154,6 +154,126 @@ Containers
 	assert.Equal(t, expectHumanFormat, w.String())
 }
 
+func TestHumanFormatRealTimeProcess(t *testing.T) {
+	msgs := []model.MessageBody{
+		&model.CollectorRealTime{
+			Stats: []*model.ProcessStat{
+				{
+					Pid:         2,
+					ContainerId: "foo-container",
+					CreateTime:  1609733040,
+					Memory: &model.MemoryStat{
+						Rss:    100,
+						Vms:    200,
+						Swap:   300,
+						Shared: 400,
+						Text:   500,
+						Lib:    600,
+						Data:   700,
+						Dirty:  800,
+					},
+					Cpu: &model.CPUStat{
+						TotalPct:   3.,
+						SystemPct:  2.,
+						UserPct:    1.,
+						NumThreads: 100,
+						Nice:       2,
+					},
+					OpenFdCount:            200,
+					VoluntaryCtxSwitches:   1234,
+					InvoluntaryCtxSwitches: 45,
+					IoStat: &model.IOStat{
+						ReadRate:       10.0,
+						WriteRate:      30.0,
+						ReadBytesRate:  100.0,
+						WriteBytesRate: 200.0,
+					},
+				},
+			},
+			ContainerStats: []*model.ContainerStat{
+				{
+					Id:          "foo-container-id",
+					CpuLimit:    2.0,
+					MemLimit:    300.0,
+					State:       model.ContainerState_running,
+					Health:      model.ContainerHealth_healthy,
+					Started:     1609733140,
+					TotalPct:    10,
+					SystemPct:   9,
+					UserPct:     1,
+					MemRss:      100,
+					MemCache:    200,
+					Rbps:        10,
+					Wbps:        20,
+					NetRcvdPs:   5,
+					NetSentPs:   10,
+					NetRcvdBps:  100,
+					NetSentBps:  200,
+					ThreadCount: 40,
+					ThreadLimit: 100,
+				},
+			},
+		},
+	}
+
+	w := &strings.Builder{}
+	err := humanFormatRealTimeProcess(msgs, w)
+	assert.NoError(t, err)
+
+	const expectHumanFormat = `RealTime Processes
+==================
+> PID: 2
+  Container ID: foo-container
+  Create Time: 1609733040
+  Memory:
+    Rss:    100
+    Vms:    200
+    Swap:   300
+    Shared: 400
+    Text:   500
+    Lib:    600
+    Data:   700
+    Dirty:  800
+  CPU: Total: 3% System: 2% User: 1%
+  Threads: 100
+  Nice: 2
+  Open Files: 200
+  Voluntary Context Switches: 1234
+  Involuntary Context Switches: 45
+  IO:
+    Read:  100 Bytes/s 10 Ops/s
+    Write: 200 Bytes/s 30 Ops/s
+
+RealTime Containers
+===================
+> ID: foo-container-id
+  CPU Limit:    2
+  Memory Limit: 300
+  State:  running
+  Health: healthy
+  Started: 1609733140
+  CPU:
+    Total:  10%
+    System: 9%
+    User:   1%
+  Memory:
+    RSS: 100
+    Cache: 200
+  IO:
+    Read Bytes/s: 10
+    Write Bytes/s: 20
+  Net:
+    Received Ops/s:   5
+    Sent Ops/s:       10
+    Received Bytes/s: 100
+    Sent Bytes/s:     200
+  Thread Count: 40
+  Thread Limit: 100
+
+`
+	assert.Equal(t, expectHumanFormat, w.String())
+}
+
 func TestHumanFormatContainer(t *testing.T) {
 	var msgs []model.MessageBody = []model.MessageBody{
 		&model.CollectorContainer{
@@ -278,7 +398,7 @@ func TestHumanFormatContainer(t *testing.T) {
 	assert.Equal(t, expectHumanFormat, w.String())
 }
 
-func TestHumanFormatRealtimeContainer(t *testing.T) {
+func TestHumanFormatRealTimeContainer(t *testing.T) {
 	msgs := []model.MessageBody{
 		&model.CollectorContainerRealTime{
 			Stats: []*model.ContainerStat{
@@ -329,7 +449,7 @@ func TestHumanFormatRealtimeContainer(t *testing.T) {
 	}
 
 	w := &strings.Builder{}
-	err := humanFormatRealtimeContainer(msgs, w)
+	err := humanFormatRealTimeContainer(msgs, w)
 	assert.NoError(t, err)
 
 	const expectHumanFormat = `RealTime Containers

--- a/pkg/process/checks/templates/rtcontainers.tmpl
+++ b/pkg/process/checks/templates/rtcontainers.tmpl
@@ -1,0 +1,27 @@
+RealTime Containers
+===================
+{{- range $c := .ContainerStats}}
+> ID: {{ .Id }}
+  CPU Limit:    {{ .CpuLimit }}
+  Memory Limit: {{ .MemLimit }}
+  State:  {{ containerState .State }}
+  Health: {{ containerHealth .Health }}
+  Started: {{ .Started }}
+  CPU:
+    Total:  {{ .TotalPct }}%
+    System: {{ .SystemPct }}%
+    User:   {{ .UserPct }}%
+  Memory:
+    RSS: {{ .MemRss }}
+    Cache: {{ .MemCache }}
+  IO:
+    Read Bytes/s: {{ .Rbps }}
+    Write Bytes/s: {{ .Wbps }}
+  Net:
+    Received Ops/s:   {{ .NetRcvdPs }}
+    Sent Ops/s:       {{ .NetSentPs }}
+    Received Bytes/s: {{ .NetRcvdBps }}
+    Sent Bytes/s:     {{ .NetSentBps }}
+  Thread Count: {{ .ThreadCount }}
+  Thread Limit: {{ .ThreadLimit }}
+{{- end }}

--- a/pkg/process/checks/templates/rtprocesses.tmpl
+++ b/pkg/process/checks/templates/rtprocesses.tmpl
@@ -1,0 +1,31 @@
+RealTime Processes
+==================
+{{- range $process := .ProcessStats}}
+> PID: {{ .Pid }}
+  Container ID: {{ .ContainerId }}
+  Create Time: {{ .CreateTime }}
+{{- with .Memory }}
+  Memory:
+    Rss:    {{.Rss}}
+    Vms:    {{.Vms}}
+    Swap:   {{.Swap}}
+    Shared: {{.Shared}}
+    Text:   {{.Text}}
+    Lib:    {{.Lib}}
+    Data:   {{.Data}}
+    Dirty:  {{.Dirty}}
+{{- end }}
+{{- with .Cpu }}
+  CPU: Total: {{ .TotalPct }}% System: {{ .SystemPct }}% User: {{ .UserPct }}%
+  Threads: {{ .NumThreads }}
+  Nice: {{ .Nice }}
+{{- end }}
+  Open Files: {{ .OpenFdCount }}
+  Voluntary Context Switches: {{ .VoluntaryCtxSwitches }}
+  Involuntary Context Switches: {{ .InvoluntaryCtxSwitches }}
+{{- with .IoStat }}
+  IO:
+    Read:  {{ .ReadBytesRate }} Bytes/s {{ .ReadRate }} Ops/s
+    Write: {{ .WriteBytesRate }} Bytes/s {{ .WriteRate }} Ops/s
+{{- end }}
+{{- end }}

--- a/pkg/process/checks/templates/rtprocesses.tmpl
+++ b/pkg/process/checks/templates/rtprocesses.tmpl
@@ -4,6 +4,7 @@ RealTime Processes
 > PID: {{ .Pid }}
   Container ID: {{ .ContainerId }}
   Create Time: {{ .CreateTime }}
+  State: {{ .ProcessState }}
 {{- with .Memory }}
   Memory:
     Rss:    {{.Rss}}


### PR DESCRIPTION
### What does this PR do?

This PR is a follow up to https://github.com/DataDog/datadog-agent/pull/11480. It follows the same approach to add human readable output to the `rtprocess` and `rtcontainer` checks when running with the `check` command.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
