### PR TITLE
[docker] Listen to "health_status" events

### DIFF
--- a/pkg/util/docker/event_stream.go
+++ b/pkg/util/docker/event_stream.go
@@ -82,10 +82,11 @@ func (e *eventStreamState) unsubscribe(name string) error {
 func (d *DockerUtil) dispatchEvents(sub *eventSubscriber) {
 	fltrs := filters.NewArgs()
 	fltrs.Add("type", "container")
-	fltrs.Add("event", "start")
-	fltrs.Add("event", "die")
-	fltrs.Add("event", "died")
-	fltrs.Add("event", "rename")
+	fltrs.Add("event", ContainerEventActionStart)
+	fltrs.Add("event", ContainerEventActionDie)
+	fltrs.Add("event", ContainerEventActionDied)
+	fltrs.Add("event", ContainerEventActionRename)
+	fltrs.Add("event", ContainerEventActionHealthStatus)
 
 	// On initial subscribe, don't go back in time. On reconnect, we'll
 	// resume at the latest timestamp we got.

--- a/pkg/util/docker/event_types.go
+++ b/pkg/util/docker/event_types.go
@@ -25,6 +25,9 @@ const (
 	ContainerEventActionDied = "died"
 	// ContainerEventActionRename is the action of renaming a docker container
 	ContainerEventActionRename = "rename"
+	// ContainerEventActionHealthStatus is the action of changing a docker
+	// container's health status
+	ContainerEventActionHealthStatus = "health_status"
 )
 
 // ContainerEvent describes an event from the docker daemon

--- a/pkg/workloadmeta/collectors/internal/docker/docker.go
+++ b/pkg/workloadmeta/collectors/internal/docker/docker.go
@@ -180,7 +180,10 @@ func (c *collector) buildCollectorEvent(ctx context.Context, ev *docker.Containe
 	}
 
 	switch ev.Action {
-	case docker.ContainerEventActionStart, docker.ContainerEventActionRename:
+	case docker.ContainerEventActionStart,
+		docker.ContainerEventActionRename,
+		docker.ContainerEventActionHealthStatus:
+
 		container, err := c.dockerUtil.InspectNoCache(ctx, ev.ContainerID, false)
 		if err != nil {
 			return event, fmt.Errorf("could not inspect container %q: %s", ev.ContainerID, err)


### PR DESCRIPTION
### What does this PR do?

This is a follow up to #11908. While it did parse the container's health
properly, it did so only once, since we did not previously listen to
events that changed the container's health. This PR adds those events to
the default event filter, and handles it in workloadmeta.

### Describe how to test/QA your changes

Same as #11908, but make sure that the container starts *after* the agent. Bonus points for being able to change back and forth between healthy and unhealthy.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
