### PR TITLE
[CWS] Copy statsd tags before calling Count or Gauge

### DIFF
--- a/pkg/security/probe/perf_buffer_monitor.go
+++ b/pkg/security/probe/perf_buffer_monitor.go
@@ -351,10 +351,11 @@ func (pbm *PerfBufferMonitor) sendEventsAndBytesReadStats(client statsd.ClientIn
 	var err error
 
 	for m := range pbm.stats {
+		mapTag := fmt.Sprintf("map:%s", m)
 		for cpu := range pbm.stats[m] {
 			for eventType := range pbm.stats[m][cpu] {
 				evtType := model.EventType(eventType)
-				tags := pbm.buildTags(fmt.Sprintf("map:%s", m), fmt.Sprintf("event_type:%s", evtType))
+				tags := pbm.buildTags(mapTag, fmt.Sprintf("event_type:%s", evtType))
 
 				if count = int64(pbm.getAndResetEventCount(evtType, m, cpu)); count > 0 {
 					if err = client.Count(metrics.MetricPerfBufferEventsRead, count, tags, 1.0); err != nil {
@@ -420,6 +421,7 @@ func (pbm *PerfBufferMonitor) collectAndSendKernelStats(client statsd.ClientInte
 
 		// loop through all the values of the active buffer
 		iterator = statsMap.Iterate()
+		mapTag := fmt.Sprintf("map:%s", perfMapName)
 		for iterator.Next(&id, &cpuStats) {
 			if id == 0 {
 				// first event type is 1
@@ -428,7 +430,7 @@ func (pbm *PerfBufferMonitor) collectAndSendKernelStats(client statsd.ClientInte
 
 			// retrieve event type from key
 			evtType := model.EventType(id % uint32(model.MaxEventType))
-			tags := pbm.buildTags(fmt.Sprintf("map:%s", perfMapName), fmt.Sprintf("event_type:%s", evtType))
+			tags := pbm.buildTags(mapTag, fmt.Sprintf("event_type:%s", evtType))
 
 			// loop over each cpu entry
 			for cpu, stats := range cpuStats {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

This PR makes a copy of the metrics tags in order to fix a bug introduced while upgrading the `statsd` library.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Fix the tags send with the monitoring metrics of CWS.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
