### PR TITLE
lints: re-enable the exported comment check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,7 @@ run:
     - pkg/util/cloudproviders/cloudfoundry/bbscache_test.go # implements interface from imported package whose method names fail linting
 
 issues:
+  exclude-use-default: false
   # Do not limit the number of issues per linter.
   max-issues-per-linter: 0
 
@@ -12,6 +13,7 @@ issues:
   max-same-issues: 0
 
   exclude:
+    - "Error return value of .((os\\.)?std(out|err)\\..*|.*Close|.*Flush|os\\.Remove(All)?|.*print(f|ln)?|os\\.(Un)?Setenv). is not checked"
     - "`eventContext` is unused"
     - "`\\(\\*DatadogLogger\\).changeLogLevel` is unused"
     - "`defaultRetryDuration` is unused" # used by APM and Process


### PR DESCRIPTION
### What does this PR do?

https://github.com/DataDog/datadog-agent/pull/11750 removed all usage of manual linters, other than `golangci-lint`. But `golangci-lint` is... opinionated and has a list of ignored issues:
```
      --exclude-use-default            Use or not use default excludes:
                                         # EXC0001 errcheck: Almost all programs ignore errors on these functions and in most cases it's ok
                                         - Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv). is not checked
                                       
                                         # EXC0002 golint: Annoying issue about not having a comment. The rare codebase has such comments
                                         - (comment on exported (method|function|type|const)|should have( a package)? comment|comment should be of the form)
                                       
                                         # EXC0003 golint: False positive when tests are defined in package 'test'
                                         - func name will be used as test\.Test.* by other packages, and that stutters; consider calling this
                                       
                                         # EXC0004 govet: Common false positives
                                         - (possible misuse of unsafe.Pointer|should have signature)
                                       
                                         # EXC0005 staticcheck: Developers tend to write in C-style with an explicit 'break' in a 'switch', so it's ok to ignore
                                         - ineffective break statement. Did you mean to break out of the outer loop
                                       # EXC0006 gosec: Too many false-positives on 'unsafe' usage
                                         - Use of unsafe calls should be audited
                                       
                                         # EXC0007 gosec: Too many false-positives for parametrized shell calls
                                         - Subprocess launch(ed with variable|ing should be audited)
                                       
                                         # EXC0008 gosec: Duplicated errcheck checks
                                         - (G104|G307)
                                       
                                         # EXC0009 gosec: Too many issues in popular repos
                                         - (Expect directory permissions to be 0750 or less|Expect file permissions to be 0600 or less)
                                       
                                         # EXC0010 gosec: False positive is triggered by 'src, err := ioutil.ReadFile(filename)'
                                         - Potential file inclusion via variable
                                       
                                         # EXC0011 stylecheck: Annoying issue about not having a comment. The rare codebase has such comments
                                         - (comment on exported (method|function|type|const)|should have( a package)? comment|comment should be of the form)
                                       
                                         # EXC0012 revive: Annoying issue about not having a comment. The rare codebase has such comments
                                         - exported (.+) should have comment( \(or a comment on this block\))? or be unexported
                                       
                                         # EXC0013 revive: Annoying issue about not having a comment. The rare codebase has such comments
                                         - package comment should be of the form "(.+)...
                                       
                                         # EXC0014 revive: Annoying issue about not having a comment. The rare codebase has such comments
                                         - comment on exported (.+) should be of the form "(.+)..."
                                       
                                         # EXC0015 revive: Annoying issue about not having a comment. The rare codebase has such comments
                                         - should have a package comment, unless it's in another file for this package
                                        (default true)
```

This PR, disable the use of those defaults, and add the first exception about error checks on `.Close()` like functions.

Open question: how to fix the reported, should I do a best effort to add the missing documentation comment, thus requesting the review of concerned teams ?

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
