### PR TITLE
[Admission Controller] Add e2e tests for mutations

### DIFF
--- a/test/e2e/argo-workflows/default-workflow.yaml
+++ b/test/e2e/argo-workflows/default-workflow.yaml
@@ -117,6 +117,24 @@ spec:
               - name: namespace
                 value: "{{workflow.namespace}}"
 
+        - - name: start-busybox
+            templateRef:
+              name: busybox
+              template: create
+            arguments:
+              parameters:
+                - name: namespace
+                  value: "{{workflow.namespace}}"
+
+        - - name: test-busybox
+            templateRef:
+              name: busybox
+              template: test
+            arguments:
+              parameters:
+                - name: namespace
+                  value: "{{workflow.namespace}}"
+
         - - name: test-datadog-agent
             templateRef:
               name: datadog-agent
@@ -273,6 +291,15 @@ spec:
                 - name: namespace
                   value: "{{workflow.namespace}}"
 
+          - name: stop-busybox
+            templateRef:
+              name: busybox
+              template: delete
+            arguments:
+              parameters:
+                - name: namespace
+                  value: "{{workflow.namespace}}"
+
     - name: diagnose
       steps:
         - - name: diagnose-datadog-agent
@@ -294,6 +321,14 @@ spec:
           - name: diagnose-nginx
             templateRef:
               name: nginx
+              template: diagnose
+            arguments:
+              parameters:
+              - name: namespace
+                value: "{{workflow.namespace}}"
+          - name: diagnose-busybox
+            templateRef:
+              name: busybox
               template: diagnose
             arguments:
               parameters:

--- a/test/e2e/argo-workflows/templates/datadog-agent.yaml
+++ b/test/e2e/argo-workflows/templates/datadog-agent.yaml
@@ -119,6 +119,8 @@ spec:
             token: c9e21a248434a400b1de021dbdd554d790983a1212a5eac0ba36e79346ec52fd
             metricsProvider:
               enabled: true
+            admissionController:
+              enabled: true
             env:
               - name: DATADOG_HOST
                 value: {{inputs.parameters.dd-url}}

