### PR TITLE
Add `agent status` OTLP section for troubleshooting

### DIFF
--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -484,10 +484,12 @@
   <div class="stat">
     <span class="stat_title">OTLP</span>
     <span class="stat_data">
-      Status: {{ if .otlpStatus }}Enabled{{else}}Not enabled{{end}}
-      <br>Collector status: {{ .otlpCollectorStatus }}
-      {{ if .otlpCollectorStatusErr }}
-        <br><span class="error">Error</span>: <b>{{ .otlpCollectorStatusErr }}</b>
+      {{ with .otlp }}
+        Status: {{ if .otlpStatus }}Enabled{{else}}Not enabled{{end}}
+        <br>Collector status: {{ .otlpCollectorStatus }}
+        {{ if .otlpCollectorStatusErr }}
+          <br><span class="error">Error</span>: <b>{{ .otlpCollectorStatusErr }}</b>
+        {{ end }}
       {{ end }}
     </span>
   </div>

--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -484,7 +484,11 @@
   <div class="stat">
     <span class="stat_title">OTLP</span>
     <span class="stat_data">
-      Status: {{ if not .otlpStatus }}not{{end}} enabled
+      Status: {{ if .otlpStatus }}Enabled{{else}}Not enabled{{end}}
+      <br>Collector status: {{ .otlpCollectorStatus }}
+      {{ if .otlpCollectorStatusErr }}
+        <br><span class="error">Error</span>: <b>{{ .otlpCollectorStatusErr }}</b>
+      {{ end }}
     </span>
   </div>
 {{- end -}}

--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -480,4 +480,11 @@
       {{- end -}}
     </span>
   </div>
+
+  <div class="stat">
+    <span class="stat_title">OTLP</span>
+    <span class="stat_data">
+      Status: {{ if not .otlpStatus }}not{{end}} enabled
+    </span>
+  </div>
 {{- end -}}

--- a/pkg/otlp/collector.go
+++ b/pkg/otlp/collector.go
@@ -106,8 +106,8 @@ type Pipeline struct {
 	col *service.Collector
 }
 
