### PR TITLE
[workloadmeta] Suppress unset events for unknown entities

### DIFF
--- a/pkg/workloadmeta/store_test.go
+++ b/pkg/workloadmeta/store_test.go
@@ -422,6 +422,21 @@ func TestSubscribe(t *testing.T) {
 				},
 			},
 		},
+		{
+			// unsetting an unknown entity should generate no events
+			name:   "unsets unknown entity",
+			filter: nil,
+			postEvents: [][]CollectorEvent{
+				{
+					{
+						Type:   EventTypeUnset,
+						Source: fooSource,
+						Entity: fooContainer,
+					},
+				},
+			},
+			expected: []EventBundle{},
+		},
 	}
 
 	for _, tt := range tests {
@@ -433,7 +448,7 @@ func TestSubscribe(t *testing.T) {
 			ch := s.Subscribe(dummySubscriber, NormalPriority, tt.filter)
 			doneCh := make(chan struct{})
 
-			var actual []EventBundle
+			actual := []EventBundle{}
 			go func() {
 				for bundle := range ch {
 					close(bundle.Ch)


### PR DESCRIPTION
### What does this PR do?

This happens sometimes to pause containers, especially in containerd: we
can filter out new pause container events, but once the container is gone we
can no longer get information about its image, so we can't filter out
deleted container events (as we identify them by the image name).

Since this is a bit hard to fix, and to prevent these events from
bothering subscribers, workloadmeta no longer emits events for entites
that were never in the store in the first place.

### Additional notes

These changes have been extract from #11631, so we can merge this as a bugfix for 7.36, while the feature changes will be merged later for 7.37.

### Describe how to test/QA your changes

Same as #11596.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
