### PR TITLE
Add more detailed leader election status logs

### DIFF
--- a/pkg/clusteragent/clusterchecks/handler.go
+++ b/pkg/clusteragent/clusterchecks/handler.go
@@ -184,10 +184,10 @@ func (h *Handler) leaderWatch(ctx context.Context) {
 			err := h.updateLeaderIP()
 			h.m.Lock()
 			if err != nil {
-				h.errCount += 1
+				h.errCount++
 				if h.errCount == 1 {
 					log.Warnf("Could not refresh leadership status: %s, will only log every %d errors", err, logFrequency)
-				} else if h.errCount % logFrequency == 0 {
+				} else if h.errCount%logFrequency == 0 {
 					log.Warnf("Could not refresh leadership status after %d tries: %s", logFrequency, err)
 				}
 			} else {

--- a/pkg/clusteragent/clusterchecks/handler.go
+++ b/pkg/clusteragent/clusterchecks/handler.go
@@ -24,6 +24,7 @@ import (
 
 const (
 	schedulerName = "clusterchecks"
+	logFrequency  = 100
 )
 
 type state int
@@ -53,6 +54,7 @@ type Handler struct {
 	state                state
 	leaderIP             string
 	port                 int
+	errCount             int
 }
 
 // NewHandler returns a populated Handler
@@ -180,9 +182,21 @@ func (h *Handler) leaderWatch(ctx context.Context) {
 			// This goroutine might hang if the leader election engine blocks
 		case <-watchTicker.C:
 			err := h.updateLeaderIP()
+			h.m.Lock()
 			if err != nil {
-				log.Warnf("Could not refresh leadership status: %s", err)
+				h.errCount += 1
+				if h.errCount == 1 {
+					log.Warnf("Could not refresh leadership status: %s, will only log every %d errors", err, logFrequency)
+				} else if h.errCount % logFrequency == 0 {
+					log.Warnf("Could not refresh leadership status after %d tries: %s", logFrequency, err)
+				}
+			} else {
+				if h.errCount > 0 {
+					log.Infof("Found leadership status after %d tries", h.errCount)
+					h.errCount = 0
+				}
 			}
+			h.m.Unlock()
 		case <-ctx.Done():
 			return
 		}

--- a/releasenotes/notes/leader-election-status-log-5c108125c3a8f585.yaml
+++ b/releasenotes/notes/leader-election-status-log-5c108125c3a8f585.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Add more detailed logging around leadership status failures.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

* Adds info on how often warning logs about getting the leader election status occurs and reduces the logging frequency to prevent them from spamming the DCA logs. 
* Adds an info log around leader election status retrieval recovery.


### Motivation

FR

### Describe how to test/QA your changes

Spin up multiple replicas of the DCA with [leader election](https://github.com/DataDog/datadog-agent/blob/e89c85fcb914566746c37e49b93f941b3f1c5db7/pkg/config/config.go#L647) enabled. Once a leader is chosen, delete the leader DCA to get warning logs about not being able to find the leader:

```
2022-04-22 17:49:37 UTC | CLUSTER | WARN | (pkg/clusteragent/clusterchecks/handler.go:189 in leaderWatch) | Could not refresh leadership status: "target named datadog-cluster-agent-xxxxxxxxxx-xxxxx" not found, will only log every 100 errors
```

The `Could not refresh leadership status` log should be logged once every 100 errors. One way to force >100 errors is to increase the `DD_LEADER_LEASE_DURATION` duration in the DCA. Example:

```
      env:
        - name: DD_LEADER_LEASE_DURATION
          value: "600"
```

```
2022-04-22 17:57:52 UTC | CLUSTER | WARN | (pkg/clusteragent/clusterchecks/handler.go:191 in leaderWatch) | Could not refresh leadership status after 100 tries: "target named datadog-cluster-agent-xxxxxxxxxx-xxxxx" not found
```

Once a new leader is elected, the following log line should show how many tries it took to recover:

```
2022-04-22 18:02:02 UTC | CLUSTER | INFO | (pkg/clusteragent/clusterchecks/handler.go:195 in leaderWatch) | Found leadership status after XX tries
```




### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
