### PR TITLE
[tasks] Updated GetHostAliases to add instance ID as alias on AWS

### DIFF
--- a/pkg/util/cloudproviders/cloudproviders.go
+++ b/pkg/util/cloudproviders/cloudproviders.go
@@ -94,6 +94,7 @@ func GetHostAliases(ctx context.Context) []string {
 
 	detectors := []cloudProviderAliasesDetector{
 		{name: alibaba.CloudProviderName, callback: alibaba.GetHostAliases},
+		{name: ec2.CloudProviderName, callback: ec2.GetHostAliases},
 		{name: azure.CloudProviderName, callback: azure.GetHostAliases},
 		{name: gce.CloudProviderName, callback: gce.GetHostAliases},
 		{name: cloudfoundry.CloudProviderName, callback: cloudfoundry.GetHostAliases},

--- a/pkg/util/ec2/ec2.go
+++ b/pkg/util/ec2/ec2.go
@@ -111,6 +111,19 @@ func IsRunningOn(ctx context.Context) bool {
 	return false
 }
 
+// GetHostAliases returns the host aliases from the EC2 metadata API.
+func GetHostAliases(ctx context.Context) ([]string, error) {
+
+	instanceID, err := GetInstanceID(ctx)
+	if err == nil {
+		return []string{instanceID}, nil
+	}
+
+	log.Debugf("failed to get instance ID to use as Host Alias: %s", err)
+
+	return []string{}, nil
+}
+
 var hostnameFetcher = cachedfetch.Fetcher{
 	Name: "EC2 Hostname",
 	Attempt: func(ctx context.Context) (interface{}, error) {

--- a/releasenotes/notes/updated-cloud-providers-to-add-instance-id-for-ec2-cfae4d12f5d3f3da.yaml
+++ b/releasenotes/notes/updated-cloud-providers-to-add-instance-id-for-ec2-cfae4d12f5d3f3da.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Updated cloud providers to add the Instance ID as a host alias
+    for EC2 instances, matching what other cloud providers do. This
+    should help with correctly identifying hosts where the customer
+    has changed the hostname to be different from the Instance ID.


### PR DESCRIPTION
### Motivation

Currently the agent doesn’t always report the AWS instance ID as a host alias, even when it doesn’t report the instance ID as a host. This can cause duplicate host issues with hosts created by the AWS Cloud Integration (which identifies hosts with their instance IDs) when agents on AWS do not report the instance ID as their hostname (for example when hostname is changed from the instance ID).

### Describe how to test/QA your changes

To test this you need to deploy a new instance with the following [User Data](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html?icmpid=docs_ec2_console#user-data-console):

```
#cloud-config
preserve_hostname: true
runcmd:
  - [ 'hostnamectl', 'set-hostname', 'myhostname' ]
  - [ 'service', 'hostname', 'start' ]
```

This can be added in the `Advanced details` section when launching a new EC2 instance.

Once the instance is launched install the Agent as normal. Eventually you should the instance running in the Infrastructure List, and it should have Instance ID as an alias for the host. 

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
