### PR TITLE
Updates release to 1.3.3 NPM driver.

### DIFF
--- a/release.json
+++ b/release.json
@@ -12,8 +12,8 @@
         "JMXFETCH_HASH": "3c41c0660e9c53451dfb51e8dad33bc87b03be1abc1fcd3c856ea81e6b0894ee",
         "MACOS_BUILD_VERSION": "7.36.x",
         "WINDOWS_DDNPM_DRIVER": "release-signed",
-        "WINDOWS_DDNPM_VERSION": "1.3.2",
-        "WINDOWS_DDNPM_SHASUM": "1f65d40519bc307d652c64183b2cac2a36da9839c21d64f9823aa158ff6336bb",
+        "WINDOWS_DDNPM_VERSION": "1.3.3",
+        "WINDOWS_DDNPM_SHASUM": "4cd504f6a1a3cd548ffc60655b8f4d616d35bed9de9bde7c80a9b8719acbb482",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "nightly-a7": {
@@ -24,8 +24,8 @@
         "JMXFETCH_HASH": "3c41c0660e9c53451dfb51e8dad33bc87b03be1abc1fcd3c856ea81e6b0894ee",
         "MACOS_BUILD_VERSION": "7.36.x",
         "WINDOWS_DDNPM_DRIVER": "release-signed",
-        "WINDOWS_DDNPM_VERSION": "1.3.2",
-        "WINDOWS_DDNPM_SHASUM": "1f65d40519bc307d652c64183b2cac2a36da9839c21d64f9823aa158ff6336bb",
+        "WINDOWS_DDNPM_VERSION": "1.3.3",
+        "WINDOWS_DDNPM_SHASUM": "4cd504f6a1a3cd548ffc60655b8f4d616d35bed9de9bde7c80a9b8719acbb482",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "release-a6": {

--- a/release.json
+++ b/release.json
@@ -37,8 +37,8 @@
         "SECURITY_AGENT_POLICIES_VERSION": "v0.25.2",
         "MACOS_BUILD_VERSION": "6.36.0-rc.1",
         "WINDOWS_DDNPM_DRIVER": "release-signed",
-        "WINDOWS_DDNPM_VERSION": "1.3.2",
-        "WINDOWS_DDNPM_SHASUM": "1f65d40519bc307d652c64183b2cac2a36da9839c21d64f9823aa158ff6336bb"
+        "WINDOWS_DDNPM_VERSION": "1.3.3",
+        "WINDOWS_DDNPM_SHASUM": "4cd504f6a1a3cd548ffc60655b8f4d616d35bed9de9bde7c80a9b8719acbb482"
     },
     "release-a7": {
         "INTEGRATIONS_CORE_VERSION": "7.36.0-rc.4",
@@ -49,8 +49,8 @@
         "SECURITY_AGENT_POLICIES_VERSION": "v0.25.2",
         "MACOS_BUILD_VERSION": "7.36.0-rc.1",
         "WINDOWS_DDNPM_DRIVER": "release-signed",
-        "WINDOWS_DDNPM_VERSION": "1.3.2",
-        "WINDOWS_DDNPM_SHASUM": "1f65d40519bc307d652c64183b2cac2a36da9839c21d64f9823aa158ff6336bb"
+        "WINDOWS_DDNPM_VERSION": "1.3.3",
+        "WINDOWS_DDNPM_SHASUM": "4cd504f6a1a3cd548ffc60655b8f4d616d35bed9de9bde7c80a9b8719acbb482"
     },
     "dca-1.17.0": {
         "SECURITY_AGENT_POLICIES_VERSION": "v0.18.6"

--- a/releasenotes/notes/winnpm133-2731a08e5b7cfde5.yaml
+++ b/releasenotes/notes/winnpm133-2731a08e5b7cfde5.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    On Windows, includes NPM driver update which fixes performance
+    problem when host is under high connection load.


### PR DESCRIPTION
1.3.3 NPM driver fixes performance problem in high connection load
situations.

### What does this PR do?

Updates release to latest version of NPM driver with performance problem mitigated.

### Motivation

Under high connection load, NPM can cause serious host performance degredation.

### Additional Notes

Comparison of before and after
https://dddev.datadoghq.com/network?destG=core_network.destination.port&destQ=&srcG=co[…]i2eifhl&from_ts=1651203253604&to_ts=1651206853604&live=truevs.
https://dddev.datadoghq.com/network?destG=%2A&destQ=&srcG=core_network.source.port&src[…]336jluk&from_ts=1651243580761&to_ts=1651247180761&live=true


### Describe how to test/QA your changes

Create two windows instances.
On one instance (the client) install `vegeta`.
On the server instance install IIS and previous version.
Using vegeta, generate load against IIS of ~1500 conns/sec
On client instance, using perfmon, note the high rate of tcp retransmit
On server instance, note the high rate of tcp retransmit in both perfmon and on the NPM page

Stop vegeta
upgrade server instance 
re-run test.
Note that tcp retransmit rate no longer spikes.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
