### PR TITLE
Add a config option for an "error tracking only" mode for APM

### DIFF
--- a/cmd/trace-agent/config/config.go
+++ b/cmd/trace-agent/config/config.go
@@ -400,6 +400,9 @@ func applyDatadogConfig(c *config.AgentConfig) error {
 	if k := "apm_config.debugger_api_key"; coreconfig.Datadog.IsSet(k) {
 		c.DebuggerProxy.APIKey = coreconfig.Datadog.GetString(k)
 	}
+	if k := "error_tracking.only"; coreconfig.Datadog.IsSet(k) {
+		c.ErrorTracking.Only = coreconfig.Datadog.GetBool(k)
+	}
 	return nil
 }
 

--- a/cmd/trace-agent/config/config.go
+++ b/cmd/trace-agent/config/config.go
@@ -281,7 +281,7 @@ func applyDatadogConfig(c *config.AgentConfig) error {
 	}
 	{
 		// TODO(x): There is an issue with coreconfig.Datadog.IsSet("apm_config.obfuscation"), probably coming from Viper,
-		// where it returns false even is "apm_config.obfuscation.credit_cards.enabled" is set via an environment
+		// where it returns false even if "apm_config.obfuscation.credit_cards.enabled" is set via an environment
 		// variable, so we need a temporary workaround by specifically setting env. var. accessible fields.
 		if coreconfig.Datadog.IsSet("apm_config.obfuscation.credit_cards.enabled") {
 			c.Obfuscation.CreditCards.Enabled = coreconfig.Datadog.GetBool("apm_config.obfuscation.credit_cards.enabled")

--- a/cmd/trace-agent/config/config_test.go
+++ b/cmd/trace-agent/config/config_test.go
@@ -376,6 +376,8 @@ func TestDefaultConfig(t *testing.T) {
 
 	assert.Equal("INFO", c.LogLevel)
 	assert.Equal(true, c.Enabled)
+
+	assert.False(c.ErrorTracking.Only)
 }
 
 func TestNoAPMConfig(t *testing.T) {
@@ -480,6 +482,7 @@ func TestFullYamlConfig(t *testing.T) {
 	assert.True(c.Obfuscation.Memcached.Enabled)
 	assert.True(c.Obfuscation.CreditCards.Enabled)
 	assert.True(c.Obfuscation.CreditCards.Luhn)
+	assert.True(c.ErrorTracking.Only)
 }
 
 func TestUndocumentedYamlConfig(t *testing.T) {

--- a/cmd/trace-agent/config/testdata/full.yaml
+++ b/cmd/trace-agent/config/testdata/full.yaml
@@ -75,3 +75,5 @@ apm_config:
     credit_cards:
       enabled: true 
       luhn: true
+error_tracking:
+  only: true

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1170,6 +1170,18 @@ api_key:
 
   {{ end }}
 
+## @param error_tracking - custom object - optional
+## Enter specific configurations for your Error Tracking collection.
+## Uncomment the parameters `error_tracking` and `only` to use Error Tracking without APM.
+#
+# error_tracking:
+#
+  ## @param only - boolean - optional - default: false
+  ## Filter spans to only keep the ones that are relevant for Error Tracking.
+  #
+  # only: true
+
+
 ####################################
 ## AppSec Configuration           ##
 ####################################
@@ -3201,7 +3213,7 @@ api_key:
         ## - `raw_value` to report the raw value as a Datadog gauge.
         #
         # cumulative_monotonic_mode: to_delta
-    
+
     ## @param summaries - custom object - optional
     ## Configuration for OTLP Summaries.
     ## See https://docs.datadoghq.com/metrics/otlp/?tab=summary for more details.

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -34,7 +34,7 @@ const (
 	tagHostname = "_dd.hostname"
 
 	// tagErrorTrackingMode is set when the agent is configured to send only ET-eligible spans
-	tagErrorTrackingMode = "_dd.error_tracking_only"
+	tagErrorTrackingMode = "_dd.error_tracking.only"
 )
 
 // Agent struct holds all the sub-routines structs and make the data flow between them
@@ -282,6 +282,7 @@ func (a *Agent) Process(p *api.Payload) {
 			var keep []*pb.Span
 			for _, span := range chunk.Spans {
 				if eligibleForErrorTracking(span) {
+					span.Meta[tagErrorTrackingMode] = "1"
 					keep = append(keep, span)
 					break
 				}
@@ -292,7 +293,6 @@ func (a *Agent) Process(p *api.Payload) {
 			}
 			// only keep eligible spans
 			chunk.Spans = keep
-			chunk.Tags[tagErrorTrackingMode] = "1"
 		}
 
 		if p.TracerPayload.Hostname == "" {

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -291,7 +291,7 @@ func (a *Agent) Process(p *api.Payload) {
 			// doing this before computing the top level spans ensures that we'll catch the top-level _error_ in error tracking
 		}
 
-		if !p.ClientComputedTopLevel {
+		if !p.ClientComputedTopLevel || a.conf.ErrorTracking.Only {
 			// Figure out the top-level spans now as it involves modifying the Metrics map
 			// which is not thread-safe while samplers and Concentrator might modify it too.
 			traceutil.ComputeTopLevel(chunk.Spans)

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -496,8 +496,16 @@ func traceContainsError(trace pb.Trace) bool {
 	return false
 }
 
+// spans are eligible for error tracking if they:
+// * are an error span
+// * are top level (i.e. a service entry span)
+// * have a stacktrace
 func eligibleForErrorTracking(span *pb.Span) bool {
-	return span.Error != 0 && traceutil.HasTopLevel(span)
+	if span.Error != 0 && traceutil.HasTopLevel(span) {
+		_, ok := span.Meta["error.stack"]
+		return ok
+	}
+	return false
 }
 
 func filteredByTags(root *pb.Span, require, reject []*config.Tag) bool {

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -32,6 +32,9 @@ const (
 	// tagHostname specifies the hostname of the tracer.
 	// DEPRECATED: Tracer hostname is now specified as a TracerPayload field.
 	tagHostname = "_dd.hostname"
+
+	// tagErrorTrackingMode is set when the agent is configured to send only ET-eligible spans
+	tagErrorTrackingMode = "_dd.error_tracking_only"
 )
 
 // Agent struct holds all the sub-routines structs and make the data flow between them
@@ -289,6 +292,7 @@ func (a *Agent) Process(p *api.Payload) {
 			}
 			// only keep eligible spans
 			chunk.Spans = keep
+			chunk.Tags[tagErrorTrackingMode] = "1"
 		}
 
 		if p.TracerPayload.Hostname == "" {

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -728,19 +728,19 @@ func TestErrorTrackingOnly(t *testing.T) {
 		eligible bool
 	}{
 		{
-			span:     pb.Span{Error: 1, Metrics: map[string]float64{"_top_level": 1}},
+			span:     pb.Span{Error: 1, Metrics: map[string]float64{"_top_level": 1}, Meta: map[string]string{"error.stack": "stack"}},
 			eligible: true,
 		},
 		{
-			span:     pb.Span{Error: 0, Metrics: map[string]float64{"_top_level": 1}},
+			span:     pb.Span{Error: 0, Metrics: map[string]float64{"_top_level": 1}, Meta: map[string]string{"error.stack": "stack"}},
 			eligible: false,
 		},
 		{
-			span:     pb.Span{Error: 1, Metrics: map[string]float64{"_top_level": 0}},
+			span:     pb.Span{Error: 1, Metrics: map[string]float64{"_top_level": 0}, Meta: map[string]string{"error.stack": "stack"}},
 			eligible: false,
 		},
 		{
-			span:     pb.Span{Error: 0, Metrics: map[string]float64{"_top_level": 0}},
+			span:     pb.Span{Error: 1, Metrics: map[string]float64{"_top_level": 1}},
 			eligible: false,
 		},
 	} {

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -728,19 +728,19 @@ func TestErrorTrackingOnly(t *testing.T) {
 		eligible bool
 	}{
 		{
-			span:     pb.Span{Error: 1, Metrics: map[string]float64{"_top_level": 1}, Meta: map[string]string{"error.stack": "stack"}},
+			span:     pb.Span{Error: 1, Meta: map[string]string{"error.stack": "stack"}},
 			eligible: true,
 		},
 		{
-			span:     pb.Span{Error: 0, Metrics: map[string]float64{"_top_level": 1}, Meta: map[string]string{"error.stack": "stack"}},
+			span:     pb.Span{Error: 0, Meta: map[string]string{"error.stack": "stack"}},
 			eligible: false,
 		},
 		{
-			span:     pb.Span{Error: 1, Metrics: map[string]float64{"_top_level": 0}, Meta: map[string]string{"error.stack": "stack"}},
+			span:     pb.Span{Error: 1, Meta: map[string]string{}},
 			eligible: false,
 		},
 		{
-			span:     pb.Span{Error: 1, Metrics: map[string]float64{"_top_level": 1}},
+			span:     pb.Span{Error: 1},
 			eligible: false,
 		},
 	} {

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -722,6 +722,34 @@ func TestFilteredByTags(t *testing.T) {
 	}
 }
 
+func TestErrorTrackingOnly(t *testing.T) {
+	for _, tt := range []struct {
+		span     pb.Span
+		eligible bool
+	}{
+		{
+			span:     pb.Span{Error: 1, Metrics: map[string]float64{"_top_level": 1}},
+			eligible: true,
+		},
+		{
+			span:     pb.Span{Error: 0, Metrics: map[string]float64{"_top_level": 1}},
+			eligible: false,
+		},
+		{
+			span:     pb.Span{Error: 1, Metrics: map[string]float64{"_top_level": 0}},
+			eligible: false,
+		},
+		{
+			span:     pb.Span{Error: 0, Metrics: map[string]float64{"_top_level": 0}},
+			eligible: false,
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			assert.Equal(t, tt.eligible, eligibleForErrorTracking(&tt.span))
+		})
+	}
+}
+
 func TestClientComputedStats(t *testing.T) {
 	cfg := config.New()
 	cfg.Endpoints[0].APIKey = "test"

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -101,6 +101,12 @@ type AppSecConfig struct {
 	DDURL string
 }
 
+// ErrorTrackingConfig ...
+type ErrorTrackingConfig struct {
+	// Only is a config that drops all spans except the ones error tracking can process
+	Only bool
+}
+
 // Export returns an obfuscate.Config matching o.
 func (o *ObfuscationConfig) Export() obfuscate.Config {
 	return obfuscate.Config{
@@ -367,6 +373,9 @@ type AgentConfig struct {
 	// AppSec contains AppSec configuration.
 	AppSec AppSecConfig
 
+	// ErrorTracking contains the config specific to Error Tracking
+	ErrorTracking ErrorTrackingConfig
+
 	// DebuggerProxy contains the settings for the Live Debugger proxy.
 	DebuggerProxy DebuggerProxyConfig
 
@@ -459,6 +468,7 @@ func New() *AgentConfig {
 			Enabled:        true,
 			MaxPayloadSize: 5 * 1024 * 1024,
 		},
+		ErrorTracking: ErrorTrackingConfig{},
 	}
 }
 

--- a/releasenotes/notes/error-tracking-standalone-e66a8f690dfa91bc.yaml
+++ b/releasenotes/notes/error-tracking-standalone-e66a8f690dfa91bc.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    Add a new config option to use APM Error Tracking as a standalone product - i.e. without the full APM product.
+    Added a new config option to use APM Error Tracking as a standalone product–as-in, without the full APM product.

--- a/releasenotes/notes/error-tracking-standalone-e66a8f690dfa91bc.yaml
+++ b/releasenotes/notes/error-tracking-standalone-e66a8f690dfa91bc.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add a new config option to use APM Error Tracking as a standalone product - i.e. without the full APM product.


### PR DESCRIPTION
### What does this PR do?

Add support for an "Error Tracking Only" mode for APM that basically filters out all spans that are not relevant to error-tracking.

### Motivation

This would allow selling APM Error Tracking independently to customers who don't want to pay for the full APM suite.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

This is meant for users that don't have an agent yet, and should be invisible to current users.

### Describe how to test/QA your changes

* set the new config to true
```
error_tracking:
  only: true
```
* have it process spans for an app that sends errors
* check that only the error spans are sent.
* they should all be tagged with `_dd.error_tracking.only:1`

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
