### PR TITLE
[CWS] general cleanup

### DIFF
--- a/cmd/security-agent/common/config.go
+++ b/cmd/security-agent/common/config.go
@@ -29,7 +29,7 @@ func MergeConfigurationFiles(configName string, configurationFilesArray []string
 			}
 			continue
 		}
-		if loadedConfiguration == false {
+		if !loadedConfiguration {
 			err := common.SetupConfig(configurationFilename)
 			if err != nil {
 				if userDefined {
@@ -49,13 +49,13 @@ func MergeConfigurationFiles(configName string, configurationFilesArray []string
 
 			err = coreconfig.Datadog.MergeConfig(file)
 			if err != nil {
-				return fmt.Errorf("Unable to merge a configuration file: %v", err)
+				return fmt.Errorf("unable to merge a configuration file: %v", err)
 			}
 		}
 	}
 
-	if loadedConfiguration == false {
-		return fmt.Errorf("Unable to load any configuration file from %s", configurationFilesArray)
+	if !loadedConfiguration {
+		return fmt.Errorf("unable to load any configuration file from %s", configurationFilesArray)
 	}
 
 	return nil

--- a/pkg/security/agent/agent.go
+++ b/pkg/security/agent/agent.go
@@ -89,7 +89,7 @@ func (rsa *RuntimeSecurityAgent) StartEventListener() {
 	logTicker := newLogBackoffTicker()
 
 	rsa.running.Store(true)
-	for rsa.running.Load() == true {
+	for rsa.running.Load() {
 		stream, err := rsa.client.GetEvents()
 		if err != nil {
 			rsa.connected.Store(false)

--- a/pkg/security/probe/doc_generator/backend_doc_gen.go
+++ b/pkg/security/probe/doc_generator/backend_doc_gen.go
@@ -9,7 +9,6 @@
 package main
 
 import (
-	"bytes"
 	"encoding/json"
 	"flag"
 	"os"
@@ -27,17 +26,13 @@ func generateBackendJSON(output string) error {
 		TypeNamer:      jsonTypeNamer,
 	}
 	schema := reflector.Reflect(&probe.EventSerializer{})
-	schemaJSON, err := schema.MarshalJSON()
+
+	schemaJSON, err := json.MarshalIndent(schema, "", "  ")
 	if err != nil {
 		return err
 	}
 
-	var out bytes.Buffer
-	if err := json.Indent(&out, schemaJSON, "", "  "); err != nil {
-		return err
-	}
-
-	return os.WriteFile(output, out.Bytes(), 0664)
+	return os.WriteFile(output, schemaJSON, 0664)
 }
 
 func jsonTypeNamer(ty reflect.Type) string {

--- a/pkg/security/secl/compiler/generators/accessors/doc/doc.go
+++ b/pkg/security/secl/compiler/generators/accessors/doc/doc.go
@@ -6,7 +6,6 @@
 package doc
 
 import (
-	"bytes"
 	"encoding/json"
 	"os"
 	"regexp"
@@ -33,20 +32,6 @@ type eventTypeProperty struct {
 	Name string `json:"name"`
 	Type string `json:"type"`
 	Doc  string `json:"definition"`
-}
-
-func prettyprint(v interface{}) ([]byte, error) {
-	base, err := json.Marshal(v)
-	if err != nil {
-		return nil, err
-	}
-
-	var out bytes.Buffer
-	if err := json.Indent(&out, base, "", "  "); err != nil {
-		return nil, err
-	}
-
-	return out.Bytes(), nil
 }
 
 func translateFieldType(rt string) string {
@@ -95,7 +80,7 @@ func GenerateDocJSON(module *common.Module, outputPath string) error {
 		Types: eventTypes,
 	}
 
-	res, err := prettyprint(doc)
+	res, err := json.MarshalIndent(doc, "", "  ")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### What does this PR do?

This PR does a few general cleanups:
- replace calls to `Marshal` followed by `Indent` with direct `MarshalIdent` calls
- simplify `== true` and `== false` comparisons

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
