### PR TITLE
Start logs-agent after AD

### DIFF
--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -28,7 +28,6 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/manager"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/api/healthprobe"
-	"github.com/DataDog/datadog-agent/pkg/autodiscovery"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/embed/jmx"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	remoteconfig "github.com/DataDog/datadog-agent/pkg/config/remote/service"
@@ -405,18 +404,6 @@ func StartAgent() error {
 		}
 	}
 
-	// start logs-agent
-	if config.Datadog.GetBool("logs_enabled") || config.Datadog.GetBool("log_enabled") {
-		if config.Datadog.GetBool("log_enabled") {
-			log.Warn(`"log_enabled" is deprecated, use "logs_enabled" instead`)
-		}
-		if _, err := logs.Start(func() *autodiscovery.AutoConfig { return common.AC }); err != nil {
-			log.Error("Could not start logs-agent: ", err)
-		}
-	} else {
-		log.Info("logs-agent disabled")
-	}
-
 	if err = common.SetupSystemProbeConfig(sysProbeConfFilePath); err != nil {
 		log.Infof("System probe config not found, disabling pulling system probe info in the status page: %v", err)
 	}
@@ -429,6 +416,20 @@ func StartAgent() error {
 
 	// create and setup the Autoconfig instance
 	common.LoadComponents(common.MainCtx, config.Datadog.GetString("confd_path"))
+
+	// start logs-agent.  This must happen after AutoConfig is set up (via common.LoadComponents) and
+	// before AutoConfig is started (va common.StartAutoConfig).
+	if config.Datadog.GetBool("logs_enabled") || config.Datadog.GetBool("log_enabled") {
+		if config.Datadog.GetBool("log_enabled") {
+			log.Warn(`"log_enabled" is deprecated, use "logs_enabled" instead`)
+		}
+		if _, err := logs.Start(common.AC); err != nil {
+			log.Error("Could not start logs-agent: ", err)
+		}
+	} else {
+		log.Info("logs-agent disabled")
+	}
+
 	// start the autoconfig, this will immediately run any configured check
 	common.StartAutoConfig()
 

--- a/cmd/agent/common/loader.go
+++ b/cmd/agent/common/loader.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/scheduler"
 	"github.com/DataDog/datadog-agent/pkg/collector"
-	"github.com/DataDog/datadog-agent/pkg/logs"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/tagger/local"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
@@ -44,8 +43,6 @@ func LoadComponents(ctx context.Context, confdPath string) {
 
 	// registering the check scheduler
 	metaScheduler.Register("check", collector.InitCheckScheduler(Coll))
-
-	logs.SetADMetaScheduler(metaScheduler)
 
 	// setup autodiscovery
 	confSearchPaths := []string{

--- a/pkg/logs/internal/util/adlistener/ad.go
+++ b/pkg/logs/internal/util/adlistener/ad.go
@@ -6,41 +6,14 @@
 package adlistener
 
 import (
-	"context"
-
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/scheduler"
 )
 
-var (
-	// The AD MetaScheduler is not available until the logs-agent has started,
-	// as part of the delicate balance of agent startup.  So, ADListener blocks
-	// its startup until that occurs.
-	//
-	// The component architecture should remove the need for this workaround.
-
-	// adMetaSchedulerCh carries the current MetaScheduler, once it is known.
-	adMetaSchedulerCh chan *scheduler.MetaScheduler
-)
-
-func init() {
-	adMetaSchedulerCh = make(chan *scheduler.MetaScheduler, 1)
-}
-
-// SetADMetaScheduler supplies this package with a reference to the AD MetaScheduler,
-// once it has been started.
-func SetADMetaScheduler(sch *scheduler.MetaScheduler) {
-	// perform a non-blocking add to the channel
-	select {
-	case adMetaSchedulerCh <- sch:
-	default:
-	}
-}
-
-// ADListener implements pkg/autodiscovery/scheduler/Scheduler.
+// ADListener implements pkg/autodiscovery/scheduler.Scheduler.
 //
-// It proxies Schedule and Unschedule calls to its parent, and also handles
-// delayed availability of the AD MetaScheduler.
+// It proxies Schedule and Unschedule calls to its parent.
 //
 // This must be a distinct type from schedulers, since both types implement
 // interfaces with different Stop methods.
@@ -48,61 +21,36 @@ type ADListener struct {
 	// name is the name of this listener
 	name string
 
+	// ac is the AutoConfig instance
+	ac *autodiscovery.AutoConfig
+
 	// schedule and unschedule are the functions to which Schedule and
 	// Unschedule calls should be proxied.
 	schedule, unschedule func([]integration.Config)
-
-	// adMetaScheduler is nil to begin with, and becomes non-nil after
-	// SetADMetaScheduler is called.
-	adMetaScheduler *scheduler.MetaScheduler
-
-	// registered is closed when the scheduler is registered (used for tests)
-	registered chan struct{}
-
-	// cancelRegister cancels efforts to register with the AD MetaScheduler
-	cancelRegister context.CancelFunc
 }
 
 var _ scheduler.Scheduler = &ADListener{}
 
 // NewADListener creates a new ADListener, proxying schedule and unschedule calls to
 // the given functions.
-func NewADListener(name string, schedule, unschedule func([]integration.Config)) *ADListener {
+func NewADListener(name string, ac *autodiscovery.AutoConfig, schedule, unschedule func([]integration.Config)) *ADListener {
 	return &ADListener{
 		name:       name,
+		ac:         ac,
 		schedule:   schedule,
 		unschedule: unschedule,
-		registered: make(chan struct{}),
 	}
 }
 
 // StartListener starts the ADListener.  It will subscribe to the MetaScheduler as soon
 // as it is available
 func (l *ADListener) StartListener() {
-	ctx, cancelRegister := context.WithCancel(context.Background())
-	go func() {
-		// wait for the scheduler to be set, and register once it is set
-		select {
-		case sch := <-adMetaSchedulerCh:
-			l.adMetaScheduler = sch
-			l.adMetaScheduler.Register(l.name, l)
-			close(l.registered)
-			// put the value back in the channel, in case it is needed again
-			SetADMetaScheduler(sch)
-
-		case <-ctx.Done():
-		}
-	}()
-
-	l.cancelRegister = cancelRegister
+	l.ac.AddScheduler(l.name, l, false)
 }
 
 // StopListener stops the ADListener
 func (l *ADListener) StopListener() {
-	l.cancelRegister()
-	if l.adMetaScheduler != nil {
-		l.adMetaScheduler.Deregister("logs")
-	}
+	l.ac.RemoveScheduler(l.name)
 }
 
 // Stop implements pkg/autodiscovery/scheduler.Scheduler#Stop.

--- a/pkg/logs/internal/util/adlistener/ad_test.go
+++ b/pkg/logs/internal/util/adlistener/ad_test.go
@@ -8,46 +8,22 @@ package adlistener
 import (
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/scheduler"
-	"github.com/stretchr/testify/require"
 )
 
-func reset() {
-	adMetaSchedulerCh = make(chan *scheduler.MetaScheduler, 1)
-}
-
-func emptyChan(ch chan struct{}) bool {
-	select {
-	case <-ch:
-		return false
-	default:
-		return true
-	}
-}
-
-func TestListenersWaitToStart(t *testing.T) {
-	reset()
+func TestListenersGetScheduleCalls(t *testing.T) {
+	adsched := scheduler.NewMetaScheduler()
+	ac := autodiscovery.NewAutoConfigNoStart(adsched)
 
 	got1 := make(chan struct{}, 1)
-	l1 := NewADListener("l1", func([]integration.Config) { got1 <- struct{}{} }, nil)
+	l1 := NewADListener("l1", ac, func([]integration.Config) { got1 <- struct{}{} }, nil)
 	l1.StartListener()
 
 	got2 := make(chan struct{}, 1)
-	l2 := NewADListener("l2", func([]integration.Config) { got2 <- struct{}{} }, nil)
+	l2 := NewADListener("l2", ac, func([]integration.Config) { got2 <- struct{}{} }, nil)
 	l2.StartListener()
-
-	adsched := scheduler.NewMetaScheduler()
-	adsched.Schedule([]integration.Config{})
-
-	require.True(t, emptyChan(got1))
-	require.True(t, emptyChan(got2))
-
-	SetADMetaScheduler(adsched)
-
-	// wait for the registration to occur before sending a config
-	<-l1.registered
-	<-l2.registered
 
 	adsched.Schedule([]integration.Config{})
 

--- a/pkg/logs/schedulers/ad/scheduler.go
+++ b/pkg/logs/schedulers/ad/scheduler.go
@@ -11,6 +11,7 @@ import (
 
 	yaml "gopkg.in/yaml.v2"
 
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers/names"
 	logsConfig "github.com/DataDog/datadog-agent/pkg/logs/config"
@@ -34,11 +35,11 @@ type Scheduler struct {
 var _ schedulers.Scheduler = &Scheduler{}
 
 // New creates a new scheduler.
-func New() schedulers.Scheduler {
+func New(ac *autodiscovery.AutoConfig) schedulers.Scheduler {
 	sch := &Scheduler{
 		sourcesByServiceID: make(map[string]*logsConfig.LogSource),
 	}
-	sch.listener = adlistener.NewADListener("logs-agent AD scheduler", sch.Schedule, sch.Unschedule)
+	sch.listener = adlistener.NewADListener("logs-agent AD scheduler", ac, sch.Schedule, sch.Unschedule)
 	return sch
 }
 

--- a/pkg/logs/schedulers/ad/scheduler_test.go
+++ b/pkg/logs/schedulers/ad/scheduler_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func setup() (scheduler *Scheduler, spy *schedulers.MockSourceManager) {
-	scheduler = New().(*Scheduler)
+	scheduler = New(nil).(*Scheduler)
 	spy = &schedulers.MockSourceManager{}
 	scheduler.mgr = spy
 	return scheduler, spy

--- a/pkg/logs/schedulers/cca/scheduler.go
+++ b/pkg/logs/schedulers/cca/scheduler.go
@@ -18,7 +18,7 @@ import (
 // Scheduler creates a single source to represent all containers collected due to
 // the `logs_config.container_collect_all` configuration.
 type Scheduler struct {
-	getAC func() *autodiscovery.AutoConfig
+	ac *autodiscovery.AutoConfig
 	// added is closed when the source is added (for testing)
 	added chan struct{}
 }
@@ -26,9 +26,9 @@ type Scheduler struct {
 var _ schedulers.Scheduler = &Scheduler{}
 
 // New creates a new scheduler.
-func New(getAC func() *autodiscovery.AutoConfig) schedulers.Scheduler {
+func New(ac *autodiscovery.AutoConfig) schedulers.Scheduler {
 	return &Scheduler{
-		getAC: getAC,
+		ac:    ac,
 		added: make(chan struct{}),
 	}
 }
@@ -62,9 +62,8 @@ func (s *Scheduler) Start(sourceMgr schedulers.SourceManager) {
 func (s *Scheduler) blockUntilAutoConfigRanOnce(timeout time.Duration) {
 	now := time.Now()
 	for {
-		ac := s.getAC()
 		time.Sleep(100 * time.Millisecond) // don't hog the CPU
-		if ac.HasRunOnce() {
+		if s.ac.HasRunOnce() {
 			return
 		}
 		if time.Since(now) > timeout {

--- a/pkg/logs/schedulers/cca/scheduler_test.go
+++ b/pkg/logs/schedulers/cca/scheduler_test.go
@@ -13,7 +13,7 @@ import (
 
 func setup() (scheduler *Scheduler, ac *autodiscovery.AutoConfig, spy *schedulers.MockSourceManager) {
 	ac = autodiscovery.NewAutoConfigNoStart(nil)
-	scheduler = New(func() *autodiscovery.AutoConfig { return ac }).(*Scheduler)
+	scheduler = New(ac).(*Scheduler)
 	spy = &schedulers.MockSourceManager{}
 	return
 }

--- a/pkg/serverless/logs/scheduler.go
+++ b/pkg/serverless/logs/scheduler.go
@@ -6,8 +6,6 @@
 package logs
 
 import (
-	"github.com/DataDog/datadog-agent/cmd/agent/common"
-	"github.com/DataDog/datadog-agent/pkg/autodiscovery"
 	"github.com/DataDog/datadog-agent/pkg/logs"
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/schedulers/channel"
@@ -20,9 +18,7 @@ var logsScheduler *channel.Scheduler
 
 // SetupLogAgent sets up the logs agent to handle messages on the given channel.
 func SetupLogAgent(logChannel chan *config.ChannelMessage) {
-	agent, err := logs.StartServerless(
-		func() *autodiscovery.AutoConfig { return common.AC },
-	)
+	agent, err := logs.StartServerless()
 	if err != nil {
 		log.Error("Could not start an instance of the Logs Agent:", err)
 		return


### PR DESCRIPTION
This massively simplifies setup of the logs agent, at the risk of
causing other issues by disturbing startup order.

Note that the serverless agent does not use autodiscovery, so the
schedulers depending on AD are not started in that mode.

This also:
 - simplifies ADListener (but the type must remain, as it must implement
   a Stop method for the AD Scheduler interface different from the Stop
   method for the logs Scheduler interface)
 - simplifies the CCA scheduler to just accept an AutoConfig instance,
   instead of a function that might return one.

### Motivation

It seems that the existing hack in ADListener, where it waits to learn about the adMetaScheduler from a channel, introduces a race condition which can be lost on loaded Windows hosts. Surprisingly, the goroutine to read from this channel is not read from after 5 seconds!

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

Changing the order in which components start may have unexpected consequences.

### Describe how to test/QA your changes

Start up an agent with a file config for logs, and verify that it tails the logfile.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
