### PR TITLE
[KSMCore] Fix concurrent map access

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -11,6 +11,7 @@ package ksm
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -119,12 +120,16 @@ type KSMConfig struct {
 // KSMCheck wraps the config and the metric stores needed to run the check
 type KSMCheck struct {
 	core.CheckBase
-	instance    *KSMConfig
-	allStores   [][]cache.Store
-	telemetry   *telemetryCache
-	cancel      context.CancelFunc
-	isCLCRunner bool
-	clusterName string
+	instance             *KSMConfig
+	allStores            [][]cache.Store
+	telemetry            *telemetryCache
+	cancel               context.CancelFunc
+	isCLCRunner          bool
+	clusterName          string
+	metricNamesMapper    map[string]string
+	metricAggregators    map[string]metricAggregator
+	metricTransformers   map[string]metricTransformerFunc
+	metadataMetricsRegex *regexp.Regexp
 }
 
 // JoinsConfig contains the config parameters for label joins
@@ -181,12 +186,14 @@ func (k *KSMCheck) Configure(config, initConfig integration.Data, source string)
 		joinConf.setupGetAllLabels()
 	}
 
-	k.mergeLabelJoins(defaultLabelJoins)
+	labelJoins := defaultLabelJoins()
+	k.mergeLabelJoins(labelJoins)
 
 	k.processLabelsAsTags()
 
 	// Prepare labels mapper
-	k.mergeLabelsMapper(defaultLabelsMapper)
+	labelsMapper := defaultLabelsMapper()
+	k.mergeLabelsMapper(labelsMapper)
 
 	// Retrieve cluster name
 	k.getClusterName()
