### PR TITLE
[CWS] Isolate the glob matcher to the `*.file.path` fields using an operator override

### DIFF
--- a/docs/cloud-workload-security/agent_expressions.md
+++ b/docs/cloud-workload-security/agent_expressions.md
@@ -179,7 +179,7 @@ The *file.rights* attribute can now be used in addition to *file.mode*. *file.mo
 | `process.ancestors.euid` | int | Effective UID of the process |
 | `process.ancestors.euser` | string | Effective user of the process |
 | `process.ancestors.file.change_time` | int | Change time of the file |
-| `process.ancestors.file.filesystem` | string | FileSystem of the process executable |
+| `process.ancestors.file.filesystem` | string | File's filesystem |
 | `process.ancestors.file.gid` | int | GID of the file's owner |
 | `process.ancestors.file.group` | string | Group of the file's owner |
 | `process.ancestors.file.in_upper_layer` | bool | Indicator of the file layer, in an OverlayFS for example |
@@ -187,8 +187,8 @@ The *file.rights* attribute can now be used in addition to *file.mode*. *file.mo
 | `process.ancestors.file.mode` | int | Mode/rights of the file |
 | `process.ancestors.file.modification_time` | int | Modification time of the file |
 | `process.ancestors.file.mount_id` | int | Mount ID of the file |
-| `process.ancestors.file.name` | string | Basename of the path of the process executable |
-| `process.ancestors.file.path` | string | Path of the process executable |
+| `process.ancestors.file.name` | string | File's basename |
+| `process.ancestors.file.path` | string | File's path |
 | `process.ancestors.file.rights` | int | Mode/rights of the file |
 | `process.ancestors.file.uid` | int | UID of the file's owner |
 | `process.ancestors.file.user` | string | User of the file's owner |
@@ -224,7 +224,7 @@ The *file.rights* attribute can now be used in addition to *file.mode*. *file.mo
 | `process.euid` | int | Effective UID of the process |
 | `process.euser` | string | Effective user of the process |
 | `process.file.change_time` | int | Change time of the file |
-| `process.file.filesystem` | string | FileSystem of the process executable |
+| `process.file.filesystem` | string | File's filesystem |
 | `process.file.gid` | int | GID of the file's owner |
 | `process.file.group` | string | Group of the file's owner |
 | `process.file.in_upper_layer` | bool | Indicator of the file layer, in an OverlayFS for example |
@@ -232,8 +232,8 @@ The *file.rights* attribute can now be used in addition to *file.mode*. *file.mo
 | `process.file.mode` | int | Mode/rights of the file |
 | `process.file.modification_time` | int | Modification time of the file |
 | `process.file.mount_id` | int | Mount ID of the file |
-| `process.file.name` | string | Basename of the path of the process executable |
-| `process.file.path` | string | Path of the process executable |
+| `process.file.name` | string | File's basename |
+| `process.file.path` | string | File's path |
 | `process.file.rights` | int | Mode/rights of the file |
 | `process.file.uid` | int | UID of the file's owner |
 | `process.file.user` | string | User of the file's owner |
@@ -363,7 +363,7 @@ A process was executed or forked
 | `exec.euid` | int | Effective UID of the process |
 | `exec.euser` | string | Effective user of the process |
 | `exec.file.change_time` | int | Change time of the file |
-| `exec.file.filesystem` | string | FileSystem of the process executable |
+| `exec.file.filesystem` | string | File's filesystem |
 | `exec.file.gid` | int | GID of the file's owner |
 | `exec.file.group` | string | Group of the file's owner |
 | `exec.file.in_upper_layer` | bool | Indicator of the file layer, in an OverlayFS for example |
@@ -371,8 +371,8 @@ A process was executed or forked
 | `exec.file.mode` | int | Mode/rights of the file |
 | `exec.file.modification_time` | int | Modification time of the file |
 | `exec.file.mount_id` | int | Mount ID of the file |
-| `exec.file.name` | string | Basename of the path of the process executable |
-| `exec.file.path` | string | Path of the process executable |
+| `exec.file.name` | string | File's basename |
+| `exec.file.path` | string | File's path |
 | `exec.file.rights` | int | Mode/rights of the file |
 | `exec.file.uid` | int | UID of the file's owner |
 | `exec.file.user` | string | User of the file's owner |
@@ -559,7 +559,7 @@ A ptrace command was executed
 | `ptrace.tracee.ancestors.euid` | int | Effective UID of the process |
 | `ptrace.tracee.ancestors.euser` | string | Effective user of the process |
 | `ptrace.tracee.ancestors.file.change_time` | int | Change time of the file |
-| `ptrace.tracee.ancestors.file.filesystem` | string | FileSystem of the process executable |
+| `ptrace.tracee.ancestors.file.filesystem` | string | File's filesystem |
 | `ptrace.tracee.ancestors.file.gid` | int | GID of the file's owner |
 | `ptrace.tracee.ancestors.file.group` | string | Group of the file's owner |
 | `ptrace.tracee.ancestors.file.in_upper_layer` | bool | Indicator of the file layer, in an OverlayFS for example |
@@ -567,8 +567,8 @@ A ptrace command was executed
 | `ptrace.tracee.ancestors.file.mode` | int | Mode/rights of the file |
 | `ptrace.tracee.ancestors.file.modification_time` | int | Modification time of the file |
 | `ptrace.tracee.ancestors.file.mount_id` | int | Mount ID of the file |
-| `ptrace.tracee.ancestors.file.name` | string | Basename of the path of the process executable |
-| `ptrace.tracee.ancestors.file.path` | string | Path of the process executable |
+| `ptrace.tracee.ancestors.file.name` | string | File's basename |
+| `ptrace.tracee.ancestors.file.path` | string | File's path |
 | `ptrace.tracee.ancestors.file.rights` | int | Mode/rights of the file |
 | `ptrace.tracee.ancestors.file.uid` | int | UID of the file's owner |
 | `ptrace.tracee.ancestors.file.user` | string | User of the file's owner |
@@ -604,7 +604,7 @@ A ptrace command was executed
 | `ptrace.tracee.euid` | int | Effective UID of the process |
 | `ptrace.tracee.euser` | string | Effective user of the process |
 | `ptrace.tracee.file.change_time` | int | Change time of the file |
-| `ptrace.tracee.file.filesystem` | string | FileSystem of the process executable |
+| `ptrace.tracee.file.filesystem` | string | File's filesystem |
 | `ptrace.tracee.file.gid` | int | GID of the file's owner |
 | `ptrace.tracee.file.group` | string | Group of the file's owner |
 | `ptrace.tracee.file.in_upper_layer` | bool | Indicator of the file layer, in an OverlayFS for example |
@@ -612,8 +612,8 @@ A ptrace command was executed
 | `ptrace.tracee.file.mode` | int | Mode/rights of the file |
 | `ptrace.tracee.file.modification_time` | int | Modification time of the file |
 | `ptrace.tracee.file.mount_id` | int | Mount ID of the file |
-| `ptrace.tracee.file.name` | string | Basename of the path of the process executable |
-| `ptrace.tracee.file.path` | string | Path of the process executable |
+| `ptrace.tracee.file.name` | string | File's basename |
+| `ptrace.tracee.file.path` | string | File's path |
 | `ptrace.tracee.file.rights` | int | Mode/rights of the file |
 | `ptrace.tracee.file.uid` | int | UID of the file's owner |
 | `ptrace.tracee.file.user` | string | User of the file's owner |
@@ -801,7 +801,7 @@ A signal was sent
 | `signal.target.ancestors.euid` | int | Effective UID of the process |
 | `signal.target.ancestors.euser` | string | Effective user of the process |
 | `signal.target.ancestors.file.change_time` | int | Change time of the file |
-| `signal.target.ancestors.file.filesystem` | string | FileSystem of the process executable |
+| `signal.target.ancestors.file.filesystem` | string | File's filesystem |
 | `signal.target.ancestors.file.gid` | int | GID of the file's owner |
 | `signal.target.ancestors.file.group` | string | Group of the file's owner |
 | `signal.target.ancestors.file.in_upper_layer` | bool | Indicator of the file layer, in an OverlayFS for example |
@@ -809,8 +809,8 @@ A signal was sent
 | `signal.target.ancestors.file.mode` | int | Mode/rights of the file |
 | `signal.target.ancestors.file.modification_time` | int | Modification time of the file |
 | `signal.target.ancestors.file.mount_id` | int | Mount ID of the file |
-| `signal.target.ancestors.file.name` | string | Basename of the path of the process executable |
-| `signal.target.ancestors.file.path` | string | Path of the process executable |
+| `signal.target.ancestors.file.name` | string | File's basename |
+| `signal.target.ancestors.file.path` | string | File's path |
 | `signal.target.ancestors.file.rights` | int | Mode/rights of the file |
 | `signal.target.ancestors.file.uid` | int | UID of the file's owner |
 | `signal.target.ancestors.file.user` | string | User of the file's owner |
@@ -846,7 +846,7 @@ A signal was sent
 | `signal.target.euid` | int | Effective UID of the process |
 | `signal.target.euser` | string | Effective user of the process |
 | `signal.target.file.change_time` | int | Change time of the file |
-| `signal.target.file.filesystem` | string | FileSystem of the process executable |
+| `signal.target.file.filesystem` | string | File's filesystem |
 | `signal.target.file.gid` | int | GID of the file's owner |
 | `signal.target.file.group` | string | Group of the file's owner |
 | `signal.target.file.in_upper_layer` | bool | Indicator of the file layer, in an OverlayFS for example |
@@ -854,8 +854,8 @@ A signal was sent
 | `signal.target.file.mode` | int | Mode/rights of the file |
 | `signal.target.file.modification_time` | int | Modification time of the file |
 | `signal.target.file.mount_id` | int | Mount ID of the file |
-| `signal.target.file.name` | string | Basename of the path of the process executable |
-| `signal.target.file.path` | string | Path of the process executable |
+| `signal.target.file.name` | string | File's basename |
+| `signal.target.file.path` | string | File's path |
 | `signal.target.file.rights` | int | Mode/rights of the file |
 | `signal.target.file.uid` | int | UID of the file's owner |
 | `signal.target.file.user` | string | User of the file's owner |

--- a/docs/cloud-workload-security/secl.json
+++ b/docs/cloud-workload-security/secl.json
@@ -165,7 +165,7 @@
         {
           "name": "process.ancestors.file.filesystem",
           "type": "string",
-          "definition": "FileSystem of the process executable"
+          "definition": "File's filesystem"
         },
         {
           "name": "process.ancestors.file.gid",
@@ -205,12 +205,12 @@
         {
           "name": "process.ancestors.file.name",
           "type": "string",
-          "definition": "Basename of the path of the process executable"
+          "definition": "File's basename"
         },
         {
           "name": "process.ancestors.file.path",
           "type": "string",
-          "definition": "Path of the process executable"
+          "definition": "File's path"
         },
         {
           "name": "process.ancestors.file.rights",
@@ -390,7 +390,7 @@
         {
           "name": "process.file.filesystem",
           "type": "string",
-          "definition": "FileSystem of the process executable"
+          "definition": "File's filesystem"
         },
         {
           "name": "process.file.gid",
@@ -430,12 +430,12 @@
         {
           "name": "process.file.name",
           "type": "string",
-          "definition": "Basename of the path of the process executable"
+          "definition": "File's basename"
         },
         {
           "name": "process.file.path",
           "type": "string",
-          "definition": "Path of the process executable"
+          "definition": "File's path"
         },
         {
           "name": "process.file.rights",
@@ -929,7 +929,7 @@
         {
           "name": "exec.file.filesystem",
           "type": "string",
-          "definition": "FileSystem of the process executable"
+          "definition": "File's filesystem"
         },
         {
           "name": "exec.file.gid",
@@ -969,12 +969,12 @@
         {
           "name": "exec.file.name",
           "type": "string",
-          "definition": "Basename of the path of the process executable"
+          "definition": "File's basename"
         },
         {
           "name": "exec.file.path",
           "type": "string",
-          "definition": "Path of the process executable"
+          "definition": "File's path"
         },
         {
           "name": "exec.file.rights",
@@ -1727,7 +1727,7 @@
         {
           "name": "ptrace.tracee.ancestors.file.filesystem",
           "type": "string",
-          "definition": "FileSystem of the process executable"
+          "definition": "File's filesystem"
         },
         {
           "name": "ptrace.tracee.ancestors.file.gid",
@@ -1767,12 +1767,12 @@
         {
           "name": "ptrace.tracee.ancestors.file.name",
           "type": "string",
-          "definition": "Basename of the path of the process executable"
+          "definition": "File's basename"
         },
         {
           "name": "ptrace.tracee.ancestors.file.path",
           "type": "string",
-          "definition": "Path of the process executable"
+          "definition": "File's path"
         },
         {
           "name": "ptrace.tracee.ancestors.file.rights",
@@ -1952,7 +1952,7 @@
         {
           "name": "ptrace.tracee.file.filesystem",
           "type": "string",
-          "definition": "FileSystem of the process executable"
+          "definition": "File's filesystem"
         },
         {
           "name": "ptrace.tracee.file.gid",
@@ -1992,12 +1992,12 @@
         {
           "name": "ptrace.tracee.file.name",
           "type": "string",
-          "definition": "Basename of the path of the process executable"
+          "definition": "File's basename"
         },
         {
           "name": "ptrace.tracee.file.path",
           "type": "string",
-          "definition": "Path of the process executable"
+          "definition": "File's path"
         },
         {
           "name": "ptrace.tracee.file.rights",
@@ -2729,7 +2729,7 @@
         {
           "name": "signal.target.ancestors.file.filesystem",
           "type": "string",
-          "definition": "FileSystem of the process executable"
+          "definition": "File's filesystem"
         },
         {
           "name": "signal.target.ancestors.file.gid",
@@ -2769,12 +2769,12 @@
         {
           "name": "signal.target.ancestors.file.name",
           "type": "string",
-          "definition": "Basename of the path of the process executable"
+          "definition": "File's basename"
         },
         {
           "name": "signal.target.ancestors.file.path",
           "type": "string",
-          "definition": "Path of the process executable"
+          "definition": "File's path"
         },
         {
           "name": "signal.target.ancestors.file.rights",
@@ -2954,7 +2954,7 @@
         {
           "name": "signal.target.file.filesystem",
           "type": "string",
-          "definition": "FileSystem of the process executable"
+          "definition": "File's filesystem"
         },
         {
           "name": "signal.target.file.gid",
@@ -2994,12 +2994,12 @@
         {
           "name": "signal.target.file.name",
           "type": "string",
-          "definition": "Basename of the path of the process executable"
+          "definition": "File's basename"
         },
         {
           "name": "signal.target.file.path",
           "type": "string",
-          "definition": "Path of the process executable"
+          "definition": "File's path"
         },
         {
           "name": "signal.target.file.rights",

--- a/pkg/security/probe/accessors.go
+++ b/pkg/security/probe/accessors.go
@@ -835,7 +835,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Exec.Process.FileFields.CTime)
+				return int((*Event)(ctx.Object).Exec.Process.FileEvent.FileFields.CTime)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -845,17 +845,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).Exec.Process.Filesystem
+				return (*Event)(ctx.Object).ResolveFileFilesystem(&(*Event)(ctx.Object).Exec.Process.FileEvent)
 			},
 			Field:  field,
-			Weight: eval.FunctionWeight,
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "exec.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Exec.Process.FileFields.GID)
+				return int((*Event)(ctx.Object).Exec.Process.FileEvent.FileFields.GID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -865,7 +865,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).ResolveFileFieldsGroup(&(*Event)(ctx.Object).Exec.Process.FileFields)
+				return (*Event)(ctx.Object).ResolveFileFieldsGroup(&(*Event)(ctx.Object).Exec.Process.FileEvent.FileFields)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -875,7 +875,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
 
-				return (*Event)(ctx.Object).ResolveFileFieldsInUpperLayer(&(*Event)(ctx.Object).Exec.Process.FileFields)
+				return (*Event)(ctx.Object).ResolveFileFieldsInUpperLayer(&(*Event)(ctx.Object).Exec.Process.FileEvent.FileFields)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -885,7 +885,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Exec.Process.FileFields.Inode)
+				return int((*Event)(ctx.Object).Exec.Process.FileEvent.FileFields.Inode)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -895,7 +895,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Exec.Process.FileFields.Mode)
+				return int((*Event)(ctx.Object).Exec.Process.FileEvent.FileFields.Mode)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -905,7 +905,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Exec.Process.FileFields.MTime)
+				return int((*Event)(ctx.Object).Exec.Process.FileEvent.FileFields.MTime)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -915,7 +915,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Exec.Process.FileFields.MountID)
+				return int((*Event)(ctx.Object).Exec.Process.FileEvent.FileFields.MountID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -925,10 +925,10 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).Exec.Process.BasenameStr
+				return (*Event)(ctx.Object).ResolveFileBasename(&(*Event)(ctx.Object).Exec.Process.FileEvent)
 			},
 			Field:  field,
-			Weight: eval.FunctionWeight,
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "exec.file.path":
@@ -936,17 +936,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).Exec.Process.PathnameStr
+				return (*Event)(ctx.Object).ResolveFilePath(&(*Event)(ctx.Object).Exec.Process.FileEvent)
 			},
 			Field:  field,
-			Weight: eval.FunctionWeight,
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "exec.file.rights":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).ResolveRights(&(*Event)(ctx.Object).Exec.Process.FileFields))
+				return int((*Event)(ctx.Object).ResolveRights(&(*Event)(ctx.Object).Exec.Process.FileEvent.FileFields))
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -956,7 +956,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Exec.Process.FileFields.UID)
+				return int((*Event)(ctx.Object).Exec.Process.FileEvent.FileFields.UID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -966,7 +966,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).ResolveFileFieldsUser(&(*Event)(ctx.Object).Exec.Process.FileFields)
+				return (*Event)(ctx.Object).ResolveFileFieldsUser(&(*Event)(ctx.Object).Exec.Process.FileEvent.FileFields)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -2204,7 +2204,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = (*Event)(ctx.Object).ResolveProcessArgs(&element.Process)
+					result = (*Event)(ctx.Object).ResolveProcessArgs(&element.ProcessContext.Process)
 
 					results = append(results, result)
 
@@ -2235,7 +2235,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = (*Event)(ctx.Object).ResolveProcessArgsFlags(&element.Process)
+					result = (*Event)(ctx.Object).ResolveProcessArgsFlags(&element.ProcessContext.Process)
 
 					results = append(results, result...)
 
@@ -2266,7 +2266,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = (*Event)(ctx.Object).ResolveProcessArgsOptions(&element.Process)
+					result = (*Event)(ctx.Object).ResolveProcessArgsOptions(&element.ProcessContext.Process)
 
 					results = append(results, result...)
 
@@ -2297,7 +2297,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = (*Event)(ctx.Object).ResolveProcessArgsTruncated(&element.Process)
+					result = (*Event)(ctx.Object).ResolveProcessArgsTruncated(&element.ProcessContext.Process)
 
 					results = append(results, result)
 
@@ -2328,7 +2328,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = (*Event)(ctx.Object).ResolveProcessArgv(&element.Process)
+					result = (*Event)(ctx.Object).ResolveProcessArgv(&element.ProcessContext.Process)
 
 					results = append(results, result...)
 
@@ -2359,7 +2359,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = (*Event)(ctx.Object).ResolveProcessArgv0(&element.Process)
+					result = (*Event)(ctx.Object).ResolveProcessArgv0(&element.ProcessContext.Process)
 
 					results = append(results, result)
 
@@ -2545,7 +2545,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = int((*Event)(ctx.Object).ResolveProcessCreatedAt(&element.Process))
+					result = int((*Event)(ctx.Object).ResolveProcessCreatedAt(&element.ProcessContext.Process))
 
 					results = append(results, result)
 
@@ -2638,7 +2638,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = (*Event)(ctx.Object).ResolveProcessEnvp(&element.Process)
+					result = (*Event)(ctx.Object).ResolveProcessEnvp(&element.ProcessContext.Process)
 
 					results = append(results, result...)
 
@@ -2669,7 +2669,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = (*Event)(ctx.Object).ResolveProcessEnvs(&element.Process)
+					result = (*Event)(ctx.Object).ResolveProcessEnvs(&element.ProcessContext.Process)
 
 					results = append(results, result...)
 
@@ -2700,7 +2700,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = (*Event)(ctx.Object).ResolveProcessEnvsTruncated(&element.Process)
+					result = (*Event)(ctx.Object).ResolveProcessEnvsTruncated(&element.ProcessContext.Process)
 
 					results = append(results, result)
 
@@ -2793,7 +2793,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = int(element.ProcessContext.Process.FileFields.CTime)
+					result = int(element.ProcessContext.Process.FileEvent.FileFields.CTime)
 
 					results = append(results, result)
 
@@ -2824,7 +2824,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = element.ProcessContext.Process.Filesystem
+					result = (*Event)(ctx.Object).ResolveFileFilesystem(&element.ProcessContext.Process.FileEvent)
 
 					results = append(results, result)
 
@@ -2855,7 +2855,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = int(element.ProcessContext.Process.FileFields.GID)
+					result = int(element.ProcessContext.Process.FileEvent.FileFields.GID)
 
 					results = append(results, result)
 
@@ -2886,7 +2886,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = (*Event)(ctx.Object).ResolveFileFieldsGroup(&element.FileFields)
+					result = (*Event)(ctx.Object).ResolveFileFieldsGroup(&element.ProcessContext.Process.FileEvent.FileFields)
 
 					results = append(results, result)
 
@@ -2917,7 +2917,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = (*Event)(ctx.Object).ResolveFileFieldsInUpperLayer(&element.FileFields)
+					result = (*Event)(ctx.Object).ResolveFileFieldsInUpperLayer(&element.ProcessContext.Process.FileEvent.FileFields)
 
 					results = append(results, result)
 
@@ -2948,7 +2948,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = int(element.ProcessContext.Process.FileFields.Inode)
+					result = int(element.ProcessContext.Process.FileEvent.FileFields.Inode)
 
 					results = append(results, result)
 
@@ -2979,7 +2979,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = int(element.ProcessContext.Process.FileFields.Mode)
+					result = int(element.ProcessContext.Process.FileEvent.FileFields.Mode)
 
 					results = append(results, result)
 
@@ -3010,7 +3010,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = int(element.ProcessContext.Process.FileFields.MTime)
+					result = int(element.ProcessContext.Process.FileEvent.FileFields.MTime)
 
 					results = append(results, result)
 
@@ -3041,7 +3041,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = int(element.ProcessContext.Process.FileFields.MountID)
+					result = int(element.ProcessContext.Process.FileEvent.FileFields.MountID)
 
 					results = append(results, result)
 
@@ -3072,7 +3072,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = element.ProcessContext.Process.BasenameStr
+					result = (*Event)(ctx.Object).ResolveFileBasename(&element.ProcessContext.Process.FileEvent)
 
 					results = append(results, result)
 
@@ -3104,7 +3104,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = element.ProcessContext.Process.PathnameStr
+					result = (*Event)(ctx.Object).ResolveFilePath(&element.ProcessContext.Process.FileEvent)
 
 					results = append(results, result)
 
@@ -3135,7 +3135,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = int((*Event)(ctx.Object).ResolveRights(&element.FileFields))
+					result = int((*Event)(ctx.Object).ResolveRights(&element.ProcessContext.Process.FileEvent.FileFields))
 
 					results = append(results, result)
 
@@ -3166,7 +3166,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = int(element.ProcessContext.Process.FileFields.UID)
+					result = int(element.ProcessContext.Process.FileEvent.FileFields.UID)
 
 					results = append(results, result)
 
@@ -3197,7 +3197,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = (*Event)(ctx.Object).ResolveFileFieldsUser(&element.FileFields)
+					result = (*Event)(ctx.Object).ResolveFileFieldsUser(&element.ProcessContext.Process.FileEvent.FileFields)
 
 					results = append(results, result)
 
@@ -3776,7 +3776,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).ProcessContext.Process.FileFields.CTime)
+				return int((*Event)(ctx.Object).ProcessContext.Process.FileEvent.FileFields.CTime)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -3786,17 +3786,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).ProcessContext.Process.Filesystem
+				return (*Event)(ctx.Object).ResolveFileFilesystem(&(*Event)(ctx.Object).ProcessContext.Process.FileEvent)
 			},
 			Field:  field,
-			Weight: eval.FunctionWeight,
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "process.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).ProcessContext.Process.FileFields.GID)
+				return int((*Event)(ctx.Object).ProcessContext.Process.FileEvent.FileFields.GID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -3806,7 +3806,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).ResolveFileFieldsGroup(&(*Event)(ctx.Object).ProcessContext.Process.FileFields)
+				return (*Event)(ctx.Object).ResolveFileFieldsGroup(&(*Event)(ctx.Object).ProcessContext.Process.FileEvent.FileFields)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -3816,7 +3816,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
 
-				return (*Event)(ctx.Object).ResolveFileFieldsInUpperLayer(&(*Event)(ctx.Object).ProcessContext.Process.FileFields)
+				return (*Event)(ctx.Object).ResolveFileFieldsInUpperLayer(&(*Event)(ctx.Object).ProcessContext.Process.FileEvent.FileFields)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -3826,7 +3826,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).ProcessContext.Process.FileFields.Inode)
+				return int((*Event)(ctx.Object).ProcessContext.Process.FileEvent.FileFields.Inode)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -3836,7 +3836,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).ProcessContext.Process.FileFields.Mode)
+				return int((*Event)(ctx.Object).ProcessContext.Process.FileEvent.FileFields.Mode)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -3846,7 +3846,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).ProcessContext.Process.FileFields.MTime)
+				return int((*Event)(ctx.Object).ProcessContext.Process.FileEvent.FileFields.MTime)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -3856,7 +3856,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).ProcessContext.Process.FileFields.MountID)
+				return int((*Event)(ctx.Object).ProcessContext.Process.FileEvent.FileFields.MountID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -3866,10 +3866,10 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).ProcessContext.Process.BasenameStr
+				return (*Event)(ctx.Object).ResolveFileBasename(&(*Event)(ctx.Object).ProcessContext.Process.FileEvent)
 			},
 			Field:  field,
-			Weight: eval.FunctionWeight,
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "process.file.path":
@@ -3877,17 +3877,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).ProcessContext.Process.PathnameStr
+				return (*Event)(ctx.Object).ResolveFilePath(&(*Event)(ctx.Object).ProcessContext.Process.FileEvent)
 			},
 			Field:  field,
-			Weight: eval.FunctionWeight,
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "process.file.rights":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).ResolveRights(&(*Event)(ctx.Object).ProcessContext.Process.FileFields))
+				return int((*Event)(ctx.Object).ResolveRights(&(*Event)(ctx.Object).ProcessContext.Process.FileEvent.FileFields))
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -3897,7 +3897,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).ProcessContext.Process.FileFields.UID)
+				return int((*Event)(ctx.Object).ProcessContext.Process.FileEvent.FileFields.UID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -3907,7 +3907,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).ResolveFileFieldsUser(&(*Event)(ctx.Object).ProcessContext.Process.FileFields)
+				return (*Event)(ctx.Object).ResolveFileFieldsUser(&(*Event)(ctx.Object).ProcessContext.Process.FileEvent.FileFields)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -4071,7 +4071,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = (*Event)(ctx.Object).ResolveProcessArgs(&element.Process)
+					result = (*Event)(ctx.Object).ResolveProcessArgs(&element.ProcessContext.Process)
 
 					results = append(results, result)
 
@@ -4102,7 +4102,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = (*Event)(ctx.Object).ResolveProcessArgsFlags(&element.Process)
+					result = (*Event)(ctx.Object).ResolveProcessArgsFlags(&element.ProcessContext.Process)
 
 					results = append(results, result...)
 
@@ -4133,7 +4133,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = (*Event)(ctx.Object).ResolveProcessArgsOptions(&element.Process)
+					result = (*Event)(ctx.Object).ResolveProcessArgsOptions(&element.ProcessContext.Process)
 
 					results = append(results, result...)
 
@@ -4164,7 +4164,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = (*Event)(ctx.Object).ResolveProcessArgsTruncated(&element.Process)
+					result = (*Event)(ctx.Object).ResolveProcessArgsTruncated(&element.ProcessContext.Process)
 
 					results = append(results, result)
 
@@ -4195,7 +4195,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = (*Event)(ctx.Object).ResolveProcessArgv(&element.Process)
+					result = (*Event)(ctx.Object).ResolveProcessArgv(&element.ProcessContext.Process)
 
 					results = append(results, result...)
 
@@ -4226,7 +4226,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = (*Event)(ctx.Object).ResolveProcessArgv0(&element.Process)
+					result = (*Event)(ctx.Object).ResolveProcessArgv0(&element.ProcessContext.Process)
 
 					results = append(results, result)
 
@@ -4412,7 +4412,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = int((*Event)(ctx.Object).ResolveProcessCreatedAt(&element.Process))
+					result = int((*Event)(ctx.Object).ResolveProcessCreatedAt(&element.ProcessContext.Process))
 
 					results = append(results, result)
 
@@ -4505,7 +4505,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = (*Event)(ctx.Object).ResolveProcessEnvp(&element.Process)
+					result = (*Event)(ctx.Object).ResolveProcessEnvp(&element.ProcessContext.Process)
 
 					results = append(results, result...)
 
@@ -4536,7 +4536,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = (*Event)(ctx.Object).ResolveProcessEnvs(&element.Process)
+					result = (*Event)(ctx.Object).ResolveProcessEnvs(&element.ProcessContext.Process)
 
 					results = append(results, result...)
 
@@ -4567,7 +4567,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = (*Event)(ctx.Object).ResolveProcessEnvsTruncated(&element.Process)
+					result = (*Event)(ctx.Object).ResolveProcessEnvsTruncated(&element.ProcessContext.Process)
 
 					results = append(results, result)
 
@@ -4660,7 +4660,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = int(element.ProcessContext.Process.FileFields.CTime)
+					result = int(element.ProcessContext.Process.FileEvent.FileFields.CTime)
 
 					results = append(results, result)
 
@@ -4691,7 +4691,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = element.ProcessContext.Process.Filesystem
+					result = (*Event)(ctx.Object).ResolveFileFilesystem(&element.ProcessContext.Process.FileEvent)
 
 					results = append(results, result)
 
@@ -4722,7 +4722,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = int(element.ProcessContext.Process.FileFields.GID)
+					result = int(element.ProcessContext.Process.FileEvent.FileFields.GID)
 
 					results = append(results, result)
 
@@ -4753,7 +4753,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = (*Event)(ctx.Object).ResolveFileFieldsGroup(&element.FileFields)
+					result = (*Event)(ctx.Object).ResolveFileFieldsGroup(&element.ProcessContext.Process.FileEvent.FileFields)
 
 					results = append(results, result)
 
@@ -4784,7 +4784,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = (*Event)(ctx.Object).ResolveFileFieldsInUpperLayer(&element.FileFields)
+					result = (*Event)(ctx.Object).ResolveFileFieldsInUpperLayer(&element.ProcessContext.Process.FileEvent.FileFields)
 
 					results = append(results, result)
 
@@ -4815,7 +4815,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = int(element.ProcessContext.Process.FileFields.Inode)
+					result = int(element.ProcessContext.Process.FileEvent.FileFields.Inode)
 
 					results = append(results, result)
 
@@ -4846,7 +4846,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = int(element.ProcessContext.Process.FileFields.Mode)
+					result = int(element.ProcessContext.Process.FileEvent.FileFields.Mode)
 
 					results = append(results, result)
 
@@ -4877,7 +4877,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = int(element.ProcessContext.Process.FileFields.MTime)
+					result = int(element.ProcessContext.Process.FileEvent.FileFields.MTime)
 
 					results = append(results, result)
 
@@ -4908,7 +4908,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = int(element.ProcessContext.Process.FileFields.MountID)
+					result = int(element.ProcessContext.Process.FileEvent.FileFields.MountID)
 
 					results = append(results, result)
 
@@ -4939,7 +4939,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = element.ProcessContext.Process.BasenameStr
+					result = (*Event)(ctx.Object).ResolveFileBasename(&element.ProcessContext.Process.FileEvent)
 
 					results = append(results, result)
 
@@ -4971,7 +4971,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = element.ProcessContext.Process.PathnameStr
+					result = (*Event)(ctx.Object).ResolveFilePath(&element.ProcessContext.Process.FileEvent)
 
 					results = append(results, result)
 
@@ -5002,7 +5002,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = int((*Event)(ctx.Object).ResolveRights(&element.FileFields))
+					result = int((*Event)(ctx.Object).ResolveRights(&element.ProcessContext.Process.FileEvent.FileFields))
 
 					results = append(results, result)
 
@@ -5033,7 +5033,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = int(element.ProcessContext.Process.FileFields.UID)
+					result = int(element.ProcessContext.Process.FileEvent.FileFields.UID)
 
 					results = append(results, result)
 
@@ -5064,7 +5064,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = (*Event)(ctx.Object).ResolveFileFieldsUser(&element.FileFields)
+					result = (*Event)(ctx.Object).ResolveFileFieldsUser(&element.ProcessContext.Process.FileEvent.FileFields)
 
 					results = append(results, result)
 
@@ -5643,7 +5643,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).PTrace.Tracee.Process.FileFields.CTime)
+				return int((*Event)(ctx.Object).PTrace.Tracee.Process.FileEvent.FileFields.CTime)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -5653,17 +5653,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).PTrace.Tracee.Process.Filesystem
+				return (*Event)(ctx.Object).ResolveFileFilesystem(&(*Event)(ctx.Object).PTrace.Tracee.Process.FileEvent)
 			},
 			Field:  field,
-			Weight: eval.FunctionWeight,
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "ptrace.tracee.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).PTrace.Tracee.Process.FileFields.GID)
+				return int((*Event)(ctx.Object).PTrace.Tracee.Process.FileEvent.FileFields.GID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -5673,7 +5673,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).ResolveFileFieldsGroup(&(*Event)(ctx.Object).PTrace.Tracee.Process.FileFields)
+				return (*Event)(ctx.Object).ResolveFileFieldsGroup(&(*Event)(ctx.Object).PTrace.Tracee.Process.FileEvent.FileFields)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -5683,7 +5683,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
 
-				return (*Event)(ctx.Object).ResolveFileFieldsInUpperLayer(&(*Event)(ctx.Object).PTrace.Tracee.Process.FileFields)
+				return (*Event)(ctx.Object).ResolveFileFieldsInUpperLayer(&(*Event)(ctx.Object).PTrace.Tracee.Process.FileEvent.FileFields)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -5693,7 +5693,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).PTrace.Tracee.Process.FileFields.Inode)
+				return int((*Event)(ctx.Object).PTrace.Tracee.Process.FileEvent.FileFields.Inode)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -5703,7 +5703,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).PTrace.Tracee.Process.FileFields.Mode)
+				return int((*Event)(ctx.Object).PTrace.Tracee.Process.FileEvent.FileFields.Mode)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -5713,7 +5713,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).PTrace.Tracee.Process.FileFields.MTime)
+				return int((*Event)(ctx.Object).PTrace.Tracee.Process.FileEvent.FileFields.MTime)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -5723,7 +5723,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).PTrace.Tracee.Process.FileFields.MountID)
+				return int((*Event)(ctx.Object).PTrace.Tracee.Process.FileEvent.FileFields.MountID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -5733,10 +5733,10 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).PTrace.Tracee.Process.BasenameStr
+				return (*Event)(ctx.Object).ResolveFileBasename(&(*Event)(ctx.Object).PTrace.Tracee.Process.FileEvent)
 			},
 			Field:  field,
