### PR TITLE
[clusteragent/clusterchecks/common_test] Ignore staticcheck SA2001

### DIFF
--- a/pkg/clusteragent/clusterchecks/common_test.go
+++ b/pkg/clusteragent/clusterchecks/common_test.go
@@ -48,6 +48,11 @@ func isLocked(l lockable) bool {
 	ok := make(chan struct{}, 1)
 	go func() {
 		l.Lock()
+		// Ignore staticcheck SA2001.
+		// This is a valid way of checking if l is locked. We will be able to
+		// simplify all of this when we update to go 1.18, which includes
+		// RWMutex.TryLock().
+		//nolint:staticcheck
 		l.Unlock()
 		ok <- struct{}{}
 	}()


### PR DESCRIPTION
### What does this PR do?

Uses `//nolint:staticcheck` to ignore a false positive of [SA2001](https://staticcheck.io/docs/checks#SA2001) in `pkg/clusteragent/clusterchecks/common_test.go`.

I've added a comment explaining why it's a false positive and also how we'll be able to simplify the code once we switch to go 1.18.

Note: I tried using `//lint:ignore SA2001` instead of `nolint:staticcheck` to be more specific, but apparently that doesn't work with golangci.

### Describe how to test/QA your changes

Skip.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
