### PR TITLE
[unrevert] Fix HTTP monitoring for Kernel 4.4 (#10133)

### DIFF
--- a/.gitlab/functional_test/system_probe.yml
+++ b/.gitlab/functional_test/system_probe.yml
@@ -35,7 +35,7 @@ kitchen_test_system_probe_linux_x64:
   parallel:
     matrix:
       - KITCHEN_PLATFORM: "ubuntu"
-        KITCHEN_OSVERS: "ubuntu-16-04,ubuntu-18-04,ubuntu-20-04,ubuntu-21-10"
+        KITCHEN_OSVERS: "ubuntu-16-04-4.4,ubuntu-18-04,ubuntu-20-04,ubuntu-21-10"
       - KITCHEN_PLATFORM: "debian"
         KITCHEN_OSVERS: "debian-10"
       - KITCHEN_PLATFORM: "centos"

--- a/pkg/ebpf/bytecode/runtime/http.go
+++ b/pkg/ebpf/bytecode/runtime/http.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Http = NewRuntimeAsset("http.c", "0f41f48727e31c65d14b54b5ac1d0d39fa8e5a74a6cfcfb8f1963a00df164825")
+var Http = NewRuntimeAsset("http.c", "904a119f926c269a2a635af8529809159de21626d3433417292ca33d3c028cc7")

--- a/pkg/network/ebpf/c/http-buffer.h
+++ b/pkg/network/ebpf/c/http-buffer.h
@@ -1,0 +1,28 @@
+#ifndef __HTTP_BUFFER_H
+#define __HTTP_BUFFER_H
+
+#include "http-types.h"
+
+// read_into_buffer copies data from an arbitrary memory address into a (statically sized) HTTP buffer.
+// Ideally we would only copy min(data_size, HTTP_BUFFER_SIZE) bytes, but the code below is the only way
+// we found to handle data sizes smaller than HTTP_BUFFER_SIZE in Kernel 4.4.
+// In a nutshell, we read HTTP_BUFFER_SIZE bytes no matter what and then get rid of garbage data.
+// Please note that even though the memset could be removed with no semantic change to the code,
+// it is still necessary to make the eBPF verifier happy.
+static __always_inline void read_into_buffer(char *buffer, char *data, size_t data_size) {
+    __builtin_memset(buffer, 0, HTTP_BUFFER_SIZE);
+    bpf_probe_read(buffer, HTTP_BUFFER_SIZE, data);
+    if (data_size >= HTTP_BUFFER_SIZE) {
+        return;
+    }
+
+    // clean up garbage
+#pragma unroll
+    for (int i = 0; i < HTTP_BUFFER_SIZE; i++) {
+        if (i >= data_size) {
+            buffer[i] = 0;
+        }
+    }
+}
+
+#endif

--- a/pkg/network/ebpf/c/http.h
+++ b/pkg/network/ebpf/c/http.h
@@ -125,9 +125,6 @@ static __always_inline int http_begin_response(http_transaction_t *http, const c
     __u8 space_found = 0;
 #pragma unroll
     for (int i = 0; i < HTTP_BUFFER_SIZE - 1; i++) {
-	    // buffer might contain a null terminator in the middle
-        if (buffer[i] == 0) break;
-
         if (!space_found && buffer[i] == ' ') {
             space_found = 1;
         } else if (space_found && status_code < 100) {

--- a/pkg/network/ebpf/c/prebuilt/http.c
+++ b/pkg/network/ebpf/c/prebuilt/http.c
@@ -4,6 +4,7 @@
 #include "ip.h"
 #include "ipv6.h"
 #include "http.h"
+#include "http-buffer.h"
 #include "sock.h"
 #include "sockfd.h"
 
@@ -198,10 +199,7 @@ int uretprobe__SSL_read(struct pt_regs* ctx) {
 
     u32 len = (u32)PT_REGS_RC(ctx);
     char buffer[HTTP_BUFFER_SIZE];
-    __builtin_memset(buffer, 0, sizeof(buffer));
-    if (len >= HTTP_BUFFER_SIZE) {
-        bpf_probe_read(buffer, sizeof(buffer), args->buf);
-    }
+    read_into_buffer(buffer, args->buf, len);
 
     skb_info_t skb_info = {0};
     __builtin_memcpy(&skb_info.tup, t, sizeof(conn_tuple_t));
@@ -223,10 +221,7 @@ int uprobe__SSL_write(struct pt_regs* ctx) {
     void *ssl_buffer = (void *)PT_REGS_PARM2(ctx);
     size_t len = (size_t)PT_REGS_PARM3(ctx);
     char buffer[HTTP_BUFFER_SIZE];
-    __builtin_memset(buffer, 0, sizeof(buffer));
-    if (len >= HTTP_BUFFER_SIZE) {
-        bpf_probe_read(buffer, sizeof(buffer), ssl_buffer);
-    }
+    read_into_buffer(buffer, ssl_buffer, len);
 
     skb_info_t skb_info = {0};
     __builtin_memcpy(&skb_info.tup, t, sizeof(conn_tuple_t));
@@ -333,12 +328,7 @@ int uretprobe__gnutls_record_recv(struct pt_regs* ctx) {
     }
 
     char buffer[HTTP_BUFFER_SIZE];
-    __builtin_memset(buffer, 0, sizeof(buffer));
-    if (read_len < sizeof(buffer)) {
-        bpf_probe_read(buffer, read_len, args->buf);
-    } else {
-        bpf_probe_read(buffer, sizeof(buffer), args->buf);
-    }
+    read_into_buffer(buffer, args->buf, read_len);
 
     skb_info_t skb_info = {0};
     __builtin_memcpy(&skb_info.tup, t, sizeof(conn_tuple_t));
@@ -362,12 +352,7 @@ int uprobe__gnutls_record_send(struct pt_regs* ctx) {
     }
 
     char buffer[HTTP_BUFFER_SIZE];
-    __builtin_memset(buffer, 0, sizeof(buffer));
-    if (data_size < sizeof(buffer)) {
-        bpf_probe_read(buffer, data_size, data);
-    } else {
-        bpf_probe_read(buffer, sizeof(buffer), data);
-    }
+    read_into_buffer(buffer, data, data_size);
 
     skb_info_t skb_info = {0};
     __builtin_memcpy(&skb_info.tup, t, sizeof(conn_tuple_t));

--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -56,6 +56,7 @@
         "azure": {
             "x86_64": {
                 "ubuntu-14-04": "urn,Canonical:UbuntuServer:14.04.5-LTS:14.04.201905140",
+                "ubuntu-16-04-4.4": "urn,Canonical:UbuntuServer:16.04.0-LTS:16.04.201608150",
                 "ubuntu-16-04": "urn,Canonical:UbuntuServer:16.04.0-LTS:16.04.202106110",
                 "ubuntu-18-04-0": "urn,Canonical:UbuntuServer:18.04-LTS:18.04.201809110",
                 "ubuntu-18-04": "urn,Canonical:UbuntuServer:18.04-LTS:18.04.201906040",


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Unrevert #10133

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

no perfomance overhead is expected (change represented by red line)

![system-probe avg k8s CPU Usage by namespace (autosmoothed)](https://user-images.githubusercontent.com/692520/165842627-e28d0bc9-1437-4feb-a85b-5860fc6d8e4b.png)

![system-probe RSS (avg over everything) (1)](https://user-images.githubusercontent.com/692520/165842694-d7289824-6064-44a2-b199-ca628118226b.png)


<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Change covered by unit tests

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
