### PR TITLE
[CWS] fix e2e tests

### DIFF
--- a/test/e2e/cws-tests/requirements.txt
+++ b/test/e2e/cws-tests/requirements.txt
@@ -1,5 +1,5 @@
 kubernetes==20.13.0
-datadog-api-client==1.8.0
+datadog-api-client==1.10.0
 pyaml==21.10.1
 docker==5.0.3
 retry==0.9.2

--- a/test/e2e/cws-tests/tests/lib/config.py
+++ b/test/e2e/cws-tests/tests/lib/config.py
@@ -11,7 +11,7 @@ def gen_system_probe_config(network_enabled=False, log_level="INFO", log_pattern
     data = {
         "system_probe_config": {"log_level": log_level},
         "network_config": {"enabled": network_enabled},
-        "runtime_security_config": {"log_patterns": log_patterns},
+        "runtime_security_config": {"log_patterns": log_patterns, "network": {"enabled": True}},
     }
     yaml.dump(data, fp)
     fp.close()

--- a/test/e2e/cws-tests/tests/lib/cws/app.py
+++ b/test/e2e/cws-tests/tests/lib/cws/app.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 import tempfile
 
@@ -29,7 +30,6 @@ from datadog_api_client.v2.models import (
     SecurityMonitoringSignalListRequestPage,
     SecurityMonitoringSignalsSort,
 )
-from dateutil.parser import parse as dateutil_parser
 from retry.api import retry_call
 
 
@@ -56,12 +56,15 @@ def get_app_log(api_client, query):
 
 
 def get_app_signal(api_client, query):
+    now = datetime.datetime.now(datetime.timezone.utc)
+    query_from = now - datetime.timedelta(minutes=15)
+
     api_instance = security_monitoring_api.SecurityMonitoringApi(api_client)
     body = SecurityMonitoringSignalListRequest(
         filter=SecurityMonitoringSignalListRequestFilter(
-            _from=dateutil_parser("2021-01-01T00:00:00.00Z"),
+            _from=query_from.isoformat(),
             query=query,
-            to=dateutil_parser("2050-01-01T00:00:00.00Z"),
+            to=now.isoformat(),
         ),
         page=SecurityMonitoringSignalListRequestPage(
             limit=25,

--- a/test/e2e/cws-tests/tests/lib/cws/app.py
+++ b/test/e2e/cws-tests/tests/lib/cws/app.py
@@ -183,10 +183,11 @@ class App:
     def wait_app_signal(self, query, tries=30, delay=10):
         return retry_call(get_app_signal, fargs=[self.api_client, query], tries=tries, delay=delay)
 
-    def check_for_ignored_policies(self, policies):
-        if "policies_ignored" in policies:
-            self.assertEqual(len(policies["policies_ignored"]), 0)
-        if "policies" in policies:
-            for policy in policies["policies"]:
-                if "rules_ignored" in policy:
-                    self.assertEqual(len(policy["rules_ignored"]), 0)
+
+def check_for_ignored_policies(test_case, policies):
+    if "policies_ignored" in policies:
+        test_case.assertEqual(len(policies["policies_ignored"]), 0)
+    if "policies" in policies:
+        for policy in policies["policies"]:
+            if "rules_ignored" in policy:
+                test_case.assertEqual(len(policy["rules_ignored"]), 0)

--- a/test/e2e/cws-tests/tests/test_e2e_cws_docker.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cws_docker.py
@@ -7,7 +7,7 @@ import warnings
 
 from lib.config import gen_datadog_agent_config, gen_system_probe_config
 from lib.const import SECURITY_START_LOG, SYS_PROBE_START_LOG
-from lib.cws.app import App
+from lib.cws.app import App, check_for_ignored_policies
 from lib.cws.policy import PolicyLoader
 from lib.docker import DockerHelper
 from lib.log import wait_agent_log
@@ -86,7 +86,7 @@ class TestE2EDocker(unittest.TestCase):
             event = self.App.wait_app_log("rule_id:ruleset_loaded")
             attributes = event["data"][-1]["attributes"]["attributes"]
             start_date = attributes["date"]
-            self.App.check_for_ignored_policies(attributes)
+            check_for_ignored_policies(self, attributes)
 
         with Step(msg="download policies", emoji=":file_folder:"):
             self.policies = self.docker_helper.download_policies().output.decode()
@@ -116,7 +116,7 @@ class TestE2EDocker(unittest.TestCase):
                 time.sleep(1)
             else:
                 self.fail("check ruleset_loaded timeouted")
-            self.App.check_for_ignored_policies(attributes)
+            check_for_ignored_policies(self, attributes)
 
         with Step(msg="wait for host tags (3m)", emoji=":alarm_clock:"):
             time.sleep(3 * 60)

--- a/test/e2e/cws-tests/tests/test_e2e_cws_kubernetes.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cws_kubernetes.py
@@ -9,7 +9,7 @@ import warnings
 
 import emoji
 from lib.const import SECURITY_START_LOG, SYS_PROBE_START_LOG
-from lib.cws.app import App
+from lib.cws.app import App, check_for_ignored_policies
 from lib.cws.policy import PolicyLoader
 from lib.kubernetes import KubernetesHelper
 from lib.log import wait_agent_log
@@ -79,7 +79,7 @@ class TestE2EKubernetes(unittest.TestCase):
             event = self.App.wait_app_log("rule_id:ruleset_loaded")
             attributes = event["data"][-1]["attributes"]["attributes"]
             start_date = attributes["date"]
-            self.App.check_for_ignored_policies(attributes)
+            check_for_ignored_policies(attributes)
 
         with Step(msg="wait for host tags (3m)", emoji=":alarm_clock:"):
             time.sleep(3 * 60)
@@ -112,7 +112,7 @@ class TestE2EKubernetes(unittest.TestCase):
                 time.sleep(1)
             else:
                 self.fail("check ruleset_loaded timeouted")
-            self.App.check_for_ignored_policies(attributes)
+            check_for_ignored_policies(attributes)
 
         with Step(msg="check agent event", emoji=":check_mark_button:"):
             os.system(f"touch {filename}")

--- a/test/e2e/cws-tests/tests/test_e2e_cws_kubernetes.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cws_kubernetes.py
@@ -79,7 +79,7 @@ class TestE2EKubernetes(unittest.TestCase):
             event = self.App.wait_app_log("rule_id:ruleset_loaded")
             attributes = event["data"][-1]["attributes"]["attributes"]
             start_date = attributes["date"]
-            check_for_ignored_policies(attributes)
+            check_for_ignored_policies(self, attributes)
 
         with Step(msg="wait for host tags (3m)", emoji=":alarm_clock:"):
             time.sleep(3 * 60)
@@ -112,7 +112,7 @@ class TestE2EKubernetes(unittest.TestCase):
                 time.sleep(1)
             else:
                 self.fail("check ruleset_loaded timeouted")
-            check_for_ignored_policies(attributes)
+            check_for_ignored_policies(self, attributes)
 
         with Step(msg="check agent event", emoji=":check_mark_button:"):
             os.system(f"touch {filename}")


### PR DESCRIPTION
### What does this PR do?

This PR fixes some issues with CWS e2e tests:
- bump of `datadog-api-client`
- enable cws network config (so that no rule in the default rule is marked as disabled)
- fix `check_for_ignored_policies` (when a rule was disabled, the assert was failing because `assert*` are not member functions of `App` but of the test_case itself

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
