### PR TITLE
Backport #12184 to 7.37.x

### DIFF
--- a/pkg/trace/writer/stats.go
+++ b/pkg/trace/writer/stats.go
@@ -287,6 +287,7 @@ func splitPayload(p pb.ClientStatsPayload, maxEntriesPerPayload int) []clientSta
 				RuntimeID:        p.RuntimeID,
 				Sequence:         p.Sequence,
 				AgentAggregation: p.AgentAggregation,
+				ContainerID:      p.ContainerID,
 				Stats:            make([]pb.ClientStatsBucket, 0, maxEntriesPerPayload),
 			},
 		}

--- a/pkg/trace/writer/stats_test.go
+++ b/pkg/trace/writer/stats_test.go
@@ -119,6 +119,7 @@ func TestStatsWriter(t *testing.T) {
 				Sequence:         34,
 				AgentAggregation: "aggregation",
 				Service:          "service",
+				ContainerID:      "container-id",
 				Stats: []pb.ClientStatsBucket{
 					testutil.RandomBucket(5),
 					testutil.RandomBucket(5),
@@ -281,8 +282,9 @@ func testStatsWriter() (*StatsWriter, chan pb.StatsPayload, *testServer) {
 	// other end.
 	in := make(chan pb.StatsPayload)
 	cfg := &config.AgentConfig{
-		Endpoints:   []*config.Endpoint{{Host: srv.URL, APIKey: "123"}},
-		StatsWriter: &config.WriterConfig{ConnectionLimit: 20, QueueSize: 20},
+		Endpoints:     []*config.Endpoint{{Host: srv.URL, APIKey: "123"}},
+		StatsWriter:   &config.WriterConfig{ConnectionLimit: 20, QueueSize: 20},
+		ContainerTags: func(cid string) ([]string, error) { return nil, nil },
 	}
 	return NewStatsWriter(cfg, in), in, srv
 }

--- a/releasenotes/notes/fix-containerid-when-payload-split-9d886c013c07d58b.yaml
+++ b/releasenotes/notes/fix-containerid-when-payload-split-9d886c013c07d58b.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: Fix the loss of trace metric container information when large payloads need to be split.


### PR DESCRIPTION
### What does this PR do?

This PR backports https://github.com/DataDog/datadog-agent/pull/12184 to 7.37.x