### PR TITLE
[CSPM] start the workloadmeta store before listing containers

### DIFF
--- a/pkg/compliance/agent/agent.go
+++ b/pkg/compliance/agent/agent.go
@@ -35,12 +35,13 @@ type Scheduler interface {
 
 // Agent defines Compliance Agent
 type Agent struct {
-	builder   checks.Builder
-	scheduler Scheduler
-	telemetry *telemetry
-	configDir string
-	endpoints *config.Endpoints
-	cancel    context.CancelFunc
+	builder     checks.Builder
+	scheduler   Scheduler
+	telemetry   *telemetry
+	startWMOnce sync.Once
+	configDir   string
+	endpoints   *config.Endpoints
+	cancel      context.CancelFunc
 }
 
 // New creates a new instance of Agent
@@ -141,10 +142,8 @@ func (a *Agent) Run() error {
 	return a.buildChecks(onCheck)
 }
 
-var startWMOnce sync.Once
-
 func (a *Agent) startWorkloadMeta(ctx context.Context) {
-	startWMOnce.Do(func() {
+	a.startWMOnce.Do(func() {
 		store := workloadmeta.GetGlobalStore()
 		store.Start(ctx)
 	})

--- a/pkg/compliance/agent/telemetry.go
+++ b/pkg/compliance/agent/telemetry.go
@@ -40,6 +40,8 @@ func (t *telemetry) run(ctx context.Context) {
 	log.Info("Start collecting Compliance telemetry")
 	defer log.Info("Stopping Compliance telemetry")
 
+	t.metadataStore.Start(ctx)
+
 	metricsTicker := time.NewTicker(1 * time.Minute)
 	defer metricsTicker.Stop()
 

--- a/pkg/compliance/agent/telemetry.go
+++ b/pkg/compliance/agent/telemetry.go
@@ -40,8 +40,6 @@ func (t *telemetry) run(ctx context.Context) {
 	log.Info("Start collecting Compliance telemetry")
 	defer log.Info("Stopping Compliance telemetry")
 
-	t.metadataStore.Start(ctx)
-
 	metricsTicker := time.NewTicker(1 * time.Minute)
 	defer metricsTicker.Stop()
 


### PR DESCRIPTION
### What does this PR do?

This PR ensures that the workloadmeta store is `Start`ed before using it to list containers.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
