### PR TITLE
Add Dump methods for various structs

### DIFF
--- a/pkg/autodiscovery/integration/config.go
+++ b/pkg/autodiscovery/integration/config.go
@@ -10,6 +10,7 @@ import (
 	"hash/fnv"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/twmb/murmur3"
 	yaml "gopkg.in/yaml.v2"
@@ -417,4 +418,42 @@ func (c *Config) FastDigest() uint64 {
 	_, _ = h.Write([]byte(strconv.FormatBool(c.IgnoreAutodiscoveryTags)))
 
 	return h.Sum64()
+}
+
+// Dump returns a multiline string representing this Config value, for debugging purposes.
+func (c *Config) Dump() string {
+	var b strings.Builder
+	dataField := func(data Data) string {
+		if data == nil {
+			return "nil"
+		}
+		return fmt.Sprintf("[]byte(%#v)", string(data))
+	}
+	fmt.Fprintf(&b, "integration.Config = {\n")
+	fmt.Fprintf(&b, "\tName: %#v,\n", c.Name)
+	if c.Instances == nil {
+		fmt.Fprintf(&b, "\tInstances: nil,\n")
+	} else {
+		fmt.Fprintf(&b, "\tInstances: {\n")
+		for _, inst := range c.Instances {
+			fmt.Fprintf(&b, "\t\t%s,", dataField(inst))
+		}
+		fmt.Fprintf(&b, "\t}\n")
+	}
+	fmt.Fprintf(&b, "\tInitConfig: %s,\n", dataField(c.InitConfig))
+	fmt.Fprintf(&b, "\tMetricConfig: %s,\n", dataField(c.MetricConfig))
+	fmt.Fprintf(&b, "\tLogsConfig: %s,\n", dataField(c.LogsConfig))
+	fmt.Fprintf(&b, "\tADIdentifiers: %#v,\n", c.ADIdentifiers)
+	fmt.Fprintf(&b, "\tAdvancedADIdentifiers: %#v,\n", c.AdvancedADIdentifiers)
+	fmt.Fprintf(&b, "\tProvider: %#v,\n", c.Provider)
+	fmt.Fprintf(&b, "\tServiceID: %#v,\n", c.ServiceID)
+	fmt.Fprintf(&b, "\tTaggerEntity: %#v,\n", c.TaggerEntity)
+	fmt.Fprintf(&b, "\tClusterCheck: %t,\n", c.ClusterCheck)
+	fmt.Fprintf(&b, "\tNodeName: %#v,\n", c.NodeName)
+	fmt.Fprintf(&b, "\tSource: %s,\n", c.Source)
+	fmt.Fprintf(&b, "\tIgnoreAutodiscoveryTags: %t,\n", c.IgnoreAutodiscoveryTags)
+	fmt.Fprintf(&b, "\tMetricsExcluded: %t,\n", c.MetricsExcluded)
+	fmt.Fprintf(&b, "\tLogsExcluded: %t,\n", c.LogsExcluded)
+	fmt.Fprintf(&b, "} (digest %s)", c.Digest())
+	return b.String()
 }

--- a/pkg/autodiscovery/integration/config_test.go
+++ b/pkg/autodiscovery/integration/config_test.go
@@ -93,6 +93,15 @@ logs_config: null
 	assert.Equal(t, config.String(), expected)
 }
 
