### PR TITLE
[Cluster Agent] Add info metric cluster_checks_configs_info

### DIFF
--- a/pkg/clusteragent/clusterchecks/dispatcher_configs.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_configs.go
@@ -50,7 +50,11 @@ func (d *dispatcher) addConfig(config integration.Config, targetNodeName string)
 	digest := config.Digest()
 	d.store.digestToConfig[digest] = config
 	for _, instance := range config.Instances {
-		d.store.idToDigest[check.BuildID(config.Name, instance, config.InitConfig)] = digest
+		checkID := check.BuildID(config.Name, instance, config.InitConfig)
+		d.store.idToDigest[checkID] = digest
+		if targetNodeName != "" {
+			configsInfo.Set(1.0, targetNodeName, string(checkID), le.JoinLeaderValue)
+		}
 	}
 
 	// No target node specified: store in danglingConfigs
@@ -91,6 +95,7 @@ func (d *dispatcher) removeConfig(digest string) {
 
 	for k, v := range d.store.idToDigest {
 		if v == digest {
+			configsInfo.Delete(node.name, string(k), le.JoinLeaderValue)
 			delete(d.store.idToDigest, k)
 		}
 	}

--- a/pkg/clusteragent/clusterchecks/dispatcher_nodes.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_nodes.go
@@ -126,6 +126,15 @@ func (d *dispatcher) expireNodes() {
 				log.Debugf("Adding %s:%s as a dangling Cluster Check config", config.Name, digest)
 				d.store.danglingConfigs[digest] = config
 				danglingConfigs.Inc(le.JoinLeaderValue)
+
+				// TODO: Use partial label matching when it becomes available:
+				// Replace the loop by a single function call (delete by node name).
+				// Requires https://github.com/prometheus/client_golang/pull/1013
+				for k, v := range d.store.idToDigest {
+					if v == digest {
+						configsInfo.Delete(name, string(k), le.JoinLeaderValue)
+					}
+				}
 			}
 			delete(d.store.nodes, name)
 

--- a/pkg/clusteragent/clusterchecks/metrics.go
+++ b/pkg/clusteragent/clusterchecks/metrics.go
@@ -41,4 +41,8 @@ var (
 	busyness = telemetry.NewGaugeWithOpts("cluster_checks", "busyness",
 		[]string{"node", le.JoinLeaderLabel}, "Busyness of a node per the number of metrics submitted and average duration of all checks run",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
+	configsInfo = telemetry.NewGaugeWithOpts("cluster_checks", "configs_info",
+		[]string{"node", "check_id", le.JoinLeaderLabel}, "Information about the dispatched checks (node, check ID)",
+		telemetry.Options{NoDoubleUnderscoreSep: true},
+	)
 )

--- a/releasenotes/notes/clc-info-metric-26bcbaa314cb8e10.yaml
+++ b/releasenotes/notes/clc-info-metric-26bcbaa314cb8e10.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    The Cluster Agent now exposes a new metric ``cluster_checks_configs_info``.
+    It exposes the node and the check ID as tags.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Add `cluster_checks_configs_info` 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

<img width="1397" alt="image" src="https://user-images.githubusercontent.com/38987709/161122666-7fcfa027-3d49-485a-84a5-5ec4ca9bace6.png">


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Schedule/unschedule multiple cluster checks with advanced dispatching enabled or disabled, trigger some rebalancing, delete runners etc.. Make sure the metric takes the check rescheduling/deletion into account.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
