### PR TITLE
bugfix: Allow the trap listener to start even with logs disabled

### DIFF
--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -396,16 +396,9 @@ func StartAgent() error {
 
 	// Start SNMP trap server
 	if traps.IsEnabled() {
-		if config.Datadog.GetBool("logs_enabled") {
-			err = traps.StartServer(hostname, demux)
-			if err != nil {
-				log.Errorf("Failed to start snmp-traps server: %s", err)
-			}
-		} else {
-			log.Warn(
-				"snmp-traps server did not start, as log collection is disabled. " +
-					"Please enable log collection to collect and forward traps.",
-			)
+		err = traps.StartServer(hostname, demux)
+		if err != nil {
+			log.Errorf("Failed to start snmp-traps server: %s", err)
 		}
 	}
 


### PR DESCRIPTION
Traps listener was not starting if logs was disabled. This is a leftover from when traps were sent to logs directly instead of being sent via the EPforwarder.