### PR TITLE
[network-agent] http: ensure data correctness

### DIFF
--- a/pkg/network/http/model.go
+++ b/pkg/network/http/model.go
@@ -9,6 +9,8 @@
 package http
 
 import (
+	"encoding/hex"
+	"strings"
 	"unsafe"
 )
 
@@ -91,6 +93,16 @@ func (tx *httpTX) Incomplete() bool {
 // Tags are defined here : pkg/network/ebpf/kprobe_types.go
 func (tx *httpTX) Tags() uint64 {
 	return uint64(tx.tags)
+}
+
+func (tx *httpTX) String() string {
+	var output strings.Builder
+	fragment := *(*[HTTPBufferSize]byte)(unsafe.Pointer(&tx.request_fragment))
+	output.WriteString("httpTX{")
+	output.WriteString("Method: '" + Method(tx.request_method).String() + "', ")
+	output.WriteString("Fragment: '" + hex.EncodeToString(fragment[:]) + "', ")
+	output.WriteString("}")
+	return output.String()
 }
 
 // IsDirty detects whether the batch page we're supposed to read from is still


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This ensures that the agent will not send incorrect/invalid http data to the outside world.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

We want to make sure only correct data are being shown to the user. This prevents malformed data from being sent. Logs will help determine what went wrong.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
