### PR TITLE
[util/kubernetes/apiserver] Use internal logging instead of klog

### DIFF
--- a/pkg/util/kubernetes/apiserver/warning_handler.go
+++ b/pkg/util/kubernetes/apiserver/warning_handler.go
@@ -11,7 +11,7 @@ package apiserver
 import (
 	"regexp"
 
-	klog "k8s.io/klog"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 var supressedWarning = regexp.MustCompile(`.*is deprecated in v.*`)
@@ -25,5 +25,5 @@ func (CustomWarningLogger) HandleWarningHeader(code int, agent string, message s
 		return
 	}
 
-	klog.Warning(message)
+	log.Warn(message)
 }

--- a/pkg/util/kubernetes/apiserver/warning_handler.go
+++ b/pkg/util/kubernetes/apiserver/warning_handler.go
@@ -19,7 +19,6 @@ var supressedWarning = regexp.MustCompile(`.*is deprecated in v.*`)
 type CustomWarningLogger struct{}
 
 // HandleWarningHeader suppresses some warning logs
-// TODO: Remove custom warning logger when we remove usage of ComponentStatus
 func (CustomWarningLogger) HandleWarningHeader(code int, agent string, message string) {
 	if code != 299 || len(message) == 0 || supressedWarning.MatchString(message) {
 		return

--- a/releasenotes/notes/warning-handler-use-dd-log-19a280ab80573399.yaml
+++ b/releasenotes/notes/warning-handler-use-dd-log-19a280ab80573399.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    The DCA and the cluster runners no longer write warning logs to `/tmp`.


### PR DESCRIPTION
### What does this PR do?

Changes the kubernetes warning handler to use our own logging instead of using klog directly.
klog was also logging the warnings in a file in `/tmp` which caused issues in some envs where the dir is not writable.


### Describe how to test/QA your changes

The DCA and the cluster runners should not write kubernetes warnings in `/tmp`.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
