### PR TITLE
pkg/trace/api: OTLP: set error.msg from status message

### DIFF
--- a/pkg/trace/api/otlp.go
+++ b/pkg/trace/api/otlp.go
@@ -439,6 +439,11 @@ func status2Error(status pdata.SpanStatus, events pdata.SpanEventSlice, span *pb
 			return true
 		})
 	}
+	if _, ok := span.Meta["error.msg"]; !ok {
+		if status.Message() != "" {
+			span.Meta["error.msg"] = status.Message()
+		}
+	}
 }
 
 // spanKind2Type returns a span's type based on the given kind and other present properties.

--- a/pkg/trace/api/otlp_test.go
+++ b/pkg/trace/api/otlp_test.go
@@ -194,6 +194,7 @@ func TestOTLPHelpers(t *testing.T) {
 	t.Run("status2Error", func(t *testing.T) {
 		for _, tt := range []struct {
 			status pdata.StatusCode
+			msg    string
 			events pdata.SpanEventSlice
 			out    pb.Span
 		}{
@@ -246,6 +247,12 @@ func TestOTLPHelpers(t *testing.T) {
 				out:    pb.Span{Error: 1},
 			},
 			{
+				status: pdata.StatusCodeError,
+				msg:    "Error number #24",
+				events: pdata.NewSpanEventSlice(),
+				out:    pb.Span{Error: 1, Meta: map[string]string{"error.msg": "Error number #24"}},
+			},
+			{
 				status: pdata.StatusCodeOk,
 				events: pdata.NewSpanEventSlice(),
 				out:    pb.Span{Error: 0},
@@ -264,6 +271,7 @@ func TestOTLPHelpers(t *testing.T) {
 			span := pb.Span{Meta: make(map[string]string)}
 			status := pdata.NewSpanStatus()
 			status.SetCode(tt.status)
+			status.SetMessage(tt.msg)
 			status2Error(status, tt.events, &span)
 			assert.Equal(tt.out.Error, span.Error)
 			for _, prop := range []string{"error.msg", "error.type", "error.stack"} {

--- a/releasenotes/notes/apm-otlp-status-message-error-e60caa6e5a14d8cb.yaml
+++ b/releasenotes/notes/apm-otlp-status-message-error-e60caa6e5a14d8cb.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: OTLP: Fixed an inconsistency where the error message was left empty in cases where the "exception" event was not found. Now, the span status message is used a as a fallback.


### PR DESCRIPTION
This change ensures that the "error.msg" is set from the span status message as a fallback, when no "exception" type span event is found.