### PR TITLE
Fix E2E tests `failed to create containerd task`

### DIFF
--- a/test/e2e/argo-workflows/templates/datadog-agent.yaml
+++ b/test/e2e/argo-workflows/templates/datadog-agent.yaml
@@ -144,7 +144,7 @@ spec:
           - name: namespace
       activeDeadlineSeconds: 300
       script:
-        image: argoproj/argoexec:latest
+        image: argoproj/argoexec:v3.3.1
         command: [sh]
         source: |
           set -euo pipefail
@@ -170,7 +170,7 @@ spec:
           - name: namespace
       activeDeadlineSeconds: 300
       script:
-        image: argoproj/argoexec:latest
+        image: argoproj/argoexec:v3.3.1
         command: [sh]
         source: |
           set -euo pipefail
@@ -191,7 +191,7 @@ spec:
           - name: namespace
       activeDeadlineSeconds: 300
       script:
-        image: argoproj/argoexec:latest
+        image: argoproj/argoexec:v3.3.1
         command: [sh]
         source: |
           set -euo pipefail
@@ -437,7 +437,7 @@ spec:
           - name: namespace
       activeDeadlineSeconds: 300
       script:
-        image: argoproj/argoexec:latest
+        image: argoproj/argoexec:v3.3.1
         command: [sh]
         source: |
           set -euo pipefail
@@ -453,7 +453,7 @@ spec:
           - name: namespace
       activeDeadlineSeconds: 300
       script:
-        image: argoproj/argoexec:latest
+        image: argoproj/argoexec:v3.3.1
         command: [sh]
         source: |
           set -euo pipefail
@@ -469,7 +469,7 @@ spec:
           - name: namespace
       activeDeadlineSeconds: 300
       script:
-        image: argoproj/argoexec:latest
+        image: argoproj/argoexec:v3.3.1
         command: [sh]
         source: |
           set -euo pipefail
@@ -485,7 +485,7 @@ spec:
           - name: namespace
       activeDeadlineSeconds: 300
       script:
-        image: argoproj/argoexec:latest
+        image: argoproj/argoexec:v3.3.1
         command: [sh]
         source: |
           set -euo pipefail
@@ -501,7 +501,7 @@ spec:
           - name: namespace
       activeDeadlineSeconds: 300
       script:
-        image: argoproj/argoexec:latest
+        image: argoproj/argoexec:v3.3.1
         command: [sh]
         source: |
           set -euo pipefail
@@ -517,7 +517,7 @@ spec:
           - name: namespace
       activeDeadlineSeconds: 300
       script:
-        image: argoproj/argoexec:latest
+        image: argoproj/argoexec:v3.3.1
         command: [sh]
         source: |
           set -euo pipefail
@@ -533,7 +533,7 @@ spec:
           - name: namespace
       activeDeadlineSeconds: 300
       script:
-        image: argoproj/argoexec:latest
+        image: argoproj/argoexec:v3.3.1
         command: [sh]
         source: |
           set -euo pipefail
@@ -549,7 +549,7 @@ spec:
           - name: namespace
       activeDeadlineSeconds: 300
       script:
-        image: argoproj/argoexec:latest
+        image: argoproj/argoexec:v3.3.1
         command: [sh]
         source: |
           set -euo pipefail
@@ -565,7 +565,7 @@ spec:
           - name: namespace
       activeDeadlineSeconds: 300
       script:
-        image: argoproj/argoexec:latest
+        image: argoproj/argoexec:v3.3.1
         command: [sh]
         source: |
           set -euo pipefail
@@ -581,7 +581,7 @@ spec:
           - name: namespace
       activeDeadlineSeconds: 300
       script:
-        image: argoproj/argoexec:latest
+        image: argoproj/argoexec:v3.3.1
         command: [sh]
         source: |
           set -euo pipefail
@@ -597,7 +597,7 @@ spec:
           - name: namespace
       activeDeadlineSeconds: 300
       script:
-        image: argoproj/argoexec:latest
+        image: argoproj/argoexec:v3.3.1
         command: [sh]
         source: |
           set -euo pipefail
@@ -613,7 +613,7 @@ spec:
           - name: namespace
       activeDeadlineSeconds: 300
       script:
-        image: argoproj/argoexec:latest
+        image: argoproj/argoexec:v3.3.1
         command: [sh]
         source: |
           set -euo pipefail

--- a/test/e2e/argo-workflows/templates/fake-datadog.yaml
+++ b/test/e2e/argo-workflows/templates/fake-datadog.yaml
@@ -131,7 +131,7 @@ spec:
           - name: namespace
       activeDeadlineSeconds: 300
       script:
-        image: argoproj/argoexec:latest
+        image: argoproj/argoexec:v3.3.1
         command: [sh]
         source: |
           set -euo pipefail

--- a/test/e2e/argo-workflows/templates/nginx.yaml
+++ b/test/e2e/argo-workflows/templates/nginx.yaml
@@ -297,7 +297,7 @@ spec:
           - name: namespace
       activeDeadlineSeconds: 300
       script:
-        image: argoproj/argoexec:latest
+        image: argoproj/argoexec:v3.3.1
         command: [sh]
         source: |
           set -euo pipefail
@@ -314,7 +314,7 @@ spec:
           - name: namespace
       activeDeadlineSeconds: 300
       script:
-        image: argoproj/argoexec:latest
+        image: argoproj/argoexec:v3.3.1
         command: [sh]
         source: |
           set -euo pipefail
@@ -396,7 +396,7 @@ spec:
           - name: namespace
       activeDeadlineSeconds: 300
       script:
-        image: argoproj/argoexec:latest
+        image: argoproj/argoexec:v3.3.1
         command: [sh]
         source: |
           set -euo pipefail

--- a/test/e2e/argo-workflows/templates/otlp-test.yaml
+++ b/test/e2e/argo-workflows/templates/otlp-test.yaml
@@ -219,7 +219,7 @@ spec:
           - name: namespace
       activeDeadlineSeconds: 300
       script:
-        image: argoproj/argoexec:latest
+        image: argoproj/argoexec:v3.3.1
         command: [sh]
         source: |
           set -euo pipefail


### PR DESCRIPTION
### What does this PR do?

Fix the following error raised in the E2E tests:
```
StartError (exit code 128): failed to create containerd task: failed to create shim: OCI runtime create failed: container_linux.go:380: starting container process caused: exec: "sh": executable file not found in $PATH: unknown
```

This error is caused by the removal of the `busybox` shell from the `latest` version of the `argoproj/argoexec` docker image.

### Motivation

Love having green tests.

### Additional Notes

For longer term, we might want to build a dedicated image rather than relying on `argoproj/argoexec`.

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Run the E2E tests.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
