### PR TITLE
[CWS] serializers improvements

### DIFF
--- a/docs/cloud-workload-security/backend.schema.json
+++ b/docs/cloud-workload-security/backend.schema.json
@@ -68,7 +68,8 @@
       "$ref": "#/definitions/ContainerContext"
     },
     "date": {
-      "$ref": "#/definitions/EasyjsonTime"
+      "type": "string",
+      "format": "date-time"
     }
   },
   "additionalProperties": false,
@@ -229,11 +230,6 @@
       "additionalProperties": false,
       "type": "object"
     },
-    "EasyjsonTime": {
-      "properties": {},
-      "additionalProperties": false,
-      "type": "object"
-    },
     "EventContext": {
       "properties": {
         "name": {
@@ -326,15 +322,18 @@
           "description": "File flags"
         },
         "access_time": {
-          "$ref": "#/definitions/EasyjsonTime"
+          "type": "string",
+          "format": "date-time"
         },
         "modification_time": {
-          "$ref": "#/definitions/EasyjsonTime",
-          "description": "File modified time"
+          "type": "string",
+          "description": "File modified time",
+          "format": "date-time"
         },
         "change_time": {
-          "$ref": "#/definitions/EasyjsonTime",
-          "description": "File change time"
+          "type": "string",
+          "description": "File change time",
+          "format": "date-time"
         }
       },
       "additionalProperties": false,
@@ -410,16 +409,18 @@
           "description": "File flags"
         },
         "access_time": {
-          "$schema": "http://json-schema.org/draft-04/schema#",
-          "$ref": "#/definitions/EasyjsonTime"
+          "type": "string",
+          "format": "date-time"
         },
         "modification_time": {
-          "$ref": "#/definitions/EasyjsonTime",
-          "description": "File modified time"
+          "type": "string",
+          "description": "File modified time",
+          "format": "date-time"
         },
         "change_time": {
-          "$ref": "#/definitions/EasyjsonTime",
-          "description": "File change time"
+          "type": "string",
+          "description": "File change time",
+          "format": "date-time"
         },
         "destination": {
           "$schema": "http://json-schema.org/draft-04/schema#",
@@ -697,16 +698,19 @@
           "description": "TTY associated with the process"
         },
         "fork_time": {
-          "$ref": "#/definitions/EasyjsonTime",
-          "description": "Fork time of the process"
+          "type": "string",
+          "description": "Fork time of the process",
+          "format": "date-time"
         },
         "exec_time": {
-          "$ref": "#/definitions/EasyjsonTime",
-          "description": "Exec time of the process"
+          "type": "string",
+          "description": "Exec time of the process",
+          "format": "date-time"
         },
         "exit_time": {
-          "$ref": "#/definitions/EasyjsonTime",
-          "description": "Exit time of the process"
+          "type": "string",
+          "description": "Exit time of the process",
+          "format": "date-time"
         },
         "credentials": {
           "$ref": "#/definitions/ProcessCredentials",
@@ -797,16 +801,19 @@
           "description": "TTY associated with the process"
         },
         "fork_time": {
-          "$ref": "#/definitions/EasyjsonTime",
-          "description": "Fork time of the process"
+          "type": "string",
+          "description": "Fork time of the process",
+          "format": "date-time"
         },
         "exec_time": {
-          "$ref": "#/definitions/EasyjsonTime",
-          "description": "Exec time of the process"
+          "type": "string",
+          "description": "Exec time of the process",
+          "format": "date-time"
         },
         "exit_time": {
-          "$ref": "#/definitions/EasyjsonTime",
-          "description": "Exit time of the process"
+          "type": "string",
+          "description": "Exit time of the process",
+          "format": "date-time"
         },
         "credentials": {
           "$schema": "http://json-schema.org/draft-04/schema#",

--- a/docs/cloud-workload-security/backend.schema.json
+++ b/docs/cloud-workload-security/backend.schema.json
@@ -68,8 +68,7 @@
       "$ref": "#/definitions/ContainerContext"
     },
     "date": {
-      "type": "string",
-      "format": "date-time"
+      "$ref": "#/definitions/EasyjsonTime"
     }
   },
   "additionalProperties": false,
@@ -230,6 +229,11 @@
       "additionalProperties": false,
       "type": "object"
     },
+    "EasyjsonTime": {
+      "properties": {},
+      "additionalProperties": false,
+      "type": "object"
+    },
     "EventContext": {
       "properties": {
         "name": {
@@ -322,18 +326,15 @@
           "description": "File flags"
         },
         "access_time": {
-          "type": "string",
-          "format": "date-time"
+          "$ref": "#/definitions/EasyjsonTime"
         },
         "modification_time": {
-          "type": "string",
-          "description": "File modified time",
-          "format": "date-time"
+          "$ref": "#/definitions/EasyjsonTime",
+          "description": "File modified time"
         },
         "change_time": {
-          "type": "string",
-          "description": "File change time",
-          "format": "date-time"
+          "$ref": "#/definitions/EasyjsonTime",
+          "description": "File change time"
         }
       },
       "additionalProperties": false,
@@ -409,18 +410,16 @@
           "description": "File flags"
         },
         "access_time": {
-          "type": "string",
-          "format": "date-time"
+          "$schema": "http://json-schema.org/draft-04/schema#",
+          "$ref": "#/definitions/EasyjsonTime"
         },
         "modification_time": {
-          "type": "string",
-          "description": "File modified time",
-          "format": "date-time"
+          "$ref": "#/definitions/EasyjsonTime",
+          "description": "File modified time"
         },
         "change_time": {
-          "type": "string",
-          "description": "File change time",
-          "format": "date-time"
+          "$ref": "#/definitions/EasyjsonTime",
+          "description": "File change time"
         },
         "destination": {
           "$schema": "http://json-schema.org/draft-04/schema#",
@@ -698,19 +697,16 @@
           "description": "TTY associated with the process"
         },
         "fork_time": {
-          "type": "string",
-          "description": "Fork time of the process",
-          "format": "date-time"
+          "$ref": "#/definitions/EasyjsonTime",
+          "description": "Fork time of the process"
         },
         "exec_time": {
-          "type": "string",
-          "description": "Exec time of the process",
-          "format": "date-time"
+          "$ref": "#/definitions/EasyjsonTime",
+          "description": "Exec time of the process"
         },
         "exit_time": {
-          "type": "string",
-          "description": "Exit time of the process",
-          "format": "date-time"
+          "$ref": "#/definitions/EasyjsonTime",
+          "description": "Exit time of the process"
         },
         "credentials": {
           "$ref": "#/definitions/ProcessCredentials",
@@ -801,19 +797,16 @@
           "description": "TTY associated with the process"
         },
         "fork_time": {
-          "type": "string",
-          "description": "Fork time of the process",
-          "format": "date-time"
+          "$ref": "#/definitions/EasyjsonTime",
+          "description": "Fork time of the process"
         },
         "exec_time": {
-          "type": "string",
-          "description": "Exec time of the process",
-          "format": "date-time"
+          "$ref": "#/definitions/EasyjsonTime",
+          "description": "Exec time of the process"
         },
         "exit_time": {
-          "type": "string",
-          "description": "Exit time of the process",
-          "format": "date-time"
+          "$ref": "#/definitions/EasyjsonTime",
+          "description": "Exit time of the process"
         },
         "credentials": {
           "$schema": "http://json-schema.org/draft-04/schema#",

--- a/pkg/security/module/module.go
+++ b/pkg/security/module/module.go
@@ -437,7 +437,7 @@ func (m *Module) HandleCustomEvent(rule *rules.Rule, event *sprobe.CustomEvent) 
 }
 
 // RuleMatch is called by the ruleset when a rule matches
