### PR TITLE
[CI] Fix revive linter `agent-core` errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,7 @@ run:
     - pkg/util/cloudproviders/cloudfoundry/bbscache_test.go # implements interface from imported package whose method names fail linting
 
 issues:
+  exclude-use-default: false
   # Do not limit the number of issues per linter.
   max-issues-per-linter: 0
 
@@ -12,6 +13,8 @@ issues:
   max-same-issues: 0
 
   exclude:
+    - "type JsonHttpTransaction should be JSONHTTPTransaction"
+    - "Error return value of .((os\\.)?std(out|err)\\..*|.*Close|.*Flush|os\\.Remove(All)?|.*print(f|ln)?|os\\.(Un)?Setenv). is not checked"
     - "`eventContext` is unused"
     - "`\\(\\*DatadogLogger\\).changeLogLevel` is unused"
     - "`defaultRetryDuration` is unused" # used by APM and Process

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,7 +5,6 @@ run:
     - pkg/util/cloudproviders/cloudfoundry/bbscache_test.go # implements interface from imported package whose method names fail linting
 
 issues:
-  exclude-use-default: false
   # Do not limit the number of issues per linter.
   max-issues-per-linter: 0
 
@@ -13,7 +12,6 @@ issues:
   max-same-issues: 0
 
   exclude:
-    - "type JsonHttpTransaction should be JSONHTTPTransaction"
     - "Error return value of .((os\\.)?std(out|err)\\..*|.*Close|.*Flush|os\\.Remove(All)?|.*print(f|ln)?|os\\.(Un)?Setenv). is not checked"
     - "`eventContext` is unused"
     - "`\\(\\*DatadogLogger\\).changeLogLevel` is unused"
@@ -73,3 +71,5 @@ linters-settings:
              "-SA6002", # TODO: Fix sync.Pools
              "-SA4025", # TODO: Fix trace unit test
             ]
+  revive:
+

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,7 +12,6 @@ issues:
   max-same-issues: 0
 
   exclude:
-    - "Error return value of .((os\\.)?std(out|err)\\..*|.*Close|.*Flush|os\\.Remove(All)?|.*print(f|ln)?|os\\.(Un)?Setenv). is not checked"
     - "`eventContext` is unused"
     - "`\\(\\*DatadogLogger\\).changeLogLevel` is unused"
     - "`defaultRetryDuration` is unused" # used by APM and Process
@@ -71,5 +70,3 @@ linters-settings:
              "-SA6002", # TODO: Fix sync.Pools
              "-SA4025", # TODO: Fix trace unit test
             ]
-  revive:
-

--- a/tools/retry_file_dump/main.go
+++ b/tools/retry_file_dump/main.go
@@ -90,7 +90,7 @@ func dumpRetryFile(file string) ([]byte, error) {
 	return json.MarshalIndent(jsonTrs, "", "  ")
 }
 
-// JsonHttpTransaction TODO (<agent-core>): XX-YYYY
+// JsonHttpTransaction TODO (<agent-core>): AC-1784
 type JsonHttpTransaction struct {
 	*HttpTransactionProto
 	Payload string // Same as HttpTransactionProto.Payload but the type is string instead of []byte

--- a/tools/retry_file_dump/main.go
+++ b/tools/retry_file_dump/main.go
@@ -90,6 +90,7 @@ func dumpRetryFile(file string) ([]byte, error) {
 	return json.MarshalIndent(jsonTrs, "", "  ")
 }
 
+// JsonHttpTransaction TODO (<agent-core>): XX-YYYY
 type JsonHttpTransaction struct {
 	*HttpTransactionProto
 	Payload string // Same as HttpTransactionProto.Payload but the type is string instead of []byte


### PR DESCRIPTION
### What does this PR do?

This PR fix [`revive` linter](https://github.com/mgechev/revive) errors in the `agent-core` team owned code by adding `TODO` comments to exported functions / types.

### Motivation

We used to enforce that exported functions and types are documented. This was done through `revive` but the check was disabled by default when we switched to `golangcli-lint`. Now that we tried to re-enable it we got a lot of errors. This PR addresses these errors and inform the relevant teams for a fix.

### Additional Notes

After this PR, the relevant teams will have to fill the `TODO` comments (see [AC-1784](https://datadoghq.atlassian.net/jira/software/projects/AC/boards/625/backlog?selectedIssue=AC-1784)).

### Describe how to test/QA your changes

You can try to run `revive ./...` in the edited files folder. You shouldn't have errors anymore.

You can also just check that the CI didn't raise an error.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
