### PR TITLE
[Serverless] Fix rounded value in inferred spans

### DIFF
--- a/pkg/serverless/trace/inferredspan/span_enrichment.go
+++ b/pkg/serverless/trace/inferredspan/span_enrichment.go
@@ -111,5 +111,5 @@ func isAsyncEvent(attributes EventKeys) bool {
 
 // CalculateStartTime converts AWS event timeEpochs to nanoseconds
 func calculateStartTime(epoch int64) int64 {
-	return (epoch / 1000) * 1e9
+	return epoch * 1e6
 }

--- a/pkg/serverless/trace/inferredspan/span_enrichment_test.go
+++ b/pkg/serverless/trace/inferredspan/span_enrichment_test.go
@@ -207,3 +207,7 @@ func mockInferredSpan() InferredSpan {
 	inferredSpan.Span.SpanID = uint64(8048964810003407541)
 	return inferredSpan
 }
+
+func TestCalculateStartTime(t *testing.T) {
+	assert.Equal(t, int64(1651863561696000000), calculateStartTime(1651863561696))
+}

--- a/pkg/serverless/trace/inferredspan/span_enrichment_test.go
+++ b/pkg/serverless/trace/inferredspan/span_enrichment_test.go
@@ -74,7 +74,7 @@ func TestEnrichInferredSpanWithAPIGatewayNonProxyAsyncRESTEvent(t *testing.T) {
 	span := inferredSpan.Span
 	assert.Equal(t, span.TraceID, uint64(7353030974370088224))
 	assert.Equal(t, span.SpanID, uint64(8048964810003407541))
-	assert.Equal(t, span.Start, int64(1631210915000000000))
+	assert.Equal(t, span.Start, int64(1631210915251000000))
 	assert.Equal(t, span.Service, "lgxbo6a518.execute-api.sa-east-1.amazonaws.com")
 	assert.Equal(t, span.Name, "aws.apigateway")
 	assert.Equal(t, span.Resource, "GET /http/get")
@@ -99,7 +99,7 @@ func TestEnrichInferredSpanWithAPIGatewayHTTPEvent(t *testing.T) {
 	span := inferredSpan.Span
 	assert.Equal(t, span.TraceID, uint64(7353030974370088224))
 	assert.Equal(t, span.SpanID, uint64(8048964810003407541))
-	assert.Equal(t, span.Start, int64(1631212283000000000))
+	assert.Equal(t, span.Start, int64(1631212283738000000))
 	assert.Equal(t, span.Service, "x02yirxc7a.execute-api.sa-east-1.amazonaws.com")
 	assert.Equal(t, span.Name, "aws.httpapi")
 	assert.Equal(t, span.Resource, "GET ")
@@ -124,7 +124,7 @@ func TestEnrichInferredSpanWithAPIGatewayWebsocketDefaultEvent(t *testing.T) {
 
 	assert.Equal(t, span.TraceID, uint64(7353030974370088224))
 	assert.Equal(t, span.SpanID, uint64(8048964810003407541))
-	assert.Equal(t, span.Start, int64(1631285061000000000))
+	assert.Equal(t, span.Start, int64(1631285061365000000))
 	assert.Equal(t, span.Service, "p62c47itsb.execute-api.sa-east-1.amazonaws.com")
 	assert.Equal(t, span.Name, "aws.apigateway.websocket")
 	assert.Equal(t, span.Resource, "$default")
@@ -151,7 +151,7 @@ func TestEnrichInferredSpanWithAPIGatewayWebsocketConnectEvent(t *testing.T) {
 
 	assert.Equal(t, span.TraceID, uint64(7353030974370088224))
 	assert.Equal(t, span.SpanID, uint64(8048964810003407541))
-	assert.Equal(t, span.Start, int64(1631284003000000000))
+	assert.Equal(t, span.Start, int64(1631284003071000000))
 	assert.Equal(t, span.Service, "p62c47itsb.execute-api.sa-east-1.amazonaws.com")
 	assert.Equal(t, span.Name, "aws.apigateway.websocket")
 	assert.Equal(t, span.Resource, "$connect")
@@ -178,7 +178,7 @@ func TestEnrichInferredSpanWithAPIGatewayWebsocketDisconnectEvent(t *testing.T) 
 
 	assert.Equal(t, span.TraceID, uint64(7353030974370088224))
 	assert.Equal(t, span.SpanID, uint64(8048964810003407541))
-	assert.Equal(t, span.Start, int64(1631284034000000000))
+	assert.Equal(t, span.Start, int64(1631284034737000000))
 	assert.Equal(t, span.Service, "p62c47itsb.execute-api.sa-east-1.amazonaws.com")
 	assert.Equal(t, span.Name, "aws.apigateway.websocket")
 	assert.Equal(t, span.Resource, "$disconnect")


### PR DESCRIPTION
### What does this PR do?

The starting time of inferred spans was rounded due to `/1000`
This PR fixes this behaviour by only multiplying.

<img width="690" alt="Screen Shot 2022-05-06 at 3 14 35 PM" src="https://user-images.githubusercontent.com/864493/167208141-31c28eff-4565-4c0e-ba08-75ffd3b26fc0.png">

Before : 
<img width="647" alt="Screen Shot 2022-05-06 at 3 41 54 PM" src="https://user-images.githubusercontent.com/864493/167208154-3c3a5879-a636-4398-97f2-24edbd128c72.png">

After :
<img width="761" alt="Screen Shot 2022-05-06 at 3 41 43 PM" src="https://user-images.githubusercontent.com/864493/167208157-b66fcb2c-4ffb-4685-be8b-baf568e5178c.png">


### Motivation

Fix inferred span start time

### Describe how to test/QA your changes

unit test

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
