### PR TITLE
Bump gosnmp to v1.34.1-0.20220306115220-ca8397b73095

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -127,7 +127,7 @@ require (
 	github.com/google/gopacket v1.1.19
 	github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1
 	github.com/gorilla/mux v1.8.0
-	github.com/gosnmp/gosnmp v1.34.0
+	github.com/gosnmp/gosnmp v1.34.1-0.20220306115220-ca8397b73095
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	github.com/h2non/filetype v1.1.2-0.20210602110014-3305bbb7ac7b

--- a/go.sum
+++ b/go.sum
@@ -877,8 +877,8 @@ github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-github.com/gosnmp/gosnmp v1.34.0 h1:p96iiNTTdL4ZYspPC3leSKXiHfE1NiIYffMu9100p5E=
-github.com/gosnmp/gosnmp v1.34.0/go.mod h1:QWTRprXN9haHFof3P96XTDYc46boCGAh5IXp0DniEx4=
+github.com/gosnmp/gosnmp v1.34.1-0.20220306115220-ca8397b73095 h1:IL2nwZxmnTCUn4fG6uIMik78zvFWZK+mr4jJ0cRupv0=
+github.com/gosnmp/gosnmp v1.34.1-0.20220306115220-ca8397b73095/go.mod h1:QWTRprXN9haHFof3P96XTDYc46boCGAh5IXp0DniEx4=
 github.com/graph-gophers/graphql-go v1.3.0/go.mod h1:9CQHMSxwO4MprSdzoIEobiHpoLtHm77vfxsvsIN5Vuc=
 github.com/gregjones/httpcache v0.0.0-20170728041850-787624de3eb7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=

--- a/pkg/snmp/traps/server_test.go
+++ b/pkg/snmp/traps/server_test.go
@@ -121,7 +121,7 @@ func TestServerV3(t *testing.T) {
 
 	sendTestV3Trap(t, config, &gosnmp.UsmSecurityParameters{
 		UserName:                 "user",
-		AuthoritativeEngineID:    "foo",
+		AuthoritativeEngineID:    "foobarbaz",
 		AuthenticationPassphrase: "password",
 		AuthenticationProtocol:   gosnmp.SHA,
 		PrivacyPassphrase:        "password",

--- a/releasenotes/notes/Bump-gosnmp-to-v1.34.1-9d5fda248a1cbba9.yaml
+++ b/releasenotes/notes/Bump-gosnmp-to-v1.34.1-9d5fda248a1cbba9.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Bump gosnmp to fix incomplete support of SNMP v3 INFORMs

--- a/releasenotes/notes/Bump-gosnmp-to-v1.34.1-9d5fda248a1cbba9.yaml
+++ b/releasenotes/notes/Bump-gosnmp-to-v1.34.1-9d5fda248a1cbba9.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Bump gosnmp to fix incomplete support of SNMP v3 INFORMs
+    Bump GoSNMP to fix incomplete support of SNMP v3 INFORMs.


### PR DESCRIPTION
### What does this PR do?
Bump the gosnmp library to an unreleased version. In particular, this fixes the compatibility of the library with SNMP v3 INFORM messages.

gosnmp PR that is now included in the agent: https://github.com/gosnmp/gosnmp/pull/394