### PR TITLE
Replay _all_ scheduled configs, including service configs

### DIFF
--- a/cmd/agent/common/loader.go
+++ b/cmd/agent/common/loader.go
@@ -42,7 +42,7 @@ func LoadComponents(ctx context.Context, confdPath string) {
 	metaScheduler := scheduler.NewMetaScheduler()
 
 	// registering the check scheduler
-	metaScheduler.Register("check", collector.InitCheckScheduler(Coll))
+	metaScheduler.Register("check", collector.InitCheckScheduler(Coll), false)
 
 	// setup autodiscovery
 	confSearchPaths := []string{

--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -44,6 +44,7 @@ type AutoConfig struct {
 	store              *store
 	cfgMgr             configManager
 	m                  sync.RWMutex
+
 	// ranOnce is set to 1 once the AutoConfig has been executed
 	ranOnce *atomic.Bool
 }
@@ -374,18 +375,13 @@ func (ac *AutoConfig) retryListenerCandidates() {
 }
 
 // AddScheduler allows to register a new scheduler to receive configurations.
-// Previously emitted configurations can be replayed with the replayConfigs flag.
+// Previously scheduled configurations that have not subsequently been
+// unscheduled can be replayed with the replayConfigs flag.
 func (ac *AutoConfig) AddScheduler(name string, s scheduler.Scheduler, replayConfigs bool) {
 	ac.m.Lock()
 	defer ac.m.Unlock()
 
-	ac.scheduler.Register(name, s)
-	if !replayConfigs {
-		return
-	}
-
-	configs := ac.LoadedConfigs()
-	s.Schedule(configs)
+	ac.scheduler.Register(name, s, replayConfigs)
 }
 
 // RemoveScheduler allows to remove a scheduler from the AD system.

--- a/pkg/autodiscovery/scheduler/meta.go
+++ b/pkg/autodiscovery/scheduler/meta.go
@@ -14,25 +14,44 @@ import (
 
 // MetaScheduler is a scheduler dispatching to all its registered schedulers
 type MetaScheduler struct {
-	m                sync.Mutex
+	// m protects all fields in this struct.
+	m sync.Mutex
+
+	// scheduledConfigs contains the set of configs that have been scheduled
+	// via the metascheduler, but not subsequently unscheduled.
+	scheduledConfigs map[string]integration.Config
+
+	// activeSchedulers is the set of schedulers currently subscribed to configs.
 	activeSchedulers map[string]Scheduler
 }
 
 // NewMetaScheduler inits a meta scheduler
 func NewMetaScheduler() *MetaScheduler {
 	return &MetaScheduler{
+		scheduledConfigs: make(map[string]integration.Config),
 		activeSchedulers: make(map[string]Scheduler),
 	}
 }
 
 // Register a scheduler in the meta scheduler to dispatch to
-func (ms *MetaScheduler) Register(name string, s Scheduler) {
+func (ms *MetaScheduler) Register(name string, s Scheduler, replayConfigs bool) {
 	ms.m.Lock()
 	defer ms.m.Unlock()
 	if _, ok := ms.activeSchedulers[name]; ok {
 		log.Warnf("Scheduler %s already registered, overriding it", name)
 	}
 	ms.activeSchedulers[name] = s
+
+	// if replaying configs, replay the currently-scheduled configs; note that
+	// this occurs under the protection of `ms.m`, so no config may be double-
+	// scheduled or missed in this process.
+	if replayConfigs {
+		configs := make([]integration.Config, 0, len(ms.scheduledConfigs))
+		for _, config := range ms.scheduledConfigs {
+			configs = append(configs, config)
+		}
+		s.Schedule(configs)
+	}
 }
 
 // Deregister a scheduler in the meta scheduler to dispatch to
@@ -50,6 +69,9 @@ func (ms *MetaScheduler) Deregister(name string) {
 func (ms *MetaScheduler) Schedule(configs []integration.Config) {
 	ms.m.Lock()
 	defer ms.m.Unlock()
+	for _, config := range configs {
+		ms.scheduledConfigs[config.Digest()] = config
+	}
 	for _, scheduler := range ms.activeSchedulers {
 		scheduler.Schedule(configs)
 	}
@@ -59,6 +81,9 @@ func (ms *MetaScheduler) Schedule(configs []integration.Config) {
 func (ms *MetaScheduler) Unschedule(configs []integration.Config) {
 	ms.m.Lock()
 	defer ms.m.Unlock()
+	for _, config := range configs {
+		delete(ms.scheduledConfigs, config.Digest())
+	}
 	for _, scheduler := range ms.activeSchedulers {
 		scheduler.Unschedule(configs)
 	}

--- a/pkg/autodiscovery/scheduler/meta_test.go
+++ b/pkg/autodiscovery/scheduler/meta_test.go
@@ -1,0 +1,85 @@
+package scheduler
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	"github.com/stretchr/testify/require"
+)
+
+func makeConfig(name string) integration.Config {
+	return integration.Config{
+		Name: name,
+	}
+}
+
+type event struct {
+	isSchedule bool
+	configName string
+}
+
+type scheduler struct {
+	events []event
+}
+
+func (s *scheduler) Schedule(configs []integration.Config) {
+	for _, config := range configs {
+		s.events = append(s.events, event{true, config.Name})
+	}
+}
+
+func (s *scheduler) Unschedule(configs []integration.Config) {
+	for _, config := range configs {
+		s.events = append(s.events, event{false, config.Name})
+	}
+}
+
+func (s *scheduler) Stop() {}
+
+func (s *scheduler) reset() {
+	s.events = []event{}
+}
+
+func TestMetaScheduler(t *testing.T) {
+	ms := NewMetaScheduler()
+
+	// schedule some configs before registering
+	c1 := makeConfig("one")
+	c2 := makeConfig("two")
+	ms.Schedule([]integration.Config{c1, c2})
+
+	// register a scheduler and see that it gets caught up
+	s1 := &scheduler{}
+	ms.Register("s1", s1, true)
+	require.ElementsMatch(t, []event{{true, "one"}, {true, "two"}}, s1.events)
+	s1.reset()
+
+	// remove one of those configs and add another
+	ms.Unschedule([]integration.Config{c1})
+	c3 := makeConfig("three")
+	ms.Schedule([]integration.Config{c3})
+
+	// check s1 was informed about those in order
+	require.Equal(t, []event{{false, "one"}, {true, "three"}}, s1.events)
+	s1.reset()
+
+	// subscribe a new scheduler and see that it does not get c1
+	s2 := &scheduler{}
+	ms.Register("s2", s2, true)
+	require.ElementsMatch(t, []event{{true, "two"}, {true, "three"}}, s2.events)
+	s2.reset()
+
+	// unsubscribe s1 and see that it no longer gets events
+	ms.Deregister("s1")
+	ms.Unschedule([]integration.Config{c2})
+	require.Equal(t, []event{}, s1.events)
+	s1.reset()
+	require.Equal(t, []event{{false, "two"}}, s2.events)
+	s2.reset()
+
+	// verify that replay does not occur if not desired
+	s3 := &scheduler{}
+	ms.Register("s3", s3, false)
+	require.ElementsMatch(t, []event{}, s3.events)
+	s3.reset()
+}


### PR DESCRIPTION
### What does this PR do?

Replay _all_ scheduled configs, including service configs

..and do so in a race-free way, avoiding either double-scheduling a
config or missing a config due to scheduling occurring concurrently with
registration.

### Motivation

#11961 assumed that "replayConfigs=true" would replay configs.  It didn't, at least not precisely.  Will I never learn??

In particular, it doesn't include service configs, which logs-agent depends on for container_collect_all.

### Alternatives

#### Store the list of scheduled configs in the configManager

The configManager currently doesn't know about service configs -- those are added by AutoConfig.  And, they are going away soon, so it'd be nice to not tie them further into the code.  Also, configManager synchronizes operations internally, but releases its lock when it returns a list of changes to be sent to subscribers, so it provides no easy way to synchronize registration of new subscribers and scheduling/unscheduling of configs, which is precisely the synchronization we need to avoid double-scheduling or missing configs.

#### Store the list of scheduled configs in AutoConfig

AutoConfig has a sync.Mutex, but on inspection it seems to mostly cover the listener-related fields. So, we would need to introduce additional locking to this type that already has multiple responsibilities, which could lead to deadlocks or performance impact.

#### Only store service configs in AutoConfig

This is sort of the worst of both of the previous alternatives: it requires locking in AutoConfig to maintain the list of services, and then coordinating that lock with the configManager to get a consistent picture of all scheduled configs.

### Possible Drawbacks / Trade-offs

This adds a new `map[string]integration.Config`.  On my system, `integration.Config` is 256 bytes and the digest is 16 bytes, so for a system with N configs this will use 272N bytes of additional memory, plus hash table overhead.  Is that problematic?

### Describe how to test/QA your changes

Using a simple, local agent with `logs_config.container_collect_all` enabled, start a container and then start the agent, and observe that the container is logged via `agent status`.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
