### PR TITLE
(rcm) update TUF to use int64, fix CVE-2022-29173 

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -694,6 +694,7 @@ core,github.com/tedsuo/rata,MIT,Copyright (c) 2014 Ted Young
 core,github.com/theupdateframework/go-tuf/client,BSD-3-Clause,"Copyright (c) 2014-2020 Prime Directive, Inc. All rights reserved"
 core,github.com/theupdateframework/go-tuf/data,BSD-3-Clause,"Copyright (c) 2014-2020 Prime Directive, Inc. All rights reserved"
 core,github.com/theupdateframework/go-tuf/internal/roles,BSD-3-Clause,"Copyright (c) 2014-2020 Prime Directive, Inc. All rights reserved"
+core,github.com/theupdateframework/go-tuf/internal/sets,BSD-3-Clause,"Copyright (c) 2014-2020 Prime Directive, Inc. All rights reserved"
 core,github.com/theupdateframework/go-tuf/pkg/keys,BSD-3-Clause,"Copyright (c) 2014-2020 Prime Directive, Inc. All rights reserved"
 core,github.com/theupdateframework/go-tuf/pkg/targets,BSD-3-Clause,"Copyright (c) 2014-2020 Prime Directive, Inc. All rights reserved"
 core,github.com/theupdateframework/go-tuf/util,BSD-3-Clause,"Copyright (c) 2014-2020 Prime Directive, Inc. All rights reserved"

--- a/go.mod
+++ b/go.mod
@@ -166,7 +166,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.1
 	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635
-	github.com/theupdateframework/go-tuf v0.1.0
+	github.com/theupdateframework/go-tuf v0.3.0
 	github.com/tinylib/msgp v1.1.6
 	github.com/twmb/murmur3 v1.1.6
 	github.com/urfave/negroni v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1667,8 +1667,8 @@ github.com/tedsuo/ifrit v0.0.0-20191009134036-9a97d0632f00 h1:mujcChM89zOHwgZBBN
 github.com/tedsuo/ifrit v0.0.0-20191009134036-9a97d0632f00/go.mod h1:eyZnKCc955uh98WQvzOm0dgAeLnf2O0Rz0LPoC5ze+0=
 github.com/tedsuo/rata v1.0.0 h1:Sf9aZrYy6ElSTncjnGkyC2yuVvz5YJetBIUKJ4CmeKE=
 github.com/tedsuo/rata v1.0.0/go.mod h1:X47ELzhOoLbfFIY0Cql9P6yo3Cdwf2CMX3FVZxRzJPc=
-github.com/theupdateframework/go-tuf v0.1.0 h1:ZtpteY7vwPlJd2x4LNaMPtL2EjKZ/YDf23rS4dTRuzQ=
-github.com/theupdateframework/go-tuf v0.1.0/go.mod h1:Vlrf6NdcfjEjbF24KDNIL07h8kUjzznkSJgihzWMC9Q=
+github.com/theupdateframework/go-tuf v0.3.0 h1:od2sc5+BSkKZhmUG2o2rmruy0BGSmhrbDhCnpxh87X8=
+github.com/theupdateframework/go-tuf v0.3.0/go.mod h1:E5XP0wXitrFUHe4b8cUcAAdxBW4LbfnqF4WXXGLgWNo=
 github.com/tidwall/assert v0.1.0/go.mod h1:QLYtGyeqse53vuELQheYl9dngGCJQ+mTtlxcktb+Kj8=
 github.com/tidwall/btree v0.3.0/go.mod h1:huei1BkDWJ3/sLXmO+bsCNELL+Bp2Kks9OLyQFkzvA8=
 github.com/tidwall/btree v1.1.0/go.mod h1:TzIRzen6yHbibdSfK6t8QimqbUnoxUSrZfeW7Uob0q4=

--- a/pkg/config/remote/client_test.go
+++ b/pkg/config/remote/client_test.go
@@ -168,7 +168,7 @@ func generateKey() keys.Signer {
 	return key
 }
 
