### PR TITLE
[Serverless] support lambda direct invocation trace propagation

### DIFF
--- a/pkg/serverless/daemon/routes.go
+++ b/pkg/serverless/daemon/routes.go
@@ -54,9 +54,14 @@ func (s *StartInvocation) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Could not read StartInvocation request body", 400)
 		return
 	}
+	lambdaInvokeContext := invocationlifecycle.LambdaInvokeEventHeaders{
+		TraceID:  r.Header.Get(invocationlifecycle.TraceIDHeader),
+		ParentID: r.Header.Get(invocationlifecycle.ParentIDHeader),
+	}
 	startDetails := &invocationlifecycle.InvocationStartDetails{
 		StartTime:             startTime,
 		InvokeEventRawPayload: string(reqBody),
+		InvokeEventHeaders:    lambdaInvokeContext,
 	}
 	s.daemon.InvocationProcessor.OnInvokeStart(startDetails)
 }

--- a/pkg/serverless/invocationlifecycle/constants.go
+++ b/pkg/serverless/invocationlifecycle/constants.go
@@ -18,5 +18,5 @@ const (
 	// used in /lambda/end-invocation
 	InvocationErrorHeader = "x-datadog-invocation-error"
 
-	parentIDHeader = "x-datadog-parent-id"
+	ParentIDHeader = "x-datadog-parent-id"
 )

