### PR TITLE
[CWS] fix multiple fields specification in struct tags

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,7 +40,7 @@ issues:
       text: "name will be used as .* by other packages, and that stutters"
     # TODO: Needs manual update
     - text: "package github.com/golang/protobuf/proto is deprecated: .*"
-      linters: [staticcheck]      
+      linters: [staticcheck]
 
 linters:
   disable-all: true
@@ -62,9 +62,8 @@ linters-settings:
     ignore: fmt:.*,github.com/DataDog/datadog-agent/pkg/util/log:.*,net/http:Write,github.com/DataDog/datadog-agent/pkg/trace/metrics:.*
   staticcheck:
     go: "1.17"
-    checks: ["all", 
+    checks: ["all",
              "-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1021", "-ST1022", # These ones are disabled by default on staticcheck
-             "-SA5008", # Duplicate struct tags are valid, even if cumbersome to use
              "-ST1013", # Use HTTP code enums instead of integers
              # Actual issues that should be fixed eventually
              "-SA5001", # TODO: Error not checked on .Close()

--- a/pkg/security/secl/compiler/generators/accessors/accessors.go
+++ b/pkg/security/secl/compiler/generators/accessors/accessors.go
@@ -221,23 +221,27 @@ func handleSpec(module *common.Module, astFile *ast.File, spec interface{}, pref
 						for _, tag := range tags.Tags() {
 							switch tag.Key {
 							case "field":
-								splitted := strings.SplitN(tag.Value(), ",", 4)
-								alias := splitted[0]
-								if alias == "-" {
-									continue FIELD
-								}
-								field := seclField{name: alias}
-								if len(splitted) > 1 {
-									field.handler, weight = parseHandler(splitted[1])
-								}
-								if len(splitted) > 2 {
-									field.iterator, weight = parseHandler(splitted[2])
-								}
-								if len(splitted) > 3 {
-									field.cachelessResolution = splitted[3] == "cacheless_resolution"
+								fieldGroups := strings.Split(tag.Value(), ";")
+								for _, fieldGroup := range fieldGroups {
+									splitted := strings.SplitN(fieldGroup, ",", 4)
+									alias := splitted[0]
+									if alias == "-" {
+										continue FIELD
+									}
+									field := seclField{name: alias}
+									if len(splitted) > 1 {
+										field.handler, weight = parseHandler(splitted[1])
+									}
+									if len(splitted) > 2 {
+										field.iterator, weight = parseHandler(splitted[2])
+									}
+									if len(splitted) > 3 {
+										field.cachelessResolution = splitted[3] == "cacheless_resolution"
+									}
+
+									fields = append(fields, field)
 								}
 
-								fields = append(fields, field)
 							case "op_override":
 								opOverrides = tag.Value()
 							}

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -102,7 +102,7 @@ func (m *Model) ValidateField(field eval.Field, fieldValue eval.FieldValue) erro
 type ChmodEvent struct {
 	SyscallEvent
 	File FileEvent `field:"file"`
-	Mode uint32    `field:"file.destination.mode" field:"file.destination.rights"` // New mode/rights of the chmod-ed file
+	Mode uint32    `field:"file.destination.mode;file.destination.rights"` // New mode/rights of the chmod-ed file
 }
 
 // ChownEvent represents a chown event
@@ -297,13 +297,13 @@ type Process struct {
 	EnvsEntry *EnvsEntry `field:"-" msg:"envs"`
 
 	// defined to generate accessors, ArgsTruncated and EnvsTruncated are used during by unmarshaller
-	Argv0         string   `field:"argv0,ResolveProcessArgv0:100" msg:"-"`                                                                                                                                     // First argument of the process
-	Args          string   `field:"args,ResolveProcessArgs:100" msg:"-"`                                                                                                                                       // Arguments of the process (as a string)
-	Argv          []string `field:"argv,ResolveProcessArgv:100" field:"args_flags,ResolveProcessArgsFlags,,cacheless_resolution" field:"args_options,ResolveProcessArgsOptions,,cacheless_resolution" msg:"-"` // Arguments of the process (as an array)
-	ArgsTruncated bool     `field:"args_truncated,ResolveProcessArgsTruncated" msg:"-"`                                                                                                                        // Indicator of arguments truncation
-	Envs          []string `field:"envs,ResolveProcessEnvs:100" msg:"-"`                                                                                                                                       // Environment variable names of the process
-	Envp          []string `field:"envp,ResolveProcessEnvp:100" msg:"-"`                                                                                                                                       // Environment variables of the process
-	EnvsTruncated bool     `field:"envs_truncated,ResolveProcessEnvsTruncated" msg:"-"`                                                                                                                        // Indicator of environment variables truncation
+	Argv0         string   `field:"argv0,ResolveProcessArgv0:100" msg:"-"`                                                                                                                     // First argument of the process
+	Args          string   `field:"args,ResolveProcessArgs:100" msg:"-"`                                                                                                                       // Arguments of the process (as a string)
+	Argv          []string `field:"argv,ResolveProcessArgv:100;args_flags,ResolveProcessArgsFlags,,cacheless_resolution;args_options,ResolveProcessArgsOptions,,cacheless_resolution" msg:"-"` // Arguments of the process (as an array)
+	ArgsTruncated bool     `field:"args_truncated,ResolveProcessArgsTruncated" msg:"-"`                                                                                                        // Indicator of arguments truncation
+	Envs          []string `field:"envs,ResolveProcessEnvs:100" msg:"-"`                                                                                                                       // Environment variable names of the process
+	Envp          []string `field:"envp,ResolveProcessEnvp:100" msg:"-"`                                                                                                                       // Environment variables of the process
+	EnvsTruncated bool     `field:"envs_truncated,ResolveProcessEnvsTruncated" msg:"-"`                                                                                                        // Indicator of environment variables truncation
 
 	// cache version
 	ScrubbedArgvResolved  bool           `field:"-" msg:"-"`
@@ -326,13 +326,13 @@ type ExecEvent struct {
 
 // FileFields holds the information required to identify a file
 type FileFields struct {
-	UID   uint32 `field:"uid" msg:"uid"`                                                      // UID of the file's owner
-	User  string `field:"user,ResolveFileFieldsUser" msg:"user"`                              // User of the file's owner
-	GID   uint32 `field:"gid" msg:"gid"`                                                      // GID of the file's owner
-	Group string `field:"group,ResolveFileFieldsGroup" msg:"group"`                           // Group of the file's owner
-	Mode  uint16 `field:"mode" field:"rights,ResolveRights,,cacheless_resolution" msg:"mode"` // Mode/rights of the file
-	CTime uint64 `field:"change_time" msg:"ctime"`                                            // Change time of the file
-	MTime uint64 `field:"modification_time" msg:"mtime"`                                      // Modification time of the file
+	UID   uint32 `field:"uid" msg:"uid"`                                              // UID of the file's owner
+	User  string `field:"user,ResolveFileFieldsUser" msg:"user"`                      // User of the file's owner
+	GID   uint32 `field:"gid" msg:"gid"`                                              // GID of the file's owner
+	Group string `field:"group,ResolveFileFieldsGroup" msg:"group"`                   // Group of the file's owner
+	Mode  uint16 `field:"mode;rights,ResolveRights,,cacheless_resolution" msg:"mode"` // Mode/rights of the file
+	CTime uint64 `field:"change_time" msg:"ctime"`                                    // Change time of the file
+	MTime uint64 `field:"modification_time" msg:"mtime"`                              // Modification time of the file
 
 	MountID      uint32 `field:"mount_id" msg:"mount_id"`                                           // Mount ID of the file
 	Inode        uint64 `field:"inode" msg:"inode"`                                                 // Inode of the file
@@ -404,7 +404,7 @@ type LinkEvent struct {
 type MkdirEvent struct {
 	SyscallEvent
 	File FileEvent `field:"file"`
-	Mode uint32    `field:"file.destination.mode" field:"file.destination.rights"` // Mode/rights of the new directory
+	Mode uint32    `field:"file.destination.mode;file.destination.rights"` // Mode/rights of the new directory
 }
 
 // ArgsEnvsEvent defines a args/envs event


### PR DESCRIPTION
### What does this PR do?

With the end-goal of reactivating linter SA5008, this PR replaces usage of `field:"A" field:"B"` with `field:"A;B"` in the model accessors generator script.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
