### PR TITLE
[Serverless] set correct service name for cloud run

### DIFF
--- a/pkg/logs/internal/tailers/channel/tailer_test.go
+++ b/pkg/logs/internal/tailers/channel/tailer_test.go
@@ -6,6 +6,7 @@
 package channel
 
 import (
+	"os"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
@@ -18,4 +19,37 @@ func TestComputeServiceName(t *testing.T) {
 	assert.Equal(t, "my-service-name", computeServiceName(lambdaConfig, "my-service-name"))
 	assert.Equal(t, "my-service-name", computeServiceName(lambdaConfig, "MY-SERVICE-NAME"))
 	assert.Equal(t, "", computeServiceName(lambdaConfig, ""))
+}
+
+func TestComputeServiceNameFromCloudRunRevision(t *testing.T) {
+	os.Setenv("K_REVISION", "version-abc")
+	defer os.Unsetenv("K_REVISION")
+	os.Setenv("K_SERVICE", "superService")
+	assert.Equal(t, "service-value", computeServiceName(nil, "service-value"))
+	assert.Equal(t, "superservice", computeServiceName(nil, ""))
+}
+
+func TestNotServerlessModeKVersionUndefined(t *testing.T) {
+	os.Setenv("K_SERVICE", "superService")
+	defer os.Unsetenv("K_SERVICE")
+	assert.False(t, isServerlessOrigin(nil))
+}
+
+func TestNotServerlessModeKServiceUndefined(t *testing.T) {
+	os.Setenv("K_REVISION", "version-abc")
+	defer os.Unsetenv("K_REVISION")
+	assert.False(t, isServerlessOrigin(nil))
+}
+
+func TestServerlessModeCloudRun(t *testing.T) {
+	os.Setenv("K_REVISION", "version-abc")
+	defer os.Unsetenv("K_REVISION")
+	os.Setenv("K_SERVICE", "superService")
+	defer os.Unsetenv("K_SERVICE")
+	assert.True(t, isServerlessOrigin(nil))
+}
+
+func TestServerlessModeLambda(t *testing.T) {
+	lambdaConfig := &config.Lambda{}
+	assert.True(t, isServerlessOrigin(lambdaConfig))
 }


### PR DESCRIPTION
### What does this PR do?

Set correct service name for CloudRun

### Motivation

Service tag was incorrect on logs

### Describe how to test/QA your changes

Unit tests
![Screen Shot 2022-05-31 at 11 37 20 AM](https://user-images.githubusercontent.com/864493/171213448-d1d7184e-1e81-4ad9-bd47-085a9e5bc800.png)


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
