### PR TITLE
[AD] Add poll duration metric

### DIFF
--- a/pkg/autodiscovery/config_poller.go
+++ b/pkg/autodiscovery/config_poller.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -122,6 +123,11 @@ func (pd *configPoller) collect(ctx context.Context) ([]integration.Config, []in
 	var newConf []integration.Config
 	var removedConf []integration.Config
 	old := pd.configs
+
+	start := time.Now()
+	defer func() {
+		telemetry.PollDuration.Observe(time.Since(start).Seconds(), pd.provider.String())
+	}()
 
 	fetched, err := pd.provider.Collect(ctx)
 	if err != nil {

--- a/pkg/autodiscovery/telemetry/telemetry.go
+++ b/pkg/autodiscovery/telemetry/telemetry.go
@@ -5,7 +5,11 @@
 
 package telemetry
 
-import "github.com/DataDog/datadog-agent/pkg/telemetry"
+import (
+	"github.com/DataDog/datadog-agent/pkg/telemetry"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 const (
 	subsystem = "autodiscovery"
@@ -37,5 +41,16 @@ var (
 		[]string{"provider"},
 		"Number of Autodiscovery errors by provider.",
 		commonOpts,
+	)
+
+	// PollDuration tracks the configs poll duration by AD providers.
+	PollDuration = telemetry.NewHistogramWithOpts(
+		subsystem,
+		"poll_duration",
+		[]string{"provider"},
+		"Poll duration distribution by config provider (in seconds).",
+		// The default prometheus buckets are adapted to measure response time of network services
+		prometheus.DefBuckets,
+		telemetry.Options{NoDoubleUnderscoreSep: true},
 	)
 )

--- a/releasenotes/notes/ad-poll-metric-10e22cfb42b44a7e.yaml
+++ b/releasenotes/notes/ad-poll-metric-10e22cfb42b44a7e.yaml
@@ -1,5 +1,5 @@
 ---
 enhancements:
   - |
-    Add a new agent telemetry metric ``autodiscovery_poll_duration`` (histogram)
+    Add a new Agent telemetry metric ``autodiscovery_poll_duration`` (histogram)
     to monitor configuration poll duration in Autodiscovery.

--- a/releasenotes/notes/ad-poll-metric-10e22cfb42b44a7e.yaml
+++ b/releasenotes/notes/ad-poll-metric-10e22cfb42b44a7e.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Add a new agent telemetry metric ``autodiscovery_poll_duration`` (histogram)
+    to monitor configuration poll duration in Autodiscovery.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Add a new agent telemetry metric `autodiscovery_poll_duration` (histogram) to monitor configuration poll duration in Autodiscovery.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Better observability

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

The metric is shared with the Cluster Agent

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Query the metrics endpoint of the agent and the cluster agent

```
# HELP autodiscovery_poll_duration Poll duration distribution by config provider (in seconds).
# TYPE autodiscovery_poll_duration histogram
autodiscovery_poll_duration_bucket{provider="kubernetes-endpoints",le="0.005"} 3
autodiscovery_poll_duration_bucket{provider="kubernetes-endpoints",le="0.01"} 3
autodiscovery_poll_duration_bucket{provider="kubernetes-endpoints",le="0.025"} 3
autodiscovery_poll_duration_bucket{provider="kubernetes-endpoints",le="0.05"} 3
autodiscovery_poll_duration_bucket{provider="kubernetes-endpoints",le="0.1"} 3
autodiscovery_poll_duration_bucket{provider="kubernetes-endpoints",le="0.25"} 3
autodiscovery_poll_duration_bucket{provider="kubernetes-endpoints",le="0.5"} 3
autodiscovery_poll_duration_bucket{provider="kubernetes-endpoints",le="1"} 3
autodiscovery_poll_duration_bucket{provider="kubernetes-endpoints",le="2.5"} 3
autodiscovery_poll_duration_bucket{provider="kubernetes-endpoints",le="5"} 3
autodiscovery_poll_duration_bucket{provider="kubernetes-endpoints",le="10"} 3
autodiscovery_poll_duration_bucket{provider="kubernetes-endpoints",le="+Inf"} 3
autodiscovery_poll_duration_sum{provider="kubernetes-endpoints"} 0.0066547590000000005
autodiscovery_poll_duration_count{provider="kubernetes-endpoints"} 3
autodiscovery_poll_duration_bucket{provider="kubernetes-services",le="0.005"} 2
autodiscovery_poll_duration_bucket{provider="kubernetes-services",le="0.01"} 3
autodiscovery_poll_duration_bucket{provider="kubernetes-services",le="0.025"} 3
autodiscovery_poll_duration_bucket{provider="kubernetes-services",le="0.05"} 3
autodiscovery_poll_duration_bucket{provider="kubernetes-services",le="0.1"} 3
autodiscovery_poll_duration_bucket{provider="kubernetes-services",le="0.25"} 3
autodiscovery_poll_duration_bucket{provider="kubernetes-services",le="0.5"} 3
autodiscovery_poll_duration_bucket{provider="kubernetes-services",le="1"} 3
autodiscovery_poll_duration_bucket{provider="kubernetes-services",le="2.5"} 3
autodiscovery_poll_duration_bucket{provider="kubernetes-services",le="5"} 3
autodiscovery_poll_duration_bucket{provider="kubernetes-services",le="10"} 3
autodiscovery_poll_duration_bucket{provider="kubernetes-services",le="+Inf"} 3
autodiscovery_poll_duration_sum{provider="kubernetes-services"} 0.013881554
autodiscovery_poll_duration_count{provider="kubernetes-services"} 3
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
