### PR TITLE
[networks] Fix HTTP stats logging

### DIFF
--- a/pkg/network/http/monitor.go
+++ b/pkg/network/http/monitor.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 
 	"sync"
-	"time"
 
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
@@ -124,8 +123,6 @@ func (m *Monitor) Start() error {
 	m.eventLoopWG.Add(1)
 	go func() {
 		defer m.eventLoopWG.Done()
-		report := time.NewTicker(30 * time.Second)
-		defer report.Stop()
 		for {
 			select {
 			case dataEvent, ok := <-m.batchCompletionHandler.DataChannel:
@@ -161,9 +158,6 @@ func (m *Monitor) Start() error {
 					requestStats: m.statkeeper.GetAndResetAllStats(),
 					telemetry:    delta,
 				}
-			case <-report.C:
-				transactions := m.batchManager.GetPendingTransactions()
-				m.process(transactions, nil)
 			}
 		}
 	}()

--- a/pkg/network/http/telemetry.go
+++ b/pkg/network/http/telemetry.go
@@ -83,32 +83,25 @@ func (t *telemetry) reset() telemetry {
 	delta.aggregations = atomic.SwapInt64(&t.aggregations, 0)
 	delta.elapsed = now - then
 
+	totalRequests := delta.hits1XX + delta.hits2XX + delta.hits3XX + delta.hits4XX + delta.hits5XX
+	log.Debugf(
+		"http stats summary: requests_processed=%d(%.2f/s) requests_missed=%d(%.2f/s) requests_dropped=%d(%.2f/s) requests_rejected=%d(%.2f/s) requests_malformed=%d(%.2f/s) aggregations=%d",
+		totalRequests,
+		float64(totalRequests)/float64(delta.elapsed),
+		delta.misses,
+		float64(delta.misses)/float64(delta.elapsed),
+		delta.dropped,
+		float64(delta.dropped)/float64(delta.elapsed),
+		delta.rejected,
+		float64(delta.rejected)/float64(delta.elapsed),
+		delta.malformed,
+		float64(delta.malformed)/float64(delta.elapsed),
+		delta.aggregations,
+	)
+
 	return *delta
 }
 
 func (t *telemetry) report() map[string]interface{} {
-	stats := t.reporter.Report()
-
-	misses := stats["misses"].(int64)
-	dropped := stats["dropped"].(int64)
-	rejected := stats["rejected"].(int64)
-	aggregations := stats["aggregations"].(int64)
-	totalRequests := stats["hits1_xx"].(int64) + stats["hits2_xx"].(int64) + stats["hits3_xx"].(int64) + stats["hits4_xx"].(int64) + stats["hits5_xx"].(int64)
-
-	log.Debugf(
-		"http stats summary: requests_processed=%d(%.2f/s) requests_missed=%d(%.2f/s) requests_dropped=%d(%.2f/s) requests_rejected=%d(%.2f/s) requests_malformed=%d(%.2f/s) aggregations=%d",
-		totalRequests,
-		float64(totalRequests)/float64(t.elapsed),
-		misses,
-		float64(misses)/float64(t.elapsed),
-		dropped,
-		float64(dropped)/float64(t.elapsed),
-		rejected,
-		float64(rejected)/float64(t.elapsed),
-		t.malformed,
-		float64(t.malformed)/float64(t.elapsed),
-		aggregations,
-	)
-
-	return stats
+	return t.reporter.Report()
 }


### PR DESCRIPTION
### What does this PR do?

* Ensure that HTTP stats are logged only once during each network check (every 30s);
* Remove unnecessary ticker from `http.Monitor` event loop. This is an artifact from the PoC made long time ago and was left in place for no reason. Removing it doesn't change the semantics of the program, but avoid iterating over HTTP eBPF maps multiple times;

### Motivation

HTTP monitoring is currently emitting duplicate log entries:
```
2022-05-25 13:13:38 UTC | SYS-PROBE | DEBUG | (pkg/network/http/telemetry.go:98 in report) | http stats summary: requests_processed=35552(1185.07/s) requests_missed=0(0.00/s) requests_dropped=0(0.00/s) requests_rejected=0(0.00/s) requests_malformed=0(0.00/s) aggregations=35541
2022-05-25 13:13:38 UTC | SYS-PROBE | DEBUG | (pkg/network/http/telemetry.go:98 in report) | http stats summary: requests_processed=35552(1185.07/s) requests_missed=0(0.00/s) requests_dropped=0(0.00/s) requests_rejected=0(0.00/s) requests_malformed=0(0.00/s) aggregations=35541
```

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

* Start system-probe with HTTP monitoring enabled and log level set to `debug`:
```
system_probe_config:
  log_level: debug
network_config:
  enabled: true
  enable_http_monitoring: true
```
* Wait until a connection check is made
* Verify that only one `http stats summary` log entry is emitted;

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
