### PR TITLE
[CSPM] rego improvements

### DIFF
--- a/cmd/security-agent/app/check.go
+++ b/cmd/security-agent/app/check.go
@@ -38,6 +38,7 @@ var (
 		overrideRegoInput string
 		dumpRegoInput     string
 		dumpReports       string
+		skipRegoEval      bool
 	}{}
 )
 
@@ -49,6 +50,7 @@ func setupCheckCmd(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&checkArgs.overrideRegoInput, "override-rego-input", "", "", "Rego input to use when running rego checks")
 	cmd.Flags().StringVarP(&checkArgs.dumpRegoInput, "dump-rego-input", "", "", "Path to file where to dump the Rego input JSON")
 	cmd.Flags().StringVarP(&checkArgs.dumpReports, "dump-reports", "", "", "Path to file where to dump reports")
+	cmd.Flags().BoolVarP(&checkArgs.skipRegoEval, "skip-rego-eval", "", false, "Skip rego evaluation")
 }
 
 // CheckCmd returns a cobra command to run security agent checks
@@ -149,6 +151,8 @@ func runCheck(cmd *cobra.Command, confPathArray []string, args []string) error {
 	if checkArgs.dumpRegoInput != "" {
 		options = append(options, checks.WithRegoInputDumpPath(checkArgs.dumpRegoInput))
 	}
+
+	options = append(options, checks.WithRegoEvalSkip(checkArgs.skipRegoEval))
 
 	if checkArgs.file != "" {
 		err = agent.RunChecksFromFile(reporter, checkArgs.file, options...)

--- a/pkg/compliance/checks/builder.go
+++ b/pkg/compliance/checks/builder.go
@@ -236,6 +236,13 @@ func WithRegoInputDumpPath(regoInputDumpPath string) BuilderOption {
 	}
 }
 
+func WithRegoEvalSkip(regoEvalSkip bool) BuilderOption {
+	return func(b *builder) error {
+		b.regoEvalSkip = regoEvalSkip
+		return nil
+	}
+}
+
 // IsFramework matches a compliance suite by the name of the framework
 func IsFramework(framework string) SuiteMatcher {
 	return func(s *compliance.SuiteMeta) bool {
@@ -296,6 +303,7 @@ type builder struct {
 
 	regoInputOverride map[string]eval.RegoInputMap
 	regoInputDumpPath string
+	regoEvalSkip      bool
 
 	status *status
 }
@@ -736,6 +744,10 @@ func (b *builder) ProvidedInput(ruleID string) eval.RegoInputMap {
 
 func (b *builder) DumpInputPath() string {
 	return b.regoInputDumpPath
+}
+
+func (b *builder) ShouldSkipRegoEval() bool {
+	return b.regoEvalSkip
 }
 
 func (b *builder) Hostname() string {

--- a/pkg/compliance/checks/env/env.go
+++ b/pkg/compliance/checks/env/env.go
@@ -29,6 +29,7 @@ type Clients interface {
 type RegoConfiguration interface {
 	ProvidedInput(ruleID string) eval.RegoInputMap
 	DumpInputPath() string
+	ShouldSkipRegoEval() bool
 }
 
 // Configuration provides an abstraction for various environment methods used by checks

--- a/pkg/compliance/checks/rego_check.go
+++ b/pkg/compliance/checks/rego_check.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/open-policy-agent/opa/ast"
@@ -27,6 +28,7 @@ import (
 )
 
 const regoEvaluator = "rego"
+const regoEvalTimeout = 20 * time.Second
 
 type regoCheck struct {
 	ruleID            string
@@ -382,7 +384,8 @@ func (r *regoCheck) check(env env.Env) []*compliance.Report {
 		_ = dumpInputToFile(r.ruleID, path, input)
 	}
 
-	ctx := context.TODO()
+	ctx, cancel := context.WithTimeout(context.Background(), regoEvalTimeout)
+	defer cancel()
 	results, err := r.preparedEvalQuery.Eval(ctx, rego.EvalInput(input))
 	if err != nil {
 		return buildErrorReports(err)

--- a/pkg/compliance/checks/rego_check.go
+++ b/pkg/compliance/checks/rego_check.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/mitchellh/mapstructure"
@@ -31,6 +32,8 @@ const regoEvaluator = "rego"
 const regoEvalTimeout = 20 * time.Second
 
 type regoCheck struct {
+	evalLock sync.Mutex
+
 	ruleID            string
 	ruleScope         compliance.RuleScope
 	inputs            []compliance.RegoInput
@@ -361,6 +364,9 @@ func findingsToReports(findings []regoFinding) []*compliance.Report {
 }
 
 func (r *regoCheck) check(env env.Env) []*compliance.Report {
+	r.evalLock.Lock()
+	defer r.evalLock.Unlock()
+
 	log.Debugf("%s: rego check starting", r.ruleID)
 
 	var input eval.RegoInputMap

--- a/pkg/compliance/checks/rego_check.go
+++ b/pkg/compliance/checks/rego_check.go
@@ -390,8 +390,13 @@ func (r *regoCheck) check(env env.Env) []*compliance.Report {
 		_ = dumpInputToFile(r.ruleID, path, input)
 	}
 
+	if env.ShouldSkipRegoEval() {
+		return nil
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), regoEvalTimeout)
 	defer cancel()
+
 	results, err := r.preparedEvalQuery.Eval(ctx, rego.EvalInput(input))
 	if err != nil {
 		return buildErrorReports(err)

--- a/pkg/compliance/checks/rego_check_input_test.go
+++ b/pkg/compliance/checks/rego_check_input_test.go
@@ -67,6 +67,7 @@ func (f *regoInputFixture) run(t *testing.T) {
 	env.On("ProvidedInput", mock.Anything).Return(nil).Once()
 	env.On("Hostname").Return("hostname_test").Once()
 	env.On("DumpInputPath").Return(tf.Name()).Once()
+	env.On("ShouldSkipRegoEval").Return(false).Once()
 
 	defer env.AssertExpectations(t)
 

--- a/pkg/compliance/checks/rego_check_test.go
+++ b/pkg/compliance/checks/rego_check_test.go
@@ -66,6 +66,7 @@ func (f *regoFixture) run(t *testing.T) {
 	env.On("ProvidedInput", mock.Anything).Return(nil).Once()
 	env.On("Hostname").Return("hostname_test").Once()
 	env.On("DumpInputPath").Return("").Once()
+	env.On("ShouldSkipRegoEval").Return(false).Once()
 
 	defer env.AssertExpectations(t)
 

--- a/pkg/compliance/mocks/env.go
+++ b/pkg/compliance/mocks/env.go
@@ -235,6 +235,20 @@ func (_m *Env) Reporter() event.Reporter {
 	return r0
 }
 
+// ShouldSkipRegoEval provides a mock function with given fields:
+func (_m *Env) ShouldSkipRegoEval() bool {
+	ret := _m.Called()
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
 // NewEnv creates a new instance of Env. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewEnv(t testing.TB) *Env {
 	mock := &Env{}

--- a/pkg/compliance/mocks/rego_configuration.go
+++ b/pkg/compliance/mocks/rego_configuration.go
@@ -44,6 +44,20 @@ func (_m *RegoConfiguration) ProvidedInput(ruleID string) eval.RegoInputMap {
 	return r0
 }
 
+// ShouldSkipRegoEval provides a mock function with given fields:
+func (_m *RegoConfiguration) ShouldSkipRegoEval() bool {
+	ret := _m.Called()
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
 // NewRegoConfiguration creates a new instance of RegoConfiguration. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewRegoConfiguration(t testing.TB) *RegoConfiguration {
 	mock := &RegoConfiguration{}


### PR DESCRIPTION
### What does this PR do?

This PR adds:
- a timeout to the rego eval context
- a lock around rego evaluation, so that a check is not evaluated by multiple threads at the same time
- an option to skip rego evaluation

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
