### PR TITLE
Simplifies windows filter definitions.

### DIFF
--- a/pkg/network/dns/driver_windows.go
+++ b/pkg/network/dns/driver_windows.go
@@ -12,7 +12,6 @@ package dns
 import "C"
 import (
 	"fmt"
-	"net"
 	"syscall"
 	"time"
 	"unsafe"
@@ -139,32 +138,26 @@ func (d *dnsDriver) GetStatsForHandle() (map[string]int64, error) {
 
 func createDNSFilters() ([]driver.FilterDefinition, error) {
 	var filters []driver.FilterDefinition
-	ifaces, err := net.Interfaces()
-	if err != nil {
-		return nil, err
-	}
+	
+	filters = append(filters, driver.FilterDefinition{
+		FilterVersion:  driver.Signature,
+		Size:           driver.FilterDefinitionSize,
+		FilterLayer:    driver.LayerTransport,
+		Af:             windows.AF_INET,
+		RemotePort:     53,
+		InterfaceIndex: uint64(0),
+		Direction:      driver.DirectionOutbound,
+	})
 
-	for _, iface := range ifaces {
-		filters = append(filters, driver.FilterDefinition{
-			FilterVersion:  driver.Signature,
-			Size:           driver.FilterDefinitionSize,
-			FilterLayer:    driver.LayerTransport,
-			Af:             windows.AF_INET,
-			RemotePort:     53,
-			InterfaceIndex: uint64(iface.Index),
-			Direction:      driver.DirectionOutbound,
-		})
-
-		filters = append(filters, driver.FilterDefinition{
-			FilterVersion:  driver.Signature,
-			Size:           driver.FilterDefinitionSize,
-			FilterLayer:    driver.LayerTransport,
-			Af:             windows.AF_INET,
-			RemotePort:     53,
-			InterfaceIndex: uint64(iface.Index),
-			Direction:      driver.DirectionInbound,
-		})
-	}
+	filters = append(filters, driver.FilterDefinition{
+		FilterVersion:  driver.Signature,
+		Size:           driver.FilterDefinitionSize,
+		FilterLayer:    driver.LayerTransport,
+		Af:             windows.AF_INET,
+		RemotePort:     53,
+		InterfaceIndex: uint64(0),
+		Direction:      driver.DirectionInbound,
+	})
 
 	return filters, nil
 }

--- a/pkg/network/driver_interface.go
+++ b/pkg/network/driver_interface.go
@@ -11,7 +11,6 @@ package network
 import (
 	"fmt"
 	"math"
-	"net"
 	"sync"
 	"sync/atomic"
 	"unsafe"
@@ -275,90 +274,83 @@ func (di *DriverInterface) setFlowParams() error {
 }
 
 func (di *DriverInterface) createFlowHandleFilters() ([]driver.FilterDefinition, error) {
-	ifaces, err := net.Interfaces()
-	if err != nil {
-		return nil, fmt.Errorf("error getting interfaces: %s", err.Error())
+	var filters []driver.FilterDefinition
+	log.Debugf("Creating filters for all interfaces")
+	if di.cfg.CollectTCPConns {
+		filters = append(filters, driver.FilterDefinition{
+			FilterVersion:  driver.Signature,
+			Size:           driver.FilterDefinitionSize,
+			Direction:      driver.DirectionOutbound,
+			FilterLayer:    driver.LayerTransport,
+			InterfaceIndex: uint64(0),
+			Af:             windows.AF_INET,
+			Protocol:       windows.IPPROTO_TCP,
+		}, driver.FilterDefinition{
+			FilterVersion:  driver.Signature,
+			Size:           driver.FilterDefinitionSize,
+			Direction:      driver.DirectionInbound,
+			FilterLayer:    driver.LayerTransport,
+			InterfaceIndex: uint64(0),
+			Af:             windows.AF_INET,
+			Protocol:       windows.IPPROTO_TCP,
+		})
+		if di.cfg.CollectIPv6Conns {
+			filters = append(filters, driver.FilterDefinition{
+				FilterVersion:  driver.Signature,
+				Size:           driver.FilterDefinitionSize,
+				Direction:      driver.DirectionOutbound,
+				FilterLayer:    driver.LayerTransport,
+				InterfaceIndex: uint64(0),
+				Af:             windows.AF_INET6,
+				Protocol:       windows.IPPROTO_TCP,
+			}, driver.FilterDefinition{
+				FilterVersion:  driver.Signature,
+				Size:           driver.FilterDefinitionSize,
+				Direction:      driver.DirectionInbound,
+				FilterLayer:    driver.LayerTransport,
+				InterfaceIndex: uint64(0),
+				Af:             windows.AF_INET6,
+				Protocol:       windows.IPPROTO_TCP,
+			})
+		}
 	}
 
-	var filters []driver.FilterDefinition
-	for _, iface := range ifaces {
-		log.Debugf("Creating filters for interface: %s [%+v]", iface.Name, iface)
-		if di.cfg.CollectTCPConns {
+	if di.cfg.CollectUDPConns {
+		filters = append(filters, driver.FilterDefinition{
+			FilterVersion:  driver.Signature,
+			Size:           driver.FilterDefinitionSize,
+			Direction:      driver.DirectionOutbound,
+			FilterLayer:    driver.LayerTransport,
+			InterfaceIndex: uint64(0),
+			Af:             windows.AF_INET,
+			Protocol:       windows.IPPROTO_UDP,
+		}, driver.FilterDefinition{
+			FilterVersion:  driver.Signature,
+			Size:           driver.FilterDefinitionSize,
+			Direction:      driver.DirectionInbound,
+			FilterLayer:    driver.LayerTransport,
+			InterfaceIndex: uint64(0),
+			Af:             windows.AF_INET,
+			Protocol:       windows.IPPROTO_UDP,
+		})
+		if di.cfg.CollectIPv6Conns {
 			filters = append(filters, driver.FilterDefinition{
 				FilterVersion:  driver.Signature,
 				Size:           driver.FilterDefinitionSize,
 				Direction:      driver.DirectionOutbound,
 				FilterLayer:    driver.LayerTransport,
-				InterfaceIndex: uint64(iface.Index),
-				Af:             windows.AF_INET,
-				Protocol:       windows.IPPROTO_TCP,
-			}, driver.FilterDefinition{
-				FilterVersion:  driver.Signature,
-				Size:           driver.FilterDefinitionSize,
-				Direction:      driver.DirectionInbound,
-				FilterLayer:    driver.LayerTransport,
-				InterfaceIndex: uint64(iface.Index),
-				Af:             windows.AF_INET,
-				Protocol:       windows.IPPROTO_TCP,
-			})
-			if di.cfg.CollectIPv6Conns {
-				filters = append(filters, driver.FilterDefinition{
-					FilterVersion:  driver.Signature,
-					Size:           driver.FilterDefinitionSize,
-					Direction:      driver.DirectionOutbound,
-					FilterLayer:    driver.LayerTransport,
-					InterfaceIndex: uint64(iface.Index),
-					Af:             windows.AF_INET6,
-					Protocol:       windows.IPPROTO_TCP,
-				}, driver.FilterDefinition{
-					FilterVersion:  driver.Signature,
-					Size:           driver.FilterDefinitionSize,
-					Direction:      driver.DirectionInbound,
-					FilterLayer:    driver.LayerTransport,
-					InterfaceIndex: uint64(iface.Index),
-					Af:             windows.AF_INET6,
-					Protocol:       windows.IPPROTO_TCP,
-				})
-			}
-		}
-
-		if di.cfg.CollectUDPConns {
-			filters = append(filters, driver.FilterDefinition{
-				FilterVersion:  driver.Signature,
-				Size:           driver.FilterDefinitionSize,
-				Direction:      driver.DirectionOutbound,
-				FilterLayer:    driver.LayerTransport,
-				InterfaceIndex: uint64(iface.Index),
-				Af:             windows.AF_INET,
+				InterfaceIndex: uint64(0),
+				Af:             windows.AF_INET6,
 				Protocol:       windows.IPPROTO_UDP,
 			}, driver.FilterDefinition{
 				FilterVersion:  driver.Signature,
 				Size:           driver.FilterDefinitionSize,
 				Direction:      driver.DirectionInbound,
 				FilterLayer:    driver.LayerTransport,
-				InterfaceIndex: uint64(iface.Index),
-				Af:             windows.AF_INET,
+				InterfaceIndex: uint64(0),
+				Af:             windows.AF_INET6,
 				Protocol:       windows.IPPROTO_UDP,
 			})
-			if di.cfg.CollectIPv6Conns {
-				filters = append(filters, driver.FilterDefinition{
-					FilterVersion:  driver.Signature,
-					Size:           driver.FilterDefinitionSize,
-					Direction:      driver.DirectionOutbound,
-					FilterLayer:    driver.LayerTransport,
-					InterfaceIndex: uint64(iface.Index),
-					Af:             windows.AF_INET6,
-					Protocol:       windows.IPPROTO_UDP,
-				}, driver.FilterDefinition{
-					FilterVersion:  driver.Signature,
-					Size:           driver.FilterDefinitionSize,
-					Direction:      driver.DirectionInbound,
-					FilterLayer:    driver.LayerTransport,
-					InterfaceIndex: uint64(iface.Index),
-					Af:             windows.AF_INET6,
-					Protocol:       windows.IPPROTO_UDP,
-				})
-			}
 		}
 	}
 


### PR DESCRIPTION
By not explicitly specifying an interface, get traffic on ALL interfaces
(including container interfaces)

### What does this PR do?
Changes windows filter definitions so we're setting fewer filters, but they're broader.
Rather than specifying per-interface, set a single filter specifying all interfaces.

### Motivation

Allow NPM to capture container traffic

### Describe how to test/QA your changes
Ensure container traffic visible in NPM visualizations

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
