### PR TITLE
Fetch each secret only once

### DIFF
--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -141,7 +141,7 @@ func Decrypt(data []byte, origin string) ([]byte, error) {
 	}
 
 	// First we collect all new handles in the config
-	newHandles := []string{}
+	newHandles := common.NewStringSet()
 	haveSecret := false
 	err = walk(&config, func(str string) (string, error) {
 		if ok, handle := isEnc(str); ok {
@@ -153,7 +153,7 @@ func Decrypt(data []byte, origin string) ([]byte, error) {
 				secretOrigin[handle].Add(origin)
 				return secret, nil
 			}
-			newHandles = append(newHandles, handle)
+			newHandles.Add(handle)
 		}
 		return str, nil
 	})
@@ -168,7 +168,7 @@ func Decrypt(data []byte, origin string) ([]byte, error) {
 
 	// check if any new secrets need to be fetch
 	if len(newHandles) != 0 {
-		secrets, err := secretFetcher(newHandles, origin)
+		secrets, err := secretFetcher(newHandles.GetAll(), origin)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Ensures that each secret gets fetch only once. 

### Motivation

During a support card investigation we noticed that system-probe was fetching the same secret handle twice:
```
calling secret_backend_command with payload: '{"secrets":["dd_api_key", "dd_api_key"],"version":"1.0"}'
```
This is due to the fact that the API key will be present in 2 locations when system-probe parses the agent configuration:

```
...
api_key: ENC[dd_api_key]
...
system_probe_config:
...
  internal_profiling:
    api_key: ENC[dd_api_key]
```
Although the response from the secret fetcher will be aggregated by default (since the payload is keyed by handle), there is no reason to query the same secret multiple times.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
