### PR TITLE
Add public ip of azure instance to metadata

### DIFF
--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -26,6 +26,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/DataDog/datadog-agent/pkg/metadata/host/container"
+	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders/azure"
 	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders/gce"
 	"github.com/DataDog/datadog-agent/pkg/util/ec2"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
@@ -106,8 +107,9 @@ func GetPythonVersion() string {
 
 func getPublicIPv4(ctx context.Context) (string, error) {
 	publicIPFetcher := map[string]func(context.Context) (string, error){
-		"EC2": ec2.GetPublicIPv4,
-		"GCE": gce.GetPublicIPv4,
+		"EC2":   ec2.GetPublicIPv4,
+		"GCE":   gce.GetPublicIPv4,
+		"Azure": azure.GetPublicIPv4,
 	}
 	for name, fetcher := range publicIPFetcher {
 		publicIPv4, err := fetcher(ctx)

--- a/pkg/util/cloudproviders/azure/azure.go
+++ b/pkg/util/cloudproviders/azure/azure.go
@@ -171,3 +171,21 @@ func getHostnameWithConfig(ctx context.Context, config config.Config) (string, e
 
 	return name, nil
 }
+
+var publicIPv4Fetcher = cachedfetch.Fetcher{
+	Name: "Azure Public IP",
+	Attempt: func(ctx context.Context) (interface{}, error) {
+		publicIPv4, err := getResponse(ctx,
+			metadataURL+"/metadata/instance/network/interface/0/ipv4/ipAddress/0/publicIpAddress?api-version=2017-04-02&format=text")
+		if err != nil {
+			return "", fmt.Errorf("failed to get Azure public ip: %s", err)
+		}
+
+		return publicIPv4, nil
+	},
+}
+
+// GetPublicIPv4 returns the public IPv4 address of the current Azure instance
+func GetPublicIPv4(ctx context.Context) (string, error) {
+	return publicIPv4Fetcher.FetchString(ctx)
+}

--- a/pkg/util/cloudproviders/azure/azure_test.go
+++ b/pkg/util/cloudproviders/azure/azure_test.go
@@ -189,7 +189,9 @@ func TestGetPublicIPv4(t *testing.T) {
 
 	defer ts.Close()
 
-	val, err := GetPublicIPv4()
+	metadataURL = ts.URL
+	val, err := GetPublicIPv4(ctx)
+
 	assert.Nil(t, err)
 	assert.Equal(t, expected, val)
 	assert.True(t, strings.HasPrefix(lastRequest.URL.Path, pathPrefix))

--- a/pkg/util/cloudproviders/azure/azure_test.go
+++ b/pkg/util/cloudproviders/azure/azure_test.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -167,4 +168,29 @@ func TestGetHostnameWithInvalidMetadata(t *testing.T) {
 
 		ts.Close()
 	}
+}
+
+func TestGetPublicIPv4(t *testing.T) {
+	var lastRequest *http.Request
+
+	ctx := context.Background()
+	pathPrefix := "/metadata/instance/network/interface/0/ipv4/ipAddress/0/publicIpAddress"
+	expected := "8.8.8.8"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(pathPrefix, r.URL.Path) {
+			io.WriteString(w, expected)
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+		}
+
+		lastRequest = r
+	}))
+
+	defer ts.Close()
+
+	val, err := GetPublicIPv4()
+	assert.Nil(t, err)
+	asser.Equal(t, expected, val)
+	assert.True(t, strings.HasPrefix(t, lastRequest.URL.Path, pathPrefix))
 }

--- a/pkg/util/cloudproviders/azure/azure_test.go
+++ b/pkg/util/cloudproviders/azure/azure_test.go
@@ -191,6 +191,6 @@ func TestGetPublicIPv4(t *testing.T) {
 
 	val, err := GetPublicIPv4()
 	assert.Nil(t, err)
-	asser.Equal(t, expected, val)
-	assert.True(t, strings.HasPrefix(t, lastRequest.URL.Path, pathPrefix))
+	assert.Equal(t, expected, val)
+	assert.True(t, strings.HasPrefix(lastRequest.URL.Path, pathPrefix))
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR adds support for querying Azure's public ip from the metadata endpoint and adding it to the host's metadata.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
