### PR TITLE
Allow fast custom image publication

### DIFF
--- a/.gitlab/internal_image_deploy.yml
+++ b/.gitlab/internal_image_deploy.yml
@@ -5,22 +5,25 @@
 docker_trigger_internal:
   stage: internal_image_deploy
   rules:
-    !reference [.on_deploy_stable_or_beta_repo_branch_a7]
+    !reference [.on_deploy_a7]
   needs:
     - job: docker_build_agent7_jmx
       artifacts: false
     - job: docker_build_agent7_jmx_arm64
       artifacts: false
-  trigger:
-    project: DataDog/images
-    branch: master
-    strategy: depend
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
+  tags: ["runner:main"]
   variables:
     IMAGE_VERSION: tmpl-v4
     IMAGE_NAME: datadog-agent
     RELEASE_TAG: ${CI_COMMIT_REF_SLUG}-jmx
     BUILD_TAG: ${CI_COMMIT_REF_SLUG}-jmx
     TMPL_AGENT_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx
-    TMPL_AGENT_SRC_REPO: ci/datadog-agent/agent-release
+    TMPL_AGENT_SRC_REPO: ci/datadog-agent/agent
     RELEASE_STAGING: "true"
     RELEASE_PROD: "true"
+  script:
+    - python3 -m pip install -r requirements.txt
+    - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_pipelines_scheduler_token --with-decryption --query "Parameter.Value" --out text)
+    - if [ "$BUCKET_BRANCH" = "beta" ] || [ "$BUCKET_BRANCH" = "stable" ]; then TMPL_AGENT_SRC_REPO="${TMPL_AGENT_SRC_REPO}-release"; fi
+    - inv pipeline.trigger-child-pipeline --project-name "DataDog/images" --git-ref "master" --variables "IMAGE_VERSION,IMAGE_NAME,RELEASE_TAG,BUILD_TAG,TMPL_AGENT_SRC_IMAGE,TMPL_AGENT_SRC_REPO,RELEASE_STAGING,RELEASE_PROD"


### PR DESCRIPTION
### What does this PR do?

Ease creation of internal custom images

### Motivation

DevExp

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

CI Works

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
