### PR TITLE
Add parsing of health in workloadmeta Docker collector

### DIFF
--- a/pkg/workloadmeta/collectors/internal/docker/docker.go
+++ b/pkg/workloadmeta/collectors/internal/docker/docker.go
@@ -223,6 +223,7 @@ func (c *collector) buildCollectorEvent(ctx context.Context, ev *docker.Containe
 			State: workloadmeta.ContainerState{
 				Running:    container.State.Running,
 				Status:     extractStatus(container.State),
+				Health:     extractHealth(container.State.Health),
 				StartedAt:  startedAt,
 				FinishedAt: finishedAt,
 				CreatedAt:  createdAt,
@@ -414,4 +415,21 @@ func extractStatus(containerState *types.ContainerState) workloadmeta.ContainerS
 	}
 
 	return workloadmeta.ContainerStatusUnknown
+}
+
+func extractHealth(containerHealth *types.Health) workloadmeta.ContainerHealth {
+	if containerHealth == nil {
+		return workloadmeta.ContainerHealthUnknown
+	}
+
+	switch containerHealth.Status {
+	case types.NoHealthcheck, types.Starting:
+		return workloadmeta.ContainerHealthUnknown
+	case types.Healthy:
+		return workloadmeta.ContainerHealthHealthy
+	case types.Unhealthy:
+		return workloadmeta.ContainerHealthUnhealthy
+	}
+
+	return workloadmeta.ContainerHealthUnknown
 }

--- a/releasenotes/notes/fix-health-process-7dc2aea8229c87ad.yaml
+++ b/releasenotes/notes/fix-health-process-7dc2aea8229c87ad.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix missing health status from Docker containers in Live Container View.


### PR DESCRIPTION
### What does this PR do?

Add parsing of health in workloadmeta Docker collector

### Motivation

Bugfix.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Run the Agent with live container enabled. Run another container with heathcheck enabled.
Verify that the Heath status shows up properly in live container view.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
