### PR TITLE
windows: close logfiles when pipeline is blocked

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -820,7 +820,11 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("logs_config.dev_mode_use_proto", true)
 	config.BindEnvAndSetDefault("logs_config.dd_url_443", "agent-443-intake.logs.datadoghq.com")
 	config.BindEnvAndSetDefault("logs_config.stop_grace_period", 30)
+	// maximum time that the unix tailer will hold a log file open after it has been rotated
 	config.BindEnvAndSetDefault("logs_config.close_timeout", 60)
+	// maximum time that the windows tailer will hold a log file open, while waiting for
+	// the downstream logs pipeline to be ready to accept more data
+	config.BindEnvAndSetDefault("logs_config.windows_open_file_timeout", 5)
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line_detection", false)
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line_extra_patterns", []string{})
 	// The following auto_multi_line settings are experimental and may change

--- a/pkg/logs/internal/tailers/file/tailer.go
+++ b/pkg/logs/internal/tailers/file/tailer.go
@@ -77,10 +77,19 @@ type Tailer struct {
 	// sleepDuration is the time between polls of the underlying file.
 	sleepDuration time.Duration
 
-	// closeTimeout is the duration the tailer will remain active after its file
-	// has been rotated.  This allows the tailer to complete reading and processing
-	// any remaining log lines in the file.
+	// closeTimeout (UNIX only) is the duration the tailer will remain active
+	// after its file has been rotated.  This allows the tailer to complete
+	// reading and processing any remaining log lines in the file.
 	closeTimeout time.Duration
+
+	// windowsOpenFileTimeout (Windows only) is the duration the tailer will
+	// hold a file open while waiting for the downstream logs pipeline to
+	// clear.  Setting this to too short a time may result in data in rotated
+	// logfiles being lost when the pipeline is briefly stalled; setting this
+	// to too long a value may result in the agent holding a rotated file open
+	// at a time that the application producing the logs would like to delete
+	// it.
+	windowsOpenFileTimeout time.Duration
 
 	// isFinished is true when the tailer has closed its input and flushed all messages.
 	isFinished *atomic.Bool
@@ -126,22 +135,24 @@ func NewTailer(outputChan chan *message.Message, file *File, sleepDuration time.
 
 	forwardContext, stopForward := context.WithCancel(context.Background())
 	closeTimeout := coreConfig.Datadog.GetDuration("logs_config.close_timeout") * time.Second
+	windowsOpenFileTimeout := coreConfig.Datadog.GetDuration("logs_config.windows_open_file_timeout") * time.Second
 
 	return &Tailer{
-		file:           file,
-		outputChan:     outputChan,
-		decoder:        decoder,
-		tagProvider:    tagProvider,
-		lastReadOffset: atomic.NewInt64(0),
-		decodedOffset:  atomic.NewInt64(0),
-		sleepDuration:  sleepDuration,
-		closeTimeout:   closeTimeout,
-		stop:           make(chan struct{}, 1),
-		done:           make(chan struct{}, 1),
-		forwardContext: forwardContext,
-		stopForward:    stopForward,
-		isFinished:     atomic.NewBool(false),
-		didFileRotate:  atomic.NewBool(false),
+		file:                   file,
+		outputChan:             outputChan,
+		decoder:                decoder,
+		tagProvider:            tagProvider,
+		lastReadOffset:         atomic.NewInt64(0),
+		decodedOffset:          atomic.NewInt64(0),
+		sleepDuration:          sleepDuration,
+		closeTimeout:           closeTimeout,
+		windowsOpenFileTimeout: windowsOpenFileTimeout,
+		stop:                   make(chan struct{}, 1),
+		done:                   make(chan struct{}, 1),
+		forwardContext:         forwardContext,
+		stopForward:            stopForward,
+		isFinished:             atomic.NewBool(false),
+		didFileRotate:          atomic.NewBool(false),
 	}
 }
 
@@ -197,6 +208,8 @@ func (t *Tailer) Stop() {
 
 // StopAfterFileRotation prepares the tailer to stop after a timeout
 // to finish reading its file that has been log-rotated
+//
+// This is the only used on UNIX.
 func (t *Tailer) StopAfterFileRotation() {
 	t.didFileRotate.Store(true)
 	go func() {

--- a/pkg/logs/internal/tailers/file/tailer.go
+++ b/pkg/logs/internal/tailers/file/tailer.go
@@ -209,7 +209,7 @@ func (t *Tailer) Stop() {
 // StopAfterFileRotation prepares the tailer to stop after a timeout
 // to finish reading its file that has been log-rotated
 //
-// This is the only used on UNIX.
+// This is only used on UNIX.
 func (t *Tailer) StopAfterFileRotation() {
 	t.didFileRotate.Store(true)
 	go func() {

--- a/pkg/logs/internal/tailers/file/tailer_windows.go
+++ b/pkg/logs/internal/tailers/file/tailer_windows.go
@@ -60,7 +60,8 @@ func (t *Tailer) readAvailable() (int, error) {
 	bytes := 0
 	for {
 		if f == nil {
-			f, err := openFile(t.fullpath)
+			var err error
+			f, err = openFile(t.fullpath)
 			if err != nil {
 				return bytes, err
 			}

--- a/pkg/logs/internal/tailers/file/tailer_windows.go
+++ b/pkg/logs/internal/tailers/file/tailer_windows.go
@@ -88,20 +88,20 @@ func (t *Tailer) readAvailable() (int, error) {
 		}
 
 		// First, try to send the data to the decoder, but only wait for
-		// closeTimeout.  This short-term blocking send allows this component
-		// to hold a file open over any short-term blockages in the logs
-		// pipeline.
-		timer := time.NewTimer(t.closeTimeout)
+		// windowsOpenFileTimeout.  This short-term blocking send allows this
+		// component to hold a file open over any short-term blockages in the
+		// logs pipeline.
+		timer := time.NewTimer(t.windowsOpenFileTimeout)
 		select {
 		case t.decoder.InputChan <- decoder.NewInput(inBuf[:n]):
 			timer.Stop()
 		case <-timer.C:
-			// The closeTimeout expired, and we want to avoid blocking with the
-			// file open. So close the file before performing a blocking send.
-			// The file will be re-opened on the next iteration, after the send
-			// succeeds.  NOTE: if the open file has been rotated, then the
-			// re-open will access a different file and any remaining data in
-			// the rotated file will not be seen.
+			// The windowsOpenFileTimeout expired, and we want to avoid
+			// blocking with the file open. So close the file before performing
+			// a blocking send.  The file will be re-opened on the next
+			// iteration, after the send succeeds.  NOTE: if the open file has
+			// been rotated, then the re-open will access a different file and
+			// any remaining data in the rotated file will not be seen.
 			f.Close()
 			f = nil
 


### PR DESCRIPTION
This allows log sources to delete or otherwise manipulate old logfiles.

### What does this PR do?

The logic is a little convoluted, but in the windows file-reading loop, it attempts a non-blocking send to the next component in the pipeline (the decoder), with the file still open.  If that fails, it closes the file and performs a blocking write.  The next loop iteration then re-opens the file.

### Motivation

Avoid holding a file open for extended periods (that is, while blocked).

### Additional Notes

The Decoder's input channel is unbuffered.  Adding a small, fixed amount of buffering there would allow more "slack", so that the channel send only fails when the pipeline is actually full, and not as a result of random goroutine scheduling.  Thoughts?

### Possible Drawbacks / Trade-offs

In high-volume situations, the re-open may open a new file, with the old file having been renamed out from under the agent -- even if that old file had not been read completely.  Data loss is going to occur any time the rate of new logs exceeds pipeline capacity, so at worst this changes the mode of data loss.

### Describe how to test/QA your changes

#### Setup the Agent

On a Windows host, setup an Agent to tail a file by adding `logs_enabled: true` to the `datadog.yaml` config file.

Also, create a new configuration file `<DATADOG_FOLDER>\conf.d\serilog.d\conf.yaml` (<DATADOG_FOLDER> is probably `C:\ProgramData\Datadog`) with the following lines : 
```
logs:
  - type: file
    path: C:\tmp\log.json
    service: serilog
    source: serilog
```

create the directory C:\tmp if it does not yet exist.

#### Set up For C#

(Note that there [may be easier ways](https://dotnet.microsoft.com/en-us/learn/dotnet/hello-world-tutorial/create))

Install Visual Studio (https://visualstudio.microsoft.com/vs) Community 2022, and install at least the ".NET desktop development" pack.  Create a new C# console app project.  Project -> Manage NuGet Packages... and install "Serilog" and "Serilog.Sinks.Async" and "Serilog.Sinks.PersistentFile" (which is pre-release so you'll need to tick the relevant box).  Paste the following source:

```c#
using System;
using System.Threading;
using Serilog;
using Serilog.Formatting.Json;

namespace serilog_test
{
    class Program
    {
        static void Main(string[] args)
        {
            
            var log = new LoggerConfiguration()  // using Serilog;

                // using Serilog.Formatting.Json;
                .WriteTo.Async(a => a.PersistentFile(new JsonFormatter(renderMessage: true), "C:\\tmp\\log.json",
                    retainedFileCountLimit: 3,
                    flushToDiskInterval: TimeSpan.FromSeconds(1),
                    persistentFileRollingInterval: PersistentFileRollingInterval.Day,
                    rollOnFileSizeLimit: true,
                    buffered: true,
                    //fileSizeLimitBytes: 5000000,
                    preserveLogFilename: true), bufferSize: 100500, blockWhenFull: true)
                .CreateLogger();

             
            uint i = 0;
            while (true) {
                Thread.Sleep(1000);

                var timeOffset =  DateTimeOffset.Now.ToUnixTimeSeconds();
                for (ulong j = 0; j < 35000; j++) {
                    log.Information("Number {@n},{@m} First log with dummies information  - {@epoch}", i, j, timeOffset);
                    log.Information("Number {@n},{@m} Second log with not so important information  - {@epoch}", i, j, timeOffset);
                }
                Console.WriteLine("Log message number " + i);
                i++; 
            }
        }
    }
}
```

#### Run the logger script

Click the "Play" button to build and run, and watch the results in C:\tmp.

This script writes logs with an average throughput of ~20MB/s to `C:\tmp\log.json` and rotates this file when its size is higher than 1GB (can be modified with `fileSizeLimitBytes`). It should also delete logs files except the last 3 created (`retainedFileCountLimit` parameter).  Depending on the capabilities of your machine, you may need to change the sleep time to get this to ensure you can replicate _before_ switching to the image containing this fix.
 
The issued is that the Agent is keeping some files open for too long while Serilog tries to remove them, so the problem can be considered as solved if : 

- There are no more than 3 logs files at the same time (`log001.json` is removed when `log003.json` is created)
- There is no missing logs in Datadog (hard to rigorously check but indexes in logs can help to at least check that logs from each rotated files are being sent to Datadog)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
