### PR TITLE
pkg/trace/api: allow OpenTelemetry clients to set their own priority

### DIFF
--- a/pkg/trace/api/otlp_test.go
+++ b/pkg/trace/api/otlp_test.go
@@ -284,7 +284,7 @@ func TestOTLPReceiveResourceSpans(t *testing.T) {
 				for i := 0; i < 4; i++ {
 					traceID := out.Chunks[i].Spans[0].TraceID
 					p, ok := traceIDPriority[traceID]
-					require.True(ok, fmt.Sprintf("%v trace ID ont found", traceID))
+					require.True(ok, fmt.Sprintf("%v trace ID not found", traceID))
 					require.Equal(p, out.Chunks[i].Priority)
 				}
 			},

--- a/pkg/trace/api/otlp_test.go
+++ b/pkg/trace/api/otlp_test.go
@@ -237,6 +237,58 @@ func TestOTLPReceiveResourceSpans(t *testing.T) {
 				require.Len(out.Chunks[1].Spans, 2)
 			},
 		},
+		{
+			in: []testutil.OTLPResourceSpan{
+				{
+					Spans: []*testutil.OTLPSpan{
+						{
+							TraceID:    [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+							Name:       "first",
+							Attributes: map[string]interface{}{"_sampling_priority_v1": -1},
+						},
+						{
+							TraceID:    [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 17},
+							SpanID:     [8]byte{10, 10, 11, 12, 13, 14, 15, 16},
+							Name:       "second",
+							Attributes: map[string]interface{}{"_sampling_priority_v1": 2},
+						},
+						{
+							TraceID:    [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 17},
+							SpanID:     [8]byte{9, 10, 11, 12, 13, 14, 15, 16},
+							Name:       "third",
+							Attributes: map[string]interface{}{"_sampling_priority_v1": 3},
+						},
+						{
+							TraceID:    [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 18},
+							SpanID:     [8]byte{9, 10, 11, 12, 13, 14, 15, 16},
+							Name:       "third",
+							Attributes: map[string]interface{}{"_sampling_priority_v1": 0},
+						},
+						{
+							TraceID: [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 19},
+							SpanID:  [8]byte{9, 10, 11, 12, 13, 14, 15, 16},
+							Name:    "third",
+						},
+					},
+				},
+			},
+			fn: func(out *pb.TracerPayload) {
+				require.Len(out.Chunks, 4) // 4 traces total
+				// expected priorities by TraceID
+				traceIDPriority := map[uint64]int32{
+					0x90a0b0c0d0e0f10: -1,
+					0x90a0b0c0d0e0f11: 3,
+					0x90a0b0c0d0e0f12: 0,
+					0x90a0b0c0d0e0f13: 1,
+				}
+				for i := 0; i < 4; i++ {
+					traceID := out.Chunks[i].Spans[0].TraceID
+					p, ok := traceIDPriority[traceID]
+					require.True(ok, fmt.Sprintf("%v trace ID ont found", traceID))
+					require.Equal(p, out.Chunks[i].Priority)
+				}
+			},
+		},
 	} {
 		t.Run("", func(t *testing.T) {
 			rcv.ReceiveResourceSpans(testutil.NewOTLPTracesRequest(tt.in).Traces().ResourceSpans().At(0), http.Header{}, "agent_tests")

--- a/releasenotes/notes/apm-otlp-allow-priority-6c224075157d8e12.yaml
+++ b/releasenotes/notes/apm-otlp-allow-priority-6c224075157d8e12.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    APM: Incoming OTLP traces are now allowed to set their own sampling priority.


### PR DESCRIPTION
This change makes it so that incoming OTLP traces are allowed to have
their own sampling priorities, whereas previously all traces were forced
to 1 (AUTO_KEEP).