### PR TITLE
[ClusterChecks] Do not unschedule checks during DCA outages

### DIFF
--- a/pkg/autodiscovery/providers/common.go
+++ b/pkg/autodiscovery/providers/common.go
@@ -1,0 +1,21 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package providers
+
+import "time"
+
+const (
+	defaultDegradedDeadline = 0 // no deadline for degraded mode
+)
+
+func withinDegradedModePeriod(lastHeartbeat time.Time, degradedDuration time.Duration) bool {
+	if degradedDuration == 0 {
+		// infinite degraded period
+		return true
+	}
+
+	return lastHeartbeat.Add(degradedDuration).After(time.Now())
+}

--- a/pkg/autodiscovery/providers/endpointschecks.go
+++ b/pkg/autodiscovery/providers/endpointschecks.go
@@ -11,10 +11,12 @@ package providers
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers/names"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/errors"
 	"github.com/DataDog/datadog-agent/pkg/util/clusteragent"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -23,16 +25,25 @@ import (
 // EndpointsChecksConfigProvider implements the ConfigProvider interface
 // for the endpoints check feature.
 type EndpointsChecksConfigProvider struct {
-	dcaClient      clusteragent.DCAClientInterface
-	nodeName       string
-	flushedConfigs bool
+	dcaClient        clusteragent.DCAClientInterface
+	degradedDuration time.Duration
+	heartbeat        time.Time
+	nodeName         string
+	flushedConfigs   bool
 }
 
 // NewEndpointsChecksConfigProvider returns a new ConfigProvider collecting
 // endpoints check configurations from the cluster-agent.
 // Connectivity is not checked at this stage to allow for retries, Collect will do it.
-func NewEndpointsChecksConfigProvider(*config.ConfigurationProviders) (ConfigProvider, error) {
-	c := &EndpointsChecksConfigProvider{}
+func NewEndpointsChecksConfigProvider(providerConfig *config.ConfigurationProviders) (ConfigProvider, error) {
+	c := &EndpointsChecksConfigProvider{
+		degradedDuration: defaultDegradedDeadline,
+	}
+
+	if providerConfig.DegradedDeadlineMinutes > 0 {
+		c.degradedDuration = time.Duration(providerConfig.DegradedDeadlineMinutes) * time.Minute
+	}
+
 	var err error
 	c.nodeName, err = getNodename(context.TODO())
 	if err != nil {
@@ -56,6 +67,10 @@ func (c *EndpointsChecksConfigProvider) IsUpToDate(ctx context.Context) (bool, e
 	return false, nil
 }
 
+func (c *EndpointsChecksConfigProvider) withinDegradedModePeriod() bool {
+	return withinDegradedModePeriod(c.heartbeat, c.degradedDuration)
+}
+
 // Collect retrieves endpoints checks configurations the cluster-agent dispatched to this agent
 func (c *EndpointsChecksConfigProvider) Collect(ctx context.Context) ([]integration.Config, error) {
 	if c.dcaClient == nil {
@@ -66,15 +81,27 @@ func (c *EndpointsChecksConfigProvider) Collect(ctx context.Context) ([]integrat
 	}
 	reply, err := c.dcaClient.GetEndpointsCheckConfigs(ctx, c.nodeName)
 	if err != nil {
+		if (errors.IsRemoteService(err) || errors.IsTimeout(err)) && c.withinDegradedModePeriod() {
+			// Degraded mode: return true to keep the configs scheduled
+			// during a Cluster Agent / network outage
+			return nil, err
+		}
+
 		if !c.flushedConfigs {
 			// On first error after grace period, mask the error once
 			// to delete the configurations and de-schedule the checks
+			// Returning nil, nil here unschedules the checks when the
+			// the degraded mode deadline is exceeded.
 			c.flushedConfigs = true
 			return nil, nil
 		}
+
 		return nil, err
 	}
+
 	c.flushedConfigs = false
+	c.heartbeat = time.Now()
+
 	return reply.Configs, nil
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -125,19 +125,20 @@ type MetadataProviders struct {
 
 // ConfigurationProviders helps unmarshalling `config_providers` config param
 type ConfigurationProviders struct {
-	Name             string `mapstructure:"name"`
-	Polling          bool   `mapstructure:"polling"`
-	PollInterval     string `mapstructure:"poll_interval"`
-	TemplateURL      string `mapstructure:"template_url"`
-	TemplateDir      string `mapstructure:"template_dir"`
-	Username         string `mapstructure:"username"`
-	Password         string `mapstructure:"password"`
-	CAFile           string `mapstructure:"ca_file"`
-	CAPath           string `mapstructure:"ca_path"`
-	CertFile         string `mapstructure:"cert_file"`
-	KeyFile          string `mapstructure:"key_file"`
-	Token            string `mapstructure:"token"`
-	GraceTimeSeconds int    `mapstructure:"grace_time_seconds"`
+	Name                    string `mapstructure:"name"`
+	Polling                 bool   `mapstructure:"polling"`
+	PollInterval            string `mapstructure:"poll_interval"`
+	TemplateURL             string `mapstructure:"template_url"`
+	TemplateDir             string `mapstructure:"template_dir"`
+	Username                string `mapstructure:"username"`
+	Password                string `mapstructure:"password"`
+	CAFile                  string `mapstructure:"ca_file"`
+	CAPath                  string `mapstructure:"ca_path"`
+	CertFile                string `mapstructure:"cert_file"`
+	KeyFile                 string `mapstructure:"key_file"`
+	Token                   string `mapstructure:"token"`
+	GraceTimeSeconds        int    `mapstructure:"grace_time_seconds"`
+	DegradedDeadlineMinutes int    `mapstructure:"degraded_deadline_minutes"`
 }
 
 // Listeners helps unmarshalling `listeners` config param

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -15,6 +15,8 @@ const (
 	partialError
 	unknownError
 	disabledError
+	remoteServiceError
+	timeoutError
 )
 
 // AgentError is an error intended for consumption by a datadog pkg; it can also be
@@ -80,6 +82,34 @@ func NewDisabled(component, reason string) *AgentError {
 // IsDisabled returns true if the specified error was created by NewDisabled.
 func IsDisabled(err error) bool {
 	return reasonForError(err) == disabledError
+}
+
+// NewRemoteServiceError returns a new error which indicates that a remote service
+// queried by the Agent is unavailable (e.g the Datadog Cluster Agent returning 500s).
+// The status string can provide additional context (e.g a http response status "500 Internal Server Error").
+func NewRemoteServiceError(target, status string) *AgentError {
+	return &AgentError{
+		message:     fmt.Sprintf("%q is unavailable: %s", target, status),
+		errorReason: remoteServiceError,
+	}
+}
+
+// IsRemoteService returns true if the specified error was created by NewRemoteServiceError.
+func IsRemoteService(err error) bool {
+	return reasonForError(err) == remoteServiceError
+}
+
+// NewTimeoutError returns a new error which was caused by a timeout.
+func NewTimeoutError(target string, err error) *AgentError {
+	return &AgentError{
+		message:     fmt.Sprintf("timeout calling %q: %v", target, err),
+		errorReason: timeoutError,
+	}
+}
+
+// IsTimeout returns true if the specified error was created by NewTimeoutError.
+func IsTimeout(err error) bool {
+	return reasonForError(err) == timeoutError
 }
 
 func reasonForError(err error) errorReason {

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -37,3 +37,27 @@ func TestRetriable(t *testing.T) {
 	require.False(t, IsRetriable(fmt.Errorf("fake")))
 	require.False(t, IsRetriable(fmt.Errorf(`couldn't fetch "foo": bar`)))
 }
+
+func TestRemoteService(t *testing.T) {
+	// New
+	err := NewRemoteServiceError("datadog cluster agent", "500 Internal Server Error")
+	require.Error(t, err)
+	require.Equal(t, `"datadog cluster agent" is unavailable: 500 Internal Server Error`, err.Error())
+
+	// Is
+	require.True(t, IsRemoteService(err))
+	require.False(t, IsRemoteService(errors.New("fake")))
+	require.False(t, IsRemoteService(errors.New(`"datadog cluster agent" is unavailable: 500 Internal Server Error`)))
+}
+
+func TestTimeout(t *testing.T) {
+	// New
+	err := NewTimeoutError("datadog cluster agent", errors.New("context deadline exceeded"))
+	require.Error(t, err)
+	require.Equal(t, `timeout calling "datadog cluster agent": context deadline exceeded`, err.Error())
+
+	// Is
+	require.True(t, IsTimeout(err))
+	require.False(t, IsTimeout(errors.New("fake")))
+	require.False(t, IsTimeout(errors.New(`timeout calling "datadog cluster agent": context deadline exceeded`)))
+}

--- a/pkg/util/clusteragent/clusterchecks.go
+++ b/pkg/util/clusteragent/clusterchecks.go
@@ -9,8 +9,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
@@ -53,21 +51,13 @@ func (c *DCAClient) doPostClusterCheckStatus(ctx context.Context, identifier str
 	}
 	req.Header = c.clusterAgentAPIRequestHeaders
 
-	resp, err := c.leaderClient.Do(req)
+	content, err := c.doLeaderRequest(req)
 	if err != nil {
 		return response, err
 	}
-	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		return response, fmt.Errorf("unexpected response: %d - %s", resp.StatusCode, resp.Status)
-	}
+	err = json.Unmarshal(content, &response)
 
-	b, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return response, err
-	}
-	err = json.Unmarshal(b, &response)
 	return response, err
 }
 
@@ -97,20 +87,12 @@ func (c *DCAClient) doGetClusterCheckConfigs(ctx context.Context, identifier str
 	}
 	req.Header = c.clusterAgentAPIRequestHeaders
 
-	resp, err := c.leaderClient.Do(req)
+	content, err := c.doLeaderRequest(req)
 	if err != nil {
 		return configs, err
 	}
-	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		return configs, fmt.Errorf("unexpected response: %d - %s", resp.StatusCode, resp.Status)
-	}
+	err = json.Unmarshal(content, &configs)
 
-	b, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return configs, err
-	}
-	err = json.Unmarshal(b, &configs)
 	return configs, err
 }

--- a/pkg/util/clusteragent/endpointschecks.go
+++ b/pkg/util/clusteragent/endpointschecks.go
@@ -8,8 +8,6 @@ package clusteragent
 import (
 	"context"
 	"encoding/json"
-	"fmt"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
@@ -47,20 +45,12 @@ func (c *DCAClient) doGetEndpointsCheckConfigs(ctx context.Context, nodeName str
 	}
 	req.Header = c.clusterAgentAPIRequestHeaders
 
-	resp, err := c.leaderClient.Do(req)
+	content, err := c.doLeaderRequest(req)
 	if err != nil {
 		return configs, err
 	}
-	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		return configs, fmt.Errorf("unexpected response: %d - %s", resp.StatusCode, resp.Status)
-	}
+	err = json.Unmarshal(content, &configs)
 
-	b, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return configs, err
-	}
-	err = json.Unmarshal(b, &configs)
 	return configs, err
 }

--- a/releasenotes/notes/clc-degraded-8f4e64c2eb84f1b7.yaml
+++ b/releasenotes/notes/clc-degraded-8f4e64c2eb84f1b7.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   - |
-    The Agent does not unschedule cluster and endpoint checks when the Cluster Agent is unavailable.
+    The Agent maintains scheduled cluster and endpoint checks when the Cluster Agent is unavailable.

--- a/releasenotes/notes/clc-degraded-8f4e64c2eb84f1b7.yaml
+++ b/releasenotes/notes/clc-degraded-8f4e64c2eb84f1b7.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    The Agent does not unschedule cluster and endpoint checks when the Cluster Agent is unavailable.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Make the cluster and endpoint checks resilient to network failures and DCA outages 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Resiliency: Keep running in a degraded mode by keep running _potentially outdated_ check configs (avoid no data)

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Schedule endpoint and cluster checks, scale the DCA deploy to 0 or make it return a 500. Make sure the endpoint and cluster checks don't get unscheduled by the node agents / cluster check runners

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
