### PR TITLE
[Serverless] support DD_SERVICE, DD_ENV and DD_VERSION for CloudRun

### DIFF
--- a/cmd/serverless-init/initcontainer/initcontainer.go
+++ b/cmd/serverless-init/initcontainer/initcontainer.go
@@ -85,7 +85,7 @@ func handleSignals(process *os.Process, config *log.Config, metricAgent *metrics
 				}
 			}
 			if sig == syscall.SIGTERM {
-				metric.AddShutdownMetric(tag.GetBaseTags(), time.Now(), metricAgent.Demux)
+				metric.AddShutdownMetric(tag.GetBaseTagsArray(), time.Now(), metricAgent.Demux)
 			}
 		}
 	}()

--- a/cmd/serverless-init/initcontainer/initcontainer.go
+++ b/cmd/serverless-init/initcontainer/initcontainer.go
@@ -39,7 +39,7 @@ func Run(logConfig *log.Config, metricAgent *metrics.ServerlessMetricAgent, trac
 }
 
 func execute(config *log.Config, metricAgent *metrics.ServerlessMetricAgent, traceAgent *trace.ServerlessTraceAgent, args []string) error {
-	commandName, commandArgs := buildCommandParam(args[0])
+	commandName, commandArgs := buildCommandParam(args)
 	cmd := exec.Command(commandName, commandArgs...)
 	cmd.Stdout = &log.CustomWriter{
 		LogConfig: config,
@@ -57,8 +57,11 @@ func execute(config *log.Config, metricAgent *metrics.ServerlessMetricAgent, tra
 	return err
 }
 
-func buildCommandParam(cmdArg string) (string, []string) {
-	fields := strings.Fields(cmdArg)
+func buildCommandParam(cmdArg []string) (string, []string) {
+	fields := cmdArg
+	if len(cmdArg) == 1 {
+		fields = strings.Fields(cmdArg[0])
+	}
 	commandName := fields[0]
 	if len(fields) > 1 {
 		return commandName, fields[1:]

--- a/cmd/serverless-init/initcontainer/initcontainer_test.go
+++ b/cmd/serverless-init/initcontainer/initcontainer_test.go
@@ -17,13 +17,13 @@ import (
 )
 
 func TestBuildCommandParamWithArgs(t *testing.T) {
-	name, args := buildCommandParam("superCmd --verbose path -i .")
+	name, args := buildCommandParam([]string{"superCmd", "--verbose", "path", "-i", "."})
 	assert.Equal(t, "superCmd", name)
 	assert.Equal(t, []string{"--verbose", "path", "-i", "."}, args)
 }
 
 func TestBuildCommandParam(t *testing.T) {
-	name, args := buildCommandParam("superCmd")
+	name, args := buildCommandParam([]string{"superCmd"})
 	assert.Equal(t, "superCmd", name)
 	assert.Equal(t, []string{}, args)
 }

--- a/cmd/serverless-init/log/log.go
+++ b/cmd/serverless-init/log/log.go
@@ -73,7 +73,7 @@ func SetupLog(conf *Config) {
 		}
 	}
 	serverlessLogs.SetupLogAgent(conf.channel, sourceName, source)
-	serverlessLogs.SetLogsTags(getTagsWithRevision(tag.GetBaseTags(), conf.containerID))
+	serverlessLogs.SetLogsTags(getTagsWithRevision(tag.GetBaseTagsArray(), conf.containerID))
 }
 
 func getTagsWithRevision(tags []string, containerID string) []string {

--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -37,13 +37,14 @@ func main() {
 	go setupTraceAgent(traceAgent)
 
 	metricAgent := setupMetricAgent()
-	metric.AddColdStartMetric(tag.GetBaseTags(), time.Now(), metricAgent.Demux)
+	metric.AddColdStartMetric(tag.GetBaseTagsArray(), time.Now(), metricAgent.Demux)
 	go metricAgent.Flush()
 	initcontainer.Run(logConfig, metricAgent, traceAgent, os.Args[1:])
 }
 
 func setupTraceAgent(traceAgent *trace.ServerlessTraceAgent) {
 	traceAgent.Start(config.Datadog.GetBool("apm_config.enabled"), &trace.LoadConfig{Path: datadogConfigPath})
+	traceAgent.SetTags(tag.GetBaseTagsMap())
 	for range time.Tick(3 * time.Second) {
 		traceAgent.Get().FlushSync()
 	}

--- a/cmd/serverless-init/tag/tag.go
+++ b/cmd/serverless-init/tag/tag.go
@@ -11,12 +11,56 @@ import (
 	"strings"
 )
 
-func GetBaseTags() []string {
-	if len(os.Getenv("K_SERVICE")) > 0 && len(os.Getenv("K_REVISION")) > 0 {
-		return []string{
-			fmt.Sprintf("revision:%s", strings.ToLower(os.Getenv("K_REVISION"))),
-			fmt.Sprintf("service:%s", strings.ToLower(os.Getenv("K_SERVICE"))),
+type tagPair struct {
+	name    string
+	envName string
+}
+
+func getTag(envName string) (string, bool) {
+	value := os.Getenv(envName)
+	if len(value) == 0 {
+		return "", false
+	}
+	return strings.ToLower(value), true
+}
+
+func GetBaseTagsMap() map[string]string {
+	tags := map[string]string{}
+	listTags := []tagPair{
+		{
+			name:    "cloudrunrevision",
+			envName: "K_REVISION",
+		},
+		{
+			name:    "cloudrunservice",
+			envName: "K_SERVICE",
+		},
+		{
+			name:    "env",
+			envName: "DD_ENV",
+		},
+		{
+			name:    "service",
+			envName: "DD_SERVICE",
+		},
+		{
+			name:    "version",
+			envName: "DD_VERSION",
+		},
+	}
+	for _, tagPair := range listTags {
+		if value, found := getTag(tagPair.envName); found {
+			tags[tagPair.name] = value
 		}
 	}
-	return []string{}
+	return tags
+}
+
+func GetBaseTagsArray() []string {
+	tagsMap := GetBaseTagsMap()
+	tagsArray := make([]string, 0, len(tagsMap))
+	for key, value := range tagsMap {
+		tagsArray = append(tagsArray, fmt.Sprintf("%s:%s", key, value))
+	}
+	return tagsArray
 }

--- a/cmd/serverless-init/tag/tag_test.go
+++ b/cmd/serverless-init/tag/tag_test.go
@@ -12,17 +12,64 @@ import (
 	"gotest.tools/assert"
 )
 
-func TestGetBaseTagsNoEnv(t *testing.T) {
-	assert.Equal(t, 0, len(GetBaseTags()))
+func TestGetBaseTagsArrayNoEnv(t *testing.T) {
+	assert.Equal(t, 0, len(GetBaseTagsArray()))
 }
 
-func TestGetBaseTags(t *testing.T) {
+func TestGetBaseTagsArray(t *testing.T) {
 	os.Setenv("K_SERVICE", "myService")
 	defer os.Unsetenv("K_SERVICE")
 	os.Setenv("K_REVISION", "FDGF34")
 	defer os.Unsetenv("K_REVISION")
-	tags := GetBaseTags()
-	assert.Equal(t, 2, len(tags))
-	assert.Equal(t, "revision:fdgf34", tags[0])
-	assert.Equal(t, "service:myservice", tags[1])
+	os.Setenv("DD_ENV", "myEnv")
+	defer os.Unsetenv("DD_ENV")
+	os.Setenv("DD_SERVICE", "superService")
+	defer os.Unsetenv("DD_SERVICE")
+	os.Setenv("DD_VERSION", "123.4")
+	defer os.Unsetenv("DD_VERSION")
+	tags := GetBaseTagsArray()
+	assert.Equal(t, 5, len(tags))
+	assert.Equal(t, "cloudrunrevision:fdgf34", tags[0])
+	assert.Equal(t, "cloudrunservice:myservice", tags[1])
+	assert.Equal(t, "env:myenv", tags[2])
+	assert.Equal(t, "service:superservice", tags[3])
+	assert.Equal(t, "version:123.4", tags[4])
+}
+
+func TestGetTagFound(t *testing.T) {
+	os.Setenv("TOTO", "coucou")
+	defer os.Unsetenv("TOTO")
+	value, found := getTag("TOTO")
+	assert.Equal(t, true, found)
+	assert.Equal(t, "coucou", value)
+}
+
+func TestGetTagNotFound(t *testing.T) {
+	value, found := getTag("XXX")
+	assert.Equal(t, false, found)
+	assert.Equal(t, "", value)
+}
+
+func TestGetBaseTagsMapNoEnv(t *testing.T) {
+	assert.Equal(t, 0, len(GetBaseTagsMap()))
+}
+
+func TestGetBaseTagsMap(t *testing.T) {
+	os.Setenv("K_SERVICE", "myService")
+	defer os.Unsetenv("K_SERVICE")
+	os.Setenv("K_REVISION", "FDGF34")
+	defer os.Unsetenv("K_REVISION")
+	os.Setenv("DD_ENV", "myEnv")
+	defer os.Unsetenv("DD_ENV")
+	os.Setenv("DD_SERVICE", "superService")
+	defer os.Unsetenv("DD_SERVICE")
+	os.Setenv("DD_VERSION", "123.4")
+	defer os.Unsetenv("DD_VERSION")
+	tags := GetBaseTagsMap()
+	assert.Equal(t, 5, len(tags))
+	assert.Equal(t, "fdgf34", tags["cloudrunrevision"])
+	assert.Equal(t, "myservice", tags["cloudrunservice"])
+	assert.Equal(t, "myenv", tags["env"])
+	assert.Equal(t, "superservice", tags["service"])
+	assert.Equal(t, "123.4", tags["version"])
 }


### PR DESCRIPTION
### What does this PR do?

Add support for DD_ENV, DD_SERVICE and DD_VERSION for CloudRun
<img width="664" alt="Screen Shot 2022-05-26 at 10 49 21 AM" src="https://user-images.githubusercontent.com/864493/170513608-0d881f63-25f6-41dc-98c4-824c270fc2c0.png">
<img width="715" alt="Screen Shot 2022-05-26 at 10 49 03 AM" src="https://user-images.githubusercontent.com/864493/170513612-c340825e-d698-44f4-8eb5-14cd0c6262ac.png">
<img width="709" alt="Screen Shot 2022-05-26 at 10 48 48 AM" src="https://user-images.githubusercontent.com/864493/170513615-f571e7a5-fb67-42a9-b42a-f3f4b2e1f3ed.png">

Note : datadog.yaml config file is not yet supported (nor DD_TAGS/DD_EXTRA_TAGS)


### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
