### PR TITLE
[CI] Fix revive linter `container-integrations` errors

### DIFF
--- a/internal/third_party/kubernetes/pkg/kubelet/types/pod_update.go
+++ b/internal/third_party/kubernetes/pkg/kubelet/types/pod_update.go
@@ -23,21 +23,21 @@ import (
 )
 
 const (
-	// ConfigSourceAnnotationKey TODO (<container-integrations>): XX-YYYY
+	// ConfigSourceAnnotationKey TODO (<container-integrations>): CONT-3353
 	ConfigSourceAnnotationKey = "kubernetes.io/config.source"
 
 	// These constants identify the sources of pods
 
-	// FileSource TODO (<container-integrations>): XX-YYYY
+	// FileSource TODO (<container-integrations>): CONT-3353
 	// Updates from a file
 	FileSource = "file"
-	// HTTPSource TODO (<container-integrations>): XX-YYYY
+	// HTTPSource TODO (<container-integrations>): CONT-3353
 	// Updates from querying a web page
 	HTTPSource = "http"
-	// ApiserverSource TODO (<container-integrations>): XX-YYYY
+	// ApiserverSource TODO (<container-integrations>): CONT-3353
 	// Updates from Kubernetes API Server
 	ApiserverSource = "api"
-	// AllSource TODO (<container-integrations>): XX-YYYY
+	// AllSource TODO (<container-integrations>): CONT-3353
 	// Updates from all sources
 	AllSource = "*"
 )

--- a/internal/third_party/kubernetes/pkg/kubelet/types/pod_update.go
+++ b/internal/third_party/kubernetes/pkg/kubelet/types/pod_update.go
@@ -23,15 +23,21 @@ import (
 )
 
 const (
+	// ConfigSourceAnnotationKey TODO (<container-integrations>): XX-YYYY
 	ConfigSourceAnnotationKey = "kubernetes.io/config.source"
 
 	// These constants identify the sources of pods
+
+	// FileSource TODO (<container-integrations>): XX-YYYY
 	// Updates from a file
 	FileSource = "file"
+	// HTTPSource TODO (<container-integrations>): XX-YYYY
 	// Updates from querying a web page
 	HTTPSource = "http"
+	// ApiserverSource TODO (<container-integrations>): XX-YYYY
 	// Updates from Kubernetes API Server
 	ApiserverSource = "api"
+	// AllSource TODO (<container-integrations>): XX-YYYY
 	// Updates from all sources
 	AllSource = "*"
 )

--- a/pkg/clusteragent/api/handler_telemetry.go
+++ b/pkg/clusteragent/api/handler_telemetry.go
@@ -16,13 +16,13 @@ var apiRequests = telemetry.NewCounterWithOpts("", "api_requests",
 	[]string{"handler", "status", "forwarded"}, "Counter of requests made to the cluster agent API.",
 	telemetry.Options{NoDoubleUnderscoreSep: true})
 
-// TelemetryHandler TODO (<container-integrations>): XX-YYYY
+// TelemetryHandler TODO (<container-integrations>): CONT-3353
 type TelemetryHandler struct {
 	handlerName string
 	handler     func(w http.ResponseWriter, r *http.Request)
 }
 
-// WithTelemetryWrapper TODO (<container-integrations>): XX-YYYY
+// WithTelemetryWrapper TODO (<container-integrations>): CONT-3353
 func WithTelemetryWrapper(handlerName string, handler func(w http.ResponseWriter, r *http.Request)) func(w http.ResponseWriter, r *http.Request) {
 	th := TelemetryHandler{
 		handlerName: handlerName,

--- a/pkg/clusteragent/api/handler_telemetry.go
+++ b/pkg/clusteragent/api/handler_telemetry.go
@@ -16,11 +16,13 @@ var apiRequests = telemetry.NewCounterWithOpts("", "api_requests",
 	[]string{"handler", "status", "forwarded"}, "Counter of requests made to the cluster agent API.",
 	telemetry.Options{NoDoubleUnderscoreSep: true})
 
+// TelemetryHandler TODO (<container-integrations>): XX-YYYY
 type TelemetryHandler struct {
 	handlerName string
 	handler     func(w http.ResponseWriter, r *http.Request)
 }
 
+// WithTelemetryWrapper TODO (<container-integrations>): XX-YYYY
 func WithTelemetryWrapper(handlerName string, handler func(w http.ResponseWriter, r *http.Request)) func(w http.ResponseWriter, r *http.Request) {
 	th := TelemetryHandler{
 		handlerName: handlerName,


### PR DESCRIPTION
### What does this PR do?

This PR fixes [`revive` linter](https://github.com/mgechev/revive) errors in the `container-integrations` team owned code by adding `TODO` comments to exported functions / types.

### Motivation

We used to enforce that exported functions and types are documented. This was done through `revive` but the check was disabled by default when we switched to `golangcli-lint`. Now that we tried to re-enable it we got a lot of errors. This PR addresses these errors and inform the relevant teams for a fix.

### Additional Notes

After this PR, the relevant teams will have to fill the `TODO` comments (see [CONT-3353](https://datadoghq.atlassian.net/jira/software/projects/CONT/boards/167/backlog?selectedIssue=CONT-3353)).

### Describe how to test/QA your changes

You can try to run `revive ./...` in the edited files folder. You shouldn't have errors anymore.

You can also just check that the CI didn't raise an error.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
