### PR TITLE
[unrevert] Migrate NPM to `ebpf-manager` library

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -32,14 +32,7 @@ core,github.com/DataDog/btf-internals/sys,MIT,"Copyright (c) 2017 Nathan Sweet |
 core,github.com/DataDog/btf-internals/unix,MIT,"Copyright (c) 2017 Nathan Sweet | Copyright (c) 2018, 2019 Cloudflare | Copyright (c) 2019 Authors of Cilium"
 core,github.com/DataDog/datadog-go/v5/statsd,MIT,"Copyright (c) 2015 Datadog, Inc"
 core,github.com/DataDog/datadog-operator/api/v1alpha1,Apache-2.0,"Copyright 2016-2020 Datadog, Inc"
-core,github.com/DataDog/ebpf,MIT,"Copyright (c) 2017 Nathan Sweet | Copyright (c) 2018, 2019 Cloudflare | Copyright (c) 2019 Authors of Cilium | Copyright (c) 2020 Authors of Datadog"
 core,github.com/DataDog/ebpf-manager,MIT,Copyright (c) 2021 Authors of Datadog
-core,github.com/DataDog/ebpf/asm,MIT,"Copyright (c) 2017 Nathan Sweet | Copyright (c) 2018, 2019 Cloudflare | Copyright (c) 2019 Authors of Cilium | Copyright (c) 2020 Authors of Datadog"
-core,github.com/DataDog/ebpf/internal,MIT,"Copyright (c) 2017 Nathan Sweet | Copyright (c) 2018, 2019 Cloudflare | Copyright (c) 2019 Authors of Cilium | Copyright (c) 2020 Authors of Datadog"
-core,github.com/DataDog/ebpf/internal/btf,MIT,"Copyright (c) 2017 Nathan Sweet | Copyright (c) 2018, 2019 Cloudflare | Copyright (c) 2019 Authors of Cilium | Copyright (c) 2020 Authors of Datadog"
-core,github.com/DataDog/ebpf/internal/unix,MIT,"Copyright (c) 2017 Nathan Sweet | Copyright (c) 2018, 2019 Cloudflare | Copyright (c) 2019 Authors of Cilium | Copyright (c) 2020 Authors of Datadog"
-core,github.com/DataDog/ebpf/manager,MIT,"Copyright (c) 2017 Nathan Sweet | Copyright (c) 2018, 2019 Cloudflare | Copyright (c) 2019 Authors of Cilium | Copyright (c) 2020 Authors of Datadog"
-core,github.com/DataDog/ebpf/perf,MIT,"Copyright (c) 2017 Nathan Sweet | Copyright (c) 2018, 2019 Cloudflare | Copyright (c) 2019 Authors of Cilium | Copyright (c) 2020 Authors of Datadog"
 core,github.com/DataDog/extendeddaemonset/api/v1alpha1,Apache-2.0,"Copyright 2016-2020 Datadog, Inc"
 core,github.com/DataDog/gohai/cpu,MIT,"Copyright (c) 2014-2015, Datadog <info@datadoghq.com> | Copyright © 2015 Kentaro Kuribayashi <kentarok@gmail.com>"
 core,github.com/DataDog/gohai/filesystem,MIT,"Copyright (c) 2014-2015, Datadog <info@datadoghq.com> | Copyright © 2015 Kentaro Kuribayashi <kentarok@gmail.com>"
@@ -340,9 +333,6 @@ core,github.com/fatih/color,MIT,Copyright (c) 2013 Fatih Arslan
 core,github.com/felixge/httpsnoop,MIT,Copyright (c) 2016 Felix Geisendörfer (felix@debuggable.com)
 core,github.com/florianl/go-conntrack,MIT,Copyright (C) 2018  Florian Lehner <dev@der-flo.net>
 core,github.com/florianl/go-conntrack/internal/unix,MIT,Copyright (C) 2018  Florian Lehner <dev@der-flo.net>
-core,github.com/florianl/go-tc,MIT,Copyright (C) 2019-2020  Florian Lehner <dev@der-flo.net>
-core,github.com/florianl/go-tc/core,MIT,Copyright (C) 2019-2020  Florian Lehner <dev@der-flo.net>
-core,github.com/florianl/go-tc/internal/unix,MIT,Copyright (C) 2019-2020  Florian Lehner <dev@der-flo.net>
 core,github.com/freddierice/go-losetup,MIT,Copyright (c) 2017 Freddie Rice
 core,github.com/fsnotify/fsnotify,BSD-3-Clause,Copyright (c) 2012 The Go Authors. All rights reserved. | Copyright (c) 2012-2019 fsnotify Authors. All rights reserved.
 core,github.com/ghodss/yaml,MIT,Copyright (c) 2012 The Go Authors. All rights reserved | Copyright (c) 2014 Sam Ghods

--- a/go.mod
+++ b/go.mod
@@ -68,7 +68,6 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/winutil v0.36.0-rc.1
 	github.com/DataDog/datadog-go/v5 v5.1.0
 	github.com/DataDog/datadog-operator v0.5.0-rc.2.0.20210402083916-25ba9a22e67a
-	github.com/DataDog/ebpf v0.0.0-20220301203322-3fc9ab3b8daf
 	github.com/DataDog/ebpf-manager v0.0.0-20220325092125-b2221d88caf3
 	github.com/DataDog/gohai v0.0.0-20220329101230-3b6a804fdd24
 	github.com/DataDog/gopsutil v0.0.0-20220308095538-d086941833e3
