### PR TITLE
[CWS] memory reduction in event serialization

### DIFF
--- a/docs/cloud-workload-security/backend.schema.json
+++ b/docs/cloud-workload-security/backend.schema.json
@@ -68,7 +68,8 @@
       "$ref": "#/definitions/ContainerContext"
     },
     "date": {
-      "$ref": "#/definitions/EasyjsonTime"
+      "type": "string",
+      "format": "date-time"
     }
   },
   "additionalProperties": false,
@@ -229,11 +230,6 @@
       "additionalProperties": false,
       "type": "object"
     },
-    "EasyjsonTime": {
-      "properties": {},
-      "additionalProperties": false,
-      "type": "object"
-    },
     "EventContext": {
       "properties": {
         "name": {
@@ -326,15 +322,18 @@
           "description": "File flags"
         },
         "access_time": {
-          "$ref": "#/definitions/EasyjsonTime"
+          "type": "string",
+          "format": "date-time"
         },
         "modification_time": {
-          "$ref": "#/definitions/EasyjsonTime",
-          "description": "File modified time"
+          "type": "string",
+          "description": "File modified time",
+          "format": "date-time"
         },
         "change_time": {
-          "$ref": "#/definitions/EasyjsonTime",
-          "description": "File change time"
+          "type": "string",
+          "description": "File change time",
+          "format": "date-time"
         }
       },
       "additionalProperties": false,
@@ -410,16 +409,18 @@
           "description": "File flags"
         },
         "access_time": {
-          "$schema": "http://json-schema.org/draft-04/schema#",
-          "$ref": "#/definitions/EasyjsonTime"
+          "type": "string",
+          "format": "date-time"
         },
         "modification_time": {
-          "$ref": "#/definitions/EasyjsonTime",
-          "description": "File modified time"
+          "type": "string",
+          "description": "File modified time",
+          "format": "date-time"
         },
         "change_time": {
-          "$ref": "#/definitions/EasyjsonTime",
-          "description": "File change time"
+          "type": "string",
+          "description": "File change time",
+          "format": "date-time"
         },
         "destination": {
           "$schema": "http://json-schema.org/draft-04/schema#",
@@ -697,16 +698,19 @@
           "description": "TTY associated with the process"
         },
         "fork_time": {
-          "$ref": "#/definitions/EasyjsonTime",
-          "description": "Fork time of the process"
+          "type": "string",
+          "description": "Fork time of the process",
+          "format": "date-time"
         },
         "exec_time": {
-          "$ref": "#/definitions/EasyjsonTime",
-          "description": "Exec time of the process"
+          "type": "string",
+          "description": "Exec time of the process",
+          "format": "date-time"
         },
         "exit_time": {
-          "$ref": "#/definitions/EasyjsonTime",
-          "description": "Exit time of the process"
+          "type": "string",
+          "description": "Exit time of the process",
+          "format": "date-time"
         },
         "credentials": {
           "$ref": "#/definitions/ProcessCredentials",
@@ -797,16 +801,19 @@
           "description": "TTY associated with the process"
         },
         "fork_time": {
-          "$ref": "#/definitions/EasyjsonTime",
-          "description": "Fork time of the process"
+          "type": "string",
+          "description": "Fork time of the process",
+          "format": "date-time"
         },
         "exec_time": {
-          "$ref": "#/definitions/EasyjsonTime",
-          "description": "Exec time of the process"
+          "type": "string",
+          "description": "Exec time of the process",
+          "format": "date-time"
         },
         "exit_time": {
-          "$ref": "#/definitions/EasyjsonTime",
-          "description": "Exit time of the process"
+          "type": "string",
+          "description": "Exit time of the process",
+          "format": "date-time"
         },
         "credentials": {
           "$schema": "http://json-schema.org/draft-04/schema#",

--- a/docs/cloud-workload-security/backend.schema.json
+++ b/docs/cloud-workload-security/backend.schema.json
@@ -68,8 +68,7 @@
       "$ref": "#/definitions/ContainerContext"
     },
     "date": {
-      "type": "string",
-      "format": "date-time"
+      "$ref": "#/definitions/EasyjsonTime"
     }
   },
   "additionalProperties": false,
@@ -230,6 +229,11 @@
       "additionalProperties": false,
       "type": "object"
     },
