### PR TITLE
Fix missing store inside configPoller

### DIFF
--- a/pkg/autodiscovery/autoconfig_test.go
+++ b/pkg/autodiscovery/autoconfig_test.go
@@ -187,6 +187,10 @@ func (suite *AutoConfigTestSuite) TestDiffConfigs() {
 	added, removed := pd.storeAndDiffConfigs([]integration.Config{c1, c3})
 	assert.ElementsMatch(suite.T(), added, []integration.Config{c3})
 	assert.ElementsMatch(suite.T(), removed, []integration.Config{c2})
+	assert.Equal(suite.T(), map[uint64]integration.Config{
+		c3.FastDigest(): c3,
+		c1.FastDigest(): c1,
+	}, pd.configs)
 }
 
 func (suite *AutoConfigTestSuite) TestStop() {

--- a/pkg/autodiscovery/config_poller.go
+++ b/pkg/autodiscovery/config_poller.go
@@ -8,6 +8,7 @@ package autodiscovery
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
@@ -21,7 +22,8 @@ import (
 // `ConfigProvider` and whether it should be polled or not.
 type configPoller struct {
 	provider     providers.ConfigProvider
-	configs      map[uint64]*integration.Config
+	configs      map[uint64]integration.Config
+	configsMu    sync.Mutex
 	canPoll      bool
 	isPolling    bool
 	pollInterval time.Duration
@@ -32,7 +34,7 @@ type configPoller struct {
 func newConfigPoller(provider providers.ConfigProvider, canPoll bool, interval time.Duration) *configPoller {
 	return &configPoller{
 		provider:     provider,
-		configs:      make(map[uint64]*integration.Config),
+		configs:      make(map[uint64]integration.Config),
 		canPoll:      canPoll,
 		pollInterval: interval,
 	}
@@ -120,10 +122,13 @@ func (pd *configPoller) poll(ac *AutoConfig) {
 }
 
 func (pd *configPoller) overwriteConfigs(configs []integration.Config) {
-	fetchedMap := make(map[uint64]*integration.Config, len(configs))
+	pd.configsMu.Lock()
+	defer pd.configsMu.Unlock()
+
+	fetchedMap := make(map[uint64]integration.Config, len(configs))
 	for _, c := range configs {
 		cHash := c.FastDigest()
-		fetchedMap[cHash] = &c
+		fetchedMap[cHash] = c
 	}
 	pd.configs = fetchedMap
 }
@@ -146,14 +151,18 @@ func (pd *configPoller) collect(ctx context.Context) ([]integration.Config, []in
 }
 
 func (pd *configPoller) storeAndDiffConfigs(configs []integration.Config) ([]integration.Config, []integration.Config) {
+	pd.configsMu.Lock()
+	defer pd.configsMu.Unlock()
+
 	var newConf []integration.Config
 	var removedConf []integration.Config
 
 	// We allocate a new map. We could do without it with a bit more processing
 	// but it allows to free some memory if number of collected configs varies a lot
-	fetchedMap := make(map[uint64]*integration.Config, len(configs))
+	fetchedMap := make(map[uint64]integration.Config, len(configs))
 	for _, c := range configs {
 		cHash := c.FastDigest()
+		fetchedMap[cHash] = c
 		if _, found := pd.configs[cHash]; found {
 			delete(pd.configs, cHash)
 		} else {
@@ -162,7 +171,7 @@ func (pd *configPoller) storeAndDiffConfigs(configs []integration.Config) ([]int
 	}
 
 	for _, c := range pd.configs {
-		removedConf = append(removedConf, *c)
+		removedConf = append(removedConf, c)
 	}
 	pd.configs = fetchedMap
 


### PR DESCRIPTION
### What does this PR do?

Storing the new config was missing.

### Motivation

Fix #11589

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

No specific QA, see #11589

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
