### PR TITLE
[CWS] Fixing io_uring mkdir/rename/unlink/rmdir/link opcodes

### DIFF
--- a/docs/cloud-workload-security/agent_expressions.md
+++ b/docs/cloud-workload-security/agent_expressions.md
@@ -273,7 +273,7 @@ A BPF command was executed
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
-| `bpf.async` | int | True if the syscall was asynchronous |
+| `bpf.async` | bool | True if the syscall was asynchronous |
 | `bpf.cmd` | int | BPF command name |
 | `bpf.map.name` | string | Name of the eBPF map (added in 7.35) |
 | `bpf.map.type` | int | Type of the eBPF map |
@@ -299,7 +299,7 @@ A file’s permissions were changed
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
-| `chmod.async` | int | True if the syscall was asynchronous |
+| `chmod.async` | bool | True if the syscall was asynchronous |
 | `chmod.file.change_time` | int | Change time of the file |
 | `chmod.file.destination.mode` | int | New mode/rights of the chmod-ed file |
 | `chmod.file.destination.rights` | int | New mode/rights of the chmod-ed file |
@@ -324,7 +324,7 @@ A file’s owner was changed
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
-| `chown.async` | int | True if the syscall was asynchronous |
+| `chown.async` | bool | True if the syscall was asynchronous |
 | `chown.file.change_time` | int | Change time of the file |
 | `chown.file.destination.gid` | int | New GID of the chown-ed file's owner |
 | `chown.file.destination.group` | string | New group of the chown-ed file's owner |
@@ -415,7 +415,7 @@ Create a new name/alias for a file
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
-| `link.async` | int | True if the syscall was asynchronous |
+| `link.async` | bool | True if the syscall was asynchronous |
 | `link.file.change_time` | int | Change time of the file |
 | `link.file.destination.change_time` | int | Change time of the file |
 | `link.file.destination.filesystem` | string | File's filesystem |
@@ -452,7 +452,7 @@ A new kernel module was loaded
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
-| `load_module.async` | int | True if the syscall was asynchronous |
+| `load_module.async` | bool | True if the syscall was asynchronous |
 | `load_module.file.change_time` | int | Change time of the file |
 | `load_module.file.filesystem` | string | File's filesystem |
 | `load_module.file.gid` | int | GID of the file's owner |
@@ -477,7 +477,7 @@ A directory was created
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
-| `mkdir.async` | int | True if the syscall was asynchronous |
+| `mkdir.async` | bool | True if the syscall was asynchronous |
 | `mkdir.file.change_time` | int | Change time of the file |
 | `mkdir.file.destination.mode` | int | Mode/rights of the new directory |
 | `mkdir.file.destination.rights` | int | Mode/rights of the new directory |
@@ -502,7 +502,7 @@ A mmap command was executed
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
-| `mmap.async` | int | True if the syscall was asynchronous |
+| `mmap.async` | bool | True if the syscall was asynchronous |
 | `mmap.file.change_time` | int | Change time of the file |
 | `mmap.file.filesystem` | string | File's filesystem |
 | `mmap.file.gid` | int | GID of the file's owner |
@@ -527,7 +527,7 @@ A mprotect command was executed
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
-| `mprotect.async` | int | True if the syscall was asynchronous |
+| `mprotect.async` | bool | True if the syscall was asynchronous |
 | `mprotect.req_protection` | int | new memory segment protection |
 | `mprotect.retval` | int | Return value of the syscall |
 | `mprotect.vm_protection` | int | initial memory segment protection |
@@ -538,7 +538,7 @@ A file was opened
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
-| `open.async` | int | True if the syscall was asynchronous |
+| `open.async` | bool | True if the syscall was asynchronous |
 | `open.file.change_time` | int | Change time of the file |
 | `open.file.destination.mode` | int | Mode of the created file |
 | `open.file.filesystem` | string | File's filesystem |
@@ -563,7 +563,7 @@ A ptrace command was executed
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
-| `ptrace.async` | int | True if the syscall was asynchronous |
+| `ptrace.async` | bool | True if the syscall was asynchronous |
 | `ptrace.request` | int | ptrace request |
 | `ptrace.retval` | int | Return value of the syscall |
 | `ptrace.tracee.ancestors.args` | string | Arguments of the process (as a string) |
@@ -663,7 +663,7 @@ Remove extended attributes
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
-| `removexattr.async` | int | True if the syscall was asynchronous |
+| `removexattr.async` | bool | True if the syscall was asynchronous |
 | `removexattr.file.change_time` | int | Change time of the file |
 | `removexattr.file.destination.name` | string | Name of the extended attribute |
 | `removexattr.file.destination.namespace` | string | Namespace of the extended attribute |
@@ -688,7 +688,7 @@ A file/directory was renamed
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
-| `rename.async` | int | True if the syscall was asynchronous |
+| `rename.async` | bool | True if the syscall was asynchronous |
 | `rename.file.change_time` | int | Change time of the file |
 | `rename.file.destination.change_time` | int | Change time of the file |
 | `rename.file.destination.filesystem` | string | File's filesystem |
@@ -725,7 +725,7 @@ A directory was removed
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
-| `rmdir.async` | int | True if the syscall was asynchronous |
+| `rmdir.async` | bool | True if the syscall was asynchronous |
 | `rmdir.file.change_time` | int | Change time of the file |
 | `rmdir.file.filesystem` | string | File's filesystem |
 | `rmdir.file.gid` | int | GID of the file's owner |
@@ -785,7 +785,7 @@ Set exteneded attributes
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
-| `setxattr.async` | int | True if the syscall was asynchronous |
+| `setxattr.async` | bool | True if the syscall was asynchronous |
 | `setxattr.file.change_time` | int | Change time of the file |
 | `setxattr.file.destination.name` | string | Name of the extended attribute |
 | `setxattr.file.destination.namespace` | string | Namespace of the extended attribute |
@@ -810,7 +810,7 @@ A signal was sent
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
-| `signal.async` | int | True if the syscall was asynchronous |
+| `signal.async` | bool | True if the syscall was asynchronous |
 | `signal.pid` | int | Target PID |
 | `signal.retval` | int | Return value of the syscall |
 | `signal.target.ancestors.args` | string | Arguments of the process (as a string) |
@@ -911,7 +911,7 @@ A splice command was executed
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
-| `splice.async` | int | True if the syscall was asynchronous |
+| `splice.async` | bool | True if the syscall was asynchronous |
 | `splice.file.change_time` | int | Change time of the file |
 | `splice.file.filesystem` | string | File's filesystem |
 | `splice.file.gid` | int | GID of the file's owner |
@@ -936,7 +936,7 @@ A file was deleted
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
-| `unlink.async` | int | True if the syscall was asynchronous |
+| `unlink.async` | bool | True if the syscall was asynchronous |
 | `unlink.file.change_time` | int | Change time of the file |
 | `unlink.file.filesystem` | string | File's filesystem |
 | `unlink.file.gid` | int | GID of the file's owner |
@@ -959,7 +959,7 @@ A kernel module was deleted
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
-| `unload_module.async` | int | True if the syscall was asynchronous |
+| `unload_module.async` | bool | True if the syscall was asynchronous |
 | `unload_module.name` | string | Name of the kernel module that was deleted |
 | `unload_module.retval` | int | Return value of the syscall |
 
@@ -969,7 +969,7 @@ Change file access/modification times
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
-| `utimes.async` | int | True if the syscall was asynchronous |
+| `utimes.async` | bool | True if the syscall was asynchronous |
 | `utimes.file.change_time` | int | Change time of the file |
 | `utimes.file.filesystem` | string | File's filesystem |
 | `utimes.file.gid` | int | GID of the file's owner |

--- a/docs/cloud-workload-security/agent_expressions.md
+++ b/docs/cloud-workload-security/agent_expressions.md
@@ -273,6 +273,7 @@ A BPF command was executed
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
+| `bpf.async` | int | True if the syscall was asynchronous |
 | `bpf.cmd` | int | BPF command name |
 | `bpf.map.name` | string | Name of the eBPF map (added in 7.35) |
 | `bpf.map.type` | int | Type of the eBPF map |
@@ -298,6 +299,7 @@ A file’s permissions were changed
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
+| `chmod.async` | int | True if the syscall was asynchronous |
 | `chmod.file.change_time` | int | Change time of the file |
 | `chmod.file.destination.mode` | int | New mode/rights of the chmod-ed file |
 | `chmod.file.destination.rights` | int | New mode/rights of the chmod-ed file |
@@ -322,6 +324,7 @@ A file’s owner was changed
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
+| `chown.async` | int | True if the syscall was asynchronous |
 | `chown.file.change_time` | int | Change time of the file |
 | `chown.file.destination.gid` | int | New GID of the chown-ed file's owner |
 | `chown.file.destination.group` | string | New group of the chown-ed file's owner |
@@ -412,6 +415,7 @@ Create a new name/alias for a file
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
+| `link.async` | int | True if the syscall was asynchronous |
 | `link.file.change_time` | int | Change time of the file |
 | `link.file.destination.change_time` | int | Change time of the file |
 | `link.file.destination.filesystem` | string | File's filesystem |
@@ -448,6 +452,7 @@ A new kernel module was loaded
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
+| `load_module.async` | int | True if the syscall was asynchronous |
 | `load_module.file.change_time` | int | Change time of the file |
 | `load_module.file.filesystem` | string | File's filesystem |
 | `load_module.file.gid` | int | GID of the file's owner |
@@ -472,6 +477,7 @@ A directory was created
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
+| `mkdir.async` | int | True if the syscall was asynchronous |
 | `mkdir.file.change_time` | int | Change time of the file |
 | `mkdir.file.destination.mode` | int | Mode/rights of the new directory |
 | `mkdir.file.destination.rights` | int | Mode/rights of the new directory |
@@ -496,6 +502,7 @@ A mmap command was executed
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
+| `mmap.async` | int | True if the syscall was asynchronous |
 | `mmap.file.change_time` | int | Change time of the file |
 | `mmap.file.filesystem` | string | File's filesystem |
 | `mmap.file.gid` | int | GID of the file's owner |
@@ -520,6 +527,7 @@ A mprotect command was executed
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
+| `mprotect.async` | int | True if the syscall was asynchronous |
 | `mprotect.req_protection` | int | new memory segment protection |
 | `mprotect.retval` | int | Return value of the syscall |
 | `mprotect.vm_protection` | int | initial memory segment protection |
@@ -530,6 +538,7 @@ A file was opened
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
+| `open.async` | int | True if the syscall was asynchronous |
 | `open.file.change_time` | int | Change time of the file |
 | `open.file.destination.mode` | int | Mode of the created file |
 | `open.file.filesystem` | string | File's filesystem |
@@ -554,6 +563,7 @@ A ptrace command was executed
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
+| `ptrace.async` | int | True if the syscall was asynchronous |
 | `ptrace.request` | int | ptrace request |
 | `ptrace.retval` | int | Return value of the syscall |
 | `ptrace.tracee.ancestors.args` | string | Arguments of the process (as a string) |
@@ -653,6 +663,7 @@ Remove extended attributes
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
+| `removexattr.async` | int | True if the syscall was asynchronous |
 | `removexattr.file.change_time` | int | Change time of the file |
 | `removexattr.file.destination.name` | string | Name of the extended attribute |
 | `removexattr.file.destination.namespace` | string | Namespace of the extended attribute |
@@ -677,6 +688,7 @@ A file/directory was renamed
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
+| `rename.async` | int | True if the syscall was asynchronous |
 | `rename.file.change_time` | int | Change time of the file |
 | `rename.file.destination.change_time` | int | Change time of the file |
 | `rename.file.destination.filesystem` | string | File's filesystem |
@@ -713,6 +725,7 @@ A directory was removed
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
+| `rmdir.async` | int | True if the syscall was asynchronous |
 | `rmdir.file.change_time` | int | Change time of the file |
 | `rmdir.file.filesystem` | string | File's filesystem |
 | `rmdir.file.gid` | int | GID of the file's owner |
@@ -772,6 +785,7 @@ Set exteneded attributes
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
+| `setxattr.async` | int | True if the syscall was asynchronous |
 | `setxattr.file.change_time` | int | Change time of the file |
 | `setxattr.file.destination.name` | string | Name of the extended attribute |
 | `setxattr.file.destination.namespace` | string | Namespace of the extended attribute |
@@ -796,6 +810,7 @@ A signal was sent
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
+| `signal.async` | int | True if the syscall was asynchronous |
 | `signal.pid` | int | Target PID |
 | `signal.retval` | int | Return value of the syscall |
 | `signal.target.ancestors.args` | string | Arguments of the process (as a string) |
@@ -896,6 +911,7 @@ A splice command was executed
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
+| `splice.async` | int | True if the syscall was asynchronous |
 | `splice.file.change_time` | int | Change time of the file |
 | `splice.file.filesystem` | string | File's filesystem |
 | `splice.file.gid` | int | GID of the file's owner |
@@ -920,6 +936,7 @@ A file was deleted
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
+| `unlink.async` | int | True if the syscall was asynchronous |
 | `unlink.file.change_time` | int | Change time of the file |
 | `unlink.file.filesystem` | string | File's filesystem |
 | `unlink.file.gid` | int | GID of the file's owner |
@@ -942,6 +959,7 @@ A kernel module was deleted
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
+| `unload_module.async` | int | True if the syscall was asynchronous |
 | `unload_module.name` | string | Name of the kernel module that was deleted |
 | `unload_module.retval` | int | Return value of the syscall |
 
@@ -951,6 +969,7 @@ Change file access/modification times
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
+| `utimes.async` | int | True if the syscall was asynchronous |
 | `utimes.file.change_time` | int | Change time of the file |
 | `utimes.file.filesystem` | string | File's filesystem |
 | `utimes.file.gid` | int | GID of the file's owner |

