### PR TITLE
[CWS] remove namespace switch event (7.36 backport)

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "2769d797def4c60a51797ce3c35894298e5be4152d5a4f8755430e7e597c2540")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "ae5cbd7b502f99a7bb5761b8aa6d0db8cb1dfd1a2a1022ca5f8091eee2b27f6b")

--- a/pkg/security/ebpf/c/defs.h
+++ b/pkg/security/ebpf/c/defs.h
@@ -226,7 +226,6 @@ enum event_type
     EVENT_DNS,
     EVENT_NET_DEVICE,
     EVENT_VETH_PAIR,
-    EVENT_NAMESPACE_SWITCH,
     EVENT_MAX, // has to be the last one
 
     EVENT_ALL = 0xffffffffffffffff // used as a mask for all the events

--- a/pkg/security/ebpf/c/process.h
+++ b/pkg/security/ebpf/c/process.h
@@ -286,14 +286,6 @@ __attribute__((always_inline)) u32 get_netns_from_nf_conn(struct nf_conn *ct) {
     return get_netns_from_net(net);
 }
 
-struct namespace_switch_event_t {
-    struct kevent_t event;
-    struct process_context_t process;
-    struct span_context_t span;
-    struct container_context_t container;
-    struct syscall_t syscall;
-};
-
 SEC("kprobe/switch_task_namespaces")
 int kprobe_switch_task_namespaces(struct pt_regs *ctx) {
     struct nsproxy *new_ns = (struct nsproxy *)PT_REGS_PARM2(ctx);
@@ -310,13 +302,6 @@ int kprobe_switch_task_namespaces(struct pt_regs *ctx) {
     u32 netns = get_netns_from_net(net);
     u32 tid = bpf_get_current_pid_tgid();
     bpf_map_update_elem(&netns_cache, &tid, &netns, BPF_ANY);
-
-    struct namespace_switch_event_t evt = {};
-    struct proc_cache_t *entry = fill_process_context(&evt.process);
-    fill_container_context(entry, &evt.container);
-    fill_span_context(&evt.span);
-
-    send_event(ctx, EVENT_NAMESPACE_SWITCH, evt);
     return 0;
 }
 

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -703,8 +703,6 @@ func (p *Probe) handleEvent(CPU uint64, data []byte) {
 			return
 		}
 		_ = p.setupNewTCClassifier(event.VethPair.PeerDevice)
-	case model.NamespaceSwitchEventType:
-		break
 	case model.DNSEventType:
 		if _, err = event.DNS.UnmarshalBinary(data[offset:]); err != nil {
 			log.Errorf("failed to decode DNS event: %s (offset %d, len %d)", err, offset, len(data))

--- a/pkg/security/secl/model/events.go
+++ b/pkg/security/secl/model/events.go
@@ -83,8 +83,6 @@ const (
 	NetDeviceEventType
 	// VethPairEventType is sent when a new veth pair is created
 	VethPairEventType
-	// NamespaceSwitchEventType is sent when a process changes one of its namespaces
-	NamespaceSwitchEventType
 	// MaxEventType is used internally to get the maximum number of kernel events.
 	MaxEventType
 
@@ -180,8 +178,6 @@ func (t EventType) String() string {
 		return "net_device"
 	case VethPairEventType:
 		return "veth_pair"
-	case NamespaceSwitchEventType:
-		return "namespace_switch"
 
 	case CustomLostReadEventType:
 		return "lost_events_read"


### PR DESCRIPTION
(cherry picked from commit b82e6922706754b52e1f3fe2c7ff31b910b045df)

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Backport of https://github.com/DataDog/datadog-agent/pull/11688

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
