### PR TITLE
Use go.uber.org/atomic in pkg/security/module/module.go

### DIFF
--- a/pkg/security/module/module.go
+++ b/pkg/security/module/module.go
@@ -18,7 +18,6 @@ import (
 	"os/signal"
 	"path/filepath"
 	"sync"
-	"sync/atomic"
 	"syscall"
 	"time"
 	"unsafe"
@@ -27,6 +26,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/skydive-project/go-debouncer"
+	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 
 	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
@@ -60,8 +60,8 @@ type Module struct {
 	wg                 sync.WaitGroup
 	probe              *sprobe.Probe
 	config             *sconfig.Config
-	currentRuleSet     atomic.Value
-	reloading          uint64
+	currentRuleSet     *atomic.Value
+	reloading          *atomic.Bool
 	statsdClient       statsd.ClientInterface
 	apiServer          *APIServer
 	grpcServer         *grpc.Server
@@ -294,8 +294,8 @@ func (m *Module) Reload(policiesDir string) error {
 	m.Lock()
 	defer m.Unlock()
 
-	atomic.StoreUint64(&m.reloading, 1)
-	defer atomic.StoreUint64(&m.reloading, 0)
+	m.reloading.Store(true)
+	defer m.reloading.Store(false)
 
 	rsa := sprobe.NewRuleSetApplier(m.config, m.probe)
 
@@ -415,7 +415,7 @@ func (m *Module) Close() {
 
 // EventDiscarderFound is called by the ruleset when a new discarder discovered
 func (m *Module) EventDiscarderFound(rs *rules.RuleSet, event eval.Event, field eval.Field, eventType eval.EventType) {
-	if atomic.LoadUint64(&m.reloading) == 1 {
+	if m.reloading.Load() {
 		return
 	}
 
@@ -585,16 +585,18 @@ func NewModule(cfg *sconfig.Config, opts ...Opts) (module.Module, error) {
 	var selfTester = sprobe.NewSelfTester()
 
 	m := &Module{
-		config:       cfg,
-		probe:        probe,
-		statsdClient: statsdClient,
-		apiServer:    NewAPIServer(cfg, probe, statsdClient),
-		grpcServer:   grpc.NewServer(),
-		rateLimiter:  NewRateLimiter(statsdClient, LimiterOpts{Limits: limits}),
-		sigupChan:    make(chan os.Signal, 1),
-		ctx:          ctx,
-		cancelFnc:    cancelFnc,
-		selfTester:   selfTester,
+		config:         cfg,
+		probe:          probe,
+		currentRuleSet: new(atomic.Value),
+		reloading:      atomic.NewBool(false),
+		statsdClient:   statsdClient,
+		apiServer:      NewAPIServer(cfg, probe, statsdClient),
+		grpcServer:     grpc.NewServer(),
+		rateLimiter:    NewRateLimiter(statsdClient, LimiterOpts{Limits: limits}),
+		sigupChan:      make(chan os.Signal, 1),
+		ctx:            ctx,
+		cancelFnc:      cancelFnc,
+		selfTester:     selfTester,
 	}
 	m.apiServer.module = m
 	m.reloader = debouncer.New(3*time.Second, m.triggerReload)


### PR DESCRIPTION
### What does this PR do?

Uses go.uber.com/atomic to ensure alignment of atomic access in pkg/security/module/module.go

*NOTE*: I don't think this atomic access is required.  https://github.com/DataDog/datadog-agent/pull/8675 added a RWLock around every access to this map, meaning that concurrent access would not occur.  @paulcacheux can you verify that?  If so, I'll revise to drop the atomic access in this PR.  (this is why I've separated this PR from #12166)

### Motivation

Alignment issues with atomic access.  See #11716 

### Additional Notes

This is a pretty trivial change, but this module is not covered by tests, so needs additional scrutiny.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

QA this along with #12166.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
