### PR TITLE
[system-probe] limit http header false positive detections

### DIFF
--- a/pkg/network/ebpf/c/http.h
+++ b/pkg/network/ebpf/c/http.h
@@ -146,25 +146,25 @@ static __always_inline int http_begin_response(http_transaction_t *http, const c
 static __always_inline void http_parse_data(char *p, http_packet_t *packet_type, http_method_t *method) {
     if ((p[0] == 'H') && (p[1] == 'T') && (p[2] == 'T') && (p[3] == 'P')) {
         *packet_type = HTTP_RESPONSE;
-    } else if ((p[0] == 'G') && (p[1] == 'E') && (p[2] == 'T')) {
+    } else if ((p[0] == 'G') && (p[1] == 'E') && (p[2] == 'T') && (p[3]  == ' ') && (p[4] == '/')) {
         *packet_type = HTTP_REQUEST;
         *method = HTTP_GET;
-    } else if ((p[0] == 'P') && (p[1] == 'O') && (p[2] == 'S') && (p[3] == 'T')) {
+    } else if ((p[0] == 'P') && (p[1] == 'O') && (p[2] == 'S') && (p[3] == 'T') && (p[4]  == ' ') && (p[5] == '/')) {
         *packet_type = HTTP_REQUEST;
         *method = HTTP_POST;
-    } else if ((p[0] == 'P') && (p[1] == 'U') && (p[2] == 'T')) {
+    } else if ((p[0] == 'P') && (p[1] == 'U') && (p[2] == 'T') && (p[3]  == ' ') && (p[4] == '/')) {
         *packet_type = HTTP_REQUEST;
         *method = HTTP_PUT;
-    } else if ((p[0] == 'D') && (p[1] == 'E') && (p[2] == 'L') && (p[3] == 'E') && (p[4] == 'T') && (p[5] == 'E')) {
+    } else if ((p[0] == 'D') && (p[1] == 'E') && (p[2] == 'L') && (p[3] == 'E') && (p[4] == 'T') && (p[5] == 'E') && (p[6]  == ' ') && (p[7] == '/')) {
         *packet_type = HTTP_REQUEST;
         *method = HTTP_DELETE;
-    } else if ((p[0] == 'H') && (p[1] == 'E') && (p[2] == 'A') && (p[3] == 'D')) {
+    } else if ((p[0] == 'H') && (p[1] == 'E') && (p[2] == 'A') && (p[3] == 'D') && (p[4]  == ' ') && (p[5] == '/')) {
         *packet_type = HTTP_REQUEST;
         *method = HTTP_HEAD;
-    } else if ((p[0] == 'O') && (p[1] == 'P') && (p[2] == 'T') && (p[3] == 'I') && (p[4] == 'O') && (p[5] == 'N') && (p[6] == 'S')) {
+    } else if ((p[0] == 'O') && (p[1] == 'P') && (p[2] == 'T') && (p[3] == 'I') && (p[4] == 'O') && (p[5] == 'N') && (p[6] == 'S') && (p[7]  == ' ') && ((p[8] == '/') || (p[8] == '*'))) {
         *packet_type = HTTP_REQUEST;
         *method = HTTP_OPTIONS;
-    } else if ((p[0] == 'P') && (p[1] == 'A') && (p[2] == 'T') && (p[3] == 'C') && (p[4] == 'H')) {
+    } else if ((p[0] == 'P') && (p[1] == 'A') && (p[2] == 'T') && (p[3] == 'C') && (p[4] == 'H') && (p[5]  == ' ') && (p[6] == '/')) {
         *packet_type = HTTP_REQUEST;
         *method = HTTP_PATCH;
     }

--- a/pkg/network/http/http_statkeeper.go
+++ b/pkg/network/http/http_statkeeper.go
@@ -65,6 +65,11 @@ func (h *httpStatKeeper) GetAndResetAllStats() map[Key]RequestStats {
 }
 
 func (h *httpStatKeeper) add(tx httpTX) {
+	if !tx.IsValid() {
+		atomic.AddInt64(&h.telemetry.rejected, 1)
+		return
+	}
+
 	path, rejected := h.processHTTPPath(tx)
 	if rejected {
 		atomic.AddInt64(&h.telemetry.rejected, 1)

--- a/pkg/network/http/http_statkeeper.go
+++ b/pkg/network/http/http_statkeeper.go
@@ -65,12 +65,12 @@ func (h *httpStatKeeper) GetAndResetAllStats() map[Key]RequestStats {
 }
 
 func (h *httpStatKeeper) add(tx httpTX) {
-	if !tx.IsValid() {
-		atomic.AddInt64(&h.telemetry.rejected, 1)
+	rawPath := tx.Path(h.buffer)
+	if rawPath == nil {
+		atomic.AddInt64(&h.telemetry.malformed, 1)
 		return
 	}
-
-	path, rejected := h.processHTTPPath(tx)
+	path, rejected := h.processHTTPPath(rawPath)
 	if rejected {
 		atomic.AddInt64(&h.telemetry.rejected, 1)
 		return
@@ -144,9 +144,7 @@ func (h *httpStatKeeper) newKey(tx httpTX, path string) Key {
 	}
 }
 
-func (h *httpStatKeeper) processHTTPPath(tx httpTX) (pathStr string, rejected bool) {
-	path := tx.Path(h.buffer)
-
+func (h *httpStatKeeper) processHTTPPath(path []byte) (pathStr string, rejected bool) {
 	for _, r := range h.replaceRules {
 		if r.Re.Match(path) {
 			if r.Repl == "" {

--- a/pkg/network/http/model.go
+++ b/pkg/network/http/model.go
@@ -23,20 +23,6 @@ const (
 	HTTPBufferSize = int(C.HTTP_BUFFER_SIZE)
 )
 
-var (
-	HTTPVerbs = map[string]struct{}{
-		"OPTIONS": {},
-		"GET":     {},
-		"HEAD":    {},
-		"POST":    {},
-		"PUT":     {},
-		"PATCH":   {},
-		"DELETE":  {},
-		"TRACE":   {},
-		"CONNECT": {},
-	}
-)
-
 type httpTX C.http_transaction_t
 type httpNotification C.http_batch_notification_t
 type httpBatch C.http_batch_t
@@ -52,7 +38,11 @@ func (k *httpBatchKey) Prepare(n httpNotification) {
 	k.page_num = C.uint(int(n.batch_idx) % HTTPBatchPages)
 }
 
-func (tx *httpTX) validateFragment(validateHTTPVerb bool, outPath []byte) (bool, []byte) {
+// Path returns the URL from the request fragment captured in eBPF with
+// GET variables excluded.
+// Example:
+// For a request fragment "GET /foo?var=bar HTTP/1.1", this method will return "/foo"
+func (tx *httpTX) Path(buffer []byte) []byte {
 	b := *(*[HTTPBufferSize]byte)(unsafe.Pointer(&tx.request_fragment))
 
 	// b might contain a null terminator in the middle
@@ -62,47 +52,18 @@ func (tx *httpTX) validateFragment(validateHTTPVerb bool, outPath []byte) (bool,
 	for i = 0; i < bLen && b[i] != ' '; i++ {
 	}
 
-	if validateHTTPVerb {
-		if _, ok := HTTPVerbs[string(b[:i])]; !ok {
-			return false, nil
-		}
-	}
-
 	i++
 
 	if i >= bLen || (b[i] != '/' && b[i] != '*') {
-		return false, nil
+		return nil
 	}
 
-	if outPath != nil {
-		var j int
-		for j = i; j < bLen && b[j] != ' ' && b[j] != '?'; j++ {
-		}
-
-		// no bound check necessary here as we know we at least have '/' character
-		n := copy(outPath, b[i:j])
-		return true, outPath[:n]
+	for j = i; j < bLen && b[j] != ' ' && b[j] != '?'; j++ {
 	}
 
-	return true, nil
-}
-
-// Path returns the URL from the request fragment captured in eBPF with
-// GET variables excluded. The transaction must be validated with `IsValid`
-// before making this call.
-// Example:
-// For a request fragment "GET /foo?var=bar HTTP/1.1", this method will return "/foo"
-func (tx *httpTX) Path(buffer []byte) []byte {
-	if ok, match := tx.validateFragment(false, buffer); ok {
-		return match
-	}
-	return nil
-}
-
-// IsValid returns true if the transaction looks like a valid transaction
-func (tx *httpTX) IsValid() bool {
-	ok, _ := tx.validateFragment(true, nil)
-	return ok
+	// no bound check necessary here as we know we at least have '/' character
+	n := copy(buffer, b[i:j])
+	return buffer[:n]
 }
 
 // StatusClass returns an integer representing the status code class

--- a/pkg/network/http/model.go
+++ b/pkg/network/http/model.go
@@ -23,6 +23,20 @@ const (
 	HTTPBufferSize = int(C.HTTP_BUFFER_SIZE)
 )
 
+var (
+	HTTPVerbs = map[string]struct{}{
+		"OPTIONS": {},
+		"GET":     {},
+		"HEAD":    {},
+		"POST":    {},
+		"PUT":     {},
+		"PATCH":   {},
+		"DELETE":  {},
+		"TRACE":   {},
+		"CONNECT": {},
+	}
+)
+
 type httpTX C.http_transaction_t
 type httpNotification C.http_batch_notification_t
 type httpBatch C.http_batch_t
@@ -38,11 +52,7 @@ func (k *httpBatchKey) Prepare(n httpNotification) {
 	k.page_num = C.uint(int(n.batch_idx) % HTTPBatchPages)
 }
 
-// Path returns the URL from the request fragment captured in eBPF with
-// GET variables excluded.
-// Example:
-// For a request fragment "GET /foo?var=bar HTTP/1.1", this method will return "/foo"
-func (tx *httpTX) Path(buffer []byte) []byte {
+func (tx *httpTX) validateFragment(validateHTTPVerb bool, outPath []byte) (bool, []byte) {
 	b := *(*[HTTPBufferSize]byte)(unsafe.Pointer(&tx.request_fragment))
 
 	// b might contain a null terminator in the middle
@@ -52,17 +62,47 @@ func (tx *httpTX) Path(buffer []byte) []byte {
 	for i = 0; i < bLen && b[i] != ' '; i++ {
 	}
 
+	if validateHTTPVerb {
+		if _, ok := HTTPVerbs[string(b[:i])]; !ok {
+			return false, nil
+		}
+	}
+
 	i++
 
-	for j = i; j < bLen && b[j] != ' ' && b[j] != '?'; j++ {
+	if i >= bLen || (b[i] != '/' && b[i] != '*') {
+		return false, nil
 	}
 
-	if i < j && j <= bLen {
-		n := copy(buffer, b[i:j])
-		return buffer[:n]
+	if outPath != nil {
+		var j int
+		for j = i; j < bLen && b[j] != ' ' && b[j] != '?'; j++ {
+		}
+
+		// no bound check necessary here as we know we at least have '/' character
+		n := copy(outPath, b[i:j])
+		return true, outPath[:n]
 	}
 
+	return true, nil
+}
+
+// Path returns the URL from the request fragment captured in eBPF with
+// GET variables excluded. The transaction must be validated with `IsValid`
+// before making this call.
+// Example:
+// For a request fragment "GET /foo?var=bar HTTP/1.1", this method will return "/foo"
+func (tx *httpTX) Path(buffer []byte) []byte {
+	if ok, match := tx.validateFragment(false, buffer); ok {
+		return match
+	}
 	return nil
+}
+
+// IsValid returns true if the transaction looks like a valid transaction
+func (tx *httpTX) IsValid() bool {
+	ok, _ := tx.validateFragment(true, nil)
+	return ok
 }
 
 // StatusClass returns an integer representing the status code class

--- a/pkg/network/http/model_test.go
+++ b/pkg/network/http/model_test.go
@@ -41,48 +41,6 @@ func TestPathHandlesNullTerminator(t *testing.T) {
 	assert.Equal(t, "/foo/", string(tx.Path(b)))
 }
 
-func TestIsValid(t *testing.T) {
-	t.Run("valid", func(t *testing.T) {
-		tx := httpTX{
-			request_fragment: requestFragment(
-				[]byte("GET /foo/bar?var1=value HTTP/1.1\nHost: example.com\nUser-Agent: example-browser/1.0"),
-			),
-		}
-
-		assert.True(t, tx.IsValid())
-	})
-
-	t.Run("no leading slash", func(t *testing.T) {
-		tx := httpTX{
-			request_fragment: requestFragment(
-				[]byte("GET foo/bar?var1=value HTTP/1.1\nHost: example.com\nUser-Agent: example-browser/1.0"),
-			),
-		}
-
-		assert.False(t, tx.IsValid())
-	})
-
-	t.Run("not existing verb", func(t *testing.T) {
-		tx := httpTX{
-			request_fragment: requestFragment(
-				[]byte("WRONG_VERB foo/bar?var1=value HTTP/1.1\nHost: example.com\nUser-Agent: example-browser/1.0"),
-			),
-		}
-
-		assert.False(t, tx.IsValid())
-	})
-
-	t.Run("verb too short", func(t *testing.T) {
-		tx := httpTX{
-			request_fragment: requestFragment(
-				[]byte("OPTIO foo/bar?var1=value HTTP/1.1\nHost: example.com\nUser-Agent: example-browser/1.0"),
-			),
-		}
-
-		assert.False(t, tx.IsValid())
-	})
-}
-
 func TestLatency(t *testing.T) {
 	tx := httpTX{
 		response_last_seen: 2e6,
@@ -106,20 +64,6 @@ func BenchmarkPath(b *testing.B) {
 		_ = tx.Path(buf)
 	}
 	runtime.KeepAlive(buf)
-}
-
-func BenchmarkIsValid(b *testing.B) {
-	tx := httpTX{
-		request_fragment: requestFragment(
-			[]byte("GET /foo/bar?var1=value HTTP/1.1\nHost: example.com\nUser-Agent: example-browser/1.0"),
-		),
-	}
-
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_ = tx.IsValid()
-	}
 }
 
 func requestFragment(fragment []byte) [HTTPBufferSize]_Ctype_char {

--- a/pkg/network/http/model_test.go
+++ b/pkg/network/http/model_test.go
@@ -41,6 +41,48 @@ func TestPathHandlesNullTerminator(t *testing.T) {
 	assert.Equal(t, "/foo/", string(tx.Path(b)))
 }
 
+func TestIsValid(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		tx := httpTX{
+			request_fragment: requestFragment(
+				[]byte("GET /foo/bar?var1=value HTTP/1.1\nHost: example.com\nUser-Agent: example-browser/1.0"),
+			),
+		}
+
+		assert.True(t, tx.IsValid())
+	})
+
+	t.Run("no leading slash", func(t *testing.T) {
+		tx := httpTX{
+			request_fragment: requestFragment(
+				[]byte("GET foo/bar?var1=value HTTP/1.1\nHost: example.com\nUser-Agent: example-browser/1.0"),
+			),
+		}
+
+		assert.False(t, tx.IsValid())
+	})
+
+	t.Run("not existing verb", func(t *testing.T) {
+		tx := httpTX{
+			request_fragment: requestFragment(
+				[]byte("WRONG_VERB foo/bar?var1=value HTTP/1.1\nHost: example.com\nUser-Agent: example-browser/1.0"),
+			),
+		}
+
+		assert.False(t, tx.IsValid())
+	})
+
+	t.Run("verb too short", func(t *testing.T) {
+		tx := httpTX{
+			request_fragment: requestFragment(
+				[]byte("OPTIO foo/bar?var1=value HTTP/1.1\nHost: example.com\nUser-Agent: example-browser/1.0"),
+			),
+		}
+
+		assert.False(t, tx.IsValid())
+	})
+}
+
 func TestLatency(t *testing.T) {
 	tx := httpTX{
 		response_last_seen: 2e6,
@@ -64,6 +106,20 @@ func BenchmarkPath(b *testing.B) {
 		_ = tx.Path(buf)
 	}
 	runtime.KeepAlive(buf)
+}
+
+func BenchmarkIsValid(b *testing.B) {
+	tx := httpTX{
+		request_fragment: requestFragment(
+			[]byte("GET /foo/bar?var1=value HTTP/1.1\nHost: example.com\nUser-Agent: example-browser/1.0"),
+		),
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = tx.IsValid()
+	}
 }
 
 func requestFragment(fragment []byte) [HTTPBufferSize]_Ctype_char {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Limits the possibility of having false positive http header detection.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

We recently had internal examples showing that we could end up with wrong detection of http headers in tcp segments. The point of this PR is not to completely solve the issue, but to reduce the possibility of having such false positive.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

On the go part, we're touching a very hot path, so we must not introduce too much overhead.

#### Performance numbers for `main`

```sh
vagrant@agent-dev-paul:/git/datadog-agent$ /git/datadog-agent/test/kitchen/site-cookbooks/dd-system-probe-check/files/default/tests/pkg/network/http/testsuite -test.bench=BenchmarkPath -test.run=none
goos: linux
goarch: arm64
pkg: github.com/DataDog/datadog-agent/pkg/network/http
BenchmarkPath-4   	125108641	         9.596 ns/op	       0 B/op	       0 allocs/op
PASS
```

#### Performance numbers for this branch

```sh
vagrant@agent-dev-paul:/git/datadog-agent$ /git/datadog-agent/test/kitchen/site-cookbooks/dd-system-probe-check/files/default/tests/pkg/network/http/testsuite -test.bench=BenchmarkPath -test.run=none
goos: linux
goarch: arm64
pkg: github.com/DataDog/datadog-agent/pkg/network/http
BenchmarkPath-4   	132811915	         9.086 ns/op	       0 B/op	       0 allocs/op
PASS
vagrant@agent-dev-paul:/git/datadog-agent$ /git/datadog-agent/test/kitchen/site-cookbooks/dd-system-probe-check/files/default/tests/pkg/network/http/testsuite -test.bench=BenchmarkIsValid -test.run=none
goos: linux
goarch: arm64
pkg: github.com/DataDog/datadog-agent/pkg/network/http
BenchmarkIsValid-4   	100000000	        11.73 ns/op	       0 B/op	       0 allocs/op
PASS
```

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
