### PR TITLE
Fix error message when tag is not found while running `inv pipeline.run`

### DIFF
--- a/tasks/libs/common/gitlab.py
+++ b/tasks/libs/common/gitlab.py
@@ -264,8 +264,9 @@ class Gitlab(RemoteAPI):
             response = self.make_request(path, json_output=True)
             return response
         except APIError as e:
+            # If Gitlab API returns a "404 not found" error we return an empty dict
             if e.status_code == 404:
-                return []
+                return dict()
             else:
                 raise e
 

--- a/tasks/libs/common/gitlab.py
+++ b/tasks/libs/common/gitlab.py
@@ -266,6 +266,9 @@ class Gitlab(RemoteAPI):
         except APIError as e:
             # If Gitlab API returns a "404 not found" error we return an empty dict
             if e.status_code == 404:
+                print(
+                    f"Couldn't find the {tag_name} tag: Gitlab returned a 404 Not Found instead of a 200 empty response."
+                )
                 return dict()
             else:
                 raise e

--- a/tasks/libs/common/gitlab.py
+++ b/tasks/libs/common/gitlab.py
@@ -260,7 +260,14 @@ class Gitlab(RemoteAPI):
         Look up a tag by its name.
         """
         path = f"/projects/{quote(self.project_name, safe='')}/repository/tags/{tag_name}"
-        return self.make_request(path, json_output=True)
+        try:
+            response = self.make_request(path, json_output=True)
+            return response
+        except APIError as e:
+            if e.status_code == 404:
+                return []
+            else:
+                raise e
 
     def make_request(
         self, path, headers=None, data=None, json_input=False, json_output=False, stream_output=False, method=None


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR fixes the error message raised when a tag is not found while running `inv pipeline.run`.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Currently the `pipeline.run` invoke task used for [custom builds](https://datadoghq.atlassian.net/wiki/spaces/agent/pages/1568966971/How+to+create+custom+Agent+builds) has code to inform the user when a specific tag (e.g 6.x.y or 7.x.y) is not found. However, the APIError is not caught, so only a `tasks.libs.common.remote_api.APIError: Gitlab says: b'{"message":"404 Tag Not Found"}`. This error should be caught for better clarity.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

You can force the `git_ref` variable in the `check_deploy_pipeline` function in the `tasks/pipeline.py` file (e.g `git_ref="7.12.24-rc2"`). Then just run `inv pipeline.run --here --deploy` and check that this command is not raising an `APIError` anymore, but a `Cannot find GitLab v6 tag...` error instead.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
