### PR TITLE
Adding an option to force EC2 instance ID as hostname

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -684,6 +684,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("ec2_metadata_timeout", 300)          // value in milliseconds
 	config.BindEnvAndSetDefault("ec2_metadata_token_lifetime", 21600) // value in seconds
 	config.BindEnvAndSetDefault("ec2_prefer_imdsv2", false)
+	config.BindEnvAndSetDefault("ec2_prioritize_instance_id_as_hostname", false) // used to bypass the hostname detection logic and force the EC2 instance ID as a hostname.
 	config.BindEnvAndSetDefault("collect_ec2_tags", false)
 	config.BindEnvAndSetDefault("collect_ec2_tags_use_imds", false)
 


### PR DESCRIPTION
### What does this PR do?
In some cases, users might want to force EC2 instance-id as an hostname.
This is needed when autoscaling a VM with a non standard EC2 hostname
(ie: not starting with "ip-", "domu", "ec2amaz-").

Due to legacy logic GCP and Azure already have the priority when
choosing an hostname but not AWS. On EC2 the OS hostname would be
picked. We need to be backward compatible for the hostname detection so
'ec2_prioritize_instance_id_as_hostname' is introduced.

### Describe how to test/QA your changes

1. Spin a EC2 instance and change the hostname to something else than the default one (ie: something not starting with "ip-", "domu", "ec2amaz-").
2. Run the Agent and check that the hostname is pulled from the OS (the one you set in step `1.`
3. Now set `ec2_prioritize_instance_id_as_hostname` to true and check that the hostname is the ec2 instance ID

