### PR TITLE
[CWS] Fix some kernel fallback offset constants

### DIFF
--- a/pkg/security/probe/constantfetch/fallback.go
+++ b/pkg/security/probe/constantfetch/fallback.go
@@ -209,8 +209,6 @@ func getSignalTTYOffset(kv *kernel.Version) uint64 {
 		ttyOffset = 400
 	case kv.IsInRangeCloseOpen(kernel.Kernel5_0, kernel.Kernel5_1):
 		ttyOffset = 408
-	case kv.IsInRangeCloseOpen(kernel.Kernel5_4, kernel.Kernel5_5) && kv.Code.Patch() >= 107:
-		ttyOffset = 400
 	case kv.IsInRangeCloseOpen(kernel.Kernel5_4, kernel.Kernel5_5):
 		ttyOffset = 408
 	case kv.IsInRangeCloseOpen(kernel.Kernel5_4, kernel.Kernel5_7):

--- a/pkg/security/probe/constantfetch/fallback.go
+++ b/pkg/security/probe/constantfetch/fallback.go
@@ -209,6 +209,8 @@ func getSignalTTYOffset(kv *kernel.Version) uint64 {
 		ttyOffset = 400
 	case kv.IsInRangeCloseOpen(kernel.Kernel5_0, kernel.Kernel5_1):
 		ttyOffset = 408
+	case kv.IsInRangeCloseOpen(kernel.Kernel5_4, kernel.Kernel5_5) && kv.Code.Patch() >= 107:
+		ttyOffset = 400
 	case kv.IsInRangeCloseOpen(kernel.Kernel5_4, kernel.Kernel5_5):
 		ttyOffset = 408
 	case kv.IsInRangeCloseOpen(kernel.Kernel5_4, kernel.Kernel5_7):
@@ -231,6 +233,8 @@ func getSignalTTYOffset(kv *kernel.Version) uint64 {
 		}
 	case kv.Code != 0 && kv.Code < kernel.Kernel5_3:
 		ttyOffset = 368
+	case kv.IsInRangeCloseOpen(kernel.Kernel5_15, kernel.Kernel5_16):
+		ttyOffset = 408
 	case kv.Code >= kernel.Kernel5_16:
 		ttyOffset = 416
 	}
@@ -522,7 +526,7 @@ func getPipeInodeInfoBufsOffset(kv *kernel.Version) uint64 {
 		offset = 120
 	case kv.IsAmazonLinuxKernel() && kv.IsInRangeCloseOpen(kernel.Kernel5_10, kernel.Kernel5_11):
 		offset = 152
-	case kv.IsDebianKernel() && kv.IsInRangeCloseOpen(kernel.Kernel5_10, kernel.Kernel5_11):
+	case kv.IsDebianKernel() && kv.IsInRangeCloseOpen(kernel.Kernel5_10, kernel.Kernel5_11) && kv.Code.Patch() > 46:
 		offset = 152
 	case kv.IsCOSKernel() && kv.IsInRangeCloseOpen(kernel.Kernel4_19, kernel.Kernel4_20):
 		fallthrough


### PR DESCRIPTION
On Debian bullseye:
- with linux-image-5.10.0-8-amd64 (kernel version 5.10.46-5): fix "pipe_inode_info_bufs_offset" from 152 to 144.
- with linux-image-5.15.0-0.bpo.3-amd64 (kernel 5.15.15-2~bpo11+1): fix "tty_offset" from 400 to 408.
- with linux-image-5.15.0-0.bpo.2-amd64 (kernel 5.15.5-2~bpo11+1): fix "tty_offset" from 400 to 408.

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
