### PR TITLE
Ensure that the output of `agent check --json` is a valid JSON

### DIFF
--- a/cmd/agent/common/commands/check.go
+++ b/cmd/agent/common/commands/check.go
@@ -417,9 +417,6 @@ func Check(loggerName config.LoggerName, confFilePath *string, flagNoColor *bool
 			}
 
 			if formatJSON {
-				fmt.Fprintln(color.Output, fmt.Sprintf("=== %s ===", color.BlueString("JSON")))
-				checkFileOutput.WriteString("=== JSON ===\n")
-
 				instancesJSON, _ := json.MarshalIndent(instancesData, "", "  ")
 				instanceJSONString := string(instancesJSON)
 


### PR DESCRIPTION
### What does this PR do?

Ensure that the output of `agent check … --json --log-level off` is a valid JSON document that can be consumed by any JSON tool.

### Motivation

A structured output of the `agent check` command is precious to build scripts on top of it to easily extract a specific pieces of information valuable for an investigation or for QAing the agent.

Unfortunately, the current output contains a header that breaks the JSON structure of the output.

### Additional Notes

Without `--log-level off`, the logs are messing up the JSON document produced on `stdout`.
Ideally, when `--json` is used, logs should be sent to `stderr` instead of `stdout`.

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Validate that the output of the `agent check … --json -l off` command can be piped to `jq`

Example that I use to get a more compact version of the metrics emitted by a check:
```
agent check -r disk --json -l off | jq -r '.[0].aggregator.metrics | sort_by(.metric, .tags)[] | .metric + "\t{" + (.tags | join(",\t")) + "\t} " + (.points[0][1] | tostring)'

system.disk.free	{device_name:overlay	} 89639300
system.disk.free	{device_name:overlay	} 89639300
system.disk.free	{device_name:root	} 89639300
system.disk.free	{device_name:root	} 89639300
system.disk.free	{device_name:shm	} 65536
system.disk.free	{device_name:shm	} 65536
[…]
```

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
