### PR TITLE
Small optimizations to image building

### DIFF
--- a/.gitlab/container_build/docker_linux.yml
+++ b/.gitlab/container_build/docker_linux.yml
@@ -14,11 +14,11 @@
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
     # Pull base images
     - inv -e docker.pull-base-images $BUILD_CONTEXT/$ARCH/Dockerfile --no-signed-pull # FIXME: currently --no-signed-pull as ubuntu:21.10 is not properly signed on DockerHub
-    # Build testing stage if provided
-    - test "$TESTING_ARG" && docker build --build-arg CIBUILD=true --file $BUILD_CONTEXT/$ARCH/Dockerfile $TESTING_ARG $BUILD_CONTEXT
-    # Build release stage and push to ECR
-    - docker build --build-arg CIBUILD=true $BUILD_ARG --file $BUILD_CONTEXT/$ARCH/Dockerfile --pull --tag ${TARGET_TAG}-unsquashed $BUILD_CONTEXT
+    # Build image
+    - docker build --build-arg CIBUILD=true $BUILD_ARG --file $BUILD_CONTEXT/$ARCH/Dockerfile --tag ${TARGET_TAG}-unsquashed $BUILD_CONTEXT
+    # Squash image, test, and push to ECR
     - docker-squash ${TARGET_TAG}-unsquashed -t ${TARGET_TAG}
+    - test "$TEST_IMG" && docker run -v `pwd`/$BUILD_CONTEXT:/tmp/build ${TARGET_TAG} python /tmp/build/test_image_contents.py
     - docker push $TARGET_TAG
   # Workaround for temporary network failures
   retry: 2
@@ -49,8 +49,8 @@ docker_build_agent6:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -6
+    TEST_IMG: "true"
     BUILD_ARG: --target release --build-arg PYTHON_VERSION=2 --build-arg DD_AGENT_ARTIFACT=datadog-agent_6*_amd64.deb
-    TESTING_ARG: --target testing --build-arg PYTHON_VERSION=2 --build-arg DD_AGENT_ARTIFACT=datadog-agent_6*_amd64.deb
 
 docker_build_agent6_arm64:
   extends: .docker_build_job_definition_arm64
@@ -63,8 +63,8 @@ docker_build_agent6_arm64:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -6
+    TEST_IMG: "true"
     BUILD_ARG: --target release --build-arg PYTHON_VERSION=2 --build-arg DD_AGENT_ARTIFACT=datadog-agent_6*arm64.deb
-    TESTING_ARG: --target testing --build-arg PYTHON_VERSION=2 --build-arg DD_AGENT_ARTIFACT=datadog-agent_6*arm64.deb
 
 # build agent6 py2 jmx image
 docker_build_agent6_jmx:
@@ -79,8 +79,8 @@ docker_build_agent6_jmx:
     BUILD_CONTEXT: Dockerfiles/agent
     BUILD_ARTIFACT_GLOB: datadog-agent_6*_amd64.deb
     TAG_SUFFIX: -6-jmx
+    TEST_IMG: "true"
     BUILD_ARG: --target release --build-arg WITH_JMX=true --build-arg PYTHON_VERSION=2 --build-arg DD_AGENT_ARTIFACT=datadog-agent_6*_amd64.deb
-    TESTING_ARG: --target testing --build-arg WITH_JMX=true --build-arg PYTHON_VERSION=2 --build-arg DD_AGENT_ARTIFACT=datadog-agent_6*_amd64.deb
 
 # build agent6 py2 jmx image
 docker_build_agent6_jmx_arm64:
@@ -95,8 +95,8 @@ docker_build_agent6_jmx_arm64:
     BUILD_CONTEXT: Dockerfiles/agent
     BUILD_ARTIFACT_GLOB: datadog-agent_6*arm64.deb
     TAG_SUFFIX: -6-jmx
+    TEST_IMG: "true"
     BUILD_ARG: --target release --build-arg WITH_JMX=true --build-arg PYTHON_VERSION=2 --build-arg DD_AGENT_ARTIFACT=datadog-agent_6*arm64.deb
-    TESTING_ARG: --target testing --build-arg WITH_JMX=true --build-arg PYTHON_VERSION=2 --build-arg DD_AGENT_ARTIFACT=datadog-agent_6*arm64.deb
 
 # TESTING ONLY: This image is for internal testing purposes, not customer facing.
 # build agent6 jmx unified image (including python3)
