### PR TITLE
Use netaddr.IP for netlink decoding

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -329,8 +329,6 @@ core,github.com/emicklei/go-restful/log,MIT,"Copyright (c) 2012,2013 Ernest Mick
 core,github.com/evanphx/json-patch,BSD-3-Clause,"Copyright (c) 2014, Evan Phoenix"
 core,github.com/fatih/color,MIT,Copyright (c) 2013 Fatih Arslan
 core,github.com/felixge/httpsnoop,MIT,Copyright (c) 2016 Felix Geisendörfer (felix@debuggable.com)
-core,github.com/florianl/go-conntrack,MIT,Copyright (C) 2018  Florian Lehner <dev@der-flo.net>
-core,github.com/florianl/go-conntrack/internal/unix,MIT,Copyright (C) 2018  Florian Lehner <dev@der-flo.net>
 core,github.com/freddierice/go-losetup,MIT,Copyright (c) 2017 Freddie Rice
 core,github.com/fsnotify/fsnotify,BSD-3-Clause,Copyright (c) 2012 The Go Authors. All rights reserved. | Copyright (c) 2012-2019 fsnotify Authors. All rights reserved.
 core,github.com/ghodss/yaml,MIT,Copyright (c) 2012 The Go Authors. All rights reserved | Copyright (c) 2014 Sam Ghods
@@ -897,6 +895,8 @@ core,go.uber.org/zap/internal/color,MIT,"Copyright (c) 2016-2017 Uber Technologi
 core,go.uber.org/zap/internal/exit,MIT,"Copyright (c) 2016-2017 Uber Technologies, Inc"
 core,go.uber.org/zap/zapcore,MIT,"Copyright (c) 2016-2017 Uber Technologies, Inc"
 core,go.uber.org/zap/zapgrpc,MIT,"Copyright (c) 2016-2017 Uber Technologies, Inc"
+core,go4.org/intern,BSD-3-Clause,"Copyright (c) 2020, Brad Fitzpatrick"
+core,go4.org/unsafe/assume-no-moving-gc,BSD-3-Clause,"Copyright (c) 2020, Brad Fitzpatrick"
 core,golang.org/x/crypto/cast5,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
 core,golang.org/x/crypto/cryptobyte,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
 core,golang.org/x/crypto/cryptobyte/asn1,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
@@ -1098,6 +1098,7 @@ core,gopkg.in/natefinch/lumberjack.v2,MIT,Copyright (c) 2014 Nate Finch
 core,gopkg.in/yaml.v2,Apache-2.0,Copyright 2011-2016 Canonical Ltd
 core,gopkg.in/yaml.v3,MIT,Copyright (c) 2006-2010 Kirill Simonov | Copyright 2011-2016 Canonical Ltd
 core,gopkg.in/zorkian/go-datadog-api.v2,BSD-3-Clause,Copyright (c) 2013 by authors and contributors | Copyright 2013-2019 by authors and contributors
+core,inet.af/netaddr,BSD-3-Clause,Alex Willmer <alex@moreati.org.uk> | Copyright (c) 2020 The Inet.af AUTHORS. All rights reserved | Matt Layher <mdlayher@gmail.com> | Tailscale Inc. | Tobias Klauser <tklauser@distanz.ch>
 core,k8s.io/api/admission/v1,Apache-2.0,Copyright 2014 The Kubernetes Authors.
 core,k8s.io/api/admission/v1beta1,Apache-2.0,Copyright 2014 The Kubernetes Authors.
 core,k8s.io/api/admissionregistration/v1,Apache-2.0,Copyright 2014 The Kubernetes Authors.

--- a/go.mod
+++ b/go.mod
@@ -113,7 +113,6 @@ require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/elastic/go-libaudit v0.4.0
 	github.com/fatih/color v1.13.0
-	github.com/florianl/go-conntrack v0.2.0
 	github.com/freddierice/go-losetup v0.0.0-20170407175016-fc9adea44124
 	github.com/go-ini/ini v1.66.4
 	github.com/go-ole/go-ole v1.2.6
