### PR TITLE
Revert "Do not hold file open when pipeline is full (#11691)"

### DIFF
--- a/pkg/logs/internal/tailers/file/tailer_windows.go
+++ b/pkg/logs/internal/tailers/file/tailer_windows.go
@@ -75,20 +75,12 @@ func (t *Tailer) readAvailable() (int, error) {
 	for {
 		inBuf := make([]byte, 4096)
 		n, err := f.Read(inBuf)
+		bytes += n
 		if n == 0 || err != nil {
 			return bytes, err
 		}
-		// try to put this buffer into the decoder channel
-		select {
-		case t.decoder.InputChan <- decoder.NewInput(inBuf[:n]):
-			t.incrementLastReadOffset(n)
-			bytes += n
-		default:
-			// the buffer is full, so pretend that this is all of the data that
-			// is available in the file at this point, in order to close the
-			// file and wait for the next poll interval.
-			return bytes, io.EOF
-		}
+		t.decoder.InputChan <- decoder.NewInput(inBuf[:n])
+		t.incrementLastReadOffset(n)
 	}
 }
 

--- a/releasenotes/notes/dont-hold-open-file-when-pipeline-full-f19561f89dab2a03.yaml
+++ b/releasenotes/notes/dont-hold-open-file-when-pipeline-full-f19561f89dab2a03.yaml
@@ -1,6 +1,0 @@
----
-enhancements:
-  - |
-    On Windows, the Agent no longer holds files open when the logs-processing
-    pipeline is full.  This prevents issues with log sources renaming or
-    rotating files in high-volume scenarios.


### PR DESCRIPTION
This change was sensitive to the pipeline bandwidth as viewed from the
input to the Decoder -- which is an unbuffered channel.  In some
scenarios this might have limited log bandwidth to 4k/s.

This reverts commit 2240c3a05cf4be04c9ef7fd94fd0259b411cfe5c.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
