### PR TITLE
use ElementsMatch to match tags irrespective of order

### DIFF
--- a/pkg/logs/internal/tailers/file/tailer_test.go
+++ b/pkg/logs/internal/tailers/file/tailer_test.go
@@ -243,8 +243,9 @@ func (suite *TailerTestSuite) TestOriginTagsWhenTailingFiles() {
 
 	msg := <-suite.outputChan
 	tags := msg.Origin.Tags()
-	suite.Equal(1, len(tags))
-	suite.Equal("filename:"+filepath.Base(suite.testFile.Name()), tags[0])
+	suite.ElementsMatch([]string{
+		"filename:" + filepath.Base(suite.testFile.Name()),
+	}, tags)
 }
 
 func (suite *TailerTestSuite) TestDirTagWhenTailingFiles() {
@@ -262,9 +263,10 @@ func (suite *TailerTestSuite) TestDirTagWhenTailingFiles() {
 
 	msg := <-suite.outputChan
 	tags := msg.Origin.Tags()
-	suite.Equal(2, len(tags))
-	suite.Equal("filename:"+filepath.Base(suite.testFile.Name()), tags[0])
-	suite.Equal("dirname:"+filepath.Dir(suite.testFile.Name()), tags[1])
+	suite.ElementsMatch([]string{
+		"filename:" + filepath.Base(suite.testFile.Name()),
+		"dirname:" + filepath.Dir(suite.testFile.Name()),
+	}, tags)
 }
 
 func (suite *TailerTestSuite) TestBuildTagsFileOnly() {
@@ -278,8 +280,9 @@ func (suite *TailerTestSuite) TestBuildTagsFileOnly() {
 	suite.tailer.StartFromBeginning()
 
 	tags := suite.tailer.buildTailerTags()
-	suite.Equal(1, len(tags))
-	suite.Equal("filename:"+filepath.Base(suite.testFile.Name()), tags[0])
+	suite.ElementsMatch([]string{
+		"filename:" + filepath.Base(suite.testFile.Name()),
+	}, tags)
 }
 
 func (suite *TailerTestSuite) TestBuildTagsFileDir() {
@@ -292,9 +295,10 @@ func (suite *TailerTestSuite) TestBuildTagsFileDir() {
 	suite.tailer.StartFromBeginning()
 
 	tags := suite.tailer.buildTailerTags()
-	suite.Equal(2, len(tags))
-	suite.Equal("filename:"+filepath.Base(suite.testFile.Name()), tags[0])
-	suite.Equal("dirname:"+filepath.Dir(suite.testFile.Name()), tags[1])
+	suite.ElementsMatch([]string{
+		"filename:" + filepath.Base(suite.testFile.Name()),
+		"dirname:" + filepath.Dir(suite.testFile.Name()),
+	}, tags)
 }
 
 func (suite *TailerTestSuite) TestMutliLineAutoDetect() {


### PR DESCRIPTION
### Motivation

Fix some intermittent tests, where tags arrive in a different order than the tests require.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
