### PR TITLE
pkg/trace: support long running spans

### DIFF
--- a/pkg/trace/api/info.go
+++ b/pkg/trace/api/info.go
@@ -64,22 +64,24 @@ func (r *HTTPReceiver) makeInfoHandler() (hash string, handler http.HandlerFunc)
 		oconf.Memcached = o.Memcached.Enabled
 	}
 	txt, err := json.MarshalIndent(struct {
-		Version         string        `json:"version"`
-		GitCommit       string        `json:"git_commit"`
-		BuildDate       string        `json:"build_date"`
-		Endpoints       []string      `json:"endpoints"`
-		FeatureFlags    []string      `json:"feature_flags,omitempty"`
-		ClientDropP0s   bool          `json:"client_drop_p0s"`
-		SpanMetaStructs bool          `json:"span_meta_structs"`
-		Config          reducedConfig `json:"config"`
+		Version          string        `json:"version"`
+		GitCommit        string        `json:"git_commit"`
+		BuildDate        string        `json:"build_date"`
+		Endpoints        []string      `json:"endpoints"`
+		FeatureFlags     []string      `json:"feature_flags,omitempty"`
+		ClientDropP0s    bool          `json:"client_drop_p0s"`
+		SpanMetaStructs  bool          `json:"span_meta_structs"`
+		LongRunningSpans bool          `json:"long_running_spans"`
+		Config           reducedConfig `json:"config"`
 	}{
-		Version:         info.Version,
-		GitCommit:       info.GitCommit,
-		BuildDate:       info.BuildDate,
-		Endpoints:       all,
-		FeatureFlags:    features.All(),
-		ClientDropP0s:   true,
-		SpanMetaStructs: true,
+		Version:          info.Version,
+		GitCommit:        info.GitCommit,
+		BuildDate:        info.BuildDate,
+		Endpoints:        all,
+		FeatureFlags:     features.All(),
+		ClientDropP0s:    true,
+		SpanMetaStructs:  true,
+		LongRunningSpans: true,
 		Config: reducedConfig{
 			DefaultEnv:             r.conf.DefaultEnv,
 			TargetTPS:              r.conf.TargetTPS,

--- a/pkg/trace/api/info_test.go
+++ b/pkg/trace/api/info_test.go
@@ -136,6 +136,7 @@ func TestInfoHandler(t *testing.T) {
 	],
 	"client_drop_p0s": true,
 	"span_meta_structs": true,
+	"long_running_spans": true,
 	"config": {
 		"default_env": "prod",
 		"target_tps": 11,
@@ -194,6 +195,7 @@ func TestInfoHandler(t *testing.T) {
 	],
 	"client_drop_p0s": true,
 	"span_meta_structs": true,
+	"long_running_spans": true,
 	"config": {
 		"default_env": "prod",
 		"target_tps": 11,

--- a/pkg/trace/stats/concentrator.go
+++ b/pkg/trace/stats/concentrator.go
@@ -163,7 +163,7 @@ func (c *Concentrator) addNow(pt *traceutil.ProcessedTrace, containerID string) 
 	}
 	for _, s := range pt.TraceChunk.Spans {
 		isTop := traceutil.HasTopLevel(s)
-		if !(isTop || traceutil.IsMeasured(s)) {
+		if !(isTop || traceutil.IsMeasured(s)) || traceutil.IsPartialSnapshot(s) {
 			continue
 		}
 		end := s.Start + s.Duration

--- a/pkg/trace/stats/concentrator_test.go
+++ b/pkg/trace/stats/concentrator_test.go
@@ -515,8 +515,7 @@ func TestIgnoresPartialSpans(t *testing.T) {
 	now := time.Now()
 
 	span := testSpan(1, 0, 50, 5, "A1", "resource1", 0)
-	span.Metrics = make(map[string]float64)
-	traceutil.SetPartialSnapshotVersion(span, 830604)
+	span.Metrics = map[string]float64{"_dd.partial_version": 830604}
 	spans := []*pb.Span{span}
 	traceutil.ComputeTopLevel(spans)
 

--- a/pkg/trace/traceutil/span.go
+++ b/pkg/trace/traceutil/span.go
@@ -21,6 +21,8 @@ const (
 	measuredKey = "_dd.measured"
 	// tracerTopLevelKey is a metric flag set by tracers on top_level spans
 	tracerTopLevelKey = "_dd.top_level"
+	// partialVersionKey is a metric carrying the snapshot seq number in the case the span is a partial snapshot
+	partialVersionKey = "_dd.partial_version"
 )
 
 // HasTopLevel returns true if span is top-level.
@@ -38,6 +40,19 @@ func UpdateTracerTopLevel(s *pb.Span) {
 // IsMeasured returns true if a span should be measured (i.e., it should get trace metrics calculated).
 func IsMeasured(s *pb.Span) bool {
 	return s.Metrics[measuredKey] == 1
+}
+
+// IsPartialSnapshot returns true if the span is a partial snapshot (has metric _dd.partial_version >= 0)
+func IsPartialSnapshot(s *pb.Span) bool {
+	value, hasKey := s.Metrics[partialVersionKey]
+	return hasKey && value >= 0
+}
+
+// SetPartialSnapshotVersion sets the metric _dd.partial_version
+func SetPartialSnapshotVersion(s *pb.Span, value uint64) {
+	if s.Metrics != nil {
+		s.Metrics[partialVersionKey] = float64(value)
+	}
 }
 
 // SetTopLevel sets the top-level attribute of the span.

--- a/pkg/trace/traceutil/span.go
+++ b/pkg/trace/traceutil/span.go
@@ -42,17 +42,13 @@ func IsMeasured(s *pb.Span) bool {
 	return s.Metrics[measuredKey] == 1
 }
 
-// IsPartialSnapshot returns true if the span is a partial snapshot (has metric _dd.partial_version >= 0)
+// IsPartialSnapshot returns true if the span is a partial snapshot.
+// This kind of spans are partial images of long-running spans.
+// When incomplete, a partial snapshot has a metric _dd.partial_version which is a positive integer.
+// The metric usually increases each time a new version of the same span is sent by the tracer
 func IsPartialSnapshot(s *pb.Span) bool {
-	value, hasKey := s.Metrics[partialVersionKey]
-	return hasKey && value >= 0
-}
-
-// SetPartialSnapshotVersion sets the metric _dd.partial_version
-func SetPartialSnapshotVersion(s *pb.Span, value uint64) {
-	if s.Metrics != nil {
-		s.Metrics[partialVersionKey] = float64(value)
-	}
+	v, ok := s.Metrics[partialVersionKey]
+	return ok && v >= 0
 }
 
 // SetTopLevel sets the top-level attribute of the span.

--- a/pkg/trace/traceutil/span_test.go
+++ b/pkg/trace/traceutil/span_test.go
@@ -6,6 +6,7 @@
 package traceutil
 
 import (
+	"math/rand"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
@@ -200,4 +201,17 @@ func TestIsMeasured(t *testing.T) {
 
 	span.Metrics = map[string]float64{"_dd.measured": 0}
 	assert.False(IsMeasured(span), "the measured key is present but the value != 1, the span should not be measured")
+}
+
+func TestIsPartialSnapshot(t *testing.T) {
+	assert := assert.New(t)
+	span := &pb.Span{}
+
+	assert.False(IsPartialSnapshot(span), "by default, a span is considered as complete")
+
+	span.Metrics = map[string]float64{"_dd.partial_version": -10}
+	assert.False(IsPartialSnapshot(span), "Negative versions do not mark the span as incomplete")
+
+	span.Metrics = map[string]float64{"_dd.partial_version": float64(rand.Uint32())}
+	assert.True(IsPartialSnapshot(span), "Any value in partialVersion key will mark the span as incomplete")
 }


### PR DESCRIPTION
### What does this PR do?

Supports long running spans (they have metric `_dd.partial_version` with positive value) excluding them from statistic calculation (like not top level or measured).
Also, we expose this capability from the info endpoint.

Some tests are provided.

### Motivation


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
