### PR TITLE
[Docs] Update dogstatsd Docker image README

### DIFF
--- a/Dockerfiles/dogstatsd/alpine/README.md
+++ b/Dockerfiles/dogstatsd/alpine/README.md
@@ -10,7 +10,7 @@ The following environment variables are supported:
   - `DD_HOSTNAME`: hostname to use for metrics
   - `DD_DOGSTATSD_SOCKET`: path to the unix socket to use instead of UDP. Must be in a `rw` mounted volume.
   - `DD_ENABLE_METADATA_COLLECTION`: whether to collect metadata (default is true, set to false only if running alonside an existing dd-agent)
-  - `DD_SITE`: Destination site for your metrics, can set to datadoghq.eu if required. Defaults to datadoghq.com.
+  - `DD_SITE`: Destination site for your metrics, should be set to the site you are using. Defaults to datadoghq.com.
 
 This is a sample Kubernetes DaemonSet, using the UDS protocol, running alongside an existing agent5:
 

--- a/Dockerfiles/dogstatsd/alpine/README.md
+++ b/Dockerfiles/dogstatsd/alpine/README.md
@@ -10,6 +10,7 @@ The following environment variables are supported:
   - `DD_HOSTNAME`: hostname to use for metrics
   - `DD_DOGSTATSD_SOCKET`: path to the unix socket to use instead of UDP. Must be in a `rw` mounted volume.
   - `DD_ENABLE_METADATA_COLLECTION`: whether to collect metadata (default is true, set to false only if running alonside an existing dd-agent)
+  - `DD_SITE`: Destination site for your metrics, can set to datadoghq.eu if required. Defaults to datadoghq.com.
 
 This is a sample Kubernetes DaemonSet, using the UDS protocol, running alongside an existing agent5:
 


### PR DESCRIPTION
### What does this PR do?

Adds info about the `DD_SITE` variable which must be set to `datadoghq.eu` to send metrics to the EU site.

### Motivation

I spent a long time trying to work out why metrics were not being sent with this image before I found this out...

### Additional Notes

N/A

### Possible Drawbacks / Trade-offs

N/A

### Describe how to test/QA your changes

N/A

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
