### PR TITLE
Filter by type when 'catching up' on source subscriptions

### DIFF
--- a/pkg/logs/config/sources.go
+++ b/pkg/logs/config/sources.go
@@ -105,7 +105,9 @@ func (s *LogSources) SubscribeForType(sourceType string) (added chan *LogSource,
 	existingSources := append([]*LogSource{}, s.sources...) // clone for goroutine
 	go func() {
 		for _, source := range existingSources {
-			added <- source
+			if source.Config.Type == sourceType {
+				added <- source
+			}
 		}
 	}()
 
@@ -131,7 +133,9 @@ func (s *LogSources) GetAddedForType(sourceType string) chan *LogSource {
 	existingSources := append([]*LogSource{}, s.sources...) // clone for goroutine
 	go func() {
 		for _, source := range existingSources {
-			stream <- source
+			if source.Config.Type == sourceType {
+				stream <- source
+			}
 		}
 	}()
 

--- a/pkg/logs/config/sources_test.go
+++ b/pkg/logs/config/sources_test.go
@@ -70,17 +70,25 @@ func TestGetAddedForType(t *testing.T) {
 func TestGetAddedForTypeExistingSources(t *testing.T) {
 	sources := NewLogSources()
 	source1 := NewLogSource("one", &LogsConfig{Type: "foo"})
+	source1bar := NewLogSource("one-bar", &LogsConfig{Type: "bar"})
 	source2 := NewLogSource("two", &LogsConfig{Type: "foo"})
+	source2bar := NewLogSource("two-bar", &LogsConfig{Type: "bar"})
 	source3 := NewLogSource("three", &LogsConfig{Type: "foo"})
 
-	go func() { sources.AddSource(source1) }()
+	go func() {
+		sources.AddSource(source1bar)
+		sources.AddSource(source1)
+	}()
 
 	streamA := sources.GetAddedForType("foo")
 	assert.NotNil(t, streamA)
 	sa1 := <-streamA
 	assert.Equal(t, sa1, source1)
 
-	go func() { sources.AddSource(source2) }()
+	go func() {
+		sources.AddSource(source2bar)
+		sources.AddSource(source2)
+	}()
 	sa2 := <-streamA
 	assert.Equal(t, sa2, source2)
 
@@ -100,10 +108,15 @@ func TestGetAddedForTypeExistingSources(t *testing.T) {
 func TestSubscribeForType(t *testing.T) {
 	sources := NewLogSources()
 	source1 := NewLogSource("one", &LogsConfig{Type: "foo"})
+	source1bar := NewLogSource("one-bar", &LogsConfig{Type: "bar"})
 	source2 := NewLogSource("two", &LogsConfig{Type: "foo"})
+	source2bar := NewLogSource("two-bar", &LogsConfig{Type: "bar"})
 	source3 := NewLogSource("three", &LogsConfig{Type: "foo"})
 
-	go func() { sources.AddSource(source1) }()
+	go func() {
+		sources.AddSource(source1bar)
+		sources.AddSource(source1)
+	}()
 
 	addA, removeA := sources.SubscribeForType("foo")
 	assert.NotNil(t, addA)
@@ -111,7 +124,10 @@ func TestSubscribeForType(t *testing.T) {
 	assert.Equal(t, sa1, source1)
 	assert.Equal(t, 0, len(removeA))
 
-	go func() { sources.AddSource(source2) }()
+	go func() {
+		sources.AddSource(source2bar)
+		sources.AddSource(source2)
+	}()
 
 	sa2 := <-addA
 	assert.Equal(t, sa2, source2)


### PR DESCRIPTION
### What does this PR do?

The Sources methods to subscribe to added sources have a "catch up" feature that provides all sources already added.  However, this "catch up" provided _all_ sources, not just those of the requested type.  This PR fixes the oversight (and adds tests).

### Motivation

Spotted a bug while working on #12128.  This is a regression in 7.37, in that I introduced a bug.  I haven’t seen any practical impact from this bug, but I don’t see any reason to think it’s harmless.


### Describe how to test/QA your changes

Any logs QA scenario that does _not_ involve `container_collect_all` should suffice.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
