### PR TITLE
Fix `tags` set in the check config

### DIFF
--- a/pkg/autodiscovery/configresolver/configresolver.go
+++ b/pkg/autodiscovery/configresolver/configresolver.go
@@ -448,11 +448,18 @@ func tagsAdder(tags []string) func(interface{}) error {
 		}
 
 		if typedTree, ok := tree.(map[interface{}]interface{}); ok {
-			tagList, _ := typedTree["tags"].([]string)
 			// Use a set to remove duplicates
 			tagSet := make(map[string]struct{})
-			for _, t := range tagList {
-				tagSet[t] = struct{}{}
+			if tagList, ok := typedTree["tags"].([]interface{}); !ok {
+				log.Errorf("Wrong type for `tags` in config. Expected []interface{}, got %T", typedTree["tags"])
+			} else {
+				for _, tag := range tagList {
+					if t, ok := tag.(string); !ok {
+						log.Errorf("Wrong type for tag \"%#v\". Expected string, got %T", tag, tag)
+					} else {
+						tagSet[t] = struct{}{}
+					}
+				}
 			}
 			for _, t := range tags {
 				tagSet[t] = struct{}{}

--- a/pkg/autodiscovery/configresolver/configresolver_test.go
+++ b/pkg/autodiscovery/configresolver/configresolver_test.go
@@ -796,6 +796,25 @@ func TestResolve(t *testing.T) {
 				Provider:      names.Kubernetes,
 			},
 		},
+		{
+			testName: "static tags",
+			svc: &dummyService{
+				ID:            "a5901276aed1",
+				ADIdentifiers: []string{"redis"},
+				Hosts:         map[string]string{"bridge": "127.0.0.1"},
+			},
+			tpl: integration.Config{
+				Name:          "cpu",
+				ADIdentifiers: []string{"redis"},
+				Instances:     []integration.Data{integration.Data("host: %%host%%\ntags:\n- statictag:TEST")},
+			},
+			out: integration.Config{
+				Name:          "cpu",
+				ADIdentifiers: []string{"redis"},
+				Instances:     []integration.Data{integration.Data("host: 127.0.0.1\ntags:\n- statictag:TEST\n- foo:bar\n")},
+				ServiceID:     "a5901276aed1",
+			},
+		},
 	}
 
 	for i, tc := range testCases {


### PR DESCRIPTION
### What does this PR do?

Fix use of tags defined in a check configuration.

### Motivation

It’s a regression.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Start an agent with a configuration of a check that has a custom `tags`.

For ex.: `/etc/datadog-agent/conf.d/nginx.yaml`
```yaml
ad_identifiers:
  - nginx
init_config:
instances:
  - tags: ["TEST:ING"]
    nginx_status_url: "http://%%host%%/nginx_status"
```

And start a container with an `nginx` image.

Check that the `TEST:ING` tag appears in:
* `agent configcheck`
```
=== nginx check ===
Configuration provider: file
Configuration source: file:/etc/datadog-agent/conf.d/nginx.yaml
[…]
tags:
- TEST:ING
[…]
```
* `agent check -r nginx`
```
=== Series ===
[
  {
    "metric": "nginx.net.reading",
    "points": [
      […]
    ],
    "tags": [
      "TEST:ING",
[…]
```

This tag was missing with `7.37.0-rc.2`.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
