### PR TITLE
use different max payload sizes for metric series

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -432,10 +432,12 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("enable_sketch_stream_payload_serialization", true)
 	config.BindEnvAndSetDefault("enable_json_stream_shared_compressor_buffers", true)
 
-	// Warning: do not change the two following values. Your payloads will get dropped by Datadog's intake.
+	// Warning: do not change the following values. Your payloads will get dropped by Datadog's intake.
 	config.BindEnvAndSetDefault("serializer_max_payload_size", 2*megaByte+megaByte/2)
 	config.BindEnvAndSetDefault("serializer_max_uncompressed_payload_size", 4*megaByte)
 	config.BindEnvAndSetDefault("serializer_max_series_points_per_payload", 10000)
+	config.BindEnvAndSetDefault("serializer_max_series_payload_size", 512000)
+	config.BindEnvAndSetDefault("serializer_max_series_uncompressed_payload_size", 5242880)
 
 	config.BindEnvAndSetDefault("use_v2_api.series", false)
 	// Serializer: allow user to blacklist any kind of payload to be sent

--- a/pkg/serializer/internal/metrics/series.go
+++ b/pkg/serializer/internal/metrics/series.go
@@ -150,6 +150,12 @@ func marshalSplitCompress(iterator serieIterator, bufferContext *marshaler.Buffe
 	var pointsThisPayload int
 	var seriesThisPayload int
 	var serie *metrics.Serie
+
+	// the backend accepts payloads up to specific compressed / uncompressed
+	// sizes, but prefers small uncompressed payloads.  For series, there is
+	// also a maximum number of points.
+	maxPayloadSize := config.Datadog.GetInt("serializer_max_series_payload_size")
+	maxUncompressedSize := config.Datadog.GetInt("serializer_max_series_uncompressed_payload_size")
 	maxPointsPerPayload := config.Datadog.GetInt("serializer_max_series_points_per_payload")
 
 	// constants for the protobuf data we will be writing, taken from MetricPayload in
@@ -166,11 +172,6 @@ func marshalSplitCompress(iterator serieIterator, bufferContext *marshaler.Buffe
 	const resourceName = 2
 	const pointValue = 1
 	const pointTimestamp = 2
-
-	// the backend accepts payloads up to specific compressed / uncompressed
-	// sizes, but prefers small uncompressed payloads.
-	maxPayloadSize := config.Datadog.GetInt("serializer_max_payload_size")
-	maxUncompressedSize := config.Datadog.GetInt("serializer_max_uncompressed_payload_size")
 
 	// Prepare to write the next payload
 	startPayload := func() error {

--- a/pkg/serializer/internal/stream/compressor.go
+++ b/pkg/serializer/internal/stream/compressor.go
@@ -14,7 +14,6 @@ import (
 	"errors"
 	"expvar"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/compression"
 )
@@ -77,11 +76,7 @@ type Compressor struct {
 	separator           []byte
 }
 
-func NewCompressor(input, output *bytes.Buffer, header, footer []byte, separator []byte) (*Compressor, error) {
-	// the backend accepts payloads up to 3MB compressed / 50MB uncompressed but
-	// prefers small uncompressed payloads of ~4MB
-	maxPayloadSize := config.Datadog.GetInt("serializer_max_payload_size")
-	maxUncompressedSize := config.Datadog.GetInt("serializer_max_uncompressed_payload_size")
+func NewCompressor(input, output *bytes.Buffer, maxPayloadSize, maxUncompressedSize int, header, footer []byte, separator []byte) (*Compressor, error) {
 	c := &Compressor{
 		header:              header,
 		footer:              footer,

--- a/pkg/serializer/internal/stream/compressor_nozlib.go
+++ b/pkg/serializer/internal/stream/compressor_nozlib.go
@@ -31,7 +31,7 @@ var (
 type Compressor struct{}
 
 // NewCompressor not implemented
-func NewCompressor(input, output *bytes.Buffer, header, footer []byte, separator []byte) (*Compressor, error) {
+func NewCompressor(input, output *bytes.Buffer, maxPayloadSize, maxUncompressedSize int, header, footer []byte, separator []byte) (*Compressor, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 

--- a/pkg/serializer/internal/stream/compressor_test.go
+++ b/pkg/serializer/internal/stream/compressor_test.go
@@ -51,7 +51,12 @@ func payloadToString(payload []byte) string {
 }
 
 func TestCompressorSimple(t *testing.T) {
-	c, err := NewCompressor(&bytes.Buffer{}, &bytes.Buffer{}, []byte("{["), []byte("]}"), []byte(","))
+	maxPayloadSize := config.Datadog.GetInt("serializer_max_payload_size")
+	maxUncompressedSize := config.Datadog.GetInt("serializer_max_uncompressed_payload_size")
+	c, err := NewCompressor(
+		&bytes.Buffer{}, &bytes.Buffer{},
+		maxPayloadSize, maxUncompressedSize,
+		[]byte("{["), []byte("]}"), []byte(","))
 	require.NoError(t, err)
 
 	for i := 0; i < 5; i++ {


### PR DESCRIPTION
### What does this PR do?

The new v2 series intake has different payload size limits than other metric types.

### Motivation

Align with intakes.

### Additional Notes

This adds configuration parameters, but the expectation is that they will not be set explicitly, so the names aren't too critical.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Verify that metrics arrive in the app with `use_v2_api.series: true` and `..false`.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
