### PR TITLE
Use UIDs for probes

### DIFF
--- a/pkg/ebpf/bytecode/runtime/http.go
+++ b/pkg/ebpf/bytecode/runtime/http.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Http = NewRuntimeAsset("http.c", "fda39306062f68ccd5339540b7d291e627a7acffa6d185e5d12cc57de6582e77")
+var Http = NewRuntimeAsset("http.c", "75c6ce75bd9178415caf88caf73fe06e5122dc82d253ffb0f7a258622489d876")

--- a/pkg/network/dns/ebpf.go
+++ b/pkg/network/dns/ebpf.go
@@ -20,6 +20,7 @@ import (
 )
 
 const funcName = "socket__dns_filter"
+const probeUID = "dns"
 
 type ebpfProgram struct {
 	*manager.Manager
@@ -38,6 +39,7 @@ func newEBPFProgram(c *config.Config) (*ebpfProgram, error) {
 			{ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				EBPFSection:  string(probes.SocketDnsFilter),
 				EBPFFuncName: funcName,
+				UID: probeUID,
 			}},
 		},
 	}
@@ -70,6 +72,7 @@ func (e *ebpfProgram) Init() error {
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
 					EBPFSection:  string(probes.SocketDnsFilter),
 					EBPFFuncName: funcName,
+					UID: probeUID,
 				},
 			},
 		},

--- a/pkg/network/dns/monitor_linux.go
+++ b/pkg/network/dns/monitor_linux.go
@@ -55,7 +55,7 @@ func NewReverseDNS(cfg *config.Config) (ReverseDNS, error) {
 			return nil, fmt.Errorf("error initializing ebpf programs: %w", err)
 		}
 
-		filter, _ = p.GetProbe(manager.ProbeIdentificationPair{EBPFSection: string(probes.SocketDnsFilter), EBPFFuncName: funcName})
+		filter, _ = p.GetProbe(manager.ProbeIdentificationPair{EBPFSection: string(probes.SocketDnsFilter), EBPFFuncName: funcName, UID: probeUID})
 		if filter == nil {
 			return nil, fmt.Errorf("error retrieving socket filter")
 		}

--- a/pkg/network/http/ebpf_main.go
+++ b/pkg/network/http/ebpf_main.go
@@ -43,6 +43,8 @@ const (
 
 	// size of the channel containing completed http_notification_objects
 	batchNotificationsChanSize = 100
+
+	probeUID = "http"
 )
 
 type ebpfProgram struct {
@@ -105,8 +107,8 @@ func newEBPFProgram(c *config.Config, offsets []manager.ConstantEditor, sockFD *
 			},
 		},
 		Probes: []*manager.Probe{
-			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: string(probes.TCPSendMsgReturn), EBPFFuncName: "kretprobe__tcp_sendmsg"}, KProbeMaxActive: maxActive},
-			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: httpSocketFilter, EBPFFuncName: "socket__http_filter"}},
+			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: string(probes.TCPSendMsgReturn), EBPFFuncName: "kretprobe__tcp_sendmsg", UID: probeUID}, KProbeMaxActive: maxActive},
+			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: httpSocketFilter, EBPFFuncName: "socket__http_filter", UID: probeUID}},
 		},
 	}
 
@@ -148,12 +150,14 @@ func (e *ebpfProgram) Init() error {
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
 					EBPFSection:  httpSocketFilter,
 					EBPFFuncName: "socket__http_filter",
+					UID: probeUID,
 				},
 			},
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
 					EBPFSection:  string(probes.TCPSendMsgReturn),
 					EBPFFuncName: "kretprobe__tcp_sendmsg",
+					UID: probeUID,
 				},
 			},
 		},

--- a/pkg/network/http/ebpf_ssl.go
+++ b/pkg/network/http/ebpf_ssl.go
@@ -102,10 +102,12 @@ func (o *sslProgram) ConfigureManager(m *manager.Manager) {
 			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				EBPFSection:  doSysOpen,
 				EBPFFuncName: "kprobe__do_sys_open",
+				UID: probeUID,
 			}, KProbeMaxActive: maxActive},
 			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				EBPFSection:  doSysOpenRet,
 				EBPFFuncName: "kretprobe__do_sys_open",
