### PR TITLE
pkg/trace/pb: add documentation comments to span.proto

### DIFF
--- a/pkg/trace/pb/span.proto
+++ b/pkg/trace/pb/span.proto
@@ -5,17 +5,30 @@ package pb;
 import "github.com/gogo/protobuf/gogoproto/gogo.proto";
 
 message Span {
+    // service is the name of the service with which this span is associated.
     string service = 1 [(gogoproto.jsontag) = "service", (gogoproto.moretags) = "msg:\"service\""];
+    // name is the operation name of this span.
     string name = 2 [(gogoproto.jsontag) = "name", (gogoproto.moretags) = "msg:\"name\""];
+    // resource is the resource name of this span, also sometimes called the endpoint (for web spans).
     string resource = 3 [(gogoproto.jsontag) = "resource", (gogoproto.moretags) = "msg:\"resource\""];
+    // traceID is the ID of the trace to which this span belongs.
     uint64 traceID = 4 [(gogoproto.jsontag) = "trace_id", (gogoproto.moretags) = "msg:\"trace_id\""];
+    // spanID is the ID of this span.
     uint64 spanID = 5 [(gogoproto.jsontag) = "span_id", (gogoproto.moretags) = "msg:\"span_id\""];
+    // parentID is the ID of this span's parent, or zero if this span has no parent.
     uint64 parentID = 6 [(gogoproto.jsontag) = "parent_id", (gogoproto.moretags) = "msg:\"parent_id\""];
+    // start is the number of nanoseconds between the Unix epoch and the beginning of this span.
     int64 start = 7 [(gogoproto.jsontag) = "start", (gogoproto.moretags) = "msg:\"start\""];
+    // duration is the time length of this span in nanoseconds.
     int64 duration = 8 [(gogoproto.jsontag) = "duration", (gogoproto.moretags) = "msg:\"duration\""];
+    // error is 1 if there is an error associated with this span, or 0 if there is not.
     int32 error = 9 [(gogoproto.jsontag) = "error", (gogoproto.moretags) = "msg:\"error\""];
+    // meta is a mapping from tag name to tag value for string-valued tags.
     map<string, string> meta = 10 [(gogoproto.jsontag) = "meta", (gogoproto.moretags) = "msg:\"meta\""];
+    // metrics is a mapping from tag name to tag value for numeric-valued tags.
     map<string, double> metrics = 11 [(gogoproto.jsontag) = "metrics", (gogoproto.moretags) = "msg:\"metrics\""];
+    // type is the type of the service with which this span is associated.  Example values: web, db, lambda.
     string type = 12 [(gogoproto.jsontag) = "type", (gogoproto.moretags) = "msg:\"type\""];
+    // meta_struct is no longer used.
     map<string, bytes> meta_struct = 13 [(gogoproto.jsontag) = "meta_struct,omitempty", (gogoproto.moretags) = "msg:\"meta_struct\""];
 }

--- a/pkg/trace/pb/span.proto
+++ b/pkg/trace/pb/span.proto
@@ -29,6 +29,6 @@ message Span {
     map<string, double> metrics = 11 [(gogoproto.jsontag) = "metrics", (gogoproto.moretags) = "msg:\"metrics\""];
     // type is the type of the service with which this span is associated.  Example values: web, db, lambda.
     string type = 12 [(gogoproto.jsontag) = "type", (gogoproto.moretags) = "msg:\"type\""];
-    // meta_struct is no longer used.
+    // meta_struct is a registry of structured "other" data used by, e.g., AppSec.
     map<string, bytes> meta_struct = 13 [(gogoproto.jsontag) = "meta_struct,omitempty", (gogoproto.moretags) = "msg:\"meta_struct\""];
 }


### PR DESCRIPTION
I was trying to figure out in which units a span's `start` and `duration` are expressed.  After looking at some code, I found that the units are nanoseconds.  I'd like to document that in the `.proto` into which tracer payloads are decoded.

While I'm at it, might as well document the other fields as well.
