### PR TITLE
Skip API Key and Site dialogs during Windows installation if datadog.yaml file is found.

### DIFF
--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -104,6 +104,15 @@
     <SetProperty Id="CONFDIRONCOMMANDLINESLASH" Value="[APPLICATIONDATADIRECTORY]\" Before="AppSearch">APPLICATIONDATADIRECTORY </SetProperty>
     
     <!--
+      The following property is set to either C:\ProgramData\Datadog or to the value of [APPLICATIONDATADIRECTORY]
+      if it is provided as installation parameter. This property will be used during AppSearch phase to detect
+      existence of datadog.yaml file
+    -->
+    <SetProperty Id="APPLICATIONDATADIRECTORY_BEFORE_APPSEARCH" Action="SetApplicationDataDirectory_FromCmdline" Value="[APPLICATIONDATADIRECTORY]" Before="AppSearch">APPLICATIONDATADIRECTORY</SetProperty>
+    <SetProperty Id="APPLICATIONDATADIRECTORY_BEFORE_APPSEARCH" Action="SetApplicationDataDirectory_NotFromCmdline" Value="[CommonAppDataFolder]Datadog" Before="AppSearch">NOT APPLICATIONDATADIRECTORY</SetProperty>
+
+
+    <!--
       The following sets a property (to be used by the custom action).
       the "&" indicates the action state of a feature (so &NPM refers to the NPM _feature_ not the NPM property that might be set on the command line)
       "3" refers to the action state "on the local computer" (which is the only one we support besides "not present", which happens to be "2")
@@ -164,6 +173,13 @@
         <Directory Id="ApplicationProgramsFolder" Name="Datadog"/>
       </Directory>
     </Directory>
+
+    <!-- Detect existence of datadog.yaml file -->    
+    <Property Id="DATADOGYAMLEXISTS">
+      <DirectorySearch Id="DatadogYamlSearchDirId" Path="[APPLICATIONDATADIRECTORY_BEFORE_APPSEARCH]" Depth="0" AssignToProperty="yes">
+        <FileSearch Id="DatadogYamlSearchFileId" Name="datadog.yaml"/>
+      </DirectorySearch>
+    </Property>
 
     <CustomAction
         Id="LaunchApp"
@@ -578,47 +594,42 @@
            -->
       <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="LicenseAgreementDlg">NOT PREVIOUSFOUND</Publish>
 
-
       <?if $(var.IncludeSysprobe) = true ?>
         <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="CustomizeDlg">PREVIOUSFOUND</Publish>
 
         <Publish Dialog="LicenseAgreementDlg" Control="Next" Event="NewDialog" Value="CustomizeDlg">NOT PREVIOUSFOUND</Publish>
 
-        <Publish Dialog="CustomizeDlg" Control="Next" Event="NewDialog" Value="ApiKeyDlg">(NOT WixUI_InstallMode) AND (NOT PREVIOUSFOUND)</Publish>
-        <Publish Dialog="CustomizeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg">WixUI_InstallMode OR PREVIOUSFOUND</Publish>
+        <Publish Dialog="CustomizeDlg" Control="Next" Event="NewDialog" Value="ApiKeyDlg">(NOT WixUI_InstallMode) AND (NOT PREVIOUSFOUND) AND (NOT DATADOGYAMLEXISTS)</Publish>
+        <Publish Dialog="CustomizeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg">WixUI_InstallMode OR PREVIOUSFOUND OR DATADOGYAMLEXISTS</Publish>
 
         <Publish Dialog="CustomizeDlg" Control="Back" Event="NewDialog" Value="LicenseAgreementDlg">(NOT WixUI_InstallMode) AND (NOT PREVIOUSFOUND)</Publish>
         <Publish Dialog="CustomizeDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">(NOT WixUI_InstallMode) AND PREVIOUSFOUND</Publish>
         <Publish Dialog="CustomizeDlg" Control="Back" Event="NewDialog" Value="MaintenanceTypeDlg"> WixUI_InstallMode </Publish>
 
-        <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="CustomizeDlg">(NOT WixUI_InstallMode) AND PREVIOUSFOUND</Publish>
+        <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="CustomizeDlg">(NOT WixUI_InstallMode) AND (PREVIOUSFOUND OR DATADOGYAMLEXISTS)</Publish>
         <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="CustomizeDlg">WixUI_InstallMode = "Change"</Publish>
 
         <Publish Dialog="MaintenanceTypeDlg" Control="ChangeButton" Event="NewDialog" Value="CustomizeDlg">1</Publish>
-
-
       <?else ?>
         <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg">PREVIOUSFOUND</Publish>
 