+				UID: probeUID,
 			}, KProbeMaxActive: maxActive},
 		)
 	}
@@ -128,12 +130,14 @@ func (o *sslProgram) ConfigureOptions(options *manager.Options) {
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
 					EBPFSection:  doSysOpen,
 					EBPFFuncName: "kprobe__do_sys_open",
+					UID: probeUID,
 				},
 			},
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
 					EBPFSection:  doSysOpenRet,
 					EBPFFuncName: "kretprobe__do_sys_open",
+					UID: probeUID,
 				},
 			},
 		)

--- a/pkg/network/http/monitor.go
+++ b/pkg/network/http/monitor.go
@@ -63,7 +63,7 @@ func NewMonitor(c *config.Config, offsets []manager.ConstantEditor, sockFD *ebpf
 		return nil, fmt.Errorf("error initializing http ebpf program: %s", err)
 	}
 
-	filter, _ := mgr.GetProbe(manager.ProbeIdentificationPair{EBPFSection: httpSocketFilter, EBPFFuncName: "socket__http_filter"})
+	filter, _ := mgr.GetProbe(manager.ProbeIdentificationPair{EBPFSection: httpSocketFilter, EBPFFuncName: "socket__http_filter", UID: probeUID})
 	if filter == nil {
 		return nil, fmt.Errorf("error retrieving socket filter")
 	}

--- a/pkg/network/tracer/connection/kprobe/manager.go
+++ b/pkg/network/tracer/connection/kprobe/manager.go
@@ -93,6 +93,7 @@ func newManager(closedHandler *ebpf.PerfHandler, runtimeTracer bool) *manager.Ma
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				EBPFSection:  string(probeName),
 				EBPFFuncName: funcName,
+				UID:          probeUID,
 			},
 		}
 		if strings.HasPrefix(funcName, "kretprobe") {
@@ -106,11 +107,11 @@ func newManager(closedHandler *ebpf.PerfHandler, runtimeTracer bool) *manager.Ma
 	// tracer.
 	if !runtimeTracer {
 		mgr.Probes = append(mgr.Probes,
-			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: string(probes.TCPRetransmitPre470), EBPFFuncName: "kprobe__tcp_retransmit_skb_pre_4_7_0"}, MatchFuncName: "^tcp_retransmit_skb$"},
-			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: string(probes.IP6MakeSkbPre470), EBPFFuncName: "kprobe__ip6_make_skb__pre_4_7_0"}, MatchFuncName: "^ip6_make_skb$"},
-			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: string(probes.UDPRecvMsgPre410), EBPFFuncName: "kprobe__udp_recvmsg_pre_4_1_0"}, MatchFuncName: "^udp_recvmsg$"},
-			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: string(probes.UDPv6RecvMsgPre410), EBPFFuncName: "kprobe__udpv6_recvmsg_pre_4_1_0"}, MatchFuncName: "^udpv6_recvmsg$"},
-			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: string(probes.TCPSendMsgPre410), EBPFFuncName: "kprobe__tcp_sendmsg__pre_4_1_0"}, MatchFuncName: "^tcp_sendmsg$"},
+			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: string(probes.TCPRetransmitPre470), EBPFFuncName: "kprobe__tcp_retransmit_skb_pre_4_7_0", UID: probeUID}, MatchFuncName: "^tcp_retransmit_skb$"},
+			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: string(probes.IP6MakeSkbPre470), EBPFFuncName: "kprobe__ip6_make_skb__pre_4_7_0", UID: probeUID}, MatchFuncName: "^ip6_make_skb$"},
+			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: string(probes.UDPRecvMsgPre410), EBPFFuncName: "kprobe__udp_recvmsg_pre_4_1_0", UID: probeUID}, MatchFuncName: "^udp_recvmsg$"},
+			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: string(probes.UDPv6RecvMsgPre410), EBPFFuncName: "kprobe__udpv6_recvmsg_pre_4_1_0", UID: probeUID}, MatchFuncName: "^udpv6_recvmsg$"},
+			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: string(probes.TCPSendMsgPre410), EBPFFuncName: "kprobe__tcp_sendmsg__pre_4_1_0", UID: probeUID}, MatchFuncName: "^tcp_sendmsg$"},
 		)
 	}
 

