### PR TITLE
[CWS] add functional test for exec through /proc/self/exe

### DIFF
--- a/pkg/security/tests/syscall_tester/c/syscall_tester.c
+++ b/pkg/security/tests/syscall_tester/c/syscall_tester.c
@@ -179,7 +179,7 @@ int test_signal_eperm(void) {
     return EXIT_SUCCESS;
 }
 
-int test_signal(int argc, char** argv) {
+int test_signal(int argc, char **argv) {
     if (argc != 2) {
         fprintf(stderr, "%s: Please pass a test case in: sigusr, eperm.\n", __FUNCTION__);
         return EXIT_FAILURE;
@@ -194,17 +194,17 @@ int test_signal(int argc, char** argv) {
 }
 
 int test_splice() {
-	const int fd = open("/tmp/splice_test", O_RDONLY | O_CREAT, 0700);
-	if (fd < 0) {
-		fprintf(stderr, "open failed");
-		return EXIT_FAILURE;
-	}
+    const int fd = open("/tmp/splice_test", O_RDONLY | O_CREAT, 0700);
+    if (fd < 0) {
+        fprintf(stderr, "open failed");
+        return EXIT_FAILURE;
+    }
 
-	int p[2];
-	if (pipe(p)) {
+    int p[2];
+    if (pipe(p)) {
         fprintf(stderr, "pipe failed");
         return EXIT_FAILURE;
-	}
+    }
 
     loff_t offset = 1;
     splice(fd, 0, p[1], NULL, 1, 0);
@@ -215,7 +215,7 @@ int test_splice() {
     return EXIT_SUCCESS;
 }
 
-int test_mkdirat_error(int argc, char** argv) {
+int test_mkdirat_error(int argc, char **argv) {
     if (argc != 2) {
         fprintf(stderr, "%s: Please pass a path to mkdirat.\n", __FUNCTION__);
         return EXIT_FAILURE;
@@ -280,6 +280,17 @@ int test_process_set(int argc, char **argv) {
     return EXIT_SUCCESS;
 }
 
+int self_exec(int argc, char **argv) {
+    if (argc < 2) {
+        fprintf(stderr, "Please pass a command name\n");
+        return EXIT_FAILURE;
+    }
+
+    execv("/proc/self/exe", argv + 1);
+
+    return EXIT_SUCCESS;
+}
+
 int main(int argc, char **argv) {
     if (argc <= 1) {
         fprintf(stderr, "Please pass a command\n");
@@ -304,6 +315,8 @@ int main(int argc, char **argv) {
         return test_mkdirat_error(argc - 1, argv + 1);
     } else if (strcmp(cmd, "process-credentials") == 0) {
         return test_process_set(argc - 1, argv + 1);
+    } else if (strcmp(cmd, "self-exec") == 0) {
+        return self_exec(argc - 1, argv + 1);
     } else {
         fprintf(stderr, "Unknown command `%s`\n", cmd);
         return EXIT_FAILURE;


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
