### PR TITLE
[Serverless] cloud run logs behaviour

### DIFF
--- a/cmd/serverless-init/log/log.go
+++ b/cmd/serverless-init/log/log.go
@@ -80,10 +80,8 @@ func SetupLog(conf *Config) {
 		}
 	}
 
-	if conf.isEnabled {
-		serverlessLogs.SetupLogAgent(conf.channel, sourceName, source)
-		serverlessLogs.SetLogsTags(tag.GetBaseTagsArrayWithMetadataTags(conf.Metadata.TagMap()))
-	}
+	serverlessLogs.SetupLogAgent(conf.channel, sourceName, source)
+	serverlessLogs.SetLogsTags(tag.GetBaseTagsArrayWithMetadataTags(conf.Metadata.TagMap()))
 }
 
 func (cw *CustomWriter) Write(p []byte) (n int, err error) {

--- a/cmd/serverless-init/log/log.go
+++ b/cmd/serverless-init/log/log.go
@@ -79,7 +79,6 @@ func SetupLog(conf *Config) {
 			log.Errorf("While changing the loglevel: %s", err)
 		}
 	}
-
 	serverlessLogs.SetupLogAgent(conf.channel, sourceName, source)
 	serverlessLogs.SetLogsTags(tag.GetBaseTagsArrayWithMetadataTags(conf.Metadata.TagMap()))
 }


### PR DESCRIPTION
### What does this PR do?

Respect `DD_LOGS_ENABLED` for cloud-run

- default : false (only log to GCP console)
- if set to `true`, logs will be sent to DD

### Motivation

Respect DD_LOGS_ENABLED

### Possible Drawbacks / Trade-offs

Unit tests
![Screen Shot 2022-05-31 at 12 51 30 PM](https://user-images.githubusercontent.com/864493/171230606-84e4631a-8232-4218-a9a6-aa7d8e6eac39.png)


### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
