### PR TITLE
Adding command to print the metadata payloads sent by the Agent

### DIFF
--- a/cmd/agent/app/troubleshooting.go
+++ b/cmd/agent/app/troubleshooting.go
@@ -1,0 +1,99 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package app
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/pkg/api/util"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+const (
+	metadataEndpoint = "/agent/metadata/"
+)
+
+var (
+	troubleshootingCmd = &cobra.Command{
+		Use:   "troubleshooting",
+		Short: "Helpers to troubleshoot the Datadog Agent.",
+		Long: `
+This command offers a list of helpers to troubleshoot the Datadog Agent.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.Help() //nolint:errcheck
+			os.Exit(0)
+			return nil
+		},
+	}
+
+	payloadV5Cmd = &cobra.Command{
+		Use:   "metadata_v5",
+		Short: "Print the metadata payload for the agent.",
+		Long: `
+This command print the V5 metadata payload for the Agent. This payload is used to populate the infra list and host map in Datadog. It's called 'V5' because it's the same payload sent since Agent V5. This payload is mandatory in order to create a new host in Datadog.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return printPayload("v5")
+		},
+	}
+
+	payloadInventoriesCmd = &cobra.Command{
+		Use:   "metadata_inventory",
+		Short: "Print the Inventory metadata payload for the agent.",
+		Long: `
+This command print the last Inventory metadata payload sent by the Agent. This payload is used by the 'inventories/sql' product.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return printPayload("inventory")
+		},
+	}
+)
+
+func init() {
+	troubleshootingCmd.AddCommand(payloadV5Cmd)
+	troubleshootingCmd.AddCommand(payloadInventoriesCmd)
+	AgentCmd.AddCommand(troubleshootingCmd)
+}
+
+func printPayload(payloadName string) error {
+	if flagNoColor {
+		color.NoColor = true
+	}
+
+	err := common.SetupConfigWithoutSecrets(confFilePath, "")
+	if err != nil {
+		fmt.Printf("unable to set up global agent configuration: %v\n", err)
+		return nil
+	}
+
+	err = config.SetupLogger(loggerName, config.GetEnvDefault("DD_LOG_LEVEL", "off"), "", "", false, true, false)
+	if err != nil {
+		fmt.Printf("Cannot setup logger, exiting: %v\n", err)
+		return err
+	}
+
+	if err := util.SetAuthToken(); err != nil {
+		fmt.Println(err)
+		return nil
+	}
+
+	c := util.GetClient(false)
+	ipcAddress, err := config.GetIPCAddress()
+	if err != nil {
+		return err
+	}
+	apiConfigURL := fmt.Sprintf("https://%v:%d%s%s", ipcAddress, config.Datadog.GetInt("cmd_port"), metadataEndpoint, payloadName)
+
+	r, err := util.DoGet(c, apiConfigURL, util.CloseConnection)
+	if err != nil {
+		return fmt.Errorf("Could not fetch metadata v5 payload: %s", err)
+	}
+
+	fmt.Println(string(r))
+	return nil
+}

--- a/releasenotes/notes/add-metatada-cmd-55a08723a7d27c7a.yaml
+++ b/releasenotes/notes/add-metatada-cmd-55a08723a7d27c7a.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    A new `troubleshooting` section has been added to the Agent CLI. This section will hold helpers to understand the
+    Agent behavior. For now, the section only has two command to print the different metadata payloads sent by the Agent
+    (`v5` and `inventory`).


### PR DESCRIPTION
### What does this PR do?

For now we print V5 and inventory. A `troubleshooting` section has been
added to the Agent CLI.

### Describe how to test/QA your changes

- Start the agent and use the CLI to print the `v5` and inventory payload:
  - `datadog-agent troubleshooting metadata_inventory`
  - `datadog-agent troubleshooting metadata_v5`
- Make sure the content was scrubbed (like the `api_key` for example)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
