### PR TITLE
(rcm) cache uptane verification

### DIFF
--- a/pkg/config/remote/uptane/client.go
+++ b/pkg/config/remote/uptane/client.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"fmt"
 	"sync"
+	"time"
 
 	rdata "github.com/DataDog/datadog-agent/pkg/config/remote/data"
 	"github.com/DataDog/datadog-agent/pkg/proto/pbgo"
@@ -34,7 +35,8 @@ type Client struct {
 
 	targetStore *targetStore
 
-	cachedVerify bool
+	cachedVerify     bool
+	cachedVerifyTime time.Time
 }
 
 // NewClient creates a new uptane client
@@ -190,7 +192,7 @@ func (c *Client) pruneTargetFiles() error {
 }
 
 func (c *Client) verify() error {
-	if c.cachedVerify {
+	if c.cachedVerify && time.Since(c.cachedVerifyTime) < time.Minute {
 		return nil
 	}
 	err := c.verifyOrgID()
@@ -202,6 +204,7 @@ func (c *Client) verify() error {
 		return err
 	}
 	c.cachedVerify = true
+	c.cachedVerifyTime = time.Now()
 	return nil
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR only verifies the integrity of configurations once per update instead of every time we access configs in the agent. It is safe to cache this validation since the state is not changed between update. To ensure expirations are still take into account the verification is cached for a minute max. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Verification was ran a bunch of times during queries and is an expensive procedure. We added more calls that triggered this verification in recent PRs. This led to 5s+ answers when multiple configurations were returned. 

This is considered a  bug as it completely broke requesting configs in a lot of scenarios in this release.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

`go-tuf` is very very inefficient under the hood, we will likely have to invest there at some point. The main issue seems to be that it re-verifies every time we call it for anything, even if its internal state is exactly the same. This is likely because TUF has `expirations` so it's easier to just re-check everything every-time but in our usecase this is not great.


