### PR TITLE
[Cluster Agent] Support internal profiling

### DIFF
--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -32,7 +32,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/embed/jmx"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	remoteconfig "github.com/DataDog/datadog-agent/pkg/config/remote/service"
-	"github.com/DataDog/datadog-agent/pkg/config/settings"
 	"github.com/DataDog/datadog-agent/pkg/dogstatsd"
 	"github.com/DataDog/datadog-agent/pkg/forwarder"
 	"github.com/DataDog/datadog-agent/pkg/logs"
@@ -259,22 +258,7 @@ func StartAgent() error {
 	}
 
 	// Setup Internal Profiling
-	if v := config.Datadog.GetInt("internal_profiling.block_profile_rate"); v > 0 {
-		if err := settings.SetRuntimeSetting("runtime_block_profile_rate", v); err != nil {
-			log.Errorf("Error setting block profile rate: %v", err)
-		}
-	}
-	if v := config.Datadog.GetInt("internal_profiling.mutex_profile_fraction"); v > 0 {
-		if err := settings.SetRuntimeSetting("runtime_mutex_profile_fraction", v); err != nil {
-			log.Errorf("Error mutex profile fraction: %v", err)
-		}
-	}
-	if config.Datadog.GetBool("internal_profiling.enabled") {
-		err := settings.SetRuntimeSetting("internal_profiling", true)
-		if err != nil {
-			log.Errorf("Error starting profiler: %v", err)
-		}
-	}
+	common.SetupInternalProfiling()
 
 	// Setup expvar server
 	telemetryHandler := telemetry.Handler()

--- a/cmd/agent/common/helpers.go
+++ b/cmd/agent/common/helpers.go
@@ -12,6 +12,9 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/config/settings"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+
 	"github.com/DataDog/viper"
 )
 
@@ -85,5 +88,27 @@ func SelectedCheckMatcherBuilder(checkNames []string, minInstances uint) func(co
 			}
 		}
 		return matchedConfigsCount >= minInstances
+	}
+}
+
+// SetupInternalProfiling is a common helper to configure runtime settings for internal profiling.
+func SetupInternalProfiling() {
+	if v := config.Datadog.GetInt("internal_profiling.block_profile_rate"); v > 0 {
+		if err := settings.SetRuntimeSetting("runtime_block_profile_rate", v); err != nil {
+			log.Errorf("Error setting block profile rate: %v", err)
+		}
+	}
+
+	if v := config.Datadog.GetInt("internal_profiling.mutex_profile_fraction"); v > 0 {
+		if err := settings.SetRuntimeSetting("runtime_mutex_profile_fraction", v); err != nil {
+			log.Errorf("Error mutex profile fraction: %v", err)
+		}
+	}
+
+	if config.Datadog.GetBool("internal_profiling.enabled") {
+		err := settings.SetRuntimeSetting("internal_profiling", true)
+		if err != nil {
+			log.Errorf("Error starting profiler: %v", err)
+		}
 	}
 }

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -39,6 +39,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/resolver"
+	"github.com/DataDog/datadog-agent/pkg/config/settings"
 	"github.com/DataDog/datadog-agent/pkg/forwarder"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
