### PR TITLE
use go.uber.org/atomic in pkg/forwarder

### DIFF
--- a/pkg/forwarder/domain_forwarder.go
+++ b/pkg/forwarder/domain_forwarder.go
@@ -8,13 +8,13 @@ package forwarder
 import (
 	"fmt"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/forwarder/internal/retry"
 	"github.com/DataDog/datadog-agent/pkg/forwarder/transaction"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"go.uber.org/atomic"
 )
 
 var (
@@ -25,7 +25,7 @@ var (
 // HTTP and retrying them if needed. One domainForwarder is created per HTTP
 // backend.
 type domainForwarder struct {
-	isRetrying                int32
+	isRetrying                *atomic.Bool
 	domain                    string
 	numberOfWorkers           int
 	highPrio                  chan transaction.Transaction // use to receive new transactions
@@ -49,6 +49,7 @@ func newDomainForwarder(
 	connectionResetInterval time.Duration,
 	transactionPrioritySorter retry.TransactionPrioritySorter) *domainForwarder {
 	return &domainForwarder{
+		isRetrying:                atomic.NewBool(false),
 		domain:                    domain,
 		numberOfWorkers:           numberOfWorkers,
 		retryQueue:                retryQueue,
@@ -62,11 +63,11 @@ func newDomainForwarder(
 func (f *domainForwarder) retryTransactions(retryBefore time.Time) {
 	// In case it takes more that flushInterval to sort and retry
 	// transactions we skip a retry.
-	if !atomic.CompareAndSwapInt32(&f.isRetrying, 0, 1) {
+	if !f.isRetrying.CAS(false, true) {
 		log.Errorf("The forwarder is still retrying Transaction: this should never happens, you might want to lower the 'forwarder_retry_queue_payloads_max_size'")
 		return
 	}
-	defer atomic.StoreInt32(&f.isRetrying, 0)
+	defer f.isRetrying.Store(false)
 
 	droppedRetryQueueFull := 0
 	droppedWorkerBusy := 0


### PR DESCRIPTION
### What does this PR do?

Uses github.com/uber-go/atomic for atomic values in pkg/forwarder.

### Motivation

See https://github.com/DataDog/datadog-agent/pull/11716.

### Additional Notes

It's not clear why forwarder's internalState is atomic, as all but one
access (`sendHTTPTransactions) is protected by a mutex, and that access
is just a debugging check.  The atomic access has been left as it was
found.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Anything that uses the forwarder -- so, basically anything -- counts as QA'ing this change.  So, you can probably just mark this as done.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
