### PR TITLE
pkg/trace/api: improve error handling of `handleTraces()`

### DIFF
--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -506,16 +506,16 @@ func (r *HTTPReceiver) handleStats(w http.ResponseWriter, req *http.Request) {
 // handleTraces knows how to handle a bunch of traces
 func (r *HTTPReceiver) handleTraces(v Version, w http.ResponseWriter, req *http.Request) {
 	ts := r.tagStats(v, req.Header)
-	var tracen int64
-	if n, err := traceCount(req); err == nil && r.rateLimited(n) {
-		tracen = n
+	tracen, err := traceCount(req)
+	if err == nil && r.rateLimited(tracen) {
 		// this payload can not be accepted
 		io.Copy(ioutil.Discard, req.Body) //nolint:errcheck
 		w.WriteHeader(r.rateLimiterResponse)
 		r.replyOK(req, v, w)
 		atomic.AddInt64(&ts.PayloadRefused, 1)
 		return
-	} else if err == errInvalidHeaderTraceCountValue {
+	}
+	if err == errInvalidHeaderTraceCountValue {
 		log.Errorf("Failed to count traces: %s", err)
 	}
 

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -518,10 +518,10 @@ func (r *HTTPReceiver) handleTraces(v Version, w http.ResponseWriter, req *http.
 	}
 	if err != nil {
 		e := err.Error()
-		if strings.Contains(e, "not found") || strings.Contains(e, "not set") {
+		if strings.Contains(e, "not found") {
 			log.Debugf("Failed to count traces: %s", err)
 		}
-		if strings.Contains(e, "not be parsed") {
+		if strings.Contains(e, "not set") || strings.Contains(e, "not be parsed") {
 			log.Errorf("Failed to count traces: %s", err)
 		}
 	}

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -525,8 +525,10 @@ func (r *HTTPReceiver) handleTraces(v Version, w http.ResponseWriter, req *http.
 		tags := append(ts.AsTags(), fmt.Sprintf("success:%v", err == nil))
 		metrics.Histogram("datadog.trace_agent.receiver.serve_traces_ms", float64(time.Since(start))/float64(time.Millisecond), tags, 1)
 	}()
-	var tp *pb.TracerPayload
-	var ranHook bool
+	var (
+		tp      *pb.TracerPayload
+		ranHook bool
+	)
 	tp, ranHook, err = decodeTracerPayload(v, req, ts)
 	if err != nil {
 		httpDecodingError(err, []string{"handler:traces", fmt.Sprintf("v:%s", v)}, w)

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -517,7 +517,13 @@ func (r *HTTPReceiver) handleTraces(v Version, w http.ResponseWriter, req *http.
 		return
 	}
 	if err != nil {
-		log.Errorf("Failed to count traces: %s", err)
+		e := err.Error()
+		if strings.Contains(e, "not found") || strings.Contains(e, "not set") {
+			log.Debugf("Failed to count traces: %s", err)
+		}
+		if strings.Contains(e, "not be parsed") {
+			log.Errorf("Failed to count traces: %s", err)
+		}
 	}
 
 	start := time.Now()

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -516,6 +516,9 @@ func (r *HTTPReceiver) handleTraces(v Version, w http.ResponseWriter, req *http.
 		atomic.AddInt64(&ts.PayloadRefused, 1)
 		return
 	}
+	if err != nil {
+		log.Errorf("Failed to count traces: %s", err)
+	}
 
 	start := time.Now()
 	defer func(err error) {

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -521,11 +521,13 @@ func (r *HTTPReceiver) handleTraces(v Version, w http.ResponseWriter, req *http.
 	}
 
 	start := time.Now()
-	defer func(err error) {
+	defer func() {
 		tags := append(ts.AsTags(), fmt.Sprintf("success:%v", err == nil))
 		metrics.Histogram("datadog.trace_agent.receiver.serve_traces_ms", float64(time.Since(start))/float64(time.Millisecond), tags, 1)
-	}(err)
-	tp, ranHook, err := decodeTracerPayload(v, req, ts)
+	}()
+	var tp *pb.TracerPayload
+	var ranHook bool
+	tp, ranHook, err = decodeTracerPayload(v, req, ts)
 	if err != nil {
 		httpDecodingError(err, []string{"handler:traces", fmt.Sprintf("v:%s", v)}, w)
 		switch err {

--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -461,19 +461,19 @@ func TestTraceCount(t *testing.T) {
 			delete(req.Header, k)
 		}
 		_, err := traceCount(req)
-		assert.Contains(t, err.Error(), "not found")
+		assert.Equal(t, err, errHeaderTraceCountNotFound)
 	})
 
 	t.Run("value-empty", func(t *testing.T) {
 		req.Header.Set(headerTraceCount, "")
 		_, err := traceCount(req)
-		assert.Contains(t, err.Error(), "value not set")
+		assert.Equal(t, err, errHeaderTraceCountNotSet)
 	})
 
 	t.Run("value-bad", func(t *testing.T) {
 		req.Header.Set(headerTraceCount, "qwe")
 		_, err := traceCount(req)
-		assert.Contains(t, err.Error(), "can not be parsed")
+		assert.Equal(t, err, errInvalidHeaderTraceCount)
 	})
 
 	t.Run("ok", func(t *testing.T) {

--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -461,19 +461,19 @@ func TestTraceCount(t *testing.T) {
 			delete(req.Header, k)
 		}
 		_, err := traceCount(req)
-		assert.Equal(t, err, errHeaderTraceCountNotFound)
+		assert.EqualError(t, err, fmt.Sprintf("HTTP header %q not found", headerTraceCount))
 	})
 
 	t.Run("value-empty", func(t *testing.T) {
 		req.Header.Set(headerTraceCount, "")
 		_, err := traceCount(req)
-		assert.Equal(t, err, errHeaderTraceCountNotSet)
+		assert.EqualError(t, err, fmt.Sprintf("HTTP header %q not found", headerTraceCount))
 	})
 
 	t.Run("value-bad", func(t *testing.T) {
 		req.Header.Set(headerTraceCount, "qwe")
 		_, err := traceCount(req)
-		assert.Equal(t, err, errInvalidHeaderTraceCount)
+		assert.Equal(t, err, errInvalidHeaderTraceCountValue)
 	})
 
 	t.Run("ok", func(t *testing.T) {

--- a/releasenotes/notes/apm-warn-bad-trace-count-c339db48e066575d.yaml
+++ b/releasenotes/notes/apm-warn-bad-trace-count-c339db48e066575d.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    APM: When the X-Datadog-Trace-Count contains an invalid value, an error will be issued.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

- Output the error of [traceCount()](https://github.com/DataDog/datadog-agent/blob/bb9dc0d9dd932d93a33864a4538b948e2730c43e/pkg/trace/api/api.go#L312) to the error log.
- Use the result of [decodeTracerPayload()](https://github.com/DataDog/datadog-agent/blob/bb9dc0d9dd932d93a33864a4538b948e2730c43e/pkg/trace/api/api.go#L402) for the `success` tag value.

### Motivation

- Don't ignore the error.
- Prevent [traceCount()](https://github.com/DataDog/datadog-agent/blob/bb9dc0d9dd932d93a33864a4538b948e2730c43e/pkg/trace/api/api.go#L312) results from being used for `success` tag. Use [decodeTracerPayload()](https://github.com/DataDog/datadog-agent/blob/bb9dc0d9dd932d93a33864a4538b948e2730c43e/pkg/trace/api/api.go#L402) results for `success` tag.

### Additional Notes

Simple reproduction of the current code in the Go playground.
https://go.dev/play/p/hzDVsO5AeoO

I think it should be this.
https://go.dev/play/p/KY0Bx8go5zt

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
