### PR TITLE
[Admission] Reset default config after tests

### DIFF
--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
@@ -440,7 +440,7 @@ func TestGenerateTemplatesV1(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.setupConfig()
-			defer mockConfig.Set("admission_controller.add_aks_selectors", false) // Reset to default
+			defer resetMockConfig(mockConfig) // Reset to default
 
 			c := &ControllerV1{}
 			c.config = tt.configFunc()

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
@@ -440,7 +440,7 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.setupConfig()
-			defer mockConfig.Set("admission_controller.add_aks_selectors", false) // Reset to default
+			defer resetMockConfig(mockConfig) // Reset to default
 
 			c := &ControllerV1beta1{}
 			c.config = tt.configFunc()

--- a/pkg/clusteragent/admission/controllers/webhook/utils_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/utils_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -55,4 +57,12 @@ func buildSecret(data map[string][]byte, cfg Config) *corev1.Secret {
 		},
 		Data: data,
 	}
+}
+
+func resetMockConfig(c *config.MockConfig) {
+	c.Set("admission_controller.mutate_unlabelled", false)
+	c.Set("admission_controller.inject_config.enabled", true)
+	c.Set("admission_controller.inject_tags.enabled", true)
+	c.Set("admission_controller.namespace_selector_fallback", false)
+	c.Set("admission_controller.add_aks_selectors", false)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Fix webhook controller unit tests by resetting the agent config

### Motivation

```
=== Failed
=== FAIL: pkg/clusteragent/admission/controllers/webhook TestCreateWebhookV1beta1 (3.19s)
    controller_v1beta1_test.go:67: Invalid Webhook: Webhooks should contain 2 entries, got 1
=== FAIL: pkg/clusteragent/admission/controllers/webhook TestUpdateOutdatedWebhookV1beta1 (3.94s)
    controller_v1beta1_test.go:114: Invalid Webhook: Webhooks should contain 2 entries, got 1
=== FAIL: pkg/logs/internal/launchers/listener TestTCPShouldReceivesMessages (unknown)
```

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
