### PR TITLE
fix(kubernetes_state_core): fix how we configure label_joins

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -533,11 +533,8 @@ func (k *KSMCheck) processLabelsAsTags() {
 			joinsConfig.LabelsToGet = append(joinsConfig.LabelsToGet, labels...)
 		} else {
 			joinsConfig := &JoinsConfig{
-				LabelsToMatch: []string{resourceKind, "namespace"},
+				LabelsToMatch: getLabelToMatchForKind(resourceKind),
 				LabelsToGet:   labels,
-			}
-			if resourceKind == "node" {
-				joinsConfig.LabelsToMatch = []string{"node"}
 			}
 			k.instance.LabelJoins["kube_"+resourceKind+"_labels"] = joinsConfig
 		}

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
@@ -123,55 +123,55 @@ func defaultLabelJoins() map[string]*JoinsConfig {
 
 	return map[string]*JoinsConfig{
 		"kube_pod_status_phase": {
-			LabelsToMatch: []string{"pod", "namespace"},
+			LabelsToMatch: getLabelToMatchForKind("pod"),
 			LabelsToGet:   []string{"phase"},
 		},
 		"kube_pod_info": {
-			LabelsToMatch: []string{"pod", "namespace"},
+			LabelsToMatch: getLabelToMatchForKind("pod"),
 			LabelsToGet:   []string{"node", "created_by_kind", "created_by_name", "priority_class"},
 		},
 		"kube_persistentvolume_info": {
-			LabelsToMatch: []string{"persistentvolume"}, // persistent volumes are not namespaced
+			LabelsToMatch: getLabelToMatchForKind("persistentvolume"),
 			LabelsToGet:   []string{"storageclass"},
 		},
 		"kube_persistentvolumeclaim_info": {
-			LabelsToMatch: []string{"persistentvolumeclaim", "namespace"},
+			LabelsToMatch: getLabelToMatchForKind("persistentvolumeclaim"),
 			LabelsToGet:   []string{"storageclass"},
 		},
 		"kube_pod_labels": {
-			LabelsToMatch: []string{"pod", "namespace"},
+			LabelsToMatch: getLabelToMatchForKind("pod"),
 			LabelsToGet:   defaultStandardLabels,
 		},
 		"kube_pod_status_reason": {
-			LabelsToMatch: []string{"pod", "namespace"},
+			LabelsToMatch: getLabelToMatchForKind("pod"),
 			LabelsToGet:   []string{"reason"},
 		},
 		"kube_deployment_labels": {
-			LabelsToMatch: []string{"deployment", "namespace"},
+			LabelsToMatch: getLabelToMatchForKind("deployment"),
 			LabelsToGet:   defaultStandardLabels,
 		},
 		"kube_replicaset_labels": {
-			LabelsToMatch: []string{"replicaset", "namespace"},
+			LabelsToMatch: getLabelToMatchForKind("replicaset"),
 			LabelsToGet:   defaultStandardLabels,
 		},
 		"kube_daemonset_labels": {
-			LabelsToMatch: []string{"daemonset", "namespace"},
+			LabelsToMatch: getLabelToMatchForKind("daemonset"),
 			LabelsToGet:   defaultStandardLabels,
 		},
 		"kube_statefulset_labels": {
-			LabelsToMatch: []string{"statefulset", "namespace"},
+			LabelsToMatch: getLabelToMatchForKind("statefulset"),
 			LabelsToGet:   defaultStandardLabels,
 		},
 		"kube_job_labels": {
-			LabelsToMatch: []string{"job_name", "namespace"},
+			LabelsToMatch: getLabelToMatchForKind("job_name"),
 			LabelsToGet:   defaultStandardLabels,
 		},
 		"kube_cronjob_labels": {
-			LabelsToMatch: []string{"cronjob", "namespace"},
+			LabelsToMatch: getLabelToMatchForKind("cronjob"),
 			LabelsToGet:   defaultStandardLabels,
 		},
 		"kube_node_labels": {
-			LabelsToMatch: []string{"node"},
+			LabelsToMatch: getLabelToMatchForKind("node"),
 			LabelsToGet: []string{
 				"label_topology_kubernetes_io_region",            // k8s v1.17+
 				"label_topology_kubernetes_io_zone",              // k8s v1.17+
@@ -180,8 +180,26 @@ func defaultLabelJoins() map[string]*JoinsConfig {
 			},
 		},
 		"kube_node_info": {
-			LabelsToMatch: []string{"node"},
+			LabelsToMatch: getLabelToMatchForKind("node"),
 			LabelsToGet:   []string{"container_runtime_version", "kernel_version", "kubelet_version", "os_image"},
 		},
+	}
+}
+
+// getLabelToMatchForKind returns the set of labels use to match
+// a resource.
+// this function centralized the logic about label_joins.labelToMatch
+// configuration, because some resource like `job` is use a non standard
+// label or and because some other resource doesn't need the `namespace` label.
+func getLabelToMatchForKind(kind string) []string {
+	switch kind {
+	case "job": // job metrics use specific label
+		return []string{"job_name", "namespace"}
+	case "node": // persistent nodes are not namespaced
+		return []string{"node"}
+	case "persistentvolume": // persistent volumes are not namespaced
+		return []string{"persistentvolume"}
+	default:
+		return []string{kind, "namespace"}
 	}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fix how we configure `kubernetes_state_core` label_joins with the `LabelsToTags`
option.
This PR create a function `getLabelToMatchForKind` that centralized the logic about 
`label_joins.labelToMatch` configuration, because some resource like `job` is use a
non standard label or and because some other resource doesn't need the `namespace` label. 

### Motivation

Fix tagging issue when using the `labelsToTags` option in `kubernetes_state_core`

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Deploy the agent/dca with `kubernetes_state_core` check enable. update the default
configuration to add `labelsToTags` option. add new labelToTags for a Pod and Job.
check that the tags are properly added to the `pod` and `job` `kubernetes_state.*` metrics. 
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