@@ -155,6 +156,26 @@ func start(cmd *cobra.Command, args []string) error {
 	// Init settings that can be changed at runtime
 	if err := initRuntimeSettings(); err != nil {
 		log.Warnf("Can't initiliaze the runtime settings: %v", err)
+	}
+
+	// Setup Internal Profiling
+	if v := config.Datadog.GetInt("internal_profiling.block_profile_rate"); v > 0 {
+		if err := settings.SetRuntimeSetting("runtime_block_profile_rate", v); err != nil {
+			log.Errorf("Error setting block profile rate: %v", err)
+		}
+	}
+
+	if v := config.Datadog.GetInt("internal_profiling.mutex_profile_fraction"); v > 0 {
+		if err := settings.SetRuntimeSetting("runtime_mutex_profile_fraction", v); err != nil {
+			log.Errorf("Error mutex profile fraction: %v", err)
+		}
+	}
+
+	if config.Datadog.GetBool("internal_profiling.enabled") {
+		err := settings.SetRuntimeSetting("internal_profiling", true)
+		if err != nil {
+			log.Errorf("Error starting profiler: %v", err)
+		}
 	}
 
 	if !config.Datadog.IsSet("api_key") {

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -39,7 +39,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/resolver"
-	"github.com/DataDog/datadog-agent/pkg/config/settings"
 	"github.com/DataDog/datadog-agent/pkg/forwarder"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
@@ -159,24 +158,7 @@ func start(cmd *cobra.Command, args []string) error {
 	}
 
 	// Setup Internal Profiling
-	if v := config.Datadog.GetInt("internal_profiling.block_profile_rate"); v > 0 {
-		if err := settings.SetRuntimeSetting("runtime_block_profile_rate", v); err != nil {
-			log.Errorf("Error setting block profile rate: %v", err)
-		}
-	}
-
-	if v := config.Datadog.GetInt("internal_profiling.mutex_profile_fraction"); v > 0 {
-		if err := settings.SetRuntimeSetting("runtime_mutex_profile_fraction", v); err != nil {
-			log.Errorf("Error mutex profile fraction: %v", err)
-		}
-	}
-
-	if config.Datadog.GetBool("internal_profiling.enabled") {
-		err := settings.SetRuntimeSetting("internal_profiling", true)
-		if err != nil {
-			log.Errorf("Error starting profiler: %v", err)
-		}
-	}
+	common.SetupInternalProfiling()
 
 	if !config.Datadog.IsSet("api_key") {
 		log.Critical("no API key configured, exiting")

--- a/cmd/cluster-agent/app/config.go
+++ b/cmd/cluster-agent/app/config.go
@@ -61,5 +61,21 @@ func getSettingsClient(_ *cobra.Command, _ []string) (commonsettings.Client, err
 
 // initRuntimeSettings builds the map of runtime Cluster Agent settings configurable at runtime.
 func initRuntimeSettings() error {
-	return commonsettings.RegisterRuntimeSetting(commonsettings.LogLevelRuntimeSetting{})
+	if err := commonsettings.RegisterRuntimeSetting(commonsettings.LogLevelRuntimeSetting{}); err != nil {
+		return err
+	}
+
+	if err := commonsettings.RegisterRuntimeSetting(commonsettings.RuntimeMutexProfileFraction("runtime_mutex_profile_fraction")); err != nil {
+		return err
+	}
+
+	if err := commonsettings.RegisterRuntimeSetting(commonsettings.RuntimeBlockProfileRate("runtime_block_profile_rate")); err != nil {
+		return err
+	}
+
+	if err := commonsettings.RegisterRuntimeSetting(commonsettings.ProfilingGoroutines("internal_profiling_goroutines")); err != nil {
+		return err
+	}
+
+	return commonsettings.RegisterRuntimeSetting(commonsettings.ProfilingRuntimeSetting("internal_profiling"))
 }

--- a/pkg/config/settings/runtime_setting_profiling.go
+++ b/pkg/config/settings/runtime_setting_profiling.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	"github.com/DataDog/datadog-agent/pkg/util/profiling"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
@@ -71,10 +72,15 @@ func (l ProfilingRuntimeSetting) Set(v interface{}) error {
 		// Note that we must derive a new profiling.Settings on every
 		// invocation, as many of these settings may have changed at runtime.
 		v, _ := version.Agent()
+		service := "datadog-agent"
+		if flavor.GetFlavor() == flavor.ClusterAgent {
+			service = "datadog-cluster-agent"
+		}
+
 		settings := profiling.Settings{
 			ProfilingURL:         site,
 			Env:                  config.Datadog.GetString("env"),
-			Service:              "datadog-agent",
+			Service:              service,
 			Period:               profiling.DefaultProfilingPeriod,
 			MutexProfileFraction: profiling.GetMutexProfileFraction(),
 			BlockProfileRate:     profiling.GetBlockProfileRate(),

--- a/releasenotes-dca/notes/dca-internal-profiling-7b501ebb50928d9f.yaml
+++ b/releasenotes-dca/notes/dca-internal-profiling-7b501ebb50928d9f.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    The Datadog Cluster Agent now supports internal profiling.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Add internal profiling support to the cluster agent

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Better observability

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Can be configured at runtime (similar to the agent)

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Enable `internal_profiling.enabled` + configure `DD_AGENT_HOST`

![image](https://user-images.githubusercontent.com/38987709/161739463-0e5e9610-065f-4f95-9db4-afdc577a11e1.png)


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
