### PR TITLE
[Contlcycle] Fix race condition in the queue

### DIFF
--- a/pkg/collector/corechecks/containerlifecycle/processor.go
+++ b/pkg/collector/corechecks/containerlifecycle/processor.go
@@ -132,18 +132,16 @@ func (p *processor) flush() {
 
 // flushContainers forwards queued container events to the aggregator
 func (p *processor) flushContainers() {
-	if !p.containersQueue.isEmpty() {
-		msgs := p.containersQueue.dump()
-		p.containersQueue.reset()
+	msgs := p.containersQueue.flush()
+	if len(msgs) > 0 {
 		p.sender.ContainerLifecycleEvent(msgs)
 	}
 }
 
 // flushPods forwards queued pod events to the aggregator
 func (p *processor) flushPods() {
-	if !p.podsQueue.isEmpty() {
-		msgs := p.podsQueue.dump()
-		p.podsQueue.reset()
+	msgs := p.podsQueue.flush()
+	if len(msgs) > 0 {
 		p.sender.ContainerLifecycleEvent(msgs)
 	}
 }

--- a/pkg/collector/corechecks/containerlifecycle/queue.go
+++ b/pkg/collector/corechecks/containerlifecycle/queue.go
@@ -36,8 +36,7 @@ func (q *queue) flush() []model.EventsPayload {
 		return nil
 	}
 
-	data := make([]model.EventsPayload, len(q.data))
-	copy(data, q.data)
+	data := q.data
 
 	// Reset the data in the queue.
 	q.data = []model.EventsPayload{}

--- a/pkg/collector/corechecks/containerlifecycle/queue.go
+++ b/pkg/collector/corechecks/containerlifecycle/queue.go
@@ -18,6 +18,7 @@ type queue struct {
 	sync.RWMutex
 }
 
+// newQueue returns a new *queue.
 func newQueue(chunkSize int) *queue {
 	return &queue{
 		chunkSize: chunkSize,
@@ -25,29 +26,58 @@ func newQueue(chunkSize int) *queue {
 	}
 }
 
-func (q *queue) dump() []model.EventsPayload {
-	q.RLock()
-	defer q.RUnlock()
-
-	return q.data
-}
-
-func (q *queue) reset() {
+// flush returns and resets the queue content. Returns nil if the queue is empty.
+// flush is thread-safe.
+func (q *queue) flush() []model.EventsPayload {
 	q.Lock()
 	defer q.Unlock()
 
+	if q.isEmpty() {
+		return nil
+	}
+
+	data := make([]model.EventsPayload, len(q.data))
+	copy(data, q.data)
+
+	// Reset the data in the queue.
 	q.data = []model.EventsPayload{}
+
+	return data
 }
 
+// add enqueues a new event.
+// add is thread-safe.
 func (q *queue) add(ev event) error {
-	if q.isEmpty() || q.isLastPayloadFull() {
-		payload, err := ev.toPayloadModel()
-		if err != nil {
-			return err
-		}
+	q.Lock()
+	defer q.Unlock()
 
-		q.addPayload(payload)
-		return nil
+	if q.isEmpty() || q.isLastPayloadFull() {
+		return q.addPayload(ev)
+	}
+
+	return q.addEvent(ev)
+}
+
+// addPayload enqueues the event in a new payload entry in the queue.
+// To be used if the queue is empty or if the last payload entry in the queue is full.
+// addPayload is not thread-safe, the caller must lock the queue.
+func (q *queue) addPayload(ev event) error {
+	payload, err := ev.toPayloadModel()
+	if err != nil {
+		return err
+	}
+
+	q.data = append(q.data, payload)
+
+	return nil
+}
+
+// addEvent enqueues the event in last payload entry.
+// To be used if the queue is not empty and the last payload entry is not full.
+// addEvent is not thread-safe, the caller must lock the queue.
+func (q *queue) addEvent(ev event) error {
+	if q.isEmpty() {
+		return errors.New("cannot add event to an empty queue")
 	}
 
 	event, err := ev.toEventModel()
@@ -55,44 +85,31 @@ func (q *queue) add(ev event) error {
 		return err
 	}
 
-	q.addEvent(event)
+	lenQueue := len(q.data)
+	q.data[lenQueue-1].Events = append(q.data[lenQueue-1].Events, event)
 
 	return nil
 }
 
-func (q *queue) addPayload(payload model.EventsPayload) {
-	q.Lock()
-	defer q.Unlock()
-
-	q.data = append(q.data, payload)
-}
-
-func (q *queue) addEvent(event *model.Event) {
-	q.Lock()
-	defer q.Unlock()
-
-	lenQueue := len(q.data)
-	q.data[lenQueue-1].Events = append(q.data[lenQueue-1].Events, event)
-}
-
+// isEmpty returns whether the queue is empty.
+// isEmpty is not thread-safe, the caller must lock the queue.
 func (q *queue) isEmpty() bool {
-	q.RLock()
-	defer q.RUnlock()
-
 	return len(q.data) == 0
 }
 
+// lastPayload returns the last payload entry in the queue.
+// lastPayload is not thread-safe, the caller must lock the queue.
 func (q *queue) lastPayload() (model.EventsPayload, error) {
 	if q.isEmpty() {
 		return model.EventsPayload{}, errors.New("empty queue")
 	}
 
-	q.RLock()
-	defer q.RUnlock()
-
 	return q.data[len(q.data)-1], nil
 }
 
+// isLastPayloadFull returns whether the last payload entry
+// is full compared to the configured chunk size.
+// isLastPayloadFull is not thread-safe, the caller must lock the queue.
 func (q *queue) isLastPayloadFull() bool {
 	lastElem, err := q.lastPayload()
 	if err != nil {

--- a/pkg/collector/corechecks/containerlifecycle/queue_test.go
+++ b/pkg/collector/corechecks/containerlifecycle/queue_test.go
@@ -83,8 +83,9 @@ func TestBatching(t *testing.T) {
 		queue.add(fakeContainerEvent(strconv.FormatInt(i, 10)))
 	}
 
-	data := queue.dump()
+	data := queue.flush()
 	assert.Len(t, data, 5)
+	assert.Len(t, queue.data, 0)
 
 	for i := int64(0); i < 5; i++ {
 		assert.Len(t, data[i].Events, commonChunkSize)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Fix index out of range panic 

```
panic: runtime error: index out of range [-1]

goroutine 516 [running]:
github.com/DataDog/datadog-agent/pkg/collector/corechecks/containerlifecycle.(*queue).addEvent(0xc0023e4080, 0xc00c65c288)
        /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/containerlifecycle/queue.go:75 +0x19d
...
```

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

This happens because the queue can be dumped and reset asynchronously by the check processor loop.

With the new logic, the number of lock/unlock operations is reduced considerably - the `flush` method waits for `add` to finish (and vice versa), which fixes the race causing the index out of range.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

- Merged `dump` and `reset` into a `flush` method to reduce lock/unlock ops
- Only the internal queue methods are not thread-safe, the queue methods used by the processor are thread-safe

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

- Make sure the panic doesn't happen anymore, clusters with high container/pod churn should be watched closely 👀 

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
