### PR TITLE
pkg/trace/api: fix CPU threshold exceeded logging

### DIFF
--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -724,7 +724,7 @@ func (r *HTTPReceiver) watchdog(now time.Time) {
 	if r.conf.MaxCPU > 0 {
 		rateCPU = computeRateLimitingRate(r.conf.MaxCPU, wi.CPU.UserAvg, r.RateLimiter.RealRate())
 		if rateCPU < 1 {
-			log.Warnf("CPU threshold exceeded (apm_config.max_cpu_percent: %.0f): %.0f", r.conf.MaxCPU*100, wi.CPU.UserAvg)
+			log.Warnf("CPU threshold exceeded (apm_config.max_cpu_percent: %.0f): %.0f", r.conf.MaxCPU*100, wi.CPU.UserAvg*100)
 		}
 	}
 

--- a/releasenotes/notes/fix-trace-agent-ratelimit-logging-16e973263676b366.yaml
+++ b/releasenotes/notes/fix-trace-agent-ratelimit-logging-16e973263676b366.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Fixed an issue where "CPU threshold exceeded" logs would show the wrong user cpu usage by a factor of 100
+    Fixed an issue where "CPU threshold exceeded" logs would show the wrong user CPU usage by a factor of 100.

--- a/releasenotes/notes/fix-trace-agent-ratelimit-logging-16e973263676b366.yaml
+++ b/releasenotes/notes/fix-trace-agent-ratelimit-logging-16e973263676b366.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed an issue where "CPU threshold exceeded" logs would show the wrong user cpu usage by a factor of 100

--- a/releasenotes/notes/fix-trace-agent-ratelimit-logging-16e973263676b366.yaml
+++ b/releasenotes/notes/fix-trace-agent-ratelimit-logging-16e973263676b366.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Fixed an issue where "CPU threshold exceeded" logs would show the wrong user CPU usage by a factor of 100.
+    APM: Fixed an issue where "CPU threshold exceeded" logs would show the wrong user CPU usage by a factor of 100.


### PR DESCRIPTION
### What does this PR do?

This corrects the printing of the "CPU Threshold exceeded" message. Previously the user would see confusing (and incorrect) messages like:
`CPU threshold exceeded (apm_config.max_cpu_percent: 50): 1`

To prove this is true just look down the file a little bit where the metric for trace_agent.cpu_percent is reported, note that it's multiplied by 100 there. 

### Possible Drawbacks / Trade-offs

I suppose it's possible someone could have built out some custom metrics or reporting on the values here and this change might break those. However given that the log is already incorrect and the value there is already properly available as a metric `datadog.trace_agent.cpu_percent` I don't think this will cause issues.


### Describe how to test/QA your changes

After deployment look for any logs like `CPU threshold exceeded (apm_config.max_cpu_percent: 50): 72` and ensure the value on the right is actually larger than the "max_cpu_percent"

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
