### PR TITLE
Avoid dead-lock in `util/sliding_window`

### DIFF
--- a/pkg/collector/worker/utilization_tracker.go
+++ b/pkg/collector/worker/utilization_tracker.go
@@ -117,9 +117,7 @@ func newUtilizationTrackerWithClock(
 		return utilization
 	}
 
-	ut.statsUpdateFunc = func(sw util.SlidingWindow) {
-		utilization := sw.Average()
-
+	ut.statsUpdateFunc = func(utilization float64) {
 		expvars.SetWorkerStats(workerName, &expvars.WorkerStats{
 			Utilization: utilization,
 		})


### PR DESCRIPTION
### What does this PR do?

Fix a dead-lock in the sliding window implementation during agent shutdown.

### Motivation

Make agent stop more reliably.

### Additional Notes

Sliding window periodically calls user function `statsUpdateFn` while holding a read-only lock (Lock A).

`statsUpdateFn` then retrieves the accumulated average by calling Average (RLock B).

If between the two calls above a call to `Stop` is made, a pending write lock would block RLock B, while RLock A would prevent the write lock inside `Stop`, leading to a deadlock.

This PR avoids the issue by computing the average upfront and passing it to the statsUpdateFn.

### Describe how to test/QA your changes

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
