### PR TITLE
Fix CodeQL warnings

### DIFF
--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -213,6 +213,14 @@ func (ku *KubeUtil) GetLocalPodList(ctx context.Context) ([]*Pod, error) {
 	tmpSlice := make([]*Pod, 0, len(pods.Items))
 	for _, pod := range pods.Items {
 		if pod != nil {
+			// Validate allocation size.
+			// Limits hardcoded here are huge enough to never be hit.
+			if len(pod.Spec.Containers) > 10000 ||
+				len(pod.Spec.InitContainers) > 10000 {
+				log.Errorf("pod %s has a crazy number of containers: %d or init containers: %d. Skipping it!",
+					pod.Metadata.UID, len(pod.Spec.Containers), len(pod.Spec.InitContainers))
+				continue
+			}
 			allContainers := make([]ContainerStatus, 0, len(pod.Status.InitContainers)+len(pod.Status.Containers))
 			allContainers = append(allContainers, pod.Status.InitContainers...)
 			allContainers = append(allContainers, pod.Status.Containers...)

--- a/pkg/workloadmeta/collectors/internal/kubelet/kubelet.go
+++ b/pkg/workloadmeta/collectors/internal/kubelet/kubelet.go
@@ -91,6 +91,14 @@ func (c *collector) parsePods(pods []*kubelet.Pod) []workloadmeta.CollectorEvent
 			continue
 		}
 
+		// Validate allocation size.
+		// Limits hardcoded here are huge enough to never be hit.
+		if len(pod.Spec.Containers) > 10000 ||
+			len(pod.Spec.InitContainers) > 10000 {
+			log.Errorf("pod %s has a crazy number of containers: %d or init containers: %d. Skipping it!",
+				podMeta.UID, len(pod.Spec.Containers), len(pod.Spec.InitContainers))
+			continue
+		}
 		containerSpecs := make(
 			[]kubelet.ContainerSpec, 0,
 			len(pod.Spec.Containers)+len(pod.Spec.InitContainers),


### PR DESCRIPTION
### What does this PR do?

Fixes https://github.com/DataDog/datadog-agent/security/code-scanning/80
Fixes https://github.com/DataDog/datadog-agent/security/code-scanning/81
Fixes https://github.com/DataDog/datadog-agent/security/code-scanning/111
Fixes https://github.com/DataDog/datadog-agent/security/code-scanning/112

### Motivation

Number of containers and init containers inside a pod will never be huge.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
