### PR TITLE
Improve `include_headers` script

### DIFF
--- a/pkg/ebpf/include_headers.go
+++ b/pkg/ebpf/include_headers.go
@@ -64,6 +64,7 @@ func runProcessing(inputFile, outputFile string, dirs []string) error {
 		}
 		includeDirs = append(includeDirs, dir)
 	}
+	ps := newPathSearcher(includeDirs)
 
 	if err := os.MkdirAll(filepath.Dir(outputFile), 0755); err != nil {
 		return err
@@ -82,7 +83,7 @@ func runProcessing(inputFile, outputFile string, dirs []string) error {
 	bof := bufio.NewWriter(of)
 
 	includedFiles := make(map[string]struct{})
-	if err := processIncludes(inputFile, bof, includeDirs, includedFiles); err != nil {
+	if err := processIncludes(inputFile, bof, ps, includedFiles); err != nil {
 		return fmt.Errorf("error processing includes: %s", err)
 	}
 
@@ -92,7 +93,7 @@ func runProcessing(inputFile, outputFile string, dirs []string) error {
 	return nil
 }
 
-func processIncludes(path string, out io.Writer, includeDirs []string, includedFiles map[string]struct{}) error {
+func processIncludes(path string, out io.Writer, ps *pathSearcher, includedFiles map[string]struct{}) error {
 	if _, included := includedFiles[path]; included {
 		return nil
 	}
@@ -110,11 +111,11 @@ func processIncludes(path string, out io.Writer, includeDirs []string, includedF
 		match := includeRegexp.FindSubmatch(scanner.Bytes())
 		if len(match) == 2 {
 			headerName := string(match[1])
-			headerPath, err := findInclude(path, headerName, includeDirs)
+			headerPath, err := ps.findInclude(path, headerName)
 			if err != nil {
 				return fmt.Errorf("error searching for header: %s", err)
 			}
-			if err := processIncludes(headerPath, out, includeDirs, includedFiles); err != nil {
+			if err := processIncludes(headerPath, out, ps, includedFiles); err != nil {
 				return err
 			}
 			continue
@@ -125,14 +126,55 @@ func processIncludes(path string, out io.Writer, includeDirs []string, includedF
 	return nil
 }
 
-func findInclude(srcPath string, headerName string, includeDirs []string) (string, error) {
-	allDirs := append([]string{filepath.Dir(srcPath)}, includeDirs...)
+type pathCacheEntry struct {
+	srcPath    string
+	headerName string
+}
 
-	for _, dir := range allDirs {
-		p := filepath.Join(dir, headerName)
-		if _, err := os.Stat(p); err == nil {
-			return p, nil
+type pathSearcher struct {
+	includeDirs []string
+	cache       map[pathCacheEntry]string
+}
+
+func newPathSearcher(includeDirs []string) *pathSearcher {
+	return &pathSearcher{
+		includeDirs: includeDirs,
+		cache:       make(map[pathCacheEntry]string),
+	}
+}
+
+func isFilePresent(dir string, headerName string) (string, bool) {
+	p := filepath.Join(dir, headerName)
+	_, err := os.Stat(p)
+	return p, err == nil
+}
+
+func (ps *pathSearcher) findIncludeInner(srcPath string, headerName string) (string, error) {
+	if fullPath, ok := isFilePresent(filepath.Dir(srcPath), headerName); ok {
+		return fullPath, nil
+	}
+
+	for _, dir := range ps.includeDirs {
+		if fullPath, ok := isFilePresent(dir, headerName); ok {
+			return fullPath, nil
 		}
 	}
 	return "", fmt.Errorf("file %s not found", headerName)
+}
+
+func (ps *pathSearcher) findInclude(srcPath string, headerName string) (string, error) {
+	ce := pathCacheEntry{
+		srcPath:    srcPath,
+		headerName: headerName,
+	}
+
+	if fullPath, present := ps.cache[ce]; present {
+		return fullPath, nil
+	}
+
+	computed, err := ps.findIncludeInner(srcPath, headerName)
+	if err == nil {
+		ps.cache[ce] = computed
+	}
+	return computed, err
 }

--- a/pkg/ebpf/include_headers.go
+++ b/pkg/ebpf/include_headers.go
@@ -80,11 +80,14 @@ func runProcessing(inputFile, outputFile string, dirs []string) error {
 	}
 
 	bof := bufio.NewWriter(of)
-	defer bof.Flush()
 
 	includedFiles := make(map[string]struct{})
 	if err := processIncludes(inputFile, bof, includeDirs, includedFiles); err != nil {
 		return fmt.Errorf("error processing includes: %s", err)
+	}
+
+	if err := bof.Flush(); err != nil {
+		return fmt.Errorf("error flushing buffer to disk: %s", err)
 	}
 	return nil
 }

--- a/pkg/ebpf/include_headers.go
+++ b/pkg/ebpf/include_headers.go
@@ -79,8 +79,11 @@ func runProcessing(inputFile, outputFile string, dirs []string) error {
 		return fmt.Errorf("error setting mode on output file: %s", err)
 	}
 
+	bof := bufio.NewWriter(of)
+	defer bof.Flush()
+
 	includedFiles := make(map[string]struct{})
-	if err := processIncludes(inputFile, of, includeDirs, includedFiles); err != nil {
+	if err := processIncludes(inputFile, bof, includeDirs, includedFiles); err != nil {
 		return fmt.Errorf("error processing includes: %s", err)
 	}
 	return nil


### PR DESCRIPTION
### What does this PR do?

This PR improves the `include_headers` script in 3 ways by:
- using Buffered IO when dumping included headers. Currently, the script does a lot of calls to write.
- caching the path search result, since the result is the same for each `(srcPath, headerName, includeDirs)`
- skipping the allocation when appending the current folder to the search tree

Benchmark:
```sh
>> time go generate -mod=mod -tags linux_bpf ./pkg/security/ebpf/compile.go
```

Before:
```
Executed in    1.89 secs    fish           external
   usr time    0.53 secs  234.00 micros    0.53 secs
   sys time    1.29 secs  221.00 micros    1.29 secs
```

After:
```
Executed in  727.89 millis    fish           external
   usr time  609.56 millis  251.00 micros  609.31 millis
   sys time  593.48 millis  237.00 micros  593.24 millis
```

### Motivation

Speed-up the `include_headers.go` tool. This is run in dev environment and on CI so no user impact but still nice to have.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
