### PR TITLE
Add a "proxy" Gemfile in the kitchen tests directory

### DIFF
--- a/test/kitchen/Gemfile
+++ b/test/kitchen/Gemfile
@@ -1,0 +1,6 @@
+require 'open-uri'
+
+# Actual gemfile is stored in the buildimages repo because it comes pre-installed in the dd-agent-testing Docker image, read it from there
+gemfile = open('https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/main/dd-agent-testing/Gemfile')
+eval gemfile.read
+


### PR DESCRIPTION
### What does this PR do?

Adds a Gemfile that read from the `dd-agent-testing` Gemfile, so `bundle install` works.

### Motivation

Useful when running these tests locally

