### PR TITLE
Fix cross-compiling IoT agent for Mac M1

### DIFF
--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -130,7 +130,10 @@ def build(
     )
 
     if sys.platform == 'darwin' and platform.processor() == 'arm64':
-        # Using amd64 when building with Mac M1
+        print("It seems that you're running a Mac M1. Cross-compiling for amd64 then.")
+        # Compiling the Agent for arm64 isn't possible yet until gopsutil is updated :
+        # https://github.com/kubernetes/minikube/pull/10115
+        # Let's use amd64 for now then.
         env["GOARCH"] = "amd64"
         # Important for x-compiling
         env["CGO_ENABLED"] = "1"

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -129,6 +129,12 @@ def build(
         python_runtimes=python_runtimes,
     )
 
+    if sys.platform == 'darwin' and platform.processor() == 'arm64':
+        # Using amd64 when building with Mac M1
+        env["GOARCH"] = "amd64"
+        # Important for x-compiling
+        env["CGO_ENABLED"] = "1"
+
     if sys.platform == 'win32':
         py_runtime_var = get_win_py_runtime_var(python_runtimes)
 

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -129,7 +129,7 @@ def build(
         python_runtimes=python_runtimes,
     )
 
-    if sys.platform == 'darwin' and platform.processor() == 'arm64':
+    if sys.platform == 'darwin' and platform.machine() == 'arm64':
         print("It seems that you're running a Mac M1. Cross-compiling for amd64 then.")
         # Compiling the Agent for arm64 isn't possible yet until gopsutil is updated :
         # https://github.com/kubernetes/minikube/pull/10115


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR allows cross-compiling the Intel Mac IoT Agent on an M1 Mac.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

I have a M1 Mac.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Try to build the Intel Mac IoT Agent on an M1 Mac on an M1 Mac.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
