### PR TITLE
[rtloader] Support building on CMake >= 3.15

### DIFF
--- a/rtloader/three/CMakeLists.txt
+++ b/rtloader/three/CMakeLists.txt
@@ -1,4 +1,6 @@
 cmake_minimum_required(VERSION 3.12)
+
+set(Python3_FIND_VIRTUALENV STANDARD) # Only link against conda's Python if nothing else is available
 find_package (Python3 COMPONENTS Interpreter Development)
 
 if(Python3_VERSION_MINOR LESS "7")

--- a/rtloader/two/CMakeLists.txt
+++ b/rtloader/two/CMakeLists.txt
@@ -1,4 +1,6 @@
 cmake_minimum_required(VERSION 3.12)
+
+set(Python2_FIND_VIRTUALENV STANDARD) # Only link against conda's Python if nothing else is available
 find_package (Python2 COMPONENTS Interpreter Development)
 
 if(Python2_VERSION_MINOR LESS "7")


### PR DESCRIPTION
### Motivation

Since CMake 3.15, `FindPython3` gives precedence to Pythons from active
virtual envs unless this flag is set [1]. Same for `FindPython2`.

[1] https://cmake.org/cmake/help/latest/module/FindPython3.html

### Describe how to test/QA your changes

We should be good as long as the `ldd` health check omnibus does on rtloader passes.
