### PR TITLE
Add config to drop connections check data in process-agent

### DIFF
--- a/cmd/process-agent/info_test.go
+++ b/cmd/process-agent/info_test.go
@@ -40,6 +40,7 @@ Processes and Containers Agent (v 0.99.0)
   Process Bytes enqueued: 0
   RTProcess Bytes enqueued: 0
   Pod Bytes enqueued: 0
+  Drop Check Payloads: []
 
   Logs: /var/log/datadog/process-agent.log
 

--- a/pkg/config/process.go
+++ b/pkg/config/process.go
@@ -151,6 +151,9 @@ func setupProcesses(config Config) {
 	)
 	procBindEnvAndSetDefault(config, "process_config.process_discovery.interval", 4*time.Hour)
 
+	// this is only used for testing purposes
+	procBindEnvAndSetDefault(config, "process_config.drop_connections_check", false)
+
 	processesAddOverrideOnce.Do(func() {
 		AddOverrideFunc(loadProcessTransforms)
 	})

--- a/pkg/config/process.go
+++ b/pkg/config/process.go
@@ -151,8 +151,7 @@ func setupProcesses(config Config) {
 	)
 	procBindEnvAndSetDefault(config, "process_config.process_discovery.interval", 4*time.Hour)
 
-	// this is only used for testing purposes
-	procBindEnvAndSetDefault(config, "process_config.drop_connections_check", false)
+	procBindEnvAndSetDefault(config, "process_config.drop_check_payloads", []string{})
 
 	processesAddOverrideOnce.Do(func() {
 		AddOverrideFunc(loadProcessTransforms)

--- a/pkg/process/util/status.go
+++ b/pkg/process/util/status.go
@@ -81,6 +81,7 @@ type ProcessExpvars struct {
 	LogFile             string              `json:"log_file"`
 	EnabledChecks       []string            `json:"enabled_checks"`
 	Endpoints           map[string][]string `json:"endpoints"`
+	DropCheckPayloads   []string            `json:"drop_check_payloads"`
 }
 
 // Status holds runtime information from process-agent

--- a/pkg/status/templates/process-agent.tmpl
+++ b/pkg/status/templates/process-agent.tmpl
@@ -45,5 +45,5 @@ Process Agent
     Process Bytes enqueued: {{.expvars.process_queue_bytes}}
     RTProcess Bytes enqueued: {{.expvars.rtprocess_queue_bytes}}
     Pod Bytes enqueued: {{.expvars.pod_queue_bytes}}
+    Drop Check Payloads: {{.expvars.drop_check_payloads}}
 {{- end }}
-


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Adds a config to drop connections check payload in process-agent. This is only needed for testing purposes and is used in the NPM performance testing setup.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
