### PR TITLE
[WIP][CWS] remove usage of btf internals

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/trace v0.36.0-rc.4
 	github.com/DataDog/datadog-go/v5 v5.1.1
 	github.com/DataDog/datadog-operator v0.5.0-rc.2.0.20210402083916-25ba9a22e67a
-	github.com/DataDog/ebpf-manager v0.0.0-20220406140358-68e6b7f54dde
+	github.com/DataDog/ebpf-manager v0.0.0-20220511155334-003a8c9ddfdf
 	github.com/DataDog/gohai v0.0.0-20220329101230-3b6a804fdd24
 	github.com/DataDog/gopsutil v0.0.0-20220308095538-d086941833e3
 	github.com/DataDog/nikos v1.7.6
@@ -89,7 +89,7 @@ require (
 	github.com/blabber/go-freebsd-sysctl v0.0.0-20201130114544-503969f39d8f
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575
-	github.com/cilium/ebpf v0.8.2-0.20220404151855-0d439865ca15
+	github.com/cilium/ebpf v0.8.2-0.20220511142539-2e33f5e2fb54
 	github.com/clbanning/mxj v1.8.4
 	github.com/cloudfoundry-community/go-cfclient v0.0.0-20210621174645-7773f7e22665
 	github.com/containerd/cgroups v1.0.2
@@ -186,7 +186,7 @@ require (
 	golang.org/x/mobile v0.0.0-20201217150744-e6ae53a27f4f
 	golang.org/x/net v0.0.0-20220225172249-27dd8689420f
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
-	golang.org/x/sys v0.0.0-20220422013727-9388b58f7150
+	golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6
 	golang.org/x/text v0.3.7
 	golang.org/x/time v0.0.0-20211116232009-f0f3c7e86c11
 	golang.org/x/tools v0.1.10

--- a/go.sum
+++ b/go.sum
@@ -135,6 +135,8 @@ github.com/DataDog/datadog-operator v0.5.0-rc.2.0.20210402083916-25ba9a22e67a h1
 github.com/DataDog/datadog-operator v0.5.0-rc.2.0.20210402083916-25ba9a22e67a/go.mod h1:2qOvG41jii2ks6Umn6MbDGlHRgwoFiYXcjgQQ9VlsS0=
 github.com/DataDog/ebpf-manager v0.0.0-20220406140358-68e6b7f54dde h1:tAtD5vDOWsD3s44PMuqVnQ4ADPwqyw1usEZ2Afs5j9g=
 github.com/DataDog/ebpf-manager v0.0.0-20220406140358-68e6b7f54dde/go.mod h1:8v4KnNvpgDUsYDSxC0cgKq8Why5Z0oI4lN9gy/sMEJs=
+github.com/DataDog/ebpf-manager v0.0.0-20220511155334-003a8c9ddfdf h1:+LiNPjmrGctZc9WYkXNMvJeGqsgYLmosF5Mbnn0aE7I=
+github.com/DataDog/ebpf-manager v0.0.0-20220511155334-003a8c9ddfdf/go.mod h1:N+/8cRkmv9za/fCFEwiDRVo+EI305QzaR7mECIgLYmc=
 github.com/DataDog/extendeddaemonset v0.5.1-0.20210315105301-41547d4ff09c h1:a9OMhZzrrB4nd2eAsXZIBkQ061Gb/QT4CI2g+OWWevs=
 github.com/DataDog/extendeddaemonset v0.5.1-0.20210315105301-41547d4ff09c/go.mod h1:lMIXf2EAzxbIv2zEvWu1bdqlaclUWoCtN13MHuPcY5I=
 github.com/DataDog/gohai v0.0.0-20220329101230-3b6a804fdd24 h1:R8hgt2Rj4j5vED8q/SLVYSqmlA466xpBjRdBe+QOwO0=
@@ -350,6 +352,8 @@ github.com/cilium/ebpf v0.5.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJ
 github.com/cilium/ebpf v0.6.2/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/cilium/ebpf v0.8.2-0.20220404151855-0d439865ca15 h1:eZrQJDHgjOgeSOw2x8tgjO9B13n1BR9yqwlq1AIu2kk=
 github.com/cilium/ebpf v0.8.2-0.20220404151855-0d439865ca15/go.mod h1:f5zLIM0FSNuAkSyLAN7X+Hy6yznlF1mNiWUMfxMtrgk=
+github.com/cilium/ebpf v0.8.2-0.20220511142539-2e33f5e2fb54 h1:2FMUI3HcSnhrOXOBSjN5PSBs7DoTsoVG9u/tYeERQbk=
+github.com/cilium/ebpf v0.8.2-0.20220511142539-2e33f5e2fb54/go.mod h1:+OhNOIXx/Fnu1IE8bJz2dzOA+VSfyTfdNUVdlQnxUFY=
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
 github.com/clbanning/mxj v1.8.4 h1:HuhwZtbyvyOw+3Z1AowPkU87JkJUSv751ELWaiTpj8I=
@@ -2218,6 +2222,8 @@ golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220422013727-9388b58f7150 h1:xHms4gcpe1YE7A3yIllJXP16CMAGuqwO2lX1mTyyRRc=
 golang.org/x/sys v0.0.0-20220422013727-9388b58f7150/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6 h1:nonptSpoQ4vQjyraW20DXPAglgQfVnM9ZC6MmNLMR60=
+golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/pkg/security/probe/bpf.go
+++ b/pkg/security/probe/bpf.go
@@ -9,7 +9,8 @@
 package probe
 
 import (
-	internal "github.com/DataDog/btf-internals"
+	"errors"
+
 	"github.com/DataDog/btf-internals/sys"
 	"github.com/cilium/ebpf"
 	"golang.org/x/sys/unix"
@@ -38,7 +39,7 @@ func haveMmapableMaps() error {
 		MapFlags:   unix.BPF_F_MMAPABLE,
 	})
 	if err != nil {
-		return internal.ErrNotSupported
+		return errors.New("not supported")
 	}
 	_ = m.Close()
 	return nil

--- a/pkg/security/probe/constantfetch/core.go
+++ b/pkg/security/probe/constantfetch/core.go
@@ -13,18 +13,18 @@ import (
 	"io"
 	"strings"
 
-	cbtf "github.com/DataDog/btf-internals/btf"
+	"github.com/cilium/ebpf/btf"
 )
 
 // BTFConstantFetcher is a constant fetcher based on BTF data (from file or current kernel)
 type BTFConstantFetcher struct {
-	spec      *cbtf.Spec
+	spec      *btf.Spec
 	constants map[string]uint64
 	err       error
 }
 
 // NewBTFConstantFetcherFromSpec creates a BTFConstantFetcher directly from a BTF spec
-func NewBTFConstantFetcherFromSpec(spec *cbtf.Spec) *BTFConstantFetcher {
+func NewBTFConstantFetcherFromSpec(spec *btf.Spec) *BTFConstantFetcher {
 	return &BTFConstantFetcher{
 		spec:      spec,
 		constants: make(map[string]uint64),
@@ -33,7 +33,7 @@ func NewBTFConstantFetcherFromSpec(spec *cbtf.Spec) *BTFConstantFetcher {
 
 // NewBTFConstantFetcherFromReader creates a BTFConstantFetcher from a reader pointing to a BTF file
 func NewBTFConstantFetcherFromReader(btfReader io.ReaderAt) (*BTFConstantFetcher, error) {
-	spec, err := cbtf.LoadSpecFromReader(btfReader)
+	spec, err := btf.LoadSpecFromReader(btfReader)
 	if err != nil {
 		return nil, err
 	}
@@ -42,7 +42,7 @@ func NewBTFConstantFetcherFromReader(btfReader io.ReaderAt) (*BTFConstantFetcher
 
 // NewBTFConstantFetcherFromCurrentKernel creates a BTFConstantFetcher, reading BTF from current kernel
 func NewBTFConstantFetcherFromCurrentKernel() (*BTFConstantFetcher, error) {
-	spec, err := cbtf.LoadKernelSpecWithoutCache()
+	spec, err := btf.LoadKernelSpec()
 	if err != nil {
 		return nil, err
 	}
@@ -121,8 +121,8 @@ func getActualTypeName(tn string) string {
 	return tn
 }
 
-func runRequestOnBTFType(r constantRequest, ty cbtf.Type) uint64 {
-	sTy, ok := ty.(*cbtf.Struct)
+func runRequestOnBTFType(r constantRequest, ty btf.Type) uint64 {
+	sTy, ok := ty.(*btf.Struct)
 	if !ok {
 		return ErrorSentinel
 	}
@@ -133,7 +133,7 @@ func runRequestOnBTFType(r constantRequest, ty cbtf.Type) uint64 {
 
 	for _, m := range sTy.Members {
 		if m.Name == r.fieldName {
-			return uint64(m.OffsetBits) / 8
+			return uint64(m.Offset.Bytes())
 		}
 	}
 


### PR DESCRIPTION
### What does this PR do?

With https://github.com/cilium/ebpf/pull/665 merged, we can remove our usage of `btf-internals` and use cilium/ebpf directly for our CORE/BTF usage.

TODO:
- cleanup the MapCreate mmapable map detection
- load the kernel spec without the cache (merged upstream)

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
