### PR TITLE
[process-agent] Fix nil derefef on MacOS and suppress RT check banner

### DIFF
--- a/cmd/process-agent/app/check.go
+++ b/cmd/process-agent/app/check.go
@@ -59,7 +59,10 @@ func runCheckCmd(cmd *cobra.Command, args []string) error {
 	ddconfig.InitSystemProbeConfig(ddconfig.Datadog)
 
 	configPath := cmd.Flag(flags.CfgPath).Value.String()
-	sysprobePath := cmd.Flag(flags.SysProbeConfig).Value.String()
+	var sysprobePath string
+	if cmd.Flag(flags.SysProbeConfig) != nil {
+		sysprobePath = cmd.Flag(flags.SysProbeConfig).Value.String()
+	}
 
 	if err := config.LoadConfigIfExists(configPath); err != nil {
 		return log.Criticalf("Error parsing config: %s", err)
@@ -174,7 +177,9 @@ func runCheckAsRealTime(cfg *config.AgentConfig, ch checks.CheckWithRealTime) er
 
 	time.Sleep(1 * time.Second)
 
-	printResultsBanner(ch.RealTimeName())
+	if !checkOutputJSON {
+		printResultsBanner(ch.RealTimeName())
+	}
 
 	run, err := ch.RunWithOptions(cfg, nextGroupID, options)
 	if err != nil {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Address a couple of issues in the `check` command:

- Fix nil dereference in the `check` command on Mac (flag not configured).
- Suppress the check results banner when JSON output is requested.

nil dereference stack:
```
❯ /opt/datadog-agent/embedded/bin/process-agent check process
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x5905b76]

goroutine 1 [running]:
github.com/DataDog/datadog-agent/cmd/process-agent/app.runCheckCmd(0x78de100, {0xc0002b3160, 0x1, 0x1})
    /private/var/cache/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/cmd/process-agent/app/check.go:62 +0xf6
github.com/spf13/cobra.(*Command).execute(0x78de100, {0xc0002b3140, 0x1, 0x1})
    /Users/runner/gomodcache/github.com/spf13/cobra@v1.4.0/command.go:856 +0x60e
github.com/spf13/cobra.(*Command).ExecuteC(0x78de880)
    /Users/runner/gomodcache/github.com/spf13/cobra@v1.4.0/command.go:974 +0x3bc
github.com/spf13/cobra.(*Command).Execute(...)
    /Users/runner/gomodcache/github.com/spf13/cobra@v1.4.0/command.go:902
main.main()
    /private/var/cache/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/cmd/process-agent/main.go:40 +0x1f1
```

### Motivation

Functional check command

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

- Run the check command in MacOS and make sure it is functioning as expected without causing a panic.
- Running `process-agent check rtprocess --json` should suppress the banner and output valid JSON.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
