### PR TITLE
Exclude teradata on mac

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -77,6 +77,7 @@ if osx?
   # Temporarily blacklist Aerospike until builder supports new dependency
   blacklist_packages.push(/^aerospike==/)
   blacklist_folders.push('aerospike')
+  blacklist_folders.push('teradata')
 end
 
 if arm?

--- a/releasenotes/notes/exclude-teradata-mac-d3b957b7066175a7.yaml
+++ b/releasenotes/notes/exclude-teradata-mac-d3b957b7066175a7.yaml
@@ -1,10 +1,3 @@
-# Each section from every release note are combined when the
-# CHANGELOG.rst is rendered. So the text needs to be worded so that
-# it does not depend on any information only available in another
-# section. This may mean repeating some details, but each section
-# must be readable independently of the other.
-#
-# Each section note must be formatted as reStructuredText.
 ---
 other:
   - |

--- a/releasenotes/notes/exclude-teradata-mac-d3b957b7066175a7.yaml
+++ b/releasenotes/notes/exclude-teradata-mac-d3b957b7066175a7.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+other:
+  - |
+    Exclude teradata on Mac agents.


### PR DESCRIPTION
### What does this PR do?

Excludes teradata on Mac builds

### Motivation
QA for https://github.com/DataDog/integrations-core/pull/11701
The teradatasql library does not appear to be properly [signed](https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution) for Macs and errors when calling the check, ie:
```
      OSError: dlopen(/opt/datadog-agent/embedded/lib/python3.8/site-packages/teradatasql/teradatasql.dylib, 0x0006): tried: '/opt/datadog-agent/embedded/lib/python3.8/site-packages/teradatasql/teradatasql.dylib' (code signature in <DB4759AB-6099-3F35-8DE9-194955E7D16A> '/opt/datadog-agent/embedded/lib/python3.8/site-packages/teradatasql/teradatasql.dylib' not valid for use in process: mapped file has no cdhash, completely unsigned? Code has to be at least ad-hoc signed.)
```
### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