--- a/docs/cloud-workload-security/backend.md
+++ b/docs/cloud-workload-security/backend.md
@@ -343,9 +343,6 @@ CWS logs have the following JSON schema:
 
 {{< code-block lang="json" collapsible="true" >}}
 {
-    "required": [
-        "async"
-    ],
     "properties": {
         "name": {
             "type": "string",

--- a/docs/cloud-workload-security/backend.md
+++ b/docs/cloud-workload-security/backend.md
@@ -343,6 +343,9 @@ CWS logs have the following JSON schema:
 
 {{< code-block lang="json" collapsible="true" >}}
 {
+    "required": [
+        "async"
+    ],
     "properties": {
         "name": {
             "type": "string",
@@ -355,6 +358,10 @@ CWS logs have the following JSON schema:
         "outcome": {
             "type": "string",
             "description": "Event outcome"
+        },
+        "async": {
+            "type": "boolean",
+            "description": "True if the event was asynchronous"
         }
     },
     "additionalProperties": false,
@@ -368,6 +375,7 @@ CWS logs have the following JSON schema:
 | `name` | Event name |
 | `category` | Event category |
 | `outcome` | Event outcome |
+| `async` | True if the event was asynchronous |
 
 
 ## `File`

--- a/docs/cloud-workload-security/backend.schema.json
+++ b/docs/cloud-workload-security/backend.schema.json
@@ -213,9 +213,6 @@
       "type": "object"
     },
     "EventContext": {
-      "required": [
-        "async"
-      ],
       "properties": {
         "name": {
           "type": "string",

--- a/docs/cloud-workload-security/backend.schema.json
+++ b/docs/cloud-workload-security/backend.schema.json
@@ -213,6 +213,9 @@
       "type": "object"
     },
     "EventContext": {
+      "required": [
+        "async"
+      ],
       "properties": {
         "name": {
           "type": "string",
@@ -225,6 +228,10 @@
         "outcome": {
           "type": "string",
           "description": "Event outcome"
+        },
+        "async": {
+          "type": "boolean",
+          "description": "True if the event was asynchronous"
         }
       },
       "additionalProperties": false,

--- a/docs/cloud-workload-security/secl.json
+++ b/docs/cloud-workload-security/secl.json
@@ -522,6 +522,11 @@
       "experimental": false,
       "properties": [
         {
+          "name": "bpf.async",
+          "type": "int",
+          "definition": "True if the syscall was asynchronous"
+        },
+        {
           "name": "bpf.cmd",
           "type": "int",
           "definition": "BPF command name"
@@ -594,6 +599,11 @@
       "from_agent_version": "7.27",
       "experimental": false,
       "properties": [
+        {
+          "name": "chmod.async",
+          "type": "int",
+          "definition": "True if the syscall was asynchronous"
+        },
         {
           "name": "chmod.file.change_time",
           "type": "int",
@@ -688,6 +698,11 @@
       "from_agent_version": "7.27",
       "experimental": false,
       "properties": [
+        {
+          "name": "chown.async",
+          "type": "int",
+          "definition": "True if the syscall was asynchronous"
+        },
         {
           "name": "chown.file.change_time",
           "type": "int",
@@ -1061,6 +1076,11 @@
       "experimental": false,
       "properties": [
         {
+          "name": "link.async",
+          "type": "int",
+          "definition": "True if the syscall was asynchronous"
+        },
+        {
           "name": "link.file.change_time",
           "type": "int",
           "definition": "Change time of the file"
@@ -1215,6 +1235,11 @@
       "experimental": false,
       "properties": [
         {
+          "name": "load_module.async",
+          "type": "int",
+          "definition": "True if the syscall was asynchronous"
+        },
+        {
           "name": "load_module.file.change_time",
           "type": "int",
           "definition": "Change time of the file"
@@ -1308,6 +1333,11 @@
       "from_agent_version": "7.27",
       "experimental": false,
       "properties": [
+        {
+          "name": "mkdir.async",
+          "type": "int",
+          "definition": "True if the syscall was asynchronous"
+        },
         {
           "name": "mkdir.file.change_time",
           "type": "int",
@@ -1403,6 +1433,11 @@
       "experimental": false,
       "properties": [
         {
+          "name": "mmap.async",
+          "type": "int",
+          "definition": "True if the syscall was asynchronous"
+        },
+        {
           "name": "mmap.file.change_time",
           "type": "int",
           "definition": "Change time of the file"
@@ -1497,6 +1532,11 @@
       "experimental": false,
       "properties": [
         {
+          "name": "mprotect.async",
+          "type": "int",
+          "definition": "True if the syscall was asynchronous"
+        },
+        {
           "name": "mprotect.req_protection",
           "type": "int",
           "definition": "new memory segment protection"
@@ -1520,6 +1560,11 @@
       "from_agent_version": "7.27",
       "experimental": false,
       "properties": [
+        {
+          "name": "open.async",
+          "type": "int",
+          "definition": "True if the syscall was asynchronous"
+        },
         {
           "name": "open.file.change_time",
           "type": "int",
@@ -1614,6 +1659,11 @@
       "from_agent_version": "7.35",
       "experimental": false,
       "properties": [
+        {
+          "name": "ptrace.async",
+          "type": "int",
+          "definition": "True if the syscall was asynchronous"
+        },
         {
           "name": "ptrace.request",
           "type": "int",
@@ -2084,6 +2134,11 @@
       "experimental": false,
       "properties": [
         {
+          "name": "removexattr.async",
+          "type": "int",
+          "definition": "True if the syscall was asynchronous"
+        },
+        {
           "name": "removexattr.file.change_time",
           "type": "int",
           "definition": "Change time of the file"
@@ -2177,6 +2232,11 @@
       "from_agent_version": "7.27",
       "experimental": false,
       "properties": [
+        {
+          "name": "rename.async",
+          "type": "int",
+          "definition": "True if the syscall was asynchronous"
+        },
         {
           "name": "rename.file.change_time",
           "type": "int",
@@ -2331,6 +2391,11 @@
       "from_agent_version": "7.27",
       "experimental": false,
       "properties": [
+        {
+          "name": "rmdir.async",
+          "type": "int",
+          "definition": "True if the syscall was asynchronous"
+        },
         {
           "name": "rmdir.file.change_time",
           "type": "int",
@@ -2523,6 +2588,11 @@
       "experimental": false,
       "properties": [
         {
+          "name": "setxattr.async",
+          "type": "int",
+          "definition": "True if the syscall was asynchronous"
+        },
+        {
           "name": "setxattr.file.change_time",
           "type": "int",
           "definition": "Change time of the file"
@@ -2616,6 +2686,11 @@
       "from_agent_version": "7.35",
       "experimental": false,
       "properties": [
+        {
+          "name": "signal.async",
+          "type": "int",
+          "definition": "True if the syscall was asynchronous"
+        },
         {
           "name": "signal.pid",
           "type": "int",
@@ -3091,6 +3166,11 @@
       "experimental": false,
       "properties": [
         {
+          "name": "splice.async",
+          "type": "int",
+          "definition": "True if the syscall was asynchronous"
+        },
+        {
           "name": "splice.file.change_time",
           "type": "int",
           "definition": "Change time of the file"
@@ -3185,6 +3265,11 @@
       "experimental": false,
       "properties": [
         {
+          "name": "unlink.async",
+          "type": "int",
+          "definition": "True if the syscall was asynchronous"
+        },
+        {
           "name": "unlink.file.change_time",
           "type": "int",
           "definition": "Change time of the file"
@@ -3269,6 +3354,11 @@
       "experimental": false,
       "properties": [
         {
+          "name": "unload_module.async",
+          "type": "int",
+          "definition": "True if the syscall was asynchronous"
+        },
+        {
           "name": "unload_module.name",
           "type": "string",
           "definition": "Name of the kernel module that was deleted"
@@ -3287,6 +3377,11 @@
       "from_agent_version": "7.27",
       "experimental": false,
       "properties": [
+        {
+          "name": "utimes.async",
+          "type": "int",
+          "definition": "True if the syscall was asynchronous"
+        },
         {
           "name": "utimes.file.change_time",
           "type": "int",

--- a/docs/cloud-workload-security/secl.json
+++ b/docs/cloud-workload-security/secl.json
@@ -523,7 +523,7 @@
       "properties": [
         {
           "name": "bpf.async",
-          "type": "int",
+          "type": "bool",
           "definition": "True if the syscall was asynchronous"
         },
         {
@@ -601,7 +601,7 @@
       "properties": [
         {
           "name": "chmod.async",
-          "type": "int",
+          "type": "bool",
           "definition": "True if the syscall was asynchronous"
         },
         {
@@ -700,7 +700,7 @@
       "properties": [
         {
           "name": "chown.async",
-          "type": "int",
+          "type": "bool",
           "definition": "True if the syscall was asynchronous"
         },
         {
@@ -1077,7 +1077,7 @@
       "properties": [
         {
           "name": "link.async",
-          "type": "int",
+          "type": "bool",
           "definition": "True if the syscall was asynchronous"
         },
         {
@@ -1236,7 +1236,7 @@
       "properties": [
         {
           "name": "load_module.async",
-          "type": "int",
+          "type": "bool",
           "definition": "True if the syscall was asynchronous"
         },
         {
@@ -1335,7 +1335,7 @@
       "properties": [
         {
           "name": "mkdir.async",
-          "type": "int",
+          "type": "bool",
           "definition": "True if the syscall was asynchronous"
         },
         {
@@ -1434,7 +1434,7 @@
       "properties": [
         {
           "name": "mmap.async",
-          "type": "int",
+          "type": "bool",
           "definition": "True if the syscall was asynchronous"
         },
         {
@@ -1533,7 +1533,7 @@
       "properties": [
         {
           "name": "mprotect.async",
-          "type": "int",
+          "type": "bool",
           "definition": "True if the syscall was asynchronous"
         },
         {
@@ -1562,7 +1562,7 @@
       "properties": [
         {
           "name": "open.async",
-          "type": "int",
+          "type": "bool",
           "definition": "True if the syscall was asynchronous"
         },
         {
@@ -1661,7 +1661,7 @@
       "properties": [
         {
           "name": "ptrace.async",
-          "type": "int",
+          "type": "bool",
           "definition": "True if the syscall was asynchronous"
         },
         {
@@ -2135,7 +2135,7 @@
       "properties": [
         {
           "name": "removexattr.async",
-          "type": "int",
+          "type": "bool",
           "definition": "True if the syscall was asynchronous"
         },
         {
@@ -2234,7 +2234,7 @@
       "properties": [
         {
           "name": "rename.async",
-          "type": "int",
+          "type": "bool",
           "definition": "True if the syscall was asynchronous"
         },
         {
@@ -2393,7 +2393,7 @@
       "properties": [
         {
           "name": "rmdir.async",
-          "type": "int",
+          "type": "bool",
           "definition": "True if the syscall was asynchronous"
         },
         {
@@ -2589,7 +2589,7 @@
       "properties": [
         {
           "name": "setxattr.async",
-          "type": "int",
+          "type": "bool",
           "definition": "True if the syscall was asynchronous"
         },
         {
@@ -2688,7 +2688,7 @@
       "properties": [
         {
           "name": "signal.async",
-          "type": "int",
+          "type": "bool",
           "definition": "True if the syscall was asynchronous"
         },
         {
@@ -3167,7 +3167,7 @@
       "properties": [
         {
           "name": "splice.async",
-          "type": "int",
+          "type": "bool",
           "definition": "True if the syscall was asynchronous"
         },
         {
@@ -3266,7 +3266,7 @@
       "properties": [
         {
           "name": "unlink.async",
-          "type": "int",
+          "type": "bool",
           "definition": "True if the syscall was asynchronous"
         },
         {
@@ -3355,7 +3355,7 @@
       "properties": [
         {
           "name": "unload_module.async",
-          "type": "int",
+          "type": "bool",
           "definition": "True if the syscall was asynchronous"
         },
         {
@@ -3379,7 +3379,7 @@
       "properties": [
         {
           "name": "utimes.async",
-          "type": "int",
+          "type": "bool",
           "definition": "True if the syscall was asynchronous"
         },
         {

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,6 @@ replace (
 	github.com/coreos/go-systemd => github.com/coreos/go-systemd v0.0.0-20180202092358-40e2722dffea
 	github.com/docker/distribution => github.com/docker/distribution v2.8.0+incompatible
 	github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.1
-	github.com/iceber/iouring-go => github.com/spikat/iouring-go v0.0.0-20220505140047-5250ffd43c76
 	github.com/lxn/walk => github.com/lxn/walk v0.0.0-20180521183810-02935bac0ab8
 	github.com/mholt/archiver => github.com/mholt/archiver v2.0.1-0.20171012052341-26cf5bb32d07+incompatible
 	github.com/spf13/cast => github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3
@@ -131,7 +130,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/hectane/go-acl v0.0.0-20190604041725-da78bae5fc95
-	github.com/iceber/iouring-go v0.0.0-20210726032807-b073cc83b2b8
+	github.com/iceber/iouring-go v0.0.0-20220511091803-99712053f7ec
 	github.com/imdario/mergo v0.3.12
 	github.com/iovisor/gobpf v0.2.0
 	github.com/itchyny/gojq v0.12.7

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ replace (
 	github.com/coreos/go-systemd => github.com/coreos/go-systemd v0.0.0-20180202092358-40e2722dffea
 	github.com/docker/distribution => github.com/docker/distribution v2.8.0+incompatible
 	github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.1
+	github.com/iceber/iouring-go => github.com/spikat/iouring-go v0.0.0-20220505140047-5250ffd43c76
 	github.com/lxn/walk => github.com/lxn/walk v0.0.0-20180521183810-02935bac0ab8
 	github.com/mholt/archiver => github.com/mholt/archiver v2.0.1-0.20171012052341-26cf5bb32d07+incompatible
 	github.com/spf13/cast => github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3

--- a/go.sum
+++ b/go.sum
@@ -1003,6 +1003,8 @@ github.com/ianlancetaylor/cgosymbolizer v0.0.0-20201204192058-7acc97e53614/go.mo
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639 h1:mV02weKRL81bEnm8A0HT1/CAelMQDBuQIfLw8n+d6xI=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/iceber/iouring-go v0.0.0-20220511091803-99712053f7ec h1:2GZMXHuaYOUFqvB3MFDsOxtuNTSCVBL+yptA99ASdvU=
+github.com/iceber/iouring-go v0.0.0-20220511091803-99712053f7ec/go.mod h1:LEzdaZarZ5aqROlLIwJ4P7h3+4o71008fSy6wpaEB+s=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
@@ -1639,8 +1641,6 @@ github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DM
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/spf13/viper v1.6.2/go.mod h1:t3iDnF5Jlj76alVNuyFBk5oUMCvsrkbvZK0WQdfDi5k=
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
-github.com/spikat/iouring-go v0.0.0-20220505140047-5250ffd43c76 h1:oKQMVSzayDXEVWekxVIuMXf9vE7ivwZYDxsrSzZYhBM=
-github.com/spikat/iouring-go v0.0.0-20220505140047-5250ffd43c76/go.mod h1:LEzdaZarZ5aqROlLIwJ4P7h3+4o71008fSy6wpaEB+s=
 github.com/square/certstrap v1.2.0 h1:ecgyABrbFLr8jSbOC6oTBmBek0t/HqtgrMUZCPuyfdw=
 github.com/square/certstrap v1.2.0/go.mod h1:CUHqV+fxJW0Y5UQFnnbYwQ7bpKXO1AKbic9g73799yw=
 github.com/stefanberger/go-pkcs11uri v0.0.0-20201008174630-78d3cae3a980/go.mod h1:AO3tvPzVZ/ayst6UlUKUv6rcPQInYe3IknH3jYhAKu8=

--- a/go.sum
+++ b/go.sum
@@ -1003,8 +1003,6 @@ github.com/ianlancetaylor/cgosymbolizer v0.0.0-20201204192058-7acc97e53614/go.mo
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639 h1:mV02weKRL81bEnm8A0HT1/CAelMQDBuQIfLw8n+d6xI=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
-github.com/iceber/iouring-go v0.0.0-20210726032807-b073cc83b2b8 h1:OwV7phffPbNO1q8WRkO0yIlwCJUE5uV8vIuWYP7iUJM=
-github.com/iceber/iouring-go v0.0.0-20210726032807-b073cc83b2b8/go.mod h1:LEzdaZarZ5aqROlLIwJ4P7h3+4o71008fSy6wpaEB+s=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
@@ -1641,6 +1639,8 @@ github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DM
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/spf13/viper v1.6.2/go.mod h1:t3iDnF5Jlj76alVNuyFBk5oUMCvsrkbvZK0WQdfDi5k=
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
+github.com/spikat/iouring-go v0.0.0-20220505140047-5250ffd43c76 h1:oKQMVSzayDXEVWekxVIuMXf9vE7ivwZYDxsrSzZYhBM=
+github.com/spikat/iouring-go v0.0.0-20220505140047-5250ffd43c76/go.mod h1:LEzdaZarZ5aqROlLIwJ4P7h3+4o71008fSy6wpaEB+s=
 github.com/square/certstrap v1.2.0 h1:ecgyABrbFLr8jSbOC6oTBmBek0t/HqtgrMUZCPuyfdw=
 github.com/square/certstrap v1.2.0/go.mod h1:CUHqV+fxJW0Y5UQFnnbYwQ7bpKXO1AKbic9g73799yw=
 github.com/stefanberger/go-pkcs11uri v0.0.0-20201008174630-78d3cae3a980/go.mod h1:AO3tvPzVZ/ayst6UlUKUv6rcPQInYe3IknH3jYhAKu8=

--- a/pkg/security/ebpf/c/bpf.h
+++ b/pkg/security/ebpf/c/bpf.h
@@ -276,6 +276,7 @@ __attribute__((always_inline)) void fill_from_syscall_args(struct syscall_cache_
 __attribute__((always_inline)) void send_bpf_event(void *ctx, struct syscall_cache_t *syscall) {
     struct bpf_event_t event = {
         .syscall.retval = syscall->bpf.retval,
+        .syscall.async = 0,
         .cmd = syscall->bpf.cmd,
     };
 

--- a/pkg/security/ebpf/c/chmod.h
+++ b/pkg/security/ebpf/c/chmod.h
@@ -61,6 +61,7 @@ int __attribute__((always_inline)) sys_chmod_ret(void *ctx, int retval) {
 
     struct chmod_event_t event = {
         .syscall.retval = retval,
+        .syscall.async = 0,
         .file = syscall->setattr.file,
         .padding = 0,
         .mode = syscall->setattr.mode,

--- a/pkg/security/ebpf/c/chown.h
+++ b/pkg/security/ebpf/c/chown.h
@@ -78,6 +78,7 @@ int __attribute__((always_inline)) sys_chown_ret(void *ctx, int retval) {
 
     struct chown_event_t event = {
         .syscall.retval = retval,
+        .syscall.async = 0,
         .file = syscall->setattr.file,
         .uid = syscall->setattr.user,
         .gid = syscall->setattr.group,

--- a/pkg/security/ebpf/c/defs.h
+++ b/pkg/security/ebpf/c/defs.h
@@ -239,6 +239,7 @@ struct kevent_t {
 
 struct syscall_t {
     s64 retval;
+    u64 async;
 };
 
 struct span_context_t {

--- a/pkg/security/ebpf/c/defs.h
+++ b/pkg/security/ebpf/c/defs.h
@@ -239,7 +239,7 @@ struct kevent_t {
 
 struct syscall_t {
     s64 retval;
-    u64 async;
+    u64 async; /* TODO: optimize the way we retrieve the async boolean */
 };
 
 struct span_context_t {

--- a/pkg/security/ebpf/c/link.h
+++ b/pkg/security/ebpf/c/link.h
@@ -18,7 +18,7 @@ int __attribute__((always_inline)) link_approvers(struct syscall_cache_t *syscal
            basename_approver(syscall, syscall->link.target_dentry, EVENT_LINK);
 }
 
-int __attribute__((always_inline)) trace__sys_link() {
+int __attribute__((always_inline)) trace__sys_link(u8 async) {
     struct policy_t policy = fetch_policy(EVENT_LINK);
     if (is_discarded_by_process(policy.mode, EVENT_LINK)) {
         return 0;
@@ -27,6 +27,7 @@ int __attribute__((always_inline)) trace__sys_link() {
     struct syscall_cache_t syscall = {
         .type = EVENT_LINK,
         .policy = policy,
+        .async = async,
     };
 
     cache_syscall(&syscall);
@@ -35,16 +36,20 @@ int __attribute__((always_inline)) trace__sys_link() {
 }
 
 SYSCALL_KPROBE0(link) {
-    return trace__sys_link();
+    return trace__sys_link(SYNC_SYSCALL);
 }
 
 SYSCALL_KPROBE0(linkat) {
-    return trace__sys_link();
+    return trace__sys_link(SYNC_SYSCALL);
 }
 
 SEC("kprobe/do_linkat")
 int kprobe_do_linkat(struct pt_regs *ctx) {
-    return trace__sys_link();
+    struct syscall_cache_t* syscall = peek_syscall(EVENT_LINK);
+    if (!syscall) {
+        return trace__sys_link(ASYNC_SYSCALL);
+    }
+    return 0;
 }
 
 SEC("kprobe/vfs_link")
@@ -196,6 +201,7 @@ int __attribute__((always_inline)) dr_link_dst_callback(void *ctx, int retval) {
         .event.type = EVENT_LINK,
         .event.timestamp = bpf_ktime_get_ns(),
         .syscall.retval = retval,
+        .syscall.async = (u64)syscall->async,
         .source = syscall->link.src_file,
         .target = syscall->link.target_file,
     };

--- a/pkg/security/ebpf/c/link.h
+++ b/pkg/security/ebpf/c/link.h
@@ -42,6 +42,11 @@ SYSCALL_KPROBE0(linkat) {
     return trace__sys_link();
 }
 
+SEC("kprobe/do_linkat")
+int kprobe_do_linkat(struct pt_regs *ctx) {
+    return trace__sys_link();
+}
+
 SEC("kprobe/vfs_link")
 int kprobe_vfs_link(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_LINK);
@@ -141,6 +146,12 @@ int __attribute__((always_inline)) sys_link_ret(void *ctx, int retval, int dr_ty
     // if the tail call fails, we need to pop the syscall cache entry
     pop_syscall(EVENT_LINK);
     return 0;
+}
+
+SEC("kretprobe/do_linkat")
+int kretprobe_do_linkat(struct pt_regs *ctx) {
+    int retval = PT_REGS_RC(ctx);
+    return sys_link_ret(ctx, retval, DR_KPROBE);
 }
 
 int __attribute__((always_inline)) kprobe_sys_link_ret(struct pt_regs *ctx) {

--- a/pkg/security/ebpf/c/mkdir.h
+++ b/pkg/security/ebpf/c/mkdir.h
@@ -18,7 +18,7 @@ int __attribute__((always_inline)) mkdir_approvers(struct syscall_cache_t *sysca
     return basename_approver(syscall, syscall->mkdir.dentry, EVENT_MKDIR);
 }
 
-long __attribute__((always_inline)) trace__sys_mkdir(umode_t mode) {
+long __attribute__((always_inline)) trace__sys_mkdir(u8 async, umode_t mode) {
     struct policy_t policy = fetch_policy(EVENT_MKDIR);
     if (is_discarded_by_process(policy.mode, EVENT_MKDIR)) {
         return 0;
@@ -27,6 +27,7 @@ long __attribute__((always_inline)) trace__sys_mkdir(umode_t mode) {
     struct syscall_cache_t syscall = {
         .type = EVENT_MKDIR,
         .policy = policy,
+        .async = async,
         .mkdir = {
             .mode = mode
         }
@@ -39,12 +40,12 @@ long __attribute__((always_inline)) trace__sys_mkdir(umode_t mode) {
 
 SYSCALL_KPROBE2(mkdir, const char*, filename, umode_t, mode)
 {
-    return trace__sys_mkdir(mode);
+    return trace__sys_mkdir(SYNC_SYSCALL, mode);
 }
 
 SYSCALL_KPROBE3(mkdirat, int, dirfd, const char*, filename, umode_t, mode)
 {
-    return trace__sys_mkdir(mode);
+    return trace__sys_mkdir(SYNC_SYSCALL, mode);
 }
 
 SEC("kprobe/vfs_mkdir")
@@ -104,8 +105,12 @@ int __attribute__((always_inline)) sys_mkdir_ret(void *ctx, int retval, int dr_t
 
 SEC("kprobe/do_mkdirat")
 int kprobe_do_mkdirat(struct pt_regs *ctx) {
-    umode_t mode = (umode_t)PT_REGS_PARM3(ctx);
-    return trace__sys_mkdir(mode);
+    struct syscall_cache_t *syscall = peek_syscall(EVENT_MKDIR);
+    if (!syscall) {
+        umode_t mode = (umode_t)PT_REGS_PARM3(ctx);
+        return trace__sys_mkdir(ASYNC_SYSCALL, mode);
+    }
+    return 0;
 }
 
 SEC("kretprobe/do_mkdirat")
@@ -160,6 +165,7 @@ int __attribute__((always_inline)) dr_mkdir_callback(void *ctx, int retval) {
 
     struct mkdir_event_t event = {
         .syscall.retval = retval,
+        .syscall.async = (u64)syscall->async,
         .file = syscall->mkdir.file,
         .mode = syscall->mkdir.mode,
     };

--- a/pkg/security/ebpf/c/mmap.h
+++ b/pkg/security/ebpf/c/mmap.h
@@ -127,6 +127,7 @@ int __attribute__((always_inline)) sys_mmap_ret(void *ctx, int retval, u64 addr)
 
     struct mmap_event_t event = {
         .syscall.retval = retval,
+        .syscall.async = 0,
         .file = syscall->mmap.file,
         .addr = addr,
         .offset = syscall->mmap.offset,

--- a/pkg/security/ebpf/c/module.h
+++ b/pkg/security/ebpf/c/module.h
@@ -101,6 +101,7 @@ int __attribute__((always_inline)) trace_init_module_ret(void *ctx, int retval) 
 
     struct init_module_event_t event = {
         .syscall.retval = retval,
+        .syscall.async = 0,
         .file = syscall->init_module.file,
         .loaded_from_memory = syscall->init_module.loaded_from_memory,
     };
@@ -171,6 +172,7 @@ int __attribute__((always_inline)) trace_delete_module_ret(void *ctx, int retval
 
     struct delete_module_event_t event = {
         .syscall.retval = retval,
+        .syscall.async = 0,
     };
     bpf_probe_read_str(&event.name, sizeof(event.name), (void *)syscall->delete_module.name);
 

--- a/pkg/security/ebpf/c/mount.h
+++ b/pkg/security/ebpf/c/mount.h
@@ -147,6 +147,7 @@ int __attribute__((always_inline)) dr_mount_callback(void *ctx, int retval) {
 
     struct mount_event_t event = {
         .syscall.retval = retval,
+        .syscall.async = 0,
         .mount_id = get_mount_mount_id(syscall->mount.src_mnt),
         .group_id = get_mount_peer_group_id(syscall->mount.src_mnt),
         .device = get_mount_dev(syscall->mount.src_mnt),

--- a/pkg/security/ebpf/c/mprotect.h
+++ b/pkg/security/ebpf/c/mprotect.h
@@ -103,6 +103,7 @@ int __attribute__((always_inline)) sys_mprotect_ret(void *ctx, int retval) {
     }
 
     struct mprotect_event_t event = {
+        .syscall.async = 0,
         .vm_protection = syscall->mprotect.vm_protection,
         .req_protection = syscall->mprotect.req_protection,
         .vm_start = syscall->mprotect.vm_start,

--- a/pkg/security/ebpf/c/net_device.h
+++ b/pkg/security/ebpf/c/net_device.h
@@ -234,6 +234,7 @@ int kretprobe_register_netdevice(struct pt_regs *ctx) {
     if (state == NULL) {
         // this is a simple device registration
         struct net_device_event_t evt = {
+            .syscall.async = 0,
             .device = device,
         };
 
@@ -282,6 +283,7 @@ int kretprobe_register_netdevice(struct pt_regs *ctx) {
             if (peer_device->netns != device.netns) {
                 // send event
                 struct veth_pair_event_t evt = {
+                    .syscall.async = 0,
                     .host_device = device,
                     .peer_device = *peer_device,
                 };
@@ -329,6 +331,7 @@ __attribute__((always_inline)) int trace_dev_change_net_namespace(struct pt_regs
 
     // send event
     struct veth_pair_event_t evt = {
+        .syscall.async = 0,
         .host_device = *peer_device,
         .peer_device = *device,
     };

--- a/pkg/security/ebpf/c/open.h
+++ b/pkg/security/ebpf/c/open.h
@@ -35,7 +35,7 @@ struct open_event_t {
     u32 mode;
 };
 
-int __attribute__((always_inline)) trace__sys_openat(int flags, umode_t mode) {
+int __attribute__((always_inline)) trace__sys_openat(u8 async, int flags, umode_t mode) {
     struct policy_t policy = fetch_policy(EVENT_OPEN);
     if (is_discarded_by_process(policy.mode, EVENT_OPEN)) {
         return 0;
@@ -44,6 +44,7 @@ int __attribute__((always_inline)) trace__sys_openat(int flags, umode_t mode) {
     struct syscall_cache_t syscall = {
         .type = EVENT_OPEN,
         .policy = policy,
+        .async = async,
         .open = {
             .flags = flags,
             .mode = mode & S_IALLUGO,
@@ -57,26 +58,26 @@ int __attribute__((always_inline)) trace__sys_openat(int flags, umode_t mode) {
 
 SYSCALL_KPROBE2(creat, const char *, filename, umode_t, mode) {
     int flags = O_CREAT|O_WRONLY|O_TRUNC;
-    return trace__sys_openat(flags, mode);
+    return trace__sys_openat(SYNC_SYSCALL, flags, mode);
 }
 
 SYSCALL_COMPAT_KPROBE3(open_by_handle_at, int, mount_fd, struct file_handle *, handle, int, flags) {
     umode_t mode = 0;
-    return trace__sys_openat(flags, mode);
+    return trace__sys_openat(SYNC_SYSCALL, flags, mode);
 }
 
 SYSCALL_COMPAT_KPROBE0(truncate) {
     int flags = O_CREAT|O_WRONLY|O_TRUNC;
     umode_t mode = 0;
-    return trace__sys_openat(flags, mode);
+    return trace__sys_openat(SYNC_SYSCALL, flags, mode);
 }
 
 SYSCALL_COMPAT_KPROBE3(open, const char*, filename, int, flags, umode_t, mode) {
-    return trace__sys_openat(flags, mode);
+    return trace__sys_openat(SYNC_SYSCALL, flags, mode);
 }
 
 SYSCALL_COMPAT_KPROBE4(openat, int, dirfd, const char*, filename, int, flags, umode_t, mode) {
-    return trace__sys_openat(flags, mode);
+    return trace__sys_openat(SYNC_SYSCALL, flags, mode);
 }
 
 struct openat2_open_how {
@@ -88,7 +89,7 @@ struct openat2_open_how {
 SYSCALL_KPROBE4(openat2, int, dirfd, const char*, filename, struct openat2_open_how*, phow, size_t, size) {
     struct openat2_open_how how;
     bpf_probe_read(&how, sizeof(struct openat2_open_how), phow);
-    return trace__sys_openat(how.flags, how.mode);
+    return trace__sys_openat(SYNC_SYSCALL, how.flags, how.mode);
 }
 
 int __attribute__((always_inline)) approve_by_flags(struct syscall_cache_t *syscall) {
@@ -222,7 +223,7 @@ int kprobe_io_openat2(struct pt_regs *ctx) {
     if (!syscall) {
         unsigned int flags = req.how.flags & VALID_OPEN_FLAGS;
         umode_t mode = req.how.mode & S_IALLUGO;
-        return trace__sys_openat(flags, mode);
+        return trace__sys_openat(ASYNC_SYSCALL, flags, mode);
     }
     return 0;
 }
@@ -375,6 +376,7 @@ int __attribute__((always_inline)) dr_open_callback(void *ctx, int retval) {
 
     struct open_event_t event = {
         .syscall.retval = retval,
+        .syscall.async = syscall->async,
         .file = syscall->open.file,
         .flags = syscall->open.flags,
         .mode = syscall->open.mode,

--- a/pkg/security/ebpf/c/ptrace.h
+++ b/pkg/security/ebpf/c/ptrace.h
@@ -46,6 +46,7 @@ int __attribute__((always_inline)) sys_ptrace_ret(void *ctx, int retval) {
 
     struct ptrace_event_t event = {
         .syscall.retval = retval,
+        .syscall.async = 0,
         .request = syscall->ptrace.request,
         .pid = namespace_nr,
         .addr = syscall->ptrace.addr,

--- a/pkg/security/ebpf/c/rename.h
+++ b/pkg/security/ebpf/c/rename.h
@@ -41,6 +41,11 @@ SYSCALL_KPROBE0(renameat2) {
     return trace__sys_rename();
 }
 
+SEC("kprobe/do_renameat2")
+int kprobe_do_renameat2(struct pt_regs *ctx) {
+    return trace__sys_rename();
+}
+
 SEC("kprobe/vfs_rename")
 int kprobe_vfs_rename(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_RENAME);
@@ -149,6 +154,12 @@ int __attribute__((always_inline)) sys_rename_ret(void *ctx, int retval, int dr_
     // if the tail call failed we need to pop the syscall cache entry
     pop_syscall(EVENT_RENAME);
     return 0;
+}
+
+SEC("kretprobe/do_renameat2")
+int kretprobe_do_renameat2(struct pt_regs *ctx) {
+    int retval = PT_REGS_RC(ctx);
+    return sys_rename_ret(ctx, retval, DR_KPROBE);
 }
 
 int __attribute__((always_inline)) kprobe_sys_rename_ret(struct pt_regs *ctx) {

--- a/pkg/security/ebpf/c/rename.h
+++ b/pkg/security/ebpf/c/rename.h
@@ -18,9 +18,10 @@ int __attribute__((always_inline)) rename_approvers(struct syscall_cache_t *sysc
            basename_approver(syscall, syscall->rename.target_dentry, EVENT_RENAME);
 }
 
-int __attribute__((always_inline)) trace__sys_rename() {
+int __attribute__((always_inline)) trace__sys_rename(u8 async) {
     struct syscall_cache_t syscall = {
         .policy = fetch_policy(EVENT_RENAME),
+        .async = async,
         .type = EVENT_RENAME,
     };
 
@@ -30,20 +31,24 @@ int __attribute__((always_inline)) trace__sys_rename() {
 }
 
 SYSCALL_KPROBE0(rename) {
-    return trace__sys_rename();
+    return trace__sys_rename(SYNC_SYSCALL);
 }
 
 SYSCALL_KPROBE0(renameat) {
-    return trace__sys_rename();
+    return trace__sys_rename(SYNC_SYSCALL);
 }
 
 SYSCALL_KPROBE0(renameat2) {
-    return trace__sys_rename();
+    return trace__sys_rename(SYNC_SYSCALL);
 }
 
 SEC("kprobe/do_renameat2")
 int kprobe_do_renameat2(struct pt_regs *ctx) {
-    return trace__sys_rename();
+    struct syscall_cache_t *syscall = peek_syscall(EVENT_RENAME);
+    if (!syscall) {
+        return trace__sys_rename(ASYNC_SYSCALL);
+    }
+    return 0;
 }
 
 SEC("kprobe/vfs_rename")
@@ -211,6 +216,7 @@ int __attribute__((always_inline)) dr_rename_callback(void *ctx, int retval) {
 
     struct rename_event_t event = {
         .syscall.retval = retval,
+        .syscall.async = syscall->async,
         .old = syscall->rename.src_file,
         .new = syscall->rename.target_file,
     };

--- a/pkg/security/ebpf/c/setxattr.h
+++ b/pkg/security/ebpf/c/setxattr.h
@@ -149,6 +149,7 @@ int __attribute__((always_inline)) sys_xattr_ret(void *ctx, int retval, u64 even
 
     struct setxattr_event_t event = {
         .syscall.retval = retval,
+        .syscall.async = 0,
         .file = syscall->xattr.file,
     };
 

--- a/pkg/security/ebpf/c/signal.h
+++ b/pkg/security/ebpf/c/signal.h
@@ -60,6 +60,7 @@ int kretprobe_check_kill_permission(struct pt_regs* ctx) {
     /* constuct and send the event */
     struct signal_event_t event = {
         .syscall.retval = retval,
+        .syscall.async = 0,
         .pid = syscall->signal.pid,
         .type = syscall->signal.type,
     };

--- a/pkg/security/ebpf/c/splice.h
+++ b/pkg/security/ebpf/c/splice.h
@@ -155,6 +155,7 @@ int __attribute__((always_inline)) sys_splice_ret(void *ctx, int retval) {
 
     struct splice_event_t event = {
         .syscall.retval = retval,
+        .syscall.async = 0,
         .file = syscall->splice.file,
         .pipe_entry_flag = syscall->splice.pipe_entry_flag,
         .pipe_exit_flag = syscall->splice.pipe_exit_flag,

--- a/pkg/security/ebpf/c/syscalls.h
+++ b/pkg/security/ebpf/c/syscalls.h
@@ -7,6 +7,11 @@
 
 #define FSTYPE_LEN 16
 
+enum {
+    SYNC_SYSCALL = 0,
+    ASYNC_SYSCALL
+};
+
 struct str_array_ref_t {
     u32 id;
     u8 index;
@@ -36,6 +41,7 @@ struct syscall_cache_t {
     struct policy_t policy;
     u64 type;
     u32 discarded;
+    u8 async;
 
     struct dentry_resolver_input_t resolver;
 

--- a/pkg/security/ebpf/c/umount.h
+++ b/pkg/security/ebpf/c/umount.h
@@ -42,7 +42,8 @@ int __attribute__((always_inline)) sys_umount_ret(void *ctx, int retval) {
     int mount_id = get_vfsmount_mount_id(syscall->umount.vfs);
 
     struct umount_event_t event = {
-        .syscall .retval = retval,
+        .syscall.retval = retval,
+        .syscall.async = 0,
         .mount_id = mount_id
     };
 

--- a/pkg/security/ebpf/c/unlink.h
+++ b/pkg/security/ebpf/c/unlink.h
@@ -41,6 +41,11 @@ SYSCALL_KPROBE3(unlinkat, int, dirfd, const char*, filename, int, flags) {
     return trace__sys_unlink(flags);
 }
 
+SEC("kprobe/do_unlinkat")
+int kprobe_do_unlinkat(struct pt_regs *ctx) {
+    return trace__sys_unlink(0);
+}
+
 SEC("kprobe/vfs_unlink")
 int kprobe_vfs_unlink(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_UNLINK);
@@ -145,6 +150,12 @@ int __attribute__((always_inline)) sys_unlink_ret(void *ctx, int retval) {
     }
 
     return 0;
+}
+
+SEC("kretprobe/do_unlinkat")
+int kretprobe_do_unlinkat(struct pt_regs *ctx) {
+    int retval = PT_REGS_RC(ctx);
+    return sys_unlink_ret(ctx, retval);
 }
 
 int __attribute__((always_inline)) kprobe_sys_unlink_ret(struct pt_regs *ctx) {

--- a/pkg/security/ebpf/c/unlink.h
+++ b/pkg/security/ebpf/c/unlink.h
@@ -19,10 +19,11 @@ int __attribute__((always_inline)) unlink_approvers(struct syscall_cache_t *sysc
     return basename_approver(syscall, syscall->unlink.dentry, EVENT_UNLINK);
 }
 
-int __attribute__((always_inline)) trace__sys_unlink(int flags) {
+int __attribute__((always_inline)) trace__sys_unlink(u8 async, int flags) {
     struct syscall_cache_t syscall = {
         .type = EVENT_UNLINK,
         .policy = fetch_policy(EVENT_UNLINK),
+        .async = async,
         .unlink = {
             .flags = flags,
         }
@@ -34,16 +35,20 @@ int __attribute__((always_inline)) trace__sys_unlink(int flags) {
 }
 
 SYSCALL_KPROBE0(unlink) {
-    return trace__sys_unlink(0);
+    return trace__sys_unlink(SYNC_SYSCALL, 0);
 }
 
 SYSCALL_KPROBE3(unlinkat, int, dirfd, const char*, filename, int, flags) {
-    return trace__sys_unlink(flags);
+    return trace__sys_unlink(SYNC_SYSCALL, flags);
 }
 
 SEC("kprobe/do_unlinkat")
 int kprobe_do_unlinkat(struct pt_regs *ctx) {
-    return trace__sys_unlink(0);
+    struct syscall_cache_t *syscall = peek_syscall(EVENT_UNLINK);
+    if (!syscall) {
+        return trace__sys_unlink(ASYNC_SYSCALL, 0);
+    }
+    return 0;
 }
 
 SEC("kprobe/vfs_unlink")
@@ -122,6 +127,7 @@ int __attribute__((always_inline)) sys_unlink_ret(void *ctx, int retval) {
         if (syscall->unlink.flags & AT_REMOVEDIR) {
             struct rmdir_event_t event = {
                 .syscall.retval = retval,
+                .syscall.async = (u64)syscall->async,
                 .file = syscall->unlink.file,
             };
 
@@ -133,6 +139,7 @@ int __attribute__((always_inline)) sys_unlink_ret(void *ctx, int retval) {
         } else {
             struct unlink_event_t event = {
                 .syscall.retval = retval,
+                .syscall.async = (u64)syscall->async,
                 .file = syscall->unlink.file,
                 .flags = syscall->unlink.flags,
             };

--- a/pkg/security/ebpf/c/utimes.h
+++ b/pkg/security/ebpf/c/utimes.h
@@ -73,6 +73,7 @@ int __attribute__((always_inline)) sys_utimes_ret(void *ctx, int retval) {
 
     struct utimes_event_t event = {
         .syscall.retval = retval,
+        .syscall.async = 0,
         .atime = syscall->setattr.atime,
         .mtime = syscall->setattr.mtime,
         .file = syscall->setattr.file,

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -235,6 +235,8 @@ var SelectorsPerEventType = map[eval.EventType][]manager.ProbesSelector{
 
 		// unlink rmdir probes
 		&manager.AllOf{Selectors: []manager.ProbesSelector{
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/do_unlinkat", EBPFFuncName: "kprobe_do_unlinkat"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kretprobe/do_unlinkat", EBPFFuncName: "kretprobe_do_unlinkat"}},
 			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/mnt_want_write", EBPFFuncName: "kprobe_mnt_want_write"}},
 		}},
 		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -218,6 +218,8 @@ var SelectorsPerEventType = map[eval.EventType][]manager.ProbesSelector{
 
 		// Rename probes
 		&manager.AllOf{Selectors: []manager.ProbesSelector{
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/do_renameat2", EBPFFuncName: "kprobe_do_renameat2"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kretprobe/do_renameat2", EBPFFuncName: "kretprobe_do_renameat2"}},
 			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/vfs_rename", EBPFFuncName: "kprobe_vfs_rename"}},
 			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/mnt_want_write", EBPFFuncName: "kprobe_mnt_want_write"}},
 		}},

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -245,6 +245,8 @@ var SelectorsPerEventType = map[eval.EventType][]manager.ProbesSelector{
 
 		// Rmdir probes
 		&manager.AllOf{Selectors: []manager.ProbesSelector{
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/do_rmdir", EBPFFuncName: "kprobe_do_rmdir"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kretprobe/do_rmdir", EBPFFuncName: "kretprobe_do_rmdir"}},
 			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/security_inode_rmdir", EBPFFuncName: "kprobe_security_inode_rmdir"}},
 		}},
 		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -255,6 +255,8 @@ var SelectorsPerEventType = map[eval.EventType][]manager.ProbesSelector{
 
 		// Unlink probes
 		&manager.AllOf{Selectors: []manager.ProbesSelector{
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/do_linkat", EBPFFuncName: "kprobe_do_linkat"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kretprobe/do_linkat", EBPFFuncName: "kretprobe_do_linkat"}},
 			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/vfs_unlink", EBPFFuncName: "kprobe_vfs_unlink"}},
 		}},
 		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -344,6 +344,8 @@ var SelectorsPerEventType = map[eval.EventType][]manager.ProbesSelector{
 	// List of probes required to capture mkdir events
 	"mkdir": {
 		&manager.AllOf{Selectors: []manager.ProbesSelector{
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/do_mkdirat", EBPFFuncName: "kprobe_do_mkdirat"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kretprobe/do_mkdirat", EBPFFuncName: "kretprobe_do_mkdirat"}},
 			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/vfs_mkdir", EBPFFuncName: "kprobe_vfs_mkdir"}},
 			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/filename_create", EBPFFuncName: "kprobe_filename_create"}},
 		}},

--- a/pkg/security/ebpf/probes/link.go
+++ b/pkg/security/ebpf/probes/link.go
@@ -19,6 +19,20 @@ var linkProbes = []*manager.Probe{
 			EBPFFuncName: "kprobe_vfs_link",
 		},
 	},
+	{
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/do_linkat",
+			EBPFFuncName: "kprobe_do_linkat",
+		},
+	},
+	{
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kretprobe/do_linkat",
+			EBPFFuncName: "kretprobe_do_linkat",
+		},
+	},
 }
 
 func getLinkProbe() []*manager.Probe {

--- a/pkg/security/ebpf/probes/mkdir.go
+++ b/pkg/security/ebpf/probes/mkdir.go
@@ -19,6 +19,20 @@ var mkdirProbes = []*manager.Probe{
 			EBPFFuncName: "kprobe_vfs_mkdir",
 		},
 	},
+	{
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/do_mkdirat",
+			EBPFFuncName: "kprobe_do_mkdirat",
+		},
+	},
+	{
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kretprobe/do_mkdirat",
+			EBPFFuncName: "kretprobe_do_mkdirat",
+		},
+	},
 }
 
 func getMkdirProbes() []*manager.Probe {

--- a/pkg/security/ebpf/probes/rename.go
+++ b/pkg/security/ebpf/probes/rename.go
@@ -19,6 +19,20 @@ var renameProbes = []*manager.Probe{
 			EBPFFuncName: "kprobe_vfs_rename",
 		},
 	},
+	{
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/do_renameat2",
+			EBPFFuncName: "kprobe_do_renameat2",
+		},
+	},
+	{
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kretprobe/do_renameat2",
+			EBPFFuncName: "kretprobe_do_renameat2",
+		},
+	},
 }
 
 func getRenameProbes() []*manager.Probe {

--- a/pkg/security/ebpf/probes/rmdir.go
+++ b/pkg/security/ebpf/probes/rmdir.go
@@ -19,6 +19,20 @@ var rmdirProbes = []*manager.Probe{
 			EBPFFuncName: "kprobe_security_inode_rmdir",
 		},
 	},
+	{
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/do_rmdir",
+			EBPFFuncName: "kprobe_do_rmdir",
+		},
+	},
+	{
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kretprobe/do_rmdir",
+			EBPFFuncName: "kretprobe_do_rmdir",
+		},
+	},
 }
 
 func getRmdirProbe() []*manager.Probe {

--- a/pkg/security/ebpf/probes/unlink.go
+++ b/pkg/security/ebpf/probes/unlink.go
@@ -19,6 +19,20 @@ var unlinkProbes = []*manager.Probe{
 			EBPFFuncName: "kprobe_vfs_unlink",
 		},
 	},
+	{
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/do_unlinkat",
+			EBPFFuncName: "kprobe_do_unlinkat",
+		},
+	},
+	{
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kretprobe/do_unlinkat",
+			EBPFFuncName: "kretprobe_do_unlinkat",
+		},
+	},
 }
 
 func getUnlinkProbes() []*manager.Probe {

--- a/pkg/security/probe/accessors.go
+++ b/pkg/security/probe/accessors.go
@@ -60,9 +60,9 @@ func (m *Model) GetEventTypes() []eval.EventType {
 func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Evaluator, error) {
 	switch field {
 	case "bpf.async":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				return int((*Event)(ctx.Object).BPF.SyscallEvent.Async)
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				return (*Event)(ctx.Object).BPF.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -160,9 +160,9 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 	case "chmod.async":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				return int((*Event)(ctx.Object).Chmod.SyscallEvent.Async)
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				return (*Event)(ctx.Object).Chmod.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -305,9 +305,9 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 	case "chown.async":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				return int((*Event)(ctx.Object).Chown.SyscallEvent.Async)
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				return (*Event)(ctx.Object).Chown.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -884,9 +884,9 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 	case "link.async":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				return int((*Event)(ctx.Object).Link.SyscallEvent.Async)
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				return (*Event)(ctx.Object).Link.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -1126,9 +1126,9 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 	case "load_module.async":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				return int((*Event)(ctx.Object).LoadModule.SyscallEvent.Async)
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				return (*Event)(ctx.Object).LoadModule.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -1271,9 +1271,9 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 	case "mkdir.async":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				return int((*Event)(ctx.Object).Mkdir.SyscallEvent.Async)
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				return (*Event)(ctx.Object).Mkdir.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -1416,9 +1416,9 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 	case "mmap.async":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				return int((*Event)(ctx.Object).MMap.SyscallEvent.Async)
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				return (*Event)(ctx.Object).MMap.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -1561,9 +1561,9 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 	case "mprotect.async":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				return int((*Event)(ctx.Object).MProtect.SyscallEvent.Async)
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				return (*Event)(ctx.Object).MProtect.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -1665,9 +1665,9 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 	case "open.async":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				return int((*Event)(ctx.Object).Open.SyscallEvent.Async)
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				return (*Event)(ctx.Object).Open.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -3162,9 +3162,9 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 	case "ptrace.async":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				return int((*Event)(ctx.Object).PTrace.SyscallEvent.Async)
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				return (*Event)(ctx.Object).PTrace.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -4538,9 +4538,9 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 	case "removexattr.async":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				return int((*Event)(ctx.Object).RemoveXAttr.SyscallEvent.Async)
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				return (*Event)(ctx.Object).RemoveXAttr.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -4683,9 +4683,9 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 	case "rename.async":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				return int((*Event)(ctx.Object).Rename.SyscallEvent.Async)
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				return (*Event)(ctx.Object).Rename.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -4925,9 +4925,9 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 	case "rmdir.async":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				return int((*Event)(ctx.Object).Rmdir.SyscallEvent.Async)
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				return (*Event)(ctx.Object).Rmdir.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -5182,9 +5182,9 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 	case "setxattr.async":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				return int((*Event)(ctx.Object).SetXAttr.SyscallEvent.Async)
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				return (*Event)(ctx.Object).SetXAttr.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -5327,9 +5327,9 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 	case "signal.async":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				return int((*Event)(ctx.Object).Signal.SyscallEvent.Async)
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				return (*Event)(ctx.Object).Signal.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -6711,9 +6711,9 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 	case "splice.async":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				return int((*Event)(ctx.Object).Splice.SyscallEvent.Async)
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				return (*Event)(ctx.Object).Splice.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -6856,9 +6856,9 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 	case "unlink.async":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				return int((*Event)(ctx.Object).Unlink.SyscallEvent.Async)
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				return (*Event)(ctx.Object).Unlink.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -6985,9 +6985,9 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 	case "unload_module.async":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				return int((*Event)(ctx.Object).UnloadModule.SyscallEvent.Async)
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				return (*Event)(ctx.Object).UnloadModule.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -7009,9 +7009,9 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 	case "utimes.async":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				return int((*Event)(ctx.Object).Utimes.SyscallEvent.Async)
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				return (*Event)(ctx.Object).Utimes.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -7792,7 +7792,7 @@ func (e *Event) GetFields() []eval.Field {
 func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	switch field {
 	case "bpf.async":
-		return int(e.BPF.SyscallEvent.Async), nil
+		return e.BPF.SyscallEvent.Async, nil
 	case "bpf.cmd":
 		return int(e.BPF.Cmd), nil
 	case "bpf.map.name":
@@ -7820,7 +7820,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "capset.cap_permitted":
 		return int(e.Capset.CapPermitted), nil
 	case "chmod.async":
-		return int(e.Chmod.SyscallEvent.Async), nil
+		return e.Chmod.SyscallEvent.Async, nil
 	case "chmod.file.change_time":
 		return int(e.Chmod.File.FileFields.CTime), nil
 	case "chmod.file.destination.mode":
@@ -7856,7 +7856,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "chmod.retval":
 		return int(e.Chmod.SyscallEvent.Retval), nil
 	case "chown.async":
-		return int(e.Chown.SyscallEvent.Async), nil
+		return e.Chown.SyscallEvent.Async, nil
 	case "chown.file.change_time":
 		return int(e.Chown.File.FileFields.CTime), nil
 	case "chown.file.destination.gid":
@@ -8000,7 +8000,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "exec.user":
 		return e.Exec.Process.Credentials.User, nil
 	case "link.async":
-		return int(e.Link.SyscallEvent.Async), nil
+		return e.Link.SyscallEvent.Async, nil
 	case "link.file.change_time":
 		return int(e.Link.Source.FileFields.CTime), nil
 	case "link.file.destination.change_time":
@@ -8060,7 +8060,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "link.retval":
 		return int(e.Link.SyscallEvent.Retval), nil
 	case "load_module.async":
-		return int(e.LoadModule.SyscallEvent.Async), nil
+		return e.LoadModule.SyscallEvent.Async, nil
 	case "load_module.file.change_time":
 		return int(e.LoadModule.File.FileFields.CTime), nil
 	case "load_module.file.filesystem":
@@ -8096,7 +8096,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "load_module.retval":
 		return int(e.LoadModule.SyscallEvent.Retval), nil
 	case "mkdir.async":
-		return int(e.Mkdir.SyscallEvent.Async), nil
+		return e.Mkdir.SyscallEvent.Async, nil
 	case "mkdir.file.change_time":
 		return int(e.Mkdir.File.FileFields.CTime), nil
 	case "mkdir.file.destination.mode":
@@ -8132,7 +8132,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "mkdir.retval":
 		return int(e.Mkdir.SyscallEvent.Retval), nil
 	case "mmap.async":
-		return int(e.MMap.SyscallEvent.Async), nil
+		return e.MMap.SyscallEvent.Async, nil
 	case "mmap.file.change_time":
 		return int(e.MMap.File.FileFields.CTime), nil
 	case "mmap.file.filesystem":
@@ -8168,7 +8168,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "mmap.retval":
 		return int(e.MMap.SyscallEvent.Retval), nil
 	case "mprotect.async":
-		return int(e.MProtect.SyscallEvent.Async), nil
+		return e.MProtect.SyscallEvent.Async, nil
 	case "mprotect.req_protection":
 		return e.MProtect.ReqProtection, nil
 	case "mprotect.retval":
@@ -8194,7 +8194,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "network.source.port":
 		return int(e.NetworkContext.Source.Port), nil
 	case "open.async":
-		return int(e.Open.SyscallEvent.Async), nil
+		return e.Open.SyscallEvent.Async, nil
 	case "open.file.change_time":
 		return int(e.Open.File.FileFields.CTime), nil
 	case "open.file.destination.mode":
@@ -8860,7 +8860,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "process.user":
 		return e.ProcessContext.Process.Credentials.User, nil
 	case "ptrace.async":
-		return int(e.PTrace.SyscallEvent.Async), nil
+		return e.PTrace.SyscallEvent.Async, nil
 	case "ptrace.request":
 		return int(e.PTrace.Request), nil
 	case "ptrace.retval":
@@ -9496,7 +9496,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "ptrace.tracee.user":
 		return e.PTrace.Tracee.Process.Credentials.User, nil
 	case "removexattr.async":
-		return int(e.RemoveXAttr.SyscallEvent.Async), nil
+		return e.RemoveXAttr.SyscallEvent.Async, nil
 	case "removexattr.file.change_time":
 		return int(e.RemoveXAttr.File.FileFields.CTime), nil
 	case "removexattr.file.destination.name":
@@ -9532,7 +9532,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "removexattr.retval":
 		return int(e.RemoveXAttr.SyscallEvent.Retval), nil
 	case "rename.async":
-		return int(e.Rename.SyscallEvent.Async), nil
+		return e.Rename.SyscallEvent.Async, nil
 	case "rename.file.change_time":
 		return int(e.Rename.Old.FileFields.CTime), nil
 	case "rename.file.destination.change_time":
@@ -9592,7 +9592,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "rename.retval":
 		return int(e.Rename.SyscallEvent.Retval), nil
 	case "rmdir.async":
-		return int(e.Rmdir.SyscallEvent.Async), nil
+		return e.Rmdir.SyscallEvent.Async, nil
 	case "rmdir.file.change_time":
 		return int(e.Rmdir.File.FileFields.CTime), nil
 	case "rmdir.file.filesystem":
@@ -9656,7 +9656,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "setuid.user":
 		return e.ResolveSetuidUser(&e.SetUID), nil
 	case "setxattr.async":
-		return int(e.SetXAttr.SyscallEvent.Async), nil
+		return e.SetXAttr.SyscallEvent.Async, nil
 	case "setxattr.file.change_time":
 		return int(e.SetXAttr.File.FileFields.CTime), nil
 	case "setxattr.file.destination.name":
@@ -9692,7 +9692,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "setxattr.retval":
 		return int(e.SetXAttr.SyscallEvent.Retval), nil
 	case "signal.async":
-		return int(e.Signal.SyscallEvent.Async), nil
+		return e.Signal.SyscallEvent.Async, nil
 	case "signal.pid":
 		return int(e.Signal.PID), nil
 	case "signal.retval":
@@ -10330,7 +10330,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "signal.type":
 		return int(e.Signal.Type), nil
 	case "splice.async":
-		return int(e.Splice.SyscallEvent.Async), nil
+		return e.Splice.SyscallEvent.Async, nil
 	case "splice.file.change_time":
 		return int(e.Splice.File.FileFields.CTime), nil
 	case "splice.file.filesystem":
@@ -10366,7 +10366,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "splice.retval":
 		return int(e.Splice.SyscallEvent.Retval), nil
 	case "unlink.async":
-		return int(e.Unlink.SyscallEvent.Async), nil
+		return e.Unlink.SyscallEvent.Async, nil
 	case "unlink.file.change_time":
 		return int(e.Unlink.File.FileFields.CTime), nil
 	case "unlink.file.filesystem":
@@ -10398,13 +10398,13 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "unlink.retval":
 		return int(e.Unlink.SyscallEvent.Retval), nil
 	case "unload_module.async":
-		return int(e.UnloadModule.SyscallEvent.Async), nil
+		return e.UnloadModule.SyscallEvent.Async, nil
 	case "unload_module.name":
 		return e.UnloadModule.Name, nil
 	case "unload_module.retval":
 		return int(e.UnloadModule.SyscallEvent.Retval), nil
 	case "utimes.async":
-		return int(e.Utimes.SyscallEvent.Async), nil
+		return e.Utimes.SyscallEvent.Async, nil
 	case "utimes.file.change_time":
 		return int(e.Utimes.File.FileFields.CTime), nil
 	case "utimes.file.filesystem":
@@ -11736,7 +11736,7 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	switch field {
 	case "bpf.async":
-		return reflect.Int, nil
+		return reflect.Bool, nil
 	case "bpf.cmd":
 		return reflect.Int, nil
 	case "bpf.map.name":
@@ -11760,7 +11760,7 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "capset.cap_permitted":
 		return reflect.Int, nil
 	case "chmod.async":
-		return reflect.Int, nil
+		return reflect.Bool, nil
 	case "chmod.file.change_time":
 		return reflect.Int, nil
 	case "chmod.file.destination.mode":
@@ -11796,7 +11796,7 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "chmod.retval":
 		return reflect.Int, nil
 	case "chown.async":
-		return reflect.Int, nil
+		return reflect.Bool, nil
 	case "chown.file.change_time":
 		return reflect.Int, nil
 	case "chown.file.destination.gid":
@@ -11940,7 +11940,7 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "exec.user":
 		return reflect.String, nil
 	case "link.async":
-		return reflect.Int, nil
+		return reflect.Bool, nil
 	case "link.file.change_time":
 		return reflect.Int, nil
 	case "link.file.destination.change_time":
@@ -12000,7 +12000,7 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "link.retval":
 		return reflect.Int, nil
 	case "load_module.async":
-		return reflect.Int, nil
+		return reflect.Bool, nil
 	case "load_module.file.change_time":
 		return reflect.Int, nil
 	case "load_module.file.filesystem":
@@ -12036,7 +12036,7 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "load_module.retval":
 		return reflect.Int, nil
 	case "mkdir.async":
-		return reflect.Int, nil
+		return reflect.Bool, nil
 	case "mkdir.file.change_time":
 		return reflect.Int, nil
 	case "mkdir.file.destination.mode":
@@ -12072,7 +12072,7 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "mkdir.retval":
 		return reflect.Int, nil
 	case "mmap.async":
-		return reflect.Int, nil
+		return reflect.Bool, nil
 	case "mmap.file.change_time":
 		return reflect.Int, nil
 	case "mmap.file.filesystem":
@@ -12108,7 +12108,7 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "mmap.retval":
 		return reflect.Int, nil
 	case "mprotect.async":
-		return reflect.Int, nil
+		return reflect.Bool, nil
 	case "mprotect.req_protection":
 		return reflect.Int, nil
 	case "mprotect.retval":
@@ -12134,7 +12134,7 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "network.source.port":
 		return reflect.Int, nil
 	case "open.async":
-		return reflect.Int, nil
+		return reflect.Bool, nil
 	case "open.file.change_time":
 		return reflect.Int, nil
 	case "open.file.destination.mode":
@@ -12350,7 +12350,7 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "process.user":
 		return reflect.String, nil
 	case "ptrace.async":
-		return reflect.Int, nil
+		return reflect.Bool, nil
 	case "ptrace.request":
 		return reflect.Int, nil
 	case "ptrace.retval":
@@ -12536,7 +12536,7 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "ptrace.tracee.user":
 		return reflect.String, nil
 	case "removexattr.async":
-		return reflect.Int, nil
+		return reflect.Bool, nil
 	case "removexattr.file.change_time":
 		return reflect.Int, nil
 	case "removexattr.file.destination.name":
@@ -12572,7 +12572,7 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "removexattr.retval":
 		return reflect.Int, nil
 	case "rename.async":
-		return reflect.Int, nil
+		return reflect.Bool, nil
 	case "rename.file.change_time":
 		return reflect.Int, nil
 	case "rename.file.destination.change_time":
@@ -12632,7 +12632,7 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "rename.retval":
 		return reflect.Int, nil
 	case "rmdir.async":
-		return reflect.Int, nil
+		return reflect.Bool, nil
 	case "rmdir.file.change_time":
 		return reflect.Int, nil
 	case "rmdir.file.filesystem":
@@ -12696,7 +12696,7 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "setuid.user":
 		return reflect.String, nil
 	case "setxattr.async":
-		return reflect.Int, nil
+		return reflect.Bool, nil
 	case "setxattr.file.change_time":
 		return reflect.Int, nil
 	case "setxattr.file.destination.name":
@@ -12732,7 +12732,7 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "setxattr.retval":
 		return reflect.Int, nil
 	case "signal.async":
-		return reflect.Int, nil
+		return reflect.Bool, nil
 	case "signal.pid":
 		return reflect.Int, nil
 	case "signal.retval":
@@ -12920,7 +12920,7 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "signal.type":
 		return reflect.Int, nil
 	case "splice.async":
-		return reflect.Int, nil
+		return reflect.Bool, nil
 	case "splice.file.change_time":
 		return reflect.Int, nil
 	case "splice.file.filesystem":
@@ -12956,7 +12956,7 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "splice.retval":
 		return reflect.Int, nil
 	case "unlink.async":
-		return reflect.Int, nil
+		return reflect.Bool, nil
 	case "unlink.file.change_time":
 		return reflect.Int, nil
 	case "unlink.file.filesystem":
@@ -12988,13 +12988,13 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "unlink.retval":
 		return reflect.Int, nil
 	case "unload_module.async":
-		return reflect.Int, nil
+		return reflect.Bool, nil
 	case "unload_module.name":
 		return reflect.String, nil
 	case "unload_module.retval":
 		return reflect.Int, nil
 	case "utimes.async":
-		return reflect.Int, nil
+		return reflect.Bool, nil
 	case "utimes.file.change_time":
 		return reflect.Int, nil
 	case "utimes.file.filesystem":
@@ -13031,11 +13031,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	switch field {
 	case "bpf.async":
-		v, ok := value.(int)
-		if !ok {
+		var ok bool
+		if e.BPF.SyscallEvent.Async, ok = value.(bool); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "BPF.SyscallEvent.Async"}
 		}
-		e.BPF.SyscallEvent.Async = int64(v)
 		return nil
 	case "bpf.cmd":
 		v, ok := value.(int)
@@ -13115,11 +13114,10 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Capset.CapPermitted = uint64(v)
 		return nil
 	case "chmod.async":
-		v, ok := value.(int)
-		if !ok {
+		var ok bool
+		if e.Chmod.SyscallEvent.Async, ok = value.(bool); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "Chmod.SyscallEvent.Async"}
 		}
-		e.Chmod.SyscallEvent.Async = int64(v)
 		return nil
 	case "chmod.file.change_time":
 		v, ok := value.(int)
@@ -13240,11 +13238,10 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Chmod.SyscallEvent.Retval = int64(v)
 		return nil
 	case "chown.async":
-		v, ok := value.(int)
-		if !ok {
+		var ok bool
+		if e.Chown.SyscallEvent.Async, ok = value.(bool); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "Chown.SyscallEvent.Async"}
 		}
-		e.Chown.SyscallEvent.Async = int64(v)
 		return nil
 	case "chown.file.change_time":
 		v, ok := value.(int)
@@ -13740,11 +13737,10 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Exec.Process.Credentials.User = str
 		return nil
 	case "link.async":
-		v, ok := value.(int)
-		if !ok {
+		var ok bool
+		if e.Link.SyscallEvent.Async, ok = value.(bool); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "Link.SyscallEvent.Async"}
 		}
-		e.Link.SyscallEvent.Async = int64(v)
 		return nil
 	case "link.file.change_time":
 		v, ok := value.(int)
@@ -13948,11 +13944,10 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Link.SyscallEvent.Retval = int64(v)
 		return nil
 	case "load_module.async":
-		v, ok := value.(int)
-		if !ok {
+		var ok bool
+		if e.LoadModule.SyscallEvent.Async, ok = value.(bool); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "LoadModule.SyscallEvent.Async"}
 		}
-		e.LoadModule.SyscallEvent.Async = int64(v)
 		return nil
 	case "load_module.file.change_time":
 		v, ok := value.(int)
@@ -14072,11 +14067,10 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.LoadModule.SyscallEvent.Retval = int64(v)
 		return nil
 	case "mkdir.async":
-		v, ok := value.(int)
-		if !ok {
+		var ok bool
+		if e.Mkdir.SyscallEvent.Async, ok = value.(bool); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "Mkdir.SyscallEvent.Async"}
 		}
-		e.Mkdir.SyscallEvent.Async = int64(v)
 		return nil
 	case "mkdir.file.change_time":
 		v, ok := value.(int)
@@ -14197,11 +14191,10 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Mkdir.SyscallEvent.Retval = int64(v)
 		return nil
 	case "mmap.async":
-		v, ok := value.(int)
-		if !ok {
+		var ok bool
+		if e.MMap.SyscallEvent.Async, ok = value.(bool); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "MMap.SyscallEvent.Async"}
 		}
-		e.MMap.SyscallEvent.Async = int64(v)
 		return nil
 	case "mmap.file.change_time":
 		v, ok := value.(int)
@@ -14322,11 +14315,10 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.MMap.SyscallEvent.Retval = int64(v)
 		return nil
 	case "mprotect.async":
-		v, ok := value.(int)
-		if !ok {
+		var ok bool
+		if e.MProtect.SyscallEvent.Async, ok = value.(bool); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "MProtect.SyscallEvent.Async"}
 		}
-		e.MProtect.SyscallEvent.Async = int64(v)
 		return nil
 	case "mprotect.req_protection":
 		v, ok := value.(int)
@@ -14413,11 +14405,10 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.NetworkContext.Source.Port = uint16(v)
 		return nil
 	case "open.async":
-		v, ok := value.(int)
-		if !ok {
+		var ok bool
+		if e.Open.SyscallEvent.Async, ok = value.(bool); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "Open.SyscallEvent.Async"}
 		}
-		e.Open.SyscallEvent.Async = int64(v)
 		return nil
 	case "open.file.change_time":
 		v, ok := value.(int)
@@ -15297,11 +15288,10 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.ProcessContext.Process.Credentials.User = str
 		return nil
 	case "ptrace.async":
-		v, ok := value.(int)
-		if !ok {
+		var ok bool
+		if e.PTrace.SyscallEvent.Async, ok = value.(bool); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "PTrace.SyscallEvent.Async"}
 		}
-		e.PTrace.SyscallEvent.Async = int64(v)
 		return nil
 	case "ptrace.request":
 		v, ok := value.(int)
@@ -16077,11 +16067,10 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.PTrace.Tracee.Process.Credentials.User = str
 		return nil
 	case "removexattr.async":
-		v, ok := value.(int)
-		if !ok {
+		var ok bool
+		if e.RemoveXAttr.SyscallEvent.Async, ok = value.(bool); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.SyscallEvent.Async"}
 		}
-		e.RemoveXAttr.SyscallEvent.Async = int64(v)
 		return nil
 	case "removexattr.file.change_time":
 		v, ok := value.(int)
@@ -16202,11 +16191,10 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.RemoveXAttr.SyscallEvent.Retval = int64(v)
 		return nil
 	case "rename.async":
-		v, ok := value.(int)
-		if !ok {
+		var ok bool
+		if e.Rename.SyscallEvent.Async, ok = value.(bool); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "Rename.SyscallEvent.Async"}
 		}
-		e.Rename.SyscallEvent.Async = int64(v)
 		return nil
 	case "rename.file.change_time":
 		v, ok := value.(int)
@@ -16410,11 +16398,10 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Rename.SyscallEvent.Retval = int64(v)
 		return nil
 	case "rmdir.async":
-		v, ok := value.(int)
-		if !ok {
+		var ok bool
+		if e.Rmdir.SyscallEvent.Async, ok = value.(bool); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "Rmdir.SyscallEvent.Async"}
 		}
-		e.Rmdir.SyscallEvent.Async = int64(v)
 		return nil
 	case "rmdir.file.change_time":
 		v, ok := value.(int)
@@ -16632,11 +16619,10 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.SetUID.User = str
 		return nil
 	case "setxattr.async":
-		v, ok := value.(int)
-		if !ok {
+		var ok bool
+		if e.SetXAttr.SyscallEvent.Async, ok = value.(bool); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.SyscallEvent.Async"}
 		}
-		e.SetXAttr.SyscallEvent.Async = int64(v)
 		return nil
 	case "setxattr.file.change_time":
 		v, ok := value.(int)
@@ -16757,11 +16743,10 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.SetXAttr.SyscallEvent.Retval = int64(v)
 		return nil
 	case "signal.async":
-		v, ok := value.(int)
-		if !ok {
+		var ok bool
+		if e.Signal.SyscallEvent.Async, ok = value.(bool); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "Signal.SyscallEvent.Async"}
 		}
-		e.Signal.SyscallEvent.Async = int64(v)
 		return nil
 	case "signal.pid":
 		v, ok := value.(int)
@@ -17544,11 +17529,10 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Signal.Type = uint32(v)
 		return nil
 	case "splice.async":
-		v, ok := value.(int)
-		if !ok {
+		var ok bool
+		if e.Splice.SyscallEvent.Async, ok = value.(bool); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "Splice.SyscallEvent.Async"}
 		}
-		e.Splice.SyscallEvent.Async = int64(v)
 		return nil
 	case "splice.file.change_time":
 		v, ok := value.(int)
@@ -17669,11 +17653,10 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Splice.SyscallEvent.Retval = int64(v)
 		return nil
 	case "unlink.async":
-		v, ok := value.(int)
-		if !ok {
+		var ok bool
+		if e.Unlink.SyscallEvent.Async, ok = value.(bool); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "Unlink.SyscallEvent.Async"}
 		}
-		e.Unlink.SyscallEvent.Async = int64(v)
 		return nil
 	case "unlink.file.change_time":
 		v, ok := value.(int)
@@ -17780,11 +17763,10 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Unlink.SyscallEvent.Retval = int64(v)
 		return nil
 	case "unload_module.async":
-		v, ok := value.(int)
-		if !ok {
+		var ok bool
+		if e.UnloadModule.SyscallEvent.Async, ok = value.(bool); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "UnloadModule.SyscallEvent.Async"}
 		}
-		e.UnloadModule.SyscallEvent.Async = int64(v)
 		return nil
 	case "unload_module.name":
 		str, ok := value.(string)
@@ -17801,11 +17783,10 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.UnloadModule.SyscallEvent.Retval = int64(v)
 		return nil
 	case "utimes.async":
-		v, ok := value.(int)
-		if !ok {
+		var ok bool
+		if e.Utimes.SyscallEvent.Async, ok = value.(bool); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "Utimes.SyscallEvent.Async"}
 		}
-		e.Utimes.SyscallEvent.Async = int64(v)
 		return nil
 	case "utimes.file.change_time":
 		v, ok := value.(int)

--- a/pkg/security/probe/accessors.go
+++ b/pkg/security/probe/accessors.go
@@ -59,6 +59,14 @@ func (m *Model) GetEventTypes() []eval.EventType {
 }
 func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Evaluator, error) {
 	switch field {
+	case "bpf.async":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				return int((*Event)(ctx.Object).BPF.SyscallEvent.Async)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
 	case "bpf.cmd":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -147,6 +155,14 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 				return int((*Event)(ctx.Object).Capset.CapPermitted)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "chmod.async":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				return int((*Event)(ctx.Object).Chmod.SyscallEvent.Async)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -284,6 +300,14 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 				return int((*Event)(ctx.Object).Chmod.SyscallEvent.Retval)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "chown.async":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				return int((*Event)(ctx.Object).Chown.SyscallEvent.Async)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -859,6 +883,14 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.FunctionWeight,
 		}, nil
+	case "link.async":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				return int((*Event)(ctx.Object).Link.SyscallEvent.Async)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
 	case "link.file.change_time":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -1093,6 +1125,14 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.FunctionWeight,
 		}, nil
+	case "load_module.async":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				return int((*Event)(ctx.Object).LoadModule.SyscallEvent.Async)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
 	case "load_module.file.change_time":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -1226,6 +1266,14 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 				return int((*Event)(ctx.Object).LoadModule.SyscallEvent.Retval)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "mkdir.async":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				return int((*Event)(ctx.Object).Mkdir.SyscallEvent.Async)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -1367,6 +1415,14 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.FunctionWeight,
 		}, nil
+	case "mmap.async":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				return int((*Event)(ctx.Object).MMap.SyscallEvent.Async)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
 	case "mmap.file.change_time":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -1504,6 +1560,14 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.FunctionWeight,
 		}, nil
+	case "mprotect.async":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				return int((*Event)(ctx.Object).MProtect.SyscallEvent.Async)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
 	case "mprotect.req_protection":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -1596,6 +1660,14 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 				return int((*Event)(ctx.Object).NetworkContext.Source.Port)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "open.async":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				return int((*Event)(ctx.Object).Open.SyscallEvent.Async)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -3089,6 +3161,14 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.FunctionWeight,
 		}, nil
+	case "ptrace.async":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				return int((*Event)(ctx.Object).PTrace.SyscallEvent.Async)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
 	case "ptrace.request":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -4457,6 +4537,14 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.FunctionWeight,
 		}, nil
+	case "removexattr.async":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				return int((*Event)(ctx.Object).RemoveXAttr.SyscallEvent.Async)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
 	case "removexattr.file.change_time":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -4590,6 +4678,14 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 				return int((*Event)(ctx.Object).RemoveXAttr.SyscallEvent.Retval)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "rename.async":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				return int((*Event)(ctx.Object).Rename.SyscallEvent.Async)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -4824,6 +4920,14 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 				return int((*Event)(ctx.Object).Rename.SyscallEvent.Retval)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "rmdir.async":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				return int((*Event)(ctx.Object).Rmdir.SyscallEvent.Async)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -5077,6 +5181,14 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.HandlerWeight,
 		}, nil
+	case "setxattr.async":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				return int((*Event)(ctx.Object).SetXAttr.SyscallEvent.Async)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
 	case "setxattr.file.change_time":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -5210,6 +5322,14 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 				return int((*Event)(ctx.Object).SetXAttr.SyscallEvent.Retval)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "signal.async":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				return int((*Event)(ctx.Object).Signal.SyscallEvent.Async)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -6590,6 +6710,14 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.FunctionWeight,
 		}, nil
+	case "splice.async":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				return int((*Event)(ctx.Object).Splice.SyscallEvent.Async)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
 	case "splice.file.change_time":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -6727,6 +6855,14 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.FunctionWeight,
 		}, nil
+	case "unlink.async":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				return int((*Event)(ctx.Object).Unlink.SyscallEvent.Async)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
 	case "unlink.file.change_time":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -6848,6 +6984,14 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.FunctionWeight,
 		}, nil
+	case "unload_module.async":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				return int((*Event)(ctx.Object).UnloadModule.SyscallEvent.Async)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
 	case "unload_module.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -6860,6 +7004,14 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 				return int((*Event)(ctx.Object).UnloadModule.SyscallEvent.Retval)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "utimes.async":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				return int((*Event)(ctx.Object).Utimes.SyscallEvent.Async)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -6990,6 +7142,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 }
 func (e *Event) GetFields() []eval.Field {
 	return []eval.Field{
+		"bpf.async",
 		"bpf.cmd",
 		"bpf.map.name",
 		"bpf.map.type",
@@ -7001,6 +7154,7 @@ func (e *Event) GetFields() []eval.Field {
 		"bpf.retval",
 		"capset.cap_effective",
 		"capset.cap_permitted",
+		"chmod.async",
 		"chmod.file.change_time",
 		"chmod.file.destination.mode",
 		"chmod.file.destination.rights",
@@ -7018,6 +7172,7 @@ func (e *Event) GetFields() []eval.Field {
 		"chmod.file.uid",
 		"chmod.file.user",
 		"chmod.retval",
+		"chown.async",
 		"chown.file.change_time",
 		"chown.file.destination.gid",
 		"chown.file.destination.group",
@@ -7089,6 +7244,7 @@ func (e *Event) GetFields() []eval.Field {
 		"exec.tty_name",
 		"exec.uid",
 		"exec.user",
+		"link.async",
 		"link.file.change_time",
 		"link.file.destination.change_time",
 		"link.file.destination.filesystem",
@@ -7118,6 +7274,7 @@ func (e *Event) GetFields() []eval.Field {
 		"link.file.uid",
 		"link.file.user",
 		"link.retval",
+		"load_module.async",
 		"load_module.file.change_time",
 		"load_module.file.filesystem",
 		"load_module.file.gid",
@@ -7135,6 +7292,7 @@ func (e *Event) GetFields() []eval.Field {
 		"load_module.loaded_from_memory",
 		"load_module.name",
 		"load_module.retval",
+		"mkdir.async",
 		"mkdir.file.change_time",
 		"mkdir.file.destination.mode",
 		"mkdir.file.destination.rights",
@@ -7152,6 +7310,7 @@ func (e *Event) GetFields() []eval.Field {
 		"mkdir.file.uid",
 		"mkdir.file.user",
 		"mkdir.retval",
+		"mmap.async",
 		"mmap.file.change_time",
 		"mmap.file.filesystem",
 		"mmap.file.gid",
@@ -7169,6 +7328,7 @@ func (e *Event) GetFields() []eval.Field {
 		"mmap.flags",
 		"mmap.protection",
 		"mmap.retval",
+		"mprotect.async",
 		"mprotect.req_protection",
 		"mprotect.retval",
 		"mprotect.vm_protection",
@@ -7181,6 +7341,7 @@ func (e *Event) GetFields() []eval.Field {
 		"network.size",
 		"network.source.ip",
 		"network.source.port",
+		"open.async",
 		"open.file.change_time",
 		"open.file.destination.mode",
 		"open.file.filesystem",
@@ -7288,6 +7449,7 @@ func (e *Event) GetFields() []eval.Field {
 		"process.tty_name",
 		"process.uid",
 		"process.user",
+		"ptrace.async",
 		"ptrace.request",
 		"ptrace.retval",
 		"ptrace.tracee.ancestors.args",
@@ -7380,6 +7542,7 @@ func (e *Event) GetFields() []eval.Field {
 		"ptrace.tracee.tty_name",
 		"ptrace.tracee.uid",
 		"ptrace.tracee.user",
+		"removexattr.async",
 		"removexattr.file.change_time",
 		"removexattr.file.destination.name",
 		"removexattr.file.destination.namespace",
@@ -7397,6 +7560,7 @@ func (e *Event) GetFields() []eval.Field {
 		"removexattr.file.uid",
 		"removexattr.file.user",
 		"removexattr.retval",
+		"rename.async",
 		"rename.file.change_time",
 		"rename.file.destination.change_time",
 		"rename.file.destination.filesystem",
@@ -7426,6 +7590,7 @@ func (e *Event) GetFields() []eval.Field {
 		"rename.file.uid",
 		"rename.file.user",
 		"rename.retval",
+		"rmdir.async",
 		"rmdir.file.change_time",
 		"rmdir.file.filesystem",
 		"rmdir.file.gid",
@@ -7457,6 +7622,7 @@ func (e *Event) GetFields() []eval.Field {
 		"setuid.fsuser",
 		"setuid.uid",
 		"setuid.user",
+		"setxattr.async",
 		"setxattr.file.change_time",
 		"setxattr.file.destination.name",
 		"setxattr.file.destination.namespace",
@@ -7474,6 +7640,7 @@ func (e *Event) GetFields() []eval.Field {
 		"setxattr.file.uid",
 		"setxattr.file.user",
 		"setxattr.retval",
+		"signal.async",
 		"signal.pid",
 		"signal.retval",
 		"signal.target.ancestors.args",
@@ -7567,6 +7734,7 @@ func (e *Event) GetFields() []eval.Field {
 		"signal.target.uid",
 		"signal.target.user",
 		"signal.type",
+		"splice.async",
 		"splice.file.change_time",
 		"splice.file.filesystem",
 		"splice.file.gid",
@@ -7584,6 +7752,7 @@ func (e *Event) GetFields() []eval.Field {
 		"splice.pipe_entry_flag",
 		"splice.pipe_exit_flag",
 		"splice.retval",
+		"unlink.async",
 		"unlink.file.change_time",
 		"unlink.file.filesystem",
 		"unlink.file.gid",
@@ -7599,8 +7768,10 @@ func (e *Event) GetFields() []eval.Field {
 		"unlink.file.uid",
 		"unlink.file.user",
 		"unlink.retval",
+		"unload_module.async",
 		"unload_module.name",
 		"unload_module.retval",
+		"utimes.async",
 		"utimes.file.change_time",
 		"utimes.file.filesystem",
 		"utimes.file.gid",
@@ -7620,6 +7791,8 @@ func (e *Event) GetFields() []eval.Field {
 }
 func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	switch field {
+	case "bpf.async":
+		return int(e.BPF.SyscallEvent.Async), nil
 	case "bpf.cmd":
 		return int(e.BPF.Cmd), nil
 	case "bpf.map.name":
@@ -7646,6 +7819,8 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return int(e.Capset.CapEffective), nil
 	case "capset.cap_permitted":
 		return int(e.Capset.CapPermitted), nil
+	case "chmod.async":
+		return int(e.Chmod.SyscallEvent.Async), nil
 	case "chmod.file.change_time":
 		return int(e.Chmod.File.FileFields.CTime), nil
 	case "chmod.file.destination.mode":
@@ -7680,6 +7855,8 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.ResolveFileFieldsUser(&e.Chmod.File.FileFields), nil
 	case "chmod.retval":
 		return int(e.Chmod.SyscallEvent.Retval), nil
+	case "chown.async":
+		return int(e.Chown.SyscallEvent.Async), nil
 	case "chown.file.change_time":
 		return int(e.Chown.File.FileFields.CTime), nil
 	case "chown.file.destination.gid":
@@ -7822,6 +7999,8 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return int(e.Exec.Process.Credentials.UID), nil
 	case "exec.user":
 		return e.Exec.Process.Credentials.User, nil
+	case "link.async":
+		return int(e.Link.SyscallEvent.Async), nil
 	case "link.file.change_time":
 		return int(e.Link.Source.FileFields.CTime), nil
 	case "link.file.destination.change_time":
@@ -7880,6 +8059,8 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.ResolveFileFieldsUser(&e.Link.Source.FileFields), nil
 	case "link.retval":
 		return int(e.Link.SyscallEvent.Retval), nil
+	case "load_module.async":
+		return int(e.LoadModule.SyscallEvent.Async), nil
 	case "load_module.file.change_time":
 		return int(e.LoadModule.File.FileFields.CTime), nil
 	case "load_module.file.filesystem":
@@ -7914,6 +8095,8 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.LoadModule.Name, nil
 	case "load_module.retval":
 		return int(e.LoadModule.SyscallEvent.Retval), nil
+	case "mkdir.async":
+		return int(e.Mkdir.SyscallEvent.Async), nil
 	case "mkdir.file.change_time":
 		return int(e.Mkdir.File.FileFields.CTime), nil
 	case "mkdir.file.destination.mode":
@@ -7948,6 +8131,8 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.ResolveFileFieldsUser(&e.Mkdir.File.FileFields), nil
 	case "mkdir.retval":
 		return int(e.Mkdir.SyscallEvent.Retval), nil
+	case "mmap.async":
+		return int(e.MMap.SyscallEvent.Async), nil
 	case "mmap.file.change_time":
 		return int(e.MMap.File.FileFields.CTime), nil
 	case "mmap.file.filesystem":
@@ -7982,6 +8167,8 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.MMap.Protection, nil
 	case "mmap.retval":
 		return int(e.MMap.SyscallEvent.Retval), nil
+	case "mprotect.async":
+		return int(e.MProtect.SyscallEvent.Async), nil
 	case "mprotect.req_protection":
 		return e.MProtect.ReqProtection, nil
 	case "mprotect.retval":
@@ -8006,6 +8193,8 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.NetworkContext.Source.IPNet, nil
 	case "network.source.port":
 		return int(e.NetworkContext.Source.Port), nil
+	case "open.async":
+		return int(e.Open.SyscallEvent.Async), nil
 	case "open.file.change_time":
 		return int(e.Open.File.FileFields.CTime), nil
 	case "open.file.destination.mode":
@@ -8670,6 +8859,8 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return int(e.ProcessContext.Process.Credentials.UID), nil
 	case "process.user":
 		return e.ProcessContext.Process.Credentials.User, nil
+	case "ptrace.async":
+		return int(e.PTrace.SyscallEvent.Async), nil
 	case "ptrace.request":
 		return int(e.PTrace.Request), nil
 	case "ptrace.retval":
@@ -9304,6 +9495,8 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return int(e.PTrace.Tracee.Process.Credentials.UID), nil
 	case "ptrace.tracee.user":
 		return e.PTrace.Tracee.Process.Credentials.User, nil
+	case "removexattr.async":
+		return int(e.RemoveXAttr.SyscallEvent.Async), nil
 	case "removexattr.file.change_time":
 		return int(e.RemoveXAttr.File.FileFields.CTime), nil
 	case "removexattr.file.destination.name":
@@ -9338,6 +9531,8 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.ResolveFileFieldsUser(&e.RemoveXAttr.File.FileFields), nil
 	case "removexattr.retval":
 		return int(e.RemoveXAttr.SyscallEvent.Retval), nil
+	case "rename.async":
+		return int(e.Rename.SyscallEvent.Async), nil
 	case "rename.file.change_time":
 		return int(e.Rename.Old.FileFields.CTime), nil
 	case "rename.file.destination.change_time":
@@ -9396,6 +9591,8 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.ResolveFileFieldsUser(&e.Rename.Old.FileFields), nil
 	case "rename.retval":
 		return int(e.Rename.SyscallEvent.Retval), nil
+	case "rmdir.async":
+		return int(e.Rmdir.SyscallEvent.Async), nil
 	case "rmdir.file.change_time":
 		return int(e.Rmdir.File.FileFields.CTime), nil
 	case "rmdir.file.filesystem":
@@ -9458,6 +9655,8 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return int(e.SetUID.UID), nil
 	case "setuid.user":
 		return e.ResolveSetuidUser(&e.SetUID), nil
+	case "setxattr.async":
+		return int(e.SetXAttr.SyscallEvent.Async), nil
 	case "setxattr.file.change_time":
 		return int(e.SetXAttr.File.FileFields.CTime), nil
 	case "setxattr.file.destination.name":
@@ -9492,6 +9691,8 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.ResolveFileFieldsUser(&e.SetXAttr.File.FileFields), nil
 	case "setxattr.retval":
 		return int(e.SetXAttr.SyscallEvent.Retval), nil
+	case "signal.async":
+		return int(e.Signal.SyscallEvent.Async), nil
 	case "signal.pid":
 		return int(e.Signal.PID), nil
 	case "signal.retval":
@@ -10128,6 +10329,8 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.Signal.Target.Process.Credentials.User, nil
 	case "signal.type":
 		return int(e.Signal.Type), nil
+	case "splice.async":
+		return int(e.Splice.SyscallEvent.Async), nil
 	case "splice.file.change_time":
 		return int(e.Splice.File.FileFields.CTime), nil
 	case "splice.file.filesystem":
@@ -10162,6 +10365,8 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return int(e.Splice.PipeExitFlag), nil
 	case "splice.retval":
 		return int(e.Splice.SyscallEvent.Retval), nil
+	case "unlink.async":
+		return int(e.Unlink.SyscallEvent.Async), nil
 	case "unlink.file.change_time":
 		return int(e.Unlink.File.FileFields.CTime), nil
 	case "unlink.file.filesystem":
@@ -10192,10 +10397,14 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.ResolveFileFieldsUser(&e.Unlink.File.FileFields), nil
 	case "unlink.retval":
 		return int(e.Unlink.SyscallEvent.Retval), nil
+	case "unload_module.async":
+		return int(e.UnloadModule.SyscallEvent.Async), nil
 	case "unload_module.name":
 		return e.UnloadModule.Name, nil
 	case "unload_module.retval":
 		return int(e.UnloadModule.SyscallEvent.Retval), nil
+	case "utimes.async":
+		return int(e.Utimes.SyscallEvent.Async), nil
 	case "utimes.file.change_time":
 		return int(e.Utimes.File.FileFields.CTime), nil
 	case "utimes.file.filesystem":
@@ -10231,6 +10440,8 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 }
 func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	switch field {
+	case "bpf.async":
+		return "bpf", nil
 	case "bpf.cmd":
 		return "bpf", nil
 	case "bpf.map.name":
@@ -10253,6 +10464,8 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "capset", nil
 	case "capset.cap_permitted":
 		return "capset", nil
+	case "chmod.async":
+		return "chmod", nil
 	case "chmod.file.change_time":
 		return "chmod", nil
 	case "chmod.file.destination.mode":
@@ -10287,6 +10500,8 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "chmod", nil
 	case "chmod.retval":
 		return "chmod", nil
+	case "chown.async":
+		return "chown", nil
 	case "chown.file.change_time":
 		return "chown", nil
 	case "chown.file.destination.gid":
@@ -10429,6 +10644,8 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "exec", nil
 	case "exec.user":
 		return "exec", nil
+	case "link.async":
+		return "link", nil
 	case "link.file.change_time":
 		return "link", nil
 	case "link.file.destination.change_time":
@@ -10487,6 +10704,8 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "link", nil
 	case "link.retval":
 		return "link", nil
+	case "load_module.async":
+		return "load_module", nil
 	case "load_module.file.change_time":
 		return "load_module", nil
 	case "load_module.file.filesystem":
@@ -10521,6 +10740,8 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "load_module", nil
 	case "load_module.retval":
 		return "load_module", nil
+	case "mkdir.async":
+		return "mkdir", nil
 	case "mkdir.file.change_time":
 		return "mkdir", nil
 	case "mkdir.file.destination.mode":
@@ -10555,6 +10776,8 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "mkdir", nil
 	case "mkdir.retval":
 		return "mkdir", nil
+	case "mmap.async":
+		return "mmap", nil
 	case "mmap.file.change_time":
 		return "mmap", nil
 	case "mmap.file.filesystem":
@@ -10589,6 +10812,8 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "mmap", nil
 	case "mmap.retval":
 		return "mmap", nil
+	case "mprotect.async":
+		return "mprotect", nil
 	case "mprotect.req_protection":
 		return "mprotect", nil
 	case "mprotect.retval":
@@ -10613,6 +10838,8 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "*", nil
 	case "network.source.port":
 		return "*", nil
+	case "open.async":
+		return "open", nil
 	case "open.file.change_time":
 		return "open", nil
 	case "open.file.destination.mode":
@@ -10827,6 +11054,8 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "*", nil
 	case "process.user":
 		return "*", nil
+	case "ptrace.async":
+		return "ptrace", nil
 	case "ptrace.request":
 		return "ptrace", nil
 	case "ptrace.retval":
@@ -11011,6 +11240,8 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "ptrace", nil
 	case "ptrace.tracee.user":
 		return "ptrace", nil
+	case "removexattr.async":
+		return "removexattr", nil
 	case "removexattr.file.change_time":
 		return "removexattr", nil
 	case "removexattr.file.destination.name":
@@ -11045,6 +11276,8 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "removexattr", nil
 	case "removexattr.retval":
 		return "removexattr", nil
+	case "rename.async":
+		return "rename", nil
 	case "rename.file.change_time":
 		return "rename", nil
 	case "rename.file.destination.change_time":
@@ -11103,6 +11336,8 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "rename", nil
 	case "rename.retval":
 		return "rename", nil
+	case "rmdir.async":
+		return "rmdir", nil
 	case "rmdir.file.change_time":
 		return "rmdir", nil
 	case "rmdir.file.filesystem":
@@ -11165,6 +11400,8 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "setuid", nil
 	case "setuid.user":
 		return "setuid", nil
+	case "setxattr.async":
+		return "setxattr", nil
 	case "setxattr.file.change_time":
 		return "setxattr", nil
 	case "setxattr.file.destination.name":
@@ -11199,6 +11436,8 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "setxattr", nil
 	case "setxattr.retval":
 		return "setxattr", nil
+	case "signal.async":
+		return "signal", nil
 	case "signal.pid":
 		return "signal", nil
 	case "signal.retval":
@@ -11385,6 +11624,8 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "signal", nil
 	case "signal.type":
 		return "signal", nil
+	case "splice.async":
+		return "splice", nil
 	case "splice.file.change_time":
 		return "splice", nil
 	case "splice.file.filesystem":
@@ -11419,6 +11660,8 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "splice", nil
 	case "splice.retval":
 		return "splice", nil
+	case "unlink.async":
+		return "unlink", nil
 	case "unlink.file.change_time":
 		return "unlink", nil
 	case "unlink.file.filesystem":
@@ -11449,10 +11692,14 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "unlink", nil
 	case "unlink.retval":
 		return "unlink", nil
+	case "unload_module.async":
+		return "unload_module", nil
 	case "unload_module.name":
 		return "unload_module", nil
 	case "unload_module.retval":
 		return "unload_module", nil
+	case "utimes.async":
+		return "utimes", nil
 	case "utimes.file.change_time":
 		return "utimes", nil
 	case "utimes.file.filesystem":
@@ -11488,6 +11735,8 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 }
 func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	switch field {
+	case "bpf.async":
+		return reflect.Int, nil
 	case "bpf.cmd":
 		return reflect.Int, nil
 	case "bpf.map.name":
@@ -11509,6 +11758,8 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "capset.cap_effective":
 		return reflect.Int, nil
 	case "capset.cap_permitted":
+		return reflect.Int, nil
+	case "chmod.async":
 		return reflect.Int, nil
 	case "chmod.file.change_time":
 		return reflect.Int, nil
@@ -11543,6 +11794,8 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "chmod.file.user":
 		return reflect.String, nil
 	case "chmod.retval":
+		return reflect.Int, nil
+	case "chown.async":
 		return reflect.Int, nil
 	case "chown.file.change_time":
 		return reflect.Int, nil
@@ -11686,6 +11939,8 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 	case "exec.user":
 		return reflect.String, nil
+	case "link.async":
+		return reflect.Int, nil
 	case "link.file.change_time":
 		return reflect.Int, nil
 	case "link.file.destination.change_time":
@@ -11744,6 +11999,8 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.String, nil
 	case "link.retval":
 		return reflect.Int, nil
+	case "load_module.async":
+		return reflect.Int, nil
 	case "load_module.file.change_time":
 		return reflect.Int, nil
 	case "load_module.file.filesystem":
@@ -11777,6 +12034,8 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "load_module.name":
 		return reflect.String, nil
 	case "load_module.retval":
+		return reflect.Int, nil
+	case "mkdir.async":
 		return reflect.Int, nil
 	case "mkdir.file.change_time":
 		return reflect.Int, nil
@@ -11812,6 +12071,8 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.String, nil
 	case "mkdir.retval":
 		return reflect.Int, nil
+	case "mmap.async":
+		return reflect.Int, nil
 	case "mmap.file.change_time":
 		return reflect.Int, nil
 	case "mmap.file.filesystem":
@@ -11846,6 +12107,8 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 	case "mmap.retval":
 		return reflect.Int, nil
+	case "mprotect.async":
+		return reflect.Int, nil
 	case "mprotect.req_protection":
 		return reflect.Int, nil
 	case "mprotect.retval":
@@ -11869,6 +12132,8 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "network.source.ip":
 		return reflect.Struct, nil
 	case "network.source.port":
+		return reflect.Int, nil
+	case "open.async":
 		return reflect.Int, nil
 	case "open.file.change_time":
 		return reflect.Int, nil
@@ -12084,6 +12349,8 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 	case "process.user":
 		return reflect.String, nil
+	case "ptrace.async":
+		return reflect.Int, nil
 	case "ptrace.request":
 		return reflect.Int, nil
 	case "ptrace.retval":
@@ -12268,6 +12535,8 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 	case "ptrace.tracee.user":
 		return reflect.String, nil
+	case "removexattr.async":
+		return reflect.Int, nil
 	case "removexattr.file.change_time":
 		return reflect.Int, nil
 	case "removexattr.file.destination.name":
@@ -12301,6 +12570,8 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "removexattr.file.user":
 		return reflect.String, nil
 	case "removexattr.retval":
+		return reflect.Int, nil
+	case "rename.async":
 		return reflect.Int, nil
 	case "rename.file.change_time":
 		return reflect.Int, nil
@@ -12359,6 +12630,8 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "rename.file.user":
 		return reflect.String, nil
 	case "rename.retval":
+		return reflect.Int, nil
+	case "rmdir.async":
 		return reflect.Int, nil
 	case "rmdir.file.change_time":
 		return reflect.Int, nil
@@ -12422,6 +12695,8 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 	case "setuid.user":
 		return reflect.String, nil
+	case "setxattr.async":
+		return reflect.Int, nil
 	case "setxattr.file.change_time":
 		return reflect.Int, nil
 	case "setxattr.file.destination.name":
@@ -12455,6 +12730,8 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "setxattr.file.user":
 		return reflect.String, nil
 	case "setxattr.retval":
+		return reflect.Int, nil
+	case "signal.async":
 		return reflect.Int, nil
 	case "signal.pid":
 		return reflect.Int, nil
@@ -12642,6 +12919,8 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.String, nil
 	case "signal.type":
 		return reflect.Int, nil
+	case "splice.async":
+		return reflect.Int, nil
 	case "splice.file.change_time":
 		return reflect.Int, nil
 	case "splice.file.filesystem":
@@ -12676,6 +12955,8 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 	case "splice.retval":
 		return reflect.Int, nil
+	case "unlink.async":
+		return reflect.Int, nil
 	case "unlink.file.change_time":
 		return reflect.Int, nil
 	case "unlink.file.filesystem":
@@ -12706,9 +12987,13 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.String, nil
 	case "unlink.retval":
 		return reflect.Int, nil
+	case "unload_module.async":
+		return reflect.Int, nil
 	case "unload_module.name":
 		return reflect.String, nil
 	case "unload_module.retval":
+		return reflect.Int, nil
+	case "utimes.async":
 		return reflect.Int, nil
 	case "utimes.file.change_time":
 		return reflect.Int, nil
@@ -12745,6 +13030,13 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 }
 func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	switch field {
+	case "bpf.async":
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BPF.SyscallEvent.Async"}
+		}
+		e.BPF.SyscallEvent.Async = int64(v)
+		return nil
 	case "bpf.cmd":
 		v, ok := value.(int)
 		if !ok {
@@ -12821,6 +13113,13 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "Capset.CapPermitted"}
 		}
 		e.Capset.CapPermitted = uint64(v)
+		return nil
+	case "chmod.async":
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chmod.SyscallEvent.Async"}
+		}
+		e.Chmod.SyscallEvent.Async = int64(v)
 		return nil
 	case "chmod.file.change_time":
 		v, ok := value.(int)
@@ -12939,6 +13238,13 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "Chmod.SyscallEvent.Retval"}
 		}
 		e.Chmod.SyscallEvent.Retval = int64(v)
+		return nil
+	case "chown.async":
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chown.SyscallEvent.Async"}
+		}
+		e.Chown.SyscallEvent.Async = int64(v)
 		return nil
 	case "chown.file.change_time":
 		v, ok := value.(int)
@@ -13433,6 +13739,13 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Exec.Process.Credentials.User = str
 		return nil
+	case "link.async":
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.SyscallEvent.Async"}
+		}
+		e.Link.SyscallEvent.Async = int64(v)
+		return nil
 	case "link.file.change_time":
 		v, ok := value.(int)
 		if !ok {
@@ -13634,6 +13947,13 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Link.SyscallEvent.Retval = int64(v)
 		return nil
+	case "load_module.async":
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "LoadModule.SyscallEvent.Async"}
+		}
+		e.LoadModule.SyscallEvent.Async = int64(v)
+		return nil
 	case "load_module.file.change_time":
 		v, ok := value.(int)
 		if !ok {
@@ -13750,6 +14070,13 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "LoadModule.SyscallEvent.Retval"}
 		}
 		e.LoadModule.SyscallEvent.Retval = int64(v)
+		return nil
+	case "mkdir.async":
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Mkdir.SyscallEvent.Async"}
+		}
+		e.Mkdir.SyscallEvent.Async = int64(v)
 		return nil
 	case "mkdir.file.change_time":
 		v, ok := value.(int)
@@ -13869,6 +14196,13 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Mkdir.SyscallEvent.Retval = int64(v)
 		return nil
+	case "mmap.async":
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "MMap.SyscallEvent.Async"}
+		}
+		e.MMap.SyscallEvent.Async = int64(v)
+		return nil
 	case "mmap.file.change_time":
 		v, ok := value.(int)
 		if !ok {
@@ -13987,6 +14321,13 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.MMap.SyscallEvent.Retval = int64(v)
 		return nil
+	case "mprotect.async":
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "MProtect.SyscallEvent.Async"}
+		}
+		e.MProtect.SyscallEvent.Async = int64(v)
+		return nil
 	case "mprotect.req_protection":
 		v, ok := value.(int)
 		if !ok {
@@ -14070,6 +14411,13 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "NetworkContext.Source.Port"}
 		}
 		e.NetworkContext.Source.Port = uint16(v)
+		return nil
+	case "open.async":
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Open.SyscallEvent.Async"}
+		}
+		e.Open.SyscallEvent.Async = int64(v)
 		return nil
 	case "open.file.change_time":
 		v, ok := value.(int)
@@ -14948,6 +15296,13 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.ProcessContext.Process.Credentials.User = str
 		return nil
+	case "ptrace.async":
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.SyscallEvent.Async"}
+		}
+		e.PTrace.SyscallEvent.Async = int64(v)
+		return nil
 	case "ptrace.request":
 		v, ok := value.(int)
 		if !ok {
@@ -15721,6 +16076,13 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.PTrace.Tracee.Process.Credentials.User = str
 		return nil
+	case "removexattr.async":
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.SyscallEvent.Async"}
+		}
+		e.RemoveXAttr.SyscallEvent.Async = int64(v)
+		return nil
 	case "removexattr.file.change_time":
 		v, ok := value.(int)
 		if !ok {
@@ -15838,6 +16200,13 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.SyscallEvent.Retval"}
 		}
 		e.RemoveXAttr.SyscallEvent.Retval = int64(v)
+		return nil
+	case "rename.async":
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.SyscallEvent.Async"}
+		}
+		e.Rename.SyscallEvent.Async = int64(v)
 		return nil
 	case "rename.file.change_time":
 		v, ok := value.(int)
@@ -16039,6 +16408,13 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "Rename.SyscallEvent.Retval"}
 		}
 		e.Rename.SyscallEvent.Retval = int64(v)
+		return nil
+	case "rmdir.async":
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rmdir.SyscallEvent.Async"}
+		}
+		e.Rmdir.SyscallEvent.Async = int64(v)
 		return nil
 	case "rmdir.file.change_time":
 		v, ok := value.(int)
@@ -16255,6 +16631,13 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.SetUID.User = str
 		return nil
+	case "setxattr.async":
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.SyscallEvent.Async"}
+		}
+		e.SetXAttr.SyscallEvent.Async = int64(v)
+		return nil
 	case "setxattr.file.change_time":
 		v, ok := value.(int)
 		if !ok {
@@ -16372,6 +16755,13 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.SyscallEvent.Retval"}
 		}
 		e.SetXAttr.SyscallEvent.Retval = int64(v)
+		return nil
+	case "signal.async":
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Signal.SyscallEvent.Async"}
+		}
+		e.Signal.SyscallEvent.Async = int64(v)
 		return nil
 	case "signal.pid":
 		v, ok := value.(int)
@@ -17153,6 +17543,13 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Signal.Type = uint32(v)
 		return nil
+	case "splice.async":
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Splice.SyscallEvent.Async"}
+		}
+		e.Splice.SyscallEvent.Async = int64(v)
+		return nil
 	case "splice.file.change_time":
 		v, ok := value.(int)
 		if !ok {
@@ -17271,6 +17668,13 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Splice.SyscallEvent.Retval = int64(v)
 		return nil
+	case "unlink.async":
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Unlink.SyscallEvent.Async"}
+		}
+		e.Unlink.SyscallEvent.Async = int64(v)
+		return nil
 	case "unlink.file.change_time":
 		v, ok := value.(int)
 		if !ok {
@@ -17375,6 +17779,13 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Unlink.SyscallEvent.Retval = int64(v)
 		return nil
+	case "unload_module.async":
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "UnloadModule.SyscallEvent.Async"}
+		}
+		e.UnloadModule.SyscallEvent.Async = int64(v)
+		return nil
 	case "unload_module.name":
 		str, ok := value.(string)
 		if !ok {
@@ -17388,6 +17799,13 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "UnloadModule.SyscallEvent.Retval"}
 		}
 		e.UnloadModule.SyscallEvent.Retval = int64(v)
+		return nil
+	case "utimes.async":
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Utimes.SyscallEvent.Async"}
+		}
+		e.Utimes.SyscallEvent.Async = int64(v)
 		return nil
 	case "utimes.file.change_time":
 		v, ok := value.(int)

--- a/pkg/security/probe/serializers.go
+++ b/pkg/security/probe/serializers.go
@@ -712,15 +712,6 @@ func serializeSyscallRetval(retval int64) string {
 	}
 }
 
-func serializeSyscallAsync(async int64) bool {
-	switch {
-	case async != 0:
-		return true
-	default:
-		return false
-	}
-}
-
 // NewEventSerializer creates a new event serializer based on the event type
 func NewEventSerializer(event *Event) *EventSerializer {
 	var pc model.ProcessContext
@@ -777,7 +768,7 @@ func NewEventSerializer(event *Event) *EventSerializer {
 			Destination:    newFileSerializer(&event.Link.Target, event, event.Link.Source.Inode),
 		}
 		s.EventContextSerializer.Outcome = serializeSyscallRetval(event.Link.Retval)
-		s.EventContextSerializer.Async = serializeSyscallAsync(event.Link.Async)
+		s.EventContextSerializer.Async = event.Link.Async
 	case model.FileOpenEventType:
 		s.FileEventSerializer = &FileEventSerializer{
 			FileSerializer: *newFileSerializer(&event.Open.File, event),
@@ -791,7 +782,7 @@ func NewEventSerializer(event *Event) *EventSerializer {
 
 		s.FileSerializer.Flags = model.OpenFlags(event.Open.Flags).StringArray()
 		s.EventContextSerializer.Outcome = serializeSyscallRetval(event.Open.Retval)
-		s.EventContextSerializer.Async = serializeSyscallAsync(event.Open.Async)
+		s.EventContextSerializer.Async = event.Open.Async
 	case model.FileMkdirEventType:
 		s.FileEventSerializer = &FileEventSerializer{
 			FileSerializer: *newFileSerializer(&event.Mkdir.File, event),
@@ -800,20 +791,20 @@ func NewEventSerializer(event *Event) *EventSerializer {
 			},
 		}
 		s.EventContextSerializer.Outcome = serializeSyscallRetval(event.Mkdir.Retval)
-		s.EventContextSerializer.Async = serializeSyscallAsync(event.Mkdir.Async)
+		s.EventContextSerializer.Async = event.Mkdir.Async
 	case model.FileRmdirEventType:
 		s.FileEventSerializer = &FileEventSerializer{
 			FileSerializer: *newFileSerializer(&event.Rmdir.File, event),
 		}
 		s.EventContextSerializer.Outcome = serializeSyscallRetval(event.Rmdir.Retval)
-		s.EventContextSerializer.Async = serializeSyscallAsync(event.Rmdir.Async)
+		s.EventContextSerializer.Async = event.Rmdir.Async
 	case model.FileUnlinkEventType:
 		s.FileEventSerializer = &FileEventSerializer{
 			FileSerializer: *newFileSerializer(&event.Unlink.File, event),
 		}
 		s.FileSerializer.Flags = model.UnlinkFlags(event.Unlink.Flags).StringArray()
 		s.EventContextSerializer.Outcome = serializeSyscallRetval(event.Unlink.Retval)
-		s.EventContextSerializer.Async = serializeSyscallAsync(event.Unlink.Async)
+		s.EventContextSerializer.Async = event.Unlink.Async
 	case model.FileRenameEventType:
 		// use the new inode as the old one is a fake inode
 		s.FileEventSerializer = &FileEventSerializer{
@@ -821,7 +812,7 @@ func NewEventSerializer(event *Event) *EventSerializer {
 			Destination:    newFileSerializer(&event.Rename.New, event),
 		}
 		s.EventContextSerializer.Outcome = serializeSyscallRetval(event.Rename.Retval)
-		s.EventContextSerializer.Async = serializeSyscallAsync(event.Rename.Async)
+		s.EventContextSerializer.Async = event.Rename.Async
 	case model.FileRemoveXAttrEventType:
 		s.FileEventSerializer = &FileEventSerializer{
 			FileSerializer: *newFileSerializer(&event.RemoveXAttr.File, event),

--- a/pkg/security/probe/serializers.go
+++ b/pkg/security/probe/serializers.go
@@ -158,6 +158,7 @@ type EventContextSerializer struct {
 	Name     string `json:"name,omitempty" jsonschema_description:"Event name"`
 	Category string `json:"category,omitempty" jsonschema_description:"Event category"`
 	Outcome  string `json:"outcome,omitempty" jsonschema_description:"Event outcome"`
+	Async    bool   `json:"async" jsonschema_description:"True if the event was asynchronous"`
 }
 
 // ProcessContextSerializer serializes a process context to JSON
@@ -711,6 +712,15 @@ func serializeSyscallRetval(retval int64) string {
 	}
 }
 
+func serializeSyscallAsync(async int64) bool {
+	switch {
+	case async != 0:
+		return true
+	default:
+		return false
+	}
+}
+
 // NewEventSerializer creates a new event serializer based on the event type
 func NewEventSerializer(event *Event) *EventSerializer {
 	var pc model.ProcessContext
@@ -767,6 +777,7 @@ func NewEventSerializer(event *Event) *EventSerializer {
 			Destination:    newFileSerializer(&event.Link.Target, event, event.Link.Source.Inode),
 		}
 		s.EventContextSerializer.Outcome = serializeSyscallRetval(event.Link.Retval)
+		s.EventContextSerializer.Async = serializeSyscallAsync(event.Link.Async)
 	case model.FileOpenEventType:
 		s.FileEventSerializer = &FileEventSerializer{
 			FileSerializer: *newFileSerializer(&event.Open.File, event),
@@ -780,6 +791,7 @@ func NewEventSerializer(event *Event) *EventSerializer {
 
 		s.FileSerializer.Flags = model.OpenFlags(event.Open.Flags).StringArray()
 		s.EventContextSerializer.Outcome = serializeSyscallRetval(event.Open.Retval)
+		s.EventContextSerializer.Async = serializeSyscallAsync(event.Open.Async)
 	case model.FileMkdirEventType:
 		s.FileEventSerializer = &FileEventSerializer{
 			FileSerializer: *newFileSerializer(&event.Mkdir.File, event),
@@ -788,17 +800,20 @@ func NewEventSerializer(event *Event) *EventSerializer {
 			},
 		}
 		s.EventContextSerializer.Outcome = serializeSyscallRetval(event.Mkdir.Retval)
+		s.EventContextSerializer.Async = serializeSyscallAsync(event.Mkdir.Async)
 	case model.FileRmdirEventType:
 		s.FileEventSerializer = &FileEventSerializer{
 			FileSerializer: *newFileSerializer(&event.Rmdir.File, event),
 		}
 		s.EventContextSerializer.Outcome = serializeSyscallRetval(event.Rmdir.Retval)
+		s.EventContextSerializer.Async = serializeSyscallAsync(event.Rmdir.Async)
 	case model.FileUnlinkEventType:
 		s.FileEventSerializer = &FileEventSerializer{
 			FileSerializer: *newFileSerializer(&event.Unlink.File, event),
 		}
 		s.FileSerializer.Flags = model.UnlinkFlags(event.Unlink.Flags).StringArray()
 		s.EventContextSerializer.Outcome = serializeSyscallRetval(event.Unlink.Retval)
+		s.EventContextSerializer.Async = serializeSyscallAsync(event.Unlink.Async)
 	case model.FileRenameEventType:
 		// use the new inode as the old one is a fake inode
 		s.FileEventSerializer = &FileEventSerializer{
@@ -806,6 +821,7 @@ func NewEventSerializer(event *Event) *EventSerializer {
 			Destination:    newFileSerializer(&event.Rename.New, event),
 		}
 		s.EventContextSerializer.Outcome = serializeSyscallRetval(event.Rename.Retval)
+		s.EventContextSerializer.Async = serializeSyscallAsync(event.Rename.Async)
 	case model.FileRemoveXAttrEventType:
 		s.FileEventSerializer = &FileEventSerializer{
 			FileSerializer: *newFileSerializer(&event.RemoveXAttr.File, event),

--- a/pkg/security/probe/serializers.go
+++ b/pkg/security/probe/serializers.go
@@ -158,7 +158,7 @@ type EventContextSerializer struct {
 	Name     string `json:"name,omitempty" jsonschema_description:"Event name"`
 	Category string `json:"category,omitempty" jsonschema_description:"Event category"`
 	Outcome  string `json:"outcome,omitempty" jsonschema_description:"Event outcome"`
-	Async    bool   `json:"async" jsonschema_description:"True if the event was asynchronous"`
+	Async    bool   `json:"async,omitempty" jsonschema_description:"True if the event was asynchronous"`
 }
 
 // ProcessContextSerializer serializes a process context to JSON

--- a/pkg/security/probe/serializers_easyjson.go
+++ b/pkg/security/probe/serializers_easyjson.go
@@ -3286,7 +3286,7 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe22(out *j
 		}
 		out.String(string(in.Outcome))
 	}
-	{
+	if in.Async {
 		const prefix string = ",\"async\":"
 		if first {
 			first = false

--- a/pkg/security/probe/serializers_easyjson.go
+++ b/pkg/security/probe/serializers_easyjson.go
@@ -3244,6 +3244,8 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe22(in *jl
 			out.Category = string(in.String())
 		case "outcome":
 			out.Outcome = string(in.String())
+		case "async":
+			out.Async = bool(in.Bool())
 		default:
 			in.SkipRecursive()
 		}
@@ -3283,6 +3285,16 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe22(out *j
 			out.RawString(prefix)
 		}
 		out.String(string(in.Outcome))
+	}
+	{
+		const prefix string = ",\"async\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Bool(bool(in.Async))
 	}
 	out.RawByte('}')
 }

--- a/pkg/security/secl/model/accessors.go
+++ b/pkg/security/secl/model/accessors.go
@@ -56,9 +56,9 @@ func (m *Model) GetEventTypes() []eval.EventType {
 func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Evaluator, error) {
 	switch field {
 	case "bpf.async":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				return int((*Event)(ctx.Object).BPF.SyscallEvent.Async)
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				return (*Event)(ctx.Object).BPF.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -156,9 +156,9 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 	case "chmod.async":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				return int((*Event)(ctx.Object).Chmod.SyscallEvent.Async)
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				return (*Event)(ctx.Object).Chmod.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -301,9 +301,9 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 	case "chown.async":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				return int((*Event)(ctx.Object).Chown.SyscallEvent.Async)
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				return (*Event)(ctx.Object).Chown.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -880,9 +880,9 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 	case "link.async":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				return int((*Event)(ctx.Object).Link.SyscallEvent.Async)
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				return (*Event)(ctx.Object).Link.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -1122,9 +1122,9 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 	case "load_module.async":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				return int((*Event)(ctx.Object).LoadModule.SyscallEvent.Async)
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				return (*Event)(ctx.Object).LoadModule.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -1267,9 +1267,9 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 	case "mkdir.async":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				return int((*Event)(ctx.Object).Mkdir.SyscallEvent.Async)
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				return (*Event)(ctx.Object).Mkdir.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -1412,9 +1412,9 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 	case "mmap.async":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				return int((*Event)(ctx.Object).MMap.SyscallEvent.Async)
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				return (*Event)(ctx.Object).MMap.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -1557,9 +1557,9 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 	case "mprotect.async":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				return int((*Event)(ctx.Object).MProtect.SyscallEvent.Async)
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				return (*Event)(ctx.Object).MProtect.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -1661,9 +1661,9 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 	case "open.async":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				return int((*Event)(ctx.Object).Open.SyscallEvent.Async)
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				return (*Event)(ctx.Object).Open.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -2888,9 +2888,9 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 	case "ptrace.async":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				return int((*Event)(ctx.Object).PTrace.SyscallEvent.Async)
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				return (*Event)(ctx.Object).PTrace.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -3994,9 +3994,9 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 	case "removexattr.async":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				return int((*Event)(ctx.Object).RemoveXAttr.SyscallEvent.Async)
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				return (*Event)(ctx.Object).RemoveXAttr.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -4139,9 +4139,9 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 	case "rename.async":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				return int((*Event)(ctx.Object).Rename.SyscallEvent.Async)
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				return (*Event)(ctx.Object).Rename.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -4381,9 +4381,9 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 	case "rmdir.async":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				return int((*Event)(ctx.Object).Rmdir.SyscallEvent.Async)
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				return (*Event)(ctx.Object).Rmdir.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -4638,9 +4638,9 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 	case "setxattr.async":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				return int((*Event)(ctx.Object).SetXAttr.SyscallEvent.Async)
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				return (*Event)(ctx.Object).SetXAttr.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -4783,9 +4783,9 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 	case "signal.async":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				return int((*Event)(ctx.Object).Signal.SyscallEvent.Async)
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				return (*Event)(ctx.Object).Signal.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -5897,9 +5897,9 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 	case "splice.async":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				return int((*Event)(ctx.Object).Splice.SyscallEvent.Async)
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				return (*Event)(ctx.Object).Splice.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -6042,9 +6042,9 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 	case "unlink.async":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				return int((*Event)(ctx.Object).Unlink.SyscallEvent.Async)
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				return (*Event)(ctx.Object).Unlink.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -6171,9 +6171,9 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 	case "unload_module.async":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				return int((*Event)(ctx.Object).UnloadModule.SyscallEvent.Async)
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				return (*Event)(ctx.Object).UnloadModule.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -6195,9 +6195,9 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 	case "utimes.async":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				return int((*Event)(ctx.Object).Utimes.SyscallEvent.Async)
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				return (*Event)(ctx.Object).Utimes.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -6978,7 +6978,7 @@ func (e *Event) GetFields() []eval.Field {
 func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	switch field {
 	case "bpf.async":
-		return int(e.BPF.SyscallEvent.Async), nil
+		return e.BPF.SyscallEvent.Async, nil
 	case "bpf.cmd":
 		return int(e.BPF.Cmd), nil
 	case "bpf.map.name":
@@ -7006,7 +7006,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "capset.cap_permitted":
 		return int(e.Capset.CapPermitted), nil
 	case "chmod.async":
-		return int(e.Chmod.SyscallEvent.Async), nil
+		return e.Chmod.SyscallEvent.Async, nil
 	case "chmod.file.change_time":
 		return int(e.Chmod.File.FileFields.CTime), nil
 	case "chmod.file.destination.mode":
@@ -7042,7 +7042,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "chmod.retval":
 		return int(e.Chmod.SyscallEvent.Retval), nil
 	case "chown.async":
-		return int(e.Chown.SyscallEvent.Async), nil
+		return e.Chown.SyscallEvent.Async, nil
 	case "chown.file.change_time":
 		return int(e.Chown.File.FileFields.CTime), nil
 	case "chown.file.destination.gid":
@@ -7186,7 +7186,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "exec.user":
 		return e.Exec.Process.Credentials.User, nil
 	case "link.async":
-		return int(e.Link.SyscallEvent.Async), nil
+		return e.Link.SyscallEvent.Async, nil
 	case "link.file.change_time":
 		return int(e.Link.Source.FileFields.CTime), nil
 	case "link.file.destination.change_time":
@@ -7246,7 +7246,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "link.retval":
 		return int(e.Link.SyscallEvent.Retval), nil
 	case "load_module.async":
-		return int(e.LoadModule.SyscallEvent.Async), nil
+		return e.LoadModule.SyscallEvent.Async, nil
 	case "load_module.file.change_time":
 		return int(e.LoadModule.File.FileFields.CTime), nil
 	case "load_module.file.filesystem":
@@ -7282,7 +7282,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "load_module.retval":
 		return int(e.LoadModule.SyscallEvent.Retval), nil
 	case "mkdir.async":
-		return int(e.Mkdir.SyscallEvent.Async), nil
+		return e.Mkdir.SyscallEvent.Async, nil
 	case "mkdir.file.change_time":
 		return int(e.Mkdir.File.FileFields.CTime), nil
 	case "mkdir.file.destination.mode":
@@ -7318,7 +7318,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "mkdir.retval":
 		return int(e.Mkdir.SyscallEvent.Retval), nil
 	case "mmap.async":
-		return int(e.MMap.SyscallEvent.Async), nil
+		return e.MMap.SyscallEvent.Async, nil
 	case "mmap.file.change_time":
 		return int(e.MMap.File.FileFields.CTime), nil
 	case "mmap.file.filesystem":
@@ -7354,7 +7354,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "mmap.retval":
 		return int(e.MMap.SyscallEvent.Retval), nil
 	case "mprotect.async":
-		return int(e.MProtect.SyscallEvent.Async), nil
+		return e.MProtect.SyscallEvent.Async, nil
 	case "mprotect.req_protection":
 		return e.MProtect.ReqProtection, nil
 	case "mprotect.retval":
@@ -7380,7 +7380,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "network.source.port":
 		return int(e.NetworkContext.Source.Port), nil
 	case "open.async":
-		return int(e.Open.SyscallEvent.Async), nil
+		return e.Open.SyscallEvent.Async, nil
 	case "open.file.change_time":
 		return int(e.Open.File.FileFields.CTime), nil
 	case "open.file.destination.mode":
@@ -8046,7 +8046,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "process.user":
 		return e.ProcessContext.Process.Credentials.User, nil
 	case "ptrace.async":
-		return int(e.PTrace.SyscallEvent.Async), nil
+		return e.PTrace.SyscallEvent.Async, nil
 	case "ptrace.request":
 		return int(e.PTrace.Request), nil
 	case "ptrace.retval":
@@ -8682,7 +8682,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "ptrace.tracee.user":
 		return e.PTrace.Tracee.Process.Credentials.User, nil
 	case "removexattr.async":
-		return int(e.RemoveXAttr.SyscallEvent.Async), nil
+		return e.RemoveXAttr.SyscallEvent.Async, nil
 	case "removexattr.file.change_time":
 		return int(e.RemoveXAttr.File.FileFields.CTime), nil
 	case "removexattr.file.destination.name":
@@ -8718,7 +8718,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "removexattr.retval":
 		return int(e.RemoveXAttr.SyscallEvent.Retval), nil
 	case "rename.async":
-		return int(e.Rename.SyscallEvent.Async), nil
+		return e.Rename.SyscallEvent.Async, nil
 	case "rename.file.change_time":
 		return int(e.Rename.Old.FileFields.CTime), nil
 	case "rename.file.destination.change_time":
@@ -8778,7 +8778,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "rename.retval":
 		return int(e.Rename.SyscallEvent.Retval), nil
 	case "rmdir.async":
-		return int(e.Rmdir.SyscallEvent.Async), nil
+		return e.Rmdir.SyscallEvent.Async, nil
 	case "rmdir.file.change_time":
 		return int(e.Rmdir.File.FileFields.CTime), nil
 	case "rmdir.file.filesystem":
@@ -8842,7 +8842,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "setuid.user":
 		return e.SetUID.User, nil
 	case "setxattr.async":
-		return int(e.SetXAttr.SyscallEvent.Async), nil
+		return e.SetXAttr.SyscallEvent.Async, nil
 	case "setxattr.file.change_time":
 		return int(e.SetXAttr.File.FileFields.CTime), nil
 	case "setxattr.file.destination.name":
@@ -8878,7 +8878,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "setxattr.retval":
 		return int(e.SetXAttr.SyscallEvent.Retval), nil
 	case "signal.async":
-		return int(e.Signal.SyscallEvent.Async), nil
+		return e.Signal.SyscallEvent.Async, nil
 	case "signal.pid":
 		return int(e.Signal.PID), nil
 	case "signal.retval":
@@ -9516,7 +9516,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "signal.type":
 		return int(e.Signal.Type), nil
 	case "splice.async":
-		return int(e.Splice.SyscallEvent.Async), nil
+		return e.Splice.SyscallEvent.Async, nil
 	case "splice.file.change_time":
 		return int(e.Splice.File.FileFields.CTime), nil
 	case "splice.file.filesystem":
@@ -9552,7 +9552,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "splice.retval":
 		return int(e.Splice.SyscallEvent.Retval), nil
 	case "unlink.async":
-		return int(e.Unlink.SyscallEvent.Async), nil
+		return e.Unlink.SyscallEvent.Async, nil
 	case "unlink.file.change_time":
 		return int(e.Unlink.File.FileFields.CTime), nil
 	case "unlink.file.filesystem":
@@ -9584,13 +9584,13 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "unlink.retval":
 		return int(e.Unlink.SyscallEvent.Retval), nil
 	case "unload_module.async":
-		return int(e.UnloadModule.SyscallEvent.Async), nil
+		return e.UnloadModule.SyscallEvent.Async, nil
 	case "unload_module.name":
 		return e.UnloadModule.Name, nil
 	case "unload_module.retval":
 		return int(e.UnloadModule.SyscallEvent.Retval), nil
 	case "utimes.async":
-		return int(e.Utimes.SyscallEvent.Async), nil
+		return e.Utimes.SyscallEvent.Async, nil
 	case "utimes.file.change_time":
 		return int(e.Utimes.File.FileFields.CTime), nil
 	case "utimes.file.filesystem":
@@ -10922,7 +10922,7 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	switch field {
 	case "bpf.async":
-		return reflect.Int, nil
+		return reflect.Bool, nil
 	case "bpf.cmd":
 		return reflect.Int, nil
 	case "bpf.map.name":
@@ -10946,7 +10946,7 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "capset.cap_permitted":
 		return reflect.Int, nil
 	case "chmod.async":
-		return reflect.Int, nil
+		return reflect.Bool, nil
 	case "chmod.file.change_time":
 		return reflect.Int, nil
 	case "chmod.file.destination.mode":
@@ -10982,7 +10982,7 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "chmod.retval":
 		return reflect.Int, nil
 	case "chown.async":
-		return reflect.Int, nil
+		return reflect.Bool, nil
 	case "chown.file.change_time":
 		return reflect.Int, nil
 	case "chown.file.destination.gid":
@@ -11126,7 +11126,7 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "exec.user":
 		return reflect.String, nil
 	case "link.async":
-		return reflect.Int, nil
+		return reflect.Bool, nil
 	case "link.file.change_time":
 		return reflect.Int, nil
 	case "link.file.destination.change_time":
@@ -11186,7 +11186,7 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "link.retval":
 		return reflect.Int, nil
 	case "load_module.async":
-		return reflect.Int, nil
+		return reflect.Bool, nil
 	case "load_module.file.change_time":
 		return reflect.Int, nil
 	case "load_module.file.filesystem":
@@ -11222,7 +11222,7 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "load_module.retval":
 		return reflect.Int, nil
 	case "mkdir.async":
-		return reflect.Int, nil
+		return reflect.Bool, nil
 	case "mkdir.file.change_time":
 		return reflect.Int, nil
 	case "mkdir.file.destination.mode":
@@ -11258,7 +11258,7 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "mkdir.retval":
 		return reflect.Int, nil
 	case "mmap.async":
-		return reflect.Int, nil
+		return reflect.Bool, nil
 	case "mmap.file.change_time":
 		return reflect.Int, nil
 	case "mmap.file.filesystem":
@@ -11294,7 +11294,7 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "mmap.retval":
 		return reflect.Int, nil
 	case "mprotect.async":
-		return reflect.Int, nil
+		return reflect.Bool, nil
 	case "mprotect.req_protection":
 		return reflect.Int, nil
 	case "mprotect.retval":
@@ -11320,7 +11320,7 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "network.source.port":
 		return reflect.Int, nil
 	case "open.async":
-		return reflect.Int, nil
+		return reflect.Bool, nil
 	case "open.file.change_time":
 		return reflect.Int, nil
 	case "open.file.destination.mode":
@@ -11536,7 +11536,7 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "process.user":
 		return reflect.String, nil
 	case "ptrace.async":
-		return reflect.Int, nil
+		return reflect.Bool, nil
 	case "ptrace.request":
 		return reflect.Int, nil
 	case "ptrace.retval":
@@ -11722,7 +11722,7 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "ptrace.tracee.user":
 		return reflect.String, nil
 	case "removexattr.async":
-		return reflect.Int, nil
+		return reflect.Bool, nil
 	case "removexattr.file.change_time":
 		return reflect.Int, nil
 	case "removexattr.file.destination.name":
@@ -11758,7 +11758,7 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "removexattr.retval":
 		return reflect.Int, nil
 	case "rename.async":
-		return reflect.Int, nil
+		return reflect.Bool, nil
 	case "rename.file.change_time":
 		return reflect.Int, nil
 	case "rename.file.destination.change_time":
@@ -11818,7 +11818,7 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "rename.retval":
 		return reflect.Int, nil
 	case "rmdir.async":
-		return reflect.Int, nil
+		return reflect.Bool, nil
 	case "rmdir.file.change_time":
 		return reflect.Int, nil
 	case "rmdir.file.filesystem":
@@ -11882,7 +11882,7 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "setuid.user":
 		return reflect.String, nil
 	case "setxattr.async":
-		return reflect.Int, nil
+		return reflect.Bool, nil
 	case "setxattr.file.change_time":
 		return reflect.Int, nil
 	case "setxattr.file.destination.name":
@@ -11918,7 +11918,7 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "setxattr.retval":
 		return reflect.Int, nil
 	case "signal.async":
-		return reflect.Int, nil
+		return reflect.Bool, nil
 	case "signal.pid":
 		return reflect.Int, nil
 	case "signal.retval":
@@ -12106,7 +12106,7 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "signal.type":
 		return reflect.Int, nil
 	case "splice.async":
-		return reflect.Int, nil
+		return reflect.Bool, nil
 	case "splice.file.change_time":
 		return reflect.Int, nil
 	case "splice.file.filesystem":
@@ -12142,7 +12142,7 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "splice.retval":
 		return reflect.Int, nil
 	case "unlink.async":
-		return reflect.Int, nil
+		return reflect.Bool, nil
 	case "unlink.file.change_time":
 		return reflect.Int, nil
 	case "unlink.file.filesystem":
@@ -12174,13 +12174,13 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "unlink.retval":
 		return reflect.Int, nil
 	case "unload_module.async":
-		return reflect.Int, nil
+		return reflect.Bool, nil
 	case "unload_module.name":
 		return reflect.String, nil
 	case "unload_module.retval":
 		return reflect.Int, nil
 	case "utimes.async":
-		return reflect.Int, nil
+		return reflect.Bool, nil
 	case "utimes.file.change_time":
 		return reflect.Int, nil
 	case "utimes.file.filesystem":
@@ -12217,11 +12217,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	switch field {
 	case "bpf.async":
-		v, ok := value.(int)
-		if !ok {
+		var ok bool
+		if e.BPF.SyscallEvent.Async, ok = value.(bool); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "BPF.SyscallEvent.Async"}
 		}
-		e.BPF.SyscallEvent.Async = int64(v)
 		return nil
 	case "bpf.cmd":
 		v, ok := value.(int)
@@ -12301,11 +12300,10 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Capset.CapPermitted = uint64(v)
 		return nil
 	case "chmod.async":
-		v, ok := value.(int)
-		if !ok {
+		var ok bool
+		if e.Chmod.SyscallEvent.Async, ok = value.(bool); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "Chmod.SyscallEvent.Async"}
 		}
-		e.Chmod.SyscallEvent.Async = int64(v)
 		return nil
 	case "chmod.file.change_time":
 		v, ok := value.(int)
@@ -12426,11 +12424,10 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Chmod.SyscallEvent.Retval = int64(v)
 		return nil
 	case "chown.async":
-		v, ok := value.(int)
-		if !ok {
+		var ok bool
+		if e.Chown.SyscallEvent.Async, ok = value.(bool); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "Chown.SyscallEvent.Async"}
 		}
-		e.Chown.SyscallEvent.Async = int64(v)
 		return nil
 	case "chown.file.change_time":
 		v, ok := value.(int)
@@ -12926,11 +12923,10 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Exec.Process.Credentials.User = str
 		return nil
 	case "link.async":
-		v, ok := value.(int)
-		if !ok {
+		var ok bool
+		if e.Link.SyscallEvent.Async, ok = value.(bool); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "Link.SyscallEvent.Async"}
 		}
-		e.Link.SyscallEvent.Async = int64(v)
 		return nil
 	case "link.file.change_time":
 		v, ok := value.(int)
@@ -13134,11 +13130,10 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Link.SyscallEvent.Retval = int64(v)
 		return nil
 	case "load_module.async":
-		v, ok := value.(int)
-		if !ok {
+		var ok bool
+		if e.LoadModule.SyscallEvent.Async, ok = value.(bool); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "LoadModule.SyscallEvent.Async"}
 		}
-		e.LoadModule.SyscallEvent.Async = int64(v)
 		return nil
 	case "load_module.file.change_time":
 		v, ok := value.(int)
@@ -13258,11 +13253,10 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.LoadModule.SyscallEvent.Retval = int64(v)
 		return nil
 	case "mkdir.async":
-		v, ok := value.(int)
-		if !ok {
+		var ok bool
+		if e.Mkdir.SyscallEvent.Async, ok = value.(bool); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "Mkdir.SyscallEvent.Async"}
 		}
-		e.Mkdir.SyscallEvent.Async = int64(v)
 		return nil
 	case "mkdir.file.change_time":
 		v, ok := value.(int)
@@ -13383,11 +13377,10 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Mkdir.SyscallEvent.Retval = int64(v)
 		return nil
 	case "mmap.async":
-		v, ok := value.(int)
-		if !ok {
+		var ok bool
+		if e.MMap.SyscallEvent.Async, ok = value.(bool); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "MMap.SyscallEvent.Async"}
 		}
-		e.MMap.SyscallEvent.Async = int64(v)
 		return nil
 	case "mmap.file.change_time":
 		v, ok := value.(int)
@@ -13508,11 +13501,10 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.MMap.SyscallEvent.Retval = int64(v)
 		return nil
 	case "mprotect.async":
-		v, ok := value.(int)
-		if !ok {
+		var ok bool
+		if e.MProtect.SyscallEvent.Async, ok = value.(bool); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "MProtect.SyscallEvent.Async"}
 		}
-		e.MProtect.SyscallEvent.Async = int64(v)
 		return nil
 	case "mprotect.req_protection":
 		v, ok := value.(int)
@@ -13599,11 +13591,10 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.NetworkContext.Source.Port = uint16(v)
 		return nil
 	case "open.async":
-		v, ok := value.(int)
-		if !ok {
+		var ok bool
+		if e.Open.SyscallEvent.Async, ok = value.(bool); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "Open.SyscallEvent.Async"}
 		}
-		e.Open.SyscallEvent.Async = int64(v)
 		return nil
 	case "open.file.change_time":
 		v, ok := value.(int)
@@ -14483,11 +14474,10 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.ProcessContext.Process.Credentials.User = str
 		return nil
 	case "ptrace.async":
-		v, ok := value.(int)
-		if !ok {
+		var ok bool
+		if e.PTrace.SyscallEvent.Async, ok = value.(bool); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "PTrace.SyscallEvent.Async"}
 		}
-		e.PTrace.SyscallEvent.Async = int64(v)
 		return nil
 	case "ptrace.request":
 		v, ok := value.(int)
@@ -15263,11 +15253,10 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.PTrace.Tracee.Process.Credentials.User = str
 		return nil
 	case "removexattr.async":
-		v, ok := value.(int)
-		if !ok {
+		var ok bool
+		if e.RemoveXAttr.SyscallEvent.Async, ok = value.(bool); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.SyscallEvent.Async"}
 		}
-		e.RemoveXAttr.SyscallEvent.Async = int64(v)
 		return nil
 	case "removexattr.file.change_time":
 		v, ok := value.(int)
@@ -15388,11 +15377,10 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.RemoveXAttr.SyscallEvent.Retval = int64(v)
 		return nil
 	case "rename.async":
-		v, ok := value.(int)
-		if !ok {
+		var ok bool
+		if e.Rename.SyscallEvent.Async, ok = value.(bool); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "Rename.SyscallEvent.Async"}
 		}
-		e.Rename.SyscallEvent.Async = int64(v)
 		return nil
 	case "rename.file.change_time":
 		v, ok := value.(int)
@@ -15596,11 +15584,10 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Rename.SyscallEvent.Retval = int64(v)
 		return nil
 	case "rmdir.async":
-		v, ok := value.(int)
-		if !ok {
+		var ok bool
+		if e.Rmdir.SyscallEvent.Async, ok = value.(bool); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "Rmdir.SyscallEvent.Async"}
 		}
-		e.Rmdir.SyscallEvent.Async = int64(v)
 		return nil
 	case "rmdir.file.change_time":
 		v, ok := value.(int)
@@ -15818,11 +15805,10 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.SetUID.User = str
 		return nil
 	case "setxattr.async":
-		v, ok := value.(int)
-		if !ok {
+		var ok bool
+		if e.SetXAttr.SyscallEvent.Async, ok = value.(bool); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.SyscallEvent.Async"}
 		}
-		e.SetXAttr.SyscallEvent.Async = int64(v)
 		return nil
 	case "setxattr.file.change_time":
 		v, ok := value.(int)
@@ -15943,11 +15929,10 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.SetXAttr.SyscallEvent.Retval = int64(v)
 		return nil
 	case "signal.async":
-		v, ok := value.(int)
-		if !ok {
+		var ok bool
+		if e.Signal.SyscallEvent.Async, ok = value.(bool); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "Signal.SyscallEvent.Async"}
 		}
-		e.Signal.SyscallEvent.Async = int64(v)
 		return nil
 	case "signal.pid":
 		v, ok := value.(int)
@@ -16730,11 +16715,10 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Signal.Type = uint32(v)
 		return nil
 	case "splice.async":
-		v, ok := value.(int)
-		if !ok {
+		var ok bool
+		if e.Splice.SyscallEvent.Async, ok = value.(bool); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "Splice.SyscallEvent.Async"}
 		}
-		e.Splice.SyscallEvent.Async = int64(v)
 		return nil
 	case "splice.file.change_time":
 		v, ok := value.(int)
@@ -16855,11 +16839,10 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Splice.SyscallEvent.Retval = int64(v)
 		return nil
 	case "unlink.async":
-		v, ok := value.(int)
-		if !ok {
+		var ok bool
+		if e.Unlink.SyscallEvent.Async, ok = value.(bool); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "Unlink.SyscallEvent.Async"}
 		}
-		e.Unlink.SyscallEvent.Async = int64(v)
 		return nil
 	case "unlink.file.change_time":
 		v, ok := value.(int)
@@ -16966,11 +16949,10 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Unlink.SyscallEvent.Retval = int64(v)
 		return nil
 	case "unload_module.async":
-		v, ok := value.(int)
-		if !ok {
+		var ok bool
+		if e.UnloadModule.SyscallEvent.Async, ok = value.(bool); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "UnloadModule.SyscallEvent.Async"}
 		}
-		e.UnloadModule.SyscallEvent.Async = int64(v)
 		return nil
 	case "unload_module.name":
 		str, ok := value.(string)
@@ -16987,11 +16969,10 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.UnloadModule.SyscallEvent.Retval = int64(v)
 		return nil
 	case "utimes.async":
-		v, ok := value.(int)
-		if !ok {
+		var ok bool
+		if e.Utimes.SyscallEvent.Async, ok = value.(bool); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "Utimes.SyscallEvent.Async"}
 		}
-		e.Utimes.SyscallEvent.Async = int64(v)
 		return nil
 	case "utimes.file.change_time":
 		v, ok := value.(int)

--- a/pkg/security/secl/model/accessors.go
+++ b/pkg/security/secl/model/accessors.go
@@ -55,6 +55,14 @@ func (m *Model) GetEventTypes() []eval.EventType {
 }
 func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Evaluator, error) {
 	switch field {
+	case "bpf.async":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				return int((*Event)(ctx.Object).BPF.SyscallEvent.Async)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
 	case "bpf.cmd":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -143,6 +151,14 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 				return int((*Event)(ctx.Object).Capset.CapPermitted)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "chmod.async":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				return int((*Event)(ctx.Object).Chmod.SyscallEvent.Async)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -280,6 +296,14 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 				return int((*Event)(ctx.Object).Chmod.SyscallEvent.Retval)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "chown.async":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				return int((*Event)(ctx.Object).Chown.SyscallEvent.Async)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -855,6 +879,14 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.FunctionWeight,
 		}, nil
+	case "link.async":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				return int((*Event)(ctx.Object).Link.SyscallEvent.Async)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
 	case "link.file.change_time":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -1089,6 +1121,14 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.FunctionWeight,
 		}, nil
+	case "load_module.async":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				return int((*Event)(ctx.Object).LoadModule.SyscallEvent.Async)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
 	case "load_module.file.change_time":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -1222,6 +1262,14 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 				return int((*Event)(ctx.Object).LoadModule.SyscallEvent.Retval)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "mkdir.async":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				return int((*Event)(ctx.Object).Mkdir.SyscallEvent.Async)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -1363,6 +1411,14 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.FunctionWeight,
 		}, nil
+	case "mmap.async":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				return int((*Event)(ctx.Object).MMap.SyscallEvent.Async)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
 	case "mmap.file.change_time":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -1500,6 +1556,14 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.FunctionWeight,
 		}, nil
+	case "mprotect.async":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				return int((*Event)(ctx.Object).MProtect.SyscallEvent.Async)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
 	case "mprotect.req_protection":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -1592,6 +1656,14 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 				return int((*Event)(ctx.Object).NetworkContext.Source.Port)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "open.async":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				return int((*Event)(ctx.Object).Open.SyscallEvent.Async)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -2815,6 +2887,14 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.FunctionWeight,
 		}, nil
+	case "ptrace.async":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				return int((*Event)(ctx.Object).PTrace.SyscallEvent.Async)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
 	case "ptrace.request":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -3913,6 +3993,14 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.FunctionWeight,
 		}, nil
+	case "removexattr.async":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				return int((*Event)(ctx.Object).RemoveXAttr.SyscallEvent.Async)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
 	case "removexattr.file.change_time":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -4046,6 +4134,14 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 				return int((*Event)(ctx.Object).RemoveXAttr.SyscallEvent.Retval)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "rename.async":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				return int((*Event)(ctx.Object).Rename.SyscallEvent.Async)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -4280,6 +4376,14 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 				return int((*Event)(ctx.Object).Rename.SyscallEvent.Retval)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "rmdir.async":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				return int((*Event)(ctx.Object).Rmdir.SyscallEvent.Async)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -4533,6 +4637,14 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.HandlerWeight,
 		}, nil
+	case "setxattr.async":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				return int((*Event)(ctx.Object).SetXAttr.SyscallEvent.Async)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
 	case "setxattr.file.change_time":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -4666,6 +4778,14 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 				return int((*Event)(ctx.Object).SetXAttr.SyscallEvent.Retval)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "signal.async":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				return int((*Event)(ctx.Object).Signal.SyscallEvent.Async)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -5776,6 +5896,14 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.FunctionWeight,
 		}, nil
+	case "splice.async":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				return int((*Event)(ctx.Object).Splice.SyscallEvent.Async)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
 	case "splice.file.change_time":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -5913,6 +6041,14 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.FunctionWeight,
 		}, nil
+	case "unlink.async":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				return int((*Event)(ctx.Object).Unlink.SyscallEvent.Async)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
 	case "unlink.file.change_time":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -6034,6 +6170,14 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.FunctionWeight,
 		}, nil
+	case "unload_module.async":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				return int((*Event)(ctx.Object).UnloadModule.SyscallEvent.Async)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
 	case "unload_module.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -6046,6 +6190,14 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 				return int((*Event)(ctx.Object).UnloadModule.SyscallEvent.Retval)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "utimes.async":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				return int((*Event)(ctx.Object).Utimes.SyscallEvent.Async)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -6176,6 +6328,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 }
 func (e *Event) GetFields() []eval.Field {
 	return []eval.Field{
+		"bpf.async",
 		"bpf.cmd",
 		"bpf.map.name",
 		"bpf.map.type",
@@ -6187,6 +6340,7 @@ func (e *Event) GetFields() []eval.Field {
 		"bpf.retval",
 		"capset.cap_effective",
 		"capset.cap_permitted",
+		"chmod.async",
 		"chmod.file.change_time",
 		"chmod.file.destination.mode",
 		"chmod.file.destination.rights",
@@ -6204,6 +6358,7 @@ func (e *Event) GetFields() []eval.Field {
 		"chmod.file.uid",
 		"chmod.file.user",
 		"chmod.retval",
+		"chown.async",
 		"chown.file.change_time",
 		"chown.file.destination.gid",
 		"chown.file.destination.group",
@@ -6275,6 +6430,7 @@ func (e *Event) GetFields() []eval.Field {
 		"exec.tty_name",
 		"exec.uid",
 		"exec.user",
+		"link.async",
 		"link.file.change_time",
 		"link.file.destination.change_time",
 		"link.file.destination.filesystem",
@@ -6304,6 +6460,7 @@ func (e *Event) GetFields() []eval.Field {
 		"link.file.uid",
 		"link.file.user",
 		"link.retval",
+		"load_module.async",
 		"load_module.file.change_time",
 		"load_module.file.filesystem",
 		"load_module.file.gid",
@@ -6321,6 +6478,7 @@ func (e *Event) GetFields() []eval.Field {
 		"load_module.loaded_from_memory",
 		"load_module.name",
 		"load_module.retval",
+		"mkdir.async",
 		"mkdir.file.change_time",
 		"mkdir.file.destination.mode",
 		"mkdir.file.destination.rights",
@@ -6338,6 +6496,7 @@ func (e *Event) GetFields() []eval.Field {
 		"mkdir.file.uid",
 		"mkdir.file.user",
 		"mkdir.retval",
+		"mmap.async",
 		"mmap.file.change_time",
 		"mmap.file.filesystem",
 		"mmap.file.gid",
@@ -6355,6 +6514,7 @@ func (e *Event) GetFields() []eval.Field {
 		"mmap.flags",
 		"mmap.protection",
 		"mmap.retval",
+		"mprotect.async",
 		"mprotect.req_protection",
 		"mprotect.retval",
 		"mprotect.vm_protection",
@@ -6367,6 +6527,7 @@ func (e *Event) GetFields() []eval.Field {
 		"network.size",
 		"network.source.ip",
 		"network.source.port",
+		"open.async",
 		"open.file.change_time",
 		"open.file.destination.mode",
 		"open.file.filesystem",
@@ -6474,6 +6635,7 @@ func (e *Event) GetFields() []eval.Field {
 		"process.tty_name",
 		"process.uid",
 		"process.user",
+		"ptrace.async",
 		"ptrace.request",
 		"ptrace.retval",
 		"ptrace.tracee.ancestors.args",
@@ -6566,6 +6728,7 @@ func (e *Event) GetFields() []eval.Field {
 		"ptrace.tracee.tty_name",
 		"ptrace.tracee.uid",
 		"ptrace.tracee.user",
+		"removexattr.async",
 		"removexattr.file.change_time",
 		"removexattr.file.destination.name",
 		"removexattr.file.destination.namespace",
@@ -6583,6 +6746,7 @@ func (e *Event) GetFields() []eval.Field {
 		"removexattr.file.uid",
 		"removexattr.file.user",
 		"removexattr.retval",
+		"rename.async",
 		"rename.file.change_time",
 		"rename.file.destination.change_time",
 		"rename.file.destination.filesystem",
@@ -6612,6 +6776,7 @@ func (e *Event) GetFields() []eval.Field {
 		"rename.file.uid",
 		"rename.file.user",
 		"rename.retval",
+		"rmdir.async",
 		"rmdir.file.change_time",
 		"rmdir.file.filesystem",
 		"rmdir.file.gid",
@@ -6643,6 +6808,7 @@ func (e *Event) GetFields() []eval.Field {
 		"setuid.fsuser",
 		"setuid.uid",
 		"setuid.user",
+		"setxattr.async",
 		"setxattr.file.change_time",
 		"setxattr.file.destination.name",
 		"setxattr.file.destination.namespace",
@@ -6660,6 +6826,7 @@ func (e *Event) GetFields() []eval.Field {
 		"setxattr.file.uid",
 		"setxattr.file.user",
 		"setxattr.retval",
+		"signal.async",
 		"signal.pid",
 		"signal.retval",
 		"signal.target.ancestors.args",
@@ -6753,6 +6920,7 @@ func (e *Event) GetFields() []eval.Field {
 		"signal.target.uid",
 		"signal.target.user",
 		"signal.type",
+		"splice.async",
 		"splice.file.change_time",
 		"splice.file.filesystem",
 		"splice.file.gid",
@@ -6770,6 +6938,7 @@ func (e *Event) GetFields() []eval.Field {
 		"splice.pipe_entry_flag",
 		"splice.pipe_exit_flag",
 		"splice.retval",
+		"unlink.async",
 		"unlink.file.change_time",
 		"unlink.file.filesystem",
 		"unlink.file.gid",
@@ -6785,8 +6954,10 @@ func (e *Event) GetFields() []eval.Field {
 		"unlink.file.uid",
 		"unlink.file.user",
 		"unlink.retval",
+		"unload_module.async",
 		"unload_module.name",
 		"unload_module.retval",
+		"utimes.async",
 		"utimes.file.change_time",
 		"utimes.file.filesystem",
 		"utimes.file.gid",
@@ -6806,6 +6977,8 @@ func (e *Event) GetFields() []eval.Field {
 }
 func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	switch field {
+	case "bpf.async":
+		return int(e.BPF.SyscallEvent.Async), nil
 	case "bpf.cmd":
 		return int(e.BPF.Cmd), nil
 	case "bpf.map.name":
@@ -6832,6 +7005,8 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return int(e.Capset.CapEffective), nil
 	case "capset.cap_permitted":
 		return int(e.Capset.CapPermitted), nil
+	case "chmod.async":
+		return int(e.Chmod.SyscallEvent.Async), nil
 	case "chmod.file.change_time":
 		return int(e.Chmod.File.FileFields.CTime), nil
 	case "chmod.file.destination.mode":
@@ -6866,6 +7041,8 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.Chmod.File.FileFields.User, nil
 	case "chmod.retval":
 		return int(e.Chmod.SyscallEvent.Retval), nil
+	case "chown.async":
+		return int(e.Chown.SyscallEvent.Async), nil
 	case "chown.file.change_time":
 		return int(e.Chown.File.FileFields.CTime), nil
 	case "chown.file.destination.gid":
@@ -7008,6 +7185,8 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return int(e.Exec.Process.Credentials.UID), nil
 	case "exec.user":
 		return e.Exec.Process.Credentials.User, nil
+	case "link.async":
+		return int(e.Link.SyscallEvent.Async), nil
 	case "link.file.change_time":
 		return int(e.Link.Source.FileFields.CTime), nil
 	case "link.file.destination.change_time":
@@ -7066,6 +7245,8 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.Link.Source.FileFields.User, nil
 	case "link.retval":
 		return int(e.Link.SyscallEvent.Retval), nil
+	case "load_module.async":
+		return int(e.LoadModule.SyscallEvent.Async), nil
 	case "load_module.file.change_time":
 		return int(e.LoadModule.File.FileFields.CTime), nil
 	case "load_module.file.filesystem":
@@ -7100,6 +7281,8 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.LoadModule.Name, nil
 	case "load_module.retval":
 		return int(e.LoadModule.SyscallEvent.Retval), nil
+	case "mkdir.async":
+		return int(e.Mkdir.SyscallEvent.Async), nil
 	case "mkdir.file.change_time":
 		return int(e.Mkdir.File.FileFields.CTime), nil
 	case "mkdir.file.destination.mode":
@@ -7134,6 +7317,8 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.Mkdir.File.FileFields.User, nil
 	case "mkdir.retval":
 		return int(e.Mkdir.SyscallEvent.Retval), nil
+	case "mmap.async":
+		return int(e.MMap.SyscallEvent.Async), nil
 	case "mmap.file.change_time":
 		return int(e.MMap.File.FileFields.CTime), nil
 	case "mmap.file.filesystem":
@@ -7168,6 +7353,8 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.MMap.Protection, nil
 	case "mmap.retval":
 		return int(e.MMap.SyscallEvent.Retval), nil
+	case "mprotect.async":
+		return int(e.MProtect.SyscallEvent.Async), nil
 	case "mprotect.req_protection":
 		return e.MProtect.ReqProtection, nil
 	case "mprotect.retval":
@@ -7192,6 +7379,8 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.NetworkContext.Source.IPNet, nil
 	case "network.source.port":
 		return int(e.NetworkContext.Source.Port), nil
+	case "open.async":
+		return int(e.Open.SyscallEvent.Async), nil
 	case "open.file.change_time":
 		return int(e.Open.File.FileFields.CTime), nil
 	case "open.file.destination.mode":
@@ -7856,6 +8045,8 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return int(e.ProcessContext.Process.Credentials.UID), nil
 	case "process.user":
 		return e.ProcessContext.Process.Credentials.User, nil
+	case "ptrace.async":
+		return int(e.PTrace.SyscallEvent.Async), nil
 	case "ptrace.request":
 		return int(e.PTrace.Request), nil
 	case "ptrace.retval":
@@ -8490,6 +8681,8 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return int(e.PTrace.Tracee.Process.Credentials.UID), nil
 	case "ptrace.tracee.user":
 		return e.PTrace.Tracee.Process.Credentials.User, nil
+	case "removexattr.async":
+		return int(e.RemoveXAttr.SyscallEvent.Async), nil
 	case "removexattr.file.change_time":
 		return int(e.RemoveXAttr.File.FileFields.CTime), nil
 	case "removexattr.file.destination.name":
@@ -8524,6 +8717,8 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.RemoveXAttr.File.FileFields.User, nil
 	case "removexattr.retval":
 		return int(e.RemoveXAttr.SyscallEvent.Retval), nil
+	case "rename.async":
+		return int(e.Rename.SyscallEvent.Async), nil
 	case "rename.file.change_time":
 		return int(e.Rename.Old.FileFields.CTime), nil
 	case "rename.file.destination.change_time":
@@ -8582,6 +8777,8 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.Rename.Old.FileFields.User, nil
 	case "rename.retval":
 		return int(e.Rename.SyscallEvent.Retval), nil
+	case "rmdir.async":
+		return int(e.Rmdir.SyscallEvent.Async), nil
 	case "rmdir.file.change_time":
 		return int(e.Rmdir.File.FileFields.CTime), nil
 	case "rmdir.file.filesystem":
@@ -8644,6 +8841,8 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return int(e.SetUID.UID), nil
 	case "setuid.user":
 		return e.SetUID.User, nil
+	case "setxattr.async":
+		return int(e.SetXAttr.SyscallEvent.Async), nil
 	case "setxattr.file.change_time":
 		return int(e.SetXAttr.File.FileFields.CTime), nil
 	case "setxattr.file.destination.name":
@@ -8678,6 +8877,8 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.SetXAttr.File.FileFields.User, nil
 	case "setxattr.retval":
 		return int(e.SetXAttr.SyscallEvent.Retval), nil
+	case "signal.async":
+		return int(e.Signal.SyscallEvent.Async), nil
 	case "signal.pid":
 		return int(e.Signal.PID), nil
 	case "signal.retval":
@@ -9314,6 +9515,8 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.Signal.Target.Process.Credentials.User, nil
 	case "signal.type":
 		return int(e.Signal.Type), nil
+	case "splice.async":
+		return int(e.Splice.SyscallEvent.Async), nil
 	case "splice.file.change_time":
 		return int(e.Splice.File.FileFields.CTime), nil
 	case "splice.file.filesystem":
@@ -9348,6 +9551,8 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return int(e.Splice.PipeExitFlag), nil
 	case "splice.retval":
 		return int(e.Splice.SyscallEvent.Retval), nil
+	case "unlink.async":
+		return int(e.Unlink.SyscallEvent.Async), nil
 	case "unlink.file.change_time":
 		return int(e.Unlink.File.FileFields.CTime), nil
 	case "unlink.file.filesystem":
@@ -9378,10 +9583,14 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.Unlink.File.FileFields.User, nil
 	case "unlink.retval":
 		return int(e.Unlink.SyscallEvent.Retval), nil
+	case "unload_module.async":
+		return int(e.UnloadModule.SyscallEvent.Async), nil
 	case "unload_module.name":
 		return e.UnloadModule.Name, nil
 	case "unload_module.retval":
 		return int(e.UnloadModule.SyscallEvent.Retval), nil
+	case "utimes.async":
+		return int(e.Utimes.SyscallEvent.Async), nil
 	case "utimes.file.change_time":
 		return int(e.Utimes.File.FileFields.CTime), nil
 	case "utimes.file.filesystem":
@@ -9417,6 +9626,8 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 }
 func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	switch field {
+	case "bpf.async":
+		return "bpf", nil
 	case "bpf.cmd":
 		return "bpf", nil
 	case "bpf.map.name":
@@ -9439,6 +9650,8 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "capset", nil
 	case "capset.cap_permitted":
 		return "capset", nil
+	case "chmod.async":
+		return "chmod", nil
 	case "chmod.file.change_time":
 		return "chmod", nil
 	case "chmod.file.destination.mode":
@@ -9473,6 +9686,8 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "chmod", nil
 	case "chmod.retval":
 		return "chmod", nil
+	case "chown.async":
+		return "chown", nil
 	case "chown.file.change_time":
 		return "chown", nil
 	case "chown.file.destination.gid":
@@ -9615,6 +9830,8 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "exec", nil
 	case "exec.user":
 		return "exec", nil
+	case "link.async":
+		return "link", nil
 	case "link.file.change_time":
 		return "link", nil
 	case "link.file.destination.change_time":
@@ -9673,6 +9890,8 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "link", nil
 	case "link.retval":
 		return "link", nil
+	case "load_module.async":
+		return "load_module", nil
 	case "load_module.file.change_time":
 		return "load_module", nil
 	case "load_module.file.filesystem":
@@ -9707,6 +9926,8 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "load_module", nil
 	case "load_module.retval":
 		return "load_module", nil
+	case "mkdir.async":
+		return "mkdir", nil
 	case "mkdir.file.change_time":
 		return "mkdir", nil
 	case "mkdir.file.destination.mode":
@@ -9741,6 +9962,8 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "mkdir", nil
 	case "mkdir.retval":
 		return "mkdir", nil
+	case "mmap.async":
+		return "mmap", nil
 	case "mmap.file.change_time":
 		return "mmap", nil
 	case "mmap.file.filesystem":
@@ -9775,6 +9998,8 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "mmap", nil
 	case "mmap.retval":
 		return "mmap", nil
+	case "mprotect.async":
+		return "mprotect", nil
 	case "mprotect.req_protection":
 		return "mprotect", nil
 	case "mprotect.retval":
@@ -9799,6 +10024,8 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "*", nil
 	case "network.source.port":
 		return "*", nil
+	case "open.async":
+		return "open", nil
 	case "open.file.change_time":
 		return "open", nil
 	case "open.file.destination.mode":
@@ -10013,6 +10240,8 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "*", nil
 	case "process.user":
 		return "*", nil
+	case "ptrace.async":
+		return "ptrace", nil
 	case "ptrace.request":
 		return "ptrace", nil
 	case "ptrace.retval":
@@ -10197,6 +10426,8 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "ptrace", nil
 	case "ptrace.tracee.user":
 		return "ptrace", nil
+	case "removexattr.async":
+		return "removexattr", nil
 	case "removexattr.file.change_time":
 		return "removexattr", nil
 	case "removexattr.file.destination.name":
@@ -10231,6 +10462,8 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "removexattr", nil
 	case "removexattr.retval":
 		return "removexattr", nil
+	case "rename.async":
+		return "rename", nil
 	case "rename.file.change_time":
 		return "rename", nil
 	case "rename.file.destination.change_time":
@@ -10289,6 +10522,8 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "rename", nil
 	case "rename.retval":
 		return "rename", nil
+	case "rmdir.async":
+		return "rmdir", nil
 	case "rmdir.file.change_time":
 		return "rmdir", nil
 	case "rmdir.file.filesystem":
@@ -10351,6 +10586,8 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "setuid", nil
 	case "setuid.user":
 		return "setuid", nil
+	case "setxattr.async":
+		return "setxattr", nil
 	case "setxattr.file.change_time":
 		return "setxattr", nil
 	case "setxattr.file.destination.name":
@@ -10385,6 +10622,8 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "setxattr", nil
 	case "setxattr.retval":
 		return "setxattr", nil
+	case "signal.async":
+		return "signal", nil
 	case "signal.pid":
 		return "signal", nil
 	case "signal.retval":
@@ -10571,6 +10810,8 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "signal", nil
 	case "signal.type":
 		return "signal", nil
+	case "splice.async":
+		return "splice", nil
 	case "splice.file.change_time":
 		return "splice", nil
 	case "splice.file.filesystem":
@@ -10605,6 +10846,8 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "splice", nil
 	case "splice.retval":
 		return "splice", nil
+	case "unlink.async":
+		return "unlink", nil
 	case "unlink.file.change_time":
 		return "unlink", nil
 	case "unlink.file.filesystem":
@@ -10635,10 +10878,14 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "unlink", nil
 	case "unlink.retval":
 		return "unlink", nil
+	case "unload_module.async":
+		return "unload_module", nil
 	case "unload_module.name":
 		return "unload_module", nil
 	case "unload_module.retval":
 		return "unload_module", nil
+	case "utimes.async":
+		return "utimes", nil
 	case "utimes.file.change_time":
 		return "utimes", nil
 	case "utimes.file.filesystem":
@@ -10674,6 +10921,8 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 }
 func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	switch field {
+	case "bpf.async":
+		return reflect.Int, nil
 	case "bpf.cmd":
 		return reflect.Int, nil
 	case "bpf.map.name":
@@ -10695,6 +10944,8 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "capset.cap_effective":
 		return reflect.Int, nil
 	case "capset.cap_permitted":
+		return reflect.Int, nil
+	case "chmod.async":
 		return reflect.Int, nil
 	case "chmod.file.change_time":
 		return reflect.Int, nil
@@ -10729,6 +10980,8 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "chmod.file.user":
 		return reflect.String, nil
 	case "chmod.retval":
+		return reflect.Int, nil
+	case "chown.async":
 		return reflect.Int, nil
 	case "chown.file.change_time":
 		return reflect.Int, nil
@@ -10872,6 +11125,8 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 	case "exec.user":
 		return reflect.String, nil
+	case "link.async":
+		return reflect.Int, nil
 	case "link.file.change_time":
 		return reflect.Int, nil
 	case "link.file.destination.change_time":
@@ -10930,6 +11185,8 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.String, nil
 	case "link.retval":
 		return reflect.Int, nil
+	case "load_module.async":
+		return reflect.Int, nil
 	case "load_module.file.change_time":
 		return reflect.Int, nil
 	case "load_module.file.filesystem":
@@ -10963,6 +11220,8 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "load_module.name":
 		return reflect.String, nil
 	case "load_module.retval":
+		return reflect.Int, nil
+	case "mkdir.async":
 		return reflect.Int, nil
 	case "mkdir.file.change_time":
 		return reflect.Int, nil
@@ -10998,6 +11257,8 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.String, nil
 	case "mkdir.retval":
 		return reflect.Int, nil
+	case "mmap.async":
+		return reflect.Int, nil
 	case "mmap.file.change_time":
 		return reflect.Int, nil
 	case "mmap.file.filesystem":
@@ -11032,6 +11293,8 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 	case "mmap.retval":
 		return reflect.Int, nil
+	case "mprotect.async":
+		return reflect.Int, nil
 	case "mprotect.req_protection":
 		return reflect.Int, nil
 	case "mprotect.retval":
@@ -11055,6 +11318,8 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "network.source.ip":
 		return reflect.Struct, nil
 	case "network.source.port":
+		return reflect.Int, nil
+	case "open.async":
 		return reflect.Int, nil
 	case "open.file.change_time":
 		return reflect.Int, nil
@@ -11270,6 +11535,8 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 	case "process.user":
 		return reflect.String, nil
+	case "ptrace.async":
+		return reflect.Int, nil
 	case "ptrace.request":
 		return reflect.Int, nil
 	case "ptrace.retval":
@@ -11454,6 +11721,8 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 	case "ptrace.tracee.user":
 		return reflect.String, nil
+	case "removexattr.async":
+		return reflect.Int, nil
 	case "removexattr.file.change_time":
 		return reflect.Int, nil
 	case "removexattr.file.destination.name":
@@ -11487,6 +11756,8 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "removexattr.file.user":
 		return reflect.String, nil
 	case "removexattr.retval":
+		return reflect.Int, nil
+	case "rename.async":
 		return reflect.Int, nil
 	case "rename.file.change_time":
 		return reflect.Int, nil
@@ -11545,6 +11816,8 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "rename.file.user":
 		return reflect.String, nil
 	case "rename.retval":
+		return reflect.Int, nil
+	case "rmdir.async":
 		return reflect.Int, nil
 	case "rmdir.file.change_time":
 		return reflect.Int, nil
@@ -11608,6 +11881,8 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 	case "setuid.user":
 		return reflect.String, nil
+	case "setxattr.async":
+		return reflect.Int, nil
 	case "setxattr.file.change_time":
 		return reflect.Int, nil
 	case "setxattr.file.destination.name":
@@ -11641,6 +11916,8 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "setxattr.file.user":
 		return reflect.String, nil
 	case "setxattr.retval":
+		return reflect.Int, nil
+	case "signal.async":
 		return reflect.Int, nil
 	case "signal.pid":
 		return reflect.Int, nil
@@ -11828,6 +12105,8 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.String, nil
 	case "signal.type":
 		return reflect.Int, nil
+	case "splice.async":
+		return reflect.Int, nil
 	case "splice.file.change_time":
 		return reflect.Int, nil
 	case "splice.file.filesystem":
@@ -11862,6 +12141,8 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 	case "splice.retval":
 		return reflect.Int, nil
+	case "unlink.async":
+		return reflect.Int, nil
 	case "unlink.file.change_time":
 		return reflect.Int, nil
 	case "unlink.file.filesystem":
@@ -11892,9 +12173,13 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.String, nil
 	case "unlink.retval":
 		return reflect.Int, nil
+	case "unload_module.async":
+		return reflect.Int, nil
 	case "unload_module.name":
 		return reflect.String, nil
 	case "unload_module.retval":
+		return reflect.Int, nil
+	case "utimes.async":
 		return reflect.Int, nil
 	case "utimes.file.change_time":
 		return reflect.Int, nil
@@ -11931,6 +12216,13 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 }
 func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	switch field {
+	case "bpf.async":
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BPF.SyscallEvent.Async"}
+		}
+		e.BPF.SyscallEvent.Async = int64(v)
+		return nil
 	case "bpf.cmd":
 		v, ok := value.(int)
 		if !ok {
@@ -12007,6 +12299,13 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "Capset.CapPermitted"}
 		}
 		e.Capset.CapPermitted = uint64(v)
+		return nil
+	case "chmod.async":
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chmod.SyscallEvent.Async"}
+		}
+		e.Chmod.SyscallEvent.Async = int64(v)
 		return nil
 	case "chmod.file.change_time":
 		v, ok := value.(int)
@@ -12125,6 +12424,13 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "Chmod.SyscallEvent.Retval"}
 		}
 		e.Chmod.SyscallEvent.Retval = int64(v)
+		return nil
+	case "chown.async":
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chown.SyscallEvent.Async"}
+		}
+		e.Chown.SyscallEvent.Async = int64(v)
 		return nil
 	case "chown.file.change_time":
 		v, ok := value.(int)
@@ -12619,6 +12925,13 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Exec.Process.Credentials.User = str
 		return nil
+	case "link.async":
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.SyscallEvent.Async"}
+		}
+		e.Link.SyscallEvent.Async = int64(v)
+		return nil
 	case "link.file.change_time":
 		v, ok := value.(int)
 		if !ok {
@@ -12820,6 +13133,13 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Link.SyscallEvent.Retval = int64(v)
 		return nil
+	case "load_module.async":
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "LoadModule.SyscallEvent.Async"}
+		}
+		e.LoadModule.SyscallEvent.Async = int64(v)
+		return nil
 	case "load_module.file.change_time":
 		v, ok := value.(int)
 		if !ok {
@@ -12936,6 +13256,13 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "LoadModule.SyscallEvent.Retval"}
 		}
 		e.LoadModule.SyscallEvent.Retval = int64(v)
+		return nil
+	case "mkdir.async":
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Mkdir.SyscallEvent.Async"}
+		}
+		e.Mkdir.SyscallEvent.Async = int64(v)
 		return nil
 	case "mkdir.file.change_time":
 		v, ok := value.(int)
@@ -13055,6 +13382,13 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Mkdir.SyscallEvent.Retval = int64(v)
 		return nil
+	case "mmap.async":
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "MMap.SyscallEvent.Async"}
+		}
+		e.MMap.SyscallEvent.Async = int64(v)
+		return nil
 	case "mmap.file.change_time":
 		v, ok := value.(int)
 		if !ok {
@@ -13173,6 +13507,13 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.MMap.SyscallEvent.Retval = int64(v)
 		return nil
+	case "mprotect.async":
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "MProtect.SyscallEvent.Async"}
+		}
+		e.MProtect.SyscallEvent.Async = int64(v)
+		return nil
 	case "mprotect.req_protection":
 		v, ok := value.(int)
 		if !ok {
@@ -13256,6 +13597,13 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "NetworkContext.Source.Port"}
 		}
 		e.NetworkContext.Source.Port = uint16(v)
+		return nil
+	case "open.async":
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Open.SyscallEvent.Async"}
+		}
+		e.Open.SyscallEvent.Async = int64(v)
 		return nil
 	case "open.file.change_time":
 		v, ok := value.(int)
@@ -14134,6 +14482,13 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.ProcessContext.Process.Credentials.User = str
 		return nil
+	case "ptrace.async":
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "PTrace.SyscallEvent.Async"}
+		}
+		e.PTrace.SyscallEvent.Async = int64(v)
+		return nil
 	case "ptrace.request":
 		v, ok := value.(int)
 		if !ok {
@@ -14907,6 +15262,13 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.PTrace.Tracee.Process.Credentials.User = str
 		return nil
+	case "removexattr.async":
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.SyscallEvent.Async"}
+		}
+		e.RemoveXAttr.SyscallEvent.Async = int64(v)
+		return nil
 	case "removexattr.file.change_time":
 		v, ok := value.(int)
 		if !ok {
@@ -15024,6 +15386,13 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.SyscallEvent.Retval"}
 		}
 		e.RemoveXAttr.SyscallEvent.Retval = int64(v)
+		return nil
+	case "rename.async":
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.SyscallEvent.Async"}
+		}
+		e.Rename.SyscallEvent.Async = int64(v)
 		return nil
 	case "rename.file.change_time":
 		v, ok := value.(int)
@@ -15225,6 +15594,13 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "Rename.SyscallEvent.Retval"}
 		}
 		e.Rename.SyscallEvent.Retval = int64(v)
+		return nil
+	case "rmdir.async":
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rmdir.SyscallEvent.Async"}
+		}
+		e.Rmdir.SyscallEvent.Async = int64(v)
 		return nil
 	case "rmdir.file.change_time":
 		v, ok := value.(int)
@@ -15441,6 +15817,13 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.SetUID.User = str
 		return nil
+	case "setxattr.async":
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.SyscallEvent.Async"}
+		}
+		e.SetXAttr.SyscallEvent.Async = int64(v)
+		return nil
 	case "setxattr.file.change_time":
 		v, ok := value.(int)
 		if !ok {
@@ -15558,6 +15941,13 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.SyscallEvent.Retval"}
 		}
 		e.SetXAttr.SyscallEvent.Retval = int64(v)
+		return nil
+	case "signal.async":
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Signal.SyscallEvent.Async"}
+		}
+		e.Signal.SyscallEvent.Async = int64(v)
 		return nil
 	case "signal.pid":
 		v, ok := value.(int)
@@ -16339,6 +16729,13 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Signal.Type = uint32(v)
 		return nil
+	case "splice.async":
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Splice.SyscallEvent.Async"}
+		}
+		e.Splice.SyscallEvent.Async = int64(v)
+		return nil
 	case "splice.file.change_time":
 		v, ok := value.(int)
 		if !ok {
@@ -16457,6 +16854,13 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Splice.SyscallEvent.Retval = int64(v)
 		return nil
+	case "unlink.async":
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Unlink.SyscallEvent.Async"}
+		}
+		e.Unlink.SyscallEvent.Async = int64(v)
+		return nil
 	case "unlink.file.change_time":
 		v, ok := value.(int)
 		if !ok {
@@ -16561,6 +16965,13 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Unlink.SyscallEvent.Retval = int64(v)
 		return nil
+	case "unload_module.async":
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "UnloadModule.SyscallEvent.Async"}
+		}
+		e.UnloadModule.SyscallEvent.Async = int64(v)
+		return nil
 	case "unload_module.name":
 		str, ok := value.(string)
 		if !ok {
@@ -16574,6 +16985,13 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "UnloadModule.SyscallEvent.Retval"}
 		}
 		e.UnloadModule.SyscallEvent.Retval = int64(v)
+		return nil
+	case "utimes.async":
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Utimes.SyscallEvent.Async"}
+		}
+		e.Utimes.SyscallEvent.Async = int64(v)
 		return nil
 	case "utimes.file.change_time":
 		v, ok := value.(int)

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -622,6 +622,7 @@ type SetXAttrEvent struct {
 // SyscallEvent contains common fields for all the event
 type SyscallEvent struct {
 	Retval int64 `field:"retval" msg:"retval"` // Return value of the syscall
+	Async  int64 `field:"async" msg:"async"`   // True if the syscall was asynchronous
 }
 
 // UnlinkEvent represents an unlink event

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -622,7 +622,7 @@ type SetXAttrEvent struct {
 // SyscallEvent contains common fields for all the event
 type SyscallEvent struct {
 	Retval int64 `field:"retval" msg:"retval"` // Return value of the syscall
-	Async  int64 `field:"async" msg:"async"`   // True if the syscall was asynchronous
+	Async  bool  `field:"async" msg:"async"`   // True if the syscall was asynchronous
 }
 
 // UnlinkEvent represents an unlink event

--- a/pkg/security/secl/model/model_gen.go
+++ b/pkg/security/secl/model/model_gen.go
@@ -2164,6 +2164,12 @@ func (z *SyscallEvent) DecodeMsg(dc *msgp.Reader) (err error) {
 				err = msgp.WrapError(err, "Retval")
 				return
 			}
+		case "async":
+			z.Async, err = dc.ReadInt64()
+			if err != nil {
+				err = msgp.WrapError(err, "Async")
+				return
+			}
 		default:
 			err = dc.Skip()
 			if err != nil {
@@ -2177,9 +2183,9 @@ func (z *SyscallEvent) DecodeMsg(dc *msgp.Reader) (err error) {
 
 // EncodeMsg implements msgp.Encodable
 func (z SyscallEvent) EncodeMsg(en *msgp.Writer) (err error) {
-	// map header, size 1
+	// map header, size 2
 	// write "retval"
-	err = en.Append(0x81, 0xa6, 0x72, 0x65, 0x74, 0x76, 0x61, 0x6c)
+	err = en.Append(0x82, 0xa6, 0x72, 0x65, 0x74, 0x76, 0x61, 0x6c)
 	if err != nil {
 		return
 	}
@@ -2188,16 +2194,29 @@ func (z SyscallEvent) EncodeMsg(en *msgp.Writer) (err error) {
 		err = msgp.WrapError(err, "Retval")
 		return
 	}
+	// write "async"
+	err = en.Append(0xa5, 0x61, 0x73, 0x79, 0x6e, 0x63)
+	if err != nil {
+		return
+	}
+	err = en.WriteInt64(z.Async)
+	if err != nil {
+		err = msgp.WrapError(err, "Async")
+		return
+	}
 	return
 }
 
 // MarshalMsg implements msgp.Marshaler
 func (z SyscallEvent) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
-	// map header, size 1
+	// map header, size 2
 	// string "retval"
-	o = append(o, 0x81, 0xa6, 0x72, 0x65, 0x74, 0x76, 0x61, 0x6c)
+	o = append(o, 0x82, 0xa6, 0x72, 0x65, 0x74, 0x76, 0x61, 0x6c)
 	o = msgp.AppendInt64(o, z.Retval)
+	// string "async"
+	o = append(o, 0xa5, 0x61, 0x73, 0x79, 0x6e, 0x63)
+	o = msgp.AppendInt64(o, z.Async)
 	return
 }
 
@@ -2225,6 +2244,12 @@ func (z *SyscallEvent) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				err = msgp.WrapError(err, "Retval")
 				return
 			}
+		case "async":
+			z.Async, bts, err = msgp.ReadInt64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Async")
+				return
+			}
 		default:
 			bts, err = msgp.Skip(bts)
 			if err != nil {
@@ -2239,6 +2264,6 @@ func (z *SyscallEvent) UnmarshalMsg(bts []byte) (o []byte, err error) {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z SyscallEvent) Msgsize() (s int) {
-	s = 1 + 7 + msgp.Int64Size
+	s = 1 + 7 + msgp.Int64Size + 6 + msgp.Int64Size
 	return
 }

--- a/pkg/security/secl/model/model_gen.go
+++ b/pkg/security/secl/model/model_gen.go
@@ -2165,7 +2165,7 @@ func (z *SyscallEvent) DecodeMsg(dc *msgp.Reader) (err error) {
 				return
 			}
 		case "async":
-			z.Async, err = dc.ReadInt64()
+			z.Async, err = dc.ReadBool()
 			if err != nil {
 				err = msgp.WrapError(err, "Async")
 				return
@@ -2199,7 +2199,7 @@ func (z SyscallEvent) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	err = en.WriteInt64(z.Async)
+	err = en.WriteBool(z.Async)
 	if err != nil {
 		err = msgp.WrapError(err, "Async")
 		return
@@ -2216,7 +2216,7 @@ func (z SyscallEvent) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.AppendInt64(o, z.Retval)
 	// string "async"
 	o = append(o, 0xa5, 0x61, 0x73, 0x79, 0x6e, 0x63)
-	o = msgp.AppendInt64(o, z.Async)
+	o = msgp.AppendBool(o, z.Async)
 	return
 }
 
@@ -2245,7 +2245,7 @@ func (z *SyscallEvent) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 		case "async":
-			z.Async, bts, err = msgp.ReadInt64Bytes(bts)
+			z.Async, bts, err = msgp.ReadBoolBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "Async")
 				return
@@ -2264,6 +2264,6 @@ func (z *SyscallEvent) UnmarshalMsg(bts []byte) (o []byte, err error) {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z SyscallEvent) Msgsize() (s int) {
-	s = 1 + 7 + msgp.Int64Size + 6 + msgp.Int64Size
+	s = 1 + 7 + msgp.Int64Size + 6 + msgp.BoolSize
 	return
 }

--- a/pkg/security/secl/model/unmarshallers.go
+++ b/pkg/security/secl/model/unmarshallers.go
@@ -435,11 +435,12 @@ func (e *SetXAttrEvent) UnmarshalBinary(data []byte) (int, error) {
 
 // UnmarshalBinary unmarshalls a binary representation of itself
 func (e *SyscallEvent) UnmarshalBinary(data []byte) (int, error) {
-	if len(data) < 8 {
+	if len(data) < 16 {
 		return 0, ErrNotEnoughData
 	}
 	e.Retval = int64(ByteOrder.Uint64(data[0:8]))
-	return 8, nil
+	e.Async = int64(ByteOrder.Uint64(data[8:16]))
+	return 16, nil
 }
 
 // UnmarshalBinary unmarshalls a binary representation of itself

--- a/pkg/security/secl/model/unmarshallers.go
+++ b/pkg/security/secl/model/unmarshallers.go
@@ -439,7 +439,11 @@ func (e *SyscallEvent) UnmarshalBinary(data []byte) (int, error) {
 		return 0, ErrNotEnoughData
 	}
 	e.Retval = int64(ByteOrder.Uint64(data[0:8]))
-	e.Async = int64(ByteOrder.Uint64(data[8:16]))
+	if ByteOrder.Uint64(data[8:16]) != 0 {
+		e.Async = true
+	} else {
+		e.Async = false
+	}
 	return 16, nil
 }
 

--- a/pkg/security/tests/chmod_test.go
+++ b/pkg/security/tests/chmod_test.go
@@ -61,7 +61,7 @@ func TestChmod(t *testing.T) {
 			assertRights(t, event.Chmod.File.Mode, expectedMode, "wrong initial mode")
 			assertNearTime(t, event.Chmod.File.MTime)
 			assertNearTime(t, event.Chmod.File.CTime)
-			assert.Equal(t, event.Chmod.Async, int64(0))
+			assert.Equal(t, event.Chmod.Async, false)
 
 			if !validateChmodSchema(t, event) {
 				t.Error(event.String())
@@ -84,7 +84,7 @@ func TestChmod(t *testing.T) {
 			assertRights(t, event.Chmod.File.Mode, expectedMode)
 			assertNearTime(t, event.Chmod.File.MTime)
 			assertNearTime(t, event.Chmod.File.CTime)
-			assert.Equal(t, event.Chmod.Async, int64(0))
+			assert.Equal(t, event.Chmod.Async, false)
 
 			if !validateChmodSchema(t, event) {
 				t.Error(event.String())
@@ -105,7 +105,7 @@ func TestChmod(t *testing.T) {
 			assertRights(t, event.Chmod.File.Mode, expectedMode, "wrong initial mode")
 			assertNearTime(t, event.Chmod.File.MTime)
 			assertNearTime(t, event.Chmod.File.CTime)
-			assert.Equal(t, event.Chmod.Async, int64(0))
+			assert.Equal(t, event.Chmod.Async, false)
 
 			if !validateChmodSchema(t, event) {
 				t.Error(event.String())

--- a/pkg/security/tests/chmod_test.go
+++ b/pkg/security/tests/chmod_test.go
@@ -61,6 +61,7 @@ func TestChmod(t *testing.T) {
 			assertRights(t, event.Chmod.File.Mode, expectedMode, "wrong initial mode")
 			assertNearTime(t, event.Chmod.File.MTime)
 			assertNearTime(t, event.Chmod.File.CTime)
+			assert.Equal(t, event.Chmod.Async, int64(0))
 
 			if !validateChmodSchema(t, event) {
 				t.Error(event.String())
@@ -83,6 +84,7 @@ func TestChmod(t *testing.T) {
 			assertRights(t, event.Chmod.File.Mode, expectedMode)
 			assertNearTime(t, event.Chmod.File.MTime)
 			assertNearTime(t, event.Chmod.File.CTime)
+			assert.Equal(t, event.Chmod.Async, int64(0))
 
 			if !validateChmodSchema(t, event) {
 				t.Error(event.String())
@@ -103,6 +105,7 @@ func TestChmod(t *testing.T) {
 			assertRights(t, event.Chmod.File.Mode, expectedMode, "wrong initial mode")
 			assertNearTime(t, event.Chmod.File.MTime)
 			assertNearTime(t, event.Chmod.File.CTime)
+			assert.Equal(t, event.Chmod.Async, int64(0))
 
 			if !validateChmodSchema(t, event) {
 				t.Error(event.String())

--- a/pkg/security/tests/chown32_test.go
+++ b/pkg/security/tests/chown32_test.go
@@ -74,6 +74,7 @@ func TestChown32(t *testing.T) {
 			assert.Equal(t, uint32(prevGID), event.Chown.File.GID, "wrong initial group")
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
+			assert.Equal(t, event.Chown.Async, int64(0))
 
 			if !validateChownSchema(t, event) {
 				t.Error(event.String())
@@ -100,6 +101,7 @@ func TestChown32(t *testing.T) {
 			assert.Equal(t, uint32(prevGID), event.Chown.File.GID, "wrong initial group")
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
+			assert.Equal(t, event.Chown.Async, int64(0))
 
 			if !validateChownSchema(t, event) {
 				t.Error(event.String())
@@ -126,6 +128,7 @@ func TestChown32(t *testing.T) {
 			assert.Equal(t, uint32(prevGID), event.Chown.File.GID, "wrong initial group")
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
+			assert.Equal(t, event.Chown.Async, int64(0))
 
 			if !validateChownSchema(t, event) {
 				t.Error(event.String())
@@ -157,6 +160,7 @@ func TestChown32(t *testing.T) {
 			assert.Equal(t, uint32(0), event.Chown.File.GID, "wrong initial group")
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
+			assert.Equal(t, event.Chown.Async, int64(0))
 
 			if !validateChownSchema(t, event) {
 				t.Error(event.String())
@@ -188,6 +192,7 @@ func TestChown32(t *testing.T) {
 			assert.Equal(t, uint32(0), event.Chown.File.GID, "wrong initial group")
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
+			assert.Equal(t, event.Chown.Async, int64(0))
 
 			if !validateChownSchema(t, event) {
 				t.Error(event.String())
@@ -215,6 +220,7 @@ func TestChown32(t *testing.T) {
 			assert.Equal(t, uint32(prevGID), event.Chown.File.GID, "wrong initial group")
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
+			assert.Equal(t, event.Chown.Async, int64(0))
 
 			if !validateChownSchema(t, event) {
 				t.Error(event.String())
@@ -241,6 +247,7 @@ func TestChown32(t *testing.T) {
 			assert.Equal(t, uint32(prevGID), event.Chown.File.GID, "wrong initial group")
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
+			assert.Equal(t, event.Chown.Async, int64(0))
 
 			if !validateChownSchema(t, event) {
 				t.Error(event.String())

--- a/pkg/security/tests/chown32_test.go
+++ b/pkg/security/tests/chown32_test.go
@@ -74,7 +74,7 @@ func TestChown32(t *testing.T) {
 			assert.Equal(t, uint32(prevGID), event.Chown.File.GID, "wrong initial group")
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
-			assert.Equal(t, event.Chown.Async, int64(0))
+			assert.Equal(t, event.Chown.Async, false)
 
 			if !validateChownSchema(t, event) {
 				t.Error(event.String())
@@ -101,7 +101,7 @@ func TestChown32(t *testing.T) {
 			assert.Equal(t, uint32(prevGID), event.Chown.File.GID, "wrong initial group")
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
-			assert.Equal(t, event.Chown.Async, int64(0))
+			assert.Equal(t, event.Chown.Async, false)
 
 			if !validateChownSchema(t, event) {
 				t.Error(event.String())
@@ -128,7 +128,7 @@ func TestChown32(t *testing.T) {
 			assert.Equal(t, uint32(prevGID), event.Chown.File.GID, "wrong initial group")
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
-			assert.Equal(t, event.Chown.Async, int64(0))
+			assert.Equal(t, event.Chown.Async, false)
 
 			if !validateChownSchema(t, event) {
 				t.Error(event.String())
@@ -160,7 +160,7 @@ func TestChown32(t *testing.T) {
 			assert.Equal(t, uint32(0), event.Chown.File.GID, "wrong initial group")
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
-			assert.Equal(t, event.Chown.Async, int64(0))
+			assert.Equal(t, event.Chown.Async, false)
 
 			if !validateChownSchema(t, event) {
 				t.Error(event.String())
@@ -192,7 +192,7 @@ func TestChown32(t *testing.T) {
 			assert.Equal(t, uint32(0), event.Chown.File.GID, "wrong initial group")
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
-			assert.Equal(t, event.Chown.Async, int64(0))
+			assert.Equal(t, event.Chown.Async, false)
 
 			if !validateChownSchema(t, event) {
 				t.Error(event.String())
@@ -220,7 +220,7 @@ func TestChown32(t *testing.T) {
 			assert.Equal(t, uint32(prevGID), event.Chown.File.GID, "wrong initial group")
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
-			assert.Equal(t, event.Chown.Async, int64(0))
+			assert.Equal(t, event.Chown.Async, false)
 
 			if !validateChownSchema(t, event) {
 				t.Error(event.String())
@@ -247,7 +247,7 @@ func TestChown32(t *testing.T) {
 			assert.Equal(t, uint32(prevGID), event.Chown.File.GID, "wrong initial group")
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
-			assert.Equal(t, event.Chown.Async, int64(0))
+			assert.Equal(t, event.Chown.Async, false)
 
 			if !validateChownSchema(t, event) {
 				t.Error(event.String())

--- a/pkg/security/tests/chown_test.go
+++ b/pkg/security/tests/chown_test.go
@@ -80,7 +80,7 @@ func TestChown(t *testing.T) {
 			assert.Equal(t, uint32(prevGID), event.Chown.File.GID, "wrong initial group")
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
-			assert.Equal(t, event.Chown.Async, int64(0))
+			assert.Equal(t, event.Chown.Async, false)
 
 			if !validateChownSchema(t, event) {
 				t.Error(event.String())
@@ -109,7 +109,7 @@ func TestChown(t *testing.T) {
 			assert.Equal(t, uint32(prevGID), event.Chown.File.GID, "wrong initial group")
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
-			assert.Equal(t, event.Chown.Async, int64(0))
+			assert.Equal(t, event.Chown.Async, false)
 
 			if !validateChownSchema(t, event) {
 				t.Error(event.String())
@@ -148,7 +148,7 @@ func TestChown(t *testing.T) {
 			assert.Equal(t, uint32(0), event.Chown.File.GID, "wrong initial group")
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
-			assert.Equal(t, event.Chown.Async, int64(0))
+			assert.Equal(t, event.Chown.Async, false)
 
 			if !validateChownSchema(t, event) {
 				t.Error(event.String())
@@ -174,7 +174,7 @@ func TestChown(t *testing.T) {
 			assert.Equal(t, uint32(prevGID), event.Chown.File.GID, "wrong initial group")
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
-			assert.Equal(t, event.Chown.Async, int64(0))
+			assert.Equal(t, event.Chown.Async, false)
 
 			if !validateChownSchema(t, event) {
 				t.Error(event.String())
@@ -196,7 +196,7 @@ func TestChown(t *testing.T) {
 			assertTriggeredRule(t, r, "test_rule3")
 			assert.Equal(t, int64(104), event.Chown.UID, "wrong user")
 			assert.Equal(t, int64(-1), event.Chown.GID, "wrong group")
-			assert.Equal(t, event.Chown.Async, int64(0))
+			assert.Equal(t, event.Chown.Async, false)
 
 			if !validateChownSchema(t, event) {
 				t.Error(event.String())
@@ -218,7 +218,7 @@ func TestChown(t *testing.T) {
 			assertTriggeredRule(t, r, "test_rule4")
 			assert.Equal(t, int64(-1), event.Chown.UID, "wrong user")
 			assert.Equal(t, int64(204), event.Chown.GID, "wrong group")
-			assert.Equal(t, event.Chown.Async, int64(0))
+			assert.Equal(t, event.Chown.Async, false)
 
 			if !validateChownSchema(t, event) {
 				t.Error(event.String())

--- a/pkg/security/tests/chown_test.go
+++ b/pkg/security/tests/chown_test.go
@@ -80,6 +80,7 @@ func TestChown(t *testing.T) {
 			assert.Equal(t, uint32(prevGID), event.Chown.File.GID, "wrong initial group")
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
+			assert.Equal(t, event.Chown.Async, int64(0))
 
 			if !validateChownSchema(t, event) {
 				t.Error(event.String())
@@ -108,6 +109,7 @@ func TestChown(t *testing.T) {
 			assert.Equal(t, uint32(prevGID), event.Chown.File.GID, "wrong initial group")
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
+			assert.Equal(t, event.Chown.Async, int64(0))
 
 			if !validateChownSchema(t, event) {
 				t.Error(event.String())
@@ -146,6 +148,7 @@ func TestChown(t *testing.T) {
 			assert.Equal(t, uint32(0), event.Chown.File.GID, "wrong initial group")
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
+			assert.Equal(t, event.Chown.Async, int64(0))
 
 			if !validateChownSchema(t, event) {
 				t.Error(event.String())
@@ -171,6 +174,7 @@ func TestChown(t *testing.T) {
 			assert.Equal(t, uint32(prevGID), event.Chown.File.GID, "wrong initial group")
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
+			assert.Equal(t, event.Chown.Async, int64(0))
 
 			if !validateChownSchema(t, event) {
 				t.Error(event.String())
@@ -192,6 +196,7 @@ func TestChown(t *testing.T) {
 			assertTriggeredRule(t, r, "test_rule3")
 			assert.Equal(t, int64(104), event.Chown.UID, "wrong user")
 			assert.Equal(t, int64(-1), event.Chown.GID, "wrong group")
+			assert.Equal(t, event.Chown.Async, int64(0))
 
 			if !validateChownSchema(t, event) {
 				t.Error(event.String())
@@ -213,6 +218,7 @@ func TestChown(t *testing.T) {
 			assertTriggeredRule(t, r, "test_rule4")
 			assert.Equal(t, int64(-1), event.Chown.UID, "wrong user")
 			assert.Equal(t, int64(204), event.Chown.GID, "wrong group")
+			assert.Equal(t, event.Chown.Async, int64(0))
 
 			if !validateChownSchema(t, event) {
 				t.Error(event.String())

--- a/pkg/security/tests/kernel_module_test.go
+++ b/pkg/security/tests/kernel_module_test.go
@@ -165,6 +165,7 @@ func TestLoadModule(t *testing.T) {
 		}, func(event *sprobe.Event, r *rules.Rule) {
 			assert.Equal(t, "test_load_module_from_memory", r.ID, "invalid rule triggered")
 			assert.Equal(t, "", event.ResolveFilePath(&event.LoadModule.File), "shouldn't get a path")
+			assert.Equal(t, event.LoadModule.Async, int64(0))
 
 			if !validateLoadModuleNoFileSchema(t, event) {
 				t.Error(event.String())

--- a/pkg/security/tests/kernel_module_test.go
+++ b/pkg/security/tests/kernel_module_test.go
@@ -165,7 +165,7 @@ func TestLoadModule(t *testing.T) {
 		}, func(event *sprobe.Event, r *rules.Rule) {
 			assert.Equal(t, "test_load_module_from_memory", r.ID, "invalid rule triggered")
 			assert.Equal(t, "", event.ResolveFilePath(&event.LoadModule.File), "shouldn't get a path")
-			assert.Equal(t, event.LoadModule.Async, int64(0))
+			assert.Equal(t, event.LoadModule.Async, false)
 
 			if !validateLoadModuleNoFileSchema(t, event) {
 				t.Error(event.String())

--- a/pkg/security/tests/link_test.go
+++ b/pkg/security/tests/link_test.go
@@ -9,11 +9,15 @@
 package tests
 
 import (
+	"fmt"
 	"os"
 	"syscall"
 	"testing"
 
+	"github.com/iceber/iouring-go"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/unix"
 
 	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
@@ -33,7 +37,7 @@ func TestLink(t *testing.T) {
 
 	fileMode := 0o447
 	expectedMode := applyUmask(fileMode)
-	_, testOldFilePtr, err := test.CreateWithOptions("test-link", 98, 99, fileMode)
+	testOldFile, testOldFilePtr, err := test.CreateWithOptions("test-link", 98, 99, fileMode)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -90,6 +94,63 @@ func TestLink(t *testing.T) {
 			if !validateLinkSchema(t, event) {
 				t.Error(event.String())
 			}
+		})
+
+		if err = os.Remove(testNewFile); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("io_uring", func(t *testing.T) {
+		iour, err := iouring.New(1)
+		if err != nil {
+			if errors.Is(err, unix.ENOTSUP) {
+				t.Fatal(err)
+			}
+			t.Skip("io_uring not supported")
+		}
+		defer iour.Close()
+
+		prepRequest, err := iouring.Linkat(unix.AT_FDCWD, testOldFile, unix.AT_FDCWD, testNewFile, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ch := make(chan iouring.Result, 1)
+
+		test.WaitSignal(t, func() error {
+			if _, err = iour.SubmitRequest(prepRequest, ch); err != nil {
+				return err
+			}
+
+			result := <-ch
+			ret, err := result.ReturnInt()
+			if err != nil {
+				if err == syscall.EBADF {
+					return ErrSkipTest{"linkat not supported by io_uring"}
+				}
+				return err
+			}
+
+			if ret < 0 {
+				return fmt.Errorf("failed to create a link with io_uring: %d", ret)
+			}
+			return nil
+		}, func(event *sprobe.Event, rule *rules.Rule) {
+			assert.Equal(t, "link", event.GetType(), "wrong event type")
+			assert.Equal(t, getInode(t, testNewFile), event.Link.Source.Inode, "wrong inode")
+			assertRights(t, event.Link.Source.Mode, uint16(expectedMode))
+			assertRights(t, event.Link.Target.Mode, uint16(expectedMode))
+			assertNearTime(t, event.Link.Source.MTime)
+			assertNearTime(t, event.Link.Source.CTime)
+			assertNearTime(t, event.Link.Target.MTime)
+			assertNearTime(t, event.Link.Target.CTime)
+
+			executable, err := os.Executable()
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertFieldEqual(t, event, "process.file.path", executable)
 		})
 	})
 }

--- a/pkg/security/tests/link_test.go
+++ b/pkg/security/tests/link_test.go
@@ -63,7 +63,7 @@ func TestLink(t *testing.T) {
 			assertNearTime(t, event.Link.Source.CTime)
 			assertNearTime(t, event.Link.Target.MTime)
 			assertNearTime(t, event.Link.Target.CTime)
-			assert.Equal(t, event.Link.Async, int64(0))
+			assert.Equal(t, event.Link.Async, false)
 
 			if !validateLinkSchema(t, event) {
 				t.Error(event.String())
@@ -91,7 +91,7 @@ func TestLink(t *testing.T) {
 			assertNearTime(t, event.Link.Source.CTime)
 			assertNearTime(t, event.Link.Target.MTime)
 			assertNearTime(t, event.Link.Target.CTime)
-			assert.Equal(t, event.Link.Async, int64(0))
+			assert.Equal(t, event.Link.Async, false)
 
 			if !validateLinkSchema(t, event) {
 				t.Error(event.String())
@@ -147,7 +147,7 @@ func TestLink(t *testing.T) {
 			assertNearTime(t, event.Link.Source.CTime)
 			assertNearTime(t, event.Link.Target.MTime)
 			assertNearTime(t, event.Link.Target.CTime)
-			assert.Equal(t, event.Link.Async, int64(1))
+			assert.Equal(t, event.Link.Async, true)
 
 			executable, err := os.Executable()
 			if err != nil {

--- a/pkg/security/tests/link_test.go
+++ b/pkg/security/tests/link_test.go
@@ -63,6 +63,7 @@ func TestLink(t *testing.T) {
 			assertNearTime(t, event.Link.Source.CTime)
 			assertNearTime(t, event.Link.Target.MTime)
 			assertNearTime(t, event.Link.Target.CTime)
+			assert.Equal(t, event.Link.Async, int64(0))
 
 			if !validateLinkSchema(t, event) {
 				t.Error(event.String())
@@ -90,6 +91,7 @@ func TestLink(t *testing.T) {
 			assertNearTime(t, event.Link.Source.CTime)
 			assertNearTime(t, event.Link.Target.MTime)
 			assertNearTime(t, event.Link.Target.CTime)
+			assert.Equal(t, event.Link.Async, int64(0))
 
 			if !validateLinkSchema(t, event) {
 				t.Error(event.String())
@@ -145,6 +147,7 @@ func TestLink(t *testing.T) {
 			assertNearTime(t, event.Link.Source.CTime)
 			assertNearTime(t, event.Link.Target.MTime)
 			assertNearTime(t, event.Link.Target.CTime)
+			assert.Equal(t, event.Link.Async, int64(1))
 
 			executable, err := os.Executable()
 			if err != nil {

--- a/pkg/security/tests/mkdir_test.go
+++ b/pkg/security/tests/mkdir_test.go
@@ -63,6 +63,7 @@ func TestMkdir(t *testing.T) {
 			assertRights(t, event.Mkdir.File.Mode, expectedMode)
 			assertNearTime(t, event.Mkdir.File.MTime)
 			assertNearTime(t, event.Mkdir.File.CTime)
+			assert.Equal(t, event.Mkdir.Async, int64(0))
 		})
 	}))
 
@@ -86,6 +87,7 @@ func TestMkdir(t *testing.T) {
 			assertRights(t, event.Mkdir.File.Mode&expectedMode, expectedMode)
 			assertNearTime(t, event.Mkdir.File.MTime)
 			assertNearTime(t, event.Mkdir.File.CTime)
+			assert.Equal(t, event.Mkdir.Async, int64(0))
 		})
 	})
 
@@ -138,6 +140,7 @@ func TestMkdir(t *testing.T) {
 			assertRights(t, event.Mkdir.File.Mode&expectedMode, expectedMode)
 			assertNearTime(t, event.Mkdir.File.MTime)
 			assertNearTime(t, event.Mkdir.File.CTime)
+			assert.Equal(t, event.Mkdir.Async, int64(1))
 
 			executable, err := os.Executable()
 			if err != nil {

--- a/pkg/security/tests/mkdir_test.go
+++ b/pkg/security/tests/mkdir_test.go
@@ -9,11 +9,15 @@
 package tests
 
 import (
+	"fmt"
 	"os"
 	"syscall"
 	"testing"
 
+	"github.com/iceber/iouring-go"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/unix"
 
 	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
@@ -82,6 +86,64 @@ func TestMkdir(t *testing.T) {
 			assertRights(t, event.Mkdir.File.Mode&expectedMode, expectedMode)
 			assertNearTime(t, event.Mkdir.File.MTime)
 			assertNearTime(t, event.Mkdir.File.CTime)
+		})
+	})
+
+	t.Run("io_uring", func(t *testing.T) {
+		testatFile, _, err := test.Path("testat-mkdir")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer syscall.Rmdir(testatFile)
+
+		iour, err := iouring.New(1)
+		if err != nil {
+			if errors.Is(err, unix.ENOTSUP) {
+				t.Fatal(err)
+			}
+			t.Skip("io_uring not supported")
+		}
+		defer iour.Close()
+
+		prepRequest, err := iouring.Mkdirat(unix.AT_FDCWD, testatFile, 0777)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ch := make(chan iouring.Result, 1)
+
+		test.WaitSignal(t, func() error {
+			if _, err = iour.SubmitRequest(prepRequest, ch); err != nil {
+				return err
+			}
+
+			result := <-ch
+			ret, err := result.ReturnInt()
+			if err != nil {
+				if err == syscall.EBADF {
+					return ErrSkipTest{"mkdirat not supported by io_uring"}
+				}
+				return err
+			}
+
+			if ret < 0 {
+				return fmt.Errorf("failed to create directory with io_uring: %d", ret)
+			}
+			return nil
+		}, func(event *sprobe.Event, rule *rules.Rule) {
+			assertTriggeredRule(t, rule, "test_rule_mkdirat")
+			assert.Equal(t, getInode(t, testatFile), event.Mkdir.File.Inode, "wrong inode")
+			assertRights(t, uint16(event.Mkdir.Mode), 0777)
+			assert.Equal(t, getInode(t, testatFile), event.Mkdir.File.Inode, "wrong inode")
+			assertRights(t, event.Mkdir.File.Mode&expectedMode, expectedMode)
+			assertNearTime(t, event.Mkdir.File.MTime)
+			assertNearTime(t, event.Mkdir.File.CTime)
+
+			executable, err := os.Executable()
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertFieldEqual(t, event, "process.file.path", executable)
 		})
 	})
 }

--- a/pkg/security/tests/mkdir_test.go
+++ b/pkg/security/tests/mkdir_test.go
@@ -63,7 +63,7 @@ func TestMkdir(t *testing.T) {
 			assertRights(t, event.Mkdir.File.Mode, expectedMode)
 			assertNearTime(t, event.Mkdir.File.MTime)
 			assertNearTime(t, event.Mkdir.File.CTime)
-			assert.Equal(t, event.Mkdir.Async, int64(0))
+			assert.Equal(t, event.Mkdir.Async, false)
 		})
 	}))
 
@@ -87,7 +87,7 @@ func TestMkdir(t *testing.T) {
 			assertRights(t, event.Mkdir.File.Mode&expectedMode, expectedMode)
 			assertNearTime(t, event.Mkdir.File.MTime)
 			assertNearTime(t, event.Mkdir.File.CTime)
-			assert.Equal(t, event.Mkdir.Async, int64(0))
+			assert.Equal(t, event.Mkdir.Async, false)
 		})
 	})
 
@@ -140,7 +140,7 @@ func TestMkdir(t *testing.T) {
 			assertRights(t, event.Mkdir.File.Mode&expectedMode, expectedMode)
 			assertNearTime(t, event.Mkdir.File.MTime)
 			assertNearTime(t, event.Mkdir.File.CTime)
-			assert.Equal(t, event.Mkdir.Async, int64(1))
+			assert.Equal(t, event.Mkdir.Async, true)
 
 			executable, err := os.Executable()
 			if err != nil {

--- a/pkg/security/tests/mmap_test.go
+++ b/pkg/security/tests/mmap_test.go
@@ -49,7 +49,7 @@ func TestMMapEvent(t *testing.T) {
 		}, func(event *sprobe.Event, r *rules.Rule) {
 			assert.Equal(t, "mmap", event.GetType(), "wrong event type")
 			assert.NotEqual(t, 0, event.MMap.Protection&(unix.PROT_READ|unix.PROT_WRITE|unix.PROT_EXEC), fmt.Sprintf("wrong protection: %s", model.Protection(event.MMap.Protection)))
-			assert.Equal(t, event.MMap.Async, int64(0))
+			assert.Equal(t, event.MMap.Async, false)
 
 			executable, err := os.Executable()
 			if err != nil {

--- a/pkg/security/tests/mmap_test.go
+++ b/pkg/security/tests/mmap_test.go
@@ -49,6 +49,7 @@ func TestMMapEvent(t *testing.T) {
 		}, func(event *sprobe.Event, r *rules.Rule) {
 			assert.Equal(t, "mmap", event.GetType(), "wrong event type")
 			assert.NotEqual(t, 0, event.MMap.Protection&(unix.PROT_READ|unix.PROT_WRITE|unix.PROT_EXEC), fmt.Sprintf("wrong protection: %s", model.Protection(event.MMap.Protection)))
+			assert.Equal(t, event.MMap.Async, int64(0))
 
 			executable, err := os.Executable()
 			if err != nil {

--- a/pkg/security/tests/mprotect_test.go
+++ b/pkg/security/tests/mprotect_test.go
@@ -51,7 +51,7 @@ func TestMProtectEvent(t *testing.T) {
 			assert.Equal(t, "mprotect", event.GetType(), "wrong event type")
 			assert.NotEqual(t, 0, event.MProtect.VMProtection&(unix.PROT_READ|unix.PROT_WRITE), fmt.Sprintf("wrong initial protection: %s", model.Protection(event.MProtect.VMProtection)))
 			assert.NotEqual(t, 0, event.MProtect.ReqProtection&(unix.PROT_READ|unix.PROT_WRITE|unix.PROT_EXEC), fmt.Sprintf("wrong requested protection: %s", model.Protection(event.MProtect.ReqProtection)))
-			assert.Equal(t, event.MProtect.Async, int64(0))
+			assert.Equal(t, event.MProtect.Async, false)
 
 			executable, err := os.Executable()
 			if err != nil {

--- a/pkg/security/tests/mprotect_test.go
+++ b/pkg/security/tests/mprotect_test.go
@@ -51,6 +51,7 @@ func TestMProtectEvent(t *testing.T) {
 			assert.Equal(t, "mprotect", event.GetType(), "wrong event type")
 			assert.NotEqual(t, 0, event.MProtect.VMProtection&(unix.PROT_READ|unix.PROT_WRITE), fmt.Sprintf("wrong initial protection: %s", model.Protection(event.MProtect.VMProtection)))
 			assert.NotEqual(t, 0, event.MProtect.ReqProtection&(unix.PROT_READ|unix.PROT_WRITE|unix.PROT_EXEC), fmt.Sprintf("wrong requested protection: %s", model.Protection(event.MProtect.ReqProtection)))
+			assert.Equal(t, event.MProtect.Async, int64(0))
 
 			executable, err := os.Executable()
 			if err != nil {

--- a/pkg/security/tests/open_test.go
+++ b/pkg/security/tests/open_test.go
@@ -60,6 +60,7 @@ func TestOpen(t *testing.T) {
 			assert.Equal(t, syscall.O_CREAT, int(event.Open.Flags), "wrong flags")
 			assertRights(t, uint16(event.Open.Mode), 0755)
 			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
+			assert.Equal(t, event.Open.Async, int64(0))
 
 			if !validateOpenSchema(t, event) {
 				t.Error(event.String())
@@ -81,6 +82,7 @@ func TestOpen(t *testing.T) {
 			assert.Equal(t, syscall.O_CREAT, int(event.Open.Flags), "wrong flags")
 			assertRights(t, uint16(event.Open.Mode), 0711)
 			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
+			assert.Equal(t, event.Open.Async, int64(0))
 		})
 	})
 
@@ -106,6 +108,7 @@ func TestOpen(t *testing.T) {
 			assert.Equal(t, syscall.O_CREAT, int(event.Open.Flags), "wrong flags")
 			assertRights(t, uint16(event.Open.Mode), 0711)
 			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
+			assert.Equal(t, event.Open.Async, int64(0))
 		})
 	})
 
@@ -123,6 +126,7 @@ func TestOpen(t *testing.T) {
 			assert.Equal(t, syscall.O_CREAT|syscall.O_WRONLY|syscall.O_TRUNC, int(event.Open.Flags), "wrong flags")
 			assertRights(t, uint16(event.Open.Mode), 0711)
 			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
+			assert.Equal(t, event.Open.Async, int64(0))
 		})
 	}))
 
@@ -154,6 +158,7 @@ func TestOpen(t *testing.T) {
 			assert.Equal(t, "open", event.GetType(), "wrong event type")
 			assert.Equal(t, syscall.O_CREAT|syscall.O_WRONLY|syscall.O_TRUNC, int(event.Open.Flags), "wrong flags")
 			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
+			assert.Equal(t, event.Open.Async, int64(0))
 		})
 	})
 
@@ -197,6 +202,7 @@ func TestOpen(t *testing.T) {
 			assert.Equal(t, "open", event.GetType(), "wrong event type")
 			assert.Equal(t, syscall.O_CREAT, int(event.Open.Flags), "wrong flags")
 			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
+			assert.Equal(t, event.Open.Async, int64(0))
 		})
 	})
 
@@ -258,6 +264,7 @@ func TestOpen(t *testing.T) {
 			assert.Equal(t, syscall.O_CREAT, int(event.Open.Flags&0xfff), "wrong flags")
 			assertRights(t, uint16(event.Open.Mode), 0747)
 			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
+			assert.Equal(t, event.Open.Async, int64(1))
 
 			executable, err := os.Executable()
 			if err != nil {
@@ -297,6 +304,7 @@ func TestOpen(t *testing.T) {
 			assert.Equal(t, syscall.O_CREAT, int(event.Open.Flags&0xfff), "wrong flags")
 			assertRights(t, uint16(event.Open.Mode), 0711)
 			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
+			assert.Equal(t, event.Open.Async, int64(1))
 
 			executable, err := os.Executable()
 			if err != nil {
@@ -345,6 +353,7 @@ func TestOpenMetadata(t *testing.T) {
 			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
 			assertNearTime(t, event.Open.File.MTime)
 			assertNearTime(t, event.Open.File.CTime)
+			assert.Equal(t, event.Open.Async, int64(0))
 		})
 	})
 }

--- a/pkg/security/tests/open_test.go
+++ b/pkg/security/tests/open_test.go
@@ -60,7 +60,7 @@ func TestOpen(t *testing.T) {
 			assert.Equal(t, syscall.O_CREAT, int(event.Open.Flags), "wrong flags")
 			assertRights(t, uint16(event.Open.Mode), 0755)
 			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
-			assert.Equal(t, event.Open.Async, int64(0))
+			assert.Equal(t, event.Open.Async, false)
 
 			if !validateOpenSchema(t, event) {
 				t.Error(event.String())
@@ -82,7 +82,7 @@ func TestOpen(t *testing.T) {
 			assert.Equal(t, syscall.O_CREAT, int(event.Open.Flags), "wrong flags")
 			assertRights(t, uint16(event.Open.Mode), 0711)
 			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
-			assert.Equal(t, event.Open.Async, int64(0))
+			assert.Equal(t, event.Open.Async, false)
 		})
 	})
 
@@ -108,7 +108,7 @@ func TestOpen(t *testing.T) {
 			assert.Equal(t, syscall.O_CREAT, int(event.Open.Flags), "wrong flags")
 			assertRights(t, uint16(event.Open.Mode), 0711)
 			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
-			assert.Equal(t, event.Open.Async, int64(0))
+			assert.Equal(t, event.Open.Async, false)
 		})
 	})
 
@@ -126,7 +126,7 @@ func TestOpen(t *testing.T) {
 			assert.Equal(t, syscall.O_CREAT|syscall.O_WRONLY|syscall.O_TRUNC, int(event.Open.Flags), "wrong flags")
 			assertRights(t, uint16(event.Open.Mode), 0711)
 			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
-			assert.Equal(t, event.Open.Async, int64(0))
+			assert.Equal(t, event.Open.Async, false)
 		})
 	}))
 
@@ -158,7 +158,7 @@ func TestOpen(t *testing.T) {
 			assert.Equal(t, "open", event.GetType(), "wrong event type")
 			assert.Equal(t, syscall.O_CREAT|syscall.O_WRONLY|syscall.O_TRUNC, int(event.Open.Flags), "wrong flags")
 			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
-			assert.Equal(t, event.Open.Async, int64(0))
+			assert.Equal(t, event.Open.Async, false)
 		})
 	})
 
@@ -202,7 +202,7 @@ func TestOpen(t *testing.T) {
 			assert.Equal(t, "open", event.GetType(), "wrong event type")
 			assert.Equal(t, syscall.O_CREAT, int(event.Open.Flags), "wrong flags")
 			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
-			assert.Equal(t, event.Open.Async, int64(0))
+			assert.Equal(t, event.Open.Async, false)
 		})
 	})
 
@@ -264,7 +264,7 @@ func TestOpen(t *testing.T) {
 			assert.Equal(t, syscall.O_CREAT, int(event.Open.Flags&0xfff), "wrong flags")
 			assertRights(t, uint16(event.Open.Mode), 0747)
 			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
-			assert.Equal(t, event.Open.Async, int64(1))
+			assert.Equal(t, event.Open.Async, true)
 
 			executable, err := os.Executable()
 			if err != nil {
@@ -304,7 +304,7 @@ func TestOpen(t *testing.T) {
 			assert.Equal(t, syscall.O_CREAT, int(event.Open.Flags&0xfff), "wrong flags")
 			assertRights(t, uint16(event.Open.Mode), 0711)
 			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
-			assert.Equal(t, event.Open.Async, int64(1))
+			assert.Equal(t, event.Open.Async, true)
 
 			executable, err := os.Executable()
 			if err != nil {
@@ -353,7 +353,7 @@ func TestOpenMetadata(t *testing.T) {
 			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
 			assertNearTime(t, event.Open.File.MTime)
 			assertNearTime(t, event.Open.File.CTime)
-			assert.Equal(t, event.Open.Async, int64(0))
+			assert.Equal(t, event.Open.Async, false)
 		})
 	})
 }

--- a/pkg/security/tests/ptrace_test.go
+++ b/pkg/security/tests/ptrace_test.go
@@ -52,7 +52,7 @@ func TestPTraceEvent(t *testing.T) {
 		}, func(event *sprobe.Event, r *rules.Rule) {
 			assert.Equal(t, "ptrace", event.GetType(), "wrong event type")
 			assert.Equal(t, uint64(42), event.PTrace.Address, "wrong address")
-			assert.Equal(t, event.PTrace.Async, int64(0))
+			assert.Equal(t, event.PTrace.Async, false)
 
 			if !validatePTraceSchema(t, event) {
 				t.Error(event.String())

--- a/pkg/security/tests/ptrace_test.go
+++ b/pkg/security/tests/ptrace_test.go
@@ -52,6 +52,7 @@ func TestPTraceEvent(t *testing.T) {
 		}, func(event *sprobe.Event, r *rules.Rule) {
 			assert.Equal(t, "ptrace", event.GetType(), "wrong event type")
 			assert.Equal(t, uint64(42), event.PTrace.Address, "wrong address")
+			assert.Equal(t, event.PTrace.Async, int64(0))
 
 			if !validatePTraceSchema(t, event) {
 				t.Error(event.String())

--- a/pkg/security/tests/rename_test.go
+++ b/pkg/security/tests/rename_test.go
@@ -69,7 +69,7 @@ func TestRename(t *testing.T) {
 			assertRights(t, event.Rename.New.Mode, expectedMode)
 			assertNearTime(t, event.Rename.New.MTime)
 			assertNearTime(t, event.Rename.New.CTime)
-			assert.Equal(t, event.Rename.Async, int64(0))
+			assert.Equal(t, event.Rename.Async, false)
 
 			if !validateRenameSchema(t, event) {
 				t.Error(event.String())
@@ -98,7 +98,7 @@ func TestRename(t *testing.T) {
 			assertRights(t, event.Rename.New.Mode, expectedMode)
 			assertNearTime(t, event.Rename.New.MTime)
 			assertNearTime(t, event.Rename.New.CTime)
-			assert.Equal(t, event.Rename.Async, int64(0))
+			assert.Equal(t, event.Rename.Async, false)
 
 			if !validateRenameSchema(t, event) {
 				t.Error(event.String())
@@ -130,7 +130,7 @@ func TestRename(t *testing.T) {
 			assertRights(t, event.Rename.New.Mode, expectedMode)
 			assertNearTime(t, event.Rename.New.MTime)
 			assertNearTime(t, event.Rename.New.CTime)
-			assert.Equal(t, event.Rename.Async, int64(0))
+			assert.Equal(t, event.Rename.Async, false)
 
 			if !validateRenameSchema(t, event) {
 				t.Error(event.String())
@@ -187,7 +187,7 @@ func TestRename(t *testing.T) {
 			assertRights(t, event.Rename.New.Mode, expectedMode)
 			assertNearTime(t, event.Rename.New.MTime)
 			assertNearTime(t, event.Rename.New.CTime)
-			assert.Equal(t, event.Rename.Async, int64(1))
+			assert.Equal(t, event.Rename.Async, true)
 
 			executable, err := os.Executable()
 			if err != nil {

--- a/pkg/security/tests/rename_test.go
+++ b/pkg/security/tests/rename_test.go
@@ -15,6 +15,8 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/iceber/iouring-go"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/sys/unix"
 
@@ -72,11 +74,11 @@ func TestRename(t *testing.T) {
 				t.Error(event.String())
 			}
 		})
-
-		if err := os.Rename(testNewFile, testOldFile); err != nil {
-			t.Fatal(err)
-		}
 	}))
+
+	if err := os.Rename(testNewFile, testOldFile); err != nil {
+		t.Fatal(err)
+	}
 
 	t.Run("renameat", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
@@ -130,6 +132,64 @@ func TestRename(t *testing.T) {
 			if !validateRenameSchema(t, event) {
 				t.Error(event.String())
 			}
+		})
+	})
+
+	if err := os.Rename(testNewFile, testOldFile); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("io_uring", func(t *testing.T) {
+		iour, err := iouring.New(1)
+		if err != nil {
+			if errors.Is(err, unix.ENOTSUP) {
+				t.Fatal(err)
+			}
+			t.Skip("io_uring not supported")
+		}
+		defer iour.Close()
+
+		prepRequest, err := iouring.Renameat(unix.AT_FDCWD, testOldFile, unix.AT_FDCWD, testNewFile)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ch := make(chan iouring.Result, 1)
+
+		test.WaitSignal(t, func() error {
+			if _, err = iour.SubmitRequest(prepRequest, ch); err != nil {
+				return err
+			}
+
+			result := <-ch
+			ret, err := result.ReturnInt()
+			if err != nil {
+				if err == syscall.EBADF {
+					return ErrSkipTest{"renameat not supported by io_uring"}
+				}
+				return err
+			}
+
+			if ret < 0 {
+				return fmt.Errorf("failed to rename file with io_uring: %d", ret)
+			}
+			return nil
+		}, func(event *sprobe.Event, rule *rules.Rule) {
+			assert.Equal(t, "rename", event.GetType(), "wrong event type")
+			assert.Equal(t, getInode(t, testNewFile), event.Rename.New.Inode, "wrong inode")
+			assertFieldEqual(t, event, "rename.file.destination.inode", int(getInode(t, testNewFile)), "wrong inode")
+			assertRights(t, event.Rename.Old.Mode, expectedMode)
+			assertNearTime(t, event.Rename.Old.MTime)
+			assertNearTime(t, event.Rename.Old.CTime)
+			assertRights(t, event.Rename.New.Mode, expectedMode)
+			assertNearTime(t, event.Rename.New.MTime)
+			assertNearTime(t, event.Rename.New.CTime)
+
+			executable, err := os.Executable()
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertFieldEqual(t, event, "process.file.path", executable)
 		})
 	})
 }

--- a/pkg/security/tests/rename_test.go
+++ b/pkg/security/tests/rename_test.go
@@ -69,6 +69,7 @@ func TestRename(t *testing.T) {
 			assertRights(t, event.Rename.New.Mode, expectedMode)
 			assertNearTime(t, event.Rename.New.MTime)
 			assertNearTime(t, event.Rename.New.CTime)
+			assert.Equal(t, event.Rename.Async, int64(0))
 
 			if !validateRenameSchema(t, event) {
 				t.Error(event.String())
@@ -97,6 +98,7 @@ func TestRename(t *testing.T) {
 			assertRights(t, event.Rename.New.Mode, expectedMode)
 			assertNearTime(t, event.Rename.New.MTime)
 			assertNearTime(t, event.Rename.New.CTime)
+			assert.Equal(t, event.Rename.Async, int64(0))
 
 			if !validateRenameSchema(t, event) {
 				t.Error(event.String())
@@ -128,6 +130,7 @@ func TestRename(t *testing.T) {
 			assertRights(t, event.Rename.New.Mode, expectedMode)
 			assertNearTime(t, event.Rename.New.MTime)
 			assertNearTime(t, event.Rename.New.CTime)
+			assert.Equal(t, event.Rename.Async, int64(0))
 
 			if !validateRenameSchema(t, event) {
 				t.Error(event.String())
@@ -184,6 +187,7 @@ func TestRename(t *testing.T) {
 			assertRights(t, event.Rename.New.Mode, expectedMode)
 			assertNearTime(t, event.Rename.New.MTime)
 			assertNearTime(t, event.Rename.New.CTime)
+			assert.Equal(t, event.Rename.Async, int64(1))
 
 			executable, err := os.Executable()
 			if err != nil {

--- a/pkg/security/tests/rmdir_test.go
+++ b/pkg/security/tests/rmdir_test.go
@@ -62,6 +62,7 @@ func TestRmdir(t *testing.T) {
 			assertRights(t, event.Rmdir.File.Mode, expectedMode, "wrong initial mode")
 			assertNearTime(t, event.Rmdir.File.MTime)
 			assertNearTime(t, event.Rmdir.File.CTime)
+			assert.Equal(t, event.Rmdir.Async, int64(0))
 		})
 	}))
 
@@ -89,6 +90,7 @@ func TestRmdir(t *testing.T) {
 			assertRights(t, event.Rmdir.File.Mode, expectedMode, "wrong initial mode")
 			assertNearTime(t, event.Rmdir.File.MTime)
 			assertNearTime(t, event.Rmdir.File.CTime)
+			assert.Equal(t, event.Rmdir.Async, int64(0))
 		})
 	})
 
@@ -145,6 +147,7 @@ func TestRmdir(t *testing.T) {
 			assertRights(t, event.Rmdir.File.Mode, expectedMode, "wrong initial mode")
 			assertNearTime(t, event.Rmdir.File.MTime)
 			assertNearTime(t, event.Rmdir.File.CTime)
+			assert.Equal(t, event.Rmdir.Async, int64(1))
 
 			executable, err := os.Executable()
 			if err != nil {

--- a/pkg/security/tests/rmdir_test.go
+++ b/pkg/security/tests/rmdir_test.go
@@ -62,7 +62,7 @@ func TestRmdir(t *testing.T) {
 			assertRights(t, event.Rmdir.File.Mode, expectedMode, "wrong initial mode")
 			assertNearTime(t, event.Rmdir.File.MTime)
 			assertNearTime(t, event.Rmdir.File.CTime)
-			assert.Equal(t, event.Rmdir.Async, int64(0))
+			assert.Equal(t, event.Rmdir.Async, false)
 		})
 	}))
 
@@ -90,7 +90,7 @@ func TestRmdir(t *testing.T) {
 			assertRights(t, event.Rmdir.File.Mode, expectedMode, "wrong initial mode")
 			assertNearTime(t, event.Rmdir.File.MTime)
 			assertNearTime(t, event.Rmdir.File.CTime)
-			assert.Equal(t, event.Rmdir.Async, int64(0))
+			assert.Equal(t, event.Rmdir.Async, false)
 		})
 	})
 
@@ -147,7 +147,7 @@ func TestRmdir(t *testing.T) {
 			assertRights(t, event.Rmdir.File.Mode, expectedMode, "wrong initial mode")
 			assertNearTime(t, event.Rmdir.File.MTime)
 			assertNearTime(t, event.Rmdir.File.CTime)
-			assert.Equal(t, event.Rmdir.Async, int64(1))
+			assert.Equal(t, event.Rmdir.Async, true)
 
 			executable, err := os.Executable()
 			if err != nil {

--- a/pkg/security/tests/rmdir_test.go
+++ b/pkg/security/tests/rmdir_test.go
@@ -14,7 +14,10 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/iceber/iouring-go"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/unix"
 
 	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
@@ -86,6 +89,68 @@ func TestRmdir(t *testing.T) {
 			assertRights(t, event.Rmdir.File.Mode, expectedMode, "wrong initial mode")
 			assertNearTime(t, event.Rmdir.File.MTime)
 			assertNearTime(t, event.Rmdir.File.CTime)
+		})
+	})
+
+	t.Run("unlinkat-io_uring", func(t *testing.T) {
+		testDir, _, err := test.Path("test-unlink-rmdir")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := syscall.Mkdir(testDir, uint32(mkdirMode)); err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(testDir)
+
+		inode := getInode(t, testDir)
+
+		iour, err := iouring.New(1)
+		if err != nil {
+			if errors.Is(err, unix.ENOTSUP) {
+				t.Fatal(err)
+			}
+			t.Skip("io_uring not supported")
+		}
+		defer iour.Close()
+
+		prepRequest, err := iouring.Unlinkat(unix.AT_FDCWD, testDir, unix.AT_REMOVEDIR)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ch := make(chan iouring.Result, 1)
+
+		test.WaitSignal(t, func() error {
+			if _, err = iour.SubmitRequest(prepRequest, ch); err != nil {
+				return err
+			}
+
+			result := <-ch
+			ret, err := result.ReturnInt()
+			if err != nil {
+				if err == syscall.EBADF {
+					return ErrSkipTest{"unlinkat not supported by io_uring"}
+				}
+				return err
+			}
+
+			if ret < 0 {
+				return fmt.Errorf("failed to unlink file with io_uring: %d", ret)
+			}
+			return nil
+		}, func(event *sprobe.Event, rule *rules.Rule) {
+			assert.Equal(t, "rmdir", event.GetType(), "wrong event type")
+			assert.Equal(t, inode, event.Rmdir.File.Inode, "wrong inode")
+			assertRights(t, event.Rmdir.File.Mode, expectedMode, "wrong initial mode")
+			assertNearTime(t, event.Rmdir.File.MTime)
+			assertNearTime(t, event.Rmdir.File.CTime)
+
+			executable, err := os.Executable()
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertFieldEqual(t, event, "process.file.path", executable)
 		})
 	})
 }

--- a/pkg/security/tests/schemas/event.json
+++ b/pkg/security/tests/schemas/event.json
@@ -14,12 +14,16 @@
                 },
                 "outcome": {
                     "type": "string"
+                },
+                "async": {
+                    "type": "boolean"
                 }
             },
             "required": [
                 "name",
                 "category",
-                "outcome"
+                "outcome",
+                "async"
             ]
         },
         "date": {

--- a/pkg/security/tests/schemas/event.json
+++ b/pkg/security/tests/schemas/event.json
@@ -22,8 +22,7 @@
             "required": [
                 "name",
                 "category",
-                "outcome",
-                "async"
+                "outcome"
             ]
         },
         "date": {

--- a/pkg/security/tests/signal_test.go
+++ b/pkg/security/tests/signal_test.go
@@ -58,6 +58,7 @@ func TestSignalEvent(t *testing.T) {
 			assert.Equal(t, "signal", event.GetType(), "wrong event type")
 			assert.Equal(t, uint32(unix.SIGUSR1), event.Signal.Type, "wrong signal")
 			assert.Equal(t, int64(0), event.Signal.Retval, "wrong retval")
+			assert.Equal(t, event.Signal.Async, int64(0))
 
 			if !validateSignalSchema(t, event) {
 				t.Error(event.String())
@@ -80,6 +81,7 @@ func TestSignalEvent(t *testing.T) {
 			assert.Equal(t, "signal", event.GetType(), "wrong event type")
 			assert.Equal(t, uint32(unix.SIGKILL), event.Signal.Type, "wrong signal")
 			assert.Equal(t, -int64(unix.EPERM), event.Signal.Retval, "wrong retval")
+			assert.Equal(t, event.Signal.Async, int64(0))
 
 			if !validateSignalSchema(t, event) {
 				t.Error(event.String())

--- a/pkg/security/tests/signal_test.go
+++ b/pkg/security/tests/signal_test.go
@@ -58,7 +58,7 @@ func TestSignalEvent(t *testing.T) {
 			assert.Equal(t, "signal", event.GetType(), "wrong event type")
 			assert.Equal(t, uint32(unix.SIGUSR1), event.Signal.Type, "wrong signal")
 			assert.Equal(t, int64(0), event.Signal.Retval, "wrong retval")
-			assert.Equal(t, event.Signal.Async, int64(0))
+			assert.Equal(t, event.Signal.Async, false)
 
 			if !validateSignalSchema(t, event) {
 				t.Error(event.String())
@@ -81,7 +81,7 @@ func TestSignalEvent(t *testing.T) {
 			assert.Equal(t, "signal", event.GetType(), "wrong event type")
 			assert.Equal(t, uint32(unix.SIGKILL), event.Signal.Type, "wrong signal")
 			assert.Equal(t, -int64(unix.EPERM), event.Signal.Retval, "wrong retval")
-			assert.Equal(t, event.Signal.Async, int64(0))
+			assert.Equal(t, event.Signal.Async, false)
 
 			if !validateSignalSchema(t, event) {
 				t.Error(event.String())

--- a/pkg/security/tests/splice_test.go
+++ b/pkg/security/tests/splice_test.go
@@ -43,7 +43,7 @@ func TestSpliceEvent(t *testing.T) {
 			assert.Equal(t, "splice", event.GetType(), "wrong event type")
 			assert.Equal(t, uint32(0), event.Splice.PipeEntryFlag, "wrong pipe entry flag")
 			assert.Equal(t, uint32(0), event.Splice.PipeExitFlag, "wrong pipe exit flag")
-			assert.Equal(t, event.Splice.Async, int64(0))
+			assert.Equal(t, event.Splice.Async, false)
 
 			if !validateSpliceSchema(t, event) {
 				t.Error(event.String())

--- a/pkg/security/tests/splice_test.go
+++ b/pkg/security/tests/splice_test.go
@@ -43,6 +43,7 @@ func TestSpliceEvent(t *testing.T) {
 			assert.Equal(t, "splice", event.GetType(), "wrong event type")
 			assert.Equal(t, uint32(0), event.Splice.PipeEntryFlag, "wrong pipe entry flag")
 			assert.Equal(t, uint32(0), event.Splice.PipeExitFlag, "wrong pipe exit flag")
+			assert.Equal(t, event.Splice.Async, int64(0))
 
 			if !validateSpliceSchema(t, event) {
 				t.Error(event.String())

--- a/pkg/security/tests/unlink_test.go
+++ b/pkg/security/tests/unlink_test.go
@@ -57,7 +57,7 @@ func TestUnlink(t *testing.T) {
 			assertRights(t, event.Unlink.File.Mode, expectedMode)
 			assertNearTime(t, event.Unlink.File.MTime)
 			assertNearTime(t, event.Unlink.File.CTime)
-			assert.Equal(t, event.Unlink.Async, int64(0))
+			assert.Equal(t, event.Unlink.Async, false)
 		})
 	}))
 
@@ -81,7 +81,7 @@ func TestUnlink(t *testing.T) {
 			assertRights(t, event.Unlink.File.Mode, expectedMode)
 			assertNearTime(t, event.Unlink.File.MTime)
 			assertNearTime(t, event.Unlink.File.CTime)
-			assert.Equal(t, event.Unlink.Async, int64(0))
+			assert.Equal(t, event.Unlink.Async, false)
 		})
 	})
 
@@ -134,7 +134,7 @@ func TestUnlink(t *testing.T) {
 			assertRights(t, event.Unlink.File.Mode, expectedMode)
 			assertNearTime(t, event.Unlink.File.MTime)
 			assertNearTime(t, event.Unlink.File.CTime)
-			assert.Equal(t, event.Unlink.Async, int64(1))
+			assert.Equal(t, event.Unlink.Async, true)
 
 			executable, err := os.Executable()
 			if err != nil {

--- a/pkg/security/tests/unlink_test.go
+++ b/pkg/security/tests/unlink_test.go
@@ -57,6 +57,7 @@ func TestUnlink(t *testing.T) {
 			assertRights(t, event.Unlink.File.Mode, expectedMode)
 			assertNearTime(t, event.Unlink.File.MTime)
 			assertNearTime(t, event.Unlink.File.CTime)
+			assert.Equal(t, event.Unlink.Async, int64(0))
 		})
 	}))
 
@@ -80,6 +81,7 @@ func TestUnlink(t *testing.T) {
 			assertRights(t, event.Unlink.File.Mode, expectedMode)
 			assertNearTime(t, event.Unlink.File.MTime)
 			assertNearTime(t, event.Unlink.File.CTime)
+			assert.Equal(t, event.Unlink.Async, int64(0))
 		})
 	})
 
@@ -132,6 +134,7 @@ func TestUnlink(t *testing.T) {
 			assertRights(t, event.Unlink.File.Mode, expectedMode)
 			assertNearTime(t, event.Unlink.File.MTime)
 			assertNearTime(t, event.Unlink.File.CTime)
+			assert.Equal(t, event.Unlink.Async, int64(1))
 
 			executable, err := os.Executable()
 			if err != nil {

--- a/pkg/security/tests/unlink_test.go
+++ b/pkg/security/tests/unlink_test.go
@@ -14,7 +14,10 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/iceber/iouring-go"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/unix"
 
 	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
@@ -77,6 +80,64 @@ func TestUnlink(t *testing.T) {
 			assertRights(t, event.Unlink.File.Mode, expectedMode)
 			assertNearTime(t, event.Unlink.File.MTime)
 			assertNearTime(t, event.Unlink.File.CTime)
+		})
+	})
+
+	testAtFile, testAtFilePtr, err = test.CreateWithOptions("test-unlinkat", 98, 99, fileMode)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(testAtFile)
+
+	inode = getInode(t, testAtFile)
+
+	t.Run("io_uring", func(t *testing.T) {
+		iour, err := iouring.New(1)
+		if err != nil {
+			if errors.Is(err, unix.ENOTSUP) {
+				t.Fatal(err)
+			}
+			t.Skip("io_uring not supported")
+		}
+		defer iour.Close()
+
+		prepRequest, err := iouring.Unlinkat(unix.AT_FDCWD, testAtFile, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ch := make(chan iouring.Result, 1)
+
+		test.WaitSignal(t, func() error {
+			if _, err = iour.SubmitRequest(prepRequest, ch); err != nil {
+				return err
+			}
+
+			result := <-ch
+			ret, err := result.ReturnInt()
+			if err != nil {
+				if err == syscall.EBADF {
+					return ErrSkipTest{"unlinkat not supported by io_uring"}
+				}
+				return err
+			}
+
+			if ret < 0 {
+				return fmt.Errorf("failed to unlink file with io_uring: %d", ret)
+			}
+			return nil
+		}, func(event *sprobe.Event, rule *rules.Rule) {
+			assert.Equal(t, "unlink", event.GetType(), "wrong event type")
+			assert.Equal(t, inode, event.Unlink.File.Inode, "wrong inode")
+			assertRights(t, event.Unlink.File.Mode, expectedMode)
+			assertNearTime(t, event.Unlink.File.MTime)
+			assertNearTime(t, event.Unlink.File.CTime)
+
+			executable, err := os.Executable()
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertFieldEqual(t, event, "process.file.path", executable)
 		})
 	})
 }

--- a/pkg/security/tests/utimes_test.go
+++ b/pkg/security/tests/utimes_test.go
@@ -60,7 +60,7 @@ func TestUtimes(t *testing.T) {
 			assertRights(t, event.Utimes.File.Mode, expectedMode)
 			assertNearTime(t, event.Utimes.File.MTime)
 			assertNearTime(t, event.Utimes.File.CTime)
-			assert.Equal(t, event.Utimes.Async, int64(0))
+			assert.Equal(t, event.Utimes.Async, false)
 		})
 	}))
 
@@ -97,7 +97,7 @@ func TestUtimes(t *testing.T) {
 			assertRights(t, event.Utimes.File.Mode, expectedMode)
 			assertNearTime(t, event.Utimes.File.MTime)
 			assertNearTime(t, event.Utimes.File.CTime)
-			assert.Equal(t, event.Utimes.Async, int64(0))
+			assert.Equal(t, event.Utimes.Async, false)
 		})
 	}))
 
@@ -137,7 +137,7 @@ func TestUtimes(t *testing.T) {
 			assertRights(t, event.Utimes.File.Mode, expectedMode)
 			assertNearTime(t, event.Utimes.File.MTime)
 			assertNearTime(t, event.Utimes.File.CTime)
-			assert.Equal(t, event.Utimes.Async, int64(0))
+			assert.Equal(t, event.Utimes.Async, false)
 		})
 	})
 }

--- a/pkg/security/tests/utimes_test.go
+++ b/pkg/security/tests/utimes_test.go
@@ -60,6 +60,7 @@ func TestUtimes(t *testing.T) {
 			assertRights(t, event.Utimes.File.Mode, expectedMode)
 			assertNearTime(t, event.Utimes.File.MTime)
 			assertNearTime(t, event.Utimes.File.CTime)
+			assert.Equal(t, event.Utimes.Async, int64(0))
 		})
 	}))
 
@@ -96,6 +97,7 @@ func TestUtimes(t *testing.T) {
 			assertRights(t, event.Utimes.File.Mode, expectedMode)
 			assertNearTime(t, event.Utimes.File.MTime)
 			assertNearTime(t, event.Utimes.File.CTime)
+			assert.Equal(t, event.Utimes.Async, int64(0))
 		})
 	}))
 
@@ -135,6 +137,7 @@ func TestUtimes(t *testing.T) {
 			assertRights(t, event.Utimes.File.Mode, expectedMode)
 			assertNearTime(t, event.Utimes.File.MTime)
 			assertNearTime(t, event.Utimes.File.CTime)
+			assert.Equal(t, event.Utimes.Async, int64(0))
 		})
 	})
 }

--- a/pkg/security/tests/xattr_test.go
+++ b/pkg/security/tests/xattr_test.go
@@ -70,7 +70,7 @@ func TestSetXAttr(t *testing.T) {
 			assertRights(t, event.SetXAttr.File.Mode, expectedMode)
 			assertNearTime(t, event.SetXAttr.File.MTime)
 			assertNearTime(t, event.SetXAttr.File.CTime)
-			assert.Equal(t, event.SetXAttr.Async, int64(0))
+			assert.Equal(t, event.SetXAttr.Async, false)
 		})
 	})
 
@@ -108,7 +108,7 @@ func TestSetXAttr(t *testing.T) {
 			assertRights(t, event.SetXAttr.File.Mode, 0777)
 			assertNearTime(t, event.SetXAttr.File.MTime)
 			assertNearTime(t, event.SetXAttr.File.CTime)
-			assert.Equal(t, event.SetXAttr.Async, int64(0))
+			assert.Equal(t, event.SetXAttr.Async, false)
 		})
 	})
 
@@ -139,7 +139,7 @@ func TestSetXAttr(t *testing.T) {
 			assertRights(t, event.SetXAttr.File.Mode, expectedMode)
 			assertNearTime(t, event.SetXAttr.File.MTime)
 			assertNearTime(t, event.SetXAttr.File.CTime)
-			assert.Equal(t, event.SetXAttr.Async, int64(0))
+			assert.Equal(t, event.SetXAttr.Async, false)
 		})
 	})
 }
@@ -205,7 +205,7 @@ func TestRemoveXAttr(t *testing.T) {
 			assertRights(t, event.RemoveXAttr.File.Mode, uint16(expectedMode))
 			assertNearTime(t, event.RemoveXAttr.File.MTime)
 			assertNearTime(t, event.RemoveXAttr.File.CTime)
-			assert.Equal(t, event.SetXAttr.Async, int64(0))
+			assert.Equal(t, event.SetXAttr.Async, false)
 		})
 	})
 
@@ -249,7 +249,7 @@ func TestRemoveXAttr(t *testing.T) {
 			assertRights(t, event.RemoveXAttr.File.Mode, 0777)
 			assertNearTime(t, event.RemoveXAttr.File.MTime)
 			assertNearTime(t, event.RemoveXAttr.File.CTime)
-			assert.Equal(t, event.SetXAttr.Async, int64(0))
+			assert.Equal(t, event.SetXAttr.Async, false)
 		})
 	})
 

--- a/pkg/security/tests/xattr_test.go
+++ b/pkg/security/tests/xattr_test.go
@@ -70,6 +70,7 @@ func TestSetXAttr(t *testing.T) {
 			assertRights(t, event.SetXAttr.File.Mode, expectedMode)
 			assertNearTime(t, event.SetXAttr.File.MTime)
 			assertNearTime(t, event.SetXAttr.File.CTime)
+			assert.Equal(t, event.SetXAttr.Async, int64(0))
 		})
 	})
 
@@ -107,6 +108,7 @@ func TestSetXAttr(t *testing.T) {
 			assertRights(t, event.SetXAttr.File.Mode, 0777)
 			assertNearTime(t, event.SetXAttr.File.MTime)
 			assertNearTime(t, event.SetXAttr.File.CTime)
+			assert.Equal(t, event.SetXAttr.Async, int64(0))
 		})
 	})
 
@@ -137,6 +139,7 @@ func TestSetXAttr(t *testing.T) {
 			assertRights(t, event.SetXAttr.File.Mode, expectedMode)
 			assertNearTime(t, event.SetXAttr.File.MTime)
 			assertNearTime(t, event.SetXAttr.File.CTime)
+			assert.Equal(t, event.SetXAttr.Async, int64(0))
 		})
 	})
 }
@@ -202,6 +205,7 @@ func TestRemoveXAttr(t *testing.T) {
 			assertRights(t, event.RemoveXAttr.File.Mode, uint16(expectedMode))
 			assertNearTime(t, event.RemoveXAttr.File.MTime)
 			assertNearTime(t, event.RemoveXAttr.File.CTime)
+			assert.Equal(t, event.SetXAttr.Async, int64(0))
 		})
 	})
 
@@ -245,6 +249,7 @@ func TestRemoveXAttr(t *testing.T) {
 			assertRights(t, event.RemoveXAttr.File.Mode, 0777)
 			assertNearTime(t, event.RemoveXAttr.File.MTime)
 			assertNearTime(t, event.RemoveXAttr.File.CTime)
+			assert.Equal(t, event.SetXAttr.Async, int64(0))
 		})
 	})
 


### PR DESCRIPTION
### What does this PR do?
Add functional tests for iouring, and fix the bpf part for mkdir/rename/unlink/rmdir/link opcodes.
Also, add an "async" field to syscalls, set to true for asynchronous syscalls done via io_uring (and update functionnal tests).

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
