### PR TITLE
(rcm) bypass orgID check for employee sourced configs

### DIFF
--- a/pkg/config/remote/client.go
+++ b/pkg/config/remote/client.go
@@ -163,11 +163,11 @@ func (c *Client) buildConfigFiles() (configFiles, error) {
 	}
 	var configFiles configFiles
 	for targetPath, target := range targets {
-		targetPathMeta, err := data.ParseFilePathMeta(targetPath)
+		targetPathMeta, err := data.ParseConfigPath(targetPath)
 		if err != nil {
 			return nil, err
 		}
-		if _, productEnabled := c.enabledProducts[targetPathMeta.Product]; productEnabled {
+		if _, productEnabled := c.enabledProducts[data.Product(targetPathMeta.Product)]; productEnabled {
 			targetContent, err := c.partialClient.TargetFile(targetPath)
 			if err != nil {
 				return nil, err

--- a/pkg/config/remote/configs.go
+++ b/pkg/config/remote/configs.go
@@ -25,7 +25,7 @@ func (c configFiles) version() uint64 {
 }
 
 type configFile struct {
-	pathMeta data.PathMeta
+	pathMeta data.ConfigPath
 	version  uint64
 	raw      []byte
 }
@@ -47,10 +47,11 @@ type update struct {
 func (c *configs) update(products []data.Product, files configFiles) update {
 	productConfigIDFiles := make(map[data.Product]map[string]configFiles)
 	for _, file := range files {
-		if _, exist := productConfigIDFiles[file.pathMeta.Product]; !exist {
-			productConfigIDFiles[file.pathMeta.Product] = make(map[string]configFiles)
+		product := data.Product(file.pathMeta.Product)
+		if _, exist := productConfigIDFiles[product]; !exist {
+			productConfigIDFiles[product] = make(map[string]configFiles)
 		}
-		productConfigIDFiles[file.pathMeta.Product][file.pathMeta.ConfigID] = append(productConfigIDFiles[file.pathMeta.Product][file.pathMeta.ConfigID], file)
+		productConfigIDFiles[product][file.pathMeta.ConfigID] = append(productConfigIDFiles[product][file.pathMeta.ConfigID], file)
 	}
 	var update update
 	for _, product := range products {

--- a/pkg/config/remote/configs_test.go
+++ b/pkg/config/remote/configs_test.go
@@ -52,8 +52,8 @@ func TestConfigsAPMSamplingUpdates(t *testing.T) {
 
 	update1 := configs.update([]data.Product{data.ProductAPMSampling}, configFiles{
 		{
-			pathMeta: data.PathMeta{
-				Product:  data.ProductAPMSampling,
+			pathMeta: data.ConfigPath{
+				Product:  string(data.ProductAPMSampling),
 				ConfigID: "config_id1",
 				Name:     "target_tps1",
 			},
@@ -61,8 +61,8 @@ func TestConfigsAPMSamplingUpdates(t *testing.T) {
 			raw:     samplingFile1Content1,
 		},
 		{
-			pathMeta: data.PathMeta{
-				Product:  data.ProductAPMSampling,
+			pathMeta: data.ConfigPath{
+				Product:  string(data.ProductAPMSampling),
 				ConfigID: "config_id2",
 				Name:     "target_tps2",
 			},
@@ -103,8 +103,8 @@ func TestConfigsAPMSamplingUpdates(t *testing.T) {
 	assert.NoError(t, err)
 	update2 := configs.update([]data.Product{data.ProductAPMSampling}, configFiles{
 		{
-			pathMeta: data.PathMeta{
-				Product:  data.ProductAPMSampling,
+			pathMeta: data.ConfigPath{
+				Product:  string(data.ProductAPMSampling),
 				ConfigID: "config_id2",
 				Name:     "target_tps2",
 			},

--- a/pkg/config/remote/data/file.go
+++ b/pkg/config/remote/data/file.go
@@ -20,8 +20,8 @@ var (
 type source uint
 
 const (
-	// SourceUnknwon is an unknown source
-	SourceUnknwon source = iota
+	// SourceUnknown is an unknown source
+	SourceUnknown source = iota
 	// SourceDatadog is a config from datadog
 	SourceDatadog
 	// SourceEmployee is a config from a datadog employee
@@ -46,7 +46,7 @@ func ParseConfigPath(path string) (ConfigPath, error) {
 	case SourceEmployee:
 		return parseEmployeeConfigPath(path)
 	}
-	return ConfigPath{}, fmt.Errorf("config path '%s' has unknwon source", path)
+	return ConfigPath{}, fmt.Errorf("config path '%s' has unknown source", path)
 }
 
 func parseDatadogConfigPath(path string) (ConfigPath, error) {
@@ -96,5 +96,5 @@ func parseConfigPathSource(path string) source {
 	case strings.HasPrefix(path, "employee/"):
 		return SourceEmployee
 	}
-	return SourceUnknwon
+	return SourceUnknown
 }

--- a/pkg/config/remote/data/file.go
+++ b/pkg/config/remote/data/file.go
@@ -28,6 +28,7 @@ const (
 	SourceEmployee
 )
 
+// ConfigPath is the extracted metadata of a config path
 type ConfigPath struct {
 	Source   source
 	OrgID    int64

--- a/pkg/config/remote/data/file.go
+++ b/pkg/config/remote/data/file.go
@@ -4,61 +4,96 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
-
-	"github.com/pkg/errors"
+	"strings"
 )
 
 var (
-	// matches <string>/<int>/<string>/<string>/<string> for <type>/<org_id>/<product>/<config_id>/<file>
-	filePathRegexp       = regexp.MustCompile(`^([^/]+)/(\d+)/([^/]+)/([^/]+)/([^/]+)$`)
-	filePathRegexpGroups = 5
+	// matches datadog/<int>/<string>/<string>/<string> for datadog/<org_id>/<product>/<config_id>/<file>
+	datadogPathRegexp       = regexp.MustCompile(`^datadog/(\d+)/([^/]+)/([^/]+)/([^/]+)$`)
+	datadogPathRegexpGroups = 4
+
+	// matches employee/<string>/<string>/<string> for employee/<org_id>/<product>/<config_id>/<file>
+	employeePathRegexp       = regexp.MustCompile(`^employee/([^/]+)/([^/]+)/([^/]+)$`)
+	employeePathRegexpGroups = 3
 )
 
-// Type is the global type the file belongs to
-type Type uint
+type source uint
 
 const (
-	// TypeUnknown is an unknown type
-	TypeUnknown Type = iota
-	// TypeDatadog is the datadog type
-	TypeDatadog
+	// SourceUnknwon is an unknown source
+	SourceUnknwon source = iota
+	// SourceDatadog is a config from datadog
+	SourceDatadog
+	// SourceEmployee is a config from a datadog employee
+	SourceEmployee
 )
 
-// PathMeta contains the metadata of a specific file contained in its path
-type PathMeta struct {
-	Type     Type
+type ConfigPath struct {
+	Source   source
 	OrgID    int64
-	Product  Product
+	Product  string
 	ConfigID string
 	Name     string
 }
 
-// ParseFilePathMeta parses a file path meta
-func ParseFilePathMeta(path string) (PathMeta, error) {
-	matchedGroups := filePathRegexp.FindStringSubmatch(path)
-	if len(matchedGroups) != filePathRegexpGroups+1 {
-		return PathMeta{}, fmt.Errorf("config file path '%s' has wrong format", path)
+// ParseConfigPath parses a config path
+func ParseConfigPath(path string) (ConfigPath, error) {
+	configType := parseConfigPathSource(path)
+	switch configType {
+	case SourceDatadog:
+		return parseDatadogConfigPath(path)
+	case SourceEmployee:
+		return parseEmployeeConfigPath(path)
 	}
-	rawType := matchedGroups[1]
-	configType := TypeUnknown
-	switch rawType {
-	case "datadog":
-		configType = TypeDatadog
+	return ConfigPath{}, fmt.Errorf("config path '%s' has unknwon source", path)
+}
+
+func parseDatadogConfigPath(path string) (ConfigPath, error) {
+	matchedGroups := datadogPathRegexp.FindStringSubmatch(path)
+	if len(matchedGroups) != datadogPathRegexpGroups+1 {
+		return ConfigPath{}, fmt.Errorf("config file path '%s' has wrong format", path)
 	}
-	rawOrgID := matchedGroups[2]
+	rawOrgID := matchedGroups[1]
 	orgID, err := strconv.ParseInt(rawOrgID, 10, 64)
 	if err != nil {
-		return PathMeta{}, errors.Wrapf(err, "could not parse orgID '%s' in config file path", rawOrgID)
+		return ConfigPath{}, fmt.Errorf("could not parse orgID '%s' in config file path: %v", rawOrgID, err)
 	}
-	rawProduct := matchedGroups[3]
+	rawProduct := matchedGroups[2]
 	if len(rawProduct) == 0 {
-		return PathMeta{}, fmt.Errorf("product is empty")
+		return ConfigPath{}, fmt.Errorf("product is empty")
 	}
-	return PathMeta{
-		Type:     configType,
+	return ConfigPath{
+		Source:   SourceDatadog,
 		OrgID:    orgID,
-		Product:  Product(rawProduct),
-		ConfigID: matchedGroups[4],
-		Name:     matchedGroups[5],
+		Product:  rawProduct,
+		ConfigID: matchedGroups[3],
+		Name:     matchedGroups[4],
 	}, nil
+}
+
+func parseEmployeeConfigPath(path string) (ConfigPath, error) {
+	matchedGroups := employeePathRegexp.FindStringSubmatch(path)
+	if len(matchedGroups) != employeePathRegexpGroups+1 {
+		return ConfigPath{}, fmt.Errorf("config file path '%s' has wrong format", path)
+	}
+	rawProduct := matchedGroups[1]
+	if len(rawProduct) == 0 {
+		return ConfigPath{}, fmt.Errorf("product is empty")
+	}
+	return ConfigPath{
+		Source:   SourceEmployee,
+		Product:  rawProduct,
+		ConfigID: matchedGroups[2],
+		Name:     matchedGroups[3],
+	}, nil
+}
+
+func parseConfigPathSource(path string) source {
+	switch {
+	case strings.HasPrefix(path, "datadog/"):
+		return SourceDatadog
+	case strings.HasPrefix(path, "employee/"):
+		return SourceEmployee
+	}
+	return SourceUnknwon
 }

--- a/pkg/config/remote/data/file_test.go
+++ b/pkg/config/remote/data/file_test.go
@@ -10,20 +10,20 @@ func TestParseFilePath(t *testing.T) {
 	tests := []struct {
 		input  string
 		err    bool
-		output PathMeta
+		output ConfigPath
 	}{
 		{
 			input:  "datadog/2/APM_SAMPLING/fc18c18f-939a-4017-b428-af03678f6c1a/file1",
 			err:    false,
-			output: PathMeta{Type: TypeDatadog, OrgID: 2, Product: ProductAPMSampling, ConfigID: "fc18c18f-939a-4017-b428-af03678f6c1a", Name: "file1"},
+			output: ConfigPath{Source: SourceDatadog, OrgID: 2, Product: "APM_SAMPLING", ConfigID: "fc18c18f-939a-4017-b428-af03678f6c1a", Name: "file1"},
 		},
 		{
-			input:  "user/5343/TESTING1/static_id/f3045934w_dogfile",
+			input:  "employee/APM_SAMPLING/fc18c18f-939a-4017-b428-af03678f6c1a/file1",
 			err:    false,
-			output: PathMeta{Type: TypeUnknown, OrgID: 5343, Product: ProductTesting1, ConfigID: "static_id", Name: "f3045934w_dogfile"},
+			output: ConfigPath{Source: SourceEmployee, Product: "APM_SAMPLING", ConfigID: "fc18c18f-939a-4017-b428-af03678f6c1a", Name: "file1"},
 		},
 		{
-			input: "user/5343/TESTING1/static_id/f3045934w_dogfile/other_file",
+			input: "user/5343/TESTING1/static_id/f3045934w_dogfile",
 			err:   true,
 		},
 		{
@@ -53,7 +53,7 @@ func TestParseFilePath(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.input, func(tt *testing.T) {
-			output, err := ParseFilePathMeta(test.input)
+			output, err := ParseConfigPath(test.input)
 			if test.err {
 				assert.Error(tt, err)
 			} else {

--- a/pkg/config/remote/service/service.go
+++ b/pkg/config/remote/service/service.go
@@ -351,11 +351,11 @@ func (s *Service) getTargetFiles(products []rdata.Product, cachedTargetFiles []*
 	}
 	var configFiles []*pbgo.File
 	for targetPath, targetMeta := range targets {
-		configFileMeta, err := rdata.ParseFilePathMeta(targetPath)
+		configPathMeta, err := rdata.ParseConfigPath(targetPath)
 		if err != nil {
 			return nil, err
 		}
-		if _, inClientProducts := productSet[configFileMeta.Product]; inClientProducts {
+		if _, inClientProducts := productSet[rdata.Product(configPathMeta.Product)]; inClientProducts {
 			if notEqualErr := tufutil.FileMetaEqual(cachedTargets[targetPath], targetMeta.FileMeta); notEqualErr == nil {
 				continue
 			}

--- a/pkg/config/remote/uptane/client.go
+++ b/pkg/config/remote/uptane/client.go
@@ -200,11 +200,12 @@ func (c *Client) verifyOrgID() error {
 		return err
 	}
 	for targetPath := range directorTargets {
-		configFileMeta, err := rdata.ParseFilePathMeta(targetPath)
+		configPathMeta, err := rdata.ParseConfigPath(targetPath)
 		if err != nil {
 			return err
 		}
-		if configFileMeta.OrgID != c.orgID {
+		checkOrgID := configPathMeta.Source != rdata.SourceEmployee
+		if checkOrgID && configPathMeta.OrgID != c.orgID {
 			return fmt.Errorf("director target '%s' does not have the correct orgID", targetPath)
 		}
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

bypass orgID check for employee sourced configs

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Employees publish configs for everyone, not specific orgs.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
