### PR TITLE
pkg/trace/api: normalize span name before remapping for OTLP

### DIFF
--- a/pkg/trace/api/otlp.go
+++ b/pkg/trace/api/otlp.go
@@ -509,6 +509,13 @@ func (o *OTLPReceiver) convertSpan(rattr map[string]string, lib pcommon.Instrume
 				name = "opentelemetry." + name
 			}
 		}
+
+		normalized, err := traceutil.NormalizeName(name)
+		if err != nil {
+			log.Warnf("failed to normalize span name, use default span name: %v", err)
+		}
+		name = normalized
+
 		if v, ok := o.conf.OTLPReceiver.SpanNameRemappings[name]; ok {
 			name = v
 		}

--- a/releasenotes/notes/apm-otlp-normalize-span-name-before-remapping-15fa7e8767cea706.yaml
+++ b/releasenotes/notes/apm-otlp-normalize-span-name-before-remapping-15fa7e8767cea706.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    APM OTLP: Normalize span name before remapping for OTLP

--- a/releasenotes/notes/apm-otlp-normalize-span-name-before-remapping-15fa7e8767cea706.yaml
+++ b/releasenotes/notes/apm-otlp-normalize-span-name-before-remapping-15fa7e8767cea706.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    APM OTLP: Normalize span name before remapping for OTLP
+    APM OTLP: Normalize span name before remapping for OTLP.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This pull request adds span name normalization before remapping for OTLP.

### Motivation

While trying https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/9693 I found that it will change the `span_name_remappings`'s behavior.

For example, if we have the following setting in otel-collector config:

```
...
      span_name_remappings: 
        go.opentelemetry.io_contrib_instrumentation_net_http_otelhttp.client: http.client

...
```

and if the OpenTelemetry library is `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp`, the current `datadogexporter` can properly remap the name to `http.client`.

However, if we use `pkg/trace` in `datadogexporter` (https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/9693), it doesn't remap because of missing the normalization.

I think `span_name_remappings`'s behavior should be compatible after the change (https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/9693)


### Additional Notes

- https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/9693
- https://github.com/DataDog/datadog-agent/pull/11548
- `span_name_remappings` example: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/143cafc3c376c627058209334d50ecf97ed7b205/exporter/datadogexporter/example/config.yaml#L199-L202

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
