### PR TITLE
[CWS] check for frankenstein kernel instead of general rh7 kernel one

### DIFF
--- a/pkg/security/ebpf/kernel/kernel.go
+++ b/pkg/security/ebpf/kernel/kernel.go
@@ -163,6 +163,11 @@ func (k *Version) UbuntuKernelVersion() *kernel.UbuntuKernelVersion {
 	return ukv
 }
 
+// Is
+func (k *Version) IsRH7FrankensteinKernel() bool {
+	return k.Code != 0 && k.Code < Kernel4_12 && k.IsRH7Kernel()
+}
+
 // IsRH7Kernel returns whether the kernel is a rh7 kernel
 func (k *Version) IsRH7Kernel() bool {
 	return (k.OsRelease["ID"] == "centos" || k.OsRelease["ID"] == "rhel") && k.OsRelease["VERSION_ID"] == "7"
@@ -211,5 +216,5 @@ func (k *Version) IsAmazonLinuxKernel() bool {
 // IsInRangeCloseOpen returns whether the kernel version is between the begin
 // version (included) and the end version (excluded)
 func (k *Version) IsInRangeCloseOpen(begin kernel.Version, end kernel.Version) bool {
-	return k.Code != 0 && begin <= k.Code && k.Code < end
+	return begin <= k.Code && k.Code < end
 }

--- a/pkg/security/ebpf/probes/syscall_helpers.go
+++ b/pkg/security/ebpf/probes/syscall_helpers.go
@@ -88,7 +88,7 @@ func getCompatSyscallFnName(name string) string {
 // ShouldUseSyscallExitTracepoints returns true if the kernel version is old and we need to use tracepoints to handle syscall exits
 // instead of kretprobes
 func ShouldUseSyscallExitTracepoints() bool {
-	return currentKernelVersion != nil && (currentKernelVersion.Code < kernel.Kernel4_12 || currentKernelVersion.IsRH7Kernel())
+	return currentKernelVersion != nil && currentKernelVersion.IsRH7FrankensteinKernel()
 }
 
 func expandKprobe(hookpoint string, syscallName string, flag int) []string {

--- a/pkg/security/probe/constantfetch/fallback.go
+++ b/pkg/security/probe/constantfetch/fallback.go
@@ -130,7 +130,7 @@ func getSizeOfStructInode(kv *kernel.Version) uint64 {
 	}
 
 	switch {
-	case kv.IsRH7Kernel():
+	case kv.IsRH7FrankensteinKernel():
 		sizeOf = 584
 	case kv.IsRH8Kernel():
 		sizeOf = 648
@@ -172,7 +172,7 @@ func getSizeOfStructInode(kv *kernel.Version) uint64 {
 func getSuperBlockMagicOffset(kv *kernel.Version) uint64 {
 	sizeOf := uint64(96)
 
-	if kv.IsRH7Kernel() {
+	if kv.IsRH7FrankensteinKernel() {
 		sizeOf = 88
 	}
 
@@ -183,7 +183,7 @@ func getSignalTTYOffset(kv *kernel.Version) uint64 {
 	ttyOffset := uint64(400)
 
 	switch {
-	case kv.IsRH7Kernel():
+	case kv.IsRH7FrankensteinKernel():
 		ttyOffset = 416
 	case kv.IsRH8Kernel():
 		ttyOffset = 392
@@ -246,7 +246,7 @@ func getTTYNameOffset(kv *kernel.Version) uint64 {
 	nameOffset := uint64(368)
 
 	switch {
-	case kv.IsRH7Kernel():
+	case kv.IsRH7FrankensteinKernel():
 		nameOffset = 312
 	case kv.IsCOSKernel() && kv.IsInRangeCloseOpen(kernel.Kernel4_19, kernel.Kernel4_20):
 		nameOffset = 552
@@ -293,7 +293,7 @@ func getBpfMapNameOffset(kv *kernel.Version) uint64 {
 	nameOffset := uint64(168)
 
 	switch {
-	case kv.IsRH7Kernel():
+	case kv.IsRH7FrankensteinKernel():
 		nameOffset = 112
 	case kv.IsRH8Kernel():
 		nameOffset = 80
@@ -374,7 +374,7 @@ func getBpfProgAuxIDOffset(kv *kernel.Version) uint64 {
 	idOffset := uint64(24)
 
 	switch {
-	case kv.IsRH7Kernel():
+	case kv.IsRH7FrankensteinKernel():
 		idOffset = 8
 	case kv.IsRH8Kernel():
 		idOffset = 32
@@ -404,7 +404,7 @@ func getBpfProgAuxNameOffset(kv *kernel.Version) uint64 {
 	nameOffset := uint64(176)
 
 	switch {
-	case kv.IsRH7Kernel():
+	case kv.IsRH7FrankensteinKernel():
 		nameOffset = 144
 	case kv.IsRH8Kernel():
 		nameOffset = 520
@@ -450,7 +450,7 @@ func getPIDNumbersOffset(kv *kernel.Version) uint64 {
 	pidNumbersOffset := uint64(48)
 
 	switch {
-	case kv.IsRH7Kernel():
+	case kv.IsRH7FrankensteinKernel():
 		pidNumbersOffset = 48
 	case kv.IsRH8Kernel():
 		pidNumbersOffset = 56
@@ -487,7 +487,7 @@ func getSizeOfUpid(kv *kernel.Version) uint64 {
 	sizeOfUpid := uint64(16)
 
 	switch {
-	case kv.IsRH7Kernel():
+	case kv.IsRH7FrankensteinKernel():
 		sizeOfUpid = 32
 	case kv.IsRH8Kernel():
 		sizeOfUpid = 16
@@ -520,7 +520,7 @@ func getPipeInodeInfoBufsOffset(kv *kernel.Version) uint64 {
 	offset := uint64(120)
 
 	switch {
-	case kv.IsRH7Kernel():
+	case kv.IsRH7FrankensteinKernel():
 		offset = 128
 	case kv.IsRH8Kernel():
 		offset = 120
@@ -551,7 +551,7 @@ func getNetDeviceIfindexOffset(kv *kernel.Version) uint64 {
 	offset := uint64(260)
 
 	switch {
-	case kv.IsRH7Kernel():
+	case kv.IsRH7FrankensteinKernel():
 		offset = 192
 	case kv.IsRH8Kernel():
 		offset = 264
@@ -619,7 +619,7 @@ func getSocketSockOffset(kv *kernel.Version) uint64 {
 	offset := uint64(32)
 
 	switch {
-	case kv.IsRH7Kernel():
+	case kv.IsRH7FrankensteinKernel():
 		offset = 32
 	case kv.IsRH8Kernel():
 		offset = 32
@@ -641,7 +641,7 @@ func getNFConnCTNetOffset(kv *kernel.Version) uint64 {
 	switch {
 	case kv.IsCOSKernel():
 		offset = 168
-	case kv.IsRH7Kernel():
+	case kv.IsRH7FrankensteinKernel():
 		offset = 240
 	}
 
@@ -656,7 +656,7 @@ func getFlowi4SAddrOffset(kv *kernel.Version) uint64 {
 	offset := uint64(40)
 
 	switch {
-	case kv.IsRH7Kernel():
+	case kv.IsRH7FrankensteinKernel():
 		offset = 20
 	case kv.IsRH8Kernel():
 		offset = 56

--- a/pkg/security/probe/namespace_resolver.go
+++ b/pkg/security/probe/namespace_resolver.go
@@ -50,7 +50,7 @@ const (
 )
 
 func getNetStructType(kv *kernel.Version) uint64 {
-	if kv.IsRH7Kernel() {
+	if kv.IsRH7FrankensteinKernel() {
 		return netStructHasProcINum
 	}
 	return netStructHasNS

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -1424,7 +1424,7 @@ func AppendProbeRequestsToFetcher(constantFetcher constantfetch.ConstantFetcher,
 	constantFetcher.AppendOffsetofRequest("flowi6_uli_offset", "struct flowi6", "uli", "net/flow.h")
 	constantFetcher.AppendOffsetofRequest("socket_sock_offset", "struct socket", "sk", "linux/net.h")
 
-	if !kv.IsRH7Kernel() {
+	if !kv.IsRH7FrankensteinKernel() {
 		constantFetcher.AppendOffsetofRequest("nf_conn_ct_net_offset", "struct nf_conn", "ct_net", "net/netfilter/nf_conntrack.h")
 	}
 

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -53,7 +53,7 @@ const (
 )
 
 func getAttr2(probe *Probe) uint64 {
-	if probe.kernelVersion.IsRH7Kernel() {
+	if probe.kernelVersion.IsRH7FrankensteinKernel() {
 		return 1
 	}
 	return 0
@@ -73,7 +73,7 @@ func getCGroupWriteConstants() manager.ConstantEditor {
 	cgroupWriteConst := uint64(1)
 	kv, err := kernel.NewKernelVersion()
 	if err == nil {
-		if kv.IsRH7Kernel() {
+		if kv.IsRH7FrankensteinKernel() {
 			cgroupWriteConst = 2
 		}
 	}

--- a/pkg/security/tests/dns_test.go
+++ b/pkg/security/tests/dns_test.go
@@ -23,7 +23,7 @@ import (
 func TestDNS(t *testing.T) {
 	checkKernelCompatibility(t, "RHEL, SLES and Oracle kernels", func(kv *kernel.Version) bool {
 		// TODO: Oracle because we are missing offsets
-		return kv.IsRH7Kernel() || kv.IsOracleUEKKernel() || kv.IsSLESKernel()
+		return kv.IsRH7FrankensteinKernel() || kv.IsOracleUEKKernel() || kv.IsSLESKernel()
 	})
 
 	if testEnvironment != DockerEnvironment && !config.IsContainerized() {

--- a/pkg/security/tests/network_device_test.go
+++ b/pkg/security/tests/network_device_test.go
@@ -29,7 +29,7 @@ import (
 func TestNetDevice(t *testing.T) {
 	checkKernelCompatibility(t, "RHEL, SLES and Oracle kernels", func(kv *kernel.Version) bool {
 		// TODO: Oracle because we are missing offsets
-		return kv.IsRH7Kernel() || kv.IsOracleUEKKernel() || kv.IsSLESKernel()
+		return kv.IsRH7FrankensteinKernel() || kv.IsOracleUEKKernel() || kv.IsSLESKernel()
 	})
 
 	if testEnvironment != DockerEnvironment && !config.IsContainerized() {

--- a/pkg/security/tests/network_test.go
+++ b/pkg/security/tests/network_test.go
@@ -26,7 +26,7 @@ import (
 func TestNetworkCIDR(t *testing.T) {
 	checkKernelCompatibility(t, "RHEL, SLES and Oracle kernels", func(kv *kernel.Version) bool {
 		// TODO: Oracle because we are missing offsets
-		return kv.IsRH7Kernel() || kv.IsOracleUEKKernel() || kv.IsSLESKernel()
+		return kv.IsRH7FrankensteinKernel() || kv.IsOracleUEKKernel() || kv.IsSLESKernel()
 	})
 
 	if testEnvironment != DockerEnvironment && !config.IsContainerized() {


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
