### PR TITLE
Do not hold file open when pipeline is full

### DIFF
--- a/pkg/logs/internal/tailers/file/tailer_windows.go
+++ b/pkg/logs/internal/tailers/file/tailer_windows.go
@@ -75,7 +75,6 @@ func (t *Tailer) readAvailable() (int, error) {
 	for {
 		inBuf := make([]byte, 4096)
 		n, err := f.Read(inBuf)
-		bytes += n
 		if n == 0 || err != nil {
 			return bytes, err
 		}
@@ -83,6 +82,7 @@ func (t *Tailer) readAvailable() (int, error) {
 		select {
 		case t.decoder.InputChan <- decoder.NewInput(inBuf[:n]):
 			t.incrementLastReadOffset(n)
+			bytes += n
 		default:
 			// the buffer is full, so pretend that this is all of the data that
 			// is available in the file at this point, in order to close the

--- a/releasenotes/notes/dont-hold-open-file-when-pipeline-full-f19561f89dab2a03.yaml
+++ b/releasenotes/notes/dont-hold-open-file-when-pipeline-full-f19561f89dab2a03.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    On Windows, the Agent no longer holds files open when the logs-processing
+    pipeline is full.  This prevents issues with log sources renaming or
+    rotating files in high-volume scenarios.


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

none - see #11706.
### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