-			Weight: eval.FunctionWeight,
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "ptrace.tracee.file.path":
@@ -5744,17 +5744,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).PTrace.Tracee.Process.PathnameStr
+				return (*Event)(ctx.Object).ResolveFilePath(&(*Event)(ctx.Object).PTrace.Tracee.Process.FileEvent)
 			},
 			Field:  field,
-			Weight: eval.FunctionWeight,
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "ptrace.tracee.file.rights":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).ResolveRights(&(*Event)(ctx.Object).PTrace.Tracee.Process.FileFields))
+				return int((*Event)(ctx.Object).ResolveRights(&(*Event)(ctx.Object).PTrace.Tracee.Process.FileEvent.FileFields))
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -5764,7 +5764,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).PTrace.Tracee.Process.FileFields.UID)
+				return int((*Event)(ctx.Object).PTrace.Tracee.Process.FileEvent.FileFields.UID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -5774,7 +5774,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).ResolveFileFieldsUser(&(*Event)(ctx.Object).PTrace.Tracee.Process.FileFields)
+				return (*Event)(ctx.Object).ResolveFileFieldsUser(&(*Event)(ctx.Object).PTrace.Tracee.Process.FileEvent.FileFields)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -6883,7 +6883,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = (*Event)(ctx.Object).ResolveProcessArgs(&element.Process)
+					result = (*Event)(ctx.Object).ResolveProcessArgs(&element.ProcessContext.Process)
 
 					results = append(results, result)
 
@@ -6914,7 +6914,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = (*Event)(ctx.Object).ResolveProcessArgsFlags(&element.Process)
+					result = (*Event)(ctx.Object).ResolveProcessArgsFlags(&element.ProcessContext.Process)
 
 					results = append(results, result...)
 
@@ -6945,7 +6945,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = (*Event)(ctx.Object).ResolveProcessArgsOptions(&element.Process)
+					result = (*Event)(ctx.Object).ResolveProcessArgsOptions(&element.ProcessContext.Process)
 
 					results = append(results, result...)
 
@@ -6976,7 +6976,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = (*Event)(ctx.Object).ResolveProcessArgsTruncated(&element.Process)
+					result = (*Event)(ctx.Object).ResolveProcessArgsTruncated(&element.ProcessContext.Process)
 
 					results = append(results, result)
 
@@ -7007,7 +7007,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = (*Event)(ctx.Object).ResolveProcessArgv(&element.Process)
+					result = (*Event)(ctx.Object).ResolveProcessArgv(&element.ProcessContext.Process)
 
 					results = append(results, result...)
 
@@ -7038,7 +7038,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = (*Event)(ctx.Object).ResolveProcessArgv0(&element.Process)
+					result = (*Event)(ctx.Object).ResolveProcessArgv0(&element.ProcessContext.Process)
 
 					results = append(results, result)
 
@@ -7224,7 +7224,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = int((*Event)(ctx.Object).ResolveProcessCreatedAt(&element.Process))
+					result = int((*Event)(ctx.Object).ResolveProcessCreatedAt(&element.ProcessContext.Process))
 
 					results = append(results, result)
 
@@ -7317,7 +7317,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = (*Event)(ctx.Object).ResolveProcessEnvp(&element.Process)
+					result = (*Event)(ctx.Object).ResolveProcessEnvp(&element.ProcessContext.Process)
 
 					results = append(results, result...)
 
@@ -7348,7 +7348,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = (*Event)(ctx.Object).ResolveProcessEnvs(&element.Process)
+					result = (*Event)(ctx.Object).ResolveProcessEnvs(&element.ProcessContext.Process)
 
 					results = append(results, result...)
 
@@ -7379,7 +7379,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = (*Event)(ctx.Object).ResolveProcessEnvsTruncated(&element.Process)
+					result = (*Event)(ctx.Object).ResolveProcessEnvsTruncated(&element.ProcessContext.Process)
 
 					results = append(results, result)
 
@@ -7472,7 +7472,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = int(element.ProcessContext.Process.FileFields.CTime)
+					result = int(element.ProcessContext.Process.FileEvent.FileFields.CTime)
 
 					results = append(results, result)
 
@@ -7503,7 +7503,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = element.ProcessContext.Process.Filesystem
+					result = (*Event)(ctx.Object).ResolveFileFilesystem(&element.ProcessContext.Process.FileEvent)
 
 					results = append(results, result)
 
@@ -7534,7 +7534,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = int(element.ProcessContext.Process.FileFields.GID)
+					result = int(element.ProcessContext.Process.FileEvent.FileFields.GID)
 
 					results = append(results, result)
 
@@ -7565,7 +7565,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = (*Event)(ctx.Object).ResolveFileFieldsGroup(&element.FileFields)
+					result = (*Event)(ctx.Object).ResolveFileFieldsGroup(&element.ProcessContext.Process.FileEvent.FileFields)
 
 					results = append(results, result)
 
@@ -7596,7 +7596,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = (*Event)(ctx.Object).ResolveFileFieldsInUpperLayer(&element.FileFields)
+					result = (*Event)(ctx.Object).ResolveFileFieldsInUpperLayer(&element.ProcessContext.Process.FileEvent.FileFields)
 
 					results = append(results, result)
 
@@ -7627,7 +7627,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = int(element.ProcessContext.Process.FileFields.Inode)
+					result = int(element.ProcessContext.Process.FileEvent.FileFields.Inode)
 
 					results = append(results, result)
 
@@ -7658,7 +7658,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = int(element.ProcessContext.Process.FileFields.Mode)
+					result = int(element.ProcessContext.Process.FileEvent.FileFields.Mode)
 
 					results = append(results, result)
 
@@ -7689,7 +7689,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = int(element.ProcessContext.Process.FileFields.MTime)
+					result = int(element.ProcessContext.Process.FileEvent.FileFields.MTime)
 
 					results = append(results, result)
 
@@ -7720,7 +7720,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = int(element.ProcessContext.Process.FileFields.MountID)
+					result = int(element.ProcessContext.Process.FileEvent.FileFields.MountID)
 
 					results = append(results, result)
 
@@ -7751,7 +7751,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = element.ProcessContext.Process.BasenameStr
+					result = (*Event)(ctx.Object).ResolveFileBasename(&element.ProcessContext.Process.FileEvent)
 
 					results = append(results, result)
 
@@ -7783,7 +7783,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = element.ProcessContext.Process.PathnameStr
+					result = (*Event)(ctx.Object).ResolveFilePath(&element.ProcessContext.Process.FileEvent)
 
 					results = append(results, result)
 
@@ -7814,7 +7814,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = int((*Event)(ctx.Object).ResolveRights(&element.FileFields))
+					result = int((*Event)(ctx.Object).ResolveRights(&element.ProcessContext.Process.FileEvent.FileFields))
 
 					results = append(results, result)
 
@@ -7845,7 +7845,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = int(element.ProcessContext.Process.FileFields.UID)
+					result = int(element.ProcessContext.Process.FileEvent.FileFields.UID)
 
 					results = append(results, result)
 
@@ -7876,7 +7876,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*model.ProcessCacheEntry)(value)
 
-					result = (*Event)(ctx.Object).ResolveFileFieldsUser(&element.FileFields)
+					result = (*Event)(ctx.Object).ResolveFileFieldsUser(&element.ProcessContext.Process.FileEvent.FileFields)
 
 					results = append(results, result)
 
@@ -8455,7 +8455,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Signal.Target.Process.FileFields.CTime)
+				return int((*Event)(ctx.Object).Signal.Target.Process.FileEvent.FileFields.CTime)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -8465,17 +8465,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).Signal.Target.Process.Filesystem
+				return (*Event)(ctx.Object).ResolveFileFilesystem(&(*Event)(ctx.Object).Signal.Target.Process.FileEvent)
 			},
 			Field:  field,
-			Weight: eval.FunctionWeight,
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "signal.target.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Signal.Target.Process.FileFields.GID)
+				return int((*Event)(ctx.Object).Signal.Target.Process.FileEvent.FileFields.GID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -8485,7 +8485,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).ResolveFileFieldsGroup(&(*Event)(ctx.Object).Signal.Target.Process.FileFields)
+				return (*Event)(ctx.Object).ResolveFileFieldsGroup(&(*Event)(ctx.Object).Signal.Target.Process.FileEvent.FileFields)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -8495,7 +8495,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
 
-				return (*Event)(ctx.Object).ResolveFileFieldsInUpperLayer(&(*Event)(ctx.Object).Signal.Target.Process.FileFields)
+				return (*Event)(ctx.Object).ResolveFileFieldsInUpperLayer(&(*Event)(ctx.Object).Signal.Target.Process.FileEvent.FileFields)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -8505,7 +8505,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Signal.Target.Process.FileFields.Inode)
+				return int((*Event)(ctx.Object).Signal.Target.Process.FileEvent.FileFields.Inode)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -8515,7 +8515,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Signal.Target.Process.FileFields.Mode)
+				return int((*Event)(ctx.Object).Signal.Target.Process.FileEvent.FileFields.Mode)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -8525,7 +8525,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Signal.Target.Process.FileFields.MTime)
+				return int((*Event)(ctx.Object).Signal.Target.Process.FileEvent.FileFields.MTime)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -8535,7 +8535,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Signal.Target.Process.FileFields.MountID)
+				return int((*Event)(ctx.Object).Signal.Target.Process.FileEvent.FileFields.MountID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -8545,10 +8545,10 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).Signal.Target.Process.BasenameStr
+				return (*Event)(ctx.Object).ResolveFileBasename(&(*Event)(ctx.Object).Signal.Target.Process.FileEvent)
 			},
 			Field:  field,
-			Weight: eval.FunctionWeight,
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "signal.target.file.path":
@@ -8556,17 +8556,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).Signal.Target.Process.PathnameStr
+				return (*Event)(ctx.Object).ResolveFilePath(&(*Event)(ctx.Object).Signal.Target.Process.FileEvent)
 			},
 			Field:  field,
-			Weight: eval.FunctionWeight,
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "signal.target.file.rights":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).ResolveRights(&(*Event)(ctx.Object).Signal.Target.Process.FileFields))
+				return int((*Event)(ctx.Object).ResolveRights(&(*Event)(ctx.Object).Signal.Target.Process.FileEvent.FileFields))
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -8576,7 +8576,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Signal.Target.Process.FileFields.UID)
+				return int((*Event)(ctx.Object).Signal.Target.Process.FileEvent.FileFields.UID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -8586,7 +8586,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).ResolveFileFieldsUser(&(*Event)(ctx.Object).Signal.Target.Process.FileFields)
+				return (*Event)(ctx.Object).ResolveFileFieldsUser(&(*Event)(ctx.Object).Signal.Target.Process.FileEvent.FileFields)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -10778,59 +10778,59 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "exec.file.change_time":
 
-		return int(e.Exec.Process.FileFields.CTime), nil
+		return int(e.Exec.Process.FileEvent.FileFields.CTime), nil
 
 	case "exec.file.filesystem":
 
-		return e.Exec.Process.Filesystem, nil
+		return e.ResolveFileFilesystem(&e.Exec.Process.FileEvent), nil
 
 	case "exec.file.gid":
 
-		return int(e.Exec.Process.FileFields.GID), nil
+		return int(e.Exec.Process.FileEvent.FileFields.GID), nil
 
 	case "exec.file.group":
 
-		return e.ResolveFileFieldsGroup(&e.Exec.Process.FileFields), nil
+		return e.ResolveFileFieldsGroup(&e.Exec.Process.FileEvent.FileFields), nil
 
 	case "exec.file.in_upper_layer":
 
-		return e.ResolveFileFieldsInUpperLayer(&e.Exec.Process.FileFields), nil
+		return e.ResolveFileFieldsInUpperLayer(&e.Exec.Process.FileEvent.FileFields), nil
 
 	case "exec.file.inode":
 
-		return int(e.Exec.Process.FileFields.Inode), nil
+		return int(e.Exec.Process.FileEvent.FileFields.Inode), nil
 
 	case "exec.file.mode":
 
-		return int(e.Exec.Process.FileFields.Mode), nil
+		return int(e.Exec.Process.FileEvent.FileFields.Mode), nil
 
 	case "exec.file.modification_time":
 
-		return int(e.Exec.Process.FileFields.MTime), nil
+		return int(e.Exec.Process.FileEvent.FileFields.MTime), nil
 
 	case "exec.file.mount_id":
 
-		return int(e.Exec.Process.FileFields.MountID), nil
+		return int(e.Exec.Process.FileEvent.FileFields.MountID), nil
 
 	case "exec.file.name":
 
-		return e.Exec.Process.BasenameStr, nil
+		return e.ResolveFileBasename(&e.Exec.Process.FileEvent), nil
 
 	case "exec.file.path":
 
-		return e.Exec.Process.PathnameStr, nil
+		return e.ResolveFilePath(&e.Exec.Process.FileEvent), nil
 
 	case "exec.file.rights":
 
-		return int(e.ResolveRights(&e.Exec.Process.FileFields)), nil
+		return int(e.ResolveRights(&e.Exec.Process.FileEvent.FileFields)), nil
 
 	case "exec.file.uid":
 
-		return int(e.Exec.Process.FileFields.UID), nil
+		return int(e.Exec.Process.FileEvent.FileFields.UID), nil
 
 	case "exec.file.user":
 
-		return e.ResolveFileFieldsUser(&e.Exec.Process.FileFields), nil
+		return e.ResolveFileFieldsUser(&e.Exec.Process.FileEvent.FileFields), nil
 
 	case "exec.fsgid":
 
@@ -11329,7 +11329,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := (*Event)(ctx.Object).ResolveProcessArgs(&element.Process)
+			result := (*Event)(ctx.Object).ResolveProcessArgs(&element.ProcessContext.Process)
 
 			values = append(values, result)
 
@@ -11351,7 +11351,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := (*Event)(ctx.Object).ResolveProcessArgsFlags(&element.Process)
+			result := (*Event)(ctx.Object).ResolveProcessArgsFlags(&element.ProcessContext.Process)
 
 			values = append(values, result...)
 
@@ -11373,7 +11373,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := (*Event)(ctx.Object).ResolveProcessArgsOptions(&element.Process)
+			result := (*Event)(ctx.Object).ResolveProcessArgsOptions(&element.ProcessContext.Process)
 
 			values = append(values, result...)
 
@@ -11395,7 +11395,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := (*Event)(ctx.Object).ResolveProcessArgsTruncated(&element.Process)
+			result := (*Event)(ctx.Object).ResolveProcessArgsTruncated(&element.ProcessContext.Process)
 
 			values = append(values, result)
 
@@ -11417,7 +11417,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := (*Event)(ctx.Object).ResolveProcessArgv(&element.Process)
+			result := (*Event)(ctx.Object).ResolveProcessArgv(&element.ProcessContext.Process)
 
 			values = append(values, result...)
 
@@ -11439,7 +11439,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := (*Event)(ctx.Object).ResolveProcessArgv0(&element.Process)
+			result := (*Event)(ctx.Object).ResolveProcessArgv0(&element.ProcessContext.Process)
 
 			values = append(values, result)
 
@@ -11571,7 +11571,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := int((*Event)(ctx.Object).ResolveProcessCreatedAt(&element.Process))
+			result := int((*Event)(ctx.Object).ResolveProcessCreatedAt(&element.ProcessContext.Process))
 
 			values = append(values, result)
 
@@ -11637,7 +11637,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := (*Event)(ctx.Object).ResolveProcessEnvp(&element.Process)
+			result := (*Event)(ctx.Object).ResolveProcessEnvp(&element.ProcessContext.Process)
 
 			values = append(values, result...)
 
@@ -11659,7 +11659,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := (*Event)(ctx.Object).ResolveProcessEnvs(&element.Process)
+			result := (*Event)(ctx.Object).ResolveProcessEnvs(&element.ProcessContext.Process)
 
 			values = append(values, result...)
 
@@ -11681,7 +11681,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := (*Event)(ctx.Object).ResolveProcessEnvsTruncated(&element.Process)
+			result := (*Event)(ctx.Object).ResolveProcessEnvsTruncated(&element.ProcessContext.Process)
 
 			values = append(values, result)
 
@@ -11747,7 +11747,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := int(element.ProcessContext.Process.FileFields.CTime)
+			result := int(element.ProcessContext.Process.FileEvent.FileFields.CTime)
 
 			values = append(values, result)
 
@@ -11769,7 +11769,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := element.ProcessContext.Process.Filesystem
+			result := (*Event)(ctx.Object).ResolveFileFilesystem(&element.ProcessContext.Process.FileEvent)
 
 			values = append(values, result)
 
@@ -11791,7 +11791,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := int(element.ProcessContext.Process.FileFields.GID)
+			result := int(element.ProcessContext.Process.FileEvent.FileFields.GID)
 
 			values = append(values, result)
 
@@ -11813,7 +11813,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := (*Event)(ctx.Object).ResolveFileFieldsGroup(&element.FileFields)
+			result := (*Event)(ctx.Object).ResolveFileFieldsGroup(&element.ProcessContext.Process.FileEvent.FileFields)
 
 			values = append(values, result)
 
@@ -11835,7 +11835,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := (*Event)(ctx.Object).ResolveFileFieldsInUpperLayer(&element.FileFields)
+			result := (*Event)(ctx.Object).ResolveFileFieldsInUpperLayer(&element.ProcessContext.Process.FileEvent.FileFields)
 
 			values = append(values, result)
 
@@ -11857,7 +11857,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := int(element.ProcessContext.Process.FileFields.Inode)
+			result := int(element.ProcessContext.Process.FileEvent.FileFields.Inode)
 
 			values = append(values, result)
 
@@ -11879,7 +11879,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := int(element.ProcessContext.Process.FileFields.Mode)
+			result := int(element.ProcessContext.Process.FileEvent.FileFields.Mode)
 
 			values = append(values, result)
 
@@ -11901,7 +11901,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := int(element.ProcessContext.Process.FileFields.MTime)
+			result := int(element.ProcessContext.Process.FileEvent.FileFields.MTime)
 
 			values = append(values, result)
 
@@ -11923,7 +11923,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := int(element.ProcessContext.Process.FileFields.MountID)
+			result := int(element.ProcessContext.Process.FileEvent.FileFields.MountID)
 
 			values = append(values, result)
 
@@ -11945,7 +11945,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := element.ProcessContext.Process.BasenameStr
+			result := (*Event)(ctx.Object).ResolveFileBasename(&element.ProcessContext.Process.FileEvent)
 
 			values = append(values, result)
 
@@ -11967,7 +11967,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := element.ProcessContext.Process.PathnameStr
+			result := (*Event)(ctx.Object).ResolveFilePath(&element.ProcessContext.Process.FileEvent)
 
 			values = append(values, result)
 
@@ -11989,7 +11989,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := int((*Event)(ctx.Object).ResolveRights(&element.FileFields))
+			result := int((*Event)(ctx.Object).ResolveRights(&element.ProcessContext.Process.FileEvent.FileFields))
 
 			values = append(values, result)
 
@@ -12011,7 +12011,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := int(element.ProcessContext.Process.FileFields.UID)
+			result := int(element.ProcessContext.Process.FileEvent.FileFields.UID)
 
 			values = append(values, result)
 
@@ -12033,7 +12033,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := (*Event)(ctx.Object).ResolveFileFieldsUser(&element.FileFields)
+			result := (*Event)(ctx.Object).ResolveFileFieldsUser(&element.ProcessContext.Process.FileEvent.FileFields)
 
 			values = append(values, result)
 
@@ -12384,59 +12384,59 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "process.file.change_time":
 
-		return int(e.ProcessContext.Process.FileFields.CTime), nil
+		return int(e.ProcessContext.Process.FileEvent.FileFields.CTime), nil
 
 	case "process.file.filesystem":
 
-		return e.ProcessContext.Process.Filesystem, nil
+		return e.ResolveFileFilesystem(&e.ProcessContext.Process.FileEvent), nil
 
 	case "process.file.gid":
 
-		return int(e.ProcessContext.Process.FileFields.GID), nil
+		return int(e.ProcessContext.Process.FileEvent.FileFields.GID), nil
 
 	case "process.file.group":
 
-		return e.ResolveFileFieldsGroup(&e.ProcessContext.Process.FileFields), nil
+		return e.ResolveFileFieldsGroup(&e.ProcessContext.Process.FileEvent.FileFields), nil
 
 	case "process.file.in_upper_layer":
 
-		return e.ResolveFileFieldsInUpperLayer(&e.ProcessContext.Process.FileFields), nil
+		return e.ResolveFileFieldsInUpperLayer(&e.ProcessContext.Process.FileEvent.FileFields), nil
 
 	case "process.file.inode":
 
-		return int(e.ProcessContext.Process.FileFields.Inode), nil
+		return int(e.ProcessContext.Process.FileEvent.FileFields.Inode), nil
 
 	case "process.file.mode":
 
-		return int(e.ProcessContext.Process.FileFields.Mode), nil
+		return int(e.ProcessContext.Process.FileEvent.FileFields.Mode), nil
 
 	case "process.file.modification_time":
 
-		return int(e.ProcessContext.Process.FileFields.MTime), nil
+		return int(e.ProcessContext.Process.FileEvent.FileFields.MTime), nil
 
 	case "process.file.mount_id":
 
-		return int(e.ProcessContext.Process.FileFields.MountID), nil
+		return int(e.ProcessContext.Process.FileEvent.FileFields.MountID), nil
 
 	case "process.file.name":
 
-		return e.ProcessContext.Process.BasenameStr, nil
+		return e.ResolveFileBasename(&e.ProcessContext.Process.FileEvent), nil
 
 	case "process.file.path":
 
-		return e.ProcessContext.Process.PathnameStr, nil
+		return e.ResolveFilePath(&e.ProcessContext.Process.FileEvent), nil
 
 	case "process.file.rights":
 
-		return int(e.ResolveRights(&e.ProcessContext.Process.FileFields)), nil
+		return int(e.ResolveRights(&e.ProcessContext.Process.FileEvent.FileFields)), nil
 
 	case "process.file.uid":
 
-		return int(e.ProcessContext.Process.FileFields.UID), nil
+		return int(e.ProcessContext.Process.FileEvent.FileFields.UID), nil
 
 	case "process.file.user":
 
-		return e.ResolveFileFieldsUser(&e.ProcessContext.Process.FileFields), nil
+		return e.ResolveFileFieldsUser(&e.ProcessContext.Process.FileEvent.FileFields), nil
 
 	case "process.fsgid":
 
@@ -12507,7 +12507,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := (*Event)(ctx.Object).ResolveProcessArgs(&element.Process)
+			result := (*Event)(ctx.Object).ResolveProcessArgs(&element.ProcessContext.Process)
 
 			values = append(values, result)
 
@@ -12529,7 +12529,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := (*Event)(ctx.Object).ResolveProcessArgsFlags(&element.Process)
+			result := (*Event)(ctx.Object).ResolveProcessArgsFlags(&element.ProcessContext.Process)
 
 			values = append(values, result...)
 
@@ -12551,7 +12551,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := (*Event)(ctx.Object).ResolveProcessArgsOptions(&element.Process)
+			result := (*Event)(ctx.Object).ResolveProcessArgsOptions(&element.ProcessContext.Process)
 
 			values = append(values, result...)
 
@@ -12573,7 +12573,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := (*Event)(ctx.Object).ResolveProcessArgsTruncated(&element.Process)
+			result := (*Event)(ctx.Object).ResolveProcessArgsTruncated(&element.ProcessContext.Process)
 
 			values = append(values, result)
 
@@ -12595,7 +12595,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := (*Event)(ctx.Object).ResolveProcessArgv(&element.Process)
+			result := (*Event)(ctx.Object).ResolveProcessArgv(&element.ProcessContext.Process)
 
 			values = append(values, result...)
 
@@ -12617,7 +12617,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := (*Event)(ctx.Object).ResolveProcessArgv0(&element.Process)
+			result := (*Event)(ctx.Object).ResolveProcessArgv0(&element.ProcessContext.Process)
 
 			values = append(values, result)
 
@@ -12749,7 +12749,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := int((*Event)(ctx.Object).ResolveProcessCreatedAt(&element.Process))
+			result := int((*Event)(ctx.Object).ResolveProcessCreatedAt(&element.ProcessContext.Process))
 
 			values = append(values, result)
 
@@ -12815,7 +12815,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := (*Event)(ctx.Object).ResolveProcessEnvp(&element.Process)
+			result := (*Event)(ctx.Object).ResolveProcessEnvp(&element.ProcessContext.Process)
 
 			values = append(values, result...)
 
@@ -12837,7 +12837,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := (*Event)(ctx.Object).ResolveProcessEnvs(&element.Process)
+			result := (*Event)(ctx.Object).ResolveProcessEnvs(&element.ProcessContext.Process)
 
 			values = append(values, result...)
 
@@ -12859,7 +12859,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := (*Event)(ctx.Object).ResolveProcessEnvsTruncated(&element.Process)
+			result := (*Event)(ctx.Object).ResolveProcessEnvsTruncated(&element.ProcessContext.Process)
 
 			values = append(values, result)
 
@@ -12925,7 +12925,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := int(element.ProcessContext.Process.FileFields.CTime)
+			result := int(element.ProcessContext.Process.FileEvent.FileFields.CTime)
 
 			values = append(values, result)
 
@@ -12947,7 +12947,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := element.ProcessContext.Process.Filesystem
+			result := (*Event)(ctx.Object).ResolveFileFilesystem(&element.ProcessContext.Process.FileEvent)
 
 			values = append(values, result)
 
@@ -12969,7 +12969,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := int(element.ProcessContext.Process.FileFields.GID)
+			result := int(element.ProcessContext.Process.FileEvent.FileFields.GID)
 
 			values = append(values, result)
 
@@ -12991,7 +12991,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := (*Event)(ctx.Object).ResolveFileFieldsGroup(&element.FileFields)
+			result := (*Event)(ctx.Object).ResolveFileFieldsGroup(&element.ProcessContext.Process.FileEvent.FileFields)
 
 			values = append(values, result)
 
@@ -13013,7 +13013,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := (*Event)(ctx.Object).ResolveFileFieldsInUpperLayer(&element.FileFields)
+			result := (*Event)(ctx.Object).ResolveFileFieldsInUpperLayer(&element.ProcessContext.Process.FileEvent.FileFields)
 
 			values = append(values, result)
 
@@ -13035,7 +13035,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := int(element.ProcessContext.Process.FileFields.Inode)
+			result := int(element.ProcessContext.Process.FileEvent.FileFields.Inode)
 
 			values = append(values, result)
 
@@ -13057,7 +13057,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := int(element.ProcessContext.Process.FileFields.Mode)
+			result := int(element.ProcessContext.Process.FileEvent.FileFields.Mode)
 
 			values = append(values, result)
 
@@ -13079,7 +13079,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := int(element.ProcessContext.Process.FileFields.MTime)
+			result := int(element.ProcessContext.Process.FileEvent.FileFields.MTime)
 
 			values = append(values, result)
 
@@ -13101,7 +13101,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := int(element.ProcessContext.Process.FileFields.MountID)
+			result := int(element.ProcessContext.Process.FileEvent.FileFields.MountID)
 
 			values = append(values, result)
 
@@ -13123,7 +13123,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := element.ProcessContext.Process.BasenameStr
+			result := (*Event)(ctx.Object).ResolveFileBasename(&element.ProcessContext.Process.FileEvent)
 
 			values = append(values, result)
 
@@ -13145,7 +13145,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := element.ProcessContext.Process.PathnameStr
+			result := (*Event)(ctx.Object).ResolveFilePath(&element.ProcessContext.Process.FileEvent)
 
 			values = append(values, result)
 
@@ -13167,7 +13167,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := int((*Event)(ctx.Object).ResolveRights(&element.FileFields))
+			result := int((*Event)(ctx.Object).ResolveRights(&element.ProcessContext.Process.FileEvent.FileFields))
 
 			values = append(values, result)
 
@@ -13189,7 +13189,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := int(element.ProcessContext.Process.FileFields.UID)
+			result := int(element.ProcessContext.Process.FileEvent.FileFields.UID)
 
 			values = append(values, result)
 
@@ -13211,7 +13211,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := (*Event)(ctx.Object).ResolveFileFieldsUser(&element.FileFields)
+			result := (*Event)(ctx.Object).ResolveFileFieldsUser(&element.ProcessContext.Process.FileEvent.FileFields)
 
 			values = append(values, result)
 
@@ -13562,59 +13562,59 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "ptrace.tracee.file.change_time":
 
-		return int(e.PTrace.Tracee.Process.FileFields.CTime), nil
+		return int(e.PTrace.Tracee.Process.FileEvent.FileFields.CTime), nil
 
 	case "ptrace.tracee.file.filesystem":
 
-		return e.PTrace.Tracee.Process.Filesystem, nil
+		return e.ResolveFileFilesystem(&e.PTrace.Tracee.Process.FileEvent), nil
 
 	case "ptrace.tracee.file.gid":
 
-		return int(e.PTrace.Tracee.Process.FileFields.GID), nil
+		return int(e.PTrace.Tracee.Process.FileEvent.FileFields.GID), nil
 
 	case "ptrace.tracee.file.group":
 
-		return e.ResolveFileFieldsGroup(&e.PTrace.Tracee.Process.FileFields), nil
+		return e.ResolveFileFieldsGroup(&e.PTrace.Tracee.Process.FileEvent.FileFields), nil
 
 	case "ptrace.tracee.file.in_upper_layer":
 
-		return e.ResolveFileFieldsInUpperLayer(&e.PTrace.Tracee.Process.FileFields), nil
+		return e.ResolveFileFieldsInUpperLayer(&e.PTrace.Tracee.Process.FileEvent.FileFields), nil
 
 	case "ptrace.tracee.file.inode":
 
-		return int(e.PTrace.Tracee.Process.FileFields.Inode), nil
+		return int(e.PTrace.Tracee.Process.FileEvent.FileFields.Inode), nil
 
 	case "ptrace.tracee.file.mode":
 
-		return int(e.PTrace.Tracee.Process.FileFields.Mode), nil
+		return int(e.PTrace.Tracee.Process.FileEvent.FileFields.Mode), nil
 
 	case "ptrace.tracee.file.modification_time":
 
-		return int(e.PTrace.Tracee.Process.FileFields.MTime), nil
+		return int(e.PTrace.Tracee.Process.FileEvent.FileFields.MTime), nil
 
 	case "ptrace.tracee.file.mount_id":
 
-		return int(e.PTrace.Tracee.Process.FileFields.MountID), nil
+		return int(e.PTrace.Tracee.Process.FileEvent.FileFields.MountID), nil
 
 	case "ptrace.tracee.file.name":
 
-		return e.PTrace.Tracee.Process.BasenameStr, nil
+		return e.ResolveFileBasename(&e.PTrace.Tracee.Process.FileEvent), nil
 
 	case "ptrace.tracee.file.path":
 
-		return e.PTrace.Tracee.Process.PathnameStr, nil
+		return e.ResolveFilePath(&e.PTrace.Tracee.Process.FileEvent), nil
 
 	case "ptrace.tracee.file.rights":
 
-		return int(e.ResolveRights(&e.PTrace.Tracee.Process.FileFields)), nil
+		return int(e.ResolveRights(&e.PTrace.Tracee.Process.FileEvent.FileFields)), nil
 
 	case "ptrace.tracee.file.uid":
 
-		return int(e.PTrace.Tracee.Process.FileFields.UID), nil
+		return int(e.PTrace.Tracee.Process.FileEvent.FileFields.UID), nil
 
 	case "ptrace.tracee.file.user":
 
-		return e.ResolveFileFieldsUser(&e.PTrace.Tracee.Process.FileFields), nil
+		return e.ResolveFileFieldsUser(&e.PTrace.Tracee.Process.FileEvent.FileFields), nil
 
 	case "ptrace.tracee.fsgid":
 
@@ -14061,7 +14061,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := (*Event)(ctx.Object).ResolveProcessArgs(&element.Process)
+			result := (*Event)(ctx.Object).ResolveProcessArgs(&element.ProcessContext.Process)
 
 			values = append(values, result)
 
@@ -14083,7 +14083,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := (*Event)(ctx.Object).ResolveProcessArgsFlags(&element.Process)
+			result := (*Event)(ctx.Object).ResolveProcessArgsFlags(&element.ProcessContext.Process)
 
 			values = append(values, result...)
 
@@ -14105,7 +14105,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := (*Event)(ctx.Object).ResolveProcessArgsOptions(&element.Process)
+			result := (*Event)(ctx.Object).ResolveProcessArgsOptions(&element.ProcessContext.Process)
 
 			values = append(values, result...)
 
@@ -14127,7 +14127,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := (*Event)(ctx.Object).ResolveProcessArgsTruncated(&element.Process)
+			result := (*Event)(ctx.Object).ResolveProcessArgsTruncated(&element.ProcessContext.Process)
 
 			values = append(values, result)
 
@@ -14149,7 +14149,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := (*Event)(ctx.Object).ResolveProcessArgv(&element.Process)
+			result := (*Event)(ctx.Object).ResolveProcessArgv(&element.ProcessContext.Process)
 
 			values = append(values, result...)
 
@@ -14171,7 +14171,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := (*Event)(ctx.Object).ResolveProcessArgv0(&element.Process)
+			result := (*Event)(ctx.Object).ResolveProcessArgv0(&element.ProcessContext.Process)
 
 			values = append(values, result)
 
@@ -14303,7 +14303,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := int((*Event)(ctx.Object).ResolveProcessCreatedAt(&element.Process))
+			result := int((*Event)(ctx.Object).ResolveProcessCreatedAt(&element.ProcessContext.Process))
 
 			values = append(values, result)
 
@@ -14369,7 +14369,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := (*Event)(ctx.Object).ResolveProcessEnvp(&element.Process)
+			result := (*Event)(ctx.Object).ResolveProcessEnvp(&element.ProcessContext.Process)
 
 			values = append(values, result...)
 
@@ -14391,7 +14391,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := (*Event)(ctx.Object).ResolveProcessEnvs(&element.Process)
+			result := (*Event)(ctx.Object).ResolveProcessEnvs(&element.ProcessContext.Process)
 
 			values = append(values, result...)
 
@@ -14413,7 +14413,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := (*Event)(ctx.Object).ResolveProcessEnvsTruncated(&element.Process)
+			result := (*Event)(ctx.Object).ResolveProcessEnvsTruncated(&element.ProcessContext.Process)
 
 			values = append(values, result)
 
@@ -14479,7 +14479,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := int(element.ProcessContext.Process.FileFields.CTime)
+			result := int(element.ProcessContext.Process.FileEvent.FileFields.CTime)
 
 			values = append(values, result)
 
@@ -14501,7 +14501,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := element.ProcessContext.Process.Filesystem
+			result := (*Event)(ctx.Object).ResolveFileFilesystem(&element.ProcessContext.Process.FileEvent)
 
 			values = append(values, result)
 
