### PR TITLE
Update viper

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/DataDog/gopsutil v0.0.0-20220308095538-d086941833e3
 	github.com/DataDog/nikos v1.7.6
 	github.com/DataDog/sketches-go v1.4.1
-	github.com/DataDog/viper v1.9.1-0.20220509135910-0b35ab449316
+	github.com/DataDog/viper v1.10.0
 	github.com/DataDog/watermarkpodautoscaler v0.3.1-logs-attributes.2.0.20211014120627-6d6a5c559fc9
 	github.com/DataDog/zstd v1.5.0
 	github.com/DataDog/zstd_0 v0.0.0-20210310093942-586c1286621f

--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/DataDog/gopsutil v0.0.0-20220308095538-d086941833e3
 	github.com/DataDog/nikos v1.7.6
 	github.com/DataDog/sketches-go v1.4.1
-	github.com/DataDog/viper v1.9.1-0.20220509130951-da54697d4620
+	github.com/DataDog/viper v1.9.1-0.20220509135910-0b35ab449316
 	github.com/DataDog/watermarkpodautoscaler v0.3.1-logs-attributes.2.0.20211014120627-6d6a5c559fc9
 	github.com/DataDog/zstd v1.5.0
 	github.com/DataDog/zstd_0 v0.0.0-20210310093942-586c1286621f

--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/DataDog/gopsutil v0.0.0-20220308095538-d086941833e3
 	github.com/DataDog/nikos v1.7.6
 	github.com/DataDog/sketches-go v1.4.1
-	github.com/DataDog/viper v1.9.0
+	github.com/DataDog/viper v1.9.1-0.20220509130951-da54697d4620
 	github.com/DataDog/watermarkpodautoscaler v0.3.1-logs-attributes.2.0.20211014120627-6d6a5c559fc9
 	github.com/DataDog/zstd v1.5.0
 	github.com/DataDog/zstd_0 v0.0.0-20210310093942-586c1286621f

--- a/go.sum
+++ b/go.sum
@@ -155,8 +155,8 @@ github.com/DataDog/nikos v1.7.6/go.mod h1:kK2wHo4SMa+qDP7cNQWzS3Ol9uJK46zPLPtK1C
 github.com/DataDog/sketches-go v1.0.0/go.mod h1:O+XkJHWk9w4hDwY2ZUDU31ZC9sNYlYo8DiFsxjYeo1k=
 github.com/DataDog/sketches-go v1.4.1 h1:j5G6as+9FASM2qC36lvpvQAj9qsv/jUs3FtO8CwZNAY=
 github.com/DataDog/sketches-go v1.4.1/go.mod h1:xJIXldczJyyjnbDop7ZZcLxJdV3+7Kra7H1KMgpgkLk=
-github.com/DataDog/viper v1.9.0 h1:9Ha1yJebecIKtboH/GXUM3brfoMofvdd8BlMck8Cs8Q=
-github.com/DataDog/viper v1.9.0/go.mod h1:Gx7+/WONkbQIh3ac52KqcFTzipQ1OYHhCQGWAgHlzpc=
+github.com/DataDog/viper v1.9.1-0.20220509130951-da54697d4620 h1:/aVVfiJjBz8UaDFlRjNXbokjFZX7bRjVI+JPbiQcy8o=
+github.com/DataDog/viper v1.9.1-0.20220509130951-da54697d4620/go.mod h1:Gx7+/WONkbQIh3ac52KqcFTzipQ1OYHhCQGWAgHlzpc=
 github.com/DataDog/watermarkpodautoscaler v0.3.1-logs-attributes.2.0.20211014120627-6d6a5c559fc9 h1:eTBekOGVnZyX9hBoYjiOpDijtOZZ8VHVC3NyrcYuC7w=
 github.com/DataDog/watermarkpodautoscaler v0.3.1-logs-attributes.2.0.20211014120627-6d6a5c559fc9/go.mod h1:p6kKSHVHifUrxvl4KhuazpnuPuqjwdGoyGRempGdZ/w=
 github.com/DataDog/zstd v1.3.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=

