### PR TITLE
Fix address of non 64-bit aligned field XXX  passed to sync/XXX

### DIFF
--- a/pkg/aggregator/internal/tags/store.go
+++ b/pkg/aggregator/internal/tags/store.go
@@ -17,8 +17,8 @@ import (
 
 // Entry is used to keep track of tag slices shared by the contexts.
 type Entry struct {
-	tags []string
 	refs uint64
+	tags []string
 }
 
 // Tags returns the strings stored in the Entry. The slice may be

--- a/pkg/metrics/iterable_series.go
+++ b/pkg/metrics/iterable_series.go
@@ -16,12 +16,12 @@ import (
 // IterableSeries represents an iterable collection of Serie.
 // Serie can be appended to IterableSeries while IterableSeries is serialized
 type IterableSeries struct {
+	count              uint64
 	ch                 *util.BufferedChan
 	bufferedChanClosed bool
 	cancel             context.CancelFunc
 	callback           func(*Serie)
 	current            *Serie
-	count              uint64
 }
 
 // NewIterableSeries creates a new instance of *IterableSeries

--- a/pkg/process/procutil/process_linux.go
+++ b/pkg/process/procutil/process_linux.go
@@ -91,12 +91,12 @@ func WithBootTimeRefreshInterval(bootTimeRefreshInterval time.Duration) Option {
 
 // probe is a service that fetches process related info on current host
 type probe struct {
+	bootTime     uint64
 	procRootLoc  string // ProcFS
 	procRootFile *os.File
 	uid          uint32 // UID
 	euid         uint32 // Effective UID
 	clockTicks   float64
-	bootTime     uint64
 	exit         chan struct{}
 
 	// configurations


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fix address of non 64-bit aligned field XXX  passed to sync/XXX.

Fix the following warnings reported by staticcheck:
- pkg/aggregator/internal/tags/store.go:38:2: address of non 64-bit aligned field refs passed to sync/atomic.AddUint64 (SA1027)
- pkg/aggregator/internal/tags/store.go:81:3: address of non 64-bit aligned field refs passed to sync/atomic.AddUint64 (SA1027)
- pkg/aggregator/internal/tags/store.go:103:14: address of non 64-bit aligned field refs passed to sync/atomic.LoadUint64 (SA1027)
- pkg/metrics/iterable_series.go:42:2: address of non 64-bit aligned field count passed to sync/atomic.AddUint64 (SA1027)
- pkg/metrics/iterable_series.go:51:9: address of non 64-bit aligned field count passed to sync/atomic.LoadUint64 (SA1027)
- pkg/process/procutil/process_linux.go:124:2: address of non 64-bit aligned field bootTime passed to sync/atomic.StoreUint64 (SA1027)
- pkg/process/procutil/process_linux.go:156:4: address of non 64-bit aligned field bootTime passed to sync/atomic.StoreUint64 (SA1027)
- pkg/process/procutil/process_linux.go:622:41: address of non 64-bit aligned field bootTime passed to sync/atomic.LoadUint64 (SA1027)
- pkg/process/procutil/process_linux_test.go:671:2: address of non 64-bit aligned field bootTime passed to sync/atomic.StoreUint64 (SA1027)
- pkg/process/procutil/process_linux_test.go:781:27: address of non 64-bit aligned field bootTime passed to sync/atomic.LoadUint64 (SA1027)
- pkg/process/procutil/process_linux_test.go:789:38: address of non 64-bit aligned field bootTime passed to sync/atomic.LoadUint64 (SA1027)
- pkg/process/procutil/process_linux_test.go:795:66: address of non 64-bit aligned field bootTime passed to sync/atomic.LoadUint64 (SA1027)

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Misalignment leads to panic on 32 bits ARM platform.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

Don't use https://pkg.go.dev/github.com/uber-go/atomic to limit the number of changes as this is a fix for `7.36`.
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
