### PR TITLE
[CWS] make use of perf readinto

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -198,13 +198,14 @@ core,github.com/cespare/xxhash/v2,MIT,Copyright (c) 2016 Caleb Spare
 core,github.com/cihub/seelog,BSD-3-Clause,"Copyright (c) 2012, Cloud Instruments Co., Ltd. <info@cin.io>"
 core,github.com/cilium/ebpf,MIT,"Copyright (c) 2017 Nathan Sweet | Copyright (c) 2018, 2019 Cloudflare | Copyright (c) 2019 Authors of Cilium"
 core,github.com/cilium/ebpf/asm,MIT,"Copyright (c) 2017 Nathan Sweet | Copyright (c) 2018, 2019 Cloudflare | Copyright (c) 2019 Authors of Cilium"
+core,github.com/cilium/ebpf/btf,MIT,"Copyright (c) 2017 Nathan Sweet | Copyright (c) 2018, 2019 Cloudflare | Copyright (c) 2019 Authors of Cilium"
 core,github.com/cilium/ebpf/internal,MIT,"Copyright (c) 2017 Nathan Sweet | Copyright (c) 2018, 2019 Cloudflare | Copyright (c) 2019 Authors of Cilium"
-core,github.com/cilium/ebpf/internal/btf,MIT,"Copyright (c) 2017 Nathan Sweet | Copyright (c) 2018, 2019 Cloudflare | Copyright (c) 2019 Authors of Cilium"
 core,github.com/cilium/ebpf/internal/epoll,MIT,"Copyright (c) 2017 Nathan Sweet | Copyright (c) 2018, 2019 Cloudflare | Copyright (c) 2019 Authors of Cilium"
 core,github.com/cilium/ebpf/internal/sys,MIT,"Copyright (c) 2017 Nathan Sweet | Copyright (c) 2018, 2019 Cloudflare | Copyright (c) 2019 Authors of Cilium"
 core,github.com/cilium/ebpf/internal/unix,MIT,"Copyright (c) 2017 Nathan Sweet | Copyright (c) 2018, 2019 Cloudflare | Copyright (c) 2019 Authors of Cilium"
 core,github.com/cilium/ebpf/link,MIT,"Copyright (c) 2017 Nathan Sweet | Copyright (c) 2018, 2019 Cloudflare | Copyright (c) 2019 Authors of Cilium"
 core,github.com/cilium/ebpf/perf,MIT,"Copyright (c) 2017 Nathan Sweet | Copyright (c) 2018, 2019 Cloudflare | Copyright (c) 2019 Authors of Cilium"
+core,github.com/cilium/ebpf/ringbuf,MIT,"Copyright (c) 2017 Nathan Sweet | Copyright (c) 2018, 2019 Cloudflare | Copyright (c) 2019 Authors of Cilium"
 core,github.com/clbanning/mxj,MIT,Copyright (c) 2012-2016 Charles Banning <clbanning@gmail.com>.  All rights reserved | Copyright 2009 The Go Authors. All rights reserved
 core,github.com/cloudfoundry-community/go-cfclient,MIT,Copyright (c) 2017 Long Nguyen
 core,github.com/containerd/cgroups,Apache-2.0,"Copyright 2012-2015 Docker, Inc."

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/trace v0.37.0-rc.3
 	github.com/DataDog/datadog-go/v5 v5.1.1
 	github.com/DataDog/datadog-operator v0.7.1-0.20220602134901-4f6af09bf54f
-	github.com/DataDog/ebpf-manager v0.0.0-20220406140358-68e6b7f54dde
+	github.com/DataDog/ebpf-manager v0.0.0-20220620150645-6cb8b3fd1984
 	github.com/DataDog/gohai v0.0.0-20220607152458-544032c46ded
 	github.com/DataDog/gopsutil v0.0.0-20220308095538-d086941833e3
 	github.com/DataDog/nikos v1.7.6
