### PR TITLE
[CSPM] start workloadmeta before listing containers

### DIFF
--- a/pkg/compliance/agent/agent.go
+++ b/pkg/compliance/agent/agent.go
@@ -11,6 +11,7 @@ import (
 	"expvar"
 	"path"
 	"path/filepath"
+	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/compliance"
@@ -18,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/compliance/event"
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
 
 var status = expvar.NewMap("compliance")
@@ -33,12 +35,13 @@ type Scheduler interface {
 
 // Agent defines Compliance Agent
 type Agent struct {
-	builder   checks.Builder
-	scheduler Scheduler
-	telemetry *telemetry
-	configDir string
-	endpoints *config.Endpoints
-	cancel    context.CancelFunc
+	builder     checks.Builder
+	scheduler   Scheduler
+	telemetry   *telemetry
+	startWMOnce sync.Once
+	configDir   string
+	endpoints   *config.Endpoints
+	cancel      context.CancelFunc
 }
 
 // New creates a new instance of Agent
@@ -109,6 +112,8 @@ func (a *Agent) Run() error {
 	ctx, cancel := context.WithCancel(context.Background())
 	a.cancel = cancel
 
+	a.startWorkloadMeta(ctx)
+
 	go a.telemetry.run(ctx)
 
 	a.scheduler.Run()
@@ -135,6 +140,13 @@ func (a *Agent) Run() error {
 		return true
 	}
 	return a.buildChecks(onCheck)
+}
+
+func (a *Agent) startWorkloadMeta(ctx context.Context) {
+	a.startWMOnce.Do(func() {
+		store := workloadmeta.GetGlobalStore()
+		store.Start(ctx)
+	})
 }
 
 func runCheck(rule *compliance.RuleCommon, check compliance.Check, err error) bool {


### PR DESCRIPTION
### What does this PR do?

Backport of 6eb2e59636ae6601feaef1d5ed3be3add0450e8e

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
