### PR TITLE
[7.37][Backport] Do not fail if we cannot chown auth_token

### DIFF
--- a/pkg/api/security/security.go
+++ b/pkg/api/security/security.go
@@ -12,13 +12,12 @@ import (
 	"crypto/x509/pkix"
 	"encoding/hex"
 	"encoding/pem"
+	"fmt"
 	"io/ioutil"
 	"math/big"
+	"net"
 	"os"
 	"path/filepath"
-
-	"fmt"
-	"net"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -66,9 +65,7 @@ func CertTemplate() (*x509.Certificate, error) {
 }
 
 // GenerateRootCert generates a root certificate
-func GenerateRootCert(hosts []string, bits int) (
-	cert *x509.Certificate, certPEM []byte, rootKey *rsa.PrivateKey, err error) {
-
+func GenerateRootCert(hosts []string, bits int) (cert *x509.Certificate, certPEM []byte, rootKey *rsa.PrivateKey, err error) {
 	rootCertTmpl, err := CertTemplate()
 	if err != nil {
 		return
@@ -235,7 +232,7 @@ func validateAuthToken(authToken string) error {
 
 // writes auth token(s) to a file with the same permissions as datadog.yaml
 func saveAuthToken(token, tokenPath string) error {
-	if err := ioutil.WriteFile(tokenPath, []byte(token), 0600); err != nil {
+	if err := ioutil.WriteFile(tokenPath, []byte(token), 0o600); err != nil {
 		return err
 	}
 
@@ -248,7 +245,7 @@ func saveAuthToken(token, tokenPath string) error {
 		log.Errorf("Failed to write auth token acl %s", err)
 		return err
 	}
-	log.Infof("Wrote auth token acl")
 
+	log.Infof("Wrote auth token")
 	return nil
 }

--- a/pkg/util/filesystem/permission_nowindows.go
+++ b/pkg/util/filesystem/permission_nowindows.go
@@ -8,10 +8,14 @@
 package filesystem
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/user"
 	"strconv"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // Permission handles permissions for Unix and Windows
@@ -25,20 +29,27 @@ func NewPermission() (*Permission, error) {
 // RestrictAccessToUser restricts the access to a file to the current user and its group
 func (p *Permission) RestrictAccessToUser(path string) error {
 	usr, err := user.Lookup("dd-agent")
-	if err == nil {
-		usrID, err := strconv.Atoi(usr.Uid)
-		if err != nil {
-			return fmt.Errorf("couldn't parse UID (%s): %w", usr.Uid, err)
+	if err != nil {
+		return nil
+	}
+
+	usrID, err := strconv.Atoi(usr.Uid)
+	if err != nil {
+		return fmt.Errorf("couldn't parse UID (%s): %w", usr.Uid, err)
+	}
+
+	grpID, err := strconv.Atoi(usr.Gid)
+	if err != nil {
+		return fmt.Errorf("couldn't parse GID (%s): %w", usr.Gid, err)
+	}
+
+	if err = os.Chown(path, usrID, grpID); err != nil {
+		if errors.Is(err, fs.ErrPermission) {
+			log.Infof("Cannot change owner of '%s', permission denied", path)
+			return nil
 		}
 
-		grpID, err := strconv.Atoi(usr.Gid)
-		if err != nil {
-			return fmt.Errorf("couldn't parse GID (%s): %w", usr.Gid, err)
-		}
-
-		if err = os.Chown(path, usrID, grpID); err != nil {
-			return fmt.Errorf("couldn't set user and group owner for %s: %w", path, err)
-		}
+		return fmt.Errorf("couldn't set user and group owner for %s: %w", path, err)
 	}
 
 	return nil

--- a/releasenotes/notes/fix-startup-restricted-user-dc3f6af4cb7a9e0e.yaml
+++ b/releasenotes/notes/fix-startup-restricted-user-dc3f6af4cb7a9e0e.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix Agent startup failure when running as a non-privileged user (for instance, when running on OpenShift with ``restricted`` SCC)

--- a/releasenotes/notes/fix-startup-restricted-user-dc3f6af4cb7a9e0e.yaml
+++ b/releasenotes/notes/fix-startup-restricted-user-dc3f6af4cb7a9e0e.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    Fix Agent startup failure when running as a non-privileged user (for instance, when running on OpenShift with ``restricted`` SCC)
+    Fix Agent startup failure when running as a non-privileged user (for instance, when running on OpenShift with ``restricted`` SCC).


### PR DESCRIPTION
### What does this PR do?

Backport #12205

### Motivation

Bugfix.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

See #12205

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
