### PR TITLE
Fix `Black` version for pre-commit use

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
         - flake8-unused-arguments==0.0.6
         - flake8-use-fstring==1.3.0
 - repo: https://github.com/psf/black
-  rev: 22.1.0
+  rev: 22.3.0
   hooks:
     - id: black
 - repo: https://github.com/timothycrosley/isort/


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR change `Black` version to `22.3.0` in the `.pre-commit-config.yaml` file to avoid errors running pre-commit.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

I just installed `pre-commit` following the [doc on GH](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/agent_dev_env.md#pre-commit-hooks). But then I tested it on a file and it gave me this:

```
alexandre.menasria@COMP-XXXXXXXXXX datadog-agent % pre-commit run --files tasks/go.py 
flake8...................................................................Passed
black....................................................................Failed
- hook id: black
- exit code: 1

Traceback (most recent call last):
  File "/Users/alexandre.menasria/.cache/pre-commit/repop0g2dnnq/py_env-python3/bin/black", line 8, in <module>
    sys.exit(patched_main())
  File "/Users/alexandre.menasria/.cache/pre-commit/repop0g2dnnq/py_env-python3/lib/python3.9/site-packages/black/__init__.py", line 1423, in patched_main
    patch_click()
  File "/Users/alexandre.menasria/.cache/pre-commit/repop0g2dnnq/py_env-python3/lib/python3.9/site-packages/black/__init__.py", line 1409, in patch_click
    from click import _unicodefun
ImportError: cannot import name '_unicodefun' from 'click' (/Users/alexandre.menasria/.cache/pre-commit/repop0g2dnnq/py_env-python3/lib/python3.9/site-packages/click/__init__.py)

isort....................................................................Passed
vulture..................................................................Passed
Test shell scripts with shellcheck...................(no files to check)Skipped
revive...............................................(no files to check)Skipped
govet................................................(no files to check)Skipped
gofmt................................................(no files to check)Skipped
win-clang-format.....................................(no files to check)Skipped
clang-format.........................................(no files to check)Skipped
```

It seems that it's a [common/famous issue for a month](https://github.com/psf/black/issues/2964) and I was able to fix it thanks to [this comment](https://github.com/psf/black/issues/2964#issuecomment-1080974737) editing the `.pre-commit-config.yaml` file and twisting `black` version.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Just run pre-commit (e.g `pre-commit run --files tasks/go.py`) on any file and it should work properly.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