@@ -14523,7 +14523,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := int(element.ProcessContext.Process.FileFields.GID)
+			result := int(element.ProcessContext.Process.FileEvent.FileFields.GID)
 
 			values = append(values, result)
 
@@ -14545,7 +14545,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := (*Event)(ctx.Object).ResolveFileFieldsGroup(&element.FileFields)
+			result := (*Event)(ctx.Object).ResolveFileFieldsGroup(&element.ProcessContext.Process.FileEvent.FileFields)
 
 			values = append(values, result)
 
@@ -14567,7 +14567,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := (*Event)(ctx.Object).ResolveFileFieldsInUpperLayer(&element.FileFields)
+			result := (*Event)(ctx.Object).ResolveFileFieldsInUpperLayer(&element.ProcessContext.Process.FileEvent.FileFields)
 
 			values = append(values, result)
 
@@ -14589,7 +14589,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := int(element.ProcessContext.Process.FileFields.Inode)
+			result := int(element.ProcessContext.Process.FileEvent.FileFields.Inode)
 
 			values = append(values, result)
 
@@ -14611,7 +14611,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := int(element.ProcessContext.Process.FileFields.Mode)
+			result := int(element.ProcessContext.Process.FileEvent.FileFields.Mode)
 
 			values = append(values, result)
 
@@ -14633,7 +14633,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := int(element.ProcessContext.Process.FileFields.MTime)
+			result := int(element.ProcessContext.Process.FileEvent.FileFields.MTime)
 
 			values = append(values, result)
 
@@ -14655,7 +14655,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := int(element.ProcessContext.Process.FileFields.MountID)
+			result := int(element.ProcessContext.Process.FileEvent.FileFields.MountID)
 
 			values = append(values, result)
 
@@ -14677,7 +14677,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := element.ProcessContext.Process.BasenameStr
+			result := (*Event)(ctx.Object).ResolveFileBasename(&element.ProcessContext.Process.FileEvent)
 
 			values = append(values, result)
 
@@ -14699,7 +14699,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := element.ProcessContext.Process.PathnameStr
+			result := (*Event)(ctx.Object).ResolveFilePath(&element.ProcessContext.Process.FileEvent)
 
 			values = append(values, result)
 
@@ -14721,7 +14721,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := int((*Event)(ctx.Object).ResolveRights(&element.FileFields))
+			result := int((*Event)(ctx.Object).ResolveRights(&element.ProcessContext.Process.FileEvent.FileFields))
 
 			values = append(values, result)
 
@@ -14743,7 +14743,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := int(element.ProcessContext.Process.FileFields.UID)
+			result := int(element.ProcessContext.Process.FileEvent.FileFields.UID)
 
 			values = append(values, result)
 
@@ -14765,7 +14765,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := (*Event)(ctx.Object).ResolveFileFieldsUser(&element.FileFields)
+			result := (*Event)(ctx.Object).ResolveFileFieldsUser(&element.ProcessContext.Process.FileEvent.FileFields)
 
 			values = append(values, result)
 
@@ -15116,59 +15116,59 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "signal.target.file.change_time":
 
-		return int(e.Signal.Target.Process.FileFields.CTime), nil
+		return int(e.Signal.Target.Process.FileEvent.FileFields.CTime), nil
 
 	case "signal.target.file.filesystem":
 
-		return e.Signal.Target.Process.Filesystem, nil
+		return e.ResolveFileFilesystem(&e.Signal.Target.Process.FileEvent), nil
 
 	case "signal.target.file.gid":
 
-		return int(e.Signal.Target.Process.FileFields.GID), nil
+		return int(e.Signal.Target.Process.FileEvent.FileFields.GID), nil
 
 	case "signal.target.file.group":
 
-		return e.ResolveFileFieldsGroup(&e.Signal.Target.Process.FileFields), nil
+		return e.ResolveFileFieldsGroup(&e.Signal.Target.Process.FileEvent.FileFields), nil
 
 	case "signal.target.file.in_upper_layer":
 
-		return e.ResolveFileFieldsInUpperLayer(&e.Signal.Target.Process.FileFields), nil
+		return e.ResolveFileFieldsInUpperLayer(&e.Signal.Target.Process.FileEvent.FileFields), nil
 
 	case "signal.target.file.inode":
 
-		return int(e.Signal.Target.Process.FileFields.Inode), nil
+		return int(e.Signal.Target.Process.FileEvent.FileFields.Inode), nil
 
 	case "signal.target.file.mode":
 
-		return int(e.Signal.Target.Process.FileFields.Mode), nil
+		return int(e.Signal.Target.Process.FileEvent.FileFields.Mode), nil
 
 	case "signal.target.file.modification_time":
 
-		return int(e.Signal.Target.Process.FileFields.MTime), nil
+		return int(e.Signal.Target.Process.FileEvent.FileFields.MTime), nil
 
 	case "signal.target.file.mount_id":
 
-		return int(e.Signal.Target.Process.FileFields.MountID), nil
+		return int(e.Signal.Target.Process.FileEvent.FileFields.MountID), nil
 
 	case "signal.target.file.name":
 
-		return e.Signal.Target.Process.BasenameStr, nil
+		return e.ResolveFileBasename(&e.Signal.Target.Process.FileEvent), nil
 
 	case "signal.target.file.path":
 
-		return e.Signal.Target.Process.PathnameStr, nil
+		return e.ResolveFilePath(&e.Signal.Target.Process.FileEvent), nil
 
 	case "signal.target.file.rights":
 
-		return int(e.ResolveRights(&e.Signal.Target.Process.FileFields)), nil
+		return int(e.ResolveRights(&e.Signal.Target.Process.FileEvent.FileFields)), nil
 
 	case "signal.target.file.uid":
 
-		return int(e.Signal.Target.Process.FileFields.UID), nil
+		return int(e.Signal.Target.Process.FileEvent.FileFields.UID), nil
 
 	case "signal.target.file.user":
 
-		return e.ResolveFileFieldsUser(&e.Signal.Target.Process.FileFields), nil
+		return e.ResolveFileFieldsUser(&e.Signal.Target.Process.FileEvent.FileFields), nil
 
 	case "signal.target.fsgid":
 
@@ -19983,9 +19983,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Chmod.File.Filesytem"}
+			return &eval.ErrValueTypeMismatch{Field: "Chmod.File.Filesystem"}
 		}
-		e.Chmod.File.Filesytem = str
+		e.Chmod.File.Filesystem = str
 
 		return nil
 
@@ -20189,9 +20189,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Chown.File.Filesytem"}
+			return &eval.ErrValueTypeMismatch{Field: "Chown.File.Filesystem"}
 		}
-		e.Chown.File.Filesytem = str
+		e.Chown.File.Filesystem = str
 
 		return nil
 
@@ -20620,9 +20620,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileFields.CTime"}
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileEvent.FileFields.CTime"}
 		}
-		e.Exec.Process.FileFields.CTime = uint64(v)
+		e.Exec.Process.FileEvent.FileFields.CTime = uint64(v)
 
 		return nil
 
@@ -20631,9 +20631,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.Filesystem"}
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileEvent.Filesystem"}
 		}
-		e.Exec.Process.Filesystem = str
+		e.Exec.Process.FileEvent.Filesystem = str
 
 		return nil
 
@@ -20642,9 +20642,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileFields.GID"}
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileEvent.FileFields.GID"}
 		}
-		e.Exec.Process.FileFields.GID = uint32(v)
+		e.Exec.Process.FileEvent.FileFields.GID = uint32(v)
 
 		return nil
 
@@ -20653,17 +20653,17 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileFields.Group"}
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileEvent.FileFields.Group"}
 		}
-		e.Exec.Process.FileFields.Group = str
+		e.Exec.Process.FileEvent.FileFields.Group = str
 
 		return nil
 
 	case "exec.file.in_upper_layer":
 
 		var ok bool
-		if e.Exec.Process.FileFields.InUpperLayer, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileFields.InUpperLayer"}
+		if e.Exec.Process.FileEvent.FileFields.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileEvent.FileFields.InUpperLayer"}
 		}
 		return nil
 
@@ -20672,9 +20672,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileFields.Inode"}
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileEvent.FileFields.Inode"}
 		}
-		e.Exec.Process.FileFields.Inode = uint64(v)
+		e.Exec.Process.FileEvent.FileFields.Inode = uint64(v)
 
 		return nil
 
@@ -20683,9 +20683,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileFields.Mode"}
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileEvent.FileFields.Mode"}
 		}
-		e.Exec.Process.FileFields.Mode = uint16(v)
+		e.Exec.Process.FileEvent.FileFields.Mode = uint16(v)
 
 		return nil
 
@@ -20694,9 +20694,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileFields.MTime"}
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileEvent.FileFields.MTime"}
 		}
-		e.Exec.Process.FileFields.MTime = uint64(v)
+		e.Exec.Process.FileEvent.FileFields.MTime = uint64(v)
 
 		return nil
 
@@ -20705,9 +20705,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileFields.MountID"}
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileEvent.FileFields.MountID"}
 		}
-		e.Exec.Process.FileFields.MountID = uint32(v)
+		e.Exec.Process.FileEvent.FileFields.MountID = uint32(v)
 
 		return nil
 
@@ -20716,9 +20716,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.BasenameStr"}
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileEvent.BasenameStr"}
 		}
-		e.Exec.Process.BasenameStr = str
+		e.Exec.Process.FileEvent.BasenameStr = str
 
 		return nil
 
@@ -20727,9 +20727,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.PathnameStr"}
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileEvent.PathnameStr"}
 		}
-		e.Exec.Process.PathnameStr = str
+		e.Exec.Process.FileEvent.PathnameStr = str
 
 		return nil
 
@@ -20738,9 +20738,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileFields.Mode"}
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileEvent.FileFields.Mode"}
 		}
-		e.Exec.Process.FileFields.Mode = uint16(v)
+		e.Exec.Process.FileEvent.FileFields.Mode = uint16(v)
 
 		return nil
 
@@ -20749,9 +20749,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileFields.UID"}
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileEvent.FileFields.UID"}
 		}
-		e.Exec.Process.FileFields.UID = uint32(v)
+		e.Exec.Process.FileEvent.FileFields.UID = uint32(v)
 
 		return nil
 
@@ -20760,9 +20760,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileFields.User"}
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileEvent.FileFields.User"}
 		}
-		e.Exec.Process.FileFields.User = str
+		e.Exec.Process.FileEvent.FileFields.User = str
 
 		return nil
 
@@ -20925,9 +20925,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Link.Target.Filesytem"}
+			return &eval.ErrValueTypeMismatch{Field: "Link.Target.Filesystem"}
 		}
-		e.Link.Target.Filesytem = str
+		e.Link.Target.Filesystem = str
 
 		return nil
 
@@ -21065,9 +21065,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Link.Source.Filesytem"}
+			return &eval.ErrValueTypeMismatch{Field: "Link.Source.Filesystem"}
 		}
-		e.Link.Source.Filesytem = str
+		e.Link.Source.Filesystem = str
 
 		return nil
 
@@ -21227,9 +21227,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "LoadModule.File.Filesytem"}
+			return &eval.ErrValueTypeMismatch{Field: "LoadModule.File.Filesystem"}
 		}
-		e.LoadModule.File.Filesytem = str
+		e.LoadModule.File.Filesystem = str
 
 		return nil
 
@@ -21430,9 +21430,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Mkdir.File.Filesytem"}
+			return &eval.ErrValueTypeMismatch{Field: "Mkdir.File.Filesystem"}
 		}
-		e.Mkdir.File.Filesytem = str
+		e.Mkdir.File.Filesystem = str
 
 		return nil
 
@@ -21592,9 +21592,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "MMap.File.Filesytem"}
+			return &eval.ErrValueTypeMismatch{Field: "MMap.File.Filesystem"}
 		}
-		e.MMap.File.Filesytem = str
+		e.MMap.File.Filesystem = str
 
 		return nil
 
@@ -21919,9 +21919,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Open.File.Filesytem"}
+			return &eval.ErrValueTypeMismatch{Field: "Open.File.Filesystem"}
 		}
-		e.Open.File.Filesytem = str
+		e.Open.File.Filesystem = str
 
 		return nil
 
@@ -22364,9 +22364,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileFields.CTime"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileEvent.FileFields.CTime"}
 		}
-		e.ProcessContext.Ancestor.ProcessContext.Process.FileFields.CTime = uint64(v)
+		e.ProcessContext.Ancestor.ProcessContext.Process.FileEvent.FileFields.CTime = uint64(v)
 
 		return nil
 
@@ -22379,9 +22379,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.Filesystem"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileEvent.Filesystem"}
 		}
-		e.ProcessContext.Ancestor.ProcessContext.Process.Filesystem = str
+		e.ProcessContext.Ancestor.ProcessContext.Process.FileEvent.Filesystem = str
 
 		return nil
 
@@ -22394,9 +22394,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileFields.GID"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileEvent.FileFields.GID"}
 		}
-		e.ProcessContext.Ancestor.ProcessContext.Process.FileFields.GID = uint32(v)
+		e.ProcessContext.Ancestor.ProcessContext.Process.FileEvent.FileFields.GID = uint32(v)
 
 		return nil
 
@@ -22409,9 +22409,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileFields.Group"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileEvent.FileFields.Group"}
 		}
-		e.ProcessContext.Ancestor.ProcessContext.Process.FileFields.Group = str
+		e.ProcessContext.Ancestor.ProcessContext.Process.FileEvent.FileFields.Group = str
 
 		return nil
 
@@ -22422,8 +22422,8 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 
 		var ok bool
-		if e.ProcessContext.Ancestor.ProcessContext.Process.FileFields.InUpperLayer, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileFields.InUpperLayer"}
+		if e.ProcessContext.Ancestor.ProcessContext.Process.FileEvent.FileFields.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileEvent.FileFields.InUpperLayer"}
 		}
 		return nil
 
@@ -22436,9 +22436,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileFields.Inode"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileEvent.FileFields.Inode"}
 		}
-		e.ProcessContext.Ancestor.ProcessContext.Process.FileFields.Inode = uint64(v)
+		e.ProcessContext.Ancestor.ProcessContext.Process.FileEvent.FileFields.Inode = uint64(v)
 
 		return nil
 
@@ -22451,9 +22451,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileFields.Mode"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileEvent.FileFields.Mode"}
 		}
-		e.ProcessContext.Ancestor.ProcessContext.Process.FileFields.Mode = uint16(v)
+		e.ProcessContext.Ancestor.ProcessContext.Process.FileEvent.FileFields.Mode = uint16(v)
 
 		return nil
 
@@ -22466,9 +22466,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileFields.MTime"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileEvent.FileFields.MTime"}
 		}
-		e.ProcessContext.Ancestor.ProcessContext.Process.FileFields.MTime = uint64(v)
+		e.ProcessContext.Ancestor.ProcessContext.Process.FileEvent.FileFields.MTime = uint64(v)
 
 		return nil
 
@@ -22481,9 +22481,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileFields.MountID"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileEvent.FileFields.MountID"}
 		}
-		e.ProcessContext.Ancestor.ProcessContext.Process.FileFields.MountID = uint32(v)
+		e.ProcessContext.Ancestor.ProcessContext.Process.FileEvent.FileFields.MountID = uint32(v)
 
 		return nil
 
@@ -22496,9 +22496,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.BasenameStr"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileEvent.BasenameStr"}
 		}
-		e.ProcessContext.Ancestor.ProcessContext.Process.BasenameStr = str
+		e.ProcessContext.Ancestor.ProcessContext.Process.FileEvent.BasenameStr = str
 
 		return nil
 
@@ -22511,9 +22511,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.PathnameStr"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileEvent.PathnameStr"}
 		}
-		e.ProcessContext.Ancestor.ProcessContext.Process.PathnameStr = str
+		e.ProcessContext.Ancestor.ProcessContext.Process.FileEvent.PathnameStr = str
 
 		return nil
 
@@ -22526,9 +22526,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileFields.Mode"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileEvent.FileFields.Mode"}
 		}
-		e.ProcessContext.Ancestor.ProcessContext.Process.FileFields.Mode = uint16(v)
+		e.ProcessContext.Ancestor.ProcessContext.Process.FileEvent.FileFields.Mode = uint16(v)
 
 		return nil
 
@@ -22541,9 +22541,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileFields.UID"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileEvent.FileFields.UID"}
 		}
-		e.ProcessContext.Ancestor.ProcessContext.Process.FileFields.UID = uint32(v)
+		e.ProcessContext.Ancestor.ProcessContext.Process.FileEvent.FileFields.UID = uint32(v)
 
 		return nil
 
@@ -22556,9 +22556,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileFields.User"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileEvent.FileFields.User"}
 		}
-		e.ProcessContext.Ancestor.ProcessContext.Process.FileFields.User = str
+		e.ProcessContext.Ancestor.ProcessContext.Process.FileEvent.FileFields.User = str
 
 		return nil
 
@@ -22950,9 +22950,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileFields.CTime"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileEvent.FileFields.CTime"}
 		}
-		e.ProcessContext.Process.FileFields.CTime = uint64(v)
+		e.ProcessContext.Process.FileEvent.FileFields.CTime = uint64(v)
 
 		return nil
 
@@ -22961,9 +22961,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.Filesystem"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileEvent.Filesystem"}
 		}
-		e.ProcessContext.Process.Filesystem = str
+		e.ProcessContext.Process.FileEvent.Filesystem = str
 
 		return nil
 
@@ -22972,9 +22972,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileFields.GID"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileEvent.FileFields.GID"}
 		}
-		e.ProcessContext.Process.FileFields.GID = uint32(v)
+		e.ProcessContext.Process.FileEvent.FileFields.GID = uint32(v)
 
 		return nil
 
@@ -22983,17 +22983,17 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileFields.Group"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileEvent.FileFields.Group"}
 		}
-		e.ProcessContext.Process.FileFields.Group = str
+		e.ProcessContext.Process.FileEvent.FileFields.Group = str
 
 		return nil
 
 	case "process.file.in_upper_layer":
 
 		var ok bool
-		if e.ProcessContext.Process.FileFields.InUpperLayer, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileFields.InUpperLayer"}
+		if e.ProcessContext.Process.FileEvent.FileFields.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileEvent.FileFields.InUpperLayer"}
 		}
 		return nil
 
@@ -23002,9 +23002,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileFields.Inode"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileEvent.FileFields.Inode"}
 		}
-		e.ProcessContext.Process.FileFields.Inode = uint64(v)
+		e.ProcessContext.Process.FileEvent.FileFields.Inode = uint64(v)
 
 		return nil
 
@@ -23013,9 +23013,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileFields.Mode"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileEvent.FileFields.Mode"}
 		}
-		e.ProcessContext.Process.FileFields.Mode = uint16(v)
+		e.ProcessContext.Process.FileEvent.FileFields.Mode = uint16(v)
 
 		return nil
 
@@ -23024,9 +23024,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileFields.MTime"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileEvent.FileFields.MTime"}
 		}
-		e.ProcessContext.Process.FileFields.MTime = uint64(v)
+		e.ProcessContext.Process.FileEvent.FileFields.MTime = uint64(v)
 
 		return nil
 
@@ -23035,9 +23035,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileFields.MountID"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileEvent.FileFields.MountID"}
 		}
-		e.ProcessContext.Process.FileFields.MountID = uint32(v)
+		e.ProcessContext.Process.FileEvent.FileFields.MountID = uint32(v)
 
 		return nil
 
@@ -23046,9 +23046,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.BasenameStr"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileEvent.BasenameStr"}
 		}
-		e.ProcessContext.Process.BasenameStr = str
+		e.ProcessContext.Process.FileEvent.BasenameStr = str
 
 		return nil
 
@@ -23057,9 +23057,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.PathnameStr"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileEvent.PathnameStr"}
 		}
-		e.ProcessContext.Process.PathnameStr = str
+		e.ProcessContext.Process.FileEvent.PathnameStr = str
 
 		return nil
 
@@ -23068,9 +23068,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileFields.Mode"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileEvent.FileFields.Mode"}
 		}
-		e.ProcessContext.Process.FileFields.Mode = uint16(v)
+		e.ProcessContext.Process.FileEvent.FileFields.Mode = uint16(v)
 
 		return nil
 
@@ -23079,9 +23079,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileFields.UID"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileEvent.FileFields.UID"}
 		}
-		e.ProcessContext.Process.FileFields.UID = uint32(v)
+		e.ProcessContext.Process.FileEvent.FileFields.UID = uint32(v)
 
 		return nil
 
@@ -23090,9 +23090,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileFields.User"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileEvent.FileFields.User"}
 		}
-		e.ProcessContext.Process.FileFields.User = str
+		e.ProcessContext.Process.FileEvent.FileFields.User = str
 
 		return nil
 
@@ -23538,9 +23538,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileFields.CTime"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.FileFields.CTime"}
 		}
-		e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileFields.CTime = uint64(v)
+		e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.FileFields.CTime = uint64(v)
 
 		return nil
 
@@ -23553,9 +23553,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.Filesystem"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.Filesystem"}
 		}
-		e.PTrace.Tracee.Ancestor.ProcessContext.Process.Filesystem = str
+		e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.Filesystem = str
 
 		return nil
 
@@ -23568,9 +23568,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileFields.GID"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.FileFields.GID"}
 		}
-		e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileFields.GID = uint32(v)
+		e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.FileFields.GID = uint32(v)
 
 		return nil
 
@@ -23583,9 +23583,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileFields.Group"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.FileFields.Group"}
 		}
-		e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileFields.Group = str
+		e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.FileFields.Group = str
 
 		return nil
 
@@ -23596,8 +23596,8 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 
 		var ok bool
-		if e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileFields.InUpperLayer, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileFields.InUpperLayer"}
+		if e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.FileFields.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.FileFields.InUpperLayer"}
 		}
 		return nil
 
@@ -23610,9 +23610,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileFields.Inode"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.FileFields.Inode"}
 		}
-		e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileFields.Inode = uint64(v)
+		e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.FileFields.Inode = uint64(v)
 
 		return nil
 
@@ -23625,9 +23625,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileFields.Mode"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.FileFields.Mode"}
 		}
-		e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileFields.Mode = uint16(v)
+		e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.FileFields.Mode = uint16(v)
 
 		return nil
 
@@ -23640,9 +23640,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileFields.MTime"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.FileFields.MTime"}
 		}
-		e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileFields.MTime = uint64(v)
+		e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.FileFields.MTime = uint64(v)
 
 		return nil
 
@@ -23655,9 +23655,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileFields.MountID"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.FileFields.MountID"}
 		}
-		e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileFields.MountID = uint32(v)
+		e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.FileFields.MountID = uint32(v)
 
 		return nil
 
@@ -23670,9 +23670,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.BasenameStr"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.BasenameStr"}
 		}
-		e.PTrace.Tracee.Ancestor.ProcessContext.Process.BasenameStr = str
+		e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.BasenameStr = str
 
 		return nil
 
@@ -23685,9 +23685,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.PathnameStr"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.PathnameStr"}
 		}
-		e.PTrace.Tracee.Ancestor.ProcessContext.Process.PathnameStr = str
+		e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.PathnameStr = str
 
 		return nil
 
@@ -23700,9 +23700,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileFields.Mode"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.FileFields.Mode"}
 		}
-		e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileFields.Mode = uint16(v)
+		e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.FileFields.Mode = uint16(v)
 
 		return nil
 
@@ -23715,9 +23715,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileFields.UID"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.FileFields.UID"}
 		}
-		e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileFields.UID = uint32(v)
+		e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.FileFields.UID = uint32(v)
 
 		return nil
 
@@ -23730,9 +23730,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileFields.User"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.FileFields.User"}
 		}
-		e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileFields.User = str
+		e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.FileFields.User = str
 
 		return nil
 
@@ -24124,9 +24124,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileFields.CTime"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileEvent.FileFields.CTime"}
 		}
-		e.PTrace.Tracee.Process.FileFields.CTime = uint64(v)
+		e.PTrace.Tracee.Process.FileEvent.FileFields.CTime = uint64(v)
 
 		return nil
 
@@ -24135,9 +24135,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.Filesystem"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileEvent.Filesystem"}
 		}
-		e.PTrace.Tracee.Process.Filesystem = str
+		e.PTrace.Tracee.Process.FileEvent.Filesystem = str
 
 		return nil
 
@@ -24146,9 +24146,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileFields.GID"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileEvent.FileFields.GID"}
 		}
-		e.PTrace.Tracee.Process.FileFields.GID = uint32(v)
+		e.PTrace.Tracee.Process.FileEvent.FileFields.GID = uint32(v)
 
 		return nil
 
@@ -24157,17 +24157,17 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileFields.Group"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileEvent.FileFields.Group"}
 		}
-		e.PTrace.Tracee.Process.FileFields.Group = str
+		e.PTrace.Tracee.Process.FileEvent.FileFields.Group = str
 
 		return nil
 
 	case "ptrace.tracee.file.in_upper_layer":
 
 		var ok bool
-		if e.PTrace.Tracee.Process.FileFields.InUpperLayer, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileFields.InUpperLayer"}
+		if e.PTrace.Tracee.Process.FileEvent.FileFields.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileEvent.FileFields.InUpperLayer"}
 		}
 		return nil
 
@@ -24176,9 +24176,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileFields.Inode"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileEvent.FileFields.Inode"}
 		}
-		e.PTrace.Tracee.Process.FileFields.Inode = uint64(v)
+		e.PTrace.Tracee.Process.FileEvent.FileFields.Inode = uint64(v)
 
 		return nil
 
@@ -24187,9 +24187,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileFields.Mode"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileEvent.FileFields.Mode"}
 		}
-		e.PTrace.Tracee.Process.FileFields.Mode = uint16(v)
+		e.PTrace.Tracee.Process.FileEvent.FileFields.Mode = uint16(v)
 
 		return nil
 
@@ -24198,9 +24198,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileFields.MTime"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileEvent.FileFields.MTime"}
 		}
-		e.PTrace.Tracee.Process.FileFields.MTime = uint64(v)
+		e.PTrace.Tracee.Process.FileEvent.FileFields.MTime = uint64(v)
 
 		return nil
 
@@ -24209,9 +24209,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileFields.MountID"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileEvent.FileFields.MountID"}
 		}
-		e.PTrace.Tracee.Process.FileFields.MountID = uint32(v)
+		e.PTrace.Tracee.Process.FileEvent.FileFields.MountID = uint32(v)
 
 		return nil
 
@@ -24220,9 +24220,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.BasenameStr"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileEvent.BasenameStr"}
 		}
-		e.PTrace.Tracee.Process.BasenameStr = str
+		e.PTrace.Tracee.Process.FileEvent.BasenameStr = str
 
 		return nil
 
@@ -24231,9 +24231,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.PathnameStr"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileEvent.PathnameStr"}
 		}
-		e.PTrace.Tracee.Process.PathnameStr = str
+		e.PTrace.Tracee.Process.FileEvent.PathnameStr = str
 
 		return nil
 
@@ -24242,9 +24242,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileFields.Mode"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileEvent.FileFields.Mode"}
 		}
-		e.PTrace.Tracee.Process.FileFields.Mode = uint16(v)
+		e.PTrace.Tracee.Process.FileEvent.FileFields.Mode = uint16(v)
 
 		return nil
 
@@ -24253,9 +24253,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileFields.UID"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileEvent.FileFields.UID"}
 		}
-		e.PTrace.Tracee.Process.FileFields.UID = uint32(v)
+		e.PTrace.Tracee.Process.FileEvent.FileFields.UID = uint32(v)
 
 		return nil
 
@@ -24264,9 +24264,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileFields.User"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileEvent.FileFields.User"}
 		}
-		e.PTrace.Tracee.Process.FileFields.User = str
+		e.PTrace.Tracee.Process.FileEvent.FileFields.User = str
 
 		return nil
 
@@ -24440,9 +24440,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.File.Filesytem"}
+			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.File.Filesystem"}
 		}
-		e.RemoveXAttr.File.Filesytem = str
+		e.RemoveXAttr.File.Filesystem = str
 
 		return nil
 
@@ -24613,9 +24613,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Rename.New.Filesytem"}
+			return &eval.ErrValueTypeMismatch{Field: "Rename.New.Filesystem"}
 		}
-		e.Rename.New.Filesytem = str
+		e.Rename.New.Filesystem = str
 
 		return nil
 
@@ -24753,9 +24753,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Rename.Old.Filesytem"}
+			return &eval.ErrValueTypeMismatch{Field: "Rename.Old.Filesystem"}
 		}
-		e.Rename.Old.Filesytem = str
+		e.Rename.Old.Filesystem = str
 
 		return nil
 
@@ -24915,9 +24915,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Rmdir.File.Filesytem"}
+			return &eval.ErrValueTypeMismatch{Field: "Rmdir.File.Filesystem"}
 		}
-		e.Rmdir.File.Filesytem = str
+		e.Rmdir.File.Filesystem = str
 
 		return nil
 
@@ -25272,9 +25272,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.File.Filesytem"}
+			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.File.Filesystem"}
 		}
-		e.SetXAttr.File.Filesytem = str
+		e.SetXAttr.File.Filesystem = str
 
 		return nil
 
@@ -25728,9 +25728,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileFields.CTime"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileEvent.FileFields.CTime"}
 		}
-		e.Signal.Target.Ancestor.ProcessContext.Process.FileFields.CTime = uint64(v)
+		e.Signal.Target.Ancestor.ProcessContext.Process.FileEvent.FileFields.CTime = uint64(v)
 
 		return nil
 
@@ -25743,9 +25743,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.Filesystem"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileEvent.Filesystem"}
 		}
-		e.Signal.Target.Ancestor.ProcessContext.Process.Filesystem = str
+		e.Signal.Target.Ancestor.ProcessContext.Process.FileEvent.Filesystem = str
 
 		return nil
 
@@ -25758,9 +25758,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileFields.GID"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileEvent.FileFields.GID"}
 		}
-		e.Signal.Target.Ancestor.ProcessContext.Process.FileFields.GID = uint32(v)
+		e.Signal.Target.Ancestor.ProcessContext.Process.FileEvent.FileFields.GID = uint32(v)
 
 		return nil
 
@@ -25773,9 +25773,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileFields.Group"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileEvent.FileFields.Group"}
 		}
-		e.Signal.Target.Ancestor.ProcessContext.Process.FileFields.Group = str
+		e.Signal.Target.Ancestor.ProcessContext.Process.FileEvent.FileFields.Group = str
 
 		return nil
 
@@ -25786,8 +25786,8 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 
 		var ok bool
-		if e.Signal.Target.Ancestor.ProcessContext.Process.FileFields.InUpperLayer, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileFields.InUpperLayer"}
+		if e.Signal.Target.Ancestor.ProcessContext.Process.FileEvent.FileFields.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileEvent.FileFields.InUpperLayer"}
 		}
 		return nil
 
@@ -25800,9 +25800,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileFields.Inode"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileEvent.FileFields.Inode"}
 		}
-		e.Signal.Target.Ancestor.ProcessContext.Process.FileFields.Inode = uint64(v)
+		e.Signal.Target.Ancestor.ProcessContext.Process.FileEvent.FileFields.Inode = uint64(v)
 
 		return nil
 
@@ -25815,9 +25815,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileFields.Mode"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileEvent.FileFields.Mode"}
 		}
-		e.Signal.Target.Ancestor.ProcessContext.Process.FileFields.Mode = uint16(v)
+		e.Signal.Target.Ancestor.ProcessContext.Process.FileEvent.FileFields.Mode = uint16(v)
 
 		return nil
 
@@ -25830,9 +25830,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileFields.MTime"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileEvent.FileFields.MTime"}
 		}
-		e.Signal.Target.Ancestor.ProcessContext.Process.FileFields.MTime = uint64(v)
+		e.Signal.Target.Ancestor.ProcessContext.Process.FileEvent.FileFields.MTime = uint64(v)
 
 		return nil
 
@@ -25845,9 +25845,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileFields.MountID"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileEvent.FileFields.MountID"}
 		}
-		e.Signal.Target.Ancestor.ProcessContext.Process.FileFields.MountID = uint32(v)
+		e.Signal.Target.Ancestor.ProcessContext.Process.FileEvent.FileFields.MountID = uint32(v)
 
 		return nil
 
@@ -25860,9 +25860,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.BasenameStr"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileEvent.BasenameStr"}
 		}
-		e.Signal.Target.Ancestor.ProcessContext.Process.BasenameStr = str
+		e.Signal.Target.Ancestor.ProcessContext.Process.FileEvent.BasenameStr = str
 
 		return nil
 
@@ -25875,9 +25875,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.PathnameStr"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileEvent.PathnameStr"}
 		}
-		e.Signal.Target.Ancestor.ProcessContext.Process.PathnameStr = str
+		e.Signal.Target.Ancestor.ProcessContext.Process.FileEvent.PathnameStr = str
 
 		return nil
 
@@ -25890,9 +25890,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileFields.Mode"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileEvent.FileFields.Mode"}
 		}
-		e.Signal.Target.Ancestor.ProcessContext.Process.FileFields.Mode = uint16(v)
+		e.Signal.Target.Ancestor.ProcessContext.Process.FileEvent.FileFields.Mode = uint16(v)
 
 		return nil
 
@@ -25905,9 +25905,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileFields.UID"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileEvent.FileFields.UID"}
 		}
-		e.Signal.Target.Ancestor.ProcessContext.Process.FileFields.UID = uint32(v)
+		e.Signal.Target.Ancestor.ProcessContext.Process.FileEvent.FileFields.UID = uint32(v)
 
 		return nil
 
@@ -25920,9 +25920,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileFields.User"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileEvent.FileFields.User"}
 		}
-		e.Signal.Target.Ancestor.ProcessContext.Process.FileFields.User = str
+		e.Signal.Target.Ancestor.ProcessContext.Process.FileEvent.FileFields.User = str
 
 		return nil
 
@@ -26314,9 +26314,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileFields.CTime"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileEvent.FileFields.CTime"}
 		}
-		e.Signal.Target.Process.FileFields.CTime = uint64(v)
+		e.Signal.Target.Process.FileEvent.FileFields.CTime = uint64(v)
 
 		return nil
 
@@ -26325,9 +26325,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.Filesystem"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileEvent.Filesystem"}
 		}
-		e.Signal.Target.Process.Filesystem = str
+		e.Signal.Target.Process.FileEvent.Filesystem = str
 
 		return nil
 
@@ -26336,9 +26336,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileFields.GID"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileEvent.FileFields.GID"}
 		}
-		e.Signal.Target.Process.FileFields.GID = uint32(v)
+		e.Signal.Target.Process.FileEvent.FileFields.GID = uint32(v)
 
 		return nil
 
@@ -26347,17 +26347,17 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileFields.Group"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileEvent.FileFields.Group"}
 		}
-		e.Signal.Target.Process.FileFields.Group = str
+		e.Signal.Target.Process.FileEvent.FileFields.Group = str
 
 		return nil
 
 	case "signal.target.file.in_upper_layer":
 
 		var ok bool
