### PR TITLE
[docs] Add guidelines for using `internal` folders feature

### DIFF
--- a/docs/dev/internal.md
+++ b/docs/dev/internal.md
@@ -1,0 +1,65 @@
+
+# How to use `internal` folders
+
+[Since Go 1.4](https://go.dev/doc/go1.4#internalpackages), Go supports the use of [`internal` folders](https://docs.google.com/document/d/1e8kOo3r51b2BWtTs_1uADIA5djfXhPT36s6eHVRIvaU/edit) to control the public API of a Go module: a package A can only be imported from packages whose path shares the prefix up until the last `internal` in A's path. For example, a package with path `a/b/internal/c/d` can only be imported by packages within the `a/b` folder. The compiler will enforce this and fail to build any code that breaks this rule.
+
+This can be used to have some packages be internal to a given folder, which is useful for decoupling different parts of our codebase. 
+Adding new code should consider carefully what API is exported, both by taking care of what symbols are uppercase and by making judicious use of `internal` folders.
+
+Use the following guidelines in order to decide when and how to use `internal` folders:
+
+1. When in doubt, prefer hiding public API: it's much easier to refactor code to expose something that was private than doing it the other way around.
+2. When refactoring a struct into its own package, try moving it into its own `internal` folder if possible (see appendix below for an example).
+3. If the folder you are editing already has `internal` folders, try to move code to these `internal` folders instead of creating new ones.
+4. When creating new `internal` folders, try to use the deepest possible `internal` folder to limit the packages that can import yours. 
+   For example, if making `a/b/c/d` internal, consider moving it to `a/b/c/internal/d` instead of `a/internal/b/c/d`.
+   With the second path code from `a/b` won't be able to access the `d` package, while it could with the first path.
+
+## Appendix: refactor example
+
+Sometimes one wants to hide private fields of a struct from other code in the same package to enforce a particular code invariant. In this case, the struct should be moved to a different folder within the same package **making this folder `internal`**.
+
+Consider a module named `example.com` where you want to move `exampleStruct` from the `a` package to a subfolder to hide its private fields from `a`s code.
+
+Before the refactor, the code will look like this:
+
+```go
+// a/code.go
+package a
+
+type exampleStruct struct {
+    // some fields
+}
+
+func doSomethingWithExampleStruct(e exampleStruct) {
+    // some code goes here ...
+}
+```
+
+After the refactor, you should move `exampleStruct` to a `a/internal/b` folder:
+
+```go
+// a/internal/b/examplestruct.go
+package b
+
+type ExampleStruct struct {
+    // some fields
+}
+```
+
+and import this package from `a/code.go`:
+
+```go
+// a/code.go
+package a
+
+import (
+    "example.com/a/internal/b"
+)
+
+func doSomethingWithExampleStruct(e b.exampleStruct) {
+    // some code goes here
+}
+```
+
+In this way, no new public API is exposed on the `a` folder: `ExampleStruct` remains private to `a`, while we have improved encapsulation as we wanted.

--- a/docs/dev/internal.md
+++ b/docs/dev/internal.md
@@ -4,7 +4,7 @@
 [Since Go 1.4](https://go.dev/doc/go1.4#internalpackages), Go supports the use of [`internal` folders](https://docs.google.com/document/d/1e8kOo3r51b2BWtTs_1uADIA5djfXhPT36s6eHVRIvaU/edit) to control the public API of a Go module: a package A can only be imported from packages whose path shares the prefix up until the last `internal` in A's path. For example, a package with path `a/b/internal/c/d` can only be imported by packages within the `a/b` folder. The compiler will enforce this and fail to build any code that breaks this rule.
 
 This can be used to have some packages be internal to a given folder, which is useful for decoupling different parts of our codebase. 
-Adding new code should consider carefully what API is exported, both by taking care of what symbols are uppercase and by making judicious use of `internal` folders.
+When adding new code, carefully consider what API is exported, both by taking care of what symbols are uppercase and by making judicious use of `internal` folders.
 
 Use the following guidelines in order to decide when and how to use `internal` folders:
 

--- a/docs/dev/internal.md
+++ b/docs/dev/internal.md
@@ -13,7 +13,7 @@ Use the following guidelines in order to decide when and how to use `internal` f
 3. If the folder you are editing already has `internal` folders, try to move code to these `internal` folders instead of creating new ones.
 4. When creating new `internal` folders, try to use the deepest possible `internal` folder to limit the packages that can import yours. 
    For example, if making `a/b/c/d` internal, consider moving it to `a/b/c/internal/d` instead of `a/internal/b/c/d`.
-   With the second path code from `a/b` won't be able to access the `d` package, while it could with the first path.
+   With the first path, code from `a/b` won't be able to access the `d` package, while it could with the second path.
 
 ## Appendix: refactor example
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Add guidelines for using `internal` folders.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Keep our codebase different parts as decoupled as possible.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
