### PR TITLE
use go.uber.org/atomic for pkg/dogstatsd

### DIFF
--- a/cmd/agent/app/internal/settings/runtime_setting_dogstatsd_stats.go
+++ b/cmd/agent/app/internal/settings/runtime_setting_dogstatsd_stats.go
@@ -7,7 +7,6 @@ package settings
 
 import (
 	"fmt"
-	"sync/atomic"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -34,7 +33,7 @@ func (s DsdStatsRuntimeSetting) Name() string {
 
 // Get returns the current value of the runtime setting
 func (s DsdStatsRuntimeSetting) Get() (interface{}, error) {
-	return atomic.LoadUint64(&common.DSD.Debug.Enabled) == 1, nil
+	return common.DSD.Debug.Enabled.Load(), nil
 }
 
 // Set changes the value of the runtime setting

--- a/cmd/agent/app/internal/settings/runtime_settings_test.go
+++ b/cmd/agent/app/internal/settings/runtime_settings_test.go
@@ -6,7 +6,6 @@
 package settings
 
 import (
-	"sync/atomic"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
@@ -34,7 +33,7 @@ func TestDogstatsdMetricsStats(t *testing.T) {
 
 	err = s.Set("true")
 	assert.Nil(err)
-	assert.Equal(atomic.LoadUint64(&common.DSD.Debug.Enabled), uint64(1))
+	assert.Equal(common.DSD.Debug.Enabled.Load(), true)
 	v, err := s.Get()
 	assert.Nil(err)
 	assert.Equal(v, true)
@@ -43,7 +42,7 @@ func TestDogstatsdMetricsStats(t *testing.T) {
 
 	err = s.Set("false")
 	assert.Nil(err)
-	assert.Equal(atomic.LoadUint64(&common.DSD.Debug.Enabled), uint64(0))
+	assert.Equal(common.DSD.Debug.Enabled.Load(), false)
 	v, err = s.Get()
 	assert.Nil(err)
 	assert.Equal(v, false)
@@ -52,7 +51,7 @@ func TestDogstatsdMetricsStats(t *testing.T) {
 
 	err = s.Set(true)
 	assert.Nil(err)
-	assert.Equal(atomic.LoadUint64(&common.DSD.Debug.Enabled), uint64(1))
+	assert.Equal(common.DSD.Debug.Enabled.Load(), true)
 	v, err = s.Get()
 	assert.Nil(err)
 	assert.Equal(v, true)
@@ -61,14 +60,14 @@ func TestDogstatsdMetricsStats(t *testing.T) {
 
 	err = s.Set(false)
 	assert.Nil(err)
-	assert.Equal(atomic.LoadUint64(&common.DSD.Debug.Enabled), uint64(0))
+	assert.Equal(common.DSD.Debug.Enabled.Load(), false)
 	v, err = s.Get()
 	assert.Nil(err)
 	assert.Equal(v, false)
 
 	// ensure the getter uses the value from the actual server
 
-	atomic.StoreUint64(&common.DSD.Debug.Enabled, 1)
+	common.DSD.Debug.Enabled.Store(true)
 	v, err = s.Get()
 	assert.Nil(err)
 	assert.Equal(v, true)

--- a/pkg/dogstatsd/listeners/named_pipe_windows.go
+++ b/pkg/dogstatsd/listeners/named_pipe_windows.go
@@ -11,13 +11,13 @@ import (
 	"bytes"
 	"io"
 	"net"
-	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/dogstatsd/packets"
 	"github.com/DataDog/datadog-agent/pkg/dogstatsd/replay"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"go.uber.org/atomic"
 
 	"github.com/Microsoft/go-winio"
 )
@@ -73,7 +73,7 @@ func newNamedPipeListener(
 			connToClose:     make(chan net.Conn),
 			closeAllConns:   make(chan struct{}),
 			allConnsClosed:  make(chan struct{}),
-			activeConnCount: 0,
+			activeConnCount: atomic.NewInt32(0),
 		},
 		trafficCapture: capture,
 	}
@@ -87,7 +87,7 @@ type namedPipeConnections struct {
 	connToClose     chan net.Conn
 	closeAllConns   chan struct{}
 	allConnsClosed  chan struct{}
-	activeConnCount int32
+	activeConnCount *atomic.Int32
 }
 
 func (l *namedPipeConnections) handleConnections() {
@@ -97,11 +97,11 @@ func (l *namedPipeConnections) handleConnections() {
 		select {
 		case conn := <-l.newConn:
 			connections[conn] = struct{}{}
-			atomic.AddInt32(&l.activeConnCount, 1)
+			l.activeConnCount.Inc()
 		case conn := <-l.connToClose:
 			conn.Close()
 			delete(connections, conn)
-			atomic.AddInt32(&l.activeConnCount, -1)
+			l.activeConnCount.Dec()
 			if requestStop && len(connections) == 0 {
 				stop = true
 			}
@@ -208,5 +208,5 @@ func (l *NamedPipeListener) Stop() {
 
 // getActiveConnectionsCount returns the number of active connections.
 func (l *NamedPipeListener) getActiveConnectionsCount() int32 {
-	return atomic.LoadInt32(&l.connections.activeConnCount)
+	return l.connections.activeConnCount.Load()
 }

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -15,7 +15,6 @@ import (
 	"sort"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
@@ -31,6 +30,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"go.uber.org/atomic"
 )
 
 var (
@@ -178,8 +178,7 @@ type metricStat struct {
 
 type dsdServerDebug struct {
 	sync.Mutex
-	// Enabled is an atomic int used as a boolean
-	Enabled uint64                         `json:"enabled"`
+	Enabled *atomic.Bool
 	Stats   map[ckey.ContextKey]metricStat `json:"stats"`
 	// counting number of metrics processed last X seconds
 	metricsCounts metricsCountBuckets
@@ -213,10 +212,10 @@ func NewServer(demultiplexer aggregator.Demultiplexer, serverless bool) (*Server
 		dogstatsdExpvars.Set("PacketsLastSecond", &dogstatsdPacketsLastSec)
 	}
 
-	var metricsStatsEnabled uint64 // we're using an uint64 for its atomic capacity
+	metricsStatsEnabled := false
 	if config.Datadog.GetBool("dogstatsd_metrics_stats_enable") == true {
 		log.Info("Dogstatsd: metrics statistics will be stored.")
-		metricsStatsEnabled = 1
+		metricsStatsEnabled = true
 	}
 
 	packetsChannel := make(chan packets.Packets, config.Datadog.GetInt("dogstatsd_queue_size"))
@@ -336,7 +335,8 @@ func NewServer(demultiplexer aggregator.Demultiplexer, serverless bool) (*Server
 		entityIDPrecedenceEnabled: entityIDPrecedenceEnabled,
 		disableVerboseLogs:        config.Datadog.GetBool("dogstatsd_disable_verbose_logs"),
 		Debug: &dsdServerDebug{
-			Stats: make(map[ckey.ContextKey]metricStat),
+			Enabled: atomic.NewBool(false),
+			Stats:   make(map[ckey.ContextKey]metricStat),
 			metricsCounts: metricsCountBuckets{
 				counts:     [5]uint64{0, 0, 0, 0, 0},
 				metricChan: make(chan struct{}),
@@ -374,7 +374,7 @@ func NewServer(demultiplexer aggregator.Demultiplexer, serverless bool) (*Server
 	// start the debug loop
 	// ----------------------
 
-	if metricsStatsEnabled == 1 {
+	if metricsStatsEnabled {
 		s.EnableMetricsStats()
 	}
 
@@ -555,7 +555,7 @@ func (s *Server) parsePackets(batcher *batcher, parser *parser, packets []*packe
 				var err error
 				samples = samples[0:0]
 
-				debugEnabled := atomic.LoadUint64(&s.Debug.Enabled) == 1
+				debugEnabled := s.Debug.Enabled.Load()
 
 				samples, err = s.parseMetricMessage(samples, parser, message, packet.Origin, debugEnabled)
 				if err != nil {
@@ -749,11 +749,11 @@ func (s *Server) EnableMetricsStats() {
 	defer s.Debug.Unlock()
 
 	// already enabled?
-	if atomic.LoadUint64(&s.Debug.Enabled) == 1 {
+	if s.Debug.Enabled.Load() {
 		return
 	}
 
-	atomic.StoreUint64(&s.Debug.Enabled, 1)
+	s.Debug.Enabled.Store(true)
 	go func() {
 		ticker := time.NewTicker(time.Millisecond * 100)
 		var closed bool
@@ -813,8 +813,8 @@ func (s *Server) DisableMetricsStats() {
 	s.Debug.Lock()
 	defer s.Debug.Unlock()
 
-	if atomic.LoadUint64(&s.Debug.Enabled) == 1 {
-		atomic.StoreUint64(&s.Debug.Enabled, 0)
+	if s.Debug.Enabled.Load() {
+		s.Debug.Enabled.Store(false)
 		s.Debug.metricsCounts.closeChan <- struct{}{}
 	}
 


### PR DESCRIPTION
Replaces direct use of the sync/atomic package with go.uber.org/atomic, in the given package

This should not change behavior.

Motivation
Alignment issues with atomic access. See https://github.com/DataDog/datadog-agent/pull/11716
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Run any basic dogstatsd scenario.  Basically, enable dogstatsd and `echo 'foo:10|g' | nc -w 0 -u localhost 8125`.

Enable the setting - `agent config set dogstatsd_stats true` and run the same scenario, checking `agent dogstatsd-stats`.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
