### PR TITLE
Fix unscheduling of template configs.

### DIFF
--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -465,6 +465,8 @@ func decryptConfig(conf integration.Config) (integration.Config, error) {
 	return conf, nil
 }
 
+// processRemovedConfigs unschedules configs that have previously been loaded,
+// including removing them from the loadeConfigs map.
 func (ac *AutoConfig) processRemovedConfigs(configs []integration.Config) {
 	ac.unschedule(configs)
 	for _, c := range configs {

--- a/pkg/autodiscovery/config_poller.go
+++ b/pkg/autodiscovery/config_poller.go
@@ -101,11 +101,23 @@ func (pd *configPoller) poll(ac *AutoConfig) {
 			} else {
 				log.Debugf("%v provider: no configuration change", pd.provider)
 			}
+
+			// divide removals into templates and non-templates
+			removedTemplateConfigs := []integration.Config{}
+			removedNonTemplateConfigs := []integration.Config{}
+			for _, cfg := range removedConfigs {
+				if cfg.IsTemplate() {
+					removedTemplateConfigs = append(removedTemplateConfigs, cfg)
+				} else {
+					removedNonTemplateConfigs = append(removedNonTemplateConfigs, cfg)
+				}
+			}
+
 			// Process removed configs first to handle the case where a
 			// container churn would result in the same configuration hash.
-			ac.processRemovedConfigs(removedConfigs)
-			// We can also remove any cached template
-			ac.removeConfigTemplates(removedConfigs)
+			ac.processRemovedConfigs(removedNonTemplateConfigs)
+			// We can also remove any cached templates
+			ac.removeConfigTemplates(removedTemplateConfigs)
 
 			for _, config := range newConfigs {
 				config.Provider = pd.provider.String()


### PR DESCRIPTION
### What does this PR do?

Fixes what I believe to be a bug in AD where Unschedule calls would be made for configs for which no corresponding Schedule call had been made, and which had unresolved template parameters.

### Motivation

Before this change, template configs (configs for which cfg.IsTemplate()
is true) were passed to processRemovedConfigs, which expects only
resolved configs or non-template configs, causing those template configs
to be unscheduled, despite never having been scheduled.

### Possible Drawbacks / Trade-offs

Something may depend on this "buggy" behavior.

### Describe how to test/QA your changes

Use a [template parameter](https://docs.datadoghq.com/agent/guide/template_variables/#pagetitle) in a config included in a container annotation.  Create and then destroy the container, and see that the configuration is added and removed correctly.  For example:

```
docker run -ti --rm --label com.datadoghq.ad.logs='[{"source": "%%host%%"}]' bash
```

and watch the log source be added (see `agent stream-logs` to see the source set to %%host%%) and removed (see `agent status`)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
