### PR TITLE
Use updated enum values for Series MetricType

### DIFF
--- a/pkg/metrics/series.go
+++ b/pkg/metrics/series.go
@@ -47,12 +47,12 @@ type Serie struct {
 // https://github.com/DataDog/agent-payload/blob/master/proto/metrics/agent_payload.proto
 func (a APIMetricType) SeriesAPIV2Enum() int32 {
 	switch a {
-	case APIGaugeType:
-		return 0
-	case APIRateType:
-		return 2
 	case APICountType:
 		return 1
+	case APIRateType:
+		return 2
+	case APIGaugeType:
+		return 3
 	default:
 		panic("unknown APIMetricType")
 	}

--- a/pkg/serializer/serializer_test.go
+++ b/pkg/serializer/serializer_test.go
@@ -284,7 +284,7 @@ func TestSendV1Series(t *testing.T) {
 
 func TestSendSeries(t *testing.T) {
 	f := &forwarder.MockedForwarder{}
-	matcher := createProtoPayloadMatcher([]byte{10, 8, 10, 6, 10, 4, 104, 111, 115, 116})
+	matcher := createProtoPayloadMatcher([]byte{0xa, 0xa, 0xa, 0x6, 0xa, 0x4, 0x68, 0x6f, 0x73, 0x74, 0x28, 0x3})
 	f.On("SubmitSeries", matcher, protobufExtraHeadersWithCompression).Return(nil).Times(1)
 	config.Datadog.Set("use_v2_api.series", true)
 	defer config.Datadog.Set("use_v2_api.series", false)


### PR DESCRIPTION
These were missed in #10722

### Additional Notes


### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Fire up an agent with `DD_USE_V2_API_SERIES=true`, feed it some series data (`echo 'test.metric:19|g' | nc -w 0 -u localhost 8125`) and check that the data are still correctly ingested and displayed in the app.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
