### PR TITLE
[network-agent] http: increase HTTP_BUFFER_SIZE to 160 bytes

### DIFF
--- a/pkg/network/ebpf/c/http-buffer.h
+++ b/pkg/network/ebpf/c/http-buffer.h
@@ -16,13 +16,41 @@ static __always_inline void read_into_buffer(char *buffer, char *data, size_t da
         return;
     }
 
-    // clean up garbage
+#define BLOCK_SIZE (8)
+
+    u32 offset = HTTP_BUFFER_SIZE;
+    buffer += (HTTP_BUFFER_SIZE - BLOCK_SIZE);
+
 #pragma unroll
-    for (int i = 0; i < HTTP_BUFFER_SIZE; i++) {
-        if (i >= data_size) {
-            buffer[i] = 0;
-        }
+    for (int i = 0; i < HTTP_BUFFER_SIZE / BLOCK_SIZE; i++) {
+        if (data_size > (offset - BLOCK_SIZE)) break;
+        *(u64 *)buffer = 0;
+        buffer -= BLOCK_SIZE;
+        offset -= BLOCK_SIZE;
     }
+
+    if (data_size <= (offset - 7)) {
+        buffer[1] = 0;
+    }
+    if (data_size <= (offset - 6)) {
+        buffer[2] = 0;
+    }
+    if (data_size <= (offset - 5)) {
+        buffer[3] = 0;
+    }
+    if (data_size <= (offset - 4)) {
+        buffer[4] = 0;
+    }
+    if (data_size <= (offset - 3)) {
+        buffer[5] = 0;
+    }
+    if (data_size <= (offset - 2)) {
+        buffer[6] = 0;
+    }
+    if (data_size <= (offset - 1)) {
+        buffer[7] = 0;
+    }
+#undef BLOCK_SIZE
 }
 
 #endif

--- a/pkg/network/ebpf/c/http-types.h
+++ b/pkg/network/ebpf/c/http-types.h
@@ -4,7 +4,7 @@
 #include "tracer.h"
 
 // This determines the size of the payload fragment that is captured for each HTTP request
-#define HTTP_BUFFER_SIZE 80
+#define HTTP_BUFFER_SIZE (8 * 20)
 // This controls the number of HTTP transactions read from userspace at a time
 #define HTTP_BATCH_SIZE 15
 // The greater this number is the less likely are colisions/data-races between the flushes

--- a/pkg/network/ebpf/c/http-types.h
+++ b/pkg/network/ebpf/c/http-types.h
@@ -14,6 +14,9 @@
 // _________^
 #define HTTP_STATUS_OFFSET 9
 
