### PR TITLE
[CWS] fix glob with '/' pattern

### DIFF
--- a/pkg/security/probe/discarders_test.go
+++ b/pkg/security/probe/discarders_test.go
@@ -227,6 +227,13 @@ func TestIsGrandParentDiscarder(t *testing.T) {
 	}
 
 	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
+	addRuleExpr(t, rs, `unlink.file.path =~ "/tmp/test"`)
+
+	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/lib", 2); is {
+		t.Error("shouldn't be a parent discarder")
+	}
+
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
 	addRuleExpr(t, rs, `unlink.file.path == "/var/run/datadog/system-probe.pid"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/run/pids/system-probe.pid", 2); is {

--- a/pkg/security/secl/compiler/eval/glob.go
+++ b/pkg/security/secl/compiler/eval/glob.go
@@ -24,6 +24,11 @@ func (g *Glob) contains(filename string) bool {
 		return false
 	}
 
+	// pattern "/"
+	if len(g.elements) == 2 && g.elements[1] == "" {
+		return true
+	}
+
 	// normalize */ == /*/
 	if g.elements[0] == "*" {
 		filename = filename[1:]

--- a/pkg/security/secl/compiler/eval/glob_test.go
+++ b/pkg/security/secl/compiler/eval/glob_test.go
@@ -28,6 +28,10 @@ func TestGlobPattern(t *testing.T) {
 }
 
 func TestGlobContains(t *testing.T) {
+	if glob, _ := NewGlob("/", false); !glob.Contains("/var/log") {
+		t.Error("should contain the filename")
+	}
+
 	if glob, _ := NewGlob("/var/log/*", false); !glob.Contains("/var/log") {
 		t.Error("should contain the filename")
 	}
@@ -208,5 +212,13 @@ func TestGlobMatches(t *testing.T) {
 
 	if glob, _ := NewGlob("mysqld", false); glob.Matches("httpd") {
 		t.Error("shouldn't contain the filename")
+	}
+
+	if glob, _ := NewGlob("/", false); glob.Matches("/httpd") {
+		t.Error("shouldn't contain the filename")
+	}
+
+	if glob, _ := NewGlob("/*", false); !glob.Matches("/httpd") {
+		t.Error("should contain the filename")
 	}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Mostly used by discarders which doesn't seem to be affected by this bug

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
