### PR TITLE
Use uber-go/atomic in pkg/autodiscovery

### DIFF
--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -75,8 +75,18 @@ func (l *listenerCandidate) try() (listeners.ServiceListener, error) {
 	return l.factory(l.config)
 }
 
-// NewAutoConfig creates an AutoConfig instance.
+// NewAutoConfig creates an AutoConfig instance and starts it.
 func NewAutoConfig(scheduler *scheduler.MetaScheduler) *AutoConfig {
+	ac := NewAutoConfigNoStart(scheduler)
+
+	// We need to listen to the service channels before anything is sent to them
+	go ac.serviceListening()
+
+	return ac
+}
+
+// NewAutoConfigNoStart creates an AutoConfig instance.
+func NewAutoConfigNoStart(scheduler *scheduler.MetaScheduler) *AutoConfig {
 	ac := &AutoConfig{
 		providers:          make([]*configPoller, 0, 9),
 		listenerCandidates: make(map[string]*listenerCandidate),
@@ -89,8 +99,6 @@ func NewAutoConfig(scheduler *scheduler.MetaScheduler) *AutoConfig {
 		scheduler:          scheduler,
 		ranOnce:            atomic.NewBool(false),
 	}
-	// We need to listen to the service channels before anything is sent to them
-	go ac.serviceListening()
 	return ac
 }
 

--- a/pkg/logs/schedulers/cca/scheduler_test.go
+++ b/pkg/logs/schedulers/cca/scheduler_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func setup() (scheduler *Scheduler, ac *autodiscovery.AutoConfig, spy *schedulers.MockSourceManager) {
-	ac = &autodiscovery.AutoConfig{}
+	ac = autodiscovery.NewAutoConfigNoStart(nil)
 	scheduler = New(func() *autodiscovery.AutoConfig { return ac }).(*Scheduler)
 	spy = &schedulers.MockSourceManager{}
 	return


### PR DESCRIPTION
This hasRunOnce functionality is destined for the scrap-heap, but until
then we can still use a properly-aligned atomic.

### What does this PR do?

Uses github.com/uber-go/atomic for the atomic used to track whether AD hasRunOnce.

### Motivation

See #11716.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Run the agent in a container environment with logs_config.container_collect_all enabled, and verify that it logs a container without any annotations or labels.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
