### PR TITLE
[networks] Use "custom" sketch encoding for HTTP latency

### DIFF
--- a/pkg/network/encoding/encoding.go
+++ b/pkg/network/encoding/encoding.go
@@ -12,7 +12,6 @@ import (
 	model "github.com/DataDog/agent-payload/v5/process"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/network"
-	"github.com/DataDog/datadog-agent/pkg/network/http"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/gogo/protobuf/jsonpb"
 )
@@ -68,25 +67,18 @@ func modelConnections(conns *network.Connections) *model.Connections {
 
 	agentConns := make([]*model.Connection, len(conns.Conns))
 	routeIndex := make(map[string]RouteIdx)
-	httpIndex := FormatHTTPStats(conns.HTTP)
-	httpMatches := make(map[http.Key]struct{}, len(httpIndex))
+	httpEncoder := newHTTPEncoder(conns)
 	ipc := make(ipCache, len(conns.Conns)/2)
 	dnsFormatter := newDNSFormatter(conns, ipc)
 
 	for i, conn := range conns.Conns {
-		httpKey := httpKeyFromConn(conn)
-		httpAggregations := httpIndex[httpKey]
-		if httpAggregations != nil {
-			httpMatches[httpKey] = struct{}{}
-		}
-
-		agentConns[i] = FormatConnection(conn, routeIndex, httpAggregations, dnsFormatter, ipc)
+		agentConns[i] = FormatConnection(conn, routeIndex, httpEncoder, dnsFormatter, ipc)
 	}
 
-	if orphans := len(httpIndex) - len(httpMatches); orphans > 0 {
+	if httpEncoder != nil && httpEncoder.orphanEntries > 0 {
 		log.Debugf(
 			"detected orphan http aggreggations. this can be either caused by conntrack sampling or missed tcp close events. count=%d",
-			orphans,
+			httpEncoder.orphanEntries,
 		)
 	}
 

--- a/pkg/network/encoding/format.go
+++ b/pkg/network/encoding/format.go
@@ -11,7 +11,6 @@ import (
 
 	model "github.com/DataDog/agent-payload/v5/process"
 	"github.com/DataDog/datadog-agent/pkg/network"
-	"github.com/DataDog/datadog-agent/pkg/network/http"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/gogo/protobuf/proto"
 )
@@ -46,7 +45,7 @@ func (ipc ipCache) Get(addr util.Address) string {
 func FormatConnection(
 	conn network.ConnectionStats,
 	routes map[string]RouteIdx,
-	httpStats *model.HTTPAggregations,
+	httpEncoder *httpEncoder,
 	dnsFormatter *dnsFormatter,
 	ipc ipCache,
 ) *model.Connection {
@@ -76,7 +75,7 @@ func FormatConnection(
 	c.RouteIdx = formatRouteIdx(conn.Via, routes)
 	dnsFormatter.FormatConnectionDNS(conn, c)
 
-	if httpStats != nil {
+	if httpStats := httpEncoder.GetHTTPAggregations(conn); httpStats != nil {
 		c.HttpAggregations, _ = proto.Marshal(httpStats)
 	}
 
@@ -112,73 +111,6 @@ func FormatConnectionTelemetry(tel map[network.ConnTelemetryType]int64) map[stri
 		ret[string(k)] = v
 	}
 	return ret
-}
-
-// FormatHTTPStats converts the HTTP map into a suitable format for serialization
-func FormatHTTPStats(httpData map[http.Key]http.RequestStats) map[http.Key]*model.HTTPAggregations {
-	var (
-		aggregationsByKey = make(map[http.Key]*model.HTTPAggregations, len(httpData))
-
-		// Pre-allocate some of the objects
-		dataPool = make([]model.HTTPStats_Data, len(httpData)*http.NumStatusClasses)
-		ptrPool  = make([]*model.HTTPStats_Data, len(httpData)*http.NumStatusClasses)
-		poolIdx  = 0
-	)
-
-	for key, stats := range httpData {
-		path := key.Path
-		method := key.Method
-		key.Path = ""
-		key.Method = http.MethodUnknown
-
-		httpAggregations, ok := aggregationsByKey[key]
-		if !ok {
-			httpAggregations = &model.HTTPAggregations{
-				EndpointAggregations: make([]*model.HTTPStats, 0, 10),
-			}
-
-			aggregationsByKey[key] = httpAggregations
-		}
-
-		ms := &model.HTTPStats{
-			Path:                  path,
-			Method:                model.HTTPMethod(method),
-			StatsByResponseStatus: ptrPool[poolIdx : poolIdx+http.NumStatusClasses],
-		}
-
-		for i := 0; i < len(stats); i++ {
-			data := &dataPool[poolIdx+i]
-			ms.StatsByResponseStatus[i] = data
-			data.Count = uint32(stats[i].Count)
-
-			if latencies := stats[i].Latencies; latencies != nil {
-				blob, _ := proto.Marshal(latencies.ToProto())
-				data.Latencies = blob
-			} else {
-				data.FirstLatencySample = stats[i].FirstLatencySample
-			}
-		}
-
-		poolIdx += http.NumStatusClasses
-		httpAggregations.EndpointAggregations = append(httpAggregations.EndpointAggregations, ms)
-	}
-
-	return aggregationsByKey
-}
-
-// Build the key for the http map based on whether the local or remote side is http.
-func httpKeyFromConn(c network.ConnectionStats) http.Key {
-	// Retrieve translated addresses
-	laddr, lport := network.GetNATLocalAddress(c)
-	raddr, rport := network.GetNATRemoteAddress(c)
-
-	// HTTP data is always indexed as (client, server), so we flip
-	// the lookup key if necessary using the port range heuristic
-	if network.IsEphemeralPort(int(lport)) {
-		return http.NewKey(laddr, raddr, lport, rport, "", http.MethodUnknown)
-	}
-
-	return http.NewKey(raddr, laddr, rport, lport, "", http.MethodUnknown)
 }
 
 func returnToPool(c *model.Connections) {

--- a/pkg/network/encoding/format_test.go
+++ b/pkg/network/encoding/format_test.go
@@ -11,9 +11,6 @@ import (
 
 	model "github.com/DataDog/agent-payload/v5/process"
 	"github.com/DataDog/datadog-agent/pkg/network"
-	"github.com/DataDog/datadog-agent/pkg/network/http"
-	"github.com/DataDog/datadog-agent/pkg/process/util"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -81,75 +78,6 @@ func TestFormatRouteIdx(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestFormatHTTPStats(t *testing.T) {
-	var (
-		clientPort = uint16(52800)
-		serverPort = uint16(8080)
-		localhost  = util.AddressFromString("127.0.0.1")
-	)
-
-	httpKey1 := http.NewKey(
-		localhost,
-		localhost,
-		clientPort,
-		serverPort,
-		"/testpath-1",
-		http.MethodGet,
-	)
-	var httpStats1 http.RequestStats
-	for i := range httpStats1 {
-		httpStats1[i].Count = 1
-		httpStats1[i].FirstLatencySample = 10
-	}
-
-	httpKey2 := httpKey1
-	httpKey2.Path = "/testpath-2"
-	var httpStats2 http.RequestStats
-	for i := range httpStats2 {
-		httpStats2[i].Count = 1
-		httpStats2[i].FirstLatencySample = 20
-	}
-
-	in := map[http.Key]http.RequestStats{
-		httpKey1: httpStats1,
-		httpKey2: httpStats2,
-	}
-	out := &model.HTTPAggregations{
-		EndpointAggregations: []*model.HTTPStats{
-			{
-				Path:   "/testpath-1",
-				Method: model.HTTPMethod_Get,
-				StatsByResponseStatus: []*model.HTTPStats_Data{
-					{Count: 1, FirstLatencySample: 10, Latencies: nil},
-					{Count: 1, FirstLatencySample: 10, Latencies: nil},
-					{Count: 1, FirstLatencySample: 10, Latencies: nil},
-					{Count: 1, FirstLatencySample: 10, Latencies: nil},
-					{Count: 1, FirstLatencySample: 10, Latencies: nil},
-				},
-			},
-			{
-				Path:   "/testpath-2",
-				Method: model.HTTPMethod_Get,
-				StatsByResponseStatus: []*model.HTTPStats_Data{
-					{Count: 1, FirstLatencySample: 20, Latencies: nil},
-					{Count: 1, FirstLatencySample: 20, Latencies: nil},
-					{Count: 1, FirstLatencySample: 20, Latencies: nil},
-					{Count: 1, FirstLatencySample: 20, Latencies: nil},
-					{Count: 1, FirstLatencySample: 20, Latencies: nil},
-				},
-			},
-		},
-	}
-
-	result := FormatHTTPStats(in)
-
-	aggregationKey := httpKey1
-	aggregationKey.Path = ""
-	aggregationKey.Method = http.MethodUnknown
-	aggregations := result[aggregationKey].EndpointAggregations
-	assert.ElementsMatch(t, out.EndpointAggregations, aggregations)
 }
 
 func BenchmarkConnectionReset(b *testing.B) {

--- a/pkg/network/encoding/http.go
+++ b/pkg/network/encoding/http.go
@@ -1,0 +1,130 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package encoding
+
+import (
+	model "github.com/DataDog/agent-payload/v5/process"
+	"github.com/DataDog/datadog-agent/pkg/network"
+	"github.com/DataDog/datadog-agent/pkg/network/http"
+	"github.com/gogo/protobuf/proto"
+)
+
+var sentinelValue = new(model.HTTPAggregations)
+
+type httpEncoder struct {
+	aggregations map[http.Key]*model.HTTPAggregations
+
+	// pre-allocated objects
+	dataPool []model.HTTPStats_Data
+	ptrPool  []*model.HTTPStats_Data
+	poolIdx  int
+
+	orphanEntries int
+}
+
+func newHTTPEncoder(payload *network.Connections) *httpEncoder {
+	if len(payload.HTTP) == 0 {
+		return nil
+	}
+
+	encoder := &httpEncoder{
+		aggregations: make(map[http.Key]*model.HTTPAggregations, len(payload.Conns)),
+
+		// pre-allocate all data objects at once
+		dataPool: make([]model.HTTPStats_Data, len(payload.HTTP)*http.NumStatusClasses),
+		ptrPool:  make([]*model.HTTPStats_Data, len(payload.HTTP)*http.NumStatusClasses),
+		poolIdx:  0,
+	}
+
+	// pre-populate aggregation map with keys for all existent connections
+	// this allows us to skip encoding orphan HTTP objects that can't be matched to a connection
+	for _, conn := range payload.Conns {
+		encoder.aggregations[httpKeyFromConn(conn)] = sentinelValue
+	}
+
+	encoder.buildAggregations(payload)
+	return encoder
+}
+
+func (e *httpEncoder) GetHTTPAggregations(c network.ConnectionStats) *model.HTTPAggregations {
+	if e == nil {
+		return nil
+	}
+
+	key := httpKeyFromConn(c)
+	if aggregation, ok := e.aggregations[key]; ok && aggregation != sentinelValue {
+		return aggregation
+	}
+
+	return nil
+}
+
+func (e *httpEncoder) buildAggregations(payload *network.Connections) {
+	for key, stats := range payload.HTTP {
+		path := key.Path
+		method := key.Method
+		key.Path = ""
+		key.Method = http.MethodUnknown
+
+		aggregation, ok := e.aggregations[key]
+		if !ok {
+			// if there is no matching connection don't even bother to serialize HTTP data
+			e.orphanEntries++
+			continue
+		}
+
+		if aggregation == sentinelValue {
+			// if this is sentinel value, instantiate a real one
+			aggregation = &model.HTTPAggregations{
+				EndpointAggregations: make([]*model.HTTPStats, 0, 10),
+			}
+			e.aggregations[key] = aggregation
+		}
+
+		ms := &model.HTTPStats{
+			Path:                  path,
+			Method:                model.HTTPMethod(method),
+			StatsByResponseStatus: e.getDataSlice(),
+		}
+
+		for i, data := range ms.StatsByResponseStatus {
+			data.Count = uint32(stats[i].Count)
+
+			if latencies := stats[i].Latencies; latencies != nil {
+				blob, _ := proto.Marshal(latencies.ToProto())
+				data.Latencies = blob
+			} else {
+				data.FirstLatencySample = stats[i].FirstLatencySample
+			}
+		}
+
+		aggregation.EndpointAggregations = append(aggregation.EndpointAggregations, ms)
+	}
+}
+
+func (e *httpEncoder) getDataSlice() []*model.HTTPStats_Data {
+	ptrs := e.ptrPool[e.poolIdx : e.poolIdx+http.NumStatusClasses]
+	for i := range ptrs {
+		ptrs[i] = &e.dataPool[e.poolIdx+i]
+	}
+	e.poolIdx += http.NumStatusClasses
+	return ptrs
+}
+
+// build the key for the http map based on whether the local or remote side is http.
+func httpKeyFromConn(c network.ConnectionStats) http.Key {
+	// Retrieve translated addresses
+	laddr, lport := network.GetNATLocalAddress(c)
+	raddr, rport := network.GetNATRemoteAddress(c)
+
+	// HTTP data is always indexed as (client, server), so we flip
+	// the lookup key if necessary using the port range heuristic
+	if network.IsEphemeralPort(int(lport)) {
+		return http.NewKey(laddr, raddr, lport, rport, "", http.MethodUnknown)
+	}
+
+	return http.NewKey(raddr, laddr, rport, lport, "", http.MethodUnknown)
+}

--- a/pkg/network/encoding/http_test.go
+++ b/pkg/network/encoding/http_test.go
@@ -1,0 +1,185 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package encoding
+
+import (
+	"testing"
+
+	model "github.com/DataDog/agent-payload/v5/process"
+	"github.com/DataDog/datadog-agent/pkg/network"
+	"github.com/DataDog/datadog-agent/pkg/network/http"
+	"github.com/DataDog/datadog-agent/pkg/process/util"
+	"github.com/DataDog/sketches-go/ddsketch"
+	"github.com/DataDog/sketches-go/ddsketch/pb/sketchpb"
+	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatHTTPStats(t *testing.T) {
+	var (
+		clientPort = uint16(52800)
+		serverPort = uint16(8080)
+		localhost  = util.AddressFromString("127.0.0.1")
+	)
+
+	httpKey1 := http.NewKey(
+		localhost,
+		localhost,
+		clientPort,
+		serverPort,
+		"/testpath-1",
+		http.MethodGet,
+	)
+	var httpStats1 http.RequestStats
+	for i := range httpStats1 {
+		httpStats1[i].Count = 1
+		httpStats1[i].FirstLatencySample = 10
+	}
+
+	httpKey2 := httpKey1
+	httpKey2.Path = "/testpath-2"
+	var httpStats2 http.RequestStats
+	for i := range httpStats2 {
+		httpStats2[i].Count = 1
+		httpStats2[i].FirstLatencySample = 20
+	}
+
+	in := &network.Connections{
+		BufferedData: network.BufferedData{
+			Conns: []network.ConnectionStats{
+				{
+					Source: localhost,
+					Dest:   localhost,
+					SPort:  clientPort,
+					DPort:  serverPort,
+				},
+			},
+		},
+		HTTP: map[http.Key]http.RequestStats{
+			httpKey1: httpStats1,
+			httpKey2: httpStats2,
+		},
+	}
+	out := &model.HTTPAggregations{
+		EndpointAggregations: []*model.HTTPStats{
+			{
+				Path:   "/testpath-1",
+				Method: model.HTTPMethod_Get,
+				StatsByResponseStatus: []*model.HTTPStats_Data{
+					{Count: 1, FirstLatencySample: 10, Latencies: nil},
+					{Count: 1, FirstLatencySample: 10, Latencies: nil},
+					{Count: 1, FirstLatencySample: 10, Latencies: nil},
+					{Count: 1, FirstLatencySample: 10, Latencies: nil},
+					{Count: 1, FirstLatencySample: 10, Latencies: nil},
+				},
+			},
+			{
+				Path:   "/testpath-2",
+				Method: model.HTTPMethod_Get,
+				StatsByResponseStatus: []*model.HTTPStats_Data{
+					{Count: 1, FirstLatencySample: 20, Latencies: nil},
+					{Count: 1, FirstLatencySample: 20, Latencies: nil},
+					{Count: 1, FirstLatencySample: 20, Latencies: nil},
+					{Count: 1, FirstLatencySample: 20, Latencies: nil},
+					{Count: 1, FirstLatencySample: 20, Latencies: nil},
+				},
+			},
+		},
+	}
+
+	httpEncoder := newHTTPEncoder(in)
+	aggregations := httpEncoder.GetHTTPAggregations(in.Conns[0])
+	require.NotNil(t, aggregations)
+	assert.ElementsMatch(t, out.EndpointAggregations, aggregations.EndpointAggregations)
+}
+
+func TestFormatHTTPStatsByPath(t *testing.T) {
+	var httpReqStats http.RequestStats
+	httpReqStats.AddRequest(100, 12.5)
+	httpReqStats.AddRequest(100, 12.5)
+	httpReqStats.AddRequest(405, 3.5)
+	httpReqStats.AddRequest(405, 3.5)
+
+	// Verify the latency data is correct prior to serialization
+	latencies := httpReqStats[model.HTTPResponseStatus_Info].Latencies
+	assert.Equal(t, 2.0, latencies.GetCount())
+	verifyQuantile(t, latencies, 0.5, 12.5)
+
+	latencies = httpReqStats[model.HTTPResponseStatus_ClientErr].Latencies
+	assert.Equal(t, 2.0, latencies.GetCount())
+	verifyQuantile(t, latencies, 0.5, 3.5)
+
+	key := http.NewKey(
+		util.AddressFromString("10.1.1.1"),
+		util.AddressFromString("10.2.2.2"),
+		60000,
+		80,
+		"/testpath",
+		http.MethodGet,
+	)
+
+	payload := &network.Connections{
+		BufferedData: network.BufferedData{
+			Conns: []network.ConnectionStats{
+				{
+					Source: util.AddressFromString("10.1.1.1"),
+					Dest:   util.AddressFromString("10.2.2.2"),
+					SPort:  60000,
+					DPort:  80,
+				},
+			},
+		},
+		HTTP: map[http.Key]http.RequestStats{
+			key: httpReqStats,
+		},
+	}
+	httpEncoder := newHTTPEncoder(payload)
+	httpAggregations := httpEncoder.GetHTTPAggregations(payload.Conns[0])
+
+	require.NotNil(t, httpAggregations)
+	endpointAggregations := httpAggregations.EndpointAggregations
+	require.Len(t, endpointAggregations, 1)
+	assert.Equal(t, "/testpath", endpointAggregations[0].Path)
+	assert.Equal(t, model.HTTPMethod_Get, endpointAggregations[0].Method)
+
+	// Deserialize the encoded latency information & confirm it is correct
+	statsByResponseStatus := endpointAggregations[0].StatsByResponseStatus
+	assert.Len(t, statsByResponseStatus, 5)
+
+	serializedLatencies := statsByResponseStatus[model.HTTPResponseStatus_Info].Latencies
+	sketch := unmarshalSketch(t, serializedLatencies)
+	assert.Equal(t, 2.0, sketch.GetCount())
+	verifyQuantile(t, sketch, 0.5, 12.5)
+
+	serializedLatencies = statsByResponseStatus[model.HTTPResponseStatus_ClientErr].Latencies
+	sketch = unmarshalSketch(t, serializedLatencies)
+	assert.Equal(t, 2.0, sketch.GetCount())
+	verifyQuantile(t, sketch, 0.5, 3.5)
+
+	serializedLatencies = statsByResponseStatus[model.HTTPResponseStatus_Success].Latencies
+	assert.Nil(t, serializedLatencies)
+}
+
+func unmarshalSketch(t *testing.T, bytes []byte) *ddsketch.DDSketch {
+	var sketchPb sketchpb.DDSketch
+	err := proto.Unmarshal(bytes, &sketchPb)
+	assert.Nil(t, err)
+
+	ret, err := ddsketch.FromProto(&sketchPb)
+	assert.Nil(t, err)
+
+	return ret
+}
+
+func verifyQuantile(t *testing.T, sketch *ddsketch.DDSketch, q float64, expectedValue float64) {
+	val, err := sketch.GetValueAtQuantile(q)
+	assert.Nil(t, err)
+
+	acceptableError := expectedValue * sketch.IndexMapping.RelativeAccuracy()
+	assert.True(t, val >= expectedValue-acceptableError)
+	assert.True(t, val <= expectedValue+acceptableError)
+}

--- a/pkg/network/encoding/http_test.go
+++ b/pkg/network/encoding/http_test.go
@@ -13,8 +13,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/http"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/sketches-go/ddsketch"
-	"github.com/DataDog/sketches-go/ddsketch/pb/sketchpb"
-	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -165,14 +163,11 @@ func TestFormatHTTPStatsByPath(t *testing.T) {
 }
 
 func unmarshalSketch(t *testing.T, bytes []byte) *ddsketch.DDSketch {
-	var sketchPb sketchpb.DDSketch
-	err := proto.Unmarshal(bytes, &sketchPb)
+	sketch, err := ddsketch.NewDefaultDDSketch(http.RelativeAccuracy)
 	assert.Nil(t, err)
-
-	ret, err := ddsketch.FromProto(&sketchPb)
+	err = sketch.DecodeAndMergeWith(bytes)
 	assert.Nil(t, err)
-
-	return ret
+	return sketch
 }
 
 func verifyQuantile(t *testing.T, sketch *ddsketch.DDSketch, q float64, expectedValue float64) {

--- a/pkg/network/state.go
+++ b/pkg/network/state.go
@@ -347,6 +347,17 @@ func (ns *networkState) storeDNSStats(stats dns.StatsByKeyByNameByType) {
 
 // storeHTTPStats stores latest HTTP stats for all clients
 func (ns *networkState) storeHTTPStats(allStats map[http.Key]http.RequestStats) {
+	if len(ns.clients) == 1 {
+		for _, client := range ns.clients {
+			if len(client.httpStatsDelta) == 0 {
+				// optimization for the common case:
+				// if there is only one client and no previous state, no memory allocation is needed
+				client.httpStatsDelta = allStats
+				return
+			}
+		}
+	}
+
 	for key, stats := range allStats {
 		for _, client := range ns.clients {
 			prevStats, ok := client.httpStatsDelta[key]


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Replaces the protobuf-based encoding of DDSketches by a "custom" one provided by `DDSketch.Encode`;
This reduces the number of allocations in the HTTP encoding path by almost 80% and has the side benefit of being mergeable in serialized form;

TODO: this is a breaking change so we should use a new protobuf field before merging it;

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
