### PR TITLE
[CWS] Optimises the async flag retrieving 

### DIFF
--- a/docs/cloud-workload-security/agent_expressions.md
+++ b/docs/cloud-workload-security/agent_expressions.md
@@ -166,6 +166,7 @@ The *file.rights* attribute can now be used in addition to *file.mode*. *file.mo
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
+| `async` | bool | True if the syscall was asynchronous |
 | `container.id` | string | ID of the container |
 | `container.tags` | string | Tags of the container |
 | `network.destination.ip` | IP/CIDR | IP address |
@@ -279,7 +280,6 @@ A bind was executed
 | `bind.addr.family` | int | Address family |
 | `bind.addr.ip` | IP/CIDR | IP address |
 | `bind.addr.port` | int | Port number |
-| `bind.async` | bool | True if the syscall was asynchronous |
 | `bind.retval` | int | Return value of the syscall |
 
 ### Event `bpf`
@@ -288,7 +288,6 @@ A BPF command was executed
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
-| `bpf.async` | bool | True if the syscall was asynchronous |
 | `bpf.cmd` | int | BPF command name |
 | `bpf.map.name` | string | Name of the eBPF map (added in 7.35) |
 | `bpf.map.type` | int | Type of the eBPF map |
@@ -314,7 +313,6 @@ A file’s permissions were changed
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
-| `chmod.async` | bool | True if the syscall was asynchronous |
 | `chmod.file.change_time` | int | Change time of the file |
 | `chmod.file.destination.mode` | int | New mode/rights of the chmod-ed file |
 | `chmod.file.destination.rights` | int | New mode/rights of the chmod-ed file |
@@ -339,7 +337,6 @@ A file’s owner was changed
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
-| `chown.async` | bool | True if the syscall was asynchronous |
 | `chown.file.change_time` | int | Change time of the file |
 | `chown.file.destination.gid` | int | New GID of the chown-ed file's owner |
 | `chown.file.destination.group` | string | New group of the chown-ed file's owner |
@@ -430,7 +427,6 @@ Create a new name/alias for a file
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
-| `link.async` | bool | True if the syscall was asynchronous |
 | `link.file.change_time` | int | Change time of the file |
 | `link.file.destination.change_time` | int | Change time of the file |
 | `link.file.destination.filesystem` | string | File's filesystem |
@@ -467,7 +463,6 @@ A new kernel module was loaded
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
-| `load_module.async` | bool | True if the syscall was asynchronous |
 | `load_module.file.change_time` | int | Change time of the file |
 | `load_module.file.filesystem` | string | File's filesystem |
 | `load_module.file.gid` | int | GID of the file's owner |
@@ -492,7 +487,6 @@ A directory was created
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
-| `mkdir.async` | bool | True if the syscall was asynchronous |
 | `mkdir.file.change_time` | int | Change time of the file |
 | `mkdir.file.destination.mode` | int | Mode/rights of the new directory |
 | `mkdir.file.destination.rights` | int | Mode/rights of the new directory |
@@ -517,7 +511,6 @@ A mmap command was executed
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
-| `mmap.async` | bool | True if the syscall was asynchronous |
 | `mmap.file.change_time` | int | Change time of the file |
 | `mmap.file.filesystem` | string | File's filesystem |
 | `mmap.file.gid` | int | GID of the file's owner |
@@ -542,7 +535,6 @@ A mprotect command was executed
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
-| `mprotect.async` | bool | True if the syscall was asynchronous |
 | `mprotect.req_protection` | int | new memory segment protection |
 | `mprotect.retval` | int | Return value of the syscall |
 | `mprotect.vm_protection` | int | initial memory segment protection |
@@ -553,7 +545,6 @@ A file was opened
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
-| `open.async` | bool | True if the syscall was asynchronous |
 | `open.file.change_time` | int | Change time of the file |
 | `open.file.destination.mode` | int | Mode of the created file |
 | `open.file.filesystem` | string | File's filesystem |
@@ -578,7 +569,6 @@ A ptrace command was executed
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
-| `ptrace.async` | bool | True if the syscall was asynchronous |
 | `ptrace.request` | int | ptrace request |
 | `ptrace.retval` | int | Return value of the syscall |
 | `ptrace.tracee.ancestors.args` | string | Arguments of the process (as a string) |
@@ -678,7 +668,6 @@ Remove extended attributes
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
-| `removexattr.async` | bool | True if the syscall was asynchronous |
 | `removexattr.file.change_time` | int | Change time of the file |
 | `removexattr.file.destination.name` | string | Name of the extended attribute |
 | `removexattr.file.destination.namespace` | string | Namespace of the extended attribute |
@@ -703,7 +692,6 @@ A file/directory was renamed
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
-| `rename.async` | bool | True if the syscall was asynchronous |
 | `rename.file.change_time` | int | Change time of the file |
 | `rename.file.destination.change_time` | int | Change time of the file |
 | `rename.file.destination.filesystem` | string | File's filesystem |
@@ -740,7 +728,6 @@ A directory was removed
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
-| `rmdir.async` | bool | True if the syscall was asynchronous |
 | `rmdir.file.change_time` | int | Change time of the file |
 | `rmdir.file.filesystem` | string | File's filesystem |
 | `rmdir.file.gid` | int | GID of the file's owner |
@@ -800,7 +787,6 @@ Set exteneded attributes
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
-| `setxattr.async` | bool | True if the syscall was asynchronous |
 | `setxattr.file.change_time` | int | Change time of the file |
 | `setxattr.file.destination.name` | string | Name of the extended attribute |
 | `setxattr.file.destination.namespace` | string | Namespace of the extended attribute |
@@ -825,7 +811,6 @@ A signal was sent
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
-| `signal.async` | bool | True if the syscall was asynchronous |
 | `signal.pid` | int | Target PID |
 | `signal.retval` | int | Return value of the syscall |
 | `signal.target.ancestors.args` | string | Arguments of the process (as a string) |
@@ -926,7 +911,6 @@ A splice command was executed
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
-| `splice.async` | bool | True if the syscall was asynchronous |
 | `splice.file.change_time` | int | Change time of the file |
 | `splice.file.filesystem` | string | File's filesystem |
 | `splice.file.gid` | int | GID of the file's owner |
@@ -951,7 +935,6 @@ A file was deleted
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
-| `unlink.async` | bool | True if the syscall was asynchronous |
 | `unlink.file.change_time` | int | Change time of the file |
 | `unlink.file.filesystem` | string | File's filesystem |
 | `unlink.file.gid` | int | GID of the file's owner |
@@ -974,7 +957,6 @@ A kernel module was deleted
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
-| `unload_module.async` | bool | True if the syscall was asynchronous |
 | `unload_module.name` | string | Name of the kernel module that was deleted |
 | `unload_module.retval` | int | Return value of the syscall |
 
@@ -984,7 +966,6 @@ Change file access/modification times
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
-| `utimes.async` | bool | True if the syscall was asynchronous |
 | `utimes.file.change_time` | int | Change time of the file |
 | `utimes.file.filesystem` | string | File's filesystem |
 | `utimes.file.gid` | int | GID of the file's owner |

