### PR TITLE
Don't destroy rtloader on shutdown

### DIFF
--- a/cmd/py-launcher/py-launcher.go
+++ b/cmd/py-launcher/py-launcher.go
@@ -69,6 +69,4 @@ func main() {
 	if res == 0 {
 		fmt.Printf("Error while running python script: %s\n", C.GoString(C.get_error(rtloader)))
 	}
-
-	python.Destroy()
 }

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -71,8 +71,7 @@ func NewCollector(paths ...string) *Collector {
 	return c
 }
 
-// Stop halts any component involved in running a Check and shuts down
-// the Python Environment
+// Stop halts any component involved in running a Check
 func (c *Collector) Stop() {
 	c.m.Lock()
 	defer c.m.Unlock()
@@ -85,7 +84,6 @@ func (c *Collector) Stop() {
 	c.scheduler = nil
 	c.runner.Stop()
 	c.runner = nil
-	pyTeardown()
 	c.state = stopped
 }
 

--- a/pkg/collector/embed_nopy.go
+++ b/pkg/collector/embed_nopy.go
@@ -15,5 +15,3 @@ func pySetup(paths ...string) (pythonVersion, pythonHome, pythonPath string) {
 func pyPrepareEnv() error {
 	return nil
 }
-
-func pyTeardown() {}

--- a/pkg/collector/embed_python.go
+++ b/pkg/collector/embed_python.go
@@ -28,7 +28,3 @@ func pyPrepareEnv() error {
 	}
 	return nil
 }
-
-func pyTeardown() {
-	python.Destroy()
-}

--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -453,25 +453,6 @@ func Initialize(paths ...string) error {
 	return nil
 }
 
-// Destroy destroys the loaded Python interpreter initialized by 'Initialize'
-func Destroy() {
-	pyDestroyLock.Lock()
-	defer pyDestroyLock.Unlock()
-
-	// Sanity check - this should ideally never happen
-	if rtloader == nil {
-		log.Warn("Python runtime already destroyed. Ignoring action.")
-		return
-	}
-
-	// Clear the C-side and Go-side rtloader pointers
-	log.Info("Destroying Python runtime")
-	C.destroy(rtloader)
-	rtloader = nil
-
-	log.Info("Python runtime destroyed")
-}
-
 // GetRtLoader returns the underlying rtloader_t struct. This is meant for testing and
 // tooling, use the rtloader_t struct at your own risk
 func GetRtLoader() *C.rtloader_t {

--- a/releasenotes/notes/shutdown-python-2f0b1137cb6d5560.yaml
+++ b/releasenotes/notes/shutdown-python-2f0b1137cb6d5560.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Fixed a potential deadlock in the Python check runner during agent shutdown.


### PR DESCRIPTION
### What does this PR do?

Fixed a potential deadlock in the Python check runner during agent shutdown.

### Additional Notes

rtloader destructor grabs GIL to drop a reference to a python class, but this may cause a deadlock if a running check holds the GIL too.

Dropping a reference to the check base class is redundant, since we're shutting down anyway. So we can skip the destructor completely, and avoid potential deadlocks.

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Create a custom check that holds the GIL: 

```
### /etc/datadog-agent/checks.d/mycheck.py
from datadog_checks.base import AgentCheck
class HelloCheck(AgentCheck):
    def check(self, instance):
        import re
        re.match(r'(a?){30}a{30}', 'a'*30)
### /etc/datadog-agent/conf.d/mycheck.yaml
instances: [{}]
```

Run the agent, wait until the check kicks in (cpu usage close to 100%), then stop the agent. The agent should exit quickly.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
