### PR TITLE
Dockerfiles: set perms for entrypoints

### DIFF
--- a/Dockerfiles/agent/amd64/Dockerfile
+++ b/Dockerfiles/agent/amd64/Dockerfile
@@ -207,5 +207,7 @@ ENV LD_PRELOAD=/lib/x86_64-linux-gnu/nosys.so \
 # Single entrypoint
 COPY entrypoint.sh /bin/entrypoint.sh
 COPY entrypoint.d /opt/entrypoints
+RUN chmod 755 /bin/entrypoint.sh \
+ && chmod 755 -R /opt/entrypoints
 
 CMD ["/bin/entrypoint.sh"]

--- a/Dockerfiles/agent/arm64/Dockerfile
+++ b/Dockerfiles/agent/arm64/Dockerfile
@@ -206,5 +206,7 @@ ENV LD_PRELOAD=/lib/x86_64-linux-gnu/nosys.so \
 # Single entrypoint
 COPY entrypoint.sh /bin/entrypoint.sh
 COPY entrypoint.d /opt/entrypoints
+RUN chmod 755 /bin/entrypoint.sh \
+ && chmod 755 -R /opt/entrypoints
 
 CMD ["/bin/entrypoint.sh"]

--- a/Dockerfiles/dogstatsd/alpine/amd64/Dockerfile
+++ b/Dockerfiles/dogstatsd/alpine/amd64/Dockerfile
@@ -13,6 +13,7 @@ RUN ALPINE_RELEASE=$(cat /etc/alpine-release | sed "s/^\(\d\+\.\d\+\).\+$/\1/") 
 RUN apk add --no-cache ca-certificates
 
 COPY entrypoint.sh probe.sh /
+RUN chmod 755 /entrypoint.sh /probe.sh
 COPY dogstatsd.yaml /etc/datadog-agent/dogstatsd.yaml
 COPY install_info /etc/datadog-agent/install_info
 COPY static/dogstatsd /dogstatsd

--- a/Dockerfiles/dogstatsd/alpine/arm64/Dockerfile
+++ b/Dockerfiles/dogstatsd/alpine/arm64/Dockerfile
@@ -13,6 +13,7 @@ RUN ALPINE_RELEASE=$(cat /etc/alpine-release | sed "s/^\(\d\+\.\d\+\).\+$/\1/") 
 RUN apk add --no-cache ca-certificates
 
 COPY entrypoint.sh probe.sh /
+RUN chmod 755 /entrypoint.sh /probe.sh
 COPY dogstatsd.yaml /etc/datadog-agent/dogstatsd.yaml
 COPY install_info /etc/datadog-agent/install_info
 COPY static/dogstatsd /dogstatsd

--- a/releasenotes/notes/dockerfile-entrypoint-perms-b660c7742c8f2124.yaml
+++ b/releasenotes/notes/dockerfile-entrypoint-perms-b660c7742c8f2124.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Restrict permissions for the entrypoint executables of the Dockerfiles.


### PR DESCRIPTION
### What does this PR do?

Sets the permissions for the entrypoints in the Dockerfiles. The permissions are the same as the ones in the files of the repo.


### Describe how to test/QA your changes

Run the agent in a container and check that the permissions of `/bin/entrypoint.sh` and the files in `/opt/entrypoints` are 755.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
