### PR TITLE
[workloadmeta] Clear list of subscribers when unsubscribing all

### DIFF
--- a/pkg/workloadmeta/store.go
+++ b/pkg/workloadmeta/store.go
@@ -495,6 +495,8 @@ func (s *store) unsubscribeAll() {
 		close(sub.ch)
 	}
 
+	s.subscribers = nil
+
 	telemetry.Subscribers.Set(0)
 }
 


### PR DESCRIPTION
### What does this PR do?

This prevents a subscriber's channel from being closed twice (generating
a panic), since it's possible for store.Unsubscribe to be called after
the workloadmeta has been asked to shut down, depending on the order
other components are shut down relative to workloadmeta.


### Describe how to test/QA your changes

Make sure that workloadmeta does not panic when shutting down the agent.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
