### PR TITLE
[corecheck/snmp] evaluate memory usage

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/report/report_bandwidth_usage.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_bandwidth_usage.go
@@ -84,6 +84,14 @@ func (ms *MetricSender) sendBandwidthUsageMetric(symbol checkconfig.SymbolConfig
 	}
 	usageValue := ((octetsFloatValue * 8) / (ifHighSpeedFloatValue * (1e6))) * 100.0
 
-	ms.sendMetric(checkconfig.SymbolConfig{Name: usageName + ".rate"}, valuestore.ResultValue{SubmissionType: "counter", Value: usageValue}, tags, checkconfig.MetricsConfig{ForcedType: "counter"})
+	sample := MetricSample{
+		value:      valuestore.ResultValue{SubmissionType: "counter", Value: usageValue},
+		tags:       tags,
+		symbol:     checkconfig.SymbolConfig{Name: usageName + ".rate"},
+		forcedType: "counter",
+		options:    checkconfig.MetricsConfigOption{},
+	}
+
+	ms.sendMetric(sample)
 	return nil
 }

--- a/pkg/collector/corechecks/snmp/internal/report/report_memory_usage.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_memory_usage.go
@@ -1,0 +1,300 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package report
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/checkconfig"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/valuestore"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// EvaluatedSampleDependencies set of supported memory usage metrics
+var EvaluatedSampleDependencies = map[string]bool{
+	"memory.usage": true,
+	"memory.used":  true,
+	"memory.total": true,
+	"memory.free":  true,
+}
+
+func (ms *MetricSender) tryReportMemoryUsage(scalarSamples map[string]MetricSample, columnSamples map[string]map[string]MetricSample) error {
+	if ms.hasScalarMemoryUsage(scalarSamples) {
+		return ms.trySendScalarMemoryUsage(scalarSamples)
+	}
+
+	return ms.trySendColumnMemoryUsage(columnSamples)
+}
+
+// hasScalarMemoryUsage is true if samples store contains at least one memory usage related metric
+func (ms *MetricSender) hasScalarMemoryUsage(scalarSamples map[string]MetricSample) bool {
+	_, scalarMemoryUsageOk := scalarSamples["memory.usage"]
+	_, scalarMemoryUsedOk := scalarSamples["memory.used"]
+	_, scalarMemoryTotalOk := scalarSamples["memory.total"]
+	_, scalarMemoryFreeOk := scalarSamples["memory.free"]
+
+	return scalarMemoryUsageOk || scalarMemoryUsedOk || scalarMemoryTotalOk || scalarMemoryFreeOk
+}
+
+func (ms *MetricSender) trySendScalarMemoryUsage(scalarSamples map[string]MetricSample) error {
+	_, scalarMemoryUsageOk := scalarSamples["memory.usage"]
+	if scalarMemoryUsageOk {
+		// memory usage is already sent through collected metrics
+		return nil
+	}
+
+	scalarMemoryUsed, scalarMemoryUsedOk := scalarSamples["memory.used"]
+	scalarMemoryTotal, scalarMemoryTotalOk := scalarSamples["memory.total"]
+	scalarMemoryFree, scalarMemoryFreeOk := scalarSamples["memory.free"]
+
+	if scalarMemoryUsedOk {
+		floatMemoryUsed, err := scalarMemoryUsed.value.ToFloat64()
+		if err != nil {
+			return fmt.Errorf("metric `%s`: failed to convert to float64: %s", "memory.used", err)
+		}
+
+		if scalarMemoryTotalOk {
+			// memory total and memory used
+			floatMemoryTotal, err := scalarMemoryTotal.value.ToFloat64()
+			if err != nil {
+				return fmt.Errorf("metric `%s`: failed to convert to float64: %s", "memory.total", err)
+			}
+
+			memoryUsageValue, err := evaluateMemoryUsage(floatMemoryUsed, floatMemoryTotal)
+			if err != nil {
+				return err
+			}
+
+			memoryUsageSample := MetricSample{
+				value:      valuestore.ResultValue{Value: memoryUsageValue},
+				tags:       scalarMemoryUsed.tags,
+				symbol:     checkconfig.SymbolConfig{Name: "memory.usage"},
+				options:    checkconfig.MetricsConfigOption{},
+				forcedType: "",
+			}
+
+			ms.sendMetric(memoryUsageSample)
+			return nil
+		}
+
+		if scalarMemoryFreeOk {
+			// memory total and memory used
+			floatMemoryFree, err := scalarMemoryFree.value.ToFloat64()
+			if err != nil {
+				log.Debugf("metric `%s`: failed to convert to float64: %s", "memory.free", err)
+				return err
+			}
+
+			floatMemoryUsed, err := scalarMemoryUsed.value.ToFloat64()
+			if err != nil {
+				log.Debugf("metric `%s`: failed to convert to float64: %s", "memory.used", err)
+				return err
+			}
+
+			memoryUsageValue, err := evaluateMemoryUsage(floatMemoryUsed, floatMemoryFree+floatMemoryUsed)
+			if err != nil {
+				return err
+			}
+
+			memoryUsageSample := MetricSample{
+				value:      valuestore.ResultValue{Value: memoryUsageValue},
+				tags:       scalarMemoryUsed.tags,
+				symbol:     checkconfig.SymbolConfig{Name: "memory.usage"},
+				options:    checkconfig.MetricsConfigOption{},
+				forcedType: "",
+			}
+
+			ms.sendMetric(memoryUsageSample)
+			return nil
+		}
+	}
+
+	if scalarMemoryFreeOk && scalarMemoryTotalOk {
+		// memory total and memory used
+		floatMemoryFree, err := scalarMemoryFree.value.ToFloat64()
+		if err != nil {
+			log.Debugf("metric `%s`: failed to convert to float64: %s", "memory.free", err)
+			return err
+		}
+
+		floatMemoryTotal, err := scalarMemoryTotal.value.ToFloat64()
+		if err != nil {
+			log.Debugf("metric `%s`: failed to convert to float64: %s", "memory.total", err)
+			return err
+		}
+
+		memoryUsageValue, err := evaluateMemoryUsage(floatMemoryTotal-floatMemoryFree, floatMemoryTotal)
+		if err != nil {
+			return err
+		}
+
+		memoryUsageSample := MetricSample{
+			value:      valuestore.ResultValue{Value: memoryUsageValue},
+			tags:       scalarMemoryTotal.tags,
+			symbol:     checkconfig.SymbolConfig{Name: "memory.usage"},
+			options:    checkconfig.MetricsConfigOption{},
+			forcedType: "",
+		}
+
+		ms.sendMetric(memoryUsageSample)
+		return nil
+	}
+
+	// report missing dependency metrics
+	missingMetrics := []string{}
+	if !scalarMemoryUsedOk {
+		missingMetrics = append(missingMetrics, "used")
+	}
+	if !scalarMemoryFreeOk {
+		missingMetrics = append(missingMetrics, "free")
+	}
+	if !scalarMemoryTotalOk {
+		missingMetrics = append(missingMetrics, "total")
+	}
+
+	return fmt.Errorf("missing %s memory metrics, skipping scalar memory usage", strings.Join(missingMetrics, ", "))
+}
+
+func (ms *MetricSender) trySendColumnMemoryUsage(columnSamples map[string]map[string]MetricSample) error {
+	_, memoryUsageOk := columnSamples["memory.usage"]
+	if memoryUsageOk {
+		// memory usage is already sent through collected metrics
+		return nil
+	}
+
+	memoryUsedRows, memoryUsedOk := columnSamples["memory.used"]
+	memoryTotalRows, memoryTotalOk := columnSamples["memory.total"]
+	memoryFreeRows, memoryFreeOk := columnSamples["memory.free"]
+
+	if memoryUsedOk {
+		if memoryTotalOk {
+			for rowIndex, memoryUsedSample := range memoryUsedRows {
+				memoryTotalSample, memoryTotalSampleOk := memoryTotalRows[rowIndex]
+				if !memoryTotalSampleOk {
+					return fmt.Errorf("missing memory total sample at row %s, skipping memory usage evaluation", rowIndex)
+				}
+				floatMemoryTotal, err := memoryTotalSample.value.ToFloat64()
+				if err != nil {
+					return fmt.Errorf("metric `%s[%s]`: failed to convert to float64: %s", "memory.total", rowIndex, err)
+				}
+
+				floatMemoryUsed, err := memoryUsedSample.value.ToFloat64()
+				if err != nil {
+					return fmt.Errorf("metric `%s[%s]`: failed to convert to float64: %s", "memory.used", rowIndex, err)
+				}
+
+				memoryUsageValue, err := evaluateMemoryUsage(floatMemoryUsed, floatMemoryTotal)
+				if err != nil {
+					return err
+				}
+
+				memoryUsageSample := MetricSample{
+					value:      valuestore.ResultValue{Value: memoryUsageValue},
+					tags:       memoryUsedSample.tags,
+					symbol:     checkconfig.SymbolConfig{Name: "memory.usage"},
+					options:    checkconfig.MetricsConfigOption{},
+					forcedType: "",
+				}
+
+				ms.sendMetric(memoryUsageSample)
+			}
+			return nil
+		}
+
+		if memoryFreeOk {
+			for rowIndex, memoryUsedSample := range memoryUsedRows {
+				memoryFreeSample, memoryFreeSampleOk := memoryFreeRows[rowIndex]
+				if !memoryFreeSampleOk {
+					return fmt.Errorf("missing memory free sample at row %s, skipping memory usage evaluation", rowIndex)
+				}
+				floatMemoryFree, err := memoryFreeSample.value.ToFloat64()
+				if err != nil {
+					return fmt.Errorf("metric `%s[%s]`: failed to convert to float64: %s", "memory.free", rowIndex, err)
+				}
+
+				floatMemoryUsed, err := memoryUsedSample.value.ToFloat64()
+				if err != nil {
+					return fmt.Errorf("metric `%s[%s]`: failed to convert to float64: %s", "memory.used", rowIndex, err)
+				}
+
+				memoryUsageValue, err := evaluateMemoryUsage(floatMemoryUsed, floatMemoryFree+floatMemoryUsed)
+				if err != nil {
+					return err
+				}
+
+				memoryUsageSample := MetricSample{
+					value:      valuestore.ResultValue{Value: memoryUsageValue},
+					tags:       memoryUsedSample.tags,
+					symbol:     checkconfig.SymbolConfig{Name: "memory.usage"},
+					options:    checkconfig.MetricsConfigOption{},
+					forcedType: "",
+				}
+
+				ms.sendMetric(memoryUsageSample)
+			}
+			return nil
+		}
+	}
+
+	if memoryFreeOk && memoryTotalOk {
+		for rowIndex, memoryTotalSample := range memoryTotalRows {
+			memoryFreeSample, memoryFreeSampleOk := memoryFreeRows[rowIndex]
+			if !memoryFreeSampleOk {
+				return fmt.Errorf("missing memory free sample at row %s, skipping memory usage evaluation", rowIndex)
+			}
+			floatMemoryFree, err := memoryFreeSample.value.ToFloat64()
+			if err != nil {
+				return fmt.Errorf("metric `%s[%s]`: failed to convert to float64: %s", "memory.free", rowIndex, err)
+			}
+
+			floatMemoryTotal, err := memoryTotalSample.value.ToFloat64()
+			if err != nil {
+				return fmt.Errorf("metric `%s[%s]`: failed to convert to float64: %s", "memory.total", rowIndex, err)
+			}
+
+			memoryUsageValue, err := evaluateMemoryUsage(floatMemoryTotal-floatMemoryFree, floatMemoryTotal)
+			if err != nil {
+				return err
+			}
+
+			memoryUsageSample := MetricSample{
+				value:      valuestore.ResultValue{Value: memoryUsageValue},
+				tags:       memoryTotalSample.tags,
+				symbol:     checkconfig.SymbolConfig{Name: "memory.usage"},
+				options:    checkconfig.MetricsConfigOption{},
+				forcedType: "",
+			}
+
+			ms.sendMetric(memoryUsageSample)
+		}
+		return nil
+	}
+
+	// report missing dependency metrics
+	missingMetrics := []string{}
+	if !memoryUsedOk {
+		missingMetrics = append(missingMetrics, "used")
+	}
+	if !memoryFreeOk {
+		missingMetrics = append(missingMetrics, "free")
+	}
+	if !memoryTotalOk {
+		missingMetrics = append(missingMetrics, "total")
+	}
+
+	return fmt.Errorf("missing %s memory metrics, skipping column memory usage", strings.Join(missingMetrics, ", "))
+}
+
+func evaluateMemoryUsage(memoryUsed float64, memoryTotal float64) (float64, error) {
+	if memoryTotal == 0 {
+		return 0, fmt.Errorf("cannot evaluate memory usage, total memory is 0")
+	}
+	if memoryUsed < 0 {
+		return 0, fmt.Errorf("cannot evaluate memory usage, memory used is < 0")
+	}
+	return (memoryUsed / memoryTotal) * 100, nil
+}