@@ -111,8 +111,8 @@ docker_build_agent6_py2py3_jmx:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -6-py2py3-jmx
+    TEST_IMG: "true"
     BUILD_ARG: --target release --build-arg WITH_JMX=true --build-arg DD_AGENT_ARTIFACT=datadog-agent_6*_amd64.deb
-    TESTING_ARG: --target testing --build-arg WITH_JMX=true --build-arg DD_AGENT_ARTIFACT=datadog-agent_6*_amd64.deb
 
 # build agent7 image
 docker_build_agent7:
@@ -126,8 +126,8 @@ docker_build_agent7:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7
+    TEST_IMG: "true"
     BUILD_ARG: --target release --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-agent_7*_amd64.deb
-    TESTING_ARG: --target testing --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-agent_7*_amd64.deb
 
 docker_build_agent7_arm64:
   extends: .docker_build_job_definition_arm64
@@ -140,8 +140,8 @@ docker_build_agent7_arm64:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7
+    TEST_IMG: "true"
     BUILD_ARG: --target release --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-agent_7*_arm64.deb
-    TESTING_ARG: --target testing --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-agent_7*_arm64.deb
 
 # build agent7 jmx image
 docker_build_agent7_jmx:
@@ -155,8 +155,8 @@ docker_build_agent7_jmx:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7-jmx
+    TEST_IMG: "true"
     BUILD_ARG: --target release --build-arg WITH_JMX=true --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-agent_7*_amd64.deb
-    TESTING_ARG: --target testing --build-arg WITH_JMX=true --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-agent_7*_amd64.deb
 
 docker_build_agent7_jmx_arm64:
   extends: .docker_build_job_definition_arm64
@@ -169,8 +169,8 @@ docker_build_agent7_jmx_arm64:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7-jmx
+    TEST_IMG: "true"
     BUILD_ARG: --target release --build-arg WITH_JMX=true --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-agent_7*_arm64.deb
-    TESTING_ARG: --target testing --build-arg WITH_JMX=true --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-agent_7*_arm64.deb
 
 # build the cluster-agent image
 docker_build_cluster_agent_amd64:

--- a/Dockerfiles/agent/amd64/Dockerfile
+++ b/Dockerfiles/agent/amd64/Dockerfile
@@ -12,12 +12,12 @@ RUN if [ "$CIBUILD" = "true" ]; then \
          -e 's#http://security.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist#g' /etc/apt/sources.list; \
   fi
 
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update
 
 FROM baseimage AS faccessat
 COPY faccessat/faccessat.c   /tmp/faccessat.c
 COPY faccessat/faccessat.sym /tmp/faccessat.sym
-ENV DEBIAN_FRONTEND=noninteractive
 RUN apt install -y gcc
 RUN gcc -pipe -Wall -Wextra -O2 -shared -o /tmp/libfaccessat.so /tmp/faccessat.c -Wl,--version-script=/tmp/faccessat.sym
 

--- a/Dockerfiles/agent/amd64/Dockerfile
+++ b/Dockerfiles/agent/amd64/Dockerfile
@@ -18,7 +18,7 @@ RUN apt update
 FROM baseimage AS faccessat
 COPY faccessat/faccessat.c   /tmp/faccessat.c
 COPY faccessat/faccessat.sym /tmp/faccessat.sym
-RUN apt install -y gcc
+RUN apt install --no-install-recommends -y gcc libc6-dev
 RUN gcc -pipe -Wall -Wextra -O2 -shared -o /tmp/libfaccessat.so /tmp/faccessat.c -Wl,--version-script=/tmp/faccessat.sym
 
 ############################################
@@ -40,7 +40,7 @@ COPY hack/s6-pgp-key /tmp/s6-pgp-key
 ENV S6_VERSION v1.22.1.0
 ADD https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-amd64.tar.gz /output/s6.tgz
 ADD https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-amd64.tar.gz.sig /tmp/s6.tgz.sig
-RUN apt install --no-install-recommends -y gpg gpg-agent curl ca-certificates \
+RUN apt install --no-install-recommends -y gpg gpg-agent \
  && cat /tmp/s6-pgp-key | gpg --import \
  && gpg --verify /tmp/s6.tgz.sig /output/s6.tgz
 

--- a/Dockerfiles/agent/amd64/Dockerfile
+++ b/Dockerfiles/agent/amd64/Dockerfile
@@ -12,12 +12,13 @@ RUN if [ "$CIBUILD" = "true" ]; then \
          -e 's#http://security.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist#g' /etc/apt/sources.list; \
   fi
 