+    "EasyjsonTime": {
+      "properties": {},
+      "additionalProperties": false,
+      "type": "object"
+    },
     "EventContext": {
       "properties": {
         "name": {
@@ -322,18 +326,15 @@
           "description": "File flags"
         },
         "access_time": {
-          "type": "string",
-          "format": "date-time"
+          "$ref": "#/definitions/EasyjsonTime"
         },
         "modification_time": {
-          "type": "string",
-          "description": "File modified time",
-          "format": "date-time"
+          "$ref": "#/definitions/EasyjsonTime",
+          "description": "File modified time"
         },
         "change_time": {
-          "type": "string",
-          "description": "File change time",
-          "format": "date-time"
+          "$ref": "#/definitions/EasyjsonTime",
+          "description": "File change time"
         }
       },
       "additionalProperties": false,
@@ -409,18 +410,16 @@
           "description": "File flags"
         },
         "access_time": {
-          "type": "string",
-          "format": "date-time"
+          "$schema": "http://json-schema.org/draft-04/schema#",
+          "$ref": "#/definitions/EasyjsonTime"
         },
         "modification_time": {
-          "type": "string",
-          "description": "File modified time",
-          "format": "date-time"
+          "$ref": "#/definitions/EasyjsonTime",
+          "description": "File modified time"
         },
         "change_time": {
-          "type": "string",
-          "description": "File change time",
-          "format": "date-time"
+          "$ref": "#/definitions/EasyjsonTime",
+          "description": "File change time"
         },
         "destination": {
           "$schema": "http://json-schema.org/draft-04/schema#",
@@ -698,19 +697,16 @@
           "description": "TTY associated with the process"
         },
         "fork_time": {
-          "type": "string",
-          "description": "Fork time of the process",
-          "format": "date-time"
+          "$ref": "#/definitions/EasyjsonTime",
+          "description": "Fork time of the process"
         },
         "exec_time": {
-          "type": "string",
-          "description": "Exec time of the process",
-          "format": "date-time"
+          "$ref": "#/definitions/EasyjsonTime",
+          "description": "Exec time of the process"
         },
         "exit_time": {
-          "type": "string",
-          "description": "Exit time of the process",
-          "format": "date-time"
+          "$ref": "#/definitions/EasyjsonTime",
+          "description": "Exit time of the process"
         },
         "credentials": {
           "$ref": "#/definitions/ProcessCredentials",
@@ -801,19 +797,16 @@
           "description": "TTY associated with the process"
         },
         "fork_time": {
-          "type": "string",
-          "description": "Fork time of the process",
-          "format": "date-time"
+          "$ref": "#/definitions/EasyjsonTime",
+          "description": "Fork time of the process"
         },
         "exec_time": {
-          "type": "string",
-          "description": "Exec time of the process",
-          "format": "date-time"
+          "$ref": "#/definitions/EasyjsonTime",
+          "description": "Exec time of the process"
         },
         "exit_time": {
-          "type": "string",
-          "description": "Exit time of the process",
-          "format": "date-time"
+          "$ref": "#/definitions/EasyjsonTime",
+          "description": "Exit time of the process"
         },
         "credentials": {
           "$schema": "http://json-schema.org/draft-04/schema#",

--- a/pkg/security/probe/doc_generator/backend_doc_gen.go
+++ b/pkg/security/probe/doc_generator/backend_doc_gen.go
@@ -14,8 +14,10 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/security/probe"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	"github.com/alecthomas/jsonschema"
 )
 