--- a/go.sum
+++ b/go.sum
@@ -155,8 +155,8 @@ github.com/DataDog/nikos v1.7.6/go.mod h1:kK2wHo4SMa+qDP7cNQWzS3Ol9uJK46zPLPtK1C
 github.com/DataDog/sketches-go v1.0.0/go.mod h1:O+XkJHWk9w4hDwY2ZUDU31ZC9sNYlYo8DiFsxjYeo1k=
 github.com/DataDog/sketches-go v1.4.1 h1:j5G6as+9FASM2qC36lvpvQAj9qsv/jUs3FtO8CwZNAY=
 github.com/DataDog/sketches-go v1.4.1/go.mod h1:xJIXldczJyyjnbDop7ZZcLxJdV3+7Kra7H1KMgpgkLk=
-github.com/DataDog/viper v1.9.1-0.20220509130951-da54697d4620 h1:/aVVfiJjBz8UaDFlRjNXbokjFZX7bRjVI+JPbiQcy8o=
-github.com/DataDog/viper v1.9.1-0.20220509130951-da54697d4620/go.mod h1:Gx7+/WONkbQIh3ac52KqcFTzipQ1OYHhCQGWAgHlzpc=
+github.com/DataDog/viper v1.9.1-0.20220509135910-0b35ab449316 h1:IRo30IBXg49gFSegsON8HrVPjkTSS7oi4tBq4cGYzto=
+github.com/DataDog/viper v1.9.1-0.20220509135910-0b35ab449316/go.mod h1:Gx7+/WONkbQIh3ac52KqcFTzipQ1OYHhCQGWAgHlzpc=
 github.com/DataDog/watermarkpodautoscaler v0.3.1-logs-attributes.2.0.20211014120627-6d6a5c559fc9 h1:eTBekOGVnZyX9hBoYjiOpDijtOZZ8VHVC3NyrcYuC7w=
 github.com/DataDog/watermarkpodautoscaler v0.3.1-logs-attributes.2.0.20211014120627-6d6a5c559fc9/go.mod h1:p6kKSHVHifUrxvl4KhuazpnuPuqjwdGoyGRempGdZ/w=
 github.com/DataDog/zstd v1.3.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=

--- a/go.sum
+++ b/go.sum
@@ -155,8 +155,8 @@ github.com/DataDog/nikos v1.7.6/go.mod h1:kK2wHo4SMa+qDP7cNQWzS3Ol9uJK46zPLPtK1C
 github.com/DataDog/sketches-go v1.0.0/go.mod h1:O+XkJHWk9w4hDwY2ZUDU31ZC9sNYlYo8DiFsxjYeo1k=
 github.com/DataDog/sketches-go v1.4.1 h1:j5G6as+9FASM2qC36lvpvQAj9qsv/jUs3FtO8CwZNAY=
 github.com/DataDog/sketches-go v1.4.1/go.mod h1:xJIXldczJyyjnbDop7ZZcLxJdV3+7Kra7H1KMgpgkLk=
-github.com/DataDog/viper v1.9.1-0.20220509135910-0b35ab449316 h1:IRo30IBXg49gFSegsON8HrVPjkTSS7oi4tBq4cGYzto=
-github.com/DataDog/viper v1.9.1-0.20220509135910-0b35ab449316/go.mod h1:Gx7+/WONkbQIh3ac52KqcFTzipQ1OYHhCQGWAgHlzpc=
+github.com/DataDog/viper v1.10.0 h1:W7pvGGEMJUcBbgeil3klCBsWwWCi4bK3CmG/eqZBMms=
+github.com/DataDog/viper v1.10.0/go.mod h1:Gx7+/WONkbQIh3ac52KqcFTzipQ1OYHhCQGWAgHlzpc=
 github.com/DataDog/watermarkpodautoscaler v0.3.1-logs-attributes.2.0.20211014120627-6d6a5c559fc9 h1:eTBekOGVnZyX9hBoYjiOpDijtOZZ8VHVC3NyrcYuC7w=
 github.com/DataDog/watermarkpodautoscaler v0.3.1-logs-attributes.2.0.20211014120627-6d6a5c559fc9/go.mod h1:p6kKSHVHifUrxvl4KhuazpnuPuqjwdGoyGRempGdZ/w=
 github.com/DataDog/zstd v1.3.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=

