### PR TITLE
[fix] check_logger now correctly logs next run message

### DIFF
--- a/pkg/collector/worker/check_logger.go
+++ b/pkg/collector/worker/check_logger.go
@@ -76,7 +76,7 @@ func (cl *CheckLogger) Debug(message string) {
 
 // shouldLogCheck returns if we should log the check start/stop message with higher
 // verbosity and if this is the end of the initial series of check log statements
-func shouldLogCheck(id check.ID) (bool, bool) {
+func shouldLogCheck(id check.ID) (shouldLog, lastVerboseLog bool) {
 	loggingFrequency := uint64(config.Datadog.GetInt64(loggingFrequencyConfigKey))
 
 	// If this is the first time we see the check, log it
@@ -86,11 +86,11 @@ func shouldLogCheck(id check.ID) (bool, bool) {
 		return true, false
 	}
 
-	// We print a special message when we change logging frequency
-	lastVerboseLog := stats.TotalRuns == initialCheckLoggingSeriesLimit
-
 	// `currentRun` is `stats.TotalRuns` + 1 as the first run would be 0.
 	currentRun := stats.TotalRuns + 1
+
+	// We print a special message when we change logging frequency
+	lastVerboseLog = currentRun == initialCheckLoggingSeriesLimit
 	// We log the first `initialCheckLoggingSeriesLimit` times, then every `loggingFrequency` times
 	if currentRun <= initialCheckLoggingSeriesLimit ||
 		currentRun%loggingFrequency == 0 {

--- a/pkg/collector/worker/check_logger_test.go
+++ b/pkg/collector/worker/check_logger_test.go
@@ -57,7 +57,7 @@ func TestShouldLogLastVerboseLog(t *testing.T) {
 	for idx := 1; idx < 10; idx++ {
 		testCheck := newTestCheck(fmt.Sprintf("testcheck %d", idx))
 
-		for logIdx := 0; logIdx < 61; logIdx++ {
+		for logIdx := 1; logIdx < 61; logIdx++ {
 			// Given a CheckLogger
 			checkLogger := CheckLogger{Check: testCheck}
 			// When I start the check
@@ -68,11 +68,14 @@ func TestShouldLogLastVerboseLog(t *testing.T) {
 			checkLogger.CheckFinished()
 
 			lastVerboseLog := checkLogger.lastVerboseLog
+			shouldLog := checkLogger.shouldLog
 
 			// Then lastVerboseLog should be true for 5th run
+			// And shouldLog should be true as well so that we log the next run message
 			// initialCheckLoggingSeriesLimit should be 5
 			if logIdx == 5 {
 				assert.True(t, lastVerboseLog, fmt.Sprintf("Loop idx: %d", logIdx))
+				assert.True(t, shouldLog, fmt.Sprintf("Loop idx: %d", logIdx))
 			} else {
 				assert.False(t, lastVerboseLog, fmt.Sprintf("Loop idx: %d", logIdx))
 			}


### PR DESCRIPTION

### What does this PR do?

This fixes the bug where the Agent would not log the frequency message after five checks.

### Motivation

Fixes a regression in the Agent.

### Additional Notes

N/A

### Possible Drawbacks / Trade-offs

N/A

### Describe how to test/QA your changes

Start the agent and tail `/var/log/datadog/agent.log`. After five checks you will see a message that is similar to the following:
```
Apr 11 16:38:47 dev-vm agent[617397]: 2022-04-11 16:38:47 CEST | CORE | INFO | (pkg/collector/worker/check_logger.go:38 in CheckStarted) | check:container | Running check...
Apr 11 16:38:47 dev-vm agent[617397]: 2022-04-11 16:38:47 CEST | CORE | INFO | (pkg/collector/worker/check_logger.go:57 in CheckFinished) | check:container | Done running check, next runs will be logged every 500 runs
```

After that, you won't see a log message for the check till the Agent has run the check 500 times. If you want to speed this up you can always set `logging_frequency` in the `datadog.yaml` to smaller value, e.g. 50.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
