### PR TITLE
[CWS] fix `clang-bpf` and `llc-bpf` availability in `docker-functional-tests`

### DIFF
--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -511,6 +511,7 @@ RUN apt-get update -y \
     cmd += '-v /usr/lib/os-release:/host/usr/lib/os-release '
     cmd += '-v /etc/passwd:/etc/passwd '
     cmd += '-v /etc/group:/etc/group '
+    cmd += '-v /opt/datadog-agent/embedded/bin/:/opt/datadog-agent/embedded/bin/ '
     cmd += '-v {GOPATH}/src/{REPO_PATH}/pkg/security/tests:/tests {image_tag} sleep 3600'
 
     args = {

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -484,8 +484,12 @@ ENV DOCKER_DD_AGENT=yes
 RUN dpkg --add-architecture i386
 
 RUN apt-get update -y \
-    && apt-get install -y --no-install-recommends xfsprogs ca-certificates iproute2 \
+    && apt-get install -y --no-install-recommends xfsprogs ca-certificates iproute2 clang-11 llvm-11 \
     && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /opt/datadog-agent/embedded/bin
+RUN ln -s $(which clang-11) /opt/datadog-agent/embedded/bin/clang-bpf
+RUN ln -s $(which llc-11) /opt/datadog-agent/embedded/bin/llc-bpf
     """
 
     docker_image_tag_name = "docker-functional-tests"
@@ -511,7 +515,6 @@ RUN apt-get update -y \
     cmd += '-v /usr/lib/os-release:/host/usr/lib/os-release '
     cmd += '-v /etc/passwd:/etc/passwd '
     cmd += '-v /etc/group:/etc/group '
-    cmd += '-v /opt/datadog-agent/embedded/bin/:/opt/datadog-agent/embedded/bin/ '
     cmd += '-v {GOPATH}/src/{REPO_PATH}/pkg/security/tests:/tests {image_tag} sleep 3600'
 
     args = {

--- a/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
@@ -115,8 +115,8 @@ if node['platform_family'] != 'windows'
       ADD nikos.tar.gz /opt/datadog-agent/embedded/nikos/embedded/
 
       RUN mkdir -p /opt/datadog-agent/embedded/bin
-      COPY clang-btf /opt/datadog-agent/embedded/bin/
-      COPY llc-btf /opt/datadog-agent/embedded/bin/
+      COPY clang-bpf /opt/datadog-agent/embedded/bin/
+      COPY llc-bpf /opt/datadog-agent/embedded/bin/
 
       RUN yum -y install xfsprogs e2fsprogs iproute
       CMD sleep 7200

--- a/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
@@ -118,6 +118,7 @@ if node['platform_family'] != 'windows'
       volumes [
         # security-agent misc
         '/tmp/security-agent:/tmp/security-agent',
+        '/opt/datadog-agent/embedded/bin:/opt/datadog-agent/embedded/bin',
         # HOST_* paths
         '/proc:/host/proc',
         '/etc:/host/etc',

--- a/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
@@ -27,7 +27,19 @@ if node['platform_family'] != 'windows'
     action :create
   end
 
+  cookbook_file "#{wrk_dir}/clang-bpf" do
+    source "clang-bpf"
+    mode '0744'
+    action :create
+  end
+
   cookbook_file "/opt/datadog-agent/embedded/bin/llc-bpf" do
+    source "llc-bpf"
+    mode '0744'
+    action :create
+  end
+
+  cookbook_file "#{wrk_dir}/llc-bpf" do
     source "llc-bpf"
     mode '0744'
     action :create
@@ -97,8 +109,15 @@ if node['platform_family'] != 'windows'
     file "#{wrk_dir}/Dockerfile" do
       content <<-EOF
       FROM centos:7
+
       ENV DOCKER_DD_AGENT=yes
+
       ADD nikos.tar.gz /opt/datadog-agent/embedded/nikos/embedded/
+
+      RUN mkdir -p /opt/datadog-agent/embedded/bin
+      COPY clang-btf /opt/datadog-agent/embedded/bin/
+      COPY llc-btf /opt/datadog-agent/embedded/bin/
+
       RUN yum -y install xfsprogs e2fsprogs iproute
       CMD sleep 7200
       EOF
@@ -118,7 +137,6 @@ if node['platform_family'] != 'windows'
       volumes [
         # security-agent misc
         '/tmp/security-agent:/tmp/security-agent',
-        '/opt/datadog-agent/embedded/bin:/opt/datadog-agent/embedded/bin',
         # HOST_* paths
         '/proc:/host/proc',
         '/etc:/host/etc',


### PR DESCRIPTION
### What does this PR do?

This allows runtime compilation to work inside the docker container used in local functional tests

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