--- a/pkg/serverless/invocationlifecycle/constants.go
+++ b/pkg/serverless/invocationlifecycle/constants.go
@@ -7,8 +7,12 @@ package invocationlifecycle
 
 const (
 	// TraceIDHeader is the header containing the traceID
-	// used in /trace-context
+	// used in /trace-context and /lambda/start-invocation
 	TraceIDHeader = "x-datadog-trace-id"
+
+	// ParentIDHeader is the header containing the parentID
+	// used in /trace-context and /lambda/start-invocation
+	ParentIDHeader = "x-datadog-parent-id"
 
 	// SpanIDHeader is the header containing the spanID
 	// used in /lambda/start-invocation
@@ -17,6 +21,4 @@ const (
 	// InvocationErrorHeader : if set to "true", the extension will know that the current invocation has failed
 	// used in /lambda/end-invocation
 	InvocationErrorHeader = "x-datadog-invocation-error"
-
-	ParentIDHeader = "x-datadog-parent-id"
 )

--- a/pkg/serverless/invocationlifecycle/invocation_details.go
+++ b/pkg/serverless/invocationlifecycle/invocation_details.go
@@ -17,6 +17,9 @@ type InvocationStartDetails struct {
 	InvokeEventHeaders    LambdaInvokeEventHeaders
 }
 
+// LambdaInvokeEventHeaders stores the headers with information needed for trace propagation
+// from a direct lambda invocation.
+// This structure is passed to the onInvokeStart method of the invocationProcessor interface
 type LambdaInvokeEventHeaders struct {
 	TraceID  string
 	ParentID string

--- a/pkg/serverless/invocationlifecycle/invocation_details.go
+++ b/pkg/serverless/invocationlifecycle/invocation_details.go
@@ -14,6 +14,12 @@ import (
 type InvocationStartDetails struct {
 	StartTime             time.Time
 	InvokeEventRawPayload string
+	InvokeEventHeaders    LambdaInvokeEventHeaders
+}
+
+type LambdaInvokeEventHeaders struct {
+	TraceID  string
+	ParentID string
 }
 
 // InvocationEndDetails stores information about the end of an invocation.

--- a/pkg/serverless/invocationlifecycle/lifecycle.go
+++ b/pkg/serverless/invocationlifecycle/lifecycle.go
@@ -30,7 +30,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 	log.Debug("[lifecycle] ---------------------------------------")
 
 	if !lp.DetectLambdaLibrary() {
-		startExecutionSpan(startDetails.StartTime, startDetails.InvokeEventRawPayload)
+		startExecutionSpan(startDetails.StartTime, startDetails.InvokeEventRawPayload, startDetails.InvokeEventHeaders)
 	}
 }
 

--- a/pkg/serverless/invocationlifecycle/trace.go
+++ b/pkg/serverless/invocationlifecycle/trace.go
@@ -51,25 +51,23 @@ func startExecutionSpan(startTime time.Time, rawPayload string, invokeEventHeade
 
 	currentExecutionInfo.requestPayload = rawPayload
 
-	if payload.Headers != nil || invokeEventHeaders.TraceID != "" {
-		var traceID, parentID uint64
-		var e1, e2 error
+	var traceID, parentID uint64
+	var e1, e2 error
 
-		if payload.Headers != nil {
-			traceID, e1 = convertStrToUnit64(payload.Headers[TraceIDHeader])
-			parentID, e2 = convertStrToUnit64(payload.Headers[ParentIDHeader])
-		} else {
-			traceID, e1 = convertStrToUnit64(invokeEventHeaders.TraceID)
-			parentID, e2 = convertStrToUnit64(invokeEventHeaders.ParentID)
-		}
+	if payload.Headers != nil {
+		traceID, e1 = convertStrToUnit64(payload.Headers[TraceIDHeader])
+		parentID, e2 = convertStrToUnit64(payload.Headers[ParentIDHeader])
+	} else if invokeEventHeaders.TraceID != "" { // trace context from a direct invocation
+		traceID, e1 = convertStrToUnit64(invokeEventHeaders.TraceID)
+		parentID, e2 = convertStrToUnit64(invokeEventHeaders.ParentID)
+	}
 
-		if e1 == nil {
-			currentExecutionInfo.traceID = traceID
-		}
+	if e1 == nil {
+		currentExecutionInfo.traceID = traceID
+	}
 
-		if e2 == nil {
-			currentExecutionInfo.parentID = parentID
-		}
+	if e2 == nil {
+		currentExecutionInfo.parentID = parentID
 	}
 }
 

--- a/pkg/serverless/invocationlifecycle/trace.go
+++ b/pkg/serverless/invocationlifecycle/trace.go
@@ -51,23 +51,23 @@ func startExecutionSpan(startTime time.Time, rawPayload string, invokeEventHeade
 
 	currentExecutionInfo.requestPayload = rawPayload
 
-	var traceID, parentID uint64
-	var e1, e2 error
+	var contextTraceID, contextParentID uint64
+	var traceIdError, parentIdError error
 
 	if payload.Headers != nil {
-		traceID, e1 = convertStrToUnit64(payload.Headers[TraceIDHeader])
-		parentID, e2 = convertStrToUnit64(payload.Headers[ParentIDHeader])
+		contextTraceID, traceIdError = convertStrToUnit64(payload.Headers[TraceIDHeader])
+		contextParentID, parentIdError = convertStrToUnit64(payload.Headers[ParentIDHeader])
 	} else if invokeEventHeaders.TraceID != "" { // trace context from a direct invocation
-		traceID, e1 = convertStrToUnit64(invokeEventHeaders.TraceID)
-		parentID, e2 = convertStrToUnit64(invokeEventHeaders.ParentID)
+		contextTraceID, traceIdError = convertStrToUnit64(invokeEventHeaders.TraceID)
+		contextParentID, parentIdError = convertStrToUnit64(invokeEventHeaders.ParentID)
 	}
 
-	if e1 == nil {
-		currentExecutionInfo.traceID = traceID
+	if traceIdError == nil {
+		currentExecutionInfo.traceID = contextTraceID
 	}
 
-	if e2 == nil {
-		currentExecutionInfo.parentID = parentID
+	if parentIdError == nil {
+		currentExecutionInfo.parentID = contextParentID
 	}
 }
 

--- a/pkg/serverless/invocationlifecycle/trace.go
+++ b/pkg/serverless/invocationlifecycle/trace.go
@@ -51,23 +51,23 @@ func startExecutionSpan(startTime time.Time, rawPayload string, invokeEventHeade
 
 	currentExecutionInfo.requestPayload = rawPayload
 
-	var contextTraceID, contextParentID uint64
-	var traceIdError, parentIdError error
+	var traceID, parentID uint64
+	var e1, e2 error
 
 	if payload.Headers != nil {
-		contextTraceID, traceIdError = convertStrToUnit64(payload.Headers[TraceIDHeader])
-		contextParentID, parentIdError = convertStrToUnit64(payload.Headers[ParentIDHeader])
+		traceID, e1 = convertStrToUnit64(payload.Headers[TraceIDHeader])
+		parentID, e2 = convertStrToUnit64(payload.Headers[ParentIDHeader])
 	} else if invokeEventHeaders.TraceID != "" { // trace context from a direct invocation
-		contextTraceID, traceIdError = convertStrToUnit64(invokeEventHeaders.TraceID)
-		contextParentID, parentIdError = convertStrToUnit64(invokeEventHeaders.ParentID)
+		traceID, e1 = convertStrToUnit64(invokeEventHeaders.TraceID)
+		parentID, e2 = convertStrToUnit64(invokeEventHeaders.ParentID)
 	}
 
-	if traceIdError == nil {
-		currentExecutionInfo.traceID = contextTraceID
+	if e1 == nil && traceID != 0 {
+		currentExecutionInfo.traceID = traceID
 	}
 
-	if parentIdError == nil {
-		currentExecutionInfo.parentID = contextParentID
+	if e2 == nil && parentID != 0 {
+		currentExecutionInfo.parentID = parentID
 	}
 }
 

--- a/pkg/serverless/invocationlifecycle/trace_test.go
+++ b/pkg/serverless/invocationlifecycle/trace_test.go
@@ -102,7 +102,7 @@ func TestEndExecutionSpanWithInvalidCaptureLambdaPayloadValue(t *testing.T) {
 	defer reset()
 	testString := `a5a{"resource":"/users/create","path":"/users/create","httpMethod":"GET","headers":{"Accept":"*/*","Accept-Encoding":"gzip","x-datadog-parent-id":"1480558859903409531","x-datadog-sampling-priority":"1","x-datadog-trace-id":"5736943178450432258"}}0`
 	startTime := time.Now()
-	startExecutionSpan(startTime, testString)
+	startExecutionSpan(startTime, testString, LambdaInvokeEventHeaders{})
 
 	duration := 1 * time.Second
 	endTime := startTime.Add(duration)

--- a/pkg/serverless/invocationlifecycle/trace_test.go
+++ b/pkg/serverless/invocationlifecycle/trace_test.go
@@ -18,7 +18,7 @@ import (
 func TestStartExecutionSpanWithoutPayload(t *testing.T) {
 	defer reset()
 	startTime := time.Now()
-	startExecutionSpan(startTime, "")
+	startExecutionSpan(startTime, "", LambdaInvokeEventHeaders{})
 	assert.Equal(t, startTime, currentExecutionInfo.startTime)
 	assert.NotEqual(t, 0, currentExecutionInfo.traceID)
 	assert.NotEqual(t, 0, currentExecutionInfo.spanID)
@@ -28,7 +28,22 @@ func TestStartExecutionSpanWithPayload(t *testing.T) {
 	defer reset()
 	testString := `a5a{"resource":"/users/create","path":"/users/create","httpMethod":"GET","headers":{"Accept":"*/*","Accept-Encoding":"gzip","x-datadog-parent-id":"1480558859903409531","x-datadog-sampling-priority":"1","x-datadog-trace-id":"5736943178450432258"}}0`
 	startTime := time.Now()
-	startExecutionSpan(startTime, testString)
+	startExecutionSpan(startTime, testString, LambdaInvokeEventHeaders{})
+	assert.Equal(t, startTime, currentExecutionInfo.startTime)
+	assert.Equal(t, uint64(5736943178450432258), currentExecutionInfo.traceID)
+	assert.Equal(t, uint64(1480558859903409531), currentExecutionInfo.parentID)
+	assert.NotEqual(t, 0, currentExecutionInfo.spanID)
+}
+
+func TestStartExecutionSpanWithPayloadAndLambdaContextHeaders(t *testing.T) {
+	defer reset()
+	testString := `a5a{"resource":"/users/create","path":"/users/create","httpMethod":"GET"}0`
+	lambdaInvokeContext := LambdaInvokeEventHeaders{
+		TraceID:  "5736943178450432258",
+		ParentID: "1480558859903409531",
+	}
+	startTime := time.Now()
+	startExecutionSpan(startTime, testString, lambdaInvokeContext)
 	assert.Equal(t, startTime, currentExecutionInfo.startTime)
 	assert.Equal(t, uint64(5736943178450432258), currentExecutionInfo.traceID)
 	assert.Equal(t, uint64(1480558859903409531), currentExecutionInfo.parentID)
@@ -39,7 +54,7 @@ func TestStartExecutionSpanWithPayloadAndInvalidIDs(t *testing.T) {
 	defer reset()
 	invalidTestString := `a5a{"resource":"/users/create","path":"/users/create","httpMethod":"GET","headers":{"Accept":"*/*","Accept-Encoding":"gzip","x-datadog-parent-id":"INVALID","x-datadog-sampling-priority":"1","x-datadog-trace-id":"INVALID"}}0`
 	startTime := time.Now()
-	startExecutionSpan(startTime, invalidTestString)
+	startExecutionSpan(startTime, invalidTestString, LambdaInvokeEventHeaders{})
 	assert.Equal(t, startTime, currentExecutionInfo.startTime)
 	assert.NotEqual(t, 9, currentExecutionInfo.traceID)
 	assert.Equal(t, uint64(0), currentExecutionInfo.parentID)
@@ -54,7 +69,7 @@ func TestEndExecutionSpanWithNoError(t *testing.T) {
 	defer reset()
 	testString := `a5a{"resource":"/users/create","path":"/users/create","httpMethod":"GET","headers":{"Accept":"*/*","Accept-Encoding":"gzip","x-datadog-parent-id":"1480558859903409531","x-datadog-sampling-priority":"1","x-datadog-trace-id":"5736943178450432258"}}0`
 	startTime := time.Now()
-	startExecutionSpan(startTime, testString)
+	startExecutionSpan(startTime, testString, LambdaInvokeEventHeaders{})
 
 	duration := 1 * time.Second
 	endTime := startTime.Add(duration)
@@ -118,7 +133,7 @@ func TestEndExecutionSpanWithError(t *testing.T) {
 	defer reset()
 	testString := `a5a{"resource":"/users/create","path":"/users/create","httpMethod":"GET","headers":{"Accept":"*/*","Accept-Encoding":"gzip","x-datadog-parent-id":"1480558859903409531","x-datadog-sampling-priority":"1","x-datadog-trace-id":"5736943178450432258"}}0`
 	startTime := time.Now()
-	startExecutionSpan(startTime, testString)
+	startExecutionSpan(startTime, testString, LambdaInvokeEventHeaders{})
 
 	duration := 1 * time.Second
 	endTime := startTime.Add(duration)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Adds support for recieving lambda direct invocation trace context for trace propagation and merging, as a part of universal instrumentation

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Step towards universal instrumentation. Coupled with [this dotnet tracer PR](https://github.com/DataDog/dd-trace-dotnet/pull/2656), we will support trace propagation/merging when an instrumented python/node lambda directly invokes a dotnet lambda synchronously using the AWS SDK

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Tested manually using the lambda-extension-dotnet lambda stack within the cloud-integrations repo, including testing with void, one param, two param, and invalid three param dotnet lambdas. Also tested changes with the current dotnet tracer version that doesnt support this feature.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
