### PR TITLE
use go.uber.org/atomic for pkg/process

### DIFF
--- a/pkg/process/checks/net.go
+++ b/pkg/process/checks/net.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"errors"
 	"sort"
-	"sync/atomic"
 	"time"
 
 	model "github.com/DataDog/agent-payload/v5/process"
@@ -23,11 +22,14 @@ import (
 	procutil "github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"go.uber.org/atomic"
 )
 
 var (
 	// Connections is a singleton ConnectionsCheck.
-	Connections = &ConnectionsCheck{}
+	Connections = &ConnectionsCheck{
+		lastConnsByPID: &atomic.Value{},
+	}
 
 	// LocalResolver is a singleton LocalResolver
 	LocalResolver = &resolver.LocalResolver{}
@@ -46,7 +48,7 @@ type ConnectionsCheck struct {
 	notInitializedLogLimit *procutil.LogLimit
 	// store the last collection result by PID, currently used to populate network data for processes
 	// it's in format map[int32][]*model.Connections
-	lastConnsByPID atomic.Value
+	lastConnsByPID *atomic.Value
 }
 
 // Init initializes a ConnectionsCheck instance.

--- a/pkg/process/checks/process.go
+++ b/pkg/process/checks/process.go
@@ -8,7 +8,6 @@ package checks
 import (
 	"context"
 	"errors"
-	"sync/atomic"
 	"time"
 
 	model "github.com/DataDog/agent-payload/v5/process"
@@ -20,12 +19,15 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/gopsutil/cpu"
+	"go.uber.org/atomic"
 )
 
 const emptyCtrID = ""
 
 // Process is a singleton ProcessCheck.
-var Process = &ProcessCheck{}
+var Process = &ProcessCheck{
+	createTimes: &atomic.Value{},
+}
 
 var _ CheckWithRealTime = (*ProcessCheck)(nil)
 
@@ -57,7 +59,7 @@ type ProcessCheck struct {
 	lastPIDs []int32
 
 	// Create times by PID used in the network check
-	createTimes atomic.Value
+	createTimes *atomic.Value
 
 	// SysprobeProcessModuleEnabled tells the process check wheither to use the RemoteSystemProbeUtil to gather privileged process stats
 	SysprobeProcessModuleEnabled bool

--- a/pkg/process/procutil/process_linux_test.go
+++ b/pkg/process/procutil/process_linux_test.go
@@ -14,7 +14,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -668,7 +667,7 @@ func TestParseStatContent(t *testing.T) {
 	defer probe.Close()
 
 	// hard code the bootTime so we get consistent calculation for createTime
-	atomic.StoreUint64(&probe.bootTime, 1606181252)
+	probe.bootTime.Store(1606181252)
 	now := time.Now()
 
 	for _, tc := range []struct {
@@ -778,7 +777,7 @@ func TestBootTimeLocalFS(t *testing.T) {
 	defer probe.Close()
 	expectT, err := host.BootTime()
 	assert.NoError(t, err)
-	assert.Equal(t, expectT, atomic.LoadUint64(&probe.bootTime))
+	assert.Equal(t, expectT, probe.bootTime.Load())
 }
 
 func TestBootTimeRefresh(t *testing.T) {
@@ -786,13 +785,13 @@ func TestBootTimeRefresh(t *testing.T) {
 	probe := getProbeWithPermission(WithBootTimeRefreshInterval(500 * time.Millisecond))
 	defer probe.Close()
 
-	assert.Equal(t, uint64(1606127264), atomic.LoadUint64(&probe.bootTime))
+	assert.Equal(t, uint64(1606127264), probe.bootTime.Load())
 	err := os.Rename("resources/test_procfs/proc/stat", "resources/test_procfs/proc/stat_temp")
 	require.NoError(t, err)
 	err = os.Rename("resources/test_procfs/proc/stat2", "resources/test_procfs/proc/stat")
 	require.NoError(t, err)
 
-	assert.Eventually(t, func() bool { return uint64(1606127364) == atomic.LoadUint64(&probe.bootTime) }, time.Second, 100*time.Millisecond)
+	assert.Eventually(t, func() bool { return uint64(1606127364) == probe.bootTime.Load() }, time.Second, 100*time.Millisecond)
 
 	err = os.Rename("resources/test_procfs/proc/stat", "resources/test_procfs/proc/stat2")
 	require.NoError(t, err)

--- a/pkg/process/util/log_limit.go
+++ b/pkg/process/util/log_limit.go
@@ -6,15 +6,16 @@
 package util
 
 import (
-	"sync/atomic"
 	"time"
+
+	"go.uber.org/atomic"
 )
 
 // LogLimit is a utility that can be used to avoid logging noisily
 type LogLimit struct {
 	// n is the times remaining that the LogLimit will return true for ShouldLog.
-	// we repeatedly add 1 to it.
-	n int32
+	// we repeatedly subtract 1 from it, if it is nonzero.
+	n *atomic.Int32
 
 	// exit and ticker must be different channels
 	// becaues Stopping a ticker will not close the ticker channel,
@@ -28,7 +29,7 @@ type LogLimit struct {
 // interval thereafter.
 func NewLogLimit(n int, interval time.Duration) *LogLimit {
 	l := &LogLimit{
-		n:      int32(n),
+		n:      atomic.NewInt32(int32(n)),
 		ticker: time.NewTicker(interval),
 		exit:   make(chan struct{}),
 	}
@@ -39,9 +40,10 @@ func NewLogLimit(n int, interval time.Duration) *LogLimit {
 
 // ShouldLog returns true if the caller should log
 func (l *LogLimit) ShouldLog() bool {
-	n := atomic.LoadInt32(&l.n)
+	n := l.n.Load()
 	if n > 0 {
-		atomic.CompareAndSwapInt32(&l.n, n, n-1)
+		// try to decrement n, doing nothing on concurrent attempts
+		l.n.CAS(n, n-1)
 		return true
 	}
 
@@ -68,5 +70,5 @@ func (l *LogLimit) resetLoop() {
 func (l *LogLimit) resetCounter() {
 	// c.n == 0, it means we have gotten through the first few logs, and after ticker.T we should
 	// do another log
-	atomic.CompareAndSwapInt32(&l.n, 0, 1)
+	l.n.CAS(0, 1)
 }


### PR DESCRIPTION
Replaces direct use of the sync/atomic package with go.uber.org/atomic, in the given package

This should not change behavior.

### Motivation

Alignment issues with atomic access. See https://github.com/DataDog/datadog-agent/pull/11716

### Possible Drawbacks / Trade-offs

None

### Describe how to test/QA your changes

[processes team: can you fill this in? I'd suspect basic process-agent QA would cover this]

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
