### PR TITLE
[CI] Fix revive linter `serverless` errors

### DIFF
--- a/pkg/serverless/trace/inferredspan/inferred_span.go
+++ b/pkg/serverless/trace/inferredspan/inferred_span.go
@@ -101,13 +101,13 @@ func (inferredSpan *InferredSpan) DispatchInferredSpan(event string) {
 	eventSource := attributes.extractEventSource()
 	switch eventSource {
 	case APIGATEWAY:
-		inferredSpan.EnrichInferredSpanWithAPIGatewayRESTEvent(attributes)
+		inferredSpan.enrichInferredSpanWithAPIGatewayRESTEvent(attributes)
 	case HTTPAPI:
-		inferredSpan.EnrichInferredSpanWithAPIGatewayHTTPEvent(attributes)
+		inferredSpan.enrichInferredSpanWithAPIGatewayHTTPEvent(attributes)
 	case WEBSOCKET:
-		inferredSpan.EnrichInferredSpanWithAPIGatewayWebsocketEvent(attributes)
+		inferredSpan.enrichInferredSpanWithAPIGatewayWebsocketEvent(attributes)
 	case SNS:
-		inferredSpan.EnrichInferredSpanWithSNSEvent(attributes)
+		inferredSpan.enrichInferredSpanWithSNSEvent(attributes)
 	}
 }
 

--- a/pkg/serverless/trace/inferredspan/span_enrichment.go
+++ b/pkg/serverless/trace/inferredspan/span_enrichment.go
@@ -13,10 +13,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// EnrichInferredSpanWithAPIGatewayRESTEvent uses the parsed event
+// enrichInferredSpanWithAPIGatewayRESTEvent uses the parsed event
 // payload to enrich the current inferred span. It applies a
 // specific set of data to the span expected from a REST event.
