### PR TITLE
add http tracing in requests sent to the endpoints in diagnose command

### DIFF
--- a/cmd/agent/app/diagnose.go
+++ b/cmd/agent/app/diagnose.go
@@ -39,12 +39,16 @@ var (
 		Hidden: true,
 		RunE:   doDiagnoseDatadogConnectivity,
 	}
+
+	noTrace bool
 )
 
 func init() {
 
 	diagnoseCommand.AddCommand(diagnoseMetadataAvailabilityCommand)
 	diagnoseCommand.AddCommand(diagnoseDatadogConnectivityCommand)
+
+	diagnoseDatadogConnectivityCommand.PersistentFlags().BoolVarP(&noTrace, "no-trace", "", false, "mute extra information about connection establishment, DNS lookup and TLS handshake")
 
 	AgentCmd.AddCommand(diagnoseCommand)
 }
@@ -62,7 +66,7 @@ func doDiagnoseDatadogConnectivity(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return connectivity.RunDatadogConnectivityDiagnose()
+	return connectivity.RunDatadogConnectivityDiagnose(noTrace)
 }
 
 func configAndLogSetup() error {

--- a/cmd/agent/app/diagnose.go
+++ b/cmd/agent/app/diagnose.go
@@ -54,10 +54,6 @@ func doDiagnoseMetadataAvailability(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if flagNoColor {
-		color.NoColor = true
-	}
-
 	return diagnose.RunAll(color.Output)
 }
 
@@ -74,6 +70,10 @@ func configAndLogSetup() error {
 	err := common.SetupConfig(confFilePath)
 	if err != nil {
 		return fmt.Errorf("unable to set up global agent configuration: %v", err)
+	}
+
+	if flagNoColor {
+		color.NoColor = true
 	}
 
 	// log level is always off since this might be use by other agent to get the hostname

--- a/pkg/diagnose/connectivity/hooks.go
+++ b/pkg/diagnose/connectivity/hooks.go
@@ -31,6 +31,10 @@ var DiagnoseTrace = &httptrace.ClientTrace{
 	// Hooks for connection establishment
 	ConnectStart: connectStartHook,
 	ConnectDone:  connectDoneHook,
+
+	// Hooks for DNS resolution
+	DNSStart: dnsStartHook,
+	DNSDone:  dnsDoneHook,
 }
 
 // connectStartHook is called when the http.Client is establishing a new connection to 'addr'
@@ -48,7 +52,6 @@ func connectDoneHook(network, addr string, err error) {
 		fmt.Printf("Unable to connect to the endpoint : %v\n", err)
 	}
 	fmt.Printf("Connection to the endpoint [%v]\n\n", statusString)
-
 }
 
 // getConnHook is called before getting a new connection.
@@ -69,4 +72,20 @@ func gotConnHook(gci httptrace.GotConnInfo) {
 	if gci.Reused {
 		fmt.Print(color.CyanString("Reusing a previous connection that was idle for %v\n", gci.IdleTime))
 	}
+}
+
+// dnsStartHook is called when starting the DNS lookup
+func dnsStartHook(di httptrace.DNSStartInfo) {
+	fmt.Printf("--- Starting DNS lookup to resolve '%v' ---\n", di.Host)
+}
+
+// dnsDoneHook is called after the DNS lookup
+// It displays the error message if there is one and indicates if this step was successful
+func dnsDoneHook(di httptrace.DNSDoneInfo) {
+	statusString := color.GreenString("OK")
+	if di.Err != nil {
+		statusString = color.RedString("KO")
+		fmt.Printf("Unable to resolve the address : %v\n", di.Err)
+	}
+	fmt.Printf("DNS Lookup [%v]\n\n", statusString)
 }

--- a/pkg/diagnose/connectivity/hooks.go
+++ b/pkg/diagnose/connectivity/hooks.go
@@ -13,6 +13,7 @@ package connectivity
 // Their prototypes are defined by htpp.Client so variables might be unused
 
 import (
+	"crypto/tls"
 	"fmt"
 	"net/http/httptrace"
 
@@ -35,6 +36,10 @@ var DiagnoseTrace = &httptrace.ClientTrace{
 	// Hooks for DNS resolution
 	DNSStart: dnsStartHook,
 	DNSDone:  dnsDoneHook,
+
+	// Hooks for TLS Handshake
+	TLSHandshakeStart: tlsHandshakeStartHook,
+	TLSHandshakeDone:  tlsHandshakeDoneHook,
 }
 
 // connectStartHook is called when the http.Client is establishing a new connection to 'addr'
@@ -88,4 +93,20 @@ func dnsDoneHook(di httptrace.DNSDoneInfo) {
 		fmt.Printf("Unable to resolve the address : %v\n", di.Err)
 	}
 	fmt.Printf("DNS Lookup [%v]\n\n", statusString)
+}
+
+// tlsHandshakeStartHook is called when starting the TLS Handshake
+func tlsHandshakeStartHook() {
+	fmt.Printf("### Starting TLS Handshake ###\n")
+}
+
+// tlsHandshakeDoneHook is called after the TLS Handshake
+// It displays the error message if there is one and indicates if this step was successful
+func tlsHandshakeDoneHook(cs tls.ConnectionState, err error) {
+	statusString := color.GreenString("OK")
+	if err != nil {
+		statusString = color.RedString("KO")
+		fmt.Printf("Unable to achieve the TLS Handshake : %v\n", err)
+	}
+	fmt.Printf("TLS Handshake [%v]\n\n", statusString)
 }

--- a/pkg/diagnose/connectivity/hooks.go
+++ b/pkg/diagnose/connectivity/hooks.go
@@ -1,0 +1,48 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package connectivity contains logic for connectivity troubleshooting between the Agent
+// and Datadog endpoints. It uses HTTP request to contact different endpoints and displays
+// some results depending on endpoints responses, if any.
+package connectivity
+
+// This file contains all the functions used by httptrace.ClientTrace.
+// Each function is called at a specific moment during the communication
+// Their prototypes are defined by htpp.Client so variables might be unused
+
+import (
+	"fmt"
+	"net/http/httptrace"
+
+	"github.com/fatih/color"
+)
+
+// During a request, the http.Client will call the functions of the ClientTrace at specific moments.
+// This is useful to get extra information about what is happening and if there are errors during
+// connection establishment, DNS resolution or TLS handshake for instance.
+var DiagnoseTrace = &httptrace.ClientTrace{
+
+	// Hooks for connection establishment
+	ConnectStart: connectStartHook,
+	ConnectDone:  connectDoneHook,
+}
+
+// connectStartHook is called when the http.Client is establishing a new connection to 'addr'
+// However, it is not called when a connection is reused.
+func connectStartHook(network, addr string) {
+	fmt.Printf("~~~ Starting a new connection ~~~\n")
+}
+
+// connectDoneHook is called when the new connection to 'addr' completes
+// It displays the error message if there is one and indicates if this step was successful
+func connectDoneHook(network, addr string, err error) {
+	statusString := color.GreenString("OK")
+	if err != nil {
+		statusString = color.RedString("KO")
+		fmt.Printf("Unable to connect to the endpoint : %v\n", err)
+	}
+	fmt.Printf("Connection to the endpoint [%v]\n\n", statusString)
+
+}

--- a/pkg/diagnose/connectivity/hooks.go
+++ b/pkg/diagnose/connectivity/hooks.go
@@ -20,9 +20,9 @@ import (
 	"github.com/fatih/color"
 )
 
-// During a request, the http.Client will call the functions of the ClientTrace at specific moments.
+// During a request, the http.Client will call the functions of the ClientTrace at specific moments
 // This is useful to get extra information about what is happening and if there are errors during
-// connection establishment, DNS resolution or TLS handshake for instance.
+// connection establishment, DNS resolution or TLS handshake for instance
 var DiagnoseTrace = &httptrace.ClientTrace{
 
 	// Hooks called before and after creating or retrieving a connection
@@ -42,7 +42,11 @@ var DiagnoseTrace = &httptrace.ClientTrace{
 	TLSHandshakeDone:  tlsHandshakeDoneHook,
 }
 
-var EmptyTrace = &httptrace.ClientTrace{}
+var (
+	EmptyTrace   = &httptrace.ClientTrace{}
+	dnsColorFunc = color.MagentaString
+	tlsColorFunc = color.YellowString
+)
 
 // connectStartHook is called when the http.Client is establishing a new connection to 'addr'
 // However, it is not called when a connection is reused (see gotConnHook)
@@ -58,7 +62,7 @@ func connectDoneHook(network, addr string, err error) {
 		statusString = color.RedString("KO")
 		fmt.Printf("Unable to connect to the endpoint : %v\n", err)
 	}
-	fmt.Printf("Connection to the endpoint [%v]\n\n", statusString)
+	fmt.Printf("• Connection to the endpoint [%v]\n\n", statusString)
 }
 
 // getConnHook is called before getting a new connection.
@@ -83,7 +87,7 @@ func gotConnHook(gci httptrace.GotConnInfo) {
 
 // dnsStartHook is called when starting the DNS lookup
 func dnsStartHook(di httptrace.DNSStartInfo) {
-	fmt.Printf("--- Starting DNS lookup to resolve '%v' ---\n", di.Host)
+	fmt.Print(dnsColorFunc("--- Starting DNS lookup to resolve '%v' ---\n", di.Host))
 }
 
 // dnsDoneHook is called after the DNS lookup
@@ -92,14 +96,14 @@ func dnsDoneHook(di httptrace.DNSDoneInfo) {
 	statusString := color.GreenString("OK")
 	if di.Err != nil {
 		statusString = color.RedString("KO")
-		fmt.Printf("Unable to resolve the address : %v\n", di.Err)
+		fmt.Print(dnsColorFunc("Unable to resolve the address : %v\n", di.Err))
 	}
-	fmt.Printf("DNS Lookup [%v]\n\n", statusString)
+	fmt.Printf("• %v [%v]\n\n", dnsColorFunc("DNS Lookup"), statusString)
 }
 
 // tlsHandshakeStartHook is called when starting the TLS Handshake
 func tlsHandshakeStartHook() {
-	fmt.Printf("### Starting TLS Handshake ###\n")
+	fmt.Print(tlsColorFunc("### Starting TLS Handshake ###\n"))
 }
 
 // tlsHandshakeDoneHook is called after the TLS Handshake
@@ -108,7 +112,7 @@ func tlsHandshakeDoneHook(cs tls.ConnectionState, err error) {
 	statusString := color.GreenString("OK")
 	if err != nil {
 		statusString = color.RedString("KO")
-		fmt.Printf("Unable to achieve the TLS Handshake : %v\n", err)
+		fmt.Print(tlsColorFunc("Unable to achieve the TLS Handshake : %v\n", err))
 	}
-	fmt.Printf("TLS Handshake [%v]\n\n", statusString)
+	fmt.Printf("• %v [%v]\n\n", tlsColorFunc("TLS Handshake"), statusString)
 }

--- a/pkg/diagnose/connectivity/hooks.go
+++ b/pkg/diagnose/connectivity/hooks.go
@@ -42,6 +42,8 @@ var DiagnoseTrace = &httptrace.ClientTrace{
 	TLSHandshakeDone:  tlsHandshakeDoneHook,
 }
 
+var EmptyTrace = &httptrace.ClientTrace{}
+
 // connectStartHook is called when the http.Client is establishing a new connection to 'addr'
 // However, it is not called when a connection is reused (see gotConnHook)
 func connectStartHook(network, addr string) {

--- a/pkg/diagnose/connectivity/hooks.go
+++ b/pkg/diagnose/connectivity/hooks.go
@@ -23,7 +23,7 @@ import (
 // During a request, the http.Client will call the functions of the ClientTrace at specific moments
 // This is useful to get extra information about what is happening and if there are errors during
 // connection establishment, DNS resolution or TLS handshake for instance
-var DiagnoseTrace = &httptrace.ClientTrace{
+var diagnoseTrace = &httptrace.ClientTrace{
 
 	// Hooks called before and after creating or retrieving a connection
 	GetConn: getConnHook,
@@ -43,7 +43,7 @@ var DiagnoseTrace = &httptrace.ClientTrace{
 }
 
 var (
-	EmptyTrace   = &httptrace.ClientTrace{}
+	emptyTrace   = &httptrace.ClientTrace{}
 	dnsColorFunc = color.MagentaString
 	tlsColorFunc = color.YellowString
 )
@@ -59,14 +59,14 @@ func connectStartHook(network, addr string) {
 func connectDoneHook(network, addr string, err error) {
 	statusString := color.GreenString("OK")
 	if err != nil {
-		statusString = color.RedString("KO")
+		statusString = color.RedString("ERROR")
 		fmt.Printf("Unable to connect to the endpoint : %v\n", err)
 	}
 	fmt.Printf("• Connection to the endpoint [%v]\n\n", statusString)
 }
 
 // getConnHook is called before getting a new connection.
-// This will be called before :
+// This is called before :
 // 		- Creating a new connection 		: getConnHook ---> connectStartHook
 //		- Retrieving an existing connection : getConnHook ---> gotConnHook
 func getConnHook(hostPort string) {
@@ -95,7 +95,7 @@ func dnsStartHook(di httptrace.DNSStartInfo) {
 func dnsDoneHook(di httptrace.DNSDoneInfo) {
 	statusString := color.GreenString("OK")
 	if di.Err != nil {
-		statusString = color.RedString("KO")
+		statusString = color.RedString("ERROR")
 		fmt.Print(dnsColorFunc("Unable to resolve the address : %v\n", di.Err))
 	}
 	fmt.Printf("• %v [%v]\n\n", dnsColorFunc("DNS Lookup"), statusString)
@@ -111,7 +111,7 @@ func tlsHandshakeStartHook() {
 func tlsHandshakeDoneHook(cs tls.ConnectionState, err error) {
 	statusString := color.GreenString("OK")
 	if err != nil {
-		statusString = color.RedString("KO")
+		statusString = color.RedString("ERROR")
 		fmt.Print(tlsColorFunc("Unable to achieve the TLS Handshake : %v\n", err))
 	}
 	fmt.Printf("• %v [%v]\n\n", tlsColorFunc("TLS Handshake"), statusString)

--- a/pkg/diagnose/connectivity/hooks.go
+++ b/pkg/diagnose/connectivity/hooks.go
@@ -20,30 +20,33 @@ import (
 	"github.com/fatih/color"
 )
 
+// createDiagnoseTrace creates a httptrace.ClientTrace containing functions that display
+// additional information when a http.Client is sending requests
 // During a request, the http.Client will call the functions of the ClientTrace at specific moments
 // This is useful to get extra information about what is happening and if there are errors during
 // connection establishment, DNS resolution or TLS handshake for instance
-var diagnoseTrace = &httptrace.ClientTrace{
+func createDiagnoseTrace() *httptrace.ClientTrace {
+	return &httptrace.ClientTrace{
 
-	// Hooks called before and after creating or retrieving a connection
-	GetConn: getConnHook,
-	GotConn: gotConnHook,
+		// Hooks called before and after creating or retrieving a connection
+		GetConn: getConnHook,
+		GotConn: gotConnHook,
 
-	// Hooks for connection establishment
-	ConnectStart: connectStartHook,
-	ConnectDone:  connectDoneHook,
+		// Hooks for connection establishment
+		ConnectStart: connectStartHook,
+		ConnectDone:  connectDoneHook,
 
-	// Hooks for DNS resolution
-	DNSStart: dnsStartHook,
-	DNSDone:  dnsDoneHook,
+		// Hooks for DNS resolution
+		DNSStart: dnsStartHook,
+		DNSDone:  dnsDoneHook,
 
-	// Hooks for TLS Handshake
-	TLSHandshakeStart: tlsHandshakeStartHook,
-	TLSHandshakeDone:  tlsHandshakeDoneHook,
+		// Hooks for TLS Handshake
+		TLSHandshakeStart: tlsHandshakeStartHook,
+		TLSHandshakeDone:  tlsHandshakeDoneHook,
+	}
 }
 
 var (
-	emptyTrace   = &httptrace.ClientTrace{}
 	dnsColorFunc = color.MagentaString
 	tlsColorFunc = color.YellowString
 )
@@ -62,7 +65,7 @@ func connectDoneHook(network, addr string, err error) {
 		statusString = color.RedString("ERROR")
 		fmt.Printf("Unable to connect to the endpoint : %v\n", err)
 	}
-	fmt.Printf("• Connection to the endpoint [%v]\n\n", statusString)
+	fmt.Printf("* Connection to the endpoint [%v]\n\n", statusString)
 }
 
 // getConnHook is called before getting a new connection.
@@ -98,7 +101,7 @@ func dnsDoneHook(di httptrace.DNSDoneInfo) {
 		statusString = color.RedString("ERROR")
 		fmt.Print(dnsColorFunc("Unable to resolve the address : %v\n", di.Err))
 	}
-	fmt.Printf("• %v [%v]\n\n", dnsColorFunc("DNS Lookup"), statusString)
+	fmt.Printf("* %v [%v]\n\n", dnsColorFunc("DNS Lookup"), statusString)
 }
 
 // tlsHandshakeStartHook is called when starting the TLS Handshake
@@ -114,5 +117,5 @@ func tlsHandshakeDoneHook(cs tls.ConnectionState, err error) {
 		statusString = color.RedString("ERROR")
 		fmt.Print(tlsColorFunc("Unable to achieve the TLS Handshake : %v\n", err))
 	}
-	fmt.Printf("• %v [%v]\n\n", tlsColorFunc("TLS Handshake"), statusString)
+	fmt.Printf("* %v [%v]\n\n", tlsColorFunc("TLS Handshake"), statusString)
 }

--- a/pkg/diagnose/connectivity/trace_request.go
+++ b/pkg/diagnose/connectivity/trace_request.go
@@ -38,7 +38,7 @@ func RunDatadogConnectivityDiagnose(noTrace bool) error {
 	client := forwarder.NewHTTPClient()
 
 	if noTrace {
-		DiagnoseTrace = EmptyTrace
+		diagnoseTrace = emptyTrace
 	}
 
 	// Send requests to all endpoints for all domains
@@ -74,7 +74,7 @@ func sendHTTPRequestToEndpoint(client *http.Client, domain string, endpointInfo 
 	logURL := scrubber.ScrubLine(url)
 
 	// Enable HTTP trace
-	ctx := httptrace.WithClientTrace(context.Background(), DiagnoseTrace)
+	ctx := httptrace.WithClientTrace(context.Background(), diagnoseTrace)
 
 	fmt.Printf("\n======== '%v' ========\n", color.BlueString(logURL))
 

--- a/pkg/diagnose/connectivity/trace_request.go
+++ b/pkg/diagnose/connectivity/trace_request.go
@@ -26,7 +26,7 @@ import (
 
 // RunDatadogConnectivityDiagnose send requests to endpoints for all domains
 // to check if there are connectivity issues between Datadog and these endpoints
-func RunDatadogConnectivityDiagnose() error {
+func RunDatadogConnectivityDiagnose(noTrace bool) error {
 	// Create domain resolvers
 	keysPerDomain, err := config.GetMultipleEndpoints()
 	if err != nil {
@@ -36,6 +36,10 @@ func RunDatadogConnectivityDiagnose() error {
 	domainResolvers := resolver.NewSingleDomainResolvers(keysPerDomain)
 
 	client := forwarder.NewHTTPClient()
+
+	if noTrace {
+		DiagnoseTrace = EmptyTrace
+	}
 
 	// Send requests to all endpoints for all domains
 	fmt.Println("\n================ Starting connectivity diagnosis ================")

--- a/pkg/diagnose/connectivity/trace_request.go
+++ b/pkg/diagnose/connectivity/trace_request.go
@@ -24,7 +24,7 @@ import (
 	"github.com/fatih/color"
 )
 
-// RunDatadogConnectivityDiagnose send requests to endpoints for all domains
+// RunDatadogConnectivityDiagnose sends requests to all known endpoints for all domains
 // to check if there are connectivity issues between Datadog and these endpoints
 func RunDatadogConnectivityDiagnose(noTrace bool) error {
 	// Create domain resolvers

--- a/pkg/diagnose/connectivity/trace_request.go
+++ b/pkg/diagnose/connectivity/trace_request.go
@@ -75,8 +75,6 @@ func sendHTTPRequestToEndpoint(ctx context.Context, client *http.Client, domain 
 	url := createEndpointURL(domain, endpointInfo, apiKey)
 	logURL := scrubber.ScrubLine(url)
 
-	// Enable HTTP trace
-
 	fmt.Printf("\n======== '%v' ========\n", color.BlueString(logURL))
 
 	// Create a request for the backend

--- a/pkg/diagnose/connectivity/trace_request_test.go
+++ b/pkg/diagnose/connectivity/trace_request_test.go
@@ -6,6 +6,7 @@
 package connectivity
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -48,13 +49,13 @@ func TestSendHTTPRequestToEndpoint(t *testing.T) {
 	client := forwarder.NewHTTPClient()
 
 	// With the API Key, it should be a 200
-	statusCodeWithKey, responseBodyWithKey, errWithKey := sendHTTPRequestToEndpoint(client, ts1.URL, endpointInfoWithAPIKey, apiKey)
+	statusCodeWithKey, responseBodyWithKey, errWithKey := sendHTTPRequestToEndpoint(context.Background(), client, ts1.URL, endpointInfoWithAPIKey, apiKey)
 	assert.Nil(t, errWithKey)
 	assert.Equal(t, statusCodeWithKey, 200)
 	assert.Equal(t, string(responseBodyWithKey), "OK")
 
 	// Without the API Key, it should be a 400
-	statusCode, responseBody, err := sendHTTPRequestToEndpoint(client, ts1.URL, endpointInfoWithoutAPIKey, apiKey)
+	statusCode, responseBody, err := sendHTTPRequestToEndpoint(context.Background(), client, ts1.URL, endpointInfoWithoutAPIKey, apiKey)
 	assert.Nil(t, err)
 	assert.Equal(t, statusCode, 400)
 	assert.Equal(t, string(responseBody), "Bad Request")


### PR DESCRIPTION
### What does this PR do?

This PR adds http tracing for requests sent in `diagnose datadog-connectivity` command to output for information about connection establishment, DNS lookup and TLS handshake. 

### Motivation

Having more information in this command to make troubleshooting easier.

### Additional Notes

- Output can be a bit messy because there is a lot of information to display, might be interesting
to add a `--json` option to format the output.

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Disclaimer : This is a PR of a long list of PRs that aims to add connectivity troubleshooting tools so it might not be up to date during the QA. Don't hesitate to ping me during the QA if there is any problem.

There are several things to check :  

- Command Flags
- Connection errors
- DNS errors
- TLS errors

#### Flags

- `--no-color`

    - Run `datadog-agent diagnose datadog-connectivity` and check that some output lines are colored. (if terminal handles colors)
    - Then run `datadog-agent --no-color diagnose datadog-connectivity` and check that there is no color on the output.

- `--no-trace` 
    - Run `datadog-agent diagnose datadog-connectivity --no-trace` and check that there is no output related to the connection establishment, DNS or TLS. The output should be way shorter.

#### Connection

- Set `dd_url` in `datadog.yaml` to a non used port, `http://localhost:6000` for instance.
- Check that the command outputs an error for the connection part. It should be close to `Unable to connect to the endpoint : dial tcp 127.0.0.1:6000: connect: connection refused`


#### DNS

- Set `dd_url` in `datadog.yaml` to a non existing address such as `https://random.url.com` and run the `diagnose datadog-connectivity` command.
- Check that the command outputs an error for the DNS part. It should be close to `lookup random.url.com: no such host`

#### TLS Handshake


On linux systems : 
- Run `SSL_CERT_FILE=test SSL_CERT_DIR=test2 datadog-agent diagnose datadog-connectivity`
- Check that the command outputs an error for the TLS part.


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
