### PR TITLE
pkg/obfuscate: replace double quoted strings after !=, <= and >= by question marks

### DIFF
--- a/pkg/obfuscate/sql.go
+++ b/pkg/obfuscate/sql.go
@@ -181,7 +181,7 @@ func (f *replaceFilter) Filter(token, lastToken TokenKind, buffer []byte) (token
 	switch lastToken {
 	case Savepoint:
 		return markFilteredGroupable(token), questionMark, nil
-	case '=':
+	case '=', LE, GE, NE:
 		switch token {
 		case DoubleQuotedString:
 			// double-quoted strings after assignments are eligible for obfuscation

--- a/pkg/obfuscate/sql_test.go
+++ b/pkg/obfuscate/sql_test.go
@@ -768,7 +768,12 @@ func TestSQLQuantizer(t *testing.T) {
 		},
 		{
 			"UPDATE user_dash_pref SET json_prefs = %(json_prefs)s, modified = '2015-08-27 22:10:32.492912' WHERE user_id = %(user_id)s AND url = %(url)s",
-			"UPDATE user_dash_pref SET json_prefs = ? modified = ? WHERE user_id = ? AND url = ?"},
+			"UPDATE user_dash_pref SET json_prefs = ? modified = ? WHERE user_id = ? AND url = ?",
+		},
+		{
+			"SELECT user_id FROM users WHERE registration >= \"2020-01-01\" AND registration <= \"2021-04-04 13:11:23.432567\" AND name != \"admin\"",
+			"SELECT user_id FROM users WHERE registration >= ? AND registration <= ? AND name != ?",
+		},
 		{
 			"SELECT DISTINCT host.id AS host_id FROM host JOIN host_alias ON host_alias.host_id = host.id WHERE host.org_id = %(org_id_1)s AND host.name NOT IN (%(name_1)s) AND host.name IN (%(name_2)s, %(name_3)s, %(name_4)s, %(name_5)s)",
 			"SELECT DISTINCT host.id FROM host JOIN host_alias ON host_alias.host_id = host.id WHERE host.org_id = ? AND host.name NOT IN ( ? ) AND host.name IN ( ? )",


### PR DESCRIPTION
### What does this PR do?

Extending the amount of cases where double quoted strings are treated as real to be filtered strings to not only include `=` (see ba8253ee1b0272ca56fe1985f67e45abd803ed05), but also `!=`, `<=` and `>=`.

### Motivation

We have a customer having a very large cardinality due to him comparing dates enclosed in double quoted strings.

### Possible Drawbacks / Trade-offs

I'm not sure about possible overeager replacing with question marks where column names were meant, but given that it works with `=`, these new cases should be fine too, I assume.

### Describe how to test/QA your changes

Added a simple test using these operators with double quoted strings.