### PR TITLE
Add `kubernetes_node_annotations_as_tags` option to use node annotations as host tags

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -573,6 +573,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("kubernetes_pod_labels_as_tags", map[string]string{})
 	config.BindEnvAndSetDefault("kubernetes_pod_annotations_as_tags", map[string]string{})
 	config.BindEnvAndSetDefault("kubernetes_node_labels_as_tags", map[string]string{})
+	config.BindEnvAndSetDefault("kubernetes_node_annotations_as_tags", map[string]string{"cluster.k8s.io/machine": "kube_machine"})
 	config.BindEnvAndSetDefault("kubernetes_node_annotations_as_host_aliases", []string{"cluster.k8s.io/machine"})
 	config.BindEnvAndSetDefault("kubernetes_namespace_labels_as_tags", map[string]string{})
 	config.BindEnvAndSetDefault("container_cgroup_prefix", "")

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2852,6 +2852,15 @@ api_key:
 #
 # DD_KUBERNETES_NODE_LABELS_AS_TAGS='{"NODE_LABEL": "TAG_KEY"}'
 
+## @param kubernetes_node_annotations_as_tags - map - optional
+## @env DD_KUBERNETES_NODE_ANNOTATIONS_AS_TAGS - json - optional
+## Configure node annotationss that should be collected and their name as host tags.
+#
+# kubernetes_node_annotations_as_tags:
+#   cluster.k8s.io/machine: machine
+#
+# DD_KUBERNETES_NODE_ANNOTATIONS_AS_TAGS='{"NODE_ANNOTATION": "TAG_KEY"}'
+
 ## @param kubernetes_node_annotations_as_host_aliases - list - optional
 ## @env DD_KUBERNETES_NODE_ANNOTATIONS_AS_HOST_ALIASES - list - optional
 ## Configure node annotations that should be collected and used as host aliases.

--- a/pkg/util/kubernetes/hostinfo/tags.go
+++ b/pkg/util/kubernetes/hostinfo/tags.go
@@ -18,19 +18,30 @@ import (
 )
 
 // GetTags gets the tags from the kubernetes apiserver
-func GetTags(ctx context.Context) ([]string, error) {
+func GetTags(ctx context.Context) (tags []string, err error) {
 	labelsToTags := getLabelsToTags()
-	if len(labelsToTags) == 0 {
-		// Nothing to extract
-		return nil, nil
+
+	if len(labelsToTags) > 0 {
+		nodeLabels, e := GetNodeLabels(ctx)
+		if e != nil {
+			err = e
+		} else {
+			tags = append(tags, extractTags(nodeLabels, labelsToTags)...)
+		}
 	}
 
-	nodeLabels, err := GetNodeLabels(ctx)
-	if err != nil {
-		return nil, err
+	annotationsToTags := getAnnotationsToTags()
+
+	if len(annotationsToTags) > 0 {
+		nodeAnnotations, e := GetNodeAnnotations(ctx)
+		if e != nil {
+			err = e
+		} else {
+			tags = append(tags, extractTags(nodeAnnotations, annotationsToTags)...)
+		}
 	}
 
-	return extractTags(nodeLabels, labelsToTags), nil
+	return
 }
 
 func getDefaultLabelsToTags() map[string]string {
@@ -47,6 +58,16 @@ func getLabelsToTags() map[string]string {
 	}
 
 	return labelsToTags
+}
+
+func getAnnotationsToTags() map[string]string {
+	annotationsToTags := map[string]string{}
+	for k, v := range config.Datadog.GetStringMapString("kubernetes_node_annotations_as_tags") {
+		// viper lower-cases map keys from yaml, but not from envvars
+		annotationsToTags[strings.ToLower(k)] = v
+	}
+
+	return annotationsToTags
 }
 
 func extractTags(nodeLabels, labelsToTags map[string]string) []string {

--- a/releasenotes/notes/kubernetes_node_annotations_as_tags-f17e597f1f881183.yaml
+++ b/releasenotes/notes/kubernetes_node_annotations_as_tags-f17e597f1f881183.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add a ``kubernetes_node_annotations_as_tags`` parameter to use Kubernetes node annotations as host tags.


### PR DESCRIPTION
### What does this PR do?

Introduce a new agent configuration parameter `kubernetes_node_annotations_as_tags` that contains a mapping between
* key of node annotation and
* tag prefix
to use for host tags.

### Motivation

The `kubernetes_node_annotations_as_host_alias` parameter already allow to use (for ex.) the `cluster.k8s.io/machine` node annotation as a host alias.
This host alias properly allows the merge of data coming from the agent and from some cloud provider.
However, the `host:` tag attached to metrics and logs allows filtering only on the “main” host name and not on its aliases.
Putting this information in a dedicated tag will allow proper filtering.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Add a `cluster.k8s.io/machine` annotation on a node (or use a Kubernetes distribution that already leverages this annotation) and check that its value is properly used as a host tag.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
