### PR TITLE
[snmp-traps] 🐛 parse config in server main

### DIFF
--- a/pkg/snmp/traps/constants.go
+++ b/pkg/snmp/traps/constants.go
@@ -8,7 +8,6 @@ package traps
 const (
 	defaultPort        = uint16(9162) // Standard UDP port for traps.
 	defaultStopTimeout = 5
-	defaultNamespace   = "default"
 	packetsChanSize    = 100
 	genericTrapOid     = "1.3.6.1.6.3.1.1.5"
 )

--- a/pkg/snmp/traps/formatter.go
+++ b/pkg/snmp/traps/formatter.go
@@ -39,11 +39,10 @@ const (
 )
 
 // NewJSONFormatter creates a new JSONFormatter instance with an optional OIDResolver variable.
-func NewJSONFormatter(oidResolver OIDResolver) (JSONFormatter, error) {
+func NewJSONFormatter(oidResolver OIDResolver, namespace string) (JSONFormatter, error) {
 	if oidResolver == nil {
 		return JSONFormatter{}, fmt.Errorf("NewJSONFormatter called with a nil OIDResolver")
 	}
-	namespace := GetNamespace()
 	return JSONFormatter{oidResolver, namespace}, nil
 }
 

--- a/pkg/snmp/traps/server_test.go
+++ b/pkg/snmp/traps/server_test.go
@@ -25,12 +25,12 @@ func TestStartFailure(t *testing.T) {
 	mockSender := mocksender.NewMockSender("snmp-traps-listener")
 	mockSender.SetupAcceptAll()
 
-	sucessServer, err := NewTrapServer("dummy_hostname", &DummyFormatter{}, mockSender)
+	sucessServer, err := NewTrapServer(config, &DummyFormatter{}, mockSender)
 	require.NoError(t, err)
 	require.NotNil(t, sucessServer)
 	defer sucessServer.Stop()
 
-	failedServer, err := NewTrapServer("dummy_hostname", &DummyFormatter{}, mockSender)
+	failedServer, err := NewTrapServer(config, &DummyFormatter{}, mockSender)
 	require.Nil(t, failedServer)
 	require.Error(t, err)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Parse configuration in the main server start function, and pass it as a dependency.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

`config.Namespace` is required by the json formatter, and it was accessed before the config was loaded. This PR loads the agent configuration once at the begining of the server Start function, and passes it to all actors, passing namespace by value to the formatter.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
