### PR TITLE
Fix panic in Docker network check if generic part fails

### DIFF
--- a/pkg/collector/corechecks/containers/docker/check_linux_test.go
+++ b/pkg/collector/corechecks/containers/docker/check_linux_test.go
@@ -286,3 +286,23 @@ func TestDockerNetworkExtension(t *testing.T) {
 	mockSender.AssertMetric(t, "Rate", "docker.net.bytes_rcvd", 7, "", []string{"foo:bar", "docker_network:bridge"})
 	mockSender.AssertMetric(t, "Rate", "docker.net.bytes_sent", 7, "", []string{"foo:bar", "docker_network:bridge"})
 }
+
+func TestNetworkCustomOnFailure(t *testing.T) {
+	// Make sure we don't panic if generic part fails
+	networkExt := dockerNetworkExtension{procPath: "/proc"}
+
+	networkExt.preRun()
+	networkExt.processContainer(dockerTypes.Container{
+		ID:      "e2d5394a5321d4a59497f53552a0131b2aafe64faba37f4738e78c531289fc45",
+		Names:   []string{"agent"},
+		Image:   "datadog/agent",
+		ImageID: "sha256:7e813d42985b2e5a0269f868aaf238ffc952a877fba964f55aa1ff35fd0bf5f6",
+		Labels: map[string]string{
+			"io.kubernetes.pod.namespace": "kubens",
+		},
+		State:      containers.ContainerRunningState,
+		SizeRw:     100,
+		SizeRootFs: 200,
+	})
+	networkExt.postRun()
+}

--- a/pkg/collector/corechecks/containers/docker/check_network.go
+++ b/pkg/collector/corechecks/containers/docker/check_network.go
@@ -115,6 +115,12 @@ func (dn *dockerNetworkExtension) preRun() {
 }
 
 func (dn *dockerNetworkExtension) processContainer(rawContainer dockerTypes.Container) {
+	// If containerNetworkEntries is nil, it means the generic check was not able to run properly.
+	// It's then useless to run.
+	if dn.containerNetworkEntries == nil {
+		return
+	}
+
 	// We keep excluded containers because pause containers are required as they usually hold
 	// the network configuration for other containers.
 	// However stopped containers are not useful there.
@@ -134,6 +140,12 @@ func (dn *dockerNetworkExtension) processContainer(rawContainer dockerTypes.Cont
 }
 
 func (dn *dockerNetworkExtension) postRun() {
+	// If containerNetworkEntries is nil, it means the generic check was not able to run properly.
+	// It's then useless to run.
+	if dn.containerNetworkEntries == nil {
+		return
+	}
+
 	for _, containerEntry := range dn.containerNetworkEntries {
 		// This is expected as we store excluded containers (like pause containers), created when processing `rawContainer`.
 		// If there was a real failure when gathering NetworkStats, a debug is emitted in `Process()`

--- a/releasenotes/notes/fix-docker-network-panic-5d574a731306232f.yaml
+++ b/releasenotes/notes/fix-docker-network-panic-5d574a731306232f.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix a panic in the Docker check when a failure happens early (when listing containers)


### PR DESCRIPTION
### What does this PR do?

Fix a panic in the Docker check when a failure happens early (when listing containers).

### Motivation

Bufix.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

We don't have a defined scenario to reproduce this bug, so QA is skipped.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
