### PR TITLE
[CWS] fix e2e tests (regarding networks default rules)

### DIFF
--- a/test/e2e/argo-workflows/templates/datadog-agent.yaml
+++ b/test/e2e/argo-workflows/templates/datadog-agent.yaml
@@ -57,6 +57,8 @@ spec:
                 enabled: true
               runtime:
                 enabled: true
+                network:
+                  enabled: true
 
             confd:
               memory.yaml: |

--- a/test/e2e/cws-tests/tests/lib/config.py
+++ b/test/e2e/cws-tests/tests/lib/config.py
@@ -3,14 +3,14 @@ import tempfile
 import yaml
 
 
-def gen_system_probe_config(network_enabled=False, log_level="INFO", log_patterns=None):
+def gen_system_probe_config(npm_enabled=False, log_level="INFO", log_patterns=None):
     fp = tempfile.NamedTemporaryFile(prefix="e2e-system-probe-", mode="w", delete=False)
 
     if not log_patterns:
         log_patterns = []
     data = {
         "system_probe_config": {"log_level": log_level},
-        "network_config": {"enabled": network_enabled},
+        "network_config": {"enabled": npm_enabled},
         "runtime_security_config": {"log_patterns": log_patterns, "network": {"enabled": True}},
     }
     yaml.dump(data, fp)


### PR DESCRIPTION
### What does this PR do?

Network-based CWS rules were previously gated to some specific orgs but are now available to everyone downloading the policy. This means that our expectation about 0 rules skipped was wrong.

This PR enables the network events for k8s e2e tests to fix this.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