+RUN apt update
+
 FROM baseimage AS faccessat
 COPY faccessat/faccessat.c   /tmp/faccessat.c
 COPY faccessat/faccessat.sym /tmp/faccessat.sym
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt update && \
-    apt install -y gcc
+RUN apt install -y gcc
 RUN gcc -pipe -Wall -Wextra -O2 -shared -o /tmp/libfaccessat.so /tmp/faccessat.c -Wl,--version-script=/tmp/faccessat.sym
 
 ############################################
@@ -39,8 +40,7 @@ COPY hack/s6-pgp-key /tmp/s6-pgp-key
 ENV S6_VERSION v1.22.1.0
 ADD https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-amd64.tar.gz /output/s6.tgz
 ADD https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-amd64.tar.gz.sig /tmp/s6.tgz.sig
-RUN apt update \
- && apt install --no-install-recommends -y gpg gpg-agent curl ca-certificates \
+RUN apt install --no-install-recommends -y gpg gpg-agent curl ca-certificates \
  && cat /tmp/s6-pgp-key | gpg --import \
  && gpg --verify /tmp/s6.tgz.sig /output/s6.tgz
 
@@ -118,10 +118,8 @@ ENV DOCKER_DD_AGENT=true \
     # Allow User Group to exec the secret backend script.
     DD_SECRET_BACKEND_COMMAND_ALLOW_GROUP_EXEC_PERM="true"
 
-# make sure we have recent dependencies
-RUN apt update \
-  # CVE-fixing time!
-  && apt full-upgrade -y \
+# make sure we have recent dependencies -- CVE-fixing time!
+RUN apt full-upgrade -y \
   # Install iproute2 package for the ss utility that is used by the network check.
   # When the network check will have switched from using ss to directly parsing /proc/net/tcp,
   # this can be removed
@@ -134,7 +132,6 @@ RUN apt update \
 
 # Install openjdk-11-jre-headless on jmx flavor
 RUN if [ -n "$WITH_JMX" ]; then echo "Pulling openjdk-11 from testing" \
- && apt update \
  && mkdir -p /usr/share/man/man1 \
  && apt install --no-install-recommends -y openjdk-11-jre-headless \
  && apt clean; fi

--- a/Dockerfiles/agent/amd64/Dockerfile
+++ b/Dockerfiles/agent/amd64/Dockerfile
@@ -207,15 +207,3 @@ COPY entrypoint.sh /bin/entrypoint.sh
 COPY entrypoint.d /opt/entrypoints
 
 CMD ["/bin/entrypoint.sh"]
-
-
-################################################################
-#  Sanity checks on the image contents                         #
-#  Build the release artifact with "--target release" to skip  #
-################################################################
-
-FROM release AS testing
-ARG WITH_JMX
-
-COPY test_*.py /
-RUN python /test_image_contents.py -v

--- a/Dockerfiles/agent/arm64/Dockerfile
+++ b/Dockerfiles/agent/arm64/Dockerfile
@@ -6,17 +6,18 @@ ARG CIBUILD
 # cause `apt update` to fail with exit code 100 or make it hang on `0% [Working]`
 # indefinitely. Therefore we create a mirrorlist with the 2 mirrors that we know
 # should be reliable enough in combination and also well maintained.
- RUN if [ "$CIBUILD" = "true" ]; then \
+RUN if [ "$CIBUILD" = "true" ]; then \
   echo "http://us-east-1.ec2.ports.ubuntu.com/ubuntu-ports\tpriority:1\nhttp://ports.ubuntu.com/ubuntu-ports" > /etc/apt/mirrorlist && \
   sed -i -e 's#http://ports.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist#g' /etc/apt/sources.list; \
-   fi
+  fi
+
+RUN apt update
 
 FROM baseimage AS faccessat
 COPY faccessat/faccessat.c   /tmp/faccessat.c
 COPY faccessat/faccessat.sym /tmp/faccessat.sym
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt update && \
-    apt install -y gcc
+RUN apt install -y gcc
 RUN gcc -pipe -Wall -Wextra -O2 -shared -o /tmp/libfaccessat.so /tmp/faccessat.c -Wl,--version-script=/tmp/faccessat.sym
 
 ############################################
@@ -38,8 +39,7 @@ COPY hack/s6-pgp-key /tmp/s6-pgp-key
 ENV S6_VERSION v1.22.1.0
 ADD https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-aarch64.tar.gz /output/s6.tgz
 ADD https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-aarch64.tar.gz.sig /tmp/s6.tgz.sig
