### PR TITLE
Create install_info from deb, rpm and dmg packages

### DIFF
--- a/omnibus/package-scripts/agent/postinst
+++ b/omnibus/package-scripts/agent/postinst
@@ -55,6 +55,27 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
             ;;
         esac
         #DEBHELPER#
+
+        # Set the installation information if not already present;
+        # This is done in posttrans for .rpm packages
+        if [ ! -f "$CONFIG_DIR/install_info" ]; then
+
+            if command -v dpkg >/dev/null 2>&1 && command -v dpkg-query >/dev/null 2>&1; then
+                tool=dpkg
+                tool_version=dpkg-$(dpkg-query --showformat='${Version}' --show dpkg  | cut -d "." -f 1-3 || echo "unknown")
+            else
+                tool=unknown
+                tool_version=unknown
+            fi
+            
+            install_info_content="---
+install_method:
+  tool: $tool
+  tool_version: $tool_version
+  installer_version: deb_package
+"
+            echo "$install_info_content" > $CONFIG_DIR/install_info
+        fi
     fi
 
     # Set proper rights to the dd-agent user

--- a/omnibus/package-scripts/agent/postinst
+++ b/omnibus/package-scripts/agent/postinst
@@ -217,6 +217,14 @@ else
         sed -E 's/^api_key:$/api_key: APIKEY/' $CONF_DIR/datadog.yaml.example > $CONF_DIR/datadog.yaml
     fi
 
+    install_info_content="---
+install_method:
+  tool: macos_dmg
+  tool_version: macos_dmg
+  installer_version: macos_dmg
+"
+    echo "$install_info_content" > $CONFIG_DIR/install_info
+
     echo "# Setting correct rights on conf"
     chown -vR "${INSTALL_USER}:admin" $CONF_DIR
 

--- a/omnibus/package-scripts/agent/postinst
+++ b/omnibus/package-scripts/agent/postinst
@@ -223,7 +223,7 @@ install_method:
   tool_version: macos_dmg
   installer_version: macos_dmg
 "
-    echo "$install_info_content" > $CONFIG_DIR/install_info
+    echo "$install_info_content" > $CONF_DIR/install_info
 
     echo "# Setting correct rights on conf"
     chown -vR "${INSTALL_USER}:admin" $CONF_DIR

--- a/omnibus/package-scripts/agent/postrm
+++ b/omnibus/package-scripts/agent/postrm
@@ -29,6 +29,9 @@ if [ -f "/etc/debian_version" ] || [ "$DISTRIBUTION" = "Debian" ] || [ "$DISTRIB
             rm -rf $LOG_DIR
             rm -rf $CONFIG_DIR
         ;;
+        remove)
+            rm $CONFIG_DIR/install_info || true
+        ;;
         *)
         ;;
     esac
@@ -37,6 +40,7 @@ elif [ -f "/etc/redhat-release" ] || [ -f "/etc/system-release" ] || [ -f "/etc/
         0)
             # We're uninstalling.
             # We don't delete the dd-agent user/group (see https://fedoraproject.org/wiki/Packaging:UsersAndGroups#Allocation_Strategies)
+            rm $CONFIG_DIR/install_info || true
         ;;
         1)
             # We're upgrading.

--- a/omnibus/package-scripts/agent/posttrans
+++ b/omnibus/package-scripts/agent/posttrans
@@ -74,6 +74,36 @@ if [ "$INSTALL_SELINUX_POLICY" = "true" ]; then
     fi
 fi
 
+
+# Set the installation information if not already present;
+# This is done in the postinst script for .deb packages
+if [ ! -f "$CONFIG_DIR/install_info" ]; then
+
+    if command -v rpm >/dev/null 2>&1; then
+        tool=rpm
+        tool_version=rpm-$(rpm -q --qf "%{VERSION}" rpm || echo "unknown")
+    else
+        tool=unknown
+        tool_version=unknown
+    fi
+
+    # Distinguish SUSE since it has a different package
+    if [ "$DISTRIBUTION_FAMILY" = "SUSE" ]; then
+        installer_version="rpm_suse_package"
+    else
+        installer_version="rpm_package"
+    fi
+
+    install_info_content="---
+install_method:
+  tool: $tool
+  tool_version: $tool_version
+  installer_version: $installer_version
+"
+    echo "$install_info_content" > $CONFIG_DIR/install_info
+    chown -R dd-agent:dd-agent ${CONFIG_DIR}
+fi
+
 # TODO: Use a configcheck command on the agent to determine if it's safe to restart,
 # and avoid restarting when a check conf is invalid
 if [ -f "$CONFIG_DIR/datadog.yaml" ]; then

