### PR TITLE
pkg/trace/writer: fix dropped ContainerID field in split trace stats payloads

### DIFF
--- a/pkg/trace/writer/stats.go
+++ b/pkg/trace/writer/stats.go
@@ -287,6 +287,7 @@ func splitPayload(p pb.ClientStatsPayload, maxEntriesPerPayload int) []clientSta
 				RuntimeID:        p.RuntimeID,
 				Sequence:         p.Sequence,
 				AgentAggregation: p.AgentAggregation,
+				ContainerID:      p.ContainerID,
 				Stats:            make([]pb.ClientStatsBucket, 0, maxEntriesPerPayload),
 			},
 		}

--- a/pkg/trace/writer/stats_test.go
+++ b/pkg/trace/writer/stats_test.go
@@ -282,8 +282,8 @@ func testStatsWriter() (*StatsWriter, chan pb.StatsPayload, *testServer) {
 	// other end.
 	in := make(chan pb.StatsPayload)
 	cfg := &config.AgentConfig{
-		Endpoints:   []*config.Endpoint{{Host: srv.URL, APIKey: "123"}},
-		StatsWriter: &config.WriterConfig{ConnectionLimit: 20, QueueSize: 20},
+		Endpoints:     []*config.Endpoint{{Host: srv.URL, APIKey: "123"}},
+		StatsWriter:   &config.WriterConfig{ConnectionLimit: 20, QueueSize: 20},
 		ContainerTags: func(cid string) ([]string, error) { return nil, nil },
 	}
 	return NewStatsWriter(cfg, in), in, srv

--- a/pkg/trace/writer/stats_test.go
+++ b/pkg/trace/writer/stats_test.go
@@ -119,6 +119,7 @@ func TestStatsWriter(t *testing.T) {
 				Sequence:         34,
 				AgentAggregation: "aggregation",
 				Service:          "service",
+				ContainerID:      "container-id",
 				Stats: []pb.ClientStatsBucket{
 					testutil.RandomBucket(5),
 					testutil.RandomBucket(5),
@@ -283,6 +284,7 @@ func testStatsWriter() (*StatsWriter, chan pb.StatsPayload, *testServer) {
 	cfg := &config.AgentConfig{
 		Endpoints:   []*config.Endpoint{{Host: srv.URL, APIKey: "123"}},
 		StatsWriter: &config.WriterConfig{ConnectionLimit: 20, QueueSize: 20},
+		ContainerTags: func(cid string) ([]string, error) { return nil, nil },
 	}
 	return NewStatsWriter(cfg, in), in, srv
 }

--- a/releasenotes/notes/fix-containerid-when-payload-split-9d886c013c07d58b.yaml
+++ b/releasenotes/notes/fix-containerid-when-payload-split-9d886c013c07d58b.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Fix the loss of trace metric container information when large payloads need to be split.
+    APM: Fix the loss of trace metric container information when large payloads need to be split.

--- a/releasenotes/notes/fix-containerid-when-payload-split-9d886c013c07d58b.yaml
+++ b/releasenotes/notes/fix-containerid-when-payload-split-9d886c013c07d58b.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix the loss of trace metric container information when large payloads need to be split.


### PR DESCRIPTION
### What does this PR do?

When an APM stats payload is split the ContainerID field was not being copied to the new payloads, resulting in it being lost. This could cause a missing second primary tag on trace metrics from Fargate tasks or some other containerized deployment environments.

### Motivation

Bug fix

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