--- a/pkg/collector/corechecks/snmp/internal/report/report_memory_usage_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_memory_usage_test.go
@@ -1,0 +1,405 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package report
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/checkconfig"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/valuestore"
+)
+
+func Test_metricSender_sendMemoryUsageMetric(t *testing.T) {
+	type MetricSamplesStore struct {
+		scalarSamples map[string]MetricSample
+		columnSamples map[string]map[string]MetricSample
+	}
+	type Metric struct {
+		name  string
+		value float64
+		tags  []string
+	}
+	tests := []struct {
+		name            string
+		samplesStore    MetricSamplesStore
+		expectedMetrics []Metric
+		expectedError   error
+	}{
+		{
+			"should not emit evaluated snmp.memory.usage when scalar memory.usage is collected",
+			MetricSamplesStore{scalarSamples: map[string]MetricSample{
+				"memory.usage": {
+					value:      valuestore.ResultValue{Value: 100.0},
+					tags:       []string{"device_namespace:default", "ip_address:192.168.10.24"},
+					symbol:     checkconfig.SymbolConfig{Name: "memory.usage"},
+					options:    checkconfig.MetricsConfigOption{},
+					forcedType: "",
+				},
+			}},
+			[]Metric{},
+			nil,
+		},
+		{
+			"should not emit evaluated snmp.memory.usage when column memory.usage is collected",
+			MetricSamplesStore{columnSamples: map[string]map[string]MetricSample{
+				"memory.usage": {
+					"123": {
+						value:      valuestore.ResultValue{Value: 100.0},
+						tags:       []string{"device_namespace:default", "ip_address:192.168.10.24", "mem:123"},
+						symbol:     checkconfig.SymbolConfig{Name: "memory.usage"},
+						options:    checkconfig.MetricsConfigOption{},
+						forcedType: "",
+					},
+					"567": {
+						value:      valuestore.ResultValue{Value: 100.0},
+						tags:       []string{"device_namespace:default", "ip_address:192.168.10.24", "mem:567"},
+						symbol:     checkconfig.SymbolConfig{Name: "memory.usage"},
+						options:    checkconfig.MetricsConfigOption{},
+						forcedType: "",
+					},
+				},
+			}},
+			[]Metric{},
+			nil,
+		},
+		{
+			"should not emit evaluated snmp.memory.usage when only scalar memory.used is collected",
+			MetricSamplesStore{scalarSamples: map[string]MetricSample{
+				"memory.used": {
+					value:      valuestore.ResultValue{Value: 100.0},
+					tags:       []string{"device_namespace:default", "ip_address:192.168.10.24"},
+					symbol:     checkconfig.SymbolConfig{Name: "memory.used"},
+					options:    checkconfig.MetricsConfigOption{},
+					forcedType: "",
+				},
+			}},
+			[]Metric{},
+			fmt.Errorf("missing free, total memory metrics, skipping scalar memory usage"),
+		},
+		{
+			"should not emit evaluated snmp.memory.usage when only scalar memory.free is collected",
+			MetricSamplesStore{scalarSamples: map[string]MetricSample{
+				"memory.free": {
+					value:      valuestore.ResultValue{Value: 100.0},
+					tags:       []string{"device_namespace:default", "ip_address:192.168.10.24"},
+					symbol:     checkconfig.SymbolConfig{Name: "memory.free"},
+					options:    checkconfig.MetricsConfigOption{},
+					forcedType: "",
+				},
+			}},
+			[]Metric{},
+			fmt.Errorf("missing used, total memory metrics, skipping scalar memory usage"),
+		},
+		{
+			"should not emit evaluated snmp.memory.usage when only scalar memory.total is collected",
+			MetricSamplesStore{scalarSamples: map[string]MetricSample{
+				"memory.total": {
+					value:      valuestore.ResultValue{Value: 100.0},
+					tags:       []string{"device_namespace:default", "ip_address:192.168.10.24"},
+					symbol:     checkconfig.SymbolConfig{Name: "memory.total"},
+					options:    checkconfig.MetricsConfigOption{},
+					forcedType: "",
+				},
+			}},
+			[]Metric{},
+			fmt.Errorf("missing used, free memory metrics, skipping scalar memory usage"),
+		},
+		{
+			"should not emit evaluated snmp.memory.usage when only column memory.used is collected",
+			MetricSamplesStore{columnSamples: map[string]map[string]MetricSample{
+				"memory.used": {
+					"123": {
+						value:      valuestore.ResultValue{Value: 100.0},
+						tags:       []string{"device_namespace:default", "ip_address:192.168.10.24", "mem:123"},
+						symbol:     checkconfig.SymbolConfig{Name: "memory.used"},
+						options:    checkconfig.MetricsConfigOption{},
+						forcedType: "",
+					},
+					"567": {
+						value:      valuestore.ResultValue{Value: 100.0},
+						tags:       []string{"device_namespace:default", "ip_address:192.168.10.24", "mem:567"},
+						symbol:     checkconfig.SymbolConfig{Name: "memory.used"},
+						options:    checkconfig.MetricsConfigOption{},
+						forcedType: "",
+					},
+				},
+			}},
+			[]Metric{},
+			fmt.Errorf("missing free, total memory metrics, skipping column memory usage"),
+		},
+		{
+			"should not emit evaluated snmp.memory.usage when only column memory.free is collected",
+			MetricSamplesStore{columnSamples: map[string]map[string]MetricSample{
+				"memory.free": {
+					"123": {
+						value:      valuestore.ResultValue{Value: 100.0},
+						tags:       []string{"device_namespace:default", "ip_address:192.168.10.24", "mem:123"},
+						symbol:     checkconfig.SymbolConfig{Name: "memory.free"},
+						options:    checkconfig.MetricsConfigOption{},
+						forcedType: "",
+					},
+					"567": {
+						value:      valuestore.ResultValue{Value: 100.0},
+						tags:       []string{"device_namespace:default", "ip_address:192.168.10.24", "mem:567"},
+						symbol:     checkconfig.SymbolConfig{Name: "memory.free"},
+						options:    checkconfig.MetricsConfigOption{},
+						forcedType: "",
+					},
+				},
+			}},
+			[]Metric{},
+			fmt.Errorf("missing used, total memory metrics, skipping column memory usage"),
+		},
+		{
+			"should not emit evaluated snmp.memory.usage when only column memory.total is collected",
+			MetricSamplesStore{columnSamples: map[string]map[string]MetricSample{
+				"memory.total": {
+					"123": {
+						value:      valuestore.ResultValue{Value: 100.0},
+						tags:       []string{"device_namespace:default", "ip_address:192.168.10.24", "mem:123"},
+						symbol:     checkconfig.SymbolConfig{Name: "memory.total"},
+						options:    checkconfig.MetricsConfigOption{},
+						forcedType: "",
+					},
+					"567": {
+						value:      valuestore.ResultValue{Value: 100.0},
+						tags:       []string{"device_namespace:default", "ip_address:192.168.10.24", "mem:567"},
+						symbol:     checkconfig.SymbolConfig{Name: "memory.total"},
+						options:    checkconfig.MetricsConfigOption{},
+						forcedType: "",
+					},
+				},
+			}},
+			[]Metric{},
+			fmt.Errorf("missing used, free memory metrics, skipping column memory usage"),
+		},
+		{
+			"should not emit evaluated snmp.memory.usage when no memory metric is collected",
+			MetricSamplesStore{},
+			[]Metric{},
+			fmt.Errorf("missing used, free, total memory metrics, skipping column memory usage"),
+		},
+		{
+			"should emit evaluated snmp.memory.usage when scalar memory.used and memory.total are collected",
+			MetricSamplesStore{scalarSamples: map[string]MetricSample{
+				"memory.used": {
+					value:      valuestore.ResultValue{Value: 50.0},
+					tags:       []string{"device_namespace:default", "ip_address:192.168.10.24"},
+					symbol:     checkconfig.SymbolConfig{Name: "memory.used"},
+					options:    checkconfig.MetricsConfigOption{},
+					forcedType: "",
+				},
+				"memory.total": {
+					value:      valuestore.ResultValue{Value: 200.0},
+					tags:       []string{"device_namespace:default", "ip_address:192.168.10.24"},
+					symbol:     checkconfig.SymbolConfig{Name: "memory.total"},
+					options:    checkconfig.MetricsConfigOption{},
+					forcedType: "",
+				},
+			}},
+			[]Metric{
+				{"snmp.memory.usage", 25.0, []string{"device_namespace:default", "ip_address:192.168.10.24"}},
+			},
+			nil,
+		},
+		{
+			"should emit evaluated snmp.memory.usage when scalar memory.used and memory.free are collected",
+			MetricSamplesStore{scalarSamples: map[string]MetricSample{
+				"memory.used": {
+					value:      valuestore.ResultValue{Value: 50.0},
+					tags:       []string{"device_namespace:default", "ip_address:192.168.10.24"},
+					symbol:     checkconfig.SymbolConfig{Name: "memory.used"},
+					options:    checkconfig.MetricsConfigOption{},
+					forcedType: "",
+				},
+				"memory.free": {
+					value:      valuestore.ResultValue{Value: 150.0},
+					tags:       []string{"device_namespace:default", "ip_address:192.168.10.24"},
+					symbol:     checkconfig.SymbolConfig{Name: "memory.free"},
+					options:    checkconfig.MetricsConfigOption{},
+					forcedType: "",
+				},
+			}},
+			[]Metric{
+				{"snmp.memory.usage", 25.0, []string{"device_namespace:default", "ip_address:192.168.10.24"}},
+			},
+			nil,
+		},
+		{
+			"should emit evaluated snmp.memory.usage when scalar memory.free and memory.total are collected",
+			MetricSamplesStore{scalarSamples: map[string]MetricSample{
+				"memory.free": {
+					value:      valuestore.ResultValue{Value: 150.0},
+					tags:       []string{"device_namespace:default", "ip_address:192.168.10.24"},
+					symbol:     checkconfig.SymbolConfig{Name: "memory.free"},
+					options:    checkconfig.MetricsConfigOption{},
+					forcedType: "",
+				},
+				"memory.total": {
+					value:      valuestore.ResultValue{Value: 200.0},
+					tags:       []string{"device_namespace:default", "ip_address:192.168.10.24"},
+					symbol:     checkconfig.SymbolConfig{Name: "memory.total"},
+					options:    checkconfig.MetricsConfigOption{},
+					forcedType: "",
+				},
+			}},
+			[]Metric{
+				{"snmp.memory.usage", 25.0, []string{"device_namespace:default", "ip_address:192.168.10.24"}},
+			},
+			nil,
+		},
+		{
+			"should emit evaluated snmp.memory.usage when column memory.used and memory.total are collected",
+			MetricSamplesStore{columnSamples: map[string]map[string]MetricSample{
+				"memory.used": {
+					"123": {
+						value:      valuestore.ResultValue{Value: 100.0},
+						tags:       []string{"device_namespace:default", "ip_address:192.168.10.24", "mem:123"},
+						symbol:     checkconfig.SymbolConfig{Name: "memory.used"},
+						options:    checkconfig.MetricsConfigOption{},
+						forcedType: "",
+					},
+					"567": {
+						value:      valuestore.ResultValue{Value: 20.0},
+						tags:       []string{"device_namespace:default", "ip_address:192.168.10.24", "mem:567"},
+						symbol:     checkconfig.SymbolConfig{Name: "memory.used"},
+						options:    checkconfig.MetricsConfigOption{},
+						forcedType: "",
+					},
+				},
+				"memory.total": {
+					"123": {
+						value:      valuestore.ResultValue{Value: 200.0},
+						tags:       []string{"device_namespace:default", "ip_address:192.168.10.24", "mem:123"},
+						symbol:     checkconfig.SymbolConfig{Name: "memory.total"},
+						options:    checkconfig.MetricsConfigOption{},
+						forcedType: "",
+					},
+					"567": {
+						value:      valuestore.ResultValue{Value: 200.0},
+						tags:       []string{"device_namespace:default", "ip_address:192.168.10.24", "mem:567"},
+						symbol:     checkconfig.SymbolConfig{Name: "memory.total"},
+						options:    checkconfig.MetricsConfigOption{},
+						forcedType: "",
+					},
+				},
+			}},
+			[]Metric{
+				{"snmp.memory.usage", 50.0, []string{"device_namespace:default", "ip_address:192.168.10.24", "mem:123"}},
+				{"snmp.memory.usage", 10.0, []string{"device_namespace:default", "ip_address:192.168.10.24", "mem:567"}},
+			},
+			nil,
+		},
+		{
+			"should emit evaluated snmp.memory.usage when column memory.used and memory.free are collected",
+			MetricSamplesStore{columnSamples: map[string]map[string]MetricSample{
+				"memory.used": {
+					"123": {
+						value:      valuestore.ResultValue{Value: 100.0},
+						tags:       []string{"device_namespace:default", "ip_address:192.168.10.24", "mem:123"},
+						symbol:     checkconfig.SymbolConfig{Name: "memory.usage"},
+						options:    checkconfig.MetricsConfigOption{},
+						forcedType: "",
+					},
+					"567": {
+						value:      valuestore.ResultValue{Value: 20.0},
+						tags:       []string{"device_namespace:default", "ip_address:192.168.10.24", "mem:567"},
+						symbol:     checkconfig.SymbolConfig{Name: "memory.usage"},
+						options:    checkconfig.MetricsConfigOption{},
+						forcedType: "",
+					},
+				},
+				"memory.free": {
+					"123": {
+						value:      valuestore.ResultValue{Value: 100.0},
+						tags:       []string{"device_namespace:default", "ip_address:192.168.10.24", "mem:123"},
+						symbol:     checkconfig.SymbolConfig{Name: "memory.usage"},
+						options:    checkconfig.MetricsConfigOption{},
+						forcedType: "",
+					},
+					"567": {
+						value:      valuestore.ResultValue{Value: 180.0},
+						tags:       []string{"device_namespace:default", "ip_address:192.168.10.24", "mem:567"},
+						symbol:     checkconfig.SymbolConfig{Name: "memory.usage"},
+						options:    checkconfig.MetricsConfigOption{},
+						forcedType: "",
+					},
+				},
+			}},
+			[]Metric{
+				{"snmp.memory.usage", 50.0, []string{"device_namespace:default", "ip_address:192.168.10.24", "mem:123"}},
+				{"snmp.memory.usage", 10.0, []string{"device_namespace:default", "ip_address:192.168.10.24", "mem:567"}},
+			},
+			nil,
+		},
+		{
+			"should emit evaluated snmp.memory.usage when column memory.free and memory.total are collected",
+			MetricSamplesStore{columnSamples: map[string]map[string]MetricSample{
+				"memory.free": {
+					"123": {
+						value:      valuestore.ResultValue{Value: 100.0},
+						tags:       []string{"device_namespace:default", "ip_address:192.168.10.24", "mem:123"},
+						symbol:     checkconfig.SymbolConfig{Name: "memory.usage"},
+						options:    checkconfig.MetricsConfigOption{},
+						forcedType: "",
+					},
+					"567": {
+						value:      valuestore.ResultValue{Value: 180.0},
+						tags:       []string{"device_namespace:default", "ip_address:192.168.10.24", "mem:567"},
+						symbol:     checkconfig.SymbolConfig{Name: "memory.usage"},
+						options:    checkconfig.MetricsConfigOption{},
+						forcedType: "",
+					},
+				},
+				"memory.total": {
+					"123": {
+						value:      valuestore.ResultValue{Value: 200.0},
+						tags:       []string{"device_namespace:default", "ip_address:192.168.10.24", "mem:123"},
+						symbol:     checkconfig.SymbolConfig{Name: "memory.usage"},
+						options:    checkconfig.MetricsConfigOption{},
+						forcedType: "",
+					},
+					"567": {
+						value:      valuestore.ResultValue{Value: 200.0},
+						tags:       []string{"device_namespace:default", "ip_address:192.168.10.24", "mem:567"},
+						symbol:     checkconfig.SymbolConfig{Name: "memory.usage"},
+						options:    checkconfig.MetricsConfigOption{},
+						forcedType: "",
+					},
+				},
+			}},
+			[]Metric{
+				{"snmp.memory.usage", 50.0, []string{"device_namespace:default", "ip_address:192.168.10.24", "mem:123"}},
+				{"snmp.memory.usage", 10.0, []string{"device_namespace:default", "ip_address:192.168.10.24", "mem:567"}},
+			},
+			nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sender := mocksender.NewMockSender("testID") // required to initiate aggregator
+			sender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+
+			ms := &MetricSender{
+				sender: sender,
+			}
+			err := ms.tryReportMemoryUsage(tt.samplesStore.scalarSamples, tt.samplesStore.columnSamples)
+			assert.Equal(t, tt.expectedError, err)
+
+			sender.AssertNumberOfCalls(t, "Gauge", len(tt.expectedMetrics))
+
+			for _, metric := range tt.expectedMetrics {
+				sender.AssertMetric(t, "Gauge", metric.name, metric.value, "", metric.tags)
+			}
+		})
+	}
+}

