### PR TITLE
telemetry retry queue duration

### DIFF
--- a/pkg/forwarder/telemetry.go
+++ b/pkg/forwarder/telemetry.go
@@ -39,12 +39,6 @@ var (
 		[]string{"domain", "endpoint"}, "Transaction retry count")
 	tlmTxRetryQueueSize = telemetry.NewGauge("transactions", "retry_queue_size",
 		[]string{"domain"}, "Retry queue size")
-	tlmRetryQueueDurationCapacity = telemetry.NewGauge("transactions", "retry_queue_duration_capacity_secs",
-		[]string{"agent", "domain"}, "How much data expressed as a duration can be buffered in the retry queue")
-	tlmRetryQueueDurationBytesPerSec = telemetry.NewGauge("transactions", "retry_queue_duration_bytes_per_sec",
-		[]string{"agent", "domain"}, "The number of bytes per second the forwarder received for this domain")
-	tlmRetryQueueDurationCapacityBytes = telemetry.NewGauge("transactions", "retry_queue_duration_capacity_bytes",
-		[]string{"agent", "domain"}, "How much data expressed as a number of bytes can be buffered in the retry queue")
 )
 
 func init() {

--- a/pkg/telemetry/stats_telemetry.go
+++ b/pkg/telemetry/stats_telemetry.go
@@ -10,6 +10,7 @@ import "sync"
 // StatsTelemetrySender contains methods needed for sending stats metrics
 type StatsTelemetrySender interface {
 	Count(metric string, value float64, hostname string, tags []string)
+	Gauge(metric string, value float64, hostname string, tags []string)
 }
 
 // StatsTelemetryProvider handles stats telemetry and passes it on to a sender
@@ -43,4 +44,15 @@ func (s *StatsTelemetryProvider) Count(metric string, value float64, tags []stri
 	}
 
 	s.sender.Count(metric, value, "", tags)
+}
+
+// Gauge reports a gauge metric to the sender
+func (s *StatsTelemetryProvider) Gauge(metric string, value float64, tags []string) {
+	s.m.RLock()
+	defer s.m.RUnlock()
+	if s.sender == nil {
+		return
+	}
+
+	s.sender.Gauge(metric, value, "", tags)
 }

--- a/releasenotes/notes/telemetry-retry-queue-duration-da549d181f0aa40d.yaml
+++ b/releasenotes/notes/telemetry-retry-queue-duration-da549d181f0aa40d.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Report telemetry metrics about the retry queue capacity: ``datadog.agent.retry_queue_duration.capacity_secs``, ``datadog.agent.retry_queue_duration.bytes_per_sec`` and ``datadog.agent.retry_queue_duration.capacity_bytes``


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR changes the way  the metrics defined in https://github.com/DataDog/datadog-agent/pull/11019 are reported. Instead of using the `telemetry` package, this PR exposes these metrics using https://github.com/DataDog/datadog-agent/blob/7.35.0/pkg/telemetry/stats_telemetry.go#L28 in order to make them available to our customer.
 
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Compare that the old and new values of the metrics are the same:
- `datadog.agent.transactions.retry_queue_duration_capacity_secs` -> `datadog.agent.retry_queue_duration.capacity_secs`
- `datadog.agent.transactions.retry_queue_duration_bytes_per_sec` -> `datadog.agent.retry_queue_duration.bytes_per_sec`
- `datadog.agent.transactions.retry_queue_duration_capacity_bytes` -> `datadog.agent.retry_queue_duration.capacity_bytes`

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
