### PR TITLE
[CWS] Fix spanID tracking

### DIFF
--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -595,6 +595,7 @@ func (p *Probe) handleEvent(CPU uint64, data []byte) {
 		}
 
 		p.resolvers.ProcessResolver.ApplyBootTime(event.processCacheEntry)
+		event.processCacheEntry.SetSpan(event.SpanContext.SpanID, event.SpanContext.TraceID)
 
 		p.resolvers.ProcessResolver.AddForkEntry(event.ProcessContext.Pid, event.processCacheEntry)
 	case model.ExecEventType:

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -271,6 +271,9 @@ type Process struct {
 	ContainerID   string   `field:"container.id" msg:"container_id"` // Container ID
 	ContainerTags []string `field:"-" msg:"container_tags"`
 
+	SpanID  uint64 `field:"-" msg:"span_id"`
+	TraceID uint64 `field:"-" msg:"trace_id"`
+
 	TTYName string `field:"tty_name" msg:"tty"` // Name of the TTY associated with the process
 	Comm    string `field:"comm" msg:"comm"`    // Comm attribute of the process
 

--- a/pkg/security/secl/model/model_gen.go
+++ b/pkg/security/secl/model/model_gen.go
@@ -1005,6 +1005,18 @@ func (z *Process) DecodeMsg(dc *msgp.Reader) (err error) {
 					return
 				}
 			}