-		if e.Signal.Target.Process.FileFields.InUpperLayer, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileFields.InUpperLayer"}
+		if e.Signal.Target.Process.FileEvent.FileFields.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileEvent.FileFields.InUpperLayer"}
 		}
 		return nil
 
@@ -26366,9 +26366,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileFields.Inode"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileEvent.FileFields.Inode"}
 		}
-		e.Signal.Target.Process.FileFields.Inode = uint64(v)
+		e.Signal.Target.Process.FileEvent.FileFields.Inode = uint64(v)
 
 		return nil
 
@@ -26377,9 +26377,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileFields.Mode"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileEvent.FileFields.Mode"}
 		}
-		e.Signal.Target.Process.FileFields.Mode = uint16(v)
+		e.Signal.Target.Process.FileEvent.FileFields.Mode = uint16(v)
 
 		return nil
 
@@ -26388,9 +26388,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileFields.MTime"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileEvent.FileFields.MTime"}
 		}
-		e.Signal.Target.Process.FileFields.MTime = uint64(v)
+		e.Signal.Target.Process.FileEvent.FileFields.MTime = uint64(v)
 
 		return nil
 
@@ -26399,9 +26399,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileFields.MountID"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileEvent.FileFields.MountID"}
 		}
-		e.Signal.Target.Process.FileFields.MountID = uint32(v)
+		e.Signal.Target.Process.FileEvent.FileFields.MountID = uint32(v)
 
 		return nil
 
@@ -26410,9 +26410,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.BasenameStr"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileEvent.BasenameStr"}
 		}
-		e.Signal.Target.Process.BasenameStr = str
+		e.Signal.Target.Process.FileEvent.BasenameStr = str
 
 		return nil
 
@@ -26421,9 +26421,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.PathnameStr"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileEvent.PathnameStr"}
 		}
-		e.Signal.Target.Process.PathnameStr = str
+		e.Signal.Target.Process.FileEvent.PathnameStr = str
 
 		return nil
 
@@ -26432,9 +26432,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileFields.Mode"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileEvent.FileFields.Mode"}
 		}
-		e.Signal.Target.Process.FileFields.Mode = uint16(v)
+		e.Signal.Target.Process.FileEvent.FileFields.Mode = uint16(v)
 
 		return nil
 
@@ -26443,9 +26443,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileFields.UID"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileEvent.FileFields.UID"}
 		}
-		e.Signal.Target.Process.FileFields.UID = uint32(v)
+		e.Signal.Target.Process.FileEvent.FileFields.UID = uint32(v)
 
 		return nil
 
@@ -26454,9 +26454,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileFields.User"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileEvent.FileFields.User"}
 		}
-		e.Signal.Target.Process.FileFields.User = str
+		e.Signal.Target.Process.FileEvent.FileFields.User = str
 
 		return nil
 
@@ -26619,9 +26619,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Splice.File.Filesytem"}
+			return &eval.ErrValueTypeMismatch{Field: "Splice.File.Filesystem"}
 		}
-		e.Splice.File.Filesytem = str
+		e.Splice.File.Filesystem = str
 
 		return nil
 
@@ -26803,9 +26803,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Unlink.File.Filesytem"}
+			return &eval.ErrValueTypeMismatch{Field: "Unlink.File.Filesystem"}
 		}
-		e.Unlink.File.Filesytem = str
+		e.Unlink.File.Filesystem = str
 
 		return nil
 
@@ -26987,9 +26987,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Utimes.File.Filesytem"}
+			return &eval.ErrValueTypeMismatch{Field: "Utimes.File.Filesystem"}
 		}
-		e.Utimes.File.Filesytem = str
+		e.Utimes.File.Filesystem = str
 
 		return nil
 

