### PR TITLE
Remove YAML Marshal/Unmarshal in AD config poller flow

### DIFF
--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -254,7 +254,7 @@ func (ac *AutoConfig) GetAllConfigs() []integration.Config {
 			cfgs = goodConfs
 		}
 		// Store all raw configs in the provider
-		pd.configs = cfgs
+		pd.overwriteConfigs(cfgs)
 
 		// resolve configs if needed
 		for _, config := range cfgs {
@@ -656,7 +656,6 @@ func (ac *AutoConfig) processNewService(ctx context.Context, svc listeners.Servi
 			LogsExcluded:    svc.HasFilter(containers.LogsFilter),
 		},
 	})
-
 }
 
 // processDelService takes a service, stops its associated checks, and updates the cache

--- a/pkg/autodiscovery/config_poller.go
+++ b/pkg/autodiscovery/config_poller.go
@@ -21,7 +21,7 @@ import (
 // `ConfigProvider` and whether it should be polled or not.
 type configPoller struct {
 	provider     providers.ConfigProvider
-	configs      []integration.Config
+	configs      map[uint64]*integration.Config
 	canPoll      bool
 	isPolling    bool
 	pollInterval time.Duration
@@ -32,20 +32,10 @@ type configPoller struct {
 func newConfigPoller(provider providers.ConfigProvider, canPoll bool, interval time.Duration) *configPoller {
 	return &configPoller{
 		provider:     provider,
-		configs:      []integration.Config{},
+		configs:      make(map[uint64]*integration.Config),
 		canPoll:      canPoll,
 		pollInterval: interval,
 	}
-}
-
-// contains checks if the providerDescriptor contains the Config passed
-func (pd *configPoller) contains(c *integration.Config) bool {
-	for _, config := range pd.configs {
-		if config.Equal(c) {
-			return true
-		}
-	}
-	return false
 }
 
 // stop stops the provider descriptor if it's polling
@@ -117,13 +107,18 @@ func (pd *configPoller) poll(ac *AutoConfig) {
 	}
 }
 
+func (pd *configPoller) overwriteConfigs(configs []integration.Config) {
+	fetchedMap := make(map[uint64]*integration.Config, len(configs))
+	for _, c := range configs {
+		cHash := c.FastDigest()
+		fetchedMap[cHash] = &c
+	}
+	pd.configs = fetchedMap
+}
+
 // collect is just a convenient wrapper to fetch configurations from a provider and
 // see what changed from the last time we called Collect().
 func (pd *configPoller) collect(ctx context.Context) ([]integration.Config, []integration.Config) {
-	var newConf []integration.Config
-	var removedConf []integration.Config
-	old := pd.configs
-
 	start := time.Now()
 	defer func() {
 		telemetry.PollDuration.Observe(time.Since(start).Seconds(), pd.provider.String())
@@ -135,17 +130,29 @@ func (pd *configPoller) collect(ctx context.Context) ([]integration.Config, []in
 		return nil, nil
 	}
 
-	for _, c := range fetched {
-		if !pd.contains(&c) {
+	return pd.storeAndDiffConfigs(fetched)
+}
+
+func (pd *configPoller) storeAndDiffConfigs(configs []integration.Config) ([]integration.Config, []integration.Config) {
+	var newConf []integration.Config
+	var removedConf []integration.Config
+
+	// We allocate a new map. We could do without it with a bit more processing
+	// but it allows to free some memory if number of collected configs varies a lot
+	fetchedMap := make(map[uint64]*integration.Config, len(configs))
+	for _, c := range configs {
+		cHash := c.FastDigest()
+		if _, found := pd.configs[cHash]; found {
+			delete(pd.configs, cHash)
+		} else {
 			newConf = append(newConf, c)
 		}
 	}
 
-	pd.configs = fetched
-	for _, c := range old {
-		if !pd.contains(&c) {
-			removedConf = append(removedConf, c)
-		}
+	for _, c := range pd.configs {
+		removedConf = append(removedConf, *c)
 	}
+	pd.configs = fetchedMap
+
 	return newConf, removedConf
 }


### PR DESCRIPTION
### What does this PR do?

Remove Marshal/Unmarshal in AD Config Poller and remove the need for linear search for each polled configuration.

### Motivation

Performance improvement

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Performance improvement: Check CPU spikes in Cluster Agent with a lot of endpoints
No regression: Check Autodiscovery works correctly in Agent and Cluster Agent

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
