### PR TITLE
try rsc workaround to see if we can get tests to pass

### DIFF
--- a/.gitlab/functional_test/system_probe.yml
+++ b/.gitlab/functional_test/system_probe.yml
@@ -83,6 +83,5 @@ kitchen_test_system_probe_windows_x64:
     - bash -l tasks/kitchen_setup.sh
   script:
     - bash -l tasks/run-test-kitchen.sh windows-sysprobe-test $AGENT_MAJOR_VERSION
-  # FIXME: temporarily allow this job to fail until we fix it
-  allow_failure: true
+  allow_failure: false
   retry: 0

--- a/.gitlab/functional_test/system_probe.yml
+++ b/.gitlab/functional_test/system_probe.yml
@@ -83,5 +83,3 @@ kitchen_test_system_probe_windows_x64:
     - bash -l tasks/kitchen_setup.sh
   script:
     - bash -l tasks/run-test-kitchen.sh windows-sysprobe-test $AGENT_MAJOR_VERSION
-  allow_failure: false
-  retry: 0

--- a/.gitlab/kitchen_testing/windows.yml
+++ b/.gitlab/kitchen_testing/windows.yml
@@ -116,8 +116,6 @@ kitchen_windows_installer_npm_install_scenarios-a7:
   extends:
     - .kitchen_scenario_windows_a7
     - .kitchen_test_windows_installer_npm
-  allow_failure: false
-  retry: 0
 
 kitchen_windows_installer_npm_driver-a7:
   # Run NPM driver installer test on branches, on a reduced number of platforms
@@ -126,8 +124,6 @@ kitchen_windows_installer_npm_driver-a7:
   extends:
     - .kitchen_scenario_windows_a7
     - .kitchen_test_windows_installer_driver
-  allow_failure: false
-  retry: 0
 
 kitchen_windows_installer_agent-a6:
   extends:

--- a/.gitlab/kitchen_testing/windows.yml
+++ b/.gitlab/kitchen_testing/windows.yml
@@ -116,8 +116,7 @@ kitchen_windows_installer_npm_install_scenarios-a7:
   extends:
     - .kitchen_scenario_windows_a7
     - .kitchen_test_windows_installer_npm
-  # FIXME: temporarily allow this job to fail, until we fix it
-  allow_failure: true
+  allow_failure: false
   retry: 0
 
 kitchen_windows_installer_npm_driver-a7:
@@ -127,8 +126,7 @@ kitchen_windows_installer_npm_driver-a7:
   extends:
     - .kitchen_scenario_windows_a7
     - .kitchen_test_windows_installer_driver
-  # FIXME: temporarily allow this job to fail, until we fix it
-  allow_failure: true
+  allow_failure: false
   retry: 0
 
 kitchen_windows_installer_agent-a6:

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -169,12 +169,12 @@ func TestGetStats(t *testing.T) {
 	expected := linuxExpected
 	if runtime.GOOS == "windows" {
 		expected = map[string]interface{}{
-			"driver":                   nil,
-			"flows":                    nil,
-			"driver_total_flow_stats":  nil,
-			"driver_flow_handle_stats": nil,
-			"state":                    nil,
-			"dns":                      nil,
+			"driver":                   map[string]interface{}{},
+			"flows":                    map[string]interface{}{},
+			"driver_total_flow_stats":  map[string]interface{}{},
+			"driver_flow_handle_stats": map[string]interface{}{},
+			"state":                    map[string]interface{}{},
+			"dns":                      map[string]interface{}{},
 		}
 	}
 

--- a/test/kitchen/drivers/hyperv-driver.yml
+++ b/test/kitchen/drivers/hyperv-driver.yml
@@ -1,7 +1,7 @@
 provisioner:
   name: chef_solo
   product_name: chef
-  product_version: 13.6.4
+  product_version: 13.9.4
   install_strategy: always
   # the following settings make it possible to do a reboot during setup
   # (necessary for FIPS tests which reboot to enable FIPS mode)

--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -111,8 +111,8 @@
                 "win2019cn": "urn,MicrosoftWindowsServer:WindowsServer:2019-Datacenter-zhcn:17763.2114.2108051826",
                 "win1903": "urn,MicrosoftWindowsServer:WindowsServer:Datacenter-Core-1903-with-Containers-smalldisk:18362.1256.2012032308",
                 "win1909": "urn,MicrosoftWindowsServer:WindowsServer:datacenter-core-1909-with-containers-smalldisk:18363.1316.2101130054",
-                "win2004": "urn,MicrosoftWindowsServer:WindowsServer:datacenter-core-2004-with-containers-smalldisk:19041.746.2101092327",
-                "win20h2": "urn,MicrosoftWindowsServer:WindowsServer:datacenter-core-20h2-with-containers-smalldisk:19042.746.2101092352",
+                "win2004": "urn,MicrosoftWindowsServer:WindowsServer:datacenter-core-2004-with-containers-smalldisk:19041.1415.2112101053",
+                "win20h2": "urn,MicrosoftWindowsServer:WindowsServer:datacenter-core-20h2-with-containers-smalldisk:19042.1645.220403",
                 "win2022": "urn,MicrosoftWindowsServer:WindowsServer:2022-datacenter-core:20348.169.2108120020"
             }
         },