@@ -23,6 +25,7 @@ func generateBackendJSON(output string) error {
 	reflector := jsonschema.Reflector{
 		ExpandedStruct: true,
 		DoNotReference: false,
+		TypeMapper:     jsonTypeMapper,
 		TypeNamer:      jsonTypeNamer,
 	}
 	schema := reflector.Reflect(&probe.EventSerializer{})
@@ -33,6 +36,13 @@ func generateBackendJSON(output string) error {
 	}
 
 	return os.WriteFile(output, schemaJSON, 0664)
+}
+
+func jsonTypeMapper(ty reflect.Type) *jsonschema.Type {
+	if ty == reflect.TypeOf(utils.EasyjsonTime{}) {
+		return jsonschema.Reflect(time.Time{}).Type
+	}
+	return nil
 }
 
 func jsonTypeNamer(ty reflect.Type) string {

--- a/pkg/security/probe/serializers.go
+++ b/pkg/security/probe/serializers.go
@@ -20,29 +20,30 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
 
 // FileSerializer serializes a file to JSON
 // easyjson:json
 type FileSerializer struct {
-	Path                string     `json:"path,omitempty" jsonschema_description:"File path"`
-	Name                string     `json:"name,omitempty" jsonschema_description:"File basename"`
-	PathResolutionError string     `json:"path_resolution_error,omitempty" jsonschema_description:"Error message from path resolution"`
-	Inode               *uint64    `json:"inode,omitempty" jsonschema_description:"File inode number"`
-	Mode                *uint32    `json:"mode,omitempty" jsonschema_description:"File mode"`
-	InUpperLayer        *bool      `json:"in_upper_layer,omitempty" jsonschema_description:"Indicator of file OverlayFS layer"`
-	MountID             *uint32    `json:"mount_id,omitempty" jsonschema_description:"File mount ID"`
-	Filesystem          string     `json:"filesystem,omitempty" jsonschema_description:"File filesystem name"`
-	UID                 int64      `json:"uid" jsonschema_description:"File User ID"`
-	GID                 int64      `json:"gid" jsonschema_description:"File Group ID"`
-	User                string     `json:"user,omitempty" jsonschema_description:"File user"`
-	Group               string     `json:"group,omitempty" jsonschema_description:"File group"`
-	XAttrName           string     `json:"attribute_name,omitempty" jsonschema_description:"File extended attribute name"`
-	XAttrNamespace      string     `json:"attribute_namespace,omitempty" jsonschema_description:"File extended attribute namespace"`
-	Flags               []string   `json:"flags,omitempty" jsonschema_description:"File flags"`
-	Atime               *time.Time `json:"access_time,omitempty" jsonschema_descrition:"File access time"`
-	Mtime               *time.Time `json:"modification_time,omitempty" jsonschema_description:"File modified time"`
-	Ctime               *time.Time `json:"change_time,omitempty" jsonschema_description:"File change time"`
+	Path                string              `json:"path,omitempty" jsonschema_description:"File path"`
+	Name                string              `json:"name,omitempty" jsonschema_description:"File basename"`
+	PathResolutionError string              `json:"path_resolution_error,omitempty" jsonschema_description:"Error message from path resolution"`
+	Inode               *uint64             `json:"inode,omitempty" jsonschema_description:"File inode number"`
+	Mode                *uint32             `json:"mode,omitempty" jsonschema_description:"File mode"`
+	InUpperLayer        *bool               `json:"in_upper_layer,omitempty" jsonschema_description:"Indicator of file OverlayFS layer"`
+	MountID             *uint32             `json:"mount_id,omitempty" jsonschema_description:"File mount ID"`
+	Filesystem          string              `json:"filesystem,omitempty" jsonschema_description:"File filesystem name"`
+	UID                 int64               `json:"uid" jsonschema_description:"File User ID"`
+	GID                 int64               `json:"gid" jsonschema_description:"File Group ID"`
+	User                string              `json:"user,omitempty" jsonschema_description:"File user"`
+	Group               string              `json:"group,omitempty" jsonschema_description:"File group"`
+	XAttrName           string              `json:"attribute_name,omitempty" jsonschema_description:"File extended attribute name"`
+	XAttrNamespace      string              `json:"attribute_namespace,omitempty" jsonschema_description:"File extended attribute namespace"`
+	Flags               []string            `json:"flags,omitempty" jsonschema_description:"File flags"`
+	Atime               *utils.EasyjsonTime `json:"access_time,omitempty" jsonschema_descrition:"File access time"`
+	Mtime               *utils.EasyjsonTime `json:"modification_time,omitempty" jsonschema_description:"File modified time"`
+	Ctime               *utils.EasyjsonTime `json:"change_time,omitempty" jsonschema_description:"File change time"`
 }
 
 // UserContextSerializer serializes a user context to JSON
@@ -120,9 +121,9 @@ type ProcessSerializer struct {
 	PathResolutionError string                        `json:"path_resolution_error,omitempty" jsonschema_description:"Description of an error in the path resolution"`
 	Comm                string                        `json:"comm,omitempty" jsonschema_description:"Command name"`
 	TTY                 string                        `json:"tty,omitempty" jsonschema_description:"TTY associated with the process"`
-	ForkTime            *time.Time                    `json:"fork_time,omitempty" jsonschema_description:"Fork time of the process"`
-	ExecTime            *time.Time                    `json:"exec_time,omitempty" jsonschema_description:"Exec time of the process"`
-	ExitTime            *time.Time                    `json:"exit_time,omitempty" jsonschema_description:"Exit time of the process"`
+	ForkTime            *utils.EasyjsonTime           `json:"fork_time,omitempty" jsonschema_description:"Fork time of the process"`
+	ExecTime            *utils.EasyjsonTime           `json:"exec_time,omitempty" jsonschema_description:"Exec time of the process"`
+	ExitTime            *utils.EasyjsonTime           `json:"exit_time,omitempty" jsonschema_description:"Exit time of the process"`
 	Credentials         *ProcessCredentialsSerializer `json:"credentials,omitempty" jsonschema_description:"Credentials associated with the process"`
 	Executable          *FileSerializer               `json:"executable,omitempty" jsonschema_description:"File information of the executable"`
 	Container           *ContainerContextSerializer   `json:"container,omitempty" jsonschema_description:"Container context"`
@@ -352,7 +353,7 @@ type EventSerializer struct {
 	*ProcessContextSerializer   `json:"process,omitempty"`
 	*DDContextSerializer        `json:"dd,omitempty"`
 	*ContainerContextSerializer `json:"container,omitempty"`
-	Date                        time.Time `json:"date,omitempty"`
+	Date                        utils.EasyjsonTime `json:"date,omitempty"`
 }
 
 func getInUpperLayer(r *Resolvers, f *model.FileFields) *bool {
@@ -403,11 +404,12 @@ func getUint32Pointer(i *uint32) *uint32 {
 	return i
 }
 
-func getTimeIfNotZero(t time.Time) *time.Time {
+func getTimeIfNotZero(t time.Time) *utils.EasyjsonTime {
 	if t.IsZero() {
 		return nil
 	}
-	return &t
+	tt := utils.EasyjsonTime(t)
+	return &tt
 }
 
 func newCredentialsSerializer(ce *model.Credentials) *CredentialsSerializer {
@@ -756,7 +758,7 @@ func NewEventSerializer(event *Event) *EventSerializer {
 		ProcessContextSerializer: newProcessContextSerializer(&pc, event, event.resolvers),
 		DDContextSerializer:      newDDContextSerializer(event),
 		UserContextSerializer:    newUserContextSerializer(event),
-		Date:                     event.ResolveEventTimestamp(),
+		Date:                     utils.EasyjsonTime(event.ResolveEventTimestamp()),
 	}
 
 	if id := event.ResolveContainerID(&event.ContainerContext); id != "" {

--- a/pkg/security/probe/serializers.go
+++ b/pkg/security/probe/serializers.go
@@ -408,7 +408,7 @@ func getTimeIfNotZero(t time.Time) *utils.EasyjsonTime {
 	if t.IsZero() {
 		return nil
 	}
-	tt := utils.EasyjsonTime(t)
+	tt := utils.NewEasyjsonTime(t)
 	return &tt
 }
 
@@ -758,7 +758,7 @@ func NewEventSerializer(event *Event) *EventSerializer {
 		ProcessContextSerializer: newProcessContextSerializer(&pc, event, event.resolvers),
 		DDContextSerializer:      newDDContextSerializer(event),
 		UserContextSerializer:    newUserContextSerializer(event),
-		Date:                     utils.EasyjsonTime(event.ResolveEventTimestamp()),
+		Date:                     utils.NewEasyjsonTime(event.ResolveEventTimestamp()),
 	}
 
 	if id := event.ResolveContainerID(&event.ContainerContext); id != "" {

--- a/pkg/security/probe/serializers_easyjson.go
+++ b/pkg/security/probe/serializers_easyjson.go
@@ -7,10 +7,10 @@ package probe
 
 import (
 	json "encoding/json"
+	utils "github.com/DataDog/datadog-agent/pkg/security/utils"
 	easyjson "github.com/mailru/easyjson"
 	jlexer "github.com/mailru/easyjson/jlexer"
 	jwriter "github.com/mailru/easyjson/jwriter"
-	time "time"
 )
 
 // suppress unused package warning
@@ -710,11 +710,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe9(in *jle
 				out.ForkTime = nil
 			} else {
 				if out.ForkTime == nil {
-					out.ForkTime = new(time.Time)
+					out.ForkTime = new(utils.EasyjsonTime)
 				}
-				if data := in.Raw(); in.Ok() {
-					in.AddError((*out.ForkTime).UnmarshalJSON(data))
-				}
+				easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityUtils(in, out.ForkTime)
 			}
 		case "exec_time":
 			if in.IsNull() {
@@ -722,11 +720,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe9(in *jle
 				out.ExecTime = nil
 			} else {
 				if out.ExecTime == nil {
-					out.ExecTime = new(time.Time)
+					out.ExecTime = new(utils.EasyjsonTime)
 				}
-				if data := in.Raw(); in.Ok() {
-					in.AddError((*out.ExecTime).UnmarshalJSON(data))
-				}
+				easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityUtils(in, out.ExecTime)
 			}
 		case "exit_time":
 			if in.IsNull() {
@@ -734,11 +730,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe9(in *jle
 				out.ExitTime = nil
 			} else {
 				if out.ExitTime == nil {
-					out.ExitTime = new(time.Time)
+					out.ExitTime = new(utils.EasyjsonTime)
 				}
-				if data := in.Raw(); in.Ok() {
-					in.AddError((*out.ExitTime).UnmarshalJSON(data))
-				}
+				easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityUtils(in, out.ExitTime)
 			}
 		case "credentials":
 			if in.IsNull() {
@@ -905,17 +899,17 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe9(out *jw
 	if in.ForkTime != nil {
 		const prefix string = ",\"fork_time\":"
 		out.RawString(prefix)
-		out.Raw((*in.ForkTime).MarshalJSON())
+		(*in.ForkTime).MarshalEasyJSON(out)
 	}
 	if in.ExecTime != nil {
 		const prefix string = ",\"exec_time\":"
 		out.RawString(prefix)
-		out.Raw((*in.ExecTime).MarshalJSON())
+		(*in.ExecTime).MarshalEasyJSON(out)
 	}
 	if in.ExitTime != nil {
 		const prefix string = ",\"exit_time\":"
 		out.RawString(prefix)
-		out.Raw((*in.ExitTime).MarshalJSON())
+		(*in.ExitTime).MarshalEasyJSON(out)
 	}
 	if in.Credentials != nil {
 		const prefix string = ",\"credentials\":"
@@ -986,6 +980,41 @@ func (v ProcessSerializer) MarshalEasyJSON(w *jwriter.Writer) {
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *ProcessSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe9(l, v)
+}
+func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityUtils(in *jlexer.Lexer, out *utils.EasyjsonTime) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityUtils(out *jwriter.Writer, in utils.EasyjsonTime) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	out.RawByte('}')
 }
 func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe10(in *jlexer.Lexer, out *ProcessCredentialsSerializer) {
 	isTopLevel := in.IsStart()
@@ -1307,11 +1336,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe11(in *jl
 				out.ForkTime = nil
 			} else {
 				if out.ForkTime == nil {
-					out.ForkTime = new(time.Time)
+					out.ForkTime = new(utils.EasyjsonTime)
 				}
-				if data := in.Raw(); in.Ok() {
-					in.AddError((*out.ForkTime).UnmarshalJSON(data))
-				}
+				easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityUtils(in, out.ForkTime)
 			}
 		case "exec_time":
 			if in.IsNull() {
@@ -1319,11 +1346,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe11(in *jl
 				out.ExecTime = nil
 			} else {
 				if out.ExecTime == nil {
-					out.ExecTime = new(time.Time)
+					out.ExecTime = new(utils.EasyjsonTime)
 				}
-				if data := in.Raw(); in.Ok() {
-					in.AddError((*out.ExecTime).UnmarshalJSON(data))
-				}
+				easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityUtils(in, out.ExecTime)
 			}
 		case "exit_time":
 			if in.IsNull() {
@@ -1331,11 +1356,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe11(in *jl
 				out.ExitTime = nil
 			} else {
 				if out.ExitTime == nil {
-					out.ExitTime = new(time.Time)
+					out.ExitTime = new(utils.EasyjsonTime)
 				}
-				if data := in.Raw(); in.Ok() {
-					in.AddError((*out.ExitTime).UnmarshalJSON(data))
-				}
+				easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityUtils(in, out.ExitTime)
 			}
 		case "credentials":
 			if in.IsNull() {
@@ -1535,17 +1558,17 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe11(out *j
 	if in.ForkTime != nil {
 		const prefix string = ",\"fork_time\":"
 		out.RawString(prefix)
-		out.Raw((*in.ForkTime).MarshalJSON())
+		(*in.ForkTime).MarshalEasyJSON(out)
 	}
 	if in.ExecTime != nil {
 		const prefix string = ",\"exec_time\":"
 		out.RawString(prefix)
-		out.Raw((*in.ExecTime).MarshalJSON())
+		(*in.ExecTime).MarshalEasyJSON(out)
 	}
 	if in.ExitTime != nil {
 		const prefix string = ",\"exit_time\":"
 		out.RawString(prefix)
-		out.Raw((*in.ExitTime).MarshalJSON())
+		(*in.ExitTime).MarshalEasyJSON(out)
 	}
 	if in.Credentials != nil {
 		const prefix string = ",\"credentials\":"
@@ -2335,11 +2358,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe20(in *jl
 				out.Atime = nil
 			} else {
 				if out.Atime == nil {
-					out.Atime = new(time.Time)
+					out.Atime = new(utils.EasyjsonTime)
 				}
-				if data := in.Raw(); in.Ok() {
-					in.AddError((*out.Atime).UnmarshalJSON(data))
-				}
+				easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityUtils(in, out.Atime)
 			}
 		case "modification_time":
 			if in.IsNull() {
@@ -2347,11 +2368,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe20(in *jl
 				out.Mtime = nil
 			} else {
 				if out.Mtime == nil {
-					out.Mtime = new(time.Time)
+					out.Mtime = new(utils.EasyjsonTime)
 				}
-				if data := in.Raw(); in.Ok() {
-					in.AddError((*out.Mtime).UnmarshalJSON(data))
-				}
+				easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityUtils(in, out.Mtime)
 			}
 		case "change_time":
 			if in.IsNull() {
@@ -2359,11 +2378,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe20(in *jl
 				out.Ctime = nil
 			} else {
 				if out.Ctime == nil {
-					out.Ctime = new(time.Time)
+					out.Ctime = new(utils.EasyjsonTime)
 				}
-				if data := in.Raw(); in.Ok() {
-					in.AddError((*out.Ctime).UnmarshalJSON(data))
-				}
+				easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityUtils(in, out.Ctime)
 			}
 		default:
 			in.SkipRecursive()
@@ -2507,17 +2524,17 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe20(out *j
 	if in.Atime != nil {
 		const prefix string = ",\"access_time\":"
 		out.RawString(prefix)
-		out.Raw((*in.Atime).MarshalJSON())
+		(*in.Atime).MarshalEasyJSON(out)
 	}
 	if in.Mtime != nil {
 		const prefix string = ",\"modification_time\":"
 		out.RawString(prefix)
-		out.Raw((*in.Mtime).MarshalJSON())
+		(*in.Mtime).MarshalEasyJSON(out)
 	}
 	if in.Ctime != nil {
 		const prefix string = ",\"change_time\":"
 		out.RawString(prefix)
-		out.Raw((*in.Ctime).MarshalJSON())
+		(*in.Ctime).MarshalEasyJSON(out)
 	}
 	out.RawByte('}')
 }
@@ -2657,11 +2674,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe21(in *jl
 				out.Atime = nil
 			} else {
 				if out.Atime == nil {
-					out.Atime = new(time.Time)
+					out.Atime = new(utils.EasyjsonTime)
 				}
-				if data := in.Raw(); in.Ok() {
-					in.AddError((*out.Atime).UnmarshalJSON(data))
-				}
+				easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityUtils(in, out.Atime)
 			}
 		case "modification_time":
 			if in.IsNull() {
@@ -2669,11 +2684,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe21(in *jl
 				out.Mtime = nil
 			} else {
 				if out.Mtime == nil {
-					out.Mtime = new(time.Time)
+					out.Mtime = new(utils.EasyjsonTime)
 				}
-				if data := in.Raw(); in.Ok() {
-					in.AddError((*out.Mtime).UnmarshalJSON(data))
-				}
+				easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityUtils(in, out.Mtime)
 			}
 		case "change_time":
 			if in.IsNull() {
@@ -2681,11 +2694,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe21(in *jl
 				out.Ctime = nil
 			} else {
 				if out.Ctime == nil {
-					out.Ctime = new(time.Time)
+					out.Ctime = new(utils.EasyjsonTime)
 				}
-				if data := in.Raw(); in.Ok() {
-					in.AddError((*out.Ctime).UnmarshalJSON(data))
-				}
+				easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityUtils(in, out.Ctime)
 			}
 		default:
 			in.SkipRecursive()
@@ -2879,17 +2890,17 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe21(out *j
 	if in.Atime != nil {
 		const prefix string = ",\"access_time\":"
 		out.RawString(prefix)
-		out.Raw((*in.Atime).MarshalJSON())
+		(*in.Atime).MarshalEasyJSON(out)
 	}
 	if in.Mtime != nil {
 		const prefix string = ",\"modification_time\":"
 		out.RawString(prefix)
-		out.Raw((*in.Mtime).MarshalJSON())
+		(*in.Mtime).MarshalEasyJSON(out)
 	}
 	if in.Ctime != nil {
 		const prefix string = ",\"change_time\":"
 		out.RawString(prefix)
-		out.Raw((*in.Ctime).MarshalJSON())
+		(*in.Ctime).MarshalEasyJSON(out)
 	}
 	out.RawByte('}')
 }
@@ -3101,9 +3112,7 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe22(in *jl
 				(*out.ContainerContextSerializer).UnmarshalEasyJSON(in)
 			}
 		case "date":
-			if data := in.Raw(); in.Ok() {
-				in.AddError((out.Date).UnmarshalJSON(data))
-			}
+			easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityUtils(in, &out.Date)
 		default:
 			in.SkipRecursive()
 		}
@@ -3292,7 +3301,7 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe22(out *j
 		} else {
 			out.RawString(prefix)
 		}
-		out.Raw((in.Date).MarshalJSON())
+		(in.Date).MarshalEasyJSON(out)
 	}
 	out.RawByte('}')
 }

--- a/pkg/security/probe/serializers_easyjson.go
+++ b/pkg/security/probe/serializers_easyjson.go
@@ -712,7 +712,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe9(in *jle
 				if out.ForkTime == nil {
 					out.ForkTime = new(utils.EasyjsonTime)
 				}
-				easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityUtils(in, out.ForkTime)
+				if data := in.Raw(); in.Ok() {
+					in.AddError((*out.ForkTime).UnmarshalJSON(data))
+				}
 			}
 		case "exec_time":
 			if in.IsNull() {
@@ -722,7 +724,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe9(in *jle
 				if out.ExecTime == nil {
 					out.ExecTime = new(utils.EasyjsonTime)
 				}
-				easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityUtils(in, out.ExecTime)
+				if data := in.Raw(); in.Ok() {
+					in.AddError((*out.ExecTime).UnmarshalJSON(data))
+				}
 			}
 		case "exit_time":
 			if in.IsNull() {
@@ -732,7 +736,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe9(in *jle
 				if out.ExitTime == nil {
 					out.ExitTime = new(utils.EasyjsonTime)
 				}
-				easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityUtils(in, out.ExitTime)
+				if data := in.Raw(); in.Ok() {
+					in.AddError((*out.ExitTime).UnmarshalJSON(data))
+				}
 			}
 		case "credentials":
 			if in.IsNull() {
@@ -980,41 +986,6 @@ func (v ProcessSerializer) MarshalEasyJSON(w *jwriter.Writer) {
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *ProcessSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe9(l, v)
-}
-func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityUtils(in *jlexer.Lexer, out *utils.EasyjsonTime) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		default:
-			in.SkipRecursive()
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityUtils(out *jwriter.Writer, in utils.EasyjsonTime) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	out.RawByte('}')
 }
 func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe10(in *jlexer.Lexer, out *ProcessCredentialsSerializer) {
 	isTopLevel := in.IsStart()
@@ -1338,7 +1309,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe11(in *jl
 				if out.ForkTime == nil {
 					out.ForkTime = new(utils.EasyjsonTime)
 				}
-				easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityUtils(in, out.ForkTime)
+				if data := in.Raw(); in.Ok() {
+					in.AddError((*out.ForkTime).UnmarshalJSON(data))
+				}
 			}
 		case "exec_time":
 			if in.IsNull() {
@@ -1348,7 +1321,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe11(in *jl
 				if out.ExecTime == nil {
 					out.ExecTime = new(utils.EasyjsonTime)
 				}
-				easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityUtils(in, out.ExecTime)
+				if data := in.Raw(); in.Ok() {
+					in.AddError((*out.ExecTime).UnmarshalJSON(data))
+				}
 			}
 		case "exit_time":
 			if in.IsNull() {
@@ -1358,7 +1333,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe11(in *jl
 				if out.ExitTime == nil {
 					out.ExitTime = new(utils.EasyjsonTime)
 				}
-				easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityUtils(in, out.ExitTime)
+				if data := in.Raw(); in.Ok() {
+					in.AddError((*out.ExitTime).UnmarshalJSON(data))
+				}
 			}
 		case "credentials":
 			if in.IsNull() {
@@ -2360,7 +2337,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe20(in *jl
 				if out.Atime == nil {
 					out.Atime = new(utils.EasyjsonTime)
 				}
-				easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityUtils(in, out.Atime)
+				if data := in.Raw(); in.Ok() {
+					in.AddError((*out.Atime).UnmarshalJSON(data))
+				}
 			}
 		case "modification_time":
 			if in.IsNull() {
@@ -2370,7 +2349,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe20(in *jl
 				if out.Mtime == nil {
 					out.Mtime = new(utils.EasyjsonTime)
 				}
-				easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityUtils(in, out.Mtime)
+				if data := in.Raw(); in.Ok() {
+					in.AddError((*out.Mtime).UnmarshalJSON(data))
+				}
 			}
 		case "change_time":
 			if in.IsNull() {
@@ -2380,7 +2361,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe20(in *jl
 				if out.Ctime == nil {
 					out.Ctime = new(utils.EasyjsonTime)
 				}
-				easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityUtils(in, out.Ctime)
+				if data := in.Raw(); in.Ok() {
+					in.AddError((*out.Ctime).UnmarshalJSON(data))
+				}
 			}
 		default:
 			in.SkipRecursive()
@@ -2676,7 +2659,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe21(in *jl
 				if out.Atime == nil {
 					out.Atime = new(utils.EasyjsonTime)
 				}
-				easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityUtils(in, out.Atime)
+				if data := in.Raw(); in.Ok() {
+					in.AddError((*out.Atime).UnmarshalJSON(data))
+				}
 			}
 		case "modification_time":
 			if in.IsNull() {
@@ -2686,7 +2671,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe21(in *jl
 				if out.Mtime == nil {
 					out.Mtime = new(utils.EasyjsonTime)
 				}
-				easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityUtils(in, out.Mtime)
+				if data := in.Raw(); in.Ok() {
+					in.AddError((*out.Mtime).UnmarshalJSON(data))
+				}
 			}
 		case "change_time":
 			if in.IsNull() {
@@ -2696,7 +2683,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe21(in *jl
 				if out.Ctime == nil {
 					out.Ctime = new(utils.EasyjsonTime)
 				}
-				easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityUtils(in, out.Ctime)
+				if data := in.Raw(); in.Ok() {
+					in.AddError((*out.Ctime).UnmarshalJSON(data))
+				}
 			}
 		default:
 			in.SkipRecursive()
@@ -3112,7 +3101,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe22(in *jl
 				(*out.ContainerContextSerializer).UnmarshalEasyJSON(in)
 			}
 		case "date":
-			easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityUtils(in, &out.Date)
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.Date).UnmarshalJSON(data))
+			}
 		default:
 			in.SkipRecursive()
 		}

--- a/pkg/security/utils/json.go
+++ b/pkg/security/utils/json.go
@@ -1,0 +1,30 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package utils
+
+import (
+	"errors"
+	"time"
+
+	"github.com/mailru/easyjson/jwriter"
+)
+
+type EasyjsonTime time.Time
+
+func (t EasyjsonTime) MarshalEasyJSON(w *jwriter.Writer) {
+	tt := time.Time(t)
+	if y := tt.Year(); y < 0 || y >= 10000 {
+		if w.Error == nil {
+			w.Error = errors.New("Time.MarshalJSON: year outside of range [0,9999]")
+		}
+		return
+	}
+
+	w.Buffer.EnsureSpace(len(time.RFC3339Nano) + 2)
+	w.Buffer.AppendByte('"')
+	w.Buffer.Buf = tt.AppendFormat(w.Buffer.Buf, time.RFC3339Nano)
+	w.Buffer.AppendByte('"')
+}

--- a/pkg/security/utils/json.go
+++ b/pkg/security/utils/json.go
@@ -12,11 +12,16 @@ import (
 	"github.com/mailru/easyjson/jwriter"
 )
 
-type EasyjsonTime time.Time
+type EasyjsonTime struct {
+	inner time.Time
+}
+
+func NewEasyjsonTime(t time.Time) EasyjsonTime {
+	return EasyjsonTime{inner: t}
+}
 
 func (t EasyjsonTime) MarshalEasyJSON(w *jwriter.Writer) {
-	tt := time.Time(t)
-	if y := tt.Year(); y < 0 || y >= 10000 {
+	if y := t.inner.Year(); y < 0 || y >= 10000 {
 		if w.Error == nil {
 			w.Error = errors.New("Time.MarshalJSON: year outside of range [0,9999]")
 		}
@@ -25,6 +30,10 @@ func (t EasyjsonTime) MarshalEasyJSON(w *jwriter.Writer) {
 
 	w.Buffer.EnsureSpace(len(time.RFC3339Nano) + 2)
 	w.Buffer.AppendByte('"')
-	w.Buffer.Buf = tt.AppendFormat(w.Buffer.Buf, time.RFC3339Nano)
+	w.Buffer.Buf = t.inner.AppendFormat(w.Buffer.Buf, time.RFC3339Nano)
 	w.Buffer.AppendByte('"')
+}
+
+func (t *EasyjsonTime) UnmarshalJSON(b []byte) error {
+	return t.inner.UnmarshalJSON(b)
 }


### PR DESCRIPTION
### What does this PR do?

Currently one of the worst offenders of the event serialization is `time.Time`. Easyjson falls back to `.MarshalJSON()` for this type and thus allocates a new buffer for this field.

This PR creates a wrapper for `time.Time` that directly implements the marshaling with the interface expected by easyjson. This allows us to use the current working buffer (which is pooled so the benefit is great in the long term).

#### Benchmark

`inv -e security-agent.functional-tests --testflags "-test.v -test.run XXX -test.bench BenchmarkSerializers -test.benchmem -test.benchtime 5s"`

Before:
```
BenchmarkSerializersEasyJson
BenchmarkSerializersEasyJson-4   	  163615	     34293 ns/op	   21614 B/op	      58 allocs/op
BenchmarkSerializersStd
BenchmarkSerializersStd-4        	   93993	     63591 ns/op	   20692 B/op	      48 allocs/op
```

After (the `Std` result is obviously not correct but is not used by the real path so no investigation was done):
```
BenchmarkSerializersEasyJson
BenchmarkSerializersEasyJson-4   	  169842	     32767 ns/op	   19342 B/op	      11 allocs/op
BenchmarkSerializersStd
BenchmarkSerializersStd-4        	  138331	     43107 ns/op	   18433 B/op	       1 allocs/op
```

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
