### PR TITLE
[CWS] fix mount id cache invalidation and fix ancestor retain leak

### DIFF
--- a/pkg/security/probe/mount_resolver.go
+++ b/pkg/security/probe/mount_resolver.go
@@ -145,6 +145,7 @@ func (mr *MountResolver) deleteDevice(mount *model.MountEvent) {
 }
 
 func (mr *MountResolver) delete(mount *model.MountEvent) {
+	mr.clearCacheForMountID(mount.MountID)
 	delete(mr.mounts, mount.MountID)
 
 	mounts, exists := mr.devices[mount.Device]
@@ -160,6 +161,8 @@ func (mr *MountResolver) delete(mount *model.MountEvent) {
 func (mr *MountResolver) Delete(mountID uint32) error {
 	mr.lock.Lock()
 	defer mr.lock.Unlock()
+
+	mr.clearCacheForMountID(mountID)
 
 	mount, exists := mr.mounts[mountID]
 	if !exists {
@@ -346,8 +349,7 @@ func (mr *MountResolver) dequeue(now time.Time) {
 		}
 
 		// clear cache anyway
-		mr.parentPathCache.Remove(req.mount.MountID)
-		mr.overlayPathCache.Remove(req.mount.MountID)
+		mr.clearCacheForMountID(req.mount.MountID)
 
 		i++
 	}
@@ -359,6 +361,11 @@ func (mr *MountResolver) dequeue(now time.Time) {
 	}
 
 	mr.lock.Unlock()
+}
+
+func (mr *MountResolver) clearCacheForMountID(mountID uint32) {
+	mr.parentPathCache.Remove(mountID)
+	mr.overlayPathCache.Remove(mountID)
 }
 
 // Start starts the resolver

--- a/pkg/security/secl/model/process_cache_entry.go
+++ b/pkg/security/secl/model/process_cache_entry.go
@@ -21,6 +21,14 @@ func (pc *ProcessCacheEntry) SetSpan(spanID uint64, traceID uint64) {
 
 // SetAncestor sets the ancestor
 func (pc *ProcessCacheEntry) SetAncestor(parent *ProcessCacheEntry) {
+	if pc.Ancestor == parent {
+		return
+	}
+
+	if pc.Ancestor != nil {
+		pc.Ancestor.Release()
+	}
+
 	pc.Ancestor = parent
 	parent.Retain()
 }

--- a/pkg/security/tests/syscall_tester/c/syscall_tester.c
+++ b/pkg/security/tests/syscall_tester/c/syscall_tester.c
@@ -113,7 +113,7 @@ static void *thread_open(void *data) {
 }
 
 int span_open(int argc, char **argv) {
-    if (argc < 3) {
+    if (argc < 4) {
         fprintf(stderr, "Please pass a span Id and a trace Id to exec_span and a command\n");
         return EXIT_FAILURE;
     }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Backport of:
- https://github.com/DataDog/datadog-agent/pull/11800
- https://github.com/DataDog/datadog-agent/pull/11779

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
