### PR TITLE
improve status message when API Key validation endpoint is unreachable

### DIFF
--- a/pkg/forwarder/forwarder_health.go
+++ b/pkg/forwarder/forwarder_health.go
@@ -26,10 +26,11 @@ const (
 )
 
 var (
-	apiKeyStatusUnknown = expvar.String{}
-	apiKeyInvalid       = expvar.String{}
-	apiKeyValid         = expvar.String{}
-	apiKeyFake          = expvar.String{}
+	apiKeyEndpointUnreachable = expvar.String{}
+	apiKeyStatusUnknown       = expvar.String{}
+	apiKeyInvalid             = expvar.String{}
+	apiKeyValid               = expvar.String{}
+	apiKeyFake                = expvar.String{}
 
 	validateAPIKeyTimeout = 10 * time.Second
 
@@ -37,7 +38,8 @@ var (
 )
 
 func init() {
-	apiKeyStatusUnknown.Set("Unable to validate API Key")
+	apiKeyEndpointUnreachable.Set("Unable to reach the API Key validation endpoint")
+	apiKeyStatusUnknown.Set("Unexpected response code from the API Key validation endpoint")
 	apiKeyInvalid.Set("API Key invalid")
 	apiKeyValid.Set("API Key valid")
 	apiKeyFake.Set("Fake API Key that skips validation")
@@ -169,7 +171,7 @@ func (fh *forwarderHealth) validateAPIKey(apiKey, domain string) (bool, error) {
 
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		fh.setAPIKeyStatus(apiKey, domain, &apiKeyStatusUnknown)
+		fh.setAPIKeyStatus(apiKey, domain, &apiKeyEndpointUnreachable)
 		return false, err
 	}
 
@@ -177,7 +179,7 @@ func (fh *forwarderHealth) validateAPIKey(apiKey, domain string) (bool, error) {
 
 	resp, err := client.Do(req)
 	if err != nil {
-		fh.setAPIKeyStatus(apiKey, domain, &apiKeyStatusUnknown)
+		fh.setAPIKeyStatus(apiKey, domain, &apiKeyEndpointUnreachable)
 		return false, err
 	}
 	defer resp.Body.Close()

--- a/pkg/forwarder/forwarder_health.go
+++ b/pkg/forwarder/forwarder_health.go
@@ -26,11 +26,11 @@ const (
 )
 
 var (
-	apiKeyEndpointUnreachable = expvar.String{}
-	apiKeyStatusUnknown       = expvar.String{}
-	apiKeyInvalid             = expvar.String{}
-	apiKeyValid               = expvar.String{}
-	apiKeyFake                = expvar.String{}
+	apiKeyEndpointUnreachable  = expvar.String{}
+	apiKeyUnexpectedStatusCode = expvar.String{}
+	apiKeyInvalid              = expvar.String{}
+	apiKeyValid                = expvar.String{}
+	apiKeyFake                 = expvar.String{}
 
 	validateAPIKeyTimeout = 10 * time.Second
 
@@ -39,7 +39,7 @@ var (
 
 func init() {
 	apiKeyEndpointUnreachable.Set("Unable to reach the API Key validation endpoint")
-	apiKeyStatusUnknown.Set("Unexpected response code from the API Key validation endpoint")
+	apiKeyUnexpectedStatusCode.Set("Unexpected response code from the API Key validation endpoint")
 	apiKeyInvalid.Set("API Key invalid")
 	apiKeyValid.Set("API Key valid")
 	apiKeyFake.Set("Fake API Key that skips validation")
@@ -193,7 +193,7 @@ func (fh *forwarderHealth) validateAPIKey(apiKey, domain string) (bool, error) {
 		return false, nil
 	}
 
-	fh.setAPIKeyStatus(apiKey, domain, &apiKeyStatusUnknown)
+	fh.setAPIKeyStatus(apiKey, domain, &apiKeyUnexpectedStatusCode)
 	return false, fmt.Errorf("Unexpected response code from the apikey validation endpoint: %v", resp.StatusCode)
 }
 

--- a/pkg/forwarder/forwarder_health_test.go
+++ b/pkg/forwarder/forwarder_health_test.go
@@ -115,7 +115,7 @@ func TestHasValidAPIKeyErrors(t *testing.T) {
 	assert.True(t, fh.hasValidAPIKey())
 
 	assert.Equal(t, &apiKeyInvalid, apiKeyStatus.Get("API key ending with _key1"))
-	assert.Equal(t, &apiKeyStatusUnknown, apiKeyStatus.Get("API key ending with _key2"))
+	assert.Equal(t, &apiKeyUnexpectedStatusCode, apiKeyStatus.Get("API key ending with _key2"))
 	assert.Equal(t, &apiKeyValid, apiKeyStatus.Get("API key ending with key3"))
 	assert.Equal(t, &apiKeyEndpointUnreachable, apiKeyStatus.Get("API key ending with key4"))
 

--- a/pkg/forwarder/forwarder_health_test.go
+++ b/pkg/forwarder/forwarder_health_test.go
@@ -94,12 +94,19 @@ func TestHasValidAPIKeyErrors(t *testing.T) {
 	ts2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
+
+	ts3 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	}))
+	ts3.URL = "unreachable/url"
+
 	defer ts1.Close()
 	defer ts2.Close()
+	defer ts3.Close()
 
 	keysPerAPIEndpoint := map[string][]string{
 		ts1.URL: {"api_key1", "api_key2"},
 		ts2.URL: {"key3"},
+		ts3.URL: {"key4"},
 	}
 
 	fh := forwarderHealth{}
@@ -110,4 +117,6 @@ func TestHasValidAPIKeyErrors(t *testing.T) {
 	assert.Equal(t, &apiKeyInvalid, apiKeyStatus.Get("API key ending with _key1"))
 	assert.Equal(t, &apiKeyStatusUnknown, apiKeyStatus.Get("API key ending with _key2"))
 	assert.Equal(t, &apiKeyValid, apiKeyStatus.Get("API key ending with key3"))
+	assert.Equal(t, &apiKeyEndpointUnreachable, apiKeyStatus.Get("API key ending with key4"))
+
 }


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR improves the status message displayed when the Agent cannot reach the API Key validation endpoint.

### Motivation

When the Agent cannot reach the API Key validation endpoint, the `status` command outputs `Unable to validate API Key` which is quite ambiguous and not clear enough that the error is caused by a connectivity issue and not by the invalidity of the API Key.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

There is one more expvar so the Agent takes up a little more memory.

### Describe how to test/QA your changes

Run the Agent, get the status with the `status` command and find the `API Key status` section under the `Forwarder` section (or just run `datadog-agent status | grep 'API key ending'`).

You should see something similar to : `API key ending with XXXXX: API Key valid`

Then you need to cut the connectivity between the Agent and Datadog, by turning off the wifi for example, restart the Agent and redo the command above.

You should now see `API key ending with XXXXX: Unable to reach the API Key validation endpoint`

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
