### PR TITLE
Keep the ServiceID -> Service mapping in AutoConfig

### DIFF
--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -435,6 +435,7 @@ func (ac *AutoConfig) GetUnresolvedTemplates() map[string][]integration.Config {
 // triggers scheduling events if it finds a valid config for it.
 func (ac *AutoConfig) processNewService(ctx context.Context, svc listeners.Service) {
 	// in any case, register the service and store its tag hash
+	ac.store.setServiceForEntity(svc, svc.GetServiceID())
 	ac.store.setTagsHashForService(
 		svc.GetTaggerEntity(),
 		tagger.GetEntityHash(svc.GetTaggerEntity(), tagger.ChecksCardinality),
@@ -463,6 +464,7 @@ func (ac *AutoConfig) processNewService(ctx context.Context, svc listeners.Servi
 
 // processDelService takes a service, stops its associated checks, and updates the cache
 func (ac *AutoConfig) processDelService(svc listeners.Service) {
+	ac.store.removeServiceForEntity(svc.GetServiceID())
 	changes := ac.cfgMgr.processDelService(svc)
 	ac.store.removeTagsHashForService(svc.GetTaggerEntity())
 


### PR DESCRIPTION
In order to check tag freshness, AutoConfig needs to keep track of all
the services currently discovered.  This information was accidentally
lost in 758b11b.

### Motivation

Fix regression: changes to pod annotations do not update configs.

### Describe how to test/QA your changes

Run a pod for which there is an integration (e.g., redis), and observe it in `agent checkconfig`.  Edit the pod to add `ad.datadoghq.com/tags: "{\"some\":\"tag\"}"`, and once the agent is updated you should see a `some:tag` tag in the `agent checkconfig` output.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
