### PR TITLE
[workloadmeta, tagger] Add QOS class to kube pods

### DIFF
--- a/pkg/tagger/collectors/workloadmeta_extract.go
+++ b/pkg/tagger/collectors/workloadmeta_extract.go
@@ -243,6 +243,7 @@ func (c *WorkloadMetaCollector) handleKubePod(ev workloadmeta.Event) []*TagInfo 
 	tags.AddLow(kubernetes.NamespaceTagName, pod.Namespace)
 	tags.AddLow("pod_phase", strings.ToLower(pod.Phase))
 	tags.AddLow("kube_priority_class", pod.PriorityClass)
+	tags.AddLow("kube_qos", pod.QOSClass)
 
 	c.extractTagsFromPodLabels(pod, tags)
 

--- a/pkg/tagger/collectors/workloadmeta_test.go
+++ b/pkg/tagger/collectors/workloadmeta_test.go
@@ -159,6 +159,9 @@ func TestHandleKubePod(t *testing.T) {
 				// PVC tags
 				PersistentVolumeClaimNames: []string{"pvc-0"},
 
+				// QOS tags
+				QOSClass: "guaranteed",
+
 				// Phase tags
 				Phase: "Running",
 			},
@@ -186,6 +189,7 @@ func TestHandleKubePod(t *testing.T) {
 						"kube_ownerref_kind:deployment",
 						"kube_service:service1",
 						"kube_service:service2",
+						"kube_qos:guaranteed",
 						"ns-team:containers",
 						"ns_env:dev",
 						"pod_phase:running",

--- a/pkg/util/kubernetes/kubelet/types_kubelet.go
+++ b/pkg/util/kubernetes/kubelet/types_kubelet.go
@@ -103,6 +103,7 @@ type Status struct {
 	InitContainers []ContainerStatus `json:"initContainerStatuses,omitempty"`
 	AllContainers  []ContainerStatus
 	Conditions     []Conditions `json:"conditions,omitempty"`
+	QOSClass       string       `json:"qosClass,omitempty"`
 }
 
 // GetAllContainers returns the list of init and regular containers

--- a/pkg/workloadmeta/collectors/internal/kubelet/kubelet.go
+++ b/pkg/workloadmeta/collectors/internal/kubelet/kubelet.go
@@ -131,6 +131,7 @@ func (c *collector) parsePods(pods []*kubelet.Pod) []workloadmeta.CollectorEvent
 			Phase:                      pod.Status.Phase,
 			IP:                         pod.Status.PodIP,
 			PriorityClass:              pod.Spec.PriorityClassName,
+			QOSClass:                   pod.Status.QOSClass,
 		}
 
 		events = append(events, containerEvents...)

--- a/pkg/workloadmeta/types.go
+++ b/pkg/workloadmeta/types.go
@@ -453,6 +453,7 @@ type KubernetesPod struct {
 	Phase                      string
 	IP                         string
 	PriorityClass              string
+	QOSClass                   string
 	KubeServices               []string
 	NamespaceLabels            map[string]string
 }
@@ -508,6 +509,7 @@ func (p KubernetesPod) String(verbose bool) string {
 
 	if verbose {
 		_, _ = fmt.Fprintln(&sb, "Priority Class:", p.PriorityClass)
+		_, _ = fmt.Fprintln(&sb, "QOS Class:", p.QOSClass)
 		_, _ = fmt.Fprintln(&sb, "PVCs:", sliceToString(p.PersistentVolumeClaimNames))
 		_, _ = fmt.Fprintln(&sb, "Kube Services:", sliceToString(p.KubeServices))
 		_, _ = fmt.Fprintln(&sb, "Namespace Labels:", mapToString(p.NamespaceLabels))

--- a/releasenotes/notes/qos-class-pods-a774cf7e4a60d703.yaml
+++ b/releasenotes/notes/qos-class-pods-a774cf7e4a60d703.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Adds a kube_qos (quality of service) tag to metrics associated with
+    kubernetes pods and their containers.


### PR DESCRIPTION
### What does this PR do?

Adds a `kube_qos` (quality of service) tag to metrics associated with kubernetes pods and their containers.
More about quality of service for pods: https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/


### Describe how to test/QA your changes

- The pods should have a QOS class. You can check it with `agent workload-list --verbose` (It doesn't appear without --verbose).
- The metrics associated with kubernetes pods and also their containers should be tagged with the appropriate `kube_qos` tag. You can check metrics like: `kubernetes.pod.running`, `container.uptime`, etc.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
