### PR TITLE
kitchen: fix deprecated warning

### DIFF
--- a/test/kitchen/Gemfile
+++ b/test/kitchen/Gemfile
@@ -1,6 +1,6 @@
 require 'open-uri'
 
 # Actual gemfile is stored in the buildimages repo because it comes pre-installed in the dd-agent-testing Docker image, read it from there
-gemfile = open('https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/main/dd-agent-testing/Gemfile')
+gemfile = URI.open('https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/main/dd-agent-testing/Gemfile')
 eval gemfile.read
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes:
```
/go/src/github.com/zbECYyMF/0/DataDog/datadog-agent/test/kitchen/Gemfile:4: warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open
```

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
