### PR TITLE
[CWS] versioned agent rules

### DIFF
--- a/cmd/security-agent/app/runtime.go
+++ b/cmd/security-agent/app/runtime.go
@@ -29,6 +29,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/diagnostic"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
+	"github.com/DataDog/datadog-agent/pkg/security/agent"
 	secagent "github.com/DataDog/datadog-agent/pkg/security/agent"
 	"github.com/DataDog/datadog-agent/pkg/security/api"
 	secconfig "github.com/DataDog/datadog-agent/pkg/security/config"
@@ -549,7 +550,7 @@ func checkPoliciesInner(dir string) error {
 	model := &model.Model{}
 	ruleSet := rules.NewRuleSet(model, model.NewEvent, &opts)
 
-	if err := rules.LoadPolicies(cfg.PoliciesDir, ruleSet); err.ErrorOrNil() != nil {
+	if err := rules.LoadPolicies(cfg.PoliciesDir, ruleSet, agent.CheckAgentVersionConstraint); err.ErrorOrNil() != nil {
 		return err
 	}
 

--- a/cmd/security-agent/app/runtime.go
+++ b/cmd/security-agent/app/runtime.go
@@ -550,7 +550,12 @@ func checkPoliciesInner(dir string) error {
 	model := &model.Model{}
 	ruleSet := rules.NewRuleSet(model, model.NewEvent, &opts)
 
-	if err := rules.LoadPolicies(cfg.PoliciesDir, ruleSet, agent.CheckAgentVersionConstraint); err.ErrorOrNil() != nil {
+	av, err := agent.GetAgentSemverVersion()
+	if err != nil {
+		return err
+	}
+
+	if err := rules.LoadPolicies(cfg.PoliciesDir, ruleSet, av); err.ErrorOrNil() != nil {
 		return err
 	}
 

--- a/pkg/security/agent/utils.go
+++ b/pkg/security/agent/utils.go
@@ -6,33 +6,16 @@
 package agent
 
 import (
-	"strings"
-
 	"github.com/DataDog/datadog-agent/pkg/version"
 	"github.com/Masterminds/semver"
 )
 
-// CheckAgentVersionConstraint checks that the semver constraint is satisfied by the agent version
-func CheckAgentVersionConstraint(constraint string) (bool, error) {
-	constraint = strings.TrimSpace(constraint)
-	if constraint == "" {
-		return true, nil
-	}
-
+// GetAgentSemverVersion returns the agent version as a semver version
+func GetAgentSemverVersion() (*semver.Version, error) {
 	av, err := version.Agent()
 	if err != nil {
-		return false, err
+		return nil, err
 	}
 
-	agentVersion, err := semver.NewVersion(av.GetNumberAndPre())
-	if err != nil {
-		return false, err
-	}
-
-	semverConstraint, err := semver.NewConstraint(constraint)
-	if err != nil {
-		return false, err
-	}
-
-	return semverConstraint.Check(agentVersion), nil
+	return semver.NewVersion(av.GetNumberAndPre())
 }

--- a/pkg/security/agent/utils.go
+++ b/pkg/security/agent/utils.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Masterminds/semver"
 )
 
+// CheckAgentVersionConstraint checks that the semver constraint is satisfied by the agent version
 func CheckAgentVersionConstraint(constraint string) (bool, error) {
 	constraint = strings.TrimSpace(constraint)
 	if constraint == "" {

--- a/pkg/security/agent/utils.go
+++ b/pkg/security/agent/utils.go
@@ -1,0 +1,37 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package agent
+
+import (
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/version"
+	"github.com/Masterminds/semver"
+)
+
+func CheckAgentVersionConstraint(constraint string) (bool, error) {
+	constraint = strings.TrimSpace(constraint)
+	if constraint == "" {
+		return true, nil
+	}
+
+	av, err := version.Agent()
+	if err != nil {
+		return false, err
+	}
+
+	agentVersion, err := semver.NewVersion(av.GetNumberAndPre())
+	if err != nil {
+		return false, err
+	}
+
+	semverConstraint, err := semver.NewConstraint(constraint)
+	if err != nil {
+		return false, err
+	}
+
+	return semverConstraint.Check(agentVersion), nil
+}

--- a/pkg/security/module/module.go
+++ b/pkg/security/module/module.go
@@ -28,6 +28,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
+	"github.com/DataDog/datadog-agent/pkg/security/agent"
 	sapi "github.com/DataDog/datadog-agent/pkg/security/api"
 	sconfig "github.com/DataDog/datadog-agent/pkg/security/config"
 	seclog "github.com/DataDog/datadog-agent/pkg/security/log"
@@ -274,7 +275,7 @@ func (m *Module) Reload() error {
 
 	model := &model.Model{}
 	approverRuleSet := rules.NewRuleSet(model, model.NewEvent, &opts)
-	loadApproversErr := rules.LoadPolicies(policiesDir, approverRuleSet)
+	loadApproversErr := rules.LoadPolicies(policiesDir, approverRuleSet, agent.CheckAgentVersionConstraint)
 
 	// switch SECLVariables to use the real Event structure and not the mock model.Event one
 	opts.WithVariables(sprobe.SECLVariables)
@@ -283,7 +284,7 @@ func (m *Module) Reload() error {
 	})
 
 	ruleSet := m.probe.NewRuleSet(&opts)
-	loadErr := rules.LoadPolicies(policiesDir, ruleSet)
+	loadErr := rules.LoadPolicies(policiesDir, ruleSet, agent.CheckAgentVersionConstraint)
 
 	if loadErr.ErrorOrNil() != nil {
 		logMultiErrors("error while loading policies: %+v", loadErr)

--- a/pkg/security/module/self_tester.go
+++ b/pkg/security/module/self_tester.go
@@ -16,11 +16,11 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/security/agent"
 	"github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/Masterminds/semver"
 	"github.com/pkg/errors"
 )
 
@@ -103,13 +103,13 @@ func (t *SelfTester) GetSelfTestPolicy() *rules.Policy {
 }
 
 // AddSelfTestRulesToRuleSets adds self test rules to the rulesets
-func (t *SelfTester) AddSelfTestRulesToRuleSets(ruleSet, approverRuleSet *rules.RuleSet) {
+func (t *SelfTester) AddSelfTestRulesToRuleSets(ruleSet, approverRuleSet *rules.RuleSet, agentVersion *semver.Version) {
 	selfTestPolicy := t.GetSelfTestPolicy()
 
 	ruleSet.AddPolicyVersion(selfTestPolicyFilename, selfTestPolicy.Version)
 	approverRuleSet.AddPolicyVersion(selfTestPolicyFilename, selfTestPolicy.Version)
 
-	_, rules, merr := selfTestPolicy.GetValidMacroAndRules(agent.CheckAgentVersionConstraint)
+	_, rules, merr := selfTestPolicy.GetValidMacroAndRules(agentVersion)
 	if merr.ErrorOrNil() != nil {
 		logMultiErrors("error while loading additional policies", merr)
 	}

--- a/pkg/security/module/self_tester.go
+++ b/pkg/security/module/self_tester.go
@@ -16,6 +16,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/security/agent"
 	"github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
@@ -108,7 +109,7 @@ func (t *SelfTester) AddSelfTestRulesToRuleSets(ruleSet, approverRuleSet *rules.
 	ruleSet.AddPolicyVersion(selfTestPolicyFilename, selfTestPolicy.Version)
 	approverRuleSet.AddPolicyVersion(selfTestPolicyFilename, selfTestPolicy.Version)
 
-	_, rules, merr := selfTestPolicy.GetValidMacroAndRules()
+	_, rules, merr := selfTestPolicy.GetValidMacroAndRules(agent.CheckAgentVersionConstraint)
 	if merr.ErrorOrNil() != nil {
 		logMultiErrors("error while loading additional policies", merr)
 	}

--- a/pkg/security/secl/go.mod
+++ b/pkg/security/secl/go.mod
@@ -3,6 +3,7 @@ module github.com/DataDog/datadog-agent/pkg/security/secl
 go 1.17
 
 require (
+	github.com/Masterminds/semver v1.5.0
 	github.com/alecthomas/participle v0.7.1
 	github.com/davecgh/go-spew v1.1.1
 	github.com/fatih/structtag v1.2.0

--- a/pkg/security/secl/go.sum
+++ b/pkg/security/secl/go.sum
@@ -1,3 +1,5 @@
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
+github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/alecthomas/participle v0.7.1 h1:2bN7reTw//5f0cugJcTOnY/NYZcWQOaajW+BwZB5xWs=
 github.com/alecthomas/participle v0.7.1/go.mod h1:HfdmEuwvr12HXQN44HPWXR0lHmVolVYe4dyL6lQ3duY=
 github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1/go.mod h1:xTS7Pm1pD1mvyM075QCDSRqH6qRLXylzS24ZTpRiSzQ=

--- a/pkg/security/secl/rules/policy.go
+++ b/pkg/security/secl/rules/policy.go
@@ -38,6 +38,7 @@ func checkRuleID(ruleID string) bool {
 	return ruleIDPattern.MatchString(ruleID)
 }
 
+// AgentConstraintVerifier represents a function checking that an agent constraint is satisfied by the current agent version
 type AgentConstraintVerifier = func(string) (bool, error)
 
 // GetValidMacroAndRules returns valid macro, rules definitions

--- a/pkg/security/secl/rules/policy_test.go
+++ b/pkg/security/secl/rules/policy_test.go
@@ -27,10 +27,6 @@ func savePolicy(filename string, testPolicy *Policy) error {
 	return os.WriteFile(filename, yamlBytes, 0700)
 }
 
-func checkAgentConstraintNoOp(constraint string) (bool, error) {
-	return true, nil
-}
-
 func TestMacroMerge(t *testing.T) {
 	var opts Opts
 	opts.
@@ -83,7 +79,7 @@ func TestMacroMerge(t *testing.T) {
 		},
 	})
 
-	if err := LoadPolicies(tmpDir, rs, checkAgentConstraintNoOp); err != nil {
+	if err := LoadPolicies(tmpDir, rs, nil); err != nil {
 		t.Error(err)
 	}
 
@@ -98,7 +94,7 @@ func TestMacroMerge(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := LoadPolicies(tmpDir, rs, checkAgentConstraintNoOp); err == nil {
+	if err := LoadPolicies(tmpDir, rs, nil); err == nil {
 		t.Error("expected macro ID conflict")
 	}
 }
@@ -142,7 +138,7 @@ func TestRuleMerge(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := LoadPolicies(tmpDir, rs, checkAgentConstraintNoOp); err != nil {
+	if err := LoadPolicies(tmpDir, rs, nil); err != nil {
 		t.Error(err)
 	}
 
@@ -157,7 +153,7 @@ func TestRuleMerge(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := LoadPolicies(tmpDir, rs, checkAgentConstraintNoOp); err == nil {
+	if err := LoadPolicies(tmpDir, rs, nil); err == nil {
 		t.Error("expected rule ID conflict")
 	}
 }
@@ -311,7 +307,7 @@ func TestActionSetVariable(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := LoadPolicies(tmpDir, rs, checkAgentConstraintNoOp); err != nil {
+	if err := LoadPolicies(tmpDir, rs, nil); err != nil {
 		t.Error(err)
 	}
 
@@ -393,7 +389,7 @@ func TestActionSetVariableConflict(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := LoadPolicies(tmpDir, rs, checkAgentConstraintNoOp); err == nil {
+	if err := LoadPolicies(tmpDir, rs, nil); err == nil {
 		t.Error("expected policy to fail to load")
 	} else {
 		t.Log(err)
@@ -421,7 +417,7 @@ func loadPolicyInner(t *testing.T, testPolicy *Policy, versionChecker AgentConst
 		t.Fatal(err)
 	}
 
-	if err := LoadPolicies(tmpDir, rs, checkAgentConstraintNoOp); err.ErrorOrNil() != nil {
+	if err := LoadPolicies(tmpDir, rs, nil); err.ErrorOrNil() != nil {
 		return nil, err
 	}
 	return rs, nil
@@ -429,7 +425,7 @@ func loadPolicyInner(t *testing.T, testPolicy *Policy, versionChecker AgentConst
 
 func loadPolicy(t *testing.T, testPolicy *Policy) *multierror.Error {
 	t.Helper()
-	_, err := loadPolicyInner(t, testPolicy, checkAgentConstraintNoOp)
+	_, err := loadPolicyInner(t, testPolicy, nil)
 	return err
 }
 

--- a/pkg/security/secl/rules/policy_test.go
+++ b/pkg/security/secl/rules/policy_test.go
@@ -27,6 +27,10 @@ func savePolicy(filename string, testPolicy *Policy) error {
 	return os.WriteFile(filename, yamlBytes, 0700)
 }
 
+func checkAgentConstraintNoOp(constraint string) (bool, error) {
+	return true, nil
+}
+
 func TestMacroMerge(t *testing.T) {
 	var opts Opts
 	opts.
@@ -79,7 +83,7 @@ func TestMacroMerge(t *testing.T) {
 		},
 	})
 
-	if err := LoadPolicies(tmpDir, rs); err != nil {
+	if err := LoadPolicies(tmpDir, rs, checkAgentConstraintNoOp); err != nil {
 		t.Error(err)
 	}
 
@@ -94,7 +98,7 @@ func TestMacroMerge(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := LoadPolicies(tmpDir, rs); err == nil {
+	if err := LoadPolicies(tmpDir, rs, checkAgentConstraintNoOp); err == nil {
 		t.Error("expected macro ID conflict")
 	}
 }
@@ -138,7 +142,7 @@ func TestRuleMerge(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := LoadPolicies(tmpDir, rs); err != nil {
+	if err := LoadPolicies(tmpDir, rs, checkAgentConstraintNoOp); err != nil {
 		t.Error(err)
 	}
 
@@ -153,7 +157,7 @@ func TestRuleMerge(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := LoadPolicies(tmpDir, rs); err == nil {
+	if err := LoadPolicies(tmpDir, rs, checkAgentConstraintNoOp); err == nil {
 		t.Error("expected rule ID conflict")
 	}
 }
@@ -307,7 +311,7 @@ func TestActionSetVariable(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := LoadPolicies(tmpDir, rs); err != nil {
+	if err := LoadPolicies(tmpDir, rs, checkAgentConstraintNoOp); err != nil {
 		t.Error(err)
 	}
 
@@ -389,7 +393,7 @@ func TestActionSetVariableConflict(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := LoadPolicies(tmpDir, rs); err == nil {
+	if err := LoadPolicies(tmpDir, rs, checkAgentConstraintNoOp); err == nil {
 		t.Error("expected policy to fail to load")
 	} else {
 		t.Log(err)
@@ -416,7 +420,7 @@ func loadPolicy(t *testing.T, testPolicy *Policy) *multierror.Error {
 		t.Fatal(err)
 	}
 
-	return LoadPolicies(tmpDir, rs)
+	return LoadPolicies(tmpDir, rs, checkAgentConstraintNoOp)
 }
 
 func TestActionSetVariableInvalid(t *testing.T) {

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -100,6 +100,11 @@ func (rd *RuleDefinition) MergeWith(rd2 *RuleDefinition) error {
 	return nil
 }
 
+type VersionedRuleDefinition struct {
+	RuleDefinition         `yaml:",inline"`
+	AgentVersionConstraint string `yaml:"agent_version"`
+}
+
 // ActionDefinition describes a rule action section
 type ActionDefinition struct {
 	Set *SetDefinition `yaml:"set"`

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -100,6 +100,7 @@ func (rd *RuleDefinition) MergeWith(rd2 *RuleDefinition) error {
 	return nil
 }
 
+// VersionedRuleDefinition holds the definition for a rule and the agent version constraint
 type VersionedRuleDefinition struct {
 	RuleDefinition         `yaml:",inline"`
 	AgentVersionConstraint string `yaml:"agent_version"`


### PR DESCRIPTION
### What does this PR do?

This PR allows to specify versioned rules in CWS policy.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
