### PR TITLE
Postpone using demultiplexer until after tagger is initialized

### DIFF
--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -363,18 +363,6 @@ func StartAgent() error {
 	opts := aggregator.DefaultDemultiplexerOptions(forwarderOpts)
 	opts.UseContainerLifecycleForwarder = config.Datadog.GetBool("container_lifecycle.enabled")
 	demux = aggregator.InitAndStartAgentDemultiplexer(opts, hostname)
-	demux.AddAgentStartupTelemetry(version.AgentVersion)
-
-	// start dogstatsd
-	if config.Datadog.GetBool("use_dogstatsd") {
-		var err error
-		common.DSD, err = dogstatsd.NewServer(demux, false)
-		if err != nil {
-			log.Errorf("Could not start dogstatsd: %s", err)
-		} else {
-			log.Debugf("dogstatsd started")
-		}
-	}
 
 	// Setup stats telemetry handler
 	if sender, err := demux.GetDefaultSender(); err == nil {
@@ -421,6 +409,19 @@ func StartAgent() error {
 
 	// create and setup the Autoconfig instance
 	common.LoadComponents(common.MainCtx, config.Datadog.GetString("confd_path"))
+
+	demux.AddAgentStartupTelemetry(version.AgentVersion)
+
+	// start dogstatsd
+	if config.Datadog.GetBool("use_dogstatsd") {
+		var err error
+		common.DSD, err = dogstatsd.NewServer(demux, false)
+		if err != nil {
+			log.Errorf("Could not start dogstatsd: %s", err)
+		} else {
+			log.Debugf("dogstatsd started")
+		}
+	}
 
 	// start logs-agent.  This must happen after AutoConfig is set up (via common.LoadComponents)
 	if config.Datadog.GetBool("logs_enabled") || config.Datadog.GetBool("log_enabled") {


### PR DESCRIPTION
### What does this PR do?

Avoid data races between tagger initialization (setting globals in tagger/global.go) and usage (sending startup telemetry and handling traffic received through dogstatsd).

### Additional Notes

### Describe how to test/QA your changes

- Run the agent in docker or k8s with dogstatsd enabled and `DD_DOGSTATSD_ORIGIN_DETECTION=true DD_DOGSTATSD_TAG_CARDINALITY=high`
- Check that `datadog.agent.started` is reported
- Send metrics from another container
- Check that metrics are tagged with `container_name`, `image_name`, `image_tag`

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
