### PR TITLE
[CSPM] only log check errors if they are critical

### DIFF
--- a/pkg/compliance/checks/check.go
+++ b/pkg/compliance/checks/check.go
@@ -113,7 +113,9 @@ func (c *complianceCheck) Run() error {
 	for _, report := range reports {
 		if report.Error != nil {
 			log.Debugf("%s: check run failed: %v", c.ruleID, report.Error)
-			err = report.Error
+			if report.CriticalError {
+				err = report.Error
+			}
 		}
 
 		data, result := reportToEventData(report)

--- a/pkg/compliance/checks/check.go
+++ b/pkg/compliance/checks/check.go
@@ -113,7 +113,7 @@ func (c *complianceCheck) Run() error {
 	for _, report := range reports {
 		if report.Error != nil {
 			log.Debugf("%s: check run failed: %v", c.ruleID, report.Error)
-			if report.CriticalError {
+			if !report.SoftError {
 				err = report.Error
 			}
 		}

--- a/pkg/compliance/checks/rego_check.go
+++ b/pkg/compliance/checks/rego_check.go
@@ -333,6 +333,7 @@ func findingsToReports(findings []regoFinding) []*compliance.Report {
 				Resource:  reportResource,
 				Passed:    false,
 				Error:     err,
+				SoftError: true,
 				Evaluator: regoEvaluator,
 			}
 		case "passed":

--- a/pkg/compliance/checks/rego_check_test.go
+++ b/pkg/compliance/checks/rego_check_test.go
@@ -234,6 +234,7 @@ func TestRegoCheck(t *testing.T) {
 					},
 					Evaluator: "rego",
 					Error:     errors.New("error message"),
+					SoftError: true,
 				},
 			},
 		},

--- a/pkg/compliance/report.go
+++ b/pkg/compliance/report.go
@@ -23,6 +23,8 @@ type Report struct {
 	Evaluator string
 	// Error of th check evaluation
 	Error error
+	// Describes if the error is critical
+	CriticalError bool
 }
 
 // ReportResource holds the id and type of the resource associated with a report

--- a/pkg/compliance/report.go
+++ b/pkg/compliance/report.go
@@ -23,8 +23,8 @@ type Report struct {
 	Evaluator string
 	// Error of th check evaluation
 	Error error
-	// Describes if the error is critical
-	CriticalError bool
+	// Describes if the error is soft (non-critical)
+	SoftError bool
 }
 
 // ReportResource holds the id and type of the resource associated with a report

--- a/pkg/compliance/report_utils.go
+++ b/pkg/compliance/report_utils.go
@@ -58,7 +58,8 @@ func BuildReportForUnstructured(passed, aggregated bool, obj *KubeUnstructuredRe
 // BuildReportForError returns a report for the given error
 func BuildReportForError(err error) *Report {
 	return &Report{
-		Passed: false,
-		Error:  err,
+		Passed:        false,
+		Error:         err,
+		CriticalError: true,
 	}
 }

--- a/pkg/compliance/report_utils.go
+++ b/pkg/compliance/report_utils.go
@@ -58,8 +58,7 @@ func BuildReportForUnstructured(passed, aggregated bool, obj *KubeUnstructuredRe
 // BuildReportForError returns a report for the given error
 func BuildReportForError(err error) *Report {
 	return &Report{
-		Passed:        false,
-		Error:         err,
-		CriticalError: true,
+		Passed: false,
+		Error:  err,
 	}
 }


### PR DESCRIPTION
### What does this PR do?

With the removal of `hostSelector` from CSPM rules, we execute a lot more rules that will end up in errors, often because the file or process they are expecting is not here. This currently triggers a lot of `log.Error` because each error report ends up triggering this log.

The solution to this issue implemented by this PR is to add the idea of `SoftError`, meaning an error that is still an error but that is "expected" or at least not as critical as rego parsing errors for example.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
