### PR TITLE
Add support for DNS inspection on older kernels (< 4.1)

### DIFF
--- a/pkg/network/dns/bpf.go
+++ b/pkg/network/dns/bpf.go
@@ -1,0 +1,72 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+// +build linux_bpf
+
+package dns
+
+import (
+	"math"
+
+	"github.com/DataDog/datadog-agent/pkg/network/config"
+	"golang.org/x/net/bpf"
+)
+
+const port = 53
+
+func generateBPFFilter(c *config.Config) ([]bpf.RawInstruction, error) {
+	allowedDestPort := uint32(math.MaxUint32)
+	if c.CollectDNSStats {
+		allowedDestPort = port
+	}
+
+	return bpf.Assemble([]bpf.Instruction{
+		//(000) ldh      [12] -- load Ethertype
+		bpf.LoadAbsolute{Size: 2, Off: 12},
+		//(001) jeq      #0x86dd          jt 2	jf 9 -- if IPv6, goto 2, else 9
+		bpf.JumpIf{Cond: bpf.JumpEqual, Val: 0x86dd, SkipTrue: 0, SkipFalse: 7},
+		//(002) ldb      [20] -- load IPv6 Next Header
+		bpf.LoadAbsolute{Size: 1, Off: 20},
+		//(003) jeq      #0x6             jt 5	jf 4 -- IPv6 Next Header: if TCP, goto 5
+		bpf.JumpIf{Cond: bpf.JumpEqual, Val: 0x6, SkipTrue: 1, SkipFalse: 0},
+		//(004) jeq      #0x11            jt 5	jf 21 -- IPv6 Next Header: if UDP, goto 5, else drop
+		bpf.JumpIf{Cond: bpf.JumpEqual, Val: 0x11, SkipTrue: 0, SkipFalse: 16},
+		//(005) ldh      [54] -- load source port
+		bpf.LoadAbsolute{Size: 2, Off: 54},
+		//(006) jeq      #0x35            jt 20	jf 7 -- if 53, capture
+		bpf.JumpIf{Cond: bpf.JumpEqual, Val: port, SkipTrue: 13, SkipFalse: 0},
+		//(007) ldh      [56] -- load dest port
+		bpf.LoadAbsolute{Size: 2, Off: 56},
+		//(008) jeq      #0x35            jt 20	jf 21 -- if allowedDestPort, capture, else drop
+		bpf.JumpIf{Cond: bpf.JumpEqual, Val: allowedDestPort, SkipTrue: 11, SkipFalse: 12},
+		//(009) jeq      #0x800           jt 10	jf 21 -- if IPv4, go next, else drop
+		bpf.JumpIf{Cond: bpf.JumpEqual, Val: 0x800, SkipTrue: 0, SkipFalse: 11},
+		//(010) ldb      [23] -- load IPv4 Protocol
+		bpf.LoadAbsolute{Size: 1, Off: 23},
+		//(011) jeq      #0x6             jt 13	jf 12 -- if TCP, goto 13
+		bpf.JumpIf{Cond: bpf.JumpEqual, Val: 0x6, SkipTrue: 1, SkipFalse: 0},
+		//(012) jeq      #0x11            jt 13	jf 21 -- if UDP, goto 13, else drop
+		bpf.JumpIf{Cond: bpf.JumpEqual, Val: 0x11, SkipTrue: 0, SkipFalse: 8},
+		//(013) ldh      [20] -- load Fragment Offset
+		bpf.LoadAbsolute{Size: 2, Off: 20},
+		//(014) jset     #0x1fff          jt 21	jf 15 -- use 0x1fff as mask for fragment offset, if != 0, drop
+		bpf.JumpIf{Cond: bpf.JumpBitsSet, Val: 0x1fff, SkipTrue: 6, SkipFalse: 0},
+		//(015) ldxb     4*([14]&0xf) -- x = IP header length
+		bpf.LoadMemShift{Off: 14},
+		//(016) ldh      [x + 14] -- load source port
+		bpf.LoadIndirect{Size: 2, Off: 14},
+		//(017) jeq      #0x35            jt 20	jf 18 -- if port 53 capture
+		bpf.JumpIf{Cond: bpf.JumpEqual, Val: port, SkipTrue: 2, SkipFalse: 0},
+		//(018) ldh      [x + 16] -- load dest port
+		bpf.LoadIndirect{Size: 2, Off: 16},
+		//(019) jeq      #0x35            jt 20	jf 21 -- if port allowedDestPort capture, else drop
+		bpf.JumpIf{Cond: bpf.JumpEqual, Val: allowedDestPort, SkipTrue: 0, SkipFalse: 1},
+		//(020) ret      #262144 -- capture
+		bpf.RetConstant{Val: 262144},
+		//(021) ret      #0 -- drop
+		bpf.RetConstant{Val: 0},
+	})
+}