+// This is needed to reduce code size on multiple copy opitmizations that were made in
+// the http eBPF program.
+_Static_assert((HTTP_BUFFER_SIZE % 8) == 0, "HTTP_BUFFER_SIZE must be a multiple of 8.");
 
 typedef enum
 {
@@ -48,7 +51,7 @@ typedef struct {
     __u64 request_started;
     __u16 response_status_code;
     __u64 response_last_seen;
-    char request_fragment[HTTP_BUFFER_SIZE];
+    char request_fragment[HTTP_BUFFER_SIZE] __attribute__ ((aligned (8)));
 
     // this field is used exclusively in the kernel side to prevent a TCP segment
     // to be processed twice in the context of localhost traffic. The field will

--- a/pkg/network/ebpf/c/prebuilt/http.c
+++ b/pkg/network/ebpf/c/prebuilt/http.c
@@ -17,18 +17,54 @@
 static __always_inline void read_into_buffer_skb(char *buffer, struct __sk_buff* skb, skb_info_t *info) {
     u64 offset = (u64)info->data_off;
 
+#define BLK_SIZE (4)
+    const u32 iter = HTTP_BUFFER_SIZE / BLK_SIZE;
+    const u32 len = HTTP_BUFFER_SIZE < (skb->len - (u32)offset) ? (u32)offset + HTTP_BUFFER_SIZE : skb->len;
+
+    unsigned i = 0;
+
 #pragma unroll
-    for (int i = 0; i < HTTP_BUFFER_SIZE; i++) {
-        if (offset < skb->len) {
-            asm("r8 = *(u64 *)%[offset]\n\t"
-                "r0 = 0\n\t"
-                "r0 = *(u8 *)skb[r8]\n\t"
-                "*(u8 *)%[buffer] = r0\n\t"
-                : [buffer]"=m"(buffer[i])
-                : [offset]"m"(offset)
-                : "r0", "r1", "r2", "r3", "r4", "r5", "r8");
-        }
-        offset++;
+    for (; i < iter; i++) {
+        if (offset + BLK_SIZE - 1 >= len) break;
+
+        // There was a bug in the bpf translatter that was incorrectly clobbering r2 register,
+        // which led to erasing r1 value in that case:
+        //      0:  r6 = r1
+        //      1:  r1 = 12
+        //      2:  r0 = *(u16 *)skb[r1]
+        // https://github.com/torvalds/linux/commit/e6a18d36118bea3bf497c9df4d9988b6df120689
+        //
+        // To prevent the compiler from using the r1 register in the `load_*` functions, we need
+        // to fake using it, so that it increases the chance for the compiler not using it.
+        asm volatile("":::"r1");
+        *(u32 *)buffer = __builtin_bswap32(load_word(skb, offset));
+        asm volatile("":::"r1");
+
+        offset += BLK_SIZE;
+        buffer += BLK_SIZE;
+    }
+
+    // This part is very hard to write in a loop and unroll it.
+    // Indeed, mostly because of 4.4 verifier, we want to make sure the offset into the buffer is not
+    // stored on the stack, so that the verifier is able to verify that we're not doing out-of-bound on
+    // the stack.
+    // Basically, we should get a register from the code block above containing an fp based address. As
+    // we are doing `buffer[0]` here, there is not dynamic computation on that said register after this,
+    // and thus the verifier is able to ensure that we are in-bound.
+    if (offset + 2 < len) {
+        asm volatile("":::"r1");
+        *(u16 *)(&buffer[0]) = __builtin_bswap16(load_half(skb, offset));
+        asm volatile("":::"r1");
+        *(&buffer[2]) = load_byte(skb, offset + 2);
+        asm volatile("":::"r1");
+    } else if (offset + 1 < len) {
+        asm volatile("":::"r1");
+        *(u16 *)(&buffer[0]) = __builtin_bswap16(load_half(skb, offset));
+        asm volatile("":::"r1");
+    } else if (offset < len) {
+        asm volatile("":::"r1");
+        *(&buffer[0]) = load_byte(skb, offset);
+        asm volatile("":::"r1");
     }
 }
 

--- a/pkg/network/ebpf/c/prebuilt/http.c
+++ b/pkg/network/ebpf/c/prebuilt/http.c
@@ -48,7 +48,7 @@ static __always_inline void read_into_buffer_skb(char *buffer, struct __sk_buff*
     // Indeed, mostly because of 4.4 verifier, we want to make sure the offset into the buffer is not
     // stored on the stack, so that the verifier is able to verify that we're not doing out-of-bound on
     // the stack.
-    // Basically, we should get a register from the code block above containing an fp based address. As
+    // Basically, we should get a register from the code block above containing an fp relative address. As
     // we are doing `buffer[0]` here, there is not dynamic computation on that said register after this,
     // and thus the verifier is able to ensure that we are in-bound.
     if (offset + 2 < len) {

--- a/pkg/network/ebpf/c/runtime/http.c
+++ b/pkg/network/ebpf/c/runtime/http.c
@@ -22,13 +22,51 @@
 static __always_inline void read_into_buffer_skb(char *buffer, struct __sk_buff* skb, skb_info_t *info) {
     u64 offset = (u64)info->data_off;
 
+#define BLK_SIZE (16)
+    const u32 iter = HTTP_BUFFER_SIZE / BLK_SIZE;
+    const u32 len = HTTP_BUFFER_SIZE < (skb->len - (u32)offset) ? (u32)offset + HTTP_BUFFER_SIZE : skb->len;
+
+    unsigned i = 0;
+
 #pragma unroll
-    for (int i = 0; i < HTTP_BUFFER_SIZE; i++) {
-        if (offset < skb->len) {
-            bpf_skb_load_bytes(skb, offset, &buffer[i], 1);
-        }
-        offset++;
+    for (; i < iter; i++) {
+        if (offset + BLK_SIZE - 1 >= len) break;
+
+        bpf_skb_load_bytes(skb, offset, &buffer[i * BLK_SIZE], BLK_SIZE);
+        offset += BLK_SIZE;
     }
+
+    void *buf = &buffer[i * BLK_SIZE];
+    if (offset + 14 < len)
+        bpf_skb_load_bytes(skb, offset, buf, 15);
+    else if (offset + 13 < len)
+        bpf_skb_load_bytes(skb, offset, buf, 14);
+    else if (offset + 12 < len)
+        bpf_skb_load_bytes(skb, offset, buf, 13);
+    else if (offset + 11 < len)
+        bpf_skb_load_bytes(skb, offset, buf, 12);
+    else if (offset + 10 < len)
+        bpf_skb_load_bytes(skb, offset, buf, 11);
+    else if (offset + 9 < len)
+        bpf_skb_load_bytes(skb, offset, buf, 10);
+    else if (offset + 8 < len)
+        bpf_skb_load_bytes(skb, offset, buf, 9);
+    else if (offset + 7 < len)
+        bpf_skb_load_bytes(skb, offset, buf, 8);
+    else if (offset + 6 < len)
+        bpf_skb_load_bytes(skb, offset, buf, 7);
+    else if (offset + 5 < len)
+        bpf_skb_load_bytes(skb, offset, buf, 6);
+    else if (offset + 4 < len)
+        bpf_skb_load_bytes(skb, offset, buf, 5);
+    else if (offset + 3 < len)
+        bpf_skb_load_bytes(skb, offset, buf, 4);
+    else if (offset + 2 < len)
+        bpf_skb_load_bytes(skb, offset, buf, 3);
+    else if (offset + 1 < len)
+        bpf_skb_load_bytes(skb, offset, buf, 2);
+    else if (offset < len)
+        bpf_skb_load_bytes(skb, offset, buf, 1);
 }
 
 SEC("socket/http_filter")

--- a/pkg/network/ebpf/c/runtime/http.c
+++ b/pkg/network/ebpf/c/runtime/http.c
@@ -37,7 +37,7 @@ static __always_inline void read_into_buffer_skb(char *buffer, struct __sk_buff*
     }
 
     // This part is very hard to write in a loop and unroll it.
-    // Indeed, mostly because of 4.4 verifier, we want to make sure the offset into the buffer is not
+    // Indeed, mostly because of older kernel verifiers, we want to make sure the offset into the buffer is not
     // stored on the stack, so that the verifier is able to verify that we're not doing out-of-bound on
     // the stack.
     // Basically, we should get a register from the code block above containing an fp relative address. As

--- a/pkg/network/ebpf/c/runtime/http.c
+++ b/pkg/network/ebpf/c/runtime/http.c
@@ -36,6 +36,13 @@ static __always_inline void read_into_buffer_skb(char *buffer, struct __sk_buff*
         offset += BLK_SIZE;
     }
 
+    // This part is very hard to write in a loop and unroll it.
+    // Indeed, mostly because of 4.4 verifier, we want to make sure the offset into the buffer is not
+    // stored on the stack, so that the verifier is able to verify that we're not doing out-of-bound on
+    // the stack.
+    // Basically, we should get a register from the code block above containing an fp relative address. As
+    // we are doing `buffer[0]` here, there is not dynamic computation on that said register after this,
+    // and thus the verifier is able to ensure that we are in-bound.
     void *buf = &buffer[i * BLK_SIZE];
     if (offset + 14 < len)
         bpf_skb_load_bytes(skb, offset, buf, 15);

--- a/pkg/network/http/model_test.go
+++ b/pkg/network/http/model_test.go
@@ -10,6 +10,7 @@ package http
 
 import (
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,14 +30,19 @@ func TestPath(t *testing.T) {
 }
 
 func TestMaximumLengthPath(t *testing.T) {
+	rep := strings.Repeat("a", HTTPBufferSize-6)
+	str := "GET /" + rep
+	str += "bc"
 	tx := httpTX{
 		request_fragment: requestFragment(
-			[]byte("GET /aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabc"),
+			[]byte(str),
 		),
 	}
 	b := make([]byte, HTTPBufferSize)
 	path, fullPath := tx.Path(b)
-	assert.Equal(t, "/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab", string(path))
+	expected := "/" + rep
+	expected = expected + "b"
+	assert.Equal(t, expected, string(path))
 	assert.False(t, fullPath)
 }
 


### PR DESCRIPTION
Signed-off-by: Paul Semel <paul.semel@datadoghq.com>

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This increases the HTTP_BUFFER_SIZE to 160 bytes. To do this, a few functions needed to be optimized to make sure we do not cross the instruction number limit.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Reading more means having a better HTTP correctness. Furthermore, some part of the code consumed a fairly big amount of instructions compared to what's available on older kernels. Decreasing this number will help:
- adding other features to the socket filter ebpf program
- increase the number of bytes that we read out of the skbuf

In addition to this, although it is hard to measure, it is very likely that it improves eBPF program performances. For instance, for the runtime compiled version, we're doing at most 10 calls (vs. 80 calls for the previous version). For the prebuilt one, we are doing at most 42 LD_ABS (vs. 80 as well) (but while increasing the buffer size).

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Behaviour remains, so ensuring data (http path for instance) is correct is enough.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
