### PR TITLE
use go.uber.com/atomic in pkg/aggregator

### DIFF
--- a/pkg/aggregator/aggregator_test.go
+++ b/pkg/aggregator/aggregator_test.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"sort"
 
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -260,7 +259,7 @@ func TestDefaultData(t *testing.T) {
 	s.AssertNotCalled(t, "SendSketch")
 
 	// not counted as huge for (just checking the first threshold..)
-	assert.Equal(t, uint64(0), atomic.LoadUint64(&tagsetTlm.hugeSeriesCount[0]))
+	assert.Equal(t, uint64(0), tagsetTlm.hugeSeriesCount[0].Load())
 }
 
 func TestSeriesTooManyTags(t *testing.T) {
@@ -309,7 +308,7 @@ func TestSeriesTooManyTags(t *testing.T) {
 
 			expMap := map[string]uint64{}
 			for i, thresh := range tagsetTlm.sizeThresholds {
-				assert.Equal(t, expHugeCounts[i], atomic.LoadUint64(&tagsetTlm.hugeSeriesCount[i]))
+				assert.Equal(t, expHugeCounts[i], tagsetTlm.hugeSeriesCount[i].Load())
 				expMap[fmt.Sprintf("Above%d", thresh)] = expHugeCounts[i]
 			}
 			gotMap := aggregatorExpvars.Get("MetricTags").(expvar.Func).Value().(map[string]map[string]uint64)["Series"]
@@ -374,7 +373,7 @@ func TestDistributionsTooManyTags(t *testing.T) {
 
 			expMap := map[string]uint64{}
 			for i, thresh := range tagsetTlm.sizeThresholds {
-				assert.Equal(t, expHugeCounts[i], atomic.LoadUint64(&tagsetTlm.hugeSketchesCount[i]))
+				assert.Equal(t, expHugeCounts[i], tagsetTlm.hugeSketchesCount[i].Load())
 				expMap[fmt.Sprintf("Above%d", thresh)] = expHugeCounts[i]
 			}
 			gotMap := aggregatorExpvars.Get("MetricTags").(expvar.Func).Value().(map[string]map[string]uint64)["Sketches"]

--- a/pkg/aggregator/internal/tags/store.go
+++ b/pkg/aggregator/internal/tags/store.go
@@ -8,16 +8,24 @@ package tags
 import (
 	"fmt"
 	"math/bits"
-	"sync/atomic"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
 	"github.com/DataDog/datadog-agent/pkg/tagset"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
+	"go.uber.org/atomic"
 )
 
 // Entry is used to keep track of tag slices shared by the contexts.
 type Entry struct {
-	refs uint64
+	// refs is the refcount of this entity.  If this value is zero, then the
+	// entity may be reclaimed in Shrink().
+	//
+	// This value must be first in the struct to ensure proper alignment.  It
+	// is not used as a pointer to avoid doubling the number of allocations
+	// required per Entry.
+	refs atomic.Uint64
+
+	// tags contains the cached tags in this entry.
 	tags []string
 }
 
@@ -34,8 +42,7 @@ func (e *Entry) Tags() []string {
 //
 // Can be called concurrently with other store operations.
 func (e *Entry) Release() {
-	const minusOne = ^uint64(0)
-	atomic.AddUint64(&e.refs, minusOne)
+	e.refs.Dec()
 }
 
 // Store is a reference counted container of tags slices, to be shared
@@ -71,20 +78,19 @@ func (tc *Store) Insert(key ckey.TagsKey, tagsBuffer *tagset.HashingTagsAccumula
 	if !tc.enabled {
 		return &Entry{
 			tags: tagsBuffer.Copy(),
-			refs: 1,
 		}
 	}
 
 	entry := tc.tagsByKey[key]
 	if entry != nil {
 		// Can happen concurrently with Release().
-		atomic.AddUint64(&entry.refs, 1)
+		entry.refs.Inc()
 		tc.telemetry.hits.Inc()
 	} else {
 		entry = &Entry{
 			tags: tagsBuffer.Copy(),
-			refs: 1,
 		}
+		entry.refs.Inc()
 		tc.tagsByKey[key] = entry
 		tc.cap++
 		tc.telemetry.miss.Inc()
@@ -100,7 +106,7 @@ func (tc *Store) Insert(key ckey.TagsKey, tagsBuffer *tagset.HashingTagsAccumula
 func (tc *Store) Shrink() {
 	stats := entryStats{}
 	for key, entry := range tc.tagsByKey {
-		if refs := atomic.LoadUint64(&entry.refs); refs > 0 {
+		if refs := entry.refs.Load(); refs > 0 {
 			stats.visit(entry, refs)
 		} else {
 			delete(tc.tagsByKey, key)

--- a/pkg/aggregator/tagset_telem.go
+++ b/pkg/aggregator/tagset_telem.go
@@ -7,10 +7,10 @@ package aggregator
 
 import (
 	"fmt"
-	"sync/atomic"
 
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
+	"go.uber.org/atomic"
 )
 
 // The tagsetTelemetry struct handles telemetry for "large" tagsets.  For
@@ -23,16 +23,16 @@ type tagsetTelemetry struct {
 	sizeThresholds []uint64
 
 	// hugeSeriesCounts contains the total count of huge metric series, by
-	// threshold. Access must be atomic.
-	hugeSeriesCount []uint64
+	// threshold.
+	hugeSeriesCount []*atomic.Uint64
 
 	// tlmHugeSeries is an array containing counters with the same values as
 	// hugeSeriesCount.
 	tlmHugeSeries []telemetry.Counter
 
 	// hugeSketchesCount contains the total count of huge distributions, by
-	// threshold. Access must be atomic.
-	hugeSketchesCount []uint64
+	// threshold.
+	hugeSketchesCount []*atomic.Uint64
 
 	// tlmHugeSketches is an array containing counters with the same values as
 	// hugeSketchesCount.
@@ -44,14 +44,16 @@ func newTagsetTelemetry(thresholds []uint64) *tagsetTelemetry {
 	t := &tagsetTelemetry{
 		size:              size,
 		sizeThresholds:    thresholds,
-		hugeSeriesCount:   make([]uint64, size, size),
+		hugeSeriesCount:   make([]*atomic.Uint64, size, size),
 		tlmHugeSeries:     make([]telemetry.Counter, size, size),
-		hugeSketchesCount: make([]uint64, size, size),
+		hugeSketchesCount: make([]*atomic.Uint64, size, size),
 		tlmHugeSketches:   make([]telemetry.Counter, size, size),
 	}
 
 	for i, thresh := range t.sizeThresholds {
+		t.hugeSeriesCount[i] = atomic.NewUint64(0)
 		t.tlmHugeSeries[i] = telemetry.NewCounter("aggregator", fmt.Sprintf("series_tags_above_%d", thresh), nil, fmt.Sprintf("Count of timeseries with over %d tags", thresh))
+		t.hugeSketchesCount[i] = atomic.NewUint64(0)
 		t.tlmHugeSketches[i] = telemetry.NewCounter("aggregator", fmt.Sprintf("distributions_tags_above_%d", thresh), nil, fmt.Sprintf("Count of distributions with over %d tags", thresh))
 	}
 
@@ -59,7 +61,7 @@ func newTagsetTelemetry(thresholds []uint64) *tagsetTelemetry {
 }
 
 // updateTelemetry implements common behavior fof the update*Telemetry methods.
-func (t *tagsetTelemetry) updateTelemetry(tagsetSizes []uint64, atomicCounts []uint64, tlms []telemetry.Counter) {
+func (t *tagsetTelemetry) updateTelemetry(tagsetSizes []uint64, atomicCounts []*atomic.Uint64, tlms []telemetry.Counter) {
 	counts := make([]uint64, t.size)
 	var found bool
 
@@ -75,7 +77,7 @@ func (t *tagsetTelemetry) updateTelemetry(tagsetSizes []uint64, atomicCounts []u
 	if found {
 		for i, count := range counts {
 			if count > 0 {
-				atomic.AddUint64(&atomicCounts[i], count)
+				atomicCounts[i].Add(count)
 				tlms[i].Add(float64(count))
 			}
 		}
@@ -97,7 +99,7 @@ func (t *tagsetTelemetry) updateHugeSerieTelemetry(serie *metrics.Serie) {
 	tagsetSize := uint64(serie.Tags.Len())
 	for i, thresh := range t.sizeThresholds {
 		if tagsetSize > thresh {
-			atomic.AddUint64(&t.hugeSeriesCount[i], 1)
+			t.hugeSeriesCount[i].Add(1)
 			t.tlmHugeSeries[i].Add(1)
 		}
 	}
@@ -110,8 +112,8 @@ func (t *tagsetTelemetry) exp() interface{} {
 	}
 
 	for i, thresh := range t.sizeThresholds {
-		serieCount := atomic.LoadUint64(&t.hugeSeriesCount[i])
-		distributionCount := atomic.LoadUint64(&t.hugeSketchesCount[i])
+		serieCount := t.hugeSeriesCount[i].Load()
+		distributionCount := t.hugeSketchesCount[i].Load()
 		rv["Series"][fmt.Sprintf("Above%d", thresh)] = serieCount
 		rv["Sketches"][fmt.Sprintf("Above%d", thresh)] = distributionCount
 	}

--- a/pkg/aggregator/tagset_telem.go
+++ b/pkg/aggregator/tagset_telem.go
@@ -99,7 +99,7 @@ func (t *tagsetTelemetry) updateHugeSerieTelemetry(serie *metrics.Serie) {
 	tagsetSize := uint64(serie.Tags.Len())
 	for i, thresh := range t.sizeThresholds {
 		if tagsetSize > thresh {
-			t.hugeSeriesCount[i].Add(1)
+			t.hugeSeriesCount[i].Inc()
 			t.tlmHugeSeries[i].Add(1)
 		}
 	}

--- a/pkg/aggregator/tagset_telem_test.go
+++ b/pkg/aggregator/tagset_telem_test.go
@@ -8,12 +8,10 @@
 
 package aggregator
 
-import "sync/atomic"
-
 // (only used in tests) reset the tagset telemetry to zeroes
 func (t *tagsetTelemetry) reset() {
 	for i := range t.sizeThresholds {
-		atomic.StoreUint64(&t.hugeSeriesCount[i], uint64(0))
-		atomic.StoreUint64(&t.hugeSketchesCount[i], uint64(0))
+		t.hugeSeriesCount[i].Store(0)
+		t.hugeSketchesCount[i].Store(0)
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Uses go.uber.com/atomic to ensure alignment of atomic access in pkg/aggregator

One of these uses -- as refcounts for cache entries -- is perf-sensitive, so please pay special attention.  See the commit message for some detail.

### Motivation

Alignment issues with atomic access. See https://github.com/DataDog/datadog-agent/pull/11716

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Any metrics-related QA should exercise this code.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