--- a/docs/cloud-workload-security/secl.json
+++ b/docs/cloud-workload-security/secl.json
@@ -8,6 +8,11 @@
       "experimental": false,
       "properties": [
         {
+          "name": "async",
+          "type": "bool",
+          "definition": "True if the syscall was asynchronous"
+        },
+        {
           "name": "container.id",
           "type": "string",
           "definition": "ID of the container"
@@ -537,11 +542,6 @@
           "definition": "Port number"
         },
         {
-          "name": "bind.async",
-          "type": "bool",
-          "definition": "True if the syscall was asynchronous"
-        },
-        {
           "name": "bind.retval",
           "type": "int",
           "definition": "Return value of the syscall"
@@ -555,11 +555,6 @@
       "from_agent_version": "7.33",
       "experimental": false,
       "properties": [
-        {
-          "name": "bpf.async",
-          "type": "bool",
-          "definition": "True if the syscall was asynchronous"
-        },
         {
           "name": "bpf.cmd",
           "type": "int",
@@ -633,11 +628,6 @@
       "from_agent_version": "7.27",
       "experimental": false,
       "properties": [
-        {
-          "name": "chmod.async",
-          "type": "bool",
-          "definition": "True if the syscall was asynchronous"
-        },
         {
           "name": "chmod.file.change_time",
           "type": "int",
@@ -732,11 +722,6 @@
       "from_agent_version": "7.27",
       "experimental": false,
       "properties": [
-        {
-          "name": "chown.async",
-          "type": "bool",
-          "definition": "True if the syscall was asynchronous"
-        },
         {
           "name": "chown.file.change_time",
           "type": "int",
@@ -1110,11 +1095,6 @@
       "experimental": false,
       "properties": [
         {
-          "name": "link.async",
-          "type": "bool",
-          "definition": "True if the syscall was asynchronous"
-        },
-        {
           "name": "link.file.change_time",
           "type": "int",
           "definition": "Change time of the file"
@@ -1269,11 +1249,6 @@
       "experimental": false,
       "properties": [
         {
-          "name": "load_module.async",
-          "type": "bool",
-          "definition": "True if the syscall was asynchronous"
-        },
-        {
           "name": "load_module.file.change_time",
           "type": "int",
           "definition": "Change time of the file"
@@ -1367,11 +1342,6 @@
       "from_agent_version": "7.27",
       "experimental": false,
       "properties": [
-        {
-          "name": "mkdir.async",
-          "type": "bool",
-          "definition": "True if the syscall was asynchronous"
-        },
         {
           "name": "mkdir.file.change_time",
           "type": "int",
@@ -1467,11 +1437,6 @@
       "experimental": false,
       "properties": [
         {
-          "name": "mmap.async",
-          "type": "bool",
-          "definition": "True if the syscall was asynchronous"
-        },
-        {
           "name": "mmap.file.change_time",
           "type": "int",
           "definition": "Change time of the file"
@@ -1566,11 +1531,6 @@
       "experimental": false,
       "properties": [
         {
-          "name": "mprotect.async",
-          "type": "bool",
-          "definition": "True if the syscall was asynchronous"
-        },
-        {
           "name": "mprotect.req_protection",
           "type": "int",
           "definition": "new memory segment protection"
@@ -1594,11 +1554,6 @@
       "from_agent_version": "7.27",
       "experimental": false,
       "properties": [
-        {
-          "name": "open.async",
-          "type": "bool",
-          "definition": "True if the syscall was asynchronous"
-        },
         {
           "name": "open.file.change_time",
           "type": "int",
@@ -1693,11 +1648,6 @@
       "from_agent_version": "7.35",
       "experimental": false,
       "properties": [
-        {
-          "name": "ptrace.async",
-          "type": "bool",
-          "definition": "True if the syscall was asynchronous"
-        },
         {
           "name": "ptrace.request",
           "type": "int",
@@ -2168,11 +2118,6 @@
       "experimental": false,
       "properties": [
         {
-          "name": "removexattr.async",
-          "type": "bool",
-          "definition": "True if the syscall was asynchronous"
-        },
-        {
           "name": "removexattr.file.change_time",
           "type": "int",
           "definition": "Change time of the file"
@@ -2266,11 +2211,6 @@
       "from_agent_version": "7.27",
       "experimental": false,
       "properties": [
-        {
-          "name": "rename.async",
-          "type": "bool",
-          "definition": "True if the syscall was asynchronous"
-        },
         {
           "name": "rename.file.change_time",
           "type": "int",
@@ -2425,11 +2365,6 @@
       "from_agent_version": "7.27",
       "experimental": false,
       "properties": [
-        {
-          "name": "rmdir.async",
-          "type": "bool",
-          "definition": "True if the syscall was asynchronous"
-        },
         {
           "name": "rmdir.file.change_time",
           "type": "int",
@@ -2622,11 +2557,6 @@
       "experimental": false,
       "properties": [
         {
-          "name": "setxattr.async",
-          "type": "bool",
-          "definition": "True if the syscall was asynchronous"
-        },
-        {
           "name": "setxattr.file.change_time",
           "type": "int",
           "definition": "Change time of the file"
@@ -2720,11 +2650,6 @@
       "from_agent_version": "7.35",
       "experimental": false,
       "properties": [
-        {
-          "name": "signal.async",
-          "type": "bool",
-          "definition": "True if the syscall was asynchronous"
-        },
         {
           "name": "signal.pid",
           "type": "int",
@@ -3200,11 +3125,6 @@
       "experimental": false,
       "properties": [
         {
-          "name": "splice.async",
-          "type": "bool",
-          "definition": "True if the syscall was asynchronous"
-        },
-        {
           "name": "splice.file.change_time",
           "type": "int",
           "definition": "Change time of the file"
@@ -3299,11 +3219,6 @@
       "experimental": false,
       "properties": [
         {
-          "name": "unlink.async",
-          "type": "bool",
-          "definition": "True if the syscall was asynchronous"
-        },
-        {
           "name": "unlink.file.change_time",
           "type": "int",
           "definition": "Change time of the file"
@@ -3388,11 +3303,6 @@
       "experimental": false,
       "properties": [
         {
-          "name": "unload_module.async",
-          "type": "bool",
-          "definition": "True if the syscall was asynchronous"
-        },
-        {
           "name": "unload_module.name",
           "type": "string",
           "definition": "Name of the kernel module that was deleted"
@@ -3411,11 +3321,6 @@
       "from_agent_version": "7.27",
       "experimental": false,
       "properties": [
-        {
-          "name": "utimes.async",
-          "type": "bool",
-          "definition": "True if the syscall was asynchronous"
-        },
         {
           "name": "utimes.file.change_time",
           "type": "int",

--- a/pkg/security/ebpf/c/bpf.h
+++ b/pkg/security/ebpf/c/bpf.h
@@ -276,7 +276,7 @@ __attribute__((always_inline)) void fill_from_syscall_args(struct syscall_cache_
 __attribute__((always_inline)) void send_bpf_event(void *ctx, struct syscall_cache_t *syscall) {
     struct bpf_event_t event = {
         .syscall.retval = syscall->bpf.retval,
-        .syscall.async = 0,
+        .event.async = 0,
         .cmd = syscall->bpf.cmd,
     };
 

--- a/pkg/security/ebpf/c/chmod.h
+++ b/pkg/security/ebpf/c/chmod.h
@@ -61,7 +61,7 @@ int __attribute__((always_inline)) sys_chmod_ret(void *ctx, int retval) {
 
     struct chmod_event_t event = {
         .syscall.retval = retval,
-        .syscall.async = 0,
+        .event.async = 0,
         .file = syscall->setattr.file,
         .padding = 0,
         .mode = syscall->setattr.mode,

--- a/pkg/security/ebpf/c/chown.h
+++ b/pkg/security/ebpf/c/chown.h
@@ -78,7 +78,7 @@ int __attribute__((always_inline)) sys_chown_ret(void *ctx, int retval) {
 
     struct chown_event_t event = {
         .syscall.retval = retval,
-        .syscall.async = 0,
+        .event.async = 0,
         .file = syscall->setattr.file,
         .uid = syscall->setattr.user,
         .gid = syscall->setattr.group,

--- a/pkg/security/ebpf/c/defs.h
+++ b/pkg/security/ebpf/c/defs.h
@@ -229,18 +229,20 @@ enum event_type
     EVENT_BIND,
     EVENT_MAX, // has to be the last one
 
-    EVENT_ALL = 0xffffffffffffffff // used as a mask for all the events
+    EVENT_ALL = 0xffffffff // used as a mask for all the events
 };
 
 struct kevent_t {
     u64 cpu;
     u64 timestamp;
-    u64 type;
+    u32 type;
+    u32 async:8,
+        padding:24;
+
 };
 
 struct syscall_t {
     s64 retval;
-    u64 async; /* TODO: optimize the way we retrieve the async boolean */
 };
 
 struct span_context_t {

--- a/pkg/security/ebpf/c/defs.h
+++ b/pkg/security/ebpf/c/defs.h
@@ -236,9 +236,8 @@ struct kevent_t {
     u64 cpu;
     u64 timestamp;
     u32 type;
-    u32 async:8,
-        padding:24;
-
+    u8 async;
+    u8 padding[3];
 };
 
 struct syscall_t {

--- a/pkg/security/ebpf/c/link.h
+++ b/pkg/security/ebpf/c/link.h
@@ -201,7 +201,7 @@ int __attribute__((always_inline)) dr_link_dst_callback(void *ctx, int retval) {
         .event.type = EVENT_LINK,
         .event.timestamp = bpf_ktime_get_ns(),
         .syscall.retval = retval,
-        .syscall.async = (u64)syscall->async,
+        .event.async = (u64)syscall->async,
         .source = syscall->link.src_file,
         .target = syscall->link.target_file,
     };

--- a/pkg/security/ebpf/c/link.h
+++ b/pkg/security/ebpf/c/link.h
@@ -201,7 +201,7 @@ int __attribute__((always_inline)) dr_link_dst_callback(void *ctx, int retval) {
         .event.type = EVENT_LINK,
         .event.timestamp = bpf_ktime_get_ns(),
         .syscall.retval = retval,
-        .event.async = (u64)syscall->async,
+        .event.async = syscall->async,
         .source = syscall->link.src_file,
         .target = syscall->link.target_file,
     };

--- a/pkg/security/ebpf/c/mkdir.h
+++ b/pkg/security/ebpf/c/mkdir.h
@@ -165,7 +165,7 @@ int __attribute__((always_inline)) dr_mkdir_callback(void *ctx, int retval) {
 
     struct mkdir_event_t event = {
         .syscall.retval = retval,
-        .syscall.async = (u64)syscall->async,
+        .event.async = (u64)syscall->async,
         .file = syscall->mkdir.file,
         .mode = syscall->mkdir.mode,
     };

--- a/pkg/security/ebpf/c/mkdir.h
+++ b/pkg/security/ebpf/c/mkdir.h
@@ -165,7 +165,7 @@ int __attribute__((always_inline)) dr_mkdir_callback(void *ctx, int retval) {
 
     struct mkdir_event_t event = {
         .syscall.retval = retval,
-        .event.async = (u64)syscall->async,
+        .event.async = syscall->async,
         .file = syscall->mkdir.file,
         .mode = syscall->mkdir.mode,
     };

--- a/pkg/security/ebpf/c/mmap.h
+++ b/pkg/security/ebpf/c/mmap.h
@@ -127,7 +127,7 @@ int __attribute__((always_inline)) sys_mmap_ret(void *ctx, int retval, u64 addr)
 
     struct mmap_event_t event = {
         .syscall.retval = retval,
-        .syscall.async = 0,
+        .event.async = 0,
         .file = syscall->mmap.file,
         .addr = addr,
         .offset = syscall->mmap.offset,

--- a/pkg/security/ebpf/c/module.h
+++ b/pkg/security/ebpf/c/module.h
@@ -101,7 +101,7 @@ int __attribute__((always_inline)) trace_init_module_ret(void *ctx, int retval) 
 
     struct init_module_event_t event = {
         .syscall.retval = retval,
-        .syscall.async = 0,
+        .event.async = 0,
         .file = syscall->init_module.file,
         .loaded_from_memory = syscall->init_module.loaded_from_memory,
     };
@@ -172,7 +172,7 @@ int __attribute__((always_inline)) trace_delete_module_ret(void *ctx, int retval
 
     struct delete_module_event_t event = {
         .syscall.retval = retval,
-        .syscall.async = 0,
+        .event.async = 0,
     };
     bpf_probe_read_str(&event.name, sizeof(event.name), (void *)syscall->delete_module.name);
 

--- a/pkg/security/ebpf/c/mount.h
+++ b/pkg/security/ebpf/c/mount.h
@@ -147,7 +147,7 @@ int __attribute__((always_inline)) dr_mount_callback(void *ctx, int retval) {
 
     struct mount_event_t event = {
         .syscall.retval = retval,
-        .syscall.async = 0,
+        .event.async = 0,
         .mount_id = get_mount_mount_id(syscall->mount.src_mnt),
         .group_id = get_mount_peer_group_id(syscall->mount.src_mnt),
         .device = get_mount_dev(syscall->mount.src_mnt),

--- a/pkg/security/ebpf/c/mprotect.h
+++ b/pkg/security/ebpf/c/mprotect.h
@@ -103,7 +103,7 @@ int __attribute__((always_inline)) sys_mprotect_ret(void *ctx, int retval) {
     }
 
     struct mprotect_event_t event = {
-        .syscall.async = 0,
+        .event.async = 0,
         .vm_protection = syscall->mprotect.vm_protection,
         .req_protection = syscall->mprotect.req_protection,
         .vm_start = syscall->mprotect.vm_start,

--- a/pkg/security/ebpf/c/net_device.h
+++ b/pkg/security/ebpf/c/net_device.h
@@ -234,7 +234,7 @@ int kretprobe_register_netdevice(struct pt_regs *ctx) {
     if (state == NULL) {
         // this is a simple device registration
         struct net_device_event_t evt = {
-            .syscall.async = 0,
+            .event.async = 0,
             .device = device,
         };
 
@@ -283,7 +283,7 @@ int kretprobe_register_netdevice(struct pt_regs *ctx) {
             if (peer_device->netns != device.netns) {
                 // send event
                 struct veth_pair_event_t evt = {
-                    .syscall.async = 0,
+                    .event.async = 0,
                     .host_device = device,
                     .peer_device = *peer_device,
                 };
@@ -331,7 +331,7 @@ __attribute__((always_inline)) int trace_dev_change_net_namespace(struct pt_regs
 
     // send event
     struct veth_pair_event_t evt = {
-        .syscall.async = 0,
+        .event.async = 0,
         .host_device = *peer_device,
         .peer_device = *device,
     };

--- a/pkg/security/ebpf/c/open.h
+++ b/pkg/security/ebpf/c/open.h
@@ -376,7 +376,7 @@ int __attribute__((always_inline)) dr_open_callback(void *ctx, int retval) {
 
     struct open_event_t event = {
         .syscall.retval = retval,
-        .syscall.async = syscall->async,
+        .event.async = syscall->async,
         .file = syscall->open.file,
         .flags = syscall->open.flags,
         .mode = syscall->open.mode,

--- a/pkg/security/ebpf/c/ptrace.h
+++ b/pkg/security/ebpf/c/ptrace.h
@@ -46,7 +46,7 @@ int __attribute__((always_inline)) sys_ptrace_ret(void *ctx, int retval) {
 
     struct ptrace_event_t event = {
         .syscall.retval = retval,
-        .syscall.async = 0,
+        .event.async = 0,
         .request = syscall->ptrace.request,
         .pid = namespace_nr,
         .addr = syscall->ptrace.addr,

--- a/pkg/security/ebpf/c/rename.h
+++ b/pkg/security/ebpf/c/rename.h
@@ -216,7 +216,7 @@ int __attribute__((always_inline)) dr_rename_callback(void *ctx, int retval) {
 
     struct rename_event_t event = {
         .syscall.retval = retval,
-        .syscall.async = syscall->async,
+        .event.async = syscall->async,
         .old = syscall->rename.src_file,
         .new = syscall->rename.target_file,
     };

--- a/pkg/security/ebpf/c/rmdir.h
+++ b/pkg/security/ebpf/c/rmdir.h
@@ -146,7 +146,7 @@ int __attribute__((always_inline)) sys_rmdir_ret(void *ctx, int retval) {
     if (pass_to_userspace) {
         struct rmdir_event_t event = {
             .syscall.retval = retval,
-            .syscall.async = syscall->async,
+            .event.async = syscall->async,
             .file = syscall->rmdir.file,
         };
 

--- a/pkg/security/ebpf/c/setxattr.h
+++ b/pkg/security/ebpf/c/setxattr.h
@@ -149,7 +149,7 @@ int __attribute__((always_inline)) sys_xattr_ret(void *ctx, int retval, u64 even
 
     struct setxattr_event_t event = {
         .syscall.retval = retval,
-        .syscall.async = 0,
+        .event.async = 0,
         .file = syscall->xattr.file,
     };
 

--- a/pkg/security/ebpf/c/signal.h
+++ b/pkg/security/ebpf/c/signal.h
@@ -60,7 +60,7 @@ int kretprobe_check_kill_permission(struct pt_regs* ctx) {
     /* constuct and send the event */
     struct signal_event_t event = {
         .syscall.retval = retval,
-        .syscall.async = 0,
+        .event.async = 0,
         .pid = syscall->signal.pid,
         .type = syscall->signal.type,
     };

--- a/pkg/security/ebpf/c/splice.h
+++ b/pkg/security/ebpf/c/splice.h
@@ -155,7 +155,7 @@ int __attribute__((always_inline)) sys_splice_ret(void *ctx, int retval) {
 
     struct splice_event_t event = {
         .syscall.retval = retval,
-        .syscall.async = 0,
+        .event.async = 0,
         .file = syscall->splice.file,
         .pipe_entry_flag = syscall->splice.pipe_entry_flag,
         .pipe_exit_flag = syscall->splice.pipe_exit_flag,

--- a/pkg/security/ebpf/c/umount.h
+++ b/pkg/security/ebpf/c/umount.h
@@ -43,7 +43,7 @@ int __attribute__((always_inline)) sys_umount_ret(void *ctx, int retval) {
 
     struct umount_event_t event = {
         .syscall.retval = retval,
-        .syscall.async = 0,
+        .event.async = 0,
         .mount_id = mount_id
     };
 

--- a/pkg/security/ebpf/c/unlink.h
+++ b/pkg/security/ebpf/c/unlink.h
@@ -127,7 +127,7 @@ int __attribute__((always_inline)) sys_unlink_ret(void *ctx, int retval) {
         if (syscall->unlink.flags & AT_REMOVEDIR) {
             struct rmdir_event_t event = {
                 .syscall.retval = retval,
-                .syscall.async = (u64)syscall->async,
+                .event.async = (u64)syscall->async,
                 .file = syscall->unlink.file,
             };
 
@@ -139,7 +139,7 @@ int __attribute__((always_inline)) sys_unlink_ret(void *ctx, int retval) {
         } else {
             struct unlink_event_t event = {
                 .syscall.retval = retval,
-                .syscall.async = (u64)syscall->async,
+                .event.async = (u64)syscall->async,
                 .file = syscall->unlink.file,
                 .flags = syscall->unlink.flags,
             };

--- a/pkg/security/ebpf/c/unlink.h
+++ b/pkg/security/ebpf/c/unlink.h
@@ -127,7 +127,7 @@ int __attribute__((always_inline)) sys_unlink_ret(void *ctx, int retval) {
         if (syscall->unlink.flags & AT_REMOVEDIR) {
             struct rmdir_event_t event = {
                 .syscall.retval = retval,
-                .event.async = (u64)syscall->async,
+                .event.async = syscall->async,
                 .file = syscall->unlink.file,
             };
 
@@ -139,7 +139,7 @@ int __attribute__((always_inline)) sys_unlink_ret(void *ctx, int retval) {
         } else {
             struct unlink_event_t event = {
                 .syscall.retval = retval,
-                .event.async = (u64)syscall->async,
+                .event.async = syscall->async,
                 .file = syscall->unlink.file,
                 .flags = syscall->unlink.flags,
             };

--- a/pkg/security/ebpf/c/utimes.h
+++ b/pkg/security/ebpf/c/utimes.h
@@ -73,7 +73,7 @@ int __attribute__((always_inline)) sys_utimes_ret(void *ctx, int retval) {
 
     struct utimes_event_t event = {
         .syscall.retval = retval,
-        .syscall.async = 0,
+        .event.async = 0,
         .atime = syscall->setattr.atime,
         .mtime = syscall->setattr.mtime,
         .file = syscall->setattr.file,

--- a/pkg/security/probe/accessors.go
+++ b/pkg/security/probe/accessors.go
@@ -60,6 +60,14 @@ func (m *Model) GetEventTypes() []eval.EventType {
 }
 func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Evaluator, error) {
 	switch field {
+	case "async":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				return (*Event)(ctx.Object).Async
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
 	case "bind.addr.family":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -84,26 +92,10 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.FunctionWeight,
 		}, nil
-	case "bind.async":
-		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool {
-				return (*Event)(ctx.Object).Bind.SyscallEvent.Async
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-		}, nil
 	case "bind.retval":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 				return int((*Event)(ctx.Object).Bind.SyscallEvent.Retval)
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-		}, nil
-	case "bpf.async":
-		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool {
-				return (*Event)(ctx.Object).BPF.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -196,14 +188,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 				return int((*Event)(ctx.Object).Capset.CapPermitted)
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-		}, nil
-	case "chmod.async":
-		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool {
-				return (*Event)(ctx.Object).Chmod.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -341,14 +325,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 				return int((*Event)(ctx.Object).Chmod.SyscallEvent.Retval)
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-		}, nil
-	case "chown.async":
-		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool {
-				return (*Event)(ctx.Object).Chown.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -924,14 +900,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.FunctionWeight,
 		}, nil
-	case "link.async":
-		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool {
-				return (*Event)(ctx.Object).Link.SyscallEvent.Async
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-		}, nil
 	case "link.file.change_time":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -1166,14 +1134,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.FunctionWeight,
 		}, nil
-	case "load_module.async":
-		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool {
-				return (*Event)(ctx.Object).LoadModule.SyscallEvent.Async
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-		}, nil
 	case "load_module.file.change_time":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -1307,14 +1267,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 				return int((*Event)(ctx.Object).LoadModule.SyscallEvent.Retval)
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-		}, nil
-	case "mkdir.async":
-		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool {
-				return (*Event)(ctx.Object).Mkdir.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -1456,14 +1408,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.FunctionWeight,
 		}, nil
-	case "mmap.async":
-		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool {
-				return (*Event)(ctx.Object).MMap.SyscallEvent.Async
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-		}, nil
 	case "mmap.file.change_time":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -1601,14 +1545,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.FunctionWeight,
 		}, nil
-	case "mprotect.async":
-		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool {
-				return (*Event)(ctx.Object).MProtect.SyscallEvent.Async
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-		}, nil
 	case "mprotect.req_protection":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -1701,14 +1637,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 				return int((*Event)(ctx.Object).NetworkContext.Source.Port)
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-		}, nil
-	case "open.async":
-		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool {
-				return (*Event)(ctx.Object).Open.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -3202,14 +3130,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.FunctionWeight,
 		}, nil
-	case "ptrace.async":
-		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool {
-				return (*Event)(ctx.Object).PTrace.SyscallEvent.Async
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-		}, nil
 	case "ptrace.request":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -4578,14 +4498,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.FunctionWeight,
 		}, nil
-	case "removexattr.async":
-		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool {
-				return (*Event)(ctx.Object).RemoveXAttr.SyscallEvent.Async
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-		}, nil
 	case "removexattr.file.change_time":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -4719,14 +4631,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 				return int((*Event)(ctx.Object).RemoveXAttr.SyscallEvent.Retval)
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-		}, nil
-	case "rename.async":
-		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool {
-				return (*Event)(ctx.Object).Rename.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -4961,14 +4865,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 				return int((*Event)(ctx.Object).Rename.SyscallEvent.Retval)
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-		}, nil
-	case "rmdir.async":
-		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool {
-				return (*Event)(ctx.Object).Rmdir.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -5222,14 +5118,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.HandlerWeight,
 		}, nil
-	case "setxattr.async":
-		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool {
-				return (*Event)(ctx.Object).SetXAttr.SyscallEvent.Async
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-		}, nil
 	case "setxattr.file.change_time":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -5363,14 +5251,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 				return int((*Event)(ctx.Object).SetXAttr.SyscallEvent.Retval)
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-		}, nil
-	case "signal.async":
-		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool {
-				return (*Event)(ctx.Object).Signal.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -6751,14 +6631,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.FunctionWeight,
 		}, nil
-	case "splice.async":
-		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool {
-				return (*Event)(ctx.Object).Splice.SyscallEvent.Async
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-		}, nil
 	case "splice.file.change_time":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -6896,14 +6768,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.FunctionWeight,
 		}, nil
-	case "unlink.async":
-		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool {
-				return (*Event)(ctx.Object).Unlink.SyscallEvent.Async
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-		}, nil
 	case "unlink.file.change_time":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -7025,14 +6889,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.FunctionWeight,
 		}, nil
-	case "unload_module.async":
-		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool {
-				return (*Event)(ctx.Object).UnloadModule.SyscallEvent.Async
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-		}, nil
 	case "unload_module.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -7045,14 +6901,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 				return int((*Event)(ctx.Object).UnloadModule.SyscallEvent.Retval)
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-		}, nil
-	case "utimes.async":
-		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool {
-				return (*Event)(ctx.Object).Utimes.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -7183,12 +7031,11 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 }
 func (e *Event) GetFields() []eval.Field {
 	return []eval.Field{
+		"async",
 		"bind.addr.family",
 		"bind.addr.ip",
 		"bind.addr.port",
-		"bind.async",
 		"bind.retval",
-		"bpf.async",
 		"bpf.cmd",
 		"bpf.map.name",
 		"bpf.map.type",
@@ -7200,7 +7047,6 @@ func (e *Event) GetFields() []eval.Field {
 		"bpf.retval",
 		"capset.cap_effective",
 		"capset.cap_permitted",
-		"chmod.async",
 		"chmod.file.change_time",
 		"chmod.file.destination.mode",
 		"chmod.file.destination.rights",
@@ -7218,7 +7064,6 @@ func (e *Event) GetFields() []eval.Field {
 		"chmod.file.uid",
 		"chmod.file.user",
 		"chmod.retval",
-		"chown.async",
 		"chown.file.change_time",
 		"chown.file.destination.gid",
 		"chown.file.destination.group",
@@ -7290,7 +7135,6 @@ func (e *Event) GetFields() []eval.Field {
 		"exec.tty_name",
 		"exec.uid",
 		"exec.user",
-		"link.async",
 		"link.file.change_time",
 		"link.file.destination.change_time",
 		"link.file.destination.filesystem",
@@ -7320,7 +7164,6 @@ func (e *Event) GetFields() []eval.Field {
 		"link.file.uid",
 		"link.file.user",
 		"link.retval",
-		"load_module.async",
 		"load_module.file.change_time",
 		"load_module.file.filesystem",
 		"load_module.file.gid",
@@ -7338,7 +7181,6 @@ func (e *Event) GetFields() []eval.Field {
 		"load_module.loaded_from_memory",
 		"load_module.name",
 		"load_module.retval",
-		"mkdir.async",
 		"mkdir.file.change_time",
 		"mkdir.file.destination.mode",
 		"mkdir.file.destination.rights",
@@ -7356,7 +7198,6 @@ func (e *Event) GetFields() []eval.Field {
 		"mkdir.file.uid",
 		"mkdir.file.user",
 		"mkdir.retval",
-		"mmap.async",
 		"mmap.file.change_time",
 		"mmap.file.filesystem",
 		"mmap.file.gid",
@@ -7374,7 +7215,6 @@ func (e *Event) GetFields() []eval.Field {
 		"mmap.flags",
 		"mmap.protection",
 		"mmap.retval",
-		"mprotect.async",
 		"mprotect.req_protection",
 		"mprotect.retval",
 		"mprotect.vm_protection",
@@ -7387,7 +7227,6 @@ func (e *Event) GetFields() []eval.Field {
 		"network.size",
 		"network.source.ip",
 		"network.source.port",
-		"open.async",
 		"open.file.change_time",
 		"open.file.destination.mode",
 		"open.file.filesystem",
@@ -7495,7 +7334,6 @@ func (e *Event) GetFields() []eval.Field {
 		"process.tty_name",
 		"process.uid",
 		"process.user",
-		"ptrace.async",
 		"ptrace.request",
 		"ptrace.retval",
 		"ptrace.tracee.ancestors.args",
@@ -7588,7 +7426,6 @@ func (e *Event) GetFields() []eval.Field {
 		"ptrace.tracee.tty_name",
 		"ptrace.tracee.uid",
 		"ptrace.tracee.user",
-		"removexattr.async",
 		"removexattr.file.change_time",
 		"removexattr.file.destination.name",
 		"removexattr.file.destination.namespace",
@@ -7606,7 +7443,6 @@ func (e *Event) GetFields() []eval.Field {
 		"removexattr.file.uid",
 		"removexattr.file.user",
 		"removexattr.retval",
-		"rename.async",
 		"rename.file.change_time",
 		"rename.file.destination.change_time",
 		"rename.file.destination.filesystem",
@@ -7636,7 +7472,6 @@ func (e *Event) GetFields() []eval.Field {
 		"rename.file.uid",
 		"rename.file.user",
 		"rename.retval",
-		"rmdir.async",
 		"rmdir.file.change_time",
 		"rmdir.file.filesystem",
 		"rmdir.file.gid",
@@ -7668,7 +7503,6 @@ func (e *Event) GetFields() []eval.Field {
 		"setuid.fsuser",
 		"setuid.uid",
 		"setuid.user",
-		"setxattr.async",
 		"setxattr.file.change_time",
 		"setxattr.file.destination.name",
 		"setxattr.file.destination.namespace",
@@ -7686,7 +7520,6 @@ func (e *Event) GetFields() []eval.Field {
 		"setxattr.file.uid",
 		"setxattr.file.user",
 		"setxattr.retval",
-		"signal.async",
 		"signal.pid",
 		"signal.retval",
 		"signal.target.ancestors.args",
@@ -7780,7 +7613,6 @@ func (e *Event) GetFields() []eval.Field {
 		"signal.target.uid",
 		"signal.target.user",
 		"signal.type",
-		"splice.async",
 		"splice.file.change_time",
 		"splice.file.filesystem",
 		"splice.file.gid",
@@ -7798,7 +7630,6 @@ func (e *Event) GetFields() []eval.Field {
 		"splice.pipe_entry_flag",
 		"splice.pipe_exit_flag",
 		"splice.retval",
-		"unlink.async",
 		"unlink.file.change_time",
 		"unlink.file.filesystem",
 		"unlink.file.gid",
@@ -7814,10 +7645,8 @@ func (e *Event) GetFields() []eval.Field {
 		"unlink.file.uid",
 		"unlink.file.user",
 		"unlink.retval",
-		"unload_module.async",
 		"unload_module.name",
 		"unload_module.retval",
-		"utimes.async",
 		"utimes.file.change_time",
 		"utimes.file.filesystem",
 		"utimes.file.gid",
@@ -7837,18 +7666,16 @@ func (e *Event) GetFields() []eval.Field {
 }
 func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	switch field {
+	case "async":
+		return e.Async, nil
 	case "bind.addr.family":
 		return int(e.Bind.AddrFamily), nil
 	case "bind.addr.ip":
 		return e.Bind.Addr.IPNet, nil
 	case "bind.addr.port":
 		return int(e.Bind.Addr.Port), nil
-	case "bind.async":
-		return e.Bind.SyscallEvent.Async, nil
 	case "bind.retval":
 		return int(e.Bind.SyscallEvent.Retval), nil
-	case "bpf.async":
-		return e.BPF.SyscallEvent.Async, nil
 	case "bpf.cmd":
 		return int(e.BPF.Cmd), nil
 	case "bpf.map.name":
@@ -7875,8 +7702,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return int(e.Capset.CapEffective), nil
 	case "capset.cap_permitted":
 		return int(e.Capset.CapPermitted), nil
-	case "chmod.async":
-		return e.Chmod.SyscallEvent.Async, nil
 	case "chmod.file.change_time":
 		return int(e.Chmod.File.FileFields.CTime), nil
 	case "chmod.file.destination.mode":
@@ -7911,8 +7736,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.ResolveFileFieldsUser(&e.Chmod.File.FileFields), nil
 	case "chmod.retval":
 		return int(e.Chmod.SyscallEvent.Retval), nil
-	case "chown.async":
-		return e.Chown.SyscallEvent.Async, nil
 	case "chown.file.change_time":
 		return int(e.Chown.File.FileFields.CTime), nil
 	case "chown.file.destination.gid":
@@ -8055,8 +7878,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return int(e.Exec.Process.Credentials.UID), nil
 	case "exec.user":
 		return e.Exec.Process.Credentials.User, nil
-	case "link.async":
-		return e.Link.SyscallEvent.Async, nil
 	case "link.file.change_time":
 		return int(e.Link.Source.FileFields.CTime), nil
 	case "link.file.destination.change_time":
@@ -8115,8 +7936,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.ResolveFileFieldsUser(&e.Link.Source.FileFields), nil
 	case "link.retval":
 		return int(e.Link.SyscallEvent.Retval), nil
-	case "load_module.async":
-		return e.LoadModule.SyscallEvent.Async, nil
 	case "load_module.file.change_time":
 		return int(e.LoadModule.File.FileFields.CTime), nil
 	case "load_module.file.filesystem":
@@ -8151,8 +7970,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.LoadModule.Name, nil
 	case "load_module.retval":
 		return int(e.LoadModule.SyscallEvent.Retval), nil
-	case "mkdir.async":
-		return e.Mkdir.SyscallEvent.Async, nil
 	case "mkdir.file.change_time":
 		return int(e.Mkdir.File.FileFields.CTime), nil
 	case "mkdir.file.destination.mode":
@@ -8187,8 +8004,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.ResolveFileFieldsUser(&e.Mkdir.File.FileFields), nil
 	case "mkdir.retval":
 		return int(e.Mkdir.SyscallEvent.Retval), nil
-	case "mmap.async":
-		return e.MMap.SyscallEvent.Async, nil
 	case "mmap.file.change_time":
 		return int(e.MMap.File.FileFields.CTime), nil
 	case "mmap.file.filesystem":
@@ -8223,8 +8038,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.MMap.Protection, nil
 	case "mmap.retval":
 		return int(e.MMap.SyscallEvent.Retval), nil
-	case "mprotect.async":
-		return e.MProtect.SyscallEvent.Async, nil
 	case "mprotect.req_protection":
 		return e.MProtect.ReqProtection, nil
 	case "mprotect.retval":
@@ -8249,8 +8062,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.NetworkContext.Source.IPNet, nil
 	case "network.source.port":
 		return int(e.NetworkContext.Source.Port), nil
-	case "open.async":
-		return e.Open.SyscallEvent.Async, nil
 	case "open.file.change_time":
 		return int(e.Open.File.FileFields.CTime), nil
 	case "open.file.destination.mode":
@@ -8915,8 +8726,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return int(e.ProcessContext.Process.Credentials.UID), nil
 	case "process.user":
 		return e.ProcessContext.Process.Credentials.User, nil
-	case "ptrace.async":
-		return e.PTrace.SyscallEvent.Async, nil
 	case "ptrace.request":
 		return int(e.PTrace.Request), nil
 	case "ptrace.retval":
@@ -9551,8 +9360,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return int(e.PTrace.Tracee.Process.Credentials.UID), nil
 	case "ptrace.tracee.user":
 		return e.PTrace.Tracee.Process.Credentials.User, nil
-	case "removexattr.async":
-		return e.RemoveXAttr.SyscallEvent.Async, nil
 	case "removexattr.file.change_time":
 		return int(e.RemoveXAttr.File.FileFields.CTime), nil
 	case "removexattr.file.destination.name":
@@ -9587,8 +9394,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.ResolveFileFieldsUser(&e.RemoveXAttr.File.FileFields), nil
 	case "removexattr.retval":
 		return int(e.RemoveXAttr.SyscallEvent.Retval), nil
-	case "rename.async":
-		return e.Rename.SyscallEvent.Async, nil
 	case "rename.file.change_time":
 		return int(e.Rename.Old.FileFields.CTime), nil
 	case "rename.file.destination.change_time":
@@ -9647,8 +9452,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.ResolveFileFieldsUser(&e.Rename.Old.FileFields), nil
 	case "rename.retval":
 		return int(e.Rename.SyscallEvent.Retval), nil
-	case "rmdir.async":
-		return e.Rmdir.SyscallEvent.Async, nil
 	case "rmdir.file.change_time":
 		return int(e.Rmdir.File.FileFields.CTime), nil
 	case "rmdir.file.filesystem":
@@ -9711,8 +9514,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return int(e.SetUID.UID), nil
 	case "setuid.user":
 		return e.ResolveSetuidUser(&e.SetUID), nil
-	case "setxattr.async":
-		return e.SetXAttr.SyscallEvent.Async, nil
 	case "setxattr.file.change_time":
 		return int(e.SetXAttr.File.FileFields.CTime), nil
 	case "setxattr.file.destination.name":
@@ -9747,8 +9548,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.ResolveFileFieldsUser(&e.SetXAttr.File.FileFields), nil
 	case "setxattr.retval":
 		return int(e.SetXAttr.SyscallEvent.Retval), nil
-	case "signal.async":
-		return e.Signal.SyscallEvent.Async, nil
 	case "signal.pid":
 		return int(e.Signal.PID), nil
 	case "signal.retval":
@@ -10385,8 +10184,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.Signal.Target.Process.Credentials.User, nil
 	case "signal.type":
 		return int(e.Signal.Type), nil
-	case "splice.async":
-		return e.Splice.SyscallEvent.Async, nil
 	case "splice.file.change_time":
 		return int(e.Splice.File.FileFields.CTime), nil
 	case "splice.file.filesystem":
@@ -10421,8 +10218,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return int(e.Splice.PipeExitFlag), nil
 	case "splice.retval":
 		return int(e.Splice.SyscallEvent.Retval), nil
-	case "unlink.async":
-		return e.Unlink.SyscallEvent.Async, nil
 	case "unlink.file.change_time":
 		return int(e.Unlink.File.FileFields.CTime), nil
 	case "unlink.file.filesystem":
@@ -10453,14 +10248,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.ResolveFileFieldsUser(&e.Unlink.File.FileFields), nil
 	case "unlink.retval":
 		return int(e.Unlink.SyscallEvent.Retval), nil
-	case "unload_module.async":
-		return e.UnloadModule.SyscallEvent.Async, nil
 	case "unload_module.name":
 		return e.UnloadModule.Name, nil
 	case "unload_module.retval":
 		return int(e.UnloadModule.SyscallEvent.Retval), nil
-	case "utimes.async":
-		return e.Utimes.SyscallEvent.Async, nil
 	case "utimes.file.change_time":
 		return int(e.Utimes.File.FileFields.CTime), nil
 	case "utimes.file.filesystem":
@@ -10496,18 +10287,16 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 }
 func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	switch field {
+	case "async":
+		return "*", nil
 	case "bind.addr.family":
 		return "bind", nil
 	case "bind.addr.ip":
 		return "bind", nil
 	case "bind.addr.port":
 		return "bind", nil
-	case "bind.async":
-		return "bind", nil
 	case "bind.retval":
 		return "bind", nil
-	case "bpf.async":
-		return "bpf", nil
 	case "bpf.cmd":
 		return "bpf", nil
 	case "bpf.map.name":
@@ -10530,8 +10319,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "capset", nil
 	case "capset.cap_permitted":
 		return "capset", nil
-	case "chmod.async":
-		return "chmod", nil
 	case "chmod.file.change_time":
 		return "chmod", nil
 	case "chmod.file.destination.mode":
@@ -10566,8 +10353,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "chmod", nil
 	case "chmod.retval":
 		return "chmod", nil
-	case "chown.async":
-		return "chown", nil
 	case "chown.file.change_time":
 		return "chown", nil
 	case "chown.file.destination.gid":
@@ -10710,8 +10495,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "exec", nil
 	case "exec.user":
 		return "exec", nil
-	case "link.async":
-		return "link", nil
 	case "link.file.change_time":
 		return "link", nil
 	case "link.file.destination.change_time":
@@ -10770,8 +10553,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "link", nil
 	case "link.retval":
 		return "link", nil
-	case "load_module.async":
-		return "load_module", nil
 	case "load_module.file.change_time":
 		return "load_module", nil
 	case "load_module.file.filesystem":
@@ -10806,8 +10587,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "load_module", nil
 	case "load_module.retval":
 		return "load_module", nil
-	case "mkdir.async":
-		return "mkdir", nil
 	case "mkdir.file.change_time":
 		return "mkdir", nil
 	case "mkdir.file.destination.mode":
@@ -10842,8 +10621,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "mkdir", nil
 	case "mkdir.retval":
 		return "mkdir", nil
-	case "mmap.async":
-		return "mmap", nil
 	case "mmap.file.change_time":
 		return "mmap", nil
 	case "mmap.file.filesystem":
@@ -10878,8 +10655,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "mmap", nil
 	case "mmap.retval":
 		return "mmap", nil
-	case "mprotect.async":
-		return "mprotect", nil
 	case "mprotect.req_protection":
 		return "mprotect", nil
 	case "mprotect.retval":
@@ -10904,8 +10679,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "*", nil
 	case "network.source.port":
 		return "*", nil
-	case "open.async":
-		return "open", nil
 	case "open.file.change_time":
 		return "open", nil
 	case "open.file.destination.mode":
@@ -11120,8 +10893,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "*", nil
 	case "process.user":
 		return "*", nil
-	case "ptrace.async":
-		return "ptrace", nil
 	case "ptrace.request":
 		return "ptrace", nil
 	case "ptrace.retval":
@@ -11306,8 +11077,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "ptrace", nil
 	case "ptrace.tracee.user":
 		return "ptrace", nil
-	case "removexattr.async":
-		return "removexattr", nil
 	case "removexattr.file.change_time":
 		return "removexattr", nil
 	case "removexattr.file.destination.name":
@@ -11342,8 +11111,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "removexattr", nil
 	case "removexattr.retval":
 		return "removexattr", nil
-	case "rename.async":
-		return "rename", nil
 	case "rename.file.change_time":
 		return "rename", nil
 	case "rename.file.destination.change_time":
@@ -11402,8 +11169,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "rename", nil
 	case "rename.retval":
 		return "rename", nil
-	case "rmdir.async":
-		return "rmdir", nil
 	case "rmdir.file.change_time":
 		return "rmdir", nil
 	case "rmdir.file.filesystem":
@@ -11466,8 +11231,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "setuid", nil
 	case "setuid.user":
 		return "setuid", nil
-	case "setxattr.async":
-		return "setxattr", nil
 	case "setxattr.file.change_time":
 		return "setxattr", nil
 	case "setxattr.file.destination.name":
@@ -11502,8 +11265,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "setxattr", nil
 	case "setxattr.retval":
 		return "setxattr", nil
-	case "signal.async":
-		return "signal", nil
 	case "signal.pid":
 		return "signal", nil
 	case "signal.retval":
@@ -11690,8 +11451,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "signal", nil
 	case "signal.type":
 		return "signal", nil
-	case "splice.async":
-		return "splice", nil
 	case "splice.file.change_time":
 		return "splice", nil
 	case "splice.file.filesystem":
@@ -11726,8 +11485,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "splice", nil
 	case "splice.retval":
 		return "splice", nil
-	case "unlink.async":
-		return "unlink", nil
 	case "unlink.file.change_time":
 		return "unlink", nil
 	case "unlink.file.filesystem":
@@ -11758,14 +11515,10 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "unlink", nil
 	case "unlink.retval":
 		return "unlink", nil
-	case "unload_module.async":
-		return "unload_module", nil
 	case "unload_module.name":
 		return "unload_module", nil
 	case "unload_module.retval":
 		return "unload_module", nil
-	case "utimes.async":
-		return "utimes", nil
 	case "utimes.file.change_time":
 		return "utimes", nil
 	case "utimes.file.filesystem":
@@ -11801,18 +11554,16 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 }
 func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	switch field {
+	case "async":
+		return reflect.Bool, nil
 	case "bind.addr.family":
 		return reflect.Int, nil
 	case "bind.addr.ip":
 		return reflect.Struct, nil
 	case "bind.addr.port":
 		return reflect.Int, nil
-	case "bind.async":
-		return reflect.Bool, nil
 	case "bind.retval":
 		return reflect.Int, nil
-	case "bpf.async":
-		return reflect.Bool, nil
 	case "bpf.cmd":
 		return reflect.Int, nil
 	case "bpf.map.name":
@@ -11835,8 +11586,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 	case "capset.cap_permitted":
 		return reflect.Int, nil
-	case "chmod.async":
-		return reflect.Bool, nil
 	case "chmod.file.change_time":
 		return reflect.Int, nil
 	case "chmod.file.destination.mode":
@@ -11871,8 +11620,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.String, nil
 	case "chmod.retval":
 		return reflect.Int, nil
-	case "chown.async":
-		return reflect.Bool, nil
 	case "chown.file.change_time":
 		return reflect.Int, nil
 	case "chown.file.destination.gid":
@@ -12015,8 +11762,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 	case "exec.user":
 		return reflect.String, nil
-	case "link.async":
-		return reflect.Bool, nil
 	case "link.file.change_time":
 		return reflect.Int, nil
 	case "link.file.destination.change_time":
@@ -12075,8 +11820,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.String, nil
 	case "link.retval":
 		return reflect.Int, nil
-	case "load_module.async":
-		return reflect.Bool, nil
 	case "load_module.file.change_time":
 		return reflect.Int, nil
 	case "load_module.file.filesystem":
@@ -12111,8 +11854,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.String, nil
 	case "load_module.retval":
 		return reflect.Int, nil
-	case "mkdir.async":
-		return reflect.Bool, nil
 	case "mkdir.file.change_time":
 		return reflect.Int, nil
 	case "mkdir.file.destination.mode":
@@ -12147,8 +11888,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.String, nil
 	case "mkdir.retval":
 		return reflect.Int, nil
-	case "mmap.async":
-		return reflect.Bool, nil
 	case "mmap.file.change_time":
 		return reflect.Int, nil
 	case "mmap.file.filesystem":
@@ -12183,8 +11922,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 	case "mmap.retval":
 		return reflect.Int, nil
-	case "mprotect.async":
-		return reflect.Bool, nil
 	case "mprotect.req_protection":
 		return reflect.Int, nil
 	case "mprotect.retval":
@@ -12209,8 +11946,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Struct, nil
 	case "network.source.port":
 		return reflect.Int, nil
-	case "open.async":
-		return reflect.Bool, nil
 	case "open.file.change_time":
 		return reflect.Int, nil
 	case "open.file.destination.mode":
@@ -12425,8 +12160,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 	case "process.user":
 		return reflect.String, nil
-	case "ptrace.async":
-		return reflect.Bool, nil
 	case "ptrace.request":
 		return reflect.Int, nil
 	case "ptrace.retval":
@@ -12611,8 +12344,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 	case "ptrace.tracee.user":
 		return reflect.String, nil
-	case "removexattr.async":
-		return reflect.Bool, nil
 	case "removexattr.file.change_time":
 		return reflect.Int, nil
 	case "removexattr.file.destination.name":
@@ -12647,8 +12378,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.String, nil
 	case "removexattr.retval":
 		return reflect.Int, nil
-	case "rename.async":
-		return reflect.Bool, nil
 	case "rename.file.change_time":
 		return reflect.Int, nil
 	case "rename.file.destination.change_time":
@@ -12707,8 +12436,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.String, nil
 	case "rename.retval":
 		return reflect.Int, nil
-	case "rmdir.async":
-		return reflect.Bool, nil
 	case "rmdir.file.change_time":
 		return reflect.Int, nil
 	case "rmdir.file.filesystem":
@@ -12771,8 +12498,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 	case "setuid.user":
 		return reflect.String, nil
-	case "setxattr.async":
-		return reflect.Bool, nil
 	case "setxattr.file.change_time":
 		return reflect.Int, nil
 	case "setxattr.file.destination.name":
@@ -12807,8 +12532,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.String, nil
 	case "setxattr.retval":
 		return reflect.Int, nil
-	case "signal.async":
-		return reflect.Bool, nil
 	case "signal.pid":
 		return reflect.Int, nil
 	case "signal.retval":
@@ -12995,8 +12718,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.String, nil
 	case "signal.type":
 		return reflect.Int, nil
-	case "splice.async":
-		return reflect.Bool, nil
 	case "splice.file.change_time":
 		return reflect.Int, nil
 	case "splice.file.filesystem":
@@ -13031,8 +12752,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 	case "splice.retval":
 		return reflect.Int, nil
-	case "unlink.async":
-		return reflect.Bool, nil
 	case "unlink.file.change_time":
 		return reflect.Int, nil
 	case "unlink.file.filesystem":
@@ -13063,14 +12782,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.String, nil
 	case "unlink.retval":
 		return reflect.Int, nil
-	case "unload_module.async":
-		return reflect.Bool, nil
 	case "unload_module.name":
 		return reflect.String, nil
 	case "unload_module.retval":
 		return reflect.Int, nil
-	case "utimes.async":
-		return reflect.Bool, nil
 	case "utimes.file.change_time":
 		return reflect.Int, nil
 	case "utimes.file.filesystem":
@@ -13106,6 +12821,12 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 }
 func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	switch field {
+	case "async":
+		var ok bool
+		if e.Async, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Async"}
+		}
+		return nil
 	case "bind.addr.family":
 		v, ok := value.(int)
 		if !ok {
@@ -13127,24 +12848,12 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Bind.Addr.Port = uint16(v)
 		return nil
-	case "bind.async":
-		var ok bool
-		if e.Bind.SyscallEvent.Async, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Bind.SyscallEvent.Async"}
-		}
-		return nil
 	case "bind.retval":
 		v, ok := value.(int)
 		if !ok {
 			return &eval.ErrValueTypeMismatch{Field: "Bind.SyscallEvent.Retval"}
 		}
 		e.Bind.SyscallEvent.Retval = int64(v)
-		return nil
-	case "bpf.async":
-		var ok bool
-		if e.BPF.SyscallEvent.Async, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "BPF.SyscallEvent.Async"}
-		}
 		return nil
 	case "bpf.cmd":
 		v, ok := value.(int)
@@ -13222,12 +12931,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "Capset.CapPermitted"}
 		}
 		e.Capset.CapPermitted = uint64(v)
-		return nil
-	case "chmod.async":
-		var ok bool
-		if e.Chmod.SyscallEvent.Async, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Chmod.SyscallEvent.Async"}
-		}
 		return nil
 	case "chmod.file.change_time":
 		v, ok := value.(int)
@@ -13346,12 +13049,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "Chmod.SyscallEvent.Retval"}
 		}
 		e.Chmod.SyscallEvent.Retval = int64(v)
-		return nil
-	case "chown.async":
-		var ok bool
-		if e.Chown.SyscallEvent.Async, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Chown.SyscallEvent.Async"}
-		}
 		return nil
 	case "chown.file.change_time":
 		v, ok := value.(int)
@@ -13981,12 +13678,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Exec.Process.Credentials.User = str
 		return nil
-	case "link.async":
-		var ok bool
-		if e.Link.SyscallEvent.Async, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Link.SyscallEvent.Async"}
-		}
-		return nil
 	case "link.file.change_time":
 		v, ok := value.(int)
 		if !ok {
@@ -14188,12 +13879,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Link.SyscallEvent.Retval = int64(v)
 		return nil
-	case "load_module.async":
-		var ok bool
-		if e.LoadModule.SyscallEvent.Async, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "LoadModule.SyscallEvent.Async"}
-		}
-		return nil
 	case "load_module.file.change_time":
 		v, ok := value.(int)
 		if !ok {
@@ -14310,12 +13995,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "LoadModule.SyscallEvent.Retval"}
 		}
 		e.LoadModule.SyscallEvent.Retval = int64(v)
-		return nil
-	case "mkdir.async":
-		var ok bool
-		if e.Mkdir.SyscallEvent.Async, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Mkdir.SyscallEvent.Async"}
-		}
 		return nil
 	case "mkdir.file.change_time":
 		v, ok := value.(int)
@@ -14435,12 +14114,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Mkdir.SyscallEvent.Retval = int64(v)
 		return nil
-	case "mmap.async":
-		var ok bool
-		if e.MMap.SyscallEvent.Async, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "MMap.SyscallEvent.Async"}
-		}
-		return nil
 	case "mmap.file.change_time":
 		v, ok := value.(int)
 		if !ok {
@@ -14559,12 +14232,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.MMap.SyscallEvent.Retval = int64(v)
 		return nil
-	case "mprotect.async":
-		var ok bool
-		if e.MProtect.SyscallEvent.Async, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "MProtect.SyscallEvent.Async"}
-		}
-		return nil
 	case "mprotect.req_protection":
 		v, ok := value.(int)
 		if !ok {
@@ -14648,12 +14315,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "NetworkContext.Source.Port"}
 		}
 		e.NetworkContext.Source.Port = uint16(v)
-		return nil
-	case "open.async":
-		var ok bool
-		if e.Open.SyscallEvent.Async, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Open.SyscallEvent.Async"}
-		}
 		return nil
 	case "open.file.change_time":
 		v, ok := value.(int)
@@ -15802,12 +15463,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.ProcessContext.Process.Credentials.User = str
 		return nil
-	case "ptrace.async":
-		var ok bool
-		if e.PTrace.SyscallEvent.Async, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.SyscallEvent.Async"}
-		}
-		return nil
 	case "ptrace.request":
 		v, ok := value.(int)
 		if !ok {
@@ -16851,12 +16506,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.PTrace.Tracee.Process.Credentials.User = str
 		return nil
-	case "removexattr.async":
-		var ok bool
-		if e.RemoveXAttr.SyscallEvent.Async, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.SyscallEvent.Async"}
-		}
-		return nil
 	case "removexattr.file.change_time":
 		v, ok := value.(int)
 		if !ok {
@@ -16974,12 +16623,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.SyscallEvent.Retval"}
 		}
 		e.RemoveXAttr.SyscallEvent.Retval = int64(v)
-		return nil
-	case "rename.async":
-		var ok bool
-		if e.Rename.SyscallEvent.Async, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Rename.SyscallEvent.Async"}
-		}
 		return nil
 	case "rename.file.change_time":
 		v, ok := value.(int)
@@ -17181,12 +16824,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "Rename.SyscallEvent.Retval"}
 		}
 		e.Rename.SyscallEvent.Retval = int64(v)
-		return nil
-	case "rmdir.async":
-		var ok bool
-		if e.Rmdir.SyscallEvent.Async, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Rmdir.SyscallEvent.Async"}
-		}
 		return nil
 	case "rmdir.file.change_time":
 		v, ok := value.(int)
@@ -17403,12 +17040,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.SetUID.User = str
 		return nil
-	case "setxattr.async":
-		var ok bool
-		if e.SetXAttr.SyscallEvent.Async, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.SyscallEvent.Async"}
-		}
-		return nil
 	case "setxattr.file.change_time":
 		v, ok := value.(int)
 		if !ok {
@@ -17526,12 +17157,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.SyscallEvent.Retval"}
 		}
 		e.SetXAttr.SyscallEvent.Retval = int64(v)
-		return nil
-	case "signal.async":
-		var ok bool
-		if e.Signal.SyscallEvent.Async, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.SyscallEvent.Async"}
-		}
 		return nil
 	case "signal.pid":
 		v, ok := value.(int)
@@ -18583,12 +18208,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Signal.Type = uint32(v)
 		return nil
-	case "splice.async":
-		var ok bool
-		if e.Splice.SyscallEvent.Async, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Splice.SyscallEvent.Async"}
-		}
-		return nil
 	case "splice.file.change_time":
 		v, ok := value.(int)
 		if !ok {
@@ -18707,12 +18326,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Splice.SyscallEvent.Retval = int64(v)
 		return nil
-	case "unlink.async":
-		var ok bool
-		if e.Unlink.SyscallEvent.Async, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Unlink.SyscallEvent.Async"}
-		}
-		return nil
 	case "unlink.file.change_time":
 		v, ok := value.(int)
 		if !ok {
@@ -18817,12 +18430,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Unlink.SyscallEvent.Retval = int64(v)
 		return nil
-	case "unload_module.async":
-		var ok bool
-		if e.UnloadModule.SyscallEvent.Async, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "UnloadModule.SyscallEvent.Async"}
-		}
-		return nil
 	case "unload_module.name":
 		str, ok := value.(string)
 		if !ok {
@@ -18836,12 +18443,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "UnloadModule.SyscallEvent.Retval"}
 		}
 		e.UnloadModule.SyscallEvent.Retval = int64(v)
-		return nil
-	case "utimes.async":
-		var ok bool
-		if e.Utimes.SyscallEvent.Async, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Utimes.SyscallEvent.Async"}
-		}
 		return nil
 	case "utimes.file.change_time":
 		v, ok := value.(int)

--- a/pkg/security/probe/activity_dump.go
+++ b/pkg/security/probe/activity_dump.go
@@ -884,7 +884,7 @@ func (pan *ProcessActivityNode) snapshotFiles(p *process.Process, ad *ActivityDu
 		}
 
 		evt := NewEvent(ad.adm.probe.resolvers, ad.adm.probe.scrubber, ad.adm.probe)
-		evt.Event.Type = uint64(model.FileOpenEventType)
+		evt.Event.Type = uint32(model.FileOpenEventType)
 
 		resolvedPath, err = filepath.EvalSymlinks(f)
 		if err != nil {

--- a/pkg/security/probe/serializers.go
+++ b/pkg/security/probe/serializers.go
@@ -798,7 +798,7 @@ func NewEventSerializer(event *Event) *EventSerializer {
 			Destination:    newFileSerializer(&event.Link.Target, event, event.Link.Source.Inode),
 		}
 		s.EventContextSerializer.Outcome = serializeSyscallRetval(event.Link.Retval)
-		s.EventContextSerializer.Async = event.Link.Async
+		s.Async = event.Async
 	case model.FileOpenEventType:
 		s.FileEventSerializer = &FileEventSerializer{
 			FileSerializer: *newFileSerializer(&event.Open.File, event),
@@ -812,7 +812,7 @@ func NewEventSerializer(event *Event) *EventSerializer {
 
 		s.FileSerializer.Flags = model.OpenFlags(event.Open.Flags).StringArray()
 		s.EventContextSerializer.Outcome = serializeSyscallRetval(event.Open.Retval)
-		s.EventContextSerializer.Async = event.Open.Async
+		s.Async = event.Async
 	case model.FileMkdirEventType:
 		s.FileEventSerializer = &FileEventSerializer{
 			FileSerializer: *newFileSerializer(&event.Mkdir.File, event),
@@ -821,20 +821,20 @@ func NewEventSerializer(event *Event) *EventSerializer {
 			},
 		}
 		s.EventContextSerializer.Outcome = serializeSyscallRetval(event.Mkdir.Retval)
-		s.EventContextSerializer.Async = event.Mkdir.Async
+		s.Async = event.Async
 	case model.FileRmdirEventType:
 		s.FileEventSerializer = &FileEventSerializer{
 			FileSerializer: *newFileSerializer(&event.Rmdir.File, event),
 		}
 		s.EventContextSerializer.Outcome = serializeSyscallRetval(event.Rmdir.Retval)
-		s.EventContextSerializer.Async = event.Rmdir.Async
+		s.Async = event.Async
 	case model.FileUnlinkEventType:
 		s.FileEventSerializer = &FileEventSerializer{
 			FileSerializer: *newFileSerializer(&event.Unlink.File, event),
 		}
 		s.FileSerializer.Flags = model.UnlinkFlags(event.Unlink.Flags).StringArray()
 		s.EventContextSerializer.Outcome = serializeSyscallRetval(event.Unlink.Retval)
-		s.EventContextSerializer.Async = event.Unlink.Async
+		s.Async = event.Async
 	case model.FileRenameEventType:
 		// use the new inode as the old one is a fake inode
 		s.FileEventSerializer = &FileEventSerializer{
@@ -842,7 +842,7 @@ func NewEventSerializer(event *Event) *EventSerializer {
 			Destination:    newFileSerializer(&event.Rename.New, event),
 		}
 		s.EventContextSerializer.Outcome = serializeSyscallRetval(event.Rename.Retval)
-		s.EventContextSerializer.Async = event.Rename.Async
+		s.Async = event.Async
 	case model.FileRemoveXAttrEventType:
 		s.FileEventSerializer = &FileEventSerializer{
 			FileSerializer: *newFileSerializer(&event.RemoveXAttr.File, event),

--- a/pkg/security/secl/model/accessors.go
+++ b/pkg/security/secl/model/accessors.go
@@ -56,6 +56,14 @@ func (m *Model) GetEventTypes() []eval.EventType {
 }
 func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Evaluator, error) {
 	switch field {
+	case "async":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				return (*Event)(ctx.Object).Async
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
 	case "bind.addr.family":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -80,26 +88,10 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.FunctionWeight,
 		}, nil
-	case "bind.async":
-		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool {
-				return (*Event)(ctx.Object).Bind.SyscallEvent.Async
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-		}, nil
 	case "bind.retval":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 				return int((*Event)(ctx.Object).Bind.SyscallEvent.Retval)
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-		}, nil
-	case "bpf.async":
-		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool {
-				return (*Event)(ctx.Object).BPF.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -192,14 +184,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 				return int((*Event)(ctx.Object).Capset.CapPermitted)
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-		}, nil
-	case "chmod.async":
-		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool {
-				return (*Event)(ctx.Object).Chmod.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -337,14 +321,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 				return int((*Event)(ctx.Object).Chmod.SyscallEvent.Retval)
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-		}, nil
-	case "chown.async":
-		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool {
-				return (*Event)(ctx.Object).Chown.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -920,14 +896,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.FunctionWeight,
 		}, nil
-	case "link.async":
-		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool {
-				return (*Event)(ctx.Object).Link.SyscallEvent.Async
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-		}, nil
 	case "link.file.change_time":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -1162,14 +1130,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.FunctionWeight,
 		}, nil
-	case "load_module.async":
-		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool {
-				return (*Event)(ctx.Object).LoadModule.SyscallEvent.Async
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-		}, nil
 	case "load_module.file.change_time":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -1303,14 +1263,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 				return int((*Event)(ctx.Object).LoadModule.SyscallEvent.Retval)
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-		}, nil
-	case "mkdir.async":
-		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool {
-				return (*Event)(ctx.Object).Mkdir.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -1452,14 +1404,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.FunctionWeight,
 		}, nil
-	case "mmap.async":
-		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool {
-				return (*Event)(ctx.Object).MMap.SyscallEvent.Async
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-		}, nil
 	case "mmap.file.change_time":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -1597,14 +1541,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.FunctionWeight,
 		}, nil
-	case "mprotect.async":
-		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool {
-				return (*Event)(ctx.Object).MProtect.SyscallEvent.Async
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-		}, nil
 	case "mprotect.req_protection":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -1697,14 +1633,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 				return int((*Event)(ctx.Object).NetworkContext.Source.Port)
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-		}, nil
-	case "open.async":
-		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool {
-				return (*Event)(ctx.Object).Open.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -2928,14 +2856,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.FunctionWeight,
 		}, nil
-	case "ptrace.async":
-		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool {
-				return (*Event)(ctx.Object).PTrace.SyscallEvent.Async
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-		}, nil
 	case "ptrace.request":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -4034,14 +3954,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.FunctionWeight,
 		}, nil
-	case "removexattr.async":
-		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool {
-				return (*Event)(ctx.Object).RemoveXAttr.SyscallEvent.Async
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-		}, nil
 	case "removexattr.file.change_time":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -4175,14 +4087,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 				return int((*Event)(ctx.Object).RemoveXAttr.SyscallEvent.Retval)
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-		}, nil
-	case "rename.async":
-		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool {
-				return (*Event)(ctx.Object).Rename.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -4417,14 +4321,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 				return int((*Event)(ctx.Object).Rename.SyscallEvent.Retval)
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-		}, nil
-	case "rmdir.async":
-		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool {
-				return (*Event)(ctx.Object).Rmdir.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -4678,14 +4574,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.HandlerWeight,
 		}, nil
-	case "setxattr.async":
-		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool {
-				return (*Event)(ctx.Object).SetXAttr.SyscallEvent.Async
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-		}, nil
 	case "setxattr.file.change_time":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -4819,14 +4707,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 				return int((*Event)(ctx.Object).SetXAttr.SyscallEvent.Retval)
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-		}, nil
-	case "signal.async":
-		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool {
-				return (*Event)(ctx.Object).Signal.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -5937,14 +5817,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.FunctionWeight,
 		}, nil
-	case "splice.async":
-		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool {
-				return (*Event)(ctx.Object).Splice.SyscallEvent.Async
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-		}, nil
 	case "splice.file.change_time":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -6082,14 +5954,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.FunctionWeight,
 		}, nil
-	case "unlink.async":
-		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool {
-				return (*Event)(ctx.Object).Unlink.SyscallEvent.Async
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-		}, nil
 	case "unlink.file.change_time":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -6211,14 +6075,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.FunctionWeight,
 		}, nil
-	case "unload_module.async":
-		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool {
-				return (*Event)(ctx.Object).UnloadModule.SyscallEvent.Async
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-		}, nil
 	case "unload_module.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -6231,14 +6087,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 				return int((*Event)(ctx.Object).UnloadModule.SyscallEvent.Retval)
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-		}, nil
-	case "utimes.async":
-		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool {
-				return (*Event)(ctx.Object).Utimes.SyscallEvent.Async
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -6369,12 +6217,11 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 }
 func (e *Event) GetFields() []eval.Field {
 	return []eval.Field{
+		"async",
 		"bind.addr.family",
 		"bind.addr.ip",
 		"bind.addr.port",
-		"bind.async",
 		"bind.retval",
-		"bpf.async",
 		"bpf.cmd",
 		"bpf.map.name",
 		"bpf.map.type",
@@ -6386,7 +6233,6 @@ func (e *Event) GetFields() []eval.Field {
 		"bpf.retval",
 		"capset.cap_effective",
 		"capset.cap_permitted",
-		"chmod.async",
 		"chmod.file.change_time",
 		"chmod.file.destination.mode",
 		"chmod.file.destination.rights",
@@ -6404,7 +6250,6 @@ func (e *Event) GetFields() []eval.Field {
 		"chmod.file.uid",
 		"chmod.file.user",
 		"chmod.retval",
-		"chown.async",
 		"chown.file.change_time",
 		"chown.file.destination.gid",
 		"chown.file.destination.group",
@@ -6476,7 +6321,6 @@ func (e *Event) GetFields() []eval.Field {
 		"exec.tty_name",
 		"exec.uid",
 		"exec.user",
-		"link.async",
 		"link.file.change_time",
 		"link.file.destination.change_time",
 		"link.file.destination.filesystem",
@@ -6506,7 +6350,6 @@ func (e *Event) GetFields() []eval.Field {
 		"link.file.uid",
 		"link.file.user",
 		"link.retval",
-		"load_module.async",
 		"load_module.file.change_time",
 		"load_module.file.filesystem",
 		"load_module.file.gid",
@@ -6524,7 +6367,6 @@ func (e *Event) GetFields() []eval.Field {
 		"load_module.loaded_from_memory",
 		"load_module.name",
 		"load_module.retval",
-		"mkdir.async",
 		"mkdir.file.change_time",
 		"mkdir.file.destination.mode",
 		"mkdir.file.destination.rights",
@@ -6542,7 +6384,6 @@ func (e *Event) GetFields() []eval.Field {
 		"mkdir.file.uid",
 		"mkdir.file.user",
 		"mkdir.retval",
-		"mmap.async",
 		"mmap.file.change_time",
 		"mmap.file.filesystem",
 		"mmap.file.gid",
@@ -6560,7 +6401,6 @@ func (e *Event) GetFields() []eval.Field {
 		"mmap.flags",
 		"mmap.protection",
 		"mmap.retval",
-		"mprotect.async",
 		"mprotect.req_protection",
 		"mprotect.retval",
 		"mprotect.vm_protection",
@@ -6573,7 +6413,6 @@ func (e *Event) GetFields() []eval.Field {
 		"network.size",
 		"network.source.ip",
 		"network.source.port",
-		"open.async",
 		"open.file.change_time",
 		"open.file.destination.mode",
 		"open.file.filesystem",
@@ -6681,7 +6520,6 @@ func (e *Event) GetFields() []eval.Field {
 		"process.tty_name",
 		"process.uid",
 		"process.user",
-		"ptrace.async",
 		"ptrace.request",
 		"ptrace.retval",
 		"ptrace.tracee.ancestors.args",
@@ -6774,7 +6612,6 @@ func (e *Event) GetFields() []eval.Field {
 		"ptrace.tracee.tty_name",
 		"ptrace.tracee.uid",
 		"ptrace.tracee.user",
-		"removexattr.async",
 		"removexattr.file.change_time",
 		"removexattr.file.destination.name",
 		"removexattr.file.destination.namespace",
@@ -6792,7 +6629,6 @@ func (e *Event) GetFields() []eval.Field {
 		"removexattr.file.uid",
 		"removexattr.file.user",
 		"removexattr.retval",
-		"rename.async",
 		"rename.file.change_time",
 		"rename.file.destination.change_time",
 		"rename.file.destination.filesystem",
@@ -6822,7 +6658,6 @@ func (e *Event) GetFields() []eval.Field {
 		"rename.file.uid",
 		"rename.file.user",
 		"rename.retval",
-		"rmdir.async",
 		"rmdir.file.change_time",
 		"rmdir.file.filesystem",
 		"rmdir.file.gid",
@@ -6854,7 +6689,6 @@ func (e *Event) GetFields() []eval.Field {
 		"setuid.fsuser",
 		"setuid.uid",
 		"setuid.user",
-		"setxattr.async",
 		"setxattr.file.change_time",
 		"setxattr.file.destination.name",
 		"setxattr.file.destination.namespace",
@@ -6872,7 +6706,6 @@ func (e *Event) GetFields() []eval.Field {
 		"setxattr.file.uid",
 		"setxattr.file.user",
 		"setxattr.retval",
-		"signal.async",
 		"signal.pid",
 		"signal.retval",
 		"signal.target.ancestors.args",
@@ -6966,7 +6799,6 @@ func (e *Event) GetFields() []eval.Field {
 		"signal.target.uid",
 		"signal.target.user",
 		"signal.type",
-		"splice.async",
 		"splice.file.change_time",
 		"splice.file.filesystem",
 		"splice.file.gid",
@@ -6984,7 +6816,6 @@ func (e *Event) GetFields() []eval.Field {
 		"splice.pipe_entry_flag",
 		"splice.pipe_exit_flag",
 		"splice.retval",
-		"unlink.async",
 		"unlink.file.change_time",
 		"unlink.file.filesystem",
 		"unlink.file.gid",
@@ -7000,10 +6831,8 @@ func (e *Event) GetFields() []eval.Field {
 		"unlink.file.uid",
 		"unlink.file.user",
 		"unlink.retval",
-		"unload_module.async",
 		"unload_module.name",
 		"unload_module.retval",
-		"utimes.async",
 		"utimes.file.change_time",
 		"utimes.file.filesystem",
 		"utimes.file.gid",
@@ -7023,18 +6852,16 @@ func (e *Event) GetFields() []eval.Field {
 }
 func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	switch field {
+	case "async":
+		return e.Async, nil
 	case "bind.addr.family":
 		return int(e.Bind.AddrFamily), nil
 	case "bind.addr.ip":
 		return e.Bind.Addr.IPNet, nil
 	case "bind.addr.port":
 		return int(e.Bind.Addr.Port), nil
-	case "bind.async":
-		return e.Bind.SyscallEvent.Async, nil
 	case "bind.retval":
 		return int(e.Bind.SyscallEvent.Retval), nil
-	case "bpf.async":
-		return e.BPF.SyscallEvent.Async, nil
 	case "bpf.cmd":
 		return int(e.BPF.Cmd), nil
 	case "bpf.map.name":
@@ -7061,8 +6888,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return int(e.Capset.CapEffective), nil
 	case "capset.cap_permitted":
 		return int(e.Capset.CapPermitted), nil
-	case "chmod.async":
-		return e.Chmod.SyscallEvent.Async, nil
 	case "chmod.file.change_time":
 		return int(e.Chmod.File.FileFields.CTime), nil
 	case "chmod.file.destination.mode":
@@ -7097,8 +6922,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.Chmod.File.FileFields.User, nil
 	case "chmod.retval":
 		return int(e.Chmod.SyscallEvent.Retval), nil
-	case "chown.async":
-		return e.Chown.SyscallEvent.Async, nil
 	case "chown.file.change_time":
 		return int(e.Chown.File.FileFields.CTime), nil
 	case "chown.file.destination.gid":
@@ -7241,8 +7064,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return int(e.Exec.Process.Credentials.UID), nil
 	case "exec.user":
 		return e.Exec.Process.Credentials.User, nil
-	case "link.async":
-		return e.Link.SyscallEvent.Async, nil
 	case "link.file.change_time":
 		return int(e.Link.Source.FileFields.CTime), nil
 	case "link.file.destination.change_time":
@@ -7301,8 +7122,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.Link.Source.FileFields.User, nil
 	case "link.retval":
 		return int(e.Link.SyscallEvent.Retval), nil
-	case "load_module.async":
-		return e.LoadModule.SyscallEvent.Async, nil
 	case "load_module.file.change_time":
 		return int(e.LoadModule.File.FileFields.CTime), nil
 	case "load_module.file.filesystem":
@@ -7337,8 +7156,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.LoadModule.Name, nil
 	case "load_module.retval":
 		return int(e.LoadModule.SyscallEvent.Retval), nil
-	case "mkdir.async":
-		return e.Mkdir.SyscallEvent.Async, nil
 	case "mkdir.file.change_time":
 		return int(e.Mkdir.File.FileFields.CTime), nil
 	case "mkdir.file.destination.mode":
@@ -7373,8 +7190,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.Mkdir.File.FileFields.User, nil
 	case "mkdir.retval":
 		return int(e.Mkdir.SyscallEvent.Retval), nil
-	case "mmap.async":
-		return e.MMap.SyscallEvent.Async, nil
 	case "mmap.file.change_time":
 		return int(e.MMap.File.FileFields.CTime), nil
 	case "mmap.file.filesystem":
@@ -7409,8 +7224,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.MMap.Protection, nil
 	case "mmap.retval":
 		return int(e.MMap.SyscallEvent.Retval), nil
-	case "mprotect.async":
-		return e.MProtect.SyscallEvent.Async, nil
 	case "mprotect.req_protection":
 		return e.MProtect.ReqProtection, nil
 	case "mprotect.retval":
@@ -7435,8 +7248,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.NetworkContext.Source.IPNet, nil
 	case "network.source.port":
 		return int(e.NetworkContext.Source.Port), nil
-	case "open.async":
-		return e.Open.SyscallEvent.Async, nil
 	case "open.file.change_time":
 		return int(e.Open.File.FileFields.CTime), nil
 	case "open.file.destination.mode":
@@ -8101,8 +7912,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return int(e.ProcessContext.Process.Credentials.UID), nil
 	case "process.user":
 		return e.ProcessContext.Process.Credentials.User, nil
-	case "ptrace.async":
-		return e.PTrace.SyscallEvent.Async, nil
 	case "ptrace.request":
 		return int(e.PTrace.Request), nil
 	case "ptrace.retval":
@@ -8737,8 +8546,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return int(e.PTrace.Tracee.Process.Credentials.UID), nil
 	case "ptrace.tracee.user":
 		return e.PTrace.Tracee.Process.Credentials.User, nil
-	case "removexattr.async":
-		return e.RemoveXAttr.SyscallEvent.Async, nil
 	case "removexattr.file.change_time":
 		return int(e.RemoveXAttr.File.FileFields.CTime), nil
 	case "removexattr.file.destination.name":
@@ -8773,8 +8580,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.RemoveXAttr.File.FileFields.User, nil
 	case "removexattr.retval":
 		return int(e.RemoveXAttr.SyscallEvent.Retval), nil
-	case "rename.async":
-		return e.Rename.SyscallEvent.Async, nil
 	case "rename.file.change_time":
 		return int(e.Rename.Old.FileFields.CTime), nil
 	case "rename.file.destination.change_time":
@@ -8833,8 +8638,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.Rename.Old.FileFields.User, nil
 	case "rename.retval":
 		return int(e.Rename.SyscallEvent.Retval), nil
-	case "rmdir.async":
-		return e.Rmdir.SyscallEvent.Async, nil
 	case "rmdir.file.change_time":
 		return int(e.Rmdir.File.FileFields.CTime), nil
 	case "rmdir.file.filesystem":
@@ -8897,8 +8700,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return int(e.SetUID.UID), nil
 	case "setuid.user":
 		return e.SetUID.User, nil
-	case "setxattr.async":
-		return e.SetXAttr.SyscallEvent.Async, nil
 	case "setxattr.file.change_time":
 		return int(e.SetXAttr.File.FileFields.CTime), nil
 	case "setxattr.file.destination.name":
@@ -8933,8 +8734,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.SetXAttr.File.FileFields.User, nil
 	case "setxattr.retval":
 		return int(e.SetXAttr.SyscallEvent.Retval), nil
-	case "signal.async":
-		return e.Signal.SyscallEvent.Async, nil
 	case "signal.pid":
 		return int(e.Signal.PID), nil
 	case "signal.retval":
@@ -9571,8 +9370,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.Signal.Target.Process.Credentials.User, nil
 	case "signal.type":
 		return int(e.Signal.Type), nil
-	case "splice.async":
-		return e.Splice.SyscallEvent.Async, nil
 	case "splice.file.change_time":
 		return int(e.Splice.File.FileFields.CTime), nil
 	case "splice.file.filesystem":
@@ -9607,8 +9404,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return int(e.Splice.PipeExitFlag), nil
 	case "splice.retval":
 		return int(e.Splice.SyscallEvent.Retval), nil
-	case "unlink.async":
-		return e.Unlink.SyscallEvent.Async, nil
 	case "unlink.file.change_time":
 		return int(e.Unlink.File.FileFields.CTime), nil
 	case "unlink.file.filesystem":
@@ -9639,14 +9434,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.Unlink.File.FileFields.User, nil
 	case "unlink.retval":
 		return int(e.Unlink.SyscallEvent.Retval), nil
-	case "unload_module.async":
-		return e.UnloadModule.SyscallEvent.Async, nil
 	case "unload_module.name":
 		return e.UnloadModule.Name, nil
 	case "unload_module.retval":
 		return int(e.UnloadModule.SyscallEvent.Retval), nil
-	case "utimes.async":
-		return e.Utimes.SyscallEvent.Async, nil
 	case "utimes.file.change_time":
 		return int(e.Utimes.File.FileFields.CTime), nil
 	case "utimes.file.filesystem":
@@ -9682,18 +9473,16 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 }
 func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	switch field {
+	case "async":
+		return "*", nil
 	case "bind.addr.family":
 		return "bind", nil
 	case "bind.addr.ip":
 		return "bind", nil
 	case "bind.addr.port":
 		return "bind", nil
-	case "bind.async":
-		return "bind", nil
 	case "bind.retval":
 		return "bind", nil
-	case "bpf.async":
-		return "bpf", nil
 	case "bpf.cmd":
 		return "bpf", nil
 	case "bpf.map.name":
@@ -9716,8 +9505,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "capset", nil
 	case "capset.cap_permitted":
 		return "capset", nil
-	case "chmod.async":
-		return "chmod", nil
 	case "chmod.file.change_time":
 		return "chmod", nil
 	case "chmod.file.destination.mode":
@@ -9752,8 +9539,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "chmod", nil
 	case "chmod.retval":
 		return "chmod", nil
-	case "chown.async":
-		return "chown", nil
 	case "chown.file.change_time":
 		return "chown", nil
 	case "chown.file.destination.gid":
@@ -9896,8 +9681,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "exec", nil
 	case "exec.user":
 		return "exec", nil
-	case "link.async":
-		return "link", nil
 	case "link.file.change_time":
 		return "link", nil
 	case "link.file.destination.change_time":
@@ -9956,8 +9739,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "link", nil
 	case "link.retval":
 		return "link", nil
-	case "load_module.async":
-		return "load_module", nil
 	case "load_module.file.change_time":
 		return "load_module", nil
 	case "load_module.file.filesystem":
@@ -9992,8 +9773,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "load_module", nil
 	case "load_module.retval":
 		return "load_module", nil
-	case "mkdir.async":
-		return "mkdir", nil
 	case "mkdir.file.change_time":
 		return "mkdir", nil
 	case "mkdir.file.destination.mode":
@@ -10028,8 +9807,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "mkdir", nil
 	case "mkdir.retval":
 		return "mkdir", nil
-	case "mmap.async":
-		return "mmap", nil
 	case "mmap.file.change_time":
 		return "mmap", nil
 	case "mmap.file.filesystem":
@@ -10064,8 +9841,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "mmap", nil
 	case "mmap.retval":
 		return "mmap", nil
-	case "mprotect.async":
-		return "mprotect", nil
 	case "mprotect.req_protection":
 		return "mprotect", nil
 	case "mprotect.retval":
@@ -10090,8 +9865,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "*", nil
 	case "network.source.port":
 		return "*", nil
-	case "open.async":
-		return "open", nil
 	case "open.file.change_time":
 		return "open", nil
 	case "open.file.destination.mode":
@@ -10306,8 +10079,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "*", nil
 	case "process.user":
 		return "*", nil
-	case "ptrace.async":
-		return "ptrace", nil
 	case "ptrace.request":
 		return "ptrace", nil
 	case "ptrace.retval":
@@ -10492,8 +10263,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "ptrace", nil
 	case "ptrace.tracee.user":
 		return "ptrace", nil
-	case "removexattr.async":
-		return "removexattr", nil
 	case "removexattr.file.change_time":
 		return "removexattr", nil
 	case "removexattr.file.destination.name":
@@ -10528,8 +10297,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "removexattr", nil
 	case "removexattr.retval":
 		return "removexattr", nil
-	case "rename.async":
-		return "rename", nil
 	case "rename.file.change_time":
 		return "rename", nil
 	case "rename.file.destination.change_time":
@@ -10588,8 +10355,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "rename", nil
 	case "rename.retval":
 		return "rename", nil
-	case "rmdir.async":
-		return "rmdir", nil
 	case "rmdir.file.change_time":
 		return "rmdir", nil
 	case "rmdir.file.filesystem":
@@ -10652,8 +10417,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "setuid", nil
 	case "setuid.user":
 		return "setuid", nil
-	case "setxattr.async":
-		return "setxattr", nil
 	case "setxattr.file.change_time":
 		return "setxattr", nil
 	case "setxattr.file.destination.name":
@@ -10688,8 +10451,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "setxattr", nil
 	case "setxattr.retval":
 		return "setxattr", nil
-	case "signal.async":
-		return "signal", nil
 	case "signal.pid":
 		return "signal", nil
 	case "signal.retval":
@@ -10876,8 +10637,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "signal", nil
 	case "signal.type":
 		return "signal", nil
-	case "splice.async":
-		return "splice", nil
 	case "splice.file.change_time":
 		return "splice", nil
 	case "splice.file.filesystem":
@@ -10912,8 +10671,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "splice", nil
 	case "splice.retval":
 		return "splice", nil
-	case "unlink.async":
-		return "unlink", nil
 	case "unlink.file.change_time":
 		return "unlink", nil
 	case "unlink.file.filesystem":
@@ -10944,14 +10701,10 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "unlink", nil
 	case "unlink.retval":
 		return "unlink", nil
-	case "unload_module.async":
-		return "unload_module", nil
 	case "unload_module.name":
 		return "unload_module", nil
 	case "unload_module.retval":
 		return "unload_module", nil
-	case "utimes.async":
-		return "utimes", nil
 	case "utimes.file.change_time":
 		return "utimes", nil
 	case "utimes.file.filesystem":
@@ -10987,18 +10740,16 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 }
 func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	switch field {
+	case "async":
+		return reflect.Bool, nil
 	case "bind.addr.family":
 		return reflect.Int, nil
 	case "bind.addr.ip":
 		return reflect.Struct, nil
 	case "bind.addr.port":
 		return reflect.Int, nil
-	case "bind.async":
-		return reflect.Bool, nil
 	case "bind.retval":
 		return reflect.Int, nil
-	case "bpf.async":
-		return reflect.Bool, nil
 	case "bpf.cmd":
 		return reflect.Int, nil
 	case "bpf.map.name":
@@ -11021,8 +10772,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 	case "capset.cap_permitted":
 		return reflect.Int, nil
-	case "chmod.async":
-		return reflect.Bool, nil
 	case "chmod.file.change_time":
 		return reflect.Int, nil
 	case "chmod.file.destination.mode":
@@ -11057,8 +10806,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.String, nil
 	case "chmod.retval":
 		return reflect.Int, nil
-	case "chown.async":
-		return reflect.Bool, nil
 	case "chown.file.change_time":
 		return reflect.Int, nil
 	case "chown.file.destination.gid":
@@ -11201,8 +10948,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 	case "exec.user":
 		return reflect.String, nil
-	case "link.async":
-		return reflect.Bool, nil
 	case "link.file.change_time":
 		return reflect.Int, nil
 	case "link.file.destination.change_time":
@@ -11261,8 +11006,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.String, nil
 	case "link.retval":
 		return reflect.Int, nil
-	case "load_module.async":
-		return reflect.Bool, nil
 	case "load_module.file.change_time":
 		return reflect.Int, nil
 	case "load_module.file.filesystem":
@@ -11297,8 +11040,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.String, nil
 	case "load_module.retval":
 		return reflect.Int, nil
-	case "mkdir.async":
-		return reflect.Bool, nil
 	case "mkdir.file.change_time":
 		return reflect.Int, nil
 	case "mkdir.file.destination.mode":
@@ -11333,8 +11074,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.String, nil
 	case "mkdir.retval":
 		return reflect.Int, nil
-	case "mmap.async":
-		return reflect.Bool, nil
 	case "mmap.file.change_time":
 		return reflect.Int, nil
 	case "mmap.file.filesystem":
@@ -11369,8 +11108,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 	case "mmap.retval":
 		return reflect.Int, nil
-	case "mprotect.async":
-		return reflect.Bool, nil
 	case "mprotect.req_protection":
 		return reflect.Int, nil
 	case "mprotect.retval":
@@ -11395,8 +11132,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Struct, nil
 	case "network.source.port":
 		return reflect.Int, nil
-	case "open.async":
-		return reflect.Bool, nil
 	case "open.file.change_time":
 		return reflect.Int, nil
 	case "open.file.destination.mode":
@@ -11611,8 +11346,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 	case "process.user":
 		return reflect.String, nil
-	case "ptrace.async":
-		return reflect.Bool, nil
 	case "ptrace.request":
 		return reflect.Int, nil
 	case "ptrace.retval":
@@ -11797,8 +11530,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 	case "ptrace.tracee.user":
 		return reflect.String, nil
-	case "removexattr.async":
-		return reflect.Bool, nil
 	case "removexattr.file.change_time":
 		return reflect.Int, nil
 	case "removexattr.file.destination.name":
@@ -11833,8 +11564,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.String, nil
 	case "removexattr.retval":
 		return reflect.Int, nil
-	case "rename.async":
-		return reflect.Bool, nil
 	case "rename.file.change_time":
 		return reflect.Int, nil
 	case "rename.file.destination.change_time":
@@ -11893,8 +11622,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.String, nil
 	case "rename.retval":
 		return reflect.Int, nil
-	case "rmdir.async":
-		return reflect.Bool, nil
 	case "rmdir.file.change_time":
 		return reflect.Int, nil
 	case "rmdir.file.filesystem":
@@ -11957,8 +11684,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 	case "setuid.user":
 		return reflect.String, nil
-	case "setxattr.async":
-		return reflect.Bool, nil
 	case "setxattr.file.change_time":
 		return reflect.Int, nil
 	case "setxattr.file.destination.name":
@@ -11993,8 +11718,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.String, nil
 	case "setxattr.retval":
 		return reflect.Int, nil
-	case "signal.async":
-		return reflect.Bool, nil
 	case "signal.pid":
 		return reflect.Int, nil
 	case "signal.retval":
@@ -12181,8 +11904,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.String, nil
 	case "signal.type":
 		return reflect.Int, nil
-	case "splice.async":
-		return reflect.Bool, nil
 	case "splice.file.change_time":
 		return reflect.Int, nil
 	case "splice.file.filesystem":
@@ -12217,8 +11938,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 	case "splice.retval":
 		return reflect.Int, nil
-	case "unlink.async":
-		return reflect.Bool, nil
 	case "unlink.file.change_time":
 		return reflect.Int, nil
 	case "unlink.file.filesystem":
@@ -12249,14 +11968,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.String, nil
 	case "unlink.retval":
 		return reflect.Int, nil
-	case "unload_module.async":
-		return reflect.Bool, nil
 	case "unload_module.name":
 		return reflect.String, nil
 	case "unload_module.retval":
 		return reflect.Int, nil
-	case "utimes.async":
-		return reflect.Bool, nil
 	case "utimes.file.change_time":
 		return reflect.Int, nil
 	case "utimes.file.filesystem":
@@ -12292,6 +12007,12 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 }
 func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	switch field {
+	case "async":
+		var ok bool
+		if e.Async, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Async"}
+		}
+		return nil
 	case "bind.addr.family":
 		v, ok := value.(int)
 		if !ok {
@@ -12313,24 +12034,12 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Bind.Addr.Port = uint16(v)
 		return nil
-	case "bind.async":
-		var ok bool
-		if e.Bind.SyscallEvent.Async, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Bind.SyscallEvent.Async"}
-		}
-		return nil
 	case "bind.retval":
 		v, ok := value.(int)
 		if !ok {
 			return &eval.ErrValueTypeMismatch{Field: "Bind.SyscallEvent.Retval"}
 		}
 		e.Bind.SyscallEvent.Retval = int64(v)
-		return nil
-	case "bpf.async":
-		var ok bool
-		if e.BPF.SyscallEvent.Async, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "BPF.SyscallEvent.Async"}
-		}
 		return nil
 	case "bpf.cmd":
 		v, ok := value.(int)
@@ -12408,12 +12117,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "Capset.CapPermitted"}
 		}
 		e.Capset.CapPermitted = uint64(v)
-		return nil
-	case "chmod.async":
-		var ok bool
-		if e.Chmod.SyscallEvent.Async, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Chmod.SyscallEvent.Async"}
-		}
 		return nil
 	case "chmod.file.change_time":
 		v, ok := value.(int)
@@ -12532,12 +12235,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "Chmod.SyscallEvent.Retval"}
 		}
 		e.Chmod.SyscallEvent.Retval = int64(v)
-		return nil
-	case "chown.async":
-		var ok bool
-		if e.Chown.SyscallEvent.Async, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Chown.SyscallEvent.Async"}
-		}
 		return nil
 	case "chown.file.change_time":
 		v, ok := value.(int)
@@ -13167,12 +12864,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Exec.Process.Credentials.User = str
 		return nil
-	case "link.async":
-		var ok bool
-		if e.Link.SyscallEvent.Async, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Link.SyscallEvent.Async"}
-		}
-		return nil
 	case "link.file.change_time":
 		v, ok := value.(int)
 		if !ok {
@@ -13374,12 +13065,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Link.SyscallEvent.Retval = int64(v)
 		return nil
-	case "load_module.async":
-		var ok bool
-		if e.LoadModule.SyscallEvent.Async, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "LoadModule.SyscallEvent.Async"}
-		}
-		return nil
 	case "load_module.file.change_time":
 		v, ok := value.(int)
 		if !ok {
@@ -13496,12 +13181,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "LoadModule.SyscallEvent.Retval"}
 		}
 		e.LoadModule.SyscallEvent.Retval = int64(v)
-		return nil
-	case "mkdir.async":
-		var ok bool
-		if e.Mkdir.SyscallEvent.Async, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Mkdir.SyscallEvent.Async"}
-		}
 		return nil
 	case "mkdir.file.change_time":
 		v, ok := value.(int)
@@ -13621,12 +13300,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Mkdir.SyscallEvent.Retval = int64(v)
 		return nil
-	case "mmap.async":
-		var ok bool
-		if e.MMap.SyscallEvent.Async, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "MMap.SyscallEvent.Async"}
-		}
-		return nil
 	case "mmap.file.change_time":
 		v, ok := value.(int)
 		if !ok {
@@ -13745,12 +13418,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.MMap.SyscallEvent.Retval = int64(v)
 		return nil
-	case "mprotect.async":
-		var ok bool
-		if e.MProtect.SyscallEvent.Async, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "MProtect.SyscallEvent.Async"}
-		}
-		return nil
 	case "mprotect.req_protection":
 		v, ok := value.(int)
 		if !ok {
@@ -13834,12 +13501,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "NetworkContext.Source.Port"}
 		}
 		e.NetworkContext.Source.Port = uint16(v)
-		return nil
-	case "open.async":
-		var ok bool
-		if e.Open.SyscallEvent.Async, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Open.SyscallEvent.Async"}
-		}
 		return nil
 	case "open.file.change_time":
 		v, ok := value.(int)
@@ -14988,12 +14649,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.ProcessContext.Process.Credentials.User = str
 		return nil
-	case "ptrace.async":
-		var ok bool
-		if e.PTrace.SyscallEvent.Async, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "PTrace.SyscallEvent.Async"}
-		}
-		return nil
 	case "ptrace.request":
 		v, ok := value.(int)
 		if !ok {
@@ -16037,12 +15692,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.PTrace.Tracee.Process.Credentials.User = str
 		return nil
-	case "removexattr.async":
-		var ok bool
-		if e.RemoveXAttr.SyscallEvent.Async, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.SyscallEvent.Async"}
-		}
-		return nil
 	case "removexattr.file.change_time":
 		v, ok := value.(int)
 		if !ok {
@@ -16160,12 +15809,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.SyscallEvent.Retval"}
 		}
 		e.RemoveXAttr.SyscallEvent.Retval = int64(v)
-		return nil
-	case "rename.async":
-		var ok bool
-		if e.Rename.SyscallEvent.Async, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Rename.SyscallEvent.Async"}
-		}
 		return nil
 	case "rename.file.change_time":
 		v, ok := value.(int)
@@ -16367,12 +16010,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "Rename.SyscallEvent.Retval"}
 		}
 		e.Rename.SyscallEvent.Retval = int64(v)
-		return nil
-	case "rmdir.async":
-		var ok bool
-		if e.Rmdir.SyscallEvent.Async, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Rmdir.SyscallEvent.Async"}
-		}
 		return nil
 	case "rmdir.file.change_time":
 		v, ok := value.(int)
@@ -16589,12 +16226,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.SetUID.User = str
 		return nil
-	case "setxattr.async":
-		var ok bool
-		if e.SetXAttr.SyscallEvent.Async, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.SyscallEvent.Async"}
-		}
-		return nil
 	case "setxattr.file.change_time":
 		v, ok := value.(int)
 		if !ok {
@@ -16712,12 +16343,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.SyscallEvent.Retval"}
 		}
 		e.SetXAttr.SyscallEvent.Retval = int64(v)
-		return nil
-	case "signal.async":
-		var ok bool
-		if e.Signal.SyscallEvent.Async, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Signal.SyscallEvent.Async"}
-		}
 		return nil
 	case "signal.pid":
 		v, ok := value.(int)
@@ -17769,12 +17394,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Signal.Type = uint32(v)
 		return nil
-	case "splice.async":
-		var ok bool
-		if e.Splice.SyscallEvent.Async, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Splice.SyscallEvent.Async"}
-		}
-		return nil
 	case "splice.file.change_time":
 		v, ok := value.(int)
 		if !ok {
@@ -17893,12 +17512,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Splice.SyscallEvent.Retval = int64(v)
 		return nil
-	case "unlink.async":
-		var ok bool
-		if e.Unlink.SyscallEvent.Async, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Unlink.SyscallEvent.Async"}
-		}
-		return nil
 	case "unlink.file.change_time":
 		v, ok := value.(int)
 		if !ok {
@@ -18003,12 +17616,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Unlink.SyscallEvent.Retval = int64(v)
 		return nil
-	case "unload_module.async":
-		var ok bool
-		if e.UnloadModule.SyscallEvent.Async, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "UnloadModule.SyscallEvent.Async"}
-		}
-		return nil
 	case "unload_module.name":
 		str, ok := value.(string)
 		if !ok {
@@ -18022,12 +17629,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "UnloadModule.SyscallEvent.Retval"}
 		}
 		e.UnloadModule.SyscallEvent.Retval = int64(v)
-		return nil
-	case "utimes.async":
-		var ok bool
-		if e.Utimes.SyscallEvent.Async, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Utimes.SyscallEvent.Async"}
-		}
 		return nil
 	case "utimes.file.change_time":
 		v, ok := value.(int)

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -128,7 +128,8 @@ type ContainerContext struct {
 // genaccessors
 type Event struct {
 	ID           string    `field:"-"`
-	Type         uint64    `field:"-"`
+	Type         uint32    `field:"-"`
+	Async        bool      `field:"async" msg:"async" event:"*"` // True if the syscall was asynchronous
 	TimestampRaw uint64    `field:"-"`
 	Timestamp    time.Time `field:"-"` // Timestamp of the event
 
@@ -636,7 +637,6 @@ type SetXAttrEvent struct {
 // SyscallEvent contains common fields for all the event
 type SyscallEvent struct {
 	Retval int64 `field:"retval" msg:"retval"` // Return value of the syscall
-	Async  bool  `field:"async" msg:"async"`   // True if the syscall was asynchronous
 }
 
 // UnlinkEvent represents an unlink event

--- a/pkg/security/secl/model/model_gen.go
+++ b/pkg/security/secl/model/model_gen.go
@@ -2347,12 +2347,6 @@ func (z *SyscallEvent) DecodeMsg(dc *msgp.Reader) (err error) {
 				err = msgp.WrapError(err, "Retval")
 				return
 			}
-		case "async":
-			z.Async, err = dc.ReadBool()
-			if err != nil {
-				err = msgp.WrapError(err, "Async")
-				return
-			}
 		default:
 			err = dc.Skip()
 			if err != nil {
@@ -2366,9 +2360,9 @@ func (z *SyscallEvent) DecodeMsg(dc *msgp.Reader) (err error) {
 
 // EncodeMsg implements msgp.Encodable
 func (z SyscallEvent) EncodeMsg(en *msgp.Writer) (err error) {
-	// map header, size 2
+	// map header, size 1
 	// write "retval"
-	err = en.Append(0x82, 0xa6, 0x72, 0x65, 0x74, 0x76, 0x61, 0x6c)
+	err = en.Append(0x81, 0xa6, 0x72, 0x65, 0x74, 0x76, 0x61, 0x6c)
 	if err != nil {
 		return
 	}
@@ -2377,29 +2371,16 @@ func (z SyscallEvent) EncodeMsg(en *msgp.Writer) (err error) {
 		err = msgp.WrapError(err, "Retval")
 		return
 	}
-	// write "async"
-	err = en.Append(0xa5, 0x61, 0x73, 0x79, 0x6e, 0x63)
-	if err != nil {
-		return
-	}
-	err = en.WriteBool(z.Async)
-	if err != nil {
-		err = msgp.WrapError(err, "Async")
-		return
-	}
 	return
 }
 
 // MarshalMsg implements msgp.Marshaler
 func (z SyscallEvent) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
-	// map header, size 2
+	// map header, size 1
 	// string "retval"
-	o = append(o, 0x82, 0xa6, 0x72, 0x65, 0x74, 0x76, 0x61, 0x6c)
+	o = append(o, 0x81, 0xa6, 0x72, 0x65, 0x74, 0x76, 0x61, 0x6c)
 	o = msgp.AppendInt64(o, z.Retval)
-	// string "async"
-	o = append(o, 0xa5, 0x61, 0x73, 0x79, 0x6e, 0x63)
-	o = msgp.AppendBool(o, z.Async)
 	return
 }
 
@@ -2427,12 +2408,6 @@ func (z *SyscallEvent) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				err = msgp.WrapError(err, "Retval")
 				return
 			}
-		case "async":
-			z.Async, bts, err = msgp.ReadBoolBytes(bts)
-			if err != nil {
-				err = msgp.WrapError(err, "Async")
-				return
-			}
 		default:
 			bts, err = msgp.Skip(bts)
 			if err != nil {
@@ -2447,6 +2422,6 @@ func (z *SyscallEvent) UnmarshalMsg(bts []byte) (o []byte, err error) {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z SyscallEvent) Msgsize() (s int) {
-	s = 1 + 7 + msgp.Int64Size + 6 + msgp.BoolSize
+	s = 1 + 7 + msgp.Int64Size
 	return
 }

--- a/pkg/security/secl/model/unmarshallers.go
+++ b/pkg/security/secl/model/unmarshallers.go
@@ -72,7 +72,13 @@ func (e *Event) UnmarshalBinary(data []byte) (int, error) {
 	}
 
 	e.TimestampRaw = ByteOrder.Uint64(data[8:16])
-	e.Type = ByteOrder.Uint64(data[16:24])
+	e.Type = ByteOrder.Uint32(data[16:20])
+	if data[20] != 0 {
+		e.Async = true
+	} else {
+		e.Async = false
+	}
+	// 21-24: padding
 
 	return 24, nil
 }
@@ -430,16 +436,11 @@ func (e *SetXAttrEvent) UnmarshalBinary(data []byte) (int, error) {
 
 // UnmarshalBinary unmarshalls a binary representation of itself
 func (e *SyscallEvent) UnmarshalBinary(data []byte) (int, error) {
-	if len(data) < 16 {
+	if len(data) < 8 {
 		return 0, ErrNotEnoughData
 	}
 	e.Retval = int64(ByteOrder.Uint64(data[0:8]))
-	if ByteOrder.Uint64(data[8:16]) != 0 {
-		e.Async = true
-	} else {
-		e.Async = false
-	}
-	return 16, nil
+	return 8, nil
 }
 
 // UnmarshalBinary unmarshalls a binary representation of itself

--- a/pkg/security/tests/chmod_test.go
+++ b/pkg/security/tests/chmod_test.go
@@ -61,7 +61,7 @@ func TestChmod(t *testing.T) {
 			assertRights(t, event.Chmod.File.Mode, expectedMode, "wrong initial mode")
 			assertNearTime(t, event.Chmod.File.MTime)
 			assertNearTime(t, event.Chmod.File.CTime)
-			assert.Equal(t, event.Chmod.Async, false)
+			assert.Equal(t, event.Async, false)
 
 			if !validateChmodSchema(t, event) {
 				t.Error(event.String())
@@ -84,7 +84,7 @@ func TestChmod(t *testing.T) {
 			assertRights(t, event.Chmod.File.Mode, expectedMode)
 			assertNearTime(t, event.Chmod.File.MTime)
 			assertNearTime(t, event.Chmod.File.CTime)
-			assert.Equal(t, event.Chmod.Async, false)
+			assert.Equal(t, event.Async, false)
 
 			if !validateChmodSchema(t, event) {
 				t.Error(event.String())
@@ -105,7 +105,7 @@ func TestChmod(t *testing.T) {
 			assertRights(t, event.Chmod.File.Mode, expectedMode, "wrong initial mode")
 			assertNearTime(t, event.Chmod.File.MTime)
 			assertNearTime(t, event.Chmod.File.CTime)
-			assert.Equal(t, event.Chmod.Async, false)
+			assert.Equal(t, event.Async, false)
 
 			if !validateChmodSchema(t, event) {
 				t.Error(event.String())

--- a/pkg/security/tests/chown32_test.go
+++ b/pkg/security/tests/chown32_test.go
@@ -74,7 +74,7 @@ func TestChown32(t *testing.T) {
 			assert.Equal(t, uint32(prevGID), event.Chown.File.GID, "wrong initial group")
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
-			assert.Equal(t, event.Chown.Async, false)
+			assert.Equal(t, event.Async, false)
 
 			if !validateChownSchema(t, event) {
 				t.Error(event.String())
@@ -101,7 +101,7 @@ func TestChown32(t *testing.T) {
 			assert.Equal(t, uint32(prevGID), event.Chown.File.GID, "wrong initial group")
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
-			assert.Equal(t, event.Chown.Async, false)
+			assert.Equal(t, event.Async, false)
 
 			if !validateChownSchema(t, event) {
 				t.Error(event.String())
@@ -128,7 +128,7 @@ func TestChown32(t *testing.T) {
 			assert.Equal(t, uint32(prevGID), event.Chown.File.GID, "wrong initial group")
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
-			assert.Equal(t, event.Chown.Async, false)
+			assert.Equal(t, event.Async, false)
 
 			if !validateChownSchema(t, event) {
 				t.Error(event.String())
@@ -160,7 +160,7 @@ func TestChown32(t *testing.T) {
 			assert.Equal(t, uint32(0), event.Chown.File.GID, "wrong initial group")
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
-			assert.Equal(t, event.Chown.Async, false)
+			assert.Equal(t, event.Async, false)
 
 			if !validateChownSchema(t, event) {
 				t.Error(event.String())
@@ -192,7 +192,7 @@ func TestChown32(t *testing.T) {
 			assert.Equal(t, uint32(0), event.Chown.File.GID, "wrong initial group")
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
-			assert.Equal(t, event.Chown.Async, false)
+			assert.Equal(t, event.Async, false)
 
 			if !validateChownSchema(t, event) {
 				t.Error(event.String())
@@ -220,7 +220,7 @@ func TestChown32(t *testing.T) {
 			assert.Equal(t, uint32(prevGID), event.Chown.File.GID, "wrong initial group")
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
-			assert.Equal(t, event.Chown.Async, false)
+			assert.Equal(t, event.Async, false)
 
 			if !validateChownSchema(t, event) {
 				t.Error(event.String())
@@ -247,7 +247,7 @@ func TestChown32(t *testing.T) {
 			assert.Equal(t, uint32(prevGID), event.Chown.File.GID, "wrong initial group")
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
-			assert.Equal(t, event.Chown.Async, false)
+			assert.Equal(t, event.Async, false)
 
 			if !validateChownSchema(t, event) {
 				t.Error(event.String())

--- a/pkg/security/tests/chown_test.go
+++ b/pkg/security/tests/chown_test.go
@@ -80,7 +80,7 @@ func TestChown(t *testing.T) {
 			assert.Equal(t, uint32(prevGID), event.Chown.File.GID, "wrong initial group")
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
-			assert.Equal(t, event.Chown.Async, false)
+			assert.Equal(t, event.Async, false)
 
 			if !validateChownSchema(t, event) {
 				t.Error(event.String())
@@ -109,7 +109,7 @@ func TestChown(t *testing.T) {
 			assert.Equal(t, uint32(prevGID), event.Chown.File.GID, "wrong initial group")
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
-			assert.Equal(t, event.Chown.Async, false)
+			assert.Equal(t, event.Async, false)
 
 			if !validateChownSchema(t, event) {
 				t.Error(event.String())
@@ -148,7 +148,7 @@ func TestChown(t *testing.T) {
 			assert.Equal(t, uint32(0), event.Chown.File.GID, "wrong initial group")
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
-			assert.Equal(t, event.Chown.Async, false)
+			assert.Equal(t, event.Async, false)
 
 			if !validateChownSchema(t, event) {
 				t.Error(event.String())
@@ -174,7 +174,7 @@ func TestChown(t *testing.T) {
 			assert.Equal(t, uint32(prevGID), event.Chown.File.GID, "wrong initial group")
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
-			assert.Equal(t, event.Chown.Async, false)
+			assert.Equal(t, event.Async, false)
 
 			if !validateChownSchema(t, event) {
 				t.Error(event.String())
@@ -196,7 +196,7 @@ func TestChown(t *testing.T) {
 			assertTriggeredRule(t, r, "test_rule3")
 			assert.Equal(t, int64(104), event.Chown.UID, "wrong user")
 			assert.Equal(t, int64(-1), event.Chown.GID, "wrong group")
-			assert.Equal(t, event.Chown.Async, false)
+			assert.Equal(t, event.Async, false)
 
 			if !validateChownSchema(t, event) {
 				t.Error(event.String())
@@ -218,7 +218,7 @@ func TestChown(t *testing.T) {
 			assertTriggeredRule(t, r, "test_rule4")
 			assert.Equal(t, int64(-1), event.Chown.UID, "wrong user")
 			assert.Equal(t, int64(204), event.Chown.GID, "wrong group")
-			assert.Equal(t, event.Chown.Async, false)
+			assert.Equal(t, event.Async, false)
 
 			if !validateChownSchema(t, event) {
 				t.Error(event.String())

--- a/pkg/security/tests/kernel_module_test.go
+++ b/pkg/security/tests/kernel_module_test.go
@@ -165,7 +165,7 @@ func TestLoadModule(t *testing.T) {
 		}, func(event *sprobe.Event, r *rules.Rule) {
 			assert.Equal(t, "test_load_module_from_memory", r.ID, "invalid rule triggered")
 			assert.Equal(t, "", event.ResolveFilePath(&event.LoadModule.File), "shouldn't get a path")
-			assert.Equal(t, event.LoadModule.Async, false)
+			assert.Equal(t, event.Async, false)
 
 			if !validateLoadModuleNoFileSchema(t, event) {
 				t.Error(event.String())

--- a/pkg/security/tests/link_test.go
+++ b/pkg/security/tests/link_test.go
@@ -63,7 +63,7 @@ func TestLink(t *testing.T) {
 			assertNearTime(t, event.Link.Source.CTime)
 			assertNearTime(t, event.Link.Target.MTime)
 			assertNearTime(t, event.Link.Target.CTime)
-			assert.Equal(t, event.Link.Async, false)
+			assert.Equal(t, event.Async, false)
 
 			if !validateLinkSchema(t, event) {
 				t.Error(event.String())
@@ -91,7 +91,7 @@ func TestLink(t *testing.T) {
 			assertNearTime(t, event.Link.Source.CTime)
 			assertNearTime(t, event.Link.Target.MTime)
 			assertNearTime(t, event.Link.Target.CTime)
-			assert.Equal(t, event.Link.Async, false)
+			assert.Equal(t, event.Async, false)
 
 			if !validateLinkSchema(t, event) {
 				t.Error(event.String())
@@ -147,7 +147,7 @@ func TestLink(t *testing.T) {
 			assertNearTime(t, event.Link.Source.CTime)
 			assertNearTime(t, event.Link.Target.MTime)
 			assertNearTime(t, event.Link.Target.CTime)
-			assert.Equal(t, event.Link.Async, true)
+			assert.Equal(t, event.Async, true)
 
 			executable, err := os.Executable()
 			if err != nil {

--- a/pkg/security/tests/mkdir_test.go
+++ b/pkg/security/tests/mkdir_test.go
@@ -63,7 +63,7 @@ func TestMkdir(t *testing.T) {
 			assertRights(t, event.Mkdir.File.Mode, expectedMode)
 			assertNearTime(t, event.Mkdir.File.MTime)
 			assertNearTime(t, event.Mkdir.File.CTime)
-			assert.Equal(t, event.Mkdir.Async, false)
+			assert.Equal(t, event.Async, false)
 		})
 	}))
 
@@ -87,7 +87,7 @@ func TestMkdir(t *testing.T) {
 			assertRights(t, event.Mkdir.File.Mode&expectedMode, expectedMode)
 			assertNearTime(t, event.Mkdir.File.MTime)
 			assertNearTime(t, event.Mkdir.File.CTime)
-			assert.Equal(t, event.Mkdir.Async, false)
+			assert.Equal(t, event.Async, false)
 		})
 	})
 
@@ -140,7 +140,7 @@ func TestMkdir(t *testing.T) {
 			assertRights(t, event.Mkdir.File.Mode&expectedMode, expectedMode)
 			assertNearTime(t, event.Mkdir.File.MTime)
 			assertNearTime(t, event.Mkdir.File.CTime)
-			assert.Equal(t, event.Mkdir.Async, true)
+			assert.Equal(t, event.Async, true)
 
 			executable, err := os.Executable()
 			if err != nil {
@@ -184,7 +184,7 @@ func TestMkdirError(t *testing.T) {
 			return runSyscallTesterFunc(t, syscallTester, "mkdirat-error", testatFile)
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_rule_mkdirat_error")
-			assertReturnValue(t, event.Mkdir.Retval, -int64(syscall.EACCES))
+			assert.Equal(t, event.Mkdir.Retval, -int64(syscall.EACCES))
 		})
 	})
 }

--- a/pkg/security/tests/mmap_test.go
+++ b/pkg/security/tests/mmap_test.go
@@ -49,7 +49,7 @@ func TestMMapEvent(t *testing.T) {
 		}, func(event *sprobe.Event, r *rules.Rule) {
 			assert.Equal(t, "mmap", event.GetType(), "wrong event type")
 			assert.NotEqual(t, 0, event.MMap.Protection&(unix.PROT_READ|unix.PROT_WRITE|unix.PROT_EXEC), fmt.Sprintf("wrong protection: %s", model.Protection(event.MMap.Protection)))
-			assert.Equal(t, event.MMap.Async, false)
+			assert.Equal(t, event.Async, false)
 
 			executable, err := os.Executable()
 			if err != nil {

--- a/pkg/security/tests/mprotect_test.go
+++ b/pkg/security/tests/mprotect_test.go
@@ -51,7 +51,7 @@ func TestMProtectEvent(t *testing.T) {
 			assert.Equal(t, "mprotect", event.GetType(), "wrong event type")
 			assert.NotEqual(t, 0, event.MProtect.VMProtection&(unix.PROT_READ|unix.PROT_WRITE), fmt.Sprintf("wrong initial protection: %s", model.Protection(event.MProtect.VMProtection)))
 			assert.NotEqual(t, 0, event.MProtect.ReqProtection&(unix.PROT_READ|unix.PROT_WRITE|unix.PROT_EXEC), fmt.Sprintf("wrong requested protection: %s", model.Protection(event.MProtect.ReqProtection)))
-			assert.Equal(t, event.MProtect.Async, false)
+			assert.Equal(t, event.Async, false)
 
 			executable, err := os.Executable()
 			if err != nil {

--- a/pkg/security/tests/open_test.go
+++ b/pkg/security/tests/open_test.go
@@ -60,7 +60,7 @@ func TestOpen(t *testing.T) {
 			assert.Equal(t, syscall.O_CREAT, int(event.Open.Flags), "wrong flags")
 			assertRights(t, uint16(event.Open.Mode), 0755)
 			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
-			assert.Equal(t, event.Open.Async, false)
+			assert.Equal(t, event.Async, false)
 
 			if !validateOpenSchema(t, event) {
 				t.Error(event.String())
@@ -82,7 +82,7 @@ func TestOpen(t *testing.T) {
 			assert.Equal(t, syscall.O_CREAT, int(event.Open.Flags), "wrong flags")
 			assertRights(t, uint16(event.Open.Mode), 0711)
 			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
-			assert.Equal(t, event.Open.Async, false)
+			assert.Equal(t, event.Async, false)
 		})
 	})
 
@@ -108,7 +108,7 @@ func TestOpen(t *testing.T) {
 			assert.Equal(t, syscall.O_CREAT, int(event.Open.Flags), "wrong flags")
 			assertRights(t, uint16(event.Open.Mode), 0711)
 			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
-			assert.Equal(t, event.Open.Async, false)
+			assert.Equal(t, event.Async, false)
 		})
 	})
 
@@ -126,7 +126,7 @@ func TestOpen(t *testing.T) {
 			assert.Equal(t, syscall.O_CREAT|syscall.O_WRONLY|syscall.O_TRUNC, int(event.Open.Flags), "wrong flags")
 			assertRights(t, uint16(event.Open.Mode), 0711)
 			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
-			assert.Equal(t, event.Open.Async, false)
+			assert.Equal(t, event.Async, false)
 		})
 	}))
 
@@ -158,7 +158,7 @@ func TestOpen(t *testing.T) {
 			assert.Equal(t, "open", event.GetType(), "wrong event type")
 			assert.Equal(t, syscall.O_CREAT|syscall.O_WRONLY|syscall.O_TRUNC, int(event.Open.Flags), "wrong flags")
 			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
-			assert.Equal(t, event.Open.Async, false)
+			assert.Equal(t, event.Async, false)
 		})
 	})
 
@@ -202,7 +202,7 @@ func TestOpen(t *testing.T) {
 			assert.Equal(t, "open", event.GetType(), "wrong event type")
 			assert.Equal(t, syscall.O_CREAT, int(event.Open.Flags), "wrong flags")
 			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
-			assert.Equal(t, event.Open.Async, false)
+			assert.Equal(t, event.Async, false)
 		})
 	})
 
@@ -264,7 +264,7 @@ func TestOpen(t *testing.T) {
 			assert.Equal(t, syscall.O_CREAT, int(event.Open.Flags&0xfff), "wrong flags")
 			assertRights(t, uint16(event.Open.Mode), 0747)
 			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
-			assert.Equal(t, event.Open.Async, true)
+			assert.Equal(t, event.Async, true)
 
 			executable, err := os.Executable()
 			if err != nil {
@@ -304,7 +304,7 @@ func TestOpen(t *testing.T) {
 			assert.Equal(t, syscall.O_CREAT, int(event.Open.Flags&0xfff), "wrong flags")
 			assertRights(t, uint16(event.Open.Mode), 0711)
 			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
-			assert.Equal(t, event.Open.Async, true)
+			assert.Equal(t, event.Async, true)
 
 			executable, err := os.Executable()
 			if err != nil {
@@ -353,7 +353,7 @@ func TestOpenMetadata(t *testing.T) {
 			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
 			assertNearTime(t, event.Open.File.MTime)
 			assertNearTime(t, event.Open.File.CTime)
-			assert.Equal(t, event.Open.Async, false)
+			assert.Equal(t, event.Async, false)
 		})
 	})
 }

--- a/pkg/security/tests/ptrace_test.go
+++ b/pkg/security/tests/ptrace_test.go
@@ -52,7 +52,7 @@ func TestPTraceEvent(t *testing.T) {
 		}, func(event *sprobe.Event, r *rules.Rule) {
 			assert.Equal(t, "ptrace", event.GetType(), "wrong event type")
 			assert.Equal(t, uint64(42), event.PTrace.Address, "wrong address")
-			assert.Equal(t, event.PTrace.Async, false)
+			assert.Equal(t, event.Async, false)
 
 			if !validatePTraceSchema(t, event) {
 				t.Error(event.String())

--- a/pkg/security/tests/rename_test.go
+++ b/pkg/security/tests/rename_test.go
@@ -69,7 +69,7 @@ func TestRename(t *testing.T) {
 			assertRights(t, event.Rename.New.Mode, expectedMode)
 			assertNearTime(t, event.Rename.New.MTime)
 			assertNearTime(t, event.Rename.New.CTime)
-			assert.Equal(t, event.Rename.Async, false)
+			assert.Equal(t, event.Async, false)
 
 			if !validateRenameSchema(t, event) {
 				t.Error(event.String())
@@ -98,7 +98,7 @@ func TestRename(t *testing.T) {
 			assertRights(t, event.Rename.New.Mode, expectedMode)
 			assertNearTime(t, event.Rename.New.MTime)
 			assertNearTime(t, event.Rename.New.CTime)
-			assert.Equal(t, event.Rename.Async, false)
+			assert.Equal(t, event.Async, false)
 
 			if !validateRenameSchema(t, event) {
 				t.Error(event.String())
@@ -130,7 +130,7 @@ func TestRename(t *testing.T) {
 			assertRights(t, event.Rename.New.Mode, expectedMode)
 			assertNearTime(t, event.Rename.New.MTime)
 			assertNearTime(t, event.Rename.New.CTime)
-			assert.Equal(t, event.Rename.Async, false)
+			assert.Equal(t, event.Async, false)
 
 			if !validateRenameSchema(t, event) {
 				t.Error(event.String())
@@ -187,7 +187,7 @@ func TestRename(t *testing.T) {
 			assertRights(t, event.Rename.New.Mode, expectedMode)
 			assertNearTime(t, event.Rename.New.MTime)
 			assertNearTime(t, event.Rename.New.CTime)
-			assert.Equal(t, event.Rename.Async, true)
+			assert.Equal(t, event.Async, true)
 
 			executable, err := os.Executable()
 			if err != nil {

--- a/pkg/security/tests/rmdir_test.go
+++ b/pkg/security/tests/rmdir_test.go
@@ -62,7 +62,7 @@ func TestRmdir(t *testing.T) {
 			assertRights(t, event.Rmdir.File.Mode, expectedMode, "wrong initial mode")
 			assertNearTime(t, event.Rmdir.File.MTime)
 			assertNearTime(t, event.Rmdir.File.CTime)
-			assert.Equal(t, event.Rmdir.Async, false)
+			assert.Equal(t, event.Async, false)
 		})
 	}))
 
@@ -90,7 +90,7 @@ func TestRmdir(t *testing.T) {
 			assertRights(t, event.Rmdir.File.Mode, expectedMode, "wrong initial mode")
 			assertNearTime(t, event.Rmdir.File.MTime)
 			assertNearTime(t, event.Rmdir.File.CTime)
-			assert.Equal(t, event.Rmdir.Async, false)
+			assert.Equal(t, event.Async, false)
 		})
 	})
 
@@ -147,7 +147,7 @@ func TestRmdir(t *testing.T) {
 			assertRights(t, event.Rmdir.File.Mode, expectedMode, "wrong initial mode")
 			assertNearTime(t, event.Rmdir.File.MTime)
 			assertNearTime(t, event.Rmdir.File.CTime)
-			assert.Equal(t, event.Rmdir.Async, true)
+			assert.Equal(t, event.Async, true)
 
 			executable, err := os.Executable()
 			if err != nil {

--- a/pkg/security/tests/signal_test.go
+++ b/pkg/security/tests/signal_test.go
@@ -58,7 +58,7 @@ func TestSignalEvent(t *testing.T) {
 			assert.Equal(t, "signal", event.GetType(), "wrong event type")
 			assert.Equal(t, uint32(unix.SIGUSR1), event.Signal.Type, "wrong signal")
 			assert.Equal(t, int64(0), event.Signal.Retval, "wrong retval")
-			assert.Equal(t, event.Signal.Async, false)
+			assert.Equal(t, event.Async, false)
 
 			if !validateSignalSchema(t, event) {
 				t.Error(event.String())
@@ -81,7 +81,7 @@ func TestSignalEvent(t *testing.T) {
 			assert.Equal(t, "signal", event.GetType(), "wrong event type")
 			assert.Equal(t, uint32(unix.SIGKILL), event.Signal.Type, "wrong signal")
 			assert.Equal(t, -int64(unix.EPERM), event.Signal.Retval, "wrong retval")
-			assert.Equal(t, event.Signal.Async, false)
+			assert.Equal(t, event.Async, false)
 
 			if !validateSignalSchema(t, event) {
 				t.Error(event.String())

--- a/pkg/security/tests/splice_test.go
+++ b/pkg/security/tests/splice_test.go
@@ -43,7 +43,7 @@ func TestSpliceEvent(t *testing.T) {
 			assert.Equal(t, "splice", event.GetType(), "wrong event type")
 			assert.Equal(t, uint32(0), event.Splice.PipeEntryFlag, "wrong pipe entry flag")
 			assert.Equal(t, uint32(0), event.Splice.PipeExitFlag, "wrong pipe exit flag")
-			assert.Equal(t, event.Splice.Async, false)
+			assert.Equal(t, event.Async, false)
 
 			if !validateSpliceSchema(t, event) {
 				t.Error(event.String())

--- a/pkg/security/tests/unlink_test.go
+++ b/pkg/security/tests/unlink_test.go
@@ -57,7 +57,7 @@ func TestUnlink(t *testing.T) {
 			assertRights(t, event.Unlink.File.Mode, expectedMode)
 			assertNearTime(t, event.Unlink.File.MTime)
 			assertNearTime(t, event.Unlink.File.CTime)
-			assert.Equal(t, event.Unlink.Async, false)
+			assert.Equal(t, event.Async, false)
 		})
 	}))
 
@@ -81,7 +81,7 @@ func TestUnlink(t *testing.T) {
 			assertRights(t, event.Unlink.File.Mode, expectedMode)
 			assertNearTime(t, event.Unlink.File.MTime)
 			assertNearTime(t, event.Unlink.File.CTime)
-			assert.Equal(t, event.Unlink.Async, false)
+			assert.Equal(t, event.Async, false)
 		})
 	})
 
@@ -134,7 +134,7 @@ func TestUnlink(t *testing.T) {
 			assertRights(t, event.Unlink.File.Mode, expectedMode)
 			assertNearTime(t, event.Unlink.File.MTime)
 			assertNearTime(t, event.Unlink.File.CTime)
-			assert.Equal(t, event.Unlink.Async, true)
+			assert.Equal(t, event.Async, true)
 
 			executable, err := os.Executable()
 			if err != nil {

--- a/pkg/security/tests/utimes_test.go
+++ b/pkg/security/tests/utimes_test.go
@@ -60,7 +60,7 @@ func TestUtimes(t *testing.T) {
 			assertRights(t, event.Utimes.File.Mode, expectedMode)
 			assertNearTime(t, event.Utimes.File.MTime)
 			assertNearTime(t, event.Utimes.File.CTime)
-			assert.Equal(t, event.Utimes.Async, false)
+			assert.Equal(t, event.Async, false)
 		})
 	}))
 
@@ -97,7 +97,7 @@ func TestUtimes(t *testing.T) {
 			assertRights(t, event.Utimes.File.Mode, expectedMode)
 			assertNearTime(t, event.Utimes.File.MTime)
 			assertNearTime(t, event.Utimes.File.CTime)
-			assert.Equal(t, event.Utimes.Async, false)
+			assert.Equal(t, event.Async, false)
 		})
 	}))
 
@@ -137,7 +137,7 @@ func TestUtimes(t *testing.T) {
 			assertRights(t, event.Utimes.File.Mode, expectedMode)
 			assertNearTime(t, event.Utimes.File.MTime)
 			assertNearTime(t, event.Utimes.File.CTime)
-			assert.Equal(t, event.Utimes.Async, false)
+			assert.Equal(t, event.Async, false)
 		})
 	})
 }

--- a/pkg/security/tests/xattr_test.go
+++ b/pkg/security/tests/xattr_test.go
@@ -70,7 +70,7 @@ func TestSetXAttr(t *testing.T) {
 			assertRights(t, event.SetXAttr.File.Mode, expectedMode)
 			assertNearTime(t, event.SetXAttr.File.MTime)
 			assertNearTime(t, event.SetXAttr.File.CTime)
-			assert.Equal(t, event.SetXAttr.Async, false)
+			assert.Equal(t, event.Async, false)
 		})
 	})
 
@@ -108,7 +108,7 @@ func TestSetXAttr(t *testing.T) {
 			assertRights(t, event.SetXAttr.File.Mode, 0777)
 			assertNearTime(t, event.SetXAttr.File.MTime)
 			assertNearTime(t, event.SetXAttr.File.CTime)
-			assert.Equal(t, event.SetXAttr.Async, false)
+			assert.Equal(t, event.Async, false)
 		})
 	})
 
@@ -139,7 +139,7 @@ func TestSetXAttr(t *testing.T) {
 			assertRights(t, event.SetXAttr.File.Mode, expectedMode)
 			assertNearTime(t, event.SetXAttr.File.MTime)
 			assertNearTime(t, event.SetXAttr.File.CTime)
-			assert.Equal(t, event.SetXAttr.Async, false)
+			assert.Equal(t, event.Async, false)
 		})
 	})
 }
@@ -205,7 +205,7 @@ func TestRemoveXAttr(t *testing.T) {
 			assertRights(t, event.RemoveXAttr.File.Mode, uint16(expectedMode))
 			assertNearTime(t, event.RemoveXAttr.File.MTime)
 			assertNearTime(t, event.RemoveXAttr.File.CTime)
-			assert.Equal(t, event.SetXAttr.Async, false)
+			assert.Equal(t, event.Async, false)
 		})
 	})
 
@@ -249,7 +249,7 @@ func TestRemoveXAttr(t *testing.T) {
 			assertRights(t, event.RemoveXAttr.File.Mode, 0777)
 			assertNearTime(t, event.RemoveXAttr.File.MTime)
 			assertNearTime(t, event.RemoveXAttr.File.CTime)
-			assert.Equal(t, event.SetXAttr.Async, false)
+			assert.Equal(t, event.Async, false)
 		})
 	})
 


### PR DESCRIPTION
### What does this PR do?

Reduce the payload size needed for retrieving the async flag for every event by 8octs.




### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
