### PR TITLE
[kitchen] Workaround dnf bug preventing installation on RHEL/CentOS 8.1

### DIFF
--- a/.gitlab/kitchen_testing/centos.yml
+++ b/.gitlab/kitchen_testing/centos.yml
@@ -147,8 +147,8 @@ kitchen_centos_fips_step_by_step_agent-a6:
   extends:
     - .kitchen_scenario_centos_8_fips_a6
     - .kitchen_test_step_by_step_agent
-  rules:
-    !reference [.on_deploy_a6]
+  #rules:
+  #  !reference [.on_deploy_a6]
 
 kitchen_centos_step_by_step_agent-a7:
   extends:
@@ -161,8 +161,8 @@ kitchen_centos_fips_step_by_step_agent-a7:
   extends:
     - .kitchen_scenario_centos_8_fips_a7
     - .kitchen_test_step_by_step_agent
-  rules:
-    !reference [.on_deploy_a7]
+  #rules:
+  #  !reference [.on_deploy_a7]
 
 # Agent 5 RPMs won't install on CentOS/RHEL 8 in FIPS mode, so we always
 # run upgrade5 on all systems with FIPS off

--- a/.gitlab/kitchen_testing/centos.yml
+++ b/.gitlab/kitchen_testing/centos.yml
@@ -147,8 +147,8 @@ kitchen_centos_fips_step_by_step_agent-a6:
   extends:
     - .kitchen_scenario_centos_8_fips_a6
     - .kitchen_test_step_by_step_agent
-  #rules:
-  #  !reference [.on_deploy_a6]
+  rules:
+    !reference [.on_deploy_a6]
 
 kitchen_centos_step_by_step_agent-a7:
   extends:
@@ -161,8 +161,8 @@ kitchen_centos_fips_step_by_step_agent-a7:
   extends:
     - .kitchen_scenario_centos_8_fips_a7
     - .kitchen_test_step_by_step_agent
-  #rules:
-  #  !reference [.on_deploy_a7]
+  rules:
+    !reference [.on_deploy_a7]
 
 # Agent 5 RPMs won't install on CentOS/RHEL 8 in FIPS mode, so we always
 # run upgrade5 on all systems with FIPS off

--- a/test/kitchen/site-cookbooks/dd-agent-step-by-step/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-step-by-step/recipes/default.rb
@@ -40,6 +40,9 @@ when 'debian'
 
 when 'rhel'
   protocol = node['platform_version'].to_i < 6 ? 'http' : 'https'
+  # Because of https://bugzilla.redhat.com/show_bug.cgi?id=1792506, we disable
+  # repo_gpgcheck on RHEL/CentOS < 8.2
+  repo_gpgcheck = node['platform_version'].to_f < 8.2 ? '0' : '1'
 
   file '/etc/yum.repos.d/datadog.repo' do
     content <<-EOF.gsub(/^ {6}/, '')
@@ -48,7 +51,7 @@ when 'rhel'
       baseurl = #{node['dd-agent-step-by-step']['yumrepo']}
       enabled=1
       gpgcheck=1
-      repo_gpgcheck=1
+      repo_gpgcheck=#{repo_gpgcheck}
       gpgkey=#{protocol}://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
              #{protocol}://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
              #{protocol}://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public


### PR DESCRIPTION
### What does this PR do?

When DNF runs in non-interactive mode on RHEL 8.1, it will run into https://bugzilla.redhat.com/show_bug.cgi?id=1792506 - essentially, if there are multiple `gpgkey` entries configured, only the first one will be respected. If the repodata is signed with key that's not the first entry, it will lead to `yum makecache -y` failing.

This PR makes us turn off repodata signature verification on RHEL 8.1 thus avoiding this issue. (I did test on RHEL 8.5 and it works fine there with repodata signature verification turned off). Note that install_script.sh and all other config mgmt tools already do this, so this is the last place affected.

I added a commit to run the step-by-step test on non-deploy pipelines so it passes for this PR. This is to be removed before merging.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
