### PR TITLE
[workloadmeta] Don't notify "unset" events for non-stored entities

### DIFF
--- a/pkg/workloadmeta/store_test.go
+++ b/pkg/workloadmeta/store_test.go
@@ -422,6 +422,23 @@ func TestSubscribe(t *testing.T) {
 				},
 			},
 		},
+		{
+			// An unset event of an entity that is not in the store should not
+			// generate any events.
+			name:      "unset event of entity that is not in the store",
+			preEvents: []CollectorEvent{}, // There's nothing stored
+			postEvents: [][]CollectorEvent{
+				{
+					{
+						Type:   EventTypeUnset,
+						Source: fooSource,
+						Entity: fooContainer.GetID(),
+					},
+				},
+			},
+			filter:   NewFilter(nil, fooSource),
+			expected: nil,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### What does this PR do?

Makes a change in the workloadmeta store so it doesn't notify "unset" events that refer to entities that are not stored.

This can happen for "pause" containers. We don't store them, but the workloadmeta might receive delete events for them. In those cases we don't want to notify the subscribers.


### Describe how to test/QA your changes

I noticed this while testing the container lifecycle events check. I noticed that for each container deleted, it emitted 2 events: one for the deleted container itself and other for its associated "pause" container. With this change, only one event will be sent.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
