### PR TITLE
Use go.uber.org/atomic in pkg/collector

### DIFF
--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -8,7 +8,6 @@ package collector
 import (
 	"fmt"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
@@ -16,6 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/runner/expvars"
 	"github.com/DataDog/datadog-agent/pkg/collector/scheduler"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"go.uber.org/atomic"
 )
 
 const (
@@ -28,7 +28,9 @@ const cancelCheckTimeout time.Duration = 500 * time.Millisecond
 // Collector abstract common operations about running a Check
 type Collector struct {
 	checkInstances int64
-	state          uint32
+
+	// state is 'started' or 'stopped'
+	state *atomic.Uint32
 
 	scheduler *scheduler.Scheduler
 	runner    *runner.Runner
@@ -50,7 +52,7 @@ func NewCollector(paths ...string) *Collector {
 		scheduler:      sched,
 		runner:         run,
 		checks:         make(map[check.ID]check.Check),
-		state:          started,
+		state:          atomic.NewUint32(started),
 		checkInstances: int64(0),
 	}
 	pyVer, pyHome, pyPath := pySetup(paths...)
@@ -76,7 +78,7 @@ func (c *Collector) Stop() {
 	c.m.Lock()
 	defer c.m.Unlock()
 
-	if c.state == stopped {
+	if c.state.Load() == stopped {
 		return
 	}
 
@@ -84,7 +86,7 @@ func (c *Collector) Stop() {
 	c.scheduler = nil
 	c.runner.Stop()
 	c.runner = nil
-	c.state = stopped
+	c.state.Store(stopped)
 }
 
 // RunCheck sends a Check in the execution queue
@@ -94,7 +96,7 @@ func (c *Collector) RunCheck(ch check.Check) (check.ID, error) {
 
 	var emptyID check.ID
 
-	if c.state != started {
+	if c.state.Load() != started {
 		return emptyID, fmt.Errorf("the collector is not running")
 	}
 
@@ -196,7 +198,7 @@ func (c *Collector) delete(id check.ID) {
 
 // lightweight shortcut to see if the collector has started
 func (c *Collector) started() bool {
-	return atomic.LoadUint32(&(c.state)) == started
+	return c.state.Load() == started
 }
 
 // GetAllInstanceIDs returns the ID's of all instances of a check

--- a/pkg/collector/collector_test.go
+++ b/pkg/collector/collector_test.go
@@ -89,14 +89,14 @@ func (suite *CollectorTestSuite) TearDownTest() {
 func (suite *CollectorTestSuite) TestNewCollector() {
 	assert.NotNil(suite.T(), suite.c.runner)
 	assert.NotNil(suite.T(), suite.c.scheduler)
-	assert.Equal(suite.T(), started, suite.c.state)
+	assert.Equal(suite.T(), started, suite.c.state.Load())
 }
 
 func (suite *CollectorTestSuite) TestStop() {
 	suite.c.Stop()
 	assert.Nil(suite.T(), suite.c.runner)
 	assert.Nil(suite.T(), suite.c.scheduler)
-	assert.Equal(suite.T(), stopped, suite.c.state)
+	assert.Equal(suite.T(), stopped, suite.c.state.Load())
 }
 
 func (suite *CollectorTestSuite) TestRunCheck() {

--- a/pkg/collector/corechecks/embed/apm.go
+++ b/pkg/collector/corechecks/embed/apm.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
@@ -23,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 	telemetry_utils "github.com/DataDog/datadog-agent/pkg/telemetry/utils"
 	"github.com/DataDog/datadog-agent/pkg/util"
+	"go.uber.org/atomic"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	yaml "gopkg.in/yaml.v2"
@@ -36,7 +36,7 @@ type apmCheckConf struct {
 type APMCheck struct {
 	binPath     string
 	commandOpts []string
-	running     uint32
+	running     *atomic.Bool
 	stop        chan struct{}
 	stopDone    chan struct{}
 	source      string
@@ -57,10 +57,10 @@ func (c *APMCheck) ConfigSource() string {
 
 // Run executes the check with retries
 func (c *APMCheck) Run() error {
-	atomic.StoreUint32(&c.running, 1)
+	c.running.Store(true)
 	// TODO: retries should be configurable with meaningful default values
 	err := check.Retry(defaultRetryDuration, defaultRetries, c.run, c.String())
-	atomic.StoreUint32(&c.running, 0)
+	c.running.Store(false)
 
 	return err
 }
@@ -193,7 +193,7 @@ func (c *APMCheck) IsTelemetryEnabled() bool {
 
 // Stop sends a termination signal to the APM process
 func (c *APMCheck) Stop() {
-	if atomic.LoadUint32(&c.running) == 0 {
+	if !c.running.Load() {
 		log.Info("APM Agent not running.")
 		return
 	}
@@ -218,6 +218,7 @@ func (c *APMCheck) GetSenderStats() (check.SenderStats, error) {
 func init() {
 	factory := func() check.Check {
 		return &APMCheck{
+			running:  atomic.NewBool(false),
 			stop:     make(chan struct{}),
 			stopDone: make(chan struct{}),
 		}

--- a/pkg/collector/scheduler/scheduler_test.go
+++ b/pkg/collector/scheduler/scheduler_test.go
@@ -48,7 +48,7 @@ func TestNewScheduler(t *testing.T) {
 
 	assert.Equal(t, c, s.checksPipe)
 	assert.Equal(t, len(s.jobQueues), 0)
-	assert.Equal(t, s.running, uint32(0))
+	assert.False(t, s.running.Load())
 }
 
 func TestEnter(t *testing.T) {
@@ -124,7 +124,7 @@ func TestRun(t *testing.T) {
 	intl := 1 * time.Second
 	s.Enter(&TestCheck{intl: intl})
 	s.Run()
-	assert.Equal(t, uint32(1), s.running)
+	assert.True(t, s.running.Load())
 	assert.True(t, s.jobQueues[intl].running)
 
 	// Calling Run again should be a non blocking, noop procedure
@@ -138,7 +138,7 @@ func TestStop(t *testing.T) {
 
 	err := s.Stop()
 	assert.Nil(t, err)
-	assert.Equal(t, uint32(0), s.running)
+	assert.False(t, s.running.Load())
 	assert.False(t, s.jobQueues[10*time.Second].running)
 
 	// stopping again should be non blocking, noop and return nil


### PR DESCRIPTION
### What does this PR do?

Uses go.uber.com/atomic to ensure alignment of atomic access in pkg/collector

### Motivation

Alignment issues with atomic access.  See #11716 

### Additional Notes

This should be a consequence-free change.  In most of the diff this is easy to validate visually.  The part that's a little hard to see is whether the pointer to the atomic value is initialized when it is used.  Please verify this carefully for the production code.  It's more complex for `_test.go` files, but those are exercised in CI so need less inspection.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Verify that basic check collection still works in a simple agent.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