-func (inferredSpan *InferredSpan) EnrichInferredSpanWithAPIGatewayRESTEvent(attributes EventKeys) {
+func (inferredSpan *InferredSpan) enrichInferredSpanWithAPIGatewayRESTEvent(attributes EventKeys) {
 
 	log.Debug("Enriching an inferred span for a REST API Gateway")
 	requestContext := attributes.RequestContext
@@ -43,10 +43,10 @@ func (inferredSpan *InferredSpan) EnrichInferredSpanWithAPIGatewayRESTEvent(attr
 	inferredSpan.IsAsync = isAsyncEvent(attributes)
 }
 
-// EnrichInferredSpanWithAPIGatewayHTTPEvent uses the parsed event
+// enrichInferredSpanWithAPIGatewayHTTPEvent uses the parsed event
 // payload to enrich the current inferred span. It applies a
 // specific set of data to the span expected from a HTTP event.
-func (inferredSpan *InferredSpan) EnrichInferredSpanWithAPIGatewayHTTPEvent(attributes EventKeys) {
+func (inferredSpan *InferredSpan) enrichInferredSpanWithAPIGatewayHTTPEvent(attributes EventKeys) {
 	log.Debug("Enriching an inferred span for a HTTP API Gateway")
 	requestContext := attributes.RequestContext
 	http := requestContext.HTTP
@@ -75,10 +75,10 @@ func (inferredSpan *InferredSpan) EnrichInferredSpanWithAPIGatewayHTTPEvent(attr
 	inferredSpan.IsAsync = isAsyncEvent(attributes)
 }
 
-// EnrichInferredSpanWithAPIGatewayWebsocketEvent uses the parsed event
+// enrichInferredSpanWithAPIGatewayWebsocketEvent uses the parsed event
 // payload to enrich the current inferred span. It applies a
 // specific set of data to the span expected from a Websocket event.
-func (inferredSpan *InferredSpan) EnrichInferredSpanWithAPIGatewayWebsocketEvent(attributes EventKeys) {
+func (inferredSpan *InferredSpan) enrichInferredSpanWithAPIGatewayWebsocketEvent(attributes EventKeys) {
 	log.Debug("Enriching an inferred span for a Websocket API Gateway")
 	requestContext := attributes.RequestContext
 	endpoint := requestContext.RouteKey
@@ -107,8 +107,7 @@ func (inferredSpan *InferredSpan) EnrichInferredSpanWithAPIGatewayWebsocketEvent
 	inferredSpan.IsAsync = isAsyncEvent(attributes)
 }
 
-// EnrichInferredSpanWithSNSEvent TODO (<serverless>): SLS-2255
-func (inferredSpan *InferredSpan) EnrichInferredSpanWithSNSEvent(attributes EventKeys) {
+func (inferredSpan *InferredSpan) enrichInferredSpanWithSNSEvent(attributes EventKeys) {
 	eventRecord := *attributes.Records[0]
 	snsMessage := eventRecord.SNS
 	splitArn := strings.Split(snsMessage.TopicArn, ":")

--- a/pkg/serverless/trace/inferredspan/span_enrichment.go
+++ b/pkg/serverless/trace/inferredspan/span_enrichment.go
@@ -107,6 +107,7 @@ func (inferredSpan *InferredSpan) EnrichInferredSpanWithAPIGatewayWebsocketEvent
 	inferredSpan.IsAsync = isAsyncEvent(attributes)
 }
 
+// EnrichInferredSpanWithSNSEvent TODO (<serverless>): SLS-2255
 func (inferredSpan *InferredSpan) EnrichInferredSpanWithSNSEvent(attributes EventKeys) {
 	eventRecord := *attributes.Records[0]
 	snsMessage := eventRecord.SNS

--- a/pkg/serverless/trace/inferredspan/span_enrichment_test.go
+++ b/pkg/serverless/trace/inferredspan/span_enrichment_test.go
@@ -44,7 +44,7 @@ func TestEnrichInferredSpanWithAPIGatewayRESTEvent(t *testing.T) {
 	_ = json.Unmarshal(getEventFromFile("api-gateway.json"), &eventKeys)
 	inferredSpan := mockInferredSpan()
 	inferredSpan.IsAsync = isAsyncEvent(eventKeys)
-	inferredSpan.EnrichInferredSpanWithAPIGatewayRESTEvent(eventKeys)
+	inferredSpan.enrichInferredSpanWithAPIGatewayRESTEvent(eventKeys)
 
 	span := inferredSpan.Span
 
@@ -71,7 +71,7 @@ func TestEnrichInferredSpanWithAPIGatewayNonProxyAsyncRESTEvent(t *testing.T) {
 	_ = json.Unmarshal(getEventFromFile("api-gateway-non-proxy-async.json"), &eventKeys)
 	inferredSpan := mockInferredSpan()
 	inferredSpan.IsAsync = isAsyncEvent(eventKeys)
-	inferredSpan.EnrichInferredSpanWithAPIGatewayRESTEvent(eventKeys)
+	inferredSpan.enrichInferredSpanWithAPIGatewayRESTEvent(eventKeys)
 
 	span := inferredSpan.Span
 	assert.Equal(t, span.TraceID, uint64(7353030974370088224))
@@ -96,7 +96,7 @@ func TestEnrichInferredSpanWithAPIGatewayHTTPEvent(t *testing.T) {
 	var eventKeys EventKeys
 	_ = json.Unmarshal(getEventFromFile("http-api.json"), &eventKeys)
 	inferredSpan := mockInferredSpan()
-	inferredSpan.EnrichInferredSpanWithAPIGatewayHTTPEvent(eventKeys)
+	inferredSpan.enrichInferredSpanWithAPIGatewayHTTPEvent(eventKeys)
 
 	span := inferredSpan.Span
 	assert.Equal(t, span.TraceID, uint64(7353030974370088224))
@@ -122,7 +122,7 @@ func TestEnrichInferredSpanWithAPIGatewayWebsocketDefaultEvent(t *testing.T) {
 	inferredSpan := mockInferredSpan()
 	span := inferredSpan.Span
 
-	inferredSpan.EnrichInferredSpanWithAPIGatewayWebsocketEvent(eventKeys)
+	inferredSpan.enrichInferredSpanWithAPIGatewayWebsocketEvent(eventKeys)
 
 	assert.Equal(t, span.TraceID, uint64(7353030974370088224))
 	assert.Equal(t, span.SpanID, uint64(8048964810003407541))
@@ -149,7 +149,7 @@ func TestEnrichInferredSpanWithAPIGatewayWebsocketConnectEvent(t *testing.T) {
 	inferredSpan := mockInferredSpan()
 	span := inferredSpan.Span
 
-	inferredSpan.EnrichInferredSpanWithAPIGatewayWebsocketEvent(eventKeys)
+	inferredSpan.enrichInferredSpanWithAPIGatewayWebsocketEvent(eventKeys)
 
 	assert.Equal(t, span.TraceID, uint64(7353030974370088224))
 	assert.Equal(t, span.SpanID, uint64(8048964810003407541))
@@ -176,7 +176,7 @@ func TestEnrichInferredSpanWithAPIGatewayWebsocketDisconnectEvent(t *testing.T) 
 	inferredSpan := mockInferredSpan()
 	span := inferredSpan.Span
 
-	inferredSpan.EnrichInferredSpanWithAPIGatewayWebsocketEvent(eventKeys)
+	inferredSpan.enrichInferredSpanWithAPIGatewayWebsocketEvent(eventKeys)
 
 	assert.Equal(t, span.TraceID, uint64(7353030974370088224))
 	assert.Equal(t, span.SpanID, uint64(8048964810003407541))
@@ -202,7 +202,7 @@ func TestEnrichInferredSpanWithSNSEvent(t *testing.T) {
 	_ = json.Unmarshal(getEventFromFile("sns.json"), &eventKeys)
 	inferredSpan := mockInferredSpan()
 	inferredSpan.IsAsync = isAsyncEvent(eventKeys)
-	inferredSpan.EnrichInferredSpanWithSNSEvent(eventKeys)
+	inferredSpan.enrichInferredSpanWithSNSEvent(eventKeys)
 
 	span := inferredSpan.Span
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes [`revive` linter](https://github.com/mgechev/revive) errors in the `serverless` team owned code by adding `TODO` comments to exported functions / types.

### Motivation

We used to enforce that exported functions and types are documented. This was done through `revive` but the check was disabled by default when we switched to `golangcli-lint`. Now that we tried to re-enable it we got a lot of errors. This PR addresses these errors and inform the relevant teams for a fix.

### Additional Notes

After this PR, the relevant teams will have to fill the `TODO` comments (see [SLS-2255](https://datadoghq.atlassian.net/jira/software/projects/SLS/boards/205/backlog?selectedIssue=SLS-2255)).

### Describe how to test/QA your changes

You can try to run `revive ./...` in the edited files folder. You shouldn't have errors anymore.

You can also just check that the CI didn't raise an error.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
