### PR TITLE
Include `log_level` in flare file names

### DIFF
--- a/cmd/agent/app/flare.go
+++ b/cmd/agent/app/flare.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/fatih/color"
 	"github.com/hashicorp/go-multierror"
@@ -197,10 +198,26 @@ func makeFlare(caseID string) error {
 		return err
 	}
 
-	logLevel := config.Datadog.GetString("log_level")
-	if len(logLevel) != 0 {
-		fmt.Fprintln(color.Output, fmt.Sprintf("Notice: This flare will be sent as %s level", color.RedString(logLevel)))
+	logLevel := ""
+
+	switch {
+	case strings.Contains(filePath, "off"):
+		logLevel = "off"
+	case strings.Contains(filePath, "critical"):
+		logLevel = "critical"
+	case strings.Contains(filePath, "error"):
+		logLevel = "error"
+	case strings.Contains(filePath, "warn"):
+		logLevel = "warn"
+	case strings.Contains(filePath, "debug"):
+		logLevel = "debug"
+	case strings.Contains(filePath, "trace"):
+		logLevel = "trace"
+	default:
+		logLevel = "info"
 	}
+	fmt.Fprintln(color.Output, fmt.Sprintf("Notice: The flare will be generated using '%s' level logging of the agent ", color.RedString(logLevel)))
+
 	fmt.Fprintln(color.Output, fmt.Sprintf("%s is going to be uploaded to Datadog", color.YellowString(filePath)))
 	if !autoconfirm {
 		confirmation := input.AskForConfirmation("Are you sure you want to upload a flare? [y/N]")

--- a/cmd/agent/app/flare.go
+++ b/cmd/agent/app/flare.go
@@ -197,9 +197,9 @@ func makeFlare(caseID string) error {
 		return err
 	}
 
-	log_level := config.Datadog.GetString("log_level")
-	if len(log_level) != 0 {
-		fmt.Fprintln(color.Output, fmt.Sprintf("Notice: This flare will be sent as %s level", color.RedString(log_level)))
+	logLevel := config.Datadog.GetString("log_level")
+	if len(logLevel) != 0 {
+		fmt.Fprintln(color.Output, fmt.Sprintf("Notice: This flare will be sent as %s level", color.RedString(logLevel)))
 	}
 	fmt.Fprintln(color.Output, fmt.Sprintf("%s is going to be uploaded to Datadog", color.YellowString(filePath)))
 	if !autoconfirm {

--- a/cmd/agent/app/flare.go
+++ b/cmd/agent/app/flare.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/fatih/color"
 	"github.com/hashicorp/go-multierror"
@@ -197,26 +196,6 @@ func makeFlare(caseID string) error {
 		fmt.Fprintln(color.Output, color.RedString("If the agent running in a different container try the '--local' option to generate the flare locally"))
 		return err
 	}
-
-	logLevel := ""
-
-	switch {
-	case strings.Contains(filePath, "off"):
-		logLevel = "off"
-	case strings.Contains(filePath, "critical"):
-		logLevel = "critical"
-	case strings.Contains(filePath, "error"):
-		logLevel = "error"
-	case strings.Contains(filePath, "warn"):
-		logLevel = "warn"
-	case strings.Contains(filePath, "debug"):
-		logLevel = "debug"
-	case strings.Contains(filePath, "trace"):
-		logLevel = "trace"
-	default:
-		logLevel = "info"
-	}
-	fmt.Fprintln(color.Output, fmt.Sprintf("Notice: The flare will be generated using '%s' level logging of the agent ", color.RedString(logLevel)))
 
 	fmt.Fprintln(color.Output, fmt.Sprintf("%s is going to be uploaded to Datadog", color.YellowString(filePath)))
 	if !autoconfirm {

--- a/cmd/agent/app/flare.go
+++ b/cmd/agent/app/flare.go
@@ -197,6 +197,10 @@ func makeFlare(caseID string) error {
 		return err
 	}
 
+	log_level := config.Datadog.GetString("log_level")
+	if len(log_level) != 0 {
+		fmt.Fprintln(color.Output, fmt.Sprintf("Notice: This flare will be sent as %s level", color.RedString(log_level)))
+	}
 	fmt.Fprintln(color.Output, fmt.Sprintf("%s is going to be uploaded to Datadog", color.YellowString(filePath)))
 	if !autoconfirm {
 		confirmation := input.AskForConfirmation("Are you sure you want to upload a flare? [y/N]")

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -173,10 +173,10 @@ func createArchive(confSearchPaths SearchPaths, local bool, zipFilePath string, 
 		hostname = "unknown"
 	}
 
-	log_level := config.Datadog.GetString("log_level")
-	if len(log_level) != 0 {
+	logLevel := config.Datadog.GetString("log_level")
+	if len(logLevel) != 0 {
 		delim := "-"
-		hostname = strings.ToUpper(log_level) + delim + hostname
+		hostname = strings.ToUpper(logLevel) + delim + hostname
 	}
 
 	hostname = cleanDirectoryName(hostname)
@@ -1007,12 +1007,12 @@ func getArchivePath() string {
 	dir := os.TempDir()
 	t := time.Now().UTC()
 	timeString := strings.ReplaceAll(t.Format(time.RFC3339), ":", "-")
-	log_level := config.Datadog.GetString("log_level")
+	logLevel := config.Datadog.GetString("log_level")
 	fileName := ""
-	if len(log_level) != 0 {
-		fileName = strings.Join([]string{strings.ToUpper(log_level), "datadog", "agent", timeString}, "-")
+	if len(logLevel) != 0 {
+		fileName = strings.Join([]string{strings.ToUpper(logLevel), "datadog", "agent", timeString}, "-")
 	} else {
-		fileName = strings.Join([]string{strings.ToUpper(log_level), "datadog", "agent", timeString}, "-")
+		fileName = strings.Join([]string{strings.ToUpper(logLevel), "datadog", "agent", timeString}, "-")
 	}
 	fileName = strings.Join([]string{fileName, "zip"}, ".")
 	filePath := filepath.Join(dir, fileName)

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -173,6 +173,12 @@ func createArchive(confSearchPaths SearchPaths, local bool, zipFilePath string, 
 		hostname = "unknown"
 	}
 
+	log_level := config.Datadog.GetString("log_level")
+	if len(log_level) != 0 {
+		delim := "-"
+		hostname = strings.ToUpper(log_level) + delim + hostname
+	}
+
 	hostname = cleanDirectoryName(hostname)
 
 	permsInfos := make(permissionsInfos)
@@ -1001,7 +1007,13 @@ func getArchivePath() string {
 	dir := os.TempDir()
 	t := time.Now().UTC()
 	timeString := strings.ReplaceAll(t.Format(time.RFC3339), ":", "-")
-	fileName := strings.Join([]string{"datadog", "agent", timeString}, "-")
+	log_level := config.Datadog.GetString("log_level")
+	fileName := ""
+	if len(log_level) != 0 {
+		fileName = strings.Join([]string{strings.ToUpper(log_level), "datadog", "agent", timeString}, "-")
+	} else {
+		fileName = strings.Join([]string{strings.ToUpper(log_level), "datadog", "agent", timeString}, "-")
+	}
 	fileName = strings.Join([]string{fileName, "zip"}, ".")
 	filePath := filepath.Join(dir, fileName)
 	return filePath

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -1003,10 +1003,10 @@ func getArchivePath() string {
 	timeString := strings.ReplaceAll(t.Format(time.RFC3339), ":", "-")
 	fileName := ""
 	lvl, err := log.GetLogLevel()
-	if err != nil {
-		fileName = strings.Join([]string{"datadog", "agent", timeString}, "-")
-	} else {
+	if err == nil {
 		fileName = strings.Join([]string{"datadog", "agent", timeString, lvl.String()}, "-")
+	} else {
+		fileName = strings.Join([]string{"datadog", "agent", timeString}, "-")
 	}
 	fileName = strings.Join([]string{fileName, "zip"}, ".")
 	filePath := filepath.Join(dir, fileName)

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -173,12 +173,6 @@ func createArchive(confSearchPaths SearchPaths, local bool, zipFilePath string, 
 		hostname = "unknown"
 	}
 
-	logLevel := config.Datadog.GetString("log_level")
-	if len(logLevel) != 0 {
-		delim := "-"
-		hostname = strings.ToUpper(logLevel) + delim + hostname
-	}
-
 	hostname = cleanDirectoryName(hostname)
 
 	permsInfos := make(permissionsInfos)
@@ -1007,12 +1001,12 @@ func getArchivePath() string {
 	dir := os.TempDir()
 	t := time.Now().UTC()
 	timeString := strings.ReplaceAll(t.Format(time.RFC3339), ":", "-")
-	logLevel := config.Datadog.GetString("log_level")
 	fileName := ""
-	if len(logLevel) != 0 {
-		fileName = strings.Join([]string{strings.ToUpper(logLevel), "datadog", "agent", timeString}, "-")
+	lvl, err := log.GetLogLevel()
+	if err != nil {
+		fileName = strings.Join([]string{"datadog", "agent", timeString}, "-")
 	} else {
-		fileName = strings.Join([]string{strings.ToUpper(logLevel), "datadog", "agent", timeString}, "-")
+		fileName = strings.Join([]string{"datadog", "agent", timeString, lvl.String()}, "-")
 	}
 	fileName = strings.Join([]string{fileName, "zip"}, ".")
 	filePath := filepath.Join(dir, fileName)

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/config/settings"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
 
@@ -63,6 +64,32 @@ func createTestDirStructure(
 	}
 
 	return srcDir, dstDir, nil
+}
+
+func TestArchiveName(t *testing.T) {
+
+	//test with No log level set
+	zipFilePath := getArchivePath()
+	assert.Contains(t, zipFilePath, "Z.zip")
+	assert.NotContains(t, zipFilePath, "info")
+
+	// init and configure logger at runtime
+	config.SetupLogger("TEST", "debug", "", "", true, true, true)
+	ll := settings.LogLevelRuntimeSetting{}
+
+	// set 'trace' level logging
+	err := ll.Set("trace")
+	assert.Nil(t, err)
+
+	// Verify the runtime setting is set to 'trace'
+	v, err := ll.Get()
+	assert.Equal(t, "trace", v)
+	assert.Nil(t, err)
+
+	// verify filePath string ends with the correct log_level
+	zipFilePath = getArchivePath()
+	assert.Contains(t, zipFilePath, "-trace.zip")
+	assert.NotContains(t, zipFilePath, "Z.zip")
 }
 
 func TestCreateArchive(t *testing.T) {

--- a/releasenotes/notes/flare-append-log_level-in-flare-archive-name-54191458542c985b.yaml
+++ b/releasenotes/notes/flare-append-log_level-in-flare-archive-name-54191458542c985b.yaml
@@ -9,5 +9,5 @@
 
 enhancements:
   - |
-    The `log_level` of the agent, is now appended
-    to the flare archive name, upon its creation.
+    The `log_level` of the agent is now appended
+    to the flare archive name upon its creation.

--- a/releasenotes/notes/flare-append-log_level-in-flare-archive-name-54191458542c985b.yaml
+++ b/releasenotes/notes/flare-append-log_level-in-flare-archive-name-54191458542c985b.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+
+enhancements:
+  - |
+    The `log_level` of the agent, is now appended
+    to the flare archive name, upon its creation.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

- Prepend the `log_level` to the hostname when generating the flare archive. 
- Prepend the agents `log_level` to the `.zip` which is created.
- Notify the user in the flare creation process, what log_level is in place at time of creation.


![example](https://p-qkfgo2.t2.n0.cdn.getcloudapp.com/items/kpu8QnBo/c52dbee7-1cd7-4bd7-9731-f3bc75c3694d.jpg?v=9f24425d8408cb172756013e3c03e064)

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

At this time, the zip file created follows the naming format `datadog-agent-<timestamp>.zip` , and when unzipped, the folder name is the agent's hostname.

Every flare must be decompressed and opened to determine what level of logging was captured at the time of its creation. 

This PR would introduce a new format of  `<log_level>-datadog-agent-<timestamp>.zip` & `<log_level>-<hostname>` to address this.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

This in its current form would effectively shorten the maximum hostname(directoryNameMaxSize) length by len(log_level) +1 

[Assertion](https://github.com/DataDog/datadog-agent/blob/main/pkg/flare/archive_test.go#L285) | [variable declaration](https://github.com/DataDog/datadog-agent/blob/1cdfcf49aeb9049ac27b5e7b59bf00543ad88ba4/pkg/flare/archive.go#L48) 

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Build agent, run agent, and send a flare.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