@@ -348,14 +355,14 @@ func (k *KSMCheck) processMetrics(sender aggregator.Sender, metrics map[string][
 	for _, metricsList := range metrics {
 		for _, metricFamily := range metricsList {
 			// First check for aggregator, because the check use _labels metrics to aggregate values.
-			if aggregator, found := metricAggregators[metricFamily.Name]; found {
+			if aggregator, found := k.metricAggregators[metricFamily.Name]; found {
 				for _, m := range metricFamily.ListMetrics {
 					aggregator.accumulate(m)
 				}
 				// Some metrics can be aggregated and consumed as-is or by a transformer.
 				// So, let’s continue the processing.
 			}
-			if transform, found := metricTransformers[metricFamily.Name]; found {
+			if transform, found := k.metricTransformers[metricFamily.Name]; found {
 				lMapperOverride := labelsMapperOverride(metricFamily.Name)
 				for _, m := range metricFamily.ListMetrics {
 					hostname, tags := k.hostnameAndTags(m.Labels, labelJoiner, lMapperOverride)
@@ -363,7 +370,7 @@ func (k *KSMCheck) processMetrics(sender aggregator.Sender, metrics map[string][
 				}
 				continue
 			}
-			if ddname, found := metricNamesMapper[metricFamily.Name]; found {
+			if ddname, found := k.metricNamesMapper[metricFamily.Name]; found {
 				lMapperOverride := labelsMapperOverride(metricFamily.Name)
 				for _, m := range metricFamily.ListMetrics {
 					hostname, tags := k.hostnameAndTags(m.Labels, labelJoiner, lMapperOverride)
@@ -371,10 +378,10 @@ func (k *KSMCheck) processMetrics(sender aggregator.Sender, metrics map[string][
 				}
 				continue
 			}
-			if _, found := metricAggregators[metricFamily.Name]; found {
+			if _, found := k.metricAggregators[metricFamily.Name]; found {
 				continue
 			}
-			if metadataMetricsRegex.MatchString(metricFamily.Name) {
+			if k.metadataMetricsRegex.MatchString(metricFamily.Name) {
 				// metadata metrics are only used by the check for label joins
 				// they shouldn't be forwarded to Datadog
 				continue
@@ -384,7 +391,7 @@ func (k *KSMCheck) processMetrics(sender aggregator.Sender, metrics map[string][
 			log.Tracef("KSM metric '%s' is unknown for the check, ignoring it", metricFamily.Name)
 		}
 	}
-	for _, aggregator := range metricAggregators {
+	for _, aggregator := range k.metricAggregators {
 		aggregator.flush(sender, k, labelJoiner)
 	}
 }
@@ -570,8 +577,8 @@ func (k *KSMCheck) processTelemetry(metrics map[string][]ksmstore.DDMetricsFam) 
 	}
 
 	for name, list := range metrics {
-		isMetadataMetric := metadataMetricsRegex.MatchString(name)
-		if !isKnownMetric(name) && !isMetadataMetric {
+		isMetadataMetric := k.metadataMetricsRegex.MatchString(name)
+		if !k.isKnownMetric(name) && !isMetadataMetric {
 			k.telemetry.incUnknown()
 			continue
 		}
@@ -630,10 +637,17 @@ func KubeStateMetricsFactoryWithParam(labelsMapper map[string]string, labelJoins
 
 func newKSMCheck(base core.CheckBase, instance *KSMConfig) *KSMCheck {
 	return &KSMCheck{
-		CheckBase:   base,
-		instance:    instance,
-		telemetry:   newTelemetryCache(),
-		isCLCRunner: config.IsCLCRunner(),
+		CheckBase:          base,
+		instance:           instance,
+		telemetry:          newTelemetryCache(),
+		isCLCRunner:        config.IsCLCRunner(),
+		metricNamesMapper:  defaultMetricNamesMapper(),
+		metricAggregators:  defaultMetricAggregators(),
+		metricTransformers: defaultMetricTransformers(),
+
+		// metadata metrics are useful for label joins
+		// but shouldn't be submitted to Datadog
+		metadataMetricsRegex: regexp.MustCompile(".*_(info|labels|status_reason)"),
 	}
 }
 
@@ -653,14 +667,14 @@ func resourceNameFromMetric(name string) string {
 //  - has a datadog metric name
 //  - has a metric transformer
 //  - has a metric aggregator
-func isKnownMetric(name string) bool {
-	if _, found := metricNamesMapper[name]; found {
+func (k *KSMCheck) isKnownMetric(name string) bool {
+	if _, found := k.metricNamesMapper[name]; found {
 		return true
 	}
-	if _, found := metricTransformers[name]; found {
+	if _, found := k.metricTransformers[name]; found {
 		return true
 	}
-	if _, found := metricAggregators[name]; found {
+	if _, found := k.metricAggregators[name]; found {
 		return true
 	}
 	return false
@@ -670,7 +684,29 @@ func isKnownMetric(name string) bool {
 // It allows us to get kube_node_created and kube_pod_created and deny
 // the rest of *_created metrics without relying on a unmaintainable and unreadable regex.
 func buildDeniedMetricsSet(collectors []string) options.MetricSet {
-	deniedMetrics := defaultDeniedMetrics
+	deniedMetrics := options.MetricSet{
+		".*_generation":                                    {},
+		".*_metadata_resource_version":                     {},
+		"kube_pod_owner":                                   {},
+		"kube_pod_restart_policy":                          {},
+		"kube_pod_completion_time":                         {},
+		"kube_pod_status_scheduled_time":                   {},
+		"kube_cronjob_status_active":                       {},
+		"kube_node_status_phase":                           {},
+		"kube_cronjob_spec_starting_deadline_seconds":      {},
+		"kube_job_spec_active_dealine_seconds":             {},
+		"kube_job_spec_completions":                        {},
+		"kube_job_spec_parallelism":                        {},
+		"kube_job_status_active":                           {},
+		"kube_job_status_.*_time":                          {},
+		"kube_service_spec_external_ip":                    {},
+		"kube_service_status_load_balancer_ingress":        {},
+		"kube_ingress_path":                                {},
+		"kube_statefulset_status_current_revision":         {},
+		"kube_statefulset_status_update_revision":          {},
+		"kube_pod_container_status_last_terminated_reason": {},
+		"kube_lease_renew_time":                            {},
+	}
 	for _, resource := range collectors {
 		// resource format: pods, nodes, jobs, deployments...
 		if resource == "pods" || resource == "nodes" {

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators.go
@@ -221,79 +221,81 @@ func (a *lastCronJobAggregator) flush(sender aggregator.Sender, k *KSMCheck, lab
 	a.accumulator = make(map[cronJob]cronJobState)
 }
 
-var cronJobAggregator = newLastCronJobAggregator()
+func defaultMetricAggregators() map[string]metricAggregator {
+	cronJobAggregator := newLastCronJobAggregator()
 
-var metricAggregators = map[string]metricAggregator{
-	"kube_persistentvolume_status_phase": newSumValuesAggregator(
-		"persistentvolumes.by_phase",
-		"kube_persistentvolume_status_phase",
-		[]string{"storageclass", "phase"},
-	),
-	"kube_service_spec_type": newCountObjectsAggregator(
-		"service.count",
-		"kube_service_spec_type",
-		[]string{"namespace", "type"},
-	),
-	"kube_namespace_status_phase": newSumValuesAggregator(
-		"namespace.count",
-		"kube_namespace_status_phase",
-		[]string{"phase"},
-	),
-	"kube_replicaset_owner": newCountObjectsAggregator(
-		"replicaset.count",
-		"kube_replicaset_owner",
-		[]string{"namespace", "owner_name", "owner_kind"},
-	),
-	"kube_job_owner": newCountObjectsAggregator(
-		"job.count",
-		"kube_job_owner",
-		[]string{"namespace", "owner_name", "owner_kind"},
-	),
-	"kube_deployment_labels": newCountObjectsAggregator(
-		"deployment.count",
-		"kube_deployment_labels",
-		[]string{"namespace"},
-	),
-	"kube_daemonset_labels": newCountObjectsAggregator(
-		"daemonset.count",
-		"kube_daemonset_labels",
-		[]string{"namespace"},
-	),
-	"kube_statefulset_labels": newCountObjectsAggregator(
-		"statefulset.count",
-		"kube_statefulset_labels",
-		[]string{"namespace"},
-	),
-	"kube_cronjob_labels": newCountObjectsAggregator(
-		"cronjob.count",
-		"kube_cronjob_labels",
-		[]string{"namespace"},
-	),
-	"kube_endpoint_labels": newCountObjectsAggregator(
-		"endpoint.count",
-		"kube_endpoint_labels",
-		[]string{"namespace"},
-	),
-	"kube_horizontalpodautoscaler_labels": newCountObjectsAggregator(
-		"hpa.count",
-		"kube_horizontalpodautoscaler_labels",
-		[]string{"namespace"},
-	),
-	"kube_verticalpodautoscaler_labels": newCountObjectsAggregator(
-		"vpa.count",
-		"kube_verticalpodautoscaler_labels",
-		[]string{"namespace"},
-	),
-	"kube_node_info": newCountObjectsAggregator(
-		"node.count",
-		"kube_node_info",
-		[]string{"kubelet_version", "container_runtime_version", "kernel_version", "os_image"},
-	),
-	"kube_pod_info": newCountObjectsAggregator(
-		"pod.count",
-		"kube_pod_info",
-		[]string{"node", "namespace", "created_by_kind", "created_by_name"},
-	),
-	"kube_job_complete": &lastCronJobCompleteAggregator{aggregator: cronJobAggregator},
-	"kube_job_failed":   &lastCronJobFailedAggregator{aggregator: cronJobAggregator},
+	return map[string]metricAggregator{
+		"kube_persistentvolume_status_phase": newSumValuesAggregator(
+			"persistentvolumes.by_phase",
+			"kube_persistentvolume_status_phase",
+			[]string{"storageclass", "phase"},
+		),
+		"kube_service_spec_type": newCountObjectsAggregator(
+			"service.count",
+			"kube_service_spec_type",
+			[]string{"namespace", "type"},
+		),
+		"kube_namespace_status_phase": newSumValuesAggregator(
+			"namespace.count",
+			"kube_namespace_status_phase",
+			[]string{"phase"},
+		),
+		"kube_replicaset_owner": newCountObjectsAggregator(
+			"replicaset.count",
+			"kube_replicaset_owner",
+			[]string{"namespace", "owner_name", "owner_kind"},
+		),
+		"kube_job_owner": newCountObjectsAggregator(
+			"job.count",
+			"kube_job_owner",
+			[]string{"namespace", "owner_name", "owner_kind"},
+		),
+		"kube_deployment_labels": newCountObjectsAggregator(
+			"deployment.count",
+			"kube_deployment_labels",
+			[]string{"namespace"},
+		),
+		"kube_daemonset_labels": newCountObjectsAggregator(
+			"daemonset.count",
+			"kube_daemonset_labels",
+			[]string{"namespace"},
+		),
+		"kube_statefulset_labels": newCountObjectsAggregator(
+			"statefulset.count",
+			"kube_statefulset_labels",
+			[]string{"namespace"},
+		),
+		"kube_cronjob_labels": newCountObjectsAggregator(
+			"cronjob.count",
+			"kube_cronjob_labels",
+			[]string{"namespace"},
+		),
+		"kube_endpoint_labels": newCountObjectsAggregator(
+			"endpoint.count",
+			"kube_endpoint_labels",
+			[]string{"namespace"},
+		),
+		"kube_horizontalpodautoscaler_labels": newCountObjectsAggregator(
+			"hpa.count",
+			"kube_horizontalpodautoscaler_labels",
+			[]string{"namespace"},
+		),
+		"kube_verticalpodautoscaler_labels": newCountObjectsAggregator(
+			"vpa.count",
+			"kube_verticalpodautoscaler_labels",
+			[]string{"namespace"},
+		),
+		"kube_node_info": newCountObjectsAggregator(
+			"node.count",
+			"kube_node_info",
+			[]string{"kubelet_version", "container_runtime_version", "kernel_version", "os_image"},
+		),
+		"kube_pod_info": newCountObjectsAggregator(
+			"pod.count",
+			"kube_pod_info",
+			[]string{"node", "namespace", "created_by_kind", "created_by_name"},
+		),
+		"kube_job_complete": &lastCronJobCompleteAggregator{aggregator: cronJobAggregator},
+		"kube_job_failed":   &lastCronJobFailedAggregator{aggregator: cronJobAggregator},
+	}
 }

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
@@ -8,44 +8,12 @@
 
 package ksm
 
-import (
-	"regexp"
-
-	"k8s.io/kube-state-metrics/v2/pkg/options"
-)
-
 // ksmMetricPrefix defines the KSM metrics namespace
 const ksmMetricPrefix = "kubernetes_state."
 
-var (
-	// defaultLabelsMapper contains the default label to tag names mapping
-	defaultLabelsMapper = map[string]string{
-		"namespace":                           "kube_namespace",
-		"job_name":                            "kube_job",
-		"cronjob":                             "kube_cronjob",
-		"pod":                                 "pod_name",
-		"priority_class":                      "kube_priority_class",
-		"daemonset":                           "kube_daemon_set",
-		"replicationcontroller":               "kube_replication_controller",
-		"replicaset":                          "kube_replica_set",
-		"statefulset":                         "kube_stateful_set",
-		"deployment":                          "kube_deployment",
-		"service":                             "kube_service",
-		"endpoint":                            "kube_endpoint",
-		"container":                           "kube_container_name",
-		"container_id":                        "container_id",
-		"image":                               "image_name",
-		"label_tags_datadoghq_com_env":        "env",
-		"label_tags_datadoghq_com_service":    "service",
-		"label_tags_datadoghq_com_version":    "version",
-		"label_topology_kubernetes_io_region": "kube_region",
-		"label_topology_kubernetes_io_zone":   "kube_zone",
-		"label_failure_domain_beta_kubernetes_io_region": "kube_region",
-		"label_failure_domain_beta_kubernetes_io_zone":   "kube_zone",
-	}
-
-	// metricNamesMapper translates KSM metric names to Datadog metric names
-	metricNamesMapper = map[string]string{
+// defaultMetricNamesMapper returns a map that translates KSM metric names to Datadog metric names
+func defaultMetricNamesMapper() map[string]string {
+	return map[string]string{
 		"kube_daemonset_status_current_number_scheduled":                                           "daemonset.scheduled",
 		"kube_daemonset_status_desired_number_scheduled":                                           "daemonset.desired",
 		"kube_daemonset_status_number_misscheduled":                                                "daemonset.misscheduled",
@@ -115,44 +83,45 @@ var (
 		"kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_maxallowed":             "vpa.spec_container_maxallowed",
 		"kube_cronjob_spec_suspend":                                                                "cronjob.spec_suspend",
 	}
+}
 
-	// metadata metrics are useful for label joins
-	// but shouldn't be submitted to Datadog
-	metadataMetricsRegex = regexp.MustCompile(".*_(info|labels|status_reason)")
-
-	// defaultDeniedMetrics used to configure the KSM store to ignore these metrics by KSM engine
-	defaultDeniedMetrics = options.MetricSet{
-		".*_generation":                                    {},
-		".*_metadata_resource_version":                     {},
-		"kube_pod_owner":                                   {},
-		"kube_pod_restart_policy":                          {},
-		"kube_pod_completion_time":                         {},
-		"kube_pod_status_scheduled_time":                   {},
-		"kube_cronjob_status_active":                       {},
-		"kube_node_status_phase":                           {},
-		"kube_cronjob_spec_starting_deadline_seconds":      {},
-		"kube_job_spec_active_dealine_seconds":             {},
-		"kube_job_spec_completions":                        {},
-		"kube_job_spec_parallelism":                        {},
-		"kube_job_status_active":                           {},
-		"kube_job_status_.*_time":                          {},
-		"kube_service_spec_external_ip":                    {},
-		"kube_service_status_load_balancer_ingress":        {},
-		"kube_ingress_path":                                {},
-		"kube_statefulset_status_current_revision":         {},
-		"kube_statefulset_status_update_revision":          {},
-		"kube_pod_container_status_last_terminated_reason": {},
-		"kube_lease_renew_time":                            {},
+// defaultLabelsMapper returns a map that contains the default labels to tag names mapping
+func defaultLabelsMapper() map[string]string {
+	return map[string]string{
+		"namespace":                           "kube_namespace",
+		"job_name":                            "kube_job",
+		"cronjob":                             "kube_cronjob",
+		"pod":                                 "pod_name",
+		"priority_class":                      "kube_priority_class",
+		"daemonset":                           "kube_daemon_set",
+		"replicationcontroller":               "kube_replication_controller",
+		"replicaset":                          "kube_replica_set",
+		"statefulset":                         "kube_stateful_set",
+		"deployment":                          "kube_deployment",
+		"service":                             "kube_service",
+		"endpoint":                            "kube_endpoint",
+		"container":                           "kube_container_name",
+		"container_id":                        "container_id",
+		"image":                               "image_name",
+		"label_tags_datadoghq_com_env":        "env",
+		"label_tags_datadoghq_com_service":    "service",
+		"label_tags_datadoghq_com_version":    "version",
+		"label_topology_kubernetes_io_region": "kube_region",
+		"label_topology_kubernetes_io_zone":   "kube_zone",
+		"label_failure_domain_beta_kubernetes_io_region": "kube_region",
+		"label_failure_domain_beta_kubernetes_io_zone":   "kube_zone",
 	}
+}
 
-	defaultStandardLabels = []string{
+// defaultLabelJoins returns a map that contains the default label joins configuration
+func defaultLabelJoins() map[string]*JoinsConfig {
+	defaultStandardLabels := []string{
 		"label_tags_datadoghq_com_env",
 		"label_tags_datadoghq_com_service",
 		"label_tags_datadoghq_com_version",
 	}
 
-	// defaultLabelJoins contains the default label joins configuration
-	defaultLabelJoins = map[string]*JoinsConfig{
+	return map[string]*JoinsConfig{
 		"kube_pod_status_phase": {
 			LabelsToMatch: []string{"pod", "namespace"},
 			LabelsToGet:   []string{"phase"},
@@ -215,4 +184,4 @@ var (
 			LabelsToGet:   []string{"container_runtime_version", "kernel_version", "kubelet_version", "os_image"},
 		},
 	}
-)
+}

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
@@ -41,7 +41,7 @@ func TestProcessMetrics(t *testing.T) {
 	}{
 		{
 			name:   "one metric family, default label mapper",
-			config: &KSMConfig{LabelsMapper: defaultLabelsMapper},
+			config: &KSMConfig{LabelsMapper: defaultLabelsMapper()},
 			metricsToProcess: map[string][]ksmstore.DDMetricsFam{
 				"kube_pod_container_status_running": {
 					{
@@ -67,7 +67,7 @@ func TestProcessMetrics(t *testing.T) {
 				},
 			},
 			metricsToGet:       []ksmstore.DDMetricsFam{},
-			metricTransformers: metricTransformers,
+			metricTransformers: defaultMetricTransformers(),
 			expected: []metricsExpected{
 				{
 					name: "kubernetes_state.container.running",
@@ -83,7 +83,7 @@ func TestProcessMetrics(t *testing.T) {
 		},
 		{
 			name:   "host tag via label join, default label mapper, default label joins",
-			config: &KSMConfig{LabelsMapper: defaultLabelsMapper, LabelJoins: defaultLabelJoins},
+			config: &KSMConfig{LabelsMapper: defaultLabelsMapper(), LabelJoins: defaultLabelJoins()},
 			metricsToProcess: map[string][]ksmstore.DDMetricsFam{
 				"kube_pod_container_status_running": {
 					{
@@ -104,7 +104,7 @@ func TestProcessMetrics(t *testing.T) {
 					ListMetrics: []ksmstore.DDMetric{{Labels: map[string]string{"created_by_kind": "ReplicaSet", "created_by_name": "kube-state-metrics-b7fbc487d", "host_ip": "192.168.99.100", "namespace": "default", "node": "minikube", "pod": "kube-state-metrics-b7fbc487d-4phhj", "pod_ip": "172.17.0.7"}}},
 				},
 			},
-			metricTransformers: metricTransformers,
+			metricTransformers: defaultMetricTransformers(),
 			expected: []metricsExpected{
 				{
 					name:     "kubernetes_state.container.running",
@@ -116,7 +116,7 @@ func TestProcessMetrics(t *testing.T) {
 		},
 		{
 			name:   "metadata metric, ignored",
-			config: &KSMConfig{LabelsMapper: defaultLabelsMapper},
+			config: &KSMConfig{LabelsMapper: defaultLabelsMapper()},
 			metricsToProcess: map[string][]ksmstore.DDMetricsFam{
 				"kube_pod_info": {
 					{
@@ -132,12 +132,12 @@ func TestProcessMetrics(t *testing.T) {
 				},
 			},
 			metricsToGet:       []ksmstore.DDMetricsFam{},
-			metricTransformers: metricTransformers,
+			metricTransformers: defaultMetricTransformers(),
 			expected:           []metricsExpected{},
 		},
 		{
 			name:   "datadog standard tags via label join, default label mapper, default label joins (deployment)",
-			config: &KSMConfig{LabelsMapper: defaultLabelsMapper, LabelJoins: defaultLabelJoins},
+			config: &KSMConfig{LabelsMapper: defaultLabelsMapper(), LabelJoins: defaultLabelJoins()},
 			metricsToProcess: map[string][]ksmstore.DDMetricsFam{
 				"kube_deployment_status_replicas": {
 					{
@@ -158,7 +158,7 @@ func TestProcessMetrics(t *testing.T) {
 					ListMetrics: []ksmstore.DDMetric{{Labels: map[string]string{"namespace": "default", "deployment": "redis", "label_tags_datadoghq_com_env": "dev", "label_tags_datadoghq_com_service": "redis", "label_tags_datadoghq_com_version": "v1"}}},
 				},
 			},
-			metricTransformers: metricTransformers,
+			metricTransformers: defaultMetricTransformers(),
 			expected: []metricsExpected{
 				{
 					name:     "kubernetes_state.deployment.replicas",
@@ -170,7 +170,7 @@ func TestProcessMetrics(t *testing.T) {
 		},
 		{
 			name:   "datadog standard tags via label join, default label mapper, default label joins (statefulset)",
-			config: &KSMConfig{LabelsMapper: defaultLabelsMapper, LabelJoins: defaultLabelJoins},
+			config: &KSMConfig{LabelsMapper: defaultLabelsMapper(), LabelJoins: defaultLabelJoins()},
 			metricsToProcess: map[string][]ksmstore.DDMetricsFam{
 				"kube_statefulset_replicas": {
 					{
@@ -191,7 +191,7 @@ func TestProcessMetrics(t *testing.T) {
 					ListMetrics: []ksmstore.DDMetric{{Labels: map[string]string{"namespace": "default", "statefulset": "redis", "label_tags_datadoghq_com_env": "dev", "label_tags_datadoghq_com_service": "redis", "label_tags_datadoghq_com_version": "v1"}}},
 				},
 			},
-			metricTransformers: metricTransformers,
+			metricTransformers: defaultMetricTransformers(),
 			expected: []metricsExpected{
 				{
 					name:     "kubernetes_state.statefulset.replicas_desired",
@@ -203,7 +203,7 @@ func TestProcessMetrics(t *testing.T) {
 		},
 		{
 			name:   "only consider datadog standard tags in label join",
-			config: &KSMConfig{LabelsMapper: defaultLabelsMapper, LabelJoins: defaultLabelJoins},
+			config: &KSMConfig{LabelsMapper: defaultLabelsMapper(), LabelJoins: defaultLabelJoins()},
 			metricsToProcess: map[string][]ksmstore.DDMetricsFam{
 				"kube_deployment_status_replicas": {
 					{
@@ -224,7 +224,7 @@ func TestProcessMetrics(t *testing.T) {
 					ListMetrics: []ksmstore.DDMetric{{Labels: map[string]string{"namespace": "default", "deployment": "redis", "label_tags_datadoghq_com_env": "dev", "ignore": "this_label"}}},
 				},
 			},
-			metricTransformers: metricTransformers,
+			metricTransformers: defaultMetricTransformers(),
 			expected: []metricsExpected{
 				{
 					name:     "kubernetes_state.deployment.replicas",
@@ -236,7 +236,7 @@ func TestProcessMetrics(t *testing.T) {
 		},
 		{
 			name:   "honour metric transformers",
-			config: &KSMConfig{LabelsMapper: defaultLabelsMapper},
+			config: &KSMConfig{LabelsMapper: defaultLabelsMapper()},
 			metricsToProcess: map[string][]ksmstore.DDMetricsFam{
 				"kube_pod_status_phase": {
 					{
@@ -268,7 +268,7 @@ func TestProcessMetrics(t *testing.T) {
 		},
 		{
 			name:   "unknown metric",
-			config: &KSMConfig{LabelsMapper: defaultLabelsMapper},
+			config: &KSMConfig{LabelsMapper: defaultLabelsMapper()},
 			metricsToProcess: map[string][]ksmstore.DDMetricsFam{
 				"kube_pod_unknown_metric": {
 					{
@@ -294,12 +294,12 @@ func TestProcessMetrics(t *testing.T) {
 				},
 			},
 			metricsToGet:       []ksmstore.DDMetricsFam{},
-			metricTransformers: metricTransformers,
+			metricTransformers: defaultMetricTransformers(),
 			expected:           []metricsExpected{},
 		},
 		{
 			name:   "kube_zone and kube_region tags from default label joins",
-			config: &KSMConfig{LabelsMapper: defaultLabelsMapper, LabelJoins: defaultLabelJoins},
+			config: &KSMConfig{LabelsMapper: defaultLabelsMapper(), LabelJoins: defaultLabelJoins()},
 			metricsToProcess: map[string][]ksmstore.DDMetricsFam{
 				"kube_node_status_capacity": {
 					{
@@ -320,7 +320,7 @@ func TestProcessMetrics(t *testing.T) {
 					ListMetrics: []ksmstore.DDMetric{{Labels: map[string]string{"node": "nodename", "label_foo": "bar", "label_topology_kubernetes_io_region": "europe-west1", "label_topology_kubernetes_io_zone": "europe-west1-b"}}},
 				},
 			},
-			metricTransformers: metricTransformers,
+			metricTransformers: defaultMetricTransformers(),
 			expected: []metricsExpected{
 				{
 					name:     "kubernetes_state.node.cpu_capacity",
@@ -332,7 +332,7 @@ func TestProcessMetrics(t *testing.T) {
 		},
 		{
 			name:   "node info tags from default label joins",
-			config: &KSMConfig{LabelsMapper: defaultLabelsMapper, LabelJoins: defaultLabelJoins},
+			config: &KSMConfig{LabelsMapper: defaultLabelsMapper(), LabelJoins: defaultLabelJoins()},
 			metricsToProcess: map[string][]ksmstore.DDMetricsFam{
 				"kube_node_status_capacity": {
 					{
@@ -353,7 +353,7 @@ func TestProcessMetrics(t *testing.T) {
 					ListMetrics: []ksmstore.DDMetric{{Labels: map[string]string{"node": "nodename", "container_runtime_version": "docker://19.3.15", "kernel_version": "5.4.109+", "kubelet_version": "v1.18.20-gke.901", "os_image": "Container-Optimized OS from Google"}}},
 				},
 			},
-			metricTransformers: metricTransformers,
+			metricTransformers: defaultMetricTransformers(),
 			expected: []metricsExpected{
 				{
 					name:     "kubernetes_state.node.cpu_capacity",
@@ -365,7 +365,7 @@ func TestProcessMetrics(t *testing.T) {
 		},
 		{
 			name:   "phase tag for pod",
-			config: &KSMConfig{LabelsMapper: defaultLabelsMapper},
+			config: &KSMConfig{LabelsMapper: defaultLabelsMapper()},
 			metricsToProcess: map[string][]ksmstore.DDMetricsFam{
 				"kube_pod_status_phase": {
 					{
@@ -381,7 +381,7 @@ func TestProcessMetrics(t *testing.T) {
 				},
 			},
 			metricsToGet:       []ksmstore.DDMetricsFam{},
-			metricTransformers: metricTransformers,
+			metricTransformers: defaultMetricTransformers(),
 			expected: []metricsExpected{
 				{
 					name:     "kubernetes_state.pod.status_phase",
@@ -393,7 +393,7 @@ func TestProcessMetrics(t *testing.T) {
 		},
 		{
 			name:   "phase tag for pvc",
-			config: &KSMConfig{LabelsMapper: defaultLabelsMapper},
+			config: &KSMConfig{LabelsMapper: defaultLabelsMapper()},
 			metricsToProcess: map[string][]ksmstore.DDMetricsFam{
 				"kube_persistentvolumeclaim_status_phase": {
 					{
@@ -409,7 +409,7 @@ func TestProcessMetrics(t *testing.T) {
 				},
 			},
 			metricsToGet:       []ksmstore.DDMetricsFam{},
-			metricTransformers: metricTransformers,
+			metricTransformers: defaultMetricTransformers(),
 			expected: []metricsExpected{
 				{
 					name:     "kubernetes_state.persistentvolumeclaim.status",
@@ -421,7 +421,7 @@ func TestProcessMetrics(t *testing.T) {
 		},
 		{
 			name:   "phase tag for ns",
-			config: &KSMConfig{LabelsMapper: defaultLabelsMapper},
+			config: &KSMConfig{LabelsMapper: defaultLabelsMapper()},
 			metricsToProcess: map[string][]ksmstore.DDMetricsFam{
 				"kube_namespace_status_phase": {
 					{
@@ -437,7 +437,7 @@ func TestProcessMetrics(t *testing.T) {
 				},
 			},
 			metricsToGet:       []ksmstore.DDMetricsFam{},
-			metricTransformers: metricTransformers,
+			metricTransformers: defaultMetricTransformers(),
 			expected: []metricsExpected{
 				{
 					name:     "kubernetes_state.namespace.count",
@@ -453,7 +453,7 @@ func TestProcessMetrics(t *testing.T) {
 		mocked := mocksender.NewMockSender(kubeStateMetricsSCheck.ID())
 		mocked.SetupAcceptAll()
 
-		metricTransformers = test.metricTransformers
+		kubeStateMetricsSCheck.metricTransformers = test.metricTransformers
 		labelJoiner := newLabelJoiner(test.config.LabelJoins)
 		for _, metricFam := range test.metricsToGet {
 			labelJoiner.insertFamily(metricFam)
@@ -481,7 +481,7 @@ func TestProcessTelemetry(t *testing.T) {
 	}{
 		{
 			name:   "pod metrics",
-			config: &KSMConfig{LabelsMapper: defaultLabelsMapper, Telemetry: true},
+			config: &KSMConfig{LabelsMapper: defaultLabelsMapper(), Telemetry: true},
 			metrics: map[string][]ksmstore.DDMetricsFam{
 				"kube_pod_container_status_running": {
 					{
@@ -518,7 +518,7 @@ func TestProcessTelemetry(t *testing.T) {
 		},
 		{
 			name:   "deployment metric",
-			config: &KSMConfig{LabelsMapper: defaultLabelsMapper, Telemetry: true},
+			config: &KSMConfig{LabelsMapper: defaultLabelsMapper(), Telemetry: true},
 			metrics: map[string][]ksmstore.DDMetricsFam{
 				"kube_deployment_status_replicas": {
 					{
@@ -541,7 +541,7 @@ func TestProcessTelemetry(t *testing.T) {
 		},
 		{
 			name:   "telemetry disabled",
-			config: &KSMConfig{LabelsMapper: defaultLabelsMapper},
+			config: &KSMConfig{LabelsMapper: defaultLabelsMapper()},
 			metrics: map[string][]ksmstore.DDMetricsFam{
 				"kube_deployment_status_replicas": {
 					{
@@ -564,7 +564,7 @@ func TestProcessTelemetry(t *testing.T) {
 		},
 		{
 			name:   "unknown metric",
-			config: &KSMConfig{LabelsMapper: defaultLabelsMapper, Telemetry: true},
+			config: &KSMConfig{LabelsMapper: defaultLabelsMapper(), Telemetry: true},
 			metrics: map[string][]ksmstore.DDMetricsFam{
 				"kube_unknown_metric": {
 					{
@@ -587,7 +587,7 @@ func TestProcessTelemetry(t *testing.T) {
 		},
 		{
 			name:   "pod, deployment and unknown metrics",
-			config: &KSMConfig{LabelsMapper: defaultLabelsMapper, Telemetry: true},
+			config: &KSMConfig{LabelsMapper: defaultLabelsMapper(), Telemetry: true},
 			metrics: map[string][]ksmstore.DDMetricsFam{
 				"kube_pod_container_status_running": {
 					{
@@ -1156,8 +1156,9 @@ var metadataMetrics = []string{
 }
 
 func TestMetadataMetricsRegex(t *testing.T) {
+	check := newKSMCheck(core.NewCheckBase(kubeStateMetricsCheckName), &KSMConfig{})
 	for _, m := range metadataMetrics {
-		assert.True(t, metadataMetricsRegex.MatchString(m))
+		assert.True(t, check.metadataMetricsRegex.MatchString(m))
 	}
 }
 
@@ -1195,13 +1196,13 @@ func TestAllowDeny(t *testing.T) {
 	}
 
 	// Make sure we don't exclude metrics by mistake
-	for metric := range metricNamesMapper {
+	for metric := range defaultMetricNamesMapper() {
 		assert.True(t, allowDenyList.IsIncluded(metric))
 		assert.False(t, allowDenyList.IsExcluded(metric))
 	}
 
 	// Make sure we don't exclude metric transformers
-	for metric := range metricTransformers {
+	for metric := range defaultMetricTransformers() {
 		assert.True(t, allowDenyList.IsIncluded(metric))
 		assert.False(t, allowDenyList.IsExcluded(metric))
 	}

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers.go
@@ -24,11 +24,11 @@ import (
 // For name translation only please use metricNamesMapper instead
 type metricTransformerFunc = func(aggregator.Sender, string, ksmstore.DDMetric, string, []string, time.Time)
 
-var (
-	// metricTransformers contains KSM metric names and their corresponding transformer functions
-	// These metrics require more than a name translation to generate Datadog metrics, as opposed to the metrics in metricNamesMapper
-	// For reference see METRIC_TRANSFORMERS in KSM check V1
-	metricTransformers = map[string]metricTransformerFunc{
+// defaultMetricTransformers returns a map that contains KSM metric names and their corresponding transformer functions
+// These metrics require more than a name translation to generate Datadog metrics, as opposed to the metrics in defaultMetricNamesMapper
+// For reference see METRIC_TRANSFORMERS in KSM check V1
+func defaultMetricTransformers() map[string]metricTransformerFunc {
+	return map[string]metricTransformerFunc{
 		"kube_pod_created":                            podCreationTransformer,
 		"kube_pod_start_time":                         podStartTimeTransformer,
 		"kube_pod_status_phase":                       podPhaseTransformer,
@@ -52,7 +52,7 @@ var (
 		"kube_persistentvolume_status_phase":          pvPhaseTransformer,
 		"kube_service_spec_type":                      serviceTypeTransformer,
 	}
-)
+}
 
 // nodeConditionTransformer generates service checks based on the metric kube_node_status_condition
 // It also submit the metric kubernetes_state.node.by_condition

--- a/releasenotes-dca/notes/ksm-core-panic-9d8d75852a512e39.yaml
+++ b/releasenotes-dca/notes/ksm-core-panic-9d8d75852a512e39.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix a risk of panic when multiple KSM Core check instances run concurrently.

--- a/releasenotes/notes/ksm-core-panic-9d8d75852a512e39.yaml
+++ b/releasenotes/notes/ksm-core-panic-9d8d75852a512e39.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix a risk of panic when multiple KSM Core check instances run concurrently.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Fixes a concurrent map access in the KSM Core check, the check itself is mono-threaded but when the agent runs multiple KSM check instances multiple goroutine will access shared global objects.
This PR removes every global variables in the check.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

```
fatal error: concurrent map iteration and map write

goroutine 334 [running]:
runtime.throw({0x469aa79, 0x7f38e96fe108})
	/goroot/src/runtime/panic.go:1198 +0x71 fp=0xc00524b670 sp=0xc00524b640 pc=0x1696b91
runtime.mapiternext(0x30)
	/goroot/src/runtime/map.go:858 +0x4eb fp=0xc00524b6e0 sp=0xc00524b670 pc=0x166f68b
runtime.mapiterinit(0x203002, 0xc00524b730, 0x166cfe7)
	/goroot/src/runtime/map.go:848 +0x236 fp=0xc00524b700 sp=0xc00524b6e0 pc=0x166f156
github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/ksm.(*counterAggregator).flush(0xc00068d400, {0x4eb74a8, 0xc001a0e690}, 0xc000688630, 0xc0003d6a10)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators.go:180 +0x8b fp=0xc00524b9a0 sp=0xc00524b700 pc=0x3a2642b
```

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Run multiple check instances on the same cluster check runner or cluster agent, make sure there are no panics.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