--- a/pkg/security/probe/accessors.go
+++ b/pkg/security/probe/accessors.go
@@ -933,6 +933,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "exec.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).Exec.Process.PathnameStr
@@ -3086,6 +3087,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "process.ancestors.file.path":
 		return &eval.StringArrayEvaluator{
+			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) []string {
 				if ptr := ctx.Cache[field]; ptr != nil {
 					if result := (*[]string)(ptr); result != nil {
@@ -3872,6 +3874,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "process.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ProcessContext.Process.PathnameStr
@@ -4951,6 +4954,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "ptrace.tracee.ancestors.file.path":
 		return &eval.StringArrayEvaluator{
+			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) []string {
 				if ptr := ctx.Cache[field]; ptr != nil {
 					if result := (*[]string)(ptr); result != nil {
@@ -5737,6 +5741,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "ptrace.tracee.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).PTrace.Tracee.Process.PathnameStr
@@ -7761,6 +7766,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "signal.target.ancestors.file.path":
 		return &eval.StringArrayEvaluator{
+			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) []string {
 				if ptr := ctx.Cache[field]; ptr != nil {
 					if result := (*[]string)(ptr); result != nil {
@@ -8547,6 +8553,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "signal.target.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).Signal.Target.Process.PathnameStr

--- a/pkg/security/probe/accessors.go
+++ b/pkg/security/probe/accessors.go
@@ -330,6 +330,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "chmod.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveFilePath(&(*Event)(ctx.Object).Chmod.File)
@@ -520,6 +521,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "chown.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveFilePath(&(*Event)(ctx.Object).Chown.File)
@@ -1201,6 +1203,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "link.file.destination.path":
 		return &eval.StringEvaluator{
+			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveFilePath(&(*Event)(ctx.Object).Link.Target)
@@ -1331,6 +1334,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "link.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveFilePath(&(*Event)(ctx.Object).Link.Source)
@@ -1481,6 +1485,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "load_module.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveFilePath(&(*Event)(ctx.Object).LoadModule.File)
@@ -1671,6 +1676,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "mkdir.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveFilePath(&(*Event)(ctx.Object).Mkdir.File)
@@ -1821,6 +1827,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "mmap.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveFilePath(&(*Event)(ctx.Object).MMap.File)
@@ -2119,6 +2126,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "open.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveFilePath(&(*Event)(ctx.Object).Open.File)
@@ -6009,6 +6017,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "removexattr.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveFilePath(&(*Event)(ctx.Object).RemoveXAttr.File)
@@ -6169,6 +6178,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "rename.file.destination.path":
 		return &eval.StringEvaluator{
+			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveFilePath(&(*Event)(ctx.Object).Rename.New)
@@ -6299,6 +6309,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "rename.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveFilePath(&(*Event)(ctx.Object).Rename.Old)
@@ -6449,6 +6460,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "rmdir.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveFilePath(&(*Event)(ctx.Object).Rmdir.File)
@@ -6779,6 +6791,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "setxattr.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveFilePath(&(*Event)(ctx.Object).SetXAttr.File)
@@ -8804,6 +8817,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "splice.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveFilePath(&(*Event)(ctx.Object).Splice.File)
@@ -8974,6 +8988,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "unlink.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveFilePath(&(*Event)(ctx.Object).Unlink.File)
@@ -9144,6 +9159,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "utimes.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveFilePath(&(*Event)(ctx.Object).Utimes.File)

--- a/pkg/security/probe/accessors.go
+++ b/pkg/security/probe/accessors.go
@@ -612,7 +612,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "dns.question.name":
 		return &eval.StringEvaluator{
-			OpOverrides: DNSNameCmp,
+			OpOverrides: eval.DNSNameCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).DNS.Name

--- a/pkg/security/probe/activity_dump.go
+++ b/pkg/security/probe/activity_dump.go
@@ -484,9 +484,9 @@ func (ad *ActivityDump) generateFIMRules(file *FileActivityNode, activityNode *P
 			file.File.GID),
 			ruleIDPrefix,
 		)
-		rule.Expression += fmt.Sprintf(" && process.file.path == \"%s\"", activityNode.Process.PathnameStr)
+		rule.Expression += fmt.Sprintf(" && process.file.path == \"%s\"", activityNode.Process.FileEvent.PathnameStr)
 		for _, parent := range ancestors {
-			rule.Expression += fmt.Sprintf(" && process.ancestors.file.path == \"%s\"", parent.Process.PathnameStr)
+			rule.Expression += fmt.Sprintf(" && process.ancestors.file.path == \"%s\"", parent.Process.FileEvent.PathnameStr)
 		}
 		rules = append(rules, rule)
 	}
@@ -505,7 +505,7 @@ func (ad *ActivityDump) generateRules(node *ProcessActivityNode, ancestors []*Pr
 	// add exec rule
 	rule := NewProfileRule(fmt.Sprintf(
 		"exec.file.path == \"%s\" && process.uid == %d && process.gid == %d && process.cap_effective == %d && process.cap_permitted == %d",
-		node.Process.PathnameStr,
+		node.Process.FileEvent.PathnameStr,
 		node.Process.UID,
 		node.Process.GID,
 		node.Process.CapEffective,
@@ -513,7 +513,7 @@ func (ad *ActivityDump) generateRules(node *ProcessActivityNode, ancestors []*Pr
 		ruleIDPrefix,
 	)
 	for _, parent := range ancestors {
-		rule.Expression += fmt.Sprintf(" && process.ancestors.file.path == \"%s\"", parent.Process.PathnameStr)
+		rule.Expression += fmt.Sprintf(" && process.ancestors.file.path == \"%s\"", parent.Process.FileEvent.PathnameStr)
 	}
 	rules = append(rules, rule)
 
@@ -687,7 +687,7 @@ func NewProcessActivityNode(entry *model.ProcessCacheEntry, generationType NodeG
 
 // nolint: unused
 func (pan *ProcessActivityNode) debug(prefix string) {
-	fmt.Printf("%s- process: %s\n", prefix, pan.Process.PathnameStr)
+	fmt.Printf("%s- process: %s\n", prefix, pan.Process.FileEvent.PathnameStr)
 	if len(pan.Files) > 0 {
 		fmt.Printf("%s  files:\n", prefix)
 		for _, f := range pan.Files {
@@ -730,7 +730,7 @@ func (pan *ProcessActivityNode) recursiveRelease() {
 // Matches return true if the process fields used to generate the dump are identical with the provided ProcessCacheEntry
 func (pan *ProcessActivityNode) Matches(entry *model.ProcessCacheEntry, matchArgs bool, resolvers *Resolvers) bool {
 
-	if pan.Process.Comm == entry.Comm && pan.Process.PathnameStr == entry.PathnameStr &&
+	if pan.Process.Comm == entry.Comm && pan.Process.FileEvent.PathnameStr == entry.FileEvent.PathnameStr &&
 		pan.Process.Credentials == entry.Credentials {
 
 		if matchArgs {
@@ -859,7 +859,7 @@ func (pan *ProcessActivityNode) snapshotFiles(p *process.Process, ad *ActivityDu
 	}
 
 	for _, mm := range *memoryMaps {
-		if mm.Path != pan.Process.PathnameStr {
+		if mm.Path != pan.Process.FileEvent.PathnameStr {
 			files = append(files, mm.Path)
 		}
 	}

--- a/pkg/security/probe/activity_dump_graph.go
+++ b/pkg/security/probe/activity_dump_graph.go
@@ -97,7 +97,7 @@ func (ad *ActivityDump) prepareProcessActivityNode(p *ProcessActivityNode, data 
 	}
 	pan := node{
 		ID:    p.GetID(),
-		Label: fmt.Sprintf("%s %s", p.Process.PathnameStr, args),
+		Label: fmt.Sprintf("%s %s", p.Process.FileEvent.PathnameStr, args),
 		Size:  60,
 		Color: processColor,
 	}

--- a/pkg/security/probe/capabilities.go
+++ b/pkg/security/probe/capabilities.go
@@ -70,7 +70,7 @@ func validateBasenameFilter(value rules.FilterValue) bool {
 	switch value.Type {
 	case eval.ScalarValueType:
 		return true
-	case eval.PatternValueType:
+	case eval.GlobValueType:
 		basename := path.Base(value.Value.(string))
 		if !strings.Contains(basename, "*") {
 			return true
@@ -84,7 +84,7 @@ func oneBasenameCapabilities(event string) Capabilities {
 	return Capabilities{
 		event + ".file.path": {
 			PolicyFlags:     PolicyFlagBasename,
-			FieldValueTypes: eval.ScalarValueType | eval.PatternValueType,
+			FieldValueTypes: eval.ScalarValueType | eval.GlobValueType,
 			ValidateFnc:     validateBasenameFilter,
 		},
 		event + ".file.name": {
@@ -98,7 +98,7 @@ func twoBasenameCapabilities(event string, field1, field2 string) Capabilities {
 	return Capabilities{
 		event + "." + field1 + ".path": {
 			PolicyFlags:     PolicyFlagBasename,
-			FieldValueTypes: eval.ScalarValueType | eval.PatternValueType,
+			FieldValueTypes: eval.ScalarValueType | eval.GlobValueType,
 			ValidateFnc:     validateBasenameFilter,
 		},
 		event + "." + field1 + ".name": {
@@ -107,7 +107,7 @@ func twoBasenameCapabilities(event string, field1, field2 string) Capabilities {
 		},
 		event + "." + field2 + ".path": {
 			PolicyFlags:     PolicyFlagBasename,
-			FieldValueTypes: eval.ScalarValueType | eval.PatternValueType,
+			FieldValueTypes: eval.ScalarValueType | eval.GlobValueType,
 			ValidateFnc:     validateBasenameFilter,
 		},
 		event + "." + field2 + ".name": {

--- a/pkg/security/probe/discarders.go
+++ b/pkg/security/probe/discarders.go
@@ -287,10 +287,10 @@ func (id *inodeDiscarders) getParentDiscarderFnc(rs *rules.RuleSet, eventType mo
 		// check filename
 		if values := rule.GetFieldValues(field); len(values) > 0 {
 			for _, value := range values {
-				if value.Type == eval.PatternValueType {
+				if value.Type == eval.GlobValueType {
 					glob, err := eval.NewGlob(value.Value.(string), false)
 					if err != nil {
-						return nil, fmt.Errorf("unexpected pattern `%v`: %w", value.Value, err)
+						return nil, fmt.Errorf("unexpected glob `%v`: %w", value.Value, err)
 					}
 
 					valueFnc = func(dirname string) (bool, bool, error) {

--- a/pkg/security/probe/discarders.go
+++ b/pkg/security/probe/discarders.go
@@ -512,14 +512,14 @@ func createInvalidDiscardersCache() map[eval.Field]map[interface{}]bool {
 func processDiscarderWrapper(eventType model.EventType, fnc onDiscarderHandler) onDiscarderHandler {
 	return func(rs *rules.RuleSet, event *Event, probe *Probe, discarder Discarder) error {
 		if discarder.Field == "process.file.path" {
-			seclog.Tracef("Apply process.file.path discarder for event `%s`, inode: %d, pid: %d", eventType, event.ProcessContext.FileFields.Inode, event.ProcessContext.Pid)
+			seclog.Tracef("Apply process.file.path discarder for event `%s`, inode: %d, pid: %d", eventType, event.ProcessContext.FileEvent.Inode, event.ProcessContext.Pid)
 
 			// discard by PID for long running process
 			if err := probe.pidDiscarders.discard(eventType, event.ProcessContext.Pid); err != nil {
 				return err
 			}
 
-			return probe.inodeDiscarders.discardInode(eventType, event.ProcessContext.FileFields.MountID, event.ProcessContext.FileFields.Inode, true)
+			return probe.inodeDiscarders.discardInode(eventType, event.ProcessContext.FileEvent.MountID, event.ProcessContext.FileEvent.Inode, true)
 		}
 
 		if fnc != nil {

--- a/pkg/security/probe/fields_resolver.go
+++ b/pkg/security/probe/fields_resolver.go
@@ -24,9 +24,12 @@ func (ev *Event) ResolveFields() {
 	_ = ev.ResolveProcessEnvp(&ev.ProcessContext.Process)
 	_ = ev.ResolveProcessEnvs(&ev.ProcessContext.Process)
 	_ = ev.ResolveProcessEnvsTruncated(&ev.ProcessContext.Process)
-	_ = ev.ResolveFileFieldsGroup(&ev.ProcessContext.Process.FileFields)
-	_ = ev.ResolveFileFieldsInUpperLayer(&ev.ProcessContext.Process.FileFields)
-	_ = ev.ResolveFileFieldsUser(&ev.ProcessContext.Process.FileFields)
+	_ = ev.ResolveFileFilesystem(&ev.ProcessContext.Process.FileEvent)
+	_ = ev.ResolveFileFieldsGroup(&ev.ProcessContext.Process.FileEvent.FileFields)
+	_ = ev.ResolveFileFieldsInUpperLayer(&ev.ProcessContext.Process.FileEvent.FileFields)
+	_ = ev.ResolveFileBasename(&ev.ProcessContext.Process.FileEvent)
+	_ = ev.ResolveFilePath(&ev.ProcessContext.Process.FileEvent)
+	_ = ev.ResolveFileFieldsUser(&ev.ProcessContext.Process.FileEvent.FileFields)
 
 	// resolve event specific fields
 	switch ev.GetEventType().String() {
@@ -57,9 +60,12 @@ func (ev *Event) ResolveFields() {
 	case "dns":
 
 	case "exec":
-		_ = ev.ResolveFileFieldsUser(&ev.Exec.Process.FileFields)
-		_ = ev.ResolveFileFieldsGroup(&ev.Exec.Process.FileFields)
-		_ = ev.ResolveFileFieldsInUpperLayer(&ev.Exec.Process.FileFields)
+		_ = ev.ResolveFileFieldsUser(&ev.Exec.Process.FileEvent.FileFields)
+		_ = ev.ResolveFileFieldsGroup(&ev.Exec.Process.FileEvent.FileFields)
+		_ = ev.ResolveFileFieldsInUpperLayer(&ev.Exec.Process.FileEvent.FileFields)
+		_ = ev.ResolveFilePath(&ev.Exec.Process.FileEvent)
+		_ = ev.ResolveFileBasename(&ev.Exec.Process.FileEvent)
+		_ = ev.ResolveFileFilesystem(&ev.Exec.Process.FileEvent)
 		_ = ev.ResolveProcessCreatedAt(&ev.Exec.Process)
 		_ = ev.ResolveProcessArgv0(&ev.Exec.Process)
 		_ = ev.ResolveProcessArgs(&ev.Exec.Process)
@@ -118,9 +124,12 @@ func (ev *Event) ResolveFields() {
 		_ = ev.ResolveFileFilesystem(&ev.Open.File)
 
 	case "ptrace":
-		_ = ev.ResolveFileFieldsUser(&ev.PTrace.Tracee.Process.FileFields)
-		_ = ev.ResolveFileFieldsGroup(&ev.PTrace.Tracee.Process.FileFields)
-		_ = ev.ResolveFileFieldsInUpperLayer(&ev.PTrace.Tracee.Process.FileFields)
+		_ = ev.ResolveFileFieldsUser(&ev.PTrace.Tracee.Process.FileEvent.FileFields)
+		_ = ev.ResolveFileFieldsGroup(&ev.PTrace.Tracee.Process.FileEvent.FileFields)
+		_ = ev.ResolveFileFieldsInUpperLayer(&ev.PTrace.Tracee.Process.FileEvent.FileFields)
+		_ = ev.ResolveFilePath(&ev.PTrace.Tracee.Process.FileEvent)
+		_ = ev.ResolveFileBasename(&ev.PTrace.Tracee.Process.FileEvent)
+		_ = ev.ResolveFileFilesystem(&ev.PTrace.Tracee.Process.FileEvent)
 		_ = ev.ResolveProcessCreatedAt(&ev.PTrace.Tracee.Process)
 		_ = ev.ResolveProcessArgv0(&ev.PTrace.Tracee.Process)
 		_ = ev.ResolveProcessArgs(&ev.PTrace.Tracee.Process)
@@ -186,9 +195,12 @@ func (ev *Event) ResolveFields() {
 		_ = ev.ResolveXAttrName(&ev.SetXAttr)
 
 	case "signal":
-		_ = ev.ResolveFileFieldsUser(&ev.Signal.Target.Process.FileFields)
-		_ = ev.ResolveFileFieldsGroup(&ev.Signal.Target.Process.FileFields)
-		_ = ev.ResolveFileFieldsInUpperLayer(&ev.Signal.Target.Process.FileFields)
+		_ = ev.ResolveFileFieldsUser(&ev.Signal.Target.Process.FileEvent.FileFields)
+		_ = ev.ResolveFileFieldsGroup(&ev.Signal.Target.Process.FileEvent.FileFields)
+		_ = ev.ResolveFileFieldsInUpperLayer(&ev.Signal.Target.Process.FileEvent.FileFields)
+		_ = ev.ResolveFilePath(&ev.Signal.Target.Process.FileEvent)
+		_ = ev.ResolveFileBasename(&ev.Signal.Target.Process.FileEvent)
+		_ = ev.ResolveFileFilesystem(&ev.Signal.Target.Process.FileEvent)
 		_ = ev.ResolveProcessCreatedAt(&ev.Signal.Target.Process)
 		_ = ev.ResolveProcessArgv0(&ev.Signal.Target.Process)
 		_ = ev.ResolveProcessArgs(&ev.Signal.Target.Process)

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -611,7 +611,7 @@ func (p *Probe) handleEvent(CPU uint64, data []byte) {
 
 		// copy some of the field from the entry
 		event.Exec.Process = event.processCacheEntry.Process
-		event.Exec.FileFields = event.processCacheEntry.Process.FileFields
+		event.Exec.FileEvent = event.processCacheEntry.Process.FileEvent
 	case model.ExitEventType:
 		// do nothing
 	case model.SetuidEventType:

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -363,12 +363,12 @@ func (p *ProcessResolver) enrichEventFromProc(entry *model.ProcessCacheEntry, pr
 			return errors.Wrapf(err, "snapshot failed for %d: couldn't parse container ID", proc.Pid)
 		}
 
-		entry.FileFields = *info
-		entry.Process.PathnameStr = pathnameStr
-		entry.Process.BasenameStr = path.Base(pathnameStr)
+		entry.FileEvent.FileFields = *info
+		entry.FileEvent.PathnameStr = pathnameStr
+		entry.FileEvent.BasenameStr = path.Base(pathnameStr)
 		entry.Process.ContainerID = string(containerID)
 		// resolve container path with the MountResolver
-		entry.Filesystem = p.resolvers.MountResolver.GetFilesystem(entry.Process.FileFields.MountID)
+		entry.FileEvent.Filesystem = p.resolvers.MountResolver.GetFilesystem(entry.Process.FileEvent.MountID)
 	}
 
 	entry.ExecTime = time.Unix(0, filledProc.CreateTime*int64(time.Millisecond))
@@ -549,22 +549,22 @@ func (p *ProcessResolver) Resolve(pid, tid uint32) *model.ProcessCacheEntry {
 func (p *ProcessResolver) SetProcessPath(entry *model.ProcessCacheEntry) (string, error) {
 	var err error
 
-	if entry.FileFields.Inode != 0 && entry.FileFields.MountID != 0 {
-		if entry.PathnameStr, err = p.resolvers.resolveFileFieldsPath(&entry.FileFields); err == nil {
-			entry.BasenameStr = path.Base(entry.PathnameStr)
+	if entry.FileEvent.Inode != 0 && entry.FileEvent.MountID != 0 {
+		if entry.FileEvent.PathnameStr, err = p.resolvers.resolveFileFieldsPath(&entry.FileEvent.FileFields); err == nil {
+			entry.FileEvent.BasenameStr = path.Base(entry.FileEvent.PathnameStr)
 		}
 	}
 
-	return entry.PathnameStr, err
+	return entry.FileEvent.PathnameStr, err
 }
 
 // SetProcessFilesystem resolves process file system
 func (p *ProcessResolver) SetProcessFilesystem(entry *model.ProcessCacheEntry) string {
-	if entry.FileFields.MountID != 0 {
-		entry.Filesystem = p.resolvers.MountResolver.GetFilesystem(entry.FileFields.MountID)
+	if entry.FileEvent.MountID != 0 {
+		entry.FileEvent.Filesystem = p.resolvers.MountResolver.GetFilesystem(entry.FileEvent.MountID)
 	}
 
-	return entry.Filesystem
+	return entry.FileEvent.Filesystem
 }
 
 // ApplyBootTime realign timestamp from the boot time
@@ -997,7 +997,7 @@ func (p *ProcessResolver) syncCache(proc *process.Process) (*model.ProcessCacheE
 		}
 	}
 
-	seclog.Tracef("New process cache entry added: %s %s %d/%d", entry.Comm, entry.PathnameStr, pid, entry.FileFields.Inode)
+	seclog.Tracef("New process cache entry added: %s %s %d/%d", entry.Comm, entry.FileEvent.PathnameStr, pid, entry.FileEvent.Inode)
 
 	return entry, true
 }

--- a/pkg/security/probe/serializers.go
+++ b/pkg/security/probe/serializers.go
@@ -374,22 +374,22 @@ func newFileSerializer(fe *model.FileEvent, e *Event, forceInode ...uint64) *Fil
 }
 
 func newProcessFileSerializerWithResolvers(process *model.Process, r *Resolvers) *FileSerializer {
-	mode := uint32(process.FileFields.Mode)
+	mode := uint32(process.FileEvent.Mode)
 	return &FileSerializer{
-		Path:                process.PathnameStr,
+		Path:                process.FileEvent.PathnameStr,
 		PathResolutionError: process.GetPathResolutionError(),
-		Name:                process.BasenameStr,
-		Inode:               getUint64Pointer(&process.FileFields.Inode),
-		MountID:             getUint32Pointer(&process.FileFields.MountID),
-		Filesystem:          process.Filesystem,
-		InUpperLayer:        getInUpperLayer(r, &process.FileFields),
+		Name:                process.FileEvent.BasenameStr,
+		Inode:               getUint64Pointer(&process.FileEvent.Inode),
+		MountID:             getUint32Pointer(&process.FileEvent.MountID),
+		Filesystem:          process.FileEvent.Filesystem,
+		InUpperLayer:        getInUpperLayer(r, &process.FileEvent.FileFields),
 		Mode:                getUint32Pointer(&mode),
-		UID:                 int64(process.FileFields.UID),
-		GID:                 int64(process.FileFields.GID),
-		User:                r.ResolveFileFieldsUser(&process.FileFields),
-		Group:               r.ResolveFileFieldsGroup(&process.FileFields),
-		Mtime:               getTimeIfNotZero(time.Unix(0, int64(process.FileFields.MTime))),
-		Ctime:               getTimeIfNotZero(time.Unix(0, int64(process.FileFields.CTime))),
+		UID:                 int64(process.FileEvent.UID),
+		GID:                 int64(process.FileEvent.GID),
+		User:                r.ResolveFileFieldsUser(&process.FileEvent.FileFields),
+		Group:               r.ResolveFileFieldsGroup(&process.FileEvent.FileFields),
+		Mtime:               getTimeIfNotZero(time.Unix(0, int64(process.FileEvent.MTime))),
+		Ctime:               getTimeIfNotZero(time.Unix(0, int64(process.FileEvent.CTime))),
 	}
 }
 

--- a/pkg/security/secl/compiler/eval/eval_test.go
+++ b/pkg/security/secl/compiler/eval/eval_test.go
@@ -287,7 +287,8 @@ func TestSimpleBitOperations(t *testing.T) {
 func TestStringMatcher(t *testing.T) {
 	event := &testEvent{
 		process: testProcess{
-			name: "/usr/bin/c$t",
+			name:  "/usr/bin/c$t",
+			argv0: "http://example.com",
 		},
 	}
 
@@ -330,6 +331,8 @@ func TestStringMatcher(t *testing.T) {
 		{Expr: `process.name =~ r".*/[abc]+/bin/.*"`, Expected: false},
 		{Expr: `process.name == r".*/bin/.*"`, Expected: true},
 		{Expr: `r".*/bin/.*" == process.name`, Expected: true},
+		{Expr: `process.argv0 =~ "http://*"`, Expected: true},
+		{Expr: `process.argv0 =~ "*example.com"`, Expected: true},
 	}
 
 	for _, test := range tests {

--- a/pkg/security/secl/compiler/eval/field.go
+++ b/pkg/security/secl/compiler/eval/field.go
@@ -19,12 +19,13 @@ type FieldValueType int
 // Field value types
 const (
 	ScalarValueType   FieldValueType = 1 << 0
-	PatternValueType  FieldValueType = 1 << 1
-	RegexpValueType   FieldValueType = 1 << 2
-	BitmaskValueType  FieldValueType = 1 << 3
-	VariableValueType FieldValueType = 1 << 4
-	IPValueType       FieldValueType = 1 << 5
-	CIDRValueType     FieldValueType = 1 << 6
+	GlobValueType     FieldValueType = 1 << 1
+	PatternValueType  FieldValueType = 1 << 2
+	RegexpValueType   FieldValueType = 1 << 3
+	BitmaskValueType  FieldValueType = 1 << 4
+	VariableValueType FieldValueType = 1 << 5
+	IPValueType       FieldValueType = 1 << 6
+	CIDRValueType     FieldValueType = 1 << 7
 )
 
 // FieldValue describes a field value with its type

--- a/pkg/security/secl/compiler/eval/glob_test.go
+++ b/pkg/security/secl/compiler/eval/glob_test.go
@@ -110,6 +110,10 @@ func TestGlobMatches(t *testing.T) {
 		t.Error("should contain the filename")
 	}
 
+	if glob, _ := NewGlob("*/abc/*", false); !glob.Matches("/1/abc/2") {
+		t.Error("should contain the filename")
+	}
+
 	if glob, _ := NewGlob("/tmp/test/test789*", false); !glob.Matches("/tmp/test/test7890") {
 		t.Error("should contain the filename")
 	}

--- a/pkg/security/secl/compiler/eval/model_test.go
+++ b/pkg/security/secl/compiler/eval/model_test.go
@@ -27,6 +27,7 @@ type testItem struct {
 
 type testProcess struct {
 	name      string
+	argv0     string
 	uid       int
 	gid       int
 	pid       int
@@ -216,6 +217,13 @@ func (m *testModel) GetEvaluator(field Field, regID RegisterID) (Evaluator, erro
 			EvalFnc:     func(ctx *Context) string { return (*testEvent)(ctx.Object).process.name },
 			Field:       field,
 			OpOverrides: GlobCmp,
+		}, nil
+
+	case "process.argv0":
+
+		return &StringEvaluator{
+			EvalFnc: func(ctx *Context) string { return (*testEvent)(ctx.Object).process.argv0 },
+			Field:   field,
 		}, nil
 
 	case "process.uid":
@@ -503,6 +511,10 @@ func (e *testEvent) GetFieldValue(field Field) (interface{}, error) {
 
 		return e.process.name, nil
 
+	case "process.argv0":
+
+		return e.process.argv0, nil
+
 	case "process.uid":
 
 		return e.process.uid, nil
@@ -568,6 +580,10 @@ func (e *testEvent) GetFieldEventType(field Field) (string, error) {
 		return "network", nil
 
 	case "process.name":
+
+		return "*", nil
+
+	case "process.argv0":
 
 		return "*", nil
 
@@ -675,6 +691,11 @@ func (e *testEvent) SetFieldValue(field Field, value interface{}) error {
 		e.process.name = value.(string)
 		return nil
 
+	case "process.argv0":
+
+		e.process.argv0 = value.(string)
+		return nil
+
 	case "process.uid":
 
 		e.process.uid = value.(int)
@@ -750,6 +771,10 @@ func (e *testEvent) GetFieldType(field Field) (reflect.Kind, error) {
 		return reflect.Array, nil
 
 	case "process.name":
+
+		return reflect.String, nil
+
+	case "process.argv0":
 
 		return reflect.String, nil
 

--- a/pkg/security/secl/compiler/eval/model_test.go
+++ b/pkg/security/secl/compiler/eval/model_test.go
@@ -213,8 +213,9 @@ func (m *testModel) GetEvaluator(field Field, regID RegisterID) (Evaluator, erro
 	case "process.name":
 
 		return &StringEvaluator{
-			EvalFnc: func(ctx *Context) string { return (*testEvent)(ctx.Object).process.name },
-			Field:   field,
+			EvalFnc:     func(ctx *Context) string { return (*testEvent)(ctx.Object).process.name },
+			Field:       field,
+			OpOverrides: GlobCmp,
 		}, nil
 
 	case "process.uid":

--- a/pkg/security/secl/compiler/eval/oo_dns_name.go
+++ b/pkg/security/secl/compiler/eval/oo_dns_name.go
@@ -3,9 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux
-// +build linux
-
 package eval
 
 var (

--- a/pkg/security/secl/compiler/eval/oo_dns_name.go
+++ b/pkg/security/secl/compiler/eval/oo_dns_name.go
@@ -6,16 +6,12 @@
 //go:build linux
 // +build linux
 
-package probe
-
-import (
-	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
-)
+package eval
 
 var (
 	// DNSNameCmp lower case values before comparing. Important : this operator override doesn't support approvers
-	DNSNameCmp = &eval.OpOverrides{
-		StringEquals: func(a *eval.StringEvaluator, b *eval.StringEvaluator, opts *eval.Opts, state *eval.State) (*eval.BoolEvaluator, error) {
+	DNSNameCmp = &OpOverrides{
+		StringEquals: func(a *StringEvaluator, b *StringEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
 			if a.Field != "" {
 				a.StringCmpOpts.ScalarCaseInsensitive = true
 				a.StringCmpOpts.GlobCaseInsensitive = true
@@ -24,17 +20,17 @@ var (
 				b.StringCmpOpts.GlobCaseInsensitive = true
 			}
 
-			return eval.StringEquals(a, b, opts, state)
+			return StringEquals(a, b, opts, state)
 		},
-		StringValuesContains: func(a *eval.StringEvaluator, b *eval.StringValuesEvaluator, opts *eval.Opts, state *eval.State) (*eval.BoolEvaluator, error) {
+		StringValuesContains: func(a *StringEvaluator, b *StringValuesEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
 			if a.Field != "" {
 				a.StringCmpOpts.ScalarCaseInsensitive = true
 				a.StringCmpOpts.GlobCaseInsensitive = true
 			}
 
-			return eval.StringValuesContains(a, b, opts, state)
+			return StringValuesContains(a, b, opts, state)
 		},
-		StringArrayContains: func(a *eval.StringEvaluator, b *eval.StringArrayEvaluator, opts *eval.Opts, state *eval.State) (*eval.BoolEvaluator, error) {
+		StringArrayContains: func(a *StringEvaluator, b *StringArrayEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
 			if a.Field != "" {
 				a.StringCmpOpts.ScalarCaseInsensitive = true
 				a.StringCmpOpts.GlobCaseInsensitive = true
@@ -43,15 +39,15 @@ var (
 				b.StringCmpOpts.GlobCaseInsensitive = true
 			}
 
-			return eval.StringArrayContains(a, b, opts, state)
+			return StringArrayContains(a, b, opts, state)
 		},
-		StringArrayMatches: func(a *eval.StringArrayEvaluator, b *eval.StringValuesEvaluator, opts *eval.Opts, state *eval.State) (*eval.BoolEvaluator, error) {
+		StringArrayMatches: func(a *StringArrayEvaluator, b *StringValuesEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
 			if a.Field != "" {
 				a.StringCmpOpts.ScalarCaseInsensitive = true
 				a.StringCmpOpts.GlobCaseInsensitive = true
 			}
 
-			return eval.StringArrayMatches(a, b, opts, state)
+			return StringArrayMatches(a, b, opts, state)
 		},
 	}
 )

--- a/pkg/security/secl/compiler/eval/oo_dns_name.go
+++ b/pkg/security/secl/compiler/eval/oo_dns_name.go
@@ -14,10 +14,10 @@ var (
 		StringEquals: func(a *StringEvaluator, b *StringEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
 			if a.Field != "" {
 				a.StringCmpOpts.ScalarCaseInsensitive = true
-				a.StringCmpOpts.GlobCaseInsensitive = true
+				a.StringCmpOpts.PatternCaseInsensitive = true
 			} else if b.Field != "" {
 				b.StringCmpOpts.ScalarCaseInsensitive = true
-				b.StringCmpOpts.GlobCaseInsensitive = true
+				b.StringCmpOpts.PatternCaseInsensitive = true
 			}
 
 			return StringEquals(a, b, opts, state)
@@ -25,7 +25,7 @@ var (
 		StringValuesContains: func(a *StringEvaluator, b *StringValuesEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
 			if a.Field != "" {
 				a.StringCmpOpts.ScalarCaseInsensitive = true
-				a.StringCmpOpts.GlobCaseInsensitive = true
+				a.StringCmpOpts.PatternCaseInsensitive = true
 			}
 
 			return StringValuesContains(a, b, opts, state)
@@ -33,10 +33,10 @@ var (
 		StringArrayContains: func(a *StringEvaluator, b *StringArrayEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
 			if a.Field != "" {
 				a.StringCmpOpts.ScalarCaseInsensitive = true
-				a.StringCmpOpts.GlobCaseInsensitive = true
+				a.StringCmpOpts.PatternCaseInsensitive = true
 			} else if b.Field != "" {
 				b.StringCmpOpts.ScalarCaseInsensitive = true
-				b.StringCmpOpts.GlobCaseInsensitive = true
+				b.StringCmpOpts.PatternCaseInsensitive = true
 			}
 
 			return StringArrayContains(a, b, opts, state)
@@ -44,7 +44,7 @@ var (
 		StringArrayMatches: func(a *StringArrayEvaluator, b *StringValuesEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
 			if a.Field != "" {
 				a.StringCmpOpts.ScalarCaseInsensitive = true
-				a.StringCmpOpts.GlobCaseInsensitive = true
+				a.StringCmpOpts.PatternCaseInsensitive = true
 			}
 
 			return StringArrayMatches(a, b, opts, state)

--- a/pkg/security/secl/compiler/eval/oo_dns_name_test.go
+++ b/pkg/security/secl/compiler/eval/oo_dns_name_test.go
@@ -236,8 +236,8 @@ func TestLowerCaseContains(t *testing.T) {
 		values.AppendFieldValue(FieldValue{Value: "fo*", Type: PatternValueType})
 
 		opts := StringCmpOpts{
-			ScalarCaseInsensitive: true,
-			GlobCaseInsensitive:   true,
+			ScalarCaseInsensitive:  true,
+			PatternCaseInsensitive: true,
 		}
 
 		if err := values.Compile(opts); err != nil {

--- a/pkg/security/secl/compiler/eval/oo_dns_name_test.go
+++ b/pkg/security/secl/compiler/eval/oo_dns_name_test.go
@@ -3,9 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux
-// +build linux
-
 package eval
 
 import (

--- a/pkg/security/secl/compiler/eval/oo_dns_name_test.go
+++ b/pkg/security/secl/compiler/eval/oo_dns_name_test.go
@@ -6,33 +6,30 @@
 //go:build linux
 // +build linux
 
-package probe
+package eval
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
-	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 )
 
 func TestLowerCaseEquals(t *testing.T) {
 	t.Run("no-match", func(t *testing.T) {
-		a := &eval.StringEvaluator{
+		a := &StringEvaluator{
 			Value:     "BAR",
-			ValueType: eval.ScalarValueType,
+			ValueType: ScalarValueType,
 		}
 
-		b := &eval.StringEvaluator{
+		b := &StringEvaluator{
 			Field: "field",
-			EvalFnc: func(ctx *eval.Context) string {
+			EvalFnc: func(ctx *Context) string {
 				return "foo"
 			},
 		}
 
-		var ctx eval.Context
-		state := eval.NewState(&model.Model{}, "", nil)
+		var ctx Context
+		state := NewState(&testModel{}, "", nil)
 
 		e, err := DNSNameCmp.StringEquals(a, b, nil, state)
 		assert.Empty(t, err)
@@ -44,20 +41,20 @@ func TestLowerCaseEquals(t *testing.T) {
 	})
 
 	t.Run("scalar", func(t *testing.T) {
-		a := &eval.StringEvaluator{
+		a := &StringEvaluator{
 			Value:     "FOO",
-			ValueType: eval.ScalarValueType,
+			ValueType: ScalarValueType,
 		}
 
-		b := &eval.StringEvaluator{
+		b := &StringEvaluator{
 			Field: "field",
-			EvalFnc: func(ctx *eval.Context) string {
+			EvalFnc: func(ctx *Context) string {
 				return "foo"
 			},
 		}
 
-		var ctx eval.Context
-		state := eval.NewState(&model.Model{}, "", nil)
+		var ctx Context
+		state := NewState(&testModel{}, "", nil)
 
 		e, err := DNSNameCmp.StringEquals(a, b, nil, state)
 		assert.Empty(t, err)
@@ -69,20 +66,20 @@ func TestLowerCaseEquals(t *testing.T) {
 	})
 
 	t.Run("glob", func(t *testing.T) {
-		a := &eval.StringEvaluator{
+		a := &StringEvaluator{
 			Value:     "FO*",
-			ValueType: eval.PatternValueType,
+			ValueType: PatternValueType,
 		}
 
-		b := &eval.StringEvaluator{
+		b := &StringEvaluator{
 			Field: "field",
-			EvalFnc: func(ctx *eval.Context) string {
+			EvalFnc: func(ctx *Context) string {
 				return "foo"
 			},
 		}
 
-		var ctx eval.Context
-		state := eval.NewState(&model.Model{}, "", nil)
+		var ctx Context
+		state := NewState(&testModel{}, "", nil)
 
 		e, err := DNSNameCmp.StringEquals(a, b, nil, state)
 		assert.Empty(t, err)
@@ -94,20 +91,20 @@ func TestLowerCaseEquals(t *testing.T) {
 	})
 
 	t.Run("regex", func(t *testing.T) {
-		a := &eval.StringEvaluator{
+		a := &StringEvaluator{
 			Value:     "FO.*",
-			ValueType: eval.RegexpValueType,
+			ValueType: RegexpValueType,
 		}
 
-		b := &eval.StringEvaluator{
+		b := &StringEvaluator{
 			Field: "field",
-			EvalFnc: func(ctx *eval.Context) string {
+			EvalFnc: func(ctx *Context) string {
 				return "foo"
 			},
 		}
 
-		var ctx eval.Context
-		state := eval.NewState(&model.Model{}, "", nil)
+		var ctx Context
+		state := NewState(&testModel{}, "", nil)
 
 		e, err := DNSNameCmp.StringEquals(a, b, nil, state)
 		assert.Empty(t, err)
@@ -121,23 +118,23 @@ func TestLowerCaseEquals(t *testing.T) {
 
 func TestLowerCaseContains(t *testing.T) {
 	t.Run("no-match", func(t *testing.T) {
-		a := &eval.StringEvaluator{
+		a := &StringEvaluator{
 			Field: "field",
-			EvalFnc: func(ctx *eval.Context) string {
+			EvalFnc: func(ctx *Context) string {
 				return "BAR"
 			},
 		}
 
-		var values eval.StringValues
-		values.AppendFieldValue(eval.FieldValue{Value: "aaa", Type: eval.ScalarValueType})
-		values.AppendFieldValue(eval.FieldValue{Value: "foo", Type: eval.ScalarValueType})
+		var values StringValues
+		values.AppendFieldValue(FieldValue{Value: "aaa", Type: ScalarValueType})
+		values.AppendFieldValue(FieldValue{Value: "foo", Type: ScalarValueType})
 
-		b := &eval.StringValuesEvaluator{
+		b := &StringValuesEvaluator{
 			Values: values,
 		}
 
-		var ctx eval.Context
-		state := eval.NewState(&model.Model{}, "", nil)
+		var ctx Context
+		state := NewState(&testModel{}, "", nil)
 
 		e, err := DNSNameCmp.StringValuesContains(a, b, nil, state)
 		assert.Empty(t, err)
@@ -145,23 +142,23 @@ func TestLowerCaseContains(t *testing.T) {
 	})
 
 	t.Run("scalar", func(t *testing.T) {
-		a := &eval.StringEvaluator{
+		a := &StringEvaluator{
 			Field: "field",
-			EvalFnc: func(ctx *eval.Context) string {
+			EvalFnc: func(ctx *Context) string {
 				return "FOO"
 			},
 		}
 
-		var values eval.StringValues
-		values.AppendFieldValue(eval.FieldValue{Value: "aaa", Type: eval.ScalarValueType})
-		values.AppendFieldValue(eval.FieldValue{Value: "foo", Type: eval.ScalarValueType})
+		var values StringValues
+		values.AppendFieldValue(FieldValue{Value: "aaa", Type: ScalarValueType})
+		values.AppendFieldValue(FieldValue{Value: "foo", Type: ScalarValueType})
 
-		b := &eval.StringValuesEvaluator{
+		b := &StringValuesEvaluator{
 			Values: values,
 		}
 
-		var ctx eval.Context
-		state := eval.NewState(&model.Model{}, "", nil)
+		var ctx Context
+		state := NewState(&testModel{}, "", nil)
 
 		e, err := DNSNameCmp.StringValuesContains(a, b, nil, state)
 		assert.Empty(t, err)
@@ -169,23 +166,23 @@ func TestLowerCaseContains(t *testing.T) {
 	})
 
 	t.Run("glob", func(t *testing.T) {
-		a := &eval.StringEvaluator{
+		a := &StringEvaluator{
 			Field: "field",
-			EvalFnc: func(ctx *eval.Context) string {
+			EvalFnc: func(ctx *Context) string {
 				return "foo"
 			},
 		}
 
-		var values eval.StringValues
-		values.AppendFieldValue(eval.FieldValue{Value: "aaa", Type: eval.ScalarValueType})
-		values.AppendFieldValue(eval.FieldValue{Value: "FOO*", Type: eval.PatternValueType})
+		var values StringValues
+		values.AppendFieldValue(FieldValue{Value: "aaa", Type: ScalarValueType})
+		values.AppendFieldValue(FieldValue{Value: "FOO*", Type: PatternValueType})
 
-		b := &eval.StringValuesEvaluator{
+		b := &StringValuesEvaluator{
 			Values: values,
 		}
 
-		var ctx eval.Context
-		state := eval.NewState(&model.Model{}, "", nil)
+		var ctx Context
+		state := NewState(&testModel{}, "", nil)
 
 		e, err := DNSNameCmp.StringValuesContains(a, b, nil, state)
 		assert.Empty(t, err)
@@ -193,31 +190,31 @@ func TestLowerCaseContains(t *testing.T) {
 	})
 
 	t.Run("regex", func(t *testing.T) {
-		a := &eval.StringEvaluator{
+		a := &StringEvaluator{
 			Field: "field",
-			EvalFnc: func(ctx *eval.Context) string {
+			EvalFnc: func(ctx *Context) string {
 				return "foo"
 			},
 		}
 
-		var values eval.StringValues
-		values.AppendFieldValue(eval.FieldValue{Value: "aaa", Type: eval.ScalarValueType})
-		values.AppendFieldValue(eval.FieldValue{Value: "FO.*", Type: eval.RegexpValueType})
+		var values StringValues
+		values.AppendFieldValue(FieldValue{Value: "aaa", Type: ScalarValueType})
+		values.AppendFieldValue(FieldValue{Value: "FO.*", Type: RegexpValueType})
 
-		b := &eval.StringValuesEvaluator{
+		b := &StringValuesEvaluator{
 			Values: values,
 		}
 
-		var ctx eval.Context
-		state := eval.NewState(&model.Model{}, "", nil)
+		var ctx Context
+		state := NewState(&testModel{}, "", nil)
 
 		e, err := DNSNameCmp.StringValuesContains(a, b, nil, state)
 		assert.Empty(t, err)
 		assert.False(t, e.Eval(&ctx).(bool))
 
-		values.AppendFieldValue(eval.FieldValue{Value: "[Ff][Oo].*", Type: eval.RegexpValueType})
+		values.AppendFieldValue(FieldValue{Value: "[Ff][Oo].*", Type: RegexpValueType})
 
-		b = &eval.StringValuesEvaluator{
+		b = &StringValuesEvaluator{
 			Values: values,
 		}
 
@@ -227,18 +224,18 @@ func TestLowerCaseContains(t *testing.T) {
 	})
 
 	t.Run("eval", func(t *testing.T) {
-		a := &eval.StringEvaluator{
+		a := &StringEvaluator{
 			Field: "field",
-			EvalFnc: func(ctx *eval.Context) string {
+			EvalFnc: func(ctx *Context) string {
 				return "FOO"
 			},
 		}
 
-		var values eval.StringValues
-		values.AppendFieldValue(eval.FieldValue{Value: "aaa", Type: eval.ScalarValueType})
-		values.AppendFieldValue(eval.FieldValue{Value: "fo*", Type: eval.PatternValueType})
+		var values StringValues
+		values.AppendFieldValue(FieldValue{Value: "aaa", Type: ScalarValueType})
+		values.AppendFieldValue(FieldValue{Value: "fo*", Type: PatternValueType})
 
-		opts := eval.StringCmpOpts{
+		opts := StringCmpOpts{
 			ScalarCaseInsensitive: true,
 			GlobCaseInsensitive:   true,
 		}
@@ -247,14 +244,14 @@ func TestLowerCaseContains(t *testing.T) {
 			t.Error(err)
 		}
 
-		b := &eval.StringValuesEvaluator{
-			EvalFnc: func(ctx *eval.Context) *eval.StringValues {
+		b := &StringValuesEvaluator{
+			EvalFnc: func(ctx *Context) *StringValues {
 				return &values
 			},
 		}
 
-		var ctx eval.Context
-		state := eval.NewState(&model.Model{}, "", nil)
+		var ctx Context
+		state := NewState(&testModel{}, "", nil)
 
 		e, err := DNSNameCmp.StringValuesContains(a, b, nil, state)
 		assert.Empty(t, err)
@@ -264,19 +261,19 @@ func TestLowerCaseContains(t *testing.T) {
 
 func TestLowerCaseArrayContains(t *testing.T) {
 	t.Run("no-match", func(t *testing.T) {
-		a := &eval.StringEvaluator{
+		a := &StringEvaluator{
 			Field: "field",
-			EvalFnc: func(ctx *eval.Context) string {
+			EvalFnc: func(ctx *Context) string {
 				return "BAR"
 			},
 		}
 
-		b := &eval.StringArrayEvaluator{
+		b := &StringArrayEvaluator{
 			Values: []string{"aaa", "bbb"},
 		}
 
-		var ctx eval.Context
-		state := eval.NewState(&model.Model{}, "", nil)
+		var ctx Context
+		state := NewState(&testModel{}, "", nil)
 
 		e, err := DNSNameCmp.StringArrayContains(a, b, nil, state)
 		assert.Empty(t, err)
@@ -284,19 +281,19 @@ func TestLowerCaseArrayContains(t *testing.T) {
 	})
 
 	t.Run("scalar", func(t *testing.T) {
-		a := &eval.StringEvaluator{
+		a := &StringEvaluator{
 			Field: "field",
-			EvalFnc: func(ctx *eval.Context) string {
+			EvalFnc: func(ctx *Context) string {
 				return "FOO"
 			},
 		}
 
-		b := &eval.StringArrayEvaluator{
+		b := &StringArrayEvaluator{
 			Values: []string{"aaa", "foo"},
 		}
 
-		var ctx eval.Context
-		state := eval.NewState(&model.Model{}, "", nil)
+		var ctx Context
+		state := NewState(&testModel{}, "", nil)
 
 		e, err := DNSNameCmp.StringArrayContains(a, b, nil, state)
 		assert.Empty(t, err)
@@ -304,21 +301,21 @@ func TestLowerCaseArrayContains(t *testing.T) {
 	})
 
 	t.Run("eval", func(t *testing.T) {
-		a := &eval.StringEvaluator{
+		a := &StringEvaluator{
 			Field: "field",
-			EvalFnc: func(ctx *eval.Context) string {
+			EvalFnc: func(ctx *Context) string {
 				return "foo"
 			},
 		}
-		b := &eval.StringArrayEvaluator{
+		b := &StringArrayEvaluator{
 			Field: "array",
-			EvalFnc: func(ctx *eval.Context) []string {
+			EvalFnc: func(ctx *Context) []string {
 				return []string{"aaa", "foo"}
 			},
 		}
 
-		var ctx eval.Context
-		state := eval.NewState(&model.Model{}, "", nil)
+		var ctx Context
+		state := NewState(&testModel{}, "", nil)
 
 		e, err := DNSNameCmp.StringArrayContains(a, b, nil, state)
 		assert.Empty(t, err)

--- a/pkg/security/secl/compiler/eval/oo_glob_cmp.go
+++ b/pkg/security/secl/compiler/eval/oo_glob_cmp.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package eval
+
+var (
+	// GlobCmp replaces a pattern matcher with a glob matcher for *file.path fields.
+	GlobCmp = &OpOverrides{
+		StringEquals: func(a *StringEvaluator, b *StringEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+			if a.ValueType == PatternValueType {
+				a.ValueType = GlobValueType
+			} else if b.ValueType == PatternValueType {
+				b.ValueType = GlobValueType
+			}
+
+			return StringEquals(a, b, opts, state)
+		},
+		StringValuesContains: func(a *StringEvaluator, b *StringValuesEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+			if a.ValueType == PatternValueType {
+				a.ValueType = GlobValueType
+			} else {
+				var values StringValues
+				for _, v := range b.Values.GetFieldValues() {
+					if v.Type == PatternValueType {
+						v.Type = GlobValueType
+					}
+					values.AppendFieldValue(v)
+				}
+				b = &StringValuesEvaluator{
+					Values: values,
+				}
+			}
+
+			return StringValuesContains(a, b, opts, state)
+		},
+		StringArrayContains: func(a *StringEvaluator, b *StringArrayEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+			if a.ValueType == PatternValueType {
+				a.ValueType = GlobValueType
+			}
+
+			return StringArrayContains(a, b, opts, state)
+		},
+		StringArrayMatches: func(a *StringArrayEvaluator, b *StringValuesEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+			var values StringValues
+			for _, v := range b.Values.GetFieldValues() {
+				if v.Type == PatternValueType {
+					v.Type = GlobValueType
+				}
+				values.AppendFieldValue(v)
+			}
+			b = &StringValuesEvaluator{
+				Values: values,
+			}
+
+			return StringArrayMatches(a, b, opts, state)
+		},
+	}
+)

--- a/pkg/security/secl/compiler/eval/oo_glob_cmp_test.go
+++ b/pkg/security/secl/compiler/eval/oo_glob_cmp_test.go
@@ -1,0 +1,191 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package eval
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOPOverrideGlobEquals(t *testing.T) {
+	t.Run("no-match", func(t *testing.T) {
+		a := &StringEvaluator{
+			Value:     "/abc/",
+			ValueType: PatternValueType,
+		}
+
+		b := &StringEvaluator{
+			Field: "field",
+			EvalFnc: func(ctx *Context) string {
+				return "/2/abc/3"
+			},
+		}
+
+		var ctx Context
+		state := NewState(&testModel{}, "", nil)
+
+		e, err := GlobCmp.StringEquals(a, b, nil, state)
+		assert.Empty(t, err)
+		assert.False(t, e.Eval(&ctx).(bool))
+
+		e, err = GlobCmp.StringEquals(b, a, nil, state)
+		assert.Empty(t, err)
+		assert.False(t, e.Eval(&ctx).(bool))
+	})
+
+	t.Run("match", func(t *testing.T) {
+		a := &StringEvaluator{
+			Value:     "*/abc/*",
+			ValueType: PatternValueType,
+		}
+
+		b := &StringEvaluator{
+			Field: "field",
+			EvalFnc: func(ctx *Context) string {
+				return "/2/abc/3"
+			},
+		}
+
+		var ctx Context
+		state := NewState(&testModel{}, "", nil)
+
+		e, err := GlobCmp.StringEquals(a, b, nil, state)
+		assert.Empty(t, err)
+		assert.True(t, e.Eval(&ctx).(bool))
+
+		e, err = GlobCmp.StringEquals(b, a, nil, state)
+		assert.Empty(t, err)
+		assert.True(t, e.Eval(&ctx).(bool))
+	})
+}
+
+func TestOPOverrideGlobContains(t *testing.T) {
+	t.Run("no-match", func(t *testing.T) {
+		a := &StringEvaluator{
+			Field: "field",
+			EvalFnc: func(ctx *Context) string {
+				return "/2/abc/3"
+			},
+		}
+
+		var values StringValues
+		values.AppendFieldValue(FieldValue{Value: "/abc/", Type: PatternValueType})
+		values.AppendFieldValue(FieldValue{Value: "abc/*", Type: PatternValueType})
+		values.AppendFieldValue(FieldValue{Value: "*/abc", Type: PatternValueType})
+
+		b := &StringValuesEvaluator{
+			Values: values,
+		}
+
+		var ctx Context
+		state := NewState(&testModel{}, "", nil)
+
+		e, err := GlobCmp.StringValuesContains(a, b, nil, state)
+		assert.Empty(t, err)
+		assert.False(t, e.Eval(&ctx).(bool))
+	})
+
+	t.Run("match", func(t *testing.T) {
+		a := &StringEvaluator{
+			Field: "field",
+			EvalFnc: func(ctx *Context) string {
+				return "/2/abc/3"
+			},
+		}
+
+		var values StringValues
+		values.AppendFieldValue(FieldValue{Value: "*/abc/*", Type: PatternValueType})
+		values.AppendFieldValue(FieldValue{Value: "abc", Type: PatternValueType})
+
+		b := &StringValuesEvaluator{
+			Values: values,
+		}
+
+		var ctx Context
+		state := NewState(&testModel{}, "", nil)
+
+		e, err := GlobCmp.StringValuesContains(a, b, nil, state)
+		assert.Empty(t, err)
+		assert.True(t, e.Eval(&ctx).(bool))
+	})
+}
+
+func TestOPOverrideGlobArrayMatches(t *testing.T) {
+	t.Run("no-match", func(t *testing.T) {
+		a := &StringArrayEvaluator{
+			Values: []string{"/2/abc/3"},
+		}
+
+		var values StringValues
+		values.AppendFieldValue(FieldValue{Value: "abc", Type: PatternValueType})
+		values.AppendFieldValue(FieldValue{Value: "abc/*", Type: PatternValueType})
+		values.AppendFieldValue(FieldValue{Value: "*/abc", Type: PatternValueType})
+
+		b := &StringValuesEvaluator{
+			Values: values,
+		}
+		state := NewState(&testModel{}, "", nil)
+
+		e, err := GlobCmp.StringArrayMatches(a, b, nil, state)
+		assert.Empty(t, err)
+		assert.False(t, e.Value)
+	})
+
+	t.Run("match", func(t *testing.T) {
+		a := &StringArrayEvaluator{
+			Values: []string{"/2/abc/3"},
+		}
+
+		var values StringValues
+		values.AppendFieldValue(FieldValue{Value: "*/abc/*", Type: PatternValueType})
+		values.AppendFieldValue(FieldValue{Value: "abc", Type: PatternValueType})
+
+		b := &StringValuesEvaluator{
+			Values: values,
+		}
+		state := NewState(&testModel{}, "", nil)
+
+		e, err := GlobCmp.StringArrayMatches(a, b, nil, state)
+		assert.Empty(t, err)
+		assert.True(t, e.Value)
+	})
+}
+
+func TestOPOverrideGlobArrayContains(t *testing.T) {
+	t.Run("no-match", func(t *testing.T) {
+		a := &StringEvaluator{
+			Value:     "/abc/",
+			ValueType: PatternValueType,
+		}
+
+		b := &StringArrayEvaluator{
+			Values: []string{"/2/abc/3"},
+		}
+		state := NewState(&testModel{}, "", nil)
+
+		e, err := GlobCmp.StringArrayContains(a, b, nil, state)
+		assert.Empty(t, err)
+		assert.False(t, e.Value)
+	})
+
+	t.Run("match", func(t *testing.T) {
+		a := &StringEvaluator{
+			Value:     "*/abc/*",
+			ValueType: PatternValueType,
+		}
+
+		b := &StringArrayEvaluator{
+			Field:  "dont_forget_me_or_it_wont_compile_a",
+			Values: []string{"/2/abc/3"},
+		}
+		state := NewState(&testModel{}, "", nil)
+
+		e, err := GlobCmp.StringArrayContains(a, b, nil, state)
+		assert.Empty(t, err)
+		assert.True(t, e.Value)
+	})
+}

--- a/pkg/security/secl/compiler/eval/pattern_test.go
+++ b/pkg/security/secl/compiler/eval/pattern_test.go
@@ -43,6 +43,10 @@ func TestPatternNextSegment(t *testing.T) {
 
 func TestPatternMatches(t *testing.T) {
 	t.Run("sensitive-case", func(t *testing.T) {
+		if !PatternMatches("*abc*", "/abc/", false) {
+			t.Error("should match")
+		}
+
 		if !PatternMatches("*test123", "aaatest123", false) {
 			t.Error("should match")
 		}

--- a/pkg/security/secl/compiler/eval/strings.go
+++ b/pkg/security/secl/compiler/eval/strings.go
@@ -15,9 +15,10 @@ import (
 
 // StringCmpOpts defines options to apply during string comparison
 type StringCmpOpts struct {
-	ScalarCaseInsensitive bool
-	GlobCaseInsensitive   bool
-	RegexpCaseInsensitive bool
+	ScalarCaseInsensitive  bool
+	PatternCaseInsensitive bool
+	GlobCaseInsensitive    bool
+	RegexpCaseInsensitive  bool
 }
 
 // DefaultStringCmpOpts defines the default comparison options
@@ -239,7 +240,7 @@ func NewStringMatcher(kind FieldValueType, pattern string, opts StringCmpOpts) (
 	switch kind {
 	case PatternValueType:
 		var matcher PatternStringMatcher
-		if err := matcher.Compile(pattern, opts.GlobCaseInsensitive); err != nil {
+		if err := matcher.Compile(pattern, opts.PatternCaseInsensitive); err != nil {
 			return nil, fmt.Errorf("invalid pattern `%s`: %s", pattern, err)
 		}
 		return &matcher, nil

--- a/pkg/security/secl/compiler/eval/strings_test.go
+++ b/pkg/security/secl/compiler/eval/strings_test.go
@@ -77,63 +77,125 @@ func TestScalar(t *testing.T) {
 	})
 }
 
-func TestGlob(t *testing.T) {
+func TestPattern(t *testing.T) {
 	t.Run("sensitive-case", func(t *testing.T) {
-		matcher, err := NewStringMatcher(PatternValueType, "test*", DefaultStringCmpOpts)
+		matcher, err := NewStringMatcher(GlobValueType, "http://test*", DefaultStringCmpOpts)
 		if err != nil {
 			t.Error(err)
 		}
 
-		if !matcher.Matches("test123") {
+		if !matcher.Matches("http://test123") {
 			t.Error("should match")
 		}
 
-		if matcher.Matches("TEST123") {
+		if matcher.Matches("http://TEST123") {
 			t.Error("shouldn't match")
 		}
 	})
 
 	t.Run("insensitive-case", func(t *testing.T) {
-		matcher, err := NewStringMatcher(PatternValueType, "TEst*", StringCmpOpts{GlobCaseInsensitive: true})
+		matcher, err := NewStringMatcher(GlobValueType, "http://TEst*", StringCmpOpts{GlobCaseInsensitive: true})
 		if err != nil {
 			t.Error(err)
 		}
 
-		if !matcher.Matches("test123") {
+		if !matcher.Matches("http://test123") {
 			t.Error("should match")
 		}
 
-		if !matcher.Matches("TEST123") {
+		if !matcher.Matches("http://TEST123") {
 			t.Error("should match")
 		}
 	})
 
 	t.Run("sensitive-case-scalar", func(t *testing.T) {
-		matcher, err := NewStringMatcher(PatternValueType, "test123", DefaultStringCmpOpts)
+		matcher, err := NewStringMatcher(GlobValueType, "http://test123", DefaultStringCmpOpts)
 		if err != nil {
 			t.Error(err)
 		}
 
-		if !matcher.Matches("test123") {
+		if !matcher.Matches("http://test123") {
 			t.Error("should match")
 		}
 
-		if matcher.Matches("TEST123") {
+		if matcher.Matches("http://TEST123") {
 			t.Error("shouldn't match")
 		}
 	})
 
 	t.Run("insensitive-case-scalar", func(t *testing.T) {
-		matcher, err := NewStringMatcher(PatternValueType, "test123", StringCmpOpts{GlobCaseInsensitive: true})
+		matcher, err := NewStringMatcher(GlobValueType, "http://test123", StringCmpOpts{GlobCaseInsensitive: true})
 		if err != nil {
 			t.Error(err)
 		}
 
-		if !matcher.Matches("test123") {
+		if !matcher.Matches("http://test123") {
 			t.Error("should match")
 		}
 
-		if !matcher.Matches("TEST123") {
+		if !matcher.Matches("http://TEST123") {
+			t.Error("should match")
+		}
+	})
+}
+
+func TestGlob(t *testing.T) {
+	t.Run("sensitive-case", func(t *testing.T) {
+		matcher, err := NewStringMatcher(GlobValueType, "/etc/test*", DefaultStringCmpOpts)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if !matcher.Matches("/etc/test123") {
+			t.Error("should match")
+		}
+
+		if matcher.Matches("/etc/TEST123") {
+			t.Error("shouldn't match")
+		}
+	})
+
+	t.Run("insensitive-case", func(t *testing.T) {
+		matcher, err := NewStringMatcher(GlobValueType, "/etc/TEst*", StringCmpOpts{GlobCaseInsensitive: true})
+		if err != nil {
+			t.Error(err)
+		}
+
+		if !matcher.Matches("/etc/test123") {
+			t.Error("should match")
+		}
+
+		if !matcher.Matches("/etc/TEST123") {
+			t.Error("should match")
+		}
+	})
+
+	t.Run("sensitive-case-scalar", func(t *testing.T) {
+		matcher, err := NewStringMatcher(GlobValueType, "/etc/test123", DefaultStringCmpOpts)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if !matcher.Matches("/etc/test123") {
+			t.Error("should match")
+		}
+
+		if matcher.Matches("/etc/TEST123") {
+			t.Error("shouldn't match")
+		}
+	})
+
+	t.Run("insensitive-case-scalar", func(t *testing.T) {
+		matcher, err := NewStringMatcher(GlobValueType, "/etc/test123", StringCmpOpts{GlobCaseInsensitive: true})
+		if err != nil {
+			t.Error(err)
+		}
+
+		if !matcher.Matches("/etc/test123") {
+			t.Error("should match")
+		}
+
+		if !matcher.Matches("/etc/TEST123") {
 			t.Error("should match")
 		}
 	})

--- a/pkg/security/secl/compiler/eval/strings_test.go
+++ b/pkg/security/secl/compiler/eval/strings_test.go
@@ -79,7 +79,7 @@ func TestScalar(t *testing.T) {
 
 func TestPattern(t *testing.T) {
 	t.Run("sensitive-case", func(t *testing.T) {
-		matcher, err := NewStringMatcher(GlobValueType, "http://test*", DefaultStringCmpOpts)
+		matcher, err := NewStringMatcher(PatternValueType, "http://test*", DefaultStringCmpOpts)
 		if err != nil {
 			t.Error(err)
 		}
@@ -94,7 +94,7 @@ func TestPattern(t *testing.T) {
 	})
 
 	t.Run("insensitive-case", func(t *testing.T) {
-		matcher, err := NewStringMatcher(GlobValueType, "http://TEst*", StringCmpOpts{GlobCaseInsensitive: true})
+		matcher, err := NewStringMatcher(PatternValueType, "http://TEst*", StringCmpOpts{PatternCaseInsensitive: true})
 		if err != nil {
 			t.Error(err)
 		}
@@ -109,7 +109,7 @@ func TestPattern(t *testing.T) {
 	})
 
 	t.Run("sensitive-case-scalar", func(t *testing.T) {
-		matcher, err := NewStringMatcher(GlobValueType, "http://test123", DefaultStringCmpOpts)
+		matcher, err := NewStringMatcher(PatternValueType, "http://test123", DefaultStringCmpOpts)
 		if err != nil {
 			t.Error(err)
 		}
@@ -124,7 +124,7 @@ func TestPattern(t *testing.T) {
 	})
 
 	t.Run("insensitive-case-scalar", func(t *testing.T) {
-		matcher, err := NewStringMatcher(GlobValueType, "http://test123", StringCmpOpts{GlobCaseInsensitive: true})
+		matcher, err := NewStringMatcher(PatternValueType, "http://test123", StringCmpOpts{PatternCaseInsensitive: true})
 		if err != nil {
 			t.Error(err)
 		}

--- a/pkg/security/secl/compiler/generators/accessors/accessors.tmpl
+++ b/pkg/security/secl/compiler/generators/accessors/accessors.tmpl
@@ -78,8 +78,9 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 						{{$Return := $SubName | printf "element%s"}}
 						{{if and (ne $Field.Handler "") (not $Mock) }}
+							{{$SubName = $Field.Iterator.Name | TrimPrefix $Field.Prefix}}
 							{{$Handler := $Field.Iterator.Name | TrimPrefix $Field.Handler}}
-							{{$Return = print "(*Event)(ctx.Object)." $Handler "(&element." $Field.Struct ")"}}
+							{{$Return = print "(*Event)(ctx.Object)." $Handler "(&element" $SubName ")"}}
 						{{end}}
 
 						{{if eq $Field.ReturnType "int"}}
@@ -199,8 +200,9 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 				{{$Return := $SubName | printf "element%s"}}
 				{{if and (ne $Field.Handler "") (not $Mock) }}
+					{{$SubName = $Field.Iterator.Name | TrimPrefix $Field.Prefix}}
 					{{$Handler := $Field.Iterator.Name | TrimPrefix $Field.Handler}}
-					{{$Return = print "(*Event)(ctx.Object)." $Handler "(&element." $Field.Struct ")"}}
+					{{$Return = print "(*Event)(ctx.Object)." $Handler "(&element" $SubName ")"}}
 				{{end}}
 
 				{{if and (eq $Field.ReturnType "int") (ne $Field.OrigType "int")}}

--- a/pkg/security/secl/compiler/generators/accessors/accessors.tmpl
+++ b/pkg/security/secl/compiler/generators/accessors/accessors.tmpl
@@ -46,7 +46,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	{{range $Name, $Field := .Fields}}
 	case "{{$Name}}":
 		return &{{$Field.GetEvaluatorType}}{
-			{{- if and $Field.OpOverrides (not $Mock)}}
+			{{- if $Field.OpOverrides}}
 			OpOverrides: {{$Field.OpOverrides}},
 			{{- end}}
 			{{- if $Field.Iterator}}

--- a/pkg/security/secl/model/accessors.go
+++ b/pkg/security/secl/model/accessors.go
@@ -929,6 +929,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "exec.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).Exec.Process.PathnameStr
@@ -2908,6 +2909,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "process.ancestors.file.path":
 		return &eval.StringArrayEvaluator{
+			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) []string {
 				var results []string
 
@@ -3598,6 +3600,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "process.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ProcessContext.Process.PathnameStr
@@ -4503,6 +4506,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "ptrace.tracee.ancestors.file.path":
 		return &eval.StringArrayEvaluator{
+			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) []string {
 				var results []string
 
@@ -5193,6 +5197,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "ptrace.tracee.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).PTrace.Tracee.Process.PathnameStr
@@ -7043,6 +7048,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "signal.target.ancestors.file.path":
 		return &eval.StringArrayEvaluator{
+			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) []string {
 				var results []string
 
@@ -7733,6 +7739,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "signal.target.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).Signal.Target.Process.PathnameStr

--- a/pkg/security/secl/model/accessors.go
+++ b/pkg/security/secl/model/accessors.go
@@ -326,6 +326,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "chmod.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).Chmod.File.PathnameStr
@@ -516,6 +517,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "chown.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).Chown.File.PathnameStr
@@ -606,6 +608,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "dns.question.name":
 		return &eval.StringEvaluator{
+			OpOverrides: eval.DNSNameCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).DNS.Name
@@ -1196,6 +1199,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "link.file.destination.path":
 		return &eval.StringEvaluator{
+			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).Link.Target.PathnameStr
@@ -1326,6 +1330,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "link.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).Link.Source.PathnameStr
@@ -1476,6 +1481,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "load_module.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).LoadModule.File.PathnameStr
@@ -1666,6 +1672,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "mkdir.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).Mkdir.File.PathnameStr
@@ -1816,6 +1823,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "mmap.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).MMap.File.PathnameStr
@@ -2114,6 +2122,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "open.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).Open.File.PathnameStr
@@ -5464,6 +5473,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "removexattr.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).RemoveXAttr.File.PathnameStr
@@ -5624,6 +5634,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "rename.file.destination.path":
 		return &eval.StringEvaluator{
+			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).Rename.New.PathnameStr
@@ -5754,6 +5765,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "rename.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).Rename.Old.PathnameStr
@@ -5904,6 +5916,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "rmdir.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).Rmdir.File.PathnameStr
@@ -6234,6 +6247,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "setxattr.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).SetXAttr.File.PathnameStr
@@ -7989,6 +8003,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "splice.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).Splice.File.PathnameStr
@@ -8159,6 +8174,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "unlink.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).Unlink.File.PathnameStr
@@ -8329,6 +8345,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "utimes.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).Utimes.File.PathnameStr

--- a/pkg/security/secl/model/accessors.go
+++ b/pkg/security/secl/model/accessors.go
@@ -238,7 +238,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).Chmod.File.Filesytem
+				return (*Event)(ctx.Object).Chmod.File.Filesystem
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -429,7 +429,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).Chown.File.Filesytem
+				return (*Event)(ctx.Object).Chown.File.Filesystem
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -831,7 +831,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Exec.Process.FileFields.CTime)
+				return int((*Event)(ctx.Object).Exec.Process.FileEvent.FileFields.CTime)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -841,17 +841,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).Exec.Process.Filesystem
+				return (*Event)(ctx.Object).Exec.Process.FileEvent.Filesystem
 			},
 			Field:  field,
-			Weight: eval.FunctionWeight,
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "exec.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Exec.Process.FileFields.GID)
+				return int((*Event)(ctx.Object).Exec.Process.FileEvent.FileFields.GID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -861,7 +861,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).Exec.Process.FileFields.Group
+				return (*Event)(ctx.Object).Exec.Process.FileEvent.FileFields.Group
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -871,7 +871,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
 
-				return (*Event)(ctx.Object).Exec.Process.FileFields.InUpperLayer
+				return (*Event)(ctx.Object).Exec.Process.FileEvent.FileFields.InUpperLayer
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -881,7 +881,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Exec.Process.FileFields.Inode)
+				return int((*Event)(ctx.Object).Exec.Process.FileEvent.FileFields.Inode)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -891,7 +891,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Exec.Process.FileFields.Mode)
+				return int((*Event)(ctx.Object).Exec.Process.FileEvent.FileFields.Mode)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -901,7 +901,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Exec.Process.FileFields.MTime)
+				return int((*Event)(ctx.Object).Exec.Process.FileEvent.FileFields.MTime)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -911,7 +911,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Exec.Process.FileFields.MountID)
+				return int((*Event)(ctx.Object).Exec.Process.FileEvent.FileFields.MountID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -921,10 +921,10 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).Exec.Process.BasenameStr
+				return (*Event)(ctx.Object).Exec.Process.FileEvent.BasenameStr
 			},
 			Field:  field,
-			Weight: eval.FunctionWeight,
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "exec.file.path":
@@ -932,17 +932,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).Exec.Process.PathnameStr
+				return (*Event)(ctx.Object).Exec.Process.FileEvent.PathnameStr
 			},
 			Field:  field,
-			Weight: eval.FunctionWeight,
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "exec.file.rights":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Exec.Process.FileFields.Mode)
+				return int((*Event)(ctx.Object).Exec.Process.FileEvent.FileFields.Mode)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -952,7 +952,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Exec.Process.FileFields.UID)
+				return int((*Event)(ctx.Object).Exec.Process.FileEvent.FileFields.UID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -962,7 +962,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).Exec.Process.FileFields.User
+				return (*Event)(ctx.Object).Exec.Process.FileEvent.FileFields.User
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -1112,7 +1112,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).Link.Target.Filesytem
+				return (*Event)(ctx.Object).Link.Target.Filesystem
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -1243,7 +1243,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).Link.Source.Filesytem
+				return (*Event)(ctx.Object).Link.Source.Filesystem
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -1394,7 +1394,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).LoadModule.File.Filesytem
+				return (*Event)(ctx.Object).LoadModule.File.Filesystem
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -1585,7 +1585,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).Mkdir.File.Filesytem
+				return (*Event)(ctx.Object).Mkdir.File.Filesystem
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -1736,7 +1736,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).MMap.File.Filesytem
+				return (*Event)(ctx.Object).MMap.File.Filesystem
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -2035,7 +2035,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).Open.File.Filesytem
+				return (*Event)(ctx.Object).Open.File.Filesystem
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -2670,7 +2670,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*ProcessCacheEntry)(value)
 
-					result = int(element.ProcessContext.Process.FileFields.CTime)
+					result = int(element.ProcessContext.Process.FileEvent.FileFields.CTime)
 
 					results = append(results, result)
 
@@ -2695,7 +2695,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*ProcessCacheEntry)(value)
 
-					result = element.ProcessContext.Process.Filesystem
+					result = element.ProcessContext.Process.FileEvent.Filesystem
 
 					results = append(results, result)
 
@@ -2720,7 +2720,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*ProcessCacheEntry)(value)
 
-					result = int(element.ProcessContext.Process.FileFields.GID)
+					result = int(element.ProcessContext.Process.FileEvent.FileFields.GID)
 
 					results = append(results, result)
 
@@ -2745,7 +2745,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*ProcessCacheEntry)(value)
 
-					result = element.ProcessContext.Process.FileFields.Group
+					result = element.ProcessContext.Process.FileEvent.FileFields.Group
 
 					results = append(results, result)
 
@@ -2770,7 +2770,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*ProcessCacheEntry)(value)
 
-					result = element.ProcessContext.Process.FileFields.InUpperLayer
+					result = element.ProcessContext.Process.FileEvent.FileFields.InUpperLayer
 
 					results = append(results, result)
 
@@ -2795,7 +2795,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*ProcessCacheEntry)(value)
 
-					result = int(element.ProcessContext.Process.FileFields.Inode)
+					result = int(element.ProcessContext.Process.FileEvent.FileFields.Inode)
 
 					results = append(results, result)
 
@@ -2820,7 +2820,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*ProcessCacheEntry)(value)
 
-					result = int(element.ProcessContext.Process.FileFields.Mode)
+					result = int(element.ProcessContext.Process.FileEvent.FileFields.Mode)
 
 					results = append(results, result)
 
@@ -2845,7 +2845,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*ProcessCacheEntry)(value)
 
-					result = int(element.ProcessContext.Process.FileFields.MTime)
+					result = int(element.ProcessContext.Process.FileEvent.FileFields.MTime)
 
 					results = append(results, result)
 
@@ -2870,7 +2870,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*ProcessCacheEntry)(value)
 
-					result = int(element.ProcessContext.Process.FileFields.MountID)
+					result = int(element.ProcessContext.Process.FileEvent.FileFields.MountID)
 
 					results = append(results, result)
 
@@ -2895,7 +2895,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*ProcessCacheEntry)(value)
 
-					result = element.ProcessContext.Process.BasenameStr
+					result = element.ProcessContext.Process.FileEvent.BasenameStr
 
 					results = append(results, result)
 
@@ -2921,7 +2921,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*ProcessCacheEntry)(value)
 
-					result = element.ProcessContext.Process.PathnameStr
+					result = element.ProcessContext.Process.FileEvent.PathnameStr
 
 					results = append(results, result)
 
@@ -2946,7 +2946,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*ProcessCacheEntry)(value)
 
-					result = int(element.ProcessContext.Process.FileFields.Mode)
+					result = int(element.ProcessContext.Process.FileEvent.FileFields.Mode)
 
 					results = append(results, result)
 
@@ -2971,7 +2971,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*ProcessCacheEntry)(value)
 
-					result = int(element.ProcessContext.Process.FileFields.UID)
+					result = int(element.ProcessContext.Process.FileEvent.FileFields.UID)
 
 					results = append(results, result)
 
@@ -2996,7 +2996,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*ProcessCacheEntry)(value)
 
-					result = element.ProcessContext.Process.FileFields.User
+					result = element.ProcessContext.Process.FileEvent.FileFields.User
 
 					results = append(results, result)
 
@@ -3502,7 +3502,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).ProcessContext.Process.FileFields.CTime)
+				return int((*Event)(ctx.Object).ProcessContext.Process.FileEvent.FileFields.CTime)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -3512,17 +3512,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).ProcessContext.Process.Filesystem
+				return (*Event)(ctx.Object).ProcessContext.Process.FileEvent.Filesystem
 			},
 			Field:  field,
-			Weight: eval.FunctionWeight,
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "process.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).ProcessContext.Process.FileFields.GID)
+				return int((*Event)(ctx.Object).ProcessContext.Process.FileEvent.FileFields.GID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -3532,7 +3532,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).ProcessContext.Process.FileFields.Group
+				return (*Event)(ctx.Object).ProcessContext.Process.FileEvent.FileFields.Group
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -3542,7 +3542,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
 
-				return (*Event)(ctx.Object).ProcessContext.Process.FileFields.InUpperLayer
+				return (*Event)(ctx.Object).ProcessContext.Process.FileEvent.FileFields.InUpperLayer
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -3552,7 +3552,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).ProcessContext.Process.FileFields.Inode)
+				return int((*Event)(ctx.Object).ProcessContext.Process.FileEvent.FileFields.Inode)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -3562,7 +3562,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).ProcessContext.Process.FileFields.Mode)
+				return int((*Event)(ctx.Object).ProcessContext.Process.FileEvent.FileFields.Mode)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -3572,7 +3572,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).ProcessContext.Process.FileFields.MTime)
+				return int((*Event)(ctx.Object).ProcessContext.Process.FileEvent.FileFields.MTime)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -3582,7 +3582,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).ProcessContext.Process.FileFields.MountID)
+				return int((*Event)(ctx.Object).ProcessContext.Process.FileEvent.FileFields.MountID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -3592,10 +3592,10 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).ProcessContext.Process.BasenameStr
+				return (*Event)(ctx.Object).ProcessContext.Process.FileEvent.BasenameStr
 			},
 			Field:  field,
-			Weight: eval.FunctionWeight,
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "process.file.path":
@@ -3603,17 +3603,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).ProcessContext.Process.PathnameStr
+				return (*Event)(ctx.Object).ProcessContext.Process.FileEvent.PathnameStr
 			},
 			Field:  field,
-			Weight: eval.FunctionWeight,
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "process.file.rights":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).ProcessContext.Process.FileFields.Mode)
+				return int((*Event)(ctx.Object).ProcessContext.Process.FileEvent.FileFields.Mode)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -3623,7 +3623,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).ProcessContext.Process.FileFields.UID)
+				return int((*Event)(ctx.Object).ProcessContext.Process.FileEvent.FileFields.UID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -3633,7 +3633,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).ProcessContext.Process.FileFields.User
+				return (*Event)(ctx.Object).ProcessContext.Process.FileEvent.FileFields.User
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -4267,7 +4267,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*ProcessCacheEntry)(value)
 
-					result = int(element.ProcessContext.Process.FileFields.CTime)
+					result = int(element.ProcessContext.Process.FileEvent.FileFields.CTime)
 
 					results = append(results, result)
 
@@ -4292,7 +4292,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*ProcessCacheEntry)(value)
 
-					result = element.ProcessContext.Process.Filesystem
+					result = element.ProcessContext.Process.FileEvent.Filesystem
 
 					results = append(results, result)
 
@@ -4317,7 +4317,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*ProcessCacheEntry)(value)
 
-					result = int(element.ProcessContext.Process.FileFields.GID)
+					result = int(element.ProcessContext.Process.FileEvent.FileFields.GID)
 
 					results = append(results, result)
 
@@ -4342,7 +4342,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*ProcessCacheEntry)(value)
 
-					result = element.ProcessContext.Process.FileFields.Group
+					result = element.ProcessContext.Process.FileEvent.FileFields.Group
 
 					results = append(results, result)
 
@@ -4367,7 +4367,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*ProcessCacheEntry)(value)
 
-					result = element.ProcessContext.Process.FileFields.InUpperLayer
+					result = element.ProcessContext.Process.FileEvent.FileFields.InUpperLayer
 
 					results = append(results, result)
 
@@ -4392,7 +4392,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*ProcessCacheEntry)(value)
 
-					result = int(element.ProcessContext.Process.FileFields.Inode)
+					result = int(element.ProcessContext.Process.FileEvent.FileFields.Inode)
 
 					results = append(results, result)
 
@@ -4417,7 +4417,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*ProcessCacheEntry)(value)
 
-					result = int(element.ProcessContext.Process.FileFields.Mode)
+					result = int(element.ProcessContext.Process.FileEvent.FileFields.Mode)
 
 					results = append(results, result)
 
@@ -4442,7 +4442,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*ProcessCacheEntry)(value)
 
-					result = int(element.ProcessContext.Process.FileFields.MTime)
+					result = int(element.ProcessContext.Process.FileEvent.FileFields.MTime)
 
 					results = append(results, result)
 
@@ -4467,7 +4467,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*ProcessCacheEntry)(value)
 
-					result = int(element.ProcessContext.Process.FileFields.MountID)
+					result = int(element.ProcessContext.Process.FileEvent.FileFields.MountID)
 
 					results = append(results, result)
 
@@ -4492,7 +4492,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*ProcessCacheEntry)(value)
 
-					result = element.ProcessContext.Process.BasenameStr
+					result = element.ProcessContext.Process.FileEvent.BasenameStr
 
 					results = append(results, result)
 
@@ -4518,7 +4518,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*ProcessCacheEntry)(value)
 
-					result = element.ProcessContext.Process.PathnameStr
+					result = element.ProcessContext.Process.FileEvent.PathnameStr
 
 					results = append(results, result)
 
@@ -4543,7 +4543,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*ProcessCacheEntry)(value)
 
-					result = int(element.ProcessContext.Process.FileFields.Mode)
+					result = int(element.ProcessContext.Process.FileEvent.FileFields.Mode)
 
 					results = append(results, result)
 
@@ -4568,7 +4568,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*ProcessCacheEntry)(value)
 
-					result = int(element.ProcessContext.Process.FileFields.UID)
+					result = int(element.ProcessContext.Process.FileEvent.FileFields.UID)
 
 					results = append(results, result)
 
@@ -4593,7 +4593,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*ProcessCacheEntry)(value)
 
-					result = element.ProcessContext.Process.FileFields.User
+					result = element.ProcessContext.Process.FileEvent.FileFields.User
 
 					results = append(results, result)
 
@@ -5099,7 +5099,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).PTrace.Tracee.Process.FileFields.CTime)
+				return int((*Event)(ctx.Object).PTrace.Tracee.Process.FileEvent.FileFields.CTime)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -5109,17 +5109,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).PTrace.Tracee.Process.Filesystem
+				return (*Event)(ctx.Object).PTrace.Tracee.Process.FileEvent.Filesystem
 			},
 			Field:  field,
-			Weight: eval.FunctionWeight,
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "ptrace.tracee.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).PTrace.Tracee.Process.FileFields.GID)
+				return int((*Event)(ctx.Object).PTrace.Tracee.Process.FileEvent.FileFields.GID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -5129,7 +5129,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).PTrace.Tracee.Process.FileFields.Group
+				return (*Event)(ctx.Object).PTrace.Tracee.Process.FileEvent.FileFields.Group
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -5139,7 +5139,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
 
-				return (*Event)(ctx.Object).PTrace.Tracee.Process.FileFields.InUpperLayer
+				return (*Event)(ctx.Object).PTrace.Tracee.Process.FileEvent.FileFields.InUpperLayer
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -5149,7 +5149,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).PTrace.Tracee.Process.FileFields.Inode)
+				return int((*Event)(ctx.Object).PTrace.Tracee.Process.FileEvent.FileFields.Inode)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -5159,7 +5159,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).PTrace.Tracee.Process.FileFields.Mode)
+				return int((*Event)(ctx.Object).PTrace.Tracee.Process.FileEvent.FileFields.Mode)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -5169,7 +5169,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).PTrace.Tracee.Process.FileFields.MTime)
+				return int((*Event)(ctx.Object).PTrace.Tracee.Process.FileEvent.FileFields.MTime)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -5179,7 +5179,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).PTrace.Tracee.Process.FileFields.MountID)
+				return int((*Event)(ctx.Object).PTrace.Tracee.Process.FileEvent.FileFields.MountID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -5189,10 +5189,10 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).PTrace.Tracee.Process.BasenameStr
+				return (*Event)(ctx.Object).PTrace.Tracee.Process.FileEvent.BasenameStr
 			},
 			Field:  field,
-			Weight: eval.FunctionWeight,
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "ptrace.tracee.file.path":
@@ -5200,17 +5200,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).PTrace.Tracee.Process.PathnameStr
+				return (*Event)(ctx.Object).PTrace.Tracee.Process.FileEvent.PathnameStr
 			},
 			Field:  field,
-			Weight: eval.FunctionWeight,
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "ptrace.tracee.file.rights":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).PTrace.Tracee.Process.FileFields.Mode)
+				return int((*Event)(ctx.Object).PTrace.Tracee.Process.FileEvent.FileFields.Mode)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -5220,7 +5220,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).PTrace.Tracee.Process.FileFields.UID)
+				return int((*Event)(ctx.Object).PTrace.Tracee.Process.FileEvent.FileFields.UID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -5230,7 +5230,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).PTrace.Tracee.Process.FileFields.User
+				return (*Event)(ctx.Object).PTrace.Tracee.Process.FileEvent.FileFields.User
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -5390,7 +5390,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).RemoveXAttr.File.Filesytem
+				return (*Event)(ctx.Object).RemoveXAttr.File.Filesystem
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -5551,7 +5551,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).Rename.New.Filesytem
+				return (*Event)(ctx.Object).Rename.New.Filesystem
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -5682,7 +5682,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).Rename.Old.Filesytem
+				return (*Event)(ctx.Object).Rename.Old.Filesystem
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -5833,7 +5833,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).Rmdir.File.Filesytem
+				return (*Event)(ctx.Object).Rmdir.File.Filesystem
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -6164,7 +6164,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).SetXAttr.File.Filesytem
+				return (*Event)(ctx.Object).SetXAttr.File.Filesystem
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -6809,7 +6809,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*ProcessCacheEntry)(value)
 
-					result = int(element.ProcessContext.Process.FileFields.CTime)
+					result = int(element.ProcessContext.Process.FileEvent.FileFields.CTime)
 
 					results = append(results, result)
 
@@ -6834,7 +6834,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*ProcessCacheEntry)(value)
 
-					result = element.ProcessContext.Process.Filesystem
+					result = element.ProcessContext.Process.FileEvent.Filesystem
 
 					results = append(results, result)
 
@@ -6859,7 +6859,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*ProcessCacheEntry)(value)
 
-					result = int(element.ProcessContext.Process.FileFields.GID)
+					result = int(element.ProcessContext.Process.FileEvent.FileFields.GID)
 
 					results = append(results, result)
 
@@ -6884,7 +6884,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*ProcessCacheEntry)(value)
 
-					result = element.ProcessContext.Process.FileFields.Group
+					result = element.ProcessContext.Process.FileEvent.FileFields.Group
 
 					results = append(results, result)
 
@@ -6909,7 +6909,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*ProcessCacheEntry)(value)
 
-					result = element.ProcessContext.Process.FileFields.InUpperLayer
+					result = element.ProcessContext.Process.FileEvent.FileFields.InUpperLayer
 
 					results = append(results, result)
 
@@ -6934,7 +6934,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*ProcessCacheEntry)(value)
 
-					result = int(element.ProcessContext.Process.FileFields.Inode)
+					result = int(element.ProcessContext.Process.FileEvent.FileFields.Inode)
 
 					results = append(results, result)
 
@@ -6959,7 +6959,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*ProcessCacheEntry)(value)
 
-					result = int(element.ProcessContext.Process.FileFields.Mode)
+					result = int(element.ProcessContext.Process.FileEvent.FileFields.Mode)
 
 					results = append(results, result)
 
@@ -6984,7 +6984,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*ProcessCacheEntry)(value)
 
-					result = int(element.ProcessContext.Process.FileFields.MTime)
+					result = int(element.ProcessContext.Process.FileEvent.FileFields.MTime)
 
 					results = append(results, result)
 
@@ -7009,7 +7009,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*ProcessCacheEntry)(value)
 
-					result = int(element.ProcessContext.Process.FileFields.MountID)
+					result = int(element.ProcessContext.Process.FileEvent.FileFields.MountID)
 
 					results = append(results, result)
 
@@ -7034,7 +7034,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*ProcessCacheEntry)(value)
 
-					result = element.ProcessContext.Process.BasenameStr
+					result = element.ProcessContext.Process.FileEvent.BasenameStr
 
 					results = append(results, result)
 
@@ -7060,7 +7060,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*ProcessCacheEntry)(value)
 
-					result = element.ProcessContext.Process.PathnameStr
+					result = element.ProcessContext.Process.FileEvent.PathnameStr
 
 					results = append(results, result)
 
@@ -7085,7 +7085,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*ProcessCacheEntry)(value)
 
-					result = int(element.ProcessContext.Process.FileFields.Mode)
+					result = int(element.ProcessContext.Process.FileEvent.FileFields.Mode)
 
 					results = append(results, result)
 
@@ -7110,7 +7110,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*ProcessCacheEntry)(value)
 
-					result = int(element.ProcessContext.Process.FileFields.UID)
+					result = int(element.ProcessContext.Process.FileEvent.FileFields.UID)
 
 					results = append(results, result)
 
@@ -7135,7 +7135,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					element := (*ProcessCacheEntry)(value)
 
-					result = element.ProcessContext.Process.FileFields.User
+					result = element.ProcessContext.Process.FileEvent.FileFields.User
 
 					results = append(results, result)
 
@@ -7641,7 +7641,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Signal.Target.Process.FileFields.CTime)
+				return int((*Event)(ctx.Object).Signal.Target.Process.FileEvent.FileFields.CTime)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -7651,17 +7651,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).Signal.Target.Process.Filesystem
+				return (*Event)(ctx.Object).Signal.Target.Process.FileEvent.Filesystem
 			},
 			Field:  field,
-			Weight: eval.FunctionWeight,
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "signal.target.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Signal.Target.Process.FileFields.GID)
+				return int((*Event)(ctx.Object).Signal.Target.Process.FileEvent.FileFields.GID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -7671,7 +7671,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).Signal.Target.Process.FileFields.Group
+				return (*Event)(ctx.Object).Signal.Target.Process.FileEvent.FileFields.Group
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -7681,7 +7681,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
 
-				return (*Event)(ctx.Object).Signal.Target.Process.FileFields.InUpperLayer
+				return (*Event)(ctx.Object).Signal.Target.Process.FileEvent.FileFields.InUpperLayer
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -7691,7 +7691,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Signal.Target.Process.FileFields.Inode)
+				return int((*Event)(ctx.Object).Signal.Target.Process.FileEvent.FileFields.Inode)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -7701,7 +7701,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Signal.Target.Process.FileFields.Mode)
+				return int((*Event)(ctx.Object).Signal.Target.Process.FileEvent.FileFields.Mode)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -7711,7 +7711,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Signal.Target.Process.FileFields.MTime)
+				return int((*Event)(ctx.Object).Signal.Target.Process.FileEvent.FileFields.MTime)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -7721,7 +7721,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Signal.Target.Process.FileFields.MountID)
+				return int((*Event)(ctx.Object).Signal.Target.Process.FileEvent.FileFields.MountID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -7731,10 +7731,10 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).Signal.Target.Process.BasenameStr
+				return (*Event)(ctx.Object).Signal.Target.Process.FileEvent.BasenameStr
 			},
 			Field:  field,
-			Weight: eval.FunctionWeight,
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "signal.target.file.path":
@@ -7742,17 +7742,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			OpOverrides: eval.GlobCmp,
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).Signal.Target.Process.PathnameStr
+				return (*Event)(ctx.Object).Signal.Target.Process.FileEvent.PathnameStr
 			},
 			Field:  field,
-			Weight: eval.FunctionWeight,
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "signal.target.file.rights":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Signal.Target.Process.FileFields.Mode)
+				return int((*Event)(ctx.Object).Signal.Target.Process.FileEvent.FileFields.Mode)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -7762,7 +7762,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Signal.Target.Process.FileFields.UID)
+				return int((*Event)(ctx.Object).Signal.Target.Process.FileEvent.FileFields.UID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -7772,7 +7772,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).Signal.Target.Process.FileFields.User
+				return (*Event)(ctx.Object).Signal.Target.Process.FileEvent.FileFields.User
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -7922,7 +7922,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).Splice.File.Filesytem
+				return (*Event)(ctx.Object).Splice.File.Filesystem
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -8093,7 +8093,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).Unlink.File.Filesytem
+				return (*Event)(ctx.Object).Unlink.File.Filesystem
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -8264,7 +8264,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).Utimes.File.Filesytem
+				return (*Event)(ctx.Object).Utimes.File.Filesystem
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -9728,7 +9728,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "chmod.file.filesystem":
 
-		return e.Chmod.File.Filesytem, nil
+		return e.Chmod.File.Filesystem, nil
 
 	case "chmod.file.gid":
 
@@ -9804,7 +9804,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "chown.file.filesystem":
 
-		return e.Chown.File.Filesytem, nil
+		return e.Chown.File.Filesystem, nil
 
 	case "chown.file.gid":
 
@@ -9964,59 +9964,59 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "exec.file.change_time":
 
-		return int(e.Exec.Process.FileFields.CTime), nil
+		return int(e.Exec.Process.FileEvent.FileFields.CTime), nil
 
 	case "exec.file.filesystem":
 
-		return e.Exec.Process.Filesystem, nil
+		return e.Exec.Process.FileEvent.Filesystem, nil
 
 	case "exec.file.gid":
 
-		return int(e.Exec.Process.FileFields.GID), nil
+		return int(e.Exec.Process.FileEvent.FileFields.GID), nil
 
 	case "exec.file.group":
 
-		return e.Exec.Process.FileFields.Group, nil
+		return e.Exec.Process.FileEvent.FileFields.Group, nil
 
 	case "exec.file.in_upper_layer":
 
-		return e.Exec.Process.FileFields.InUpperLayer, nil
+		return e.Exec.Process.FileEvent.FileFields.InUpperLayer, nil
 
 	case "exec.file.inode":
 
-		return int(e.Exec.Process.FileFields.Inode), nil
+		return int(e.Exec.Process.FileEvent.FileFields.Inode), nil
 
 	case "exec.file.mode":
 
-		return int(e.Exec.Process.FileFields.Mode), nil
+		return int(e.Exec.Process.FileEvent.FileFields.Mode), nil
 
 	case "exec.file.modification_time":
 
-		return int(e.Exec.Process.FileFields.MTime), nil
+		return int(e.Exec.Process.FileEvent.FileFields.MTime), nil
 
 	case "exec.file.mount_id":
 
-		return int(e.Exec.Process.FileFields.MountID), nil
+		return int(e.Exec.Process.FileEvent.FileFields.MountID), nil
 
 	case "exec.file.name":
 
-		return e.Exec.Process.BasenameStr, nil
+		return e.Exec.Process.FileEvent.BasenameStr, nil
 
 	case "exec.file.path":
 
-		return e.Exec.Process.PathnameStr, nil
+		return e.Exec.Process.FileEvent.PathnameStr, nil
 
 	case "exec.file.rights":
 
-		return int(e.Exec.Process.FileFields.Mode), nil
+		return int(e.Exec.Process.FileEvent.FileFields.Mode), nil
 
 	case "exec.file.uid":
 
-		return int(e.Exec.Process.FileFields.UID), nil
+		return int(e.Exec.Process.FileEvent.FileFields.UID), nil
 
 	case "exec.file.user":
 
-		return e.Exec.Process.FileFields.User, nil
+		return e.Exec.Process.FileEvent.FileFields.User, nil
 
 	case "exec.fsgid":
 
@@ -10076,7 +10076,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "link.file.destination.filesystem":
 
-		return e.Link.Target.Filesytem, nil
+		return e.Link.Target.Filesystem, nil
 
 	case "link.file.destination.gid":
 
@@ -10128,7 +10128,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "link.file.filesystem":
 
-		return e.Link.Source.Filesytem, nil
+		return e.Link.Source.Filesystem, nil
 
 	case "link.file.gid":
 
@@ -10188,7 +10188,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "load_module.file.filesystem":
 
-		return e.LoadModule.File.Filesytem, nil
+		return e.LoadModule.File.Filesystem, nil
 
 	case "load_module.file.gid":
 
@@ -10264,7 +10264,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "mkdir.file.filesystem":
 
-		return e.Mkdir.File.Filesytem, nil
+		return e.Mkdir.File.Filesystem, nil
 
 	case "mkdir.file.gid":
 
@@ -10324,7 +10324,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "mmap.file.filesystem":
 
-		return e.MMap.File.Filesytem, nil
+		return e.MMap.File.Filesystem, nil
 
 	case "mmap.file.gid":
 
@@ -10444,7 +10444,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "open.file.filesystem":
 
-		return e.Open.File.Filesytem, nil
+		return e.Open.File.Filesystem, nil
 
 	case "open.file.gid":
 
@@ -10933,7 +10933,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*ProcessCacheEntry)(ptr)
 
-			result := int(element.ProcessContext.Process.FileFields.CTime)
+			result := int(element.ProcessContext.Process.FileEvent.FileFields.CTime)
 
 			values = append(values, result)
 
@@ -10955,7 +10955,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*ProcessCacheEntry)(ptr)
 
-			result := element.ProcessContext.Process.Filesystem
+			result := element.ProcessContext.Process.FileEvent.Filesystem
 
 			values = append(values, result)
 
@@ -10977,7 +10977,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*ProcessCacheEntry)(ptr)
 
-			result := int(element.ProcessContext.Process.FileFields.GID)
+			result := int(element.ProcessContext.Process.FileEvent.FileFields.GID)
 
 			values = append(values, result)
 
@@ -10999,7 +10999,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*ProcessCacheEntry)(ptr)
 
-			result := element.ProcessContext.Process.FileFields.Group
+			result := element.ProcessContext.Process.FileEvent.FileFields.Group
 
 			values = append(values, result)
 
@@ -11021,7 +11021,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*ProcessCacheEntry)(ptr)
 
-			result := element.ProcessContext.Process.FileFields.InUpperLayer
+			result := element.ProcessContext.Process.FileEvent.FileFields.InUpperLayer
 
 			values = append(values, result)
 
@@ -11043,7 +11043,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*ProcessCacheEntry)(ptr)
 
-			result := int(element.ProcessContext.Process.FileFields.Inode)
+			result := int(element.ProcessContext.Process.FileEvent.FileFields.Inode)
 
 			values = append(values, result)
 
@@ -11065,7 +11065,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*ProcessCacheEntry)(ptr)
 
-			result := int(element.ProcessContext.Process.FileFields.Mode)
+			result := int(element.ProcessContext.Process.FileEvent.FileFields.Mode)
 
 			values = append(values, result)
 
@@ -11087,7 +11087,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*ProcessCacheEntry)(ptr)
 
-			result := int(element.ProcessContext.Process.FileFields.MTime)
+			result := int(element.ProcessContext.Process.FileEvent.FileFields.MTime)
 
 			values = append(values, result)
 
@@ -11109,7 +11109,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*ProcessCacheEntry)(ptr)
 
-			result := int(element.ProcessContext.Process.FileFields.MountID)
+			result := int(element.ProcessContext.Process.FileEvent.FileFields.MountID)
 
 			values = append(values, result)
 
@@ -11131,7 +11131,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*ProcessCacheEntry)(ptr)
 
-			result := element.ProcessContext.Process.BasenameStr
+			result := element.ProcessContext.Process.FileEvent.BasenameStr
 
 			values = append(values, result)
 
@@ -11153,7 +11153,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*ProcessCacheEntry)(ptr)
 
-			result := element.ProcessContext.Process.PathnameStr
+			result := element.ProcessContext.Process.FileEvent.PathnameStr
 
 			values = append(values, result)
 
@@ -11175,7 +11175,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*ProcessCacheEntry)(ptr)
 
-			result := int(element.ProcessContext.Process.FileFields.Mode)
+			result := int(element.ProcessContext.Process.FileEvent.FileFields.Mode)
 
 			values = append(values, result)
 
@@ -11197,7 +11197,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*ProcessCacheEntry)(ptr)
 
-			result := int(element.ProcessContext.Process.FileFields.UID)
+			result := int(element.ProcessContext.Process.FileEvent.FileFields.UID)
 
 			values = append(values, result)
 
@@ -11219,7 +11219,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*ProcessCacheEntry)(ptr)
 
-			result := element.ProcessContext.Process.FileFields.User
+			result := element.ProcessContext.Process.FileEvent.FileFields.User
 
 			values = append(values, result)
 
@@ -11570,59 +11570,59 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "process.file.change_time":
 
-		return int(e.ProcessContext.Process.FileFields.CTime), nil
+		return int(e.ProcessContext.Process.FileEvent.FileFields.CTime), nil
 
 	case "process.file.filesystem":
 
-		return e.ProcessContext.Process.Filesystem, nil
+		return e.ProcessContext.Process.FileEvent.Filesystem, nil
 
 	case "process.file.gid":
 
-		return int(e.ProcessContext.Process.FileFields.GID), nil
+		return int(e.ProcessContext.Process.FileEvent.FileFields.GID), nil
 
 	case "process.file.group":
 
-		return e.ProcessContext.Process.FileFields.Group, nil
+		return e.ProcessContext.Process.FileEvent.FileFields.Group, nil
 
 	case "process.file.in_upper_layer":
 
-		return e.ProcessContext.Process.FileFields.InUpperLayer, nil
+		return e.ProcessContext.Process.FileEvent.FileFields.InUpperLayer, nil
 
 	case "process.file.inode":
 
-		return int(e.ProcessContext.Process.FileFields.Inode), nil
+		return int(e.ProcessContext.Process.FileEvent.FileFields.Inode), nil
 
 	case "process.file.mode":
 
-		return int(e.ProcessContext.Process.FileFields.Mode), nil
+		return int(e.ProcessContext.Process.FileEvent.FileFields.Mode), nil
 
 	case "process.file.modification_time":
 
-		return int(e.ProcessContext.Process.FileFields.MTime), nil
+		return int(e.ProcessContext.Process.FileEvent.FileFields.MTime), nil
 
 	case "process.file.mount_id":
 
-		return int(e.ProcessContext.Process.FileFields.MountID), nil
+		return int(e.ProcessContext.Process.FileEvent.FileFields.MountID), nil
 
 	case "process.file.name":
 
-		return e.ProcessContext.Process.BasenameStr, nil
+		return e.ProcessContext.Process.FileEvent.BasenameStr, nil
 
 	case "process.file.path":
 
-		return e.ProcessContext.Process.PathnameStr, nil
+		return e.ProcessContext.Process.FileEvent.PathnameStr, nil
 
 	case "process.file.rights":
 
-		return int(e.ProcessContext.Process.FileFields.Mode), nil
+		return int(e.ProcessContext.Process.FileEvent.FileFields.Mode), nil
 
 	case "process.file.uid":
 
-		return int(e.ProcessContext.Process.FileFields.UID), nil
+		return int(e.ProcessContext.Process.FileEvent.FileFields.UID), nil
 
 	case "process.file.user":
 
-		return e.ProcessContext.Process.FileFields.User, nil
+		return e.ProcessContext.Process.FileEvent.FileFields.User, nil
 
 	case "process.fsgid":
 
@@ -12111,7 +12111,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*ProcessCacheEntry)(ptr)
 
-			result := int(element.ProcessContext.Process.FileFields.CTime)
+			result := int(element.ProcessContext.Process.FileEvent.FileFields.CTime)
 
 			values = append(values, result)
 
@@ -12133,7 +12133,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*ProcessCacheEntry)(ptr)
 
-			result := element.ProcessContext.Process.Filesystem
+			result := element.ProcessContext.Process.FileEvent.Filesystem
 
 			values = append(values, result)
 
@@ -12155,7 +12155,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*ProcessCacheEntry)(ptr)
 
-			result := int(element.ProcessContext.Process.FileFields.GID)
+			result := int(element.ProcessContext.Process.FileEvent.FileFields.GID)
 
 			values = append(values, result)
 
@@ -12177,7 +12177,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*ProcessCacheEntry)(ptr)
 
-			result := element.ProcessContext.Process.FileFields.Group
+			result := element.ProcessContext.Process.FileEvent.FileFields.Group
 
 			values = append(values, result)
 
@@ -12199,7 +12199,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*ProcessCacheEntry)(ptr)
 
-			result := element.ProcessContext.Process.FileFields.InUpperLayer
+			result := element.ProcessContext.Process.FileEvent.FileFields.InUpperLayer
 
 			values = append(values, result)
 
@@ -12221,7 +12221,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*ProcessCacheEntry)(ptr)
 
-			result := int(element.ProcessContext.Process.FileFields.Inode)
+			result := int(element.ProcessContext.Process.FileEvent.FileFields.Inode)
 
 			values = append(values, result)
 
@@ -12243,7 +12243,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*ProcessCacheEntry)(ptr)
 
-			result := int(element.ProcessContext.Process.FileFields.Mode)
+			result := int(element.ProcessContext.Process.FileEvent.FileFields.Mode)
 
 			values = append(values, result)
 
@@ -12265,7 +12265,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*ProcessCacheEntry)(ptr)
 
-			result := int(element.ProcessContext.Process.FileFields.MTime)
+			result := int(element.ProcessContext.Process.FileEvent.FileFields.MTime)
 
 			values = append(values, result)
 
@@ -12287,7 +12287,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*ProcessCacheEntry)(ptr)
 
-			result := int(element.ProcessContext.Process.FileFields.MountID)
+			result := int(element.ProcessContext.Process.FileEvent.FileFields.MountID)
 
 			values = append(values, result)
 
@@ -12309,7 +12309,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*ProcessCacheEntry)(ptr)
 
-			result := element.ProcessContext.Process.BasenameStr
+			result := element.ProcessContext.Process.FileEvent.BasenameStr
 
 			values = append(values, result)
 
@@ -12331,7 +12331,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*ProcessCacheEntry)(ptr)
 
-			result := element.ProcessContext.Process.PathnameStr
+			result := element.ProcessContext.Process.FileEvent.PathnameStr
 
 			values = append(values, result)
 
@@ -12353,7 +12353,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*ProcessCacheEntry)(ptr)
 
-			result := int(element.ProcessContext.Process.FileFields.Mode)
+			result := int(element.ProcessContext.Process.FileEvent.FileFields.Mode)
 
 			values = append(values, result)
 
@@ -12375,7 +12375,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*ProcessCacheEntry)(ptr)
 
-			result := int(element.ProcessContext.Process.FileFields.UID)
+			result := int(element.ProcessContext.Process.FileEvent.FileFields.UID)
 
 			values = append(values, result)
 
@@ -12397,7 +12397,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*ProcessCacheEntry)(ptr)
 
-			result := element.ProcessContext.Process.FileFields.User
+			result := element.ProcessContext.Process.FileEvent.FileFields.User
 
 			values = append(values, result)
 
@@ -12748,59 +12748,59 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "ptrace.tracee.file.change_time":
 
-		return int(e.PTrace.Tracee.Process.FileFields.CTime), nil
+		return int(e.PTrace.Tracee.Process.FileEvent.FileFields.CTime), nil
 
 	case "ptrace.tracee.file.filesystem":
 
-		return e.PTrace.Tracee.Process.Filesystem, nil
+		return e.PTrace.Tracee.Process.FileEvent.Filesystem, nil
 
 	case "ptrace.tracee.file.gid":
 
-		return int(e.PTrace.Tracee.Process.FileFields.GID), nil
+		return int(e.PTrace.Tracee.Process.FileEvent.FileFields.GID), nil
 
 	case "ptrace.tracee.file.group":
 
-		return e.PTrace.Tracee.Process.FileFields.Group, nil
+		return e.PTrace.Tracee.Process.FileEvent.FileFields.Group, nil
 
 	case "ptrace.tracee.file.in_upper_layer":
 
-		return e.PTrace.Tracee.Process.FileFields.InUpperLayer, nil
+		return e.PTrace.Tracee.Process.FileEvent.FileFields.InUpperLayer, nil
 
 	case "ptrace.tracee.file.inode":
 
-		return int(e.PTrace.Tracee.Process.FileFields.Inode), nil
+		return int(e.PTrace.Tracee.Process.FileEvent.FileFields.Inode), nil
 
 	case "ptrace.tracee.file.mode":
 
-		return int(e.PTrace.Tracee.Process.FileFields.Mode), nil
+		return int(e.PTrace.Tracee.Process.FileEvent.FileFields.Mode), nil
 
 	case "ptrace.tracee.file.modification_time":
 
-		return int(e.PTrace.Tracee.Process.FileFields.MTime), nil
+		return int(e.PTrace.Tracee.Process.FileEvent.FileFields.MTime), nil
 
 	case "ptrace.tracee.file.mount_id":
 
-		return int(e.PTrace.Tracee.Process.FileFields.MountID), nil
+		return int(e.PTrace.Tracee.Process.FileEvent.FileFields.MountID), nil
 
 	case "ptrace.tracee.file.name":
 
-		return e.PTrace.Tracee.Process.BasenameStr, nil
+		return e.PTrace.Tracee.Process.FileEvent.BasenameStr, nil
 
 	case "ptrace.tracee.file.path":
 
-		return e.PTrace.Tracee.Process.PathnameStr, nil
+		return e.PTrace.Tracee.Process.FileEvent.PathnameStr, nil
 
 	case "ptrace.tracee.file.rights":
 
-		return int(e.PTrace.Tracee.Process.FileFields.Mode), nil
+		return int(e.PTrace.Tracee.Process.FileEvent.FileFields.Mode), nil
 
 	case "ptrace.tracee.file.uid":
 
-		return int(e.PTrace.Tracee.Process.FileFields.UID), nil
+		return int(e.PTrace.Tracee.Process.FileEvent.FileFields.UID), nil
 
 	case "ptrace.tracee.file.user":
 
-		return e.PTrace.Tracee.Process.FileFields.User, nil
+		return e.PTrace.Tracee.Process.FileEvent.FileFields.User, nil
 
 	case "ptrace.tracee.fsgid":
 
@@ -12864,7 +12864,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "removexattr.file.filesystem":
 
-		return e.RemoveXAttr.File.Filesytem, nil
+		return e.RemoveXAttr.File.Filesystem, nil
 
 	case "removexattr.file.gid":
 
@@ -12928,7 +12928,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "rename.file.destination.filesystem":
 
-		return e.Rename.New.Filesytem, nil
+		return e.Rename.New.Filesystem, nil
 
 	case "rename.file.destination.gid":
 
@@ -12980,7 +12980,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "rename.file.filesystem":
 
-		return e.Rename.Old.Filesytem, nil
+		return e.Rename.Old.Filesystem, nil
 
 	case "rename.file.gid":
 
@@ -13040,7 +13040,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "rmdir.file.filesystem":
 
-		return e.Rmdir.File.Filesytem, nil
+		return e.Rmdir.File.Filesystem, nil
 
 	case "rmdir.file.gid":
 
@@ -13172,7 +13172,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "setxattr.file.filesystem":
 
-		return e.SetXAttr.File.Filesytem, nil
+		return e.SetXAttr.File.Filesystem, nil
 
 	case "setxattr.file.gid":
 
@@ -13665,7 +13665,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*ProcessCacheEntry)(ptr)
 
-			result := int(element.ProcessContext.Process.FileFields.CTime)
+			result := int(element.ProcessContext.Process.FileEvent.FileFields.CTime)
 
 			values = append(values, result)
 
@@ -13687,7 +13687,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*ProcessCacheEntry)(ptr)
 
-			result := element.ProcessContext.Process.Filesystem
+			result := element.ProcessContext.Process.FileEvent.Filesystem
 
 			values = append(values, result)
 
@@ -13709,7 +13709,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*ProcessCacheEntry)(ptr)
 
-			result := int(element.ProcessContext.Process.FileFields.GID)
+			result := int(element.ProcessContext.Process.FileEvent.FileFields.GID)
 
 			values = append(values, result)
 
@@ -13731,7 +13731,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*ProcessCacheEntry)(ptr)
 
-			result := element.ProcessContext.Process.FileFields.Group
+			result := element.ProcessContext.Process.FileEvent.FileFields.Group
 
 			values = append(values, result)
 
@@ -13753,7 +13753,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*ProcessCacheEntry)(ptr)
 
-			result := element.ProcessContext.Process.FileFields.InUpperLayer
+			result := element.ProcessContext.Process.FileEvent.FileFields.InUpperLayer
 
 			values = append(values, result)
 
@@ -13775,7 +13775,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*ProcessCacheEntry)(ptr)
 
-			result := int(element.ProcessContext.Process.FileFields.Inode)
+			result := int(element.ProcessContext.Process.FileEvent.FileFields.Inode)
 
 			values = append(values, result)
 
@@ -13797,7 +13797,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*ProcessCacheEntry)(ptr)
 
-			result := int(element.ProcessContext.Process.FileFields.Mode)
+			result := int(element.ProcessContext.Process.FileEvent.FileFields.Mode)
 
 			values = append(values, result)
 
@@ -13819,7 +13819,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*ProcessCacheEntry)(ptr)
 
-			result := int(element.ProcessContext.Process.FileFields.MTime)
+			result := int(element.ProcessContext.Process.FileEvent.FileFields.MTime)
 
 			values = append(values, result)
 
@@ -13841,7 +13841,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*ProcessCacheEntry)(ptr)
 
-			result := int(element.ProcessContext.Process.FileFields.MountID)
+			result := int(element.ProcessContext.Process.FileEvent.FileFields.MountID)
 
 			values = append(values, result)
 
@@ -13863,7 +13863,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*ProcessCacheEntry)(ptr)
 
-			result := element.ProcessContext.Process.BasenameStr
+			result := element.ProcessContext.Process.FileEvent.BasenameStr
 
 			values = append(values, result)
 
@@ -13885,7 +13885,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*ProcessCacheEntry)(ptr)
 
-			result := element.ProcessContext.Process.PathnameStr
+			result := element.ProcessContext.Process.FileEvent.PathnameStr
 
 			values = append(values, result)
 
@@ -13907,7 +13907,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*ProcessCacheEntry)(ptr)
 
-			result := int(element.ProcessContext.Process.FileFields.Mode)
+			result := int(element.ProcessContext.Process.FileEvent.FileFields.Mode)
 
 			values = append(values, result)
 
@@ -13929,7 +13929,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*ProcessCacheEntry)(ptr)
 
-			result := int(element.ProcessContext.Process.FileFields.UID)
+			result := int(element.ProcessContext.Process.FileEvent.FileFields.UID)
 
 			values = append(values, result)
 
@@ -13951,7 +13951,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 			element := (*ProcessCacheEntry)(ptr)
 
-			result := element.ProcessContext.Process.FileFields.User
+			result := element.ProcessContext.Process.FileEvent.FileFields.User
 
 			values = append(values, result)
 
@@ -14302,59 +14302,59 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "signal.target.file.change_time":
 
-		return int(e.Signal.Target.Process.FileFields.CTime), nil
+		return int(e.Signal.Target.Process.FileEvent.FileFields.CTime), nil
 
 	case "signal.target.file.filesystem":
 
-		return e.Signal.Target.Process.Filesystem, nil
+		return e.Signal.Target.Process.FileEvent.Filesystem, nil
 
 	case "signal.target.file.gid":
 
-		return int(e.Signal.Target.Process.FileFields.GID), nil
+		return int(e.Signal.Target.Process.FileEvent.FileFields.GID), nil
 
 	case "signal.target.file.group":
 
-		return e.Signal.Target.Process.FileFields.Group, nil
+		return e.Signal.Target.Process.FileEvent.FileFields.Group, nil
 
 	case "signal.target.file.in_upper_layer":
 
-		return e.Signal.Target.Process.FileFields.InUpperLayer, nil
+		return e.Signal.Target.Process.FileEvent.FileFields.InUpperLayer, nil
 
 	case "signal.target.file.inode":
 
-		return int(e.Signal.Target.Process.FileFields.Inode), nil
+		return int(e.Signal.Target.Process.FileEvent.FileFields.Inode), nil
 
 	case "signal.target.file.mode":
 
-		return int(e.Signal.Target.Process.FileFields.Mode), nil
+		return int(e.Signal.Target.Process.FileEvent.FileFields.Mode), nil
 
 	case "signal.target.file.modification_time":
 
-		return int(e.Signal.Target.Process.FileFields.MTime), nil
+		return int(e.Signal.Target.Process.FileEvent.FileFields.MTime), nil
 
 	case "signal.target.file.mount_id":
 
-		return int(e.Signal.Target.Process.FileFields.MountID), nil
+		return int(e.Signal.Target.Process.FileEvent.FileFields.MountID), nil
 
 	case "signal.target.file.name":
 
-		return e.Signal.Target.Process.BasenameStr, nil
+		return e.Signal.Target.Process.FileEvent.BasenameStr, nil
 
 	case "signal.target.file.path":
 
-		return e.Signal.Target.Process.PathnameStr, nil
+		return e.Signal.Target.Process.FileEvent.PathnameStr, nil
 
 	case "signal.target.file.rights":
 
-		return int(e.Signal.Target.Process.FileFields.Mode), nil
+		return int(e.Signal.Target.Process.FileEvent.FileFields.Mode), nil
 
 	case "signal.target.file.uid":
 
-		return int(e.Signal.Target.Process.FileFields.UID), nil
+		return int(e.Signal.Target.Process.FileEvent.FileFields.UID), nil
 
 	case "signal.target.file.user":
 
-		return e.Signal.Target.Process.FileFields.User, nil
+		return e.Signal.Target.Process.FileEvent.FileFields.User, nil
 
 	case "signal.target.fsgid":
 
@@ -14414,7 +14414,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "splice.file.filesystem":
 
-		return e.Splice.File.Filesytem, nil
+		return e.Splice.File.Filesystem, nil
 
 	case "splice.file.gid":
 
@@ -14482,7 +14482,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "unlink.file.filesystem":
 
-		return e.Unlink.File.Filesytem, nil
+		return e.Unlink.File.Filesystem, nil
 
 	case "unlink.file.gid":
 
@@ -14550,7 +14550,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "utimes.file.filesystem":
 
-		return e.Utimes.File.Filesytem, nil
+		return e.Utimes.File.Filesystem, nil
 
 	case "utimes.file.gid":
 
@@ -19169,9 +19169,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Chmod.File.Filesytem"}
+			return &eval.ErrValueTypeMismatch{Field: "Chmod.File.Filesystem"}
 		}
-		e.Chmod.File.Filesytem = str
+		e.Chmod.File.Filesystem = str
 
 		return nil
 
@@ -19375,9 +19375,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Chown.File.Filesytem"}
+			return &eval.ErrValueTypeMismatch{Field: "Chown.File.Filesystem"}
 		}
