### PR TITLE
[unrevert] Fixup GNUTLS by hooking gnutls_deinit(ctx) (#10507)

### DIFF
--- a/pkg/ebpf/bytecode/runtime/http.go
+++ b/pkg/ebpf/bytecode/runtime/http.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Http = NewRuntimeAsset("http.c", "5cc32ade09d51ddbab3a4c55529d03cdf8b0544b5d81d6e2b570769f09efbb11")
+var Http = NewRuntimeAsset("http.c", "0f41f48727e31c65d14b54b5ac1d0d39fa8e5a74a6cfcfb8f1963a00df164825")

--- a/pkg/network/ebpf/c/prebuilt/http.c
+++ b/pkg/network/ebpf/c/prebuilt/http.c
@@ -375,15 +375,11 @@ int uprobe__gnutls_record_send(struct pt_regs* ctx) {
     return 0;
 }
 
-// int gnutls_bye (gnutls_session_t session, gnutls_close_request_t how)
-SEC("uprobe/gnutls_bye")
-int uprobe__gnutls_bye(struct pt_regs* ctx) {
-    void *ssl_session = (void *)PT_REGS_PARM1(ctx);
-
+static __always_inline void gnutls_goodbye(void *ssl_session) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     conn_tuple_t *t = tup_from_ssl_ctx(ssl_session, pid_tgid);
     if (t == NULL) {
-        return 0;
+        return;
     }
 
     char buffer[HTTP_BUFFER_SIZE];
@@ -396,6 +392,21 @@ int uprobe__gnutls_bye(struct pt_regs* ctx) {
     skb_info.tcp_flags |= TCPHDR_FIN;
     http_process(buffer, &skb_info, skb_info.tup.sport);
     bpf_map_delete_elem(&ssl_sock_by_ctx, &ssl_session);
+}
+
+// int gnutls_bye (gnutls_session_t session, gnutls_close_request_t how)
+SEC("uprobe/gnutls_bye")
+int uprobe__gnutls_bye(struct pt_regs* ctx) {
+    void *ssl_session = (void *)PT_REGS_PARM1(ctx);
+    gnutls_goodbye(ssl_session);
+    return 0;
+}
+
+// void gnutls_deinit (gnutls_session_t session)
+SEC("uprobe/gnutls_deinit")
+int uprobe__gnutls_deinit(struct pt_regs* ctx) {
+    void *ssl_session = (void *)PT_REGS_PARM1(ctx);
+    gnutls_goodbye(ssl_session);
     return 0;
 }
 

--- a/pkg/network/ebpf/c/runtime/http.c
+++ b/pkg/network/ebpf/c/runtime/http.c
@@ -374,15 +374,11 @@ int uprobe__gnutls_record_send(struct pt_regs* ctx) {
     return 0;
 }
 
-// int gnutls_bye (gnutls_session_t session, gnutls_close_request_t how)
-SEC("uprobe/gnutls_bye")
-int uprobe__gnutls_bye(struct pt_regs* ctx) {
-    void *ssl_session = (void *)PT_REGS_PARM1(ctx);
-
+static __always_inline void gnutls_goodbye(void *ssl_session) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     conn_tuple_t *t = tup_from_ssl_ctx(ssl_session, pid_tgid);
     if (t == NULL) {
-        return 0;
+        return;
     }
 
     char buffer[HTTP_BUFFER_SIZE];
@@ -395,6 +391,21 @@ int uprobe__gnutls_bye(struct pt_regs* ctx) {
     skb_info.tcp_flags |= TCPHDR_FIN;
     http_process(buffer, &skb_info, skb_info.tup.sport);
     bpf_map_delete_elem(&ssl_sock_by_ctx, &ssl_session);
+}
+
+// int gnutls_bye (gnutls_session_t session, gnutls_close_request_t how)
+SEC("uprobe/gnutls_bye")
+int uprobe__gnutls_bye(struct pt_regs* ctx) {
+    void *ssl_session = (void *)PT_REGS_PARM1(ctx);
+    gnutls_goodbye(ssl_session);
+    return 0;
+}
+
+// void gnutls_deinit (gnutls_session_t session)
+SEC("uprobe/gnutls_deinit")
+int uprobe__gnutls_deinit(struct pt_regs* ctx) {
+    void *ssl_session = (void *)PT_REGS_PARM1(ctx);
+    gnutls_goodbye(ssl_session);
     return 0;
 }
 


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Unrevert #10507

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Please refer to the QA steps from the original GNU TLS PR: https://github.com/DataDog/datadog-agent/pull/9462

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
