### PR TITLE
Fix errors not displaying in the `agent status` OTLP section

### DIFF
--- a/pkg/otlp/collector.go
+++ b/pkg/otlp/collector.go
@@ -187,9 +187,14 @@ func BuildAndStart(ctx context.Context, cfg config.Config, s serializer.MetricSe
 
 // GetCollectorStatus get the collector status and error message (if there is one)
 func GetCollectorStatus(p *Pipeline) CollectorStatus {
+	statusMessage, errMessage := "Failed to start", ""
 	if p != nil {
-		return CollectorStatus{Status: p.col.GetState().String(), ErrorMessage: ""}
+		statusMessage = p.col.GetState().String()
 	}
-	// If the pipeline is nil then it failed to start so we return the error.
-	return CollectorStatus{Status: "Failed to start", ErrorMessage: pipelineError.Load().Error()}
+	err := pipelineError.Load()
+	if err != nil {
+		// If the pipeline is nil then it failed to start so we return the error.
+		errMessage = err.Error()
+	}
+	return CollectorStatus{Status: statusMessage, ErrorMessage: errMessage}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR fixes #11822. All errors weren't caught and displayed on the `agent status` OTLP section.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

In [#11943](https://github.com/DataDog/datadog-agent/pull/11943#issuecomment-1120878415), the `invalid key` error supposed to be displayed on the `Collector status` field wasn't there. After looking it up we figured it was because the `GetCollectorStatus` was only displaying the error when the pipeline was `nil` which is not covering all cases.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

To kind of reproduce #11943 you can add an invalid key in the `config.yaml` file. So your config.yaml file should look like this:
```
api_key: your_api_key_here

otlp_config:
  receiver:
    protocols:
      grpc:
  metrics:
    that_s_not_a_valid_key: true
```
Then, after building the agent, you can run the agent with `./bin/agent/agent run -c config.yaml`

Checking the Agent Status OTLP section (`./bin/agent/agent launch-gui -c config.yaml` or `./bin/agent/agent status -c config.yaml`) you should be able to see the error message such as:

```
Status: Enabled
Collector status: Closed
Error: Error running the OTLP pipeline: failed to get config: cannot unmarshal the configuration: error reading exporters configuration for "serializer": 1 error(s) decoding: * 'metrics' has invalid keys: that_s_not_a_valid_key
```

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