-		e.Chown.File.Filesytem = str
+		e.Chown.File.Filesystem = str
 
 		return nil
 
@@ -19806,9 +19806,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileFields.CTime"}
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileEvent.FileFields.CTime"}
 		}
-		e.Exec.Process.FileFields.CTime = uint64(v)
+		e.Exec.Process.FileEvent.FileFields.CTime = uint64(v)
 
 		return nil
 
@@ -19817,9 +19817,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.Filesystem"}
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileEvent.Filesystem"}
 		}
-		e.Exec.Process.Filesystem = str
+		e.Exec.Process.FileEvent.Filesystem = str
 
 		return nil
 
@@ -19828,9 +19828,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileFields.GID"}
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileEvent.FileFields.GID"}
 		}
-		e.Exec.Process.FileFields.GID = uint32(v)
+		e.Exec.Process.FileEvent.FileFields.GID = uint32(v)
 
 		return nil
 
@@ -19839,17 +19839,17 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileFields.Group"}
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileEvent.FileFields.Group"}
 		}
-		e.Exec.Process.FileFields.Group = str
+		e.Exec.Process.FileEvent.FileFields.Group = str
 
 		return nil
 
 	case "exec.file.in_upper_layer":
 
 		var ok bool
-		if e.Exec.Process.FileFields.InUpperLayer, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileFields.InUpperLayer"}
+		if e.Exec.Process.FileEvent.FileFields.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileEvent.FileFields.InUpperLayer"}
 		}
 		return nil
 
