### PR TITLE
Fix conflict with probe names between NPM/OOM/TCPQ

### DIFF
--- a/pkg/collector/corechecks/ebpf/probe/oom_kill.go
+++ b/pkg/collector/corechecks/ebpf/probe/oom_kill.go
@@ -49,6 +49,7 @@ func NewOOMKillProbe(cfg *ebpf.Config) (*OOMKillProbe, error) {
 	probes := []*manager.Probe{
 		{
 			Section: "kprobe/oom_kill_process",
+			UID:     "oom",
 		},
 	}
 

--- a/pkg/collector/corechecks/ebpf/probe/tcp_queue_length.go
+++ b/pkg/collector/corechecks/ebpf/probe/tcp_queue_length.go
@@ -51,10 +51,10 @@ func NewTCPQueueLengthTracer(cfg *ebpf.Config) (*TCPQueueLengthTracer, error) {
 	defer compiledOutput.Close()
 
 	probes := []*manager.Probe{
-		{Section: "kprobe/tcp_recvmsg"},
-		{Section: "kretprobe/tcp_recvmsg"},
-		{Section: "kprobe/tcp_sendmsg"},
-		{Section: "kretprobe/tcp_sendmsg"},
+		{Section: "kprobe/tcp_recvmsg", UID: "tcpq"},
+		{Section: "kretprobe/tcp_recvmsg", UID: "tcpq"},
+		{Section: "kprobe/tcp_sendmsg", UID: "tcpq"},
+		{Section: "kretprobe/tcp_sendmsg", UID: "tcpq"},
 	}
 
 	maps := []*manager.Map{

--- a/releasenotes/notes/fix-npm-usm-tcpq-conflict-057cecf8699eda30.yaml
+++ b/releasenotes/notes/fix-npm-usm-tcpq-conflict-057cecf8699eda30.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes a conflict preventing NPM/USM and the TCP Queue Length check from being enabled at the same time.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Add UIDs to OOM/TCPQ checks to prevent conflicts with NPM. Similar to #10504 which was reverted. 

### Motivation

The ebpf library uses a deterministic probe event naming method. Since the TCP Queue Length Check uses some of the same kprobes as NPM, this can cause a conflict if both are enabled.

```
unable to start the TCP queue length tracer: failed to start manager: probes activation validation failed: 2 errors occurred:

        * {UID: Section:kprobe/tcp_sendmsg}: couldn't enable kprobe kprobe/tcp_sendmsg: cannot write "p:p_tcp_sendmsg__1 tcp_sendmsg\n" to kprobe_events: write /sys/kernel/debug/tracing/kprobe_events: device or resource busy

        * {UID: Section:kretprobe/tcp_sendmsg}: couldn't enable kprobe kretprobe/tcp_sendmsg: cannot write "r:r_tcp_sendmsg__1 tcp_sendmsg\n" to kprobe_events: write /sys/kernel/debug/tracing/kprobe_events: device or resource busy
```

### Additional Notes

This was introduced with https://github.com/DataDog/datadog-agent/pull/8779

Preemptively adding UID to all probes in the OOM Kill and TCP Queue Length checks.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Enable both TCP Queue Length check and NPM. The system-probe should start both modules successfully.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
