### PR TITLE
Cluster agent check command panics if the orchestrator explorer is enabled

### DIFF
--- a/cmd/agent/common/commands/check.go
+++ b/cmd/agent/common/commands/check.go
@@ -148,7 +148,7 @@ func Check(loggerName config.LoggerName, confFilePath *string, flagNoColor *bool
 			opts.FlushInterval = 0
 			opts.UseNoopForwarder = true
 			opts.UseNoopEventPlatformForwarder = true
-			opts.UseOrchestratorForwarder = false
+			opts.UseNoopOrchestratorForwarder = true
 			demux := aggregator.InitAndStartAgentDemultiplexer(opts, hostname)
 
 			common.LoadComponents(context.Background(), config.Datadog.GetString("confd_path"))

--- a/pkg/aggregator/demultiplexer.go
+++ b/pkg/aggregator/demultiplexer.go
@@ -82,6 +82,7 @@ type DemultiplexerOptions struct {
 	SharedForwarderOptions         *forwarder.Options
 	UseNoopForwarder               bool
 	UseNoopEventPlatformForwarder  bool
+	UseNoopOrchestratorForwarder   bool
 	UseEventPlatformForwarder      bool
 	UseOrchestratorForwarder       bool
 	UseContainerLifecycleForwarder bool

--- a/pkg/aggregator/demultiplexer_agent.go
+++ b/pkg/aggregator/demultiplexer_agent.go
@@ -61,7 +61,7 @@ type statsd struct {
 
 type forwarders struct {
 	shared             forwarder.Forwarder
-	orchestrator       *forwarder.DefaultForwarder
+	orchestrator       forwarder.Forwarder
 	eventPlatform      epforwarder.EventPlatformForwarder
 	containerLifecycle *forwarder.DefaultForwarder
 }
@@ -96,8 +96,10 @@ func initAgentDemultiplexer(options DemultiplexerOptions, hostname string) *Agen
 
 	log.Debugf("Creating forwarders")
 	// orchestrator forwarder
-	var orchestratorForwarder *forwarder.DefaultForwarder
-	if options.UseOrchestratorForwarder {
+	var orchestratorForwarder forwarder.Forwarder
+	if options.UseNoopOrchestratorForwarder {
+		orchestratorForwarder = new(forwarder.NoopForwarder)
+	} else if options.UseOrchestratorForwarder {
 		orchestratorForwarder = buildOrchestratorForwarder()
 	}
 

--- a/pkg/aggregator/demultiplexer_orchestrator.go
+++ b/pkg/aggregator/demultiplexer_orchestrator.go
@@ -13,6 +13,6 @@ import (
 	orch "github.com/DataDog/datadog-agent/pkg/orchestrator/config"
 )
 
-func buildOrchestratorForwarder() *forwarder.DefaultForwarder {
+func buildOrchestratorForwarder() forwarder.Forwarder {
 	return orch.NewOrchestratorForwarder()
 }

--- a/pkg/aggregator/demultiplexer_test.go
+++ b/pkg/aggregator/demultiplexer_test.go
@@ -123,6 +123,17 @@ func TestDemuxForwardersCreated(t *testing.T) {
 	require.NotNil(demux.forwarders.shared)
 	demux.Stop(false)
 
+	// options noop orchestrator forwarder
+
+	opts = demuxTestOptions()
+	opts.UseNoopOrchestratorForwarder = true
+	demux = InitAndStartAgentDemultiplexer(opts, "")
+	require.NotNil(demux)
+	require.NotNil(demux.forwarders.eventPlatform)
+	require.NotNil(demux.forwarders.orchestrator)
+	require.NotNil(demux.forwarders.shared)
+	demux.Stop(false)
+
 	// no options to disable it, but the feature is not enabled
 
 	config.Datadog.Set("orchestrator_explorer.enabled", false)

--- a/pkg/orchestrator/config/config.go
+++ b/pkg/orchestrator/config/config.go
@@ -159,7 +159,7 @@ func extractOrchestratorDDUrl() (*url.URL, error) {
 
 // NewOrchestratorForwarder returns an orchestratorForwarder
 // if the feature is activated on the cluster-agent/cluster-check runner, nil otherwise
-func NewOrchestratorForwarder() *forwarder.DefaultForwarder {
+func NewOrchestratorForwarder() forwarder.Forwarder {
 	if !config.Datadog.GetBool(key(orchestratorNS, "enabled")) {
 		return nil
 	}

--- a/releasenotes-dca/notes/bugfix-cli-check-9b56486b158ebb93.yaml
+++ b/releasenotes-dca/notes/bugfix-cli-check-9b56486b158ebb93.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG-DCA.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix a panic occuring during the invocation of the `check` command on the
+    cluster agent if the orchestrator explorer feature is enabled.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Use a no-op forwarder in the check command. Prior to that change the orchestrator forwarder was left uninitialized leading to a nil pointer dereference.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

A panic was spotted while invoking the CLI `check` command upon testing.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
