### PR TITLE
[CWS] add eval command line to test a rule against json data file

### DIFF
--- a/cmd/security-agent/app/runtime.go
+++ b/cmd/security-agent/app/runtime.go
@@ -69,6 +69,13 @@ var (
 		dir string
 	}{}
 
+	evalArgs = struct {
+		dir       string
+		ruleID    string
+		eventFile string
+		debug     bool
+	}{}
+
 	networkNamespaceCmd = &cobra.Command{
 		Use:   "network-namespace",
 		Short: "network namespace command",
@@ -169,6 +176,12 @@ var (
 		Use:   "check",
 		Short: "Check policies and return a report",
 		RunE:  checkPolicies,
+	}
+
+	evalCmd = &cobra.Command{
+		Use:   "eval",
+		Short: "Evaluate given event data against the give rule",
+		RunE:  evalRule,
 	}
 
 	downloadPolicyCmd = &cobra.Command{
@@ -304,6 +317,14 @@ func init() {
 
 	runtimeCmd.AddCommand(checkPoliciesCmd)
 	checkPoliciesCmd.Flags().StringVar(&checkPoliciesArgs.dir, "policies-dir", coreconfig.DefaultRuntimePoliciesDir, "Path to policies directory")
+
+	commonPolicyCmd.AddCommand(evalCmd)
+	evalCmd.Flags().StringVar(&evalArgs.dir, "policies-dir", coreconfig.DefaultRuntimePoliciesDir, "Path to policies directory")
+	evalCmd.Flags().StringVar(&evalArgs.ruleID, "rule-id", "", "Rule ID to evaluate")
+	_ = evalCmd.MarkFlagRequired("rule-id")
+	evalCmd.Flags().StringVar(&evalArgs.eventFile, "event-file", "", "File of the event data")
+	_ = evalCmd.MarkFlagRequired("event-file")
+	evalCmd.Flags().BoolVar(&evalArgs.debug, "debug", false, "Display an event dump if the evaluation fail")
 
 	runtimeCmd.AddCommand(selfTestCmd)
 	runtimeCmd.AddCommand(reloadPoliciesCmd)
@@ -621,14 +642,22 @@ func checkPoliciesInner(dir string) error {
 		return err
 	}
 
-	provider, err := rules.NewPoliciesDirProvider(cfg.PoliciesDir, false, agentVersion)
+	loaderOpts := rules.PolicyLoaderOpts{
+		RuleFilters: []rules.RuleFilter{
+			&rules.AgentVersionFilter{
+				Version: agentVersion,
+			},
+		},
+	}
+
+	provider, err := rules.NewPoliciesDirProvider(cfg.PoliciesDir, false)
 	if err != nil {
 		return err
 	}
 
 	loader := rules.NewPolicyLoader(provider)
 
-	if err := ruleSet.LoadPolicies(loader); err.ErrorOrNil() != nil {
+	if err := ruleSet.LoadPolicies(loader, loaderOpts); err.ErrorOrNil() != nil {
 		return err
 	}
 
@@ -652,6 +681,151 @@ func checkPoliciesInner(dir string) error {
 
 func checkPolicies(cmd *cobra.Command, args []string) error {
 	return checkPoliciesInner(checkPoliciesArgs.dir)
+}
+
+// RuleIDFilter used by the policy load to filter out rules
+type RuleIDFilter struct {
+	ID string
+}
+
+// IsAccepted implment the RuleFilter interface
+func (r *RuleIDFilter) IsAccepted(rule *rules.RuleDefinition) bool {
+	return r.ID == rule.ID
+}
+
+// EvalReport defines a report of an evaluation
+type EvalReport struct {
+	Succeeded bool
+	Approvers map[string]rules.Approvers
+	Event     eval.Event
+	Error     error `json:",omitempty"`
+}
+
+// EventData defines the structure used to represent an event
+type EventData struct {
+	Type   eval.EventType
+	Values map[string]interface{}
+}
+
+func eventDataFromJSON(file string) (eval.Event, error) {
+	f, err := os.Open(file)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	decoder := json.NewDecoder(f)
+	decoder.UseNumber()
+
+	var eventData EventData
+	if err := decoder.Decode(&eventData); err != nil {
+		return nil, err
+	}
+
+	kind := model.ParseEvalEventType(eventData.Type)
+	if kind == model.UnknownEventType {
+		return nil, errors.New("unknown event type")
+	}
+
+	m := &model.Model{}
+	event := m.NewEventWithType(kind)
+	event.Init()
+
+	for k, v := range eventData.Values {
+		switch v := v.(type) {
+		case json.Number:
+			value, err := v.Int64()
+			if err != nil {
+				return nil, err
+			}
+			if err := event.SetFieldValue(k, int(value)); err != nil {
+				return nil, err
+			}
+		default:
+			if err := event.SetFieldValue(k, v); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return event, nil
+}
+
+func evalRule(cmd *cobra.Command, args []string) error {
+	cfg := &secconfig.Config{
+		PoliciesDir:         evalArgs.dir,
+		EnableKernelFilters: true,
+		EnableApprovers:     true,
+		EnableDiscarders:    true,
+		PIDCacheSize:        1,
+	}
+
+	// enabled all the rules
+	enabled := map[eval.EventType]bool{"*": true}
+
+	var evalOpts eval.Opts
+	evalOpts.
+		WithConstants(model.SECLConstants).
+		WithVariables(model.SECLVariables).
+		WithLegacyFields(model.SECLLegacyFields)
+
+	var opts rules.Opts
+	opts.
+		WithSupportedDiscarders(sprobe.SupportedDiscarders).
+		WithEventTypeEnabled(enabled).
+		WithReservedRuleIDs(sprobe.AllCustomRuleIDs()).
+		WithLogger(&seclog.PatternLogger{})
+
+	model := &model.Model{}
+	ruleSet := rules.NewRuleSet(model, model.NewEvent, &opts, &evalOpts, &eval.MacroStore{})
+
+	loaderOpts := rules.PolicyLoaderOpts{
+		RuleFilters: []rules.RuleFilter{
+			&RuleIDFilter{
+				ID: evalArgs.ruleID,
+			},
+		},
+	}
+
+	provider, err := rules.NewPoliciesDirProvider(cfg.PoliciesDir, false)
+	if err != nil {
+		return err
+	}
+
+	loader := rules.NewPolicyLoader(provider)
+
+	if err := ruleSet.LoadPolicies(loader, loaderOpts); err.ErrorOrNil() != nil {
+		return err
+	}
+
+	event, err := eventDataFromJSON(evalArgs.eventFile)
+	if err != nil {
+		return err
+	}
+
+	report := EvalReport{
+		Event: event,
+	}
+
+	approvers, err := ruleSet.GetApprovers(sprobe.GetCapababilities())
+	if err != nil {
+		report.Error = err
+	} else {
+		report.Approvers = approvers
+	}
+
+	report.Succeeded = ruleSet.Evaluate(event)
+	output, err := json.MarshalIndent(report, "", "    ")
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%s\n", string(output))
+
+	if !report.Succeeded {
+		os.Exit(-1)
+	}
+
+	return nil
 }
 
 func runRuntimeSelfTest(cmd *cobra.Command, args []string) error {

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -402,7 +402,7 @@ func (a *APIServer) RunSelfTest(ctx context.Context, params *api.RunSelfTestPara
 		}, nil
 	}
 
-	if err := a.module.RunSelfTest(false, true); err != nil {
+	if err := a.module.RunSelfTest(false); err != nil {
 		return &api.SecuritySelfTestResultMessage{
 			Ok:    false,
 			Error: err.Error(),

--- a/pkg/security/probe/selftests/tester.go
+++ b/pkg/security/probe/selftests/tester.go
@@ -85,7 +85,7 @@ func (t *SelfTester) GetStatus() *api.SelfTestsStatus {
 }
 
 // LoadPolicies implements the PolicyProvider interface
-func (t *SelfTester) LoadPolicies() ([]*rules.Policy, *multierror.Error) {
+func (t *SelfTester) LoadPolicies(filters []rules.RuleFilter) ([]*rules.Policy, *multierror.Error) {
 	p := &rules.Policy{
 		Name:    policyName,
 		Source:  policySource,

--- a/pkg/security/rconfig/rconfig.go
+++ b/pkg/security/rconfig/rconfig.go
@@ -28,7 +28,6 @@ const securityAgentRCPollInterval = time.Second * 1
 // RCPolicyProvider defines a remote config policy provider
 type RCPolicyProvider struct {
 	sync.RWMutex
-	agentVersion *semver.Version
 
 	client               *remote.Client
 	onNewPoliciesReadyCb func()
@@ -45,8 +44,7 @@ func NewRCPolicyProvider(name string, agentVersion *semver.Version) (*RCPolicyPr
 	}
 
 	return &RCPolicyProvider{
-		client:       c,
-		agentVersion: agentVersion,
+		client: c,
 	}, nil
 }
 
@@ -78,7 +76,7 @@ func normalize(policy *rules.Policy) {
 }
 
 // LoadPolicies implements the PolicyProvider interface
-func (r *RCPolicyProvider) LoadPolicies() ([]*rules.Policy, *multierror.Error) {
+func (r *RCPolicyProvider) LoadPolicies(filters []rules.RuleFilter) ([]*rules.Policy, *multierror.Error) {
 	var policies []*rules.Policy
 	var errs *multierror.Error
 
@@ -88,7 +86,7 @@ func (r *RCPolicyProvider) LoadPolicies() ([]*rules.Policy, *multierror.Error) {
 	for _, c := range r.lastConfigs {
 		reader := bytes.NewReader(c.Config)
 
-		policy, err := rules.LoadPolicy(c.Metadata.ID, "remote-config", reader, r.agentVersion)
+		policy, err := rules.LoadPolicy(c.Metadata.ID, "remote-config", reader, filters)
 
 		if err != nil {
 			errs = multierror.Append(errs, err)

--- a/pkg/security/secl/compiler/eval/event.go
+++ b/pkg/security/secl/compiler/eval/event.go
@@ -15,6 +15,8 @@ type EventType = string
 
 // Event is an interface that an Event has to implement for the evaluation
 type Event interface {
+	// Init initialize the event
+	Init()
 	// GetType returns the Type of the Event
 	GetType() EventType
 	// GetFieldEventType returns the Event Type for the given Field

--- a/pkg/security/secl/compiler/eval/model_test.go
+++ b/pkg/security/secl/compiler/eval/model_test.go
@@ -494,6 +494,8 @@ func (m *testModel) GetEvaluator(field Field, regID RegisterID) (Evaluator, erro
 	return nil, &ErrFieldNotFound{Field: field}
 }
 
+func (e *testEvent) Init() {}
+
 func (e *testEvent) GetFieldValue(field Field) (interface{}, error) {
 	switch field {
 

--- a/pkg/security/secl/rules/model_test.go
+++ b/pkg/security/secl/rules/model_test.go
@@ -154,6 +154,8 @@ func (m *testModel) GetEvaluator(key string, regID eval.RegisterID) (eval.Evalua
 	return nil, &eval.ErrFieldNotFound{Field: key}
 }
 
+func (e *testEvent) Init() {}
+
 func (e *testEvent) GetFieldValue(key string) (interface{}, error) {
 	switch key {
 

--- a/pkg/security/secl/rules/policy_dir.go
+++ b/pkg/security/secl/rules/policy_dir.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"sort"
 
-	"github.com/Masterminds/semver"
 	"github.com/fsnotify/fsnotify"
 	"github.com/hashicorp/go-multierror"
 )
@@ -22,8 +21,7 @@ var _ PolicyProvider = (*PoliciesDirProvider)(nil)
 
 // PoliciesDirProvider defines a new policy dir provider
 type PoliciesDirProvider struct {
-	PoliciesDir  string
-	agentVersion *semver.Version
+	PoliciesDir string
 
 	onNewPoliciesReadyCb func()
 	cancelFnc            func()
@@ -39,7 +37,7 @@ func (p *PoliciesDirProvider) SetOnNewPoliciesReadyCb(cb func()) {
 // Start starts the policy dir provider
 func (p *PoliciesDirProvider) Start() {}
 
-func (p *PoliciesDirProvider) loadPolicy(filename string) (*Policy, error) {
+func (p *PoliciesDirProvider) loadPolicy(filename string, filters []RuleFilter) (*Policy, error) {
 	f, err := os.Open(filename)
 	if err != nil {
 		return nil, &ErrPolicyLoad{Name: filename, Err: err}
@@ -48,7 +46,7 @@ func (p *PoliciesDirProvider) loadPolicy(filename string) (*Policy, error) {
 
 	name := filepath.Base(filename)
 
-	policy, err := LoadPolicy(name, "file", f, p.agentVersion)
+	policy, err := LoadPolicy(name, "file", f, filters)
 	if err != nil {
 		return nil, &ErrPolicyLoad{Name: name, Err: err}
 	}
@@ -86,7 +84,7 @@ func (p *PoliciesDirProvider) getPolicyFiles() ([]string, error) {
 }
 
 // LoadPolicies implements the policy provider interface
-func (p *PoliciesDirProvider) LoadPolicies() ([]*Policy, *multierror.Error) {
+func (p *PoliciesDirProvider) LoadPolicies(filters []RuleFilter) ([]*Policy, *multierror.Error) {
 	var errs *multierror.Error
 
 	var policies []*Policy
@@ -106,7 +104,7 @@ func (p *PoliciesDirProvider) LoadPolicies() ([]*Policy, *multierror.Error) {
 
 	// Load and parse policies
 	for _, filename := range policyFiles {
-		policy, err := p.loadPolicy(filename)
+		policy, err := p.loadPolicy(filename, filters)
 		if err != nil {
 			errs = multierror.Append(errs, err)
 		} else {
@@ -178,11 +176,10 @@ func (p *PoliciesDirProvider) watch(ctx context.Context) {
 }
 
 // NewPoliciesDirProvider returns providers for the given policies dir
-func NewPoliciesDirProvider(policiesDir string, watch bool, agentVersion *semver.Version) (*PoliciesDirProvider, error) {
+func NewPoliciesDirProvider(policiesDir string, watch bool) (*PoliciesDirProvider, error) {
 
 	p := &PoliciesDirProvider{
-		PoliciesDir:  policiesDir,
-		agentVersion: agentVersion,
+		PoliciesDir: policiesDir,
 	}
 
 	if watch {

--- a/pkg/security/secl/rules/policy_loader.go
+++ b/pkg/security/secl/rules/policy_loader.go
@@ -17,6 +17,11 @@ var (
 	debounceDelay = 5 * time.Second
 )
 
+// PolicyLoaderOpts options used during the loading
+type PolicyLoaderOpts struct {
+	RuleFilters []RuleFilter
+}
+
 // PolicyLoader defines a policy loader
 type PolicyLoader struct {
 	sync.RWMutex
@@ -28,7 +33,7 @@ type PolicyLoader struct {
 }
 
 // LoadPolicies loads the policies
-func (p *PolicyLoader) LoadPolicies() ([]*Policy, *multierror.Error) {
+func (p *PolicyLoader) LoadPolicies(opts PolicyLoaderOpts) ([]*Policy, *multierror.Error) {
 	p.RLock()
 	defer p.RUnlock()
 
@@ -40,7 +45,7 @@ func (p *PolicyLoader) LoadPolicies() ([]*Policy, *multierror.Error) {
 
 	// use the provider in the order of insertion, keep the very last default policy
 	for _, provider := range p.Providers {
-		policies, err := provider.LoadPolicies()
+		policies, err := provider.LoadPolicies(opts.RuleFilters)
 		if err.ErrorOrNil() != nil {
 			errs = multierror.Append(errs, err)
 		}

--- a/pkg/security/secl/rules/policy_provider.go
+++ b/pkg/security/secl/rules/policy_provider.go
@@ -15,7 +15,7 @@ const DefaultPolicyName = "default.policy"
 
 // PolicyProvider defines a rule provider
 type PolicyProvider interface {
-	LoadPolicies() ([]*Policy, *multierror.Error)
+	LoadPolicies([]RuleFilter) ([]*Policy, *multierror.Error)
 	SetOnNewPoliciesReadyCb(func())
 
 	Start()

--- a/pkg/security/secl/rules/rule_filters.go
+++ b/pkg/security/secl/rules/rule_filters.go
@@ -1,0 +1,57 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package rules
+
+import (
+	"strings"
+
+	"github.com/Masterminds/semver"
+)
+
+// RuleFilter definition of a rule filter
+type RuleFilter interface {
+	IsAccepted(rule *RuleDefinition) bool
+}
+
+// RuleIDFilter defines a ID based filter
+type RuleIDFilter struct {
+	ID string
+}
+
+// IsAccepted checks whether the rule is accepted
+func (r *RuleIDFilter) IsAccepted(rule *RuleDefinition) bool {
+	return r.ID == rule.ID
+}
+
+// AgentVersionFilter defines a agent version filter
+type AgentVersionFilter struct {
+	Version *semver.Version
+}
+
+// IsAccepted checks whether the rule is accepted
+func (r *AgentVersionFilter) IsAccepted(rule *RuleDefinition) bool {
+	withoutPreAgentVersion, err := r.Version.SetPrerelease("")
+	if err != nil {
+		return true
+	}
+
+	cleanAgentVersion, err := withoutPreAgentVersion.SetMetadata("")
+	if err != nil {
+		return true
+	}
+
+	constraint := strings.TrimSpace(rule.AgentVersionConstraint)
+	if constraint == "" {
+		return true
+	}
+
+	semverConstraint, err := semver.NewConstraint(constraint)
+	if err != nil {
+		return false
+	}
+
+	return semverConstraint.Check(&cleanAgentVersion)
+}

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -611,7 +611,7 @@ func (rs *RuleSet) generatePartials() error {
 }
 
 // LoadPolicies loads policies from the provided policy loader
-func (rs *RuleSet) LoadPolicies(loader *PolicyLoader) *multierror.Error {
+func (rs *RuleSet) LoadPolicies(loader *PolicyLoader, opts PolicyLoaderOpts) *multierror.Error {
 	var (
 		errs       *multierror.Error
 		allRules   []*RuleDefinition
@@ -620,7 +620,7 @@ func (rs *RuleSet) LoadPolicies(loader *PolicyLoader) *multierror.Error {
 		ruleIndex  = make(map[string]*RuleDefinition)
 	)
 
-	policies, err := loader.LoadPolicies()
+	policies, err := loader.LoadPolicies(opts)
 	if err != nil {
 		errs = multierror.Append(errs, err)
 	}

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -715,7 +715,7 @@ func (tm *testModule) reloadConfiguration() error {
 	log.Debugf("reload configuration with testDir: %s", tm.Root())
 	tm.config.PoliciesDir = tm.Root()
 
-	provider, err := rules.NewPoliciesDirProvider(tm.config.PoliciesDir, false, nil)
+	provider, err := rules.NewPoliciesDirProvider(tm.config.PoliciesDir, false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR add a command line to the security agent which brings the ability to run an evaluation of a given rule using event data from a json file

```
sudo ./bin/security-agent/security-agent runtime policy eval --rule-id kernel_module_open --event-file /tmp/event.json --debug
```

Data file: 
```
{
        "type": "open",
        "values":
        {
                "open.file.path": "/lib/modules/test",
                "open.flags": 512
        }
}

```

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