-RUN apt update \
- && apt install --no-install-recommends -y gpg gpg-agent curl ca-certificates \
+RUN apt install --no-install-recommends -y gpg gpg-agent curl ca-certificates \
  && cat /tmp/s6-pgp-key | gpg --import \
  && gpg --verify /tmp/s6.tgz.sig /output/s6.tgz
 
@@ -117,10 +117,8 @@ ENV DOCKER_DD_AGENT=true \
     # Allow User Group to exec the secret backend script.
     DD_SECRET_BACKEND_COMMAND_ALLOW_GROUP_EXEC_PERM="true"
 
-# make sure we have recent dependencies
-RUN apt update \
-  # CVE-fixing time!
-  && apt full-upgrade -y \
+# make sure we have recent dependencies -- CVE-fixing time!
+RUN apt full-upgrade -y \
   # Install iproute2 package for the ss utility that is used by the network check.
   # When the network check will have switched from using ss to directly parsing /proc/net/tcp,
   # this can be removed
@@ -133,7 +131,6 @@ RUN apt update \
 
 # Install openjdk-11-jre-headless on jmx flavor
 RUN if [ -n "$WITH_JMX" ]; then echo "Pulling openjdk-11 from testing" \
- && apt update \
  && mkdir -p /usr/share/man/man1 \
  && apt install --no-install-recommends -y openjdk-11-jre-headless \
  && apt clean; fi

--- a/Dockerfiles/agent/arm64/Dockerfile
+++ b/Dockerfiles/agent/arm64/Dockerfile
@@ -11,12 +11,12 @@ RUN if [ "$CIBUILD" = "true" ]; then \
   sed -i -e 's#http://ports.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist#g' /etc/apt/sources.list; \
   fi
 
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update
 
 FROM baseimage AS faccessat
 COPY faccessat/faccessat.c   /tmp/faccessat.c
 COPY faccessat/faccessat.sym /tmp/faccessat.sym
-ENV DEBIAN_FRONTEND=noninteractive
 RUN apt install -y gcc
 RUN gcc -pipe -Wall -Wextra -O2 -shared -o /tmp/libfaccessat.so /tmp/faccessat.c -Wl,--version-script=/tmp/faccessat.sym
 

--- a/Dockerfiles/agent/arm64/Dockerfile
+++ b/Dockerfiles/agent/arm64/Dockerfile
@@ -206,15 +206,3 @@ COPY entrypoint.sh /bin/entrypoint.sh
 COPY entrypoint.d /opt/entrypoints
 
 CMD ["/bin/entrypoint.sh"]
-
-
-################################################################
-#  Sanity checks on the image contents                         #
-#  Build the release artifact with "--target release" to skip  #
-################################################################
-
-FROM release AS testing
-ARG WITH_JMX
-
-COPY test_*.py /
-RUN python /test_image_contents.py -v

--- a/Dockerfiles/agent/arm64/Dockerfile
+++ b/Dockerfiles/agent/arm64/Dockerfile
@@ -17,7 +17,7 @@ RUN apt update
 FROM baseimage AS faccessat
 COPY faccessat/faccessat.c   /tmp/faccessat.c
 COPY faccessat/faccessat.sym /tmp/faccessat.sym
-RUN apt install -y gcc
+RUN apt install --no-install-recommends -y gcc libc6-dev
 RUN gcc -pipe -Wall -Wextra -O2 -shared -o /tmp/libfaccessat.so /tmp/faccessat.c -Wl,--version-script=/tmp/faccessat.sym
 
 ############################################
@@ -39,7 +39,7 @@ COPY hack/s6-pgp-key /tmp/s6-pgp-key
 ENV S6_VERSION v1.22.1.0
 ADD https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-aarch64.tar.gz /output/s6.tgz
 ADD https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-aarch64.tar.gz.sig /tmp/s6.tgz.sig
-RUN apt install --no-install-recommends -y gpg gpg-agent curl ca-certificates \
+RUN apt install --no-install-recommends -y gpg gpg-agent \
  && cat /tmp/s6-pgp-key | gpg --import \
  && gpg --verify /tmp/s6.tgz.sig /output/s6.tgz
 


### PR DESCRIPTION
### What does this PR do?

This removes some redundant steps when building docker images of the agent. In the end, the image should be functionally identical, but during the build some things moved around.

### Motivation

Speeding up the build. From my observation, this manages to reduce a little bit less than 30 seconds from each of the image build steps.

### Describe how to test/QA your changes

CI is green, and the agent image is still able to start properly. I'm adding `skip-qa` since *nothing* would work if this is somehow broken, and all other QA would catch it.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
