### PR TITLE
cmd/agent/gui: add polyfill for Object.entries

### DIFF
--- a/cmd/agent/gui/views/private/js/polyfills.js
+++ b/cmd/agent/gui/views/private/js/polyfills.js
@@ -1,0 +1,13 @@
+// Object.entries polyfill
+if (!Object.entries) {
+  Object.entries = function( obj ){
+    var ownProps = Object.keys( obj ),
+        i = ownProps.length,
+        resArray = new Array(i); // preallocate the Array
+    while (i--)
+      resArray[i] = [ownProps[i], obj[ownProps[i]]];
+
+    return resArray;
+  };
+}
+

--- a/cmd/agent/gui/views/templates/index.tmpl
+++ b/cmd/agent/gui/views/templates/index.tmpl
@@ -6,6 +6,7 @@
     <link rel="stylesheet" href="view/css/font-awesome.min.css">
     <link rel="stylesheet" href="view/css/codemirror.css">
     <link rel="stylesheet" href="view/css/stylesheet.css">
+    <script src="view/js/polyfills.js"> </script>
     <script src="view/js/jquery-3.5.1.min.js"> </script>
     <script src="view/js/ejs.min.js"> </script>
     <script src="view/js/apm.js"> </script>

--- a/releasenotes/notes/apm-windows-polyfills-2fb54c2af32e8630.yaml
+++ b/releasenotes/notes/apm-windows-polyfills-2fb54c2af32e8630.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: Fix a bug where the APM section of the GUI would not show up in older Internet Explorer versions on Windows.


### PR DESCRIPTION
This change adds a polyfill for older IE versions to ensure the APM
section of ghte GUI works.