### PR TITLE
[CSPM] do not read file if no parser is provided

### DIFF
--- a/pkg/compliance/checks/helpers.go
+++ b/pkg/compliance/checks/helpers.go
@@ -73,6 +73,10 @@ func validateParserKind(parser string) (string, error) {
 
 // readContent unmarshal file
 func readContent(filePath, parser string) (interface{}, error) {
+	if parser == "" {
+		return "", nil
+	}
+
 	f, err := os.Open(filePath)
 	if err != nil {
 		return "", err

--- a/pkg/compliance/checks/helpers.go
+++ b/pkg/compliance/checks/helpers.go
@@ -30,6 +30,10 @@ type getter func([]byte, string) (string, error)
 
 type contentParser func([]byte) (interface{}, error)
 
+func parseRawContent(data []byte) (interface{}, error) {
+	return string(data), nil
+}
+
 func parseJSONContent(data []byte) (interface{}, error) {
 	var content interface{}
 
@@ -56,10 +60,10 @@ func parseYAMLContent(data []byte) (interface{}, error) {
 var contentParsers = map[string]contentParser{
 	"json": parseJSONContent,
 	"yaml": parseYAMLContent,
+	"raw":  parseRawContent,
 }
 
 func validateParserKind(parser string) (string, error) {
-
 	if parser == "" {
 		return "", nil
 	}


### PR DESCRIPTION
### What does this PR do?

This PR makes it so that CSPM file check do not read file content is no parser is provided.

Currently the user can provide a `parser:` field that indicates the file format to populate the `file.content` field in the rego input. If no parser is provided, `file.content` will contain the whole raw content of the file, as a string.

The PR introduces a new parser type, `raw`, that indicates that the raw content of the file is desired. If no parser type is provided, `file.content` will no longer be defined, allowing rules that do not need the file content to operate without the overhead of a file read.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
