### PR TITLE
[install_script] Pin Debian 7 installation to 6.35/7.35 on Debian 7

### DIFF
--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -472,8 +472,8 @@ elif [ "$OS" = "Debian" ]; then
           fi
       else
           if ! echo "$agent_flavor" | grep '[0-9]' > /dev/null; then
-              echo -e "  \033[33m$nice_flavor $agent_major_version.35 will be the last supported version on $DISTRIBUTION $release_version. Installing $agent_major_version.34 now.\n\033[0m"
-              agent_minor_version=34
+              echo -e "  \033[33m$nice_flavor $agent_major_version.35 is the last supported version on $DISTRIBUTION $release_version. Installing $agent_major_version.35 now.\n\033[0m"
+              agent_minor_version=35
           fi
       fi
     fi

--- a/releasenotes-installscript/notes/debian-7-install-7-35-e4f92a56d026abd5.yaml
+++ b/releasenotes-installscript/notes/debian-7-install-7-35-e4f92a56d026abd5.yaml
@@ -9,5 +9,5 @@
 upgrade:
   - |
     Since datadog-agent 6.36/7.36, Debian 7 (Wheezy) is no longer supported,
-    ``install_script.sh`` now installs 6.35/7.35 when the minor version is unpinned
+    ``install_script.sh`` now installs 6.35/7.35 when the minor version is unpinned,
     and ``DD_AGENT_FLAVOR`` doesn't specify a version.

--- a/releasenotes-installscript/notes/debian-7-install-7-35-e4f92a56d026abd5.yaml
+++ b/releasenotes-installscript/notes/debian-7-install-7-35-e4f92a56d026abd5.yaml
@@ -1,0 +1,13 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG-INSTALLSCRIPT.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+upgrade:
+  - |
+    Since datadog-agent 6.36/7.36, Debian 7 (Wheezy) is no longer supported,
+    ``install_script.sh`` now installs 6.35/7.35 when the minor version is unpinned
+    and ``DD_AGENT_FLAVOR`` doesn't specify a version.


### PR DESCRIPTION
### What does this PR do?

Pins Agent minor version to 35 on Debian 7, as 36 is built on Debian 8 and no longer supported on Debian 7.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

* Ensure that installation on the lowest supported systems - Debian 8 and Ubuntu 14 - still works as expected, even if choosing a minor version >= 36.
* Ensure that installation on Debian 7:
  * Fails if minor version >= 36 is provided.
  * Pins minor version to 35 if minor version is not provided.


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
