### PR TITLE
[staticcheck] enable SA5001 check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -75,7 +75,6 @@ linters-settings:
              "-SA5008", # Duplicate struct tags are valid, even if cumbersome to use
              "-ST1013", # Use HTTP code enums instead of integers
              # Actual issues that should be fixed eventually
-             "-SA5001", # TODO: Error not checked on .Close()
              "-SA2001", # TODO: empty critical section, seems to be used for something?
              "-SA4004", # TODO: should the loop be removed or the return be removed?
              "-SA6002", # TODO: Fix sync.Pools

--- a/pkg/compliance/checks/file_check_test.go
+++ b/pkg/compliance/checks/file_check_test.go
@@ -49,8 +49,8 @@ func TestFileCheck(t *testing.T) {
 			paths = append(paths, filePath)
 
 			f, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0644)
-			defer f.Close()
 			assert.NoError(err)
+			defer f.Close()
 		}
 
 		return dir, paths

--- a/pkg/dogstatsd/listeners/uds_linux_test.go
+++ b/pkg/dogstatsd/listeners/uds_linux_test.go
@@ -46,8 +46,8 @@ func TestUDSPassCred(t *testing.T) {
 
 	// Test socket has PASSCRED option set to 1
 	f, err := s.conn.File()
+	require.Nil(t, err)
 	defer f.Close()
-	assert.Nil(t, err)
 
 	enabled, err := unix.GetsockoptInt(int(f.Fd()), unix.SOL_SOCKET, unix.SO_PASSCRED)
 	assert.Nil(t, err)

--- a/pkg/dogstatsd/listeners/uds_linux_test.go
+++ b/pkg/dogstatsd/listeners/uds_linux_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/dogstatsd/packets"

--- a/pkg/flare/flare.go
+++ b/pkg/flare/flare.go
@@ -64,11 +64,12 @@ func getFlareReader(multipartBoundary, archivePath, caseID, email, hostname stri
 			return
 		}
 		file, err := os.Open(archivePath)
-		defer file.Close()
 		if err != nil {
 			bodyWriter.CloseWithError(err) //nolint:errcheck
 			return
 		}
+		defer file.Close()
+
 		_, err = io.Copy(p, file)
 		if err != nil {
 			bodyWriter.CloseWithError(err) //nolint:errcheck

--- a/pkg/logs/internal/tailers/file/rotate_nix.go
+++ b/pkg/logs/internal/tailers/file/rotate_nix.go
@@ -20,10 +20,10 @@ import (
 // - truncated
 func (t *Tailer) DidRotate() (bool, error) {
 	f, err := openFile(t.osFile.Name())
-	defer f.Close()
 	if err != nil {
 		return false, err
 	}
+	defer f.Close()
 
 	fi1, err := f.Stat()
 	if err != nil {

--- a/pkg/obfuscate/json_test.go
+++ b/pkg/obfuscate/json_test.go
@@ -42,10 +42,10 @@ func loadTests() ([]*xmlObfuscateTest, error) {
 		return nil, err
 	}
 	f, err := os.Open(path)
-	defer f.Close()
 	if err != nil {
 		return nil, err
 	}
+	defer f.Close()
 	var suite xmlObfuscateTests
 	if err := xml.NewDecoder(f).Decode(&suite); err != nil {
 		return nil, err

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -1054,14 +1054,13 @@ func (p *Probe) setupNewTCClassifier(device model.NetDevice) error {
 	netns := p.resolvers.NamespaceResolver.ResolveNetworkNamespace(device.NetNS)
 	if netns != nil {
 		handle, err = netns.GetNamespaceHandleDup()
-		defer handle.Close()
 	}
 	if netns == nil || err != nil || handle == nil {
 		// queue network device so that a TC classifier can be added later
 		p.resolvers.NamespaceResolver.QueueNetworkDevice(device)
 		return QueuedNetworkDeviceError{msg: fmt.Sprintf("device %s is queued until %d is resolved", device.Name, device.NetNS)}
 	}
-
+	defer handle.Close()
 	return p.setupNewTCClassifierWithNetNSHandle(device, handle)
 }
 

--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/testutil"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tinylib/msgp/msgp"
 	vmsgp "github.com/vmihailenco/msgpack/v4"
 )
@@ -118,8 +119,8 @@ func TestListenTCP(t *testing.T) {
 	t.Run("measured", func(t *testing.T) {
 		r := &HTTPReceiver{conf: &config.AgentConfig{ConnectionLimit: 0}}
 		ln, err := r.listenTCP(":0")
+		require.NoError(t, err)
 		defer ln.Close()
-		assert.NoError(t, err)
 		_, ok := ln.(*measuredListener)
 		assert.True(t, ok)
 	})
@@ -127,8 +128,8 @@ func TestListenTCP(t *testing.T) {
 	t.Run("limited", func(t *testing.T) {
 		r := &HTTPReceiver{conf: &config.AgentConfig{ConnectionLimit: 10}}
 		ln, err := r.listenTCP(":0")
+		require.NoError(t, err)
 		defer ln.Close()
-		assert.NoError(t, err)
 		_, ok := ln.(*rateLimitedListener)
 		assert.True(t, ok)
 	})

--- a/pkg/util/clusteragent/clcrunner_test.go
+++ b/pkg/util/clusteragent/clcrunner_test.go
@@ -127,8 +127,8 @@ func (suite *clcRunnerSuite) TestGetCLCRunnerStats() {
 	require.Nil(suite.T(), err, fmt.Sprintf("%v", err))
 
 	ts, p, err := clcRunner.StartTLS()
-	defer ts.Close()
 	require.Nil(suite.T(), err, fmt.Sprintf("%v", err))
+	defer ts.Close()
 
 	c, err := GetCLCRunnerClient()
 	c.(*CLCRunnerClient).clcRunnerPort = p
@@ -160,8 +160,8 @@ func (suite *clcRunnerSuite) TestGetCLCRunnerVersion() {
 	require.Nil(suite.T(), err, fmt.Sprintf("%v", err))
 
 	ts, p, err := clcRunner.StartTLS()
-	defer ts.Close()
 	require.Nil(suite.T(), err, fmt.Sprintf("%v", err))
+	defer ts.Close()
 
 	c, err := GetCLCRunnerClient()
 	c.(*CLCRunnerClient).clcRunnerPort = p

--- a/pkg/util/clusteragent/clusteragent_test.go
+++ b/pkg/util/clusteragent/clusteragent_test.go
@@ -424,8 +424,8 @@ func (suite *clusterAgentSuite) TestGetKubernetesNodeLabels() {
 	require.Nil(suite.T(), err, fmt.Sprintf("%v", err))
 
 	ts, p, err := dca.StartTLS()
-	defer ts.Close()
 	require.Nil(suite.T(), err, fmt.Sprintf("%v", err))
+	defer ts.Close()
 
 	mockConfig.Set("cluster_agent.url", fmt.Sprintf("https://127.0.0.1:%d", p))
 
@@ -477,8 +477,8 @@ func (suite *clusterAgentSuite) TestGetKubernetesNodeAnnotations() {
 	require.Nil(suite.T(), err, fmt.Sprintf("%v", err))
 
 	ts, p, err := dca.StartTLS()
-	defer ts.Close()
 	require.Nil(suite.T(), err, fmt.Sprintf("%v", err))
+	defer ts.Close()
 
 	mockConfig.Set("cluster_agent.url", fmt.Sprintf("https://127.0.0.1:%d", p))
 
@@ -522,8 +522,8 @@ func (suite *clusterAgentSuite) TestGetKubernetesMetadataNames() {
 	require.Nil(suite.T(), err, fmt.Sprintf("%v", err))
 
 	ts, p, err := dca.StartTLS()
-	defer ts.Close()
 	require.Nil(suite.T(), err, fmt.Sprintf("%v", err))
+	defer ts.Close()
 
 	mockConfig.Set("cluster_agent.url", fmt.Sprintf("https://127.0.0.1:%d", p))
 
@@ -592,8 +592,8 @@ func (suite *clusterAgentSuite) TestGetCFAppsMetadataForNode() {
 	require.Nil(suite.T(), err, fmt.Sprintf("%v", err))
 
 	ts, p, err := dca.StartTLS()
-	defer ts.Close()
 	require.Nil(suite.T(), err, fmt.Sprintf("%v", err))
+	defer ts.Close()
 
 	mockConfig.Set("cluster_agent.url", fmt.Sprintf("https://127.0.0.1:%d", p))
 
@@ -634,8 +634,8 @@ func (suite *clusterAgentSuite) TestGetPodsMetadataForNode() {
 	require.Nil(suite.T(), err, fmt.Sprintf("%v", err))
 
 	ts, p, err := dca.StartTLS()
-	defer ts.Close()
 	require.Nil(suite.T(), err, fmt.Sprintf("%v", err))
+	defer ts.Close()
 
 	mockConfig.Set("cluster_agent.url", fmt.Sprintf("https://127.0.0.1:%d", p))
 
@@ -706,8 +706,8 @@ func (suite *clusterAgentSuite) TestGetKubernetesClusterID() {
 	require.Nil(suite.T(), err, fmt.Sprintf("%v", err))
 
 	ts, p, err := dca.StartTLS()
-	defer ts.Close()
 	require.Nil(suite.T(), err, fmt.Sprintf("%v", err))
+	defer ts.Close()
 
 	mockConfig.Set("cluster_agent.url", fmt.Sprintf("https://127.0.0.1:%d", p))
 

--- a/pkg/util/clusteragent/clusterchecks_test.go
+++ b/pkg/util/clusteragent/clusterchecks_test.go
@@ -38,8 +38,8 @@ func (suite *clusterAgentSuite) TestClusterChecksNominal() {
 	dca.rawResponses["/api/v1/clusterchecks/configs/mynode"] = dummyConfigs
 
 	ts, p, err := dca.StartTLS()
-	defer ts.Close()
 	require.NoError(suite.T(), err)
+	defer ts.Close()
 	mockConfig.Set("cluster_agent.url", fmt.Sprintf("https://127.0.0.1:%d", p))
 
 	ca, err := GetClusterAgentClient()
@@ -66,8 +66,8 @@ func (suite *clusterAgentSuite) TestClusterChecksRedirect() {
 	leader.rawResponses["/api/v1/clusterchecks/status/mynode"] = `{"isuptodate": true}`
 	leader.rawResponses["/api/v1/clusterchecks/configs/mynode"] = dummyConfigs
 	ts, p, err := leader.StartTLS()
-	defer ts.Close()
 	require.NoError(suite.T(), err)
+	defer ts.Close()
 
 	// Follower redirects to the leader
 	follower, err := newDummyClusterAgent()
@@ -76,8 +76,8 @@ func (suite *clusterAgentSuite) TestClusterChecksRedirect() {
 	follower.rawResponses["/api/v1/clusterchecks/status/mynode"] = `{"isuptodate": false}`
 	follower.rawResponses["/api/v1/clusterchecks/configs/mynode"] = dummyConfigs
 	ts, p, err = follower.StartTLS()
-	defer ts.Close()
 	require.NoError(suite.T(), err)
+	defer ts.Close()
 
 	// Make sure both DCAs have the same token
 	assert.Equal(suite.T(), follower.token, leader.token)

--- a/pkg/util/clusteragent/endpointschecks_test.go
+++ b/pkg/util/clusteragent/endpointschecks_test.go
@@ -33,8 +33,8 @@ func (suite *clusterAgentSuite) TestEndpointsChecksNominal() {
 	dca.rawResponses["/api/v1/endpointschecks/configs/mynode"] = dummyEndpointsConfigs
 
 	ts, p, err := dca.StartTLS()
-	defer ts.Close()
 	require.NoError(suite.T(), err)
+	defer ts.Close()
 	mockConfig.Set("cluster_agent.url", fmt.Sprintf("https://127.0.0.1:%d", p))
 
 	ca, err := GetClusterAgentClient()

--- a/pkg/util/ecs/metadata/detection_test.go
+++ b/pkg/util/ecs/metadata/detection_test.go
@@ -35,8 +35,8 @@ func TestLocateECSHTTP(t *testing.T) {
 	require.Nil(t, err)
 
 	ts, ecsAgentPort, err := ecsinterface.Start()
-	defer ts.Close()
 	require.Nil(t, err)
+	defer ts.Close()
 
 	config.Datadog.SetDefault("ecs_agent_url", fmt.Sprintf("http://localhost:%d/", ecsAgentPort))
 
@@ -59,8 +59,8 @@ func TestLocateECSHTTPFail(t *testing.T) {
 	require.Nil(t, err)
 
 	ts, ecsAgentPort, err := ecsinterface.Start()
-	defer ts.Close()
 	require.Nil(t, err)
+	defer ts.Close()
 
 	config.Datadog.SetDefault("ecs_agent_url", fmt.Sprintf("http://localhost:%d/", ecsAgentPort))
 

--- a/pkg/util/ecs/metadata/v1/client_test.go
+++ b/pkg/util/ecs/metadata/v1/client_test.go
@@ -30,8 +30,8 @@ func TestGetInstance(t *testing.T) {
 
 	require.Nil(t, err)
 	ts, _, err := ecsinterface.Start()
-	defer ts.Close()
 	require.Nil(t, err)
+	defer ts.Close()
 
 	expected := &Instance{
 		Cluster: "ecs_cluster",
@@ -61,8 +61,8 @@ func TestGetTasks(t *testing.T) {
 
 	require.Nil(t, err)
 	ts, _, err := ecsinterface.Start()
-	defer ts.Close()
 	require.Nil(t, err)
+	defer ts.Close()
 
 	expected := []Task{
 		{
@@ -110,8 +110,8 @@ func TestGetTasksFail(t *testing.T) {
 
 	require.Nil(t, err)
 	ts, _, err := ecsinterface.Start()
-	defer ts.Close()
 	require.Nil(t, err)
+	defer ts.Close()
 
 	var expected []Task
 	expectedErr := errors.New("Failed to decode metadata v1 JSON payload to type *v1.Tasks: EOF")

--- a/pkg/util/ecs/metadata/v2/client_test.go
+++ b/pkg/util/ecs/metadata/v2/client_test.go
@@ -28,8 +28,8 @@ func TestGetTask(t *testing.T) {
 	require.Nil(t, err)
 
 	ts, _, err := ecsinterface.Start()
-	defer ts.Close()
 	require.Nil(t, err)
+	defer ts.Close()
 
 	expected := &Task{
 		ClusterName: "default",
@@ -129,8 +129,8 @@ func TestGetTaskWithTags(t *testing.T) {
 	require.Nil(t, err)
 
 	ts, _, err := ecsinterface.Start()
-	defer ts.Close()
 	require.Nil(t, err)
+	defer ts.Close()
 
 	expected := &Task{
 		ClusterName: "ecs-cluster",
@@ -452,8 +452,8 @@ func TestGetContainerStats(t *testing.T) {
 			require.Nil(t, err)
 
 			ts, _, err := ecsinterface.Start()
-			defer ts.Close()
 			require.Nil(t, err)
+			defer ts.Close()
 
 			metadata, err := NewClient(ts.URL).GetContainerStats(ctx, test.containerID)
 			assert.Equal(test.expectedStats, metadata)

--- a/pkg/util/kubernetes/kubelet/kubelet_orchestrator_test.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_orchestrator_test.go
@@ -51,8 +51,8 @@ func (suite *KubeletOrchestratorTestSuite) TestGetRawLocalPodList() {
 	kubelet, err := newDummyKubelet("./testdata/podlist_1.8-2.json")
 	require.Nil(suite.T(), err)
 	ts, kubeletPort, err := kubelet.Start()
-	defer ts.Close()
 	require.Nil(suite.T(), err)
+	defer ts.Close()
 
 	mockConfig.Set("kubernetes_kubelet_host", "localhost")
 	mockConfig.Set("kubernetes_http_kubelet_port", kubeletPort)

--- a/pkg/util/kubernetes/kubelet/kubelet_test.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_test.go
@@ -192,8 +192,8 @@ func (suite *KubeletTestSuite) TestLocateKubeletHTTP() {
 	kubelet, err := newDummyKubelet("./testdata/podlist_1.8-2.json")
 	require.Nil(suite.T(), err)
 	ts, kubeletPort, err := kubelet.Start()
-	defer ts.Close()
 	require.Nil(suite.T(), err)
+	defer ts.Close()
 
 	mockConfig.Set("kubernetes_kubelet_host", "127.0.0.1")
 	mockConfig.Set("kubernetes_http_kubelet_port", kubeletPort)
@@ -227,8 +227,8 @@ func (suite *KubeletTestSuite) TestGetLocalPodList() {
 	kubelet, err := newDummyKubelet("./testdata/podlist_1.8-2.json")
 	require.Nil(suite.T(), err)
 	ts, kubeletPort, err := kubelet.Start()
-	defer ts.Close()
 	require.Nil(suite.T(), err)
+	defer ts.Close()
 
 	mockConfig.Set("kubernetes_kubelet_host", "localhost")
 	mockConfig.Set("kubernetes_http_kubelet_port", kubeletPort)
@@ -260,8 +260,8 @@ func (suite *KubeletTestSuite) TestGetLocalPodListWithBrokenKubelet() {
 	kubelet, err := newDummyKubelet("./testdata/invalid.json")
 	require.Nil(suite.T(), err)
 	ts, kubeletPort, err := kubelet.Start()
-	defer ts.Close()
 	require.Nil(suite.T(), err)
+	defer ts.Close()
 
 	mockConfig.Set("kubernetes_kubelet_host", "localhost")
 	mockConfig.Set("kubernetes_http_kubelet_port", kubeletPort)
@@ -285,8 +285,8 @@ func (suite *KubeletTestSuite) TestGetNodeInfo() {
 	kubelet, err := newDummyKubelet("./testdata/podlist_1.8-2.json")
 	require.Nil(suite.T(), err)
 	ts, kubeletPort, err := kubelet.Start()
-	defer ts.Close()
 	require.Nil(suite.T(), err)
+	defer ts.Close()
 
 	mockConfig.Set("kubernetes_kubelet_host", "localhost")
 	mockConfig.Set("kubernetes_http_kubelet_port", kubeletPort)
@@ -318,8 +318,8 @@ func (suite *KubeletTestSuite) TestGetNodename() {
 	kubelet, err := newDummyKubelet("./testdata/podlist_1.8-2.json")
 	require.Nil(suite.T(), err)
 	ts, kubeletPort, err := kubelet.Start()
-	defer ts.Close()
 	require.Nil(suite.T(), err)
+	defer ts.Close()
 
 	mockConfig.Set("kubernetes_kubelet_host", "localhost")
 	mockConfig.Set("kubernetes_http_kubelet_port", kubeletPort)
@@ -350,8 +350,8 @@ func (suite *KubeletTestSuite) TestPodlistCache() {
 	kubelet, err := newDummyKubelet("./testdata/podlist_1.8-2.json")
 	require.Nil(suite.T(), err)
 	ts, kubeletPort, err := kubelet.Start()
-	defer ts.Close()
 	require.Nil(suite.T(), err)
+	defer ts.Close()
 
 	mockConfig.Set("kubernetes_kubelet_host", "localhost")
 	mockConfig.Set("kubernetes_http_kubelet_port", kubeletPort)
@@ -390,8 +390,8 @@ func (suite *KubeletTestSuite) TestGetPodForContainerID() {
 	kubelet, err := newDummyKubelet("./testdata/podlist_1.8-2.json")
 	require.Nil(suite.T(), err)
 	ts, kubeletPort, err := kubelet.Start()
-	defer ts.Close()
 	require.Nil(suite.T(), err)
+	defer ts.Close()
 
 	mockConfig.Set("kubernetes_kubelet_host", "localhost")
 	mockConfig.Set("kubernetes_http_kubelet_port", kubeletPort)
@@ -429,8 +429,8 @@ func (suite *KubeletTestSuite) TestGetPodFromUID() {
 	kubelet, err := newDummyKubelet("./testdata/podlist_1.8-2.json")
 	require.Nil(suite.T(), err)
 	ts, kubeletPort, err := kubelet.Start()
-	defer ts.Close()
 	require.Nil(suite.T(), err)
+	defer ts.Close()
 
 	mockConfig.Set("kubernetes_kubelet_host", "localhost")
 	mockConfig.Set("kubernetes_http_kubelet_port", kubeletPort)
@@ -465,8 +465,8 @@ func (suite *KubeletTestSuite) TestGetPodWaitForContainer() {
 	kubelet, err := newDummyKubelet("./testdata/podlist_empty.json")
 	require.NoError(suite.T(), err)
 	ts, kubeletPort, err := kubelet.Start()
-	defer ts.Close()
 	require.NoError(suite.T(), err)
+	defer ts.Close()
 
 	mockConfig.Set("kubernetes_kubelet_host", "localhost")
 	mockConfig.Set("kubernetes_http_kubelet_port", kubeletPort)
@@ -510,8 +510,8 @@ func (suite *KubeletTestSuite) TestGetPodDontWaitForContainer() {
 	kubelet, err := newDummyKubelet("./testdata/podlist_empty.json")
 	require.NoError(suite.T(), err)
 	ts, kubeletPort, err := kubelet.Start()
-	defer ts.Close()
 	require.NoError(suite.T(), err)
+	defer ts.Close()
 
 	mockConfig.Set("kubernetes_kubelet_host", "localhost")
 	mockConfig.Set("kubernetes_http_kubelet_port", kubeletPort)
@@ -786,8 +786,8 @@ func (suite *KubeletTestSuite) TestPodListNoExpire() {
 	kubelet, err := newDummyKubelet("./testdata/podlist_expired.json")
 	require.Nil(suite.T(), err)
 	ts, kubeletPort, err := kubelet.Start()
-	defer ts.Close()
 	require.Nil(suite.T(), err)
+	defer ts.Close()
 
 	mockConfig.Set("kubernetes_kubelet_host", "localhost")
 	mockConfig.Set("kubernetes_http_kubelet_port", kubeletPort)
@@ -820,8 +820,8 @@ func (suite *KubeletTestSuite) TestPodListExpire() {
 	kubelet, err := newDummyKubelet("./testdata/podlist_expired.json")
 	require.Nil(suite.T(), err)
 	ts, kubeletPort, err := kubelet.Start()
-	defer ts.Close()
 	require.Nil(suite.T(), err)
+	defer ts.Close()
 
 	mockConfig.Set("kubernetes_kubelet_host", "localhost")
 	mockConfig.Set("kubernetes_http_kubelet_port", kubeletPort)
@@ -964,8 +964,8 @@ func (suite *KubeletTestSuite) TestPodListWithNullPod() {
 	kubelet, err := newDummyKubelet("./testdata/podlist_null_pod.json")
 	require.Nil(suite.T(), err)
 	ts, kubeletPort, err := kubelet.Start()
-	defer ts.Close()
 	require.Nil(suite.T(), err)
+	defer ts.Close()
 
 	mockConfig.Set("kubernetes_kubelet_host", "localhost")
 	mockConfig.Set("kubernetes_http_kubelet_port", kubeletPort)
@@ -993,8 +993,8 @@ func (suite *KubeletTestSuite) TestPodListOnKubeletInit() {
 	kubelet, err := newDummyKubelet("./testdata/podlist_startup.json")
 	require.Nil(suite.T(), err)
 	ts, kubeletPort, err := kubelet.Start()
-	defer ts.Close()
 	require.Nil(suite.T(), err)
+	defer ts.Close()
 
 	mockConfig.Set("kubernetes_kubelet_host", "localhost")
 	mockConfig.Set("kubernetes_http_kubelet_port", kubeletPort)
@@ -1017,8 +1017,8 @@ func (suite *KubeletTestSuite) TestPodListWithPersistentVolumeClaim() {
 	kubelet, err := newDummyKubelet("./testdata/podlist_persistent_volume_claim.json")
 	require.Nil(suite.T(), err)
 	ts, kubeletPort, err := kubelet.Start()
-	defer ts.Close()
 	require.Nil(suite.T(), err)
+	defer ts.Close()
 
 	mockConfig.Set("kubernetes_kubelet_host", "localhost")
 	mockConfig.Set("kubernetes_http_kubelet_port", kubeletPort)

--- a/pkg/util/kubernetes/kubelet/podwatcher_test.go
+++ b/pkg/util/kubernetes/kubelet/podwatcher_test.go
@@ -392,8 +392,8 @@ func (suite *PodwatcherTestSuite) TestPullChanges() {
 	kubelet, err := newDummyKubelet("./testdata/podlist_1.8-2.json")
 	require.Nil(suite.T(), err)
 	ts, kubeletPort, err := kubelet.StartTLS()
-	defer ts.Close()
 	require.Nil(suite.T(), err)
+	defer ts.Close()
 
 	mockConfig.Set("kubernetes_kubelet_host", "127.0.0.1")
 	mockConfig.Set("kubernetes_https_kubelet_port", kubeletPort)

--- a/pkg/util/scrubber/scrubber.go
+++ b/pkg/util/scrubber/scrubber.go
@@ -87,10 +87,10 @@ func (c *Scrubber) AddReplacer(kind ReplacerKind, replacer Replacer) {
 // ScrubFile scrubs credentials from file given by pathname
 func (c *Scrubber) ScrubFile(filePath string) ([]byte, error) {
 	file, err := os.Open(filePath)
-	defer file.Close()
 	if err != nil {
 		return nil, err
 	}
+	defer file.Close()
 	return c.scrubReader(file)
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Fix all instances of [SA5001](https://staticcheck.io/docs/checks#SA5001).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Avoid errors.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