@@ -77,7 +77,7 @@ require (
 	github.com/blabber/go-freebsd-sysctl v0.0.0-20201130114544-503969f39d8f
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575
-	github.com/cilium/ebpf v0.8.2-0.20220404151855-0d439865ca15
+	github.com/cilium/ebpf v0.9.0
 	github.com/clbanning/mxj v1.8.4
 	github.com/cloudfoundry-community/go-cfclient v0.0.0-20210621174645-7773f7e22665
 	github.com/containerd/cgroups v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -142,8 +142,8 @@ github.com/DataDog/datadog-go/v5 v5.1.1 h1:JLZ6s2K1pG2h9GkvEvMdEGqMDyVLEAccdX5Tl
 github.com/DataDog/datadog-go/v5 v5.1.1/go.mod h1:KhiYb2Badlv9/rofz+OznKoEF5XKTonWyhx5K83AP8E=
 github.com/DataDog/datadog-operator v0.7.1-0.20220602134901-4f6af09bf54f h1:A7WPfKHAeZB+yD83KtY8Y4mZKFAbZgBziulshnpErK4=
 github.com/DataDog/datadog-operator v0.7.1-0.20220602134901-4f6af09bf54f/go.mod h1:KAQEFctpgWNlJ2/ef9PRKqy79UAa/URSOWZzgaCrwug=
-github.com/DataDog/ebpf-manager v0.0.0-20220406140358-68e6b7f54dde h1:tAtD5vDOWsD3s44PMuqVnQ4ADPwqyw1usEZ2Afs5j9g=
-github.com/DataDog/ebpf-manager v0.0.0-20220406140358-68e6b7f54dde/go.mod h1:8v4KnNvpgDUsYDSxC0cgKq8Why5Z0oI4lN9gy/sMEJs=
+github.com/DataDog/ebpf-manager v0.0.0-20220620150645-6cb8b3fd1984 h1:cV9+8zq97OBbzWX5yCByYcfjM7DED+DeEuDXHayRci8=
+github.com/DataDog/ebpf-manager v0.0.0-20220620150645-6cb8b3fd1984/go.mod h1:8bqjDI64T80GHECNIJp9nY4+0mgX4Tc+Kcdk3p0NeIA=
 github.com/DataDog/extendeddaemonset v0.7.1-0.20220530183123-9c60ea5abbc6 h1:XDD6SEIEpe5CAa7esIWlgdXLQgLKN4hvPw+Wd8pJQFU=
 github.com/DataDog/extendeddaemonset v0.7.1-0.20220530183123-9c60ea5abbc6/go.mod h1:YxkO6rhI37nstfxBAdk4fVi5kheKJRMk9AtqDdl/mSQ=
 github.com/DataDog/gohai v0.0.0-20220607152458-544032c46ded h1:n6a9LvGX2CkDiecmdwUpapbhSXzu73zEmQITIysvkq4=
@@ -354,8 +354,8 @@ github.com/cilium/ebpf v0.2.0/go.mod h1:To2CFviqOWL/M0gIMsvSMlqe7em/l1ALkX1PyjrX
 github.com/cilium/ebpf v0.4.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/cilium/ebpf v0.6.2/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/cilium/ebpf v0.7.0/go.mod h1:/oI2+1shJiTGAMgl6/RgJr36Eo1jzrRcAWbcXO2usCA=
-github.com/cilium/ebpf v0.8.2-0.20220404151855-0d439865ca15 h1:eZrQJDHgjOgeSOw2x8tgjO9B13n1BR9yqwlq1AIu2kk=
-github.com/cilium/ebpf v0.8.2-0.20220404151855-0d439865ca15/go.mod h1:f5zLIM0FSNuAkSyLAN7X+Hy6yznlF1mNiWUMfxMtrgk=
+github.com/cilium/ebpf v0.9.0 h1:ldiV+FscPCQ/p3mNEV4O02EPbUZJFsoEtHvIr9xLTvk=
+github.com/cilium/ebpf v0.9.0/go.mod h1:+OhNOIXx/Fnu1IE8bJz2dzOA+VSfyTfdNUVdlQnxUFY=
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
 github.com/clbanning/mxj v1.8.4 h1:HuhwZtbyvyOw+3Z1AowPkU87JkJUSv751ELWaiTpj8I=

--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	manager "github.com/DataDog/ebpf-manager"
+	"github.com/cilium/ebpf/perf"
 	"github.com/mailru/easyjson/jwriter"
 
 	pconfig "github.com/DataDog/datadog-agent/pkg/process/config"
@@ -447,12 +448,12 @@ func (ev *Event) MarshalJSON() ([]byte, error) {
 }
 
 // ExtractEventInfo extracts cpu and timestamp from the raw data event
-func ExtractEventInfo(data []byte) (uint64, uint64, error) {
-	if len(data) < 16 {
+func ExtractEventInfo(record *perf.Record) (uint64, uint64, error) {
+	if len(record.RawSample) < 16 {
 		return 0, 0, model.ErrNotEnoughData
 	}
 
-	return model.ByteOrder.Uint64(data[0:8]), model.ByteOrder.Uint64(data[8:16]), nil
+	return model.ByteOrder.Uint64(record.RawSample[0:8]), model.ByteOrder.Uint64(record.RawSample[8:16]), nil
 }
 
 // ResolveEventTimestamp resolves the monolitic kernel event timestamp to an absolute time

--- a/pkg/security/probe/perf.go
+++ b/pkg/security/probe/perf.go
@@ -1,0 +1,41 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+// +build linux
+
+package probe
+
+import (
+	"sync"
+
+	"github.com/cilium/ebpf/perf"
+)
+
+// RecordPool defines a perf record pool
+type RecordPool struct {
+	pool sync.Pool
+}
+
+// Get returns a record
+func (p *RecordPool) Get() *perf.Record {
+	return p.pool.Get().(*perf.Record)
+}
+
+// Release a record
+func (p *RecordPool) Release(record *perf.Record) {
+	p.pool.Put(record)
+}
+
+// NewRecordPool returns a new RecordPool
+func NewRecordPool() *RecordPool {
+	return &RecordPool{
+		pool: sync.Pool{
+			New: func() interface{} {
+				return &perf.Record{}
+			},
+		},
+	}
+}

--- a/pkg/security/probe/reorderer_test.go
+++ b/pkg/security/probe/reorderer_test.go
@@ -10,12 +10,13 @@ package probe
 
 import (
 	"context"
+	"math/rand"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/cilium/ebpf/perf"
 	"github.com/stretchr/testify/assert"
-	"k8s.io/apimachinery/pkg/util/rand"
 )
 
 func TestOrder(t *testing.T) {
@@ -26,17 +27,21 @@ func TestOrder(t *testing.T) {
 
 	for i := 0; i != 200; i++ {
 		n := rand.Int()%254 + 1
-		heap.enqueue(0, []byte{byte(n)}, uint64(n), 1, &metric)
+
+		record := perf.Record{
+			RawSample: []byte{byte(n)},
+		}
+		heap.enqueue(&record, uint64(n), 1, &metric)
 	}
 
 	var count int
 	var last byte
-	heap.dequeue(func(cpu uint64, data []byte) {
+	heap.dequeue(func(record *perf.Record) {
 		count++
 		if last > 0 {
-			assert.GreaterOrEqual(t, data[0], last)
+			assert.GreaterOrEqual(t, record.RawSample[0], last)
 		}
-		last = data[0]
+		last = record.RawSample[0]
 	}, 1, &metric, &ReOrdererOpts{})
 
 	assert.Equal(t, 200, count)
@@ -49,15 +54,19 @@ func TestOrderRetention(t *testing.T) {
 	metric := ReOrdererMetric{}
 
 	for i := 0; i != 90; i++ {
-		heap.enqueue(0, []byte{byte(i)}, uint64(i), uint64(i/30+1), &metric)
+		record := perf.Record{
+			RawSample: []byte{byte(i)},
+		}
+
+		heap.enqueue(&record, uint64(i), uint64(i/30+1), &metric)
 	}
 
 	var count int
-	heap.dequeue(func(cpu uint64, data []byte) { count++ }, 1, &metric, &ReOrdererOpts{})
+	heap.dequeue(func(record *perf.Record) { count++ }, 1, &metric, &ReOrdererOpts{})
 	assert.Equal(t, 30, count)
-	heap.dequeue(func(cpu uint64, data []byte) { count++ }, 2, &metric, &ReOrdererOpts{})
+	heap.dequeue(func(record *perf.Record) { count++ }, 2, &metric, &ReOrdererOpts{})
 	assert.Equal(t, 60, count)
-	heap.dequeue(func(cpu uint64, data []byte) { count++ }, 3, &metric, &ReOrdererOpts{})
+	heap.dequeue(func(record *perf.Record) { count++ }, 3, &metric, &ReOrdererOpts{})
 	assert.Equal(t, 90, count)
 }
 
@@ -67,14 +76,21 @@ func TestOrderGeneration(t *testing.T) {
 	}
 	metric := ReOrdererMetric{}
 
-	heap.enqueue(0, []byte{byte(10)}, uint64(10), uint64(1), &metric)
-	heap.enqueue(0, []byte{byte(1)}, uint64(1), uint64(2), &metric)
+	record1 := perf.Record{
+		RawSample: []byte{byte(10)},
+	}
+	heap.enqueue(&record1, uint64(10), uint64(1), &metric)
+
+	record2 := perf.Record{
+		RawSample: []byte{byte(1)},
+	}
+	heap.enqueue(&record2, uint64(1), uint64(2), &metric)
 
 	var data []byte
-	heap.dequeue(func(c uint64, d []byte) { data = d }, 1, &metric, &ReOrdererOpts{})
+	heap.dequeue(func(record *perf.Record) { data = record.RawSample }, 1, &metric, &ReOrdererOpts{})
 	assert.Equal(t, 1, int(data[0]))
 
-	heap.dequeue(func(c uint64, d []byte) { data = d }, 2, &metric, &ReOrdererOpts{})
+	heap.dequeue(func(record *perf.Record) { data = record.RawSample }, 2, &metric, &ReOrdererOpts{})
 	assert.Equal(t, 10, int(data[0]))
 }
 
@@ -86,13 +102,13 @@ func TestOrderRate(t *testing.T) {
 	var lock sync.RWMutex
 	ctx, cancel := context.WithCancel(context.Background())
 
-	reOrderer := NewReOrderer(ctx, func(cpu uint64, data []byte) {
+	reOrderer := NewReOrderer(ctx, func(record *perf.Record) {
 		lock.Lock()
-		event = append(event, data[2])
+		event = append(event, record.RawSample[2])
 		lock.Unlock()
 	},
-		func(data []byte) (uint64, uint64, error) {
-			return uint64(data[0]), uint64(data[1]), nil
+		func(record *perf.Record) (uint64, uint64, error) {
+			return uint64(record.RawSample[0]), uint64(record.RawSample[1]), nil
 		},
 		ReOrdererOpts{
 			QueueSize:  100,
@@ -109,7 +125,11 @@ func TestOrderRate(t *testing.T) {
 
 	var e uint8
 	for i := 0; i != 10; i++ {
-		reOrderer.HandleEvent(0, []byte{0, byte(i + 1), e}, nil, nil)
+		record := perf.Record{
+			RawSample: []byte{0, byte(i + 1), e},
+		}
+
+		reOrderer.HandleEvent(&record, nil, nil)
 		e++
 	}
 

--- a/pkg/security/secl/model/unmarshallers.go
+++ b/pkg/security/secl/model/unmarshallers.go
@@ -786,7 +786,9 @@ func (e *NetworkContext) UnmarshalBinary(data []byte) (int, error) {
 		return 0, ErrNotEnoughData
 	}
 
-	srcIP, dstIP := data[read:read+16], data[read+16:read+32]
+	var srcIP, dstIP [16]byte
+	SliceToArray(data[read:read+16], unsafe.Pointer(&srcIP))
+	SliceToArray(data[read+16:read+32], unsafe.Pointer(&dstIP))
 	e.Source.Port = binary.BigEndian.Uint16(data[read+32 : read+34])
 	e.Destination.Port = binary.BigEndian.Uint16(data[read+34 : read+36])
 	// padding 4 bytes
@@ -801,8 +803,8 @@ func (e *NetworkContext) UnmarshalBinary(data []byte) (int, error) {
 		e.Source.IPNet = *eval.IPNetFromIP(srcIP[0:4])
 		e.Destination.IPNet = *eval.IPNetFromIP(dstIP[0:4])
 	default:
-		e.Source.IPNet = *eval.IPNetFromIP(srcIP)
-		e.Destination.IPNet = *eval.IPNetFromIP(dstIP)
+		e.Source.IPNet = *eval.IPNetFromIP(srcIP[:])
+		e.Destination.IPNet = *eval.IPNetFromIP(dstIP[:])
 	}
 	return read + 48, nil
 }
@@ -916,7 +918,8 @@ func (e *BindEvent) UnmarshalBinary(data []byte) (int, error) {
 		return 0, ErrNotEnoughData
 	}
 
-	ipRaw := data[read : read+16]
+	var ipRaw [16]byte
+	SliceToArray(data[read:read+16], unsafe.Pointer(&ipRaw))
 	e.AddrFamily = ByteOrder.Uint16(data[read+16 : read+18])
 	e.Addr.Port = binary.BigEndian.Uint16(data[read+18 : read+20])
 
@@ -925,7 +928,7 @@ func (e *BindEvent) UnmarshalBinary(data []byte) (int, error) {
 	case 0x2: // unix.AF_INET
 		e.Addr.IPNet = *eval.IPNetFromIP(ipRaw[0:4])
 	case 0xa: // unix.AF_INET6
-		e.Addr.IPNet = *eval.IPNetFromIP(ipRaw)
+		e.Addr.IPNet = *eval.IPNetFromIP(ipRaw[:])
 	}
 
 	return read + 20, nil


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Add a pool to allocated perf record and make use of the newly added ReadInto function.

before : 

```
1130.40MB 62.38% 62.38%  1130.40MB 62.38%  github.com/tinylib/msgp/msgp.Require
  183.06MB 10.10% 72.49%   183.06MB 10.10%  github.com/cilium/ebpf/perf.readRawSample
   88.02MB  4.86% 77.34%    88.02MB  4.86%  github.com/DataDog/datadog-agent/pkg/security/probe.(*ArgsEnvsPool).GetFrom
   63.51MB  3.51% 80.85%   104.01MB  5.74%  github.com/DataDog/datadog-agent/pkg/security/log.(*PatternLogger).trace
   36.62MB  2.02% 82.87%    36.62MB  2.02%  os.ReadFile
   23.91MB  1.32% 84.19%    27.41MB  1.51%  github.com/cilium/ebpf/asm.(*Instructions).Unmarshal
   22.41MB  1.24% 85.43%    27.62MB  1.52%  github.com/DataDog/btf-internals/btf.inflateRawTypes
   20.50MB  1.13% 86.56%    20.50MB  1.13%  regexp.(*Regexp).backtrack
      20MB  1.10% 87.66%    40.50MB  2.24%  regexp.(*Regexp).FindStringSubmatch
   18.51MB  1.02% 88.68%    18.51MB  1.02%  github.com/cilium/ebpf/asm.Instructions.ReferenceOffsets
```

after :

```
    1.67GB 55.85% 55.85%     1.67GB 55.85%  github.com/tinylib/msgp/msgp.Require
    0.25GB  8.33% 64.18%     0.41GB 13.83%  github.com/DataDog/datadog-agent/pkg/security/secl/model.UnmarshalStringArray
    0.19GB  6.38% 70.56%     0.19GB  6.38%  bytes.genSplit
    0.13GB  4.42% 74.98%     0.13GB  4.44%  github.com/DataDog/datadog-agent/pkg/security/probe.(*ArgsEnvsPool).GetFrom
    0.10GB  3.36% 78.35%     0.51GB 17.19%  github.com/DataDog/datadog-agent/pkg/security/secl/model.(*ArgsEnvsCacheEntry).toArray
    0.10GB  3.27% 81.61%     0.15GB  4.90%  github.com/DataDog/datadog-agent/pkg/security/log.(*PatternLogger).trace
    0.08GB  2.71% 84.32%     0.08GB  2.71%  strings.genSplit
    0.05GB  1.75% 86.07%     0.13GB  4.42%  github.com/DataDog/datadog-agent/pkg/security/secl/model.(*EnvsEntry).Keys
    0.03GB  1.17% 87.23%     0.04GB  1.22%  os.ReadFile
    0.02GB  0.83% 88.07%     0.05GB  1.65%  regexp.(*Regexp).FindStringSubmatch
```
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
