### PR TITLE
pkg/trace/api: OTLP: Backport fix to 7.35.x 

### DIFF
--- a/pkg/trace/api/otlp.go
+++ b/pkg/trace/api/otlp.go
@@ -327,6 +327,10 @@ func convertSpan(rattr map[string]string, lib *otlppb.InstrumentationLibrary, in
 	} else {
 		name = "opentelemetry." + name
 	}
+	meta := make(map[string]string, len(rattr))
+	for k, v := range rattr {
+		meta[k] = v
+	}
 	span := &pb.Span{
 		Name:     name,
 		TraceID:  byteArrayToUint64(in.TraceId),
@@ -336,7 +340,7 @@ func convertSpan(rattr map[string]string, lib *otlppb.InstrumentationLibrary, in
 		Duration: int64(in.EndTimeUnixNano) - int64(in.StartTimeUnixNano),
 		Service:  rattr[string(semconv.AttributeServiceName)],
 		Resource: in.Name,
-		Meta:     rattr,
+		Meta:     meta,
 		Metrics:  map[string]float64{},
 	}
 	span.Meta["otel.trace_id"] = hex.EncodeToString(in.TraceId)

--- a/releasenotes/notes/apm-otlp-backport-fix-merged-attributes-b3efe6911a28ff6d.yaml
+++ b/releasenotes/notes/apm-otlp-backport-fix-merged-attributes-b3efe6911a28ff6d.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: OTLP: Fixes an issue where attributes from different spans were merged leading to spans containing incorrect attributes.


### PR DESCRIPTION
Backport #11525 

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