-func (m *Module) RuleMatch(rule *rules.Rule, event eval.Event) {
+func (m *Module) RuleMatch(rule *rules.Rule, event eval.EventMarshaler) {
 	// prepare the event
 	m.probe.OnRuleMatch(rule, event.(*sprobe.Event))
 

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -27,6 +27,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
 	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
@@ -373,13 +374,13 @@ func (a *APIServer) SendEvent(rule *rules.Rule, event Event, extTagsCb func() []
 		ruleEvent.AgentContext.PolicyVersion = policy.Version
 	}
 
-	probeJSON, err := easyjson.Marshal(event)
+	probeJSON, err := utils.EasyjsonMarshal(event)
 	if err != nil {
 		log.Error(errors.Wrap(err, "failed to marshal event"))
 		return
 	}
 
-	ruleEventJSON, err := easyjson.Marshal(ruleEvent)
+	ruleEventJSON, err := utils.EasyjsonMarshal(ruleEvent)
 	if err != nil {
 		log.Error(errors.Wrap(err, "failed to marshal event context"))
 		return

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -374,13 +374,13 @@ func (a *APIServer) SendEvent(rule *rules.Rule, event Event, extTagsCb func() []
 		ruleEvent.AgentContext.PolicyVersion = policy.Version
 	}
 
-	probeJSON, err := utils.EasyjsonMarshal(event)
+	probeJSON, err := utils.EasyjsonMarshal(event, 20000)
 	if err != nil {
 		log.Error(errors.Wrap(err, "failed to marshal event"))
 		return
 	}
 
-	ruleEventJSON, err := utils.EasyjsonMarshal(ruleEvent)
+	ruleEventJSON, err := utils.EasyjsonMarshal(ruleEvent, -1)
 	if err != nil {
 		log.Error(errors.Wrap(err, "failed to marshal event context"))
 		return

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -10,7 +10,6 @@ package module
 
 import (
 	"context"
-	json "encoding/json"
 	"fmt"
 	"strings"
 	"sync"
@@ -93,6 +92,7 @@ LOOP:
 type Event interface {
 	GetTags() []string
 	GetType() string
+	easyjson.Marshaler
 }
 
 // RuleEvent is a wrapper used to send an event to the backend
@@ -373,7 +373,7 @@ func (a *APIServer) SendEvent(rule *rules.Rule, event Event, extTagsCb func() []
 		ruleEvent.AgentContext.PolicyVersion = policy.Version
 	}
 
-	probeJSON, err := json.Marshal(event)
+	probeJSON, err := easyjson.Marshal(event)
 	if err != nil {
 		log.Error(errors.Wrap(err, "failed to marshal event"))
 		return

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -386,7 +386,9 @@ func (a *APIServer) SendEvent(rule *rules.Rule, event Event, extTagsCb func() []
 		return
 	}
 
-	data := append(probeJSON[:len(probeJSON)-1], ',')
+	data := make([]byte, 0, len(probeJSON)+len(ruleEventJSON)-1) // -2 for the '}' and '{' +1 for the ','
+	data = append(data, probeJSON[:len(probeJSON)-1]...)
+	data = append(data, ',')
 	data = append(data, ruleEventJSON[1:]...)
 	seclog.Tracef("Sending event message for rule `%s` to security-agent `%s`", rule.ID, string(data))
 

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -374,13 +374,13 @@ func (a *APIServer) SendEvent(rule *rules.Rule, event Event, extTagsCb func() []
 		ruleEvent.AgentContext.PolicyVersion = policy.Version
 	}
 
-	probeJSON, err := utils.EasyjsonMarshal(event, 20000)
+	probeJSON, err := utils.EasyjsonMarshal(event)
 	if err != nil {
 		log.Error(errors.Wrap(err, "failed to marshal event"))
 		return
 	}
 
-	ruleEventJSON, err := utils.EasyjsonMarshal(ruleEvent, -1)
+	ruleEventJSON, err := utils.EasyjsonMarshal(ruleEvent)
 	if err != nil {
 		log.Error(errors.Wrap(err, "failed to marshal event context"))
 		return

--- a/pkg/security/probe/custom_events.go
+++ b/pkg/security/probe/custom_events.go
@@ -89,15 +89,6 @@ func (ce *CustomEvent) MarshalEasyJSON(w *jwriter.Writer) {
 	ce.inner.MarshalEasyJSON(w)
 }
 
-// String returns the string representation of a custom event
-func (ce *CustomEvent) String() string {
-	d, err := json.Marshal(ce)
-	if err != nil {
-		return err.Error()
-	}
-	return string(d)
-}
-
 func newRule(ruleDef *rules.RuleDefinition) *rules.Rule {
 	return &rules.Rule{
 		Rule:       &eval.Rule{ID: ruleDef.ID},

--- a/pkg/security/probe/custom_events.go
+++ b/pkg/security/probe/custom_events.go
@@ -19,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 	"github.com/hashicorp/go-multierror"
 	"github.com/mailru/easyjson"
+	jwriter "github.com/mailru/easyjson/jwriter"
 )
 
 const (
@@ -45,10 +46,10 @@ func AllCustomRuleIDs() []string {
 	}
 }
 
-func newCustomEvent(eventType model.EventType, marshaler easyjson.Marshaler) *CustomEvent {
+func newCustomEvent(eventType model.EventType, inner easyjson.Marshaler) *CustomEvent {
 	return &CustomEvent{
 		eventType: eventType,
-		marshaler: marshaler,
+		inner:     inner,
 	}
 }
 
@@ -56,7 +57,7 @@ func newCustomEvent(eventType model.EventType, marshaler easyjson.Marshaler) *Cu
 type CustomEvent struct {
 	eventType model.EventType
 	tags      []string
-	marshaler easyjson.Marshaler
+	inner     easyjson.Marshaler
 }
 
 // Clone returns a copy of the current CustomEvent
@@ -64,7 +65,7 @@ func (ce *CustomEvent) Clone() CustomEvent {
 	return CustomEvent{
 		eventType: ce.eventType,
 		tags:      ce.tags,
-		marshaler: ce.marshaler,
+		inner:     ce.inner,
 	}
 }
 
@@ -83,9 +84,9 @@ func (ce *CustomEvent) GetEventType() model.EventType {
 	return ce.eventType
 }
 
-// MarshalJSON is the JSON marshaller function of the custom event
-func (ce *CustomEvent) MarshalJSON() ([]byte, error) {
-	return easyjson.Marshal(ce.marshaler)
+// MarshalEasyJSON is the JSON marshaller function of the custom event
+func (ce *CustomEvent) MarshalEasyJSON(w *jwriter.Writer) {
+	ce.inner.MarshalEasyJSON(w)
 }
 
 // String returns the string representation of a custom event

--- a/pkg/security/probe/doc_generator/backend_doc_gen.go
+++ b/pkg/security/probe/doc_generator/backend_doc_gen.go
@@ -14,8 +14,10 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/security/probe"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	"github.com/alecthomas/jsonschema"
 )
 
@@ -23,6 +25,7 @@ func generateBackendJSON(output string) error {
 	reflector := jsonschema.Reflector{
 		ExpandedStruct: true,
 		DoNotReference: false,
+		TypeMapper:     jsonTypeMapper,
 		TypeNamer:      jsonTypeNamer,
 	}
 	schema := reflector.Reflect(&probe.EventSerializer{})
@@ -33,6 +36,13 @@ func generateBackendJSON(output string) error {
 	}
 
 	return os.WriteFile(output, schemaJSON, 0664)
+}
+
+func jsonTypeMapper(ty reflect.Type) *jsonschema.Type {
+	if ty == reflect.TypeOf(utils.EasyjsonTime{}) {
+		return jsonschema.Reflect(time.Time{}).Type
+	}
+	return nil
 }
 
 func jsonTypeNamer(ty reflect.Type) string {

--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -16,13 +16,13 @@ import (
 	"time"
 
 	manager "github.com/DataDog/ebpf-manager"
-	"github.com/mailru/easyjson"
 	"github.com/mailru/easyjson/jwriter"
 
 	pconfig "github.com/DataDog/datadog-agent/pkg/process/config"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/constantfetch"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
 
 const (
@@ -425,7 +425,7 @@ func (ev *Event) ResolveSELinuxBoolName(e *model.SELinuxEvent) string {
 }
 
 func (ev *Event) String() string {
-	d, err := easyjson.Marshal(ev)
+	d, err := utils.EasyjsonMarshal(ev)
 	if err != nil {
 		return err.Error()
 	}

--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -423,27 +423,15 @@ func (ev *Event) ResolveSELinuxBoolName(e *model.SELinuxEvent) string {
 	return ev.SELinux.BoolName
 }
 
-func (ev *Event) String() string {
-	d, err := ev.MarshalJSON()
-	if err != nil {
-		return err.Error()
-	}
-	return string(d)
-}
-
 // SetPathResolutionError sets the Event.pathResolutionError
 func (ev *Event) SetPathResolutionError(err error) {
 	ev.pathResolutionError = err
 }
 
-// MarshalJSON returns the JSON encoding of the event
-func (ev *Event) MarshalJSON() ([]byte, error) {
+// MarshalEasyJSON returns the JSON encoding of the event
+func (ev *Event) MarshalEasyJSON(w *jwriter.Writer) {
 	s := NewEventSerializer(ev)
-	w := &jwriter.Writer{
-		Flags: jwriter.NilSliceAsEmpty | jwriter.NilMapAsEmpty,
-	}
 	s.MarshalEasyJSON(w)
-	return w.BuildBytes()
 }
 
 // ExtractEventInfo extracts cpu and timestamp from the raw data event

--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -425,7 +425,7 @@ func (ev *Event) ResolveSELinuxBoolName(e *model.SELinuxEvent) string {
 }
 
 func (ev *Event) String() string {
-	d, err := utils.EasyjsonMarshal(ev, -1)
+	d, err := utils.EasyjsonMarshal(ev)
 	if err != nil {
 		return err.Error()
 	}

--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	manager "github.com/DataDog/ebpf-manager"
+	"github.com/mailru/easyjson"
 	"github.com/mailru/easyjson/jwriter"
 
 	pconfig "github.com/DataDog/datadog-agent/pkg/process/config"
@@ -421,6 +422,14 @@ func (ev *Event) ResolveSELinuxBoolName(e *model.SELinuxEvent) string {
 		ev.SELinux.BoolName = ev.resolvers.resolveBasename(&e.File.FileFields)
 	}
 	return ev.SELinux.BoolName
+}
+
+func (ev *Event) String() string {
+	d, err := easyjson.Marshal(ev)
+	if err != nil {
+		return err.Error()
+	}
+	return string(d)
 }
 
 // SetPathResolutionError sets the Event.pathResolutionError

--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -425,7 +425,7 @@ func (ev *Event) ResolveSELinuxBoolName(e *model.SELinuxEvent) string {
 }
 
 func (ev *Event) String() string {
-	d, err := utils.EasyjsonMarshal(ev)
+	d, err := utils.EasyjsonMarshal(ev, -1)
 	if err != nil {
 		return err.Error()
 	}

--- a/pkg/security/probe/serializers.go
+++ b/pkg/security/probe/serializers.go
@@ -20,29 +20,30 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
 
 // FileSerializer serializes a file to JSON
 // easyjson:json
 type FileSerializer struct {
-	Path                string     `json:"path,omitempty" jsonschema_description:"File path"`
-	Name                string     `json:"name,omitempty" jsonschema_description:"File basename"`
-	PathResolutionError string     `json:"path_resolution_error,omitempty" jsonschema_description:"Error message from path resolution"`
-	Inode               *uint64    `json:"inode,omitempty" jsonschema_description:"File inode number"`
-	Mode                *uint32    `json:"mode,omitempty" jsonschema_description:"File mode"`
-	InUpperLayer        *bool      `json:"in_upper_layer,omitempty" jsonschema_description:"Indicator of file OverlayFS layer"`
-	MountID             *uint32    `json:"mount_id,omitempty" jsonschema_description:"File mount ID"`
-	Filesystem          string     `json:"filesystem,omitempty" jsonschema_description:"File filesystem name"`
-	UID                 int64      `json:"uid" jsonschema_description:"File User ID"`
-	GID                 int64      `json:"gid" jsonschema_description:"File Group ID"`
-	User                string     `json:"user,omitempty" jsonschema_description:"File user"`
-	Group               string     `json:"group,omitempty" jsonschema_description:"File group"`
-	XAttrName           string     `json:"attribute_name,omitempty" jsonschema_description:"File extended attribute name"`
-	XAttrNamespace      string     `json:"attribute_namespace,omitempty" jsonschema_description:"File extended attribute namespace"`
-	Flags               []string   `json:"flags,omitempty" jsonschema_description:"File flags"`
-	Atime               *time.Time `json:"access_time,omitempty" jsonschema_descrition:"File access time"`
-	Mtime               *time.Time `json:"modification_time,omitempty" jsonschema_description:"File modified time"`
-	Ctime               *time.Time `json:"change_time,omitempty" jsonschema_description:"File change time"`
+	Path                string              `json:"path,omitempty" jsonschema_description:"File path"`
+	Name                string              `json:"name,omitempty" jsonschema_description:"File basename"`
+	PathResolutionError string              `json:"path_resolution_error,omitempty" jsonschema_description:"Error message from path resolution"`
+	Inode               *uint64             `json:"inode,omitempty" jsonschema_description:"File inode number"`
+	Mode                *uint32             `json:"mode,omitempty" jsonschema_description:"File mode"`
+	InUpperLayer        *bool               `json:"in_upper_layer,omitempty" jsonschema_description:"Indicator of file OverlayFS layer"`
+	MountID             *uint32             `json:"mount_id,omitempty" jsonschema_description:"File mount ID"`
+	Filesystem          string              `json:"filesystem,omitempty" jsonschema_description:"File filesystem name"`
+	UID                 int64               `json:"uid" jsonschema_description:"File User ID"`
+	GID                 int64               `json:"gid" jsonschema_description:"File Group ID"`
+	User                string              `json:"user,omitempty" jsonschema_description:"File user"`
+	Group               string              `json:"group,omitempty" jsonschema_description:"File group"`
+	XAttrName           string              `json:"attribute_name,omitempty" jsonschema_description:"File extended attribute name"`
+	XAttrNamespace      string              `json:"attribute_namespace,omitempty" jsonschema_description:"File extended attribute namespace"`
+	Flags               []string            `json:"flags,omitempty" jsonschema_description:"File flags"`
+	Atime               *utils.EasyjsonTime `json:"access_time,omitempty" jsonschema_descrition:"File access time"`
+	Mtime               *utils.EasyjsonTime `json:"modification_time,omitempty" jsonschema_description:"File modified time"`
+	Ctime               *utils.EasyjsonTime `json:"change_time,omitempty" jsonschema_description:"File change time"`
 }
 
 // UserContextSerializer serializes a user context to JSON
@@ -120,9 +121,9 @@ type ProcessSerializer struct {
 	PathResolutionError string                        `json:"path_resolution_error,omitempty" jsonschema_description:"Description of an error in the path resolution"`
 	Comm                string                        `json:"comm,omitempty" jsonschema_description:"Command name"`
 	TTY                 string                        `json:"tty,omitempty" jsonschema_description:"TTY associated with the process"`
-	ForkTime            *time.Time                    `json:"fork_time,omitempty" jsonschema_description:"Fork time of the process"`
-	ExecTime            *time.Time                    `json:"exec_time,omitempty" jsonschema_description:"Exec time of the process"`
-	ExitTime            *time.Time                    `json:"exit_time,omitempty" jsonschema_description:"Exit time of the process"`
+	ForkTime            *utils.EasyjsonTime           `json:"fork_time,omitempty" jsonschema_description:"Fork time of the process"`
+	ExecTime            *utils.EasyjsonTime           `json:"exec_time,omitempty" jsonschema_description:"Exec time of the process"`
+	ExitTime            *utils.EasyjsonTime           `json:"exit_time,omitempty" jsonschema_description:"Exit time of the process"`
 	Credentials         *ProcessCredentialsSerializer `json:"credentials,omitempty" jsonschema_description:"Credentials associated with the process"`
 	Executable          *FileSerializer               `json:"executable,omitempty" jsonschema_description:"File information of the executable"`
 	Container           *ContainerContextSerializer   `json:"container,omitempty" jsonschema_description:"Container context"`
@@ -352,7 +353,7 @@ type EventSerializer struct {
 	*ProcessContextSerializer   `json:"process,omitempty"`
 	*DDContextSerializer        `json:"dd,omitempty"`
 	*ContainerContextSerializer `json:"container,omitempty"`
-	Date                        time.Time `json:"date,omitempty"`
+	Date                        utils.EasyjsonTime `json:"date,omitempty"`
 }
 
 func getInUpperLayer(r *Resolvers, f *model.FileFields) *bool {
@@ -403,11 +404,12 @@ func getUint32Pointer(i *uint32) *uint32 {
 	return i
 }
 
-func getTimeIfNotZero(t time.Time) *time.Time {
+func getTimeIfNotZero(t time.Time) *utils.EasyjsonTime {
 	if t.IsZero() {
 		return nil
 	}
-	return &t
+	tt := utils.EasyjsonTime(t)
+	return &tt
 }
 
 func newCredentialsSerializer(ce *model.Credentials) *CredentialsSerializer {
@@ -756,7 +758,7 @@ func NewEventSerializer(event *Event) *EventSerializer {
 		ProcessContextSerializer: newProcessContextSerializer(&pc, event, event.resolvers),
 		DDContextSerializer:      newDDContextSerializer(event),
 		UserContextSerializer:    newUserContextSerializer(event),
-		Date:                     event.ResolveEventTimestamp(),
+		Date:                     utils.EasyjsonTime(event.ResolveEventTimestamp()),
 	}
 
 	if id := event.ResolveContainerID(&event.ContainerContext); id != "" {

--- a/pkg/security/probe/serializers_easyjson.go
+++ b/pkg/security/probe/serializers_easyjson.go
@@ -7,10 +7,10 @@ package probe
 
 import (
 	json "encoding/json"
+	utils "github.com/DataDog/datadog-agent/pkg/security/utils"
 	easyjson "github.com/mailru/easyjson"
 	jlexer "github.com/mailru/easyjson/jlexer"
 	jwriter "github.com/mailru/easyjson/jwriter"
-	time "time"
 )
 
 // suppress unused package warning
@@ -710,11 +710,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe9(in *jle
 				out.ForkTime = nil
 			} else {
 				if out.ForkTime == nil {
-					out.ForkTime = new(time.Time)
+					out.ForkTime = new(utils.EasyjsonTime)
 				}
-				if data := in.Raw(); in.Ok() {
-					in.AddError((*out.ForkTime).UnmarshalJSON(data))
-				}
+				easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityUtils(in, out.ForkTime)
 			}
 		case "exec_time":
 			if in.IsNull() {
@@ -722,11 +720,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe9(in *jle
 				out.ExecTime = nil
 			} else {
 				if out.ExecTime == nil {
-					out.ExecTime = new(time.Time)
+					out.ExecTime = new(utils.EasyjsonTime)
 				}
-				if data := in.Raw(); in.Ok() {
-					in.AddError((*out.ExecTime).UnmarshalJSON(data))
-				}
+				easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityUtils(in, out.ExecTime)
 			}
 		case "exit_time":
 			if in.IsNull() {
@@ -734,11 +730,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe9(in *jle
 				out.ExitTime = nil
 			} else {
 				if out.ExitTime == nil {
-					out.ExitTime = new(time.Time)
+					out.ExitTime = new(utils.EasyjsonTime)
 				}
-				if data := in.Raw(); in.Ok() {
-					in.AddError((*out.ExitTime).UnmarshalJSON(data))
-				}
+				easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityUtils(in, out.ExitTime)
 			}
 		case "credentials":
 			if in.IsNull() {
@@ -905,17 +899,17 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe9(out *jw
 	if in.ForkTime != nil {
 		const prefix string = ",\"fork_time\":"
 		out.RawString(prefix)
-		out.Raw((*in.ForkTime).MarshalJSON())
+		(*in.ForkTime).MarshalEasyJSON(out)
 	}
 	if in.ExecTime != nil {
 		const prefix string = ",\"exec_time\":"
 		out.RawString(prefix)
-		out.Raw((*in.ExecTime).MarshalJSON())
+		(*in.ExecTime).MarshalEasyJSON(out)
 	}
 	if in.ExitTime != nil {
 		const prefix string = ",\"exit_time\":"
 		out.RawString(prefix)
-		out.Raw((*in.ExitTime).MarshalJSON())
+		(*in.ExitTime).MarshalEasyJSON(out)
 	}
 	if in.Credentials != nil {
 		const prefix string = ",\"credentials\":"
@@ -986,6 +980,41 @@ func (v ProcessSerializer) MarshalEasyJSON(w *jwriter.Writer) {
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *ProcessSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe9(l, v)
+}
+func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityUtils(in *jlexer.Lexer, out *utils.EasyjsonTime) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityUtils(out *jwriter.Writer, in utils.EasyjsonTime) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	out.RawByte('}')
 }
 func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe10(in *jlexer.Lexer, out *ProcessCredentialsSerializer) {
 	isTopLevel := in.IsStart()
@@ -1307,11 +1336,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe11(in *jl
 				out.ForkTime = nil
 			} else {
 				if out.ForkTime == nil {
-					out.ForkTime = new(time.Time)
+					out.ForkTime = new(utils.EasyjsonTime)
 				}
-				if data := in.Raw(); in.Ok() {
-					in.AddError((*out.ForkTime).UnmarshalJSON(data))
-				}
+				easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityUtils(in, out.ForkTime)
 			}
 		case "exec_time":
 			if in.IsNull() {
@@ -1319,11 +1346,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe11(in *jl
 				out.ExecTime = nil
 			} else {
 				if out.ExecTime == nil {
-					out.ExecTime = new(time.Time)
+					out.ExecTime = new(utils.EasyjsonTime)
 				}
-				if data := in.Raw(); in.Ok() {
-					in.AddError((*out.ExecTime).UnmarshalJSON(data))
-				}
+				easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityUtils(in, out.ExecTime)
 			}
 		case "exit_time":
 			if in.IsNull() {
@@ -1331,11 +1356,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe11(in *jl
 				out.ExitTime = nil
 			} else {
 				if out.ExitTime == nil {
-					out.ExitTime = new(time.Time)
+					out.ExitTime = new(utils.EasyjsonTime)
 				}
-				if data := in.Raw(); in.Ok() {
-					in.AddError((*out.ExitTime).UnmarshalJSON(data))
-				}
+				easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityUtils(in, out.ExitTime)
 			}
 		case "credentials":
 			if in.IsNull() {
@@ -1535,17 +1558,17 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe11(out *j
 	if in.ForkTime != nil {
 		const prefix string = ",\"fork_time\":"
 		out.RawString(prefix)
-		out.Raw((*in.ForkTime).MarshalJSON())
+		(*in.ForkTime).MarshalEasyJSON(out)
 	}
 	if in.ExecTime != nil {
 		const prefix string = ",\"exec_time\":"
 		out.RawString(prefix)
-		out.Raw((*in.ExecTime).MarshalJSON())
+		(*in.ExecTime).MarshalEasyJSON(out)
 	}
 	if in.ExitTime != nil {
 		const prefix string = ",\"exit_time\":"
 		out.RawString(prefix)
-		out.Raw((*in.ExitTime).MarshalJSON())
+		(*in.ExitTime).MarshalEasyJSON(out)
 	}
 	if in.Credentials != nil {
 		const prefix string = ",\"credentials\":"
@@ -2335,11 +2358,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe20(in *jl
 				out.Atime = nil
 			} else {
 				if out.Atime == nil {
-					out.Atime = new(time.Time)
+					out.Atime = new(utils.EasyjsonTime)
 				}
-				if data := in.Raw(); in.Ok() {
-					in.AddError((*out.Atime).UnmarshalJSON(data))
-				}
+				easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityUtils(in, out.Atime)
 			}
 		case "modification_time":
 			if in.IsNull() {
@@ -2347,11 +2368,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe20(in *jl
 				out.Mtime = nil
 			} else {
 				if out.Mtime == nil {
-					out.Mtime = new(time.Time)
+					out.Mtime = new(utils.EasyjsonTime)
 				}
-				if data := in.Raw(); in.Ok() {
-					in.AddError((*out.Mtime).UnmarshalJSON(data))
-				}
+				easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityUtils(in, out.Mtime)
 			}
 		case "change_time":
 			if in.IsNull() {
@@ -2359,11 +2378,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe20(in *jl
 				out.Ctime = nil
 			} else {
 				if out.Ctime == nil {
-					out.Ctime = new(time.Time)
+					out.Ctime = new(utils.EasyjsonTime)
 				}
-				if data := in.Raw(); in.Ok() {
-					in.AddError((*out.Ctime).UnmarshalJSON(data))
-				}
+				easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityUtils(in, out.Ctime)
 			}
 		default:
 			in.SkipRecursive()
@@ -2507,17 +2524,17 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe20(out *j
 	if in.Atime != nil {
 		const prefix string = ",\"access_time\":"
 		out.RawString(prefix)
-		out.Raw((*in.Atime).MarshalJSON())
+		(*in.Atime).MarshalEasyJSON(out)
 	}
 	if in.Mtime != nil {
 		const prefix string = ",\"modification_time\":"
 		out.RawString(prefix)
-		out.Raw((*in.Mtime).MarshalJSON())
+		(*in.Mtime).MarshalEasyJSON(out)
 	}
 	if in.Ctime != nil {
 		const prefix string = ",\"change_time\":"
 		out.RawString(prefix)
-		out.Raw((*in.Ctime).MarshalJSON())
+		(*in.Ctime).MarshalEasyJSON(out)
 	}
 	out.RawByte('}')
 }
@@ -2657,11 +2674,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe21(in *jl
 				out.Atime = nil
 			} else {
 				if out.Atime == nil {
-					out.Atime = new(time.Time)
+					out.Atime = new(utils.EasyjsonTime)
 				}
-				if data := in.Raw(); in.Ok() {
-					in.AddError((*out.Atime).UnmarshalJSON(data))
-				}
+				easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityUtils(in, out.Atime)
 			}
 		case "modification_time":
 			if in.IsNull() {
@@ -2669,11 +2684,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe21(in *jl
 				out.Mtime = nil
 			} else {
 				if out.Mtime == nil {
-					out.Mtime = new(time.Time)
+					out.Mtime = new(utils.EasyjsonTime)
 				}
-				if data := in.Raw(); in.Ok() {
-					in.AddError((*out.Mtime).UnmarshalJSON(data))
-				}
+				easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityUtils(in, out.Mtime)
 			}
 		case "change_time":
 			if in.IsNull() {
@@ -2681,11 +2694,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe21(in *jl
 				out.Ctime = nil
 			} else {
 				if out.Ctime == nil {
-					out.Ctime = new(time.Time)
+					out.Ctime = new(utils.EasyjsonTime)
 				}
-				if data := in.Raw(); in.Ok() {
-					in.AddError((*out.Ctime).UnmarshalJSON(data))
-				}
+				easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityUtils(in, out.Ctime)
 			}
 		default:
 			in.SkipRecursive()
@@ -2879,17 +2890,17 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe21(out *j
 	if in.Atime != nil {
 		const prefix string = ",\"access_time\":"
 		out.RawString(prefix)
-		out.Raw((*in.Atime).MarshalJSON())
+		(*in.Atime).MarshalEasyJSON(out)
 	}
 	if in.Mtime != nil {
 		const prefix string = ",\"modification_time\":"
 		out.RawString(prefix)
-		out.Raw((*in.Mtime).MarshalJSON())
+		(*in.Mtime).MarshalEasyJSON(out)
 	}
 	if in.Ctime != nil {
 		const prefix string = ",\"change_time\":"
 		out.RawString(prefix)
-		out.Raw((*in.Ctime).MarshalJSON())
+		(*in.Ctime).MarshalEasyJSON(out)
 	}
 	out.RawByte('}')
 }
@@ -3101,9 +3112,7 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe22(in *jl
 				(*out.ContainerContextSerializer).UnmarshalEasyJSON(in)
 			}
 		case "date":
-			if data := in.Raw(); in.Ok() {
-				in.AddError((out.Date).UnmarshalJSON(data))
-			}
+			easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityUtils(in, &out.Date)
 		default:
 			in.SkipRecursive()
 		}
@@ -3292,7 +3301,7 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe22(out *j
 		} else {
 			out.RawString(prefix)
 		}
-		out.Raw((in.Date).MarshalJSON())
+		(in.Date).MarshalEasyJSON(out)
 	}
 	out.RawByte('}')
 }

--- a/pkg/security/secl/compiler/eval/event.go
+++ b/pkg/security/secl/compiler/eval/event.go
@@ -8,6 +8,8 @@ package eval
 import (
 	"reflect"
 	"unsafe"
+
+	"github.com/mailru/easyjson"
 )
 
 // EventType is the type of an event
@@ -29,6 +31,11 @@ type Event interface {
 	GetPointer() unsafe.Pointer
 	// GetTags returns a list of tags
 	GetTags() []string
+}
+
+type EventMarshaler interface {
+	easyjson.Marshaler
+	Event
 }
 
 func eventTypesFromFields(model Model, state *State) ([]EventType, error) {

--- a/pkg/security/secl/go.mod
+++ b/pkg/security/secl/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/fatih/structtag v1.2.0
 	github.com/hashicorp/go-multierror v1.1.1
+	github.com/mailru/easyjson v0.7.7
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cast v1.4.1
 	github.com/stretchr/testify v1.7.1
@@ -18,6 +19,7 @@ require (
 
 require (
 	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/philhofer/fwd v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/pkg/security/secl/go.sum
+++ b/pkg/security/secl/go.sum
@@ -11,6 +11,8 @@ github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/U
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
+github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
+github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
@@ -19,6 +21,8 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
+github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/philhofer/fwd v1.1.1 h1:GdGcTjf5RNAxwS4QLsiMzJYj5KEvPJD3Abr261yRQXQ=
 github.com/philhofer/fwd v1.1.1/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG3ZVNU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/pkg/security/secl/rules/model_test.go
+++ b/pkg/security/secl/rules/model_test.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 	"unsafe"
 
+	"github.com/mailru/easyjson/jwriter"
 	"github.com/pkg/errors"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
@@ -40,6 +41,9 @@ type testEvent struct {
 	process testProcess
 	open    testOpen
 	mkdir   testMkdir
+}
+
+func (e *testEvent) MarshalEasyJSON(w *jwriter.Writer) {
 }
 
 type testModel struct {

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -143,7 +143,7 @@ type Rule struct {
 // RuleSetListener describes the methods implemented by an object used to be
 // notified of events on a rule set.
 type RuleSetListener interface {
-	RuleMatch(rule *Rule, event eval.Event)
+	RuleMatch(rule *Rule, event eval.EventMarshaler)
 	EventDiscarderFound(rs *RuleSet, event eval.Event, field eval.Field, eventType eval.EventType)
 }
 
@@ -351,7 +351,7 @@ func (rs *RuleSet) AddRule(ruleDef *RuleDefinition) (*eval.Rule, error) {
 }
 
 // NotifyRuleMatch notifies all the ruleset listeners that an event matched a rule
-func (rs *RuleSet) NotifyRuleMatch(rule *Rule, event eval.Event) {
+func (rs *RuleSet) NotifyRuleMatch(rule *Rule, event eval.EventMarshaler) {
 	for _, listener := range rs.listeners {
 		listener.RuleMatch(rule, event)
 	}
@@ -493,7 +493,7 @@ func (rs *RuleSet) runRuleActions(ctx *eval.Context, rule *Rule) error {
 }
 
 // Evaluate the specified event against the set of rules
-func (rs *RuleSet) Evaluate(event eval.Event) bool {
+func (rs *RuleSet) Evaluate(event eval.EventMarshaler) bool {
 	ctx := rs.pool.Get(event.GetPointer())
 	defer rs.pool.Put(ctx)
 

--- a/pkg/security/secl/rules/ruleset_test.go
+++ b/pkg/security/secl/rules/ruleset_test.go
@@ -22,7 +22,7 @@ type testHandler struct {
 	filters map[string]testFieldValues
 }
 
-func (f *testHandler) RuleMatch(rule *Rule, event eval.Event) {
+func (f *testHandler) RuleMatch(rule *Rule, event eval.EventMarshaler) {
 }
 
 func (f *testHandler) EventDiscarderFound(rs *RuleSet, event eval.Event, field string, eventType eval.EventType) {

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -718,7 +718,7 @@ func (tm *testModule) Root() string {
 	return tm.st.root
 }
 
-func (tm *testModule) RuleMatch(rule *rules.Rule, event eval.Event) {
+func (tm *testModule) RuleMatch(rule *rules.Rule, event eval.EventMarshaler) {
 	tm.ruleHandler.RLock()
 	callback := tm.ruleHandler.callback
 	tm.ruleHandler.RUnlock()

--- a/pkg/security/tests/serializers_test.go
+++ b/pkg/security/tests/serializers_test.go
@@ -9,35 +9,46 @@
 package tests
 
 import (
+	"encoding/json"
+	"sync"
 	"syscall"
 	"testing"
 
 	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
+	"github.com/mailru/easyjson"
 	"github.com/stretchr/testify/assert"
 )
 
-func BenchmarkSerializers(b *testing.B) {
-	// Let's first fetch a realistic event
+var eventOnce sync.Once
+var eventSerializer *sprobe.EventSerializer
 
+func fetchRealisticEventSerializer(tb testing.TB) *sprobe.EventSerializer {
+	eventOnce.Do(func() {
+		eventSerializer = fetchRealisticEventSerializerInner(tb)
+	})
+	return eventSerializer
+}
+
+func fetchRealisticEventSerializerInner(tb testing.TB) *sprobe.EventSerializer {
 	rule := &rules.RuleDefinition{
 		ID:         "test_rule",
 		Expression: `open.file.path == "{{.Root}}/test-open" && open.flags & O_CREAT != 0`,
 	}
 
-	test, err := newTestModule(b, nil, []*rules.RuleDefinition{rule}, testOpts{})
+	test, err := newTestModule(tb, nil, []*rules.RuleDefinition{rule}, testOpts{})
 	if err != nil {
-		b.Fatal(err)
+		tb.Fatal(err)
 	}
 	defer test.Close()
 
 	_, testFilePtr, err := test.Path("test-open")
 	if err != nil {
-		b.Fatal(err)
+		tb.Fatal(err)
 	}
 
 	var workingEvent *sprobe.Event
-	test.WaitSignal(b, func() error {
+	test.WaitSignal(tb, func() error {
 		fd, _, errno := syscall.Syscall6(syscall.SYS_OPENAT, 0, uintptr(testFilePtr), syscall.O_CREAT, 0711, 0, 0)
 		if errno != 0 {
 			return error(errno)
@@ -45,14 +56,36 @@ func BenchmarkSerializers(b *testing.B) {
 		return syscall.Close(int(fd))
 	}, func(event *sprobe.Event, r *rules.Rule) {
 		workingEvent = event
-		assert.Equal(b, "open", event.GetType(), "wrong event type")
+		assert.Equal(tb, "open", event.GetType(), "wrong event type")
 	})
+
+	return sprobe.NewEventSerializer(workingEvent)
+}
+
+func BenchmarkSerializersEasyJson(b *testing.B) {
+	// Let's first fetch a realistic event
+	es := fetchRealisticEventSerializer(b)
 
 	// then we run the benchmark
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		_, err := workingEvent.MarshalJSON()
+		_, err := easyjson.Marshal(es)
+		if err != nil {
+			b.Error(err)
+		}
+	}
+}
+
+func BenchmarkSerializersStd(b *testing.B) {
+	// Let's first fetch a realistic event
+	es := fetchRealisticEventSerializer(b)
+
+	// then we run the benchmark
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, err := json.Marshal(es)
 		if err != nil {
 			b.Error(err)
 		}

--- a/pkg/security/tests/serializers_test.go
+++ b/pkg/security/tests/serializers_test.go
@@ -16,7 +16,7 @@ import (
 
 	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
-	"github.com/mailru/easyjson"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -70,7 +70,7 @@ func BenchmarkSerializersEasyJson(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		_, err := easyjson.Marshal(es)
+		_, err := utils.EasyjsonMarshal(es, -1)
 		if err != nil {
 			b.Error(err)
 		}

--- a/pkg/security/tests/serializers_test.go
+++ b/pkg/security/tests/serializers_test.go
@@ -70,7 +70,7 @@ func BenchmarkSerializersEasyJson(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		_, err := utils.EasyjsonMarshal(es, -1)
+		_, err := utils.EasyjsonMarshal(es)
 		if err != nil {
 			b.Error(err)
 		}

--- a/pkg/security/utils/json.go
+++ b/pkg/security/utils/json.go
@@ -10,13 +10,9 @@ import (
 	"github.com/mailru/easyjson/jwriter"
 )
 
-func EasyjsonMarshal(v easyjson.Marshaler, preEnsure int) ([]byte, error) {
+func EasyjsonMarshal(v easyjson.Marshaler) ([]byte, error) {
 	w := jwriter.Writer{
 		Flags: jwriter.NilSliceAsEmpty | jwriter.NilMapAsEmpty,
-	}
-
-	if preEnsure > 0 {
-		w.Buffer.EnsureSpace(preEnsure)
 	}
 
 	v.MarshalEasyJSON(&w)

--- a/pkg/security/utils/json.go
+++ b/pkg/security/utils/json.go
@@ -10,10 +10,15 @@ import (
 	"github.com/mailru/easyjson/jwriter"
 )
 
-func EasyjsonMarshal(v easyjson.Marshaler) ([]byte, error) {
+func EasyjsonMarshal(v easyjson.Marshaler, preEnsure int) ([]byte, error) {
 	w := jwriter.Writer{
 		Flags: jwriter.NilSliceAsEmpty | jwriter.NilMapAsEmpty,
 	}
+
+	if preEnsure > 0 {
+		w.Buffer.EnsureSpace(preEnsure)
+	}
+
 	v.MarshalEasyJSON(&w)
 	return w.BuildBytes()
 }

--- a/pkg/security/utils/json.go
+++ b/pkg/security/utils/json.go
@@ -1,0 +1,19 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package utils
+
+import (
+	"github.com/mailru/easyjson"
+	"github.com/mailru/easyjson/jwriter"
+)
+
+func EasyjsonMarshal(v easyjson.Marshaler) ([]byte, error) {
+	w := jwriter.Writer{
+		Flags: jwriter.NilSliceAsEmpty | jwriter.NilMapAsEmpty,
+	}
+	v.MarshalEasyJSON(&w)
+	return w.BuildBytes()
+}

--- a/pkg/security/utils/json.go
+++ b/pkg/security/utils/json.go
@@ -6,6 +6,9 @@
 package utils
 
 import (
+	"errors"
+	"time"
+
 	"github.com/mailru/easyjson"
 	"github.com/mailru/easyjson/jwriter"
 )
@@ -17,4 +20,21 @@ func EasyjsonMarshal(v easyjson.Marshaler) ([]byte, error) {
 
 	v.MarshalEasyJSON(&w)
 	return w.BuildBytes()
+}
+
+type EasyjsonTime time.Time
+
+func (t EasyjsonTime) MarshalEasyJSON(w *jwriter.Writer) {
+	tt := time.Time(t)
+	if y := tt.Year(); y < 0 || y >= 10000 {
+		if w.Error == nil {
+			w.Error = errors.New("Time.MarshalJSON: year outside of range [0,9999]")
+		}
+		return
+	}
+
+	w.Buffer.EnsureSpace(len(time.RFC3339Nano) + 2)
+	w.Buffer.AppendByte('"')
+	w.Buffer.Buf = tt.AppendFormat(w.Buffer.Buf, time.RFC3339Nano)
+	w.Buffer.AppendByte('"')
 }


### PR DESCRIPTION
### What does this PR do?

This PR ensures that we are actually using easyjson e2e through the events pipeline.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