--- a/test/e2e/argo-workflows/templates/mutate-busybox.yaml
+++ b/test/e2e/argo-workflows/templates/mutate-busybox.yaml
@@ -1,0 +1,348 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: busybox
+spec:
+  templates:
+    - name: create-busybox-tags
+      inputs:
+        parameters:
+          - name: namespace
+      resource:
+        action: apply
+        manifest: |
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: busybox-tags
+            namespace: {{inputs.parameters.namespace}}
+            labels:
+              "app": "busybox"
+              "admission.datadoghq.com/enabled": "true"
+              "tags.datadoghq.com/env": "busybox-env"
+              "tags.datadoghq.com/service": "busybox-service"
+              "tags.datadoghq.com/version": "busybox-version"
+          spec:
+            containers:
+              - command:
+                  - sleep
+                  - "3600"
+                image: busybox
+                name: busybox
+    - name: create-busybox-hostip
+      inputs:
+        parameters:
+          - name: namespace
+      resource:
+        action: apply
+        manifest: |
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: busybox-hostip
+            namespace: {{inputs.parameters.namespace}}
+            labels:
+              "app": "busybox"
+              "admission.datadoghq.com/enabled": "true"
+          spec:
+            containers:
+              - command:
+                  - sleep
+                  - "3600"
+                image: busybox
+                name: busybox
+    - name: create-busybox-service
+      inputs:
+        parameters:
+          - name: namespace
+      resource:
+        action: apply
+        manifest: |
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: busybox-service
+            namespace: {{inputs.parameters.namespace}}
+            labels:
+              "app": "busybox"
+              "admission.datadoghq.com/enabled": "true"
+              "admission.datadoghq.com/config.mode": "service"
+          spec:
+            containers:
+              - command:
+                  - sleep
+                  - "3600"
+                image: busybox
+                name: busybox
+    - name: create-busybox-socket
+      inputs:
+        parameters:
+          - name: namespace
+      resource:
+        action: apply
+        manifest: |
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: busybox-socket
+            namespace: {{inputs.parameters.namespace}}
+            labels:
+              "app": "busybox"
+              "admission.datadoghq.com/enabled": "true"
+              "admission.datadoghq.com/config.mode": "socket"
+          spec:
+            containers:
+              - command:
+                  - sleep
+                  - "3600"
+                image: busybox
+                name: busybox
+    - name: create
+      inputs:
+        parameters:
+          - name: namespace
+      steps:
+        - - name: busybox-hostip
+            template: create-busybox-hostip
+            arguments:
+              parameters:
+                - name: namespace
+                  value: "{{inputs.parameters.namespace}}"
+        - - name: busybox-service
+            template: create-busybox-service
+            arguments:
+              parameters:
+                - name: namespace
+                  value: "{{inputs.parameters.namespace}}"
+        - - name: busybox-socket
+            template: create-busybox-socket
+            arguments:
+              parameters:
+                - name: namespace
+                  value: "{{inputs.parameters.namespace}}"
+        - - name: busybox-tags
+            template: create-busybox-tags
+            arguments:
+              parameters:
+                - name: namespace
+                  value: "{{inputs.parameters.namespace}}"
+    - name: delete-all
+      inputs:
+        parameters:
+          - name: namespace
+      activeDeadlineSeconds: 300
+      script:
+        image: argoproj/argoexec:v3.3.1
+        command: [sh]
+        source: |
+          set -euo pipefail
+          set -x
+
+          kubectl delete pods -l app=busybox --namespace {{inputs.parameters.namespace}}
+    - name: delete
+      inputs:
+        parameters:
+          - name: namespace
+      steps:
+        - - name: delete-pods
+            template: delete-all
+            arguments:
+              parameters:
+                - name: namespace
+                  value: "{{inputs.parameters.namespace}}"
+    - name: test-env-fieldPath
+      inputs:
+        parameters:
+          - name: namespace
+          - name: envKey
+          - name: envFieldPath
+          - name: target
+      activeDeadlineSeconds: 300
+      script:
+        image: argoproj/argoexec:v3.3.1
+        command: [sh]
+        source: |
+          set -euo pipefail
+          set -x
+
+          until kubectl get pods -o json --namespace {{inputs.parameters.namespace}} | jq '.items[] | select(.spec.containers[].env[]? | .name == "{{inputs.parameters.envKey}}" and .valueFrom.fieldRef.fieldPath == "{{inputs.parameters.envFieldPath}}") | .metadata.name' | grep {{inputs.parameters.target}}; do
+            sleep 2
+          done
+    - name: test-env-value
+      inputs:
+        parameters:
+          - name: namespace
+          - name: envKey
+          - name: envValue
+          - name: target
+      activeDeadlineSeconds: 300
+      script:
+        image: argoproj/argoexec:v3.3.1
+        command: [sh]
+        source: |
+          set -euo pipefail
+          set -x
+
+          until kubectl get pods -o json --namespace {{inputs.parameters.namespace}} | jq '.items[] | select(.spec.containers[].env[]? | .name == "{{inputs.parameters.envKey}}" and .value == "{{inputs.parameters.envValue}}") | .metadata.name' | grep {{inputs.parameters.target}}; do
+            sleep 2
+          done
+    - name: test-volume
+      inputs:
+        parameters:
+          - name: namespace
+          - name: volumeName
+          - name: volumePath
+          - name: target
+      activeDeadlineSeconds: 300
+      script:
+        image: argoproj/argoexec:v3.3.1
+        command: [sh]
+        source: |
+          set -euo pipefail
+          set -x
+
+          until kubectl get pods -o json --namespace {{inputs.parameters.namespace}} | jq '.items[] | select(.spec.containers[].volumeMount[]? | .name == "{{inputs.parameters.volumeName}}" and .mountPath == "{{inputs.parameters.volumePath}}") | .metadata.name' | grep {{inputs.parameters.target}}; do
+            sleep 2
+          done
+
+          until kubectl get pods -o json --namespace {{inputs.parameters.namespace}} | jq '.items[] | select(.spec.volumes[]? | .name == "{{inputs.parameters.volumeName}}" and .hostPath.path == "{{inputs.parameters.volumePath}}") | .metadata.name' | grep {{inputs.parameters.target}}; do
+            sleep 2
+          done
+    - name: test
+      inputs:
+        parameters:
+          - name: namespace
+      steps:
+        - - name: agent-host-hostip
+            template: test-env-fieldPath
+            arguments:
+              parameters:
+                - name: namespace
+                  value: "{{inputs.parameters.namespace}}"
+                - name: envKey
+                  value: DD_AGENT_HOST
+                - name: envFieldPath
+                  value: "status.hostIP"
+                - name: target
+                  value: busybox-hostip
+        - - name: entity-id-hostip
+            template: test-env-fieldPath
+            arguments:
+              parameters:
+                - name: namespace
+                  value: "{{inputs.parameters.namespace}}"
+                - name: envKey
+                  value: DD_ENTITY_ID
+                - name: envFieldPath
+                  value: "metadata.uid"
+                - name: target
+                  value: busybox-hostip
+        - - name: agent-host-service
+            template: test-env-value
+            arguments:
+              parameters:
+                - name: namespace
+                  value: "{{inputs.parameters.namespace}}"
+                - name: envValue
+                  value: datadog.{{inputs.parameters.namespace}}.svc.cluster.local
+                - name: envKey
+                  value: DD_AGENT_HOST
+                - name: target
+                  value: busybox-service
+        - - name: entity-id-service
+            template: test-env-fieldPath
+            arguments:
+              parameters:
+                - name: namespace
+                  value: "{{inputs.parameters.namespace}}"
+                - name: envKey
+                  value: DD_ENTITY_ID
+                - name: envFieldPath
+                  value: "metadata.uid"
+                - name: target
+                  value: busybox-service
+        - - name: trace-url-socket
+            template: test-env-value
+            arguments:
+              parameters:
+                - name: namespace
+                  value: "{{inputs.parameters.namespace}}"
+                - name: envValue
+                  value: "unix:///var/run/datadog/apm.socket"
+                - name: envKey
+                  value: DD_TRACE_AGENT_URL
+                - name: target
+                  value: busybox-socket
+        - - name: volume-socket
+            template: test-volume
+            arguments:
+              parameters:
+                - name: namespace
+                  value: "{{inputs.parameters.namespace}}"
+                - name: volumeName
+                  value: datadog
+                - name: volumePath
+                  value: "/var/run/datadog"
+                - name: target
+                  value: busybox-socket
+        - - name: entity-id-socket
+            template: test-env-fieldPath
+            arguments:
+              parameters:
+                - name: namespace
+                  value: "{{inputs.parameters.namespace}}"
+                - name: envKey
+                  value: DD_ENTITY_ID
+                - name: envFieldPath
+                  value: "metadata.uid"
+                - name: target
+                  value: busybox-socket
+        - - name: env-tag
+            template: test-env-value
+            arguments:
+              parameters:
+                - name: namespace
+                  value: "{{inputs.parameters.namespace}}"
+                - name: envValue
+                  value: busybox-env
+                - name: envKey
+                  value: DD_ENV
+                - name: target
+                  value: busybox-tags
+        - - name: service-tag
+            template: test-env-value
+            arguments:
+              parameters:
+                - name: namespace
+                  value: "{{inputs.parameters.namespace}}"
+                - name: envValue
+                  value: busybox-service
+                - name: envKey
+                  value: DD_SERVICE
+                - name: target
+                  value: busybox-tags
+        - - name: version-tag
+            template: test-env-value
+            arguments:
+              parameters:
+                - name: namespace
+                  value: "{{inputs.parameters.namespace}}"
+                - name: envValue
+                  value: busybox-version
+                - name: envKey
+                  value: DD_VERSION
+                - name: target
+                  value: busybox-tags
+    - name: diagnose
+      inputs:
+        parameters:
+          - name: namespace
+      activeDeadlineSeconds: 300
+      script:
+        image: argoproj/argoexec:v3.3.1
+        command: [sh]
+        source: |
+          set -euo pipefail
+          set -x
+
+          kubectl describe pods -l app=busybox --namespace {{inputs.parameters.namespace}}