-        <Publish Dialog="LicenseAgreementDlg" Control="Next" Event="NewDialog" Value="ApiKeyDlg">NOT PREVIOUSFOUND</Publish>
+        <Publish Dialog="LicenseAgreementDlg" Control="Next" Event="NewDialog" Value="ApiKeyDlg">(NOT PREVIOUSFOUND) AND (NOT DATADOGYAMLEXISTS)</Publish>
 
-        <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">(NOT WixUI_InstallMode) AND PREVIOUSFOUND</Publish>
+        <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">(NOT WixUI_InstallMode) AND (PREVIOUSFOUND OR DATADOGYAMLEXISTS)</Publish>
       <?endif ?>
 
-      <!-- if the dialog is displayed, there's only one back from here, which is the welcome -->
+      <!-- if the dialog is displayed, there is only one back from here, which is the welcome -->
       <Publish Dialog="LicenseAgreementDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg"></Publish>
 
       <Publish Dialog="ExitDialog" Control="Finish" Event="EndDialog" Value="Return" Order="3">1</Publish>
       <Publish Dialog="SiteDlg" Control="Back" Event="NewDialog" Value="ApiKeyDlg">NOT PREVIOUSFOUND</Publish>
-      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="SiteDlg">NOT PREVIOUSFOUND</Publish>
 
+      <!-- if the previous installation or the datadog.yaml file exists, implying the API key and Site are known, go back to the CustomizeDlg or LicenseAgreementDlg -->
+      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="SiteDlg">(NOT PREVIOUSFOUND) AND (NOT DATADOGYAMLEXISTS)</Publish>
 
       <Publish Dialog="MaintenanceWelcomeDlg" Control="Next" Event="NewDialog" Value="MaintenanceTypeDlg">1</Publish>
 
       <Publish Dialog="MaintenanceTypeDlg" Control="Back" Event="NewDialog" Value="MaintenanceWelcomeDlg">1</Publish>
-
-
-
 
       <Publish Dialog="MaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="ApiKeyDlg">NOT APIKEY</Publish>
       <Publish Dialog="MaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="SiteDlg">APIKEY AND (NOT SITE)</Publish>

--- a/releasenotes/notes/skip-api-dlg-when-datadog-yaml-exists-a6bcd55c84ca80de.yaml
+++ b/releasenotes/notes/skip-api-dlg-when-datadog-yaml-exists-a6bcd55c84ca80de.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    On Windows, if during installation or upgrade a datadog.yaml file is
+    found, the dialogs collecting the API Key and Site are skipped.

--- a/releasenotes/notes/skip-api-dlg-when-datadog-yaml-exists-a6bcd55c84ca80de.yaml
+++ b/releasenotes/notes/skip-api-dlg-when-datadog-yaml-exists-a6bcd55c84ca80de.yaml
@@ -8,5 +8,5 @@
 ---
 enhancements:
   - |
-    On Windows, if during installation or upgrade a datadog.yaml file is
-    found, the dialogs collecting the API Key and Site are skipped.
+    On Windows, if a datadog.yaml file is found during an installation or
+    upgrade, the dialogs collecting the API Key and Site are skipped.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
In certain cases, for example when Datadog is uninstalled already but C:\ProgramData\Datadog\datadog.yaml file is left (accidently or on purpose), we find it useful to reuse API Key and Site information this file contains. Accordingly, it makes no sense to ask about these details again. This Pull Request implements just that, it skips the said dialogs which collects API Key and Site if C:\ProgramData\Datadog\datadog.yaml is found.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
See above

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
N/A

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
Theoretically if datadog.yaml is corrupted there is a chance that we allow installation to proceed without asking for API Key or Site,

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

- Install and Uninstall Agent (if it is VM save a snapshot, if not save datadog.yaml)
- Install Agent again API key or Site dialogs should not be shown (because datadog.yaml is still in original location)
- Restore snapshot or uninstall Agent and delete C:\ProgramData\Datadog directory with its content
- Install Agent again. API key or Site dialogs should be shown
- Restore snapshot or uninstall Agent and delete C:\ProgramData\Datadog directory with its content. Create C:\ProgramData\DatadogTest directory, copy saved datadog.yaml there and install Agent from cmdline using following command ```msiexec.exe -i <path to msi> APPLICATIONDATADIRECTORY=C:\ProgramData\DatadogTest```. API key or Site dialogs should not be shown
- Restore snapshot or uninstall Agent and delete C:\ProgramData\Datadog directory with its content. Create C:\ProgramData\DatadogTest directory. Do not copy saved datadog.yaml there (delete if it is there already) and install Agent from cmdline using following command ```msiexec.exe -i <path to msi> APPLICATIONDATADIRECTORY=C:\ProgramData\DatadogTest```. API key or Site dialogs should be shown

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
