### PR TITLE
Use go.uber.org/atomic in pkg/collector/corechecks/cluster/orchestrator/

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1300,7 +1300,6 @@ github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh
 github.com/mitchellh/mapstructure v1.3.2/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.4.2/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
-github.com/mitchellh/mapstructure v1.4.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=

--- a/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
@@ -54,7 +54,7 @@ func NewCollectorBundle(chk *OrchestratorCheck) *CollectorBundle {
 			APIClient:   chk.apiClient,
 			ClusterID:   chk.clusterID,
 			Config:      chk.orchestratorConfig,
-			MsgGroupRef: &chk.groupID,
+			MsgGroupRef: chk.groupID,
 		},
 		stopCh: make(chan struct{}),
 	}

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/collector.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/collector.go
@@ -13,6 +13,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/orchestrator"
 	"github.com/DataDog/datadog-agent/pkg/orchestrator/config"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
+	"go.uber.org/atomic"
 
 	"k8s.io/client-go/tools/cache"
 )
@@ -54,7 +55,7 @@ type CollectorRunConfig struct {
 	APIClient   *apiserver.APIClient
 	ClusterID   string
 	Config      *config.OrchestratorConfig
-	MsgGroupRef *int32
+	MsgGroupRef *atomic.Int32
 }
 
 // CollectorRunResult contains information about what the collector has done.

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/cluster.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/cluster.go
@@ -9,8 +9,6 @@
 package k8s
 
 import (
-	"sync/atomic"
-
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
 	k8sProcessors "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors/k8s"
@@ -73,7 +71,7 @@ func (c *ClusterCollector) Run(rcfg *collectors.CollectorRunConfig) (*collectors
 		APIClient:  rcfg.APIClient,
 		Cfg:        rcfg.Config,
 		ClusterID:  rcfg.ClusterID,
-		MsgGroupID: atomic.AddInt32(rcfg.MsgGroupRef, 1),
+		MsgGroupID: rcfg.MsgGroupRef.Inc(),
 		NodeType:   c.metadata.NodeType,
 	}
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/clusterrole.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/clusterrole.go
@@ -9,8 +9,6 @@
 package k8s
 
 import (
-	"sync/atomic"
-
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
 	k8sProcessors "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors/k8s"
@@ -73,7 +71,7 @@ func (c *ClusterRoleCollector) Run(rcfg *collectors.CollectorRunConfig) (*collec
 		APIClient:  rcfg.APIClient,
 		Cfg:        rcfg.Config,
 		ClusterID:  rcfg.ClusterID,
-		MsgGroupID: atomic.AddInt32(rcfg.MsgGroupRef, 1),
+		MsgGroupID: rcfg.MsgGroupRef.Inc(),
 		NodeType:   c.metadata.NodeType,
 	}
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/clusterrolebinding.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/clusterrolebinding.go
@@ -9,8 +9,6 @@
 package k8s
 
 import (
-	"sync/atomic"
-
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
 	k8sProcessors "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors/k8s"
@@ -73,7 +71,7 @@ func (c *ClusterRoleBindingCollector) Run(rcfg *collectors.CollectorRunConfig) (
 		APIClient:  rcfg.APIClient,
 		Cfg:        rcfg.Config,
 		ClusterID:  rcfg.ClusterID,
-		MsgGroupID: atomic.AddInt32(rcfg.MsgGroupRef, 1),
+		MsgGroupID: rcfg.MsgGroupRef.Inc(),
 		NodeType:   c.metadata.NodeType,
 	}
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/cronjob.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/cronjob.go
@@ -9,8 +9,6 @@
 package k8s
 
 import (
-	"sync/atomic"
-
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
 	k8sProcessors "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors/k8s"
@@ -72,7 +70,7 @@ func (c *CronJobCollector) Run(rcfg *collectors.CollectorRunConfig) (*collectors
 		APIClient:  rcfg.APIClient,
 		Cfg:        rcfg.Config,
 		ClusterID:  rcfg.ClusterID,
-		MsgGroupID: atomic.AddInt32(rcfg.MsgGroupRef, 1),
+		MsgGroupID: rcfg.MsgGroupRef.Inc(),
 		NodeType:   c.metadata.NodeType,
 	}
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/daemonset.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/daemonset.go
@@ -9,8 +9,6 @@
 package k8s
 
 import (
-	"sync/atomic"
-
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
 	k8sProcessors "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors/k8s"
@@ -73,7 +71,7 @@ func (c *DaemonSetCollector) Run(rcfg *collectors.CollectorRunConfig) (*collecto
 		APIClient:  rcfg.APIClient,
 		Cfg:        rcfg.Config,
 		ClusterID:  rcfg.ClusterID,
-		MsgGroupID: atomic.AddInt32(rcfg.MsgGroupRef, 1),
+		MsgGroupID: rcfg.MsgGroupRef.Inc(),
 		NodeType:   c.metadata.NodeType,
 	}
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/deployment.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/deployment.go
@@ -9,8 +9,6 @@
 package k8s
 
 import (
-	"sync/atomic"
-
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
 	k8sProcessors "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors/k8s"
@@ -73,7 +71,7 @@ func (c *DeploymentCollector) Run(rcfg *collectors.CollectorRunConfig) (*collect
 		APIClient:  rcfg.APIClient,
 		Cfg:        rcfg.Config,
 		ClusterID:  rcfg.ClusterID,
-		MsgGroupID: atomic.AddInt32(rcfg.MsgGroupRef, 1),
+		MsgGroupID: rcfg.MsgGroupRef.Inc(),
 		NodeType:   c.metadata.NodeType,
 	}
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/ingress.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/ingress.go
@@ -10,7 +10,6 @@ package k8s
 
 import (
 	"context"
-	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors"
@@ -96,7 +95,7 @@ func (c *IngressCollector) Run(rcfg *collectors.CollectorRunConfig) (*collectors
 		APIClient:  rcfg.APIClient,
 		Cfg:        rcfg.Config,
 		ClusterID:  rcfg.ClusterID,
-		MsgGroupID: atomic.AddInt32(rcfg.MsgGroupRef, 1),
+		MsgGroupID: rcfg.MsgGroupRef.Inc(),
 		NodeType:   c.metadata.NodeType,
 	}
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/job.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/job.go
@@ -9,8 +9,6 @@
 package k8s
 
 import (
-	"sync/atomic"
-
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
 	k8sProcessors "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors/k8s"
@@ -72,7 +70,7 @@ func (c *JobCollector) Run(rcfg *collectors.CollectorRunConfig) (*collectors.Col
 		APIClient:  rcfg.APIClient,
 		Cfg:        rcfg.Config,
 		ClusterID:  rcfg.ClusterID,
-		MsgGroupID: atomic.AddInt32(rcfg.MsgGroupRef, 1),
+		MsgGroupID: rcfg.MsgGroupRef.Inc(),
 		NodeType:   c.metadata.NodeType,
 	}
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/node.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/node.go
@@ -9,8 +9,6 @@
 package k8s
 
 import (
-	"sync/atomic"
-
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
 	k8sProcessors "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors/k8s"
@@ -72,7 +70,7 @@ func (c *NodeCollector) Run(rcfg *collectors.CollectorRunConfig) (*collectors.Co
 		APIClient:  rcfg.APIClient,
 		Cfg:        rcfg.Config,
 		ClusterID:  rcfg.ClusterID,
-		MsgGroupID: atomic.AddInt32(rcfg.MsgGroupRef, 1),
+		MsgGroupID: rcfg.MsgGroupRef.Inc(),
 		NodeType:   c.metadata.NodeType,
 	}
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/persistentvolume.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/persistentvolume.go
@@ -9,8 +9,6 @@
 package k8s
 
 import (
-	"sync/atomic"
-
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
 	k8sProcessors "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors/k8s"
@@ -73,7 +71,7 @@ func (c *PersistentVolumeCollector) Run(rcfg *collectors.CollectorRunConfig) (*c
 		APIClient:  rcfg.APIClient,
 		Cfg:        rcfg.Config,
 		ClusterID:  rcfg.ClusterID,
-		MsgGroupID: atomic.AddInt32(rcfg.MsgGroupRef, 1),
+		MsgGroupID: rcfg.MsgGroupRef.Inc(),
 		NodeType:   c.metadata.NodeType,
 	}
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/persistentvolumeclaim.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/persistentvolumeclaim.go
@@ -9,8 +9,6 @@
 package k8s
 
 import (
-	"sync/atomic"
-
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
 	k8sProcessors "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors/k8s"
@@ -73,7 +71,7 @@ func (c *PersistentVolumeClaimCollector) Run(rcfg *collectors.CollectorRunConfig
 		APIClient:  rcfg.APIClient,
 		Cfg:        rcfg.Config,
 		ClusterID:  rcfg.ClusterID,
-		MsgGroupID: atomic.AddInt32(rcfg.MsgGroupRef, 1),
+		MsgGroupID: rcfg.MsgGroupRef.Inc(),
 		NodeType:   c.metadata.NodeType,
 	}
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/pod_unassigned.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/pod_unassigned.go
@@ -9,8 +9,6 @@
 package k8s
 
 import (
-	"sync/atomic"
-
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
 	k8sProcessors "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors/k8s"
@@ -74,7 +72,7 @@ func (c *UnassignedPodCollector) Run(rcfg *collectors.CollectorRunConfig) (*coll
 		APIClient:  rcfg.APIClient,
 		Cfg:        rcfg.Config,
 		ClusterID:  rcfg.ClusterID,
-		MsgGroupID: atomic.AddInt32(rcfg.MsgGroupRef, 1),
+		MsgGroupID: rcfg.MsgGroupRef.Inc(),
 		NodeType:   c.metadata.NodeType,
 	}
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/replicaset.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/replicaset.go
@@ -9,8 +9,6 @@
 package k8s
 
 import (
-	"sync/atomic"
-
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
 	k8sProcessors "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors/k8s"
@@ -73,7 +71,7 @@ func (c *ReplicaSetCollector) Run(rcfg *collectors.CollectorRunConfig) (*collect
 		APIClient:  rcfg.APIClient,
 		Cfg:        rcfg.Config,
 		ClusterID:  rcfg.ClusterID,
-		MsgGroupID: atomic.AddInt32(rcfg.MsgGroupRef, 1),
+		MsgGroupID: rcfg.MsgGroupRef.Inc(),
 		NodeType:   c.metadata.NodeType,
 	}
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/role.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/role.go
@@ -9,8 +9,6 @@
 package k8s
 
 import (
-	"sync/atomic"
-
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
 	k8sProcessors "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors/k8s"
@@ -72,7 +70,7 @@ func (c *RoleCollector) Run(rcfg *collectors.CollectorRunConfig) (*collectors.Co
 		APIClient:  rcfg.APIClient,
 		Cfg:        rcfg.Config,
 		ClusterID:  rcfg.ClusterID,
-		MsgGroupID: atomic.AddInt32(rcfg.MsgGroupRef, 1),
+		MsgGroupID: rcfg.MsgGroupRef.Inc(),
 		NodeType:   c.metadata.NodeType,
 	}
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/rolebinding.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/rolebinding.go
@@ -9,8 +9,6 @@
 package k8s
 
 import (
-	"sync/atomic"
-
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
 	k8sProcessors "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors/k8s"
@@ -73,7 +71,7 @@ func (c *RoleBindingCollector) Run(rcfg *collectors.CollectorRunConfig) (*collec
 		APIClient:  rcfg.APIClient,
 		Cfg:        rcfg.Config,
 		ClusterID:  rcfg.ClusterID,
-		MsgGroupID: atomic.AddInt32(rcfg.MsgGroupRef, 1),
+		MsgGroupID: rcfg.MsgGroupRef.Inc(),
 		NodeType:   c.metadata.NodeType,
 	}
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/service.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/service.go
@@ -9,8 +9,6 @@
 package k8s
 
 import (
-	"sync/atomic"
-
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
 	k8sProcessors "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors/k8s"
@@ -73,7 +71,7 @@ func (c *ServiceCollector) Run(rcfg *collectors.CollectorRunConfig) (*collectors
 		APIClient:  rcfg.APIClient,
 		Cfg:        rcfg.Config,
 		ClusterID:  rcfg.ClusterID,
-		MsgGroupID: atomic.AddInt32(rcfg.MsgGroupRef, 1),
+		MsgGroupID: rcfg.MsgGroupRef.Inc(),
 		NodeType:   c.metadata.NodeType,
 	}
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/serviceaccount.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/serviceaccount.go
@@ -9,8 +9,6 @@
 package k8s
 
 import (
-	"sync/atomic"
-
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
 	k8sProcessors "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors/k8s"
@@ -73,7 +71,7 @@ func (c *ServiceAccountCollector) Run(rcfg *collectors.CollectorRunConfig) (*col
 		APIClient:  rcfg.APIClient,
 		Cfg:        rcfg.Config,
 		ClusterID:  rcfg.ClusterID,
-		MsgGroupID: atomic.AddInt32(rcfg.MsgGroupRef, 1),
+		MsgGroupID: rcfg.MsgGroupRef.Inc(),
 		NodeType:   c.metadata.NodeType,
 	}
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/statefulset.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/statefulset.go
@@ -9,8 +9,6 @@
 package k8s
 
 import (
-	"sync/atomic"
-
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
 	k8sProcessors "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors/k8s"
@@ -73,7 +71,7 @@ func (c *StatefulSetCollector) Run(rcfg *collectors.CollectorRunConfig) (*collec
 		APIClient:  rcfg.APIClient,
 		Cfg:        rcfg.Config,
 		ClusterID:  rcfg.ClusterID,
-		MsgGroupID: atomic.AddInt32(rcfg.MsgGroupRef, 1),
+		MsgGroupID: rcfg.MsgGroupRef.Inc(),
 		NodeType:   c.metadata.NodeType,
 	}
 

--- a/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
@@ -24,6 +24,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"go.uber.org/atomic"
 
 	"gopkg.in/yaml.v2"
 )
@@ -61,7 +62,7 @@ type OrchestratorCheck struct {
 	collectorBundle    *CollectorBundle
 	stopCh             chan struct{}
 	clusterID          string
-	groupID            int32
+	groupID            *atomic.Int32
 	isCLCRunner        bool
 	apiClient          *apiserver.APIClient
 }
@@ -72,7 +73,7 @@ func newOrchestratorCheck(base core.CheckBase, instance *OrchestratorInstance) *
 		orchestratorConfig: orchcfg.NewDefaultOrchestratorConfig(),
 		instance:           instance,
 		stopCh:             make(chan struct{}),
-		groupID:            rand.Int31(),
+		groupID:            atomic.NewInt32(rand.Int31()),
 		isCLCRunner:        config.IsCLCRunner(),
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Replaces direct use of the `sync/atomic` package with `go.uber.org/atomic`, in the given package

This should not change behavior.

### Motivation

Alignment issues with atomic access. See https://github.com/DataDog/datadog-agent/pull/11716

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Ordinary DCA QA should catch any issues here.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
