### PR TITLE
send http request to endpoint to verify connectivity issue

### DIFF
--- a/cmd/agent/app/diagnose.go
+++ b/cmd/agent/app/diagnose.go
@@ -50,34 +50,26 @@ func init() {
 }
 
 func doDiagnoseMetadataAvailability(cmd *cobra.Command, args []string) error {
-	// Global config setup
-	err := common.SetupConfig(confFilePath)
-	if err != nil {
-		return fmt.Errorf("unable to set up global agent configuration: %v", err)
+	if err := configAndLogSetup(); err != nil {
+		return err
 	}
 
 	if flagNoColor {
 		color.NoColor = true
 	}
 
-	err = config.SetupLogger(
-		loggerName,
-		config.Datadog.GetString("log_level"),
-		common.DefaultLogFile,
-		config.GetSyslogURI(),
-		config.Datadog.GetBool("syslog_rfc"),
-		config.Datadog.GetBool("log_to_console"),
-		config.Datadog.GetBool("log_format_json"),
-	)
-	if err != nil {
-		return fmt.Errorf("error while setting up logging, exiting: %v", err)
-	}
-
 	return diagnose.RunAll(color.Output)
 }
 
 func doDiagnoseDatadogConnectivity(cmd *cobra.Command, args []string) error {
+	if err := configAndLogSetup(); err != nil {
+		return err
+	}
 
+	return connectivity.RunDatadogConnectivityDiagnose()
+}
+
+func configAndLogSetup() error {
 	// Global config setup
 	err := common.SetupConfig(confFilePath)
 	if err != nil {
@@ -99,5 +91,5 @@ func doDiagnoseDatadogConnectivity(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("error while setting up logging, exiting: %v", err)
 	}
 
-	return connectivity.RunDatadogConnectivityDiagnose()
+	return nil
 }

--- a/cmd/agent/app/diagnose.go
+++ b/cmd/agent/app/diagnose.go
@@ -99,5 +99,5 @@ func doDiagnoseDatadogConnectivity(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("error while setting up logging, exiting: %v", err)
 	}
 
-	return connectivity.RunDatadogConnectivityChecks()
+	return connectivity.RunDatadogConnectivityDiagnose()
 }

--- a/cmd/agent/app/diagnose.go
+++ b/cmd/agent/app/diagnose.go
@@ -11,6 +11,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/diagnose"
+	"github.com/DataDog/datadog-agent/pkg/diagnose/connectivity"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -76,5 +77,27 @@ func doDiagnoseMetadataAvailability(cmd *cobra.Command, args []string) error {
 }
 
 func doDiagnoseDatadogConnectivity(cmd *cobra.Command, args []string) error {
-	return fmt.Errorf("this command is not implemented yet")
+
+	// Global config setup
+	err := common.SetupConfig(confFilePath)
+	if err != nil {
+		return fmt.Errorf("unable to set up global agent configuration: %v", err)
+	}
+
+	// log level is always off since this might be use by other agent to get the hostname
+	err = config.SetupLogger(
+		loggerName,
+		config.Datadog.GetString("log_level"),
+		common.DefaultLogFile,
+		config.GetSyslogURI(),
+		config.Datadog.GetBool("syslog_rfc"),
+		config.Datadog.GetBool("log_to_console"),
+		config.Datadog.GetBool("log_format_json"),
+	)
+
+	if err != nil {
+		return fmt.Errorf("error while setting up logging, exiting: %v", err)
+	}
+
+	return connectivity.RunDatadogConnectivityChecks()
 }

--- a/pkg/diagnose/connectivity/endpoint_info.go
+++ b/pkg/diagnose/connectivity/endpoint_info.go
@@ -39,8 +39,8 @@ var (
 	emptyPayload = []byte("")
 
 	// TODO : add more endpoints info and a filtering function to only keep used endpoints
-	V1SeriesEndpointInfo   = EndpointInfo{endpoints.V1SeriesEndpoint, "POST", emptyPayload, apiKeyInQueryString}
-	V1ValidateEndpointInfo = EndpointInfo{endpoints.V1ValidateEndpoint, "GET", emptyPayload, apiKeyInQueryString}
+	v1SeriesEndpointInfo   = endpointInfo{endpoints.V1SeriesEndpoint, "POST", emptyPayload, apiKeyInQueryString}
+	v1ValidateEndpointInfo = endpointInfo{endpoints.V1ValidateEndpoint, "GET", emptyPayload, apiKeyInQueryString}
 
-	endpointsInfo = []EndpointInfo{V1SeriesEndpointInfo, V1ValidateEndpointInfo}
+	endpointsInfo = []endpointInfo{v1SeriesEndpointInfo, v1ValidateEndpointInfo}
 )

--- a/pkg/diagnose/connectivity/endpoint_info.go
+++ b/pkg/diagnose/connectivity/endpoint_info.go
@@ -1,0 +1,22 @@
+package connectivity
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/forwarder/endpoints"
+	"github.com/DataDog/datadog-agent/pkg/forwarder/transaction"
+)
+
+type EndpointInfo struct {
+	endpoint            transaction.Endpoint
+	apiKeyInQueryString bool
+	payload             []byte
+	method              string
+}
+
+var (
+	emptyPayload = []byte("")
+
+	V1SeriesEndpointInfo   = EndpointInfo{endpoints.V1SeriesEndpoint, true, emptyPayload, "POST"}
+	V1ValidateEndpointInfo = EndpointInfo{endpoints.V1ValidateEndpoint, true, emptyPayload, "GET"}
+
+	endpointsInfo = []EndpointInfo{V1SeriesEndpointInfo, V1ValidateEndpointInfo}
+)

