### PR TITLE
Remove unnecessary taghash update

### DIFF
--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -541,7 +541,7 @@ func (ac *AutoConfig) resolveTemplate(tpl integration.Config) []integration.Conf
 // resolveTemplateForService calls the config resolver for the template against the service,
 // decrypts secrets and stores the resolved config and service mapping if successful
 func (ac *AutoConfig) resolveTemplateForService(tpl integration.Config, svc listeners.Service) (integration.Config, error) {
-	config, tagsHash, err := configresolver.Resolve(tpl, svc)
+	config, _, err := configresolver.Resolve(tpl, svc)
 	if err != nil {
 		newErr := fmt.Errorf("error resolving template %s for service %s: %v", tpl.Name, svc.GetServiceID(), err)
 		errorStats.setResolveWarning(tpl.Name, newErr.Error())
@@ -555,10 +555,6 @@ func (ac *AutoConfig) resolveTemplateForService(tpl integration.Config, svc list
 	ac.store.setLoadedConfig(resolvedConfig)
 	ac.store.addConfigForService(svc.GetServiceID(), resolvedConfig)
 	ac.store.addConfigForTemplate(tpl.Digest(), resolvedConfig)
-	ac.store.setTagsHashForService(
-		svc.GetTaggerEntity(),
-		tagsHash,
-	)
 	errorStats.removeResolveWarnings(tpl.Name)
 	return resolvedConfig, nil
 }

--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -541,7 +541,7 @@ func (ac *AutoConfig) resolveTemplate(tpl integration.Config) []integration.Conf
 // resolveTemplateForService calls the config resolver for the template against the service,
 // decrypts secrets and stores the resolved config and service mapping if successful
 func (ac *AutoConfig) resolveTemplateForService(tpl integration.Config, svc listeners.Service) (integration.Config, error) {
-	config, _, err := configresolver.Resolve(tpl, svc)
+	config, err := configresolver.Resolve(tpl, svc)
 	if err != nil {
 		newErr := fmt.Errorf("error resolving template %s for service %s: %v", tpl.Name, svc.GetServiceID(), err)
 		errorStats.setResolveWarning(tpl.Name, newErr.Error())

--- a/pkg/autodiscovery/common_test.go
+++ b/pkg/autodiscovery/common_test.go
@@ -47,9 +47,9 @@ func (s *dummyService) GetPorts(context.Context) ([]listeners.ContainerPort, err
 	return s.Ports, nil
 }
 
-// GetTags returns mil
-func (s *dummyService) GetTags() ([]string, string, error) {
-	return nil, "", nil
+// GetTags returns the tags for this service
+func (s *dummyService) GetTags() ([]string, error) {
+	return nil, nil
 }
 
 // GetPid return a dummy pid

--- a/pkg/autodiscovery/configresolver/configresolver.go
+++ b/pkg/autodiscovery/configresolver/configresolver.go
@@ -106,7 +106,7 @@ func Resolve(tpl integration.Config, svc listeners.Service) (integration.Config,
 		return resolvedConfig, fmt.Errorf("%w, skipping service %s", err, svc.GetServiceID())
 	}
 
-	tags, _, err := svc.GetTags()
+	tags, err := svc.GetTags()
 	if err != nil {
 		return resolvedConfig, fmt.Errorf("couldn't get tags for service '%s', err: %w", svc.GetServiceID(), err)
 	}

--- a/pkg/autodiscovery/configresolver/configresolver.go
+++ b/pkg/autodiscovery/configresolver/configresolver.go
@@ -52,9 +52,7 @@ func SubstituteTemplateEnvVars(config *integration.Config) error {
 
 // Resolve takes a template and a service and generates a config with
 // valid connection info and relevant tags.
-// Resolve also returns the hash of the tags to the config.
-// The tags and hashes are computed once and in this function, then propagated to the main AD to avoid having inconsistent tags and hashes in the AD store.
-func Resolve(tpl integration.Config, svc listeners.Service) (integration.Config, string, error) {
+func Resolve(tpl integration.Config, svc listeners.Service) (integration.Config, error) {
 	ctx := context.TODO()
 	// Copy original template
 	resolvedConfig := integration.Config{
@@ -84,42 +82,42 @@ func Resolve(tpl integration.Config, svc listeners.Service) (integration.Config,
 			// Empty check names on k8s annotations or container labels override the check config from file
 			// Used to deactivate unneeded OOTB autodiscovery checks defined in files
 			// The checkNames slice is considered empty also if it contains one single empty string
-			return resolvedConfig, "", fmt.Errorf("ignoring config from %s: another empty config is defined with the same AD identifier: %v", tpl.Source, tpl.ADIdentifiers)
+			return resolvedConfig, fmt.Errorf("ignoring config from %s: another empty config is defined with the same AD identifier: %v", tpl.Source, tpl.ADIdentifiers)
 		}
 		for _, checkName := range checkNames {
 			if tpl.Name == checkName {
 				// Ignore config from file when the same check is activated on the same service via other config providers (k8s annotations or container labels)
-				return resolvedConfig, "", fmt.Errorf("ignoring config from %s: another config is defined for the check %s", tpl.Source, tpl.Name)
+				return resolvedConfig, fmt.Errorf("ignoring config from %s: another config is defined for the check %s", tpl.Source, tpl.Name)
 			}
 		}
 
 	}
 
 	if resolvedConfig.IsCheckConfig() && !svc.IsReady(ctx) {
-		return resolvedConfig, "", errors.New("unable to resolve, service not ready")
+		return resolvedConfig, errors.New("unable to resolve, service not ready")
 	}
 
 	if err := substituteTemplateVariables(ctx, &resolvedConfig, svc); err != nil {
-		return resolvedConfig, "", err
+		return resolvedConfig, err
 	}
 
 	if err := SubstituteTemplateEnvVars(&resolvedConfig); err != nil {
 		// We add the service name to the error here, since SubstituteTemplateEnvVars doesn't know about that
-		return resolvedConfig, "", fmt.Errorf("%w, skipping service %s", err, svc.GetServiceID())
+		return resolvedConfig, fmt.Errorf("%w, skipping service %s", err, svc.GetServiceID())
 	}
 
-	tags, tagsHash, err := svc.GetTags()
+	tags, _, err := svc.GetTags()
 	if err != nil {
-		return resolvedConfig, "", fmt.Errorf("couldn't get tags for service '%s', err: %w", svc.GetServiceID(), err)
+		return resolvedConfig, fmt.Errorf("couldn't get tags for service '%s', err: %w", svc.GetServiceID(), err)
 	}
 
 	if !tpl.IgnoreAutodiscoveryTags {
 		if err := addServiceTags(&resolvedConfig, tags); err != nil {
-			return resolvedConfig, "", fmt.Errorf("unable to add tags for service '%s', err: %w", svc.GetServiceID(), err)
+			return resolvedConfig, fmt.Errorf("unable to add tags for service '%s', err: %w", svc.GetServiceID(), err)
 		}
 	}
 
-	return resolvedConfig, tagsHash, nil
+	return resolvedConfig, nil
 }
 
 // substituteTemplateVariables replaces %%VARIABLES%% in the config init,

--- a/pkg/autodiscovery/configresolver/configresolver_test.go
+++ b/pkg/autodiscovery/configresolver/configresolver_test.go
@@ -707,14 +707,13 @@ func TestResolve(t *testing.T) {
 			// Make sure we don't modify the template object
 			checksum := tc.tpl.Digest()
 
-			cfg, hash, err := Resolve(tc.tpl, tc.svc)
+			cfg, err := Resolve(tc.tpl, tc.svc)
 			if tc.errorString != "" {
 				assert.EqualError(t, err, tc.errorString)
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, tc.out, cfg)
 				assert.Equal(t, checksum, tc.tpl.Digest())
-				assert.Equal(t, "hash", hash) // Resolve must return a non-empty hash if err == nil
 			}
 		})
 	}

--- a/pkg/autodiscovery/configresolver/configresolver_test.go
+++ b/pkg/autodiscovery/configresolver/configresolver_test.go
@@ -59,8 +59,8 @@ func (s *dummyService) GetPorts(context.Context) ([]listeners.ContainerPort, err
 }
 
 // GetTags returns static tags
-func (s *dummyService) GetTags() ([]string, string, error) {
-	return []string{"foo:bar"}, "hash", nil
+func (s *dummyService) GetTags() ([]string, error) {
+	return []string{"foo:bar"}, nil
 }
 
 // GetPid return a dummy pid

--- a/pkg/autodiscovery/listeners/cloudfoundry.go
+++ b/pkg/autodiscovery/listeners/cloudfoundry.go
@@ -221,8 +221,8 @@ func (s *CloudFoundryService) GetPorts(context.Context) ([]ContainerPort, error)
 }
 
 // GetTags returns the list of container tags
-func (s *CloudFoundryService) GetTags() ([]string, string, error) {
-	return s.tags, "", nil
+func (s *CloudFoundryService) GetTags() ([]string, error) {
+	return s.tags, nil
 }
 
 // GetPid returns nil and an error because pids are currently not supported in CF

--- a/pkg/autodiscovery/listeners/environment.go
+++ b/pkg/autodiscovery/listeners/environment.go
@@ -99,8 +99,8 @@ func (s *EnvironmentService) GetPorts(context.Context) ([]ContainerPort, error) 
 }
 
 // GetTags retrieves a container's tags
-func (s *EnvironmentService) GetTags() ([]string, string, error) {
-	return nil, "", nil
+func (s *EnvironmentService) GetTags() ([]string, error) {
+	return nil, nil
 }
 
 // GetPid inspect the container and return its pid

--- a/pkg/autodiscovery/listeners/kube_endpoints.go
+++ b/pkg/autodiscovery/listeners/kube_endpoints.go
@@ -415,11 +415,11 @@ func (s *KubeEndpointService) GetPorts(context.Context) ([]ContainerPort, error)
 }
 
 // GetTags retrieves tags
-func (s *KubeEndpointService) GetTags() ([]string, string, error) {
+func (s *KubeEndpointService) GetTags() ([]string, error) {
 	if s.tags == nil {
-		return []string{}, "", nil
+		return []string{}, nil
 	}
-	return s.tags, "", nil
+	return s.tags, nil
 }
 
 // GetHostname returns nil and an error because port is not supported in Kubelet

--- a/pkg/autodiscovery/listeners/kube_endpoints_test.go
+++ b/pkg/autodiscovery/listeners/kube_endpoints_test.go
@@ -73,7 +73,7 @@ func TestProcessEndpoints(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []ContainerPort{{123, "port123"}, {126, "port126"}}, ports)
 
-	tags, _, err := eps[0].GetTags()
+	tags, err := eps[0].GetTags()
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"kube_service:myservice", "kube_namespace:default", "kube_endpoint_ip:10.0.0.1", "foo:bar"}, tags)
 
@@ -91,7 +91,7 @@ func TestProcessEndpoints(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []ContainerPort{{123, "port123"}, {126, "port126"}}, ports)
 
-	tags, _, err = eps[1].GetTags()
+	tags, err = eps[1].GetTags()
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"kube_service:myservice", "kube_namespace:default", "kube_endpoint_ip:10.0.0.2", "foo:bar"}, tags)
 }

