### PR TITLE
[kitchen] Add Ubuntu x64 22.04 tests

### DIFF
--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -41,7 +41,6 @@ kitchen_test_security_agent_x64:
         KITCHEN_OSVERS: "ubuntu-20-04,ubuntu-20-04-2"
       - KITCHEN_PLATFORM: "ubuntu"
         KITCHEN_OSVERS: "ubuntu-21-10,ubuntu-22-04"
-        KITCHEN_SKIP_MANUAL_SSH_KEY: "true"
       - KITCHEN_PLATFORM: "suse"
         KITCHEN_OSVERS: "sles-12,sles-15"
       - KITCHEN_PLATFORM: "suse"

--- a/.gitlab/kitchen_testing/ubuntu.yml
+++ b/.gitlab/kitchen_testing/ubuntu.yml
@@ -20,8 +20,8 @@
 
 .kitchen_scenario_ubuntu_a6_x64:
   variables:
-    KITCHEN_OSVERS: "ubuntu-14-04,ubuntu-16-04,ubuntu-18-04,ubuntu-20-04"
-    DEFAULT_KITCHEN_OSVERS: "ubuntu-20-04"
+    KITCHEN_OSVERS: "ubuntu-14-04,ubuntu-16-04,ubuntu-18-04,ubuntu-20-04,ubuntu-22-04"
+    DEFAULT_KITCHEN_OSVERS: "ubuntu-22-04"
   extends:
     - .kitchen_agent_a6
     - .kitchen_os_ubuntu
@@ -30,8 +30,8 @@
 
 .kitchen_scenario_ubuntu_a7_x64:
   variables:
-    KITCHEN_OSVERS: "ubuntu-14-04,ubuntu-16-04,ubuntu-18-04,ubuntu-20-04"
-    DEFAULT_KITCHEN_OSVERS: "ubuntu-20-04"
+    KITCHEN_OSVERS: "ubuntu-14-04,ubuntu-16-04,ubuntu-18-04,ubuntu-20-04,ubuntu-22-04"
+    DEFAULT_KITCHEN_OSVERS: "ubuntu-22-04"
   extends:
     - .kitchen_agent_a7
     - .kitchen_os_ubuntu

--- a/test/kitchen/drivers/azure-driver.yml
+++ b/test/kitchen/drivers/azure-driver.yml
@@ -111,6 +111,15 @@ platforms:
         size = sizes[idx % sizes.length]
       end
 
+      # Check if we should use an ed25519 key, an rsa key or the default key
+      # Some newer platforms don't support rsa, while some older platforms don't support ed25519
+      # In Azure, ed25519 is not supported, but the default key created by the driver works
+      default_key_platforms = ["ubuntu-22-04"]
+      use_default_key = default_key_platforms.any? { |p| platform_name.include?(p) }
+
+      ed25519_platforms = []
+      use_ed25519 = ed25519_platforms.any? { |p| platform_name.include?(p) }
+
       vm_username = ENV['VM_USERNAME'] ? ENV['VM_USERNAME'] : "datadog"
       vm_password = ENV['SERVER_PASSWORD']
 
@@ -154,8 +163,12 @@ platforms:
     <% else %>
     connection_retries: 30
     connection_retry_sleep: 2
-    <% unless ENV['KITCHEN_SKIP_MANUAL_SSH_KEY'] %>
-    ssh_key: <%= ENV['KITCHEN_SSH_KEY_PATH'] %>
+    <% if use_default_key %>
+    ssh_key:
+    <% elsif use_ed25519 %>
+    ssh_key: <%= ENV['KITCHEN_ED25519_SSH_KEY_PATH'] %>
+    <% else %>
+    ssh_key: <%= ENV['KITCHEN_RSA_SSH_KEY_PATH'] %>
     <% end %>
     <% end %>
 

--- a/test/kitchen/drivers/ec2-driver.yml
+++ b/test/kitchen/drivers/ec2-driver.yml
@@ -18,7 +18,7 @@ provisioner:
 
 driver:
   name: ec2
-  aws_ssh_key_id: <%= ENV['KITCHEN_EC2_SSH_ID'] %>
+  aws_ssh_key_id: <%= ENV['KITCHEN_EC2_SSH_KEY_ID'] %>
   security_group_ids: <%= [ENV['KITCHEN_EC2_SG_IDS']] || ["sg-7fedd80a","sg-46506837"] %>
   region: <%= ENV['KITCHEN_EC2_REGION'] ||= "us-east-1" %>
   instance_type: <%= ENV['KITCHEN_EC2_INSTANCE_TYPE'] ||= 't3.xlarge' %>
