### PR TITLE
SNMP Resolve Integer Enumerations for Trap Variables

### DIFF
--- a/pkg/snmp/traps/formatter.go
+++ b/pkg/snmp/traps/formatter.go
@@ -169,8 +169,7 @@ func parseValue(variable trapVariable, varMetadata VariableMetadata) interface{}
 			log.Debugf("unable to parse value of type \"integer\": %+v", variable.Value)
 		} else {
 			// if we find a mapping set it and return
-			value := varMetadata.Enumeration[i]
-			if value == "" {
+			if value, ok := varMetadata.Enumeration[i]; !ok {
 				log.Debugf("unable to find enum mapping for value %d variable %q", i, varMetadata.Name)
 			} else {
 				return value

--- a/pkg/snmp/traps/formatter.go
+++ b/pkg/snmp/traps/formatter.go
@@ -168,13 +168,13 @@ func parseValue(variable trapVariable, varMetadata VariableMetadata) interface{}
 		if f, ok := variable.Value.(int); !ok {
 			// TODO(ken): should we do more here? Should we even handle this scenario?
 			log.Debugf("unable to parse value of type \"integer\": %+v", variable.Value)
-		} else if len(varMetadata.Mapping) > 0 {
+		} else if len(varMetadata.Enumeration) > 0 {
 			// if we find a mapping set it and return
-			mapping := varMetadata.Mapping[f]
-			if mapping == "" {
+			value := varMetadata.Enumeration[f]
+			if value == "" {
 				log.Debugf("unable to find enum mapping for value %f variable %q", f, varMetadata.Name)
 			} else {
-				return mapping
+				return value
 			}
 		}
 	}

--- a/pkg/snmp/traps/formatter.go
+++ b/pkg/snmp/traps/formatter.go
@@ -164,11 +164,10 @@ func NormalizeOID(value string) string {
 // parseValue checks to see if the variable has a mapping in an enum and
 // returns the mapping if it exists, otherwise returns the value unchanged
 func parseValue(variable trapVariable, varMetadata VariableMetadata) interface{} {
-	if variable.VarType == "integer" {
+	if len(varMetadata.Enumeration) > 0 {
 		if i, ok := variable.Value.(int); !ok {
-			// TODO(ken): should we do more here? Should we even handle this scenario?
 			log.Debugf("unable to parse value of type \"integer\": %+v", variable.Value)
-		} else if len(varMetadata.Enumeration) > 0 {
+		} else {
 			// if we find a mapping set it and return
 			value := varMetadata.Enumeration[i]
 			if value == "" {

--- a/pkg/snmp/traps/formatter.go
+++ b/pkg/snmp/traps/formatter.go
@@ -165,14 +165,14 @@ func NormalizeOID(value string) string {
 // returns the mapping if it exists, otherwise returns the value unchanged
 func parseValue(variable trapVariable, varMetadata VariableMetadata) interface{} {
 	if variable.VarType == "integer" {
-		if f, ok := variable.Value.(int); !ok {
+		if i, ok := variable.Value.(int); !ok {
 			// TODO(ken): should we do more here? Should we even handle this scenario?
 			log.Debugf("unable to parse value of type \"integer\": %+v", variable.Value)
 		} else if len(varMetadata.Enumeration) > 0 {
 			// if we find a mapping set it and return
-			value := varMetadata.Enumeration[f]
+			value := varMetadata.Enumeration[i]
 			if value == "" {
-				log.Debugf("unable to find enum mapping for value %f variable %q", f, varMetadata.Name)
+				log.Debugf("unable to find enum mapping for value %d variable %q", i, varMetadata.Name)
 			} else {
 				return value
 			}

--- a/pkg/snmp/traps/formatter_test.go
+++ b/pkg/snmp/traps/formatter_test.go
@@ -21,9 +21,6 @@ import (
 type (
 	// NoOpOIDResolver is a dummy OIDResolver implementation that is unable to get any Trap or Variable metadata.
 	NoOpOIDResolver struct{}
-
-	// ByOID is a wrapper to sort formatted variables by OID
-	byOID []interface{}
 )
 
 // GetTrapMetadata always return an error in this OIDResolver implementation
@@ -34,19 +31,6 @@ func (or NoOpOIDResolver) GetTrapMetadata(trapOID string) (TrapMetadata, error) 
 // GetVariableMetadata always return an error in this OIDResolver implementation
 func (or NoOpOIDResolver) GetVariableMetadata(trapOID string, varOID string) (VariableMetadata, error) {
 	return VariableMetadata{}, fmt.Errorf("trap OID %s is not defined", trapOID)
-}
-
-func (b byOID) Len() int {
-	return len(b)
-}
-
-func (b byOID) Swap(i, j int) {
-	b[i], b[j] = b[j], b[i]
-}
-
-func (b byOID) Less(i, j int) bool {
-	// TODO(ken): this is ugly
-	return b[i].(map[string]interface{})["oid"].(string) < b[j].(map[string]interface{})["oid"].(string)
 }
 
 var (
@@ -350,14 +334,14 @@ func TestFormatterWithResolverAndTrapV2(t *testing.T) {
 						"value": float64(9001),
 					},
 					map[string]interface{}{
-						"oid":   "1.3.6.1.2.1.2.2.1.8",
-						"type":  "integer",
-						"value": float64(7),
-					},
-					map[string]interface{}{
 						"oid":   "1.3.6.1.2.1.2.2.1.7",
 						"type":  "integer",
 						"value": float64(2),
+					},
+					map[string]interface{}{
+						"oid":   "1.3.6.1.2.1.2.2.1.8",
+						"type":  "integer",
+						"value": float64(7),
 					},
 				},
 			},
@@ -386,14 +370,14 @@ func TestFormatterWithResolverAndTrapV2(t *testing.T) {
 						"value": float64(9001),
 					},
 					map[string]interface{}{
-						"oid":   "1.3.6.1.2.1.2.2.1.8",
-						"type":  "integer",
-						"value": float64(7),
-					},
-					map[string]interface{}{
 						"oid":   "1.3.6.1.2.1.2.2.1.7",
 						"type":  "integer",
 						"value": "test",
+					},
+					map[string]interface{}{
+						"oid":   "1.3.6.1.2.1.2.2.1.8",
+						"type":  "integer",
+						"value": float64(7),
 					},
 				},
 			},
@@ -422,14 +406,14 @@ func TestFormatterWithResolverAndTrapV2(t *testing.T) {
 						"value": float64(9001),
 					},
 					map[string]interface{}{
-						"oid":   "1.3.6.1.2.1.2.2.1.8",
-						"type":  "integer",
-						"value": float64(7),
-					},
-					map[string]interface{}{
 						"oid":   "1.3.6.1.2.1.2.2.1.7",
 						"type":  "integer",
 						"value": float64(8),
+					},
+					map[string]interface{}{
+						"oid":   "1.3.6.1.2.1.2.2.1.8",
+						"type":  "integer",
+						"value": float64(7),
 					},
 				},
 			},
@@ -453,8 +437,6 @@ func TestFormatterWithResolverAndTrapV2(t *testing.T) {
 
 			// map comparisons shouldn't be reliant on ordering with this lib
 			// however variables are a slice, they must be sorted
-			sort.Stable(byOID(content["variables"].([]interface{})))
-			sort.Stable(byOID(d.expectedContent["variables"].([]interface{})))
 			if diff := cmp.Diff(content, d.expectedContent); diff != "" {
 				t.Error(diff)
 			}

--- a/pkg/snmp/traps/oid_resolver_test.go
+++ b/pkg/snmp/traps/oid_resolver_test.go
@@ -20,11 +20,12 @@ var dummyTrapDB = trapDBFileContent{
 	Traps: TrapSpec{
 		"1.3.6.1.6.3.1.1.5.3":      TrapMetadata{Name: "ifDown", MIBName: "IF-MIB"},                                             // v1 Trap
 		"1.3.6.1.4.1.8072.2.3.0.1": TrapMetadata{Name: "netSnmpExampleHeartbeatNotification", MIBName: "NET-SNMP-EXAMPLES-MIB"}, // v2+
+		"1.3.6.1.6.3.1.1.5.4":      TrapMetadata{Name: "linkUp", MIBName: "IF-MIB"},
 	},
 	Variables: variableSpec{
 		"1.3.6.1.2.1.2.2.1.1":      VariableMetadata{Name: "ifIndex"},
-		"1.3.6.1.2.1.2.2.1.7":      VariableMetadata{Name: "ifAdminStatus"},
-		"1.3.6.1.2.1.2.2.1.8":      VariableMetadata{Name: "ifOperStatus"},
+		"1.3.6.1.2.1.2.2.1.7":      VariableMetadata{Name: "ifAdminStatus", Mapping: map[int]string{1: "up", 2: "down", 3: "testing"}},
+		"1.3.6.1.2.1.2.2.1.8":      VariableMetadata{Name: "ifOperStatus", Mapping: map[int]string{1: "up", 2: "down", 3: "testing", 4: "unknown", 5: "dormant", 6: "notPresent", 7: "lowerLayerDown"}},
 		"1.3.6.1.4.1.8072.2.3.2.1": VariableMetadata{Name: "netSnmpExampleHeartbeatRate"},
 	},
 }
@@ -84,12 +85,13 @@ func TestDecoding(t *testing.T) {
 			"bar": VariableMetadata{
 				Name:        "yy",
 				Description: "dummy description",
+				Mapping:     map[int]string{2: "test"},
 			},
 		},
 	}
 	data, err := json.Marshal(trapDBFile)
 	require.NoError(t, err)
-	require.Equal(t, []byte("{\"traps\":{\"foo\":{\"name\":\"xx\",\"mib\":\"yy\",\"descr\":\"\"}},\"vars\":{\"bar\":{\"name\":\"yy\",\"descr\":\"dummy description\"}}}"), data)
+	require.Equal(t, []byte("{\"traps\":{\"foo\":{\"name\":\"xx\",\"mib\":\"yy\",\"descr\":\"\"}},\"vars\":{\"bar\":{\"name\":\"yy\",\"descr\":\"dummy description\",\"map\":{\"2\":\"test\"}}}}"), data)
 	err = json.Unmarshal([]byte("{\"traps\": {\"1.2\": {\"name\": \"dd\"}}}"), &trapDBFile)
 	require.NoError(t, err)
 }

--- a/pkg/snmp/traps/oid_resolver_test.go
+++ b/pkg/snmp/traps/oid_resolver_test.go
@@ -24,8 +24,8 @@ var dummyTrapDB = trapDBFileContent{
 	},
 	Variables: variableSpec{
 		"1.3.6.1.2.1.2.2.1.1":      VariableMetadata{Name: "ifIndex"},
-		"1.3.6.1.2.1.2.2.1.7":      VariableMetadata{Name: "ifAdminStatus", Mapping: map[int]string{1: "up", 2: "down", 3: "testing"}},
-		"1.3.6.1.2.1.2.2.1.8":      VariableMetadata{Name: "ifOperStatus", Mapping: map[int]string{1: "up", 2: "down", 3: "testing", 4: "unknown", 5: "dormant", 6: "notPresent", 7: "lowerLayerDown"}},
+		"1.3.6.1.2.1.2.2.1.7":      VariableMetadata{Name: "ifAdminStatus", Enumeration: map[int]string{1: "up", 2: "down", 3: "testing"}},
+		"1.3.6.1.2.1.2.2.1.8":      VariableMetadata{Name: "ifOperStatus", Enumeration: map[int]string{1: "up", 2: "down", 3: "testing", 4: "unknown", 5: "dormant", 6: "notPresent", 7: "lowerLayerDown"}},
 		"1.3.6.1.4.1.8072.2.3.2.1": VariableMetadata{Name: "netSnmpExampleHeartbeatRate"},
 	},
 }
@@ -85,13 +85,13 @@ func TestDecoding(t *testing.T) {
 			"bar": VariableMetadata{
 				Name:        "yy",
 				Description: "dummy description",
-				Mapping:     map[int]string{2: "test"},
+				Enumeration: map[int]string{2: "test"},
 			},
 		},
 	}
 	data, err := json.Marshal(trapDBFile)
 	require.NoError(t, err)
-	require.Equal(t, []byte("{\"traps\":{\"foo\":{\"name\":\"xx\",\"mib\":\"yy\",\"descr\":\"\"}},\"vars\":{\"bar\":{\"name\":\"yy\",\"descr\":\"dummy description\",\"map\":{\"2\":\"test\"}}}}"), data)
+	require.Equal(t, []byte("{\"traps\":{\"foo\":{\"name\":\"xx\",\"mib\":\"yy\",\"descr\":\"\"}},\"vars\":{\"bar\":{\"name\":\"yy\",\"descr\":\"dummy description\",\"enum\":{\"2\":\"test\"}}}}"), data)
 	err = json.Unmarshal([]byte("{\"traps\": {\"1.2\": {\"name\": \"dd\"}}}"), &trapDBFile)
 	require.NoError(t, err)
 }

--- a/pkg/snmp/traps/traps_db.go
+++ b/pkg/snmp/traps/traps_db.go
@@ -7,8 +7,9 @@ package traps
 
 // VariableMetadata is the MIB-extracted information of a given trap variable
 type VariableMetadata struct {
-	Name        string `yaml:"name" json:"name"`
-	Description string `yaml:"descr" json:"descr"`
+	Name        string         `yaml:"name" json:"name"`
+	Description string         `yaml:"descr" json:"descr"`
+	Mapping     map[int]string `yaml:"map" json:"map"`
 }
 
 // variableSpec contains the variableMetadata for each known variable of a given trap db file

--- a/pkg/snmp/traps/traps_db.go
+++ b/pkg/snmp/traps/traps_db.go
@@ -9,7 +9,7 @@ package traps
 type VariableMetadata struct {
 	Name        string         `yaml:"name" json:"name"`
 	Description string         `yaml:"descr" json:"descr"`
-	Mapping     map[int]string `yaml:"map" json:"map"`
+	Enumeration map[int]string `yaml:"enum" json:"enum"`
 }
 
 // variableSpec contains the variableMetadata for each known variable of a given trap db file

--- a/releasenotes/notes/snmp-traps-resolve-enums-e66ef9e51a9269aa.yaml
+++ b/releasenotes/notes/snmp-traps-resolve-enums-e66ef9e51a9269aa.yaml
@@ -9,6 +9,3 @@
 enhancements:
   - |
     Resolve SNMP trap variables with integer enumerations to their string representation.
-issues:
-  - |
-    Enumerations for the BITS type are not yet supported.

--- a/releasenotes/notes/snmp-traps-resolve-enums-e66ef9e51a9269aa.yaml
+++ b/releasenotes/notes/snmp-traps-resolve-enums-e66ef9e51a9269aa.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Resolve SNMP trap variables with integer enumerations to their string representation.
+issues:
+  - |
+    Enumerations for the BITS type are not yet supported.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Adds support for resolving integer enumerations to their string values assuming such a mapping exists in the traps database. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Enriches data for our customers so they don't have to reference MIBs to determine what the value of a trap variable actually means.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
There will be another PR out for `integrations-core` which adds the enum definitions to the traps database.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
Initial start up may take longer as the default traps_db will be increasing in size. This also increases the memory footprint of the application. The compressed traps_db goes up in size from about 1MB to 1.4MB and uncompressed from 9MB to 12MB.

There is a bit more processing that must be done to perform matching between the enum and the variable, but since we're using a `map` this should be negligible.

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Unit tests have been added to ensure the new traps_db format is accepted by the application and that enums are being properly handled.

To test end to end, you'll need an updated version of the traps_db which you can generate it yourself using the branch of `integrations-core` with my changes, or wait for that PR to be merged. Replace the existing traps_db on your agent with the updated one containing enums. Run the agent and send a trap like the following:

```sh
sudo snmptrap -c <community-string> -v 2c <agent-host:agent-traps-port> "" 1.3.6.1.6.3.1.1.5.4 1.3.6.1.2.1.2.2.1.1 i 1337 1.3.6.1.2.1.2.2.1.7 i 3 1.3.6.1.2.1.2.2.1.8 i 7
```

The above sends a trap with 3 variables, ifAdminStatus and ifOperStatus should have enums in the IF-MIB and be resolved as strings in the Even Attributes. Look at the logs in your Datadog instance and the variables should be resolved.

![image (1)](https://user-images.githubusercontent.com/103530259/165960295-1e091437-9f68-47c0-a595-77095703fac1.png)

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
