### PR TITLE
[CWS] do not add twice the same parent discarders

### DIFF
--- a/pkg/security/probe/discarders.go
+++ b/pkg/security/probe/discarders.go
@@ -42,6 +42,9 @@ const (
 
 	// allEventTypes is a mask to match all the events
 	allEventTypes = 0xffffffffffffffff
+
+	// inode/mountid that won't be resubmitted
+	maxRecentlyAddedCacheSize = uint64(64)
 )
 
 var (
@@ -56,6 +59,9 @@ var (
 			Value: uint64(maxParentDiscarderDepth),
 		},*/
 	}
+
+	// recentlyAddedTimeout do not add twice the same discarder in 2sec
+	recentlyAddedTimeout = uint64(2 * time.Second.Nanoseconds())
 )
 
 // Discarder represents a discarder which is basically the field that we know for sure
@@ -134,10 +140,20 @@ func newPidDiscarders(m *lib.Map, erpc *ERPC) *pidDiscarders {
 	return &pidDiscarders{Map: m, erpc: erpc, req: ERPCRequest{OP: DiscardPidOp}}
 }
 
-type inodeDiscarder struct {
+type inodeDiscarderMapEntry struct {
 	PathKey PathKey
 	IsLeaf  uint32
 	Padding uint32
+}
+
+type inodeDiscarderEntry struct {
+	Inode     uint64
+	MountID   uint32
+	Timestamp uint64
+}
+
+func recentlyAddedIndex(mountID uint32, inode uint64) uint64 {
+	return (uint64(mountID)<<32 | inode) % maxRecentlyAddedCacheSize
 }
 
 // inodeDiscarders is used to issue eRPC discarder requests
@@ -151,6 +167,8 @@ type inodeDiscarders struct {
 
 	// parentDiscarderFncs holds parent discarder functions per depth
 	parentDiscarderFncs [maxParentDiscarderDepth]map[eval.Field]func(dirname string) (bool, error)
+
+	recentlyAddedEntries [maxRecentlyAddedCacheSize]inodeDiscarderEntry
 }
 
 func newDiscarderRequest() *ERPCRequest {
@@ -168,6 +186,26 @@ func newInodeDiscarders(inodesMap, revisionsMap *lib.Map, erpc *ERPC, dentryReso
 	id.initParentDiscarderFncs()
 
 	return id, nil
+}
+
+func (id *inodeDiscarders) isRecentlyAdded(mountID uint32, inode uint64, timestamp uint64) bool {
+	entry := id.recentlyAddedEntries[recentlyAddedIndex(mountID, inode)]
+
+	var delta uint64
+	if timestamp > entry.Timestamp {
+		delta = timestamp - entry.Timestamp
+	} else {
+		delta = entry.Timestamp - timestamp
+	}
+
+	return entry.MountID == mountID && entry.Inode == inode && delta < recentlyAddedTimeout
+}
+
+func (id *inodeDiscarders) recentlyAdded(mountID uint32, inode uint64, timestamp uint64) {
+	entry := &id.recentlyAddedEntries[recentlyAddedIndex(mountID, inode)]
+	entry.MountID = mountID
+	entry.Inode = inode
+	entry.Timestamp = timestamp
 }
 
 func (id *inodeDiscarders) discardInode(req *ERPCRequest, eventType model.EventType, mountID uint32, inode uint64, isLeaf bool) error {
@@ -393,7 +431,7 @@ func (id *inodeDiscarders) isParentPathDiscarder(rs *rules.RuleSet, eventType mo
 	return true, nil
 }
 
-func (id *inodeDiscarders) discardParentInode(req *ERPCRequest, rs *rules.RuleSet, eventType model.EventType, field eval.Field, filename string, mountID uint32, inode uint64, pathID uint32) (bool, uint32, uint64, error) {
+func (id *inodeDiscarders) discardParentInode(req *ERPCRequest, rs *rules.RuleSet, eventType model.EventType, field eval.Field, filename string, mountID uint32, inode uint64, pathID uint32, timestamp uint64) (bool, uint32, uint64, error) {
 	var discarderDepth int
 	var isDiscarder bool
 	var err error
@@ -420,9 +458,16 @@ func (id *inodeDiscarders) discardParentInode(req *ERPCRequest, rs *rules.RuleSe
 		mountID, inode = parentMountID, parentInode
 	}
 
+	// do not insert multiple time the same discarder
+	if id.isRecentlyAdded(mountID, inode, timestamp) {
+		return false, 0, 0, nil
+	}
+
 	if err := id.discardInode(req, eventType, mountID, inode, false); err != nil {
 		return false, 0, 0, err
 	}
+
+	id.recentlyAdded(mountID, inode, timestamp)
 
 	return true, mountID, inode, nil
 }
@@ -454,7 +499,7 @@ func filenameDiscarderWrapper(eventType model.EventType, handler onDiscarderHand
 				return nil
 			}
 
-			isDiscarded, _, parentInode, err := probe.inodeDiscarders.discardParentInode(probe.discarderReq, rs, eventType, field, filename, mountID, inode, pathID)
+			isDiscarded, _, parentInode, err := probe.inodeDiscarders.discardParentInode(probe.discarderReq, rs, eventType, field, filename, mountID, inode, pathID, event.TimestampRaw)
 			if !isDiscarded && !isDeleted {
 				if _, ok := err.(*ErrInvalidKeyPath); !ok {
 					if !IsFakeInode(inode) {

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -961,10 +961,10 @@ func (p *Probe) FlushDiscarders() error {
 	// Sleeping a bit to avoid races with executing kprobes and setting discarders
 	time.Sleep(time.Second)
 
-	var discardedInodes []inodeDiscarder
+	var discardedInodes []inodeDiscarderMapEntry
 	var mapValue [256]byte
 
-	var inode inodeDiscarder
+	var inode inodeDiscarderMapEntry
 	for entries := p.inodeDiscarders.Iterate(); entries.Next(&inode, unsafe.Pointer(&mapValue[0])); {
 		discardedInodes = append(discardedInodes, inode)
 	}

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -50,6 +50,7 @@ const (
 const (
 	procResolveMaxDepth = 16
 	maxArgsEnvResidents = 1024
+	maxParallelArgsEnvs = 512 // == number of parallel starting processes
 )
 
 func getAttr2(probe *Probe) uint64 {
@@ -1129,7 +1130,7 @@ func (p *ProcessResolver) NewProcessVariables() rules.VariableProvider {
 
 // NewProcessResolver returns a new process resolver
 func NewProcessResolver(probe *Probe, resolvers *Resolvers, opts ProcessResolverOpts) (*ProcessResolver, error) {
-	argsEnvsCache, err := simplelru.NewLRU(512, nil)
+	argsEnvsCache, err := simplelru.NewLRU(maxParallelArgsEnvs, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Reduce nb of eprc call thus CPU/Memory impact

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
