### PR TITLE
Always "catch up" subscriptions to integration.Config's and LogSources

### DIFF
--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -422,8 +422,7 @@ func StartAgent() error {
 	// create and setup the Autoconfig instance
 	common.LoadComponents(common.MainCtx, config.Datadog.GetString("confd_path"))
 
-	// start logs-agent.  This must happen after AutoConfig is set up (via common.LoadComponents) and
-	// before AutoConfig is started (va common.StartAutoConfig).
+	// start logs-agent.  This must happen after AutoConfig is set up (via common.LoadComponents)
 	if config.Datadog.GetBool("logs_enabled") || config.Datadog.GetBool("log_enabled") {
 		if config.Datadog.GetBool("log_enabled") {
 			log.Warn(`"log_enabled" is deprecated, use "logs_enabled" instead`)
@@ -435,8 +434,8 @@ func StartAgent() error {
 		log.Info("logs-agent disabled")
 	}
 
-	// start the autoconfig, this will immediately run any configured check
-	common.StartAutoConfig()
+	// load and run all configs in AD
+	common.AC.LoadAndRun()
 
 	// check for common misconfigurations and report them to log
 	misconfig.ToLog()

--- a/cmd/agent/common/autodiscovery.go
+++ b/cmd/agent/common/autodiscovery.go
@@ -183,11 +183,6 @@ func setupAutoDiscovery(confSearchPaths []string, metaScheduler *scheduler.MetaS
 	return ad
 }
 
-// StartAutoConfig starts auto discovery
-func StartAutoConfig() {
-	AC.LoadAndRun()
-}
-
 // WaitForConfigs retries the collection of Autodiscovery configs until the checkMatcher function (which
 // defines whether the list of integration configs collected is sufficient) returns true or the timeout is reached.
 // Autodiscovery listeners run asynchronously, AC.GetAllConfigs() can fail at the beginning to resolve templated configs

--- a/cmd/cluster-agent-cloudfoundry/app/app.go
+++ b/cmd/cluster-agent-cloudfoundry/app/app.go
@@ -43,7 +43,7 @@ import (
 // loggerName is the name of the cluster agent logger
 const loggerName config.LoggerName = "CLUSTER"
 
-// FIXME: move LoadComponents and StartAutoConfig in their own package so we don't import cmd/agent
+// FIXME: move LoadComponents and LoadAndRun in their own package so we don't import cmd/agent
 var (
 	ClusterAgentCmd = &cobra.Command{
 		Use:   "datadog-cluster-agent-cloudfoundry [command]",
@@ -193,7 +193,7 @@ func run(cmd *cobra.Command, args []string) error {
 	// create and setup the Autoconfig instance
 	common.LoadComponents(mainCtx, config.Datadog.GetString("confd_path"))
 	// start the autoconfig, this will immediately run any configured check
-	common.StartAutoConfig()
+	common.AC.LoadAndRun()
 
 	if err = api.StartServer(); err != nil {
 		return log.Errorf("Error while starting agent API, exiting: %v", err)

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -55,7 +55,7 @@ import (
 // loggerName is the name of the cluster agent logger
 const loggerName config.LoggerName = "CLUSTER"
 
-// FIXME: move LoadComponents and StartAutoConfig in their own package so we don't import cmd/agent
+// FIXME: move LoadComponents and AC.LoadAndRun in their own package so we don't import cmd/agent
 var (
 	ClusterAgentCmd = &cobra.Command{
 		Use:   "datadog-cluster-agent [command]",
@@ -284,7 +284,7 @@ func start(cmd *cobra.Command, args []string) error {
 	// create and setup the Autoconfig instance
 	common.LoadComponents(mainCtx, config.Datadog.GetString("confd_path"))
 	// start the autoconfig, this will immediately run any configured check
-	common.StartAutoConfig()
+	common.AC.LoadAndRun()
 
 	if config.Datadog.GetBool("cluster_checks.enabled") {
 		// Start the cluster check Autodiscovery

--- a/pkg/logs/config/sources.go
+++ b/pkg/logs/config/sources.go
@@ -12,29 +12,32 @@ import (
 // LogSources serves as the interface between Schedulers and Launchers, distributing
 // notifications of added/removed LogSources to subscribed Launchers.
 //
-// If more than one Launcher subscribes to the same type, the sources will be
-// distributed randomly to the Launchers.  This is generally undesirable, and the
-// caller should ensure at most one subscriber for each type.
+// Each subscription receives its own unbuffered channel for sources, and should
+// consume from the channel quickly to avoid blocking other goroutines.  There is
+// no means to unsubscribe.
+//
+// If any sources have been added when GetAddedForType is called, then those sources
+// are immediately sent to the channel.
 //
 // This type is threadsafe, and all of its methods can be called concurrently.
 type LogSources struct {
 	mu            sync.Mutex
 	sources       []*LogSource
-	addedByType   map[string]chan *LogSource
-	removedByType map[string]chan *LogSource
+	addedByType   map[string][]chan *LogSource
+	removedByType map[string][]chan *LogSource
 }
 
 // NewLogSources creates a new log sources.
 func NewLogSources() *LogSources {
 	return &LogSources{
-		addedByType:   make(map[string]chan *LogSource),
-		removedByType: make(map[string]chan *LogSource),
+		addedByType:   make(map[string][]chan *LogSource),
+		removedByType: make(map[string][]chan *LogSource),
 	}
 }
 
 // AddSource adds a new source.
 //
-// One of the subscribers registered for this source's type (src.Config.Type) will be
+// All of the subscribers registered for this source's type (src.Config.Type) will be
 // notified.
 func (s *LogSources) AddSource(source *LogSource) {
 	s.mu.Lock()
@@ -43,17 +46,19 @@ func (s *LogSources) AddSource(source *LogSource) {
 		s.mu.Unlock()
 		return
 	}
-	stream, exists := s.addedByType[source.Config.Type]
+	streams, exists := s.addedByType[source.Config.Type]
 	s.mu.Unlock()
 
 	if exists {
-		stream <- source
+		for _, stream := range streams {
+			stream <- source
+		}
 	}
 }
 
 // RemoveSource removes a source.
 //
-// One of the subscribers registered for this source's type (src.Config.Type) will be
+// All of the subscribers registered for this source's type (src.Config.Type) will be
 // notified of its removal.
 func (s *LogSources) RemoveSource(source *LogSource) {
 	s.mu.Lock()
@@ -65,27 +70,39 @@ func (s *LogSources) RemoveSource(source *LogSource) {
 			break
 		}
 	}
-	stream, streamExists := s.removedByType[source.Config.Type]
+	streams, streamExists := s.removedByType[source.Config.Type]
 	s.mu.Unlock()
 
 	if sourceFound && streamExists {
-		stream <- source
+		for _, stream := range streams {
+			stream <- source
+		}
 	}
 }
 
 // GetAddedForType returns a channel carrying notifications of new sources
 // with the given type.
 //
-// Any sources added before this call are not included.
+// Any sources added before this call are delivered from a new goroutine.
 func (s *LogSources) GetAddedForType(sourceType string) chan *LogSource {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	stream, exists := s.addedByType[sourceType]
+	_, exists := s.addedByType[sourceType]
 	if !exists {
-		stream = make(chan *LogSource)
-		s.addedByType[sourceType] = stream
+		s.addedByType[sourceType] = []chan *LogSource{}
 	}
+
+	stream := make(chan *LogSource)
+	s.addedByType[sourceType] = append(s.addedByType[sourceType], stream)
+
+	existingSources := append([]*LogSource{}, s.sources...) // clone for goroutine
+	go func() {
+		for _, source := range existingSources {
+			stream <- source
+		}
+	}()
+
 	return stream
 }
 
@@ -95,11 +112,14 @@ func (s *LogSources) GetRemovedForType(sourceType string) chan *LogSource {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	stream, exists := s.removedByType[sourceType]
+	_, exists := s.removedByType[sourceType]
 	if !exists {
-		stream = make(chan *LogSource)
-		s.removedByType[sourceType] = stream
+		s.removedByType[sourceType] = []chan *LogSource{}
 	}
+
+	stream := make(chan *LogSource)
+	s.removedByType[sourceType] = append(s.removedByType[sourceType], stream)
+
 	return stream
 }
 

--- a/pkg/logs/internal/launchers/docker/launcher.go
+++ b/pkg/logs/internal/launchers/docker/launcher.go
@@ -137,8 +137,7 @@ func (l *Launcher) run(sourceProvider launchers.SourceProvider, pipelineProvider
 	l.pipelineProvider = pipelineProvider
 	l.registry = registry
 
-	addedSources := sourceProvider.GetAddedForType(config.DockerType)
-	removedSources := sourceProvider.GetRemovedForType(config.DockerType)
+	addedSources, removedSources := sourceProvider.SubscribeForType(config.DockerType)
 	addedServices := l.services.GetAddedServicesForType(config.DockerType)
 	removedServices := l.services.GetRemovedServicesForType(config.DockerType)
 

--- a/pkg/logs/internal/launchers/file/launcher.go
+++ b/pkg/logs/internal/launchers/file/launcher.go
@@ -74,8 +74,7 @@ func NewLauncher(tailingLimit int, tailerSleepDuration time.Duration, validatePo
 // Start starts the Launcher
 func (s *Launcher) Start(sourceProvider launchers.SourceProvider, pipelineProvider pipeline.Provider, registry auditor.Registry) {
 	s.pipelineProvider = pipelineProvider
-	s.addedSources = sourceProvider.GetAddedForType(config.FileType)
-	s.removedSources = sourceProvider.GetRemovedForType(config.FileType)
+	s.addedSources, s.removedSources = sourceProvider.SubscribeForType(config.FileType)
 	s.registry = registry
 	go s.run()
 }

--- a/pkg/logs/internal/launchers/mock_source_provider.go
+++ b/pkg/logs/internal/launchers/mock_source_provider.go
@@ -26,12 +26,12 @@ func NewMockSourceProvider() *MockSourceProvider {
 	}
 }
 
-// GetAddedForType implements SourceProvider#GetAddedForType.
-func (sp *MockSourceProvider) GetAddedForType(sourceType string) chan *config.LogSource {
-	return sp.SourceChan
+// SubscribeForType implements SourceProvider#SubscribeForType.
+func (sp *MockSourceProvider) SubscribeForType(sourceType string) (chan *config.LogSource, chan *config.LogSource) {
+	return sp.SourceChan, sp.SourceChan
 }
 
-// GetRemovedForType implements SourceProvider#GetRemovedForType.
-func (sp *MockSourceProvider) GetRemovedForType(sourceType string) chan *config.LogSource {
+// GetAddedForType implements SourceProvider#GetAddedForType.
+func (sp *MockSourceProvider) GetAddedForType(sourceType string) chan *config.LogSource {
 	return sp.SourceChan
 }

--- a/pkg/logs/internal/launchers/types.go
+++ b/pkg/logs/internal/launchers/types.go
@@ -30,9 +30,9 @@ type Launcher interface {
 //
 // The *config.LogSources type satisfies this interface.
 type SourceProvider interface {
-	// GetAddedForType returns the new added sources matching the provided type.
-	GetAddedForType(sourceType string) chan *config.LogSource
+	// SubscribeForType returns channels containing the new added and removed sources matching the provided type.
+	SubscribeForType(sourceType string) (added chan *config.LogSource, removed chan *config.LogSource)
 
-	// GetRemovedForType returns the new removed sources matching the provided type.
-	GetRemovedForType(sourceType string) chan *config.LogSource
+	// GetAddedForType returns channels containing the new added sources matching the provided type.
+	GetAddedForType(sourceType string) chan *config.LogSource
 }

--- a/pkg/logs/internal/util/adlistener/ad.go
+++ b/pkg/logs/internal/util/adlistener/ad.go
@@ -42,10 +42,10 @@ func NewADListener(name string, ac *autodiscovery.AutoConfig, schedule, unschedu
 	}
 }
 
-// StartListener starts the ADListener.  It will subscribe to the MetaScheduler as soon
-// as it is available
+// StartListener starts the ADListener, subscribing to the feed of integration.Configs and
+// additionally gathering any currently-scheduled configs.
 func (l *ADListener) StartListener() {
-	l.ac.AddScheduler(l.name, l, false)
+	l.ac.AddScheduler(l.name, l, true)
 }
 
 // StopListener stops the ADListener

--- a/pkg/logs/internal/util/adlistener/ad_test.go
+++ b/pkg/logs/internal/util/adlistener/ad_test.go
@@ -18,14 +18,22 @@ func TestListenersGetScheduleCalls(t *testing.T) {
 	ac := autodiscovery.NewAutoConfigNoStart(adsched)
 
 	got1 := make(chan struct{}, 1)
-	l1 := NewADListener("l1", ac, func([]integration.Config) { got1 <- struct{}{} }, nil)
+	l1 := NewADListener("l1", ac, func(configs []integration.Config) {
+		for range configs {
+			got1 <- struct{}{}
+		}
+	}, nil)
 	l1.StartListener()
 
 	got2 := make(chan struct{}, 1)
-	l2 := NewADListener("l2", ac, func([]integration.Config) { got2 <- struct{}{} }, nil)
+	l2 := NewADListener("l2", ac, func(configs []integration.Config) {
+		for range configs {
+			got2 <- struct{}{}
+		}
+	}, nil)
 	l2.StartListener()
 
-	adsched.Schedule([]integration.Config{})
+	adsched.Schedule([]integration.Config{{}})
 
 	// wait for each of the two listeners to get notified
 	<-got1


### PR DESCRIPTION
### What does this PR do?

Ensures that the various layers of subscription used by the logs-agent to find out about things it should log do not depend on ordering of the subscription operation and the event being subscribed to.

### Motivation

A long bunch of bugs where logs-agent "missed" events from AD.

### Additional Notes

This changes how subscriptions to logs sources work -- see the comments in [eb0d768](https://github.com/DataDog/datadog-agent/pull/11961/commits/eb0d768fff1ae6f832efb152031b9ec3bd93ad8b).  I'm fairly confident that change is OK, but please verify the assumption.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Set up the agent in a k8s environment.  First, start a pod containing annotations.  The logs benchmarks are an example of this; for example:
```
metadata:
  annotations:
    ad.datadoghq.com/flog-0.logs: '[{"source":"flog","service":"flog"}]'
```

Start the agent _after_ this pod is running.  Observe that the agent logs the pod.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
