### PR TITLE
[CWS] fix mmap mprotect SECL evaluation

### DIFF
--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -17,7 +17,6 @@ import (
 
 	manager "github.com/DataDog/ebpf-manager"
 	"github.com/mailru/easyjson/jwriter"
-	"golang.org/x/sys/unix"
 
 	pconfig "github.com/DataDog/datadog-agent/pkg/process/config"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/constantfetch"
@@ -104,19 +103,7 @@ func (ev *Event) GetPathResolutionError() error {
 
 // ResolveFilePath resolves the inode to a full path
 func (ev *Event) ResolveFilePath(f *model.FileEvent) string {
-	// do not try to resolve mmap events when they aren't backed by any file
-	switch ev.GetEventType() {
-	case model.MMapEventType:
-		if ev.MMap.Flags&unix.MAP_ANONYMOUS != 0 {
-			return ""
-		}
-	case model.LoadModuleEventType:
-		if ev.LoadModule.LoadedFromMemory {
-			return ""
-		}
-	}
-
-	if len(f.PathnameStr) == 0 {
+	if !f.IsPathnameStrResolved && len(f.PathnameStr) == 0 {
 		path, err := ev.resolvers.resolveFileFieldsPath(&f.FileFields)
 		if err != nil {
 			switch err.(type) {
@@ -127,18 +114,18 @@ func (ev *Event) ResolveFilePath(f *model.FileEvent) string {
 				ev.SetPathResolutionError(err)
 			}
 		}
-		f.PathnameStr = path
+		f.SetPathnameStr(path)
 	}
 	return f.PathnameStr
 }
 
 // ResolveFileBasename resolves the inode to a full path
 func (ev *Event) ResolveFileBasename(f *model.FileEvent) string {
-	if len(f.BasenameStr) == 0 {
+	if !f.IsBasenameStrResolved && len(f.BasenameStr) == 0 {
 		if f.PathnameStr != "" {
-			f.BasenameStr = path.Base(f.PathnameStr)
+			f.SetBasenameStr(path.Base(f.PathnameStr))
 		} else {
-			f.BasenameStr = ev.resolvers.resolveBasename(&f.FileFields)
+			f.SetBasenameStr(ev.resolvers.resolveBasename(&f.FileFields))
 		}
 	}
 	return f.BasenameStr
@@ -489,6 +476,10 @@ func (ev *Event) ResolveProcessCacheEntry() *model.ProcessCacheEntry {
 		ev.processCacheEntry = ev.resolvers.ProcessResolver.Resolve(ev.ProcessContext.Pid, ev.ProcessContext.Tid)
 		if ev.processCacheEntry == nil {
 			ev.processCacheEntry = &model.ProcessCacheEntry{}
+
+			// mark context as resolved to avoid resolution with empty inode/mount id
+			ev.processCacheEntry.FileEvent.SetPathnameStr("")
+			ev.processCacheEntry.FileEvent.SetBasenameStr("")
 		}
 	}
 

--- a/pkg/security/probe/serializers.go
+++ b/pkg/security/probe/serializers.go
@@ -373,26 +373,6 @@ func newFileSerializer(fe *model.FileEvent, e *Event, forceInode ...uint64) *Fil
 	}
 }
 
-func newProcessFileSerializerWithResolvers(process *model.Process, r *Resolvers) *FileSerializer {
-	mode := uint32(process.FileEvent.Mode)
-	return &FileSerializer{
-		Path:                process.FileEvent.PathnameStr,
-		PathResolutionError: process.GetPathResolutionError(),
-		Name:                process.FileEvent.BasenameStr,
-		Inode:               getUint64Pointer(&process.FileEvent.Inode),
-		MountID:             getUint32Pointer(&process.FileEvent.MountID),
-		Filesystem:          process.FileEvent.Filesystem,
-		InUpperLayer:        getInUpperLayer(r, &process.FileEvent.FileFields),
-		Mode:                getUint32Pointer(&mode),
-		UID:                 int64(process.FileEvent.UID),
-		GID:                 int64(process.FileEvent.GID),
-		User:                r.ResolveFileFieldsUser(&process.FileEvent.FileFields),
-		Group:               r.ResolveFileFieldsGroup(&process.FileEvent.FileFields),
-		Mtime:               getTimeIfNotZero(time.Unix(0, int64(process.FileEvent.MTime))),
-		Ctime:               getTimeIfNotZero(time.Unix(0, int64(process.FileEvent.CTime))),
-	}
-}
-
 func getUint64Pointer(i *uint64) *uint64 {
 	if *i == 0 {
 		return nil
@@ -448,7 +428,7 @@ func newProcessSerializer(ps *model.Process, e *Event) *ProcessSerializer {
 		PPid:          ps.PPid,
 		Comm:          ps.Comm,
 		TTY:           ps.TTYName,
-		Executable:    newProcessFileSerializerWithResolvers(ps, e.resolvers),
+		Executable:    newFileSerializer(&ps.FileEvent, e),
 		Argv0:         argv0,
 		Args:          argv,
 		ArgsTruncated: argvTruncated,
@@ -910,7 +890,7 @@ func NewEventSerializer(event *Event) *EventSerializer {
 		s.EventContextSerializer.Outcome = serializeSyscallRetval(0)
 	case model.ExecEventType:
 		s.FileEventSerializer = &FileEventSerializer{
-			FileSerializer: *newProcessFileSerializerWithResolvers(&event.processCacheEntry.Process, event.resolvers),
+			FileSerializer: *newFileSerializer(&event.processCacheEntry.Process.FileEvent, event),
 		}
 		s.EventContextSerializer.Outcome = serializeSyscallRetval(0)
 	case model.SELinuxEventType:

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -361,11 +361,28 @@ func (f *FileFields) GetInUpperLayer() bool {
 // FileEvent is the common file event type
 type FileEvent struct {
 	FileFields
+
 	PathnameStr string `field:"path,ResolveFilePath" msg:"path" op_override:"eval.GlobCmp"` // File's path
 	BasenameStr string `field:"name,ResolveFileBasename" msg:"name"`                        // File's basename
 	Filesystem  string `field:"filesystem,ResolveFileFilesystem" msg:"filesystem"`          // File's filesystem
 
 	PathResolutionError error `field:"-" msg:"-"`
+
+	// used to mark as already resolved, can be used in case of empty path
+	IsPathnameStrResolved bool `field:"-" msg:"-"`
+	IsBasenameStrResolved bool `field:"-" msg:"-"`
+}
+
+// SetPathnameStr set and mark as resolved
+func (e *FileEvent) SetPathnameStr(str string) {
+	e.PathnameStr = str
+	e.IsPathnameStrResolved = true
+}
+
+// SetBasenameStr set and mark as resolved
+func (e *FileEvent) SetBasenameStr(str string) {
+	e.BasenameStr = str
+	e.IsBasenameStrResolved = true
 }
 
 // GetPathResolutionError returns the path resolution error as a string if there is one

--- a/pkg/security/secl/model/process_cache_entry.go
+++ b/pkg/security/secl/model/process_cache_entry.go
@@ -84,10 +84,14 @@ func (pc *ProcessCacheEntry) ShareArgsEnvs(childEntry *ProcessCacheEntry) {
 	}
 }
 
+// SetParent set the parent of a fork child
+func (pc *ProcessCacheEntry) SetParent(parent *ProcessCacheEntry) {
+	pc.SetAncestor(parent)
+	parent.ShareArgsEnvs(pc)
+}
+
 // Fork returns a copy of the current ProcessCacheEntry
 func (pc *ProcessCacheEntry) Fork(childEntry *ProcessCacheEntry) {
-	childEntry.SetAncestor(pc)
-
 	childEntry.PPid = pc.Pid
 	childEntry.TTYName = pc.TTYName
 	childEntry.Comm = pc.Comm
@@ -97,7 +101,12 @@ func (pc *ProcessCacheEntry) Fork(childEntry *ProcessCacheEntry) {
 	childEntry.Credentials = pc.Credentials
 	childEntry.Cookie = pc.Cookie
 
-	pc.ShareArgsEnvs(childEntry)
+	childEntry.SetParent(pc)
+}
+
+// Equals returns whether process cache entries share the same values for comm and args/envs
+func (pc *ProcessCacheEntry) Equals(entry *ProcessCacheEntry) bool {
+	return pc.Comm == entry.Comm && pc.ArgsEntry.Equals(entry.ArgsEntry) && pc.EnvsEntry.Equals(entry.EnvsEntry)
 }
 
 /*func (pc *ProcessCacheEntry) String() string {

--- a/pkg/security/tests/mmap_test.go
+++ b/pkg/security/tests/mmap_test.go
@@ -50,6 +50,12 @@ func TestMMapEvent(t *testing.T) {
 			assert.Equal(t, "mmap", event.GetType(), "wrong event type")
 			assert.NotEqual(t, 0, event.MMap.Protection&(unix.PROT_READ|unix.PROT_WRITE|unix.PROT_EXEC), fmt.Sprintf("wrong protection: %s", model.Protection(event.MMap.Protection)))
 
+			executable, err := os.Executable()
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertFieldEqual(t, event, "process.file.path", executable)
+
 			if !validateMMapSchema(t, event) {
 				t.Error(event.String())
 			}

--- a/pkg/security/tests/mprotect_test.go
+++ b/pkg/security/tests/mprotect_test.go
@@ -52,6 +52,12 @@ func TestMProtectEvent(t *testing.T) {
 			assert.NotEqual(t, 0, event.MProtect.VMProtection&(unix.PROT_READ|unix.PROT_WRITE), fmt.Sprintf("wrong initial protection: %s", model.Protection(event.MProtect.VMProtection)))
 			assert.NotEqual(t, 0, event.MProtect.ReqProtection&(unix.PROT_READ|unix.PROT_WRITE|unix.PROT_EXEC), fmt.Sprintf("wrong requested protection: %s", model.Protection(event.MProtect.ReqProtection)))
 
+			executable, err := os.Executable()
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertFieldEqual(t, event, "process.file.path", executable)
+
 			if !validateMProtectSchema(t, event) {
 				t.Error(event.String())
 			}


### PR DESCRIPTION
* fix mmap and mprotect secl evaluation

* mark empty process cache entry as resolved

(cherry picked from commit 2566e4edeb33166398d1314f41e963924081c279)

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
