### PR TITLE
[CWS/CSPM] workloadmeta commonification

### DIFF
--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -43,6 +43,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/startstop"
 	"github.com/DataDog/datadog-agent/pkg/version"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 	ddgostatsd "github.com/DataDog/datadog-go/v5/statsd"
 
 	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
@@ -289,6 +290,10 @@ func RunAgent(ctx context.Context) (err error) {
 			log.Errorf("failed to start the tagger: %s", err)
 		}
 	}
+
+	// Start workloadmeta store
+	store := workloadmeta.GetGlobalStore()
+	store.Start(ctx)
 
 	complianceAgent, err := startCompliance(hostname, stopper, statsdClient)
 	if err != nil {

--- a/pkg/compliance/agent/telemetry_test.go
+++ b/pkg/compliance/agent/telemetry_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/DataDog/datadog-agent/pkg/security/common"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 
 	"github.com/stretchr/testify/assert"
@@ -33,8 +34,10 @@ func TestReportContainersCount(t *testing.T) {
 
 	fakeStore := workloadmeta.NewMockStore()
 	telemetry := &telemetry{
-		sender:        mockSender,
-		metadataStore: fakeStore,
+		containers: &common.ContainersTelemetry{
+			Sender:        mockSender,
+			MetadataStore: fakeStore,
+		},
 	}
 
 	containersCount := 10

--- a/pkg/compliance/event/reporter.go
+++ b/pkg/compliance/event/reporter.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/diagnostic"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
+	"github.com/DataDog/datadog-agent/pkg/security/common"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/startstop"
@@ -23,8 +24,8 @@ import (
 
 // Reporter defines an interface for reporting rule events
 type Reporter interface {
+	common.RawReporter
 	Report(event *Event)
-	ReportRaw(content []byte, service string, tags ...string)
 }
 
 type reporter struct {

--- a/pkg/security/agent/agent.go
+++ b/pkg/security/agent/agent.go
@@ -22,13 +22,14 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/compliance/event"
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/security/api"
+	"github.com/DataDog/datadog-agent/pkg/security/common"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // RuntimeSecurityAgent represents the main wrapper for the Runtime Security product
 type RuntimeSecurityAgent struct {
 	hostname      string
-	reporter      event.Reporter
+	reporter      common.RawReporter
 	client        *RuntimeSecurityClient
 	running       uatomic.Bool
 	wg            sync.WaitGroup

--- a/pkg/security/common/raw_reporter.go
+++ b/pkg/security/common/raw_reporter.go
@@ -5,6 +5,7 @@
 
 package common
 
+// RawReporter defines an interface for reporting raw rule events
 type RawReporter interface {
 	ReportRaw(content []byte, service string, tags ...string)
 }

--- a/pkg/security/common/raw_reporter.go
+++ b/pkg/security/common/raw_reporter.go
@@ -1,0 +1,10 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package common
+
+type RawReporter interface {
+	ReportRaw(content []byte, service string, tags ...string)
+}

--- a/pkg/security/common/telemetry.go
+++ b/pkg/security/common/telemetry.go
@@ -11,8 +11,8 @@ import (
 )
 
 type ContainersTelemetry struct {
-	sender        aggregator.Sender
-	metadataStore workloadmeta.Store
+	Sender        aggregator.Sender
+	MetadataStore workloadmeta.Store
 }
 
 func NewContainersTelemetry() (*ContainersTelemetry, error) {
@@ -22,24 +22,24 @@ func NewContainersTelemetry() (*ContainersTelemetry, error) {
 	}
 
 	return &ContainersTelemetry{
-		sender:        sender,
-		metadataStore: workloadmeta.GetGlobalStore(),
+		Sender:        sender,
+		MetadataStore: workloadmeta.GetGlobalStore(),
 	}, nil
 }
 
 func (c *ContainersTelemetry) ReportContainers(metricName string) error {
-	containers, err := c.metadataStore.ListContainers()
+	containers, err := c.MetadataStore.ListContainers()
 	if err != nil {
 		return err
 	}
 
 	for _, container := range containers {
 		if container.State.Running {
-			c.sender.Gauge(metricName, 1.0, "", []string{"container_id:" + container.ID})
+			c.Sender.Gauge(metricName, 1.0, "", []string{"container_id:" + container.ID})
 		}
 	}
 
-	c.sender.Commit()
+	c.Sender.Commit()
 
 	return nil
 }

--- a/pkg/security/common/telemetry.go
+++ b/pkg/security/common/telemetry.go
@@ -1,0 +1,45 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package common
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
+)
+
+type ContainersTelemetry struct {
+	sender        aggregator.Sender
+	metadataStore workloadmeta.Store
+}
+
+func NewContainersTelemetry() (*ContainersTelemetry, error) {
+	sender, err := aggregator.GetDefaultSender()
+	if err != nil {
+		return nil, err
+	}
+
+	return &ContainersTelemetry{
+		sender:        sender,
+		metadataStore: workloadmeta.GetGlobalStore(),
+	}, nil
+}
+
+func (c *ContainersTelemetry) ReportContainers(metricName string) error {
+	containers, err := c.metadataStore.ListContainers()
+	if err != nil {
+		return err
+	}
+
+	for _, container := range containers {
+		if container.State.Running {
+			c.sender.Gauge(metricName, 1.0, "", []string{"container_id:" + container.ID})
+		}
+	}
+
+	c.sender.Commit()
+
+	return nil
+}

--- a/pkg/security/common/telemetry.go
+++ b/pkg/security/common/telemetry.go
@@ -10,11 +10,13 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
 
+// ContainersTelemetry represents the objects necessary to send metrics listing containers
 type ContainersTelemetry struct {
 	Sender        aggregator.Sender
 	MetadataStore workloadmeta.Store
 }
 
+// NewContainersTelemetry returns a new ContainersTelemetry based on default/global objects
 func NewContainersTelemetry() (*ContainersTelemetry, error) {
 	sender, err := aggregator.GetDefaultSender()
 	if err != nil {
@@ -27,6 +29,7 @@ func NewContainersTelemetry() (*ContainersTelemetry, error) {
 	}, nil
 }
 
+// ReportContainers sends the metrics about currently running containers
 func (c *ContainersTelemetry) ReportContainers(metricName string) error {
 	containers, err := c.MetadataStore.ListContainers()
 	if err != nil {


### PR DESCRIPTION
**THIS PR TOUCHES BILLING RELATED CODE. PLEASE QA CAREFULLY**

### What does this PR do?

This PR:
- Extract workloadmeta store start to agent startup. Before the start of both compliance and security. This allows us to ensure that it's started only once
- Use common containers telemetry code between CWS and CSPM
- Move CWS/CSPM common code to `pkg/security/common`

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
