### PR TITLE
Exclude env variables from the workload dump

### DIFF
--- a/pkg/workloadmeta/dump_test.go
+++ b/pkg/workloadmeta/dump_test.go
@@ -26,6 +26,12 @@ func TestDump(t *testing.T) {
 			Name: "ctr-image",
 		},
 		Runtime: ContainerRuntimeDocker,
+		EnvVars: map[string]string{
+			"DD_SERVICE":  "my-svc",
+			"DD_ENV":      "prod",
+			"DD_VERSION":  "v1",
+			"NOT_ALLOWED": "not-allowed",
+		},
 	}
 
 	ctrToMerge := &Container{
@@ -105,7 +111,7 @@ Health:
 Created At: 0001-01-01 00:00:00 +0000 UTC
 Started At: 0001-01-01 00:00:00 +0000 UTC
 Finished At: 0001-01-01 00:00:00 +0000 UTC
-Env Variables: 
+Allowed env variables: DD_SERVICE:my-svc DD_ENV:prod DD_VERSION:v1 
 Hostname: 
 Network IPs: 
 PID: 0
@@ -131,7 +137,7 @@ Health:
 Created At: 0001-01-01 00:00:00 +0000 UTC
 Started At: 0001-01-01 00:00:00 +0000 UTC
 Finished At: 0001-01-01 00:00:00 +0000 UTC
-Env Variables: 
+Allowed env variables: 
 Hostname: 
 Network IPs: 
 PID: 1
@@ -157,7 +163,7 @@ Health:
 Created At: 0001-01-01 00:00:00 +0000 UTC
 Started At: 0001-01-01 00:00:00 +0000 UTC
 Finished At: 0001-01-01 00:00:00 +0000 UTC
-Env Variables: 
+Allowed env variables: DD_SERVICE:my-svc DD_ENV:prod DD_VERSION:v1 
 Hostname: 
 Network IPs: 
 PID: 1

--- a/pkg/workloadmeta/types.go
+++ b/pkg/workloadmeta/types.go
@@ -400,7 +400,7 @@ func (c Container) String(verbose bool) string {
 	_, _ = fmt.Fprint(&sb, c.State.String(verbose))
 
 	if verbose {
-		_, _ = fmt.Fprintln(&sb, "Env Variables:", mapToString(c.EnvVars))
+		_, _ = fmt.Fprintln(&sb, "Allowed env variables:", filterAndFormatEnvVars(c.EnvVars))
 		_, _ = fmt.Fprintln(&sb, "Hostname:", c.Hostname)
 		_, _ = fmt.Fprintln(&sb, "Network IPs:", mapToString(c.NetworkIPs))
 		_, _ = fmt.Fprintln(&sb, "PID:", c.PID)

--- a/pkg/workloadmeta/utils.go
+++ b/pkg/workloadmeta/utils.go
@@ -22,3 +22,16 @@ func mapToString(m map[string]string) string {
 func sliceToString(s []string) string {
 	return strings.Join(s, " ")
 }
+
+// filterAndFormatEnvVars extracts and formats a subset of allowed environment variables.
+func filterAndFormatEnvVars(envs map[string]string) string {
+	allowedEnvVariables := []string{"DD_SERVICE", "DD_ENV", "DD_VERSION"}
+	var sb strings.Builder
+	for _, allowed := range allowedEnvVariables {
+		if val, found := envs[allowed]; found {
+			fmt.Fprintf(&sb, "%s:%s ", allowed, val)
+		}
+	}
+
+	return sb.String()
+}

--- a/releasenotes/notes/rm-env-wld-list-e907b7025c1373cb.yaml
+++ b/releasenotes/notes/rm-env-wld-list-e907b7025c1373cb.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    The ``agent workload-list --verbose`` command and the ``workload-list.log`` file in the flare
+    do not show containers' environment variables anymore. Except for ``DD_SERVICE``, ``DD_ENV`` and ``DD_VERSION``.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

- Do not include container env vars in the workloadmeta dump except for DD standard env vars (useful for debugging)

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

- Avoid including sensitive data / creds in the flare

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

- `agent workload-list --verbose` and `workload-list.log` in the flare should only include the following env vars for containers: `DD_SERVICE`, `DD_ENV`, `DD_VERSION`

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
