### PR TITLE
[tagger] Add static tags to container/pod entities

### DIFF
--- a/pkg/tagger/collectors/workloadmeta_extract.go
+++ b/pkg/tagger/collectors/workloadmeta_extract.go
@@ -222,6 +222,11 @@ func (c *WorkloadMetaCollector) handleContainer(ev workloadmeta.Event) []*TagInf
 		utils.AddMetadataAsTags(envName, envValue, c.containerEnvAsTags, c.globContainerEnvLabels, tags)
 	}
 
+	// static tags for ECS and EKS Fargate containers
+	for tag, value := range c.staticTags {
+		tags.AddLow(tag, value)
+	}
+
 	low, orch, high, standard := tags.Compute()
 	return []*TagInfo{
 		{
@@ -274,6 +279,11 @@ func (c *WorkloadMetaCollector) handleKubePod(ev workloadmeta.Event) []*TagInfo 
 		tags.AddOrchestrator(kubernetes.OwnerRefNameTagName, owner.Name)
 
 		c.extractTagsFromPodOwner(pod, owner, tags)
+	}
+
+	// static tags for EKS Fargate pods
+	for tag, value := range c.staticTags {
+		tags.AddLow(tag, value)
 	}
 
 	low, orch, high, standard := tags.Compute()

--- a/pkg/tagger/collectors/workloadmeta_test.go
+++ b/pkg/tagger/collectors/workloadmeta_test.go
@@ -83,6 +83,7 @@ func TestHandleKubePod(t *testing.T) {
 
 	tests := []struct {
 		name              string
+		staticTags        map[string]string
 		labelsAsTags      map[string]string
 		annotationsAsTags map[string]string
 		nsLabelsAsTags    map[string]string
@@ -334,13 +335,42 @@ func TestHandleKubePod(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "static tags",
+			staticTags: map[string]string{
+				"eks_fargate_node": "foobar",
+			},
+			pod: workloadmeta.KubernetesPod{
+				EntityID: podEntityID,
+				EntityMeta: workloadmeta.EntityMeta{
+					Name:      podName,
+					Namespace: podNamespace,
+				},
+			},
+			expected: []*TagInfo{
+				{
+					Source:       podSource,
+					Entity:       podTaggerEntityID,
+					HighCardTags: []string{},
+					OrchestratorCardTags: []string{
+						fmt.Sprintf("pod_name:%s", podName),
+					},
+					LowCardTags: append([]string{
+						fmt.Sprintf("kube_namespace:%s", podNamespace),
+						"eks_fargate_node:foobar",
+					}),
+					StandardTags: []string{},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			collector := &WorkloadMetaCollector{
-				store:    store,
-				children: make(map[string]map[string]struct{}),
+				store:      store,
+				children:   make(map[string]map[string]struct{}),
+				staticTags: tt.staticTags,
 			}
 
 			collector.initPodMetaAsTags(tt.labelsAsTags, tt.annotationsAsTags, tt.nsLabelsAsTags)
@@ -530,6 +560,7 @@ func TestHandleContainer(t *testing.T) {
 
 	tests := []struct {
 		name         string
+		staticTags   map[string]string
 		labelsAsTags map[string]string
 		envAsTags    map[string]string
 		container    workloadmeta.Container
@@ -894,11 +925,40 @@ func TestHandleContainer(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "static tags",
+			staticTags: map[string]string{
+				"eks_fargate_node": "foobar",
+			},
+			container: workloadmeta.Container{
+				EntityID: entityID,
+				EntityMeta: workloadmeta.EntityMeta{
+					Name: containerName,
+				},
+			},
+			expected: []*TagInfo{
+				{
+					Source: containerSource,
+					Entity: taggerEntityID,
+					HighCardTags: []string{
+						fmt.Sprintf("container_name:%s", containerName),
+						fmt.Sprintf("container_id:%s", entityID.ID),
+					},
+					OrchestratorCardTags: []string{},
+					LowCardTags: []string{
+						"eks_fargate_node:foobar",
+					},
+					StandardTags: []string{},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			collector := &WorkloadMetaCollector{}
+			collector := &WorkloadMetaCollector{
+				staticTags: tt.staticTags,
+			}
 			collector.initContainerMetaAsTags(tt.labelsAsTags, tt.envAsTags)
 
 			actual := collector.handleContainer(workloadmeta.Event{


### PR DESCRIPTION
### What does this PR do?

These were removed in #11293, and then lived just in GlobalEntityID,
with the assumption that all data coming out of the agent would call
`tagger.EnrichTags`, where we add GlobalEntityID's tags to another set
of tags. That assumption is wrong, as it turns out that process and
container collection (and possibly other components) *do not* call that
func, and therefore would not have the static tags added.

### Possible Drawbacks / Trade-offs

Now it's possible that static tags are added to metrics twice, since they live both in an entity of themselves, and `GlobalEntityID`, which is applied by `EnrichTags`. [There's a comment saying we shouldn't worry about this anymore](https://github.com/DataDog/datadog-agent/blob/2feec31ceaccfb9bca975bf2a9a51368d05b5dc0/pkg/tagger/global.go#L262-L264), but it's still worth pointing out if we see the issue occurring.

### Describe how to test/QA your changes

In ECS Fargate, check that the live containers view shows `DD_TAGS`. Also in ECS Fargate, ensure that metrics don't have `DD_TAGS` applied twice (`agent check ecs_fargate` seems to be a good way to check, I have no idea how this would show up in the app).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