@@ -205,6 +204,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	gopkg.in/zorkian/go-datadog-api.v2 v2.30.0
 	gotest.tools v2.2.0+incompatible
+	inet.af/netaddr v0.0.0-20211027220019-c74959edd3b6
 	k8s.io/api v0.21.5
 	k8s.io/apimachinery v0.21.5
 	k8s.io/apiserver v0.21.5
@@ -386,6 +386,8 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v0.29.0 // indirect
 	go.opentelemetry.io/otel/trace v1.6.3 // indirect
 	go.uber.org/atomic v1.9.0
+	go4.org/intern v0.0.0-20211027215823-ae77deb06f29 // indirect
+	go4.org/unsafe/assume-no-moving-gc v0.0.0-20211027215541-db492cf91b37 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 // indirect
 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect

--- a/go.sum
+++ b/go.sum
@@ -527,6 +527,7 @@ github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdf
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/dvyukov/go-fuzz v0.0.0-20210103155950-6a8e9d1f2415/go.mod h1:11Gm+ccJnvAhCNLlf5+cS9KjtbaD5I5zaZpFMsTHWTw=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
@@ -558,8 +559,6 @@ github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYF
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/felixge/httpsnoop v1.0.2 h1:+nS9g82KMXccJ/wp0zyRW9ZBHFETmMGtkk+2CTTrW4o=
 github.com/felixge/httpsnoop v1.0.2/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/florianl/go-conntrack v0.2.0 h1:JEB4w895ZX35tvNH5JjNM9pxa+Qn73paiA37VeCZGfc=
-github.com/florianl/go-conntrack v0.2.0/go.mod h1:HRSlXmrl5M//9hiHmkwyLDwlaoba2sVDcBpHFRiVo1Q=
 github.com/flynn/go-docopt v0.0.0-20140912013429-f6dd2ebbb31e/go.mod h1:HyVoz1Mz5Co8TFO8EupIdlcpwShBmY98dkT2xeHkvEI=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
@@ -1878,6 +1877,10 @@ go.uber.org/zap v1.15.0/go.mod h1:Mb2vm2krFEG5DV0W9qcHBYFtp/Wku1cvYaqPsS/WYfc=
 go.uber.org/zap v1.17.0/go.mod h1:MXVU+bhUf/A7Xi2HNOnopQOrmycQ5Ih87HtOu4q5SSo=
 go.uber.org/zap v1.21.0 h1:WefMeulhovoZ2sYXz7st6K0sLj7bBhpiFaud4r4zST8=
 go.uber.org/zap v1.21.0/go.mod h1:wjWOCqI0f2ZZrJF/UufIOkiC8ii6tm1iqIsLo76RfJw=
+go4.org/intern v0.0.0-20211027215823-ae77deb06f29 h1:UXLjNohABv4S58tHmeuIZDO6e3mHpW2Dx33gaNt03LE=
+go4.org/intern v0.0.0-20211027215823-ae77deb06f29/go.mod h1:cS2ma+47FKrLPdXFpr7CuxiTW3eyJbWew4qx0qtQWDA=
+go4.org/unsafe/assume-no-moving-gc v0.0.0-20211027215541-db492cf91b37 h1:Tx9kY6yUkLge/pFG7IEMwDZy6CS2ajFc9TvQdPCW0uA=
+go4.org/unsafe/assume-no-moving-gc v0.0.0-20211027215541-db492cf91b37/go.mod h1:FftLjUGFEDu5k8lt0ddY+HcrH/qU/0qk+H8j9/nTl3E=
 golang.org/x/crypto v0.0.0-20171113213409-9f005a07e0d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20180403160946-b2aa35443fbc/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