@@ -98,6 +98,6 @@ platforms:
     <% if sles15 %>
     username: ec2-user
     <% end %>
-    ssh_key: <%= ENV['KITCHEN_EC2_SSH_KEY'] %>
+    ssh_key: <%= ENV['KITCHEN_EC2_SSH_KEY_PATH'] %>
 
 <% end %>

--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -73,7 +73,8 @@
                 "ubuntu-20-04": "ami-0b75998a97c952252",
                 "ubuntu-20-04-2": "ami-0a82127206c2824a1",
                 "ubuntu-21-04": "ami-044f0ceee8e885e87",
-                "ubuntu-21-10": "ami-0419d418f41aa4a0f"
+                "ubuntu-21-10": "ami-0419d418f41aa4a0f",
+                "ubuntu-22-04": "ami-02ddaf75821f25213"
             }
         },
         "vagrant": {

--- a/test/kitchen/tasks/run-test-kitchen.sh
+++ b/test/kitchen/tasks/run-test-kitchen.sh
@@ -14,17 +14,26 @@ if [ -f "$(pwd)/ssh-key.pub" ]; then
   rm ssh-key.pub
 fi
 
-ssh-keygen -f "$(pwd)/ssh-key" -P "" -t rsa -b 2048
-KITCHEN_SSH_KEY_PATH="$(pwd)/ssh-key"
-export KITCHEN_SSH_KEY_PATH
+ssh-keygen -f "$(pwd)/ed25519-key" -P "" -a 100 -t ed25519
+KITCHEN_ED25519_SSH_KEY_PATH="$(pwd)/ed25519-key"
+export KITCHEN_ED25519_SSH_KEY_PATH
 
-# show that the ssh key is there
-echo "$(pwd)/ssh-key"
-echo "$KITCHEN_SSH_KEY_PATH"
+# show that the ed25519 ssh key is there
+echo "$(pwd)/ed25519-key"
+echo "$KITCHEN_ED25519_SSH_KEY_PATH"
 
-# start the ssh-agent and add the key
+ssh-keygen -f "$(pwd)/rsa-key" -P "" -t rsa -b 2048
+KITCHEN_RSA_SSH_KEY_PATH="$(pwd)/rsa-key"
+export KITCHEN_RSA_SSH_KEY_PATH
+
+# show that the rsa ssh key is there
+echo "$(pwd)/rsa-key"
+echo "$KITCHEN_RSA_SSH_KEY_PATH"
+
+# start the ssh-agent and add the keys
 eval "$(ssh-agent -s)"
-ssh-add "$KITCHEN_SSH_KEY_PATH"
+ssh-add "$KITCHEN_RSA_SSH_KEY_PATH"
+ssh-add "$KITCHEN_ED25519_SSH_KEY_PATH"
 
 # in docker we cannot interact to do this so we must disable it
 mkdir -p ~/.ssh

--- a/test/kitchen/uservars-example.json
+++ b/test/kitchen/uservars-example.json
@@ -18,9 +18,9 @@
     "ec2" : {
         "comment-ec2-vars": "Variables specific to the hyper-v driver",
         "comment_SSH_KEY": "path to ssh key used to create instances",
-        "KITCHEN_EC2_SSH_KEY" : "<filename>",
+        "KITCHEN_EC2_SSH_KEY_PATH" : "<filename>",
         "comment_SSH_ID": "friendly name in EC2 associated with above ssh key",
-        "KITCHEN_EC2_SSH_ID" : "derek-sandbox-2",
+        "KITCHEN_EC2_SSH_KEY_ID" : "derek-sandbox-2",
         "KITCHEN_EC2_TAG_CREATOR" : "db"
     },
     "azure" : {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Adds Ubuntu 22.04 x64 tests to kitchen.

Modifies the test suites generation to automatically detect whether an rsa, ed25519, or the default key created by kitchen, should be used, depending on the target platforms.

Renames some EC2 driver variables for consistency.

Note: Ubuntu 22.04 arm64 tests can be added once https://github.com/test-kitchen/kitchen-ec2/pull/583 is merged and released (to support ed25519 key creation).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

More kitchen test coverage, remove manual variables to decide if a platform should use the default SSH keys or the generated ones.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Some new OS versions like Ubuntu 22.04 reject rsa keys, so they can't be used.
Azure currently doesn't accept ed25519 keys, so they can't be used.
As a result, only the automatic key creation done by kitchen works, so we have to use it for now.

On EC2, we rely on the automatic key generation done by the driver when the VM is created, but for now it only supports rsa. The alternative would be manually creating an ed25519 key, uploading the public part to AWS, the private part in SSM, and then retrieving it in kitchen jobs to use it.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
