### PR TITLE
Fix telemetry to be monotonic counters

### DIFF
--- a/pkg/network/dns/snooper.go
+++ b/pkg/network/dns/snooper.go
@@ -221,17 +221,20 @@ func (s *socketFilterSnooper) logDNSStats() {
 	defer ticker.Stop()
 
 	var (
-		queries   int64
-		successes int64
-		errors    int64
+		queries, lastQueries     int64
+		successes, lastSuccesses int64
+		errors, lastErrors       int64
 	)
 	for {
 		select {
 		case <-ticker.C:
-			queries = atomic.SwapInt64(&s.queries, 0)
-			successes = atomic.SwapInt64(&s.successes, 0)
-			errors = atomic.SwapInt64(&s.errors, 0)
-			log.Infof("DNS Stats. Queries :%d, Successes :%d, Errors: %d", queries, successes, errors)
+			queries = atomic.LoadInt64(&s.queries)
+			successes = atomic.LoadInt64(&s.successes)
+			errors = atomic.LoadInt64(&s.errors)
+			log.Infof("DNS Stats. Queries :%d, Successes :%d, Errors: %d", queries-lastQueries, successes-lastSuccesses, errors-lastErrors)
+			lastQueries = queries
+			lastSuccesses = successes
+			lastErrors = errors
 		case <-s.exit:
 			return
 		}

--- a/pkg/network/tracer/connection/kprobe/tcp_close_consumer.go
+++ b/pkg/network/tracer/connection/kprobe/tcp_close_consumer.go
@@ -73,8 +73,8 @@ func (c *tcpCloseConsumer) FlushPending() {
 
 func (c *tcpCloseConsumer) GetStats() map[string]int64 {
 	return map[string]int64{
-		perfReceivedStat: atomic.SwapInt64(&c.perfReceived, 0),
-		perfLostStat:     atomic.SwapInt64(&c.perfLost, 0),
+		perfReceivedStat: atomic.LoadInt64(&c.perfReceived),
+		perfLostStat:     atomic.LoadInt64(&c.perfLost),
 	}
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Changes some telemetry that was being reset on unpredictable intervals to be monotonic counters

### Motivation

More reliable telemetry for network tracer

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