--- a/pkg/diagnose/connectivity/endpoint_info.go
+++ b/pkg/diagnose/connectivity/endpoint_info.go
@@ -39,8 +39,8 @@ var (
 	emptyPayload = []byte("")
 
 	// TODO : add more endpoints info and a filtering function to only keep used endpoints
-	v1SeriesEndpointInfo   = endpointInfo{endpoints.V1SeriesEndpoint, "POST", emptyPayload, apiKeyInQueryString}
-	v1ValidateEndpointInfo = endpointInfo{endpoints.V1ValidateEndpoint, "GET", emptyPayload, apiKeyInQueryString}
+	v1SeriesEndpointInfo   = EndpointInfo{endpoints.V1SeriesEndpoint, "POST", emptyPayload, apiKeyInQueryString}
+	v1ValidateEndpointInfo = EndpointInfo{endpoints.V1ValidateEndpoint, "GET", emptyPayload, apiKeyInQueryString}
 
-	endpointsInfo = []endpointInfo{v1SeriesEndpointInfo, v1ValidateEndpointInfo}
+	endpointsInfo = []EndpointInfo{v1SeriesEndpointInfo, v1ValidateEndpointInfo}
 )

--- a/pkg/diagnose/connectivity/endpoint_info.go
+++ b/pkg/diagnose/connectivity/endpoint_info.go
@@ -7,16 +7,19 @@ import (
 
 type EndpointInfo struct {
 	endpoint            transaction.Endpoint
-	apiKeyInQueryString bool
 	payload             []byte
 	method              string
+	apiKeyInQueryString bool
 }
 
 var (
+	apiKeyInQueryString = true
+
 	emptyPayload = []byte("")
 
-	V1SeriesEndpointInfo   = EndpointInfo{endpoints.V1SeriesEndpoint, true, emptyPayload, "POST"}
-	V1ValidateEndpointInfo = EndpointInfo{endpoints.V1ValidateEndpoint, true, emptyPayload, "GET"}
+	// TODO : add more endpoints info and a filtering function to only keep used endpoints
+	V1SeriesEndpointInfo   = EndpointInfo{endpoints.V1SeriesEndpoint, emptyPayload, "POST", apiKeyInQueryString}
+	V1ValidateEndpointInfo = EndpointInfo{endpoints.V1ValidateEndpoint, emptyPayload, "GET", apiKeyInQueryString}
 
 	endpointsInfo = []EndpointInfo{V1SeriesEndpointInfo, V1ValidateEndpointInfo}
 )

--- a/pkg/diagnose/connectivity/endpoint_info.go
+++ b/pkg/diagnose/connectivity/endpoint_info.go
@@ -30,7 +30,7 @@ type EndpointInfo struct {
 
 	// ApiKeyInQueryString is set to true if the API Key has to be in the query string
 	// i.e. https://domain/endpoint?api_key=***************************XXXXX
-	ApiKeyInQueryString bool
+	APIKeyInQueryString bool
 }
 
 var (

--- a/pkg/diagnose/connectivity/endpoint_info.go
+++ b/pkg/diagnose/connectivity/endpoint_info.go
@@ -14,11 +14,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/forwarder/transaction"
 )
 
-// EndpointInfo is a value object that contains all the information we need to
+// endpointInfo is a value object that contains all the information we need to
 // contact an endpoint to troubleshoot connectivity issues.
 // It can be seen as a very lightweight version of transaction.HTTPTransaction.
-// One EndpointInfo should be define for each endpoint we want to troubleshoot.
-type EndpointInfo struct {
+// One endpointInfo should be defined for each endpoint we want to troubleshoot.
+type endpointInfo struct {
 	// Endpoint is the API Endpoint we want to contact.
 	Endpoint transaction.Endpoint
 
@@ -39,8 +39,8 @@ var (
 	emptyPayload = []byte("")
 
 	// TODO : add more endpoints info and a filtering function to only keep used endpoints
-	v1SeriesEndpointInfo   = EndpointInfo{endpoints.V1SeriesEndpoint, "POST", emptyPayload, apiKeyInQueryString}
-	v1ValidateEndpointInfo = EndpointInfo{endpoints.V1ValidateEndpoint, "GET", emptyPayload, apiKeyInQueryString}
+	v1SeriesEndpointInfo   = endpointInfo{endpoints.V1SeriesEndpoint, "POST", emptyPayload, apiKeyInQueryString}
+	v1ValidateEndpointInfo = endpointInfo{endpoints.V1ValidateEndpoint, "GET", emptyPayload, apiKeyInQueryString}
 
-	endpointsInfo = []EndpointInfo{v1SeriesEndpointInfo, v1ValidateEndpointInfo}
+	endpointsInfo = []endpointInfo{v1SeriesEndpointInfo, v1ValidateEndpointInfo}
 )

--- a/pkg/diagnose/connectivity/endpoint_info.go
+++ b/pkg/diagnose/connectivity/endpoint_info.go
@@ -1,3 +1,12 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package connectivity contains logic for connectivity troubleshooting between the Agent
+// and Datadog endpoints. It uses HTTP request to contact different endpoints and displays
+// some results depending on endpoints responses, if any, and aims to imitate the Forwarder
+// behavior in order to get a more relevant troubleshooting.
 package connectivity
 
 import (
@@ -5,11 +14,23 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/forwarder/transaction"
 )
 
+// EndpointInfo is a value object that contains all the information we need to
+// contact an endpoint to troubleshoot connectivity issues.
+// It can be seen as a very lightweight version of transaction.HTTPTransaction.
+// One EndpointInfo should be define for each endpoint we want to troubleshoot.
 type EndpointInfo struct {
-	endpoint            transaction.Endpoint
-	payload             []byte
-	method              string
-	apiKeyInQueryString bool
+	// Endpoint is the API Endpoint we want to contact.
+	Endpoint transaction.Endpoint
+
+	// Method is the HTTP request method we want to send to the endpoint.
+	Method string
+
+	// Payload is the HTTP request body we want to send to the endpoint.
+	Payload []byte
+
+	// ApiKeyInQueryString is set to true if the API Key has to be in the query string
+	// i.e. https://domain/endpoint?api_key=***************************XXXXX
+	ApiKeyInQueryString bool
 }
 
 var (
@@ -18,8 +39,8 @@ var (
 	emptyPayload = []byte("")
 
 	// TODO : add more endpoints info and a filtering function to only keep used endpoints
-	V1SeriesEndpointInfo   = EndpointInfo{endpoints.V1SeriesEndpoint, emptyPayload, "POST", apiKeyInQueryString}
-	V1ValidateEndpointInfo = EndpointInfo{endpoints.V1ValidateEndpoint, emptyPayload, "GET", apiKeyInQueryString}
+	V1SeriesEndpointInfo   = EndpointInfo{endpoints.V1SeriesEndpoint, "POST", emptyPayload, apiKeyInQueryString}
+	V1ValidateEndpointInfo = EndpointInfo{endpoints.V1ValidateEndpoint, "GET", emptyPayload, apiKeyInQueryString}
 
 	endpointsInfo = []EndpointInfo{V1SeriesEndpointInfo, V1ValidateEndpointInfo}
 )

--- a/pkg/diagnose/connectivity/trace_request.go
+++ b/pkg/diagnose/connectivity/trace_request.go
@@ -1,0 +1,7 @@
+package connectivity
+
+import "fmt"
+
+func RunDatadogConnectivityChecks() error {
+	return fmt.Errorf("this command is not implemented yet")
+}

--- a/pkg/diagnose/connectivity/trace_request.go
+++ b/pkg/diagnose/connectivity/trace_request.go
@@ -28,7 +28,7 @@ func RunDatadogConnectivityDiagnose() error {
 	// Create domain resolvers
 	keysPerDomain, err := config.GetMultipleEndpoints()
 	if err != nil {
-		log.Error("Misconfiguration of agent endpoints: ", err)
+		return log.Error("Misconfiguration of agent endpoints: ", err)
 	}
 
 	domainResolvers := resolver.NewSingleDomainResolvers(keysPerDomain)

--- a/pkg/diagnose/connectivity/trace_request.go
+++ b/pkg/diagnose/connectivity/trace_request.go
@@ -82,7 +82,7 @@ func sendHTTPRequestToEndpoint(client *http.Client, url string, method string, p
 	req, err := http.NewRequest(method, url, reader)
 
 	if err != nil {
-		log.Errorf("Could not create request for transaction to invalid URL %q (dropping transaction): %s", url, err)
+		log.Errorf("Could not create request for transaction to invalid URL '%v' : %v", logURL, err)
 	}
 
 	//req = req.WithContext(ctx)
@@ -91,12 +91,14 @@ func sendHTTPRequestToEndpoint(client *http.Client, url string, method string, p
 
 	if err != nil {
 		fmt.Printf("Could not send the HTTP request to '%v'\n", logURL)
+		return
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Errorf("Fail to read the response Body: %s", err)
+		return
 	}
 
 	fmt.Printf("Endpoint '%v' answers with status code %v\n", logURL, resp.StatusCode)

--- a/pkg/diagnose/connectivity/trace_request.go
+++ b/pkg/diagnose/connectivity/trace_request.go
@@ -13,24 +13,14 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/resolver"
-	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
+	"github.com/DataDog/datadog-agent/pkg/forwarder"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
 	"github.com/fatih/color"
 )
-
-func newHTTPClient() *http.Client {
-	transport := httputils.CreateHTTPTransport()
-
-	return &http.Client{
-		Timeout:   config.Datadog.GetDuration("forwarder_timeout") * time.Second,
-		Transport: transport,
-	}
-}
 
 // RunDatadogConnectivityDiagnose send requests to all known endpoints for all domains
 // to check if there are connectivity issues between Datadog and these endpoints
@@ -44,7 +34,7 @@ func RunDatadogConnectivityDiagnose() error {
 	// XXX: use NewDomainResolverWithMetricToVector ?
 	domainResolvers := resolver.NewSingleDomainResolvers(keysPerDomain)
 
-	client := newHTTPClient()
+	client := forwarder.NewHTTPClient()
 
 	// Send requests to all endpoints for all domains
 	for _, domainResolver := range domainResolvers {

--- a/pkg/diagnose/connectivity/trace_request.go
+++ b/pkg/diagnose/connectivity/trace_request.go
@@ -1,7 +1,57 @@
 package connectivity
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/config/resolver"
+	"github.com/DataDog/datadog-agent/pkg/forwarder/endpoints"
+	"github.com/DataDog/datadog-agent/pkg/forwarder/transaction"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
+)
 
 func RunDatadogConnectivityChecks() error {
+
+	// Build endpoints
+	keysPerDomain, err := config.GetMultipleEndpoints()
+	if err != nil {
+		log.Error("Misconfiguration of agent endpoints: ", err)
+	}
+
+	endpoint := endpoints.V1SeriesEndpoint
+	// Create a domain resolver
+	// Should we use NewDomainResolverWithMetricToVector ?
+	domainResolvers := resolver.NewSingleDomainResolvers(keysPerDomain)
+
+	urls := getAllUrlForAnEndpoint(domainResolvers, endpoint, true)
+	fmt.Printf("'%v'\n", urls)
+
 	return fmt.Errorf("this command is not implemented yet")
+}
+
+func getAllUrlForAnEndpoint(domainResolvers map[string]resolver.DomainResolver, endpoint transaction.Endpoint, apiKeyInQueryString bool) []string {
+
+	urls := make([]string, 0)
+
+	for _, resolver := range domainResolvers {
+		for _, apiKey := range resolver.GetAPIKeys() {
+			domain, _ := resolver.Resolve(endpoint)
+			url := createEndpointURL(domain, endpoint, apiKey, apiKeyInQueryString)
+
+			urls = append(urls, url)
+		}
+	}
+
+	return urls
+}
+
+func createEndpointURL(domain string, endpoint transaction.Endpoint, apiKey string, apiKeyInQueryString bool) string {
+
+	url := domain + endpoint.Route
+	if apiKeyInQueryString {
+		url = fmt.Sprintf("%s?api_key=%s", url, apiKey)
+	}
+
+	return scrubber.ScrubLine(url)
 }

--- a/pkg/diagnose/connectivity/trace_request.go
+++ b/pkg/diagnose/connectivity/trace_request.go
@@ -22,7 +22,7 @@ import (
 	"github.com/fatih/color"
 )
 
-// RunDatadogConnectivityDiagnose send requests to all known endpoints for all domains
+// RunDatadogConnectivityDiagnose send requests to endpoints for all domains
 // to check if there are connectivity issues between Datadog and these endpoints
 func RunDatadogConnectivityDiagnose() error {
 	// Create domain resolvers
@@ -31,7 +31,6 @@ func RunDatadogConnectivityDiagnose() error {
 		log.Error("Misconfiguration of agent endpoints: ", err)
 	}
 
-	// XXX: use NewDomainResolverWithMetricToVector ?
 	domainResolvers := resolver.NewSingleDomainResolvers(keysPerDomain)
 
 	client := forwarder.NewHTTPClient()
@@ -73,13 +72,14 @@ func sendHTTPRequestToEndpoint(client *http.Client, domain string, endpointInfo 
 
 	if err != nil {
 		log.Errorf("Could not create request for transaction to invalid URL '%v' : %v", logURL, scrubber.ScrubLine(err.Error()))
+		return
 	}
 
 	// Send the request
 	resp, err := client.Do(req)
 
 	if err != nil {
-		fmt.Printf("Could not send the HTTP request to '%v' : %v\n", logURL, scrubber.ScrubLine(err.Error()))
+		log.Errorf("Could not send the HTTP request to '%v' : %v\n", logURL, scrubber.ScrubLine(err.Error()))
 		return
 	}
 	defer func() { _ = resp.Body.Close() }()

--- a/pkg/diagnose/connectivity/trace_request.go
+++ b/pkg/diagnose/connectivity/trace_request.go
@@ -37,6 +37,7 @@ func RunDatadogConnectivityDiagnose() error {
 	client := forwarder.NewHTTPClient()
 
 	// Send requests to all endpoints for all domains
+	fmt.Println("\n================ Starting connectivity diagnosis ================")
 	for _, domainResolver := range domainResolvers {
 		sendRequestToAllEndpointOfADomain(client, domainResolver)
 	}
@@ -64,7 +65,7 @@ func sendHTTPRequestToEndpoint(client *http.Client, domain string, endpointInfo 
 	url := createEndpointURL(domain, endpointInfo, apiKey)
 	logURL := scrubber.ScrubLine(url)
 
-	fmt.Printf("\n======== '%v' ========\n", logURL)
+	fmt.Printf("\n======== '%v' ========\n", color.BlueString(logURL))
 
 	// Create a request for the backend
 	reader := bytes.NewReader(endpointInfo.Payload)

--- a/pkg/diagnose/connectivity/trace_request.go
+++ b/pkg/diagnose/connectivity/trace_request.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/resolver"
-	"github.com/DataDog/datadog-agent/pkg/forwarder/endpoints"
 	"github.com/DataDog/datadog-agent/pkg/forwarder/transaction"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -23,24 +22,20 @@ func RunDatadogConnectivityChecks() error {
 	if err != nil {
 		log.Error("Misconfiguration of agent endpoints: ", err)
 	}
-
-	endpoint := endpoints.V1ValidateEndpoint
-	// Create a domain resolver
-	// Should we use NewDomainResolverWithMetricToVector ?
 	domainResolvers := resolver.NewSingleDomainResolvers(keysPerDomain)
 
-	method := "GET"
-	payload := []byte("")
 	client := newHTTPClient()
 
-	urls := getAllUrlForAnEndpoint(domainResolvers, endpoint, true)
-	fmt.Printf("'%v'\n", urls)
+	for _, endpointInfo := range endpointsInfo {
 
-	for _, url := range urls {
-		sendHTTPRequestToEndpoint(client, url, method, payload)
+		urls := getAllUrlForAnEndpoint(domainResolvers, endpointInfo.endpoint, endpointInfo.apiKeyInQueryString)
+
+		for _, url := range urls {
+			sendHTTPRequestToEndpoint(client, url, endpointInfo.method, endpointInfo.payload)
+		}
 	}
 
-	return fmt.Errorf("this command is not implemented yet")
+	return nil
 }
 
 func getAllUrlForAnEndpoint(domainResolvers map[string]resolver.DomainResolver, endpoint transaction.Endpoint, apiKeyInQueryString bool) []string {

--- a/pkg/diagnose/connectivity/trace_request.go
+++ b/pkg/diagnose/connectivity/trace_request.go
@@ -106,7 +106,7 @@ func sendHTTPRequestToEndpoint(client *http.Client, domain string, endpointInfo 
 func createEndpointURL(domain string, endpointInfo EndpointInfo, apiKey string) string {
 	url := domain + endpointInfo.Endpoint.Route
 
-	if endpointInfo.ApiKeyInQueryString {
+	if endpointInfo.APIKeyInQueryString {
 		url = fmt.Sprintf("%s?api_key=%s", url, apiKey)
 	}
 

--- a/pkg/diagnose/connectivity/trace_request.go
+++ b/pkg/diagnose/connectivity/trace_request.go
@@ -1,3 +1,11 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package connectivity contains logic for connectivity troubleshooting between the Agent
+// and Datadog endpoints. It uses HTTP request to contact different endpoints and displays
+// some results depending on endpoints responses, if any.
 package connectivity
 
 import (
@@ -48,7 +56,7 @@ func sendRequestToAllEndpointOfADomain(client *http.Client, domainResolver resol
 	for _, apiKey := range domainResolver.GetAPIKeys() {
 
 		for _, endpointInfo := range endpointsInfo {
-			domain, _ := domainResolver.Resolve(endpointInfo.endpoint)
+			domain, _ := domainResolver.Resolve(endpointInfo.Endpoint)
 
 			// Create the endpoint URL and send the request
 			url := createEndpointURL(domain, apiKey, endpointInfo)
@@ -59,9 +67,9 @@ func sendRequestToAllEndpointOfADomain(client *http.Client, domainResolver resol
 
 func createEndpointURL(domain string, apiKey string, endpointInfo EndpointInfo) string {
 
-	url := domain + endpointInfo.endpoint.Route
+	url := domain + endpointInfo.Endpoint.Route
 
-	if endpointInfo.apiKeyInQueryString {
+	if endpointInfo.ApiKeyInQueryString {
 		url = fmt.Sprintf("%s?api_key=%s", url, apiKey)
 	}
 
@@ -71,11 +79,11 @@ func createEndpointURL(domain string, apiKey string, endpointInfo EndpointInfo) 
 func sendHTTPRequestToUrl(client *http.Client, url string, info EndpointInfo) {
 	logURL := scrubber.ScrubLine(url)
 
-	fmt.Printf("======== '%v' ========\n", logURL)
+	fmt.Printf("\n======== '%v' ========\n", logURL)
 
 	// Create a request for the backend
-	reader := bytes.NewReader(info.payload)
-	req, err := http.NewRequest(info.method, url, reader)
+	reader := bytes.NewReader(info.Payload)
+	req, err := http.NewRequest(info.Method, url, reader)
 
 	if err != nil {
 		log.Errorf("Could not create request for transaction to invalid URL '%v' : %v", logURL, scrubber.ScrubLine(err.Error()))
@@ -103,6 +111,6 @@ func sendHTTPRequestToUrl(client *http.Client, url string, info EndpointInfo) {
 		//fmt.Printf("Endpoint '%v' answers with status code %v\n", logURL, resp.StatusCode)
 		fmt.Printf("Received response : '%v'\n", string(body))
 	}
-	fmt.Printf("Received status code %v from the endpoint ====> %v\n\n", resp.StatusCode, statusString)
+	fmt.Printf("Received status code %v from the endpoint ====> %v\n", resp.StatusCode, statusString)
 
 }

--- a/pkg/diagnose/connectivity/trace_request.go
+++ b/pkg/diagnose/connectivity/trace_request.go
@@ -12,6 +12,7 @@ import (
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
+	"github.com/fatih/color"
 )
 
 func newHTTPClient() *http.Client {
@@ -70,6 +71,8 @@ func createEndpointURL(domain string, apiKey string, endpointInfo EndpointInfo) 
 func sendHTTPRequestToUrl(client *http.Client, url string, info EndpointInfo) {
 	logURL := scrubber.ScrubLine(url)
 
+	fmt.Printf("======== '%v' ========\n", logURL)
+
 	// Create a request for the backend
 	reader := bytes.NewReader(info.payload)
 	req, err := http.NewRequest(info.method, url, reader)
@@ -77,10 +80,6 @@ func sendHTTPRequestToUrl(client *http.Client, url string, info EndpointInfo) {
 	if err != nil {
 		log.Errorf("Could not create request for transaction to invalid URL '%v' : %v", logURL, scrubber.ScrubLine(err.Error()))
 	}
-
-	//req = req.WithContext(ctx)
-	//req.Header = t.Headers
-	//req = req.WithContext(httptrace.WithClientTrace(context.Background(), Trace))
 
 	// Send the request
 	resp, err := client.Do(req)
@@ -98,6 +97,12 @@ func sendHTTPRequestToUrl(client *http.Client, url string, info EndpointInfo) {
 		return
 	}
 
-	fmt.Printf("Endpoint '%v' answers with status code %v\n", logURL, resp.StatusCode)
-	fmt.Printf("Response : '%v'\n", string(body))
+	statusString := color.GreenString("PASS")
+	if resp.StatusCode != http.StatusOK {
+		statusString = color.RedString("FAIL")
+		//fmt.Printf("Endpoint '%v' answers with status code %v\n", logURL, resp.StatusCode)
+		fmt.Printf("Received response : '%v'\n", string(body))
+	}
+	fmt.Printf("Received status code %v from the endpoint ====> %v\n\n", resp.StatusCode, statusString)
+
 }

--- a/pkg/diagnose/connectivity/trace_request_test.go
+++ b/pkg/diagnose/connectivity/trace_request_test.go
@@ -17,17 +17,17 @@ import (
 
 var (
 	apiKey                    = "api_key1"
-	endpointInfoWithApiKey    = endpointInfo{Endpoint: endpoints.V1ValidateEndpoint, APIKeyInQueryString: true}
-	endpointInfoWithoutApiKey = endpointInfo{Endpoint: endpoints.V1SeriesEndpoint, APIKeyInQueryString: false}
+	endpointInfoWithAPIKey    = endpointInfo{Endpoint: endpoints.V1ValidateEndpoint, APIKeyInQueryString: true}
+	endpointInfoWithoutAPIKey = endpointInfo{Endpoint: endpoints.V1SeriesEndpoint, APIKeyInQueryString: false}
 )
 
 func TestCreateEndpointUrl(t *testing.T) {
 
-	urlWithApiKey := createEndpointURL("https://domain", endpointInfoWithApiKey, apiKey)
-	urlWithoutApiKey := createEndpointURL("https://domain2", endpointInfoWithoutApiKey, apiKey)
+	urlWithAPIKey := createEndpointURL("https://domain", endpointInfoWithAPIKey, apiKey)
+	urlWithoutAPIKey := createEndpointURL("https://domain2", endpointInfoWithoutAPIKey, apiKey)
 
-	assert.Equal(t, urlWithApiKey, "https://domain/api/v1/validate?api_key=api_key1")
-	assert.Equal(t, urlWithoutApiKey, "https://domain2/api/v1/series")
+	assert.Equal(t, urlWithAPIKey, "https://domain/api/v1/validate?api_key=api_key1")
+	assert.Equal(t, urlWithoutAPIKey, "https://domain2/api/v1/series")
 }
 
 func TestSendHTTPRequestToEndpoint(t *testing.T) {
@@ -48,13 +48,13 @@ func TestSendHTTPRequestToEndpoint(t *testing.T) {
 	client := forwarder.NewHTTPClient()
 
 	// With the API Key, it should be a 200
-	statusCodeWithKey, responseBodyWithKey, errWithKey := sendHTTPRequestToEndpoint(client, ts1.URL, endpointInfoWithApiKey, apiKey)
+	statusCodeWithKey, responseBodyWithKey, errWithKey := sendHTTPRequestToEndpoint(client, ts1.URL, endpointInfoWithAPIKey, apiKey)
 	assert.Nil(t, errWithKey)
 	assert.Equal(t, statusCodeWithKey, 200)
 	assert.Equal(t, string(responseBodyWithKey), "OK")
 
 	// Without the API Key, it should be a 400
-	statusCode, responseBody, err := sendHTTPRequestToEndpoint(client, ts1.URL, endpointInfoWithoutApiKey, apiKey)
+	statusCode, responseBody, err := sendHTTPRequestToEndpoint(client, ts1.URL, endpointInfoWithoutAPIKey, apiKey)
 	assert.Nil(t, err)
 	assert.Equal(t, statusCode, 400)
 	assert.Equal(t, string(responseBody), "Bad Request")

--- a/pkg/diagnose/connectivity/trace_request_test.go
+++ b/pkg/diagnose/connectivity/trace_request_test.go
@@ -1,0 +1,73 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package connectivity
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/forwarder"
+	"github.com/DataDog/datadog-agent/pkg/forwarder/endpoints"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	apiKey                    = "api_key1"
+	endpointInfoWithApiKey    = EndpointInfo{Endpoint: endpoints.V1ValidateEndpoint, APIKeyInQueryString: true}
+	endpointInfoWithoutApiKey = EndpointInfo{Endpoint: endpoints.V1SeriesEndpoint, APIKeyInQueryString: false}
+)
+
+func TestCreateEndpointUrl(t *testing.T) {
+
+	urlWithApiKey := createEndpointURL("https://domain", endpointInfoWithApiKey, apiKey)
+	urlWithoutApiKey := createEndpointURL("https://domain2", endpointInfoWithoutApiKey, apiKey)
+
+	assert.Equal(t, urlWithApiKey, "https://domain/api/v1/validate?api_key=api_key1")
+	assert.Equal(t, urlWithoutApiKey, "https://domain2/api/v1/series")
+}
+
+func TestSendHTTPRequestToEndpointPass(t *testing.T) {
+
+	// Create a fake server that send a 200 Response if there is 'api_key1' in the query string
+	// or a 400 response otherwise.
+	ts1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.ParseForm()
+		if r.Form.Get("api_key") == "api_key1" {
+			w.WriteHeader(http.StatusOK)
+		} else {
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+	defer ts1.Close()
+
+	client := forwarder.NewHTTPClient()
+
+	output := captureOutputSendHTTPRequestToEndpoint(client, ts1.URL, endpointInfoWithApiKey, apiKey)
+	assert.True(t, strings.Contains(output, "PASS"))
+
+	output2 := captureOutputSendHTTPRequestToEndpoint(client, ts1.URL, endpointInfoWithoutApiKey, apiKey)
+	assert.True(t, strings.Contains(output2, "FAIL"))
+}
+
+// captureOutputSendHTTPRequestToEndpoint is a helper to get the output of the
+// sendHTTPRequestToEndpoint function into a string
+func captureOutputSendHTTPRequestToEndpoint(client *http.Client, domain string, endpointInfo EndpointInfo, apiKey string) string {
+	rescueStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	sendHTTPRequestToEndpoint(client, domain, endpointInfo, apiKey)
+
+	w.Close()
+	out, _ := ioutil.ReadAll(r)
+	os.Stdout = rescueStdout
+
+	return string(out)
+}

--- a/pkg/forwarder/worker.go
+++ b/pkg/forwarder/worker.go
@@ -52,12 +52,12 @@ func NewWorker(
 		resetConnectionChan: make(chan struct{}, 1),
 		stopChan:            make(chan struct{}),
 		stopped:             make(chan struct{}),
-		Client:              newHTTPClient(),
+		Client:              NewHTTPClient(),
 		blockedList:         blocked,
 	}
 }
 
-func newHTTPClient() *http.Client {
+func NewHTTPClient() *http.Client {
 	transport := httputils.CreateHTTPTransport()
 
 	return &http.Client{
@@ -192,5 +192,5 @@ func (w *Worker) process(ctx context.Context, t transaction.Transaction) {
 func (w *Worker) resetConnections() {
 	log.Debug("Resetting worker's connections")
 	w.Client.CloseIdleConnections()
-	w.Client = newHTTPClient()
+	w.Client = NewHTTPClient()
 }

--- a/pkg/forwarder/worker.go
+++ b/pkg/forwarder/worker.go
@@ -57,6 +57,7 @@ func NewWorker(
 	}
 }
 
+// NewHTTPClient creates a new http.Client
 func NewHTTPClient() *http.Client {
 	transport := httputils.CreateHTTPTransport()
 


### PR DESCRIPTION
### What does this PR do?

This PR adds content for `diagnose datadog-connectivity` command. This command now sends HTTP request to endpoints with a defined method and body to check if the endpoints is correctly receiving the data. 

### Motivation

Troubleshooting connectivity issues is hard so we want to have a command in the Agent to help us on that.
The goal of this PR is to create the foundations for this command so that we can easily add new features or new endpoints.

### Additional Notes

Not addressed in this PR : 

- Only status code 200 is considered to be valid for now
- Possibility to redirect to Vector
- Add more endpoints and only diagnose endpoints that are used by the Forwarder
- Different kind of payload
- Multiple HTTP method for an endpoint 
- HTTP tracing
- ...


 Open questions : 
- I exported `NewHTTPClient` to be sure to use the same client as in the forwarder, but I believe that the function is not in the correct place now. Where can I put it ?
- Should I encapsulate the `httpClient` and `domainResolvers` into an object ?

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

- Disclaimer : This is a PR of a long list of PRs that aims to add connectivity troubleshooting tools so it might not be up to date during the QA. Don't hesitate to ping me during the QA if there is any problem.


Run `datadog-agent diagnose datadog-connectivity`. For this specific PR, it should displays something similar to : 

```
======== 'https://app.datadoghq.com/api/v1/series?api_key=***************************XXXXX' ========
Received response : 'Payload is empty'
Received status code 400 from the endpoint ====> FAIL

======== 'https://app.datadoghq.com/api/v1/validate?api_key=***************************XXXXX' ========
Received status code 200 from the endpoint ====> PASS
``` 

or if you disable your internet connection : 

```
======= 'https://app.datadoghq.com/api/v1/series?api_key=***************************XXXXX' ========
Could not send the HTTP request to 'url' .... dial tcp: lookup ... : no such host

======== 'https://app.datadoghq.com/api/v1/validate?api_key=***************************XXXXX' ========
Could not send the HTTP request to 'url' .... dial tcp: lookup ... : no such host
```

In short, just verify that you can run the command, and that the command displays connectivity information about the endpoints. Don't hesitate to ping me if you have any questions or concerns.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
