### PR TITLE
Use github.com/uber-go/atomic in pkg/util + docs

### DIFF
--- a/docs/dev/atomics.md
+++ b/docs/dev/atomics.md
@@ -1,6 +1,6 @@
 # Atomic Access
 
-tl;dr: use `github.com/uber-go/atomic` for all atomic access.  Use pointers (`*atomic.Uint64`, etc.) in structs to ensure proper alignment.
+tl;dr: use `go.uber.org/atomic` for all atomic access.  Use pointers (`*atomic.Uint64`, etc.) in structs to ensure proper alignment.
 
 ## Prefer Not
 
@@ -17,12 +17,12 @@ Even here, be wary of race conditions, such as assuming that a background gorout
 ## Use uber-go/atomic
 
 OK, so you've decided to use atomics.
-Use `github.com/uber-go/atomic`, rather than the built-in `sync/atomic` package.
+Use `go.uber.org/atomic`, rather than the built-in `sync/atomic` package.
 
 ### How
 
 Always declare atomic types using a pointer.
-The ensures proper alignment.
+This ensures proper alignment.
 
 ```golang
 //  global variable

--- a/docs/dev/atomics.md
+++ b/docs/dev/atomics.md
@@ -21,23 +21,29 @@ Use `github.com/uber-go/atomic`, rather than the built-in `sync/atomic` package.
 
 ### How
 
-If your atomic is a global variable, you may declare it using its zero value:
+Always declare atomic types using a pointer.
+The ensures proper alignment.
 
 ```golang
-var maxFooCount atomic.Uint64
-```
+//  global variable
+var maxFooCount *atomic.Uint64 = atomic.NewUint64(42)
 
-If your atomic is in a struct, declare it as a pointer, to ensure proper alignment:
-
-```golang
+// in a struct
 type FooTracker struct {
     maxCount *atomic.Uint64
 }
