### PR TITLE
cmd/trace-agent: enhance DD_APM_FILTER_TAGS_* support

### DIFF
--- a/cmd/trace-agent/config/config_test.go
+++ b/cmd/trace-agent/config/config_test.go
@@ -841,6 +841,16 @@ func TestLoadEnv(t *testing.T) {
 		assert.NoError(err)
 		assert.Equal(cfg.RequireTags, []*config.Tag{{K: "important1", V: ""}, {K: "important2", V: "value1"}})
 	})
+	t.Run(env, func(t *testing.T) {
+		defer cleanConfig()()
+		assert := assert.New(t)
+		err := os.Setenv(env, `["important1:value with a space"]`)
+		assert.NoError(err)
+		defer os.Unsetenv(env)
+		cfg, err := LoadConfigFile("./testdata/full.yaml")
+		assert.NoError(err)
+		assert.Equal(cfg.RequireTags, []*config.Tag{{K: "important1", V: "value with a space"}})
+	})
 
 	env = "DD_APM_FILTER_TAGS_REJECT"
 	t.Run(env, func(t *testing.T) {
@@ -852,6 +862,16 @@ func TestLoadEnv(t *testing.T) {
 		cfg, err := LoadConfigFile("./testdata/full.yaml")
 		assert.NoError(err)
 		assert.Equal(cfg.RejectTags, []*config.Tag{{K: "bad1", V: "value1"}})
+	})
+	t.Run(env, func(t *testing.T) {
+		defer cleanConfig()()
+		assert := assert.New(t)
+		err := os.Setenv(env, `["bad1:value with a space"]`)
+		assert.NoError(err)
+		defer os.Unsetenv(env)
+		cfg, err := LoadConfigFile("./testdata/full.yaml")
+		assert.NoError(err)
+		assert.Equal(cfg.RejectTags, []*config.Tag{{K: "bad1", V: "value with a space"}})
 	})
 
 	for _, envKey := range []string{

--- a/cmd/trace-agent/config/config_test.go
+++ b/cmd/trace-agent/config/config_test.go
@@ -841,6 +841,7 @@ func TestLoadEnv(t *testing.T) {
 		assert.NoError(err)
 		assert.Equal(cfg.RequireTags, []*config.Tag{{K: "important1", V: ""}, {K: "important2", V: "value1"}})
 	})
+
 	t.Run(env, func(t *testing.T) {
 		defer cleanConfig()()
 		assert := assert.New(t)
@@ -863,6 +864,7 @@ func TestLoadEnv(t *testing.T) {
 		assert.NoError(err)
 		assert.Equal(cfg.RejectTags, []*config.Tag{{K: "bad1", V: "value1"}})
 	})
+
 	t.Run(env, func(t *testing.T) {
 		defer cleanConfig()()
 		assert := assert.New(t)

--- a/pkg/config/apm.go
+++ b/pkg/config/apm.go
@@ -110,10 +110,26 @@ func setupAPM(config Config) {
 	})
 
 	config.SetEnvKeyTransformer("apm_config.filter_tags.require", func(in string) interface{} {
+		if len(in) > 0 && in[0] == '[' {
+			var values []string
+			if err := json.Unmarshal([]byte(in), &values); err != nil {
+				log.Warnf(`"apm_config.filter_tags.require" can not be parsed: %v`, err)
+				return []string{}
+			}
+			return values
+		}
 		return strings.Split(in, " ")
 	})
 
 	config.SetEnvKeyTransformer("apm_config.filter_tags.reject", func(in string) interface{} {
+		if len(in) > 0 && in[0] == '[' {
+			var values []string
+			if err := json.Unmarshal([]byte(in), &values); err != nil {
+				log.Warnf(`"apm_config.filter_tags.reject" can not be parsed: %v`, err)
+				return []string{}
+			}
+			return values
+		}
 		return strings.Split(in, " ")
 	})
 

--- a/pkg/config/apm.go
+++ b/pkg/config/apm.go
@@ -132,7 +132,10 @@ func setupAPM(config Config) {
 
 func parseKVList(key string) func(string) interface{} {
 	return func(in string) interface{} {
-		if len(in) == 0 || in[0] != '[' {
+		if len(in) == 0 {
+			return []string{}
+		}
+		if in[0] != '[' {
 			return strings.Split(in, " ")
 		}
 		// '[' as a first character signals JSON array format

--- a/pkg/config/apm.go
+++ b/pkg/config/apm.go
@@ -109,29 +109,9 @@ func setupAPM(config Config) {
 		return r
 	})
 
-	config.SetEnvKeyTransformer("apm_config.filter_tags.require", func(in string) interface{} {
-		if len(in) > 0 && in[0] == '[' {
-			var values []string
-			if err := json.Unmarshal([]byte(in), &values); err != nil {
-				log.Warnf(`"apm_config.filter_tags.require" can not be parsed: %v`, err)
-				return []string{}
-			}
-			return values
-		}
-		return strings.Split(in, " ")
-	})
+	config.SetEnvKeyTransformer("apm_config.filter_tags.require", parseKVList("apm_config.filter_tags.require"))
 
-	config.SetEnvKeyTransformer("apm_config.filter_tags.reject", func(in string) interface{} {
-		if len(in) > 0 && in[0] == '[' {
-			var values []string
-			if err := json.Unmarshal([]byte(in), &values); err != nil {
-				log.Warnf(`"apm_config.filter_tags.reject" can not be parsed: %v`, err)
-				return []string{}
-			}
-			return values
-		}
-		return strings.Split(in, " ")
-	})
+	config.SetEnvKeyTransformer("apm_config.filter_tags.reject", parseKVList("apm_config.filter_tags.reject"))
 
 	config.SetEnvKeyTransformer("apm_config.replace_tags", func(in string) interface{} {
 		var out []map[string]string
@@ -148,6 +128,21 @@ func setupAPM(config Config) {
 		}
 		return out
 	})
+}
+
+func parseKVList(key string) func(string) interface{} {
+	return func(in string) interface{} {
+		if len(in) == 0 || in[0] != '[' {
+			return strings.Split(in, " ")
+		}
+		// '[' as a first character signals JSON array format
+		var values []string
+		if err := json.Unmarshal([]byte(in), &values); err != nil {
+			log.Warnf(`"%s" can not be parsed: %v`, key, err)
+			return []string{}
+		}
+		return values
+	}
 }
 
 func splitCSVString(s string, sep rune) ([]string, error) {

--- a/releasenotes/notes/Array-Syntax-for-DD_APM_FILTER_TAGS-f29b167d13cf88d6.yaml
+++ b/releasenotes/notes/Array-Syntax-for-DD_APM_FILTER_TAGS-f29b167d13cf88d6.yaml
@@ -1,5 +1,5 @@
 ---
 enhancements:
   - |
-    DD_APM_FILTER_TAGS_REQUIRE and DD_APM_FILTER_TAGS_REJECT can now be a literal json array.
+    APM: DD_APM_FILTER_TAGS_REQUIRE and DD_APM_FILTER_TAGS_REJECT can now be a literal JSON array.
     e.g. ``["someKey:someValue"]`` This allows for matching tag values with the space character in them.

--- a/releasenotes/notes/Array-Syntax-for-DD_APM_FILTER_TAGS-f29b167d13cf88d6.yaml
+++ b/releasenotes/notes/Array-Syntax-for-DD_APM_FILTER_TAGS-f29b167d13cf88d6.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    DD_APM_FILTER_TAGS_REQUIRE and DD_APM_FILTER_TAGS_REJECT can now be a literal json array.
+    e.g. ``["someKey:someValue"]`` This allows for matching tag values with the space character in them.


### PR DESCRIPTION
### What does this PR do?

Support array values for these two environment variables. This allows customers to filter or require tag values that have a space in them.

### Motivation

This is based on a customer support request APMS-7131

### Describe how to test/QA your changes

Can be tested by setting the environment variable for the running agent to include this new format
DD_APM_FILTER_TAGS_REQUIRE='["someKey:some Value"]'
DD_APM_FILTER_TAGS_REJECT='["someBadKey:some Bad Value"]'

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