--- a/pkg/network/dns/monitor_linux.go
+++ b/pkg/network/dns/monitor_linux.go
@@ -10,12 +10,16 @@ package dns
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
 	filterpkg "github.com/DataDog/datadog-agent/pkg/network/filter"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	manager "github.com/DataDog/ebpf-manager"
+	"golang.org/x/net/bpf"
 )
 
 type dnsMonitor struct {
@@ -25,18 +29,36 @@ type dnsMonitor struct {
 
 // NewReverseDNS starts snooping on DNS traffic to allow IP -> domain reverse resolution
 func NewReverseDNS(cfg *config.Config) (ReverseDNS, error) {
-	p, err := newEBPFProgram(cfg)
+	currKernelVersion, err := kernel.HostVersion()
 	if err != nil {
-		return nil, fmt.Errorf("error creating ebpf program: %w", err)
+		// if the platform couldn't be determined, treat it as new kernel case
+		log.Warn("could not detect the platform, will use kprobes from kernel version >= 4.1.0")
+		currKernelVersion = math.MaxUint32
 	}
+	pre410Kernel := currKernelVersion < kernel.VersionCode(4, 1, 0)
 
-	if err := p.Init(); err != nil {
-		return nil, fmt.Errorf("error initializing ebpf programs: %w", err)
-	}
+	var p *ebpfProgram
+	var filter *manager.Probe
+	var bpfFilter []bpf.RawInstruction
+	if pre410Kernel {
+		bpfFilter, err = generateBPFFilter(cfg)
+		if err != nil {
+			return nil, fmt.Errorf("error creating bpf classic filter: %w", err)
+		}
+	} else {
+		p, err = newEBPFProgram(cfg)
+		if err != nil {
+			return nil, fmt.Errorf("error creating ebpf program: %w", err)
+		}
 
-	filter, _ := p.GetProbe(manager.ProbeIdentificationPair{EBPFSection: string(probes.SocketDnsFilter), EBPFFuncName: funcName})
-	if filter == nil {
-		return nil, fmt.Errorf("error retrieving socket filter")
+		if err := p.Init(); err != nil {
+			return nil, fmt.Errorf("error initializing ebpf programs: %w", err)
+		}
+
+		filter, _ = p.GetProbe(manager.ProbeIdentificationPair{EBPFSection: string(probes.SocketDnsFilter), EBPFFuncName: funcName})
+		if filter == nil {
+			return nil, fmt.Errorf("error retrieving socket filter")
+		}
 	}
 
 	// Create the RAW_SOCKET inside the root network namespace
@@ -45,7 +67,7 @@ func NewReverseDNS(cfg *config.Config) (ReverseDNS, error) {
 		srcErr    error
 	)
 	err = util.WithRootNS(cfg.ProcRoot, func() error {
-		packetSrc, srcErr = filterpkg.NewPacketSource(filter)
+		packetSrc, srcErr = filterpkg.NewPacketSource(filter, bpfFilter)
 		return srcErr
 	})
 	if err != nil {
@@ -64,11 +86,16 @@ func NewReverseDNS(cfg *config.Config) (ReverseDNS, error) {
 
 // Start starts the monitor
 func (m *dnsMonitor) Start() error {
-	return m.p.Start()
+	if m.p != nil {
+		return m.p.Start()
+	}
+	return nil
 }
 
 // Close releases associated resources
 func (m *dnsMonitor) Close() {
 	m.socketFilterSnooper.Close()
-	_ = m.p.Stop(manager.CleanAll)
+	if m.p != nil {
+		_ = m.p.Stop(manager.CleanAll)
+	}
 }

--- a/pkg/network/dns/snooper_test.go
+++ b/pkg/network/dns/snooper_test.go
@@ -121,8 +121,6 @@ func initDNSTestsWithDomainCollection(t *testing.T, localDNS bool) *dnsMonitor {
 }
 
 func initDNSTests(t *testing.T, localDNS bool, collectDomain bool) *dnsMonitor {
-	skipIfDNSNotSupported(t)
-
 	cfg := testConfig()
 	cfg.CollectDNSStats = true
 	cfg.CollectLocalDNS = localDNS
@@ -401,8 +399,6 @@ func TestDNSOverUDPTimeoutCountWithoutDomain(t *testing.T) {
 }
 
 func TestParsingError(t *testing.T) {
-	skipIfDNSNotSupported(t)
-
 	cfg := testConfig()
 	cfg.CollectDNSStats = false
 	cfg.CollectLocalDNS = false

--- a/pkg/network/dns/snooper_test.go
+++ b/pkg/network/dns/snooper_test.go
@@ -139,6 +139,10 @@ func sendDNSQueries(
 	serverIP string,
 	protocol string,
 ) (string, int, []*mdns.Msg) {
+	return sendDNSQueriesOnPort(t, domains, serverIP, "53", protocol)
+}
+
+func sendDNSQueriesOnPort(t *testing.T, domains []string, serverIP string, port string, protocol string) (string, int, []*mdns.Msg) {
 	// Create a DNS query message
 	msg := new(mdns.Msg)
 	msg.RecursionDesired = true
@@ -160,7 +164,7 @@ func sendDNSQueries(
 	}
 
 	dnsClient := mdns.Client{Net: protocol, Dialer: localAddrDialer}
-	dnsHost := net.JoinHostPort(serverIP, "53")
+	dnsHost := net.JoinHostPort(serverIP, port)
 	var reps []*mdns.Msg
 
 	if protocol == "tcp" {
@@ -351,6 +355,41 @@ func TestDNSFailedResponseCount(t *testing.T) {
 		require.Equal(t, 1, len(allStats[key2][intern.GetByString(d)][TypeA].CountByRcode))
 		assert.Equal(t, uint32(1), allStats[key2][intern.GetByString(d)][TypeA].CountByRcode[uint32(layers.DNSResponseCodeServFail)])
 	}
+}
+
+func TestDNSOverNonPort53(t *testing.T) {
+	reverseDNS := initDNSTestsWithDomainCollection(t, true)
+	defer reverseDNS.Close()
+	statKeeper := reverseDNS.statKeeper
+
+	domains := []string{
+		"nonexistent.com.net",
+	}
+	// Set up a local DNS server to return SERVFAIL
+	localServerAddr := &net.UDPAddr{IP: net.ParseIP(localhost), Port: 5353}
+	localServer := &mdns.Server{Addr: localServerAddr.String(), Net: "udp"}
+	localServer.Handler = &handler{}
+	waitLock := sync.Mutex{}
+	waitLock.Lock()
+	localServer.NotifyStartedFunc = waitLock.Unlock
+	defer localServer.Shutdown()
+
+	go func() {
+		if err := localServer.ListenAndServe(); err != nil {
+			t.Fatalf("Failed to set listener %s\n", err.Error())
+		}
+	}()
+	waitLock.Lock()
+	queryIP, queryPort, reps := sendDNSQueriesOnPort(t, domains, localhost, "5353", "udp")
+	require.NotNil(t, reps[0])
+
+	// we only pick up on port 53 traffic, so we shouldn't ever get stats
+	key := getKey(queryIP, queryPort, localhost, syscall.IPPROTO_UDP)
+	var allStats StatsByKeyByNameByType
+	require.Never(t, func() bool {
+		allStats = statKeeper.Snapshot()
+		return allStats[key] != nil
+	}, 3*time.Second, 10*time.Millisecond, "found DNS data for key %v when it should be missing", key)
 }
 
 func TestDNSOverUDPTimeoutCount(t *testing.T) {

--- a/pkg/network/filter/packet_source_linux.go
+++ b/pkg/network/filter/packet_source_linux.go
@@ -16,17 +16,17 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/ebpf-manager"
+	manager "github.com/DataDog/ebpf-manager"
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/afpacket"
 	"github.com/google/gopacket/layers"
+	"golang.org/x/net/bpf"
 )
 
 // AFPacketSource provides a RAW_SOCKET attached to an eBPF SOCKET_FILTER
 type AFPacketSource struct {
 	*afpacket.TPacket
 	socketFilter *manager.Probe
-	socketFD     int
 
 	exit chan struct{}
 
@@ -37,7 +37,7 @@ type AFPacketSource struct {
 	dropped   int64
 }
 
-func NewPacketSource(filter *manager.Probe) (*AFPacketSource, error) {
+func NewPacketSource(filter *manager.Probe, bpfFilter []bpf.RawInstruction) (*AFPacketSource, error) {
 	rawSocket, err := afpacket.NewTPacket(
 		afpacket.OptPollTimeout(1*time.Second),
 		// This setup will require ~4Mb that is mmap'd into the process virtual space
@@ -50,17 +50,21 @@ func NewPacketSource(filter *manager.Probe) (*AFPacketSource, error) {
 		return nil, fmt.Errorf("error creating raw socket: %s", err)
 	}
 
-	// The underlying socket file descriptor is private, hence the use of reflection
-	socketFD := int(reflect.ValueOf(rawSocket).Elem().FieldByName("fd").Int())
-
-	// Point socket filter program to the RAW_SOCKET file descriptor
-	// Note the filter attachment itself is triggered by the ebpf.Manager
-	filter.SocketFD = socketFD
+	if filter != nil {
+		// The underlying socket file descriptor is private, hence the use of reflection
+		// Point socket filter program to the RAW_SOCKET file descriptor
+		// Note the filter attachment itself is triggered by the ebpf.Manager
+		filter.SocketFD = int(reflect.ValueOf(rawSocket).Elem().FieldByName("fd").Int())
+	} else {
+		err = rawSocket.SetBPF(bpfFilter)
+		if err != nil {
+			return nil, fmt.Errorf("error setting classic bpf filter: %w", err)
+		}
+	}
 
 	ps := &AFPacketSource{
 		TPacket:      rawSocket,
 		socketFilter: filter,
-		socketFD:     socketFD,
 		exit:         make(chan struct{}),
 	}
 	go ps.pollStats()

--- a/pkg/network/filter/socket_filter.go
+++ b/pkg/network/filter/socket_filter.go
@@ -24,7 +24,7 @@ func HeadlessSocketFilter(rootPath string, filter *manager.Probe) (closeFn func(
 	)
 
 	err = util.WithRootNS(rootPath, func() error {
-		packetSrc, srcErr = NewPacketSource(filter)
+		packetSrc, srcErr = NewPacketSource(filter, nil)
 		return srcErr
 	})
 	if err != nil {

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -154,7 +154,7 @@ func NewTracer(config *config.Config) (*Tracer, error) {
 	tr := &Tracer{
 		config:                     config,
 		state:                      state,
-		reverseDNS:                 newReverseDNS(!pre410Kernel, config),
+		reverseDNS:                 newReverseDNS(config),
 		httpMonitor:                newHTTPMonitor(!pre410Kernel, config, ebpfTracer, constantEditors),
 		activeBuffer:               network.NewConnectionBuffer(512, 256),
 		conntracker:                conntracker,
@@ -219,12 +219,8 @@ func newConntracker(cfg *config.Config) (netlink.Conntracker, error) {
 	return c, nil
 }
 
-func newReverseDNS(supported bool, c *config.Config) dns.ReverseDNS {
+func newReverseDNS(c *config.Config) dns.ReverseDNS {
 	if !c.DNSInspection {
-		return dns.NewNullReverseDNS()
-	}
-	if !supported {
-		log.Warnf("DNS inspection not supported by kernel versions < 4.1.0. Please see https://docs.datadoghq.com/network_performance_monitoring/installation for more details.")
 		return dns.NewNullReverseDNS()
 	}
 

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -41,12 +41,6 @@ import (
 	vnetns "github.com/vishvananda/netns"
 )
 
-func dnsSupported(t *testing.T) bool {
-	currKernelVersion, err := kernel.HostVersion()
-	require.NoError(t, err)
-	return currKernelVersion >= kernel.VersionCode(4, 1, 0)
-}
-
 func httpSupported(t *testing.T) bool {
 	currKernelVersion, err := kernel.HostVersion()
 	require.NoError(t, err)

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -64,7 +64,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestGetStats(t *testing.T) {
-	dnsSupported := dnsSupported(t)
 	httpSupported := httpSupported(t)
 	cfg := testConfig()
 	cfg.EnableHTTPMonitoring = true
@@ -182,10 +181,6 @@ func TestGetStats(t *testing.T) {
 	actual, _ := tr.GetStats()
 
 	for section, entries := range expected {
-		if section == "dns" && !dnsSupported {
-			// DNS stats not supported on some systems
-			continue
-		}
 		if section == "http" && !httpSupported {
 			continue
 		}
@@ -1086,11 +1081,6 @@ const (
 )
 
 func testDNSStats(t *testing.T, domain string, success int, failure int, timeout int, serverIP string) {
-	if !dnsSupported(t) {
-		t.Skip("DNS feature not available on pre 4.1.0 kernels")
-		return
-	}
-
 	config := testConfig()
 	config.CollectDNSStats = true
 	config.DNSTimeout = 1 * time.Second

--- a/releasenotes/notes/npm-dns-on-older-kernels-b03a1407e2366d6d.yaml
+++ b/releasenotes/notes/npm-dns-on-older-kernels-b03a1407e2366d6d.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Add support for the DNS Monitoring feature of NPM to Linux kernels older than 4.1.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This adds a BPF classic socket filter that filters to UDP/TCP traffic on port 53. This is similar to what our eBPF-based socket filter does.

### Motivation

Adding support for our DNS feature on our older kernel targets.

### Additional Notes

Added an additional test to ensure we aren't picking up DNS stats on non-port 53 traffic.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Automated tests cover this feature, so no need for manual QA.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
