### PR TITLE
Update SNMP traps DB with integer enums

### DIFF
--- a/omnibus/config/software/snmp-traps.rb
+++ b/omnibus/config/software/snmp-traps.rb
@@ -1,8 +1,8 @@
 name "snmp-traps"
-default_version "0.2.1"
+default_version "0.3.0"
 
 source :url => "https://s3.amazonaws.com/dd-agent-omnibus/snmp_traps_db/dd_traps_db-#{version}.json.gz",
-       :sha256 => "e79274eddd119b59f55ee57106c7cced91facba24db132d4b37194e16defb7f1",
+       :sha256 => "d2fc278b31e36b23a3f64f87a0c46b857bee4e31313b6eaef90af42d9ab3cf93",
        :target_filename => "dd_traps_db.json.gz"
 
 

--- a/releasenotes/notes/Update-SNMP-Traps_DB-76a39128d7b2b4e9.yaml
+++ b/releasenotes/notes/Update-SNMP-Traps_DB-76a39128d7b2b4e9.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Update SNMP traps database to include integer enumerations.
+


### PR DESCRIPTION
Update SNMP traps DB with integer enums

https://github.com/DataDog/datadog-agent/pull/11838