@@ -273,7 +272,6 @@ require (
 	github.com/emicklei/go-restful-swagger12 v0.0.0-20201014110547-68ccff494617 // indirect
 	github.com/evanphx/json-patch v4.9.0+incompatible // indirect
 	github.com/felixge/httpsnoop v1.0.2 // indirect
-	github.com/florianl/go-tc v0.3.0 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-kit/log v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -130,8 +130,6 @@ github.com/DataDog/datadog-go/v5 v5.1.0 h1:Zmq3tCk9+Tdq8Du73M71Zo6Dyx+cEo9QkCSCq
 github.com/DataDog/datadog-go/v5 v5.1.0/go.mod h1:KhiYb2Badlv9/rofz+OznKoEF5XKTonWyhx5K83AP8E=
 github.com/DataDog/datadog-operator v0.5.0-rc.2.0.20210402083916-25ba9a22e67a h1:vqz6k806rvz01tIzOA2UHE3j1IEAMcDxw8O+nA3H+Mk=
 github.com/DataDog/datadog-operator v0.5.0-rc.2.0.20210402083916-25ba9a22e67a/go.mod h1:2qOvG41jii2ks6Umn6MbDGlHRgwoFiYXcjgQQ9VlsS0=
-github.com/DataDog/ebpf v0.0.0-20220301203322-3fc9ab3b8daf h1:RySWcA0EFIp3NL9ebHOZ6yfmF5jz00nC6pOjn+qABhs=
-github.com/DataDog/ebpf v0.0.0-20220301203322-3fc9ab3b8daf/go.mod h1:tSPYMUcskM0OLVEJSoydgYUVuhX8hOSmtaSLNtOQThg=
 github.com/DataDog/ebpf-manager v0.0.0-20220325092125-b2221d88caf3 h1:QixW0L0iCNVo/7+rt/dggbp0Qq29bLMO3Uqf4jgfPUw=
 github.com/DataDog/ebpf-manager v0.0.0-20220325092125-b2221d88caf3/go.mod h1:eOlqnaKvEMqn47uNlK+UMdQHwpnL0xXFJAhxwYgLqT0=
 github.com/DataDog/extendeddaemonset v0.5.1-0.20210315105301-41547d4ff09c h1:a9OMhZzrrB4nd2eAsXZIBkQ061Gb/QT4CI2g+OWWevs=
@@ -255,7 +253,6 @@ github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgI
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/aslakhellesoy/gox v1.0.100/go.mod h1:AJl542QsKKG96COVsv0N74HHzVQgDIQPceVUh1aeU2M=
-github.com/avast/retry-go v2.7.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/awalterschulze/gographviz v0.0.0-20160912181450-761fd5fbb34e/go.mod h1:GEV5wmg4YquNw7v1kkyoX9etIk8yVmXj+AkDHuuETHs=
@@ -566,9 +563,6 @@ github.com/felixge/httpsnoop v1.0.2 h1:+nS9g82KMXccJ/wp0zyRW9ZBHFETmMGtkk+2CTTrW
 github.com/felixge/httpsnoop v1.0.2/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/florianl/go-conntrack v0.2.0 h1:JEB4w895ZX35tvNH5JjNM9pxa+Qn73paiA37VeCZGfc=
 github.com/florianl/go-conntrack v0.2.0/go.mod h1:HRSlXmrl5M//9hiHmkwyLDwlaoba2sVDcBpHFRiVo1Q=
-github.com/florianl/go-tc v0.2.0/go.mod h1:aWdDOHrIpaff8cZp6z7dgJZ1bRsgTS6pXIW0xRdFTK8=
-github.com/florianl/go-tc v0.3.0 h1:qeqQB5kp2lwJP1p/8krLQIuRfkHWpiPPcYr3rhRSaC8=
-github.com/florianl/go-tc v0.3.0/go.mod h1:Ni/GTSK8ymDnsRQfL2meJeGmcXy7RFIvchiVHizU76U=
 github.com/flynn/go-docopt v0.0.0-20140912013429-f6dd2ebbb31e/go.mod h1:HyVoz1Mz5Co8TFO8EupIdlcpwShBmY98dkT2xeHkvEI=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
@@ -1105,7 +1099,6 @@ github.com/josharian/native v0.0.0-20200817173448-b6b71def0850/go.mod h1:7X/rasw
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/jsimonetti/rtnetlink v0.0.0-20190606172950-9527aa82566a/go.mod h1:Oz+70psSo5OFh8DBl0Zv2ACw7Esh6pPUphlvZG9x7uw=
 github.com/jsimonetti/rtnetlink v0.0.0-20200117123717-f846d4f6c1f4/go.mod h1:WGuG/smIU4J/54PblvSbh+xvCZmpJnFgr3ds6Z55XMQ=
-github.com/jsimonetti/rtnetlink v0.0.0-20200319143528-d89fb9e42094/go.mod h1:WGuG/smIU4J/54PblvSbh+xvCZmpJnFgr3ds6Z55XMQ=
 github.com/jsimonetti/rtnetlink v0.0.0-20201009170750-9c6f07d100c1/go.mod h1:hqoO/u39cqLeBLebZ8fWdE96O7FxrAsRYhnVOdgHxok=
 github.com/jsimonetti/rtnetlink v0.0.0-20201216134343-bde56ed16391/go.mod h1:cR77jAZG3Y3bsb8hF6fHJbFoyFukLFOkQ98S0pQz3xw=
 github.com/jsimonetti/rtnetlink v0.0.0-20201220180245-69540ac93943/go.mod h1:z4c53zj6Eex712ROyh8WI0ihysb5j2ROyV42iNogmAs=
@@ -2155,7 +2148,6 @@ golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200217220822-9197077df867/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200320181252-af34d8274f85/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200331124033-c3d80250170d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/collector/corechecks/ebpf/probe/oom_kill.go
+++ b/pkg/collector/corechecks/ebpf/probe/oom_kill.go
@@ -48,7 +48,7 @@ func NewOOMKillProbe(cfg *ebpf.Config) (*OOMKillProbe, error) {
 
 	probes := []*manager.Probe{
 		{
-			ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: "kprobe/oom_kill_process", EBPFFuncName: "kprobe__oom_kill_process"},
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: "kprobe/oom_kill_process", EBPFFuncName: "kprobe__oom_kill_process", UID: "oom"},
 		},
 	}
 