--- a/pkg/collector/corechecks/snmp/internal/report/report_metrics.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_metrics.go
@@ -24,6 +24,15 @@ type MetricSender struct {
 	submittedMetrics int
 }
 
+// MetricSample is a collected metric sample with its metadata, ready to be submitted through the metric sender
+type MetricSample struct {
+	value      valuestore.ResultValue
+	tags       []string
+	symbol     checkconfig.SymbolConfig
+	forcedType string
+	options    checkconfig.MetricsConfigOption
+}
+
 // NewMetricSender create a new MetricSender
 func NewMetricSender(sender aggregator.Sender, hostname string) *MetricSender {
 	return &MetricSender{sender: sender, hostname: hostname}
@@ -33,7 +42,10 @@ func NewMetricSender(sender aggregator.Sender, hostname string) *MetricSender {
 func (ms *MetricSender) ReportMetrics(metrics []checkconfig.MetricsConfig, values *valuestore.ResultValueStore, tags []string) {
 	for _, metric := range metrics {
 		if metric.IsScalar() {
-			ms.reportScalarMetrics(metric, values, tags)
+			_, err := ms.reportScalarMetrics(metric, values, tags)
+			if err != nil {
+				continue
+			}
 		} else if metric.IsColumn() {
 			ms.reportColumnMetrics(metric, values, tags)
 		}
@@ -60,20 +72,29 @@ func (ms *MetricSender) GetCheckInstanceMetricTags(metricTags []checkconfig.Metr
 	return globalTags
 }
 
-func (ms *MetricSender) reportScalarMetrics(metric checkconfig.MetricsConfig, values *valuestore.ResultValueStore, tags []string) {
+func (ms *MetricSender) reportScalarMetrics(metric checkconfig.MetricsConfig, values *valuestore.ResultValueStore, tags []string) (MetricSample, error) {
 	value, err := getScalarValueFromSymbol(values, metric.Symbol)
 	if err != nil {
 		log.Debugf("report scalar: error getting scalar value: %v", err)
-		return
+		return MetricSample{}, err
 	}
 
 	scalarTags := common.CopyStrings(tags)
 	scalarTags = append(scalarTags, metric.GetSymbolTags()...)
-	ms.sendMetric(metric.Symbol, value, scalarTags, metric)
+	sample := MetricSample{
+		value:      value,
+		tags:       scalarTags,
+		symbol:     metric.Symbol,
+		forcedType: metric.ForcedType,
+		options:    metric.Options,
+	}
+	ms.sendMetric(sample)
+	return sample, nil
 }
 
-func (ms *MetricSender) reportColumnMetrics(metricConfig checkconfig.MetricsConfig, values *valuestore.ResultValueStore, tags []string) {
+func (ms *MetricSender) reportColumnMetrics(metricConfig checkconfig.MetricsConfig, values *valuestore.ResultValueStore, tags []string) map[string]map[string]MetricSample {
 	rowTagsCache := make(map[string][]string)
+	samples := map[string]map[string]MetricSample{}
 	for _, symbol := range metricConfig.Symbols {
 		metricValues, err := getColumnValueFromSymbol(values, symbol)
 		if err != nil {
@@ -88,65 +109,77 @@ func (ms *MetricSender) reportColumnMetrics(metricConfig checkconfig.MetricsConf
 				rowTagsCache[fullIndex] = tmpTags
 			}
 			rowTags := rowTagsCache[fullIndex]
-			ms.sendMetric(symbol, value, rowTags, metricConfig)
+			sample := MetricSample{
+				value:      value,
+				tags:       rowTags,
+				symbol:     symbol,
+				forcedType: metricConfig.ForcedType,
+				options:    metricConfig.Options,
+			}
+			ms.sendMetric(sample)
+			if _, ok := samples[sample.symbol.Name]; !ok {
+				samples[sample.symbol.Name] = make(map[string]MetricSample)
+			}
+			samples[sample.symbol.Name][fullIndex] = sample
 			ms.trySendBandwidthUsageMetric(symbol, fullIndex, values, rowTags)
 		}
 	}
+	return samples
 }
 
-func (ms *MetricSender) sendMetric(symbol checkconfig.SymbolConfig, value valuestore.ResultValue, tags []string, metricConfig checkconfig.MetricsConfig) {
-	metricFullName := "snmp." + symbol.Name
-	forcedType := metricConfig.ForcedType
+func (ms *MetricSender) sendMetric(metricSample MetricSample) {
+	metricFullName := "snmp." + metricSample.symbol.Name
+	forcedType := metricSample.forcedType
 	if forcedType == "" {
-		if value.SubmissionType != "" {
-			forcedType = value.SubmissionType
+		if metricSample.value.SubmissionType != "" {
+			forcedType = metricSample.value.SubmissionType
 		} else {
 			forcedType = "gauge"
 		}
 	} else if forcedType == "flag_stream" {
-		strValue, err := value.ToString()
+		strValue, err := metricSample.value.ToString()
 		if err != nil {
-			log.Debugf("error converting value (%#v) to string : %v", value, err)
+			log.Debugf("error converting value (%#v) to string : %v", metricSample.value, err)
 			return
 		}
-		options := metricConfig.Options
+		options := metricSample.options
 		floatValue, err := getFlagStreamValue(options.Placement, strValue)
 		if err != nil {
 			log.Debugf("metric `%s`: failed to get flag stream value: %s", metricFullName, err)
 			return
 		}
 		metricFullName = metricFullName + "." + options.MetricSuffix
-		value = valuestore.ResultValue{Value: floatValue}
+		metricSample.value = valuestore.ResultValue{Value: floatValue}
 		forcedType = "gauge"
 	}
 
-	floatValue, err := value.ToFloat64()
+	floatValue, err := metricSample.value.ToFloat64()
 	if err != nil {
 		log.Debugf("metric `%s`: failed to convert to float64: %s", metricFullName, err)
 		return
 	}
 
-	scaleFactor := symbol.ScaleFactor
+	scaleFactor := metricSample.symbol.ScaleFactor
 	if scaleFactor != 0 {
 		floatValue *= scaleFactor
 	}
 
 	switch forcedType {
 	case "gauge":
-		ms.Gauge(metricFullName, floatValue, tags)
+		ms.Gauge(metricFullName, floatValue, metricSample.tags)
 		ms.submittedMetrics++
 	case "counter":
-		ms.Rate(metricFullName, floatValue, tags)
+		ms.Rate(metricFullName, floatValue, metricSample.tags)
 		ms.submittedMetrics++
 	case "percent":
-		ms.Rate(metricFullName, floatValue*100, tags)
+		ms.Rate(metricFullName, floatValue*100, metricSample.tags)
 		ms.submittedMetrics++
 	case "monotonic_count":
-		ms.MonotonicCount(metricFullName, floatValue, tags)
+		ms.MonotonicCount(metricFullName, floatValue, metricSample.tags)
 		ms.submittedMetrics++
 	case "monotonic_count_and_rate":
-		ms.MonotonicCount(metricFullName, floatValue, tags)
-		ms.Rate(metricFullName+".rate", floatValue, tags)
+		ms.MonotonicCount(metricFullName, floatValue, metricSample.tags)
+		ms.Rate(metricFullName+".rate", floatValue, metricSample.tags)
 		ms.submittedMetrics += 2
 	default:
 		log.Debugf("metric `%s`: unsupported forcedType: %s", metricFullName, forcedType)

--- a/pkg/collector/corechecks/snmp/internal/report/report_metrics_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_metrics_test.go
@@ -284,7 +284,14 @@ func TestSendMetric(t *testing.T) {
 			mockSender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 			mockSender.On("Rate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 
-			metricSender.sendMetric(tt.symbol, tt.value, tt.tags, tt.metricConfig)
+			sample := MetricSample{
+				value:      tt.value,
+				tags:       tt.tags,
+				symbol:     tt.symbol,
+				forcedType: tt.metricConfig.ForcedType,
+				options:    tt.metricConfig.Options,
+			}
+			metricSender.sendMetric(sample)
 			assert.Equal(t, tt.expectedSubMetrics, metricSender.submittedMetrics)
 			if tt.expectedMethod != "" {
 				mockSender.AssertCalled(t, tt.expectedMethod, tt.expectedMetricName, tt.expectedValue, "", tt.expectedTags)

--- a/releasenotes/notes/snmp-evaluate-memory-usage-cb61f9b8dd52f988.yaml
+++ b/releasenotes/notes/snmp-evaluate-memory-usage-cb61f9b8dd52f988.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Evaluate memory.usage metrics based on collected metrics.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->


* Store dependencies collected samples, required to evaluate memory.usage
* Evaluate memory usage based on scalar/column collected samples

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

As part of UI improvements, we are looking into showing memory usage information in NDM overview. Memory usage is often the result of an algebraic operation between a couple of snmp metrics in `memory.used`, `memory.total`, `memory.free`. 

In this PR we evaluate, when possible, `memory.usage` based on the following logic. 

```
if memory.usage  => do nothing as memory.usage is submitted through collected metrics
if memory.used {
 if memory.available => submit ( memory.used / memory.available ) * 100
 if memory.free => submit ( memory.used / ( memory.free + memory.used ) ) * 100
}
if memory.available && memory.free => submit ( ( memory.available - memory.free ) / memory.available ) * 100
``` 

While iterating through collected metrics we save to a local sample store all metrics required to evaluate `memory.usage` and available in collected metrics. Later we try to evaluate `memory.usage` based on scalar and column collected metrics.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

An end to end test covering following profiles will be implemented in #integrations-core
* aruba-switch (column total + used)
* checkpoint-firewall (scalar total + used)
* any cisco (column used + free)
* fortinet-fortigate (scalar usage)


### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

We store only `memory.usage` collected metrics to limit the impact on agent's host runtime memory

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

* Ensure `report_memory_usage_test` passes locally
* Using following profiles, verify `memory.usage` is submitted
  * aruba-switch (column total + used)
  * checkpoint-firewall (scalar total + used)
  * any cisco (column used + free)
  * fortinet-fortigate (scalar usage)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
