### PR TITLE
[CWS] octogon improvements and fix offset guesser

### DIFF
--- a/pkg/security/ebpf/c/offset.h
+++ b/pkg/security/ebpf/c/offset.h
@@ -24,8 +24,8 @@ int kprobe_get_pid_task(struct pt_regs *ctx) {
     for (int i = MIN_PID_OFFSET; i != MAX_PID_OFFSET; i++) {
         u32 root_nr = 0;
 
-        bpf_probe_read(&root_nr, sizeof(root_nr), (void *)pid + offset);
-        if (root_nr == pid_expected) {
+        int read_ok = bpf_probe_read(&root_nr, sizeof(root_nr), (void *)pid + offset);
+        if (!read_ok && root_nr == pid_expected) {
             // found it twice, thus error
             if (success) {
                 return 0;

--- a/pkg/security/probe/constantfetch/offset_guesser.go
+++ b/pkg/security/probe/constantfetch/offset_guesser.go
@@ -115,7 +115,7 @@ func (og *OffsetGuesser) FinishAndGetResults() (map[string]uint64, error) {
 		ConstantEditors: []manager.ConstantEditor{
 			{
 				Name:  "pid_expected",
-				Value: uint64(os.Getpid()),
+				Value: uint64(utils.Getpid()),
 			},
 		},
 		RLimit: &unix.Rlimit{

--- a/pkg/security/tests/constants_test.go
+++ b/pkg/security/tests/constants_test.go
@@ -134,7 +134,7 @@ func assertConstantContains(t *testing.T, champion, challenger constantfetch.Con
 		if !ok {
 			t.Errorf("champion (`%s`) does not contain the expected constant `%s`", champion.String(), k)
 		} else if v != expected {
-			t.Errorf("expected constants `%s` = %d not found", k, v)
+			t.Errorf("difference between fighters for `%s`: `%s`:%d and `%s`:%d", k, champion.String(), expected, challenger.String(), v)
 		}
 	}
 }

--- a/pkg/security/tests/constants_test.go
+++ b/pkg/security/tests/constants_test.go
@@ -130,8 +130,11 @@ func assertConstantContains(t *testing.T, champion, challenger constantfetch.Con
 			continue
 		}
 
-		if expected, ok := championConstants[k]; !ok || v != expected {
-			t.Errorf("expected %s:%d not found", k, v)
+		expected, ok := championConstants[k]
+		if !ok {
+			t.Errorf("champion (`%s`) does not contain the expected constant `%s`", champion.String(), k)
+		} else if v != expected {
+			t.Errorf("expected constants `%s` = %d not found", k, v)
 		}
 	}
 }

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -1255,6 +1255,7 @@ func randStringRunes(n int) string {
 
 //nolint:deadcode,unused
 func checkKernelCompatibility(t *testing.T, why string, skipCheck func(kv *kernel.Version) bool) {
+	t.Helper()
 	kv, err := kernel.NewKernelVersion()
 	if err != nil {
 		t.Errorf("failed to get kernel version: %s", err)


### PR DESCRIPTION
### What does this PR do?

This PR fixes the `pid_numbers_offset` offset guesser, and improve the failure output for octogon tests

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
