### PR TITLE
[workloadmeta] Copy entity before merging

### DIFF
--- a/pkg/workloadmeta/store.go
+++ b/pkg/workloadmeta/store.go
@@ -452,6 +452,7 @@ func (s *store) handleEvents(evs []CollectorEvent) {
 					Entity: entity,
 				})
 			} else {
+				entity = entity.DeepCopy()
 				err := entity.Merge(ev.Entity)
 				if err != nil {
 					log.Errorf("cannot merge %+v into %+v: %s", entity, ev.Entity, err)


### PR DESCRIPTION
### What does this PR do?

This manifested as a race condition (see below) when processing an
EventTypeUnset event that on the surface looks benign, but actually
uncovers a correctness issue: `Entity.Merge()` mutates the entity, and
since the entity might be the source of truth living in the store, that
changes data that it shouldn't.

To prevent both changing shared state, and the race condition, we now
deep-copy the entity before merging it. Since it's a deep copy, nothing
upstream will see the changes, and downstream it is only shared with the
one subscriber, and never changed again.

```
Write at 0x00c000132cc8 by goroutine 153:
  reflect.typedmemmove()
      /usr/lib/go-1.17/src/runtime/mbarrier.go:178 +0x0
  reflect.Value.Set()
      /usr/lib/go-1.17/src/reflect/value.go:1923 +0x10b
  github.com/imdario/mergo.deepMerge()
      /go/pkg/mod/github.com/imdario/mergo@v0.3.12/merge.go:218 +0x1304
  github.com/imdario/mergo.deepMerge()
      /go/pkg/mod/github.com/imdario/mergo@v0.3.12/merge.go:93 +0x160f
  github.com/imdario/mergo.merge()
      /go/pkg/mod/github.com/imdario/mergo@v0.3.12/merge.go:366 +0x43c
  github.com/imdario/mergo.Merge()
      /go/pkg/mod/github.com/imdario/mergo@v0.3.12/merge.go:296 +0xc4
  github.com/DataDog/datadog-agent/pkg/workloadmeta.merge()
      /go/src/github.com/DataDog/datadog-agent/pkg/workloadmeta/merge.go:95 +0x78
  github.com/DataDog/datadog-agent/pkg/workloadmeta.(*Container).Merge()
      /go/src/github.com/DataDog/datadog-agent/pkg/workloadmeta/types.go:376 +0x64
  github.com/DataDog/datadog-agent/pkg/workloadmeta.(*store).handleEvents()
      /go/src/github.com/DataDog/datadog-agent/pkg/workloadmeta/store.go:455 +0x12cb
  github.com/DataDog/datadog-agent/pkg/workloadmeta.(*store).Start.func1()
      /go/src/github.com/DataDog/datadog-agent/pkg/workloadmeta/store.go:89 +0x1d0

Previous read at 0x00c000132cc8 by goroutine 189:
  runtime.racereadrange()
      <autogenerated>:1 +0x1b
  github.com/DataDog/datadog-agent/pkg/autodiscovery/providers.(*ContainerConfigProvider).processEvents()
      /go/src/github.com/DataDog/datadog-agent/pkg/autodiscovery/providers/container.go:111 +0xef
  github.com/DataDog/datadog-agent/pkg/autodiscovery/providers.(*ContainerConfigProvider).listen()
      /go/src/github.com/DataDog/datadog-agent/pkg/autodiscovery/providers/container.go:99 +0x2ac
  github.com/DataDog/datadog-agent/pkg/autodiscovery/providers.(*ContainerConfigProvider).Collect.func1·dwrap·3()
      /go/src/github.com/DataDog/datadog-agent/pkg/autodiscovery/providers/container.go:63 +0x39
```

### Describe how to test/QA your changes

The issue is quite obvious from the code, but I wasn't able to reproduce it with a default agent build, since the effect is difficult to see. Vikentiy that found the issue said the following:

> I had agent built with --race running on a linux host with docker, and simply starting a new container in docker triggered the race detector.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
