### PR TITLE
Ensure AD subscription happens before scheduling

### DIFF
--- a/pkg/logs/internal/util/adlistener/ad_test.go
+++ b/pkg/logs/internal/util/adlistener/ad_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func reset() {
-	instance = nil
+	adListener = nil
 }
 
 func emptyChan(ch chan struct{}) bool {

--- a/pkg/logs/internal/util/adlistener/ad_test.go
+++ b/pkg/logs/internal/util/adlistener/ad_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func reset() {
-	adMetaSchedulerCh = make(chan *scheduler.MetaScheduler, 1)
+	instance = nil
 }
 
 func emptyChan(ch chan struct{}) bool {
@@ -33,25 +33,15 @@ func TestListenersWaitToStart(t *testing.T) {
 	l1 := NewADListener("l1", func([]integration.Config) { got1 <- struct{}{} }, nil)
 	l1.StartListener()
 
-	got2 := make(chan struct{}, 1)
-	l2 := NewADListener("l2", func([]integration.Config) { got2 <- struct{}{} }, nil)
-	l2.StartListener()
-
 	adsched := scheduler.NewMetaScheduler()
 	adsched.Schedule([]integration.Config{})
 
 	require.True(t, emptyChan(got1))
-	require.True(t, emptyChan(got2))
 
 	SetADMetaScheduler(adsched)
-
-	// wait for the registration to occur before sending a config
-	<-l1.registered
-	<-l2.registered
 
 	adsched.Schedule([]integration.Config{})
 
 	// wait for each of the two listeners to get notified
 	<-got1
-	<-got2
 }

--- a/pkg/logs/schedulers/ad/scheduler_test.go
+++ b/pkg/logs/schedulers/ad/scheduler_test.go
@@ -25,6 +25,7 @@ func setup() (scheduler *Scheduler, spy *schedulers.MockSourceManager) {
 
 func TestScheduleConfigCreatesNewSource(t *testing.T) {
 	scheduler, spy := setup()
+	defer scheduler.Stop()
 	configSource := integration.Config{
 		LogsConfig:    []byte(`[{"service":"foo","source":"bar"}]`),
 		ADIdentifiers: []string{"docker://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b"},
@@ -50,6 +51,7 @@ func TestScheduleConfigCreatesNewSource(t *testing.T) {
 
 func TestScheduleConfigCreatesNewSourceServiceFallback(t *testing.T) {
 	scheduler, spy := setup()
+	defer scheduler.Stop()
 	configSource := integration.Config{
 		InitConfig:    []byte(`{"service":"foo"}`),
 		LogsConfig:    []byte(`[{"source":"bar"}]`),
@@ -76,6 +78,7 @@ func TestScheduleConfigCreatesNewSourceServiceFallback(t *testing.T) {
 
 func TestScheduleConfigCreatesNewSourceServiceOverride(t *testing.T) {
 	scheduler, spy := setup()
+	defer scheduler.Stop()
 	configSource := integration.Config{
 		InitConfig:    []byte(`{"service":"foo"}`),
 		LogsConfig:    []byte(`[{"source":"bar","service":"baz"}]`),
@@ -102,6 +105,7 @@ func TestScheduleConfigCreatesNewSourceServiceOverride(t *testing.T) {
 
 func TestScheduleConfigCreatesNewService(t *testing.T) {
 	scheduler, spy := setup()
+	defer scheduler.Stop()
 	configService := integration.Config{
 		LogsConfig:   []byte(""),
 		TaggerEntity: "container_id://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b",
@@ -130,6 +134,7 @@ func TestScheduleConfigCreatesNewService(t *testing.T) {
 
 func TestUnscheduleConfigRemovesSource(t *testing.T) {
 	scheduler, spy := setup()
+	defer scheduler.Stop()
 	configSource := integration.Config{
 		LogsConfig:    []byte(`[{"service":"foo","source":"bar"}]`),
 		ADIdentifiers: []string{"docker://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b"},
@@ -159,6 +164,7 @@ func TestUnscheduleConfigRemovesSource(t *testing.T) {
 
 func TestUnscheduleConfigRemovesService(t *testing.T) {
 	scheduler, spy := setup()
+	defer scheduler.Stop()
 	configService := integration.Config{
 		LogsConfig:   []byte(""),
 		TaggerEntity: "container_id://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b",
@@ -186,6 +192,7 @@ func TestUnscheduleConfigRemovesService(t *testing.T) {
 
 func TestIgnoreConfigIfLogsExcluded(t *testing.T) {
 	scheduler, spy := setup()
+	defer scheduler.Stop()
 	configService := integration.Config{
 		LogsConfig:   []byte(""),
 		TaggerEntity: "container_id://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b",


### PR DESCRIPTION
Without this change, on a heavily-loaded system, the ADListener might
not call sch.Register(..) before AD has gotten to the point of
scheduling configs -- leading to logs-agent missing configs.

This patch is temporary for 7.36, and makes some assumptions which are
true in that version:
 * ADListener is only ever instantiated once (for pkg/logs/schedulers/ad)
 * ADListener is instantiated before AD (this is the source of the bug)

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

I added panic() here to verify some assumptions that I'm _pretty sure_ are true in 7.36.  I'd like failures of those assumptions to be very obvious.  This won't be forward-ported to 7.37, so the panic's wont' stick around.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Start up an agent with a file config for logs, and verify that it tails the logfile.

Run `agent check load` and verify it doesn't panic.

Start up an agent in a container environment (k8s or docker) with DD_LOGS_AGENT_CONTAINER_COLLECT_ALL=true and start a container (`docker run -ti --rm bash`) and see that it gets logged (via `agent status`).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
