### PR TITLE
[CWS] fix/improve `BenchmarkSerializers`

### DIFF
--- a/pkg/security/tests/serializers_test.go
+++ b/pkg/security/tests/serializers_test.go
@@ -9,35 +9,46 @@
 package tests
 
 import (
+	"encoding/json"
+	"sync"
 	"syscall"
 	"testing"
 
 	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
+	"github.com/mailru/easyjson"
 	"github.com/stretchr/testify/assert"
 )
 
-func BenchmarkSerializers(b *testing.B) {
-	// Let's first fetch a realistic event
+var eventOnce sync.Once
+var eventSerializer *sprobe.EventSerializer
 
+func fetchRealisticEventSerializer(tb testing.TB) *sprobe.EventSerializer {
+	eventOnce.Do(func() {
+		eventSerializer = fetchRealisticEventSerializerInner(tb)
+	})
+	return eventSerializer
+}
+
+func fetchRealisticEventSerializerInner(tb testing.TB) *sprobe.EventSerializer {
 	rule := &rules.RuleDefinition{
 		ID:         "test_rule",
 		Expression: `open.file.path == "{{.Root}}/test-open" && open.flags & O_CREAT != 0`,
 	}
 
-	test, err := newTestModule(b, nil, []*rules.RuleDefinition{rule}, testOpts{})
+	test, err := newTestModule(tb, nil, []*rules.RuleDefinition{rule}, testOpts{})
 	if err != nil {
-		b.Fatal(err)
+		tb.Fatal(err)
 	}
 	defer test.Close()
 
 	_, testFilePtr, err := test.Path("test-open")
 	if err != nil {
-		b.Fatal(err)
+		tb.Fatal(err)
 	}
 
 	var workingEvent *sprobe.Event
-	test.WaitSignal(b, func() error {
+	test.WaitSignal(tb, func() error {
 		fd, _, errno := syscall.Syscall6(syscall.SYS_OPENAT, 0, uintptr(testFilePtr), syscall.O_CREAT, 0711, 0, 0)
 		if errno != 0 {
 			return error(errno)
@@ -45,14 +56,36 @@ func BenchmarkSerializers(b *testing.B) {
 		return syscall.Close(int(fd))
 	}, func(event *sprobe.Event, r *rules.Rule) {
 		workingEvent = event
-		assert.Equal(b, "open", event.GetType(), "wrong event type")
+		assert.Equal(tb, "open", event.GetType(), "wrong event type")
 	})
+
+	return sprobe.NewEventSerializer(workingEvent)
+}
+
+func BenchmarkSerializersEasyJson(b *testing.B) {
+	// Let's first fetch a realistic event
+	es := fetchRealisticEventSerializer(b)
 
 	// then we run the benchmark
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		_, err := workingEvent.MarshalJSON()
+		_, err := easyjson.Marshal(es)
+		if err != nil {
+			b.Error(err)
+		}
+	}
+}
+
+func BenchmarkSerializersStd(b *testing.B) {
+	// Let's first fetch a realistic event
+	es := fetchRealisticEventSerializer(b)
+
+	// then we run the benchmark
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, err := json.Marshal(es)
 		if err != nil {
 			b.Error(err)
 		}


### PR DESCRIPTION
### What does this PR do?

Currently `BenchmarkSerializers` has a `defer test.Close()` that makes it impossible to have precise timing/memory reporting.

```
inv -e security-agent.functional-tests --testflags "-test.v -test.run XXX -test.bench BenchmarkSerializers -test.benchmem"
```

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
