### PR TITLE
Fix cri metrics on cri-o due to excluded containers

### DIFF
--- a/pkg/collector/corechecks/containers/cri/check.go
+++ b/pkg/collector/corechecks/containers/cri/check.go
@@ -21,6 +21,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/containers/cri"
 	"github.com/DataDog/datadog-agent/pkg/util/containers/v2/metrics"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
@@ -96,7 +97,7 @@ func (c *CRICheck) Run() error {
 	}
 	defer sender.Commit()
 
-	return c.processor.Run(sender, cacheValidity)
+	return c.runProcessor(sender)
 }
 
 func (c *CRICheck) runProcessor(sender aggregator.Sender) error {
@@ -108,7 +109,7 @@ func getProcessorFilter(legacyFilter *containers.Filter) generic.ContainerFilter
 	return generic.ANDContainerFilter{
 		Filters: []generic.ContainerFilter{
 			generic.FuncContainerFilter(func(container *workloadmeta.Container) bool {
-				return container.Labels["io.kubernetes.pod.namespace"] == ""
+				return container.Labels[kubernetes.CriContainerNamespaceLabel] == ""
 			}),
 			generic.LegacyContainerFilter{OldFilter: legacyFilter},
 		},

--- a/pkg/collector/corechecks/containers/docker/check.go
+++ b/pkg/collector/corechecks/containers/docker/check.go
@@ -26,6 +26,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/containers/v2/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	dockerTypes "github.com/docker/docker/api/types"
 )
@@ -187,7 +188,7 @@ func (d *DockerCheck) runDockerCustom(sender aggregator.Sender, du docker.Client
 		if len(rawContainer.Names) > 0 {
 			containerName = rawContainer.Names[0]
 		}
-		isContainerExcluded := d.containerFilter.IsExcluded(containerName, resolvedImageName, rawContainer.Labels["io.kubernetes.pod.namespace"])
+		isContainerExcluded := d.containerFilter.IsExcluded(containerName, resolvedImageName, rawContainer.Labels[kubernetes.CriContainerNamespaceLabel])
 		isContainerRunning := rawContainer.State == containers.ContainerRunningState
 		taggerEntityID := containers.BuildTaggerEntityName(rawContainer.ID)
 

--- a/pkg/collector/corechecks/containers/generic/filters.go
+++ b/pkg/collector/corechecks/containers/generic/filters.go
@@ -7,6 +7,7 @@ package generic
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
 
@@ -50,7 +51,7 @@ func (f LegacyContainerFilter) IsExcluded(container *workloadmeta.Container) boo
 		return false
 	}
 
-	return f.OldFilter.IsExcluded(container.Name, container.Image.Name, container.Labels["io.kubernetes.pod.namespace"])
+	return f.OldFilter.IsExcluded(container.Name, container.Image.Name, container.Labels[kubernetes.CriContainerNamespaceLabel])
 }
 
 // RuntimeContainerFilter filters containers by runtime

--- a/pkg/collector/corechecks/containers/generic/processor.go
+++ b/pkg/collector/corechecks/containers/generic/processor.go
@@ -16,6 +16,7 @@ import (
 	taggerUtils "github.com/DataDog/datadog-agent/pkg/tagger/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/containers/v2/metrics"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
@@ -84,7 +85,7 @@ func (p *Processor) Run(sender aggregator.Sender, cacheValidity time.Duration) e
 		}
 
 		if p.ctrFilter != nil && p.ctrFilter.IsExcluded(container) {
-			log.Tracef("Container excluded due to filter, name: %s - image: %s - namespace: %s", container.Name, container.Image.Name, container.Labels["io.kubernetes.pod.namespace"])
+			log.Tracef("Container excluded due to filter, name: %s - image: %s - namespace: %s", container.Name, container.Image.Name, container.Labels[kubernetes.CriContainerNamespaceLabel])
 			continue
 		}
 

--- a/pkg/process/util/containers.go
+++ b/pkg/process/util/containers.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/containers/v2/metrics"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/system"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
@@ -108,7 +109,7 @@ func (p *containerProvider) GetContainers(cacheValidity time.Duration, previousC
 			continue
 		}
 
-		if p.filter != nil && p.filter.IsExcluded(container.Name, container.Image.Name, container.Labels["io.kubernetes.pod.namespace"]) {
+		if p.filter != nil && p.filter.IsExcluded(container.Name, container.Image.Name, container.Labels[kubernetes.CriContainerNamespaceLabel]) {
 			continue
 		}
 

--- a/pkg/util/kubernetes/const.go
+++ b/pkg/util/kubernetes/const.go
@@ -89,6 +89,9 @@ const (
 	OwnerRefNameTagName = "kube_ownerref_name"
 	// OwnerRefKindTagName represents any owner ref kind
 	OwnerRefKindTagName = "kube_ownerref_kind"
+
+	// CriContainerNamespaceLabel is the label set on containers by runtimes with Pod Namespace
+	CriContainerNamespaceLabel = "io.kubernetes.pod.namespace"
 )
 
 // KindToTagName returns the tag name for a given kubernetes object name

--- a/pkg/workloadmeta/collectors/internal/kubelet/kubelet.go
+++ b/pkg/workloadmeta/collectors/internal/kubelet/kubelet.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/errors"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
@@ -107,6 +108,7 @@ func (c *collector) parsePods(pods []*kubelet.Pod) []workloadmeta.CollectorEvent
 		containerSpecs = append(containerSpecs, pod.Spec.Containers...)
 
 		podContainers, containerEvents := c.parsePodContainers(
+			pod,
 			containerSpecs,
 			pod.Status.GetAllContainers(),
 		)
@@ -154,6 +156,7 @@ func (c *collector) parsePods(pods []*kubelet.Pod) []workloadmeta.CollectorEvent
 }
 
 func (c *collector) parsePodContainers(
+	pod *kubelet.Pod,
 	containerSpecs []kubelet.ContainerSpec,
 	containerStatuses []kubelet.ContainerStatus,
 ) ([]workloadmeta.OrchestratorContainer, []workloadmeta.CollectorEvent) {
@@ -232,6 +235,9 @@ func (c *collector) parsePodContainers(
 				},
 				EntityMeta: workloadmeta.EntityMeta{
 					Name: container.Name,
+					Labels: map[string]string{
+						kubernetes.CriContainerNamespaceLabel: pod.Metadata.Namespace,
+					},
 				},
 				Image:   image,
 				EnvVars: env,

--- a/releasenotes/notes/fix-cri-check-on-crio-11f0ca4adef730b4.yaml
+++ b/releasenotes/notes/fix-cri-check-on-crio-11f0ca4adef730b4.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix `cri` check producing no metrics when running on `OpenShift / cri-o`.


### PR DESCRIPTION
### What does this PR do?

Fix `cri` check on `cri-o` due to all containers being excluded as Kubernetes namespace label is not present in internal container store.

### Motivation

Bugfix.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Run the `cri` check on `cri-o` (for instance, in OpenShift). The `cri.*` metrics should be emitted.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
