### PR TITLE
Correctly unschedule all sources for a multi-source config (7.36.x)

### DIFF
--- a/pkg/logs/schedulers/ad/scheduler.go
+++ b/pkg/logs/schedulers/ad/scheduler.go
@@ -26,18 +26,15 @@ import (
 //
 // This type implements  pkg/logs/schedulers.Scheduler.
 type Scheduler struct {
-	mgr                schedulers.SourceManager
-	listener           *adlistener.ADListener
-	sourcesByServiceID map[string]*logsConfig.LogSource
+	mgr      schedulers.SourceManager
+	listener *adlistener.ADListener
 }
 
 var _ schedulers.Scheduler = &Scheduler{}
 
 // New creates a new scheduler.
 func New() schedulers.Scheduler {
-	sch := &Scheduler{
-		sourcesByServiceID: make(map[string]*logsConfig.LogSource),
-	}
+	sch := &Scheduler{}
 	sch.listener = adlistener.NewADListener("logs-agent AD scheduler", sch.Schedule, sch.Unschedule)
 	return sch
 }
@@ -77,7 +74,6 @@ func (s *Scheduler) Schedule(configs []integration.Config) {
 			}
 			for _, source := range sources {
 				s.mgr.AddSource(source)
-				s.sourcesByServiceID[source.Config.Identifier] = source
 			}
 		case s.newService(config):
 			entityType, _, err := s.parseEntity(config.TaggerEntity)
@@ -118,9 +114,19 @@ func (s *Scheduler) Unschedule(configs []integration.Config) {
 				log.Warnf("Invalid configuration: %v", err)
 				continue
 			}
-			if source, found := s.sourcesByServiceID[identifier]; found {
-				delete(s.sourcesByServiceID, identifier)
-				s.mgr.RemoveSource(source)
+
+			// remove all the sources for this ServiceID.  This makes the
+			// implicit, and not-quite-correct assumption that we only ever
+			// receive one config for a given ServiceID, and that it generates
+			// the same sources.
+			//
+			// This may also remove sources not added by this scheduler, for
+			// example sources added by other schedulers or sources added by
+			// launchers.
+			for _, source := range s.mgr.GetSources() {
+				if identifier == source.Config.Identifier {
+					s.mgr.RemoveSource(source)
+				}
 			}
 		case s.newService(config):
 			// new service to remove

--- a/pkg/logs/schedulers/ad/scheduler_test.go
+++ b/pkg/logs/schedulers/ad/scheduler_test.go
@@ -146,7 +146,7 @@ func TestUnscheduleConfigRemovesSource(t *testing.T) {
 
 	// We need to have a source to remove
 	sources, _ := scheduler.toSources(configSource)
-	scheduler.sourcesByServiceID[sources[0].Config.Identifier] = sources[0]
+	spy.Sources = sources
 
 	scheduler.Unschedule([]integration.Config{configSource})
 

--- a/pkg/logs/schedulers/source_manager.go
+++ b/pkg/logs/schedulers/source_manager.go
@@ -19,6 +19,8 @@ type sourceManager struct {
 	services *service.Services
 }
 
+var _ SourceManager = &sourceManager{}
+
 // AddSource implements SourceManager#AddSource.
 func (sm *sourceManager) AddSource(source *logsConfig.LogSource) {
 	sm.sources.AddSource(source)
@@ -27,6 +29,11 @@ func (sm *sourceManager) AddSource(source *logsConfig.LogSource) {
 // RemoveSource implements SourceManager#RemoveSource.
 func (sm *sourceManager) RemoveSource(source *logsConfig.LogSource) {
 	sm.sources.RemoveSource(source)
+}
+
+// GetSources implements SourceManager#GetSources.
+func (sm *sourceManager) GetSources() []*logsConfig.LogSource {
+	return sm.sources.GetSources()
 }
 
 // AddService implements SourceManager#AddService.
@@ -59,7 +66,12 @@ type MockAddRemove struct {
 type MockSourceManager struct {
 	// Events are the events that occurred in the spy
 	Events []MockAddRemove
+
+	// Sources are the sources returned by GetSources
+	Sources []*logsConfig.LogSource
 }
+
+var _ SourceManager = &MockSourceManager{}
 
 // AddSource implements SourceManager#AddSource.
 func (sm *MockSourceManager) AddSource(source *logsConfig.LogSource) {
@@ -69,6 +81,13 @@ func (sm *MockSourceManager) AddSource(source *logsConfig.LogSource) {
 // RemoveSource implements SourceManager#RemoveSource.
 func (sm *MockSourceManager) RemoveSource(source *logsConfig.LogSource) {
 	sm.Events = append(sm.Events, MockAddRemove{Add: false, Source: source})
+}
+
+// GetSources implements SourceManager#GetSources.
+func (sm *MockSourceManager) GetSources() []*logsConfig.LogSource {
+	sources := make([]*logsConfig.LogSource, len(sm.Sources))
+	copy(sources, sm.Sources)
+	return sources
 }
 
 // AddService implements SourceManager#AddService.

--- a/pkg/logs/schedulers/types.go
+++ b/pkg/logs/schedulers/types.go
@@ -36,6 +36,11 @@ type SourceManager interface {
 	// source is recognized by pointer equality.
 	RemoveSource(source *logsConfig.LogSource)
 
+	// GetSources returns all the sources currently held.  The result is copied and
+	// will not be modified after it is returned, and represents a "snapshot" of the
+	// state when the function was called.
+	GetSources() []*logsConfig.LogSource
+
 	// AddService adds a new service to the logs agent.
 	AddService(service *service.Service)
 

--- a/releasenotes/notes/fix-logs-unschedule-multi-source-config-765449fb8a43fee6.yaml
+++ b/releasenotes/notes/fix-logs-unschedule-multi-source-config-765449fb8a43fee6.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    This fixes a regression introduced in ``7.36.0`` where some logs sources attached to a container/pod would not be
+    unscheduled on container/pod stop if multiple logs configs were attached to the container/pod.
+    This could lead to duplicate log entries being created on container/pod restart as there would
+    be more than one tailer tailing the targeted source.


### PR DESCRIPTION
This duplicates the functionality in 7.35.x: remove all sources with a
matching identifier (in general, these identifiers are container sha's).

Backport of #12175; see that PR for the remaining details.

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
