### PR TITLE
[workloadmeta] Add ListContainersWithFilter func

### DIFF
--- a/pkg/collector/corechecks/containers/generic/adapters.go
+++ b/pkg/collector/corechecks/containers/generic/adapters.go
@@ -17,17 +17,17 @@ type MetricsAdapter interface {
 	AdaptMetrics(metricName string, value float64) (string, float64)
 }
 
-// ContainerAccessor abstracts away how to list all known containers
+// ContainerAccessor abstracts away how to list all running containers
 type ContainerAccessor interface {
-	List() []*workloadmeta.Container
+	ListRunning() []*workloadmeta.Container
 }
 
 // MetadataContainerAccessor implements ContainerLister interface using Workload meta service
 type MetadataContainerAccessor struct{}
 
-// List returns all known containers
-func (l MetadataContainerAccessor) List() []*workloadmeta.Container {
-	return workloadmeta.GetGlobalStore().ListContainers()
+// ListRunning returns all running containers
+func (l MetadataContainerAccessor) ListRunning() []*workloadmeta.Container {
+	return workloadmeta.GetGlobalStore().ListContainersWithFilter(workloadmeta.GetRunningContainers)
 }
 
 // GenericMetricsAdapter implements MetricsAdapter API in a basic way.

--- a/pkg/collector/corechecks/containers/generic/mock.go
+++ b/pkg/collector/corechecks/containers/generic/mock.go
@@ -19,8 +19,8 @@ type MockContainerAccessor struct {
 	containers []*workloadmeta.Container
 }
 
-// List returns the mocked containers
-func (l *MockContainerAccessor) List() []*workloadmeta.Container {
+// ListRunning returns the mocked containers
+func (l *MockContainerAccessor) ListRunning() []*workloadmeta.Container {
 	return l.containers
 }
 

--- a/pkg/collector/corechecks/containers/generic/processor.go
+++ b/pkg/collector/corechecks/containers/generic/processor.go
@@ -54,7 +54,7 @@ func (p *Processor) RegisterExtension(id string, extension ProcessorExtension) {
 
 // Run executes the check
 func (p *Processor) Run(sender aggregator.Sender, cacheValidity time.Duration) error {
-	allContainers := p.ctrLister.List()
+	allContainers := p.ctrLister.ListRunning()
 
 	if len(allContainers) == 0 {
 		return nil
@@ -79,11 +79,6 @@ func (p *Processor) Run(sender aggregator.Sender, cacheValidity time.Duration) e
 	}
 
 	for _, container := range allContainers {
-		// We surely won't get stats for not running containers
-		if !container.State.Running {
-			continue
-		}
-
 		if p.ctrFilter != nil && p.ctrFilter.IsExcluded(container) {
 			log.Tracef("Container excluded due to filter, name: %s - image: %s - namespace: %s", container.Name, container.Image.Name, container.Labels[kubernetes.CriContainerNamespaceLabel])
 			continue

--- a/pkg/compliance/agent/telemetry_test.go
+++ b/pkg/compliance/agent/telemetry_test.go
@@ -38,12 +38,21 @@ func TestReportContainersCount(t *testing.T) {
 		},
 	}
 
-	containersCount := 10
-	createRandomContainers(fakeStore, containersCount)
+	runningContainersCount := 10
+	createRandomContainers(fakeStore, runningContainersCount)
+
+	// Create a non-running container. It should not appear in the result
+	fakeStore.SetEntity(&workloadmeta.Container{
+		EntityID: workloadmeta.EntityID{
+			Kind: workloadmeta.KindContainer,
+			ID:   strconv.FormatInt(int64(runningContainersCount), 10),
+		},
+		State: workloadmeta.ContainerState{Running: false},
+	})
 
 	telemetry.reportContainers()
-	mockSender.AssertNumberOfCalls(t, "Gauge", containersCount)
-	for i := 0; i < containersCount; i++ {
+	mockSender.AssertNumberOfCalls(t, "Gauge", runningContainersCount)
+	for i := 0; i < runningContainersCount; i++ {
 		mockSender.AssertCalled(t, "Gauge", containersCountMetricName, 1.0, "", []string{"container_id:" + strconv.Itoa(i)})
 	}
 }

--- a/pkg/process/util/containers.go
+++ b/pkg/process/util/containers.go
@@ -95,17 +95,13 @@ func NewDefaultContainerProvider() ContainerProvider {
 
 // GetContainers returns containers found on the machine
 func (p *containerProvider) GetContainers(cacheValidity time.Duration, previousContainers map[string]*ContainerRateMetrics) ([]*model.Container, map[string]*ContainerRateMetrics, map[int]string, error) {
-	containersMetadata := p.metadataStore.ListContainers()
+	containersMetadata := p.metadataStore.ListContainersWithFilter(workloadmeta.GetRunningContainers)
 
 	hostCPUCount := float64(system.HostCPUCount())
 	processContainers := make([]*model.Container, 0)
 	rateStats := make(map[string]*ContainerRateMetrics)
 	pidToCid := make(map[int]string)
 	for _, container := range containersMetadata {
-		if !container.State.Running {
-			continue
-		}
-
 		if p.filter != nil && p.filter.IsExcluded(container.Name, container.Image.Name, container.Labels[kubernetes.CriContainerNamespaceLabel]) {
 			continue
 		}

--- a/pkg/security/common/telemetry.go
+++ b/pkg/security/common/telemetry.go
@@ -32,12 +32,10 @@ func NewContainersTelemetry() (*ContainersTelemetry, error) {
 // ReportContainers sends the metrics about currently running containers
 // This function is critical for CWS/CSPM metering. Please tread carefully.
 func (c *ContainersTelemetry) ReportContainers(metricName string) {
-	containers := c.MetadataStore.ListContainers()
+	containers := c.MetadataStore.ListContainersWithFilter(workloadmeta.GetRunningContainers)
 
 	for _, container := range containers {
-		if container.State.Running {
-			c.Sender.Gauge(metricName, 1.0, "", []string{"container_id:" + container.ID})
-		}
+		c.Sender.Gauge(metricName, 1.0, "", []string{"container_id:" + container.ID})
 	}
 
 	c.Sender.Commit()

--- a/pkg/workloadmeta/store.go
+++ b/pkg/workloadmeta/store.go
@@ -249,12 +249,21 @@ func (s *store) GetContainer(id string) (*Container, error) {
 
 // ListContainers implements Store#ListContainers.
 func (s *store) ListContainers() []*Container {
+	return s.ListContainersWithFilter(nil)
+}
+
+// ListContainersWithFilter implements Store#ListContainersWithFilter
+func (s *store) ListContainersWithFilter(filter ContainerFilterFunc) []*Container {
 	entities := s.listEntitiesByKind(KindContainer)
 
 	// Not very efficient
 	containers := make([]*Container, 0, len(entities))
 	for _, entity := range entities {
-		containers = append(containers, entity.(*Container))
+		container := entity.(*Container)
+
+		if filter == nil || filter(container) {
+			containers = append(containers, container)
+		}
 	}
 
 	return containers

--- a/pkg/workloadmeta/store_test.go
+++ b/pkg/workloadmeta/store_test.go
@@ -598,6 +598,47 @@ func TestListContainers(t *testing.T) {
 	}
 }
 
+func TestListContainersWithFilter(t *testing.T) {
+	runningContainer := &Container{
+		EntityID: EntityID{
+			Kind: KindContainer,
+			ID:   "1",
+		},
+		State: ContainerState{
+			Running: true,
+		},
+	}
+
+	nonRunningContainer := &Container{
+		EntityID: EntityID{
+			Kind: KindContainer,
+			ID:   "2",
+		},
+		State: ContainerState{
+			Running: false,
+		},
+	}
+
+	testStore := newTestStore()
+
+	testStore.handleEvents([]CollectorEvent{
+		{
+			Type:   EventTypeSet,
+			Source: fooSource,
+			Entity: runningContainer,
+		},
+		{
+			Type:   EventTypeSet,
+			Source: fooSource,
+			Entity: nonRunningContainer,
+		},
+	})
+
+	runningContainers := testStore.ListContainersWithFilter(GetRunningContainers)
+
+	assert.DeepEqual(t, []*Container{runningContainer}, runningContainers)
+}
+
 func newTestStore() *store {
 	return &store{
 		store: make(map[Kind]map[string]*cachedEntity),

--- a/pkg/workloadmeta/testing/store.go
+++ b/pkg/workloadmeta/testing/store.go
@@ -51,6 +51,19 @@ func (s *Store) ListContainers() []*workloadmeta.Container {
 	return containers
 }
 
+// ListContainersWithFilter returns metadata about the containers that pass the given filter.
+func (s *Store) ListContainersWithFilter(filter workloadmeta.ContainerFilterFunc) []*workloadmeta.Container {
+	var res []*workloadmeta.Container
+
+	for _, container := range s.ListContainers() {
+		if filter(container) {
+			res = append(res, container)
+		}
+	}
+
+	return res
+}
+
 // GetKubernetesPod returns metadata about a Kubernetes pod.
 func (s *Store) GetKubernetesPod(id string) (*workloadmeta.KubernetesPod, error) {
 	entity, err := s.getEntityByKind(workloadmeta.KindKubernetesPod, id)

--- a/pkg/workloadmeta/types.go
+++ b/pkg/workloadmeta/types.go
@@ -57,6 +57,10 @@ type Store interface {
 	// to all entities with kind KindContainer.
 	ListContainers() []*Container
 
+	// ListContainersWithFilter returns all the containers for which the passed
+	// filter evaluates to true.
+	ListContainersWithFilter(filter ContainerFilterFunc) []*Container
+
 	// GetKubernetesPod returns metadata about a Kubernetes pod.  It fetches
 	// the entity with kind KindKubernetesPod and the given ID.
 	GetKubernetesPod(id string) (*KubernetesPod, error)
@@ -421,6 +425,12 @@ func (c Container) String(verbose bool) string {
 }
 
 var _ Entity = &Container{}
+
+// ContainerFilterFunc is a function used to filter containers.
+type ContainerFilterFunc func(container *Container) bool
+
+// GetRunningContainers is a function that evaluates to true for running containers.
+var GetRunningContainers ContainerFilterFunc = func(container *Container) bool { return container.State.Running }
 
 // KubernetesPod is an Entity representing a Kubernetes Pod.
 type KubernetesPod struct {


### PR DESCRIPTION
### What does this PR do?

This PR adds the possibility to use a filter when listing the containers stored in workloadmeta.

One of the filters defined allows the caller to receive only containers that are running. This helps us simplify some parts of the code that until now were listing all the containers and then discarding the ones that weren't running.


### Describe how to test/QA your changes

The features that rely on listing containers from the workloadmeta store should keep working as before and without reporting data from containers that are not running. Those features are: the container check, the process-agent and the security-agent. This PR modifies the same code as https://github.com/DataDog/datadog-agent/pull/12355 so they can be QA'd together.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