--- a/pkg/network/tracer/connection/kprobe/tracer.go
+++ b/pkg/network/tracer/connection/kprobe/tracer.go
@@ -32,6 +32,8 @@ import (
 
 const (
 	defaultClosedChannelSize = 500
+
+	probeUid = "net"
 )
 
 type kprobeTracer struct {
@@ -131,6 +133,7 @@ func New(config *config.Config, constants []manager.ConstantEditor) (connection.
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
 					EBPFSection:  string(probeName),
 					EBPFFuncName: funcName,
+					UID:          probeUID,
 				},
 			})
 	}

--- a/pkg/network/tracer/connection/kprobe/tracer.go
+++ b/pkg/network/tracer/connection/kprobe/tracer.go
@@ -33,7 +33,7 @@ import (
 const (
 	defaultClosedChannelSize = 500
 
-	probeUid = "net"
+	probeUID = "net"
 )
 
 type kprobeTracer struct {

--- a/pkg/network/tracer/ebpf_conntracker.go
+++ b/pkg/network/tracer/ebpf_conntracker.go
@@ -361,7 +361,13 @@ func getManager(buf io.ReaderAt, maxStateSize int) (*manager.Manager, error) {
 		},
 		PerfMaps: []*manager.PerfMap{},
 		Probes: []*manager.Probe{
-			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: string(probes.ConntrackHashInsert), EBPFFuncName: "kprobe___nf_conntrack_hash_insert"}},
+			{
+				ProbeIdentificationPair: manager.ProbeIdentificationPair{
+					EBPFSection:  string(probes.ConntrackHashInsert),
+					EBPFFuncName: "kprobe___nf_conntrack_hash_insert",
+					UID:          "conntracker",
+				},
+			},
 		},
 	}
 

--- a/pkg/network/tracer/offsetguess.go
+++ b/pkg/network/tracer/offsetguess.go
@@ -133,6 +133,7 @@ func idPair(name probes.ProbeName) manager.ProbeIdentificationPair {
 	return manager.ProbeIdentificationPair{
 		EBPFSection:  string(name),
 		EBPFFuncName: offsetProbes[name],
+		UID:          "offset",
 	}
 }
 

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -260,6 +260,7 @@ func runOffsetGuessing(config *config.Config, buf bytecode.AssetReader) ([]manag
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
 					EBPFSection:  string(probeName),
 					EBPFFuncName: funcName,
+					UID:          "offset",
 				},
 			})
 	}

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -131,6 +131,7 @@ def test(
     run=None,
     windows=is_windows,
     parallel_build=True,
+    failfast=False,
 ):
     """
     Run tests on eBPF parts
@@ -163,6 +164,7 @@ def test(
         "output_params": "-c -o " + output_path if output_path else "",
         "pkgs": packages,
         "run": "-run " + run if run else "",
+        "failfast": "-failfast" if failfast else "",
     }
 
     _, _, env = get_build_flags(ctx)
@@ -170,7 +172,7 @@ def test(
     if runtime_compiled:
         env['DD_TESTS_RUNTIME_COMPILED'] = "1"
 
-    cmd = 'go test -mod=mod -v -tags "{build_tags}" {output_params} {pkgs} {run}'
+    cmd = 'go test -mod=mod -v {failfast} -tags "{build_tags}" {output_params} {pkgs} {run}'
     if not windows and not output_path and not is_root():
         cmd = 'sudo -E ' + cmd
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Use UIDs for all probes for the network module of system-probe to fix probe naming conflicts when multiple probes are set on the same endpoint.

### Motivation
Errors like https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/133356508/raw

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
