### PR TITLE
Better use strings.HasPrefix to compare paths

### DIFF
--- a/cmd/secrets/providers/file.go
+++ b/cmd/secrets/providers/file.go
@@ -31,8 +31,11 @@ func ReadSecretFile(path string) s.Secret {
 		return s.Secret{Value: "", ErrorMsg: err.Error()}
 	}
 
+	// In kubernetes when kubelet mounts the secret|configmap key as a file, it
+	// is always a symlink to allow “atomic update“.
 	if fi.Mode()&os.ModeSymlink != 0 {
-		// Ensure that the symlink is in the same dir
+		// Check that the symlink is in the same dir.  This is not a security measure, but just a
+		// sanity check.
 		target, err := os.Readlink(path)
 		if err != nil {
 			return s.Secret{Value: "", ErrorMsg: fmt.Sprintf("failed to read symlink target: %v", err)}
@@ -46,14 +49,14 @@ func ReadSecretFile(path string) s.Secret {
 			}
 		}
 
+		targetDir := filepath.Dir(target)
+
 		dirAbs, err := filepath.Abs(dir)
 		if err != nil {
 			return s.Secret{Value: "", ErrorMsg: fmt.Sprintf("failed to resolve absolute path of directory: %v", err)}
 		}
 
-		// This used to use filepath.HasPrefix, it has been changed to strings.HasPrefix for clarity and to preserve behavior.
-		// filepath.HasPrefix is broken but there is no stdlib replacement.
-		if !strings.HasPrefix(target, dirAbs) {
+		if !strings.HasPrefix(targetDir+"/", dirAbs+"/") {
 			return s.Secret{Value: "", ErrorMsg: fmt.Sprintf("not following symlink %q outside of %q", target, dir)}
 		}
 	}

--- a/cmd/secrets/providers/file_test.go
+++ b/cmd/secrets/providers/file_test.go
@@ -67,7 +67,7 @@ func TestReadSecretFile(t *testing.T) {
 			inputFile: fileThatIsASymlinkToOtherDir,
 			expectedError: fmt.Sprintf(
 				"not following symlink \"%s\" outside of \"%s\"",
-				testDataAbsPath+"/secret5-target",
+				testDataAbsPath+"/read-secrets-secret5-target",
 				testSecretsAbsPath,
 			),
 			skipWindows: true,

--- a/cmd/secrets/testdata/read-secrets/secret5
+++ b/cmd/secrets/testdata/read-secrets/secret5
@@ -1,1 +1,1 @@
-../secret5-target
+../read-secrets-secret5-target


### PR DESCRIPTION
This uses a trailing `/` on the directory names to avoid ambiguity.

### Motivation

Address weaknesses in filepath.HasPrefix / strings.HasPrefix.

### Describe how to test/QA your changes

Run the agent in a situation where file-based secrets (`ENC[file@some-path]`) are utilized, and check that the secrets are read correctly.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
