### PR TITLE
[gitlab] Increase datadog-(heroku)-agent size delta threshold to 25MB

### DIFF
--- a/.gitlab/pkg_metrics.yml
+++ b/.gitlab/pkg_metrics.yml
@@ -217,11 +217,11 @@ check_pkg_size-a6:
     MAJOR_VERSION: 6
     FLAVORS: "datadog-agent"
   before_script:
-    # FIXME: ["datadog-agent"]="20000000" should probably replaced by "15000000"
-    # "20000000" is needed as of now because of a large bump in size in system-probe in 7.35
+    # FIXME: ["datadog-agent"]="25000000" should be replaced by "15000000"
+    # "25000000" is needed as of now because of a large bump in size in system-probe in 7.35
     - |
         declare -Ar max_sizes=(
-            ["datadog-agent"]="20000000"
+            ["datadog-agent"]="25000000"
         )
 
 check_pkg_size-a7:
@@ -243,14 +243,14 @@ check_pkg_size-a7:
     MAJOR_VERSION: 7
     FLAVORS: "datadog-agent datadog-iot-agent datadog-dogstatsd datadog-heroku-agent"
   before_script:
-    # FIXME: ["datadog-agent"]="20000000" and ["datadog-heroku-agent"]="20000000" should
-    # probably replaced by "15000000"
-    # "20000000" is needed as of now because of a large bump in size in system-probe in 7.35
+    # FIXME: ["datadog-agent"]="25000000" and ["datadog-heroku-agent"]="25000000" should
+    # be replaced by "15000000"
+    # "25000000" is needed as of now because of a large bump in size in system-probe in 7.35
     # If this happens often we could exclude system-probe from the heroku build, it's not used.
     - |
         declare -Ar max_sizes=(
-            ["datadog-agent"]="20000000"
+            ["datadog-agent"]="25000000"
             ["datadog-iot-agent"]="10000000"
             ["datadog-dogstatsd"]="10000000"
-            ["datadog-heroku-agent"]="20000000"
+            ["datadog-heroku-agent"]="25000000"
         )


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Increases the `check_pkg_size` threshold from 20MB to 25MB for the `datadog-agent` and `datadog-heroku-agent` packages.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Fix pipeline.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

We could also leave the job broken until `7.35.0` is released, or make it temporarily allowed to fail.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
