### PR TITLE
CWS/CSPM: fix missing doc comments

### DIFF
--- a/pkg/compliance/checks/builder.go
+++ b/pkg/compliance/checks/builder.go
@@ -236,6 +236,7 @@ func WithRegoInputDumpPath(regoInputDumpPath string) BuilderOption {
 	}
 }
 
+// WithRegoEvalSkip configures a builder to skip the rego evaluation, while still building the input
 func WithRegoEvalSkip(regoEvalSkip bool) BuilderOption {
 	return func(b *builder) error {
 		b.regoEvalSkip = regoEvalSkip

--- a/pkg/security/log/logger.go
+++ b/pkg/security/log/logger.go
@@ -273,6 +273,7 @@ func init() {
 	DefaultLogger = &PatternLogger{}
 }
 
+// RuleLoadingErrors logs the errors related to loading rules
 func RuleLoadingErrors(msg string, m *multierror.Error) {
 	var errorLevel bool
 	for _, err := range m.Errors {

--- a/pkg/security/probe/self_tester.go
+++ b/pkg/security/probe/self_tester.go
@@ -191,7 +191,7 @@ type selfTestEvent struct {
 	Filepath string
 }
 
-// isExpectedEvent sends an event to the tester
+// IsExpectedEvent sends an event to the tester
 func (t *SelfTester) IsExpectedEvent(rule *rules.Rule, event eval.Event) bool {
 	if atomic.LoadUint32(&t.waitingForEvent) != 0 && rule.Definition.Policy.Name == selfTestPolicyName {
 		ev, ok := event.(*Event)


### PR DESCRIPTION
### What does this PR do?

This PR fix [revive linter](https://github.com/mgechev/revive) errors regarding code from security agent team:
- `pkg/security`
- `pkg/compliance`

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
