### PR TITLE
Add debugging info for team labels check

### DIFF
--- a/tasks/test.py
+++ b/tasks/test.py
@@ -433,7 +433,9 @@ def lint_teamassignment(_):
                 print(f"Team Assignment: {label}")
                 return
 
-        print(f"PR {pr_url} requires team assignment")
+        print(f"PR {pr_url} requires team assignment label (team/...); got labels:")
+        for label in labels:
+            print(f" {label}")
         raise Exit(code=1)
 
     # No PR is associated with this build: given that we have the "run only on PRs" setting activated,


### PR DESCRIPTION
### What does this PR do?

Adds some debugging info to the `team_label` check.

### Motivation

This check seems to fail sometimes in cases where the team label exists.  Ex: [this build](https://app.circleci.com/pipelines/github/DataDog/datadog-agent/44245/workflows/693df89a-3ecf-4298-822b-cd3e945d39cd/jobs/620558).  Let's gather some debugging info to see what's going on.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
