### PR TITLE
[Serverless] remove ParentID field in inferred spans

### DIFF
--- a/pkg/serverless/trace/inferredspan/constants.go
+++ b/pkg/serverless/trace/inferredspan/constants.go
@@ -56,7 +56,6 @@ type RequestContextKeys struct {
 // HeaderKeys holds the extracted headers from the trace context
 type HeaderKeys struct {
 	InvocationType string `json:"X-Amz-Invocation-Type"`
-	ParentID       uint64 `json:"x-datadog-parent-id"`
 }
 
 // HTTPKeys holds the nested HTTP data from the event payload


### PR DESCRIPTION
### What does this PR do?

This field was unused and caused an error while marshalling : 
![Screen Shot 2022-05-05 at 11 24 11 AM](https://user-images.githubusercontent.com/864493/166961971-aa02d485-3d9b-47c6-bcbd-9d5045455ed6.png)

### Motivation

Fix parsing events for inferred spans logic

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
