### PR TITLE
Optimize HTTP stats storage

### DIFF
--- a/pkg/network/encoding/encoding_test.go
+++ b/pkg/network/encoding/encoding_test.go
@@ -189,7 +189,7 @@ func TestSerialization(t *testing.T) {
 				},
 			},
 		},
-		HTTP: map[http.Key]http.RequestStats{
+		HTTP: map[http.Key]*http.RequestStats{
 			http.NewKey(
 				util.AddressFromString("20.1.1.1"),
 				util.AddressFromString("20.1.1.1"),
@@ -197,7 +197,7 @@ func TestSerialization(t *testing.T) {
 				80,
 				"/testpath",
 				http.MethodGet,
-			): httpReqStats,
+			): &httpReqStats,
 		},
 	}
 
@@ -418,7 +418,7 @@ func TestHTTPSerializationWithLocalhostTraffic(t *testing.T) {
 				},
 			},
 		},
-		HTTP: map[http.Key]http.RequestStats{
+		HTTP: map[http.Key]*http.RequestStats{
 			http.NewKey(
 				localhost,
 				localhost,
@@ -426,7 +426,7 @@ func TestHTTPSerializationWithLocalhostTraffic(t *testing.T) {
 				serverPort,
 				"/testpath",
 				http.MethodGet,
-			): httpReqStats,
+			): &httpReqStats,
 		},
 	}
 
