### PR TITLE
remove non-looping loop

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -68,7 +68,6 @@ linters-settings:
              # Actual issues that should be fixed eventually
              "-SA5001", # TODO: Error not checked on .Close()
              "-SA2001", # TODO: empty critical section, seems to be used for something?
-             "-SA4004", # TODO: should the loop be removed or the return be removed?
              "-SA6002", # TODO: Fix sync.Pools
              "-SA4025", # TODO: Fix trace unit test
             ]

--- a/pkg/logs/client/mock/mock.go
+++ b/pkg/logs/client/mock/mock.go
@@ -12,7 +12,7 @@ import (
 )
 
 // NewMockLogsIntake creates a TCP server that mimics the logs backend and returns
-// a Listener. It's the caller's responsibility to close the listener.
+// a Listener. The intake only accepts one connection and then exits.
 func NewMockLogsIntake(t *testing.T) net.Listener {
 	// This needs to be an IPv4 because most of the code doesn't handle IPv6 yet.
 	l, err := net.Listen("tcp", "127.0.0.1:0")
@@ -21,20 +21,17 @@ func NewMockLogsIntake(t *testing.T) net.Listener {
 	}
 	go func() {
 		defer l.Close()
-		for {
-			conn, err := l.Accept()
-			if err != nil {
-				return
-			}
-			defer conn.Close()
-
-			for {
-				_, err := ioutil.ReadAll(conn)
-				if err != nil {
-					break
-				}
-			}
+		conn, err := l.Accept()
+		if err != nil {
 			return
+		}
+		defer conn.Close()
+
+		for {
+			_, err := ioutil.ReadAll(conn)
+			if err != nil {
+				break
+			}
 		}
 	}()
 	return l


### PR DESCRIPTION
### What does this PR do?

Removes
```
for {
    return
}
```

### Motivation

https://staticcheck.io/docs/checks#SA4004

### Additional Notes

I assume at one point this was intended to run forever, and was later changed to only run once without looking too hard at how that was done.

### Describe how to test/QA your changes

Only used in CI, so if CI passes, it's good.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
