### PR TITLE
[config/environment_containers] Add workaround for merging containerd namespaces

### DIFF
--- a/releasenotes/notes/workaround-merge-containerd-namespaces-6ae0d6cf8450a28c.yaml
+++ b/releasenotes/notes/workaround-merge-containerd-namespaces-6ae0d6cf8450a28c.yaml
@@ -8,7 +8,7 @@
 ---
 fixes:
   - |
-    Fixed the error "svType != tvType; key=containerd_namespace, st=[]interface
-    {}, tt=[]string, sv=[], tv=[]" that triggered when using a secret backend
+    Fixed the triggered "svType != tvType; key=containerd_namespace, st=[]interface
+    {}, tt=[]string, sv=[], tv=[]" error when using a secret backend
     reader.
 

--- a/releasenotes/notes/workaround-merge-containerd-namespaces-6ae0d6cf8450a28c.yaml
+++ b/releasenotes/notes/workaround-merge-containerd-namespaces-6ae0d6cf8450a28c.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed the error "svType != tvType; key=containerd_namespace, st=[]interface
+    {}, tt=[]string, sv=[], tv=[]" that triggered when using a secret backend
+    reader.
+


### PR DESCRIPTION
### What does this PR do?

Fixes the issue that causes these errors:
```
svType != tvType; key=containerd_namespace, st=[]interface {}, tt=[]string, sv=[], tv=[]
svType != tvType; key=containerd_namespaces, st=[]interface {}, tt=[]string, sv=[], tv=[]
```

The issue is only triggered when `DD_SECRET_BACKEND_COMMAND` is set.

The issue is caused by the `AddOverride` calls in:
https://github.com/DataDog/datadog-agent/blob/dc45ea11356f629dba5105f9bb6bdf8a6a841eb9/pkg/config/environment_containers.go#L135

There, we're setting `containerd_namespaces` as a `[]string`, but Viper expects a `[]interface{}` when merging configs. We need that merging when using `DD_SECRET_BACKEND_COMMAND` because the standard config is "merged" with the one with the secrets fetched. 

The current fix is a workaround. I believe it won't be needed once we upgrade our fork of Viper. I saw a PR that addresses a similar issue, but I haven't tried it.


### Describe how to test/QA your changes

Run the agent with `DD_SECRET_BACKEND_COMMAND` set and verify that the errors listed above don't appear in the logs.
For completeness, run the agent on containerd (outside kubernetes) and define both `DD_CONTAINERD_NAMESPACE` and `DD_CONTAINERD_NAMESPACES`. Verify that the containers that appear in ` agent workload-list` are only the ones specified in either of those 2 envs.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
