### PR TITLE
[Cluster Agent] Add endpoint checks by node metric

### DIFF
--- a/pkg/clusteragent/clusterchecks/dispatcher_endpoints_configs.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_endpoints_configs.go
@@ -11,6 +11,7 @@ package clusterchecks
 import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers/names"
+	le "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection/metrics"
 )
 
 // getEndpointsConfigs provides configs templates of endpoints checks queried by node name.
@@ -46,13 +47,21 @@ func (d *dispatcher) addEndpointConfig(config integration.Config, nodename strin
 		d.store.endpointsConfigs[nodename] = map[string]integration.Config{}
 	}
 	d.store.endpointsConfigs[nodename][config.Digest()] = config
+	dispatchedEndpoints.Inc(nodename, le.JoinLeaderValue)
 }
 
 // removeEndpointConfig deletes a given endpoint configuration
 func (d *dispatcher) removeEndpointConfig(config integration.Config, nodename string) {
 	d.store.Lock()
 	defer d.store.Unlock()
-	delete(d.store.endpointsConfigs[nodename], config.Digest())
+
+	digest := config.Digest()
+	if _, found := d.store.endpointsConfigs[nodename][digest]; !found {
+		return
+	}
+
+	delete(d.store.endpointsConfigs[nodename], digest)
+	dispatchedEndpoints.Dec(nodename, le.JoinLeaderValue)
 }
 
 // patchEndpointsConfiguration transforms the endpoint configuration from AD into a config

--- a/pkg/clusteragent/clusterchecks/metrics.go
+++ b/pkg/clusteragent/clusterchecks/metrics.go
@@ -23,6 +23,9 @@ var (
 	dispatchedConfigs = telemetry.NewGaugeWithOpts("cluster_checks", "configs_dispatched",
 		[]string{"node", le.JoinLeaderLabel}, "Number of check configurations dispatched, by node.",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
+	dispatchedEndpoints = telemetry.NewGaugeWithOpts("endpoint_checks", "configs_dispatched",
+		[]string{"node", le.JoinLeaderLabel}, "Number of endpoint check configurations dispatched, by node.",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
 	rebalancingDecisions = telemetry.NewCounterWithOpts("cluster_checks", "rebalancing_decisions",
 		[]string{le.JoinLeaderLabel}, "Total number of check rebalancing decisions",
 		telemetry.Options{NoDoubleUnderscoreSep: true})

--- a/releasenotes-dca/notes/dca-ep-metric-60ee3d19e42f31f6.yaml
+++ b/releasenotes-dca/notes/dca-ep-metric-60ee3d19e42f31f6.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    The Datadog Cluster Agent exposes a new metric ``endpoint_checks_configs_dispatched``.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

The Datadog Cluster Agent exposes a new metric `endpoint_checks_configs_dispatched`.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Better observability

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Schedule and unschedule multiple endpoint checks, make sure the metric is accurate (`agent telemetry` to dump the prometheus payload)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
