### PR TITLE
[pkg/metadata] Remove double resource payload collection during sending

### DIFF
--- a/pkg/metadata/resources.go
+++ b/pkg/metadata/resources.go
@@ -27,12 +27,14 @@ func (rp *ResourcesCollector) Send(ctx context.Context, s serializer.MetricSeria
 	if res == nil {
 		return errors.New("empty processes metadata")
 	}
+
 	payload := map[string]interface{}{
 		"resources": res,
 	}
 	if err := s.SendProcessesMetadata(payload); err != nil {
 		return fmt.Errorf("unable to serialize processes metadata payload, %s", err)
 	}
+
 	return nil
 }
 

--- a/pkg/metadata/resources.go
+++ b/pkg/metadata/resources.go
@@ -28,7 +28,7 @@ func (rp *ResourcesCollector) Send(ctx context.Context, s serializer.MetricSeria
 		return errors.New("empty processes metadata")
 	}
 	payload := map[string]interface{}{
-		"resources": resources.GetPayload(hostname),
+		"resources": res,
 	}
 	if err := s.SendProcessesMetadata(payload); err != nil {
 		return fmt.Errorf("unable to serialize processes metadata payload, %s", err)


### PR DESCRIPTION
### What does this PR do?

Removes double collection of resource metadata payload when sending.

### Motivation

We don't need to generate the payload twice in this block (once for
error check, one for sending) since it's the same data. Since this data
may not be cached, the impact may not be negligible either.

### Additional Notes

### Possible Drawbacks / Trade-offs

N/A

### Describe how to test/QA your changes

“process treemap” (“Process memory usage” widget) on host dashboards should contain same info about the host.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
