### PR TITLE
Check for read and execute permissions on docker directory

### DIFF
--- a/pkg/logs/internal/launchers/docker/launcher_nix.go
+++ b/pkg/logs/internal/launchers/docker/launcher_nix.go
@@ -27,7 +27,7 @@ func checkReadAccess() error {
 	if coreConfig.Datadog.GetBool("logs_config.use_podman_logs") {
 		path = podmanBasePath
 	}
-	err := unix.Access(path, unix.X_OK)
+	err := unix.Access(path, unix.R_OK|unix.X_OK)
 	if err != nil {
 		return fmt.Errorf("Error accessing %s: %w", path, err)
 	}


### PR DESCRIPTION
checkReadAccess used to check for just execute access, but reading a
directory requires both R and X, so the function should check for both.


### Motivation

Fixes #11473.

### Describe how to test/QA your changes

The condition where the old code failed is unusual.  QA should primarily verify only that there is no regression.  Run the agent on a host with Docker installed, after verifying that `/var/lib/docker` is owned by root:root, and that the user running the agent is not root or in the root group.  Enable `logs_config.container_collect_all` and create a container.  Check in `agent status` that the container is logged with the docker socket (Inputs: SHA) and not a file (Path: ...).

With that in place, add `x` permission on the directory (`sudo chmod o+x /var/lib/docker`) and verify the behavior is the same.  Don't forget to reset that permission.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
