### PR TITLE
[logs] Disable compression when sending to Vector

### DIFF
--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -230,6 +230,7 @@ func BuildHTTPEndpointsWithConfig(logsConfig *LogsConfigKeys, endpointPrefix str
 				main.UseSSL = false
 			}
 			main.Host = u.Hostname()
+			main.UseCompression = false
 			if u.Port() != "" {
 				port, err := strconv.Atoi(u.Port())
 				if err != nil {
@@ -245,6 +246,7 @@ func BuildHTTPEndpointsWithConfig(logsConfig *LogsConfigKeys, endpointPrefix str
 			main.Host = host
 			main.Port = port
 			main.UseSSL = !defaultNoSSL
+			main.UseCompression = false
 		}
 
 	} else if logsDDURL, logsDDURLDefined := logsConfig.logsDDURL(); logsDDURLDefined {

--- a/pkg/logs/config/config_test.go
+++ b/pkg/logs/config/config_test.go
@@ -550,13 +550,13 @@ func (suite *ConfigTestSuite) TestBuildServerlessEndpoints() {
 	suite.Equal(expectedEndpoints, endpoints)
 }
 
-func getTestEndpoint(host string, port int, ssl bool) Endpoint {
+func getTestEndpoint(host string, port int, ssl bool, compression bool) Endpoint {
 	return Endpoint{
 		APIKey:           "123",
 		Host:             host,
 		Port:             port,
 		UseSSL:           ssl,
-		UseCompression:   true,
+		UseCompression:   compression,
 		CompressionLevel: 6,
 		BackoffFactor:    coreConfig.DefaultLogsSenderBackoffFactor,
 		BackoffBase:      coreConfig.DefaultLogsSenderBackoffBase,
@@ -586,7 +586,7 @@ func (suite *ConfigTestSuite) TestBuildEndpointsWithVectorHttpOverride() {
 	suite.config.Set("vector.logs.url", "http://vector.host:8080/")
 	endpoints, err := BuildHTTPEndpointsWithVectorOverride("test-track", "test-proto", "test-source")
 	suite.Nil(err)
-	expectedEndpoints := getTestEndpoints(getTestEndpoint("vector.host", 8080, false))
+	expectedEndpoints := getTestEndpoints(getTestEndpoint("vector.host", 8080, false, false))
 	suite.Nil(err)
 	suite.Equal(expectedEndpoints, endpoints)
 }
@@ -597,7 +597,7 @@ func (suite *ConfigTestSuite) TestBuildEndpointsWithVectorHttpsOverride() {
 	suite.config.Set("vector.logs.url", "https://vector.host:8443/")
 	endpoints, err := BuildHTTPEndpointsWithVectorOverride("test-track", "test-proto", "test-source")
 	suite.Nil(err)
-	expectedEndpoints := getTestEndpoints(getTestEndpoint("vector.host", 8443, true))
+	expectedEndpoints := getTestEndpoints(getTestEndpoint("vector.host", 8443, true, false))
 	suite.Nil(err)
 	suite.Equal(expectedEndpoints, endpoints)
 }
@@ -608,7 +608,7 @@ func (suite *ConfigTestSuite) TestBuildEndpointsWithVectorHostAndPortOverride() 
 	suite.config.Set("vector.logs.url", "vector.host:8443")
 	endpoints, err := BuildHTTPEndpointsWithVectorOverride("test-track", "test-proto", "test-source")
 	suite.Nil(err)
-	expectedEndpoints := getTestEndpoints(getTestEndpoint("vector.host", 8443, true))
+	expectedEndpoints := getTestEndpoints(getTestEndpoint("vector.host", 8443, true, false))
 	suite.Nil(err)
 	suite.Equal(expectedEndpoints, endpoints)
 }
@@ -620,7 +620,7 @@ func (suite *ConfigTestSuite) TestBuildEndpointsWithVectorHostAndPortNoSSLOverri
 	suite.config.Set("vector.logs.url", "vector.host:8443")
 	endpoints, err := BuildHTTPEndpointsWithVectorOverride("test-track", "test-proto", "test-source")
 	suite.Nil(err)
-	expectedEndpoints := getTestEndpoints(getTestEndpoint("vector.host", 8443, false))
+	expectedEndpoints := getTestEndpoints(getTestEndpoint("vector.host", 8443, false, false))
 	suite.Nil(err)
 	suite.Equal(expectedEndpoints, endpoints)
 }
@@ -632,7 +632,7 @@ func (suite *ConfigTestSuite) TestBuildEndpointsWithoutVector() {
 	suite.config.Set("vector.logs.url", "vector.host:8443")
 	endpoints, err := BuildHTTPEndpoints("test-track", "test-proto", "test-source")
 	suite.Nil(err)
-	expectedEndpoints := getTestEndpoints(getTestEndpoint("agent-http-intake.logs.datadoghq.com", 0, true))
+	expectedEndpoints := getTestEndpoints(getTestEndpoint("agent-http-intake.logs.datadoghq.com", 0, true, true))
 	suite.Nil(err)
 	suite.Equal(expectedEndpoints, endpoints)
 }

--- a/releasenotes/notes/Disable-compression-with-Vector-d84089ab9a730416.yaml
+++ b/releasenotes/notes/Disable-compression-with-Vector-d84089ab9a730416.yaml
@@ -1,0 +1,7 @@
+---
+upgrade:
+  - |
+    This change disables compression when the Datadog Agent is configured to
+    use a Vector aggregator through the `vector.*` options. The expected impact
+    of this change is that while internal bandwidth usage will increase
+    slightly, significant CPU savings can be achieved.


### PR DESCRIPTION
### What does this PR do?
We've discussed internally and determined that it might make more sense to disable HTTP compression when the agent is connecting to a Vector instance. This'll save on a lot of CPU in both ends of the connection, and rarely will internal bandwidth be the issue.

### Motivation
We've received reports from customers that they are disabling compression on their own.

### Possible Drawbacks / Trade-offs
Greater bandwidth utilization on the customer internal network.

### Describe how to test/QA your changes
* Spin up a Datadog Agent and a Vector process to point it at.
* Run a `mitmproxy` that sits between the two.
* Observe that log data being sent is no longer compressed on the wire.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
