### PR TITLE
re-initialize default taggers when they are changed

### DIFF
--- a/pkg/tagger/global.go
+++ b/pkg/tagger/global.go
@@ -23,11 +23,16 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// defaultTagger is the shared tagger instance backing the global Tag and Init functions
 var (
+	// defaultTagger is the shared tagger instance backing the global Tag and Init functions
 	defaultTagger Tagger
-	initOnce      sync.Once
-	initErr       error
+
+	// initOnce ensures that the default tagger is only initialized once.  It is reset every
+	// time the default tagger is set.
+	initOnce sync.Once
+
+	// initErr is the error from intializing the default tagger
+	initErr error
 )
 
 // captureTagger is a tagger instance that contains a tagger that will contain the tagger
@@ -221,6 +226,8 @@ func List(cardinality collectors.TagCardinality) response.TaggerListResponse {
 
 // SetDefaultTagger sets the global Tagger instance
 func SetDefaultTagger(tagger Tagger) {
+	// reset initOnce so that this new tagger's Init(..) will get called
+	initOnce = sync.Once{}
 	defaultTagger = tagger
 }
 


### PR DESCRIPTION
This is a forward-port of #11829

### Describe how to test/QA your changes

Set up an agent to replicate the circumstances described in #11829: tries to use a remote tagger, but that's unavailable. Observe no panic on shutdown.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
