### PR TITLE
[CWS] fix discarder erpc race

### DIFF
--- a/pkg/security/probe/discarders.go
+++ b/pkg/security/probe/discarders.go
@@ -144,7 +144,6 @@ type inodeDiscarder struct {
 type inodeDiscarders struct {
 	*lib.Map
 	erpc           *ERPC
-	req            ERPCRequest
 	revisions      *lib.Map
 	revisionCache  [discarderRevisionSize]uint32
 	dentryResolver *DentryResolver
@@ -154,11 +153,14 @@ type inodeDiscarders struct {
 	parentDiscarderFncs [maxParentDiscarderDepth]map[eval.Field]func(dirname string) (bool, error)
 }
 
+func newDiscarderRequest() *ERPCRequest {
+	return &ERPCRequest{OP: DiscardInodeOp}
+}
+
 func newInodeDiscarders(inodesMap, revisionsMap *lib.Map, erpc *ERPC, dentryResolver *DentryResolver) (*inodeDiscarders, error) {
 	id := &inodeDiscarders{
 		Map:            inodesMap,
 		erpc:           erpc,
-		req:            ERPCRequest{OP: DiscardInodeOp},
 		revisions:      revisionsMap,
 		dentryResolver: dentryResolver,
 	}
@@ -168,26 +170,26 @@ func newInodeDiscarders(inodesMap, revisionsMap *lib.Map, erpc *ERPC, dentryReso
 	return id, nil
 }
 
-func (id *inodeDiscarders) discardInode(eventType model.EventType, mountID uint32, inode uint64, isLeaf bool) error {
+func (id *inodeDiscarders) discardInode(req *ERPCRequest, eventType model.EventType, mountID uint32, inode uint64, isLeaf bool) error {
 	var isLeafInt uint32
 	if isLeaf {
 		isLeafInt = 1
 	}
 
-	offset := marshalDiscardHeader(&id.req, eventType, 0)
-	model.ByteOrder.PutUint64(id.req.Data[offset:offset+8], inode)
-	model.ByteOrder.PutUint32(id.req.Data[offset+8:offset+12], mountID)
-	model.ByteOrder.PutUint32(id.req.Data[offset+12:offset+16], isLeafInt)
+	offset := marshalDiscardHeader(req, eventType, 0)
+	model.ByteOrder.PutUint64(req.Data[offset:offset+8], inode)
+	model.ByteOrder.PutUint32(req.Data[offset+8:offset+12], mountID)
+	model.ByteOrder.PutUint32(req.Data[offset+12:offset+16], isLeafInt)
 
-	return id.erpc.Request(&id.req)
+	return id.erpc.Request(req)
 }
 
 // expireInodeDiscarder sends an eRPC request to expire a discarder
-func (id *inodeDiscarders) expireInodeDiscarder(mountID uint32, inode uint64) error {
-	model.ByteOrder.PutUint64(id.req.Data[0:8], inode)
-	model.ByteOrder.PutUint32(id.req.Data[8:12], mountID)
+func (id *inodeDiscarders) expireInodeDiscarder(req *ERPCRequest, mountID uint32, inode uint64) error {
+	model.ByteOrder.PutUint64(req.Data[0:8], inode)
+	model.ByteOrder.PutUint32(req.Data[8:12], mountID)
 
-	return id.erpc.Request(&id.req)
+	return id.erpc.Request(req)
 }
 
 func (id *inodeDiscarders) setRevision(mountID uint32, revision uint32) {
@@ -391,7 +393,7 @@ func (id *inodeDiscarders) isParentPathDiscarder(rs *rules.RuleSet, eventType mo
 	return true, nil
 }
 
-func (id *inodeDiscarders) discardParentInode(rs *rules.RuleSet, eventType model.EventType, field eval.Field, filename string, mountID uint32, inode uint64, pathID uint32) (bool, uint32, uint64, error) {
+func (id *inodeDiscarders) discardParentInode(req *ERPCRequest, rs *rules.RuleSet, eventType model.EventType, field eval.Field, filename string, mountID uint32, inode uint64, pathID uint32) (bool, uint32, uint64, error) {
 	var discarderDepth int
 	var isDiscarder bool
 	var err error
@@ -418,7 +420,7 @@ func (id *inodeDiscarders) discardParentInode(rs *rules.RuleSet, eventType model
 		mountID, inode = parentMountID, parentInode
 	}
 
-	if err := id.discardInode(eventType, mountID, inode, false); err != nil {
+	if err := id.discardInode(req, eventType, mountID, inode, false); err != nil {
 		return false, 0, 0, err
 	}
 
@@ -452,14 +454,14 @@ func filenameDiscarderWrapper(eventType model.EventType, handler onDiscarderHand
 				return nil
 			}
 
-			isDiscarded, _, parentInode, err := probe.inodeDiscarders.discardParentInode(rs, eventType, field, filename, mountID, inode, pathID)
+			isDiscarded, _, parentInode, err := probe.inodeDiscarders.discardParentInode(probe.discarderReq, rs, eventType, field, filename, mountID, inode, pathID)
 			if !isDiscarded && !isDeleted {
 				if _, ok := err.(*ErrInvalidKeyPath); !ok {
 					if !IsFakeInode(inode) {
 						seclog.Tracef("Apply `%s.file.path` inode discarder for event `%s`, inode: %d(%s)", eventType, eventType, inode, filename)
 
 						// not able to discard the parent then only discard the filename
-						_ = probe.inodeDiscarders.discardInode(eventType, mountID, inode, true)
+						_ = probe.inodeDiscarders.discardInode(probe.discarderReq, eventType, mountID, inode, true)
 					}
 				}
 			} else if !isDeleted {
@@ -519,7 +521,7 @@ func processDiscarderWrapper(eventType model.EventType, fnc onDiscarderHandler) 
 				return err
 			}
 
-			return probe.inodeDiscarders.discardInode(eventType, event.ProcessContext.FileEvent.MountID, event.ProcessContext.FileEvent.Inode, true)
+			return probe.inodeDiscarders.discardInode(probe.discarderReq, eventType, event.ProcessContext.FileEvent.MountID, event.ProcessContext.FileEvent.Inode, true)
 		}
 
 		if fnc != nil {

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -76,6 +76,7 @@ type Probe struct {
 
 	// Approvers / discarders section
 	erpc               *ERPC
+	discarderReq       *ERPCRequest
 	pidDiscarders      *pidDiscarders
 	inodeDiscarders    *inodeDiscarders
 	flushingDiscarders int64
@@ -933,10 +934,11 @@ func (p *Probe) FlushDiscarders() error {
 	}
 	defer unfreezeDiscarders()
 
-	// Sleeping a bit to avoid races with executing kprobes and setting discarders
 	if !atomic.CompareAndSwapInt64(&p.flushingDiscarders, 0, 1) {
 		return errors.New("already flushing discarders")
 	}
+	// Sleeping a bit to avoid races with executing kprobes and setting discarders
+	time.Sleep(time.Second)
 
 	var discardedInodes []inodeDiscarder
 	var mapValue [256]byte
@@ -963,8 +965,10 @@ func (p *Probe) FlushDiscarders() error {
 	flushDiscarders := func() {
 		log.Debugf("Flushing discarders")
 
+		req := newDiscarderRequest()
+
 		for _, inode := range discardedInodes {
-			if err := p.inodeDiscarders.expireInodeDiscarder(inode.PathKey.MountID, inode.PathKey.Inode); err != nil {
+			if err := p.inodeDiscarders.expireInodeDiscarder(req, inode.PathKey.MountID, inode.PathKey.Inode); err != nil {
 				seclog.Tracef("Failed to flush discarder for inode %d: %s", inode, err)
 			}
 
@@ -1151,6 +1155,7 @@ func NewProbe(config *config.Config, statsdClient statsd.ClientInterface) (*Prob
 		ctx:            ctx,
 		cancelFnc:      cancel,
 		erpc:           erpc,
+		discarderReq:   newDiscarderRequest(),
 		tcPrograms:     make(map[NetDeviceKey]*manager.Probe),
 		statsdClient:   statsdClient,
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fix race while accessing the same "req" object from event discarders and the flush function.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
