### PR TITLE
'Catch up' on service subscriptions, just like sources

### DIFF
--- a/pkg/logs/service/services.go
+++ b/pkg/logs/service/services.go
@@ -11,6 +11,7 @@ import (
 
 // Services provides new and removed services.
 type Services struct {
+	services       []*Service
 	addedPerType   map[string][]chan *Service
 	removedPerType map[string][]chan *Service
 	allAdded       []chan *Service
@@ -31,6 +32,8 @@ func (s *Services) AddService(service *Service) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	s.services = append(s.services, service)
+
 	added, _ := s.addedPerType[service.Type]
 	for _, ch := range append(added, s.allAdded...) {
 		ch <- service
@@ -42,6 +45,12 @@ func (s *Services) RemoveService(service *Service) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	for i, svc := range s.services {
+		if svc.Type == service.Type && svc.Identifier == service.Identifier {
+			s.services = append(s.services[:i], s.services[i+1:]...)
+		}
+	}
+
 	removed, _ := s.removedPerType[service.Type]
 	for _, ch := range append(removed, s.allRemoved...) {
 		ch <- service
@@ -49,12 +58,23 @@ func (s *Services) RemoveService(service *Service) {
 }
 
 // GetAddedServicesForType returns a stream of new services for a given type.
+//
+// Any services added before this call are delivered from a new goroutine.
 func (s *Services) GetAddedServicesForType(serviceType string) chan *Service {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	added := make(chan *Service)
 	s.addedPerType[serviceType] = append(s.addedPerType[serviceType], added)
+
+	existingServices := append([]*Service{}, s.services...) // clone for goroutine
+	go func() {
+		for _, svc := range existingServices {
+			if svc.Type == serviceType {
+				added <- svc
+			}
+		}
+	}()
 
 	return added
 }
@@ -71,12 +91,21 @@ func (s *Services) GetRemovedServicesForType(serviceType string) chan *Service {
 }
 
 // GetAllAddedServices registers the channel to receive all added services.
+//
+// Any services added before this call are delivered from a new goroutine.
 func (s *Services) GetAllAddedServices() chan *Service {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	added := make(chan *Service)
 	s.allAdded = append(s.allAdded, added)
+
+	existingServices := append([]*Service{}, s.services...) // clone for goroutine
+	go func() {
+		for _, svc := range existingServices {
+			added <- svc
+		}
+	}()
 
 	return added
 }


### PR DESCRIPTION
### What does this PR do?

When a launcher subscribes to services (as the kubernetes and docker launchers do), if any services have already been added, send those to the launcher right away.

### Motivation

Yet another logs-agent startup race condition.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

 * Set up the agent to log containers with container_collect_all, in a docker scenario
 * Start a container
 * Start the agent
 * See the container being logged, with an input, in `agent status`

Repeat for a kubernetes scenario.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
