### PR TITLE
Updates localbuild script to accommodate the included python zip.

### DIFF
--- a/omnibus/resources/agent/msi/localbuild/README.md
+++ b/omnibus/resources/agent/msi/localbuild/README.md
@@ -16,4 +16,7 @@ and the configuration files directory, `c:\omnibus-ruby\src\etc\datadog-agent\ex
 
 It includes `parameters.wxi`, where the variables such as the installation version can be changed (note that the included binaries will not be rebuilt, so the included binaries will not necessarily report the version specified in `parameters.wxi`.  However, the MSI itself will report itself as that version).
 
+The first time it is run after a full build, it will generate the 7z (zip) file of the python directory that
+is used in the msi.  On each subsequent execution, it will reuse that zip file.
+
 

--- a/omnibus/resources/agent/msi/localbuild/parameters.wxi
+++ b/omnibus/resources/agent/msi/localbuild/parameters.wxi
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Include>
-  <?define VersionNumber="7.27.1.1" ?>
-  <?define DisplayVersionNumber="7.27.1" ?>
+  <?define VersionNumber="7.36.0.1" ?>
+  <?define DisplayVersionNumber="7.36.0" ?>
   <?define UpgradeCode="0c50421b-aefb-4f15-a809-7af256d608a5" ?>
   <?define InstallDir="C:/opt/datadog-agent" ?>
   <?define InstallFiles="C:/omnibus-ruby/src/datadog-agent/dd-agent/packaging/datadog-agent/win32/install_files" ?>

--- a/omnibus/resources/agent/msi/localbuild/parameters.wxi
+++ b/omnibus/resources/agent/msi/localbuild/parameters.wxi
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Include>
-  <?define VersionNumber="7.36.0.1" ?>
-  <?define DisplayVersionNumber="7.36.0" ?>
+  <?define VersionNumber="7.99.0.1" ?>
+  <?define DisplayVersionNumber="7.99.0" ?>
   <?define UpgradeCode="0c50421b-aefb-4f15-a809-7af256d608a5" ?>
   <?define InstallDir="C:/opt/datadog-agent" ?>
   <?define InstallFiles="C:/omnibus-ruby/src/datadog-agent/dd-agent/packaging/datadog-agent/win32/install_files" ?>

--- a/omnibus/resources/agent/msi/localbuild/rebuild.bat
+++ b/omnibus/resources/agent/msi/localbuild/rebuild.bat
@@ -3,7 +3,15 @@ rem
 @set WD=%CD%
 cd %~dp0
 
+REM Copy few resource files locally, source.wxs AS IS and
+REM localization-en-us.wxl.erb replace template value currently via "Agent",
+REM unless localization-en-us.wxl already exhists (e.g. from previous copy)
 copy ..\source.wxs.erb source.wxs
+if not exist localization-en-us.wxl (
+    REM Note "complicated" %% escape BATCH characters
+    PowerShell -Command "Get-Content ..\localization-en-us.wxl.erb | %%{$_ -replace '<%%= friendly_name %%>', 'Agent'} | Out-File -Encoding utf8 'localization-en-us.wxl'"
+)
+
 xcopy /y/e/s/i ..\assets\*.* resources\assets
 
 REM first create zip file if it's not already there (of the embedded directory)

--- a/omnibus/resources/agent/msi/localbuild/rebuild.bat
+++ b/omnibus/resources/agent/msi/localbuild/rebuild.bat
@@ -5,8 +5,23 @@ cd %~dp0
 
 copy ..\source.wxs.erb source.wxs
 xcopy /y/e/s/i ..\assets\*.* resources\assets
+
+REM first create zip file if it's not already there (of the embedded directory)
+REM this assumes always A7 for now
+
 REM run HEAT on c:\opt\datadog-agent
 REM
+if not exist c:\opt\datadog-agent\embedded3.7z (
+    @echo Zip file not present, creating
+    if not exist c:\opt\datadog-agent\embedded3 (
+        @echo no embedded3 directory, can't make zip
+        exit /b 5
+    )
+    7z a -mx=5 -ms=on c:\opt\datadog-agent\embedded3.7z c:\opt\datadog-agent\embedded3
+    rd /s/q c:\opt\datadog-agent\embedded3
+) else (
+    @echo zip file present, using existing zip
+)
 heat.exe dir "c:\opt\datadog-agent" -nologo -srd -sreg -gg -cg ProjectDir -dr PROJECTLOCATION -var "var.ProjectSourceDir" -out "project-files.wxs"
 
 REM 


### PR DESCRIPTION
Internal developer tool change only.

### What does this PR do?

Updates the windows `localbuild` script to accommodate the fact that the embedded python
is now zipped inside the installer.

### Motivation

Allows faster iteration on windows install packages

### Reviewer's Checklist
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
