### PR TITLE
Send Keep-Alive messages on the remote tagger grpc stream when it is idle

### DIFF
--- a/cmd/agent/api/grpc.go
+++ b/cmd/agent/api/grpc.go
@@ -36,6 +36,7 @@ import (
 
 const (
 	taggerStreamSendTimeout = 1 * time.Minute
+	streamKeepAliveInterval = 9 * time.Minute
 )
 
 type server struct {
@@ -137,9 +138,13 @@ func (s *serverSecure) TaggerStreamEntities(in *pb.StreamTagsRequest, out pb.Age
 	eventCh := t.Subscribe(cardinality)
 	defer t.Unsubscribe(eventCh)
 
+	ticker := time.NewTicker(streamKeepAliveInterval)
+	defer ticker.Stop()
 	for {
 		select {
 		case events := <-eventCh:
+			ticker.Reset(streamKeepAliveInterval)
+
 			responseEvents := make([]*pb.StreamTagsEvent, 0, len(events))
 			for _, event := range events {
 				e, err := pbutils.Tagger2PbEntityEvent(event)
@@ -165,6 +170,24 @@ func (s *serverSecure) TaggerStreamEntities(in *pb.StreamTagsRequest, out pb.Age
 
 		case <-out.Context().Done():
 			return nil
+
+		// The remote tagger client has a timeout that closes the connection after 10 minutes of inactivity
+		// (implemented in pkg/tagger/remote/tagger.go)
+		// In order to avoid closing the connection and having to open it again, the server will send an empty
+		// message after 9 minutes of inactivity.
+		// The goal is only to keep the connection alive without losing the protection against “half” closed connections brought by the timeout.
+		case <-ticker.C:
+			err = grpc.DoWithTimeout(func() error {
+				return out.Send(&pb.StreamTagsResponse{
+					Events: []*pb.StreamTagsEvent{},
+				})
+			}, taggerStreamSendTimeout)
+
+			if err != nil {
+				log.Warnf("error sending tagger keep-alive: %s", err)
+				telemetry.ServerStreamErrors.Inc()
+				return err
+			}
 		}
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Ensure there are (possibly empty) grpc events sent on the remote tagger often enough to prevent client timeout.

### Motivation

Under some circonstances, users are repeatedly seeing the following warnings every 10 minutes:
```
2022-04-11 16:41:52 UTC | SYS-PROBE | WARN | (pkg/tagger/remote/tagger.go:239 in run) | error received from remote tagger: rpc error: code = DeadlineExceeded desc = timed out waiting for operation
2022-04-11 16:41:52 UTC | SYS-PROBE | INFO | (pkg/tagger/remote/tagger.go:337 in func1) | tagger stream established successfully
2022-04-11 16:51:52 UTC | SYS-PROBE | WARN | (pkg/tagger/remote/tagger.go:239 in run) | error received from remote tagger: rpc error: code = DeadlineExceeded desc = timed out waiting for operation
2022-04-11 16:51:52 UTC | SYS-PROBE | INFO | (pkg/tagger/remote/tagger.go:337 in func1) | tagger stream established successfully
2022-04-11 17:01:52 UTC | SYS-PROBE | WARN | (pkg/tagger/remote/tagger.go:239 in run) | error received from remote tagger: rpc error: code = DeadlineExceeded desc = timed out waiting for operation
2022-04-11 17:01:52 UTC | SYS-PROBE | INFO | (pkg/tagger/remote/tagger.go:337 in func1) | tagger stream established successfully
```

The precision of the repetition period (exactly every 10 minutes) and the fact that the reconnection following the timeout is always instantaneously successful rules out the network glitch hypothesis.

This is most probably caused by the fact that the remote tagger client has a timeout of 10 minutes when waiting for updates. When no update is received during a 10 minutes timeframe, the connection is closed and re-opened.

The above log is coming from https://github.com/DataDog/datadog-agent/blob/21bb524d1d8937b454a648c12506ba70f74ee93e/pkg/tagger/remote/tagger.go#L243
because this operation has timed out https://github.com/DataDog/datadog-agent/blob/21bb524d1d8937b454a648c12506ba70f74ee93e/pkg/tagger/remote/tagger.go#L226-L230
where the value of the timeout is defined at https://github.com/DataDog/datadog-agent/blob/21bb524d1d8937b454a648c12506ba70f74ee93e/pkg/tagger/remote/tagger.go#L37

Sending a remote tagger message with an empty event list should prevent the client side timeout without giving up the protection against “half dead” connections.

### Additional Notes

* The client side timeout was introduced by https://github.com/DataDog/datadog-agent/pull/7558
* The server side disconnection was introduced by https://github.com/DataDog/datadog-agent/pull/9452

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Validate that the remote tagger is still working by validating that `system-probe` and the `process-agent` still get proper tags.
Validate that, on an idle node where there is no activity for a long period of time (> 10 minutes), remote tagger clients (`system-probe` and `process-agent`) are not logging that they are disconnecting themselves an reconnecting every 10 minutes.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
