### PR TITLE
[CWS] extract `extractField` regexp to State cache

### DIFF
--- a/pkg/security/secl/compiler/eval/state.go
+++ b/pkg/security/secl/compiler/eval/state.go
@@ -5,10 +5,18 @@
 
 package eval
 
+import "regexp"
+
 type registerInfo struct {
 	iterator  Iterator
 	field     Field
 	subFields map[Field]bool
+}
+
+// StateRegexpCache is used to cache regexps used in the rule compilation process
+type StateRegexpCache struct {
+	arraySubscriptFindRE    *regexp.Regexp
+	arraySubscriptReplaceRE *regexp.Regexp
 }
 
 // State defines the current state of the rule compilation
@@ -19,6 +27,7 @@ type State struct {
 	fieldValues   map[Field][]FieldValue
 	macros        map[MacroID]*MacroEvaluator
 	registersInfo map[RegisterID]*registerInfo
+	regexpCache   StateRegexpCache
 }
 
 // UpdateFields updates the fields used in the rule


### PR DESCRIPTION
### What does this PR do?

This PR extracts the computation of `extractField` regexps to a cache stored in the eval State. This allows to do the compilation of those regexps only once, and the state is cleared at the end of the evaluation (instead of keeping the regexps forever if stored in a global var).

### Motivation

Memory/CPU improvements

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