--- a/test/e2e/argo-workflows/templates/mutate-busybox.yaml
+++ b/test/e2e/argo-workflows/templates/mutate-busybox.yaml
@@ -163,7 +163,7 @@ spec:
           set -euo pipefail
           set -x
 
-          until kubectl get pods -o json --namespace {{inputs.parameters.namespace}} | jq '.items[] | select(.spec.containers[].volumeMount[]? | .name == "{{inputs.parameters.volumeName}}" and .mountPath == "{{inputs.parameters.volumePath}}") | .metadata.name' | grep {{inputs.parameters.target}}; do
+          until kubectl get pods -o json --namespace {{inputs.parameters.namespace}} | jq '.items[] | select(.spec.containers[].volumeMounts[]? | .name == "{{inputs.parameters.volumeName}}" and .mountPath == "{{inputs.parameters.volumePath}}") | .metadata.name' | grep {{inputs.parameters.target}}; do
             sleep 2
           done
 

--- a/test/e2e/argo-workflows/templates/mutate-busybox.yaml
+++ b/test/e2e/argo-workflows/templates/mutate-busybox.yaml
@@ -4,7 +4,7 @@ metadata:
   name: busybox
 spec:
   templates:
-    - name: create-busybox-tags
+    - name: create-busybox-with-tags
       inputs:
         parameters:
           - name: namespace
