### PR TITLE
Simplify the usage of IterableSeries

### DIFF
--- a/pkg/aggregator/aggregator_test.go
+++ b/pkg/aggregator/aggregator_test.go
@@ -565,11 +565,9 @@ type MockSerializerIterableSerie struct {
 	serializer.MockSerializer
 }
 
-func (s *MockSerializerIterableSerie) SendIterableSeries(iterableSerie *metrics.IterableSeries) error {
-	defer iterableSerie.IterationStopped()
-
-	for iterableSerie.MoveNext() {
-		s.series = append(s.series, iterableSerie.Current())
+func (s *MockSerializerIterableSerie) SendIterableSeries(seriesSource metrics.SerieSource) error {
+	for seriesSource.MoveNext() {
+		s.series = append(s.series, seriesSource.Current())
 	}
 	return nil
 }

--- a/pkg/metrics/iterable_series.go
+++ b/pkg/metrics/iterable_series.go
@@ -15,11 +15,12 @@ import (
 
 // IterableSeries represents an iterable collection of Serie.  Serie can be
 // appended to IterableSeries while IterableSeries is serialized.
+// IterableSeries is designed be used with StartIteration.
 //
 // An IterableSeries interfaces two goroutines, referred to below as "sender"
 // and "receiver".  The sender calls Append any number of times followed by
-// SenderStopped.  The receiver calls MoveNext and Current to iterate through
-// the items, and IterationStopped when it is finished.
+// senderStopped.  The receiver calls MoveNext and Current to iterate through
+// the items, and iterationStopped when it is finished.
 type IterableSeries struct {
 	count              *atomic.Uint64
 	ch                 *util.BufferedChan
@@ -62,20 +63,22 @@ func (series *IterableSeries) SeriesCount() uint64 {
 	return series.count.Load()
 }
 
-// SenderStopped must be called when sender stop calling Append.
+// senderStopped must be called when sender stop calling Append.
 //
 // This method must only be called by the sender.
-func (series *IterableSeries) SenderStopped() {
+// It is automatically called by StartIteration.
+func (series *IterableSeries) senderStopped() {
 	series.ch.Close()
 }
 
-// IterationStopped must be called when the receiver stops calling `MoveNext`.
+// iterationStopped must be called when the receiver stops calling `MoveNext`.
 // This function prevents the case when the receiver stops iterating before the
 // end of the iteration because of an error and so blocks the sender forever
 // as no goroutine read the channel.
 //
 // This method must only be called by the receiver.
-func (series *IterableSeries) IterationStopped() {
+// It is automatically called by StartIteration.
+func (series *IterableSeries) iterationStopped() {
 	series.cancel()
 }
 
@@ -115,10 +118,10 @@ func StartIteration(iterableSeries *IterableSeries, sink func(SerieSink), source
 	done := make(chan struct{})
 	go func() {
 		source(iterableSeries)
-		iterableSeries.IterationStopped()
+		iterableSeries.iterationStopped()
 		close(done)
 	}()
 	sink(iterableSeries)
-	iterableSeries.SenderStopped()
+	iterableSeries.senderStopped()
 	<-done
 }

--- a/pkg/metrics/iterable_series_test.go
+++ b/pkg/metrics/iterable_series_test.go
@@ -1,0 +1,109 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package metrics
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIterableSeries(t *testing.T) {
+	iterableSeries := NewIterableSeries(func(*Serie) {}, 10, 1)
+	done := make(chan struct{})
+	var names []string
+	go func() {
+		defer iterableSeries.IterationStopped()
+		for iterableSeries.MoveNext() {
+			names = append(names, iterableSeries.Current().Name)
+		}
+		close(done)
+	}()
+	iterableSeries.Append(&Serie{Name: "serie1"})
+	iterableSeries.Append(&Serie{Name: "serie2"})
+	iterableSeries.Append(&Serie{Name: "serie3"})
+	iterableSeries.SenderStopped()
+	<-done
+	r := require.New(t)
+	r.Len(names, 3)
+	r.True(strings.Contains(names[0], "serie1"))
+	r.True(strings.Contains(names[1], "serie2"))
+	r.True(strings.Contains(names[2], "serie3"))
+}
+
+func TestIterableSeriesCallback(t *testing.T) {
+	var series Series
+	callback := func(s *Serie) { series = append(series, s) }
+	iterableSeries := NewIterableSeries(callback, 10, 10)
+	iterableSeries.Append(&Serie{Name: "serie1"})
+	iterableSeries.Append(&Serie{Name: "serie2"})
+
+	r := require.New(t)
+	r.Equal(uint64(2), iterableSeries.SeriesCount())
+	r.Len(series, 2)
+	r.Equal("serie1", series[0].Name)
+	r.Equal("serie2", series[1].Name)
+}
+
+func TestIterableSeriesReceiverStopped(t *testing.T) {
+	iterableSeries := NewIterableSeries(func(*Serie) {}, 1, 1)
+	iterableSeries.Append(&Serie{Name: "serie1"})
+
+	// Next call to Append must not block
+	go iterableSeries.IterationStopped()
+	iterableSeries.Append(&Serie{Name: "serie2"})
+	iterableSeries.Append(&Serie{Name: "serie3"})
+}
+
+func BenchmarkIterableSeries(b *testing.B) {
+	for bufferSize := 1000; bufferSize <= 8000; bufferSize *= 2 {
+		b.Run(fmt.Sprintf("%v", bufferSize), func(b *testing.B) {
+			iterableSeries := NewIterableSeries(func(*Serie) {}, 100, bufferSize)
+			done := make(chan struct{})
+			go func() {
+				defer iterableSeries.IterationStopped()
+				for iterableSeries.MoveNext() {
+				}
+				close(done)
+			}()
+
+			for i := 0; i < b.N; i++ {
+				iterableSeries.Append(&Serie{Name: "name"})
+			}
+			iterableSeries.SenderStopped()
+			<-done
+		})
+	}
+}
+
+func TestIterableSeriesSeveralValues(t *testing.T) {
+	iterableSeries := NewIterableSeries(func(*Serie) {}, 10, 2)
+	done := make(chan struct{})
+	var series []*Serie
+	go func() {
+		defer iterableSeries.IterationStopped()
+		for iterableSeries.MoveNext() {
+			series = append(series, iterableSeries.Current())
+		}
+		close(done)
+	}()
+	var expected []string
+	for i := 0; i < 101; i++ {
+		name := "serie" + strconv.Itoa(i)
+		expected = append(expected, name)
+		iterableSeries.Append(&Serie{Name: name})
+	}
+	iterableSeries.SenderStopped()
+	<-done
+	r := require.New(t)
+	r.Len(series, len(expected))
+	for i, v := range expected {
+		r.Equal(v, series[i].Name)
+	}
+}

--- a/pkg/serializer/internal/metrics/iterable_series.go
+++ b/pkg/serializer/internal/metrics/iterable_series.go
@@ -86,7 +86,7 @@ func (series IterableSeries) MarshalSplitCompress(bufferContext *marshaler.Buffe
 // MarshalSplitCompress uses the stream compressor to marshal and compress series payloads.
 // If a compressed payload is larger than the max, a new payload will be generated. This method returns a slice of
 // compressed protobuf marshaled MetricPayload objects.
-func marshalSplitCompress(iterator serieIterator, bufferContext *marshaler.BufferContext) ([]*[]byte, error) {
+func marshalSplitCompress(iterator metrics.SerieSource, bufferContext *marshaler.BufferContext) ([]*[]byte, error) {
 	var err error
 	var compressor *stream.Compressor
 	buf := bufferContext.PrecompressionBuf
@@ -309,11 +309,6 @@ func marshalSplitCompress(iterator serieIterator, bufferContext *marshaler.Buffe
 	}
 
 	return payloads, nil
-}
-
-type serieIterator interface {
-	MoveNext() bool
-	Current() *metrics.Serie
 }
 
 // MarshalJSON serializes timeseries to JSON so it can be sent to V1 endpoints

--- a/pkg/serializer/internal/metrics/iterable_series.go
+++ b/pkg/serializer/internal/metrics/iterable_series.go
@@ -22,7 +22,7 @@ import (
 
 // IterableSeries is a serializer for metrics.IterableSeries
 type IterableSeries struct {
-	*metrics.IterableSeries
+	metrics.SerieSource
 }
 
 // WriteHeader writes the payload header for this type

--- a/pkg/serializer/internal/metrics/iterable_series_test.go
+++ b/pkg/serializer/internal/metrics/iterable_series_test.go
@@ -6,109 +6,12 @@
 package metrics
 
 import (
-	"fmt"
-	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/metrics"
-	_ "github.com/DataDog/datadog-agent/pkg/tagset"
 	"github.com/stretchr/testify/require"
 )
-
-func TestIterableSeries(t *testing.T) {
-	iterableSeries := IterableSeries{IterableSeries: metrics.NewIterableSeries(func(*metrics.Serie) {}, 10, 1)}
-	done := make(chan struct{})
-	var descritions []string
-	go func() {
-		defer iterableSeries.IterationStopped()
-		for iterableSeries.MoveNext() {
-			descritions = append(descritions, iterableSeries.DescribeCurrentItem())
-		}
-		close(done)
-	}()
-	iterableSeries.Append(&metrics.Serie{Name: "serie1"})
-	iterableSeries.Append(&metrics.Serie{Name: "serie2"})
-	iterableSeries.Append(&metrics.Serie{Name: "serie3"})
-	iterableSeries.SenderStopped()
-	<-done
-	r := require.New(t)
-	r.Len(descritions, 3)
-	r.True(strings.Contains(descritions[0], "serie1"))
-	r.True(strings.Contains(descritions[1], "serie2"))
-	r.True(strings.Contains(descritions[2], "serie3"))
-}
-
-func TestIterableSeriesCallback(t *testing.T) {
-	var series Series
-	callback := func(s *metrics.Serie) { series = append(series, s) }
-	iterableSeries := IterableSeries{IterableSeries: metrics.NewIterableSeries(callback, 10, 10)}
-	iterableSeries.Append(&metrics.Serie{Name: "serie1"})
-	iterableSeries.Append(&metrics.Serie{Name: "serie2"})
-
-	r := require.New(t)
-	r.Equal(uint64(2), iterableSeries.SeriesCount())
-	r.Len(series, 2)
-	r.Equal("serie1", series[0].Name)
-	r.Equal("serie2", series[1].Name)
-}
-
-func TestIterableSeriesReceiverStopped(t *testing.T) {
-	iterableSeries := IterableSeries{IterableSeries: metrics.NewIterableSeries(func(*metrics.Serie) {}, 1, 1)}
-	iterableSeries.Append(&metrics.Serie{Name: "serie1"})
-
-	// Next call to Append must not block
-	go iterableSeries.IterationStopped()
-	iterableSeries.Append(&metrics.Serie{Name: "serie2"})
-	iterableSeries.Append(&metrics.Serie{Name: "serie3"})
-}
-
-func BenchmarkIterableSeries(b *testing.B) {
-	for bufferSize := 1000; bufferSize <= 8000; bufferSize *= 2 {
-		b.Run(fmt.Sprintf("%v", bufferSize), func(b *testing.B) {
-			iterableSeries := IterableSeries{IterableSeries: metrics.NewIterableSeries(func(*metrics.Serie) {}, 100, bufferSize)}
-			done := make(chan struct{})
-			go func() {
-				defer iterableSeries.IterationStopped()
-				for iterableSeries.MoveNext() {
-				}
-				close(done)
-			}()
-
-			for i := 0; i < b.N; i++ {
-				iterableSeries.Append(&metrics.Serie{Name: "name"})
-			}
-			iterableSeries.SenderStopped()
-			<-done
-		})
-	}
-}
-
-func TestIterableSeriesSeveralValues(t *testing.T) {
-	iterableSeries := IterableSeries{IterableSeries: metrics.NewIterableSeries(func(*metrics.Serie) {}, 10, 2)}
-	done := make(chan struct{})
-	var series []*metrics.Serie
-	go func() {
-		defer iterableSeries.IterationStopped()
-		for iterableSeries.MoveNext() {
-			series = append(series, iterableSeries.Current())
-		}
-		close(done)
-	}()
-	var expected []string
-	for i := 0; i < 101; i++ {
-		name := "serie" + strconv.Itoa(i)
-		expected = append(expected, name)
-		iterableSeries.Append(&metrics.Serie{Name: name})
-	}
-	iterableSeries.SenderStopped()
-	<-done
-	r := require.New(t)
-	r.Len(series, len(expected))
-	for i, v := range expected {
-		r.Equal(v, series[i].Name)
-	}
-}
 
 func TestIterableSeriesEmptyMarshalJSON(t *testing.T) {
 	r := require.New(t)

--- a/pkg/serializer/internal/metrics/iterable_series_test.go
+++ b/pkg/serializer/internal/metrics/iterable_series_test.go
@@ -15,9 +15,10 @@ import (
 
 func TestIterableSeriesEmptyMarshalJSON(t *testing.T) {
 	r := require.New(t)
-	iterableSeries := IterableSeries{IterableSeries: metrics.NewIterableSeries(func(*metrics.Serie) {}, 10, 2)}
-	iterableSeries.SenderStopped()
-	bytes, err := iterableSeries.MarshalJSON()
+	iterableSerie := metrics.NewIterableSeries(func(*metrics.Serie) {}, 10, 2)
+	iterableSeriesSerializer := IterableSeries{SerieSource: iterableSerie}
+	iterableSerie.SenderStopped()
+	bytes, err := iterableSeriesSerializer.MarshalJSON()
 	r.NoError(err)
 	r.Equal(`{"series":[]}`, strings.TrimSpace(string(bytes)))
 }

--- a/pkg/serializer/internal/metrics/iterable_series_test.go
+++ b/pkg/serializer/internal/metrics/iterable_series_test.go
@@ -15,10 +15,8 @@ import (
 
 func TestIterableSeriesEmptyMarshalJSON(t *testing.T) {
 	r := require.New(t)
-	iterableSerie := metrics.NewIterableSeries(func(*metrics.Serie) {}, 10, 2)
-	iterableSeriesSerializer := IterableSeries{SerieSource: iterableSerie}
-	iterableSerie.SenderStopped()
-	bytes, err := iterableSeriesSerializer.MarshalJSON()
+	iterableSerie := IterableSeries{SerieSource: CreateSerieSource(metrics.Series{})}
+	bytes, err := iterableSerie.MarshalJSON()
 	r.NoError(err)
 	r.Equal(`{"series":[]}`, strings.TrimSpace(string(bytes)))
 }

--- a/pkg/serializer/internal/metrics/series_test.go
+++ b/pkg/serializer/internal/metrics/series_test.go
@@ -247,7 +247,7 @@ func TestStreamJSONMarshalerWithDevice(t *testing.T) {
 	}
 
 	stream := jsoniter.NewStream(jsoniter.ConfigDefault, nil, 0)
-	serializer := IterableSeries{SerieSource: CreateIterableSeries(series)}
+	serializer := IterableSeries{SerieSource: CreateSerieSource(series)}
 	serializer.MoveNext()
 	err := serializer.WriteCurrentItem(stream)
 	assert.NoError(t, err)
@@ -275,7 +275,7 @@ func TestDescribeItem(t *testing.T) {
 		},
 	}
 
-	serializer := IterableSeries{SerieSource: CreateIterableSeries(series)}
+	serializer := IterableSeries{SerieSource: CreateSerieSource(series)}
 	serializer.MoveNext()
 	desc1 := serializer.DescribeCurrentItem()
 	assert.Equal(t, "name \"test.metrics\", 2 points", desc1)
@@ -299,7 +299,7 @@ func makeSeries(numItems, numPoints int) *IterableSeries {
 			Tags:     tagset.CompositeTagsFromSlice([]string{"tag1", "tag2:yes"}),
 		})
 	}
-	return &IterableSeries{SerieSource: CreateIterableSeries(series)}
+	return &IterableSeries{SerieSource: CreateSerieSource(series)}
 }
 
 func TestMarshalSplitCompress(t *testing.T) {
@@ -372,7 +372,7 @@ func TestPayloadsSeries(t *testing.T) {
 
 	originalLength := len(testSeries)
 	builder := stream.NewJSONPayloadBuilder(true)
-	iterableSeries := &IterableSeries{SerieSource: CreateIterableSeries(testSeries)}
+	iterableSeries := &IterableSeries{SerieSource: CreateSerieSource(testSeries)}
 	payloads, err := builder.BuildWithOnErrItemTooBigPolicy(iterableSeries, stream.DropItemOnErrItemTooBig)
 	require.Nil(t, err)
 	var splitSeries = []Series{}
@@ -420,7 +420,7 @@ func BenchmarkPayloadsSeries(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		// always record the result of Payloads to prevent
 		// the compiler eliminating the function call.
-		iterableSeries := &IterableSeries{SerieSource: CreateIterableSeries(testSeries)}
+		iterableSeries := &IterableSeries{SerieSource: CreateSerieSource(testSeries)}
 		r, _ = builder.BuildWithOnErrItemTooBigPolicy(iterableSeries, stream.DropItemOnErrItemTooBig)
 	}
 	// ensure we actually had to split

--- a/pkg/serializer/internal/metrics/series_test.go
+++ b/pkg/serializer/internal/metrics/series_test.go
@@ -247,7 +247,7 @@ func TestStreamJSONMarshalerWithDevice(t *testing.T) {
 	}
 
 	stream := jsoniter.NewStream(jsoniter.ConfigDefault, nil, 0)
-	serializer := IterableSeries{IterableSeries: CreateIterableSeries(series)}
+	serializer := IterableSeries{SerieSource: CreateIterableSeries(series)}
 	serializer.MoveNext()
 	err := serializer.WriteCurrentItem(stream)
 	assert.NoError(t, err)
@@ -275,7 +275,7 @@ func TestDescribeItem(t *testing.T) {
 		},
 	}
 
-	serializer := IterableSeries{IterableSeries: CreateIterableSeries(series)}
+	serializer := IterableSeries{SerieSource: CreateIterableSeries(series)}
 	serializer.MoveNext()
 	desc1 := serializer.DescribeCurrentItem()
 	assert.Equal(t, "name \"test.metrics\", 2 points", desc1)
@@ -299,7 +299,7 @@ func makeSeries(numItems, numPoints int) *IterableSeries {
 			Tags:     tagset.CompositeTagsFromSlice([]string{"tag1", "tag2:yes"}),
 		})
 	}
-	return &IterableSeries{IterableSeries: CreateIterableSeries(series)}
+	return &IterableSeries{SerieSource: CreateIterableSeries(series)}
 }
 
 func TestMarshalSplitCompress(t *testing.T) {
@@ -372,7 +372,7 @@ func TestPayloadsSeries(t *testing.T) {
 
 	originalLength := len(testSeries)
 	builder := stream.NewJSONPayloadBuilder(true)
-	iterableSeries := &IterableSeries{IterableSeries: CreateIterableSeries(testSeries)}
+	iterableSeries := &IterableSeries{SerieSource: CreateIterableSeries(testSeries)}
 	payloads, err := builder.BuildWithOnErrItemTooBigPolicy(iterableSeries, stream.DropItemOnErrItemTooBig)
 	require.Nil(t, err)
 	var splitSeries = []Series{}
@@ -420,7 +420,7 @@ func BenchmarkPayloadsSeries(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		// always record the result of Payloads to prevent
 		// the compiler eliminating the function call.
-		iterableSeries := &IterableSeries{IterableSeries: CreateIterableSeries(testSeries)}
+		iterableSeries := &IterableSeries{SerieSource: CreateIterableSeries(testSeries)}
 		r, _ = builder.BuildWithOnErrItemTooBigPolicy(iterableSeries, stream.DropItemOnErrItemTooBig)
 	}
 	// ensure we actually had to split

--- a/pkg/serializer/internal/metrics/test_helper.go
+++ b/pkg/serializer/internal/metrics/test_helper.go
@@ -52,11 +52,27 @@ func makesketch(n int) *quantile.Sketch {
 	return s
 }
 
-func CreateIterableSeries(series metrics.Series) *metrics.IterableSeries {
-	iterableSeries := metrics.NewIterableSeries(func(*metrics.Serie) {}, 1000, 1000)
-	for _, serie := range series {
-		iterableSeries.Append(serie)
+type serieSourceMock struct {
+	series metrics.Series
+	index  int
+}
+
+func (s *serieSourceMock) MoveNext() bool {
+	s.index++
+	return s.index < len(s.series)
+}
+
+func (s *serieSourceMock) Current() *metrics.Serie {
+	return s.series[s.index]
+}
+
+func (s *serieSourceMock) SeriesCount() uint64 {
+	return uint64(len(s.series))
+}
+
+func CreateSerieSource(series metrics.Series) metrics.SerieSource {
+	return &serieSourceMock{
+		series: series,
+		index:  -1,
 	}
-	iterableSeries.SenderStopped()
-	return iterableSeries
 }

--- a/pkg/serializer/marshaler/marshaler.go
+++ b/pkg/serializer/marshaler/marshaler.go
@@ -58,7 +58,6 @@ type IterableStreamJSONMarshaler interface {
 	WriteCurrentItem(*jsoniter.Stream) error
 	DescribeCurrentItem() string
 	MoveNext() bool
-	IterationStopped()
 }
 
 // BufferContext contains the buffers used for MarshalSplitCompress so they can be shared between invocations

--- a/pkg/serializer/marshaler/marshaler.go
+++ b/pkg/serializer/marshaler/marshaler.go
@@ -46,7 +46,6 @@ type StreamJSONMarshaler interface {
 // serialize themselves in a stream.
 // Expected usage:
 //
-//  defer m.IterationStopped()
 //	m.WriteHeader(stream)
 //	for m.MoveNext() {
 //		m.WriteCurrentItem(stream)

--- a/pkg/serializer/marshaler/marshaler_adapter.go
+++ b/pkg/serializer/marshaler/marshaler_adapter.go
@@ -52,8 +52,3 @@ func (a *IterableStreamJSONMarshalerAdapter) MoveNext() bool {
 	}
 	return true
 }
-
-// IterationStopped must be called when receiver stop calling MoveNext.
-func (a *IterableStreamJSONMarshalerAdapter) IterationStopped() {
-	// Nothing
-}

--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -87,7 +87,7 @@ func initExtraHeaders() {
 type MetricSerializer interface {
 	SendEvents(e metrics.Events) error
 	SendServiceChecks(serviceChecks metrics.ServiceChecks) error
-	SendIterableSeries(series *metrics.IterableSeries) error
+	SendIterableSeries(serieSource metrics.SerieSource) error
 	SendSketch(sketches metrics.SketchSeriesList) error
 	SendMetadata(m marshaler.JSONMarshaler) error
 	SendHostMetadata(m marshaler.JSONMarshaler) error
@@ -297,13 +297,13 @@ func (s *Serializer) SendServiceChecks(serviceChecks metrics.ServiceChecks) erro
 }
 
 // SendIterableSeries serializes a list of series and sends the payload to the forwarder
-func (s *Serializer) SendIterableSeries(series *metrics.IterableSeries) error {
+func (s *Serializer) SendIterableSeries(serieSource metrics.SerieSource) error {
 	if !s.enableSeries {
 		log.Debug("series payloads are disabled: dropping it")
 		return nil
 	}
 
-	seriesSerializer := metricsserializer.IterableSeries{IterableSeries: series}
+	seriesSerializer := metricsserializer.IterableSeries{SerieSource: serieSource}
 	useV1API := !config.Datadog.GetBool("use_v2_api.series")
 
 	var seriesPayloads forwarder.Payloads

--- a/pkg/serializer/serializer_test.go
+++ b/pkg/serializer/serializer_test.go
@@ -277,7 +277,7 @@ func TestSendV1Series(t *testing.T) {
 
 	s := NewSerializer(f, nil, nil)
 
-	err := s.SendIterableSeries(metricsserializer.CreateIterableSeries(metrics.Series{}))
+	err := s.SendIterableSeries(metricsserializer.CreateSerieSource(metrics.Series{}))
 	require.Nil(t, err)
 	f.AssertExpectations(t)
 }
@@ -291,7 +291,7 @@ func TestSendSeries(t *testing.T) {
 
 	s := NewSerializer(f, nil, nil)
 
-	err := s.SendIterableSeries(metricsserializer.CreateIterableSeries(metrics.Series{&metrics.Serie{}}))
+	err := s.SendIterableSeries(metricsserializer.CreateSerieSource(metrics.Series{&metrics.Serie{}}))
 	require.Nil(t, err)
 	f.AssertExpectations(t)
 }
@@ -375,7 +375,7 @@ func TestSendWithDisabledKind(t *testing.T) {
 	payload := &testPayload{}
 
 	s.SendEvents(make(metrics.Events, 0))
-	s.SendIterableSeries(metricsserializer.CreateIterableSeries(metrics.Series{}))
+	s.SendIterableSeries(metricsserializer.CreateSerieSource(metrics.Series{}))
 	s.SendSketch(make(metrics.SketchSeriesList, 0))
 	s.SendServiceChecks(make(metrics.ServiceChecks, 0))
 	s.SendProcessesMetadata("test")

--- a/pkg/serializer/series_benchmark_test.go
+++ b/pkg/serializer/series_benchmark_test.go
@@ -75,13 +75,13 @@ func BenchmarkSeries(b *testing.B) {
 	}
 	bufferContext := marshaler.DefaultBufferContext()
 	pb := func(series metrics.Series) (forwarder.Payloads, error) {
-		iterableSeries := &metricsserializer.IterableSeries{SerieSource: metricsserializer.CreateIterableSeries(series)}
+		iterableSeries := &metricsserializer.IterableSeries{SerieSource: metricsserializer.CreateSerieSource(series)}
 		return iterableSeries.MarshalSplitCompress(bufferContext)
 	}
 
 	payloadBuilder := stream.NewJSONPayloadBuilder(true)
 	json := func(series metrics.Series) (forwarder.Payloads, error) {
-		iterableSeries := &metricsserializer.IterableSeries{SerieSource: metricsserializer.CreateIterableSeries(series)}
+		iterableSeries := &metricsserializer.IterableSeries{SerieSource: metricsserializer.CreateSerieSource(series)}
 		return payloadBuilder.BuildWithOnErrItemTooBigPolicy(iterableSeries, stream.DropItemOnErrItemTooBig)
 	}
 

--- a/pkg/serializer/series_benchmark_test.go
+++ b/pkg/serializer/series_benchmark_test.go
@@ -75,13 +75,13 @@ func BenchmarkSeries(b *testing.B) {
 	}
 	bufferContext := marshaler.DefaultBufferContext()
 	pb := func(series metrics.Series) (forwarder.Payloads, error) {
-		iterableSeries := &metricsserializer.IterableSeries{IterableSeries: metricsserializer.CreateIterableSeries(series)}
+		iterableSeries := &metricsserializer.IterableSeries{SerieSource: metricsserializer.CreateIterableSeries(series)}
 		return iterableSeries.MarshalSplitCompress(bufferContext)
 	}
 
 	payloadBuilder := stream.NewJSONPayloadBuilder(true)
 	json := func(series metrics.Series) (forwarder.Payloads, error) {
-		iterableSeries := &metricsserializer.IterableSeries{IterableSeries: metricsserializer.CreateIterableSeries(series)}
+		iterableSeries := &metricsserializer.IterableSeries{SerieSource: metricsserializer.CreateIterableSeries(series)}
 		return payloadBuilder.BuildWithOnErrItemTooBigPolicy(iterableSeries, stream.DropItemOnErrItemTooBig)
 	}
 

--- a/pkg/serializer/test_common.go
+++ b/pkg/serializer/test_common.go
@@ -31,8 +31,8 @@ func (s *MockSerializer) SendServiceChecks(serviceChecks metrics.ServiceChecks) 
 }
 
 // SendIterableSeries serializes a list of Serie and sends the payload to the forwarder
-func (s *MockSerializer) SendIterableSeries(series *metrics.IterableSeries) error {
-	return s.Called(series).Error(0)
+func (s *MockSerializer) SendIterableSeries(serieSource metrics.SerieSource) error {
+	return s.Called(serieSource).Error(0)
 }
 
 // SendSketch serializes a list of SketSeriesList and sends the payload to the forwarder


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR simplifies the usage of `IterableSeries`:
- `IterationStopped()` and `SenderStopped()` don't need to be called anymore
- Make clear what methods the producer and the consumer can called.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
The correct pattern to use `IterableSerie` can be tricky and I didn't have the time to implement it in the initial version.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

It is recommended to ignore the whitespaces when reviewing this PR.
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
- Agent Core: Use DogStatsD to send 50 000 series and check they are correctly received by the WebApp. Check the Serverless Agent can send series.
- Agent Platform: Check the series can be send from OTLP.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