@@ -19858,9 +19858,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileFields.Inode"}
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileEvent.FileFields.Inode"}
 		}
-		e.Exec.Process.FileFields.Inode = uint64(v)
+		e.Exec.Process.FileEvent.FileFields.Inode = uint64(v)
 
 		return nil
 
@@ -19869,9 +19869,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileFields.Mode"}
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileEvent.FileFields.Mode"}
 		}
-		e.Exec.Process.FileFields.Mode = uint16(v)
+		e.Exec.Process.FileEvent.FileFields.Mode = uint16(v)
 
 		return nil
 
@@ -19880,9 +19880,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileFields.MTime"}
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileEvent.FileFields.MTime"}
 		}
-		e.Exec.Process.FileFields.MTime = uint64(v)
+		e.Exec.Process.FileEvent.FileFields.MTime = uint64(v)
 
 		return nil
 
@@ -19891,9 +19891,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileFields.MountID"}
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileEvent.FileFields.MountID"}
 		}
-		e.Exec.Process.FileFields.MountID = uint32(v)
+		e.Exec.Process.FileEvent.FileFields.MountID = uint32(v)
 
 		return nil
 
@@ -19902,9 +19902,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.BasenameStr"}
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileEvent.BasenameStr"}
 		}
-		e.Exec.Process.BasenameStr = str
+		e.Exec.Process.FileEvent.BasenameStr = str
 
 		return nil
 
@@ -19913,9 +19913,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.PathnameStr"}
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileEvent.PathnameStr"}
 		}
-		e.Exec.Process.PathnameStr = str
+		e.Exec.Process.FileEvent.PathnameStr = str
 
 		return nil
 
@@ -19924,9 +19924,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileFields.Mode"}
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileEvent.FileFields.Mode"}
 		}
-		e.Exec.Process.FileFields.Mode = uint16(v)
+		e.Exec.Process.FileEvent.FileFields.Mode = uint16(v)
 
 		return nil
 
@@ -19935,9 +19935,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileFields.UID"}
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileEvent.FileFields.UID"}
 		}
-		e.Exec.Process.FileFields.UID = uint32(v)
+		e.Exec.Process.FileEvent.FileFields.UID = uint32(v)
 
 		return nil
 
@@ -19946,9 +19946,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileFields.User"}
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileEvent.FileFields.User"}
 		}
-		e.Exec.Process.FileFields.User = str
+		e.Exec.Process.FileEvent.FileFields.User = str
 
 		return nil
 
@@ -20111,9 +20111,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Link.Target.Filesytem"}
+			return &eval.ErrValueTypeMismatch{Field: "Link.Target.Filesystem"}
 		}
-		e.Link.Target.Filesytem = str
+		e.Link.Target.Filesystem = str
 
 		return nil
 
@@ -20251,9 +20251,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Link.Source.Filesytem"}
+			return &eval.ErrValueTypeMismatch{Field: "Link.Source.Filesystem"}
 		}
-		e.Link.Source.Filesytem = str
+		e.Link.Source.Filesystem = str
 
 		return nil
 
@@ -20413,9 +20413,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "LoadModule.File.Filesytem"}
+			return &eval.ErrValueTypeMismatch{Field: "LoadModule.File.Filesystem"}
 		}
-		e.LoadModule.File.Filesytem = str
+		e.LoadModule.File.Filesystem = str
 
 		return nil
 
@@ -20616,9 +20616,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Mkdir.File.Filesytem"}
+			return &eval.ErrValueTypeMismatch{Field: "Mkdir.File.Filesystem"}
 		}
-		e.Mkdir.File.Filesytem = str
+		e.Mkdir.File.Filesystem = str
 
 		return nil
 
@@ -20778,9 +20778,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "MMap.File.Filesytem"}
+			return &eval.ErrValueTypeMismatch{Field: "MMap.File.Filesystem"}
 		}
-		e.MMap.File.Filesytem = str
+		e.MMap.File.Filesystem = str
 
 		return nil
 
@@ -21105,9 +21105,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Open.File.Filesytem"}
+			return &eval.ErrValueTypeMismatch{Field: "Open.File.Filesystem"}
 		}
-		e.Open.File.Filesytem = str
+		e.Open.File.Filesystem = str
 
 		return nil
 
@@ -21550,9 +21550,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileFields.CTime"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileEvent.FileFields.CTime"}
 		}
-		e.ProcessContext.Ancestor.ProcessContext.Process.FileFields.CTime = uint64(v)
+		e.ProcessContext.Ancestor.ProcessContext.Process.FileEvent.FileFields.CTime = uint64(v)
 
 		return nil
 
@@ -21565,9 +21565,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.Filesystem"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileEvent.Filesystem"}
 		}
-		e.ProcessContext.Ancestor.ProcessContext.Process.Filesystem = str
+		e.ProcessContext.Ancestor.ProcessContext.Process.FileEvent.Filesystem = str
 
 		return nil
 
@@ -21580,9 +21580,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileFields.GID"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileEvent.FileFields.GID"}
 		}
-		e.ProcessContext.Ancestor.ProcessContext.Process.FileFields.GID = uint32(v)
+		e.ProcessContext.Ancestor.ProcessContext.Process.FileEvent.FileFields.GID = uint32(v)
 
 		return nil
 
@@ -21595,9 +21595,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileFields.Group"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileEvent.FileFields.Group"}
 		}
-		e.ProcessContext.Ancestor.ProcessContext.Process.FileFields.Group = str
+		e.ProcessContext.Ancestor.ProcessContext.Process.FileEvent.FileFields.Group = str
 
 		return nil
 
@@ -21608,8 +21608,8 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 
 		var ok bool
-		if e.ProcessContext.Ancestor.ProcessContext.Process.FileFields.InUpperLayer, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileFields.InUpperLayer"}
+		if e.ProcessContext.Ancestor.ProcessContext.Process.FileEvent.FileFields.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileEvent.FileFields.InUpperLayer"}
 		}
 		return nil
 
@@ -21622,9 +21622,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileFields.Inode"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileEvent.FileFields.Inode"}
 		}
-		e.ProcessContext.Ancestor.ProcessContext.Process.FileFields.Inode = uint64(v)
+		e.ProcessContext.Ancestor.ProcessContext.Process.FileEvent.FileFields.Inode = uint64(v)
 
 		return nil
 
@@ -21637,9 +21637,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileFields.Mode"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileEvent.FileFields.Mode"}
 		}
-		e.ProcessContext.Ancestor.ProcessContext.Process.FileFields.Mode = uint16(v)
+		e.ProcessContext.Ancestor.ProcessContext.Process.FileEvent.FileFields.Mode = uint16(v)
 
 		return nil
 
@@ -21652,9 +21652,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileFields.MTime"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileEvent.FileFields.MTime"}
 		}
-		e.ProcessContext.Ancestor.ProcessContext.Process.FileFields.MTime = uint64(v)
+		e.ProcessContext.Ancestor.ProcessContext.Process.FileEvent.FileFields.MTime = uint64(v)
 
 		return nil
 
@@ -21667,9 +21667,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileFields.MountID"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileEvent.FileFields.MountID"}
 		}
-		e.ProcessContext.Ancestor.ProcessContext.Process.FileFields.MountID = uint32(v)
+		e.ProcessContext.Ancestor.ProcessContext.Process.FileEvent.FileFields.MountID = uint32(v)
 
 		return nil
 
@@ -21682,9 +21682,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.BasenameStr"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileEvent.BasenameStr"}
 		}
-		e.ProcessContext.Ancestor.ProcessContext.Process.BasenameStr = str
+		e.ProcessContext.Ancestor.ProcessContext.Process.FileEvent.BasenameStr = str
 
 		return nil
 
@@ -21697,9 +21697,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.PathnameStr"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileEvent.PathnameStr"}
 		}
-		e.ProcessContext.Ancestor.ProcessContext.Process.PathnameStr = str
+		e.ProcessContext.Ancestor.ProcessContext.Process.FileEvent.PathnameStr = str
 
 		return nil
 
@@ -21712,9 +21712,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileFields.Mode"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileEvent.FileFields.Mode"}
 		}
-		e.ProcessContext.Ancestor.ProcessContext.Process.FileFields.Mode = uint16(v)
+		e.ProcessContext.Ancestor.ProcessContext.Process.FileEvent.FileFields.Mode = uint16(v)
 
 		return nil
 
@@ -21727,9 +21727,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileFields.UID"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileEvent.FileFields.UID"}
 		}
-		e.ProcessContext.Ancestor.ProcessContext.Process.FileFields.UID = uint32(v)
+		e.ProcessContext.Ancestor.ProcessContext.Process.FileEvent.FileFields.UID = uint32(v)
 
 		return nil
 
@@ -21742,9 +21742,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileFields.User"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileEvent.FileFields.User"}
 		}
-		e.ProcessContext.Ancestor.ProcessContext.Process.FileFields.User = str
+		e.ProcessContext.Ancestor.ProcessContext.Process.FileEvent.FileFields.User = str
 
 		return nil
 
@@ -22136,9 +22136,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileFields.CTime"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileEvent.FileFields.CTime"}
 		}
-		e.ProcessContext.Process.FileFields.CTime = uint64(v)
+		e.ProcessContext.Process.FileEvent.FileFields.CTime = uint64(v)
 
 		return nil
 
@@ -22147,9 +22147,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.Filesystem"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileEvent.Filesystem"}
 		}
-		e.ProcessContext.Process.Filesystem = str
+		e.ProcessContext.Process.FileEvent.Filesystem = str
 
 		return nil
 
@@ -22158,9 +22158,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileFields.GID"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileEvent.FileFields.GID"}
 		}
-		e.ProcessContext.Process.FileFields.GID = uint32(v)
+		e.ProcessContext.Process.FileEvent.FileFields.GID = uint32(v)
 
 		return nil
 
@@ -22169,17 +22169,17 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileFields.Group"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileEvent.FileFields.Group"}
 		}
-		e.ProcessContext.Process.FileFields.Group = str
+		e.ProcessContext.Process.FileEvent.FileFields.Group = str
 
 		return nil
 
 	case "process.file.in_upper_layer":
 
 		var ok bool
-		if e.ProcessContext.Process.FileFields.InUpperLayer, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileFields.InUpperLayer"}
+		if e.ProcessContext.Process.FileEvent.FileFields.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileEvent.FileFields.InUpperLayer"}
 		}
 		return nil
 
@@ -22188,9 +22188,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileFields.Inode"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileEvent.FileFields.Inode"}
 		}
-		e.ProcessContext.Process.FileFields.Inode = uint64(v)
+		e.ProcessContext.Process.FileEvent.FileFields.Inode = uint64(v)
 
 		return nil
 
@@ -22199,9 +22199,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileFields.Mode"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileEvent.FileFields.Mode"}
 		}
-		e.ProcessContext.Process.FileFields.Mode = uint16(v)
+		e.ProcessContext.Process.FileEvent.FileFields.Mode = uint16(v)
 
 		return nil
 
@@ -22210,9 +22210,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileFields.MTime"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileEvent.FileFields.MTime"}
 		}
-		e.ProcessContext.Process.FileFields.MTime = uint64(v)
+		e.ProcessContext.Process.FileEvent.FileFields.MTime = uint64(v)
 
 		return nil
 
@@ -22221,9 +22221,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileFields.MountID"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileEvent.FileFields.MountID"}
 		}
-		e.ProcessContext.Process.FileFields.MountID = uint32(v)
+		e.ProcessContext.Process.FileEvent.FileFields.MountID = uint32(v)
 
 		return nil
 
@@ -22232,9 +22232,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.BasenameStr"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileEvent.BasenameStr"}
 		}
-		e.ProcessContext.Process.BasenameStr = str
+		e.ProcessContext.Process.FileEvent.BasenameStr = str
 
 		return nil
 
@@ -22243,9 +22243,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.PathnameStr"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileEvent.PathnameStr"}
 		}
-		e.ProcessContext.Process.PathnameStr = str
+		e.ProcessContext.Process.FileEvent.PathnameStr = str
 
 		return nil
 
@@ -22254,9 +22254,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileFields.Mode"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileEvent.FileFields.Mode"}
 		}
-		e.ProcessContext.Process.FileFields.Mode = uint16(v)
+		e.ProcessContext.Process.FileEvent.FileFields.Mode = uint16(v)
 
 		return nil
 
@@ -22265,9 +22265,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileFields.UID"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileEvent.FileFields.UID"}
 		}
-		e.ProcessContext.Process.FileFields.UID = uint32(v)
+		e.ProcessContext.Process.FileEvent.FileFields.UID = uint32(v)
 
 		return nil
 
@@ -22276,9 +22276,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileFields.User"}
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileEvent.FileFields.User"}
 		}
-		e.ProcessContext.Process.FileFields.User = str
+		e.ProcessContext.Process.FileEvent.FileFields.User = str
 
 		return nil
 
@@ -22724,9 +22724,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileFields.CTime"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.FileFields.CTime"}
 		}
-		e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileFields.CTime = uint64(v)
+		e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.FileFields.CTime = uint64(v)
 
 		return nil
 
@@ -22739,9 +22739,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.Filesystem"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.Filesystem"}
 		}
-		e.PTrace.Tracee.Ancestor.ProcessContext.Process.Filesystem = str
+		e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.Filesystem = str
 
 		return nil
 
@@ -22754,9 +22754,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileFields.GID"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.FileFields.GID"}
 		}
-		e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileFields.GID = uint32(v)
+		e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.FileFields.GID = uint32(v)
 
 		return nil
 
@@ -22769,9 +22769,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileFields.Group"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.FileFields.Group"}
 		}
-		e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileFields.Group = str
+		e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.FileFields.Group = str
 
 		return nil
 
@@ -22782,8 +22782,8 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 
 		var ok bool
-		if e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileFields.InUpperLayer, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileFields.InUpperLayer"}
+		if e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.FileFields.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.FileFields.InUpperLayer"}
 		}
 		return nil
 
@@ -22796,9 +22796,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileFields.Inode"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.FileFields.Inode"}
 		}
-		e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileFields.Inode = uint64(v)
+		e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.FileFields.Inode = uint64(v)
 
 		return nil
 
@@ -22811,9 +22811,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileFields.Mode"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.FileFields.Mode"}
 		}
-		e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileFields.Mode = uint16(v)
+		e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.FileFields.Mode = uint16(v)
 
 		return nil
 
@@ -22826,9 +22826,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileFields.MTime"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.FileFields.MTime"}
 		}
-		e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileFields.MTime = uint64(v)
+		e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.FileFields.MTime = uint64(v)
 
 		return nil
 
@@ -22841,9 +22841,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileFields.MountID"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.FileFields.MountID"}
 		}
-		e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileFields.MountID = uint32(v)
+		e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.FileFields.MountID = uint32(v)
 
 		return nil
 
@@ -22856,9 +22856,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.BasenameStr"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.BasenameStr"}
 		}
-		e.PTrace.Tracee.Ancestor.ProcessContext.Process.BasenameStr = str
+		e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.BasenameStr = str
 
 		return nil
 
@@ -22871,9 +22871,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.PathnameStr"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.PathnameStr"}
 		}
-		e.PTrace.Tracee.Ancestor.ProcessContext.Process.PathnameStr = str
+		e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.PathnameStr = str
 
 		return nil
 
@@ -22886,9 +22886,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileFields.Mode"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.FileFields.Mode"}
 		}
-		e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileFields.Mode = uint16(v)
+		e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.FileFields.Mode = uint16(v)
 
 		return nil
 
@@ -22901,9 +22901,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileFields.UID"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.FileFields.UID"}
 		}
-		e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileFields.UID = uint32(v)
+		e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.FileFields.UID = uint32(v)
 
 		return nil
 
@@ -22916,9 +22916,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileFields.User"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.FileFields.User"}
 		}
-		e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileFields.User = str
+		e.PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.FileFields.User = str
 
 		return nil
 
@@ -23310,9 +23310,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileFields.CTime"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileEvent.FileFields.CTime"}
 		}
