### PR TITLE
Workloadmeta: when a pod is not ready, skip kube_service but not namespace labels

### DIFF
--- a/releasenotes/notes/fix_namespace_labels_as_tags_on_unready_pods-1b0b438ca0b6d00e.yaml
+++ b/releasenotes/notes/fix_namespace_labels_as_tags_on_unready_pods-1b0b438ca0b6d00e.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Ensure that, when ``kubernetes_namespace_labels_as_tags`` is set, the namespace labels are always attached to metrics and logs, even when the pod is not ready yet.

--- a/releasenotes/notes/fix_namespace_labels_as_tags_on_unready_pods-1b0b438ca0b6d00e.yaml
+++ b/releasenotes/notes/fix_namespace_labels_as_tags_on_unready_pods-1b0b438ca0b6d00e.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Ensure that, when ``kubernetes_namespace_labels_as_tags`` is set, the namespace labels are always attached to metrics and logs, even when the pod is not ready yet.
+    Ensures that when ``kubernetes_namespace_labels_as_tags`` is set, the namespace labels are always attached to metrics and logs, even when the pod is not ready yet.


### PR DESCRIPTION
### What does this PR do?

Ensure that, when `kubernetes_namespace_labels_as_tags` is set, the namespace labels are always attached to the pod metrics and logs, even before it becomes ready.

### Motivation

Today, when a pod starts sending logs before becoming ready, the first logs are missing the tags corresponding to the namespace labels.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Create a pod the readiness of which flips and verify that:
* the `kube_service` tag comes and leaves
* the namespace labels are always there

```yaml
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: flipready
  labels:
    app: flipready
spec:
  replicas: 1
  selector:
    matchLabels:
      app: flipready
  template:
    metadata:
      labels:
        app: flipready
    spec:
      containers:
        - name: flipready
          image: busybox
          command:
            - /bin/sh
            - -c
            - |
              while true; do
                date
                sleep 10
              done
          readinessProbe:
            exec:
              command:
                - /bin/sh
                - -c
                - |
                  # Flip readiness every 5 minutes
                  [ $(($(date +%M)/5%2)) -eq 1 ]
            periodSeconds: 5
            successThreshold: 1
            failureThreshold: 1
...
---
apiVersion: v1
kind: Service
metadata:
  labels:
    app: flipready
  name: flipready
spec:
  selector:
    app: flipready
  ports:
    - name: http
      port: 80
      targetPort: 80
...
```

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
