### PR TITLE
pkg/trace/api: OTLP: fix race with merge attributes

### DIFF
--- a/pkg/trace/api/otlp.go
+++ b/pkg/trace/api/otlp.go
@@ -338,7 +338,7 @@ func convertSpan(rattr map[string]string, lib pdata.InstrumentationLibrary, in p
 		name = "opentelemetry." + name
 	}
 	traceID := in.TraceID().Bytes()
-	meta := map[string]string{}
+	meta := make(map[string]string, len(rattr))
 	for k, v := range rattr {
 		meta[k] = v
 	}

--- a/pkg/trace/api/otlp.go
+++ b/pkg/trace/api/otlp.go
@@ -338,6 +338,10 @@ func convertSpan(rattr map[string]string, lib pdata.InstrumentationLibrary, in p
 		name = "opentelemetry." + name
 	}
 	traceID := in.TraceID().Bytes()
+	meta := map[string]string{}
+	for k, v := range rattr {
+		meta[k] = v
+	}
 	span := &pb.Span{
 		Name:     name,
 		TraceID:  traceIDToUint64(traceID),
@@ -347,7 +351,7 @@ func convertSpan(rattr map[string]string, lib pdata.InstrumentationLibrary, in p
 		Duration: int64(in.EndTimestamp()) - int64(in.StartTimestamp()),
 		Service:  rattr[string(semconv.AttributeServiceName)],
 		Resource: in.Name(),
-		Meta:     rattr,
+		Meta:     meta,
 		Metrics:  map[string]float64{},
 	}
 	span.Meta["otel.trace_id"] = hex.EncodeToString(traceID[:])

--- a/pkg/trace/api/otlp_test.go
+++ b/pkg/trace/api/otlp_test.go
@@ -621,6 +621,8 @@ func TestOTLPConvertSpan(t *testing.T) {
 	}
 }
 
+// TestResourceAttributesMap is a regression test ensuring that the resource attributes map
+// passed to convertSpan is not modified by it.
 func TestResourceAttributesMap(t *testing.T) {
 	rattr := map[string]string{"key": "val"}
 	lib := pdata.NewInstrumentationLibrary()

--- a/pkg/trace/api/otlp_test.go
+++ b/pkg/trace/api/otlp_test.go
@@ -621,6 +621,15 @@ func TestOTLPConvertSpan(t *testing.T) {
 	}
 }
 
+func TestResourceAttributesMap(t *testing.T) {
+	rattr := map[string]string{"key": "val"}
+	lib := pdata.NewInstrumentationLibrary()
+	span := testutil.NewOTLPSpan(&testutil.OTLPSpan{})
+	convertSpan(rattr, lib, span)
+	assert.Len(t, rattr, 1) // ensure "rattr" has no new entries
+	assert.Equal(t, "val", rattr["key"])
+}
+
 func makeEventsSlice(name string, attrs map[string]string, timestamp int, dropped uint32) pdata.SpanEventSlice {
 	s := pdata.NewSpanEventSlice()
 	e := s.AppendEmpty()

--- a/releasenotes/notes/apm-otlp-fix-merged-attributes-314024861a58788e.yaml
+++ b/releasenotes/notes/apm-otlp-fix-merged-attributes-314024861a58788e.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: OTLP: Fixes an issue where attributes from different spans were merged leading to spans containing incorrect attributes.


### PR DESCRIPTION
### What does this PR do?
Fixes an issue where attributes from different spans were merged leading to spans containing incorrect attributes.

### Motivation
APMS-6999

### Describe how to test/QA your changes
Added a test

### Reviewer's Checklist
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