-		e.PTrace.Tracee.Process.FileFields.CTime = uint64(v)
+		e.PTrace.Tracee.Process.FileEvent.FileFields.CTime = uint64(v)
 
 		return nil
 
@@ -23321,9 +23321,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.Filesystem"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileEvent.Filesystem"}
 		}
-		e.PTrace.Tracee.Process.Filesystem = str
+		e.PTrace.Tracee.Process.FileEvent.Filesystem = str
 
 		return nil
 
@@ -23332,9 +23332,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileFields.GID"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileEvent.FileFields.GID"}
 		}
-		e.PTrace.Tracee.Process.FileFields.GID = uint32(v)
+		e.PTrace.Tracee.Process.FileEvent.FileFields.GID = uint32(v)
 
 		return nil
 
@@ -23343,17 +23343,17 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileFields.Group"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileEvent.FileFields.Group"}
 		}
-		e.PTrace.Tracee.Process.FileFields.Group = str
+		e.PTrace.Tracee.Process.FileEvent.FileFields.Group = str
 
 		return nil
 
 	case "ptrace.tracee.file.in_upper_layer":
 
 		var ok bool
-		if e.PTrace.Tracee.Process.FileFields.InUpperLayer, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileFields.InUpperLayer"}
+		if e.PTrace.Tracee.Process.FileEvent.FileFields.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileEvent.FileFields.InUpperLayer"}
 		}
 		return nil
 
@@ -23362,9 +23362,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileFields.Inode"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileEvent.FileFields.Inode"}
 		}
-		e.PTrace.Tracee.Process.FileFields.Inode = uint64(v)
+		e.PTrace.Tracee.Process.FileEvent.FileFields.Inode = uint64(v)
 
 		return nil
 
@@ -23373,9 +23373,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileFields.Mode"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileEvent.FileFields.Mode"}
 		}
-		e.PTrace.Tracee.Process.FileFields.Mode = uint16(v)
+		e.PTrace.Tracee.Process.FileEvent.FileFields.Mode = uint16(v)
 
 		return nil
 
@@ -23384,9 +23384,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileFields.MTime"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileEvent.FileFields.MTime"}
 		}
-		e.PTrace.Tracee.Process.FileFields.MTime = uint64(v)
+		e.PTrace.Tracee.Process.FileEvent.FileFields.MTime = uint64(v)
 
 		return nil
 
@@ -23395,9 +23395,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileFields.MountID"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileEvent.FileFields.MountID"}
 		}
-		e.PTrace.Tracee.Process.FileFields.MountID = uint32(v)
+		e.PTrace.Tracee.Process.FileEvent.FileFields.MountID = uint32(v)
 
 		return nil
 
@@ -23406,9 +23406,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.BasenameStr"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileEvent.BasenameStr"}
 		}
-		e.PTrace.Tracee.Process.BasenameStr = str
+		e.PTrace.Tracee.Process.FileEvent.BasenameStr = str
 
 		return nil
 
@@ -23417,9 +23417,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.PathnameStr"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileEvent.PathnameStr"}
 		}
-		e.PTrace.Tracee.Process.PathnameStr = str
+		e.PTrace.Tracee.Process.FileEvent.PathnameStr = str
 
 		return nil
 
@@ -23428,9 +23428,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileFields.Mode"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileEvent.FileFields.Mode"}
 		}
-		e.PTrace.Tracee.Process.FileFields.Mode = uint16(v)
+		e.PTrace.Tracee.Process.FileEvent.FileFields.Mode = uint16(v)
 
 		return nil
 
@@ -23439,9 +23439,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileFields.UID"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileEvent.FileFields.UID"}
 		}
-		e.PTrace.Tracee.Process.FileFields.UID = uint32(v)
+		e.PTrace.Tracee.Process.FileEvent.FileFields.UID = uint32(v)
 
 		return nil
 
@@ -23450,9 +23450,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileFields.User"}
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.FileEvent.FileFields.User"}
 		}
-		e.PTrace.Tracee.Process.FileFields.User = str
+		e.PTrace.Tracee.Process.FileEvent.FileFields.User = str
 
 		return nil
 
@@ -23626,9 +23626,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.File.Filesytem"}
+			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.File.Filesystem"}
 		}
-		e.RemoveXAttr.File.Filesytem = str
+		e.RemoveXAttr.File.Filesystem = str
 
 		return nil
 
@@ -23799,9 +23799,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Rename.New.Filesytem"}
+			return &eval.ErrValueTypeMismatch{Field: "Rename.New.Filesystem"}
 		}
-		e.Rename.New.Filesytem = str
+		e.Rename.New.Filesystem = str
 
 		return nil
 
@@ -23939,9 +23939,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Rename.Old.Filesytem"}
+			return &eval.ErrValueTypeMismatch{Field: "Rename.Old.Filesystem"}
 		}
-		e.Rename.Old.Filesytem = str
+		e.Rename.Old.Filesystem = str
 
 		return nil
 
@@ -24101,9 +24101,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Rmdir.File.Filesytem"}
+			return &eval.ErrValueTypeMismatch{Field: "Rmdir.File.Filesystem"}
 		}
-		e.Rmdir.File.Filesytem = str
+		e.Rmdir.File.Filesystem = str
 
 		return nil
 
@@ -24458,9 +24458,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.File.Filesytem"}
+			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.File.Filesystem"}
 		}
-		e.SetXAttr.File.Filesytem = str
+		e.SetXAttr.File.Filesystem = str
 
 		return nil
 
@@ -24914,9 +24914,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileFields.CTime"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileEvent.FileFields.CTime"}
 		}
-		e.Signal.Target.Ancestor.ProcessContext.Process.FileFields.CTime = uint64(v)
+		e.Signal.Target.Ancestor.ProcessContext.Process.FileEvent.FileFields.CTime = uint64(v)
 
 		return nil
 
@@ -24929,9 +24929,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.Filesystem"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileEvent.Filesystem"}
 		}
-		e.Signal.Target.Ancestor.ProcessContext.Process.Filesystem = str
+		e.Signal.Target.Ancestor.ProcessContext.Process.FileEvent.Filesystem = str
 
 		return nil
 
@@ -24944,9 +24944,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileFields.GID"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileEvent.FileFields.GID"}
 		}
-		e.Signal.Target.Ancestor.ProcessContext.Process.FileFields.GID = uint32(v)
+		e.Signal.Target.Ancestor.ProcessContext.Process.FileEvent.FileFields.GID = uint32(v)
 
 		return nil
 
@@ -24959,9 +24959,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileFields.Group"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileEvent.FileFields.Group"}
 		}
-		e.Signal.Target.Ancestor.ProcessContext.Process.FileFields.Group = str
+		e.Signal.Target.Ancestor.ProcessContext.Process.FileEvent.FileFields.Group = str
 
 		return nil
 
@@ -24972,8 +24972,8 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 
 		var ok bool
-		if e.Signal.Target.Ancestor.ProcessContext.Process.FileFields.InUpperLayer, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileFields.InUpperLayer"}
+		if e.Signal.Target.Ancestor.ProcessContext.Process.FileEvent.FileFields.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileEvent.FileFields.InUpperLayer"}
 		}
 		return nil
 
@@ -24986,9 +24986,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileFields.Inode"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileEvent.FileFields.Inode"}
 		}
-		e.Signal.Target.Ancestor.ProcessContext.Process.FileFields.Inode = uint64(v)
+		e.Signal.Target.Ancestor.ProcessContext.Process.FileEvent.FileFields.Inode = uint64(v)
 
 		return nil
 
@@ -25001,9 +25001,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileFields.Mode"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileEvent.FileFields.Mode"}
 		}
-		e.Signal.Target.Ancestor.ProcessContext.Process.FileFields.Mode = uint16(v)
+		e.Signal.Target.Ancestor.ProcessContext.Process.FileEvent.FileFields.Mode = uint16(v)
 
 		return nil
 
@@ -25016,9 +25016,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileFields.MTime"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileEvent.FileFields.MTime"}
 		}
-		e.Signal.Target.Ancestor.ProcessContext.Process.FileFields.MTime = uint64(v)
+		e.Signal.Target.Ancestor.ProcessContext.Process.FileEvent.FileFields.MTime = uint64(v)
 
 		return nil
 
@@ -25031,9 +25031,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileFields.MountID"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileEvent.FileFields.MountID"}
 		}
-		e.Signal.Target.Ancestor.ProcessContext.Process.FileFields.MountID = uint32(v)
+		e.Signal.Target.Ancestor.ProcessContext.Process.FileEvent.FileFields.MountID = uint32(v)
 
 		return nil
 
@@ -25046,9 +25046,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.BasenameStr"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileEvent.BasenameStr"}
 		}
-		e.Signal.Target.Ancestor.ProcessContext.Process.BasenameStr = str
+		e.Signal.Target.Ancestor.ProcessContext.Process.FileEvent.BasenameStr = str
 
 		return nil
 
@@ -25061,9 +25061,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.PathnameStr"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileEvent.PathnameStr"}
 		}
-		e.Signal.Target.Ancestor.ProcessContext.Process.PathnameStr = str
+		e.Signal.Target.Ancestor.ProcessContext.Process.FileEvent.PathnameStr = str
 
 		return nil
 
@@ -25076,9 +25076,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileFields.Mode"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileEvent.FileFields.Mode"}
 		}
-		e.Signal.Target.Ancestor.ProcessContext.Process.FileFields.Mode = uint16(v)
+		e.Signal.Target.Ancestor.ProcessContext.Process.FileEvent.FileFields.Mode = uint16(v)
 
 		return nil
 
@@ -25091,9 +25091,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileFields.UID"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileEvent.FileFields.UID"}
 		}
-		e.Signal.Target.Ancestor.ProcessContext.Process.FileFields.UID = uint32(v)
+		e.Signal.Target.Ancestor.ProcessContext.Process.FileEvent.FileFields.UID = uint32(v)
 
 		return nil
 
@@ -25106,9 +25106,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileFields.User"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Ancestor.ProcessContext.Process.FileEvent.FileFields.User"}
 		}
-		e.Signal.Target.Ancestor.ProcessContext.Process.FileFields.User = str
+		e.Signal.Target.Ancestor.ProcessContext.Process.FileEvent.FileFields.User = str
 
 		return nil
 
@@ -25500,9 +25500,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileFields.CTime"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileEvent.FileFields.CTime"}
 		}
-		e.Signal.Target.Process.FileFields.CTime = uint64(v)
+		e.Signal.Target.Process.FileEvent.FileFields.CTime = uint64(v)
 
 		return nil
 
@@ -25511,9 +25511,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.Filesystem"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileEvent.Filesystem"}
 		}
-		e.Signal.Target.Process.Filesystem = str
+		e.Signal.Target.Process.FileEvent.Filesystem = str
 
 		return nil
 
@@ -25522,9 +25522,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileFields.GID"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileEvent.FileFields.GID"}
 		}
-		e.Signal.Target.Process.FileFields.GID = uint32(v)
+		e.Signal.Target.Process.FileEvent.FileFields.GID = uint32(v)
 
 		return nil
 
@@ -25533,17 +25533,17 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileFields.Group"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileEvent.FileFields.Group"}
 		}
-		e.Signal.Target.Process.FileFields.Group = str
+		e.Signal.Target.Process.FileEvent.FileFields.Group = str
 
 		return nil
 
 	case "signal.target.file.in_upper_layer":
 
 		var ok bool
-		if e.Signal.Target.Process.FileFields.InUpperLayer, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileFields.InUpperLayer"}
+		if e.Signal.Target.Process.FileEvent.FileFields.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileEvent.FileFields.InUpperLayer"}
 		}
 		return nil
 
@@ -25552,9 +25552,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileFields.Inode"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileEvent.FileFields.Inode"}
 		}
-		e.Signal.Target.Process.FileFields.Inode = uint64(v)
+		e.Signal.Target.Process.FileEvent.FileFields.Inode = uint64(v)
 
 		return nil
 
@@ -25563,9 +25563,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileFields.Mode"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileEvent.FileFields.Mode"}
 		}
-		e.Signal.Target.Process.FileFields.Mode = uint16(v)
+		e.Signal.Target.Process.FileEvent.FileFields.Mode = uint16(v)
 
 		return nil
 
@@ -25574,9 +25574,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileFields.MTime"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileEvent.FileFields.MTime"}
 		}
-		e.Signal.Target.Process.FileFields.MTime = uint64(v)
+		e.Signal.Target.Process.FileEvent.FileFields.MTime = uint64(v)
 
 		return nil
 
@@ -25585,9 +25585,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileFields.MountID"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileEvent.FileFields.MountID"}
 		}
-		e.Signal.Target.Process.FileFields.MountID = uint32(v)
+		e.Signal.Target.Process.FileEvent.FileFields.MountID = uint32(v)
 
 		return nil
 
@@ -25596,9 +25596,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.BasenameStr"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileEvent.BasenameStr"}
 		}
-		e.Signal.Target.Process.BasenameStr = str
+		e.Signal.Target.Process.FileEvent.BasenameStr = str
 
 		return nil
 
@@ -25607,9 +25607,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.PathnameStr"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileEvent.PathnameStr"}
 		}
-		e.Signal.Target.Process.PathnameStr = str
+		e.Signal.Target.Process.FileEvent.PathnameStr = str
 
 		return nil
 
@@ -25618,9 +25618,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileFields.Mode"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileEvent.FileFields.Mode"}
 		}
-		e.Signal.Target.Process.FileFields.Mode = uint16(v)
+		e.Signal.Target.Process.FileEvent.FileFields.Mode = uint16(v)
 
 		return nil
 
@@ -25629,9 +25629,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileFields.UID"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileEvent.FileFields.UID"}
 		}
-		e.Signal.Target.Process.FileFields.UID = uint32(v)
+		e.Signal.Target.Process.FileEvent.FileFields.UID = uint32(v)
 
 		return nil
 
@@ -25640,9 +25640,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileFields.User"}
+			return &eval.ErrValueTypeMismatch{Field: "Signal.Target.Process.FileEvent.FileFields.User"}
 		}
-		e.Signal.Target.Process.FileFields.User = str
+		e.Signal.Target.Process.FileEvent.FileFields.User = str
 
 		return nil
 
@@ -25805,9 +25805,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Splice.File.Filesytem"}
+			return &eval.ErrValueTypeMismatch{Field: "Splice.File.Filesystem"}
 		}
-		e.Splice.File.Filesytem = str
+		e.Splice.File.Filesystem = str
 
 		return nil
 
@@ -25989,9 +25989,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Unlink.File.Filesytem"}
+			return &eval.ErrValueTypeMismatch{Field: "Unlink.File.Filesystem"}
 		}
-		e.Unlink.File.Filesytem = str
+		e.Unlink.File.Filesystem = str
 
 		return nil
 
@@ -26173,9 +26173,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Utimes.File.Filesytem"}
+			return &eval.ErrValueTypeMismatch{Field: "Utimes.File.Filesystem"}
 		}
-		e.Utimes.File.Filesytem = str
+		e.Utimes.File.Filesystem = str
 
 		return nil
 

--- a/pkg/security/secl/model/marshallers.go
+++ b/pkg/security/secl/model/marshallers.go
@@ -76,7 +76,7 @@ func (e *Process) MarshalProcCache(data []byte) (int, error) {
 	copy(data[0:ContainerIDLen], e.ContainerID)
 	written := ContainerIDLen
 
-	toAdd, err := MarshalBinary(data[written:], &e.FileFields)
+	toAdd, err := MarshalBinary(data[written:], &e.FileEvent)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -364,9 +364,9 @@ func (f *FileFields) GetInUpperLayer() bool {
 // FileEvent is the common file event type
 type FileEvent struct {
 	FileFields
-	PathnameStr string `field:"path,ResolveFilePath" msg:"path"`                   // File's path
-	BasenameStr string `field:"name,ResolveFileBasename" msg:"name"`               // File's basename
-	Filesytem   string `field:"filesystem,ResolveFileFilesystem" msg:"filesystem"` // File's filesystem
+	PathnameStr string `field:"path,ResolveFilePath" msg:"path" op_override:"eval.GlobCmp"` // File's path
+	BasenameStr string `field:"name,ResolveFileBasename" msg:"name"`                        // File's basename
+	Filesytem   string `field:"filesystem,ResolveFileFilesystem" msg:"filesystem"`          // File's filesystem
 
 	PathResolutionError error `field:"-" msg:"-"`
 }

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -269,9 +269,9 @@ type Process struct {
 	Tid   uint32 `field:"tid" msg:"tid"` // Thread ID of the thread
 	NetNS uint32 `field:"-" msg:"-"`
 
-	PathnameStr         string `field:"file.path" msg:"path"`             // Path of the process executable
-	BasenameStr         string `field:"file.name" msg:"name"`             // Basename of the path of the process executable
-	Filesystem          string `field:"file.filesystem" msg:"filesystem"` // FileSystem of the process executable
+	PathnameStr         string `field:"file.path" msg:"path" op_override:"eval.GlobCmp"` // Path of the process executable
+	BasenameStr         string `field:"file.name" msg:"name"`                            // Basename of the path of the process executable
+	Filesystem          string `field:"file.filesystem" msg:"filesystem"`                // FileSystem of the process executable
 	PathResolutionError error  `field:"-" msg:"-"`
 
 	ContainerID   string   `field:"container.id" msg:"container_id"` // Container ID

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -775,11 +775,11 @@ type NetworkContext struct {
 //msgp:ignore DNSEvent
 type DNSEvent struct {
 	ID    uint16 `field:"-"`
-	Name  string `field:"question.name" op_override:"DNSNameCmp"` // the queried domain name
-	Type  uint16 `field:"question.type"`                          // a two octet code which specifies the DNS question type
-	Class uint16 `field:"question.class"`                         // the class looked up by the DNS question
-	Size  uint16 `field:"question.size"`                          // the total DNS request size in bytes
-	Count uint16 `field:"question.count"`                         // the total count of questions in the DNS request
+	Name  string `field:"question.name" op_override:"eval.DNSNameCmp"` // the queried domain name
+	Type  uint16 `field:"question.type"`                               // a two octet code which specifies the DNS question type
+	Class uint16 `field:"question.class"`                              // the class looked up by the DNS question
+	Size  uint16 `field:"question.size"`                               // the total DNS request size in bytes
+	Count uint16 `field:"question.count"`                              // the total count of questions in the DNS request
 }
 
 // NetDevice represents a network device

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -254,8 +254,8 @@ type Credentials struct {
 
 // GetPathResolutionError returns the path resolution error as a string if there is one
 func (e *Process) GetPathResolutionError() string {
-	if e.PathResolutionError != nil {
-		return e.PathResolutionError.Error()
+	if e.FileEvent.PathResolutionError != nil {
+		return e.FileEvent.PathResolutionError.Error()
 	}
 	return ""
 }
@@ -263,16 +263,11 @@ func (e *Process) GetPathResolutionError() string {
 // Process represents a process
 type Process struct {
 	// proc_cache_t
-	FileFields FileFields `field:"file" msg:"file"`
+	FileEvent FileEvent `field:"file" msg:"file"`
 
 	Pid   uint32 `field:"pid" msg:"pid"` // Process ID of the process (also called thread group ID)
 	Tid   uint32 `field:"tid" msg:"tid"` // Thread ID of the thread
 	NetNS uint32 `field:"-" msg:"-"`
-
-	PathnameStr         string `field:"file.path" msg:"path" op_override:"eval.GlobCmp"` // Path of the process executable
-	BasenameStr         string `field:"file.name" msg:"name"`                            // Basename of the path of the process executable
-	Filesystem          string `field:"file.filesystem" msg:"filesystem"`                // FileSystem of the process executable
-	PathResolutionError error  `field:"-" msg:"-"`
 
 	ContainerID   string   `field:"container.id" msg:"container_id"` // Container ID
 	ContainerTags []string `field:"-" msg:"container_tags"`
@@ -366,7 +361,7 @@ type FileEvent struct {
 	FileFields
 	PathnameStr string `field:"path,ResolveFilePath" msg:"path" op_override:"eval.GlobCmp"` // File's path
 	BasenameStr string `field:"name,ResolveFileBasename" msg:"name"`                        // File's basename
-	Filesytem   string `field:"filesystem,ResolveFileFilesystem" msg:"filesystem"`          // File's filesystem
+	Filesystem  string `field:"filesystem,ResolveFileFilesystem" msg:"filesystem"`          // File's filesystem
 
 	PathResolutionError error `field:"-" msg:"-"`
 }

--- a/pkg/security/secl/model/model_gen.go
+++ b/pkg/security/secl/model/model_gen.go
@@ -471,9 +471,9 @@ func (z *FileEvent) DecodeMsg(dc *msgp.Reader) (err error) {
 				return
 			}
 		case "filesystem":
-			z.Filesytem, err = dc.ReadString()
+			z.Filesystem, err = dc.ReadString()
 			if err != nil {
-				err = msgp.WrapError(err, "Filesytem")
+				err = msgp.WrapError(err, "Filesystem")
 				return
 			}
 		default:
@@ -525,9 +525,9 @@ func (z *FileEvent) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	err = en.WriteString(z.Filesytem)
+	err = en.WriteString(z.Filesystem)
 	if err != nil {
-		err = msgp.WrapError(err, "Filesytem")
+		err = msgp.WrapError(err, "Filesystem")
 		return
 	}
 	return
@@ -552,7 +552,7 @@ func (z *FileEvent) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.AppendString(o, z.BasenameStr)
 	// string "filesystem"
 	o = append(o, 0xaa, 0x66, 0x69, 0x6c, 0x65, 0x73, 0x79, 0x73, 0x74, 0x65, 0x6d)
-	o = msgp.AppendString(o, z.Filesytem)
+	o = msgp.AppendString(o, z.Filesystem)
 	return
 }
 
@@ -593,9 +593,9 @@ func (z *FileEvent) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 		case "filesystem":
-			z.Filesytem, bts, err = msgp.ReadStringBytes(bts)
+			z.Filesystem, bts, err = msgp.ReadStringBytes(bts)
 			if err != nil {
-				err = msgp.WrapError(err, "Filesytem")
+				err = msgp.WrapError(err, "Filesystem")
 				return
 			}
 		default:
@@ -612,7 +612,7 @@ func (z *FileEvent) UnmarshalMsg(bts []byte) (o []byte, err error) {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *FileEvent) Msgsize() (s int) {
-	s = 1 + 11 + z.FileFields.Msgsize() + 5 + msgp.StringPrefixSize + len(z.PathnameStr) + 5 + msgp.StringPrefixSize + len(z.BasenameStr) + 11 + msgp.StringPrefixSize + len(z.Filesytem)
+	s = 1 + 11 + z.FileFields.Msgsize() + 5 + msgp.StringPrefixSize + len(z.PathnameStr) + 5 + msgp.StringPrefixSize + len(z.BasenameStr) + 11 + msgp.StringPrefixSize + len(z.Filesystem)
 	return
 }
 
@@ -963,9 +963,9 @@ func (z *Process) DecodeMsg(dc *msgp.Reader) (err error) {
 		}
 		switch msgp.UnsafeString(field) {
 		case "file":
-			err = z.FileFields.DecodeMsg(dc)
+			err = z.FileEvent.DecodeMsg(dc)
 			if err != nil {
-				err = msgp.WrapError(err, "FileFields")
+				err = msgp.WrapError(err, "FileEvent")
 				return
 			}
 		case "pid":
@@ -978,24 +978,6 @@ func (z *Process) DecodeMsg(dc *msgp.Reader) (err error) {
 			z.Tid, err = dc.ReadUint32()
 			if err != nil {
 				err = msgp.WrapError(err, "Tid")
-				return
-			}
-		case "path":
-			z.PathnameStr, err = dc.ReadString()
-			if err != nil {
-				err = msgp.WrapError(err, "PathnameStr")
-				return
-			}
-		case "name":
-			z.BasenameStr, err = dc.ReadString()
-			if err != nil {
-				err = msgp.WrapError(err, "BasenameStr")
-				return
-			}
-		case "filesystem":
-			z.Filesystem, err = dc.ReadString()
-			if err != nil {
-				err = msgp.WrapError(err, "Filesystem")
 				return
 			}
 		case "container_id":
@@ -1126,15 +1108,15 @@ func (z *Process) DecodeMsg(dc *msgp.Reader) (err error) {
 
 // EncodeMsg implements msgp.Encodable
 func (z *Process) EncodeMsg(en *msgp.Writer) (err error) {
-	// map header, size 19
+	// map header, size 16
 	// write "file"
-	err = en.Append(0xde, 0x0, 0x13, 0xa4, 0x66, 0x69, 0x6c, 0x65)
+	err = en.Append(0xde, 0x0, 0x10, 0xa4, 0x66, 0x69, 0x6c, 0x65)
 	if err != nil {
 		return
 	}
-	err = z.FileFields.EncodeMsg(en)
+	err = z.FileEvent.EncodeMsg(en)
 	if err != nil {
-		err = msgp.WrapError(err, "FileFields")
+		err = msgp.WrapError(err, "FileEvent")
 		return
 	}
 	// write "pid"
@@ -1155,36 +1137,6 @@ func (z *Process) EncodeMsg(en *msgp.Writer) (err error) {
 	err = en.WriteUint32(z.Tid)
 	if err != nil {
 		err = msgp.WrapError(err, "Tid")
-		return
-	}
-	// write "path"
-	err = en.Append(0xa4, 0x70, 0x61, 0x74, 0x68)
-	if err != nil {
-		return
-	}
-	err = en.WriteString(z.PathnameStr)
-	if err != nil {
-		err = msgp.WrapError(err, "PathnameStr")
-		return
-	}
-	// write "name"
-	err = en.Append(0xa4, 0x6e, 0x61, 0x6d, 0x65)
-	if err != nil {
-		return
-	}
-	err = en.WriteString(z.BasenameStr)
-	if err != nil {
-		err = msgp.WrapError(err, "BasenameStr")
-		return
-	}
-	// write "filesystem"
-	err = en.Append(0xaa, 0x66, 0x69, 0x6c, 0x65, 0x73, 0x79, 0x73, 0x74, 0x65, 0x6d)
-	if err != nil {
-		return
-	}
-	err = en.WriteString(z.Filesystem)
-	if err != nil {
-		err = msgp.WrapError(err, "Filesystem")
 		return
 	}
 	// write "container_id"
@@ -1344,12 +1296,12 @@ func (z *Process) EncodeMsg(en *msgp.Writer) (err error) {
 // MarshalMsg implements msgp.Marshaler
 func (z *Process) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
-	// map header, size 19
+	// map header, size 16
 	// string "file"
-	o = append(o, 0xde, 0x0, 0x13, 0xa4, 0x66, 0x69, 0x6c, 0x65)
-	o, err = z.FileFields.MarshalMsg(o)
+	o = append(o, 0xde, 0x0, 0x10, 0xa4, 0x66, 0x69, 0x6c, 0x65)
+	o, err = z.FileEvent.MarshalMsg(o)
 	if err != nil {
-		err = msgp.WrapError(err, "FileFields")
+		err = msgp.WrapError(err, "FileEvent")
 		return
 	}
 	// string "pid"
@@ -1358,15 +1310,6 @@ func (z *Process) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "tid"
 	o = append(o, 0xa3, 0x74, 0x69, 0x64)
 	o = msgp.AppendUint32(o, z.Tid)
-	// string "path"
-	o = append(o, 0xa4, 0x70, 0x61, 0x74, 0x68)
-	o = msgp.AppendString(o, z.PathnameStr)
-	// string "name"
-	o = append(o, 0xa4, 0x6e, 0x61, 0x6d, 0x65)
-	o = msgp.AppendString(o, z.BasenameStr)
-	// string "filesystem"
-	o = append(o, 0xaa, 0x66, 0x69, 0x6c, 0x65, 0x73, 0x79, 0x73, 0x74, 0x65, 0x6d)
-	o = msgp.AppendString(o, z.Filesystem)
 	// string "container_id"
 	o = append(o, 0xac, 0x63, 0x6f, 0x6e, 0x74, 0x61, 0x69, 0x6e, 0x65, 0x72, 0x5f, 0x69, 0x64)
 	o = msgp.AppendString(o, z.ContainerID)
@@ -1451,9 +1394,9 @@ func (z *Process) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		switch msgp.UnsafeString(field) {
 		case "file":
-			bts, err = z.FileFields.UnmarshalMsg(bts)
+			bts, err = z.FileEvent.UnmarshalMsg(bts)
 			if err != nil {
-				err = msgp.WrapError(err, "FileFields")
+				err = msgp.WrapError(err, "FileEvent")
 				return
 			}
 		case "pid":
@@ -1466,24 +1409,6 @@ func (z *Process) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			z.Tid, bts, err = msgp.ReadUint32Bytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "Tid")
-				return
-			}
-		case "path":
-			z.PathnameStr, bts, err = msgp.ReadStringBytes(bts)
-			if err != nil {
-				err = msgp.WrapError(err, "PathnameStr")
-				return
-			}
-		case "name":
-			z.BasenameStr, bts, err = msgp.ReadStringBytes(bts)
-			if err != nil {
-				err = msgp.WrapError(err, "BasenameStr")
-				return
-			}
-		case "filesystem":
-			z.Filesystem, bts, err = msgp.ReadStringBytes(bts)
-			if err != nil {
-				err = msgp.WrapError(err, "Filesystem")
 				return
 			}
 		case "container_id":
@@ -1613,7 +1538,7 @@ func (z *Process) UnmarshalMsg(bts []byte) (o []byte, err error) {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *Process) Msgsize() (s int) {
-	s = 3 + 5 + z.FileFields.Msgsize() + 4 + msgp.Uint32Size + 4 + msgp.Uint32Size + 5 + msgp.StringPrefixSize + len(z.PathnameStr) + 5 + msgp.StringPrefixSize + len(z.BasenameStr) + 11 + msgp.StringPrefixSize + len(z.Filesystem) + 13 + msgp.StringPrefixSize + len(z.ContainerID) + 15 + msgp.ArrayHeaderSize
+	s = 3 + 5 + z.FileEvent.Msgsize() + 4 + msgp.Uint32Size + 4 + msgp.Uint32Size + 13 + msgp.StringPrefixSize + len(z.ContainerID) + 15 + msgp.ArrayHeaderSize
 	for za0001 := range z.ContainerTags {
 		s += msgp.StringPrefixSize + len(z.ContainerTags[za0001])
 	}

--- a/pkg/security/secl/model/process_cache_entry.go
+++ b/pkg/security/secl/model/process_cache_entry.go
@@ -85,10 +85,7 @@ func (pc *ProcessCacheEntry) Fork(childEntry *ProcessCacheEntry) {
 	childEntry.PPid = pc.Pid
 	childEntry.TTYName = pc.TTYName
 	childEntry.Comm = pc.Comm
-	childEntry.FileFields = pc.FileFields
-	childEntry.PathnameStr = pc.PathnameStr
-	childEntry.BasenameStr = pc.BasenameStr
-	childEntry.Filesystem = pc.Filesystem
+	childEntry.FileEvent = pc.FileEvent
 	childEntry.ContainerID = pc.ContainerID
 	childEntry.ExecTime = pc.ExecTime
 	childEntry.Credentials = pc.Credentials

--- a/pkg/security/secl/model/unmarshallers.go
+++ b/pkg/security/secl/model/unmarshallers.go
@@ -139,7 +139,7 @@ func isValidTTYName(ttyName string) bool {
 // UnmarshalBinary unmarshalls a binary representation of itself
 func (e *Process) UnmarshalBinary(data []byte) (int, error) {
 	// Unmarshal proc_cache_t
-	read, err := UnmarshalBinary(data, &e.FileFields)
+	read, err := UnmarshalBinary(data, &e.FileEvent)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/security/secl/rules/approvers.go
+++ b/pkg/security/secl/rules/approvers.go
@@ -82,7 +82,7 @@ func GetApprovers(rules []*Rule, event eval.Event, fieldCaps FieldCapabilities) 
 
 			for _, value := range rule.GetFieldValues(field) {
 				switch value.Type {
-				case eval.ScalarValueType, eval.PatternValueType:
+				case eval.ScalarValueType, eval.PatternValueType, eval.GlobValueType:
 					isAnApprover, err := isAnApprover(event, ctx, rule, field, value.Value)
 					if err != nil {
 						return nil, err

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -109,7 +109,7 @@ func TestProcessContext(t *testing.T) {
 		},
 		{
 			ID:         "test_rule_envp",
-			Expression: `exec.file.name == "ls" && exec.envp in ["ENVP=test"]`,
+			Expression: `exec.file.name == "ls" && exec.envp in ["ENVP=test"] && exec.args =~ "*example.com"`,
 		},
 		{
 			ID:         "test_rule_args_envs_dedup",
@@ -264,7 +264,7 @@ func TestProcessContext(t *testing.T) {
 	})
 
 	test.Run(t, "envp", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
-		args := []string{"-al"}
+		args := []string{"-al", "http://example.com"}
 		envs := []string{"ENVP=test"}
 
 		test.WaitSignal(t, func() error {

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -569,7 +569,6 @@ func TestProcessContext(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			cmd := cmdFunc(shell, args, envs)
-			// we need to ignore the error because the string of "a" generates a "File name too long" error
 			_ = cmd.Run()
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -192,7 +192,7 @@ func TestProcessContext(t *testing.T) {
 			return f.Close()
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assertFieldEqual(t, event, "process.file.path", executable)
-			assert.Equal(t, getInode(t, executable), event.ResolveProcessCacheEntry().FileFields.Inode, "wrong inode")
+			assert.Equal(t, getInode(t, executable), event.ResolveProcessCacheEntry().FileEvent.Inode, "wrong inode")
 		})
 	})
 
@@ -442,8 +442,8 @@ func TestProcessContext(t *testing.T) {
 				t.Errorf("not able to get a tty name: %s\n", name)
 			}
 
-			if inode := getInode(t, executable); inode != event.ResolveProcessCacheEntry().FileFields.Inode {
-				t.Errorf("expected inode %d, got %d => %+v", event.ResolveProcessCacheEntry().FileFields.Inode, inode, event)
+			if inode := getInode(t, executable); inode != event.ResolveProcessCacheEntry().FileEvent.Inode {
+				t.Errorf("expected inode %d, got %d => %+v", event.ResolveProcessCacheEntry().FileEvent.Inode, inode, event)
 			}
 
 			str := event.String()
@@ -845,9 +845,9 @@ func TestProcessMetadata(t *testing.T) {
 			return cmd.Run()
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assert.Equal(t, "exec", event.GetType(), "wrong event type")
-			assertRights(t, event.Exec.FileFields.Mode, uint16(expectedMode))
-			assertNearTime(t, event.Exec.FileFields.MTime)
-			assertNearTime(t, event.Exec.FileFields.CTime)
+			assertRights(t, event.Exec.FileEvent.Mode, uint16(expectedMode))
+			assertNearTime(t, event.Exec.FileEvent.MTime)
+			assertNearTime(t, event.Exec.FileEvent.CTime)
 		})
 	})
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

This PR uses an operator override to isolate the glob matcher to the `*.file.path` fields. See the rule documentation update to understand the difference with what we have today.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Allow writing patterns without using the filesystem interpretation of `*` and `**`. See the documentation for a more in depth explanation.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
