### PR TITLE
[config] enable pod container ID validation using `/var/log/containers`

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -789,7 +789,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("logs_config.docker_container_force_use_file", false)
 	// While parsing Kubernetes pod logs, use /var/log/containers to validate that
 	// the pod container ID is matching.
-	config.BindEnvAndSetDefault("logs_config.validate_pod_container_id", false)
+	config.BindEnvAndSetDefault("logs_config.validate_pod_container_id", true)
 	// additional config to ensure initial logs are tagged with kubelet tags
 	// wait (seconds) for tagger before start fetching tags of new AD services
 	config.BindEnvAndSetDefault("logs_config.tagger_warmup_duration", 0) // Disabled by default (0 seconds)

--- a/releasenotes/notes/validate-container-id-2d10a2378ed23982.yaml
+++ b/releasenotes/notes/validate-container-id-2d10a2378ed23982.yaml
@@ -8,8 +8,5 @@
 ---
 enhancements:
   - |
-    Kubernetes pod with short-lived containers won't have a few logs of lines
-    duplicated with both container tag (the stopped one and the running one) anymore
-    while logs are being collected.
-    This feature is enabled by default, set ``logs_config.validate_pod_container_id``
-    to ``false`` to disable it.
+    Kubernetes pod with short-lived containers do not have log lines duplicated with both container tags (the stopped one and the running one) when logs are collected.
+    This feature is enabled by default, set ``logs_config.validate_pod_container_id`` to ``false`` to disable it.

--- a/releasenotes/notes/validate-container-id-2d10a2378ed23982.yaml
+++ b/releasenotes/notes/validate-container-id-2d10a2378ed23982.yaml
@@ -1,0 +1,15 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Kubernetes pod with short-lived containers won't have a few logs of lines
+    duplicated with both container tag (the stopped one and the running one) anymore
+    while logs are being collected.
+    This feature is enabled by default, set ``logs_config.validate_pod_container_id``
+    to ``false`` to disable it.


### PR DESCRIPTION
### What does this PR do?

This feature uses log files present in `/var/log/containers` to validate that an ID assigned to a container by the Tagger matches what's visible on the filesystem.

### Motivation

It is helping with short-lived containers where the Tagger could be out-of-touch compared to what's on the filesystem.

### Additional Notes

### Possible Drawbacks / Trade-offs

Could theoretically have some impact with FS usage if `/var/log/containers` is filled with files as it is listing its content every time we start tailing a new container log file. None has been observed while running this internally.

### Describe how to test/QA your changes

Use the logs agent to tail logs from containers and validate that they're reaching the intake, and that the container ID assigned to the log lines is correct. Running some short-lived containers would be great while QAing this.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
