### PR TITLE
Remove team/agent-platform default label from dependabot PR

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,7 +5,6 @@ updates:
     labels:
       - dependencies
       - dependencies-go
-      - team/agent-platform
       - changelog/no-changelog
     milestone: 22
     ignore:
@@ -94,7 +93,7 @@ updates:
     labels:
       - dependencies
       - dependencies-go
-      - team/agent-platform
+      - team/agent-core
       - changelog/no-changelog
     milestone: 22
     ignore:

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,6 +5,7 @@ updates:
     labels:
       - dependencies
       - dependencies-go
+      - team/triage
       - changelog/no-changelog
     milestone: 22
     ignore:


### PR DESCRIPTION
### What does this PR do?

If we don't know the team that owns a dependency beforehand, don't add any team tag. This makes it easier to identify and assign them.

This makes the CI that checks for that label fail, but I think it's okay since they shouldn't be merged anyway before assigning a team, and then we can re-run the test.

### Motivation

Ease the triage of dependabot PRs.