--- a/omnibus/package-scripts/iot-agent/postinst
+++ b/omnibus/package-scripts/iot-agent/postinst
@@ -55,6 +55,27 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
             ;;
         esac
         #DEBHELPER#
+        
+        # Set the installation information if not already present;
+        # This is done in posttrans for .rpm packages
+	    if [ ! -f "$CONFIG_DIR/install_info" ]; then
+
+		    if command -v dpkg >/dev/null 2>&1 && command -v dpkg-query >/dev/null 2>&1; then
+			    tool=dpkg
+			    tool_version=dpkg-$(dpkg-query --showformat='${Version}' --show dpkg | cut -d "." -f 1-3 || echo "unknown")
+		    else
+			    tool=unknown
+			    tool_version=unknown
+		    fi
+		    
+		    install_info_content="---
+install_method:
+  tool: $tool
+  tool_version: $tool_version
+  installer_version: deb_package-iot
+"
+		    echo "$install_info_content" > $CONFIG_DIR/install_info
+	    fi
     fi
 
     # Set proper rights to the dd-agent user

--- a/omnibus/package-scripts/iot-agent/postrm
+++ b/omnibus/package-scripts/iot-agent/postrm
@@ -29,6 +29,9 @@ if [ -f "/etc/debian_version" ] || [ "$DISTRIBUTION" = "Debian" ] || [ "$DISTRIB
             rm -rf $LOG_DIR
             rm -rf $CONFIG_DIR
         ;;
+        remove)
+            rm $CONFIG_DIR/install_info || true
+        ;;
         *)
         ;;
     esac
@@ -37,6 +40,7 @@ elif [ -f "/etc/redhat-release" ] || [ -f "/etc/system-release" ] || [ -f "/etc/
         0)
             # We're uninstalling.
             # We don't delete the dd-agent user/group (see https://fedoraproject.org/wiki/Packaging:UsersAndGroups#Allocation_Strategies)
+            rm $CONFIG_DIR/install_info || true
         ;;
         1)
             # We're upgrading.

--- a/omnibus/package-scripts/iot-agent/posttrans
+++ b/omnibus/package-scripts/iot-agent/posttrans
@@ -24,6 +24,28 @@ else
     echo "[ WARNING ]\tCannot detect a supported init system. The datadog-iot-agent package only provides service files for systemd and upstart."
 fi
 
+# Set the installation information if not already present;
+# This is done in the postinst script for .deb packages
+if [ ! -f "$CONFIG_DIR/install_info" ]; then
+
+    if command -v rpm >/dev/null 2>&1; then
+        tool=rpm
+        tool_version=rpm-$(rpm -q --qf "%{VERSION}" rpm || echo "unknown")
+    else
+        tool=unknown
+        tool_version=unknown
+    fi
+
+    install_info_content="---
+install_method:
+  tool: $tool
+  tool_version: $tool_version
+  installer_version: rpm_package-iot
+"
+    echo "$install_info_content" > $CONFIG_DIR/install_info
+    chown -R dd-agent:dd-agent ${CONFIG_DIR}
+fi
+
 # TODO: Use a configcheck command on the agent to determine if it's safe to restart,
 # and avoid restarting when a check conf is invalid
 if [ -f "$CONFIG_DIR/datadog.yaml" ]; then


### PR DESCRIPTION
### What does this PR do?

Reverts the revert of #5481 and adds similar behavior for MacOS.

### Motivation

The `install_info` wasn't populated in many installations and we can't always infer it based on other info like the OS.

### Describe how to test/QA your changes

Repeat on both Debian and CentOS:
- Install the Agent with an install method (eg: install_script.sh): the script `install_info` is present.
- Then, upgrade the Agent manually using the distro package manager (apt/yum): the script `install_info` is still present.
- Uninstall the Agent: `install_info` is removed.
- Install the agent directly using the distro package manager (apt/yum): this new `install_info` is created.

On MacOS:
- Install the Agent with an install method (eg: install_mac_os.sh): the script `install_info` is present.
- Then, upgrade the Agent manually using the dmg file: the new dmg `install_info` is present instead.
