### PR TITLE
pkg/trace/agent: all trace chunks go through the rare sampler

### DIFF
--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -450,6 +450,7 @@ func (a *Agent) samplePriorityTrace(now time.Time, pt traceutil.ProcessedTrace) 
 	if a.conf.DisableRareSampler {
 		rare = false
 	} else {
+		// run this early to make sure the signature gets counted by the RareSampler.
 		rare = a.RareSampler.Sample(now, pt.TraceChunk, pt.TracerEnv)
 	}
 	if a.PrioritySampler.Sample(now, pt.TraceChunk, pt.Root, pt.TracerEnv, pt.ClientDroppedP0sWeight) {

--- a/pkg/trace/agent/releasenotes/notes/apm-fix-rare-sampler-0b53b0e5705d3ad0.yaml
+++ b/pkg/trace/agent/releasenotes/notes/apm-fix-rare-sampler-0b53b0e5705d3ad0.yaml
@@ -1,7 +1,0 @@
----
-fixes:
-  - |
-    The rare samplers now processes every span and no longer operates on only
-    unsampled spans, which was causing some spans to be sampled unnecessarily.
-
-

--- a/pkg/trace/agent/releasenotes/notes/apm-fix-rare-sampler-0b53b0e5705d3ad0.yaml
+++ b/pkg/trace/agent/releasenotes/notes/apm-fix-rare-sampler-0b53b0e5705d3ad0.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    The rare samplers now processes every span and no longer operates on only
+    unsampled spans, which was causing some spans to be sampled unnecessarily.
+
+

--- a/releasenotes/notes/apm-fix-rare-sampler-0b53b0e5705d3ad0.yaml
+++ b/releasenotes/notes/apm-fix-rare-sampler-0b53b0e5705d3ad0.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    APM: The agent is now performing rare span detection on all spans,
+    as opposed to only dropped spans. This change will slightly reduce
+    the amount of rare spans kept unnecessarily.

--- a/releasenotes/notes/apm-fix-rare-sampler-0b53b0e5705d3ad0.yaml
+++ b/releasenotes/notes/apm-fix-rare-sampler-0b53b0e5705d3ad0.yaml
@@ -1,6 +1,6 @@
 ---
 fixes:
   - |
-    APM: The agent is now performing rare span detection on all spans,
+    APM: The Agent is now performing rare span detection on all spans,
     as opposed to only dropped spans. This change will slightly reduce
-    the amount of rare spans kept unnecessarily.
+    the number of rare spans kept unnecessarily.


### PR DESCRIPTION
Prior to this change, the rare sampler was only seeing the chunks
being dropped and wasn't aware of the chunks already seen by the
priority sampler. This was causing more chunks to be kept unnecessarily.

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
