### PR TITLE
[test/e2e] Add retries when installing kubectl

### DIFF
--- a/test/e2e/scripts/run-instance/10-setup-kind.sh
+++ b/test/e2e/scripts/run-instance/10-setup-kind.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 download_and_install_kubectl() {
-    curl --retry 5 -LO "https://dl.k8s.io/release/$(curl --retry 5 -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+    curl --retry 5 --fail --retry-all-errors -LO "https://dl.k8s.io/release/$(curl --retry 5 --fail --retry-all-errors -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
     sudo install kubectl /usr/local/bin/kubectl
 }
 
@@ -22,7 +22,7 @@ if [[ ! -f ./kubectl ]]; then
     download_and_install_kubectl
 else
     # else, download the SHA256 of the wanted version
-    curl --retry 5 -LO "https://dl.k8s.io/release/$(curl --retry 5 -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl.sha256"
+    curl --retry 5 --fail --retry-all-errors -LO "https://dl.k8s.io/release/$(curl --retry 5 --fail --retry-all-errors -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl.sha256"
     # And if it differs, force the download again
     if ! echo "$(<kubectl.sha256)  kubectl" | sha256sum --check ; then
         echo "SHA256 of kubectl differs, downloading it again"

--- a/test/e2e/scripts/run-instance/10-setup-kind.sh
+++ b/test/e2e/scripts/run-instance/10-setup-kind.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 download_and_install_kubectl() {
-    curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+    curl --retry 5 -LO "https://dl.k8s.io/release/$(curl --retry 5 -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
     sudo install kubectl /usr/local/bin/kubectl
 }
 
@@ -22,7 +22,7 @@ if [[ ! -f ./kubectl ]]; then
     download_and_install_kubectl
 else
     # else, download the SHA256 of the wanted version
-    curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl.sha256"
+    curl --retry 5 -LO "https://dl.k8s.io/release/$(curl --retry 5 -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl.sha256"
     # And if it differs, force the download again
     if ! echo "$(<kubectl.sha256)  kubectl" | sha256sum --check ; then
         echo "SHA256 of kubectl differs, downloading it again"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Adds `--retry 5` to curl commands fetching kubectl.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Reduce flakiness of e2e tests.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
