### PR TITLE
use_local_defined_servers: include OpenNTPD support

### DIFF
--- a/pkg/collector/corechecks/net/ntp_local_defined_server_nowindows.go
+++ b/pkg/collector/corechecks/net/ntp_local_defined_server_nowindows.go
@@ -15,7 +15,7 @@ import (
 )
 
 func getLocalDefinedNTPServers() ([]string, error) {
-	return getNTPServersFromFiles([]string{"/etc/ntp.conf", "/etc/xntp.conf", "/etc/chrony.conf"})
+	return getNTPServersFromFiles([]string{"/etc/ntp.conf", "/etc/xntp.conf", "/etc/chrony.conf", "/etc/ntpd.conf", "/etc/openntpd/ntpd.conf"})
 }
 
 func getNTPServersFromFiles(files []string) ([]string, error) {

--- a/releasenotes/notes/use_local_defined_servers_include_openntpd_support-73c99224234b225f.yaml
+++ b/releasenotes/notes/use_local_defined_servers_include_openntpd_support-73c99224234b225f.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    Include `/etc/ntpd.conf` and `/etc/openntpd/ntpd.conf` for `use_local_defined_servers`
+    NTP check: Include ``/etc/ntpd.conf`` and ``/etc/openntpd/ntpd.conf`` for ``use_local_defined_servers``.

--- a/releasenotes/notes/use_local_defined_servers_include_openntpd_support-73c99224234b225f.yaml
+++ b/releasenotes/notes/use_local_defined_servers_include_openntpd_support-73c99224234b225f.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Include `/etc/ntpd.conf` and `/etc/openntpd/ntpd.conf` for `use_local_defined_servers`


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Includes NTP servers in `/etc/ntpd.conf` and `/etc/openntpd/ntpf.conf` for use with `use_local_defined_servers`

### Motivation

* Customer reached out to support as the NTP check would not work after they switched to OpenNTPD
* Similar PR for Chrony : https://github.com/DataDog/datadog-agent/pull/10915

### Additional Notes

* No additional tests are needed as the configuration file shares the same format as `ntp.conf` : `server XXX`

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

* For Ubuntu : 
    * apt install openntpd
    * Configuration file will be `/etc/openntpd/ntpd.conf`
    * Test
* For OpenBSD : 
    * Configuration file will be `/etc/ntpd.conf`
    * Test

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