--- a/test/kitchen/site-cookbooks/dd-agent-install/recipes/_install_windows.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-install/recipes/_install_windows.rb
@@ -26,7 +26,8 @@ end
 ## remove this once bug is fixed
 execute 'disable RSC' do
   command "netsh.exe int tcp set global rsc=disable"
-  #command "disable-netadapterrsc *"
+  # ignore failure b/c this will fail on win2008r2 (setting doesn't exist)
+  # however, we don't need it on 2008r2 b/c NPM isn't supported on 2008r2
   ignore_failure true
 end
 

--- a/test/kitchen/site-cookbooks/dd-agent-install/recipes/_install_windows.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-install/recipes/_install_windows.rb
@@ -20,6 +20,16 @@ if node['dd-agent-install']['enable_testsigning']
   end
 end
 
+##
+## temporarily disable recv segment coalescing.  This appears to be
+## the root cause of the azure bug causing things to hang.
+## remove this once bug is fixed
+execute 'disable RSC' do
+  command "netsh.exe int tcp set global rsc=disable"
+  #command "disable-netadapterrsc *"
+  ignore_failure true
+end
+
 include_recipe 'dd-agent-install::_install_windows_base'
 
 agent_config_file = ::File.join(node['dd-agent-install']['config_dir'], 'datadog.conf')

--- a/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/windows.rb
+++ b/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/windows.rb
@@ -18,6 +18,14 @@ remote_file "#{tmp_dir}\\wix311-binaries.zip" do
   source "https://github.com/wixtoolset/wix3/releases/download/wix3112rtm/wix311-binaries.zip"
 end
 
+##
+## temporarily disable recv segment coalescing.  This appears to be
+## the root cause of the azure bug causing things to hang.
+## remove this once bug is fixed
+execute 'disable RSC' do
+  command "powershell /c disable-netadapterrsc *"
+end
+
 execute 'wix-extract' do
   cwd tmp_dir
   command "powershell -C \"Add-Type -A 'System.IO.Compression.FileSystem'; [IO.Compression.ZipFile]::ExtractToDirectory('wix311-binaries.zip', 'wix');\""

--- a/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/windows.rb
+++ b/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/windows.rb
@@ -23,7 +23,7 @@ end
 ## the root cause of the azure bug causing things to hang.
 ## remove this once bug is fixed
 execute 'disable RSC' do
-  command "powershell /c disable-netadapterrsc *"
+  command "netsh.exe int tcp set global rsc=disable"
 end
 
 execute 'wix-extract' do

--- a/test/kitchen/tasks/kitchen.py
+++ b/test/kitchen/tasks/kitchen.py
@@ -197,7 +197,7 @@ def load_user_env(_, provider, varsfile):
     env = {}
     commentpattern = re.compile("^comment")
     if os.path.exists(varsfile):
-        with open("uservars.json", "r") as f:
+        with open(varsfile, "r") as f:
             vars = json.load(f)
             for key, val in vars['global'].items():
                 if commentpattern.match(key):


### PR DESCRIPTION
### What does this PR do?

Disable receive segment coalescing in an attempt to get kitchen tests to pass.
After opening a ticket with Microsoft over this issue, this is a potential workaround
pending an actual fix

- Turns off recv segment coalescing, which according to MS is the source of the bug in Windows
- Turns off "allowed to fail" on tests that were previously failing
- Fixes windows test that was broken while tests were set to "allowed to fail"
- Updates missing azure images

### Motivation

Keeping automated testing working with minimal disruption

### Possible Drawbacks / Trade-offs

Tests could still fail

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