@@ -29,67 +29,23 @@ spec:
                   - "3600"
                 image: busybox
                 name: busybox
-    - name: create-busybox-hostip
+    - name: create-busybox-with-mode
       inputs:
         parameters:
           - name: namespace
+          - name: mode
       resource:
         action: apply
         manifest: |
           apiVersion: v1
           kind: Pod
           metadata:
-            name: busybox-hostip
+            name: busybox-{{inputs.parameters.mode}}
             namespace: {{inputs.parameters.namespace}}
             labels:
               "app": "busybox"
               "admission.datadoghq.com/enabled": "true"
-          spec:
-            containers:
-              - command:
-                  - sleep
-                  - "3600"
-                image: busybox
-                name: busybox
-    - name: create-busybox-service
-      inputs:
-        parameters:
-          - name: namespace
-      resource:
-        action: apply
-        manifest: |
-          apiVersion: v1
-          kind: Pod
-          metadata:
-            name: busybox-service
-            namespace: {{inputs.parameters.namespace}}
-            labels:
-              "app": "busybox"
-              "admission.datadoghq.com/enabled": "true"
-              "admission.datadoghq.com/config.mode": "service"
-          spec:
-            containers:
-              - command:
-                  - sleep
-                  - "3600"
-                image: busybox
-                name: busybox
-    - name: create-busybox-socket
-      inputs:
-        parameters:
-          - name: namespace
-      resource:
-        action: apply
-        manifest: |
-          apiVersion: v1
-          kind: Pod
-          metadata:
-            name: busybox-socket
-            namespace: {{inputs.parameters.namespace}}
-            labels:
-              "app": "busybox"
-              "admission.datadoghq.com/enabled": "true"
-              "admission.datadoghq.com/config.mode": "socket"
+              "admission.datadoghq.com/config.mode": "{{inputs.parameters.mode}}"
           spec:
             containers:
               - command:
@@ -103,25 +59,31 @@ spec:
           - name: namespace
       steps:
         - - name: busybox-hostip
-            template: create-busybox-hostip
+            template: create-busybox-with-mode
             arguments:
               parameters:
                 - name: namespace
                   value: "{{inputs.parameters.namespace}}"
+                - name: mode
+                  value: hostip
         - - name: busybox-service
-            template: create-busybox-service
+            template: create-busybox-with-mode
             arguments:
               parameters:
                 - name: namespace
                   value: "{{inputs.parameters.namespace}}"
+                - name: mode
+                  value: service
         - - name: busybox-socket
-            template: create-busybox-socket
+            template: create-busybox-with-mode
             arguments:
               parameters:
                 - name: namespace
                   value: "{{inputs.parameters.namespace}}"
+                - name: mode
+                  value: socket
         - - name: busybox-tags
-            template: create-busybox-tags
+            template: create-busybox-with-tags
             arguments:
               parameters:
                 - name: namespace


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

- Add e2e tests for config and tags injection performed by the admission controller - mutating webhook
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

- Improve the test coverage
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

- The e2e job is 🟢 

```
 ├───✔ test-busybox                            busybox/test                                                                                                                      
 │   ├───✔ agent-host-hostip                   test-env-fieldPath                  argo-datadog-agent-lj8gv-1947261437  2s                                                       
 │   ├───✔ entity-id-hostip                    test-env-fieldPath                  argo-datadog-agent-lj8gv-3680464419  2s                                                       
 │   ├───✔ agent-host-service                  test-env-value                      argo-datadog-agent-lj8gv-482291079   2s                                                       
 │   ├───✔ entity-id-service                   test-env-fieldPath                  argo-datadog-agent-lj8gv-2391863225  2s                                                       
 │   ├───✔ trace-url-socket                    test-env-value                      argo-datadog-agent-lj8gv-1689768144  2s                                                       
 │   ├───✔ volume-socket                       test-volume                         argo-datadog-agent-lj8gv-3848178562  2s                                                       
 │   ├───✔ entity-id-socket                    test-env-fieldPath                  argo-datadog-agent-lj8gv-1496849508  2s                                                       
 │   ├───✔ env-tag                             test-env-value                      argo-datadog-agent-lj8gv-455404518   2s                                                       
 │   ├───✔ service-tag                         test-env-value                      argo-datadog-agent-lj8gv-3403316737  2s                                                       
 │   └───✔ version-tag                         test-env-value                      argo-datadog-agent-lj8gv-1263272723  2s                                         
```
### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
