### PR TITLE
[Serverless] Fix registration flaky tests

### DIFF
--- a/pkg/serverless/registration/logs_api_test.go
+++ b/pkg/serverless/registration/logs_api_test.go
@@ -84,7 +84,7 @@ func TestSubscribeLogsTimeout(t *testing.T) {
 	//fake the register route
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// timeout
-		time.Sleep(registerLogsTimeout + 10*time.Millisecond)
+		time.Sleep(registerLogsTimeout + 100*time.Millisecond)
 		w.WriteHeader(200)
 	}))
 	defer ts.Close()

--- a/pkg/serverless/registration/logs_api_test.go
+++ b/pkg/serverless/registration/logs_api_test.go
@@ -74,7 +74,7 @@ func TestSubscribeLogsSuccess(t *testing.T) {
 		w.WriteHeader(200)
 	}))
 	defer ts.Close()
-
+	time.Sleep(100 * time.Millisecond)
 	err := subscribeLogs("myId", ts.URL, registerLogsTimeout, payload)
 	assert.Nil(t, err)
 }


### PR DESCRIPTION
### What does this PR do?

This PR fixes two flaky tests : 
- TestSubscribeLogsTimeout
- TestSubscribeLogsSuccess


I was not able to reproduce any flakiness out of 1k executions by running 

`go test -tags static -run ^TestSubscribeLogsTimeout$ github.com/DataDog/datadog-agent/pkg/serverless/registration -count 1000`
and
`go test -tags static -run ^TestSubscribeLogsSuccess$ github.com/DataDog/datadog-agent/pkg/serverless/registration -count 1000`

### Motivation

Fix flakiness

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
