### PR TITLE
Use svc.FilterTemplates for overriding OOTB configs

### DIFF
--- a/pkg/autodiscovery/configresolver/configresolver.go
+++ b/pkg/autodiscovery/configresolver/configresolver.go
@@ -19,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/listeners"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers/names"
+	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
@@ -68,24 +69,28 @@ func Resolve(tpl integration.Config, svc listeners.Service) (integration.Config,
 	copy(resolvedConfig.InitConfig, tpl.InitConfig)
 	copy(resolvedConfig.Instances, tpl.Instances)
 
-	// Ignore the config from file if it's overridden by an empty config
-	// or by a different config for the same check
-	if tpl.Provider == names.File && svc.GetCheckNames(ctx) != nil {
-		checkNames := svc.GetCheckNames(ctx)
-		lenCheckNames := len(checkNames)
-		if lenCheckNames == 0 || (lenCheckNames == 1 && checkNames[0] == "") {
-			// Empty check names on k8s annotations or container labels override the check config from file
-			// Used to deactivate unneeded OOTB autodiscovery checks defined in files
-			// The checkNames slice is considered empty also if it contains one single empty string
-			return resolvedConfig, fmt.Errorf("ignoring config from %s: another empty config is defined with the same AD identifier: %v", tpl.Source, tpl.ADIdentifiers)
-		}
-		for _, checkName := range checkNames {
-			if tpl.Name == checkName {
-				// Ignore config from file when the same check is activated on the same service via other config providers (k8s annotations or container labels)
-				return resolvedConfig, fmt.Errorf("ignoring config from %s: another config is defined for the check %s", tpl.Source, tpl.Name)
+	// Ignore the config from file if it's overridden by an empty config or by
+	// a different config for the same check.  If
+	// `logs_config.cca_in_ad` is set, this is not necessary as the
+	// relevant services will filter out these configs.
+	if !util.CcaInAD() {
+		if tpl.Provider == names.File && svc.GetCheckNames(ctx) != nil {
+			checkNames := svc.GetCheckNames(ctx)
+			lenCheckNames := len(checkNames)
+			if lenCheckNames == 0 || (lenCheckNames == 1 && checkNames[0] == "") {
+				// Empty check names on k8s annotations or container labels override the check config from file
+				// Used to deactivate unneeded OOTB autodiscovery checks defined in files
+				// The checkNames slice is considered empty also if it contains one single empty string
+				return resolvedConfig, fmt.Errorf("ignoring config from %s: another empty config is defined with the same AD identifier: %v", tpl.Source, tpl.ADIdentifiers)
 			}
-		}
+			for _, checkName := range checkNames {
+				if tpl.Name == checkName {
+					// Ignore config from file when the same check is activated on the same service via other config providers (k8s annotations or container labels)
+					return resolvedConfig, fmt.Errorf("ignoring config from %s: another config is defined for the check %s", tpl.Source, tpl.Name)
+				}
+			}
 
+		}
 	}
 
 	if resolvedConfig.IsCheckConfig() && !svc.IsReady(ctx) {

--- a/pkg/autodiscovery/listeners/service_test.go
+++ b/pkg/autodiscovery/listeners/service_test.go
@@ -1,0 +1,101 @@
+package listeners
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers/names"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
+	"github.com/stretchr/testify/assert"
+)
+
+// filterConfigsDropped applies the given filter to the given configs, and
+// returns the configs that the filter dropped.
+func filterConfigsDropped(filter func(map[string]integration.Config), configs ...integration.Config) (dropped []integration.Config) {
+	byDigest := map[string]integration.Config{}
+	for _, c := range configs {
+		if _, found := byDigest[c.Digest()]; found {
+			panic("duplicate digest") // easy mistake to make with fake templates
+		}
+		byDigest[c.Digest()] = c
+	}
+
+	filter(byDigest)
+
+	dropped = []integration.Config{}
+	for _, c := range configs {
+		if _, found := byDigest[c.Digest()]; !found {
+			dropped = append(dropped, c)
+		}
+	}
+	return
+}
+
+func TestServiceFilterTemplatesEmptyOverrides(t *testing.T) {
+	filterDrops := func(svc *service, configs ...integration.Config) (dropped []integration.Config) {
+		return filterConfigsDropped(svc.filterTemplatesEmptyOverrides, configs...)
+	}
+
+	entity := &workloadmeta.Container{EntityID: workloadmeta.EntityID{Kind: "container", ID: "testy"}}
+	fileTpl := integration.Config{Provider: names.File, LogsConfig: []byte(`{"source":"file"}`)}
+	nonFileTpl := integration.Config{Provider: "something-else", LogsConfig: []byte(`{"source":"nonfile"}`)}
+	nothingDropped := []integration.Config{}
+
+	t.Run("nil checkNames", func(t *testing.T) {
+		assert.Equal(t, nothingDropped,
+			filterDrops(&service{entity: entity, checkNames: nil}, fileTpl))
+	})
+
+	t.Run("one checkName", func(t *testing.T) {
+		assert.Equal(t, nothingDropped,
+			filterDrops(&service{entity: entity, checkNames: []string{"foo"}}, fileTpl))
+	})
+
+	t.Run("some checkNames", func(t *testing.T) {
+		assert.Equal(t, nothingDropped,
+			filterDrops(&service{entity: entity, checkNames: []string{"foo", "bar"}}, fileTpl))
+	})
+
+	t.Run("zero checkNames", func(t *testing.T) {
+		assert.Equal(t, []integration.Config{fileTpl}, // fileTpl gets dropped, but not non-file
+			filterDrops(&service{entity: entity, checkNames: []string{}}, fileTpl, nonFileTpl))
+	})
+
+	t.Run("one empty checkName", func(t *testing.T) {
+		assert.Equal(t, []integration.Config{fileTpl}, // fileTpl gets dropped, but not non-file
+			filterDrops(&service{entity: entity, checkNames: []string{""}}, fileTpl, nonFileTpl))
+	})
+}
+
+func TestServiceFilterTemplatesOverriddenChecks(t *testing.T) {
+	filterDrops := func(svc *service, configs ...integration.Config) (dropped []integration.Config) {
+		return filterConfigsDropped(svc.filterTemplatesOverriddenChecks, configs...)
+	}
+
+	entity := &workloadmeta.Container{EntityID: workloadmeta.EntityID{Kind: "container", ID: "testy"}}
+	fooTpl := integration.Config{Name: "foo", Provider: names.File, LogsConfig: []byte(`{"source":"foo"}`)}
+	barTpl := integration.Config{Name: "bar", Provider: names.File, LogsConfig: []byte(`{"source":"bar"}`)}
+	fooNonFileTpl := integration.Config{Name: "foo", Provider: "xxx", LogsConfig: []byte(`{"source":"foo-nf"}`)}
+	barNonFileTpl := integration.Config{Name: "bar", Provider: "xxx", LogsConfig: []byte(`{"source":"bar-nf"}`)}
+	nothingDropped := []integration.Config{}
+
+	t.Run("nil checkNames", func(t *testing.T) {
+		assert.Equal(t, nothingDropped,
+			filterDrops(&service{entity: entity, checkNames: nil}, fooTpl, barTpl))
+	})
+
+	t.Run("one checkName", func(t *testing.T) {
+		assert.Equal(t, []integration.Config{fooTpl},
+			filterDrops(&service{entity: entity, checkNames: []string{"foo"}}, fooTpl, barTpl, fooNonFileTpl))
+	})
+
+	t.Run("some checkNames", func(t *testing.T) {
+		assert.Equal(t, []integration.Config{fooTpl, barTpl},
+			filterDrops(&service{entity: entity, checkNames: []string{"foo", "bar"}}, fooTpl, barTpl, fooNonFileTpl, barNonFileTpl))
+	})
+
+	t.Run("some checkNames, partial match", func(t *testing.T) {
+		assert.Equal(t, []integration.Config{barTpl},
+			filterDrops(&service{entity: entity, checkNames: []string{"bing", "bar"}}, fooTpl, barTpl, fooNonFileTpl, barNonFileTpl))
+	})
+}


### PR DESCRIPTION
### What does this PR do?

If a pod or container annotation specifies a check configuration, then
any configuration for that check found in files should be ignored.

As a further undocumented feature, a pod or container annotation containing
`ad.datadoghq.com/<container>.checks: {}` or
`com.datadoghq.ad.check_names: []` will override any configs associated
with the container from other sources.

Both of these behaviors were implemented in the config resolver, by
returning an error when these situations occurred.  This change uses
svc.FilterTemplates to accomplish the same behavior in a more natural
fashion.  This change is controlled by the `cca_in_ad` feature flag.

### Motivation

Regularize this functionality, and also test out the use of config filtering.

### Additional Notes

Please examine commit-by-commit, and verify that if the feature flag is false, by inspection nothing will change.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Make the `cpu` check config into a template:

```
ad_identifiers:
  - bash
init_config:
instances:
  - tags: [TEST:ING]
```

Run the agent with

```
log_level: DEBUG
log_payloads: true
```

First, check that an empty check_names annotation/label will disable a check.

The `cpu` check should not appear in `agent status` when no container is
running.  When a `bash` container is running (`docker run -ti --rm bash`), you
should see (after about 5 seconds):

```
    cpu
    ---
      Instance ID: cpu [OK]
      Configuration Source: file:/etc/datadog-agent/conf.d/cpu.yaml
```

Now run a `bash` container with an empty check annotation:

```
docker run -ti --rm --label 'com.datadoghq.ad.check_names=[]' bash
```

and no `cpu` check should appear, even after 5 seconds.  You can also verify
that payloads with the TEST:ING tag appear:

```
2022-04-25 20:59:18 UTC | CORE | DEBUG | (..) | Flushing serie: {"metric":"system.cpu.idle","tags":["TEST:ING",..], ..}
```

Now, check that check configuration in a container overrides that in a file

```
docker run -ti --rm  \
  -l com.datadoghq.ad.check_names='["cpu"]' \
  -l com.datadoghq.ad.init_configs='[{}]' \
  -l com.datadoghq.ad.instances='[{"tags":["OVER:RIDE"]}]' \
  bash
```

You should now see `OVER:RIDE` in the logs, and not `TEST:ING`.

You can also look for the following in the logs:

```
Ignoring config from file:/etc/datadog-agent/conf.d/cpu.yaml: the service docker://.. overrides check cpu
Ignoring config from file:/etc/datadog-agent/conf.d/cpu.yaml, as the service docker://.. defines an empty set of checkNames
```
### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
