### PR TITLE
[tasks] Removing duplicate tags from Origin of a log message

### DIFF
--- a/pkg/logs/internal/processor/encoder_test.go
+++ b/pkg/logs/internal/processor/encoder_test.go
@@ -7,6 +7,7 @@ package processor
 
 import (
 	"encoding/json"
+	"regexp"
 	"testing"
 
 	"strings"
@@ -51,9 +52,19 @@ func TestRawEncoder(t *testing.T) {
 	assert.Equal(t, "-", parts[4])
 	assert.Equal(t, "-", parts[5])
 	extra := content[strings.Index(content, "[") : strings.LastIndex(content, "]")+1]
-	assert.Equal(t, "[dd ddsource=\"Source\"][dd ddsourcecategory=\"SourceCategory\"][dd ddtags=\"foo:bar,baz,a,b:c\"]", extra)
+	assert.True(t, strings.HasPrefix(extra, "[dd ddsource=\"Source\"][dd ddsourcecategory=\"SourceCategory\"][dd ddtags=\""), "Payload did not have correct prefix", extra)
+	assertDDTags(t, []string{"foo:bar", "baz", "a", "b:c"}, extra)
 	assert.Equal(t, "redacted", content[strings.LastIndex(content, " ")+1:])
+}
 
+func assertDDTags(t *testing.T, expectedTags []string, ddtags string) {
+	if len(expectedTags) == 0 {
+		return
+	}
+	r, _ := regexp.Compile("ddtags=\"(.*)\"]")
+	submatch := r.FindStringSubmatch(ddtags)
+	assert.NotEmpty(t, submatch)
+	assert.ElementsMatch(t, expectedTags, strings.Split(submatch[1], ","))
 }
 
 func TestRawEncoderDefaults(t *testing.T) {
@@ -139,7 +150,7 @@ func TestProtoEncoder(t *testing.T) {
 
 	assert.Equal(t, logsConfig.Service, log.Service)
 	assert.Equal(t, logsConfig.Source, log.Source)
-	assert.Equal(t, []string{"a", "b:c", "sourcecategory:" + logsConfig.SourceCategory, "foo:bar", "baz"}, log.Tags)
+	assert.ElementsMatch(t, []string{"a", "b:c", "sourcecategory:" + logsConfig.SourceCategory, "foo:bar", "baz"}, log.Tags)
 
 	assert.Equal(t, redactedMessage, log.Message)
 	assert.Equal(t, message.StatusError, log.Status)
@@ -214,7 +225,8 @@ func TestJsonEncoder(t *testing.T) {
 
 	assert.Equal(t, logsConfig.Service, log.Service)
 	assert.Equal(t, logsConfig.Source, log.Source)
-	assert.Equal(t, "a,b:c,sourcecategory:"+logsConfig.SourceCategory+",foo:bar,baz", log.Tags)
+	// Turning tags into an array as can't guarantee order of Tags
+	assert.ElementsMatch(t, []string{"a", "b:c", "sourcecategory:" + logsConfig.SourceCategory, "foo:bar", "baz"}, strings.Split(log.Tags, ","))
 
 	assert.Equal(t, redactedMessage, log.Message)
 	assert.Equal(t, message.StatusError, log.Status)

--- a/pkg/logs/message/origin.go
+++ b/pkg/logs/message/origin.go
@@ -28,14 +28,14 @@ func NewOrigin(source *config.LogSource) *Origin {
 	}
 }
 
-// Tags returns the tags of the origin.
+// Tags returns the tags of the origin merged with those from the LogSource config
 //
 // The returned slice must not be modified by the caller.
 func (o *Origin) Tags() []string {
-	return o.tagsToStringArray()
+	return o.tagsToStringArray(true)
 }
 
-// TagsPayload returns the raw tag payload of the origin.
+// TagsPayload returns the raw tag payload of the origin (including those from the LogSource config).
 func (o *Origin) TagsPayload() []byte {
 	var tagsPayload []byte
 
@@ -48,9 +48,7 @@ func (o *Origin) TagsPayload() []byte {
 		tagsPayload = append(tagsPayload, []byte("[dd ddsourcecategory=\""+sourceCategory+"\"]")...)
 	}
 
-	var tags []string
-	tags = append(tags, o.LogSource.Config.Tags...)
-	tags = append(tags, o.tags...)
+	tags := o.tagsToStringArray(false)
 
 	if len(tags) > 0 {
 		tagsPayload = append(tagsPayload, []byte("[dd ddtags=\""+strings.Join(tags, ",")+"\"]")...)
@@ -61,9 +59,9 @@ func (o *Origin) TagsPayload() []byte {
 	return tagsPayload
 }
 
-// TagsToString encodes tags to a single string, in a comma separated format
+// TagsToString encodes tags of the origin (including those from the LogSource config) to a single string, in a comma separated format
 func (o *Origin) TagsToString() string {
-	tags := o.tagsToStringArray()
+	tags := o.tagsToStringArray(true)
 
 	if tags == nil {
 		return ""
@@ -72,16 +70,25 @@ func (o *Origin) TagsToString() string {
 	return strings.Join(tags, ",")
 }
 
-func (o *Origin) tagsToStringArray() []string {
-	tags := o.tags
+func (o *Origin) tagsToStringArray(addSourceCategory bool) []string {
+	tmpMap := make(map[string]struct{}, len(o.tags)+len(o.LogSource.Config.Tags)+1)
 
+	for i := range o.tags {
+		tmpMap[o.tags[i]] = struct{}{}
+	}
 	sourceCategory := o.LogSource.Config.SourceCategory
-	if sourceCategory != "" {
-		tags = append(tags, "sourcecategory"+":"+sourceCategory)
+	if addSourceCategory && sourceCategory != "" {
+		tmpMap["sourcecategory"+":"+sourceCategory] = struct{}{}
 	}
 
-	tags = append(tags, o.LogSource.Config.Tags...)
+	for i := range o.LogSource.Config.Tags {
+		tmpMap[o.LogSource.Config.Tags[i]] = struct{}{}
+	}
 
+	tags := make([]string, 0, len(tmpMap))
+	for k := range tmpMap {
+		tags = append(tags, k)
+	}
 	return tags
 }
 

--- a/pkg/logs/message/origin_test.go
+++ b/pkg/logs/message/origin_test.go
@@ -6,6 +6,8 @@
 package message
 
 import (
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
@@ -22,44 +24,79 @@ func TestSetTagsEmpty(t *testing.T) {
 	assert.Equal(t, []byte{}, origin.TagsPayload())
 }
 
-func TestTagsWithConfigTagsOnly(t *testing.T) {
-	cfg := &config.LogsConfig{
-		Source:         "a",
-		SourceCategory: "b",
-		Tags:           []string{"c:d", "e"},
+func TestSetTags(t *testing.T) {
+
+	tests := []struct {
+		name         string
+		configTags   []string
+		setTags      []string
+		expectedTags []string
+	}{
+		{
+			name: "Empty tags",
+		},
+		{
+			name:         "Config tags only",
+			configTags:   []string{"c:d", "e"},
+			expectedTags: []string{"c:d", "e"},
+		},
+		{
+			name:         "Set tags with no config tags",
+			setTags:      []string{"foo:bar", "baz"},
+			expectedTags: []string{"foo:bar", "baz"},
+		},
+		{
+			name:         "Set tags with config tags",
+			configTags:   []string{"c:d", "e"},
+			setTags:      []string{"foo:bar", "baz"},
+			expectedTags: []string{"c:d", "e", "foo:bar", "baz"},
+		},
+		{
+			name:         "Set tags with duplicate config tags",
+			configTags:   []string{"c:d", "e", "dupe:tag"},
+			setTags:      []string{"foo:bar", "baz", "dupe:tag"},
+			expectedTags: []string{"c:d", "e", "foo:bar", "baz", "dupe:tag"},
+		},
 	}
-	source := config.NewLogSource("", cfg)
-	origin := NewOrigin(source)
-	assert.Equal(t, []string{"sourcecategory:b", "c:d", "e"}, origin.Tags())
-	assert.Equal(t, "[dd ddsource=\"a\"][dd ddsourcecategory=\"b\"][dd ddtags=\"c:d,e\"]", string(origin.TagsPayload()))
-	assert.Equal(t, "sourcecategory:b,c:d,e", origin.TagsToString())
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Given a LogsConfig exists with configTags
+			cfg := &config.LogsConfig{
+				Source:         "a",
+				SourceCategory: "b",
+				Tags:           tc.configTags,
+			}
+			source := config.NewLogSource("", cfg)
+			origin := NewOrigin(source)
+			// When origin.SetTags is set to setTags
+			origin.SetTags(tc.setTags)
+
+			// Then origin.Tags match the expected tags with sourcecategory
+			expectedTags := append(tc.expectedTags, "sourcecategory:b")
+			assert.ElementsMatch(t, expectedTags, origin.Tags())
+			// And origin.TagsToString match the expected tags with sourcecategory
+			assert.ElementsMatch(t, expectedTags, strings.Split(origin.TagsToString(), ","))
+			// And origin.TagsPayload() matches
+			tagsPayload := string(origin.TagsPayload())
+			if len(tc.expectedTags) == 0 { // Should have no tags in payload
+				assert.Equal(t, "[dd ddsource=\"a\"][dd ddsourcecategory=\"b\"]", tagsPayload)
+				return
+			}
+			assert.True(t, strings.HasPrefix(tagsPayload, "[dd ddsource=\"a\"][dd ddsourcecategory=\"b\"][dd ddtags=\""), "Payload did not have correct prefix", tagsPayload)
+			assertDDTags(t, tc.expectedTags, tagsPayload)
+		})
+	}
 }
 
-func TestSetTagsWithNoConfigTags(t *testing.T) {
-	cfg := &config.LogsConfig{
-		Source:         "a",
-		SourceCategory: "b",
+func assertDDTags(t *testing.T, expectedTags []string, ddtags string) {
+	if len(expectedTags) == 0 {
+		return
 	}
-	source := config.NewLogSource("", cfg)
-	origin := NewOrigin(source)
-	origin.SetTags([]string{"foo:bar", "baz"})
-	assert.Equal(t, []string{"foo:bar", "baz", "sourcecategory:b"}, origin.Tags())
-	assert.Equal(t, "foo:bar,baz,sourcecategory:b", origin.TagsToString())
-	assert.Equal(t, "[dd ddsource=\"a\"][dd ddsourcecategory=\"b\"][dd ddtags=\"foo:bar,baz\"]", string(origin.TagsPayload()))
-}
-
-func TestSetTagsWithConfigTags(t *testing.T) {
-	cfg := &config.LogsConfig{
-		Source:         "a",
-		SourceCategory: "b",
-		Tags:           []string{"c:d", "e"},
-	}
-	source := config.NewLogSource("", cfg)
-	origin := NewOrigin(source)
-	origin.SetTags([]string{"foo:bar", "baz"})
-	assert.Equal(t, []string{"foo:bar", "baz", "sourcecategory:b", "c:d", "e"}, origin.Tags())
-	assert.Equal(t, "foo:bar,baz,sourcecategory:b,c:d,e", origin.TagsToString())
-	assert.Equal(t, "[dd ddsource=\"a\"][dd ddsourcecategory=\"b\"][dd ddtags=\"c:d,e,foo:bar,baz\"]", string(origin.TagsPayload()))
+	r, _ := regexp.Compile("ddtags=\"(.*)\"]")
+	submatch := r.FindStringSubmatch(ddtags)
+	assert.NotEmpty(t, submatch)
+	assert.ElementsMatch(t, expectedTags, strings.Split(submatch[1], ","))
 }
 
 func TestDefaultSourceValueIsSourceFromConfig(t *testing.T) {

--- a/releasenotes/notes/log-message-origin-tags-now-deduped-6111901d6151f5d0.yaml
+++ b/releasenotes/notes/log-message-origin-tags-now-deduped-6111901d6151f5d0.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    The tag data for a log message origin could potentially have
+    duplicate tags. Tags are now filtered to remove any duplicates
+    before creating the tags payload.


### PR DESCRIPTION
### What does this PR do?

Currently the `Origin.Tags()` returns a slice of tags that has both the tags set by calling `Origin.SetTags()` and those found in the `config` in `LogSource`. This PR updates the behaviour so that the tags from both sources are merged, removing any duplicate tags.

### Motivation

Remove the duplication of tags, such as those [in serverless](https://github.com/DataDog/datadog-agent/runs/5629413513?check_suite_focus=true).

### Possible Drawbacks / Trade-offs

As long as tag order is not important, this should not have any knock on effects.

### Describe how to test/QA your changes

On Linux, enable logs collection on the Agent and create a log config as follow:

```
logs:
  - type: file
    path: /var/log/datadog/agent.log
    source: agent
    serivce: agent
    tags:
      - "duplicate:tag"
      - "my_tag:is_awesome"
```

In the Agent config (`datadog.yaml`) add the following tags:

```
tags:
  - duplicate:tag
  -  some_other:tag
```

When the Agent is run you should see log messages that don't contain duplicate tags.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