--- a/pkg/aggregator/aggregator_test.go
+++ b/pkg/aggregator/aggregator_test.go
@@ -530,7 +530,7 @@ func TestTags(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			defer config.Datadog.Set("basic_telemetry_add_container_tags", nil)
+			defer config.Datadog.Unset("basic_telemetry_add_container_tags")
 			config.Datadog.Set("basic_telemetry_add_container_tags", tt.tlmContainerTagsEnabled)
 			agg := NewBufferedAggregator(nil, nil, "hostname", time.Second)
 			agg.agentTags = tt.agentTags

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver_test.go
@@ -206,7 +206,7 @@ func TestProcessBundledEvents(t *testing.T) {
 	mockConfig.Set("cluster_name", testClusterName)
 	clustername.ResetClusterName() // reset state as clustername was already read
 	// defer a reset of the state so that future hostname fetches are not impacted
-	defer mockConfig.Set("cluster_name", nil)
+	defer mockConfig.Unset("cluster_name")
 	defer clustername.ResetClusterName()
 
 	modifiedNewDatadogEventsWithClusterName := metrics.Event{

--- a/pkg/config/config_change_checker_test.go
+++ b/pkg/config/config_change_checker_test.go
@@ -27,6 +27,6 @@ func TestChangeChecker(t *testing.T) {
 func assertConfigChangeDetected(r *require.Assertions, checker *ChangeChecker, key string, value interface{}) {
 	Datadog.Set(key, value)
 	r.True(checker.HasChanged())
-	Datadog.Set(key, nil)
+	Datadog.Unset(key)
 	r.False(checker.HasChanged())
 }

--- a/pkg/config/legacy/converter_test.go
+++ b/pkg/config/legacy/converter_test.go
@@ -321,9 +321,9 @@ func TestConverter(t *testing.T) {
 func TestExtractURLAPIKeys(t *testing.T) {
 	configConverter := config.NewConfigConverter()
 	defer func() {
-		configConverter.Set("dd_url", "")
-		configConverter.Set("api_key", "")
-		configConverter.Set("additional_endpoints", nil)
+		configConverter.Unset("dd_url")
+		configConverter.Unset("api_key")
+		configConverter.Unset("additional_endpoints")
 	}()
 	agentConfig := make(Config)
 

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -26,6 +26,7 @@ type Config interface {
 	// API implemented by viper.Viper
 
 	Set(key string, value interface{})
+	Unset(key string)
 	SetDefault(key string, value interface{})
 	SetFs(fs afero.Fs)
 	IsSet(key string) bool

--- a/pkg/config/viper.go
+++ b/pkg/config/viper.go
@@ -41,6 +41,13 @@ func (c *safeConfig) Set(key string, value interface{}) {
 	c.Viper.Set(key, value)
 }
 
+// Unset wraps Viper for concurrent access
+func (c *safeConfig) Unset(key string) {
+	c.Lock()
+	defer c.Unlock()
+	c.Viper.Unset(key)
+}
+
 // SetDefault wraps Viper for concurrent access
 func (c *safeConfig) SetDefault(key string, value interface{}) {
 	c.Lock()

--- a/pkg/forwarder/forwarder_test.go
+++ b/pkg/forwarder/forwarder_test.go
@@ -629,7 +629,7 @@ func TestHighPriorityTransaction(t *testing.T) {
 	}))
 
 	config.Datadog.Set("forwarder_backoff_max", 0.5)
-	defer config.Datadog.Set("forwarder_backoff_max", nil)
+	defer config.Datadog.Unset("forwarder_backoff_max")
 
 	oldFlushInterval := flushInterval
 	flushInterval = 500 * time.Millisecond

--- a/pkg/logs/config/config_test.go
+++ b/pkg/logs/config/config_test.go
@@ -54,7 +54,7 @@ func (suite *ConfigTestSuite) TestGlobalProcessingRulesShouldReturnNoRulesWithEm
 		err   error
 	)
 
-	suite.config.Set("logs_config.processing_rules", nil)
+	suite.config.Unset("logs_config.processing_rules")
 
 	rules, err = GlobalProcessingRules()
 	suite.Nil(err)

--- a/pkg/logs/internal/tag/local_provider_test.go
+++ b/pkg/logs/internal/tag/local_provider_test.go
@@ -23,7 +23,7 @@ func TestLocalProviderShouldReturnEmptyList(t *testing.T) {
 	tags := []string{"tag1:value1", "tag2", "tag3"}
 
 	mockConfig.Set("tags", tags)
-	defer mockConfig.Set("tags", nil)
+	defer mockConfig.Unset("tags")
 
 	mockConfig.Set("logs_config.expected_tags_duration", "0")
 
@@ -44,7 +44,7 @@ func TestLocalProviderExpectedTags(t *testing.T) {
 	tags := []string{"tag1:value1", "tag2", "tag3"}
 
 	mockConfig.Set("tags", tags)
-	defer mockConfig.Set("tags", nil)
+	defer mockConfig.Unset("tags")
 
 	expectedTagsDuration := 5 * time.Second
 	mockConfig.Set("logs_config.expected_tags_duration", "5s")

--- a/pkg/logs/internal/tag/provider_benchmark_test.go
+++ b/pkg/logs/internal/tag/provider_benchmark_test.go
@@ -31,7 +31,7 @@ func BenchmarkProviderExpectedTags(b *testing.B) {
 		config.StartTime = start
 	}()
 
-	defer m.Set("tags", nil)
+	defer m.Unset("tags")
 
 	// Setting a test-friendly value for the deadline (test should not take 1m)
 	m.Set("logs_config.expected_tags_duration", "1m")
@@ -98,7 +98,7 @@ func BenchmarkProviderNoExpectedTags(b *testing.B) {
 		config.StartTime = start
 	}()
 
-	defer m.Set("tags", nil)
+	defer m.Unset("tags")
 
 	// Setting a test-friendly value for the deadline (test should not take 1m)
 	m.Set("logs_config.expected_tags_duration", "0")
@@ -118,7 +118,7 @@ func BenchmarkProviderNoExpectedTagsNil(b *testing.B) {
 		config.StartTime = start
 	}()
 
-	defer m.Set("tags", nil)
+	defer m.Unset("tags")
 
 	// Setting a test-friendly value for the deadline (test should not take 1m)
 	m.Set("logs_config.expected_tags_duration", "0")

--- a/pkg/logs/internal/tag/provider_test.go
+++ b/pkg/logs/internal/tag/provider_test.go
@@ -28,7 +28,7 @@ func TestProviderExpectedTags(t *testing.T) {
 
 	tags := []string{"tag1:value1", "tag2", "tag3"}
 	m.Set("tags", tags)
-	defer m.Set("tags", nil)
+	defer m.Unset("tags")
 
 	m.Set("logs_config.tagger_warmup_duration", "2")
 

--- a/pkg/metadata/host/host_no_otlp_test.go
+++ b/pkg/metadata/host/host_no_otlp_test.go
@@ -16,11 +16,14 @@ import (
 )
 
 func TestGetOtlpMetaWithoutOtlp(t *testing.T) {
-	config.Datadog.Set(config.OTLPReceiverSection+".protocols.grpc.endpoint", "localhost:9999")
 	meta := getOtlpMeta()
 	assert.Equal(t, false, meta.Enabled)
 
-	config.Datadog.Set(config.OTLPSection, nil)
+	config.Datadog.Set(config.OTLPReceiverSection+".protocols.grpc.endpoint", "localhost:9999")
+	meta = getOtlpMeta()
+	assert.Equal(t, false, meta.Enabled)
+
+	config.Datadog.Unset(config.OTLPSection)
 	meta = getOtlpMeta()
 	assert.Equal(t, false, meta.Enabled)
 }

--- a/pkg/metadata/host/host_otlp_test.go
+++ b/pkg/metadata/host/host_otlp_test.go
@@ -16,11 +16,14 @@ import (
 )
 
 func TestGetOtlpMetaWithOtlp(t *testing.T) {
-	config.Datadog.Set(config.OTLPReceiverSection+".protocols.grpc.endpoint", "localhost:9999")
 	meta := getOtlpMeta()
+	assert.Equal(t, false, meta.Enabled)
+
+	config.Datadog.Set(config.OTLPReceiverSection+".protocols.grpc.endpoint", "localhost:9999")
+	meta = getOtlpMeta()
 	assert.Equal(t, true, meta.Enabled)
 
-	config.Datadog.Set(config.OTLPSection, nil)
+	config.Datadog.Unset(config.OTLPSection)
 	meta = getOtlpMeta()
 	assert.Equal(t, false, meta.Enabled)
 }

--- a/pkg/metadata/host/host_tags_test.go
+++ b/pkg/metadata/host/host_tags_test.go
@@ -22,7 +22,7 @@ func TestGetHostTags(t *testing.T) {
 	ctx := context.Background()
 	mockConfig := config.Mock()
 	mockConfig.Set("tags", []string{"tag1:value1", "tag2", "tag3"})
-	defer mockConfig.Set("tags", nil)
+	defer mockConfig.Unset("tags")
 
 	hostTags := GetHostTags(ctx, false)
 	assert.NotNil(t, hostTags.System)
@@ -42,7 +42,7 @@ func TestGetHostTagsWithSplits(t *testing.T) {
 	mockConfig := config.Mock()
 	mockConfig.Set("tag_value_split_separator", map[string]string{"kafka_partition": ","})
 	mockConfig.Set("tags", []string{"tag1:value1", "tag2", "tag3", "kafka_partition:0,1,2"})
-	defer mockConfig.Set("tags", nil)
+	defer mockConfig.Unset("tags")
 
 	hostTags := GetHostTags(ctx, false)
 	assert.NotNil(t, hostTags.System)
@@ -54,7 +54,7 @@ func TestGetHostTagsWithoutSplits(t *testing.T) {
 	mockConfig := config.Mock()
 	mockConfig.Set("tag_value_split_separator", map[string]string{"kafka_partition": ";"})
 	mockConfig.Set("tags", []string{"tag1:value1", "tag2", "tag3", "kafka_partition:0,1,2"})
-	defer mockConfig.Set("tags", nil)
+	defer mockConfig.Unset("tags")
 
 	hostTags := GetHostTags(ctx, false)
 	assert.NotNil(t, hostTags.System)
@@ -66,7 +66,7 @@ func TestGetHostTagsWithEnv(t *testing.T) {
 	mockConfig := config.Mock()
 	mockConfig.Set("tags", []string{"tag1:value1", "tag2", "tag3", "env:prod"})
 	mockConfig.Set("env", "preprod")
-	defer mockConfig.Set("tags", nil)
+	defer mockConfig.Unset("tags")
 	defer mockConfig.Set("env", "")
 
 	hostTags := GetHostTags(ctx, false)
@@ -91,8 +91,8 @@ func TestCombineExtraTags(t *testing.T) {
 	mockConfig := config.Mock()
 	mockConfig.Set("tags", []string{"tag1:value1", "tag2", "tag4"})
 	mockConfig.Set("extra_tags", []string{"tag1:value2", "tag3", "tag4"})
-	defer mockConfig.Set("tags", nil)
-	defer mockConfig.Set("extra_tags", nil)
+	defer mockConfig.Unset("tags")
+	defer mockConfig.Unset("extra_tags")
 
 	hostTags := GetHostTags(ctx, false)
 	assert.NotNil(t, hostTags.System)

--- a/pkg/serializer/internal/metrics/events_test.go
+++ b/pkg/serializer/internal/metrics/events_test.go
@@ -164,7 +164,7 @@ func TestEventsSeveralPayloadsCreateSingleMarshaler(t *testing.T) {
 	events := createEvents("3", "3", "2", "2", "1", "1")
 
 	config.Datadog.Set("serializer_max_payload_size", 500)
-	defer config.Datadog.Set("serializer_max_payload_size", nil)
+	defer config.Datadog.Unset("serializer_max_payload_size")
 
 	expectedPayloads, err := events.MarshalJSON()
 	assert.NoError(t, err)
@@ -178,7 +178,7 @@ func TestEventsSeveralPayloadsCreateMarshalersBySourceType(t *testing.T) {
 	events := createEvents("3", "3", "2", "2", "1", "1")
 
 	config.Datadog.Set("serializer_max_payload_size", 300)
-	defer config.Datadog.Set("serializer_max_payload_size", nil)
+	defer config.Datadog.Unset("serializer_max_payload_size")
 
 	expectedPayloads, err := events.MarshalJSON()
 	assert.NoError(t, err)

--- a/pkg/serializer/serializer_test.go
+++ b/pkg/serializer/serializer_test.go
@@ -206,7 +206,7 @@ func createProtoPayloadMatcher(content []byte) interface{} {
 }
 func TestSendV1Events(t *testing.T) {
 	config.Datadog.Set("enable_events_stream_payload_serialization", false)
-	defer config.Datadog.Set("enable_events_stream_payload_serialization", nil)
+	defer config.Datadog.Unset("enable_events_stream_payload_serialization")
 
 	f := &forwarder.MockedForwarder{}
 
@@ -228,7 +228,7 @@ func (p *testPayloadMutipleValues) Len() int { return p.count }
 
 func TestSendV1EventsCreateMarshalersBySourceType(t *testing.T) {
 	config.Datadog.Set("enable_events_stream_payload_serialization", true)
-	defer config.Datadog.Set("enable_events_stream_payload_serialization", nil)
+	defer config.Datadog.Unset("enable_events_stream_payload_serialization")
 	f := &forwarder.MockedForwarder{}
 
 	s := NewSerializer(f, nil, nil)
@@ -246,7 +246,7 @@ func TestSendV1EventsCreateMarshalersBySourceType(t *testing.T) {
 	f.AssertExpectations(t)
 
 	config.Datadog.Set("serializer_max_payload_size", 20)
-	defer config.Datadog.Set("serializer_max_payload_size", nil)
+	defer config.Datadog.Unset("serializer_max_payload_size")
 
 	f.On("SubmitV1Intake", payloadsCountMatcher(3), jsonExtraHeadersWithCompression).Return(nil)
 	err = s.SendEvents(events)
@@ -259,7 +259,7 @@ func TestSendV1ServiceChecks(t *testing.T) {
 	matcher := createJSONPayloadMatcher(`[{"check":"","host_name":"","timestamp":0,"status":0,"message":"","tags":null}]`)
 	f.On("SubmitV1CheckRuns", matcher, jsonExtraHeadersWithCompression).Return(nil).Times(1)
 	config.Datadog.Set("enable_service_checks_stream_payload_serialization", false)
-	defer config.Datadog.Set("enable_service_checks_stream_payload_serialization", nil)
+	defer config.Datadog.Unset("enable_service_checks_stream_payload_serialization")
 
 	s := NewSerializer(f, nil, nil)
 	err := s.SendServiceChecks(metrics.ServiceChecks{&metrics.ServiceCheck{}})
@@ -273,7 +273,7 @@ func TestSendV1Series(t *testing.T) {
 
 	f.On("SubmitV1Series", matcher, jsonExtraHeadersWithCompression).Return(nil).Times(1)
 	config.Datadog.Set("enable_stream_payload_serialization", false)
-	defer config.Datadog.Set("enable_stream_payload_serialization", nil)
+	defer config.Datadog.Unset("enable_stream_payload_serialization")
 
 	s := NewSerializer(f, nil, nil)
 

--- a/pkg/util/kubernetes/clustername/clustername_test.go
+++ b/pkg/util/kubernetes/clustername/clustername_test.go
@@ -22,7 +22,7 @@ func TestGetClusterName(t *testing.T) {
 
 	var testClusterName = "laika"
 	mockConfig.Set("cluster_name", testClusterName)
-	defer mockConfig.Set("cluster_name", nil)
+	defer mockConfig.Unset("cluster_name")
 
 	assert.Equal(t, testClusterName, getClusterName(ctx, data, "hostname"))
 


### PR DESCRIPTION
### What does this PR do?
Updates viper to include https://github.com/DataDog/viper/pull/21

### Motivation

Makes the `datadog-agent config` (which relies on viper's `AllSettings()`) command return set-but-empty fields, typically used in the OTLP receiver config, eg:
```
otlp_config:
  receiver:
    protocols:
      grpc:
      http:
``` 
Now shows up as:
```
otlp_config.receiver.protocols.grpc: null
otlp_config.receiver.protocols.http: null
```
### Describe how to test/QA your changes

Set the above config in `datadog.yaml` and verify that `datadog-agent config` returns the empty fields.