+func TestDump(t *testing.T) {
+	config := &Config{}
+	config.Name = "foo"
+	config.InitConfig = Data("fooBarBaz: test")
+	config.Instances = []Data{Data("justFoo")}
+	dump := config.Dump()
+	assert.Contains(t, dump, `[]byte("justFoo")`)
+}
+
 func TestMergeAdditionalTags(t *testing.T) {
 	config := &Config{}
 	assert.False(t, config.Equal(nil))

--- a/pkg/logs/config/integration_config.go
+++ b/pkg/logs/config/integration_config.go
@@ -83,6 +83,63 @@ type LogsConfig struct {
 	AutoMultiLineMatchThreshold float64 `mapstructure:"auto_multi_line_match_threshold" json:"auto_multi_line_match_threshold"`
 }
 
+// Dump dumps the contents of this struct to a string, for debugging purposes.
+func (c *LogsConfig) Dump() string {
+	var b strings.Builder
+	if c == nil {
+		return "&LogsConfig(nil)"
+	}
+	fmt.Fprintf(&b, "&LogsConfig{\n")
+	fmt.Fprintf(&b, "\tType: %#v,\n", c.Type)
+	switch c.Type {
+	case TCPType:
+		fmt.Fprintf(&b, "\tPort: %d,\n", c.Port)
+		fmt.Fprintf(&b, "\tIdleTimeout: %#v,\n", c.IdleTimeout)
+	case UDPType:
+		fmt.Fprintf(&b, "\tPort: %d,\n", c.Port)
+		fmt.Fprintf(&b, "\tIdleTimeout: %#v,\n", c.IdleTimeout)
+	case FileType:
+		fmt.Fprintf(&b, "\tPath: %#v,\n", c.Path)
+		fmt.Fprintf(&b, "\tEncoding: %#v,\n", c.Encoding)
+		fmt.Fprintf(&b, "\tExcludePaths: %#v,\n", c.ExcludePaths)
+		fmt.Fprintf(&b, "\tTailingMode: %#v,\n", c.TailingMode)
+	case DockerType:
+		fmt.Fprintf(&b, "\tImage: %#v,\n", c.Image)
+		fmt.Fprintf(&b, "\tLabel: %#v,\n", c.Label)
+		fmt.Fprintf(&b, "\tName: %#v,\n", c.Name)
+		fmt.Fprintf(&b, "\tIdentifier: %#v,\n", c.Identifier)
+	case JournaldType:
+		fmt.Fprintf(&b, "\tPath: %#v,\n", c.Path)
+		fmt.Fprintf(&b, "\tIncludeSystemUnits: %#v,\n", c.IncludeSystemUnits)
+		fmt.Fprintf(&b, "\tExcludeSystemUnits: %#v,\n", c.ExcludeSystemUnits)
+		fmt.Fprintf(&b, "\tIncludeUserUnits: %#v,\n", c.IncludeUserUnits)
+		fmt.Fprintf(&b, "\tExcludeUserUnits: %#v,\n", c.ExcludeUserUnits)
+		fmt.Fprintf(&b, "\tContainerMode: %t,\n", c.ContainerMode)
+	case WindowsEventType:
+		fmt.Fprintf(&b, "\tChannelPath: %#v,\n", c.ChannelPath)
+		fmt.Fprintf(&b, "\tQuery: %#v,\n", c.Query)
+	case StringChannelType:
+		fmt.Fprintf(&b, "\tChannel: %p,\n", c.Channel)
+		c.ChannelTagsMutex.Lock()
+		fmt.Fprintf(&b, "\tChannelTags: %#v,\n", c.ChannelTags)
+		c.ChannelTagsMutex.Unlock()
+	}
+	fmt.Fprintf(&b, "\tService: %#v,\n", c.Service)
+	fmt.Fprintf(&b, "\tSource: %#v,\n", c.Source)
+	fmt.Fprintf(&b, "\tSourceCategory: %#v,\n", c.SourceCategory)
+	fmt.Fprintf(&b, "\tTags: %#v,\n", c.Tags)
+	fmt.Fprintf(&b, "\tProcessingRules: %#v,\n", c.ProcessingRules)
+	if c.AutoMultiLine != nil {
+		fmt.Fprintf(&b, "\tAutoMultiLine: %t,\n", *c.AutoMultiLine)
+	} else {
+		fmt.Fprintf(&b, "\tAutoMultiLine: nil,\n")
+	}
+	fmt.Fprintf(&b, "\tAutoMultiLineSampleSize: %d,\n", c.AutoMultiLineSampleSize)
+	fmt.Fprintf(&b, "\tAutoMultiLineMatchThreshold: %f,\n", c.AutoMultiLineMatchThreshold)
+	fmt.Fprintf(&b, "}")
+	return b.String()
+}
+
 // TailingMode type
 type TailingMode uint8
 

--- a/pkg/logs/config/integration_config_test.go
+++ b/pkg/logs/config/integration_config_test.go
@@ -80,3 +80,9 @@ func TestAutoMultilineEnabled(t *testing.T) {
 	assert.False(t, decode(`{}`).AutoMultiLineEnabled())
 
 }
+
+func TestConfigDump(t *testing.T) {
+	config := LogsConfig{Type: FileType, Path: "/var/log/foo.log"}
+	dump := config.Dump()
+	assert.Contains(t, dump, `Path: "/var/log/foo.log",`)
+}

--- a/pkg/logs/config/source.go
+++ b/pkg/logs/config/source.go
@@ -6,6 +6,8 @@
 package config
 
 import (
+	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -144,4 +146,30 @@ func (s *LogSource) IsHiddenFromStatus() bool {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	return s.hiddenFromStatus
+}
+
+// Dump provides a multi-line dump of the LogSource contents, for debugging purposes
+func (s *LogSource) Dump() string {
+	if s == nil {
+		return "&LogSource(nil)"
+	}
+
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "&LogsSource @ %p = {\n", s)
+	fmt.Fprintf(&b, "\tName: %#v,\n", s.Name)
+	fmt.Fprintf(&b, "\tConfig: %s,\n", strings.ReplaceAll(s.Config.Dump(), "\n", "\n\t"))
+	fmt.Fprintf(&b, "\tStatus: %s,\n", strings.ReplaceAll(s.Status.Dump(), "\n", "\n\t"))
+	fmt.Fprintf(&b, "\tinputs: %#v,\n", s.inputs)
+	fmt.Fprintf(&b, "\tMessages: %#v,\n", s.Messages.GetMessages())
+	fmt.Fprintf(&b, "\tsourceType: %#v,\n", s.sourceType)
+	fmt.Fprintf(&b, "\tinfo: %#v,\n", s.info)
+	fmt.Fprintf(&b, "\tparentSource: %p,\n", s.ParentSource)
+	fmt.Fprintf(&b, "\tLatencyStats: %#v,\n", s.LatencyStats)
+	fmt.Fprintf(&b, "\tBytesRead: %d,\n", s.BytesRead.Load())
+	fmt.Fprintf(&b, "\thiddenFromStatus: %t,\n", s.hiddenFromStatus)
+	fmt.Fprintf(&b, "}")
+	return b.String()
 }

--- a/pkg/logs/config/source_test.go
+++ b/pkg/logs/config/source_test.go
@@ -8,6 +8,7 @@ package config
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -26,6 +27,12 @@ func (s *LogSourceSuite) TestInputs() {
 	s.Equal(0, len(s.source.GetInputs()))
 	s.source.RemoveInput("bar")
 
+}
+
+func (s *LogSourceSuite) TestDump() {
+	s.source = NewLogSource("mysource", nil)
+	dump := s.source.Dump()
+	assert.Contains(s.T(), dump, "mysource")
 }
 
 func TestTrackerSuite(t *testing.T) {

--- a/pkg/logs/config/status.go
+++ b/pkg/logs/config/status.go
@@ -76,3 +76,22 @@ func (s *LogStatus) GetError() string {
 	defer s.mu.Unlock()
 	return s.err
 }
+
+// Dump provides a single-line dump of the status, for debugging purposes.
+func (s *LogStatus) Dump() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var status string
+	switch s.status {
+	case isPending:
+		status = "isPending"
+	case isSuccess:
+		status = "isSuccess"
+	case isError:
+		status = "isError"
+	default:
+		status = fmt.Sprintf("%d", s.status)
+	}
+	return fmt.Sprintf("&LogStatus{status: %s, err: %#v}", status, s.err)
+}


### PR DESCRIPTION
These methods are often helpful in tracing the handling of
integration.Configs through the logs agent.

### Motivation

These have been useful a few times in the last week since I wrote them.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
