### PR TITLE
pkg/trace: Fix deadlock

### DIFF
--- a/pkg/trace/sampler/coresampler.go
+++ b/pkg/trace/sampler/coresampler.go
@@ -313,7 +313,7 @@ func (s *Sampler) report() {
 	kept := atomic.SwapInt64(&s.totalKept, 0)
 	metrics.Count("datadog.trace_agent.sampler.kept", kept, s.tags, 1)
 	metrics.Count("datadog.trace_agent.sampler.seen", seen, s.tags, 1)
-	metrics.Gauge("datadog.trace_agent.sampler.size", s.size(), s.tags, 1)
+	metrics.Gauge("datadog.trace_agent.sampler.size", float64(s.size()), s.tags, 1)
 }
 
 // Stop stops the main Run loop

--- a/pkg/trace/sampler/coresampler.go
+++ b/pkg/trace/sampler/coresampler.go
@@ -251,8 +251,8 @@ func (s *Sampler) countSample() {
 // getSignatureSampleRate returns the sampling rate to apply to a signature
 func (s *Sampler) getSignatureSampleRate(sig Signature) float64 {
 	s.muRates.RLock()
-	defer s.muRates.RUnlock()
 	rate, ok := s.rates[sig]
+	s.muRates.RUnlock()
 	if !ok {
 		return s.defaultRate()
 	}
@@ -262,11 +262,11 @@ func (s *Sampler) getSignatureSampleRate(sig Signature) float64 {
 // getAllSignatureSampleRates returns the sampling rate to apply to each signature
 func (s *Sampler) getAllSignatureSampleRates() (map[Signature]float64, float64) {
 	s.muRates.RLock()
-	defer s.muRates.RUnlock()
 	rates := make(map[Signature]float64, len(s.rates))
 	for sig, val := range s.rates {
 		rates[sig] = val * s.extraRate
 	}
+	s.muRates.RUnlock()
 	return rates, s.defaultRate()
 }
 
@@ -281,6 +281,7 @@ func (s *Sampler) defaultRate() float64 {
 
 	var maxSeen float32
 	s.muSeen.RLock()
+	defer s.muSeen.RUnlock()
 	for _, c := range s.allSigsSeen {
 		if c > maxSeen {
 			maxSeen = c
@@ -292,7 +293,6 @@ func (s *Sampler) defaultRate() float64 {
 	if targetTPS < seenTPS && seenTPS > 0 {
 		rate = targetTPS / seenTPS
 	}
-	s.muSeen.RUnlock()
 	if s.lowestRate < rate && s.lowestRate != 0 {
 		return s.lowestRate
 	}
@@ -313,7 +313,7 @@ func (s *Sampler) report() {
 	kept := atomic.SwapInt64(&s.totalKept, 0)
 	metrics.Count("datadog.trace_agent.sampler.kept", kept, s.tags, 1)
 	metrics.Count("datadog.trace_agent.sampler.seen", seen, s.tags, 1)
-	metrics.Count("datadog.trace_agent.sampler.size", s.size(), s.tags, 1)
+	metrics.Gauge("datadog.trace_agent.sampler.size", s.size(), s.tags, 1)
 }
 
 // Stop stops the main Run loop

--- a/pkg/trace/sampler/coresampler_test.go
+++ b/pkg/trace/sampler/coresampler_test.go
@@ -16,20 +16,19 @@ import (
 
 func TestSamplerAccessRace(t *testing.T) {
 	s := newSampler(1, 2, nil)
-	testTime := time.Now()
 	var wg sync.WaitGroup
 	wg.Add(5)
 	for j := 0; j < 5; j++ {
-		go func() {
+		go func(j int) {
 			defer wg.Done()
 			for i := 0; i < 10000; i++ {
-				s.countWeightedSig(testTime, Signature(i%3), 5)
+				s.countWeightedSig(time.Now().Add(time.Duration(5*(j+i))*time.Second), Signature(i%3), 5)
 				s.report()
 				s.countSample()
 				s.getSignatureSampleRate(Signature(i % 3))
 				s.getAllSignatureSampleRates()
 			}
-		}()
+		}(j)
 	}
 	wg.Wait()
 }


### PR DESCRIPTION
### What does this PR do?

I introduced a dead lock on agent 7.35.RC2 with https://github.com/DataDog/datadog-agent/pull/11069. Every 5s muRates.Lock is called while muSeen is locked (`countWeightedSig` calls `updateRates`).


#### Deadlock example

1. muSeen.Lock() aquired by goroutine A `countWeightedSample`
2. muRate.Rlock() aquired by goroutine B `getSignatureSampleRate`
3. goroutine B tries to aquire muSee.Rlock() and waits (new signature triggers a defaultRate() call)
4. goroutine A tries to aquire muRate.Lock() and waits (5s rotation of the rates)

#### PR changes
- fixes the deadlock by releasing muRate as soon as possible on getSignature functions
- ensures TestSamplerAccessRace catch this deadlock and future ones by forcing bucket rotations
- move sampler size metric to Gauge type



This deadlock was caught on one container about to OOM. Chan to trace-agent main goroutines was full and no metrics were reported on those goroutines while stats/trace writer and http receiver goroutines were sending stats.

<img width="583" alt="image" src="https://user-images.githubusercontent.com/22001182/161360096-068a8ed8-736e-456f-80a9-af0b4a2dee6b.png">



### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
