### PR TITLE
Optimize allocations netlink receive path

### DIFF
--- a/pkg/network/netlink/conntracker.go
+++ b/pkg/network/netlink/conntracker.go
@@ -267,20 +267,24 @@ func (ctr *realConntracker) run() error {
 		return err
 	}
 
+	done := make(chan struct{})
 	go func() {
 		for {
 			select {
-			case e, ok := <-events:
-				if !ok {
-					return
-				}
-				conns := ctr.decoder.DecodeAndReleaseEvent(e)
-				for _, c := range conns {
-					ctr.register(c)
-				}
-
+			case <-done:
+				return
 			case <-ctr.compactTicker.C:
 				ctr.compact()
+			}
+		}
+	}()
+
+	go func() {
+		defer close(done)
+		for e := range events {
+			conns := ctr.decoder.DecodeAndReleaseEvent(e)
+			for _, c := range conns {
+				ctr.register(c)
 			}
 		}
 	}()

--- a/pkg/network/netlink/consumer.go
+++ b/pkg/network/netlink/consumer.go
@@ -36,7 +36,7 @@ const (
 	ipctnlMsgCtGet = 1
 
 	// outputBuffer is he size of the Consumer output channel.
-	outputBuffer = 100
+	outputBuffer = 200
 
 	// overShootFactor is used sampling rate calculation after the circuit breaker trips.
 	overshootFactor = 0.95
@@ -469,7 +469,7 @@ func (c *Consumer) eventFor(msgs []netlink.Message, netns uint32, buffer *[]byte
 func (c *Consumer) throttle(numMessages int) error {
 	// We don't throttle the socket during initialization
 	// (when we dump the whole Conntrack table)
-	if !c.streaming {
+	if !c.streaming || c.targetRateLimit == -1 {
 		return nil
 	}
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Reduces heap allocations on the netlink receive path

### Motivation

Reduced memory usage.

### Additional Notes

This reduces total allocations by 25% and allocated heap memory by 200MB every 5min. I also increased the default buffer size from 100 to 200, because it was blocking occasionally. 

TIL that a `select` statement performs worse CPU-wise than a simple channel receive. This is why I removed that from the hot path.

![Screen Shot 2022-05-09 at 10 36 55 AM](https://user-images.githubusercontent.com/1010430/167465949-7170fea1-6014-4b40-82fa-2619303104bd.png)
![Screen Shot 2022-05-09 at 10 40 27 AM](https://user-images.githubusercontent.com/1010430/167466462-7af7d79c-28e6-41e5-8416-5fb16e38521f.png)
![Screen Shot 2022-05-09 at 10 40 10 AM](https://user-images.githubusercontent.com/1010430/167466487-c1619d2e-f150-42dd-aa6a-6234e35aa240.png)

### Possible Drawbacks / Trade-offs

This does increase CPU% usage, which seems to be spent in syscalls or runtime functions.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