-func generateTargets(key keys.Signer, version int, targets data.TargetFiles) []byte {
+func generateTargets(key keys.Signer, version int64, targets data.TargetFiles) []byte {
 	meta := data.NewTargets()
 	meta.Expires = time.Now().Add(1 * time.Hour)
 	meta.Version = version
@@ -178,7 +178,7 @@ func generateTargets(key keys.Signer, version int, targets data.TargetFiles) []b
 	return serialized
 }
 
-func generateRoot(key keys.Signer, version int, targetsKey keys.Signer) []byte {
+func generateRoot(key keys.Signer, version int64, targetsKey keys.Signer) []byte {
 	root := data.NewRoot()
 	root.Version = version
 	root.Expires = time.Now().Add(1 * time.Hour)

--- a/pkg/config/remote/uptane/client_test.go
+++ b/pkg/config/remote/uptane/client_test.go
@@ -256,14 +256,14 @@ type testRepositories struct {
 	directorSnapshotKey  keys.Signer
 	directorRootKey      keys.Signer
 
-	configTimestampVersion   int
-	configTargetsVersion     int
-	configSnapshotVersion    int
-	configRootVersion        int
-	directorTimestampVersion int
-	directorTargetsVersion   int
-	directorSnapshotVersion  int
-	directorRootVersion      int
+	configTimestampVersion   int64
+	configTargetsVersion     int64
+	configSnapshotVersion    int64
+	configRootVersion        int64
+	directorTimestampVersion int64
+	directorTargetsVersion   int64
+	directorSnapshotVersion  int64
+	directorRootVersion      int64
 
 	configTimestamp   []byte
 	configTargets     []byte
@@ -277,7 +277,7 @@ type testRepositories struct {
 	targetFiles []*pbgo.File
 }
 
-func newTestRepository(version int, configTargets data.TargetFiles, directorTargets data.TargetFiles, targetFiles []*pbgo.File) testRepositories {
+func newTestRepository(version int64, configTargets data.TargetFiles, directorTargets data.TargetFiles, targetFiles []*pbgo.File) testRepositories {
 	repos := testRepositories{
 		configTimestampKey:   generateKey(),
 		configTargetsKey:     generateKey(),
@@ -326,7 +326,7 @@ func (r testRepositories) toUpdate() *pbgo.LatestConfigsResponse {
 	}
 }
 
-func generateRoot(key keys.Signer, version int, timestampKey keys.Signer, targetsKey keys.Signer, snapshotKey keys.Signer, previousRootKey keys.Signer) []byte {
+func generateRoot(key keys.Signer, version int64, timestampKey keys.Signer, targetsKey keys.Signer, snapshotKey keys.Signer, previousRootKey keys.Signer) []byte {
 	root := data.NewRoot()
 	root.Version = version
 	root.Expires = time.Now().Add(1 * time.Hour)
@@ -361,7 +361,7 @@ func generateRoot(key keys.Signer, version int, timestampKey keys.Signer, target
 	return serializedRoot
 }
 
-func generateTimestamp(key keys.Signer, version int, snapshotVersion int, snapshot []byte) []byte {
+func generateTimestamp(key keys.Signer, version int64, snapshotVersion int64, snapshot []byte) []byte {
 	meta := data.NewTimestamp()
 	meta.Expires = time.Now().Add(1 * time.Hour)
 	meta.Version = version
@@ -373,7 +373,7 @@ func generateTimestamp(key keys.Signer, version int, snapshotVersion int, snapsh
 	return serialized
 }
 
-func generateTargets(key keys.Signer, version int, targets data.TargetFiles) []byte {
+func generateTargets(key keys.Signer, version int64, targets data.TargetFiles) []byte {
 	meta := data.NewTargets()
 	meta.Expires = time.Now().Add(1 * time.Hour)
 	meta.Version = version
@@ -383,7 +383,7 @@ func generateTargets(key keys.Signer, version int, targets data.TargetFiles) []b
 	return serialized
 }
 
-func generateSnapshot(key keys.Signer, version int, targetsVersion int) []byte {
+func generateSnapshot(key keys.Signer, version int64, targetsVersion int64) []byte {
 	meta := data.NewSnapshot()
 	meta.Expires = time.Now().Add(1 * time.Hour)
 	meta.Version = version

--- a/pkg/remoteconfig/client/go.mod
+++ b/pkg/remoteconfig/client/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/stretchr/testify v1.7.1
-	github.com/theupdateframework/go-tuf v0.1.0
+	github.com/theupdateframework/go-tuf v0.3.0
 	github.com/tinylib/msgp v1.1.6
 )
 

--- a/pkg/remoteconfig/client/go.sum
+++ b/pkg/remoteconfig/client/go.sum
@@ -55,8 +55,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
-github.com/theupdateframework/go-tuf v0.1.0 h1:ZtpteY7vwPlJd2x4LNaMPtL2EjKZ/YDf23rS4dTRuzQ=
-github.com/theupdateframework/go-tuf v0.1.0/go.mod h1:Vlrf6NdcfjEjbF24KDNIL07h8kUjzznkSJgihzWMC9Q=
+github.com/theupdateframework/go-tuf v0.3.0 h1:od2sc5+BSkKZhmUG2o2rmruy0BGSmhrbDhCnpxh87X8=
+github.com/theupdateframework/go-tuf v0.3.0/go.mod h1:E5XP0wXitrFUHe4b8cUcAAdxBW4LbfnqF4WXXGLgWNo=
 github.com/tinylib/msgp v1.1.6 h1:i+SbKraHhnrf9M5MYmvQhFnbLhAXSDWF8WWsuyRdocw=
 github.com/tinylib/msgp v1.1.6/go.mod h1:75BAfg2hauQhs3qedfdDZmWAPcFMAvJE5b9rGOMufyw=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/remoteconfig/client/internal/uptane/partial_client.go
+++ b/pkg/remoteconfig/client/internal/uptane/partial_client.go
@@ -200,7 +200,7 @@ func (c *PartialClient) Update(roots [][]byte, previousTargets *PartialClientTar
 	}
 	purgeTargetFiles(targets.Targets, mergedTargetFiles)
 	return &PartialClientTargets{
-		version:     int64(targets.Version),
+		version:     targets.Version,
 		metas:       targets.Targets,
 		targetFiles: mergedTargetFiles,
 	}, nil

--- a/pkg/remoteconfig/client/internal/uptane/tuf_test.go
+++ b/pkg/remoteconfig/client/internal/uptane/tuf_test.go
@@ -25,8 +25,8 @@ type testRepositories struct {
 	directorTargetsKey keys.Signer
 	directorRootKey    keys.Signer
 
-	directorTargetsVersion int
-	directorRootVersion    int
+	directorTargetsVersion int64
+	directorRootVersion    int64
 
 	directorTargets []byte
 	directorRoot    []byte
@@ -34,7 +34,7 @@ type testRepositories struct {
 	targetFiles map[string][]byte
 }
 
-func newTestRepository(version int, configTargets data.TargetFiles, directorTargets data.TargetFiles, targetFiles map[string][]byte) testRepositories {
+func newTestRepository(version int64, configTargets data.TargetFiles, directorTargets data.TargetFiles, targetFiles map[string][]byte) testRepositories {
 	repos := testRepositories{
 		directorTargetsKey: generateKey(),
 		directorRootKey:    generateKey(),
@@ -47,7 +47,7 @@ func newTestRepository(version int, configTargets data.TargetFiles, directorTarg
 	return repos
 }
 
-func generateRoot(key keys.Signer, version int, targetsKey keys.Signer, previousRootKey keys.Signer) []byte {
+func generateRoot(key keys.Signer, version int64, targetsKey keys.Signer, previousRootKey keys.Signer) []byte {
 	root := data.NewRoot()
 	root.Version = version
 	root.Expires = time.Now().Add(1 * time.Hour)
@@ -79,7 +79,7 @@ func generateRoot(key keys.Signer, version int, targetsKey keys.Signer, previous
 	return serializedRoot
 }
 
-func generateTargets(key keys.Signer, version int, targets data.TargetFiles) []byte {
+func generateTargets(key keys.Signer, version int64, targets data.TargetFiles) []byte {
 	meta := data.NewTargets()
 	meta.Expires = time.Now().Add(1 * time.Hour)
 	meta.Version = version

--- a/pkg/trace/go.mod
+++ b/pkg/trace/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.3.1 // indirect
-	github.com/theupdateframework/go-tuf v0.1.0 // indirect
+	github.com/theupdateframework/go-tuf v0.3.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.9 // indirect
 	github.com/tklauser/numcpus v0.3.0 // indirect
 	github.com/vmihailenco/tagparser v0.1.1 // indirect

--- a/pkg/trace/go.sum
+++ b/pkg/trace/go.sum
@@ -180,8 +180,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
-github.com/theupdateframework/go-tuf v0.1.0 h1:ZtpteY7vwPlJd2x4LNaMPtL2EjKZ/YDf23rS4dTRuzQ=
-github.com/theupdateframework/go-tuf v0.1.0/go.mod h1:Vlrf6NdcfjEjbF24KDNIL07h8kUjzznkSJgihzWMC9Q=
+github.com/theupdateframework/go-tuf v0.3.0 h1:od2sc5+BSkKZhmUG2o2rmruy0BGSmhrbDhCnpxh87X8=
+github.com/theupdateframework/go-tuf v0.3.0/go.mod h1:E5XP0wXitrFUHe4b8cUcAAdxBW4LbfnqF4WXXGLgWNo=
 github.com/tinylib/msgp v1.1.6 h1:i+SbKraHhnrf9M5MYmvQhFnbLhAXSDWF8WWsuyRdocw=
 github.com/tinylib/msgp v1.1.6/go.mod h1:75BAfg2hauQhs3qedfdDZmWAPcFMAvJE5b9rGOMufyw=
 github.com/tklauser/go-sysconf v0.3.9 h1:JeUVdAOWhhxVcU6Eqr/ATFHgXk/mmiItdKeJPev3vTo=


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Updates the `go-tuf` dependency to version 0.3.0 for:
- [CVE-2022-29173](https://github.com/theupdateframework/go-tuf/security/advisories/GHSA-66x3-6cw3-v5gj) fix
- Use of int64 instead of int for TUF versions to avoid issue in 32bit agents

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
