### PR TITLE
[CWS] replace usages of LockOSThread with syscall tester in functional tests

### DIFF
--- a/pkg/security/tests/syscall_tester/c/syscall_tester.c
+++ b/pkg/security/tests/syscall_tester/c/syscall_tester.c
@@ -214,6 +214,31 @@ int test_splice() {
     return EXIT_SUCCESS;
 }
 
+int test_mkdirat_error(int argc, char** argv) {
+    if (argc != 2) {
+        fprintf(stderr, "%s: Please pass a path to mkdirat.\n", __FUNCTION__);
+        return EXIT_FAILURE;
+    }
+
+    if (setregid(1, 1) != 0) {
+        fprintf(stderr, "setregid failed");
+        return EXIT_FAILURE;
+    }
+
+    if (setreuid(1, 1) != 0) {
+        fprintf(stderr, "setreuid failed");
+        return EXIT_FAILURE;
+    }
+
+    fprintf(stderr, "mkdir path: %s\n", argv[1]);
+    if (mkdirat(0, argv[1], 0777) == 0) {
+        fprintf(stderr, "mkdirat succeeded event though we expected it to fail");
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}
+
 int main(int argc, char **argv) {
     if (argc <= 1) {
         fprintf(stderr, "Please pass a command\n");
@@ -234,6 +259,8 @@ int main(int argc, char **argv) {
         return test_signal(argc - 1, argv + 1);
     } else if (strcmp(cmd, "splice") == 0) {
         return test_splice();
+    } else if (strcmp(cmd, "mkdirat-error") == 0) {
+        return test_mkdirat_error(argc - 1, argv + 1);
     } else {
         fprintf(stderr, "Unknown command `%s`\n", cmd);
         return EXIT_FAILURE;

--- a/pkg/security/tests/syscall_tester/c/syscall_tester.c
+++ b/pkg/security/tests/syscall_tester/c/syscall_tester.c
@@ -231,9 +231,8 @@ int test_mkdirat_error(int argc, char** argv) {
         return EXIT_FAILURE;
     }
 
-    fprintf(stderr, "mkdir path: %s\n", argv[1]);
     if (mkdirat(0, argv[1], 0777) == 0) {
-        fprintf(stderr, "mkdirat succeeded event though we expected it to fail");
+        fprintf(stderr, "mkdirat succeeded even though we expected it to fail");
         return EXIT_FAILURE;
     }
 

--- a/pkg/security/tests/syscall_tester/go/syscall_go_tester.go
+++ b/pkg/security/tests/syscall_tester/go/syscall_go_tester.go
@@ -16,11 +16,13 @@ import (
 	_ "embed"
 
 	manager "github.com/DataDog/ebpf-manager"
+	"github.com/syndtr/gocapability/capability"
 )
 
 var (
 	bpfLoad  bool
 	bpfClone bool
+	capsetProcessCreds bool
 )
 
 //go:embed ebpf_probe.o
@@ -65,14 +67,35 @@ func BPFLoad() error {
 	return nil
 }
 
+func CapsetTest() error {
+	threadCapabilities, err := capability.NewPid2(0)
+	if err != nil {
+		return err
+	}
+	if err := threadCapabilities.Load(); err != nil {
+		return err
+	}
+
+	threadCapabilities.Unset(capability.PERMITTED|capability.EFFECTIVE, capability.CAP_SYS_BOOT)
+	threadCapabilities.Unset(capability.EFFECTIVE, capability.CAP_WAKE_ALARM)
+	return threadCapabilities.Apply(capability.CAPS)
+}
+
 func main() {
 	flag.BoolVar(&bpfLoad, "load-bpf", false, "load the eBPF progams")
 	flag.BoolVar(&bpfClone, "clone-bpf", false, "clone maps")
+	flag.BoolVar(&capsetProcessCreds, "process-credentials-capset", false, "capset test content")
 
 	flag.Parse()
 
 	if bpfLoad {
 		if err := BPFLoad(); err != nil {
+			panic(err)
+		}
+	}
+
+	if capsetProcessCreds {
+		if err := CapsetTest(); err != nil {
 			panic(err)
 		}
 	}

--- a/pkg/security/tests/syscall_tester/go/syscall_go_tester.go
+++ b/pkg/security/tests/syscall_tester/go/syscall_go_tester.go
@@ -20,8 +20,8 @@ import (
 )
 
 var (
-	bpfLoad  bool
-	bpfClone bool
+	bpfLoad            bool
+	bpfClone           bool
 	capsetProcessCreds bool
 )
 


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
