### PR TITLE
[CWS] Fix span exec tests

### DIFF
--- a/pkg/security/tests/span_test.go
+++ b/pkg/security/tests/span_test.go
@@ -20,6 +20,8 @@ import (
 )
 
 func TestSpan(t *testing.T) {
+	executable := which(t, "touch")
+
 	ruleDefs := []*rules.RuleDefinition{
 		{
 			ID:         "test_span_rule_open",
@@ -27,7 +29,7 @@ func TestSpan(t *testing.T) {
 		},
 		{
 			ID:         "test_span_rule_exec",
-			Expression: `exec.file.path == "/usr/bin/touch"`,
+			Expression: fmt.Sprintf(`exec.file.path in [ "/usr/bin/touch", "%s" ]`, executable),
 		},
 	}
 
@@ -80,8 +82,13 @@ func TestSpan(t *testing.T) {
 		}
 		defer os.Remove(testFile)
 
-		args := []string{"span-exec", "104", "204", "/usr/bin/touch", testFile}
-		envs := []string{}
+		var args []string
+		var envs []string
+		if kind == dockerWrapperType {
+			args = []string{"span-exec", "104", "204", "/usr/bin/touch", testFile}
+		} else if kind == stdWrapperType {
+			args = []string{"span-exec", "104", "204", executable, testFile}
+		}
 
 		test.WaitSignal(t, func() error {
 			cmd := cmdFunc(syscallTester, args, envs)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

This PR fixes the span exec functional tests. In the test container, we know that the path to `touch` will always be `/usr/bin/touch` (we control this container), but on the host, it might be a symbolic link to `/bin/touch` for example. This PR resolves the path to `touch` dynamically and inserts it in the rule prior to starting the test module.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Improve the CI.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
