### PR TITLE
Fix a spammy error log

### DIFF
--- a/pkg/autodiscovery/configresolver/configresolver.go
+++ b/pkg/autodiscovery/configresolver/configresolver.go
@@ -450,14 +450,16 @@ func tagsAdder(tags []string) func(interface{}) error {
 		if typedTree, ok := tree.(map[interface{}]interface{}); ok {
 			// Use a set to remove duplicates
 			tagSet := make(map[string]struct{})
-			if tagList, ok := typedTree["tags"].([]interface{}); !ok {
-				log.Errorf("Wrong type for `tags` in config. Expected []interface{}, got %T", typedTree["tags"])
-			} else {
-				for _, tag := range tagList {
-					if t, ok := tag.(string); !ok {
-						log.Errorf("Wrong type for tag \"%#v\". Expected string, got %T", tag, tag)
-					} else {
-						tagSet[t] = struct{}{}
+			if typedTreeTags, ok := typedTree["tags"]; ok {
+				if tagList, ok := typedTreeTags.([]interface{}); !ok {
+					log.Errorf("Wrong type for `tags` in config. Expected []interface{}, got %T", typedTree["tags"])
+				} else {
+					for _, tag := range tagList {
+						if t, ok := tag.(string); !ok {
+							log.Errorf("Wrong type for tag \"%#v\". Expected string, got %T", tag, tag)
+						} else {
+							tagSet[t] = struct{}{}
+						}
 					}
 				}
 			}


### PR DESCRIPTION
### What does this PR do?

Remove a spammy error log generated each time the agent parses a check config which doesn’t specify any check-specific `tags`.

### Motivation

#12161 generates a lot of spammy error logs like:
```
2022-05-27 09:48:19 UTC | CORE | ERROR | (pkg/autodiscovery/configresolver/configresolver.go:454 in func1) | Wrong type for `tags` in config. Expected []interface{}, got <nil>
```

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Follow the same QA instructions as the one provided in #12161 and additionally check that the agent doesn’t generate tons of `Wrong type for 'tags' in config` errors in logs.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
