### PR TITLE
[logs] Include .Identifier in Dump for LogsConfig#Type=File

### DIFF
--- a/pkg/logs/config/integration_config.go
+++ b/pkg/logs/config/integration_config.go
@@ -54,8 +54,9 @@ type LogsConfig struct {
 	Label string // Docker
 	// Name contains the container name
 	Name string // Docker
-	// Identifier contains the container ID
-	Identifier string // Docker
+	// Identifier contains the container ID.  This is also set for File sources and used to
+	// determine the appropriate tags for the logs.
+	Identifier string // Docker, File
 
 	ChannelPath string `mapstructure:"channel_path" json:"channel_path"` // Windows Event
 	Query       string // Windows Event
@@ -100,6 +101,7 @@ func (c *LogsConfig) Dump() string {
 	case FileType:
 		fmt.Fprintf(&b, "\tPath: %#v,\n", c.Path)
 		fmt.Fprintf(&b, "\tEncoding: %#v,\n", c.Encoding)
+		fmt.Fprintf(&b, "\tIdentifier: %#v,\n", c.Identifier)
 		fmt.Fprintf(&b, "\tExcludePaths: %#v,\n", c.ExcludePaths)
 		fmt.Fprintf(&b, "\tTailingMode: %#v,\n", c.TailingMode)
 	case DockerType:


### PR DESCRIPTION
A LogsConfig with Type=File references the Identifier field.  This adds
a comment and includes the field in the dump for that type.

### Motivation

Noticed this value missing while reading some dumps.


### Describe how to test/QA your changes

None

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
