### PR TITLE
Fix dependency of deb packages on datadog-signing-keys

### DIFF
--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -53,7 +53,7 @@ else
   end
 
   if debian?
-    runtime_recommended_dependency 'datadog-signing-keys (>= 1.1.0)'
+    runtime_recommended_dependency 'datadog-signing-keys (>= 1:1.1.0)'
   end
 
   if osx?

--- a/omnibus/config/projects/dogstatsd.rb
+++ b/omnibus/config/projects/dogstatsd.rb
@@ -44,7 +44,7 @@ else
   end
 
   if debian?
-    runtime_recommended_dependency 'datadog-signing-keys (>= 1.1.0)'
+    runtime_recommended_dependency 'datadog-signing-keys (>= 1:1.1.0)'
   end
 end
 

--- a/omnibus/config/projects/iot-agent.rb
+++ b/omnibus/config/projects/iot-agent.rb
@@ -46,7 +46,7 @@ else
   end
 
   if debian?
-    runtime_recommended_dependency 'datadog-signing-keys (>= 1.1.0)'
+    runtime_recommended_dependency 'datadog-signing-keys (>= 1:1.1.0)'
   end
 end
 

--- a/releasenotes/notes/fix-signing-keys-dependency-84fb4c017cab72af.yaml
+++ b/releasenotes/notes/fix-signing-keys-dependency-84fb4c017cab72af.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    The weak dependency of datadog-agent, datadog-iot-agent and dogstatsd deb
+    packages on the datadog-signing-keys package has been fixed to ensure
+    proper upgrade to version 1:1.1.0.


### PR DESCRIPTION
### What does this PR do?

The previous dependency was ineffective in terms of updating to 1.1.0, because it didn't actually ensure upgrade if an earlier version was installed.

Example: The earlier version was `1:1.0.1`. Depending on `>= 1.1.0` effectively translates to `>= 0:1.1.0`, which is actually satisfied by `1:1.0.1` (because epoch trumps everything). Depending on `1:1.1.0` will actually ensure upgrade of datadog-signing-keys.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Same as https://github.com/DataDog/datadog-agent/pull/11447, but add this point:

* On a system with earlier datadog-signing-keys version (e.g. 1.0.1) and a datadog source list file configured, running `apt install ./datadog-agent_<...>.deb` installs agent correctly and upgrades the datadog-signing-keys package to at least 1.1.0.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
