### PR TITLE
Correctly unschedule all sources for a multi-source config

### DIFF
--- a/pkg/logs/schedulers/ad/scheduler.go
+++ b/pkg/logs/schedulers/ad/scheduler.go
@@ -27,18 +27,15 @@ import (
 //
 // This type implements  pkg/logs/schedulers.Scheduler.
 type Scheduler struct {
-	mgr                schedulers.SourceManager
-	listener           *adlistener.ADListener
-	sourcesByServiceID map[string]*logsConfig.LogSource
+	mgr      schedulers.SourceManager
+	listener *adlistener.ADListener
 }
 
 var _ schedulers.Scheduler = &Scheduler{}
 
 // New creates a new scheduler.
 func New(ac *autodiscovery.AutoConfig) schedulers.Scheduler {
-	sch := &Scheduler{
-		sourcesByServiceID: make(map[string]*logsConfig.LogSource),
-	}
+	sch := &Scheduler{}
 	sch.listener = adlistener.NewADListener("logs-agent AD scheduler", ac, sch.Schedule, sch.Unschedule)
 	return sch
 }
@@ -78,7 +75,6 @@ func (s *Scheduler) Schedule(configs []integration.Config) {
 			}
 			for _, source := range sources {
 				s.mgr.AddSource(source)
-				s.sourcesByServiceID[source.Config.Identifier] = source
 			}
 		case s.newService(config):
 			entityType, _, err := s.parseEntity(config.TaggerEntity)
@@ -119,9 +115,19 @@ func (s *Scheduler) Unschedule(configs []integration.Config) {
 				log.Warnf("Invalid configuration: %v", err)
 				continue
 			}
-			if source, found := s.sourcesByServiceID[identifier]; found {
-				delete(s.sourcesByServiceID, identifier)
-				s.mgr.RemoveSource(source)
+
+			// remove all the sources for this ServiceID.  This makes the
+			// implicit, and not-quite-correct assumption that we only ever
+			// receive one config for a given ServiceID, and that it generates
+			// the same sources.
+			//
+			// This may also remove sources not added by this scheduler, for
+			// example sources added by other schedulers or sources added by
+			// launchers.
+			for _, source := range s.mgr.GetSources() {
+				if identifier == source.Config.Identifier {
+					s.mgr.RemoveSource(source)
+				}
 			}
 		case s.newService(config):
 			// new service to remove

--- a/pkg/logs/schedulers/ad/scheduler_test.go
+++ b/pkg/logs/schedulers/ad/scheduler_test.go
@@ -141,7 +141,7 @@ func TestUnscheduleConfigRemovesSource(t *testing.T) {
 
 	// We need to have a source to remove
 	sources, _ := scheduler.toSources(configSource)
-	scheduler.sourcesByServiceID[sources[0].Config.Identifier] = sources[0]
+	spy.Sources = sources
 
 	scheduler.Unschedule([]integration.Config{configSource})
 

--- a/pkg/logs/schedulers/source_manager.go
+++ b/pkg/logs/schedulers/source_manager.go
@@ -19,6 +19,8 @@ type sourceManager struct {
 	services *service.Services
 }
 
+var _ SourceManager = &sourceManager{}
+
 // AddSource implements SourceManager#AddSource.
 func (sm *sourceManager) AddSource(source *logsConfig.LogSource) {
 	sm.sources.AddSource(source)
@@ -27,6 +29,11 @@ func (sm *sourceManager) AddSource(source *logsConfig.LogSource) {
 // RemoveSource implements SourceManager#RemoveSource.
 func (sm *sourceManager) RemoveSource(source *logsConfig.LogSource) {
 	sm.sources.RemoveSource(source)
+}
+
+// GetSources implements SourceManager#GetSources.
+func (sm *sourceManager) GetSources() []*logsConfig.LogSource {
+	return sm.sources.GetSources()
 }
 
 // AddService implements SourceManager#AddService.
@@ -59,7 +66,12 @@ type MockAddRemove struct {
 type MockSourceManager struct {
 	// Events are the events that occurred in the spy
 	Events []MockAddRemove
+
+	// Sources are the sources returned by GetSources
+	Sources []*logsConfig.LogSource
 }
+
+var _ SourceManager = &MockSourceManager{}
 
 // AddSource implements SourceManager#AddSource.
 func (sm *MockSourceManager) AddSource(source *logsConfig.LogSource) {
@@ -69,6 +81,13 @@ func (sm *MockSourceManager) AddSource(source *logsConfig.LogSource) {
 // RemoveSource implements SourceManager#RemoveSource.
 func (sm *MockSourceManager) RemoveSource(source *logsConfig.LogSource) {
 	sm.Events = append(sm.Events, MockAddRemove{Add: false, Source: source})
+}
+
+// GetSources implements SourceManager#GetSources.
+func (sm *MockSourceManager) GetSources() []*logsConfig.LogSource {
+	sources := make([]*logsConfig.LogSource, len(sm.Sources))
+	copy(sources, sm.Sources)
+	return sources
 }
 
 // AddService implements SourceManager#AddService.

--- a/pkg/logs/schedulers/types.go
+++ b/pkg/logs/schedulers/types.go
@@ -36,6 +36,11 @@ type SourceManager interface {
 	// source is recognized by pointer equality.
 	RemoveSource(source *logsConfig.LogSource)
 
+	// GetSources returns all the sources currently held.  The result is copied and
+	// will not be modified after it is returned, and represents a "snapshot" of the
+	// state when the function was called.
+	GetSources() []*logsConfig.LogSource
+
 	// AddService adds a new service to the logs agent.
 	AddService(service *service.Service)
 


### PR DESCRIPTION
### What does this PR do?

Reverts the logs-agent scheduler's approach to removing sources back to that of 7.35.0.

### Motivation

Bug discovered with 
```
docker run --rm \
  -v /tmp/share:/tmp/share  \
  -l com.datadoghq.ad.logs='[{"type":"file","path":"/tmp/share/test.log"},{"type":"docker"}]' \
  mingrammer/flog /bin/flog -f apache_error -o /tmp/share/test.log -d 1 -t log
```

where the file source remains even after the container exits.

This was a regression in 7.36.

### Additional Notes

### Possible Drawbacks / Trade-offs

There is an issue with this approach, present in 7.35.0 as well: the scheduler removes _all_ sources with a matching identifier, even if it didn't schedule them, or scheduled them for a different config.  We can address that shortcoming in the future.

### Describe how to test/QA your changes

See AML-174 for details.  Basically, run the agent in a docker-standalone environment and start a container as described above, then stop the container.  Observe in `agent status` that all of the log sources are gone.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