@@ -2560,6 +2563,8 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
+inet.af/netaddr v0.0.0-20211027220019-c74959edd3b6 h1:acCzuUSQ79tGsM/O50VRFySfMm19IoMKL+sZztZkCxw=
+inet.af/netaddr v0.0.0-20211027220019-c74959edd3b6/go.mod h1:y3MGhcFMlh0KZPMuXXow8mpjxxAk3yoDNsp4cQz54i8=
 k8s.io/api v0.0.0-20191016110408-35e52d86657a/go.mod h1:/L5qH+AD540e7Cetbui1tuJeXdmNhO8jM6VkXeDdDhQ=
 k8s.io/api v0.0.0-20191109101512-6d4d1612ba53/go.mod h1:VJq7+38rpM4TSUbRiZX4P5UVAKK2UQpNQLZClkFQkpE=
 k8s.io/api v0.0.0-20191112020540-7f9008e52f64/go.mod h1:8svLRMiLwQReMTycutfjsaQ0ackWIf8HCT4UcixYLjI=

--- a/pkg/network/netlink/conntrack.go
+++ b/pkg/network/netlink/conntrack.go
@@ -48,8 +48,8 @@ type conntrack struct {
 
 func (c *conntrack) Exists(conn *Con) (bool, error) {
 	var family byte = unix.AF_INET
-	if (conn.Con.Origin != nil && conn.Con.Origin.Src != nil && conn.Con.Origin.Src.To4() == nil) ||
-		(conn.Con.Reply != nil && conn.Con.Reply.Src != nil && conn.Con.Reply.Src.To4() == nil) {
+	if (!conn.Origin.IsZero() && !conn.Origin.Src.IsZero() && conn.Origin.Src.IP().Is6() && !conn.Origin.Src.IP().Is4in6()) ||
+		(!conn.Reply.IsZero() && !conn.Reply.Src.IsZero() && conn.Reply.Src.IP().Is6() && !conn.Reply.Src.IP().Is4in6()) {
 		family = unix.AF_INET6
 	}
 

--- a/pkg/network/netlink/conntrack_integration_test.go
+++ b/pkg/network/netlink/conntrack_integration_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/netlink/testutil"
 	nettestutil "github.com/DataDog/datadog-agent/pkg/network/testutil"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
-	ct "github.com/florianl/go-conntrack"
 	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netns"
 	"golang.org/x/sys/unix"
@@ -137,9 +136,7 @@ func TestConntrackExistsRootDNAT(t *testing.T) {
 
 	tcpLaddr := tcpConn.LocalAddr().(*net.TCPAddr)
 	c := &Con{
-		Con: ct.Con{
-			Origin: newIPTuple(tcpLaddr.IP.String(), destIP, uint16(tcpLaddr.Port), uint16(destPort), unix.IPPROTO_TCP),
-		},
+		Origin: newIPTuple(tcpLaddr.IP.String(), destIP, uint16(tcpLaddr.Port), uint16(destPort), unix.IPPROTO_TCP),
 	}
 
 	exists, err := rootck.Exists(c)
@@ -169,9 +166,7 @@ func testConntrackExists(t *testing.T, laddrIP string, laddrPort int, proto stri
 		{
 			desc: fmt.Sprintf("net ns 0, origin exists, proto %s", proto),
 			c: Con{
-				Con: ct.Con{
-					Origin: newIPTuple(laddrIP, "2.2.2.4", uint16(laddrPort), 80, ipProto),
-				},
+				Origin: newIPTuple(laddrIP, "2.2.2.4", uint16(laddrPort), 80, ipProto),
 			},
 			exists: true,
 			ns:     int(rootNs),
@@ -179,9 +174,7 @@ func testConntrackExists(t *testing.T, laddrIP string, laddrPort int, proto stri
 		{
 			desc: fmt.Sprintf("net ns 0, reply exists, proto %s", proto),
 			c: Con{
-				Con: ct.Con{
-					Reply: newIPTuple("2.2.2.4", laddrIP, 80, uint16(laddrPort), ipProto),
-				},
+				Reply: newIPTuple("2.2.2.4", laddrIP, 80, uint16(laddrPort), ipProto),
 			},
 			exists: true,
 			ns:     int(rootNs),
@@ -189,9 +182,7 @@ func testConntrackExists(t *testing.T, laddrIP string, laddrPort int, proto stri
 		{
 			desc: fmt.Sprintf("net ns 0, origin does not exist, proto %s", proto),
 			c: Con{
-				Con: ct.Con{
-					Origin: newIPTuple(laddrIP, "2.2.2.3", uint16(laddrPort), 80, ipProto),
-				},
+				Origin: newIPTuple(laddrIP, "2.2.2.3", uint16(laddrPort), 80, ipProto),
 			},
 			exists: false,
 			ns:     int(rootNs),
@@ -199,9 +190,7 @@ func testConntrackExists(t *testing.T, laddrIP string, laddrPort int, proto stri
 		{
 			desc: fmt.Sprintf("net ns %d, origin exists, proto %s", int(testNs), proto),
 			c: Con{
-				Con: ct.Con{
-					Origin: newIPTuple(laddrIP, "2.2.2.4", uint16(laddrPort), 80, ipProto),
-				},
+				Origin: newIPTuple(laddrIP, "2.2.2.4", uint16(laddrPort), 80, ipProto),
 			},
 			exists: true,
 			ns:     int(testNs),
@@ -209,9 +198,7 @@ func testConntrackExists(t *testing.T, laddrIP string, laddrPort int, proto stri
 		{
 			desc: fmt.Sprintf("net ns %d, reply exists, proto %s", int(testNs), proto),
 			c: Con{
-				Con: ct.Con{
-					Reply: newIPTuple("2.2.2.4", laddrIP, 8080, uint16(laddrPort), ipProto),
-				},
+				Reply: newIPTuple("2.2.2.4", laddrIP, 8080, uint16(laddrPort), ipProto),
 			},
 			exists: true,
 			ns:     int(testNs),
@@ -219,9 +206,7 @@ func testConntrackExists(t *testing.T, laddrIP string, laddrPort int, proto stri
 		{
 			desc: fmt.Sprintf("net ns %d, origin does not exist, proto %s", int(testNs), proto),
 			c: Con{
-				Con: ct.Con{
-					Origin: newIPTuple(laddrIP, "2.2.2.3", uint16(laddrPort), 80, ipProto),
-				},
+				Origin: newIPTuple(laddrIP, "2.2.2.3", uint16(laddrPort), 80, ipProto),
 			},
 			exists: false,
 			ns:     int(testNs),
@@ -264,9 +249,7 @@ func testConntrackExists6(t *testing.T, laddrIP string, laddrPort int, proto str
 		{
 			desc: fmt.Sprintf("net ns 0, origin exists, proto %s", proto),
 			c: Con{
-				Con: ct.Con{
-					Origin: newIPTuple(laddrIP, "fd00::2", uint16(laddrPort), 80, ipProto),
-				},
+				Origin: newIPTuple(laddrIP, "fd00::2", uint16(laddrPort), 80, ipProto),
 			},
 			exists: true,
 			ns:     int(rootNs),
@@ -274,9 +257,7 @@ func testConntrackExists6(t *testing.T, laddrIP string, laddrPort int, proto str
 		{
 			desc: fmt.Sprintf("net ns 0, reply exists, proto %s", proto),
 			c: Con{
-				Con: ct.Con{
-					Reply: newIPTuple("fd00::2", laddrIP, 80, uint16(laddrPort), ipProto),
-				},
+				Reply: newIPTuple("fd00::2", laddrIP, 80, uint16(laddrPort), ipProto),
 			},
 			exists: true,
 			ns:     int(rootNs),
@@ -284,9 +265,7 @@ func testConntrackExists6(t *testing.T, laddrIP string, laddrPort int, proto str
 		{
 			desc: fmt.Sprintf("net ns 0, origin does not exist, proto %s", proto),
 			c: Con{
-				Con: ct.Con{
-					Origin: newIPTuple(laddrIP, "fd00::1", uint16(laddrPort), 80, ipProto),
-				},
+				Origin: newIPTuple(laddrIP, "fd00::1", uint16(laddrPort), 80, ipProto),
 			},
 			exists: false,
 			ns:     int(rootNs),
@@ -294,9 +273,7 @@ func testConntrackExists6(t *testing.T, laddrIP string, laddrPort int, proto str
 		{
 			desc: fmt.Sprintf("net ns %d, origin exists, proto %s", int(testNs), proto),
 			c: Con{
-				Con: ct.Con{
-					Origin: newIPTuple(laddrIP, "fd00::2", uint16(laddrPort), 80, ipProto),
-				},
+				Origin: newIPTuple(laddrIP, "fd00::2", uint16(laddrPort), 80, ipProto),
 			},
 			exists: true,
 			ns:     int(testNs),
@@ -304,9 +281,7 @@ func testConntrackExists6(t *testing.T, laddrIP string, laddrPort int, proto str
 		{
 			desc: fmt.Sprintf("net ns %d, reply exists, proto %s", int(testNs), proto),
 			c: Con{
-				Con: ct.Con{
-					Reply: newIPTuple("fd00::2", laddrIP, 8080, uint16(laddrPort), ipProto),
-				},
+				Reply: newIPTuple("fd00::2", laddrIP, 8080, uint16(laddrPort), ipProto),
 			},
 			exists: true,
 			ns:     int(testNs),
@@ -314,9 +289,7 @@ func testConntrackExists6(t *testing.T, laddrIP string, laddrPort int, proto str
 		{
 			desc: fmt.Sprintf("net ns %d, origin does not exist, proto %s", int(testNs), proto),
 			c: Con{
-				Con: ct.Con{
-					Origin: newIPTuple(laddrIP, "fd00::1", uint16(laddrPort), 80, ipProto),
-				},
+				Origin: newIPTuple(laddrIP, "fd00::1", uint16(laddrPort), 80, ipProto),
 			},
 			exists: false,
 			ns:     int(testNs),

--- a/pkg/network/netlink/decoding_test.go
+++ b/pkg/network/netlink/decoding_test.go
@@ -13,12 +13,12 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net"
 	"os"
 	"testing"
 
 	"github.com/mdlayher/netlink"
 	"github.com/stretchr/testify/assert"
+	"inet.af/netaddr"
 )
 
 func TestDecodeAndReleaseEvent(t *testing.T) {
@@ -36,19 +36,19 @@ func TestDecodeAndReleaseEvent(t *testing.T) {
 	assert.Len(t, connections, 1)
 	c := connections[0]
 
-	assert.True(t, net.ParseIP("10.0.2.15").Equal(*c.Origin.Src))
-	assert.True(t, net.ParseIP("2.2.2.2").Equal(*c.Origin.Dst))
+	assert.Equal(t, netaddr.MustParseIP("10.0.2.15"), c.Origin.Src.IP())
+	assert.Equal(t, netaddr.MustParseIP("2.2.2.2"), c.Origin.Dst.IP())
 
-	assert.Equal(t, uint16(58472), *c.Origin.Proto.SrcPort)
-	assert.Equal(t, uint16(5432), *c.Origin.Proto.DstPort)
-	assert.Equal(t, uint8(6), *c.Origin.Proto.Number)
+	assert.Equal(t, uint16(58472), c.Origin.Src.Port())
+	assert.Equal(t, uint16(5432), c.Origin.Dst.Port())
+	assert.Equal(t, uint8(6), c.Origin.Proto)
 
-	assert.True(t, net.ParseIP("1.1.1.1").Equal(*c.Reply.Src))
-	assert.True(t, net.ParseIP("10.0.2.15").Equal(*c.Reply.Dst))
+	assert.Equal(t, netaddr.MustParseIP("1.1.1.1"), c.Reply.Src.IP())
+	assert.Equal(t, netaddr.MustParseIP("10.0.2.15"), c.Reply.Dst.IP())
 
-	assert.Equal(t, uint16(5432), *c.Reply.Proto.SrcPort)
-	assert.Equal(t, uint16(58472), *c.Reply.Proto.DstPort)
-	assert.Equal(t, uint8(6), *c.Reply.Proto.Number)
+	assert.Equal(t, uint16(5432), c.Reply.Src.Port())
+	assert.Equal(t, uint16(58472), c.Reply.Dst.Port())
+	assert.Equal(t, uint8(6), c.Reply.Proto)
 }
 
 func BenchmarkDecodeSingleMessage(b *testing.B) {

--- a/pkg/network/netlink/encoding_test.go
+++ b/pkg/network/netlink/encoding_test.go
@@ -9,27 +9,22 @@
 package netlink
 
 import (
-	"net"
 	"testing"
 
-	ct "github.com/florianl/go-conntrack"
 	"github.com/mdlayher/netlink"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
+	"inet.af/netaddr"
 )
 
-func newIPTuple(srcIP, dstIP string, srcPort, dstPort uint16, proto uint8) *ct.IPTuple {
-	_s := net.ParseIP(srcIP)
-	_d := net.ParseIP(dstIP)
-	return &ct.IPTuple{
-		Src: &_s,
-		Dst: &_d,
-		Proto: &ct.ProtoTuple{
-			Number:  &proto,
-			SrcPort: &srcPort,
-			DstPort: &dstPort,
-		},
+func newIPTuple(srcIP, dstIP string, srcPort, dstPort uint16, proto uint8) ConTuple {
+	_s := netaddr.MustParseIP(srcIP)
+	_d := netaddr.MustParseIP(dstIP)
+	return ConTuple{
+		Src:   netaddr.IPPortFrom(_s, srcPort),
+		Dst:   netaddr.IPPortFrom(_d, dstPort),
+		Proto: proto,
 	}
 }
 
@@ -38,10 +33,8 @@ func TestEncodeConn(t *testing.T) {
 	origin := newIPTuple("10.0.2.15", "2.2.2.2", 58472, 5432, uint8(unix.IPPROTO_TCP))
 	reply := newIPTuple("1.1.1.1", "10.0.2.15", 5432, 58472, uint8(unix.IPPROTO_TCP))
 	conn := Con{
-		Con: ct.Con{
-			Origin: origin,
-			Reply:  reply,
-		},
+		Origin: origin,
+		Reply:  reply,
 	}
 
 	data, err := EncodeConn(&conn)
@@ -59,18 +52,12 @@ func TestEncodeConn(t *testing.T) {
 	require.Len(t, connections, 1)
 	c := connections[0]
 
-	assert.True(t, conn.Con.Origin.Src.Equal(*c.Origin.Src))
-	assert.True(t, conn.Con.Origin.Dst.Equal(*c.Origin.Dst))
+	assert.Equal(t, conn.Origin.Src, c.Origin.Src)
+	assert.Equal(t, conn.Origin.Dst, c.Origin.Dst)
+	assert.Equal(t, conn.Origin.Proto, c.Origin.Proto)
 
-	assert.Equal(t, *conn.Con.Origin.Proto.SrcPort, *c.Origin.Proto.SrcPort)
-	assert.Equal(t, *conn.Con.Origin.Proto.DstPort, *c.Origin.Proto.DstPort)
-	assert.Equal(t, *conn.Con.Origin.Proto.Number, *c.Origin.Proto.Number)
-
-	assert.True(t, conn.Con.Reply.Src.Equal(*c.Reply.Src))
-	assert.True(t, conn.Con.Reply.Dst.Equal(*c.Reply.Dst))
-
-	assert.Equal(t, *conn.Con.Reply.Proto.SrcPort, *c.Reply.Proto.SrcPort)
-	assert.Equal(t, *conn.Con.Reply.Proto.DstPort, *c.Reply.Proto.DstPort)
-	assert.Equal(t, *conn.Con.Reply.Proto.Number, *c.Reply.Proto.Number)
+	assert.Equal(t, conn.Reply.Src, c.Reply.Src)
+	assert.Equal(t, conn.Reply.Dst, c.Reply.Dst)
+	assert.Equal(t, conn.Reply.Proto, c.Reply.Proto)
 
 }

--- a/pkg/network/tracer/cached_conntrack_test.go
+++ b/pkg/network/tracer/cached_conntrack_test.go
@@ -109,11 +109,11 @@ func TestCachedConntrackExists(t *testing.T) {
 	}
 
 	m.EXPECT().Exists(gomock.Not(gomock.Nil())).Times(1).DoAndReturn(func(c *netlink.Con) (bool, error) {
-		require.Equal(t, saddr.String(), c.Origin.Src.String())
-		require.Equal(t, daddr.String(), c.Origin.Dst.String())
-		require.Equal(t, sport, *c.Origin.Proto.SrcPort)
-		require.Equal(t, dport, *c.Origin.Proto.DstPort)
-		require.Equal(t, uint8(unix.IPPROTO_TCP), *c.Origin.Proto.Number)
+		require.Equal(t, saddr.String(), c.Origin.Src.IP().String())
+		require.Equal(t, daddr.String(), c.Origin.Dst.IP().String())
+		require.Equal(t, sport, c.Origin.Src.Port())
+		require.Equal(t, dport, c.Origin.Dst.Port())
+		require.Equal(t, uint8(unix.IPPROTO_TCP), c.Origin.Proto)
 		return true, nil
 	})
 
@@ -127,22 +127,22 @@ func TestCachedConntrackExists(t *testing.T) {
 		i++
 
 		if i == 1 {
-			require.Nil(t, c.Reply)
-			require.Equal(t, saddr.String(), c.Origin.Src.String())
-			require.Equal(t, daddr.String(), c.Origin.Dst.String())
-			require.Equal(t, sport, *c.Origin.Proto.SrcPort)
-			require.Equal(t, dport, *c.Origin.Proto.DstPort)
-			require.Equal(t, uint8(unix.IPPROTO_TCP), *c.Origin.Proto.Number)
+			require.True(t, c.Reply.IsZero())
+			require.Equal(t, saddr.String(), c.Origin.Src.IP().String())
+			require.Equal(t, daddr.String(), c.Origin.Dst.IP().String())
+			require.Equal(t, sport, c.Origin.Src.Port())
+			require.Equal(t, dport, c.Origin.Dst.Port())
+			require.Equal(t, uint8(unix.IPPROTO_TCP), c.Origin.Proto)
 			return false, nil
 		}
 
 		if i == 2 {
-			require.Nil(t, c.Origin)
-			require.Equal(t, saddr.String(), c.Reply.Src.String())
-			require.Equal(t, daddr.String(), c.Reply.Dst.String())
-			require.Equal(t, sport, *c.Reply.Proto.SrcPort)
-			require.Equal(t, dport, *c.Reply.Proto.DstPort)
-			require.Equal(t, uint8(unix.IPPROTO_TCP), *c.Reply.Proto.Number)
+			require.True(t, c.Origin.IsZero())
+			require.Equal(t, saddr.String(), c.Reply.Src.IP().String())
+			require.Equal(t, daddr.String(), c.Reply.Dst.IP().String())
+			require.Equal(t, sport, c.Reply.Src.Port())
+			require.Equal(t, dport, c.Reply.Dst.Port())
+			require.Equal(t, uint8(unix.IPPROTO_TCP), c.Reply.Proto)
 			return true, nil
 		}
 

--- a/pkg/network/tracer/ebpf_conntracker.go
+++ b/pkg/network/tracer/ebpf_conntracker.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"net"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -30,7 +29,6 @@ import (
 	manager "github.com/DataDog/ebpf-manager"
 	"github.com/cihub/seelog"
 	"github.com/cilium/ebpf"
-	ct "github.com/florianl/go-conntrack"
 	"golang.org/x/sys/unix"
 )
 
@@ -149,8 +147,8 @@ func (e *ebpfConntracker) processEvent(ev netlink.Event) {
 	for _, c := range conns {
 		if netlink.IsNAT(c) {
 			log.Tracef("initial conntrack %s", c)
-			src := formatKey(c.NetNS, c.Origin)
-			dst := formatKey(c.NetNS, c.Reply)
+			src := formatKey(c.NetNS, &c.Origin)
+			dst := formatKey(c.NetNS, &c.Reply)
 			if src != nil && dst != nil {
 				if err := e.addTranslation(src, dst); err != nil {
 					log.Warnf("error adding initial conntrack entry to ebpf map: %s", err)
@@ -170,39 +168,28 @@ func (e *ebpfConntracker) addTranslation(src *netebpf.ConntrackTuple, dst *neteb
 	return nil
 }
 
-func formatKey(netns uint32, tuple *ct.IPTuple) *netebpf.ConntrackTuple {
-	var proto network.ConnectionType
-	switch *tuple.Proto.Number {
-	case unix.IPPROTO_TCP:
-		proto = network.TCP
-	case unix.IPPROTO_UDP:
-		proto = network.UDP
-	default:
-		return nil
-	}
-
+func formatKey(netns uint32, tuple *netlink.ConTuple) *netebpf.ConntrackTuple {
 	nct := &netebpf.ConntrackTuple{
 		Netns: netns,
-		Sport: *tuple.Proto.SrcPort,
-		Dport: *tuple.Proto.DstPort,
+		Sport: tuple.Src.Port(),
+		Dport: tuple.Dst.Port(),
 	}
-	src := util.AddressFromNetIP(*tuple.Src)
-	nct.Saddr_l, nct.Saddr_h = util.ToLowHigh(src)
-	nct.Daddr_l, nct.Daddr_h = util.ToLowHigh(util.AddressFromNetIP(*tuple.Dst))
+	src := tuple.Src.IP()
+	nct.Saddr_l, nct.Saddr_h = util.ToLowHighIP(src)
+	nct.Daddr_l, nct.Daddr_h = util.ToLowHighIP(tuple.Dst.IP())
 
-	switch len(src.Bytes()) {
-	case net.IPv4len:
+	if src.Is4() {
 		nct.Metadata |= uint32(netebpf.IPv4)
-	case net.IPv6len:
+	} else {
 		nct.Metadata |= uint32(netebpf.IPv6)
+	}
+	switch tuple.Proto {
+	case unix.IPPROTO_TCP:
+		nct.Metadata |= uint32(netebpf.TCP)
+	case unix.IPPROTO_UDP:
+		nct.Metadata |= uint32(netebpf.UDP)
 	default:
 		return nil
-	}
-	switch proto {
-	case network.TCP:
-		nct.Metadata |= uint32(netebpf.TCP)
-	case network.UDP:
-		nct.Metadata |= uint32(netebpf.UDP)
 	}
 
 	return nct

--- a/pkg/process/util/address.go
+++ b/pkg/process/util/address.go
@@ -9,6 +9,8 @@ import (
 	"encoding/binary"
 	"net"
 	"sync"
+
+	"inet.af/netaddr"
 )
 
 // Address is an IP abstraction that is family (v4/v6) agnostic
@@ -65,6 +67,20 @@ func ToLowHigh(addr Address) (l, h uint64) {
 	}
 
 	return
+}
+
+// ToLowHighIP converts a netaddr.IP into a pair of uint64 numbers
+func ToLowHighIP(a netaddr.IP) (l, h uint64) {
+	if a.Is6() {
+		return toLowHigh16(a.As16())
+	}
+	return toLowHigh4(a.As4())
+}
+func toLowHigh4(b [4]byte) (l, h uint64) {
+	return uint64(binary.LittleEndian.Uint32(b[:4])), uint64(0)
+}
+func toLowHigh16(b [16]byte) (l, h uint64) {
+	return binary.LittleEndian.Uint64(b[8:]), binary.LittleEndian.Uint64(b[:8])
 }
 
 type v4Address [4]byte


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Uses `netaddr.IP` type for IP addresses within the `netlink` module, including when decoding netlink messages.

### Motivation

`netaddr.IP` does not allocate on the heap. This will have memory usage savings for us.

### Additional Notes

![Screen Shot 2022-05-02 at 10 14 44 AM](https://user-images.githubusercontent.com/1010430/166293554-8d85c1e4-64d2-4f0d-b201-92ee1112b3f7.png)
![Screen Shot 2022-05-02 at 10 17 05 AM](https://user-images.githubusercontent.com/1010430/166293837-c77a42af-9c4b-4582-bc40-1280c36fbb91.png)


### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
