### PR TITLE
fix(containerd): rely on labels and annotations to identify pause containers

### DIFF
--- a/pkg/util/containerd/containerd_util_test.go
+++ b/pkg/util/containerd/containerd_util_test.go
@@ -279,6 +279,49 @@ func TestStatus(t *testing.T) {
 	require.Equal(t, resultStatus, status)
 }
 
+func TestIsSandbox(t *testing.T) {
+	mockUtil := ContainerdUtil{}
+
+	withSandboxLabel := &mockContainer{
+		mockSpec: func() (*oci.Spec, error) {
+			return &oci.Spec{Annotations: map[string]string{}}, nil
+		},
+		mockLabels: func() (map[string]string, error) {
+			return map[string]string{"io.cri-containerd.kind": "sandbox"}, nil
+		},
+	}
+
+	isSandbox, err := mockUtil.IsSandbox(withSandboxLabel)
+	require.NoError(t, err)
+	require.True(t, isSandbox)
+
+	withSandboxAnnotation := &mockContainer{
+		mockSpec: func() (*oci.Spec, error) {
+			return &oci.Spec{Annotations: map[string]string{"io.kubernetes.cri.container-type": "sandbox"}}, nil
+		},
+		mockLabels: func() (map[string]string, error) {
+			return map[string]string{}, nil
+		},
+	}
+
+	isSandbox, err = mockUtil.IsSandbox(withSandboxAnnotation)
+	require.NoError(t, err)
+	require.True(t, isSandbox)
+
+	notSandbox := &mockContainer{
+		mockSpec: func() (*oci.Spec, error) {
+			return &oci.Spec{Annotations: map[string]string{"annotation_key": "annotation_val"}}, nil
+		},
+		mockLabels: func() (map[string]string, error) {
+			return map[string]string{"label_key": "label_val"}, nil
+		},
+	}
+
+	isSandbox, err = mockUtil.IsSandbox(notSandbox)
+	require.NoError(t, err)
+	require.False(t, isSandbox)
+}
+
 func makeCtn(value v1.Metrics, typeURL string, taskMetricsError error) containerd.Container {
 	taskStruct := &mockTaskStruct{
 		mockMectric: func(ctx context.Context) (*types.Metric, error) {

--- a/pkg/util/containerd/fake/containerd_util.go
+++ b/pkg/util/containerd/fake/containerd_util.go
@@ -45,6 +45,8 @@ type MockedContainerdClient struct {
 	MockSpecWithContext       func(ctx context.Context, ctn containerd.Container) (*oci.Spec, error)
 	MockStatus                func(ctn containerd.Container) (containerd.ProcessStatus, error)
 	MockCallWithClientContext func(f func(context.Context) error) error
+	MockAnnotations           func(ctn containerd.Container) (map[string]string, error)
+	MockIsSandbox             func(ctn containerd.Container) (bool, error)
 }
 
 func (client *MockedContainerdClient) Close() error {
@@ -137,4 +139,12 @@ func (client *MockedContainerdClient) Status(ctn containerd.Container) (containe
 
 func (client *MockedContainerdClient) CallWithClientContext(f func(context.Context) error) error {
 	return client.MockCallWithClientContext(f)
+}
+
+func (client *MockedContainerdClient) Annotations(ctn containerd.Container) (map[string]string, error) {
+	return client.MockAnnotations(ctn)
+}
+
+func (client *MockedContainerdClient) IsSandbox(ctn containerd.Container) (bool, error) {
+	return client.MockIsSandbox(ctn)
 }

--- a/pkg/workloadmeta/collectors/internal/containerd/containerd_test.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/containerd_test.go
@@ -34,6 +34,7 @@ func TestIgnoreContainer(t *testing.T) {
 	tests := []struct {
 		name           string
 		imgName        string
+		isSandbox      bool
 		container      containerd.Container
 		expectsIgnored bool
 	}{
@@ -41,12 +42,21 @@ func TestIgnoreContainer(t *testing.T) {
 			name:           "pause image",
 			imgName:        "k8s.gcr.io/pause",
 			container:      &container,
+			isSandbox:      false,
+			expectsIgnored: true,
+		},
+		{
+			name:           "is sandbox",
+			imgName:        "k8s.gcr.io/pause",
+			container:      &container,
+			isSandbox:      true,
 			expectsIgnored: true,
 		},
 		{
 			name:           "non-pause container that exists",
 			imgName:        "datadog/agent",
 			container:      &container,
+			isSandbox:      false,
 			expectsIgnored: false,
 		},
 	}
@@ -58,6 +68,9 @@ func TestIgnoreContainer(t *testing.T) {
 					return containerdcontainers.Container{
 						Image: test.imgName,
 					}, nil
+				},
+				MockIsSandbox: func(ctn containerd.Container) (bool, error) {
+					return test.isSandbox, nil
 				},
 			}
 

--- a/releasenotes/notes/containerd-pause-caea4ba26fb08708.yaml
+++ b/releasenotes/notes/containerd-pause-caea4ba26fb08708.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Enhanced the coverage of pause-containers filtering on Containerd.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Identify `containerd` pause containers via labels and annotations in addition to image filtering

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

In some environments the image returned by `containerd` is a `sha256:<hash>`. The image-based filtering doesn't work in this case. This is reproducible on minikube.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

More robust filtering but it requires an additional api call

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

This can be tested with container lifecycle events + `containerd`: This [log](https://github.com/DataDog/datadog-agent/blob/ed0d80089c054fe8a60eeab3ea628cfaa2280332/pkg/serializer/serializer.go#L471) should not show pause containers when pods are deleted.

Pause containers look like this in `agent workload-list --verbose`

```
=== Entity container sources(merged):[runtime] id: b0416bbb118b0ae8d4fc5a26c3814cf2ad0b71c8027aaca667f15660e69bb0a0 ===
----------- Entity ID -----------
Kind: container ID: b0416bbb118b0ae8d4fc5a26c3814cf2ad0b71c8027aaca667f15660e69bb0a0
----------- Entity Meta -----------
Name:
Namespace: k8s.io
Annotations:
Labels: io.kubernetes.pod.name:redis io.cri-containerd.kind:sandbox tags.datadoghq.com/version:v1 tags.datadoghq.com/service:redis-svc-3 tags.datadoghq.com/env:dev name:redis io.kubernetes.pod.uid:5656f30d-fefc-4189-8bc0-55585ffce82d io.kubernetes.pod.namespace:default
----------- Image -----------
Name: sha256:ed210e3e4a5bae1237f1bb44d72a05a2f1e5c6bfe7a7e73da179e2534269c459
Tag:
ID:
Raw Name: sha256:ed210e3e4a5bae1237f1bb44d72a05a2f1e5c6bfe7a7e73da179e2534269c459
Short Name:
----------- Container Info -----------
Runtime: containerd
Running: false
Status: unknown
Health:
Created At: 2022-05-11 09:28:07.147848379 +0000 UTC
Started At: 2022-05-11 09:28:07.147848379 +0000 UTC
Finished At: 0001-01-01 00:00:00 +0000 UTC
Env Variables: PATH:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
Hostname: redis
Network IPs:
PID: 0
===
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