@@ -530,7 +530,7 @@ func TestPooledObjectGarbageRegression(t *testing.T) {
 	for i := 0; i < 1000; i++ {
 		if (i % 2) == 0 {
 			httpKey.Path = fmt.Sprintf("/path-%d", i)
-			in.HTTP = map[http.Key]http.RequestStats{httpKey: {}}
+			in.HTTP = map[http.Key]*http.RequestStats{httpKey: {}}
 			out := encodeAndDecodeHTTP(in)
 
 			require.NotNil(t, out)

--- a/pkg/network/encoding/http.go
+++ b/pkg/network/encoding/http.go
@@ -13,7 +13,7 @@ import (
 )
 
 type httpEncoder struct {
-	aggregations map[http.Key]*model.HTTPAggregations
+	aggregations map[http.KeyTuple]*model.HTTPAggregations
 
 	// pre-allocated objects
 	dataPool []model.HTTPStats_Data
@@ -29,7 +29,7 @@ func newHTTPEncoder(payload *network.Connections) *httpEncoder {
 	}
 
 	encoder := &httpEncoder{
-		aggregations: make(map[http.Key]*model.HTTPAggregations, len(payload.Conns)),
+		aggregations: make(map[http.KeyTuple]*model.HTTPAggregations, len(payload.Conns)),
 
 		// pre-allocate all data objects at once
 		dataPool: make([]model.HTTPStats_Data, len(payload.HTTP)*http.NumStatusClasses),
@@ -40,7 +40,7 @@ func newHTTPEncoder(payload *network.Connections) *httpEncoder {
 	// pre-populate aggregation map with keys for all existent connections
 	// this allows us to skip encoding orphan HTTP objects that can't be matched to a connection
 	for _, conn := range payload.Conns {
-		encoder.aggregations[httpKeyFromConn(conn)] = nil
+		encoder.aggregations[httpKeyTupleFromConn(conn)] = nil
 	}
 
 	encoder.buildAggregations(payload)
@@ -52,17 +52,17 @@ func (e *httpEncoder) GetHTTPAggregations(c network.ConnectionStats) *model.HTTP
 		return nil
 	}
 
-	return e.aggregations[httpKeyFromConn(c)]
+	return e.aggregations[httpKeyTupleFromConn(c)]
 }
 
 func (e *httpEncoder) buildAggregations(payload *network.Connections) {
-	for key, stats := range payload.HTTP {
-		path := key.Path
-		method := key.Method
-		key.Path = ""
-		key.Method = http.MethodUnknown
+	aggrSize := make(map[http.KeyTuple]int)
+	for key := range payload.HTTP {
+		aggrSize[key.KeyTuple]++
+	}
 
-		aggregation, ok := e.aggregations[key]
+	for key, stats := range payload.HTTP {
+		aggregation, ok := e.aggregations[key.KeyTuple]
 		if !ok {
 			// if there is no matching connection don't even bother to serialize HTTP data
 			e.orphanEntries++
@@ -71,25 +71,30 @@ func (e *httpEncoder) buildAggregations(payload *network.Connections) {
 
 		if aggregation == nil {
 			aggregation = &model.HTTPAggregations{
-				EndpointAggregations: make([]*model.HTTPStats, 0, 10),
+				EndpointAggregations: make([]*model.HTTPStats, 0, aggrSize[key.KeyTuple]),
 			}
-			e.aggregations[key] = aggregation
+			e.aggregations[key.KeyTuple] = aggregation
 		}
 
 		ms := &model.HTTPStats{
-			Path:                  path,
-			Method:                model.HTTPMethod(method),
+			Path:                  key.Path,
+			Method:                model.HTTPMethod(key.Method),
 			StatsByResponseStatus: e.getDataSlice(),
 		}
 
 		for i, data := range ms.StatsByResponseStatus {
-			data.Count = uint32(stats[i].Count)
+			class := (i + 1) * 100
+			if !stats.HasStats(class) {
+				continue
+			}
+			s := stats.Stats(class)
+			data.Count = uint32(s.Count)
 
-			if latencies := stats[i].Latencies; latencies != nil {
+			if latencies := s.Latencies; latencies != nil {
 				blob, _ := proto.Marshal(latencies.ToProto())
 				data.Latencies = blob
 			} else {
-				data.FirstLatencySample = stats[i].FirstLatencySample
+				data.FirstLatencySample = s.FirstLatencySample
 			}
 		}
 
@@ -107,7 +112,7 @@ func (e *httpEncoder) getDataSlice() []*model.HTTPStats_Data {
 }
 
 // Build the key for the http map based on whether the local or remote side is http.
-func httpKeyFromConn(c network.ConnectionStats) http.Key {
+func httpKeyTupleFromConn(c network.ConnectionStats) http.KeyTuple {
 	// Retrieve translated addresses
 	laddr, lport := network.GetNATLocalAddress(c)
 	raddr, rport := network.GetNATRemoteAddress(c)
@@ -118,8 +123,8 @@ func httpKeyFromConn(c network.ConnectionStats) http.Key {
 	// to mimic the normalization heuristic done in the eBPF side (see `port_range.h`)
 	if (network.IsEphemeralPort(int(lport)) && !network.IsEphemeralPort(int(rport))) ||
 		(network.IsEphemeralPort(int(lport)) == network.IsEphemeralPort(int(rport)) && lport < rport) {
-		return http.NewKey(laddr, raddr, lport, rport, "", http.MethodUnknown)
+		return http.NewKeyTuple(laddr, raddr, lport, rport)
 	}
 
-	return http.NewKey(raddr, laddr, rport, lport, "", http.MethodUnknown)
+	return http.NewKeyTuple(raddr, laddr, rport, lport)
 }

--- a/pkg/network/event_common.go
+++ b/pkg/network/event_common.go
@@ -120,7 +120,7 @@ type Connections struct {
 	DNS                         map[util.Address][]dns.Hostname
 	ConnTelemetry               map[ConnTelemetryType]int64
 	CompilationTelemetryByAsset map[string]RuntimeCompilationTelemetry
-	HTTP                        map[http.Key]http.RequestStats
+	HTTP                        map[http.Key]*http.RequestStats
 	DNSStats                    dns.StatsByKeyByNameByType
 }
 

--- a/pkg/network/http/debugging/debugging.go
+++ b/pkg/network/http/debugging/debugging.go
@@ -37,7 +37,7 @@ type Stats struct {
 }
 
 // HTTP returns a debug-friendly representation of map[http.Key]http.RequestStats
-func HTTP(stats map[http.Key]http.RequestStats, dns map[util.Address][]dns.Hostname) []RequestSummary {
+func HTTP(stats map[http.Key]*http.RequestStats, dns map[util.Address][]dns.Hostname) []RequestSummary {
 	all := make([]RequestSummary, 0, len(stats))
 	for k, v := range stats {
 		clientAddr := formatIP(k.SrcIPLow, k.SrcIPHigh)
@@ -58,12 +58,12 @@ func HTTP(stats map[http.Key]http.RequestStats, dns map[util.Address][]dns.Hostn
 			ByStatus: make(map[int]Stats),
 		}
 
-		for i, stat := range v {
+		for status := 100; status <= 500; status += 100 {
+			stat := v.Stats(status)
 			if stat.Count == 0 {
 				continue
 			}
 
-			status := (i + 1) * 100
 			debug.ByStatus[status] = Stats{
 				Count:              stat.Count,
 				FirstLatencySample: stat.FirstLatencySample,

--- a/pkg/network/http/http_statkeeper.go
+++ b/pkg/network/http/http_statkeeper.go
@@ -15,8 +15,8 @@ import (
 )
 
 type httpStatKeeper struct {
-	stats      map[Key]RequestStats
-	incomplete map[Key]httpTX
+	stats      map[Key]*RequestStats
+	incomplete map[KeyTuple]*httpTX
 	maxEntries int
 	telemetry  *telemetry
 
@@ -33,8 +33,8 @@ type httpStatKeeper struct {
 
 func newHTTPStatkeeper(c *config.Config, telemetry *telemetry) *httpStatKeeper {
 	return &httpStatKeeper{
-		stats:        make(map[Key]RequestStats),
-		incomplete:   make(map[Key]httpTX),
+		stats:        make(map[Key]*RequestStats),
+		incomplete:   make(map[KeyTuple]*httpTX),
 		maxEntries:   c.MaxHTTPStatsBuffered,
 		replaceRules: c.HTTPReplaceRules,
 		buffer:       make([]byte, HTTPBufferSize),
@@ -44,7 +44,8 @@ func newHTTPStatkeeper(c *config.Config, telemetry *telemetry) *httpStatKeeper {
 }
 
 func (h *httpStatKeeper) Process(transactions []httpTX) {
-	for _, tx := range transactions {
+	for i := range transactions {
+		tx := &transactions[i]
 		if tx.Incomplete() {
 			h.handleIncomplete(tx)
 			continue
@@ -56,15 +57,15 @@ func (h *httpStatKeeper) Process(transactions []httpTX) {
 	atomic.StoreInt64(&h.telemetry.aggregations, int64(len(h.stats)))
 }
 
-func (h *httpStatKeeper) GetAndResetAllStats() map[Key]RequestStats {
+func (h *httpStatKeeper) GetAndResetAllStats() map[Key]*RequestStats {
 	ret := h.stats // No deep copy needed since `h.stats` gets reset
-	h.stats = make(map[Key]RequestStats)
-	h.incomplete = make(map[Key]httpTX)
+	h.stats = make(map[Key]*RequestStats)
+	h.incomplete = make(map[KeyTuple]*httpTX)
 	h.interned = make(map[string]string)
 	return ret
 }
 
-func (h *httpStatKeeper) add(tx httpTX) {
+func (h *httpStatKeeper) add(tx *httpTX) {
 	rawPath := tx.Path(h.buffer)
 	if rawPath == nil {
 		atomic.AddInt64(&h.telemetry.malformed, 1)
@@ -78,21 +79,24 @@ func (h *httpStatKeeper) add(tx httpTX) {
 
 	key := h.newKey(tx, path)
 	stats, ok := h.stats[key]
-	if !ok && len(h.stats) >= h.maxEntries {
-		atomic.AddInt64(&h.telemetry.dropped, 1)
-		return
+	if !ok {
+		if len(h.stats) >= h.maxEntries {
+			atomic.AddInt64(&h.telemetry.dropped, 1)
+			return
+		}
+		stats = new(RequestStats)
+		h.stats[key] = stats
 	}
 
 	stats.AddRequest(tx.StatusClass(), tx.RequestLatency())
-	h.stats[key] = stats
 }
 
 // handleIncomplete is responsible for handling incomplete transactions
 // (eg. httpTX objects that have either only the request or response information)
 // this happens only in the context of localhost traffic with NAT and these disjoint
 // parts of the transactions are joined here by src port
-func (h *httpStatKeeper) handleIncomplete(tx httpTX) {
-	key := Key{
+func (h *httpStatKeeper) handleIncomplete(tx *httpTX) {
+	key := KeyTuple{
 		SrcIPHigh: uint64(tx.tup.saddr_h),
 		SrcIPLow:  uint64(tx.tup.saddr_l),
 		SrcPort:   uint16(tx.tup.sport),
@@ -105,7 +109,6 @@ func (h *httpStatKeeper) handleIncomplete(tx httpTX) {
 		} else {
 			h.incomplete[key] = tx
 		}
-
 		return
 	}
 
@@ -131,16 +134,18 @@ func (h *httpStatKeeper) handleIncomplete(tx httpTX) {
 	delete(h.incomplete, key)
 }
 
-func (h *httpStatKeeper) newKey(tx httpTX, path string) Key {
+func (h *httpStatKeeper) newKey(tx *httpTX, path string) Key {
 	return Key{
-		SrcIPHigh: uint64(tx.tup.saddr_h),
-		SrcIPLow:  uint64(tx.tup.saddr_l),
-		SrcPort:   uint16(tx.tup.sport),
-		DstIPHigh: uint64(tx.tup.daddr_h),
-		DstIPLow:  uint64(tx.tup.daddr_l),
-		DstPort:   uint16(tx.tup.dport),
-		Path:      path,
-		Method:    Method(tx.request_method),
+		KeyTuple: KeyTuple{
+			SrcIPHigh: uint64(tx.tup.saddr_h),
+			SrcIPLow:  uint64(tx.tup.saddr_l),
+			SrcPort:   uint16(tx.tup.sport),
+			DstIPHigh: uint64(tx.tup.daddr_h),
+			DstIPLow:  uint64(tx.tup.daddr_l),
+			DstPort:   uint16(tx.tup.dport),
+		},
+		Path:   path,
+		Method: Method(tx.request_method),
 	}
 }
 

--- a/pkg/network/http/http_stats.go
+++ b/pkg/network/http/http_stats.go
@@ -75,9 +75,9 @@ type KeyTuple struct {
 
 // Key is an identifier for a group of HTTP transactions
 type Key struct {
+	// this field order is intentional to help the GC pointer tracking
+	Path string
 	KeyTuple
-
-	Path   string
 	Method Method
 }
 
@@ -115,11 +115,12 @@ type RequestStats struct {
 
 // RequestStat stores stats for HTTP requests to a particular path
 type RequestStat struct {
-	// Note: every time we add a latency value to the DDSketch below, it's possible for the sketch to discard that value
+	// this field order is intentional to help the GC pointer tracking
+	Latencies *ddsketch.DDSketch
+	// Note: every time we add a latency value to the DDSketch, it's possible for the sketch to discard that value
 	// (ie if it is outside the range that is tracked by the sketch). For that reason, in order to keep an accurate count
 	// the number of http transactions processed, we have our own count field (rather than relying on DDSketch.GetCount())
-	Count     int
-	Latencies *ddsketch.DDSketch
+	Count int
 
 	// This field holds the value (in nanoseconds) of the first HTTP request
 	// in this bucket. We do this as optimization to avoid creating sketches with

--- a/pkg/network/http/http_stats_test.go
+++ b/pkg/network/http/http_stats_test.go
@@ -21,26 +21,28 @@ func TestAddRequest(t *testing.T) {
 	stats.AddRequest(404, 15.0)
 	stats.AddRequest(405, 20.0)
 
-	for i := 0; i < 5; i++ {
-		if i == 3 {
-			assert.Equal(t, 3, stats[i].Count)
-			assert.Equal(t, 3.0, stats[i].Latencies.GetCount())
+	for i := 100; i <= 500; i += 100 {
+		s := stats.Stats(i)
+		if i == 400 {
+			if assert.NotNil(t, s) {
+				assert.Equal(t, 3, s.Count)
+				assert.Equal(t, 3.0, s.Latencies.GetCount())
 
-			verifyQuantile(t, stats[i].Latencies, 0.0, 10.0)  // min item
-			verifyQuantile(t, stats[i].Latencies, 0.99, 15.0) // median
-			verifyQuantile(t, stats[i].Latencies, 1.0, 20.0)  // max item
+				verifyQuantile(t, s.Latencies, 0.0, 10.0)  // min item
+				verifyQuantile(t, s.Latencies, 0.99, 15.0) // median
+				verifyQuantile(t, s.Latencies, 1.0, 20.0)  // max item
+			}
 		} else {
-			assert.Equal(t, 0, stats[i].Count)
-			assert.Nil(t, stats[i].Latencies)
+			assert.Nil(t, s)
 		}
 	}
 }
 
 func TestCombineWith(t *testing.T) {
 	var stats RequestStats
-	for i := 0; i < 5; i++ {
-		assert.Equal(t, 0, stats[i].Count)
-		assert.True(t, stats[i].Latencies == nil)
+	for i := 100; i <= 500; i += 100 {
+		s := stats.Stats(i)
+		assert.Nil(t, s)
 	}
 
 	var stats2, stats3, stats4 RequestStats
@@ -48,19 +50,21 @@ func TestCombineWith(t *testing.T) {
 	stats3.AddRequest(404, 15.0)
 	stats4.AddRequest(405, 20.0)
 
-	stats.CombineWith(stats2)
-	stats.CombineWith(stats3)
-	stats.CombineWith(stats4)
+	stats.CombineWith(&stats2)
+	stats.CombineWith(&stats3)
+	stats.CombineWith(&stats4)
 
-	for i := 0; i < 5; i++ {
-		if i == 3 {
-			assert.Equal(t, 3, stats[i].Count)
-			verifyQuantile(t, stats[i].Latencies, 0.0, 10.0)
-			verifyQuantile(t, stats[i].Latencies, 0.5, 15.0)
-			verifyQuantile(t, stats[i].Latencies, 1.0, 20.0)
+	for i := 100; i <= 500; i += 100 {
+		s := stats.Stats(i)
+		if i == 400 {
+			if assert.NotNil(t, s) {
+				assert.Equal(t, 3, s.Count)
+				verifyQuantile(t, s.Latencies, 0.0, 10.0)
+				verifyQuantile(t, s.Latencies, 0.5, 15.0)
+				verifyQuantile(t, s.Latencies, 1.0, 20.0)
+			}
 		} else {
-			assert.Equal(t, 0, stats[i].Count)
-			assert.True(t, stats[i].Latencies == nil)
+			assert.Nil(t, s)
 		}
 	}
 }

--- a/pkg/network/http/model.go
+++ b/pkg/network/http/model.go
@@ -74,6 +74,9 @@ func (tx *httpTX) StatusClass() int {
 
 // RequestLatency returns the latency of the request in nanoseconds
 func (tx *httpTX) RequestLatency() float64 {
+	if uint64(tx.request_started) == 0 || uint64(tx.response_last_seen) == 0 {
+		return 0
+	}
 	return nsTimestampToFloat(uint64(tx.response_last_seen - tx.request_started))
 }
 

--- a/pkg/network/http/monitor.go
+++ b/pkg/network/http/monitor.go
@@ -25,7 +25,7 @@ import (
 // * requestsStats which are the http data stats
 // * telemetry which are telemetry stats
 type HTTPMonitorStats struct {
-	requestStats map[Key]RequestStats
+	requestStats map[Key]*RequestStats
 	telemetry    telemetry
 }
 
@@ -173,7 +173,7 @@ func (m *Monitor) Start() error {
 
 // GetHTTPStats returns a map of HTTP stats stored in the following format:
 // [source, dest tuple, request path] -> RequestStats object
-func (m *Monitor) GetHTTPStats() map[Key]RequestStats {
+func (m *Monitor) GetHTTPStats() map[Key]*RequestStats {
 	if m == nil {
 		return nil
 	}

--- a/pkg/network/http/monitor_test.go
+++ b/pkg/network/http/monitor_test.go
@@ -152,11 +152,10 @@ func requestGenerator(t *testing.T, targetAddr string) func() *nethttp.Request {
 	}
 }
 
-func includesRequest(t *testing.T, allStats map[Key]RequestStats, req *nethttp.Request) {
+func includesRequest(t *testing.T, allStats map[Key]*RequestStats, req *nethttp.Request) {
 	expectedStatus := testutil.StatusFromPath(req.URL.Path)
 	for key, stats := range allStats {
-		i := expectedStatus/100 - 1
-		if key.Path == req.URL.Path && stats[i].Count == 1 {
+		if key.Path == req.URL.Path && stats.HasStats(expectedStatus) {
 			return
 		}
 	}

--- a/pkg/network/state_test.go
+++ b/pkg/network/state_test.go
@@ -1304,9 +1304,9 @@ func TestHTTPStats(t *testing.T) {
 
 	key := http.NewKey(c.Source, c.Dest, c.SPort, c.DPort, "/testpath", http.MethodGet)
 
-	httpStats := make(map[http.Key]http.RequestStats)
+	httpStats := make(map[http.Key]*http.RequestStats)
 	var rs http.RequestStats
-	httpStats[key] = rs
+	httpStats[key] = &rs
 
 	// Register client & pass in HTTP stats
 	state := newDefaultState()
@@ -1328,11 +1328,11 @@ func TestHTTPStatsWithMultipleClients(t *testing.T) {
 		DPort:  80,
 	}
 
-	getStats := func(path string) map[http.Key]http.RequestStats {
-		httpStats := make(map[http.Key]http.RequestStats)
+	getStats := func(path string) map[http.Key]*http.RequestStats {
+		httpStats := make(map[http.Key]*http.RequestStats)
 		key := http.NewKey(c.Source, c.Dest, c.SPort, c.DPort, path, http.MethodGet)
 		var rs http.RequestStats
-		httpStats[key] = rs
+		httpStats[key] = &rs
 		return httpStats
 	}
 

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -1578,7 +1578,7 @@ func TestHTTPStats(t *testing.T) {
 	resp.Body.Close()
 
 	// Iterate through active connections until we find connection created above
-	var httpReqStats http.RequestStats
+	var httpReqStats *http.RequestStats
 	require.Eventuallyf(t, func() bool {
 		payload, err := tr.GetActiveConnections("1")
 		if err != nil {
@@ -1596,11 +1596,12 @@ func TestHTTPStats(t *testing.T) {
 	}, 3*time.Second, 10*time.Millisecond, "couldn't find http connection matching: %s", serverAddr)
 
 	// Verify HTTP stats
-	assert.Equal(t, 0, httpReqStats[0].Count, "100s") // number of requests with response status 100
-	assert.Equal(t, 1, httpReqStats[1].Count, "200s") // 200
-	assert.Equal(t, 0, httpReqStats[2].Count, "300s") // 300
-	assert.Equal(t, 0, httpReqStats[3].Count, "400s") // 400
-	assert.Equal(t, 0, httpReqStats[4].Count, "500s") // 500
+	require.NotNil(t, httpReqStats)
+	assert.Nil(t, httpReqStats.Stats(100), "100s")            // number of requests with response status 100
+	assert.Equal(t, 1, httpReqStats.Stats(200).Count, "200s") // 200
+	assert.Nil(t, httpReqStats.Stats(300), "300s")            // 300
+	assert.Nil(t, httpReqStats.Stats(400), "400s")            // 400
+	assert.Nil(t, httpReqStats.Stats(500), "500s")            // 500
 }
 
 var regexSSL = regexp.MustCompile(`/[^\ ]+libssl.so[^\ ]*`)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

The PR optimizes how we store http stats by doing three things:
1. Using a pointer as the map value, this reduces the amount of storage necessary for the map. It does increase the number of allocations, but the total memory allocation is down.
2. Use an array to pointers for the data-per-status class. We can save the allocation for status classes which are not used, which is likely to be a common scenario.
3. Optimizes the map keys used in different scenarios to be already present (with or without path and method).

### Motivation

Lower memory usage.

### Additional Notes

When changing `RequestStats` from `[5]RequestStat` to `[5]*RequestStat`, it became difficult to verify that it was being used safely everywhere. This led me to embedding the array inside a struct and creating a good abstraction to use.

![Screen Shot 2022-05-06 at 8 14 02 AM](https://user-images.githubusercontent.com/1010430/167161868-c3c1e48a-734a-45cb-9acb-f9b92f11c009.png)


### Possible Drawbacks / Trade-offs

There is an increase in CPU% usage. It seems to be coming from the GC having to scan a lot more pointers on the heap. I believe this is an acceptable increase, due to the memory savings.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