--- a/pkg/autodiscovery/listeners/kube_services.go
+++ b/pkg/autodiscovery/listeners/kube_services.go
@@ -313,8 +313,8 @@ func (s *KubeServiceService) GetPorts(context.Context) ([]ContainerPort, error) 
 }
 
 // GetTags retrieves tags
-func (s *KubeServiceService) GetTags() ([]string, string, error) {
-	return s.tags, "", nil
+func (s *KubeServiceService) GetTags() ([]string, error) {
+	return s.tags, nil
 }
 
 // GetHostname returns nil and an error because port is not supported in Kubelet

--- a/pkg/autodiscovery/listeners/kube_services_test.go
+++ b/pkg/autodiscovery/listeners/kube_services_test.go
@@ -62,7 +62,7 @@ func TestProcessService(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []ContainerPort{{123, "test1"}, {126, "test2"}}, ports)
 
-	tags, _, err := svc.GetTags()
+	tags, err := svc.GetTags()
 	assert.NoError(t, err)
 	expectedTags := []string{
 		"kube_service:myservice",

--- a/pkg/autodiscovery/listeners/service.go
+++ b/pkg/autodiscovery/listeners/service.go
@@ -79,8 +79,8 @@ func (s *service) GetPorts(_ context.Context) ([]ContainerPort, error) {
 }
 
 // GetTags returns the tags associated with the service.
-func (s *service) GetTags() ([]string, string, error) {
-	return tagger.TagWithHash(s.GetTaggerEntity(), tagger.ChecksCardinality)
+func (s *service) GetTags() ([]string, error) {
+	return tagger.Tag(s.GetTaggerEntity(), tagger.ChecksCardinality)
 }
 
 // GetPid returns the process ID of the service.

--- a/pkg/autodiscovery/listeners/snmp.go
+++ b/pkg/autodiscovery/listeners/snmp.go
@@ -348,8 +348,8 @@ func (s *SNMPService) GetPorts(context.Context) ([]ContainerPort, error) {
 }
 
 // GetTags returns the list of container tags - currently always empty
-func (s *SNMPService) GetTags() ([]string, string, error) {
-	return []string{}, "", nil
+func (s *SNMPService) GetTags() ([]string, error) {
+	return []string{}, nil
 }
 
 // GetPid returns nil and an error because pids are currently not supported

--- a/pkg/autodiscovery/listeners/types.go
+++ b/pkg/autodiscovery/listeners/types.go
@@ -28,7 +28,7 @@ type Service interface {
 	GetADIdentifiers(context.Context) ([]string, error)  // identifiers on which templates will be matched
 	GetHosts(context.Context) (map[string]string, error) // network --> IP address
 	GetPorts(context.Context) ([]ContainerPort, error)   // network ports
-	GetTags() ([]string, string, error)                  // tags and tags hash
+	GetTags() ([]string, error)                          // tags
 	GetPid(context.Context) (int, error)                 // process identifier
 	GetHostname(context.Context) (string, error)         // hostname.domainname for the entity
 	IsReady(context.Context) bool                        // is the service ready

--- a/pkg/tagger/global.go
+++ b/pkg/tagger/global.go
@@ -134,20 +134,14 @@ func AccumulateTagsFor(entity string, cardinality collectors.TagCardinality, tb 
 	return defaultTagger.AccumulateTagsFor(entity, cardinality, tb)
 }
 
-// TagWithHash is similar to Tag but it also computes and returns the hash of the tags found
-func TagWithHash(entity string, cardinality collectors.TagCardinality) ([]string, string, error) {
-	tags, err := Tag(entity, cardinality)
-	if err != nil {
-		return tags, "", err
-	}
-	return tags, utils.ComputeTagsHash(tags), nil
-}
-
 // GetEntityHash returns the hash for the tags associated with the given entity
 // Returns an empty string if the tags lookup fails
 func GetEntityHash(entity string, cardinality collectors.TagCardinality) string {
-	_, hash, _ := TagWithHash(entity, cardinality)
-	return hash
+	tags, err := Tag(entity, cardinality)
+	if err != nil {
+		return ""
+	}
+	return utils.ComputeTagsHash(tags)
 }
 
 // StandardTags queries the defaultTagger to get entity

--- a/test/integration/listeners/docker/docker_listener_test.go
+++ b/test/integration/listeners/docker/docker_listener_test.go
@@ -224,9 +224,8 @@ func (suite *DockerListenerTestSuite) commonSection(containerIDs []string) {
 		expectedTags, found := expectedADIDs[entity]
 		assert.True(suite.T(), found, "entity not found in expected ones")
 
-		tags, hash, err := service.GetTags()
+		tags, err := service.GetTags()
 		assert.Nil(suite.T(), err)
-		assert.NotEqual(suite.T(), "", hash)
 		assert.Contains(suite.T(), tags, "docker_image:datadog/docker-library:redis_3_2_11-alpine")
 		assert.Contains(suite.T(), tags, "image_name:datadog/docker-library")
 		assert.Contains(suite.T(), tags, "image_tag:redis_3_2_11-alpine")


### PR DESCRIPTION
### What does this PR do?

Removes a superfluous call to `setTagsHashForService` in AD.

### Motivation

In #11640, I'm separating two concerns of the AutoConfig type: managing services, and managing config template resolution.  the service tagshash tracking is related to the "service" concern, while everything else in this function is related to config template resolution.  So, I'd like to remove this.

I suspect that this is somewhere between "unnecessary" and a subtle bug.  The AutoConfig type has a goroutine polling for tags to change on a service (`checkTagFreshness`) which uses the tagshash to determine when a service's tags have changed.  But if `setTagsHashForService` is installs the new tagshash before that check can occur, the check will miss the tags change (this is the potential "subtle bug").

A bit of staring at git annotations didn't reveal much in the way of history here.  I suspect that at one point tags hashes were handled only during template resolution, and during that era there was a race condition between getting a service's tags and getting the hash of those tags -- so the two were combined in the tagger and in the `listener.Service#GetTags` method and fetched consistently.  Later, the polling for changes to tagshash was added, and this one reference to tagshashes in template resolution was missed at that point.

### Additional Notes

As a follow-on, it turns out that nothing was using the second return value from `configresolver.Resolve`, so I removed that. As a further follow-on, it turns out that with this change nothing was using the second return value from `listener.Service#GetTags`, so I removed that.  As a further follow-on, it turns out that with this change nothing is calling `tagger.TagWithHash`, so I removed that.  All of which means removing a good chunk of old code!

Also, apologies to the spew of teams this PR is pinging, due to trivial changes to files in your CODEOWNERS.  Please rubber-stamp this PR for those changes, filtering by "Files owned by me" in the review page.

### Possible Drawbacks / Trade-offs

Something may depend on this behavior!

### Describe how to test/QA your changes

In a k8s environment, with this agent running:

```
kubectl run bash --image=bash \
  --annotations ad.datadoghq.com/bash.logs='[{"source":"dustin", "service":"dustin"}]' \
  --annotations ad.datadoghq.com/bash.tags='{"dustin":"testing"}' \
  --command -- bash -c 'while true; do date; sleep 1; done'
```
then either look in the app to find that container's logs, or run `agent stream-logs` on the relevant agent container.  You should see the "dustin:testing" tag,
```
kubectl annotate pod --overwrite bash ad.datadoghq.com/bash.tags='{"dustin":"changed"}'
```
..and soon, you should see that change to "dustin:changed"

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
