### PR TITLE
[process-agent] Add the Event Store

### DIFF
--- a/cmd/process-agent/app/events.go
+++ b/cmd/process-agent/app/events.go
@@ -6,9 +6,12 @@
 package app
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
+	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/spf13/cobra"
 
 	"github.com/DataDog/datadog-agent/cmd/process-agent/flags"
@@ -19,6 +22,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/events/model"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+var (
+	pullInterval = 5 * time.Second
 )
 
 // EventsCmd is a command to interact with process lifecycle events
@@ -36,11 +43,20 @@ var EventsListenCmd = &cobra.Command{
 	SilenceUsage: true,
 }
 
-func init() {
-	EventsCmd.AddCommand(EventsListenCmd)
+// EventsPullCmd is a command to pull process lifecycle events
+var EventsPullCmd = &cobra.Command{
+	Use:          "pull",
+	Short:        "Periodically pull process lifecycle events. This feature is currently in alpha version and needs root privilege to run.",
+	RunE:         runEventStore,
+	SilenceUsage: true,
 }
 
-func runEventListener(cmd *cobra.Command, args []string) error {
+func init() {
+	EventsCmd.AddCommand(EventsListenCmd, EventsPullCmd)
+	EventsPullCmd.Flags().DurationVarP(&pullInterval, "tick", "t", 5*time.Second, "The period between 2 consecutive pulls to fetch process events")
+}
+
+func bootstrapEventsCmd(cmd *cobra.Command) error {
 	ddconfig.InitSystemProbeConfig(ddconfig.Datadog)
 
 	configPath := cmd.Flag(flags.CfgPath).Value.String()
@@ -65,13 +81,26 @@ func runEventListener(cmd *cobra.Command, args []string) error {
 		return log.Criticalf("Error parsing config: %s", err)
 	}
 
+	return nil
+}
+
+func printEvent(e *model.ProcessEvent) {
+	b, err := json.MarshalIndent(e, "", "  ")
+	if err != nil {
+		log.Error("Error while marshalling process event: ", err.Error())
+	}
+	fmt.Println(string(b))
+}
+
+func runEventListener(cmd *cobra.Command, args []string) error {
+	err := bootstrapEventsCmd(cmd)
+	if err != nil {
+		return err
+	}
+
 	// Create a handler to print the collected event to stdout
 	handler := func(e *model.ProcessEvent) {
-		b, err := json.MarshalIndent(e, "", "  ")
-		if err != nil {
-			log.Errorf("Error while marshalling process event: %v", err)
-		}
-		fmt.Println(string(b))
+		printEvent(e)
 	}
 
 	l, err := events.NewListener(handler)
@@ -85,6 +114,59 @@ func runEventListener(cmd *cobra.Command, args []string) error {
 
 	<-exit
 	l.Stop()
+	log.Flush()
+
+	return nil
+}
+
+func runEventStore(cmd *cobra.Command, args []string) error {
+	err := bootstrapEventsCmd(cmd)
+	if err != nil {
+		return err
+	}
+
+	store, err := events.NewRingStore(&statsd.NoOpClient{})
+	if err != nil {
+		return err
+	}
+
+	l, err := events.NewListener(func(e *model.ProcessEvent) {
+		// push events to the store asynchronously
+		store.Push(e, nil)
+	})
+	if err != nil {
+		return err
+	}
+
+	store.Run()
+	l.Run()
+
+	exit := make(chan struct{})
+	go util.HandleSignals(exit)
+
+	ticker := time.NewTicker(pullInterval)
+	go func() {
+		for {
+			select {
+			case <-ticker.C:
+				events, err := store.Pull(context.Background(), time.Second)
+				if err != nil {
+					log.Error(err)
+					continue
+				}
+
+				for _, e := range events {
+					printEvent(e)
+				}
+			case <-exit:
+				return
+			}
+		}
+	}()
+
+	<-exit
+	l.Stop()
+	store.Stop()
 	log.Flush()
 
 	return nil

--- a/cmd/process-agent/app/events.go
+++ b/cmd/process-agent/app/events.go
@@ -135,8 +135,8 @@ func runEventStore(cmd *cobra.Command, args []string) error {
 	}
 
 	l, err := events.NewListener(func(e *model.ProcessEvent) {
-		// push events to the store asynchronously
-		store.Push(e, nil)
+		// push events to the store asynchronously without checking for errors
+		_ = store.Push(e, nil)
 	})
 	if err != nil {
 		return err

--- a/cmd/process-agent/app/events.go
+++ b/cmd/process-agent/app/events.go
@@ -25,7 +25,11 @@ import (
 )
 
 var (
-	pullInterval = 5 * time.Second
+	pullInterval time.Duration
+)
+
+const (
+	defaultPullInterval = time.Duration(5) * time.Second
 )
 
 // EventsCmd is a command to interact with process lifecycle events
@@ -53,7 +57,7 @@ var EventsPullCmd = &cobra.Command{
 
 func init() {
 	EventsCmd.AddCommand(EventsListenCmd, EventsPullCmd)
-	EventsPullCmd.Flags().DurationVarP(&pullInterval, "tick", "t", 5*time.Second, "The period between 2 consecutive pulls to fetch process events")
+	EventsPullCmd.Flags().DurationVarP(&pullInterval, "tick", "t", defaultPullInterval, "The period between 2 consecutive pulls to fetch process events")
 }
 
 func bootstrapEventsCmd(cmd *cobra.Command) error {
@@ -87,7 +91,7 @@ func bootstrapEventsCmd(cmd *cobra.Command) error {
 func printEvent(e *model.ProcessEvent) {
 	b, err := json.MarshalIndent(e, "", "  ")
 	if err != nil {
-		log.Error("Error while marshalling process event: ", err.Error())
+		log.Errorf("Error while marshalling process event: %v", err)
 	}
 	fmt.Println(string(b))
 }

--- a/cmd/process-agent/app/events.go
+++ b/cmd/process-agent/app/events.go
@@ -149,6 +149,7 @@ func runEventStore(cmd *cobra.Command, args []string) error {
 	go util.HandleSignals(exit)
 
 	ticker := time.NewTicker(pullInterval)
+	defer ticker.Stop()
 	go func() {
 		for {
 			select {

--- a/pkg/config/process.go
+++ b/pkg/config/process.go
@@ -45,6 +45,18 @@ const (
 
 	// DefaultProcessEndpoint is the default endpoint for the process agent to send payloads to
 	DefaultProcessEndpoint = "https://process.datadoghq.com"
+
+	// DefaultProcessEventStoreMaxItems is the default maximum amount of events that can be stored in the Event Store
+	DefaultProcessEventStoreMaxItems = 200
+
+	// DefaultProcessEventStoreMaxPendingPushes is the default amount of pending push operations can be handled by the Event Store
+	DefaultProcessEventStoreMaxPendingPushes = 10
+
+	// DefaultProcessEventStoreMaxPendingPulls is the default amount of pending pull operations can be handled by the Event Store
+	DefaultProcessEventStoreMaxPendingPulls = 10
+
+	// DefaultProcessEventStoreStatsInterval is the default frequency at which the event store sends stats about expired events, in seconds
+	DefaultProcessEventStoreStatsInterval = 20
 )
 
 // setupProcesses is meant to be called multiple times for different configs, but overrides apply to all configs, so
@@ -152,6 +164,12 @@ func setupProcesses(config Config) {
 	procBindEnvAndSetDefault(config, "process_config.process_discovery.interval", 4*time.Hour)
 
 	procBindEnvAndSetDefault(config, "process_config.drop_check_payloads", []string{})
+
+	// Process Lifecycle Events
+	procBindEnvAndSetDefault(config, "process_config.event_collection.store.max_items", DefaultProcessEventStoreMaxItems)
+	procBindEnvAndSetDefault(config, "process_config.event_collection.store.max_pending_pushes", DefaultProcessEventStoreMaxPendingPushes)
+	procBindEnvAndSetDefault(config, "process_config.event_collection.store.max_pending_pulls", DefaultProcessEventStoreMaxPendingPulls)
+	procBindEnvAndSetDefault(config, "process_config.event_collection.store.stats_interval", DefaultProcessEventStoreStatsInterval)
 
 	processesAddOverrideOnce.Do(func() {
 		AddOverrideFunc(loadProcessTransforms)

--- a/pkg/config/process_test.go
+++ b/pkg/config/process_test.go
@@ -94,6 +94,22 @@ func TestProcessDefaultConfig(t *testing.T) {
 			key:          "process_config.cmd_port",
 			defaultValue: DefaultProcessCmdPort,
 		},
+		{
+			key:          "process_config.event_collection.store.max_items",
+			defaultValue: DefaultProcessEventStoreMaxItems,
+		},
+		{
+			key:          "process_config.event_collection.store.max_pending_pushes",
+			defaultValue: DefaultProcessEventStoreMaxPendingPushes,
+		},
+		{
+			key:          "process_config.event_collection.store.max_pending_pulls",
+			defaultValue: DefaultProcessEventStoreMaxPendingPulls,
+		},
+		{
+			key:          "process_config.event_collection.store.stats_interval",
+			defaultValue: DefaultProcessEventStoreStatsInterval,
+		},
 	} {
 		t.Run(tc.key+" default", func(t *testing.T) {
 			assert.Equal(t, tc.defaultValue, cfg.Get(tc.key))
@@ -346,6 +362,30 @@ func TestEnvVarOverride(t *testing.T) {
 			value:    "true",
 			expType:  "boolean",
 			expected: true,
+		},
+		{
+			key:      "process_config.event_collection.store.max_items",
+			env:      "DD_PROCESS_CONFIG_EVENT_COLLECTION_STORE_MAX_ITEMS",
+			value:    "400",
+			expected: 400,
+		},
+		{
+			key:      "process_config.event_collection.store.max_pending_pushes",
+			env:      "DD_PROCESS_CONFIG_EVENT_COLLECTION_STORE_MAX_PENDING_PUSHES",
+			value:    "100",
+			expected: 100,
+		},
+		{
+			key:      "process_config.event_collection.store.max_pending_pulls",
+			env:      "DD_PROCESS_CONFIG_EVENT_COLLECTION_STORE_MAX_PENDING_PULLS",
+			value:    "50",
+			expected: 50,
+		},
+		{
+			key:      "process_config.event_collection.store.stats_interval",
+			env:      "DD_PROCESS_CONFIG_EVENT_COLLECTION_STORE_STATS_INTERVAL",
+			value:    "60",
+			expected: 60,
 		},
 	} {
 		t.Run(tc.env, func(t *testing.T) {

--- a/pkg/process/events/listener_linux.go
+++ b/pkg/process/events/listener_linux.go
@@ -32,7 +32,7 @@ type SysProbeListener struct {
 	client api.SecurityModuleClient
 	// conn holds the connection used by the client, so it can be closed once the listener is stopped
 	conn *grpc.ClientConn
-	// retryInterval is how long the listener will wait before trying to reconnect to system-probe if there's a connection failure
+	// retryInterval is how long the listener will wait before trying to reconnect to System-Probe if there's a connection failure
 	retryInterval time.Duration
 	// handler is the EventHandler function applied to every event collected by the listener
 	handler EventHandler

--- a/pkg/process/events/listener_linux.go
+++ b/pkg/process/events/listener_linux.go
@@ -32,7 +32,7 @@ type SysProbeListener struct {
 	client api.SecurityModuleClient
 	// conn holds the connection used by the client, so it can be closed once the listener is stopped
 	conn *grpc.ClientConn
-	// retryInterval is how long the listener will wait before trying to reconnect to System-Probe if there's a connection failure
+	// retryInterval is how long the listener will wait before trying to reconnect to system-probe if there's a connection failure
 	retryInterval time.Duration
 	// handler is the EventHandler function applied to every event collected by the listener
 	handler EventHandler

--- a/pkg/process/events/listener_linux_test.go
+++ b/pkg/process/events/listener_linux_test.go
@@ -49,16 +49,16 @@ func TestProcessEventFiltering(t *testing.T) {
 	handlers := make([]EventHandler, 0)
 
 	// The listener should drop unexpected events and not call the EventHandler for it
-	rawEvents = append(rawEvents, model.NewProcessMonitoringEvent(model.Fork, time.Now(), 23, "/usr/bin/ls", []string{"ls", "-lah"}))
+	rawEvents = append(rawEvents, model.NewMockedProcessMonitoringEvent(model.Fork, time.Now(), 23, "/usr/bin/ls", []string{"ls", "-lah"}))
 
 	// Verify that expected events are correctly consumed
-	rawEvents = append(rawEvents, model.NewProcessMonitoringEvent(model.Exec, time.Now(), 23, "/usr/bin/ls", []string{"ls", "-lah"}))
+	rawEvents = append(rawEvents, model.NewMockedProcessMonitoringEvent(model.Exec, time.Now(), 23, "/usr/bin/ls", []string{"ls", "-lah"}))
 	handlers = append(handlers, func(e *model.ProcessEvent) {
 		require.Equal(t, model.Exec, e.EventType)
 		require.Equal(t, uint32(23), e.Pid)
 	})
 
-	rawEvents = append(rawEvents, model.NewProcessMonitoringEvent(model.Exit, time.Now(), 23, "/usr/bin/ls", []string{"ls", "-lah"}))
+	rawEvents = append(rawEvents, model.NewMockedProcessMonitoringEvent(model.Exit, time.Now(), 23, "/usr/bin/ls", []string{"ls", "-lah"}))
 	handlers = append(handlers, func(e *model.ProcessEvent) {
 		require.Equal(t, model.Exit, e.EventType)
 		require.Equal(t, uint32(23), e.Pid)
@@ -128,7 +128,7 @@ func TestProcessEventHandling(t *testing.T) {
 			t.Error("should not have received more process events")
 		}
 
-		assertProcessEvents(t, events[i], e)
+		model.AssertProcessEvents(t, events[i], e)
 		// all message have been consumed
 		if i == len(events)-1 {
 			close(rcvMessage)

--- a/pkg/process/events/listener_linux_test.go
+++ b/pkg/process/events/listener_linux_test.go
@@ -23,26 +23,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/api/mocks"
 )
 
-// assertProcessEvents compares two ProcessEvents. Two events can't be compared using directly assert.Equal
-// due to the embedded time fields
-func assertProcessEvents(t *testing.T, expected, actual *model.ProcessEvent) {
-	t.Helper()
-
-	assert.Equal(t, expected.EventType, actual.EventType)
-	assert.WithinDuration(t, expected.CollectionTime, actual.CollectionTime, 0)
-	assert.Equal(t, expected.Pid, actual.Pid)
-	assert.Equal(t, expected.Ppid, actual.Ppid)
-	assert.Equal(t, expected.UID, actual.UID)
-	assert.Equal(t, expected.GID, actual.GID)
-	assert.Equal(t, expected.Username, actual.Username)
-	assert.Equal(t, expected.Group, actual.Group)
-	assert.Equal(t, expected.Exe, actual.Exe)
-	assert.Equal(t, expected.Cmdline, actual.Cmdline)
-	assert.WithinDuration(t, expected.ForkTime, actual.ForkTime, 0)
-	assert.WithinDuration(t, expected.ExecTime, actual.ExecTime, 0)
-	assert.WithinDuration(t, expected.ExitTime, actual.ExitTime, 0)
-}
-
 // TestProcessEventFiltering asserts that sysProbeListener collects only expected events and drops everything else
 func TestProcessEventFiltering(t *testing.T) {
 	rawEvents := make([]*model.ProcessMonitoringEvent, 0)

--- a/pkg/process/events/model/model_common.go
+++ b/pkg/process/events/model/model_common.go
@@ -67,6 +67,8 @@ func NewMockedProcessEvent(evtType string, ts time.Time, pid uint32, exe string,
 // AssertProcessEvents compares two ProcessEvents. Two events can't be compared using directly assert.Equal
 // due to the embedded time fields
 func AssertProcessEvents(t *testing.T, expected, actual *ProcessEvent) {
+	t.Helper()
+
 	assert.Equal(t, expected.EventType, actual.EventType)
 	assert.WithinDuration(t, expected.CollectionTime, actual.CollectionTime, 0)
 	assert.Equal(t, expected.Pid, actual.Pid)

--- a/pkg/process/events/model/model_common.go
+++ b/pkg/process/events/model/model_common.go
@@ -5,7 +5,12 @@
 
 package model
 
-import "time"
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
 
 const (
 	Exec = "exec"
@@ -28,4 +33,51 @@ type ProcessEvent struct {
 	ForkTime       time.Time `json:"fork_time,omitempty"`
 	ExecTime       time.Time `json:"exec_time,omitempty"`
 	ExitTime       time.Time `json:"exit_time,omitempty"`
+}
+
+// NewMockedProcessEvent creates a mocked ProcessEvent for tests
+func NewMockedProcessEvent(evtType string, ts time.Time, pid uint32, exe string, args []string) *ProcessEvent {
+	var forkTime, execTime, exitTime time.Time
+	switch evtType {
+	case Fork:
+		forkTime = ts
+	case Exec:
+		execTime = ts
+	case Exit:
+		exitTime = ts
+	}
+
+	return &ProcessEvent{
+		EventType:      evtType,
+		CollectionTime: time.Now(),
+		Pid:            pid,
+		Ppid:           1,
+		UID:            100,
+		GID:            100,
+		Username:       "dog",
+		Group:          "dd-agent",
+		Exe:            exe,
+		Cmdline:        args,
+		ForkTime:       forkTime,
+		ExecTime:       execTime,
+		ExitTime:       exitTime,
+	}
+}
+
+// AssertProcessEvents compares two ProcessEvents. Two events can't be compared using directly assert.Equal
+// due to the embedded time fields
+func AssertProcessEvents(t *testing.T, expected, actual *ProcessEvent) {
+	assert.Equal(t, expected.EventType, actual.EventType)
+	assert.WithinDuration(t, expected.CollectionTime, actual.CollectionTime, 0)
+	assert.Equal(t, expected.Pid, actual.Pid)
+	assert.Equal(t, expected.Ppid, actual.Ppid)
+	assert.Equal(t, expected.UID, actual.UID)
+	assert.Equal(t, expected.GID, actual.GID)
+	assert.Equal(t, expected.Username, actual.Username)
+	assert.Equal(t, expected.Group, actual.Group)
+	assert.Equal(t, expected.Exe, actual.Exe)
+	assert.Equal(t, expected.Cmdline, actual.Cmdline)
+	assert.WithinDuration(t, expected.ForkTime, actual.ForkTime, 0)
+	assert.WithinDuration(t, expected.ExecTime, actual.ExecTime, 0)
+	assert.WithinDuration(t, expected.ExitTime, actual.ExitTime, 0)
 }

--- a/pkg/process/events/model/model_sysprobe.go
+++ b/pkg/process/events/model/model_sysprobe.go
@@ -78,8 +78,8 @@ func ProcessEventToProcessMonitoringEvent(e *ProcessEvent) *ProcessMonitoringEve
 	}
 }
 
-// NewProcessMonitoringEvent returns a new mocked ProcessMonitoringEvent
-func NewProcessMonitoringEvent(evtType string, ts time.Time, pid uint32, exe string, args []string) *ProcessMonitoringEvent {
+// NewMockedProcessMonitoringEvent returns a new mocked ProcessMonitoringEvent
+func NewMockedProcessMonitoringEvent(evtType string, ts time.Time, pid uint32, exe string, args []string) *ProcessMonitoringEvent {
 	var forkTime, execTime, exitTime time.Time
 	switch evtType {
 	case Fork:

--- a/pkg/process/events/model/serialization_test.go
+++ b/pkg/process/events/model/serialization_test.go
@@ -20,7 +20,7 @@ func newBenchmarkProcessEvent(argCount int) *ProcessMonitoringEvent {
 		args = append(args, fmt.Sprintf("arg_%d", i))
 	}
 
-	return NewProcessMonitoringEvent(Exit, time.Now(), 42, "/usr/bin/exe", args)
+	return NewMockedProcessMonitoringEvent(Exit, time.Now(), 42, "/usr/bin/exe", args)
 }
 
 // Benchmark between JSON and messagePack serialization changing the command-line length of the collected event

--- a/pkg/process/events/store.go
+++ b/pkg/process/events/store.go
@@ -1,0 +1,277 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package events
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/DataDog/datadog-go/v5/statsd"
+	"go.uber.org/atomic"
+
+	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/process/events/model"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// Ensure in compile time that the RingStore satisfies the Store interface
+var _ Store = &RingStore{}
+
+// Store defines an interface to store process events in-memory
+type Store interface {
+	// Run starts the store
+	Run()
+	// Stop stops the store
+	Stop()
+	// Push sends an event to be stored. An optional channel can be passed to acknowledge when the event is successfully written
+	Push(*model.ProcessEvent, chan bool)
+	// Pull fetches all events in the store that haven't been consumed yet
+	Pull(context.Context, time.Duration) ([]*model.ProcessEvent, error)
+}
+
+// ringNode represents an event stored in the RingStore buffer
+// It can eventually hold more data as lastUpdate, event hash etc
+type ringNode struct {
+	data *model.ProcessEvent
+}
+
+// pushRequest is a request sent to the internal RingBuffer routine to add an event to its buffer
+type pushRequest struct {
+	event *model.ProcessEvent
+	done  chan bool
+}
+
+// pullRequest is a request sent to the internal RingBuffer routine to fetch events from its buffer
+type pullRequest struct {
+	results chan []*model.ProcessEvent
+}
+
+// RingStore implements the Store interface using a ring buffer
+// The buffer is accessed by a single routine so it doesn't need to be protected by a mutex
+// It holds two pointers, head and tail, to access the ring buffer
+// head points to the oldest event in the buffer, where data should be consumed from
+// tail points to the node where the next event will be inserted into
+// head = tail if
+//		* the store is empty, in which case the underlying ringNode doesn't have any data
+// 		* the store is full. Subsequent Push operations override the data pointed by head and move both head and tail
+//		to the next position
+type RingStore struct {
+	head     int
+	tail     int
+	buffer   []ringNode
+	maxItems int
+
+	dropHandler EventHandler // applied to an event before it's dropped. Used for test's purposes
+	pushReq     chan *pushRequest
+	pullReq     chan *pullRequest
+
+	wg   sync.WaitGroup
+	exit chan struct{}
+
+	statsdClient  statsd.ClientInterface
+	statsInterval time.Duration
+	expiredInput  *atomic.Int64 // how many events have been dropped due to a full pushReq channel
+	expiredBuffer *atomic.Int64 // how many events have been dropped due to a full buffer
+}
+
+// readPositiveInt reads a config stored in the given key and asserts that it's a positive value
+func readPositiveInt(key string) (int, error) {
+	i := ddconfig.Datadog.GetInt(key)
+	if i <= 0 {
+		return 0, errors.New("invalid setting. " + key + " should be > 0")
+	}
+
+	return i, nil
+}
+
+// NewRingStore creates a new RingStore to store process events
+func NewRingStore(client statsd.ClientInterface) (Store, error) {
+	maxItems, err := readPositiveInt("process_config.event_collection.store.max_items")
+	if err != nil {
+		return nil, err
+	}
+
+	maxPushes, err := readPositiveInt("process_config.event_collection.store.max_pending_pushes")
+	if err != nil {
+		return nil, err
+	}
+
+	maxPulls, err := readPositiveInt("process_config.event_collection.store.max_pending_pulls")
+	if err != nil {
+		return nil, err
+	}
+
+	statsInterval, err := readPositiveInt("process_config.event_collection.store.stats_interval")
+	if err != nil {
+		return nil, err
+	}
+
+	return &RingStore{
+		buffer:        make([]ringNode, maxItems),
+		head:          0,
+		tail:          0,
+		maxItems:      maxItems,
+		pushReq:       make(chan *pushRequest, maxPushes),
+		pullReq:       make(chan *pullRequest, maxPulls),
+		exit:          make(chan struct{}),
+		statsdClient:  client,
+		statsInterval: time.Duration(statsInterval) * time.Second,
+		expiredInput:  atomic.NewInt64(0),
+		expiredBuffer: atomic.NewInt64(0),
+	}, nil
+}
+
+// Run starts the RingStore. A go routine is created to serve push and pull requests in order to protect the underlying
+// storage from concurrent access
+func (s *RingStore) Run() {
+	log.Info("Starting the RingStore")
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		s.run()
+	}()
+}
+
+// Stop stops the RingStore's internal routine
+func (s *RingStore) Stop() {
+	log.Info("Stopping the RingStore")
+	close(s.exit)
+	s.wg.Wait()
+	log.Info("RingStore stopped")
+}
+
+// Push adds an event to the RingStore. If the store is full, the oldest event is dropped to make space for the new one
+// The done channel is optional. It's used to signal if the event has been successfully written to the Store
+func (s *RingStore) Push(e *model.ProcessEvent, done chan bool) {
+	r := &pushRequest{
+		event: e,
+		done:  done,
+	}
+
+	select {
+	case s.pushReq <- r:
+	default:
+		log.Trace("RingStore input channel is full, dropping event")
+		s.expiredInput.Inc()
+
+		if done != nil {
+			done <- false
+		}
+	}
+}
+
+// Pull returns all events stored in the RingStore
+func (s *RingStore) Pull(ctx context.Context, timeout time.Duration) ([]*model.ProcessEvent, error) {
+	timer := time.NewTimer(timeout)
+
+	q := &pullRequest{
+		results: make(chan []*model.ProcessEvent),
+	}
+
+	select {
+	case s.pullReq <- q:
+	default:
+		log.Warn("Can't Pull RingStore: too many pending requests")
+		return nil, errors.New("too many pending pull requests")
+	}
+
+	var batch []*model.ProcessEvent
+	select {
+	case batch = <-q.results:
+		timer.Stop()
+		break
+	case <-timer.C:
+		log.Warn("Timed out while fetching events from the RingStore")
+		return nil, errors.New("pull request timed out")
+	}
+
+	return batch, nil
+}
+
+// size returns how many events are currently stored in the RingStore
+// This function is not thread-safe and should only be called internally by the RingStore routine or during tests
+func (s *RingStore) size() int {
+	// When buffer is full, tail points to a node whose data that hasn't been consumed yet
+	if s.buffer[s.tail].data != nil {
+		return len(s.buffer)
+	}
+
+	if s.head <= s.tail {
+		return s.tail - s.head
+	}
+
+	return (len(s.buffer) - s.head) + s.tail
+}
+
+// push adds an event to the RingStore buffer
+// This function is not thread-safe and should only be called internally by the RingStore routine or during tests
+func (s *RingStore) push(e *model.ProcessEvent) {
+	if old := s.buffer[s.tail].data; old != nil {
+		if s.dropHandler != nil {
+			s.dropHandler(old)
+		}
+
+		// When store is full, tail = head. Head is moved since the pointed data will be dropped to make space for the new event
+		s.head = (s.head + 1) % len(s.buffer)
+		log.Tracef("Dropping %s event with PID %d and exe %s", old.EventType, old.Pid, old.Exe)
+		s.expiredBuffer.Inc()
+	}
+
+	s.buffer[s.tail].data = e
+	s.tail = (s.tail + 1) % len(s.buffer)
+}
+
+// pull returns all events stored in the RingStore buffer
+// This function is not thread-safe and should only be called internally by the RingStore routine or during tests
+func (s *RingStore) pull() []*model.ProcessEvent {
+	size := s.size()
+	batch := make([]*model.ProcessEvent, 0, size)
+
+	// Iterate though the buffer consuming all nodes that still have data
+	for ; s.buffer[s.head].data != nil; s.head = (s.head + 1) % len(s.buffer) {
+		batch = append(batch, s.buffer[s.head].data)
+		s.buffer[s.head].data = nil // do not hold more reference to the data so it can be GC'ed.
+	}
+
+	return batch
+}
+
+func (s *RingStore) sendStats() {
+	inputCount := s.expiredInput.Swap(0)
+	bufferCount := s.expiredBuffer.Swap(0)
+
+	if err := s.statsdClient.Count("datadog.process.events.expired", inputCount, []string{"type:input_full"}, 1.0); err != nil {
+		log.Debug(err)
+	}
+
+	if err := s.statsdClient.Count("datadog.process.events.expired", bufferCount, []string{"type:buffer_full"}, 1.0); err != nil {
+		log.Debug(err)
+	}
+}
+
+// run listens for requests sent to the RingStore channels
+func (s *RingStore) run() {
+	statsTicker := time.NewTicker(s.statsInterval)
+	defer statsTicker.Stop()
+
+	for {
+		select {
+		case req := <-s.pushReq:
+			s.push(req.event)
+			if req.done != nil {
+				req.done <- true
+			}
+		case req := <-s.pullReq:
+			req.results <- s.pull()
+		case <-statsTicker.C:
+			s.sendStats()
+		case <-s.exit:
+			return
+		}
+	}
+}

--- a/pkg/process/events/store.go
+++ b/pkg/process/events/store.go
@@ -8,6 +8,7 @@ package events
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"time"
 
@@ -83,7 +84,7 @@ type RingStore struct {
 func readPositiveInt(key string) (int, error) {
 	i := ddconfig.Datadog.GetInt(key)
 	if i <= 0 {
-		return 0, errors.New("invalid setting. " + key + " should be > 0")
+		return 0, fmt.Errorf("invalid setting. %s must be > 0", key)
 	}
 
 	return i, nil

--- a/pkg/process/events/store.go
+++ b/pkg/process/events/store.go
@@ -62,10 +62,9 @@ type pullRequest struct {
 // 		* the store is full. Subsequent Push operations override the data pointed by head and move both head and tail
 //		to the next position
 type RingStore struct {
-	head     int
-	tail     int
-	buffer   []ringNode
-	maxItems int
+	head   int
+	tail   int
+	buffer []ringNode
 
 	dropHandler EventHandler // applied to an event before it's dropped. Used for test's purposes
 	pushReq     chan *pushRequest
@@ -116,7 +115,6 @@ func NewRingStore(client statsd.ClientInterface) (Store, error) {
 		buffer:        make([]ringNode, maxItems),
 		head:          0,
 		tail:          0,
-		maxItems:      maxItems,
 		pushReq:       make(chan *pushRequest, maxPushes),
 		pullReq:       make(chan *pullRequest, maxPulls),
 		exit:          make(chan struct{}),
@@ -172,8 +170,6 @@ func (s *RingStore) Push(e *model.ProcessEvent, done chan bool) error {
 
 // Pull returns all events stored in the RingStore
 func (s *RingStore) Pull(ctx context.Context, timeout time.Duration) ([]*model.ProcessEvent, error) {
-	timer := time.NewTimer(timeout)
-
 	q := &pullRequest{
 		results: make(chan []*model.ProcessEvent),
 	}
@@ -186,6 +182,7 @@ func (s *RingStore) Pull(ctx context.Context, timeout time.Duration) ([]*model.P
 	}
 
 	var batch []*model.ProcessEvent
+	timer := time.NewTimer(timeout)
 	select {
 	case batch = <-q.results:
 		timer.Stop()

--- a/pkg/process/events/store_test.go
+++ b/pkg/process/events/store_test.go
@@ -21,18 +21,19 @@ import (
 // pushSync is an auxiliary function to push events to the RingStore synchronously
 func pushSync(t *testing.T, r *RingStore, e *model.ProcessEvent) {
 	done := make(chan bool)
-	r.Push(e, done)
+	err := r.Push(e, done)
+	require.NoError(t, err)
 	ok := <-done
 	require.True(t, ok)
 }
 
-func TestRingStore(t *testing.T) {
+func TestRingStoreWithoutLoop(t *testing.T) {
 	now := time.Now()
 	ctx := context.Background()
 	timeout := time.Second
 
 	cfg := config.Mock()
-	cfg.Set("process_config.event_collection.store.max_items", 3)
+	cfg.Set("process_config.event_collection.store.max_items", 4)
 	store, err := NewRingStore(&statsd.NoOpClient{})
 	require.NoError(t, err)
 
@@ -46,23 +47,62 @@ func TestRingStore(t *testing.T) {
 	e2 := model.NewMockedProcessEvent(model.Exit, now, 23, "/usr/bin/curl", []string{"curl", "localhost:6062"})
 	e3 := model.NewMockedProcessEvent(model.Exit, now, 23, "/usr/bin/ls", []string{"ls", "-lah"})
 
-	// Push and pull 2 elements - no data loss
+	// Push and pull 1 event
 	pushSync(t, s, e1)
 	require.Equal(t, 0, s.head)
 	require.Equal(t, 1, s.tail)
 	require.Equal(t, 1, s.size())
 
-	pushSync(t, s, e2)
-	require.Equal(t, 0, s.head)
-	require.Equal(t, 2, s.tail)
-	require.Equal(t, 2, s.size())
-
 	data, err := s.Pull(ctx, timeout)
 	assert.NoError(t, err)
-	require.Equal(t, []*model.ProcessEvent{e1, e2}, data)
-	require.Equal(t, 2, s.head)
-	require.Equal(t, 2, s.tail)
+	require.Equal(t, []*model.ProcessEvent{e1}, data)
+	require.Equal(t, 1, s.head)
+	require.Equal(t, 1, s.tail)
 	require.Equal(t, 0, s.size())
+
+	// Push and pull 2 more events
+	pushSync(t, s, e2)
+	require.Equal(t, 1, s.head)
+	require.Equal(t, 2, s.tail)
+	require.Equal(t, 1, s.size())
+
+	pushSync(t, s, e3)
+	require.Equal(t, 1, s.head)
+	require.Equal(t, 3, s.tail)
+	require.Equal(t, 2, s.size())
+
+	data, err = s.Pull(ctx, timeout)
+	assert.NoError(t, err)
+	require.Equal(t, []*model.ProcessEvent{e2, e3}, data)
+	require.Equal(t, 3, s.head)
+	require.Equal(t, 3, s.tail)
+	require.Equal(t, 0, s.size())
+}
+
+func TestRingStoreWithLoop(t *testing.T) {
+	now := time.Now()
+	ctx := context.Background()
+	timeout := time.Second
+
+	cfg := config.Mock()
+	cfg.Set("process_config.event_collection.store.max_items", 3)
+	store, err := NewRingStore(&statsd.NoOpClient{})
+	require.NoError(t, err)
+
+	s, ok := store.(*RingStore)
+	require.True(t, ok)
+
+	e1 := model.NewMockedProcessEvent(model.Exec, now, 23, "/usr/bin/curl", []string{"curl", "localhost:6062"})
+	e2 := model.NewMockedProcessEvent(model.Exit, now, 23, "/usr/bin/curl", []string{"curl", "localhost:6062"})
+	e3 := model.NewMockedProcessEvent(model.Exit, now, 23, "/usr/bin/ls", []string{"ls", "-lah"})
+
+	// Initialize store with len(buffer)-1 events that have already been consumed
+	s.head = 2
+	s.tail = 2
+	require.Equal(t, 0, s.size())
+
+	s.Run()
+	defer s.Stop()
 
 	// Push 1 elements to reach end of buffer - no data loss
 	pushSync(t, s, e1)
@@ -82,24 +122,11 @@ func TestRingStore(t *testing.T) {
 	require.Equal(t, 3, s.size())
 
 	// Retrieve all events from buffer
-	data, err = s.Pull(ctx, timeout)
+	data, err := s.Pull(ctx, timeout)
 	assert.NoError(t, err)
 	require.Equal(t, []*model.ProcessEvent{e1, e2, e3}, data)
 	require.Equal(t, 2, s.head)
 	require.Equal(t, 2, s.tail)
-	require.Equal(t, 0, s.size())
-
-	// Add one more element to reset head and tail
-	pushSync(t, s, e1)
-	require.Equal(t, 2, s.head)
-	require.Equal(t, 0, s.tail)
-	require.Equal(t, 1, s.size())
-
-	data, err = s.Pull(ctx, timeout)
-	assert.NoError(t, err)
-	require.Equal(t, []*model.ProcessEvent{e1}, data)
-	require.Equal(t, 0, s.head)
-	require.Equal(t, 0, s.tail)
 	require.Equal(t, 0, s.size())
 }
 
@@ -175,8 +202,11 @@ func TestRingStoreAsynchronousPush(t *testing.T) {
 
 	e1 := model.NewMockedProcessEvent(model.Exec, now, 23, "/usr/bin/curl", []string{"curl", "localhost:6062"})
 	e2 := model.NewMockedProcessEvent(model.Exit, now, 23, "/usr/bin/curl", []string{"curl", "localhost:6062"})
-	s.Push(e1, nil)
-	s.Push(e2, nil)
+	err = s.Push(e1, nil)
+	require.NoError(t, err)
+
+	err = s.Push(e2, nil)
+	require.NoError(t, err)
 
 	res := make([]*model.ProcessEvent, 0, 2)
 	count := 0
@@ -192,4 +222,63 @@ func TestRingStoreAsynchronousPush(t *testing.T) {
 	}, time.Second, 100*time.Millisecond, "can't pull and events pushed to the store")
 
 	assert.Equal(t, []*model.ProcessEvent{e1, e2}, res)
+}
+
+func TestRingStorePullErrors(t *testing.T) {
+	ctx := context.Background()
+	timeout := 10 * time.Millisecond // simulate timeout for all pending requests
+
+	cfg := config.Mock()
+	maxPulls := 2
+	cfg.Set("process_config.event_collection.store.max_pending_pulls", maxPulls)
+	store, err := NewRingStore(&statsd.NoOpClient{})
+	require.NoError(t, err)
+
+	s, ok := store.(*RingStore)
+	require.True(t, ok)
+
+	// Do not start the store in order to queue pull requests
+	for i := 0; i < maxPulls; i++ {
+		go func() {
+			data, err := s.Pull(ctx, timeout)
+			assert.EqualError(t, err, "pull request timed out")
+			assert.Equal(t, 0, len(data))
+		}()
+	}
+
+	// Wait for pull requests to pile up
+	assert.Eventually(t, func() bool { return len(s.pullReq) == maxPulls }, time.Second, 100*time.Millisecond)
+
+	// Since pending requests are never served, next request will be rejected
+	data, err := store.Pull(ctx, timeout)
+	assert.EqualError(t, err, "too many pending pull requests")
+	assert.Equal(t, 0, len(data))
+}
+
+func TestRingStorePushErrors(t *testing.T) {
+	cfg := config.Mock()
+	maxPushes := 2
+	cfg.Set("process_config.event_collection.store.max_pending_pushes", 2)
+	store, err := NewRingStore(&statsd.NoOpClient{})
+	require.NoError(t, err)
+
+	s, ok := store.(*RingStore)
+	require.True(t, ok)
+
+	e := model.NewMockedProcessEvent(model.Exec, time.Now(), 23, "/usr/bin/curl", []string{"curl", "localhost:6062"})
+
+	// Do not start the store in order to queue push requests
+	for i := 0; i < maxPushes; i++ {
+		go func() {
+			err := store.Push(e, nil)
+			assert.NoError(t, err)
+		}()
+	}
+
+	// Wait for push requests to pile up
+	assert.Eventually(t, func() bool { return len(s.pushReq) == maxPushes }, time.Second, 100*time.Millisecond)
+
+	// Next push request should return an error
+	err = store.Push(e, nil)
+	assert.EqualError(t, err, "too many pending push requests")
 }

--- a/pkg/process/events/store_test.go
+++ b/pkg/process/events/store_test.go
@@ -1,0 +1,195 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package events
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-go/v5/statsd"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/process/events/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// pushSync is an auxiliary function to push events to the RingStore synchronously
+func pushSync(t *testing.T, r *RingStore, e *model.ProcessEvent) {
+	done := make(chan bool)
+	r.Push(e, done)
+	ok := <-done
+	require.True(t, ok)
+}
+
+func TestRingStore(t *testing.T) {
+	now := time.Now()
+	ctx := context.Background()
+	timeout := time.Second
+
+	cfg := config.Mock()
+	cfg.Set("process_config.event_collection.store.max_items", 3)
+	store, err := NewRingStore(&statsd.NoOpClient{})
+	require.NoError(t, err)
+
+	s, ok := store.(*RingStore)
+	require.True(t, ok)
+
+	s.Run()
+	defer s.Stop()
+
+	e1 := model.NewMockedProcessEvent(model.Exec, now, 23, "/usr/bin/curl", []string{"curl", "localhost:6062"})
+	e2 := model.NewMockedProcessEvent(model.Exit, now, 23, "/usr/bin/curl", []string{"curl", "localhost:6062"})
+	e3 := model.NewMockedProcessEvent(model.Exit, now, 23, "/usr/bin/ls", []string{"ls", "-lah"})
+
+	// Push and pull 2 elements - no data loss
+	pushSync(t, s, e1)
+	require.Equal(t, 0, s.head)
+	require.Equal(t, 1, s.tail)
+	require.Equal(t, 1, s.size())
+
+	pushSync(t, s, e2)
+	require.Equal(t, 0, s.head)
+	require.Equal(t, 2, s.tail)
+	require.Equal(t, 2, s.size())
+
+	data, err := s.Pull(ctx, timeout)
+	assert.NoError(t, err)
+	require.Equal(t, []*model.ProcessEvent{e1, e2}, data)
+	require.Equal(t, 2, s.head)
+	require.Equal(t, 2, s.tail)
+	require.Equal(t, 0, s.size())
+
+	// Push 1 elements to reach end of buffer - no data loss
+	pushSync(t, s, e1)
+	require.Equal(t, 2, s.head)
+	require.Equal(t, 0, s.tail)
+	require.Equal(t, 1, s.size())
+
+	// Push 2 more elements - buffer full - no data loss
+	pushSync(t, s, e2)
+	require.Equal(t, 2, s.head)
+	require.Equal(t, 1, s.tail)
+	require.Equal(t, 2, s.size())
+
+	pushSync(t, s, e3)
+	require.Equal(t, 2, s.head)
+	require.Equal(t, 2, s.tail)
+	require.Equal(t, 3, s.size())
+
+	// Retrieve all events from buffer
+	data, err = s.Pull(ctx, timeout)
+	assert.NoError(t, err)
+	require.Equal(t, []*model.ProcessEvent{e1, e2, e3}, data)
+	require.Equal(t, 2, s.head)
+	require.Equal(t, 2, s.tail)
+	require.Equal(t, 0, s.size())
+
+	// Add one more element to reset head and tail
+	pushSync(t, s, e1)
+	require.Equal(t, 2, s.head)
+	require.Equal(t, 0, s.tail)
+	require.Equal(t, 1, s.size())
+
+	data, err = s.Pull(ctx, timeout)
+	assert.NoError(t, err)
+	require.Equal(t, []*model.ProcessEvent{e1}, data)
+	require.Equal(t, 0, s.head)
+	require.Equal(t, 0, s.tail)
+	require.Equal(t, 0, s.size())
+}
+
+func TestRingStoreWithDroppedData(t *testing.T) {
+	now := time.Now()
+	ctx := context.Background()
+	timeout := time.Second
+
+	cfg := config.Mock()
+	cfg.Set("process_config.event_collection.store.max_items", 3)
+	store, err := NewRingStore(&statsd.NoOpClient{})
+	require.NoError(t, err)
+
+	s, ok := store.(*RingStore)
+	require.True(t, ok)
+
+	s.Run()
+	defer s.Stop()
+
+	e1 := model.NewMockedProcessEvent(model.Exec, now, 23, "/usr/bin/curl", []string{"curl", "localhost:6062"})
+	e2 := model.NewMockedProcessEvent(model.Exit, now, 23, "/usr/bin/curl", []string{"curl", "localhost:6062"})
+	e3 := model.NewMockedProcessEvent(model.Exit, now, 23, "/usr/bin/ls", []string{"ls", "-lah"})
+	e4 := model.NewMockedProcessEvent(model.Exit, now, 23, "/usr/bin/ls", []string{"ls", "-lah"})
+
+	// Fill up buffer
+	pushSync(t, s, e1)
+	pushSync(t, s, e2)
+	pushSync(t, s, e3)
+	require.Equal(t, 0, s.head)
+	require.Equal(t, 0, s.tail)
+	require.Equal(t, 3, s.size())
+
+	// Pushing new elements should drop old data
+	s.dropHandler = func(e *model.ProcessEvent) {
+		model.AssertProcessEvents(t, e1, e)
+	}
+	pushSync(t, s, e4) // drop e1
+	require.Equal(t, 1, s.head)
+	require.Equal(t, 1, s.tail)
+	require.Equal(t, 3, s.size())
+
+	s.dropHandler = func(e *model.ProcessEvent) {
+		model.AssertProcessEvents(t, e2, e)
+	}
+	pushSync(t, s, e1) // drop e2
+	require.Equal(t, 2, s.head)
+	require.Equal(t, 2, s.tail)
+	require.Equal(t, 3, s.size())
+
+	data, err := s.Pull(ctx, timeout)
+	assert.NoError(t, err)
+	require.Equal(t, []*model.ProcessEvent{e3, e4, e1}, data)
+	require.Equal(t, 2, s.head)
+	require.Equal(t, 2, s.tail)
+	require.Equal(t, 0, s.size())
+}
+
+func TestRingStoreAsynchronousPush(t *testing.T) {
+	now := time.Now()
+	ctx := context.Background()
+	timeout := time.Second
+
+	cfg := config.Mock()
+	cfg.Set("process_config.event_collection.store.max_items", 3)
+	store, err := NewRingStore(&statsd.NoOpClient{})
+	require.NoError(t, err)
+
+	s, ok := store.(*RingStore)
+	require.True(t, ok)
+
+	s.Run()
+	defer s.Stop()
+
+	e1 := model.NewMockedProcessEvent(model.Exec, now, 23, "/usr/bin/curl", []string{"curl", "localhost:6062"})
+	e2 := model.NewMockedProcessEvent(model.Exit, now, 23, "/usr/bin/curl", []string{"curl", "localhost:6062"})
+	s.Push(e1, nil)
+	s.Push(e2, nil)
+
+	res := make([]*model.ProcessEvent, 0, 2)
+	count := 0
+	assert.Eventually(t, func() bool {
+		events, err := s.Pull(ctx, timeout)
+		assert.NoError(t, err)
+		for _, e := range events {
+			count++
+			res = append(res, e)
+		}
+
+		return count == 2
+	}, time.Second, 100*time.Millisecond, "can't pull and events pushed to the store")
+
+	assert.Equal(t, []*model.ProcessEvent{e1, e2}, res)
+}


### PR DESCRIPTION
### What does this PR do?

This PR adds the event `Store` interface to define how process events should be stored in-memory so they can be consumed by a new check. It adds the `RingStore` implementation which uses a ring buffer to store data.

The `RingStore` is created with a predefined size and when full, it drops old events in order to make space for new ones. When pulled, the store returns events in a FIFO manner.

The PR also adds a new `events pull` command that can be used to test both event `Listener` and `RingStore` on Linux.

### Motivation

Add a component to store process lifecycle events collected with the event Listener so they can be consumed by a new process-agent check.

### Additional Notes

Since this feature is currently in alpha, it's not advertised in the `CHANGELOG`.

### Possible Drawbacks / Trade-offs

In this first implementation, for the sake of simplicity, I didn't add any kind of aggregation in the RingStore. However, it can eventually be extended to support it. 

### Describe how to test/QA your changes

On Linux, update `system-probe.yaml` with
```yaml
runtime_security_config:
  event_monitoring:
    enabled: true
```

Start the datadog-agent and make sure that system-probe is running. 

#### Happy path

Run the new `events pull` command with process-agent on sudo mode and make sure that process events are displayed on the terminal every 5s:
```
sudo ./process-agent events pull
```

* Stop system-probe and make sure that process-agent displays a connection error message.
* Restart system-probe and make sure that process-agent is able to reconnect to it.
* Stop the `events pull` command with `CTRL-C` and make sure that it terminates gracefully.

#### Simulate event loss

Update the `datadog.yaml` file with the following settings to create a smaller buffer
```yaml 
log_level: 'trace'

process_config:
    event_collection:
    store:
      max_items: 1
```

Start the events pull command with a longer ticker so events are pulled less frequently
``` 
sudo ./bin/process-agent/process-agent events pull -t 10s
```

Start some processes (e.g. ls, curl, ps). Make sure that trace logs show that the events are dropped in the correct order.

#### Event collection on non-supported systems

On `Windows` and `MacOS`, the `events pull` command should return an error:
```
Error: Process event collection is not yet supported on this system
```

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
