### PR TITLE
(rcm) missing product filter on client predicates

### DIFF
--- a/pkg/config/remote/service/client_predicates.go
+++ b/pkg/config/remote/service/client_predicates.go
@@ -20,12 +20,11 @@ type DirectorTargetsCustomMetadata struct {
 func executeClientPredicates(
 	client *pbgo.Client,
 	directorTargets data.TargetFiles,
-	products []string,
 ) ([]string, error) {
 	configs := make([]string, 0)
 
 	productsMap := make(map[string]struct{})
-	for _, product := range products {
+	for _, product := range client.Products {
 		productsMap[product] = struct{}{}
 	}
 

--- a/pkg/config/remote/service/service.go
+++ b/pkg/config/remote/service/service.go
@@ -284,7 +284,7 @@ func (s *Service) ClientGetConfigs(request *pbgo.ClientGetConfigsRequest) (*pbgo
 	if err != nil {
 		return nil, err
 	}
-	matchedClientConfigs, err := executeClientPredicates(request.Client, directorTargets)
+	matchedClientConfigs, err := executeClientPredicates(request.Client, directorTargets, request.Client.Products)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/config/remote/service/service.go
+++ b/pkg/config/remote/service/service.go
@@ -284,7 +284,7 @@ func (s *Service) ClientGetConfigs(request *pbgo.ClientGetConfigsRequest) (*pbgo
 	if err != nil {
 		return nil, err
 	}
-	matchedClientConfigs, err := executeClientPredicates(request.Client, directorTargets, request.Client.Products)
+	matchedClientConfigs, err := executeClientPredicates(request.Client, directorTargets)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/config/remote/service/service_test.go
+++ b/pkg/config/remote/service/service_test.go
@@ -311,8 +311,6 @@ func TestService(t *testing.T) {
 		[]string{
 			"datadog/2/APM_SAMPLING/id/1",
 			"datadog/2/APM_SAMPLING/id/2",
-			"datadog/2/TESTING1/id/1",
-			"datadog/2/APPSEC/id/1",
 		},
 	)
 	err = service.refresh()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Currently the products asked by clients are not being taken into account in the client predicate execution. This will lead to all configs matching the client being sent, even if the client only asked for specific products.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
