### PR TITLE
[docker] Don't generate events for un-inspectable containers

### DIFF
--- a/pkg/workloadmeta/collectors/internal/docker/docker.go
+++ b/pkg/workloadmeta/collectors/internal/docker/docker.go
@@ -145,6 +145,7 @@ func (c *collector) generateEventsFromContainerList(ctx context.Context, filter 
 		})
 		if err != nil {
 			log.Warnf(err.Error())
+			continue
 		}
 
 		events = append(events, ev)

--- a/releasenotes/notes/wlmeta-docker-panic-0bcfeb177e8d3833.yaml
+++ b/releasenotes/notes/wlmeta-docker-panic-0bcfeb177e8d3833.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixes an issue where the Agent would panic when trying to inspect Docker
+    containers while the Docker daemon was unavailable or taking too long to
+    respond.


### PR DESCRIPTION
### What does this PR do?

See https://github.com/DataDog/datadog-agent/issues/10716#issuecomment-1126298463 for a customer facing this issue:

```
2022-05-13 16:47:46 UTC | CORE | WARN | (pkg/workloadmeta/collectors/docker/docker.go:147 in generateEventsFromContainerList) | could not inspect container "57e87b2163036b874c02d4823338f6d85cde112b2e39d3ab751a1271adf4c782": Get "http://%!F(MISSING)host%!F(MISSING)var%!F(MISSING)run%!F(MISSING)docker.sock/v1.40/containers/57e87b2163036b874c02d4823338f6d85cde112b2e39d3ab751a1271adf4c782/json": context deadline exceeded
2022-05-13 16:47:51 UTC | CORE | WARN | (pkg/workloadmeta/collectors/docker/docker.go:147 in generateEventsFromContainerList) | could not inspect container "024f53d01821a7b787e8efd9156daffc9affbcd332503a527fa5ea46350cbdd0": Get "http://%!F(MISSING)host%!F(MISSING)var%!F(MISSING)run%!F(MISSING)docker.sock/v1.40/containers/024f53d01821a7b787e8efd9156daffc9affbcd332503a527fa5ea46350cbdd0/json": context deadline exceeded
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x263bfda]

goroutine 356 [running]:
github.com/DataDog/datadog-agent/pkg/workloadmeta.(*store).handleEvents(0xc0000f2d80, {0xc000844b40, 0xd, 0xd})
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/workloadmeta/store.go:364 +0x8da
```

When `buildCollectorEvent` returns an error, the event it also returns
will not contain an Entity, so trying to call `GetID()` on it while
trying to handle that event will panic. To prevent that, we now skip
the event if there is an error when building it.

### Describe how to test/QA your changes

This is a hard failure to induce, I can't think of the required magic to allow communication to the docker daemon to allow streaming of events, but prevent container inspection. Evidence for the rarity of this is that this code has been there since 7.34, and only now we got reports of this panic. I'll leave QA of this to the discretion of the QA'er, but the straight-forwardness of the patch and the effort required to reproduce may not be worth it, but do prove me wrong :D 

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