+		case "span_id":
+			z.SpanID, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "SpanID")
+				return
+			}
+		case "trace_id":
+			z.TraceID, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "TraceID")
+				return
+			}
 		case "tty":
 			z.TTYName, err = dc.ReadString()
 			if err != nil {
@@ -1108,9 +1120,9 @@ func (z *Process) DecodeMsg(dc *msgp.Reader) (err error) {
 
 // EncodeMsg implements msgp.Encodable
 func (z *Process) EncodeMsg(en *msgp.Writer) (err error) {
-	// map header, size 16
+	// map header, size 18
 	// write "file"
-	err = en.Append(0xde, 0x0, 0x10, 0xa4, 0x66, 0x69, 0x6c, 0x65)
+	err = en.Append(0xde, 0x0, 0x12, 0xa4, 0x66, 0x69, 0x6c, 0x65)
 	if err != nil {
 		return
 	}
@@ -1165,6 +1177,26 @@ func (z *Process) EncodeMsg(en *msgp.Writer) (err error) {
 			err = msgp.WrapError(err, "ContainerTags", za0001)
 			return
 		}
+	}
+	// write "span_id"
+	err = en.Append(0xa7, 0x73, 0x70, 0x61, 0x6e, 0x5f, 0x69, 0x64)
+	if err != nil {
+		return
+	}
+	err = en.WriteUint64(z.SpanID)
+	if err != nil {
+		err = msgp.WrapError(err, "SpanID")
+		return
+	}
+	// write "trace_id"
+	err = en.Append(0xa8, 0x74, 0x72, 0x61, 0x63, 0x65, 0x5f, 0x69, 0x64)
+	if err != nil {
+		return
+	}
+	err = en.WriteUint64(z.TraceID)
+	if err != nil {
+		err = msgp.WrapError(err, "TraceID")
+		return
 	}
 	// write "tty"
 	err = en.Append(0xa3, 0x74, 0x74, 0x79)
@@ -1296,9 +1328,9 @@ func (z *Process) EncodeMsg(en *msgp.Writer) (err error) {
 // MarshalMsg implements msgp.Marshaler
 func (z *Process) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
-	// map header, size 16
+	// map header, size 18
 	// string "file"
-	o = append(o, 0xde, 0x0, 0x10, 0xa4, 0x66, 0x69, 0x6c, 0x65)
+	o = append(o, 0xde, 0x0, 0x12, 0xa4, 0x66, 0x69, 0x6c, 0x65)
 	o, err = z.FileEvent.MarshalMsg(o)
 	if err != nil {
 		err = msgp.WrapError(err, "FileEvent")
@@ -1319,6 +1351,12 @@ func (z *Process) MarshalMsg(b []byte) (o []byte, err error) {
 	for za0001 := range z.ContainerTags {
 		o = msgp.AppendString(o, z.ContainerTags[za0001])
 	}
+	// string "span_id"
+	o = append(o, 0xa7, 0x73, 0x70, 0x61, 0x6e, 0x5f, 0x69, 0x64)
+	o = msgp.AppendUint64(o, z.SpanID)
+	// string "trace_id"
+	o = append(o, 0xa8, 0x74, 0x72, 0x61, 0x63, 0x65, 0x5f, 0x69, 0x64)
+	o = msgp.AppendUint64(o, z.TraceID)
 	// string "tty"
 	o = append(o, 0xa3, 0x74, 0x74, 0x79)
 	o = msgp.AppendString(o, z.TTYName)
@@ -1436,6 +1474,18 @@ func (z *Process) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+		case "span_id":
+			z.SpanID, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "SpanID")
+				return
+			}
+		case "trace_id":
+			z.TraceID, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "TraceID")
+				return
+			}
 		case "tty":
 			z.TTYName, bts, err = msgp.ReadStringBytes(bts)
 			if err != nil {
@@ -1542,7 +1592,7 @@ func (z *Process) Msgsize() (s int) {
 	for za0001 := range z.ContainerTags {
 		s += msgp.StringPrefixSize + len(z.ContainerTags[za0001])
 	}
-	s += 4 + msgp.StringPrefixSize + len(z.TTYName) + 5 + msgp.StringPrefixSize + len(z.Comm) + 10 + msgp.TimeSize + 10 + msgp.TimeSize + 10 + msgp.TimeSize + 11 + msgp.Uint64Size + 7 + msgp.Uint32Size + 5 + msgp.Uint32Size + 12 + z.Credentials.Msgsize() + 5
+	s += 8 + msgp.Uint64Size + 9 + msgp.Uint64Size + 4 + msgp.StringPrefixSize + len(z.TTYName) + 5 + msgp.StringPrefixSize + len(z.Comm) + 10 + msgp.TimeSize + 10 + msgp.TimeSize + 10 + msgp.TimeSize + 11 + msgp.Uint64Size + 7 + msgp.Uint32Size + 5 + msgp.Uint32Size + 12 + z.Credentials.Msgsize() + 5
 	if z.ArgsEntry == nil {
 		s += msgp.NilSize
 	} else {

--- a/pkg/security/secl/model/process_cache_entry.go
+++ b/pkg/security/secl/model/process_cache_entry.go
@@ -13,7 +13,13 @@ import (
 	"time"
 )
 
-// SetAncestor set the ancestor
+// SetSpan sets the span
+func (pc *ProcessCacheEntry) SetSpan(spanID uint64, traceID uint64) {
+	pc.SpanID = spanID
+	pc.TraceID = traceID
+}
+
+// SetAncestor sets the ancestor
 func (pc *ProcessCacheEntry) SetAncestor(parent *ProcessCacheEntry) {
 	pc.Ancestor = parent
 	parent.Retain()

--- a/pkg/security/tests/span_test.go
+++ b/pkg/security/tests/span_test.go
@@ -20,6 +20,8 @@ import (
 )
 
 func TestSpan(t *testing.T) {
+	executable := which(t, "touch")
+
 	ruleDefs := []*rules.RuleDefinition{
 		{
 			ID:         "test_span_rule_open",
@@ -27,7 +29,7 @@ func TestSpan(t *testing.T) {
 		},
 		{
 			ID:         "test_span_rule_exec",
-			Expression: `exec.file.path == "/usr/bin/touch"`,
+			Expression: fmt.Sprintf(`exec.file.path in [ "/usr/bin/touch", "%s" ]`, executable),
 		},
 	}
 
@@ -80,8 +82,13 @@ func TestSpan(t *testing.T) {
 		}
 		defer os.Remove(testFile)
 
-		args := []string{"span-exec", "104", "204", "/usr/bin/touch", testFile}
-		envs := []string{}
+		var args []string
+		var envs []string
+		if kind == dockerWrapperType {
+			args = []string{"span-exec", "104", "204", "/usr/bin/touch", testFile}
+		} else if kind == stdWrapperType {
+			args = []string{"span-exec", "104", "204", executable, testFile}
+		}
 
 		test.WaitSignal(t, func() error {
 			cmd := cmdFunc(syscallTester, args, envs)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

This PR introduces SpanID / TraceID per processCacheEntries. The point is to store which span initiated a fork. Ultimately this is useful to grab the user space flame graph that spawned a thread in case of an RCE.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

This PR fixes the spanID tracking feature on fork.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