-// OTLPCollectorStatus is the status struct for an OTLP pipeline's collector
-type OTLPCollectorStatus struct {
+// CollectorStatus is the status struct for an OTLP pipeline's collector
+type CollectorStatus struct {
 	Status       string
 	ErrorMessage string
 }
@@ -186,10 +186,10 @@ func BuildAndStart(ctx context.Context, cfg config.Config, s serializer.MetricSe
 }
 
 // GetCollectorStatus get the collector status and error message (if there is one)
-func GetCollectorStatus(p *Pipeline) OTLPCollectorStatus {
+func GetCollectorStatus(p *Pipeline) CollectorStatus {
 	if p != nil {
-		return OTLPCollectorStatus{Status: p.col.GetState().String(), ErrorMessage: ""}
+		return CollectorStatus{Status: p.col.GetState().String(), ErrorMessage: ""}
 	}
 	// If the pipeline is nil then it failed to start so we return the error.
-	return OTLPCollectorStatus{Status: "Failed to start", ErrorMessage: pipelineError.Load().Error()}
+	return CollectorStatus{Status: "Failed to start", ErrorMessage: pipelineError.Load().Error()}
 }

--- a/pkg/otlp/collector.go
+++ b/pkg/otlp/collector.go
@@ -105,6 +105,12 @@ type Pipeline struct {
 	col *service.Collector
 }
 
+// OTLPCollectorStatus is the status struct for an OTLP pipeline's collector
+type OTLPCollectorStatus struct {
+	Status       string
+	ErrorMessage string
+}
+
 // NewPipeline defines a new OTLP pipeline.
 func NewPipeline(cfg PipelineConfig, s serializer.MetricSerializer) (*Pipeline, error) {
 	buildInfo, err := getBuildInfo()
@@ -179,10 +185,10 @@ func BuildAndStart(ctx context.Context, cfg config.Config, s serializer.MetricSe
 }
 
 // GetCollectorStatus get the collector status and error message (if there is one)
-func GetCollectorStatus(p *Pipeline) (string, string) {
+func GetCollectorStatus(p *Pipeline) OTLPCollectorStatus {
 	if p != nil {
-		return p.col.GetState().String(), ""
+		return OTLPCollectorStatus{Status: p.col.GetState().String(), ErrorMessage: ""}
 	}
 	// If the pipeline is nil then it failed to start so we return the error.
-	return "Failed to start", pipelineError.Error()
+	return OTLPCollectorStatus{Status: "Failed to start", ErrorMessage: pipelineError.Error()}
 }

--- a/pkg/otlp/config.go
+++ b/pkg/otlp/config.go
@@ -101,6 +101,11 @@ func IsEnabled(cfg config.Config) bool {
 	return ok
 }
 
+// IsDisplayed checks if the OTLP section should be rendered in the Agent
+func IsDisplayed() bool {
+	return true
+}
+
 // FromAgentConfig builds a pipeline configuration from an Agent configuration.
 func FromAgentConfig(cfg config.Config) (PipelineConfig, error) {
 	// TODO (AP-1267): Check stable config too

--- a/pkg/otlp/config_serverless_noop.go
+++ b/pkg/otlp/config_serverless_noop.go
@@ -16,3 +16,8 @@ import (
 func IsEnabled(cfg config.Config) bool {
 	return false
 }
+
+// IsDisplayed checks if the OTLP section should be rendered in the Agent
+func IsDisplayed() bool {
+	return false
+}

--- a/pkg/otlp/no_otlp.go
+++ b/pkg/otlp/no_otlp.go
@@ -21,6 +21,11 @@ func IsEnabled(cfg config.Config) bool {
 	return false
 }
 
+// IsDisplayed checks if the OTLP section should be rendered in the Agent
+func IsDisplayed() bool {
+	return false
+}
+
 // Pipeline is an OTLP pipeline.
 type Pipeline struct{}
 

--- a/pkg/status/render.go
+++ b/pkg/status/render.go
@@ -94,7 +94,7 @@ func FormatStatus(data []byte) (string, error) {
 	}
 
 	otlpFunc := func() {
-		if otlp.IsEnabled(config.Datadog) {
+		if otlp.IsDisplayed() {
 			renderStatusTemplate(b, "/otlp.tmpl", stats)
 		}
 	}

--- a/pkg/status/render.go
+++ b/pkg/status/render.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/otlp"
 	"github.com/DataDog/datadog-agent/pkg/snmp/traps"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -92,6 +93,12 @@ func FormatStatus(data []byte) (string, error) {
 		}
 	}
 
+	otlpFunc := func() {
+		if otlp.IsEnabled(config.Datadog) {
+			renderStatusTemplate(b, "/otlp.tmpl", stats)
+		}
+	}
+
 	var renderFuncs []func()
 
 	if config.IsCLCRunner() {
@@ -100,7 +107,7 @@ func FormatStatus(data []byte) (string, error) {
 	} else {
 		renderFuncs = []func(){headerFunc, checkStatsFunc, jmxFetchFunc, forwarderFunc, endpointsFunc,
 			logsAgentFunc, systemProbeFunc, processAgentFunc, traceAgentFunc, aggregatorFunc, dogstatsdFunc,
-			clusterAgentFunc, snmpTrapFunc, autodiscoveryFunc}
+			clusterAgentFunc, snmpTrapFunc, autodiscoveryFunc, otlpFunc}
 	}
 
 	renderAgentSections(renderFuncs)

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -25,6 +25,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/logs"
 	"github.com/DataDog/datadog-agent/pkg/metadata/host"
+	"github.com/DataDog/datadog-agent/pkg/otlp"
 	"github.com/DataDog/datadog-agent/pkg/snmp/traps"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
@@ -60,6 +61,8 @@ func GetStatus() (map[string]interface{}, error) {
 	stats["JMXStartupError"] = GetJMXStartupError()
 
 	stats["logsStats"] = logs.GetStatus()
+
+	stats["otlpStatus"] = otlp.IsEnabled(config.Datadog)
 
 	endpointsInfos, err := getEndpointsInfos()
 	if endpointsInfos != nil && err == nil {

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -67,7 +67,7 @@ func GetStatus() (map[string]interface{}, error) {
 	if otlpIsEnabled {
 		otlpCollectorStatus = otlp.GetCollectorStatus(common.OTLP)
 	} else {
-		otlpCollectorStatus = otlp.OTLPCollectorStatus{"Not running", ""}
+		otlpCollectorStatus = otlp.OTLPCollectorStatus{Status: "Not running", ErrorMessage: ""}
 	}
 
 	stats["otlpStatus"] = otlpIsEnabled

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -63,16 +63,16 @@ func GetStatus() (map[string]interface{}, error) {
 	stats["logsStats"] = logs.GetStatus()
 
 	otlpIsEnabled := otlp.IsEnabled(config.Datadog)
-	var otlpCollectorStatus, otlpCollectorStatusErr string
+	var otlpCollectorStatus otlp.OTLPCollectorStatus
 	if otlpIsEnabled {
-		otlpCollectorStatus, otlpCollectorStatusErr = otlp.GetCollectorStatus(common.OTLP)
+		otlpCollectorStatus = otlp.GetCollectorStatus(common.OTLP)
 	} else {
-		otlpCollectorStatus, otlpCollectorStatusErr = "Not running", ""
+		otlpCollectorStatus = otlp.OTLPCollectorStatus{"Not running", ""}
 	}
 
 	stats["otlpStatus"] = otlpIsEnabled
-	stats["otlpCollectorStatus"] = otlpCollectorStatus
-	stats["otlpCollectorStatusErr"] = otlpCollectorStatusErr
+	stats["otlpCollectorStatus"] = otlpCollectorStatus.Status
+	stats["otlpCollectorStatusErr"] = otlpCollectorStatus.ErrorMessage
 
 	endpointsInfos, err := getEndpointsInfos()
 	if endpointsInfos != nil && err == nil {

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -67,7 +67,7 @@ func GetStatus() (map[string]interface{}, error) {
 	if otlpIsEnabled {
 		otlpCollectorStatus, otlpCollectorStatusErr = otlp.GetCollectorStatus(common.OTLP)
 	} else {
-		otlpCollectorStatus, otlpCollectorStatusErr = "N/A", ""
+		otlpCollectorStatus, otlpCollectorStatusErr = "Not running", ""
 	}
 
 	stats["otlpStatus"] = otlpIsEnabled

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -25,7 +25,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/logs"
 	"github.com/DataDog/datadog-agent/pkg/metadata/host"
-	"github.com/DataDog/datadog-agent/pkg/otlp"
 	"github.com/DataDog/datadog-agent/pkg/snmp/traps"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
@@ -62,17 +61,7 @@ func GetStatus() (map[string]interface{}, error) {
 
 	stats["logsStats"] = logs.GetStatus()
 
-	otlpIsEnabled := otlp.IsEnabled(config.Datadog)
-	var otlpCollectorStatus otlp.CollectorStatus
-	if otlpIsEnabled {
-		otlpCollectorStatus = otlp.GetCollectorStatus(common.OTLP)
-	} else {
-		otlpCollectorStatus = otlp.CollectorStatus{Status: "Not running", ErrorMessage: ""}
-	}
-
-	stats["otlpStatus"] = otlpIsEnabled
-	stats["otlpCollectorStatus"] = otlpCollectorStatus.Status
-	stats["otlpCollectorStatusErr"] = otlpCollectorStatus.ErrorMessage
+	stats["otlp"] = GetOTLPStatus()
 
 	endpointsInfos, err := getEndpointsInfos()
 	if endpointsInfos != nil && err == nil {

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -63,11 +63,11 @@ func GetStatus() (map[string]interface{}, error) {
 	stats["logsStats"] = logs.GetStatus()
 
 	otlpIsEnabled := otlp.IsEnabled(config.Datadog)
-	var otlpCollectorStatus otlp.OTLPCollectorStatus
+	var otlpCollectorStatus otlp.CollectorStatus
 	if otlpIsEnabled {
 		otlpCollectorStatus = otlp.GetCollectorStatus(common.OTLP)
 	} else {
-		otlpCollectorStatus = otlp.OTLPCollectorStatus{Status: "Not running", ErrorMessage: ""}
+		otlpCollectorStatus = otlp.CollectorStatus{Status: "Not running", ErrorMessage: ""}
 	}
 
 	stats["otlpStatus"] = otlpIsEnabled

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -62,7 +62,17 @@ func GetStatus() (map[string]interface{}, error) {
 
 	stats["logsStats"] = logs.GetStatus()
 
-	stats["otlpStatus"] = otlp.IsEnabled(config.Datadog)
+	otlpIsEnabled := otlp.IsEnabled(config.Datadog)
+	var otlpCollectorStatus, otlpCollectorStatusErr string
+	if otlpIsEnabled {
+		otlpCollectorStatus, otlpCollectorStatusErr = otlp.GetCollectorStatus(common.OTLP)
+	} else {
+		otlpCollectorStatus, otlpCollectorStatusErr = "N/A", ""
+	}
+
+	stats["otlpStatus"] = otlpIsEnabled
+	stats["otlpCollectorStatus"] = otlpCollectorStatus
+	stats["otlpCollectorStatusErr"] = otlpCollectorStatusErr
 
 	endpointsInfos, err := getEndpointsInfos()
 	if endpointsInfos != nil && err == nil {

--- a/pkg/status/status_no_otlp.go
+++ b/pkg/status/status_no_otlp.go
@@ -1,0 +1,15 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !otlp
+// +build !otlp
+
+package status
+
+// GetOTLPStatus parses the otlp pipeline and its collector info to be sent to the frontend
+func GetOTLPStatus() map[string]interface{} {
+	status := make(map[string]interface{})
+	return status
+}

--- a/pkg/status/status_otlp.go
+++ b/pkg/status/status_otlp.go
@@ -1,0 +1,32 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build otlp
+// +build otlp
+
+package status
+
+import (
+	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/otlp"
+)
+
+// GetOTLPStatus parses the otlp pipeline and its collector info to be sent to the frontend
+func GetOTLPStatus() map[string]interface{} {
+	status := make(map[string]interface{})
+	otlpIsEnabled := otlp.IsEnabled(config.Datadog)
+	var otlpCollectorStatus otlp.CollectorStatus
+	if otlpIsEnabled {
+		otlpCollectorStatus = otlp.GetCollectorStatus(common.OTLP)
+	} else {
+		otlpCollectorStatus = otlp.CollectorStatus{Status: "Not running", ErrorMessage: ""}
+	}
+
+	status["otlpStatus"] = otlpIsEnabled
+	status["otlpCollectorStatus"] = otlpCollectorStatus.Status
+	status["otlpCollectorStatusErr"] = otlpCollectorStatus.ErrorMessage
+	return status
+}

--- a/pkg/status/templates/otlp.tmpl
+++ b/pkg/status/templates/otlp.tmpl
@@ -5,6 +5,8 @@ NOTE: Changes made to this template should be reflected on the following templat
 ====
 OTLP
 ====
+  {{ with .otlp }}
   Status: {{ if .otlpStatus }}Enabled{{else}}Not enabled{{ end }}
   Collector status: {{ .otlpCollectorStatus }}
   {{ if .otlpCollectorStatusErr }}Error: {{ .otlpCollectorStatusErr }}{{ end }}
+  {{ end }}

--- a/pkg/status/templates/otlp.tmpl
+++ b/pkg/status/templates/otlp.tmpl
@@ -1,0 +1,10 @@
+{{/*
+NOTE: Changes made to this template should be reflected on the following templates, if applicable:
+* cmd/agent/gui/views/templates/generalStatus.tmpl
+*/}}
+====
+OTLP
+====
+  Status: {{ if .otlpStatus }}Enabled{{else}}Not enabled{{ end }}
+  Collector status: {{ .otlpCollectorStatus }}
+  {{ if .otlpCollectorStatusErr }}Error: {{ .otlpCollectorStatusErr }}{{ end }}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR adds an OpenTelemetry Protocol (OTLP) section to the `agent status` command and web UI.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

The goal is to be able to easily debug OTLP related issues.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

To save any build/run error I created a package-level variable named `pipelineError`. On the long run it would be better to have this variable attached to some class to have a cleaner/safer code (as stated [here](https://github.com/DataDog/architecture/pull/990)). But for now it would have been too much of a code refactor for such a small feature.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

**EDIT: This PR should be QA-ed with #11948 since it's the followup of this PR**

To enable OTLP in your agent, you have to enable it in your config file. You can create an `config.yaml` file just like that:

```
api_key: your_api_key

otlp_config:
  receiver:
    protocols:
      grpc:

site: datadoghq.com
```

Then run your agent with `./bin/agent/agent run -c config.yaml` and open the gui with `./bin/agent/agent launch-gui -c config.yaml` or print in cli with `./bin/agent/agent status -c config.yaml`.

You should be able to see an `OTLP` section at the end of main page. Now, to test that it's working well, 3 cases are possible:


#### OTLP is enabled and running:

After enabling OTLP as explained above, you should see in the OTLP section:

```
Status: Enabled
Collector state: Running
```

#### OTLP is enabled but failed to start.

You can try to manually create a start/build error by importing the `errors` package and adding the following line to the `BuildAndStart` function in the `pkg/otlp/collector.go` file:

`err = errors.New("testing things are working well")`

You should now see in the OTLP section:

```
Status: Enabled
Collector state: Failed to start
Error: error_message: testing things are working well
```

#### OTLP is disabled:

Just comment the oltp lines in the config file an rerun the agent:
```
#otlp_config:
#  receiver:
#    protocols:
#      grpc:
```

You should see in the OTLP section:

```
Status: Not enabled
Collector state: N/A
```

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
