### PR TITLE
use go.uber.org/atomic for refcounts in IterableSeries

### DIFF
--- a/pkg/metrics/iterable_series.go
+++ b/pkg/metrics/iterable_series.go
@@ -7,16 +7,21 @@ package metrics
 
 import (
 	"context"
-	"sync/atomic"
 
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"go.uber.org/atomic"
 )
 
-// IterableSeries represents an iterable collection of Serie.
-// Serie can be appended to IterableSeries while IterableSeries is serialized
+// IterableSeries represents an iterable collection of Serie.  Serie can be
+// appended to IterableSeries while IterableSeries is serialized.
+//
+// An IterableSeries interfaces two goroutines, referred to below as "sender"
+// and "receiver".  The sender calls Append any number of times followed by
+// SenderStopped.  The receiver calls MoveNext and Current to iterate through
+// the items, and IterationStopped when it is finished.
 type IterableSeries struct {
-	count              uint64
+	count              *atomic.Uint64
 	ch                 *util.BufferedChan
 	bufferedChanClosed bool
 	cancel             context.CancelFunc
@@ -25,10 +30,12 @@ type IterableSeries struct {
 }
 
 // NewIterableSeries creates a new instance of *IterableSeries
-// `callback` is called each time `Append` is called.
+//
+// `callback` is called in the context of the sender's goroutine each time `Append` is called.
 func NewIterableSeries(callback func(*Serie), chanSize int, bufferSize int) *IterableSeries {
 	ctx, cancel := context.WithCancel(context.Background())
 	return &IterableSeries{
+		count:    atomic.NewUint64(0),
 		ch:       util.NewBufferedChan(ctx, chanSize, bufferSize),
 		cancel:   cancel,
 		callback: callback,
@@ -37,9 +44,11 @@ func NewIterableSeries(callback func(*Serie), chanSize int, bufferSize int) *Ite
 }
 
 // Append appends a serie
+//
+// This method must only be called by the sender.
 func (series *IterableSeries) Append(serie *Serie) {
 	series.callback(serie)
-	atomic.AddUint64(&series.count, 1)
+	series.count.Inc()
 	if !series.ch.Put(serie) && !series.bufferedChanClosed {
 		series.bufferedChanClosed = true
 		log.Errorf("Cannot append a serie in a closed buffered channel")
@@ -47,11 +56,15 @@ func (series *IterableSeries) Append(serie *Serie) {
 }
 
 // SeriesCount returns the number of series appended with `IterableSeries.Append`.
+//
+// SeriesCount can be called by any goroutine.
 func (series *IterableSeries) SeriesCount() uint64 {
-	return atomic.LoadUint64(&series.count)
+	return series.count.Load()
 }
 
 // SenderStopped must be called when sender stop calling Append.
+//
+// This method must only be called by the sender.
 func (series *IterableSeries) SenderStopped() {
 	series.ch.Close()
 }
@@ -60,12 +73,16 @@ func (series *IterableSeries) SenderStopped() {
 // This function prevents the case when the receiver stops iterating before the
 // end of the iteration because of an error and so blocks the sender forever
 // as no goroutine read the channel.
+//
+// This method must only be called by the receiver.
 func (series *IterableSeries) IterationStopped() {
 	series.cancel()
 }
 
 // MoveNext advances to the next element.
 // Returns false for the end of the iteration.
+//
+// This method must only be called by the receiver.
 func (series *IterableSeries) MoveNext() bool {
 	v, ok := series.ch.Get()
 	if v != nil {
@@ -77,6 +94,8 @@ func (series *IterableSeries) MoveNext() bool {
 }
 
 // Current returns the current serie.
+//
+// This method must only be called by the receiver.
 func (series *IterableSeries) Current() *Serie {
 	return series.current
 }


### PR DESCRIPTION
### What does this PR do?

Uses go.uber.org/atomic in pkg/metrics.IterableSeries, and also adds some comments to that type to indicate how different goroutines can use it.  Please verify the correctness of my comments!

### Motivation

Alignment issues with atomic access. See https://github.com/DataDog/datadog-agent/pull/11716

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Any QA which involves series metrics will test this functionality.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
