### PR TITLE
Only report kprobe stats for current pid

### DIFF
--- a/pkg/ebpf/debugfs.go
+++ b/pkg/ebpf/debugfs.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	manager "github.com/DataDog/ebpf-manager"
 	"github.com/pkg/errors"
 )
 
@@ -43,6 +44,14 @@ func GetProbeStats() map[string]int64 {
 	for event, st := range m {
 		parts := eventRegexp.FindStringSubmatch(event)
 		if len(parts) > 2 {
+			// only get stats for our pid
+			if len(parts) > 3 {
+				if pid, err := strconv.ParseInt(parts[3], 10, 32); err != nil {
+					if int(pid) != manager.Getpid() {
+						continue
+					}
+				}
+			}
 			// strip UID and PID from name
 			event = parts[1]
 		}

--- a/pkg/ebpf/debugfs.go
+++ b/pkg/ebpf/debugfs.go
@@ -21,13 +21,19 @@ import (
 	"github.com/pkg/errors"
 )
 
+var myPid int
+
+func init() {
+	myPid = manager.Getpid()
+}
+
 type KprobeStats struct {
 	Hits   int64
 	Misses int64
 }
 
 // event name format is p|r_<funcname>_<uid>_<pid>
-var eventRegexp = regexp.MustCompile(`^((?:p|r)_.+?)(_[^_]*)(_[^_]*)$`)
+var eventRegexp = regexp.MustCompile(`^((?:p|r)_.+?)_([^_]*)_([^_]*)$`)
 
 // KprobeProfile is the default path to the kprobe_profile file
 const KprobeProfile = "/sys/kernel/debug/tracing/kprobe_profile"
@@ -47,7 +53,7 @@ func GetProbeStats() map[string]int64 {
 			// only get stats for our pid
 			if len(parts) > 3 {
 				if pid, err := strconv.ParseInt(parts[3], 10, 32); err != nil {
-					if int(pid) != manager.Getpid() {
+					if int(pid) != myPid {
 						continue
 					}
 				}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Only reports stats for kprobes for the current pid. This is a problem on deployments with multiple system-probes where we combine the stats since we get rid of the pid.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
