### PR TITLE
[CWS] other fixes to constant tests

### DIFF
--- a/pkg/security/probe/constantfetch/fallback.go
+++ b/pkg/security/probe/constantfetch/fallback.go
@@ -522,6 +522,8 @@ func getPipeInodeInfoBufsOffset(kv *kernel.Version) uint64 {
 		offset = 120
 	case kv.IsAmazonLinuxKernel() && kv.IsInRangeCloseOpen(kernel.Kernel5_10, kernel.Kernel5_11):
 		offset = 152
+	case kv.IsDebianKernel() && kv.IsInRangeCloseOpen(kernel.Kernel5_10, kernel.Kernel5_11):
+		offset = 152
 
 	case kv.IsInRangeCloseOpen(kernel.Kernel4_13, kernel.Kernel5_6):
 		offset = 120

--- a/pkg/security/probe/constantfetch/offset_guesser.go
+++ b/pkg/security/probe/constantfetch/offset_guesser.go
@@ -127,6 +127,7 @@ func (og *OffsetGuesser) FinishAndGetResults() (map[string]uint64, error) {
 	for _, probe := range probes.AllProbes() {
 		options.ExcludedFunctions = append(options.ExcludedFunctions, probe.ProbeIdentificationPair.EBPFFuncName)
 	}
+	options.ExcludedFunctions = append(options.ExcludedFunctions, probes.GetAllTCProgramFunctions()...)
 
 	if err := og.manager.InitWithOptions(bytecodeReader, options); err != nil {
 		return og.res, err

--- a/pkg/security/tests/constants_test.go
+++ b/pkg/security/tests/constants_test.go
@@ -114,7 +114,8 @@ func assertConstantsEqual(t *testing.T, champion, challenger constantfetch.Const
 	}
 
 	if !assert.Equal(t, championConstants, challengerConstants) {
-		t.Logf("comparison between `%s`(-) and `%s`(+). kernel version: %v", champion.String(), challenger.String(), kv)
+		t.Logf("comparison between `%s`(-) and `%s`(+)", champion.String(), challenger.String())
+		t.Logf("kernel version: %v", kv)
 	}
 }
 
@@ -136,6 +137,10 @@ func assertConstantContains(t *testing.T, champion, challenger constantfetch.Con
 		} else if v != expected {
 			t.Errorf("difference between fighters for `%s`: `%s`:%d and `%s`:%d", k, champion.String(), expected, challenger.String(), v)
 		}
+	}
+
+	if t.Failed() {
+		t.Logf("kernel version: %v", kv)
 	}
 }
 

--- a/pkg/security/tests/dns_test.go
+++ b/pkg/security/tests/dns_test.go
@@ -23,7 +23,7 @@ import (
 func TestDNS(t *testing.T) {
 	checkKernelCompatibility(t, "RHEL, SLES and Oracle kernels", func(kv *kernel.Version) bool {
 		// TODO: Oracle because we are missing offsets
-		return kv.IsRH7Kernel() || kv.IsOracleUEKKernel()
+		return kv.IsRH7Kernel() || kv.IsOracleUEKKernel() || kv.IsSLESKernel()
 	})
 
 	if testEnvironment != DockerEnvironment && !config.IsContainerized() {

--- a/pkg/security/tests/network_device_test.go
+++ b/pkg/security/tests/network_device_test.go
@@ -29,7 +29,7 @@ import (
 func TestNetDevice(t *testing.T) {
 	checkKernelCompatibility(t, "RHEL, SLES and Oracle kernels", func(kv *kernel.Version) bool {
 		// TODO: Oracle because we are missing offsets
-		return kv.IsRH7Kernel() || kv.IsOracleUEKKernel()
+		return kv.IsRH7Kernel() || kv.IsOracleUEKKernel() || kv.IsSLESKernel()
 	})
 
 	if testEnvironment != DockerEnvironment && !config.IsContainerized() {

--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -29,7 +29,7 @@
                 "debian-8": "urn,credativ:Debian:8:8.0.201901221",
                 "debian-9": "urn,credativ:Debian:9:9.20200722.0",
                 "debian-10": "urn,Debian:debian-10:10:0.20211011.792",
-                "debian-11": "urn,Debian:debian-11:11:0.20210814.734"
+                "debian-11": "urn,Debian:debian-11:11:0.20220328.962"
             }
         },
         "ec2": {
@@ -91,7 +91,7 @@
         }
     },
     "amazonlinux": {
-        "ec2" : {
+        "ec2": {
             "x86_64": {
                 "amazonlinux2-4-14": "ami-038b3df3312ddf25d",
                 "amazonlinux2-5-10": "ami-033b95fb8079dc481"


### PR DESCRIPTION
### What does this PR do?

This PR represents the latest improvements to the constant tests, it:
- bumps Debian 11 version to a version with available kernel headers, and fix a constant
- skips DNS and network device tests on SLES (the kernel headers are not available, so the constants are not correct)
- improves the kernel version display when a constant test is failing
- exclude TC programs when loading offset guesser eBPF

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
