### PR TITLE
use go.uber.com/atomic in pkg/logs

### DIFF
--- a/pkg/logs/config/info.go
+++ b/pkg/logs/config/info.go
@@ -8,7 +8,8 @@ package config
 import (
 	"fmt"
 	"sync"
-	"sync/atomic"
+
+	"go.uber.org/atomic"
 )
 
 // InfoProvider is a general interface to provide info about a log source.
@@ -35,21 +36,21 @@ type InfoProvider interface {
 
 // CountInfo records a simple count
 type CountInfo struct {
-	count int32
+	count *atomic.Int32
 	key   string
 }
 
 // NewCountInfo creates a new CountInfo instance
 func NewCountInfo(key string) *CountInfo {
 	return &CountInfo{
-		count: 0,
+		count: atomic.NewInt32(0),
 		key:   key,
 	}
 }
 
 // Add a new value to the count
 func (c *CountInfo) Add(v int32) {
-	atomic.AddInt32(&c.count, v)
+	c.count.Add(v)
 }
 
 // InfoKey returns the key
@@ -59,7 +60,7 @@ func (c *CountInfo) InfoKey() string {
 
 // Info returns the info
 func (c *CountInfo) Info() []string {
-	return []string{fmt.Sprintf("%d", atomic.LoadInt32(&c.count))}
+	return []string{fmt.Sprintf("%d", c.count.Load())}
 }
 
 // MappedInfo collects multiple info messages with a unique key

--- a/pkg/logs/internal/tailers/file/rotate_nix.go
+++ b/pkg/logs/internal/tailers/file/rotate_nix.go
@@ -36,7 +36,7 @@ func (t *Tailer) DidRotate() (bool, error) {
 	}
 
 	recreated := !os.SameFile(fi1, fi2)
-	truncated := fi1.Size() < t.getLastReadOffset()
+	truncated := fi1.Size() < t.lastReadOffset.Load()
 
 	return recreated || truncated, nil
 }

--- a/pkg/logs/internal/tailers/file/rotate_windows.go
+++ b/pkg/logs/internal/tailers/file/rotate_windows.go
@@ -33,7 +33,7 @@ func (t *Tailer) DidRotate() (bool, error) {
 	// increased, so the check that size < offset is valid as long as size is
 	// polled before the offset.
 	sz := st.Size()
-	offset := t.getLastReadOffset()
+	offset := t.lastReadOffset.Load()
 
 	if sz < offset {
 		return true, nil

--- a/pkg/logs/internal/tailers/file/tailer_nix.go
+++ b/pkg/logs/internal/tailers/file/tailer_nix.go
@@ -35,8 +35,8 @@ func (t *Tailer) setup(offset int64, whence int) error {
 
 	t.osFile = f
 	ret, _ := f.Seek(offset, whence)
-	t.lastReadOffset = ret
-	t.decodedOffset = ret
+	t.lastReadOffset.Store(ret)
+	t.decodedOffset.Store(ret)
 
 	return nil
 }
@@ -56,6 +56,6 @@ func (t *Tailer) read() (int, error) {
 		return 0, nil
 	}
 	t.decoder.InputChan <- decoder.NewInput(inBuf[:n])
-	t.incrementLastReadOffset(n)
+	t.lastReadOffset.Add(int64(n))
 	return n, nil
 }

--- a/pkg/logs/internal/tailers/file/tailer_test.go
+++ b/pkg/logs/internal/tailers/file/tailer_test.go
@@ -138,7 +138,7 @@ func (suite *TailerTestSuite) TestTailFromBeginning() {
 	suite.Equal("good bye", string(msg.Content))
 	suite.Equal(len(lines[0])+len(lines[1])+len(lines[2]), toInt(msg.Origin.Offset))
 
-	suite.Equal(len(lines[0])+len(lines[1])+len(lines[2]), int(suite.tailer.decodedOffset))
+	suite.Equal(len(lines[0])+len(lines[1])+len(lines[2]), int(suite.tailer.decodedOffset.Load()))
 }
 
 func (suite *TailerTestSuite) TestTailFromEnd() {
@@ -167,7 +167,7 @@ func (suite *TailerTestSuite) TestTailFromEnd() {
 	suite.Equal("good bye", string(msg.Content))
 	suite.Equal(len(lines[0])+len(lines[1])+len(lines[2]), toInt(msg.Origin.Offset))
 
-	suite.Equal(len(lines[0])+len(lines[1])+len(lines[2]), int(suite.tailer.decodedOffset))
+	suite.Equal(len(lines[0])+len(lines[1])+len(lines[2]), int(suite.tailer.decodedOffset.Load()))
 }
 
 func (suite *TailerTestSuite) TestRecoverTailing() {
@@ -198,7 +198,7 @@ func (suite *TailerTestSuite) TestRecoverTailing() {
 	suite.Equal("good bye", string(msg.Content))
 	suite.Equal(len(lines[0])+len(lines[1])+len(lines[2]), toInt(msg.Origin.Offset))
 
-	suite.Equal(len(lines[0])+len(lines[1])+len(lines[2]), int(suite.tailer.decodedOffset))
+	suite.Equal(len(lines[0])+len(lines[1])+len(lines[2]), int(suite.tailer.decodedOffset.Load()))
 }
 
 func (suite *TailerTestSuite) TestWithBlanklines() {
@@ -226,7 +226,7 @@ func (suite *TailerTestSuite) TestWithBlanklines() {
 	msg = <-suite.outputChan
 	suite.Equal("message 3", string(msg.Content))
 
-	suite.Equal(len(lines), int(suite.tailer.decodedOffset))
+	suite.Equal(len(lines), int(suite.tailer.decodedOffset.Load()))
 }
 
 func (suite *TailerTestSuite) TestTailerIdentifier() {

--- a/pkg/logs/internal/tailers/file/tailer_windows.go
+++ b/pkg/logs/internal/tailers/file/tailer_windows.go
@@ -45,7 +45,7 @@ func (t *Tailer) setup(offset int64, whence int) error {
 func (t *Tailer) readAvailable() (int, error) {
 	// If the file has already rotated, there is nothing to be done. Unlike on *nix,
 	// there is no open file handle from which remaining data might be read.
-	if t.hasFileRotated() {
+	if t.didFileRotate.Load() {
 		return 0, io.EOF
 	}
 
@@ -79,7 +79,7 @@ func (t *Tailer) readAvailable() (int, error) {
 			return bytes, err
 		}
 		t.decoder.InputChan <- decoder.NewInput(inBuf[:n])
-		t.lastReadOffset.Add(n)
+		t.lastReadOffset.Add(int64(n))
 	}
 }
 

--- a/pkg/logs/internal/tailers/file/tailer_windows.go
+++ b/pkg/logs/internal/tailers/file/tailer_windows.go
@@ -12,7 +12,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"sync/atomic"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/decoder"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -37,8 +36,8 @@ func (t *Tailer) setup(offset int64, whence int) error {
 	filePos, _ := f.Seek(offset, whence)
 	f.Close()
 
-	t.setLastReadOffset(filePos)
-	t.setDecodedOffset(filePos)
+	t.lastReadOffset.Store(filePos)
+	t.decodedOffset.Store(filePos)
 
 	return nil
 }
@@ -63,7 +62,7 @@ func (t *Tailer) readAvailable() (int, error) {
 	}
 
 	sz := st.Size()
-	offset := t.getLastReadOffset()
+	offset := t.lastReadOffset.Load()
 	if sz < offset {
 		log.Debugf("File size of %s is shorter than last read offset; returning EOF", t.fullpath)
 		return 0, io.EOF
@@ -80,7 +79,7 @@ func (t *Tailer) readAvailable() (int, error) {
 			return bytes, err
 		}
 		t.decoder.InputChan <- decoder.NewInput(inBuf[:n])
-		t.incrementLastReadOffset(n)
+		t.lastReadOffset.Add(n)
 	}
 }
 
@@ -96,17 +95,4 @@ func (t *Tailer) read() (int, error) {
 		return n, log.Error("Err: ", err)
 	}
 	return n, nil
-}
-
-// setLastReadOffset sets the value of lastReadOffset, atomically.
-func (t *Tailer) setLastReadOffset(off int64) {
-	atomic.StoreInt64(&t.lastReadOffset, off)
-}
-
-// setDecodedOffset sets decodedOffset, atomically.
-//
-// NOTE: other access to this field is not made atomically, so calling this
-// method may lead to undefined behavior.
-func (t *Tailer) setDecodedOffset(off int64) {
-	atomic.StoreInt64(&t.decodedOffset, off)
 }

--- a/pkg/logs/pipeline/provider.go
+++ b/pkg/logs/pipeline/provider.go
@@ -7,9 +7,9 @@ package pipeline
 
 import (
 	"context"
-	"sync/atomic"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/diagnostic"
+	"go.uber.org/atomic"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
 	"github.com/DataDog/datadog-agent/pkg/logs/client"
@@ -37,7 +37,7 @@ type provider struct {
 	endpoints                 *config.Endpoints
 
 	pipelines            []*Pipeline
-	currentPipelineIndex uint32
+	currentPipelineIndex *atomic.Uint32
 	destinationsContext  *client.DestinationsContext
 
 	serverless bool
@@ -61,6 +61,7 @@ func newProvider(numberOfPipelines int, auditor auditor.Auditor, diagnosticMessa
 		processingRules:           processingRules,
 		endpoints:                 endpoints,
 		pipelines:                 []*Pipeline{},
+		currentPipelineIndex:      atomic.NewUint32(0),
 		destinationsContext:       destinationsContext,
 		serverless:                serverless,
 	}
@@ -96,7 +97,7 @@ func (p *provider) NextPipelineChan() chan *message.Message {
 	if pipelinesLen == 0 {
 		return nil
 	}
-	index := atomic.AddUint32(&p.currentPipelineIndex, uint32(1)) % uint32(pipelinesLen)
+	index := p.currentPipelineIndex.Inc() % uint32(pipelinesLen)
 	nextPipeline := p.pipelines[index]
 	return nextPipeline.InputChan
 }

--- a/pkg/logs/pipeline/provider_test.go
+++ b/pkg/logs/pipeline/provider_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
+	"go.uber.org/atomic"
 
 	"github.com/stretchr/testify/suite"
 
@@ -27,33 +28,34 @@ type ProviderTestSuite struct {
 func (suite *ProviderTestSuite) SetupTest() {
 	suite.a = auditor.New("", auditor.DefaultRegistryFilename, time.Hour, health.RegisterLiveness("fake"))
 	suite.p = &provider{
-		numberOfPipelines: 3,
-		auditor:           suite.a,
-		pipelines:         []*Pipeline{},
-		endpoints:         config.NewEndpoints(config.Endpoint{}, nil, true, false),
+		numberOfPipelines:    3,
+		auditor:              suite.a,
+		pipelines:            []*Pipeline{},
+		endpoints:            config.NewEndpoints(config.Endpoint{}, nil, true, false),
+		currentPipelineIndex: atomic.NewUint32(0),
 	}
 }
 
 func (suite *ProviderTestSuite) TestProvider() {
 	suite.a.Start()
 	suite.p.Start()
-	suite.Equal(uint32(0), suite.p.currentPipelineIndex)
+	suite.Equal(uint32(0), suite.p.currentPipelineIndex.Load())
 	suite.Equal(3, len(suite.p.pipelines))
 
 	c := suite.p.NextPipelineChan()
-	suite.Equal(uint32(1), suite.p.currentPipelineIndex)
+	suite.Equal(uint32(1), suite.p.currentPipelineIndex.Load())
 	suite.Equal(suite.p.pipelines[1].InputChan, c)
 
 	c = suite.p.NextPipelineChan()
-	suite.Equal(uint32(2), suite.p.currentPipelineIndex)
+	suite.Equal(uint32(2), suite.p.currentPipelineIndex.Load())
 	suite.Equal(suite.p.pipelines[2].InputChan, c)
 
 	c = suite.p.NextPipelineChan()
-	suite.Equal(uint32(3), suite.p.currentPipelineIndex)
+	suite.Equal(uint32(3), suite.p.currentPipelineIndex.Load())
 	suite.Equal(suite.p.pipelines[0].InputChan, c) // wraps
 
 	c = suite.p.NextPipelineChan()
-	suite.Equal(uint32(4), suite.p.currentPipelineIndex)
+	suite.Equal(uint32(4), suite.p.currentPipelineIndex.Load())
 	suite.Equal(suite.p.pipelines[1].InputChan, c)
 
 	suite.p.Stop()

--- a/pkg/logs/status/builder.go
+++ b/pkg/logs/status/builder.go
@@ -8,15 +8,15 @@ package status
 import (
 	"expvar"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
+	"go.uber.org/atomic"
 )
 
 // Builder is used to build the status.
 type Builder struct {
-	isRunning   *int32
+	isRunning   *atomic.Bool
 	endpoints   *config.Endpoints
 	sources     *config.LogSources
 	warnings    *config.Messages
@@ -25,7 +25,7 @@ type Builder struct {
 }
 
 // NewBuilder returns a new builder.
-func NewBuilder(isRunning *int32, endpoints *config.Endpoints, sources *config.LogSources, warnings *config.Messages, errors *config.Messages, logExpVars *expvar.Map) *Builder {
+func NewBuilder(isRunning *atomic.Bool, endpoints *config.Endpoints, sources *config.LogSources, warnings *config.Messages, errors *config.Messages, logExpVars *expvar.Map) *Builder {
 	return &Builder{
 		isRunning:   isRunning,
 		endpoints:   endpoints,
@@ -53,7 +53,7 @@ func (b *Builder) BuildStatus() Status {
 // this needs to be thread safe as it can be accessed
 // from different commands (start, stop, status).
 func (b *Builder) getIsRunning() bool {
-	return atomic.LoadInt32(b.isRunning) != 0
+	return b.isRunning.Load()
 }
 
 func (b *Builder) getUseHTTP() bool {

--- a/pkg/logs/status/builder.go
+++ b/pkg/logs/status/builder.go
@@ -83,7 +83,7 @@ func (b *Builder) getIntegrations() []Integration {
 		var sources []Source
 		for _, source := range logSources {
 			sources = append(sources, Source{
-				BytesRead:          source.BytesRead.Value(),
+				BytesRead:          source.BytesRead.Load(),
 				AllTimeAvgLatency:  source.LatencyStats.AllTimeAvg() / int64(time.Millisecond),
 				AllTimePeakLatency: source.LatencyStats.AllTimePeak() / int64(time.Millisecond),
 				RecentAvgLatency:   source.LatencyStats.MovingAvg() / int64(time.Millisecond),

--- a/pkg/logs/status/status.go
+++ b/pkg/logs/status/status.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/metrics"
+	"go.uber.org/atomic"
 )
 
 // Transport is the transport used by logs-agent, i.e TCP or HTTP
@@ -65,7 +66,7 @@ type Status struct {
 }
 
 // Init instantiates the builder that builds the status on the fly.
-func Init(isRunning *int32, endpoints *config.Endpoints, sources *config.LogSources, logExpVars *expvar.Map) {
+func Init(isRunning *atomic.Bool, endpoints *config.Endpoints, sources *config.LogSources, logExpVars *expvar.Map) {
 	warnings = config.NewMessages()
 	errors = config.NewMessages()
 	builder = NewBuilder(isRunning, endpoints, sources, warnings, errors, logExpVars)

--- a/pkg/logs/status/test_utils.go
+++ b/pkg/logs/status/test_utils.go
@@ -8,11 +8,12 @@ package status
 import (
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/metrics"
+	"go.uber.org/atomic"
 )
 
 // InitStatus initialize a status builder
 func InitStatus(sources *config.LogSources) {
-	var isRunning int32 = 1
+	var isRunning *atomic.Bool = atomic.NewBool(true)
 	endpoints, _ := config.BuildEndpoints(config.HTTPConnectivityFailure, "test-track", "test-proto", "test-source")
-	Init(&isRunning, endpoints, sources, metrics.LogsExpvars)
+	Init(isRunning, endpoints, sources, metrics.LogsExpvars)
 }


### PR DESCRIPTION
### What does this PR do?

Uses go.uber.com/atomic to ensure alignment of atomic access in pkg/logs

### Motivation

Alignment issues with atomic access.  See #11716 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Test tailing a file with rotation, on both nix and windows.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
