### PR TITLE
[workloadmeta/filter] Allow filtering by event type

### DIFF
--- a/pkg/autodiscovery/listeners/container.go
+++ b/pkg/autodiscovery/listeners/container.go
@@ -43,6 +43,7 @@ func NewContainerListener(Config) (ServiceListener, error) {
 	f := workloadmeta.NewFilter(
 		[]workloadmeta.Kind{workloadmeta.KindContainer},
 		workloadmeta.SourceRuntime,
+		workloadmeta.EventTypeAll,
 	)
 
 	var err error

--- a/pkg/autodiscovery/listeners/kubelet.go
+++ b/pkg/autodiscovery/listeners/kubelet.go
@@ -38,6 +38,7 @@ func NewKubeletListener(Config) (ServiceListener, error) {
 	f := workloadmeta.NewFilter(
 		[]workloadmeta.Kind{workloadmeta.KindKubernetesPod},
 		workloadmeta.SourceNodeOrchestrator,
+		workloadmeta.EventTypeAll,
 	)
 
 	var err error

--- a/pkg/autodiscovery/providers/container.go
+++ b/pkg/autodiscovery/providers/container.go
@@ -87,6 +87,7 @@ func (d *ContainerConfigProvider) listen() {
 	workloadmetaEventsChannel := d.workloadmetaStore.Subscribe("ad-containerprovider", workloadmeta.NormalPriority, workloadmeta.NewFilter(
 		[]workloadmeta.Kind{workloadmeta.KindContainer},
 		workloadmeta.SourceRuntime,
+		workloadmeta.EventTypeAll,
 	))
 
 	for {

--- a/pkg/autodiscovery/providers/kubelet.go
+++ b/pkg/autodiscovery/providers/kubelet.go
@@ -79,6 +79,7 @@ func (k *KubeletConfigProvider) listen() {
 	ch := k.workloadmetaStore.Subscribe(name, workloadmeta.NormalPriority, workloadmeta.NewFilter(
 		[]workloadmeta.Kind{workloadmeta.KindKubernetesPod},
 		workloadmeta.SourceNodeOrchestrator,
+		workloadmeta.EventTypeAll,
 	))
 
 	for {

--- a/pkg/collector/corechecks/containerlifecycle/check.go
+++ b/pkg/collector/corechecks/containerlifecycle/check.go
@@ -97,6 +97,7 @@ func (c *Check) Run() error {
 		workloadmeta.NewFilter(
 			[]workloadmeta.Kind{workloadmeta.KindContainer},
 			workloadmeta.SourceRuntime,
+			workloadmeta.EventTypeAll,
 		),
 	)
 
@@ -106,6 +107,7 @@ func (c *Check) Run() error {
 		workloadmeta.NewFilter(
 			[]workloadmeta.Kind{workloadmeta.KindKubernetesPod},
 			workloadmeta.SourceNodeOrchestrator,
+			workloadmeta.EventTypeAll,
 		),
 	)
 

--- a/pkg/collector/corechecks/containerlifecycle/check.go
+++ b/pkg/collector/corechecks/containerlifecycle/check.go
@@ -97,7 +97,7 @@ func (c *Check) Run() error {
 		workloadmeta.NewFilter(
 			[]workloadmeta.Kind{workloadmeta.KindContainer},
 			workloadmeta.SourceRuntime,
-			workloadmeta.EventTypeAll,
+			workloadmeta.EventTypeUnset,
 		),
 	)
 
@@ -107,7 +107,7 @@ func (c *Check) Run() error {
 		workloadmeta.NewFilter(
 			[]workloadmeta.Kind{workloadmeta.KindKubernetesPod},
 			workloadmeta.SourceNodeOrchestrator,
-			workloadmeta.EventTypeAll,
+			workloadmeta.EventTypeUnset,
 		),
 	)
 

--- a/pkg/collector/corechecks/containerlifecycle/processor.go
+++ b/pkg/collector/corechecks/containerlifecycle/processor.go
@@ -43,33 +43,26 @@ func (p *processor) processEvents(evBundle workloadmeta.EventBundle) {
 	for _, event := range evBundle.Events {
 		entityID := event.Entity.GetID()
 
-		switch event.Type {
-		case workloadmeta.EventTypeUnset:
-			switch entityID.Kind {
-			case workloadmeta.KindContainer:
-				container, ok := event.Entity.(*workloadmeta.Container)
-				if !ok {
-					log.Debugf("Expected workloadmeta.Container got %T, skipping", event.Entity)
-					continue
-				}
-
-				err := p.processContainer(container, []workloadmeta.Source{workloadmeta.SourceRuntime})
-				if err != nil {
-					log.Debugf("Couldn't process container %q: %v", container.ID, err)
-				}
-			case workloadmeta.KindKubernetesPod:
-				err := p.processPod(event.Entity)
-				if err != nil {
-					log.Debugf("Couldn't process pod %q: %v", event.Entity.GetID().ID, err)
-				}
-			case workloadmeta.KindECSTask: // not supported
-			default:
-				log.Tracef("Cannot handle event for entity %q with kind %q", entityID.ID, entityID.Kind)
+		switch entityID.Kind {
+		case workloadmeta.KindContainer:
+			container, ok := event.Entity.(*workloadmeta.Container)
+			if !ok {
+				log.Debugf("Expected workloadmeta.Container got %T, skipping", event.Entity)
+				continue
 			}
 
-		case workloadmeta.EventTypeSet: // not supported
+			err := p.processContainer(container, []workloadmeta.Source{workloadmeta.SourceRuntime})
+			if err != nil {
+				log.Debugf("Couldn't process container %q: %v", container.ID, err)
+			}
+		case workloadmeta.KindKubernetesPod:
+			err := p.processPod(event.Entity)
+			if err != nil {
+				log.Debugf("Couldn't process pod %q: %v", event.Entity.GetID().ID, err)
+			}
+		case workloadmeta.KindECSTask: // not supported
 		default:
-			log.Tracef("Cannot handle event of type %d", event.Type)
+			log.Tracef("Cannot handle event for entity %q with kind %q", entityID.ID, entityID.Kind)
 		}
 	}
 }

--- a/pkg/workloadmeta/filter.go
+++ b/pkg/workloadmeta/filter.go
@@ -5,18 +5,20 @@
 
 package workloadmeta
 
-// Filter allows a subscriber to filter events by entity kind or event source.
+// Filter allows a subscriber to filter events by entity kind, event source, and
+// event type.
 //
 // A nil filter matches all events.
 type Filter struct {
-	kinds  map[Kind]struct{}
-	source Source
+	kinds     map[Kind]struct{}
+	source    Source
+	eventType EventType
 }
 
 // NewFilter creates a new filter for subscribing to workloadmeta events.
 //
 // Only events for entities with one of the given kinds will be delivered.  If
-// kinds is nil or empty, events for entities of of any kind will be delivered.
+// kinds is nil or empty, events for entities of any kind will be delivered.
 //
 // Similarly, only events for entities collected from the given source will be
 // delivered, and the entities in the events will contain data only from that
@@ -24,7 +26,10 @@ type Filter struct {
 // runtime will be delivered, and they will not contain any additional metadata
 // from orchestrators or cluster orchestrators.  Use SourceAll to collect data
 // from all sources.
-func NewFilter(kinds []Kind, source Source) *Filter {
+//
+// Only events of the given type will be delivered. Use EventTypeAll to collect
+// data from all the event types.
+func NewFilter(kinds []Kind, source Source, eventType EventType) *Filter {
 	var kindSet map[Kind]struct{}
 	if len(kinds) > 0 {
 		kindSet = make(map[Kind]struct{})
@@ -34,8 +39,9 @@ func NewFilter(kinds []Kind, source Source) *Filter {
 	}
 
 	return &Filter{
-		kinds:  kindSet,
-		source: source,
+		kinds:     kindSet,
+		source:    source,
+		eventType: eventType,
 	}
 }
 
@@ -57,6 +63,12 @@ func (f *Filter) MatchSource(source Source) bool {
 	return f.Source() == SourceAll || f.Source() == source
 }
 
+// MatchEventType returns true if the filter matches the passed EventType. If
+// the filter is nil, or has EventTypeAll, it always matches.
+func (f *Filter) MatchEventType(eventType EventType) bool {
+	return f.EventType() == EventTypeAll || f.EventType() == eventType
+}
+
 // Source returns the source this filter is filtering by. If the filter is nil,
 // returns SourceAll.
 func (f *Filter) Source() Source {
@@ -65,4 +77,14 @@ func (f *Filter) Source() Source {
 	}
 
 	return f.source
+}
+
+// EventType returns the event type this filter is filtering by. If the filter
+// is nil, it returns EventTypeAll.
+func (f *Filter) EventType() EventType {
+	if f == nil {
+		return EventTypeAll
+	}
+
+	return f.eventType
 }

--- a/pkg/workloadmeta/store.go
+++ b/pkg/workloadmeta/store.go
@@ -430,7 +430,7 @@ func (s *store) handleEvents(evs []CollectorEvent) {
 
 		for _, sub := range s.subscribers {
 			filter := sub.filter
-			if !filter.MatchKind(entityID.Kind) || !filter.MatchSource(ev.Source) {
+			if !filter.MatchKind(entityID.Kind) || !filter.MatchSource(ev.Source) || !filter.MatchEventType(ev.Type) {
 				// event should be filtered out because it
 				// doesn't match the filter
 				continue

--- a/pkg/workloadmeta/store_example_test.go
+++ b/pkg/workloadmeta/store_example_test.go
@@ -8,7 +8,7 @@ package workloadmeta
 import "fmt"
 
 func ExampleStore_Subscribe() {
-	filter := NewFilter([]Kind{KindContainer}, SourceRuntime)
+	filter := NewFilter([]Kind{KindContainer}, SourceRuntime, EventTypeAll)
 	ch := GetGlobalStore().Subscribe("test", NormalPriority, filter)
 
 	go func() {

--- a/pkg/workloadmeta/store_test.go
+++ b/pkg/workloadmeta/store_test.go
@@ -152,7 +152,7 @@ func TestSubscribe(t *testing.T) {
 			// that don't match the filter at all should not
 			// generate an event.
 			name:   "receive events for entities in the store pre-subscription with filter",
-			filter: NewFilter(nil, fooSource),
+			filter: NewFilter(nil, fooSource, EventTypeAll),
 			preEvents: []CollectorEvent{
 				// set container with two sources, delete one source
 				{
@@ -314,7 +314,7 @@ func TestSubscribe(t *testing.T) {
 			// unsetting from only one (that matches the filter)
 			// correctly generates an unset event
 			name:   "sets and unsets an entity with source filters",
-			filter: NewFilter(nil, fooSource),
+			filter: NewFilter(nil, fooSource, EventTypeAll),
 			postEvents: [][]CollectorEvent{
 				{
 					{
@@ -485,6 +485,36 @@ func TestSubscribe(t *testing.T) {
 				},
 			},
 			expected: []EventBundle{},
+		},
+		{
+			name:   "filters by event type",
+			filter: NewFilter(nil, SourceAll, EventTypeUnset),
+			postEvents: [][]CollectorEvent{
+				{
+					{
+						Type:   EventTypeSet,
+						Source: fooSource,
+						Entity: fooContainer,
+					},
+				},
+				{
+					{
+						Type:   EventTypeUnset,
+						Source: fooSource,
+						Entity: fooContainer,
+					},
+				},
+			},
+			expected: []EventBundle{
+				{
+					Events: []Event{
+						{
+							Type:   EventTypeUnset,
+							Entity: fooContainer,
+						},
+					},
+				},
+			},
 		},
 	}
 

--- a/pkg/workloadmeta/types.go
+++ b/pkg/workloadmeta/types.go
@@ -163,8 +163,12 @@ const (
 type EventType int
 
 const (
+	// EventTypeAll matches any event type. Should not be returned by
+	// collectors, as it is only meant to be used in filters.
+	EventTypeAll EventType = iota
+
 	// EventTypeSet indicates that an entity has been added or updated.
-	EventTypeSet EventType = iota
+	EventTypeSet
 
 	// EventTypeUnset indicates that an entity has been removed.  If multiple
 	// sources provide data for an entity, this message is only sent when the


### PR DESCRIPTION

### What does this PR do?

This PR adds the possibility to filter events by type (set, unset) in the workloadmeta store.

The second commit uses the new feature to simplify a bit the code in the `containerlifecycle` check which only needs to subscribe to unset events.


### Describe how to test/QA your changes

- Check that the container lifecycle check emits events when pods and containers are deleted, but not when they're created. You can look for this in the logs "Sent container lifecycle event" (TRACE level).
- As an extra precaution, if not already tested for other PRs, do a quick test to verify that AD still works. Deploy a container, verify that its check has been scheduled, then delete it and verify that the check has been unscheduled.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
