### PR TITLE
Update tools/gdb/Dockerfile

### DIFF
--- a/tools/gdb/.gdbinit
+++ b/tools/gdb/.gdbinit
@@ -1,4 +1,4 @@
-add-auto-load-safe-path /root/.gimme/versions
+add-auto-load-safe-path /goroot
 add-auto-load-safe-path /opt/datadog-agent/.debug
 set debug-file-directory /opt/datadog-agent/.debug
 set pagination off

--- a/tools/gdb/Dockerfile
+++ b/tools/gdb/Dockerfile
@@ -1,29 +1,20 @@
 ARG AGENT_VERSION
 FROM datadog/agent:${AGENT_VERSION}
 
-# Install gdb
-# Use the debian snapshot repo commented out in the sources.list file, so that we install
-# the same versions of the debug packages (that are deps of gdb) as what's originally installed in the image
-ARG DEBIAN_REPO_SNAPSHOT_DATE
-RUN grep '^\#' /etc/apt/sources.list | sed 's/# //' > /etc/apt/sources.list.tmp \
- && if [ -f ".debian_repo_snapshot_date" ]; then \
-    sed -i -r "s/[0-9]+T[0-9]+Z/$(cat .debian_repo_snapshot_date)/" /etc/apt/sources.list.tmp; \
-    mv /etc/apt/sources.list.tmp /etc/apt/sources.list; \
-elif [ ! -z "$DEBIAN_REPO_SNAPSHOT_DATE"]; then \
-    sed -i -r "s/[0-9]+T[0-9]+Z/${DEBIAN_REPO_SNAPSHOT_DATE}/" /etc/apt/sources.list.tmp; \
-    mv /etc/apt/sources.list.tmp /etc/apt/sources.list; \
- fi \
- && cat /etc/apt/sources.list \ 
- && apt-get -o Acquire::Check-Valid-Until=false update \
- && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" gdb
+RUN apt-get update
+RUN DEBIAN_FRONTEND=noninteractiv TZ=Etc/UTC apt-get install -y gdb build-essential strace less vim
 
-# Install Go version used to build the Agent, to get appropriate GDB debug script
-RUN export GIMME_GO_VERSION=$(agent version | grep --only-matching -E 'go[0-9\.]*' | sed 's/go//') \
- && eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | bash)"
+# Install go
+RUN curl -fSL -o golang.tgz https://go.dev/dl/go1.17.6.linux-amd64.tar.gz
+RUN tar xzvf golang.tgz
+RUN ln -s /go /goroot
+
+# Install go-delve
+RUN /go/bin/go install github.com/go-delve/delve/cmd/dlv@latest
 
 # Install datadog-agent-dbg at the right version
 RUN apt-get install -o Dpkg::Options::="--force-confold" --no-install-recommends -y gnupg dirmngr ca-certificates \
- && apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 A2923DFF56EDA6E76E55E492D3A80E30382E94DE
+ && apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 33EE313BAD9589B7
 ARG AGENT_VERSION
 ARG APT_REPO=apt.datadoghq.com
 ARG APT_DISTRIBUTION=stable
@@ -32,12 +23,15 @@ RUN echo "deb https://${APT_REPO}/ ${APT_DISTRIBUTION} 7 6" > /etc/apt/sources.l
  && cd /root/ \
  && DEB_AGENT_VERSION=$(echo "${AGENT_VERSION}" | sed "s/-/~/") \
  && apt-get download datadog-agent-dbg=1:${DEB_AGENT_VERSION}-1 \
- && dpkg -i --ignore-depends=datadog-agent ./datadog-agent-dbg*.deb \
+ && dpkg -X ./datadog-agent-dbg*.deb / \
  && rm -f ./datadog-agent-dbg*.deb
 
 # Add GDB debug script for libpython
 RUN TARGET_FILE=$(find /opt/datadog-agent/.debug/opt/datadog-agent/embedded/lib/ -name 'libpython3.*0.dbg' | sed 's/.dbg/-gdb.py/') \
  && curl https://raw.githubusercontent.com/python/cpython/master/Tools/gdb/libpython.py -o ${TARGET_FILE}
+
+RUN cp /opt/datadog-agent/.debug/opt/datadog-agent/bin/agent/agent.dbg \
+       /usr/lib/debug/.build-id/$(readelf -n /opt/datadog-agent/bin/agent/agent | perl -nE 'say "$1/$2.debug" if /Build ID: (..)(.*)/')
 
 # Configure  gdb
 COPY .gdbinit /root/

--- a/tools/gdb/README.md
+++ b/tools/gdb/README.md
@@ -36,6 +36,12 @@ The image is based on the `datadog/agent` image for the version of the Agent you
   docker run -it -v /path/to/core_dump_file:/root/core gdb-agent:7.18.0 /root/core
   ```
 
+  To use go-delve instead of gdb:
+  ```sh
+  docker run -it -v /path/to/core_dump_file:/root/core --entrypoint /root/go/bin/dlv \
+    gdb-agent:7.18.0 core /opt/datadog-agent/bin/agent/agent /root/core
+  ```
+
 You now have access to a regular gdb prompt, with the Python GDB extension. Example of commands:
 
 ```


### PR DESCRIPTION
### What does this PR do?

Freshen up tools/gdb/Dockerfile so it builds a container that can be used to debug recent builds of the agent.

  - Install more gnu tools
  - Install go-delve
  - Install static go version (gimme installation didn't work for some reason)
  - sources.list does not contain dated snapshots any more
  - Update apt key
  - Copy debug info to a location where go-delve can find it
  - Extract dbg package instead of installing it to avoid breaking dpkg state
    (datadog-agent is not installed via dpkg either)

### Motivation

Have a ready to use container spec to debug the agent.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
