### PR TITLE
Fix flaky test : TestTrapsShouldReceiveMessages

### DIFF
--- a/pkg/logs/internal/tailers/traps/tailer_test.go
+++ b/pkg/logs/internal/tailers/traps/tailer_test.go
@@ -8,6 +8,7 @@ package traps
 import (
 	"fmt"
 	"net"
+	"sort"
 	"testing"
 	"time"
 
@@ -64,11 +65,16 @@ func TestTrapsShouldReceiveMessages(t *testing.T) {
 	formattedPacket := format(t, p)
 	assert.Equal(t, message.StatusInfo, msg.GetStatus())
 	assert.Equal(t, formattedPacket, msg.Content)
-	assert.Equal(t, []string{
-		"snmp_version:2",
+	sort.Strings(msg.Origin.Tags())
+	expectedTags := []string{
 		"device_namespace:default",
 		"snmp_device:127.0.0.1",
-	}, msg.Origin.Tags())
+		"snmp_version:2",
+	}
+	tags := msg.Origin.Tags()
+	sort.Strings(expectedTags)
+	sort.Strings(tags)
+	assert.Equal(t, expectedTags, tags)
 
 	close(inputChan)
 	tailer.WaitFlush()

--- a/pkg/logs/internal/tailers/traps/tailer_test.go
+++ b/pkg/logs/internal/tailers/traps/tailer_test.go
@@ -65,7 +65,6 @@ func TestTrapsShouldReceiveMessages(t *testing.T) {
 	formattedPacket := format(t, p)
 	assert.Equal(t, message.StatusInfo, msg.GetStatus())
 	assert.Equal(t, formattedPacket, msg.Content)
-	sort.Strings(msg.Origin.Tags())
 	expectedTags := []string{
 		"device_namespace:default",
 		"snmp_device:127.0.0.1",

--- a/pkg/logs/internal/tailers/traps/tailer_test.go
+++ b/pkg/logs/internal/tailers/traps/tailer_test.go
@@ -8,7 +8,6 @@ package traps
 import (
 	"fmt"
 	"net"
-	"sort"
 	"testing"
 	"time"
 
@@ -65,15 +64,11 @@ func TestTrapsShouldReceiveMessages(t *testing.T) {
 	formattedPacket := format(t, p)
 	assert.Equal(t, message.StatusInfo, msg.GetStatus())
 	assert.Equal(t, formattedPacket, msg.Content)
-	expectedTags := []string{
+	assert.ElementsMatch(t, []string{
 		"device_namespace:default",
 		"snmp_device:127.0.0.1",
 		"snmp_version:2",
-	}
-	tags := msg.Origin.Tags()
-	sort.Strings(expectedTags)
-	sort.Strings(tags)
-	assert.Equal(t, expectedTags, tags)
+	}, msg.Origin.Tags())
 
 	close(inputChan)
 	tailer.WaitFlush()


### PR DESCRIPTION
### What does this PR do?

It seems that `TestTrapsShouldReceiveMessages` is flaky.

```
=== FAIL: pkg/logs/internal/tailers/traps TestTrapsShouldReceiveMessages (re-run 2) (0.00s)
    tailer_test.go:67: 
        	Error Trace:	tailer_test.go:67
        	Error:      	Not equal: 
        	            	expected: []string{"snmp_version:2", "device_namespace:default", "snmp_device:127.0.0.1"}
        	            	actual  : []string{"snmp_device:127.0.0.1", "snmp_version:2", "device_namespace:default"}
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1,5 +1,5 @@
        	            	 ([]string) (len=3) {
        	            	+ (string) (len=21) "snmp_device:127.0.0.1",
        	            	  (string) (len=14) "snmp_version:2",
        	            	- (string) (len=24) "device_namespace:default",
        	            	- (string) (len=21) "snmp_device:127.0.0.1"
        	            	+ (string) (len=24) "device_namespace:default"
        	            	 }
        	Test:       	TestTrapsShouldReceiveMessages
```

This PR sorts tags so the result should be more predictable.
I've run the test 10k times with : 

`go test -timeout 30s -tags static -run ^TestTrapsShouldReceiveMessages$ github.com/DataDog/datadog-agent/pkg/logs/internal/tailers/traps -count 10000`

and it seems fixed
### Motivation

Fix flaky test

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
