### PR TITLE
[CWS] fix iouring process context

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "ef47197732ac678950d443f7ab8bc05528f6b33192fe8cb0c41140450c87eea9")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "a915a120138e0d746230d73466ac9c15ed76970012daad01f2741c4f445a1565")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "a915a120138e0d746230d73466ac9c15ed76970012daad01f2741c4f445a1565")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "72328f80ff119f58e04fdbbfbfbdc4eee7fb12badba1f228d8f68477404aade3")

--- a/pkg/security/ebpf/c/open.h
+++ b/pkg/security/ebpf/c/open.h
@@ -213,12 +213,8 @@ int kprobe___io_openat_prep(struct pt_regs *ctx) {
 
 SEC("kprobe/io_openat2")
 int kprobe_io_openat2(struct pt_regs *ctx) {
-    u64 pid_tgid = bpf_get_current_pid_tgid();
-    void *raw_req = (void*) PT_REGS_PARM1(ctx);
-    bpf_printk("# HELLO ENTRY WTF; tgid = %d; req = %p\n", pid_tgid >> 32, raw_req);
-
     struct io_open req;
-    if (bpf_probe_read(&req, sizeof(req), raw_req)) {
+    if (bpf_probe_read(&req, sizeof(req), (void*) PT_REGS_PARM1(ctx))) {
         return 0;
     }
 
@@ -336,7 +332,6 @@ int tracepoint_handle_sys_open_exit(struct tracepoint_raw_syscalls_sys_exit_t *a
 SEC("kretprobe/io_openat2")
 int kretprobe_io_openat2(struct pt_regs *ctx) {
     int retval = PT_REGS_RC(ctx);
-    bpf_printk("# HELLO EXIT WTF\n");
 
     void *raw_req = (void*) PT_REGS_PARM1(ctx);
     u64 *pid_tgid_ptr = bpf_map_lookup_elem(&io_uring_req_pid, &raw_req);

--- a/pkg/security/ebpf/c/open.h
+++ b/pkg/security/ebpf/c/open.h
@@ -15,6 +15,15 @@ struct bpf_map_def SEC("maps/open_flags_approvers") open_flags_approvers = {
     .namespace = "",
 };
 
+struct bpf_map_def SEC("maps/io_uring_req_pid") io_uring_req_pid = {
+    .type = BPF_MAP_TYPE_LRU_HASH,
+    .key_size = sizeof(void*),
+    .value_size = sizeof(u64),
+    .max_entries = 2048,
+    .pinning = 0,
+    .namespace = "",
+};
+
 struct open_event_t {
     struct kevent_t event;
     struct process_context_t process;
@@ -196,8 +205,14 @@ struct io_open {
 
 SEC("kprobe/io_openat2")
 int kprobe_io_openat2(struct pt_regs *ctx) {
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    void *raw_req = (void*) PT_REGS_PARM1(ctx);
+
+    bpf_map_update_elem(&io_uring_req_pid, &raw_req, &pid_tgid, BPF_ANY);
+
+    bpf_printk("# HELLO ENTRY WTF; tgid = %d; req = %p\n", pid_tgid >> 32);
     struct io_open req;
-    if (bpf_probe_read(&req, sizeof(req), (void*) PT_REGS_PARM1(ctx))) {
+    if (bpf_probe_read(&req, sizeof(req), raw_req)) {
         return 0;
     }
 
@@ -307,12 +322,9 @@ int tracepoint_handle_sys_open_exit(struct tracepoint_raw_syscalls_sys_exit_t *a
 
 SEC("kretprobe/io_openat2")
 int kretprobe_io_openat2(struct pt_regs *ctx) {
-    struct file *f = (struct file *) PT_REGS_RC(ctx);
-    if (IS_ERR(f)) {
-        return 0;
-    }
-
-    return sys_open_ret(ctx, 0, DR_KPROBE);
+    int retval = PT_REGS_RC(ctx);
+    bpf_printk("# HELLO EXIT WTF\n");
+    return sys_open_resys_open_rett(ctx, retval, DR_KPROBE);
 }
 
 SEC("kprobe/filp_close")
@@ -353,7 +365,12 @@ int __attribute__((always_inline)) dr_open_callback(void *ctx, int retval) {
     };
 
     fill_file_metadata(syscall->open.dentry, &event.file.metadata);
-    struct proc_cache_t *entry = fill_process_context(&event.process);
+    struct proc_cache_t *entry;
+    if syscall->open.pid_tgid != 0 {
+        entry = fill_process_context_with_pid_tgid(&event.process, syscall->open.pid_tgid);
+    } else {
+        entry = fill_process_context(&event.process);
+    }
     fill_container_context(entry, &event.container);
     fill_span_context(&event.span);
 

--- a/pkg/security/ebpf/c/process.h
+++ b/pkg/security/ebpf/c/process.h
@@ -119,9 +119,7 @@ struct bpf_map_def SEC("maps/netns_cache") netns_cache = {
     .namespace = "",
 };
 
-static struct proc_cache_t * __attribute__((always_inline)) fill_process_context(struct process_context_t *data) {
-    // Pid & Tid
-    u64 pid_tgid = bpf_get_current_pid_tgid();
+static struct proc_cache_t * __attribute__((always_inline)) fill_process_context_with_pid_tgid(struct process_context_t *data, u64 pid_tgid) {
     u32 tgid = pid_tgid >> 32;
 
     // https://github.com/iovisor/bcc/blob/master/docs/reference_guide.md#4-bpf_get_current_pid_tgid
@@ -134,6 +132,11 @@ static struct proc_cache_t * __attribute__((always_inline)) fill_process_context
     }
 
     return get_proc_cache(tgid);
+}
+
+static struct proc_cache_t * __attribute__((always_inline)) fill_process_context(struct process_context_t *data) {
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    return fill_process_context_with_pid_tgid(data, pid_tgid);
 }
 
 struct bpf_map_def SEC("maps/root_nr_namespace_nr") root_nr_namespace_nr = {

--- a/pkg/security/ebpf/c/syscalls.h
+++ b/pkg/security/ebpf/c/syscalls.h
@@ -45,6 +45,7 @@ struct syscall_cache_t {
             umode_t mode;
             struct dentry *dentry;
             struct file_t file;
+            u64 pid_tgid;
         } open;
 
         struct {

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -104,6 +104,7 @@ func AllMaps() []*manager.Map {
 		{Name: "exec_file_cache"},
 		// Open tables
 		{Name: "open_flags_approvers"},
+		{Name: "io_uring_req_pid"},
 		// Exec tables
 		{Name: "proc_cache"},
 		{Name: "pid_cache"},

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -195,6 +195,7 @@ var SelectorsPerEventType = map[eval.EventType][]manager.ProbesSelector{
 			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "open_by_handle_at"}, EntryAndExit, true),
 		},
 		&manager.BestEffort{Selectors: []manager.ProbesSelector{
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/__io_openat_prep", EBPFFuncName: "kprobe___io_openat_prep"}},
 			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/io_openat2", EBPFFuncName: "kprobe_io_openat2"}},
 			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kretprobe/io_openat2", EBPFFuncName: "kretprobe_io_openat2"}},
 		}},

--- a/pkg/security/ebpf/probes/open.go
+++ b/pkg/security/ebpf/probes/open.go
@@ -36,6 +36,13 @@ var openProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/__io_openat_prep",
+			EBPFFuncName: "kprobe___io_openat_prep",
+		},
+	},
+	{
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
 			EBPFSection:  "kprobe/io_openat2",
 			EBPFFuncName: "kprobe_io_openat2",
 		},

--- a/pkg/security/tests/open_test.go
+++ b/pkg/security/tests/open_test.go
@@ -258,6 +258,12 @@ func TestOpen(t *testing.T) {
 			assert.Equal(t, syscall.O_CREAT, int(event.Open.Flags&0xfff), "wrong flags")
 			assertRights(t, uint16(event.Open.Mode), 0747)
 			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
+
+			executable, err := os.Executable()
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertFieldEqual(t, event, "process.file.path", executable)
 		})
 
 		prepRequest, err = iouring.Openat2(unix.AT_FDCWD, testFile, &openHow)
@@ -291,6 +297,12 @@ func TestOpen(t *testing.T) {
 			assert.Equal(t, syscall.O_CREAT, int(event.Open.Flags&0xfff), "wrong flags")
 			assertRights(t, uint16(event.Open.Mode), 0711)
 			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
+
+			executable, err := os.Executable()
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertFieldEqual(t, event, "process.file.path", executable)
 		})
 	})
 


### PR DESCRIPTION
### What does this PR do?

iouring requests can be run from a worker kernel thread and not directly from the process itself. This means that when fetching the process context to fill the event we are not fetching the correct process context since the pid/tgid does not match the actual process.

This PR adds a LRU hash to map the request to the calling process pid/tgid.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
