### PR TITLE
[CI] Fix revive linter `remote-config` errors

### DIFF
--- a/pkg/config/remote/service/client_predicates.go
+++ b/pkg/config/remote/service/client_predicates.go
@@ -10,6 +10,7 @@ import (
 	"github.com/theupdateframework/go-tuf/data"
 )
 
+// DirectorTargetsCustomMetadata TODO (<remote-config>): RCM-228
 type DirectorTargetsCustomMetadata struct {
 	Predicates *pbgo.TracerPredicates `json:"tracer-predicates,omitempty"`
 }


### PR DESCRIPTION
### What does this PR do?

This PR fixes [`revive` linter](https://github.com/mgechev/revive) errors in the `remote-config` team owned code by adding `TODO` comments to exported functions / types.

### Motivation

We used to enforce that exported functions and types are documented. This was done through `revive` but the check was disabled by default when we switched to `golangcli-lint`. Now that we tried to re-enable it we got a lot of errors. This PR addresses these errors and inform the relevant teams for a fix.

### Additional Notes

After this PR, the relevant teams will have to fill the `TODO` comments (see [RCM-228(https://datadoghq.atlassian.net/jira/software/projects/RCM/boards/1613/backlog?selectedIssue=RCM-228)).

### Describe how to test/QA your changes

You can try to run `revive ./...` in the edited files folder. You shouldn't have errors anymore.

You can also just check that the CI didn't raise an error.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
