### PR TITLE
Create unix.Recvmsg without alloc for msg_name

### DIFF
--- a/pkg/network/netlink/recvmsg.go
+++ b/pkg/network/netlink/recvmsg.go
@@ -1,0 +1,89 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+// +build linux
+
+package netlink
+
+import (
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// noallocRecvmsg is a copy of unix.Recvmsg without the allocation from unix.RawSockaddrAny
+func noallocRecvmsg(fd int, p, oob []byte, flags int) (n, oobn int, recvflags int, err error) {
+	n, oobn, recvflags, err = recvmsgRaw(fd, p, oob, flags)
+	return
+}
+
+func recvmsgRaw(fd int, p, oob []byte, flags int) (n, oobn int, recvflags int, err error) {
+	var msg unix.Msghdr
+	var iov unix.Iovec
+	if len(p) > 0 {
+		iov.Base = &p[0]
+		iov.SetLen(len(p))
+	}
+	var dummy byte
+	if len(oob) > 0 {
+		if len(p) == 0 {
+			var sockType int
+			sockType, err = unix.GetsockoptInt(fd, unix.SOL_SOCKET, unix.SO_TYPE)
+			if err != nil {
+				return
+			}
+			// receive at least one normal byte
+			if sockType != unix.SOCK_DGRAM {
+				iov.Base = &dummy
+				iov.SetLen(1)
+			}
+		}
+		msg.Control = &oob[0]
+		msg.SetControllen(len(oob))
+	}
+	msg.Iov = &iov
+	msg.Iovlen = 1
+	if n, err = recvmsg(fd, &msg, flags); err != nil {
+		return
+	}
+	oobn = int(msg.Controllen)
+	recvflags = int(msg.Flags)
+	return
+}
+
+func recvmsg(s int, msg *unix.Msghdr, flags int) (n int, err error) {
+	r0, _, e1 := unix.Syscall(unix.SYS_RECVMSG, uintptr(s), uintptr(unsafe.Pointer(msg)), uintptr(flags))
+	n = int(r0)
+	if e1 != 0 {
+		err = errnoErr(e1)
+	}
+	return
+}
+
+// Do the interface allocations only once for common
+// Errno values.
+var (
+	errEAGAIN error = syscall.EAGAIN
+	errEINVAL error = syscall.EINVAL
+	errENOENT error = syscall.ENOENT
+)
+
+// errnoErr returns common boxed Errno values, to prevent
+// allocations at runtime.
+func errnoErr(e syscall.Errno) error {
+	switch e {
+	case 0:
+		return nil
+	case unix.EAGAIN:
+		return errEAGAIN
+	case unix.EINVAL:
+		return errEINVAL
+	case unix.ENOENT:
+		return errENOENT
+	}
+	return e
+}

--- a/pkg/network/netlink/socket.go
+++ b/pkg/network/netlink/socket.go
@@ -267,7 +267,7 @@ func (s *Socket) recvmsg(b []byte, oob []byte, flags int) (int, int, error) {
 	)
 
 	ctrlErr := s.conn.Read(func(fd uintptr) bool {
-		n, oobn, _, _, err = unix.Recvmsg(int(fd), b, oob, flags)
+		n, oobn, _, err = noallocRecvmsg(int(fd), b, oob, flags)
 		return ready(err)
 	})
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Create a version of `unix.Recvmsg` that does not allocate for the unused `unix.RawSockaddrAny` argument.

### Motivation

Remove unnecessary allocations from netlink socket receive path.

### Additional Notes

![Screen Shot 2022-04-25 at 2 06 08 PM](https://user-images.githubusercontent.com/1010430/165175097-4db6f105-c17d-4bf8-b8ff-70c05753c92b.png)


### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
