### PR TITLE
Set `system_probe_config.max_closed_connections_buffered` to at least `system_probe_config.max_tracked_connections`

### DIFF
--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -111,7 +111,7 @@ func InitSystemProbeConfig(cfg Config) {
 	cfg.BindEnvAndSetDefault(join(spNS, "offset_guess_threshold"), int64(defaultOffsetThreshold))
 
 	cfg.BindEnvAndSetDefault(join(spNS, "max_tracked_connections"), 65536)
-	cfg.BindEnvAndSetDefault(join(spNS, "max_closed_connections_buffered"), 50000)
+	cfg.BindEnv(join(spNS, "max_closed_connections_buffered"))
 	cfg.BindEnvAndSetDefault(join(spNS, "closed_channel_size"), 500)
 	cfg.BindEnvAndSetDefault(join(spNS, "max_connection_state_buffered"), 75000)
 

--- a/pkg/network/config/config.go
+++ b/pkg/network/config/config.go
@@ -223,6 +223,15 @@ func New() *Config {
 		RecordedQueryTypes: cfg.GetStringSlice(join(netNS, "dns_recorded_query_types")),
 	}
 
+	if !cfg.IsSet(join(spNS, "max_closed_connections_buffered")) {
+		// make sure max_closed_connections_buffered is equal to
+		// max_tracked_connections, since the former is not set.
+		// this helps with lowering or eliminating dropped
+		// closed connections in environments with mostly short-lived
+		// connections
+		c.MaxClosedConnectionsBuffered = int(c.MaxTrackedConnections)
+	}
+
 	httpRRKey := join(netNS, "http_replace_rules")
 	rr, err := parseReplaceRules(cfg, httpRRKey)
 	if err != nil {

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -6,6 +6,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"regexp"
 	"strings"
@@ -297,5 +298,30 @@ func TestHTTPReplaceRules(t *testing.T) {
 		for i, r := range expected {
 			assert.Equal(t, r, cfg.HTTPReplaceRules[i])
 		}
+	})
+}
+
+func TestMaxClosedConnectionsBuffered(t *testing.T) {
+	newConfig()
+	defer restoreGlobalConfig()
+
+	maxTrackedConnections := New().MaxTrackedConnections
+
+	t.Run("value set", func(t *testing.T) {
+		v := os.Getenv("DD_SYSTEM_PROBE_CONFIG_MAX_CLOSED_CONNECTIONS_BUFFERED")
+		defer func() {
+			os.Setenv("DD_SYSTEM_PROBE_CONFIG_MAX_CLOSED_CONNECTIONS_BUFFERED", v)
+		}()
+
+		err := os.Setenv("DD_SYSTEM_PROBE_CONFIG_MAX_CLOSED_CONNECTIONS_BUFFERED", fmt.Sprintf("%d", maxTrackedConnections-1))
+		require.NoError(t, err)
+
+		cfg := New()
+		require.Equal(t, int(maxTrackedConnections-1), cfg.MaxClosedConnectionsBuffered)
+	})
+
+	t.Run("value not set", func(t *testing.T) {
+		cfg := New()
+		require.Equal(t, int(cfg.MaxTrackedConnections), cfg.MaxClosedConnectionsBuffered)
 	})
 }


### PR DESCRIPTION
### What does this PR do?

Sets `system_probe_config.max_closed_connections_buffered` to at least `system_probe_config.max_tracked_connections` in case the former is not set. This is to help reduce closed connections dropped by the system-probe in environments where there are lots of short-lived connections.

### Motivation

Dropped connections and established counts in environments with lots of short-lived tcp connections.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
