### PR TITLE
[mod tidy gh action] Checkout PR branch explicitly

### DIFF
--- a/.github/workflows/go_mod_tidy.yml
+++ b/.github/workflows/go_mod_tidy.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.head_ref }}
     - name: Checkout PR
       # run only if triggered manually, otherwise we are already on the right branch and we won't have `pr_number`
       if: ${{ github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
### Motivation

Otherwise it checks out the post-merge branch by default, to which we can't
push. Should fix "Your local changes to the following files would be
overwritten by checkout" errors when the action did change something.
