### PR TITLE
[containerd] Exclude "moby" namespace by default

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -586,6 +586,7 @@ func InitConfig(config Config) {
 	// Containerd
 	config.BindEnvAndSetDefault("containerd_namespace", []string{})
 	config.BindEnvAndSetDefault("containerd_namespaces", []string{}) // alias for containerd_namespace
+	config.BindEnvAndSetDefault("containerd_exclude_namespaces", []string{"moby"})
 	config.BindEnvAndSetDefault("container_env_as_tags", map[string]string{})
 	config.BindEnvAndSetDefault("container_labels_as_tags", map[string]string{})
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2689,6 +2689,16 @@ api_key:
 #
 # containerd_namespaces:
 #   - k8s.io
+#
+## @param containerd_exclude_namespaces - list of strings - optional - default: ["moby"]
+## @env DD_CONTAINERD_EXCLUDE_NAMESPACES - space separated list of strings - optional - default: ["moby"]
+## When containerd_namespaces is set to [], containerd_exclude_namespaces
+## allows the exclusion of containers from specific namespaces. By default it
+## excludes "moby", to prevent Docker containers from being detected as
+## containerd containers.
+#
+# containerd_exclude_namespaces:
+#   - moby
 
 {{ end -}}
 {{- if .Kubelet }}

--- a/pkg/util/containerd/namespaces.go
+++ b/pkg/util/containerd/namespaces.go
@@ -23,7 +23,31 @@ func NamespacesToWatch(ctx context.Context, containerdClient ContainerdItf) ([]s
 		return namespaces, nil
 	}
 
-	return containerdClient.Namespaces(ctx)
+	namespaces, err := containerdClient.Namespaces(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	excludeNamespaces := config.Datadog.GetStringSlice("containerd_exclude_namespaces")
+	if len(excludeNamespaces) == 0 {
+		return namespaces, nil
+	}
+
+	excludeNamespacesSet := make(map[string]struct{}, len(excludeNamespaces))
+	for _, namespace := range excludeNamespaces {
+		excludeNamespacesSet[namespace] = struct{}{}
+	}
+
+	filteredNamespaces := make([]string, 0, len(namespaces))
+	for _, namespace := range namespaces {
+		if _, exclude := excludeNamespacesSet[namespace]; exclude {
+			continue
+		}
+
+		filteredNamespaces = append(filteredNamespaces, namespace)
+	}
+
+	return filteredNamespaces, nil
 }
 
 // FiltersWithNamespaces returns the given list of filters adapted to take into
@@ -33,8 +57,9 @@ func NamespacesToWatch(ctx context.Context, containerdClient ContainerdItf) ([]s
 // `topic=="/container/create",namespace=="ns1"`.
 func FiltersWithNamespaces(filters []string) []string {
 	namespaces := config.Datadog.GetStringSlice("containerd_namespaces")
+	excludeNamespaces := config.Datadog.GetStringSlice("containerd_exclude_namespaces")
 
-	if len(namespaces) == 0 {
+	if len(namespaces) == 0 && len(excludeNamespaces) == 0 {
 		// Watch all namespaces. No need to add them to the filters.
 		return filters
 	}
@@ -42,8 +67,14 @@ func FiltersWithNamespaces(filters []string) []string {
 	var res []string
 
 	for _, filter := range filters {
-		for _, namespace := range namespaces {
-			res = append(res, fmt.Sprintf(`%s,namespace==%q`, filter, namespace))
+		if len(namespaces) > 0 {
+			for _, namespace := range namespaces {
+				res = append(res, fmt.Sprintf(`%s,namespace==%q`, filter, namespace))
+			}
+		} else if len(excludeNamespaces) > 0 {
+			for _, namespace := range excludeNamespaces {
+				res = append(res, fmt.Sprintf(`%s,namespace!=%q`, filter, namespace))
+			}
 		}
 	}
 

--- a/releasenotes/notes/containerd-exclude-namespaces-106c69dad4a2e056.yaml
+++ b/releasenotes/notes/containerd-exclude-namespaces-106c69dad4a2e056.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Add a `containerd_exclude_namespaces` configuration option to the Agent, to
+    ignore containers from specific containerd namespaces.

--- a/releasenotes/notes/containerd-exclude-namespaces-106c69dad4a2e056.yaml
+++ b/releasenotes/notes/containerd-exclude-namespaces-106c69dad4a2e056.yaml
@@ -1,5 +1,5 @@
 ---
 enhancements:
   - |
-    Add a `containerd_exclude_namespaces` configuration option to the Agent, to
+    Add a `containerd_exclude_namespaces` configuration option for the Agent to
     ignore containers from specific containerd namespaces.


### PR DESCRIPTION
### What does this PR do?

This introduces a `containerd_exclude_namespaces` config option to the
agent, to exclude containers from the specified containerd namespaces
from being seen by the agent.

By default, we're also setting this to exclude `moby`, as those are
containers being run by Docker. If both Docker and containerd are
autodiscovered, Docker containers will be seen in containerd as well.
Workloadmeta does not like a container being present in more than one
runtime, as that generates data conflicts it currently can't merge,
causing undeterministic behavior.

### Describe how to test/QA your changes

1. Ensure that by default containerd containers still get collected by workloadmeta (`agent workload-list`)
2. Set `DD_CONTAINERD_EXCLUDE_NAMESPACES`, and check that containers in the set namespaces no longer get collected. Important to test with containers that exist before the agent starts, and after (they're different code paths).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
