### PR TITLE
Fix reporting of docker.memory.limit on Windows

### DIFF
--- a/pkg/util/containers/v2/metrics/docker/collector.go
+++ b/pkg/util/containers/v2/metrics/docker/collector.go
@@ -204,6 +204,17 @@ func fillStatsFromSpec(containerStats *provider.ContainerStats, spec *types.Cont
 	}
 
 	computeCPULimit(containerStats, spec)
+	computeMemoryLimit(containerStats, spec)
+}
+
+func computeMemoryLimit(containerStats *provider.ContainerStats, spec *types.ContainerJSON) {
+	if spec == nil || spec.HostConfig == nil || containerStats.Memory == nil {
+		return
+	}
+
+	if spec.HostConfig.Memory > 0 {
+		containerStats.Memory.Limit = pointer.IntToFloatPtr(spec.HostConfig.Memory)
+	}
 }
 
 func convertNetworkStats(stats *types.StatsJSON) *provider.ContainerNetworkStats {

--- a/pkg/util/containers/v2/metrics/docker/collector_test.go
+++ b/pkg/util/containers/v2/metrics/docker/collector_test.go
@@ -13,12 +13,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/docker/api/types"
-	"github.com/stretchr/testify/assert"
-
 	"github.com/DataDog/datadog-agent/pkg/util/containers/v2/metrics/provider"
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestConvertNetworkStats(t *testing.T) {
@@ -114,4 +115,48 @@ func TestGetContainerIDForPID(t *testing.T) {
 	cID2, err = collector.GetContainerIDForPID(200, 0)
 	assert.NoError(t, err)
 	assert.Equal(t, "cID2", cID2)
+}
+
+func Test_fillStatsFromSpec(t *testing.T) {
+	tests := []struct {
+		name          string
+		spec          *types.ContainerJSON
+		expectedStats *provider.ContainerStats
+	}{
+		{
+			name: "Empty HostConfig",
+			spec: &types.ContainerJSON{
+				ContainerJSONBase: &types.ContainerJSONBase{
+					HostConfig: &container.HostConfig{},
+				},
+			},
+			expectedStats: &provider.ContainerStats{
+				Memory: &provider.ContainerMemStats{},
+			},
+		},
+		{
+			name: "Memory Limit set",
+			spec: &types.ContainerJSON{
+				ContainerJSONBase: &types.ContainerJSONBase{
+					HostConfig: &container.HostConfig{
+						Resources: container.Resources{
+							Memory: 500,
+						},
+					},
+				},
+			},
+			expectedStats: &provider.ContainerStats{
+				Memory: &provider.ContainerMemStats{
+					Limit: pointer.Float64Ptr(500),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			containerStats := &provider.ContainerStats{Memory: &provider.ContainerMemStats{}}
+			fillStatsFromSpec(containerStats, tt.spec)
+			assert.Equal(t, "", cmp.Diff(*tt.expectedStats, *containerStats))
+		})
+	}
 }

--- a/pkg/util/pointer/pointer.go
+++ b/pkg/util/pointer/pointer.go
@@ -31,6 +31,12 @@ func Float64Ptr(v float64) *float64 {
 	return &v
 }
 
+// IntToFloatPtr converts a int64 value to float64 and returns a pointer.
+func IntToFloatPtr(u int64) *float64 {
+	f := float64(u)
+	return &f
+}
+
 // UIntToFloatPtr converts a uint64 value to float64 and returns a pointer.
 func UIntToFloatPtr(u uint64) *float64 {
 	f := float64(u)

--- a/releasenotes/notes/fix-memory-limit-windows-c2ea98aaf59024e7.yaml
+++ b/releasenotes/notes/fix-memory-limit-windows-c2ea98aaf59024e7.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix missing docker.memory.limit (and docker.memory.in_use) on Windows


### PR DESCRIPTION
### What does this PR do?

Fix missing `docker.memory.limit` on Windows

### Motivation

Bugfix.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Deploy the Agent as a container or on-host on Windows. Deploy another container with a memory limit set, the `docker.memory.limit` and `docker.memory.in_use` should be reported.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
