### PR TITLE
pkg/config: fix logging problem with default value

### DIFF
--- a/pkg/config/otlp.go
+++ b/pkg/config/otlp.go
@@ -58,7 +58,7 @@ func setupOTLPEnvironmentVariables(config Config) {
 	config.BindEnv(OTLPSection + ".receiver.protocols.grpc.include_metadata")
 
 	// Traces settingds
-	config.BindEnv("otlp_config.traces.span_name_remappings")
+	config.BindEnvAndSetDefault("otlp_config.traces.span_name_remappings", map[string]string{})
 	config.BindEnv("otlp_config.traces.span_name_as_resource_name")
 
 	// HTTP settings


### PR DESCRIPTION
The `otlp_config.span_name_remappings` was throwing a harmless warning in the logs
about its default value of <nil> not being valid as map[string]string.

```
2022-05-20 10:58:14 CEST | TRACE | WARN | (pkg/util/log/log.go:592 in func1) | failed to get configuration value for key "otlp_config.traces.span_name_remappings": unable to cast <nil> of type <nil> to map[string]string
```

This change fixes the issue by setting its default to be a map.