### PR TITLE
Remove `invoke deps` from instructions everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,8 @@ To start working on the Agent, you can build the `main` branch:
 1. Checkout the repo: `git clone https://github.com/DataDog/datadog-agent.git $GOPATH/src/github.com/DataDog/datadog-agent`.
 2. cd into the project folder: `cd $GOPATH/src/github.com/DataDog/datadog-agent`.
 3. Install go tools: `invoke install-tools`.
-4. Install go dependencies: `invoke deps`.
-   Make sure that `$GOPATH/bin` is in your `$PATH` otherwise this step might fail.
-5. Create a development `datadog.yaml` configuration file in `dev/dist/datadog.yaml`, containing a valid API key: `api_key: <API_KEY>`
-6. Build the agent with `invoke agent.build --build-exclude=systemd`.
+4. Create a development `datadog.yaml` configuration file in `dev/dist/datadog.yaml`, containing a valid API key: `api_key: <API_KEY>`
+5. Build the agent with `invoke agent.build --build-exclude=systemd`.
 
     By default, the Agent will be built to use Python 3 but you can select which Python version you want to use:
 

--- a/cmd/process-agent/README.md
+++ b/cmd/process-agent/README.md
@@ -21,10 +21,9 @@ cd datadog-agent
 
 Note that you must be in `$GOPATH/src/github.com/DataDog/datadog-agent`, NOT `~/dd/datadog-agent`.
 
-Pull down the latest dependencies via `dep`, and build the Process Agent:
+To build the Process Agent run:
 
 ```
-inv -e deps
 inv -e process-agent.build
 ```
 

--- a/docs/dev/agent_dev_env.md
+++ b/docs/dev/agent_dev_env.md
@@ -102,9 +102,9 @@ specified in our build images (see e.g. [here](https://github.com/DataDog/datado
 may not be able to build the agent and/or the [rtloader](https://github.com/DataDog/datadog-agent/tree/main/rtloader)
 binary properly.**
 
-## Installing dependencies
+## Installing tooling
 
-From the root of `datadog-agent`, run `invoke install-tools` to install go tooling, then `invoke deps` to install go dependencies. This uses `go` to install the necessary dependencies.
+From the root of `datadog-agent`, run `invoke install-tools` to install go tooling. This uses `go` to install the necessary dependencies.
 
 ## System or Embedded?
 

--- a/pkg/clusteragent/README.md
+++ b/pkg/clusteragent/README.md
@@ -30,9 +30,7 @@ To start working on the Cluster Agent, you can build the `main` branch:
 1. Clone the repo: `git clone https://github.com/DataDog/datadog-agent.git $GOPATH/src/github.com/DataDog/datadog-agent`.
 2. cd into the project folder: `cd $GOPATH/src/github.com/DataDog/datadog-agent`.
 3. Install go tools: `invoke install-tools`.
-4. Install go dependencies: `invoke deps`.
-   Make sure that `$GOPATH/bin` is in your `$PATH` otherwise this step might fail.
-5. Build the whole project with `invoke cluster-agent.build`
+4. Build the whole project with `invoke cluster-agent.build`
 
 Please refer to the [Agent Developer Guide](docs/dev/README.md) for more details.
 

--- a/pkg/proto/datadog/README.md
+++ b/pkg/proto/datadog/README.md
@@ -34,18 +34,6 @@ gRPC gateway code that will allow us to serve the API also as a
 REST application.
 
 
-### Compiling the Agent
-
-Remember to make sure your gRPC go dependencies are current for
-the agent by running:
-```
-inv -e deps
-```
-
-The grpc deps are defined [here](https://github.com/DataDog/datadog-agent/blob/main/cmd/agent/api/tools.go)
-and are tracked by gomod.
-
-
 ### Note/ToDo
 
 At the time of this writing we had been using the dev branch for

--- a/pkg/proto/datadog/api/README.md
+++ b/pkg/proto/datadog/api/README.md
@@ -31,19 +31,6 @@ Those two will generate the protobuf golang definitions _and_ the
 gRPC gateway code that will allow us to serve the API also as a 
 REST application.
 
-
-### Compiling the Agent
-
-Remember to make sure your gRPC go dependencies are current for
-the agent by running:
-```
-inv -e deps
-```
-
-The grpc deps are defined [here](https://github.com/DataDog/datadog-agent/blob/main/cmd/agent/api/tools.go)
-and are tracked by gomod.
-
-
 ### Notes
 
 We are currently pinned to fairly old versions for some of the 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Remove `invoke deps` from instructions everywhere.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

This is not needed; `go build` will automatically download needed dependencies and update them if they are out of date. The only use of `invoke deps` is for caching on our CI, where we want to separate installing dependencies from building the Agent.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

This is a historical artifact from when we used vendoring. Found while onboarding new people.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
