### PR TITLE
[Process Agent] Disable console logging when running `check --json`

### DIFF
--- a/cmd/process-agent/app/check.go
+++ b/cmd/process-agent/app/check.go
@@ -49,6 +49,11 @@ const loggerName ddconfig.LoggerName = "PROCESS"
 var checkOutputJSON = false
 
 func runCheckCmd(cmd *cobra.Command, args []string) error {
+	// Override the log_to_console setting if `--json` is specified. This way the check command will output proper json.
+	if checkOutputJSON {
+		ddconfig.Datadog.Set("log_to_console", false)
+	}
+
 	// We need to load in the system probe environment variables before we load the config, otherwise an
 	// "Unknown environment variable" warning will show up whenever valid system probe environment variables are defined.
 	ddconfig.InitSystemProbeConfig(ddconfig.Datadog)
@@ -64,11 +69,6 @@ func runCheckCmd(cmd *cobra.Command, args []string) error {
 	syscfg, err := sysconfig.Merge(sysprobePath)
 	if err != nil {
 		return log.Critical(err)
-	}
-
-	// Override the log_to_console setting if `--json` is specified. This way the check command will output proper json.
-	if checkOutputJSON {
-		ddconfig.Datadog.Set("process_config.log_to_console", false)
 	}
 
 	cfg, err := config.NewAgentConfig(loggerName, configPath, syscfg)
@@ -142,7 +142,9 @@ func runCheck(cfg *config.AgentConfig, ch checks.Check) error {
 
 	time.Sleep(1 * time.Second)
 
-	printResultsBanner(ch.Name())
+	if !checkOutputJSON {
+		printResultsBanner(ch.Name())
+	}
 
 	msgs, err := ch.Run(cfg, 1)
 	if err != nil {

--- a/cmd/process-agent/app/check.go
+++ b/cmd/process-agent/app/check.go
@@ -66,6 +66,11 @@ func runCheckCmd(cmd *cobra.Command, args []string) error {
 		return log.Critical(err)
 	}
 
+	// Override the log_to_console setting if `--json` is specified. This way the check command will output proper json.
+	if checkOutputJSON {
+		ddconfig.Datadog.Set("process_config.log_to_console", false)
+	}
+
 	cfg, err := config.NewAgentConfig(loggerName, configPath, syscfg)
 	if err != nil {
 		return log.Criticalf("Error parsing config: %s", err)

--- a/releasenotes/notes/process-agent-fix-json-output-bc58ab39de316bc4.yaml
+++ b/releasenotes/notes/process-agent-fix-json-output-bc58ab39de316bc4.yaml
@@ -1,0 +1,3 @@
+---
+fixes:
+  - `process-agent check --json` now outputs valid json.

--- a/releasenotes/notes/process-agent-fix-json-output-bc58ab39de316bc4.yaml
+++ b/releasenotes/notes/process-agent-fix-json-output-bc58ab39de316bc4.yaml
@@ -1,3 +1,3 @@
 ---
 fixes:
-  - `process-agent check --json` now outputs valid json.
+  - Adds new `--json` flag to `check`. `process-agent check --json` now outputs valid json.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->
This PR fixes json output with the `check --json` command. You can now pipe to `jq`!

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Run `process-agent check process --json` and ensure that there is no console output besides the json. You can also quickly verify that the output is proper json by running `process-agent check process --json | jq` and making sure there are no errors.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