+
+func NewFooTracker() *FooTracker {
+    return &FooTracker {
+        maxCount: atomic.NewUint64(42),
+    }
+}
 ```
 
-In this case, initialize the pointer in the constructor (`atomic.NewUint64(..)`) and use the `atomic.Uint64` methods to perform atomic operations on the value.
+Use the `atomic.Uint64` methods to perform atomic operations on the value.
+These include some conveniences not available in `sync/atomic`, such as Inc/Dec and `atomic.Bool`.
 
-If the additional pointer allocation poses an undue performance burden, include the value as the first element in the struct and include a comment indicating
+If the additional pointer allocation poses an undue performance burden, include the value as the *first* element in the struct (to ensure alignment) and include a comment indicating
  * that it must remain in that position; and
  * why a pointer was not suitable.
 

--- a/docs/dev/atomics.md
+++ b/docs/dev/atomics.md
@@ -1,0 +1,52 @@
+# Atomic Access
+
+tl;dr: use `github.com/uber-go/atomic` for all atomic access.  Use pointers (`*atomic.Uint64`, etc.) in structs to ensure proper alignment.
+
+## Prefer Not
+
+First, atomics are a _very_ low-level concept and full of subtle gotchas and dramatic performance differences across platforms.
+If you can use something higher-level, such as something from the `sync` package, prefer to do so.
+Otherwise, if you are in search of performance, be sure to benchmark your work carefully and on multiple platforms.
+
+It's tempting to use an atomic to avoid complaints from the race detector, but this is almost always a mistake -- it is merely hiding your race from the race detector.
+Consider carefully why the implementation is racing, and try to address that behavior directly.
+
+The exception to this is tests, where atomics can be useful for sensing some value that you would like to assert on that is manipulated in another goroutine.
+Even here, be wary of race conditions, such as assuming that a background goroutine has executed before the test goroutine makes its assertions.
+
+## Use uber-go/atomic
+
+OK, so you've decided to use atomics.
+Use `github.com/uber-go/atomic`, rather than the built-in `sync/atomic` package.
+
+### How
+
+If your atomic is a global variable, you may declare it using its zero value:
+
+```golang
+var maxFooCount atomic.Uint64
+```
+
+If your atomic is in a struct, declare it as a pointer, to ensure proper alignment:
+
+```golang
+type FooTracker struct {
+    maxCount *atomic.Uint64
+}
+```
+
+In this case, initialize the pointer in the constructor (`atomic.NewUint64(..)`) and use the `atomic.Uint64` methods to perform atomic operations on the value.
+
+If the additional pointer allocation poses an undue performance burden, include the value as the first element in the struct and include a comment indicating
+ * that it must remain in that position; and
+ * why a pointer was not suitable.
+
+### Why
+
+There are two main issues with the built-in `sync/atomic` package:
+
+1. It has an unresolved [alignment bug](https://pkg.go.dev/sync/atomic#pkg-note-BUG) requiring users to manually ensure alignment.
+   This is frequently forgotten, and only causes issues on less-common platforms, leading to undetected bugs.
+
+1. It is very easy to access a raw integer variable using a mix of atomic and non-atomic operations.
+   This mix may be enough to satisfy the race detector, but not sufficient to actually prevent undefined behavior.

--- a/docs/dev/atomics.md
+++ b/docs/dev/atomics.md
@@ -43,7 +43,7 @@ func NewFooTracker() *FooTracker {
 Use the `atomic.Uint64` methods to perform atomic operations on the value.
 These include some conveniences not available in `sync/atomic`, such as Inc/Dec and `atomic.Bool`.
 
-If the additional pointer allocation poses an undue performance burden, include the value as the *first* element in the struct (to ensure alignment) and include a comment indicating
+If the additional pointer allocation poses an undue performance burden, include the value as the *first* element in the struct (to ensure alignment) and include a comment indicating:
  * that it must remain in that position; and
  * why a pointer was not suitable.
 

--- a/pkg/util/sliding_window_test.go
+++ b/pkg/util/sliding_window_test.go
@@ -8,13 +8,13 @@ package util
 import (
 	"math/rand"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 )
 
 const DefaultDelta = 0.001
@@ -22,13 +22,13 @@ const DefaultDelta = 0.001
 var (
 	dummyPollingFuncToggle = true
 
-	pollingFuncInvocationCount     int64
-	statsUpdateFuncInvocationCount int64
+	pollingFuncInvocationCount     atomic.Int64
+	statsUpdateFuncInvocationCount atomic.Int64
 )
 
 // This function on average should return 0.5 value
 func dummyTogglingPollingFunc() float64 {
-	atomic.AddInt64(&pollingFuncInvocationCount, 1)
+	pollingFuncInvocationCount.Add(1)
 
 	dummyPollingFuncToggle = !dummyPollingFuncToggle
 
@@ -40,12 +40,12 @@ func dummyTogglingPollingFunc() float64 {
 }
 
 func dummyStatsUpdateFunc(sw SlidingWindow) {
-	atomic.AddInt64(&statsUpdateFuncInvocationCount, 1)
+	statsUpdateFuncInvocationCount.Add(1)
 }
 
 // This function on average should return about 0.3 value
 func dummyFractionalPollingFunc() float64 {
-	atomic.AddInt64(&pollingFuncInvocationCount, 1)
+	pollingFuncInvocationCount.Add(1)
 	randBusy := 0.3 + ((rand.Float64() - 0.5) * 0.001)
 
 	return randBusy
@@ -118,15 +118,15 @@ func TestSlidingWindowAverage(t *testing.T) {
 }
 
 func TestSlidingWindowCallback(t *testing.T) {
-	atomic.StoreInt64(&statsUpdateFuncInvocationCount, 0)
-	atomic.StoreInt64(&pollingFuncInvocationCount, 0)
+	statsUpdateFuncInvocationCount.Store(0)
+	pollingFuncInvocationCount.Store(0)
 
 	clk := clock.NewMock()
 	sw, err := NewSlidingWindowWithClock(100*time.Millisecond, 10*time.Millisecond, clk)
 	require.Nil(t, err)
 
 	pollingFunc := func() float64 {
-		atomic.StoreInt64(&pollingFuncInvocationCount, 1)
+		pollingFuncInvocationCount.Store(1)
 
 		return 0.0
 	}
@@ -137,10 +137,10 @@ func TestSlidingWindowCallback(t *testing.T) {
 
 		require.True(
 			t,
-			atomic.LoadInt64(&pollingFuncInvocationCount) > atomic.LoadInt64(&statsUpdateFuncInvocationCount),
+			pollingFuncInvocationCount.Load() > statsUpdateFuncInvocationCount.Load(),
 		)
 
-		atomic.StoreInt64(&pollingFuncInvocationCount, 1)
+		pollingFuncInvocationCount.Store(1)
 	}
 
 	err = sw.Start(pollingFunc, statsUpdateFunc)
@@ -151,8 +151,8 @@ func TestSlidingWindowCallback(t *testing.T) {
 }
 
 func TestSlidingWindowFuncInvocationCounts(t *testing.T) {
-	atomic.StoreInt64(&statsUpdateFuncInvocationCount, 0)
-	atomic.StoreInt64(&pollingFuncInvocationCount, 0)
+	statsUpdateFuncInvocationCount.Store(0)
+	pollingFuncInvocationCount.Store(0)
 
 	windowSize := 2000 * time.Millisecond
 	pollingInterval := 100 * time.Millisecond
@@ -168,12 +168,12 @@ func TestSlidingWindowFuncInvocationCounts(t *testing.T) {
 	assert.Equal(t, windowSize, sw.WindowSize())
 
 	clk.Add(windowSize)
-	assert.InDelta(t, atomic.LoadInt64(&pollingFuncInvocationCount), 19, 3)
-	assert.InDelta(t, atomic.LoadInt64(&statsUpdateFuncInvocationCount), 19, 3)
+	assert.InDelta(t, pollingFuncInvocationCount.Load(), 19, 3)
+	assert.InDelta(t, statsUpdateFuncInvocationCount.Load(), 19, 3)
 
 	clk.Add(200 * time.Millisecond)
-	assert.InDelta(t, atomic.LoadInt64(&pollingFuncInvocationCount), 21, 3)
-	assert.InDelta(t, atomic.LoadInt64(&statsUpdateFuncInvocationCount), 21, 3)
+	assert.InDelta(t, pollingFuncInvocationCount.Load(), 21, 3)
+	assert.InDelta(t, statsUpdateFuncInvocationCount.Load(), 21, 3)
 }
 
 func TestNewSlidingWindowStop(t *testing.T) {

--- a/pkg/util/sliding_window_test.go
+++ b/pkg/util/sliding_window_test.go
@@ -22,8 +22,8 @@ const DefaultDelta = 0.001
 var (
 	dummyPollingFuncToggle = true
 
-	pollingFuncInvocationCount     atomic.Int64
-	statsUpdateFuncInvocationCount atomic.Int64
+	pollingFuncInvocationCount     *atomic.Int64 = atomic.NewInt64(0)
+	statsUpdateFuncInvocationCount *atomic.Int64 = atomic.NewInt64(0)
 )
 
 // This function on average should return 0.5 value

--- a/pkg/util/system/cpu.go
+++ b/pkg/util/system/cpu.go
@@ -9,10 +9,10 @@ import (
 	"context"
 	"runtime"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"go.uber.org/atomic"
 )
 
 const (
@@ -20,7 +20,7 @@ const (
 )
 
 var (
-	hostCPUCount           int64
+	hostCPUCount           atomic.Int64
 	hostCPUFailedAttempts  int
 	hostCPUCountUpdateLock sync.Mutex
 	cpuInfoFunc            func(context.Context, bool) (int, error)
@@ -28,7 +28,7 @@ var (
 
 // HostCPUCount returns the number of logical CPUs from host
 func HostCPUCount() int {
-	if v := atomic.LoadInt64(&hostCPUCount); v != 0 {
+	if v := hostCPUCount.Load(); v != 0 {
 		return int(v)
 	}
 
@@ -53,7 +53,7 @@ func HostCPUCount() int {
 			return runtime.NumCPU()
 		}
 	}
-	atomic.StoreInt64(&hostCPUCount, int64(cpuCount))
+	hostCPUCount.Store(int64(cpuCount))
 
 	return cpuCount
 }

--- a/pkg/util/system/cpu.go
+++ b/pkg/util/system/cpu.go
@@ -20,7 +20,7 @@ const (
 )
 
 var (
-	hostCPUCount           atomic.Int64
+	hostCPUCount           *atomic.Int64 = atomic.NewInt64(0)
 	hostCPUFailedAttempts  int
 	hostCPUCountUpdateLock sync.Mutex
 	cpuInfoFunc            func(context.Context, bool) (int, error)

--- a/pkg/util/system/cpu_test.go
+++ b/pkg/util/system/cpu_test.go
@@ -22,7 +22,7 @@ type fakeCPUCount struct {
 func newFakeCPUCount(count int, err error) *fakeCPUCount {
 	f := fakeCPUCount{count: count, err: err}
 	cpuInfoFunc = f.info
-	hostCPUCount = 0
+	hostCPUCount.Store(0)
 	hostCPUFailedAttempts = 0
 	return &f
 }


### PR DESCRIPTION
### What does this PR do?

Adds some documentation about using atomics, and then follows that advice in pkg/util

### Motivation

Safer use of atomics; details in [the dev docs](https://github.com/DataDog/datadog-agent/pull/11716/files?short_path=1d177b1#diff-1d177b1cd865323bfd694812c25f610f9d8e9018f10594d2ca9a39b77acd103f).

### Additional Notes

I'll follow this up with more PRs for other directories.  Eventually we can add a check to ensure sync/atomic isn't used.

### Possible Drawbacks / Trade-offs

None

### Describe how to test/QA your changes

No need.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