--- a/pkg/collector/corechecks/ebpf/probe/oom_kill.go
+++ b/pkg/collector/corechecks/ebpf/probe/oom_kill.go
@@ -18,8 +18,8 @@ import (
 
 	"golang.org/x/sys/unix"
 
-	bpflib "github.com/DataDog/ebpf"
-	"github.com/DataDog/ebpf/manager"
+	manager "github.com/DataDog/ebpf-manager"
+	bpflib "github.com/cilium/ebpf"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode/runtime"
@@ -48,8 +48,7 @@ func NewOOMKillProbe(cfg *ebpf.Config) (*OOMKillProbe, error) {
 
 	probes := []*manager.Probe{
 		{
-			Section: "kprobe/oom_kill_process",
-			UID:     "oom",
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: "kprobe/oom_kill_process", EBPFFuncName: "kprobe__oom_kill_process"},
 		},
 	}
 

--- a/pkg/collector/corechecks/ebpf/probe/tcp_queue_length.go
+++ b/pkg/collector/corechecks/ebpf/probe/tcp_queue_length.go
@@ -50,10 +50,10 @@ func NewTCPQueueLengthTracer(cfg *ebpf.Config) (*TCPQueueLengthTracer, error) {
 	defer compiledOutput.Close()
 
 	probes := []*manager.Probe{
-		{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: "kprobe/tcp_recvmsg", EBPFFuncName: "kprobe__tcp_recvmsg"}},
-		{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: "kretprobe/tcp_recvmsg", EBPFFuncName: "kretprobe__tcp_recvmsg"}},
-		{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: "kprobe/tcp_sendmsg", EBPFFuncName: "kprobe__tcp_sendmsg"}},
-		{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: "kretprobe/tcp_sendmsg", EBPFFuncName: "kretprobe__tcp_sendmsg"}},
+		{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: "kprobe/tcp_recvmsg", EBPFFuncName: "kprobe__tcp_recvmsg", UID: "tcpq"}},
+		{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: "kretprobe/tcp_recvmsg", EBPFFuncName: "kretprobe__tcp_recvmsg", UID: "tcpq"}},
+		{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: "kprobe/tcp_sendmsg", EBPFFuncName: "kprobe__tcp_sendmsg", UID: "tcpq"}},
+		{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: "kretprobe/tcp_sendmsg", EBPFFuncName: "kretprobe__tcp_sendmsg", UID: "tcpq"}},
 	}
 
 	maps := []*manager.Map{

--- a/pkg/collector/corechecks/ebpf/probe/tcp_queue_length.go
+++ b/pkg/collector/corechecks/ebpf/probe/tcp_queue_length.go
@@ -19,8 +19,8 @@ import (
 	"github.com/iovisor/gobpf/pkg/cpupossible"
 	"golang.org/x/sys/unix"
 
-	bpflib "github.com/DataDog/ebpf"
-	"github.com/DataDog/ebpf/manager"
+	manager "github.com/DataDog/ebpf-manager"
+	bpflib "github.com/cilium/ebpf"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode/runtime"
@@ -34,8 +34,7 @@ import (
 import "C"
 
 const (
-	TCPQueueLengthUID = "tcp-queue-length"
-	statsMapName      = "tcp_queue_stats"
+	statsMapName = "tcp_queue_stats"
 )
 
 type TCPQueueLengthTracer struct {
@@ -51,10 +50,10 @@ func NewTCPQueueLengthTracer(cfg *ebpf.Config) (*TCPQueueLengthTracer, error) {
 	defer compiledOutput.Close()
 
 	probes := []*manager.Probe{
-		{Section: "kprobe/tcp_recvmsg", UID: "tcpq"},
-		{Section: "kretprobe/tcp_recvmsg", UID: "tcpq"},
-		{Section: "kprobe/tcp_sendmsg", UID: "tcpq"},
-		{Section: "kretprobe/tcp_sendmsg", UID: "tcpq"},
+		{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: "kprobe/tcp_recvmsg", EBPFFuncName: "kprobe__tcp_recvmsg"}},
+		{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: "kretprobe/tcp_recvmsg", EBPFFuncName: "kretprobe__tcp_recvmsg"}},
+		{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: "kprobe/tcp_sendmsg", EBPFFuncName: "kprobe__tcp_sendmsg"}},
+		{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: "kretprobe/tcp_sendmsg", EBPFFuncName: "kretprobe__tcp_sendmsg"}},
 	}
 
 	maps := []*manager.Map{

--- a/pkg/ebpf/perf.go
+++ b/pkg/ebpf/perf.go
@@ -11,7 +11,7 @@ package ebpf
 import (
 	"sync"
 
-	"github.com/DataDog/ebpf/manager"
+	manager "github.com/DataDog/ebpf-manager"
 )
 
 type PerfHandler struct {

--- a/pkg/ebpf/probes.go
+++ b/pkg/ebpf/probes.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/ebpf/manager"
+	manager "github.com/DataDog/ebpf-manager"
 )
 
 var indirectSyscallPrefixes = map[string]string{

--- a/pkg/ebpf/probes_test.go
+++ b/pkg/ebpf/probes_test.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/DataDog/ebpf/manager"
+	manager "github.com/DataDog/ebpf-manager"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/network/dns/ebpf.go
+++ b/pkg/network/dns/ebpf.go
@@ -15,9 +15,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	netebpf "github.com/DataDog/datadog-agent/pkg/network/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
-	"github.com/DataDog/ebpf/manager"
+	manager "github.com/DataDog/ebpf-manager"
 	"golang.org/x/sys/unix"
 )
+
+const funcName = "socket__dns_filter"
 
 type ebpfProgram struct {
 	*manager.Manager
@@ -33,7 +35,10 @@ func newEBPFProgram(c *config.Config) (*ebpfProgram, error) {
 
 	mgr := &manager.Manager{
 		Probes: []*manager.Probe{
-			{Section: string(probes.SocketDnsFilter)},
+			{ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFSection:  string(probes.SocketDnsFilter),
+				EBPFFuncName: funcName,
+			}},
 		},
 	}
 
@@ -63,7 +68,8 @@ func (e *ebpfProgram) Init() error {
 		ActivatedProbes: []manager.ProbesSelector{
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					Section: string(probes.SocketDnsFilter),
+					EBPFSection:  string(probes.SocketDnsFilter),
+					EBPFFuncName: funcName,
 				},
 			},
 		},

--- a/pkg/network/dns/monitor_linux.go
+++ b/pkg/network/dns/monitor_linux.go
@@ -15,7 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
 	filterpkg "github.com/DataDog/datadog-agent/pkg/network/filter"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
-	"github.com/DataDog/ebpf/manager"
+	manager "github.com/DataDog/ebpf-manager"
 )
 
 type dnsMonitor struct {
@@ -34,7 +34,7 @@ func NewReverseDNS(cfg *config.Config) (ReverseDNS, error) {
 		return nil, fmt.Errorf("error initializing ebpf programs: %w", err)
 	}
 
-	filter, _ := p.GetProbe(manager.ProbeIdentificationPair{Section: string(probes.SocketDnsFilter)})
+	filter, _ := p.GetProbe(manager.ProbeIdentificationPair{EBPFSection: string(probes.SocketDnsFilter), EBPFFuncName: funcName})
 	if filter == nil {
 		return nil, fmt.Errorf("error retrieving socket filter")
 	}

--- a/pkg/network/ebpf/probes/probes.go
+++ b/pkg/network/ebpf/probes/probes.go
@@ -92,11 +92,6 @@ const (
 	// SockMapFdReturn maps a file descriptor to a kernel sock
 	SockMapFdReturn ProbeName = "kretprobe/sockfd_lookup_light"
 
-	// IPRouteOutputFlow is the kprobe of an ip_route_output_flow call
-	IPRouteOutputFlow ProbeName = "kprobe/ip_route_output_flow"
-	// IPRouteOutputFlow is the kretprobe of an ip_route_output_flow call
-	IPRouteOutputFlowReturn ProbeName = "kretprobe/ip_route_output_flow"
-
 	// ConntrackHashInsert is the probe for new conntrack entries
 	ConntrackHashInsert ProbeName = "kprobe/__nf_conntrack_hash_insert"
 

--- a/pkg/network/filter/packet_source_linux.go
+++ b/pkg/network/filter/packet_source_linux.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/ebpf/manager"
+	"github.com/DataDog/ebpf-manager"
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/afpacket"
 	"github.com/google/gopacket/layers"

--- a/pkg/network/filter/socket_filter.go
+++ b/pkg/network/filter/socket_filter.go
@@ -10,7 +10,7 @@ package filter
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/process/util"
-	"github.com/DataDog/ebpf/manager"
+	manager "github.com/DataDog/ebpf-manager"
 )
 
 // HeadlessSocketFilter creates a raw socket attached to the given socket filter.

--- a/pkg/network/http/batch_manager.go
+++ b/pkg/network/http/batch_manager.go
@@ -14,7 +14,7 @@ import (
 
 	"fmt"
 
-	"github.com/DataDog/ebpf"
+	"github.com/cilium/ebpf"
 )
 
 /*

--- a/pkg/network/http/dump.go
+++ b/pkg/network/http/dump.go
@@ -12,26 +12,20 @@ import (
 	"strings"
 	"unsafe"
 
-	"github.com/DataDog/datadog-agent/pkg/network/ebpf"
-	"github.com/DataDog/ebpf/manager"
-
+	ddebpf "github.com/DataDog/datadog-agent/pkg/network/ebpf"
+	manager "github.com/DataDog/ebpf-manager"
+	"github.com/cilium/ebpf"
 	"github.com/davecgh/go-spew/spew"
 )
 
-func dumpMapsHandler(managerMap *manager.Map, manager *manager.Manager) string {
+func dumpMapsHandler(manager *manager.Manager, mapName string, currentMap *ebpf.Map) string {
 	var output strings.Builder
-
-	mapName := managerMap.Name
-	currentMap, found, err := manager.GetMap(mapName)
-	if err != nil || !found {
-		return ""
-	}
 
 	switch mapName {
 	case httpInFlightMap: // maps/http_in_flight (BPF_MAP_TYPE_HASH), key ConnTuple, value httpTX
 		output.WriteString("Map: '" + mapName + "', key: 'ConnTuple', value: 'httpTX'\n")
 		iter := currentMap.Iterate()
-		var key ebpf.ConnTuple
+		var key ddebpf.ConnTuple
 		var value httpTX
 		for iter.Next(unsafe.Pointer(&key), unsafe.Pointer(&value)) {
 			output.WriteString(spew.Sdump(key, value))
@@ -50,7 +44,7 @@ func dumpMapsHandler(managerMap *manager.Map, manager *manager.Manager) string {
 		output.WriteString("Map: '" + mapName + "', key: 'C.__u32', value: 'C.http_batch_state_t'\n")
 		iter := currentMap.Iterate()
 		var key uint32
-		var value ebpf.HTTPBatchState
+		var value ddebpf.HTTPBatchState
 		for iter.Next(unsafe.Pointer(&key), unsafe.Pointer(&value)) {
 			output.WriteString(spew.Sdump(key, value))
 		}
@@ -59,7 +53,7 @@ func dumpMapsHandler(managerMap *manager.Map, manager *manager.Manager) string {
 		output.WriteString("Map: '" + mapName + "', key: 'uintptr // C.void *', value: 'C.ssl_sock_t'\n")
 		iter := currentMap.Iterate()
 		var key uintptr // C.void *
-		var value ebpf.SSLSock
+		var value ddebpf.SSLSock
 		for iter.Next(unsafe.Pointer(&key), unsafe.Pointer(&value)) {
 			output.WriteString(spew.Sdump(key, value))
 		}
@@ -68,7 +62,7 @@ func dumpMapsHandler(managerMap *manager.Map, manager *manager.Manager) string {
 		output.WriteString("Map: '" + mapName + "', key: 'C.__u64', value: 'C.ssl_read_args_t'\n")
 		iter := currentMap.Iterate()
 		var key uint64
-		var value ebpf.SSLReadArgs
+		var value ddebpf.SSLReadArgs
 		for iter.Next(unsafe.Pointer(&key), unsafe.Pointer(&value)) {
 			output.WriteString(spew.Sdump(key, value))
 		}
@@ -92,10 +86,4 @@ func dumpMapsHandler(managerMap *manager.Map, manager *manager.Manager) string {
 		}
 	}
 	return output.String()
-}
-
-func setupDumpHandler(manager *manager.Manager) {
-	for _, m := range manager.Maps {
-		m.DumpHandler = dumpMapsHandler
-	}
 }

--- a/pkg/network/http/monitor.go
+++ b/pkg/network/http/monitor.go
@@ -17,8 +17,8 @@ import (
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	filterpkg "github.com/DataDog/datadog-agent/pkg/network/filter"
-	"github.com/DataDog/ebpf"
-	"github.com/DataDog/ebpf/manager"
+	manager "github.com/DataDog/ebpf-manager"
+	"github.com/cilium/ebpf"
 )
 
 // HTTPMonitorStats is used for holding two kinds of stats:
@@ -63,7 +63,7 @@ func NewMonitor(c *config.Config, offsets []manager.ConstantEditor, sockFD *ebpf
 		return nil, fmt.Errorf("error initializing http ebpf program: %s", err)
 	}
 
-	filter, _ := mgr.GetProbe(manager.ProbeIdentificationPair{Section: httpSocketFilter})
+	filter, _ := mgr.GetProbe(manager.ProbeIdentificationPair{EBPFSection: httpSocketFilter, EBPFFuncName: "socket__http_filter"})
 	if filter == nil {
 		return nil, fmt.Errorf("error retrieving socket filter")
 	}
@@ -84,7 +84,7 @@ func NewMonitor(c *config.Config, offsets []manager.ConstantEditor, sockFD *ebpf
 	}
 
 	notificationMap, _, _ := mgr.GetMap(httpNotificationsPerfMap)
-	numCPUs := int(notificationMap.ABI().MaxEntries)
+	numCPUs := int(notificationMap.MaxEntries())
 
 	telemetry := newTelemetry()
 	statkeeper := newHTTPStatkeeper(c, telemetry)

--- a/pkg/network/tracer/connection/kprobe/dump.go
+++ b/pkg/network/tracer/connection/kprobe/dump.go
@@ -12,22 +12,16 @@ import (
 	"strings"
 	"unsafe"
 
-	"github.com/DataDog/datadog-agent/pkg/network/ebpf"
+	ddebpf "github.com/DataDog/datadog-agent/pkg/network/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/ebpf/manager"
-
+	manager "github.com/DataDog/ebpf-manager"
+	"github.com/cilium/ebpf"
 	"github.com/davecgh/go-spew/spew"
 )
 
-func dumpMapsHandler(managerMap *manager.Map, manager *manager.Manager) string {
+func dumpMapsHandler(manager *manager.Manager, mapName string, currentMap *ebpf.Map) string {
 	var output strings.Builder
-
-	mapName := managerMap.Name
-	currentMap, found, err := manager.GetMap(mapName)
-	if err != nil || !found {
-		return ""
-	}
 
 	switch mapName {
 
@@ -44,7 +38,7 @@ func dumpMapsHandler(managerMap *manager.Map, manager *manager.Manager) string {
 		output.WriteString("Map: '" + mapName + "', key: 'C.__u64', value: 'tracerStatus'\n")
 		iter := currentMap.Iterate()
 		var key uint64
-		var value ebpf.TracerStatus
+		var value ddebpf.TracerStatus
 		for iter.Next(unsafe.Pointer(&key), unsafe.Pointer(&value)) {
 			output.WriteString(spew.Sdump(key, value))
 		}
@@ -52,8 +46,8 @@ func dumpMapsHandler(managerMap *manager.Map, manager *manager.Manager) string {
 	case string(probes.ConntrackMap): // maps/conntrack (BPF_MAP_TYPE_HASH), key ConnTuple, value ConnTuple
 		output.WriteString("Map: '" + mapName + "', key: 'ConnTuple', value: 'ConnTuple'\n")
 		iter := currentMap.Iterate()
-		var key ebpf.ConnTuple
-		var value ebpf.ConnTuple
+		var key ddebpf.ConnTuple
+		var value ddebpf.ConnTuple
 		for iter.Next(unsafe.Pointer(&key), unsafe.Pointer(&value)) {
 			output.WriteString(spew.Sdump(key, value))
 		}
@@ -61,7 +55,7 @@ func dumpMapsHandler(managerMap *manager.Map, manager *manager.Manager) string {
 	case string(probes.ConntrackTelemetryMap): // maps/conntrack_telemetry (BPF_MAP_TYPE_ARRAY), key C.u32, value conntrackTelemetry
 		output.WriteString("Map: '" + mapName + "', key: 'C.u32', value: 'conntrackTelemetry'\n")
 		var zero uint64
-		telemetry := &ebpf.ConntrackTelemetry{}
+		telemetry := &ddebpf.ConntrackTelemetry{}
 		if err := currentMap.Lookup(unsafe.Pointer(&zero), unsafe.Pointer(telemetry)); err != nil {
 			log.Tracef("error retrieving the contrack telemetry struct: %s", err)
 		}
@@ -79,7 +73,7 @@ func dumpMapsHandler(managerMap *manager.Map, manager *manager.Manager) string {
 	case string(probes.SockByPidFDMap): // maps/sock_by_pid_fd (BPF_MAP_TYPE_HASH), key C.pid_fd_t, value uintptr // C.struct sock*
 		output.WriteString("Map: '" + mapName + "', key: 'C.pid_fd_t', value: 'uintptr // C.struct sock*'\n")
 		iter := currentMap.Iterate()
-		var key ebpf.PIDFD
+		var key ddebpf.PIDFD
 		var value uintptr // C.struct sock*
 		for iter.Next(unsafe.Pointer(&key), unsafe.Pointer(&value)) {
 			output.WriteString(spew.Sdump(key, value))
@@ -89,7 +83,7 @@ func dumpMapsHandler(managerMap *manager.Map, manager *manager.Manager) string {
 		output.WriteString("Map: '" + mapName + "', key: 'uintptr // C.struct sock*', value: 'C.pid_fd_t'\n")
 		iter := currentMap.Iterate()
 		var key uintptr // C.struct sock*
-		var value ebpf.PIDFD
+		var value ddebpf.PIDFD
 		for iter.Next(unsafe.Pointer(&key), unsafe.Pointer(&value)) {
 			output.WriteString(spew.Sdump(key, value))
 		}
@@ -97,8 +91,8 @@ func dumpMapsHandler(managerMap *manager.Map, manager *manager.Manager) string {
 	case string(probes.ConnMap): // maps/conn_stats (BPF_MAP_TYPE_HASH), key ConnTuple, value ConnStatsWithTimestamp
 		output.WriteString("Map: '" + mapName + "', key: 'ConnTuple', value: 'ConnStatsWithTimestamp'\n")
 		iter := currentMap.Iterate()
-		var key ebpf.ConnTuple
-		var value ebpf.ConnStats
+		var key ddebpf.ConnTuple
+		var value ddebpf.ConnStats
 		for iter.Next(unsafe.Pointer(&key), unsafe.Pointer(&value)) {
 			output.WriteString(spew.Sdump(key, value))
 		}
@@ -106,8 +100,8 @@ func dumpMapsHandler(managerMap *manager.Map, manager *manager.Manager) string {
 	case string(probes.TcpStatsMap): // maps/tcp_stats (BPF_MAP_TYPE_HASH), key ConnTuple, value TCPStats
 		output.WriteString("Map: '" + mapName + "', key: 'ConnTuple', value: 'TCPStats'\n")
 		iter := currentMap.Iterate()
-		var key ebpf.ConnTuple
-		var value ebpf.TCPStats
+		var key ddebpf.ConnTuple
+		var value ddebpf.TCPStats
 		for iter.Next(unsafe.Pointer(&key), unsafe.Pointer(&value)) {
 			output.WriteString(spew.Sdump(key, value))
 		}
@@ -116,7 +110,7 @@ func dumpMapsHandler(managerMap *manager.Map, manager *manager.Manager) string {
 		output.WriteString("Map: '" + mapName + "', key: 'C.__u32', value: 'batch'\n")
 		iter := currentMap.Iterate()
 		var key uint32
-		var value ebpf.Batch
+		var value ddebpf.Batch
 		for iter.Next(unsafe.Pointer(&key), unsafe.Pointer(&value)) {
 			output.WriteString(spew.Sdump(key, value))
 		}
@@ -125,7 +119,7 @@ func dumpMapsHandler(managerMap *manager.Map, manager *manager.Manager) string {
 		output.WriteString("Map: '" + mapName + "', key: 'C.__u64', value: 'C.udp_recv_sock_t'\n")
 		iter := currentMap.Iterate()
 		var key uint64
-		var value ebpf.UDPRecvSock
+		var value ddebpf.UDPRecvSock
 		for iter.Next(unsafe.Pointer(&key), unsafe.Pointer(&value)) {
 			output.WriteString(spew.Sdump(key, value))
 		}
@@ -133,7 +127,7 @@ func dumpMapsHandler(managerMap *manager.Map, manager *manager.Manager) string {
 	case string(probes.PortBindingsMap): // maps/port_bindings (BPF_MAP_TYPE_HASH), key portBindingTuple, value C.__u8
 		output.WriteString("Map: '" + mapName + "', key: 'portBindingTuple', value: 'C.__u8'\n")
 		iter := currentMap.Iterate()
-		var key ebpf.PortBinding
+		var key ddebpf.PortBinding
 		var value uint8
 		for iter.Next(unsafe.Pointer(&key), unsafe.Pointer(&value)) {
 			output.WriteString(spew.Sdump(key, value))
@@ -142,7 +136,7 @@ func dumpMapsHandler(managerMap *manager.Map, manager *manager.Manager) string {
 	case string(probes.UdpPortBindingsMap): // maps/udp_port_bindings (BPF_MAP_TYPE_HASH), key portBindingTuple, value C.__u8
 		output.WriteString("Map: '" + mapName + "', key: 'portBindingTuple', value: 'C.__u8'\n")
 		iter := currentMap.Iterate()
-		var key ebpf.PortBinding
+		var key ddebpf.PortBinding
 		var value uint8
 		for iter.Next(unsafe.Pointer(&key), unsafe.Pointer(&value)) {
 			output.WriteString(spew.Sdump(key, value))
@@ -152,7 +146,7 @@ func dumpMapsHandler(managerMap *manager.Map, manager *manager.Manager) string {
 		output.WriteString("Map: '" + mapName + "', key: 'C.__u64', value: 'C.bind_syscall_args_t'\n")
 		iter := currentMap.Iterate()
 		var key uint64
-		var value ebpf.BindSyscallArgs
+		var value ddebpf.BindSyscallArgs
 		for iter.Next(unsafe.Pointer(&key), unsafe.Pointer(&value)) {
 			output.WriteString(spew.Sdump(key, value))
 		}
@@ -160,7 +154,7 @@ func dumpMapsHandler(managerMap *manager.Map, manager *manager.Manager) string {
 	case string(probes.TelemetryMap): // maps/telemetry (BPF_MAP_TYPE_ARRAY), key C.u32, value kernelTelemetry
 		output.WriteString("Map: '" + mapName + "', key: 'C.u32', value: 'kernelTelemetry'\n")
 		var zero uint64
-		telemetry := &ebpf.Telemetry{}
+		telemetry := &ddebpf.Telemetry{}
 		if err := currentMap.Lookup(unsafe.Pointer(&zero), unsafe.Pointer(telemetry)); err != nil {
 			// This can happen if we haven't initialized the telemetry object yet
 			// so let's just use a trace log
@@ -180,10 +174,4 @@ func dumpMapsHandler(managerMap *manager.Map, manager *manager.Manager) string {
 	}
 
 	return output.String()
-}
-
-func setupDumpHandler(manager *manager.Manager) {
-	for _, m := range manager.Maps {
-		m.DumpHandler = dumpMapsHandler
-	}
 }

--- a/pkg/network/tracer/connection/kprobe/manager.go
+++ b/pkg/network/tracer/connection/kprobe/manager.go
@@ -10,10 +10,11 @@ package kprobe
 
 import (
 	"os"
+	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
-	"github.com/DataDog/ebpf/manager"
+	manager "github.com/DataDog/ebpf-manager"
 )
 
 const (
@@ -21,6 +22,38 @@ const (
 	// This value should be enough for typical workloads (e.g. some amount of processes blocked on the `accept` syscall).
 	maxActive = 128
 )
+
+var mainProbes = map[probes.ProbeName]string{
+	probes.TCPSendMsg:           "kprobe__tcp_sendmsg",
+	probes.TCPCleanupRBuf:       "kprobe__tcp_cleanup_rbuf",
+	probes.TCPClose:             "kprobe__tcp_close",
+	probes.TCPCloseReturn:       "kretprobe__tcp_close",
+	probes.TCPSetState:          "kprobe__tcp_set_state",
+	probes.IPMakeSkb:            "kprobe__ip_make_skb",
+	probes.IP6MakeSkb:           "kprobe__ip6_make_skb",
+	probes.UDPRecvMsg:           "kprobe__udp_recvmsg",
+	probes.UDPRecvMsgReturn:     "kretprobe__udp_recvmsg",
+	probes.TCPRetransmit:        "kprobe__tcp_retransmit_skb",
+	probes.InetCskAcceptReturn:  "kretprobe__inet_csk_accept",
+	probes.InetCskListenStop:    "kprobe__inet_csk_listen_stop",
+	probes.UDPDestroySock:       "kprobe__udp_destroy_sock",
+	probes.UDPDestroySockReturn: "kretprobe__udp_destroy_sock",
+	probes.InetBind:             "kprobe__inet_bind",
+	probes.Inet6Bind:            "kprobe__inet6_bind",
+	probes.InetBindRet:          "kretprobe__inet_bind",
+	probes.Inet6BindRet:         "kretprobe__inet6_bind",
+	probes.SockFDLookup:         "kprobe__sockfd_lookup_light",
+	probes.SockFDLookupRet:      "kretprobe__sockfd_lookup_light",
+	probes.DoSendfile:           "kprobe__do_sendfile",
+	probes.DoSendfileRet:        "kretprobe__do_sendfile",
+}
+
+var altProbes = map[probes.ProbeName]string{
+	probes.TCPRetransmitPre470: "kprobe__tcp_retransmit_skb_pre_4_7_0",
+	probes.IP6MakeSkbPre470:    "kprobe__ip6_make_skb__pre_4_7_0",
+	probes.UDPRecvMsgPre410:    "kprobe__udp_recvmsg_pre_4_1_0",
+	probes.TCPSendMsgPre410:    "kprobe__tcp_sendmsg__pre_4_1_0",
+}
 
 func newManager(closedHandler *ebpf.PerfHandler, runtimeTracer bool) *manager.Manager {
 	mgr := &manager.Manager{
@@ -49,32 +82,19 @@ func newManager(closedHandler *ebpf.PerfHandler, runtimeTracer bool) *manager.Ma
 				},
 			},
 		},
-		Probes: []*manager.Probe{
-			{Section: string(probes.TCPSendMsg)},
-			{Section: string(probes.TCPCleanupRBuf)},
-			{Section: string(probes.TCPClose)},
-			{Section: string(probes.TCPCloseReturn), KProbeMaxActive: maxActive},
-			{Section: string(probes.TCPSetState)},
-			{Section: string(probes.IPMakeSkb)},
-			{Section: string(probes.IP6MakeSkb)},
-			{Section: string(probes.UDPRecvMsg)},
-			{Section: string(probes.UDPRecvMsgReturn), KProbeMaxActive: maxActive},
-			{Section: string(probes.TCPRetransmit)},
-			{Section: string(probes.InetCskAcceptReturn), KProbeMaxActive: maxActive},
-			{Section: string(probes.InetCskListenStop)},
-			{Section: string(probes.UDPDestroySock)},
-			{Section: string(probes.UDPDestroySockReturn), KProbeMaxActive: maxActive},
-			{Section: string(probes.InetBind)},
-			{Section: string(probes.Inet6Bind)},
-			{Section: string(probes.InetBindRet), KProbeMaxActive: maxActive},
-			{Section: string(probes.Inet6BindRet), KProbeMaxActive: maxActive},
-			{Section: string(probes.IPRouteOutputFlow)},
-			{Section: string(probes.IPRouteOutputFlowReturn), KProbeMaxActive: maxActive},
-			{Section: string(probes.SockFDLookup)},
-			{Section: string(probes.SockFDLookupRet), KProbeMaxActive: maxActive},
-			{Section: string(probes.DoSendfile)},
-			{Section: string(probes.DoSendfileRet), KProbeMaxActive: maxActive},
-		},
+	}
+
+	for probeName, funcName := range mainProbes {
+		p := &manager.Probe{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFSection:  string(probeName),
+				EBPFFuncName: funcName,
+			},
+		}
+		if strings.HasPrefix(funcName, "kretprobe") {
+			p.KProbeMaxActive = maxActive
+		}
+		mgr.Probes = append(mgr.Probes, p)
 	}
 
 	// the runtime compiled tracer has no need for separate probes targeting specific kernel versions, since it can
@@ -82,10 +102,10 @@ func newManager(closedHandler *ebpf.PerfHandler, runtimeTracer bool) *manager.Ma
 	// tracer.
 	if !runtimeTracer {
 		mgr.Probes = append(mgr.Probes,
-			&manager.Probe{Section: string(probes.TCPRetransmitPre470), MatchFuncName: "^tcp_retransmit_skb$"},
-			&manager.Probe{Section: string(probes.IP6MakeSkbPre470), MatchFuncName: "^ip6_make_skb$"},
-			&manager.Probe{Section: string(probes.UDPRecvMsgPre410), MatchFuncName: "^udp_recvmsg$"},
-			&manager.Probe{Section: string(probes.TCPSendMsgPre410), MatchFuncName: "^tcp_sendmsg$"},
+			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: string(probes.TCPRetransmitPre470), EBPFFuncName: "kprobe__tcp_retransmit_skb_pre_4_7_0"}, MatchFuncName: "^tcp_retransmit_skb$"},
+			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: string(probes.IP6MakeSkbPre470), EBPFFuncName: "kprobe__ip6_make_skb__pre_4_7_0"}, MatchFuncName: "^ip6_make_skb$"},
+			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: string(probes.UDPRecvMsgPre410), EBPFFuncName: "kprobe__udp_recvmsg_pre_4_1_0"}, MatchFuncName: "^udp_recvmsg$"},
+			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: string(probes.TCPSendMsgPre410), EBPFFuncName: "kprobe__tcp_sendmsg__pre_4_1_0"}, MatchFuncName: "^tcp_sendmsg$"},
 		)
 	}
 

--- a/pkg/network/tracer/connection/kprobe/perf_batching.go
+++ b/pkg/network/tracer/connection/kprobe/perf_batching.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/network"
 	netebpf "github.com/DataDog/datadog-agent/pkg/network/ebpf"
-	"github.com/DataDog/ebpf"
+	"github.com/cilium/ebpf"
 )
 
 const defaultExpiredStateInterval = 60 * time.Second

--- a/pkg/network/tracer/connection/kprobe/tcp_close_consumer.go
+++ b/pkg/network/tracer/connection/kprobe/tcp_close_consumer.go
@@ -16,7 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network"
 	netebpf "github.com/DataDog/datadog-agent/pkg/network/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
-	"github.com/DataDog/ebpf/manager"
+	manager "github.com/DataDog/ebpf-manager"
 )
 
 const (
@@ -46,7 +46,7 @@ func newTCPCloseConsumer(m *manager.Manager, perfHandler *ddebpf.PerfHandler) (*
 		return nil, err
 	}
 
-	numCPUs := int(connCloseEventMap.ABI().MaxEntries)
+	numCPUs := int(connCloseEventMap.MaxEntries())
 	batchManager, err := newPerfBatchManager(connCloseMap, numCPUs)
 	if err != nil {
 		return nil, err

--- a/pkg/network/tracer/connection/tracer.go
+++ b/pkg/network/tracer/connection/tracer.go
@@ -7,7 +7,7 @@ package connection
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/network"
-	"github.com/DataDog/ebpf"
+	"github.com/cilium/ebpf"
 )
 
 // Tracer is the common interface implemented by all connection tracers.

--- a/pkg/network/tracer/ebpf_conntracker.go
+++ b/pkg/network/tracer/ebpf_conntracker.go
@@ -27,9 +27,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/netlink"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/ebpf"
-	"github.com/DataDog/ebpf/manager"
+	manager "github.com/DataDog/ebpf-manager"
 	"github.com/cihub/seelog"
+	"github.com/cilium/ebpf"
 	ct "github.com/florianl/go-conntrack"
 	"golang.org/x/sys/unix"
 )
@@ -361,7 +361,7 @@ func getManager(buf io.ReaderAt, maxStateSize int) (*manager.Manager, error) {
 		},
 		PerfMaps: []*manager.PerfMap{},
 		Probes: []*manager.Probe{
-			{Section: string(probes.ConntrackHashInsert)},
+			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: string(probes.ConntrackHashInsert), EBPFFuncName: "kprobe___nf_conntrack_hash_insert"}},
 		},
 	}
 

--- a/pkg/network/tracer/offsetguess.go
+++ b/pkg/network/tracer/offsetguess.go
@@ -29,8 +29,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/ebpf"
-	"github.com/DataDog/ebpf/manager"
+	manager "github.com/DataDog/ebpf-manager"
+	"github.com/cilium/ebpf"
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
@@ -119,6 +119,23 @@ type fieldValues struct {
 	dportFl6 uint16
 }
 
+var offsetProbes = map[probes.ProbeName]string{
+	probes.TCPGetSockOpt:      "kprobe__tcp_getsockopt",
+	probes.SockGetSockOpt:     "kprobe__sock_common_getsockopt",
+	probes.TCPv6Connect:       "kprobe__tcp_v6_connect",
+	probes.IPMakeSkb:          "kprobe__ip_make_skb",
+	probes.IP6MakeSkb:         "kprobe__ip6_make_skb",
+	probes.IP6MakeSkbPre470:   "kprobe__ip6_make_skb__pre_4_7_0",
+	probes.TCPv6ConnectReturn: "kretprobe__tcp_v6_connect",
+}
+
+func idPair(name probes.ProbeName) manager.ProbeIdentificationPair {
+	return manager.ProbeIdentificationPair{
+		EBPFSection:  string(name),
+		EBPFFuncName: offsetProbes[name],
+	}
+}
+
 func newOffsetManager() *manager.Manager {
 	return &manager.Manager{
 		Maps: []*manager.Map{
@@ -127,13 +144,13 @@ func newOffsetManager() *manager.Manager {
 		},
 		PerfMaps: []*manager.PerfMap{},
 		Probes: []*manager.Probe{
-			{Section: string(probes.TCPGetSockOpt)},
-			{Section: string(probes.SockGetSockOpt)},
-			{Section: string(probes.TCPv6Connect)},
-			{Section: string(probes.IPMakeSkb)},
-			{Section: string(probes.IP6MakeSkb)},
-			{Section: string(probes.IP6MakeSkbPre470), MatchFuncName: "^ip6_make_skb$"},
-			{Section: string(probes.TCPv6ConnectReturn), KProbeMaxActive: 128},
+			{ProbeIdentificationPair: idPair(probes.TCPGetSockOpt)},
+			{ProbeIdentificationPair: idPair(probes.SockGetSockOpt)},
+			{ProbeIdentificationPair: idPair(probes.TCPv6Connect)},
+			{ProbeIdentificationPair: idPair(probes.IPMakeSkb)},
+			{ProbeIdentificationPair: idPair(probes.IP6MakeSkb)},
+			{ProbeIdentificationPair: idPair(probes.IP6MakeSkbPre470), MatchFuncName: "^ip6_make_skb$"},
+			{ProbeIdentificationPair: idPair(probes.TCPv6ConnectReturn), KProbeMaxActive: 128},
 		},
 	}
 }
@@ -234,16 +251,21 @@ func waitUntilStable(conn net.Conn, window time.Duration, attempts int) (*fieldV
 	return nil, errors.New("unstable TCP socket params")
 }
 
-func offsetGuessProbes(c *config.Config) (map[probes.ProbeName]struct{}, error) {
-	p := map[probes.ProbeName]struct{}{
-		probes.TCPGetSockOpt:  {},
-		probes.SockGetSockOpt: {},
-		probes.IPMakeSkb:      {},
+func enableProbe(enabled map[probes.ProbeName]string, name probes.ProbeName) {
+	if fn, ok := offsetProbes[name]; ok {
+		enabled[name] = fn
 	}
+}
+
+func offsetGuessProbes(c *config.Config) (map[probes.ProbeName]string, error) {
+	p := map[probes.ProbeName]string{}
+	enableProbe(p, probes.TCPGetSockOpt)
+	enableProbe(p, probes.SockGetSockOpt)
+	enableProbe(p, probes.IPMakeSkb)
 
 	if c.CollectIPv6Conns {
-		p[probes.TCPv6Connect] = struct{}{}
-		p[probes.TCPv6ConnectReturn] = struct{}{}
+		enableProbe(p, probes.TCPv6Connect)
+		enableProbe(p, probes.TCPv6ConnectReturn)
 
 		kv, err := kernel.HostVersion()
 		if err != nil {
@@ -251,11 +273,10 @@ func offsetGuessProbes(c *config.Config) (map[probes.ProbeName]struct{}, error) 
 		}
 
 		if kv < kernel.VersionCode(4, 7, 0) {
-			p[probes.IP6MakeSkbPre470] = struct{}{}
+			enableProbe(p, probes.IP6MakeSkbPre470)
 		} else {
-			p[probes.IP6MakeSkb] = struct{}{}
+			enableProbe(p, probes.IP6MakeSkb)
 		}
-
 	}
 	return p, nil
 }

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -34,8 +34,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/ebpf"
-	"github.com/DataDog/ebpf/manager"
+	manager "github.com/DataDog/ebpf-manager"
+	"github.com/cilium/ebpf"
 	"golang.org/x/sys/unix"
 )
 
@@ -240,16 +240,17 @@ func runOffsetGuessing(config *config.Config, buf bytecode.AssetReader) ([]manag
 	}
 
 	for _, p := range offsetMgr.Probes {
-		if _, enabled := enabledProbes[probes.ProbeName(p.Section)]; !enabled {
-			offsetOptions.ExcludedSections = append(offsetOptions.ExcludedSections, p.Section)
+		if _, enabled := enabledProbes[probes.ProbeName(p.EBPFSection)]; !enabled {
+			offsetOptions.ExcludedFunctions = append(offsetOptions.ExcludedFunctions, p.EBPFFuncName)
 		}
 	}
-	for probeName := range enabledProbes {
+	for probeName, funcName := range enabledProbes {
 		offsetOptions.ActivatedProbes = append(
 			offsetOptions.ActivatedProbes,
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					Section: string(probeName),
+					EBPFSection:  string(probeName),
+					EBPFFuncName: funcName,
 				},
 			})
 	}

--- a/pkg/util/kernel/version_test.go
+++ b/pkg/util/kernel/version_test.go
@@ -42,3 +42,90 @@ func TestUbuntuKernelVersion(t *testing.T) {
 	assert.Equal(t, ukv.Abi, 35)
 	assert.Equal(t, ukv.Flavor, "generic-lpae")
 }
+
+var testData = []struct {
+	succeed       bool
+	releaseString string
+	kernelVersion uint32
+}{
+	{true, "4.1.2-3", 262402},
+	{true, "4.8.14-200.fc24.x86_64", 264206},
+	{true, "4.1.2-3foo", 262402},
+	{true, "4.1.2foo-1", 262402},
+	{true, "4.1.2-rkt-v1", 262402},
+	{true, "4.1.2rkt-v1", 262402},
+	{true, "4.1.2-3 foo", 262402},
+	{false, "foo 4.1.2-3", 0},
+	{true, "4.1.2", 262402},
+	{false, ".4.1.2", 0},
+	{false, "4", 0},
+	{false, "4.", 0},
+	{true, "4.1.", 262400},
+	{true, "4.1", 262400},
+	{true, "4.19-ovh", 267008},
+	{true, "4.14.252", 265983},
+}
+
+func TestParseReleaseString(t *testing.T) {
+	for _, test := range testData {
+		version, err := ParseReleaseString(test.releaseString)
+		if err != nil && test.succeed {
+			t.Errorf("expected %q to succeed: %s", test.releaseString, err)
+		} else if err == nil && !test.succeed {
+			t.Errorf("expected %q to fail", test.releaseString)
+		}
+		if version != Version(test.kernelVersion) {
+			t.Errorf("expected kernel version %d, got %d", test.kernelVersion, version)
+		}
+	}
+}
+
+func TestParseDebianVersion(t *testing.T) {
+	for _, tc := range []struct {
+		succeed       bool
+		releaseString string
+		kernelVersion uint32
+	}{
+		// 4.9.168
+		{true, "Linux version 4.9.0-9-amd64 (debian-kernel@lists.debian.org) (gcc version 6.3.0 20170516 (Debian 6.3.0-18+deb9u1) ) #1 SMP Debian 4.9.168-1+deb9u3 (2019-06-16)", 264616},
+		// 4.9.88
+		{true, "Linux ip-10-0-75-49 4.9.0-6-amd64 #1 SMP Debian 4.9.88-1+deb9u1 (2018-05-07) x86_64 GNU/Linux", 264536},
+		// 3.0.4
+		{true, "Linux version 3.16.0-9-amd64 (debian-kernel@lists.debian.org) (gcc version 4.9.2 (Debian 4.9.2-10+deb8u2) ) #1 SMP Debian 3.16.68-1 (2019-05-22)", 200772},
+		// Invalid
+		{false, "Linux version 4.9.125-linuxkit (root@659b6d51c354) (gcc version 6.4.0 (Alpine 6.4.0) ) #1 SMP Fri Sep 7 08:20:28 UTC 2018", 0},
+		// 4.9.258-1 overflow of patch version which has max 255
+		{true, "Linux version 4.9.0-15-amd64 (debian-kernel@lists.debian.org) (gcc version 6.3.0 20170516 (Debian 6.3.0-18+deb9u1) ) #1 SMP Debian 4.9.258-1 (2021-03-08)", 264703},
+	} {
+		version, err := parseDebianVersion(tc.releaseString)
+		if err != nil && tc.succeed {
+			t.Errorf("expected %q to succeed: %s", tc.releaseString, err)
+		} else if err == nil && !tc.succeed {
+			t.Errorf("expected %q to fail", tc.releaseString)
+		}
+		if version != Version(tc.kernelVersion) {
+			t.Errorf("expected kernel version %d, got %d", tc.kernelVersion, version)
+		}
+	}
+}
+
+func TestParseUbuntuVersion(t *testing.T) {
+	for _, tc := range []struct {
+		succeed       bool
+		procVersion   string
+		kernelVersion uint32
+	}{
+		// 5.4.0-52.57
+		{true, "Ubuntu 5.4.0-52.57-generic 5.4.65", 328769},
+	} {
+		version, err := parseUbuntuVersion(tc.procVersion)
+		if err != nil && tc.succeed {
+			t.Errorf("expected %q to succeed: %s", tc.procVersion, err)
+		} else if err == nil && !tc.succeed {
+			t.Errorf("expected %q to fail", tc.procVersion)
+		}
+		if version != Version(tc.kernelVersion) {
+			t.Errorf("expected kernel version %d, got %d", tc.kernelVersion, version)
+		}
+	}
+}


### PR DESCRIPTION
### What does this PR do?

This is an "un-revert" of #10388 and #10504

### Motivation

Reintroduction of changes after evaluating performance.

### Additional Notes

No performance changes in CPU compared to current `main` (orange vs red):
https://ddstaging.datadoghq.com/s/c894ecec5/c3z-d5p-8nn
Or Memory:
https://ddstaging.datadoghq.com/s/c894ecec5/hmu-c4a-tcz
https://ddstaging.datadoghq.com/s/c894ecec5/7fk-tms-mgy

Full dashboard: https://ddstaging.datadoghq.com/dashboard/k7g-xnw-wjp/npm-performance-evaluation?tpl_var_base_env=main&tpl_var_base_namespace=main&tpl_var_compare_env=bryce-kahle&tpl_var_compare_namespace=hasan&tpl_var_role=server&from_ts=1649442477376&to_ts=1649446077376&live=false

Targeting `npm-main` branch while `main` is frozen.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Enabling each of the three modules: NPM, OOM Kill, and TCPQ and ensuring they startup and function is sufficient.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
