### PR TITLE
Move some types and values out of pkg/logs/config

### DIFF
--- a/cmd/security-agent/app/runtime.go
+++ b/cmd/security-agent/app/runtime.go
@@ -29,6 +29,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/diagnostic"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	secagent "github.com/DataDog/datadog-agent/pkg/security/agent"
 	"github.com/DataDog/datadog-agent/pkg/security/api"
 	secconfig "github.com/DataDog/datadog-agent/pkg/security/config"
@@ -628,7 +629,7 @@ func newRuntimeReporter(stopper startstop.Stopper, sourceName, sourceType string
 	pipelineProvider.Start()
 	stopper.Add(pipelineProvider)
 
-	logSource := config.NewLogSource(
+	logSource := sources.NewLogSource(
 		sourceName,
 		&config.LogsConfig{
 			Type:   sourceType,

--- a/pkg/compliance/event/reporter.go
+++ b/pkg/compliance/event/reporter.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/diagnostic"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/security/common"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -29,7 +30,7 @@ type Reporter interface {
 }
 
 type reporter struct {
-	logSource *config.LogSource
+	logSource *sources.LogSource
 	logChan   chan *message.Message
 }
 
@@ -48,7 +49,7 @@ func NewLogReporter(stopper startstop.Stopper, sourceName, sourceType, runPath s
 	stopper.Add(pipelineProvider)
 	stopper.Add(auditor)
 
-	logSource := config.NewLogSource(
+	logSource := sources.NewLogSource(
 		sourceName,
 		&config.LogsConfig{
 			Type:    sourceType,
@@ -61,7 +62,7 @@ func NewLogReporter(stopper startstop.Stopper, sourceName, sourceType, runPath s
 }
 
 // NewReporter returns an instance of Reporter
-func NewReporter(logSource *config.LogSource, logChan chan *message.Message) Reporter {
+func NewReporter(logSource *sources.LogSource, logChan chan *message.Message) Reporter {
 	return &reporter{
 		logSource: logSource,
 		logChan:   logChan,

--- a/pkg/logs/README.md
+++ b/pkg/logs/README.md
@@ -20,7 +20,7 @@ The first part has an architecture like this:
              | │   Scheduler  │   │ ad.Scheduler │ … |
                └──────────────┘   └──────────────┘
              └ - - - - - - - - - - - - - - - - - - - ┘
-              config.LogSource│    │service.Service
+             sources.LogSource│    │service.Service
                               │    │
                               ▼    ▼
                      ┌─────────┐  ┌──────────┐
@@ -87,7 +87,7 @@ The logs-agent delays startup of the `container_collect_all` support until after
 
 The agent can use two mechanisms to capture log messages from a Docker container (configured with `logs_config.docker_container_use_file` and `logs_config.docker_container_force_use_file`):
  * Docker API - the launcher creates a tailer which reads from the Docker API socket and sends messages into the logging pipeline.
- * File - the launcher determines the on-disk filename of the container's logfile and creates a "child" `config.LogSource`  with `source.Config.Type = "file"`.
+ * File - the launcher determines the on-disk filename of the container's logfile and creates a "child" `sources.LogSource`  with `source.Config.Type = "file"`.
    The file launcher receives this source from the sources store and tails the logfile.
 
 ##### kubernetes.Launcher

--- a/pkg/logs/agent.go
+++ b/pkg/logs/agent.go
@@ -26,6 +26,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
 	"github.com/DataDog/datadog-agent/pkg/logs/schedulers"
 	"github.com/DataDog/datadog-agent/pkg/logs/service"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -36,7 +37,7 @@ import (
 // processes and sends logs to the backend.  See the package README for
 // a description of its operation.
 type Agent struct {
-	sources                   *config.LogSources
+	sources                   *sources.LogSources
 	services                  *service.Services
 	schedulers                *schedulers.Schedulers
 	auditor                   auditor.Auditor
@@ -51,7 +52,7 @@ type Agent struct {
 }
 
 // NewAgent returns a new Logs Agent
-func NewAgent(sources *config.LogSources, services *service.Services, processingRules []*config.ProcessingRule, endpoints *config.Endpoints) *Agent {
+func NewAgent(sources *sources.LogSources, services *service.Services, processingRules []*config.ProcessingRule, endpoints *config.Endpoints) *Agent {
 	health := health.RegisterLiveness("logs-agent")
 
 	// setup the auditor
@@ -106,7 +107,7 @@ func NewAgent(sources *config.LogSources, services *service.Services, processing
 // NewServerless returns a Logs Agent instance to run in a serverless environment.
 // The Serverless Logs Agent has only one input being the channel to receive the logs to process.
 // It is using a NullAuditor because we've nothing to do after having sent the logs to the intake.
-func NewServerless(sources *config.LogSources, services *service.Services, processingRules []*config.ProcessingRule, endpoints *config.Endpoints) *Agent {
+func NewServerless(sources *sources.LogSources, services *service.Services, processingRules []*config.ProcessingRule, endpoints *config.Endpoints) *Agent {
 	health := health.RegisterLiveness("logs-agent")
 
 	diagnosticMessageReceiver := diagnostic.NewBufferedMessageReceiver()

--- a/pkg/logs/agent_test.go
+++ b/pkg/logs/agent_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/client/http"
 	"github.com/DataDog/datadog-agent/pkg/logs/client/mock"
 	"github.com/DataDog/datadog-agent/pkg/logs/client/tcp"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/metrics"
@@ -33,7 +34,7 @@ type AgentTestSuite struct {
 	testLogFile string
 	fakeLogs    int64
 
-	source *config.LogSource
+	source *sources.LogSource
 }
 
 func (suite *AgentTestSuite) SetupTest() {
@@ -57,7 +58,7 @@ func (suite *AgentTestSuite) SetupTest() {
 		Path:       suite.testLogFile,
 		Identifier: "test", // As it was from service-discovery to force the tailer to read from the start.
 	}
-	suite.source = config.NewLogSource("", &logConfig)
+	suite.source = sources.NewLogSource("", &logConfig)
 
 	mockConfig.Set("logs_config.run_path", suite.testDir)
 	// Shorter grace period for tests.
@@ -75,9 +76,9 @@ func (suite *AgentTestSuite) TearDownTest() {
 	metrics.DestinationLogsDropped.Init()
 }
 
-func createAgent(endpoints *config.Endpoints) (*Agent, *config.LogSources, *service.Services) {
+func createAgent(endpoints *config.Endpoints) (*Agent, *sources.LogSources, *service.Services) {
 	// setup the sources and the services
-	sources := config.NewLogSources()
+	sources := sources.NewLogSources()
 	services := service.NewServices()
 
 	// setup and start the agent

--- a/pkg/logs/auditor/auditor_test.go
+++ b/pkg/logs/auditor/auditor_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 )
 
 var testpath = "testpath"
@@ -28,7 +29,7 @@ type AuditorTestSuite struct {
 	testPath string
 
 	a      *RegistryAuditor
-	source *config.LogSource
+	source *sources.LogSource
 }
 
 func (suite *AuditorTestSuite) SetupTest() {
@@ -44,7 +45,7 @@ func (suite *AuditorTestSuite) SetupTest() {
 
 	suite.a = New("", DefaultRegistryFilename, time.Hour, health.RegisterLiveness("fake"))
 	suite.a.registryPath = suite.testPath
-	suite.source = config.NewLogSource("", &config.LogsConfig{Path: testpath})
+	suite.source = sources.NewLogSource("", &config.LogsConfig{Path: testpath})
 }
 
 func (suite *AuditorTestSuite) TearDownTest() {
@@ -98,7 +99,7 @@ func (suite *AuditorTestSuite) TestAuditorRecoversRegistryForOffset() {
 	offset := suite.a.GetOffset(suite.source.Config.Path)
 	suite.Equal("42", offset)
 
-	othersource := config.NewLogSource("", &config.LogsConfig{Path: "anotherpath"})
+	othersource := sources.NewLogSource("", &config.LogsConfig{Path: "anotherpath"})
 	offset = suite.a.GetOffset(othersource.Config.Path)
 	suite.Equal("", offset)
 }

--- a/pkg/logs/client/tcp/connection_manager_test.go
+++ b/pkg/logs/client/tcp/connection_manager_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/client"
 	"github.com/DataDog/datadog-agent/pkg/logs/client/mock"
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/util"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 )
 
 func newConnectionManagerForAddr(addr net.Addr) *ConnectionManager {
@@ -36,7 +38,7 @@ func TestAddress(t *testing.T) {
 func TestNewConnection(t *testing.T) {
 	l := mock.NewMockLogsIntake(t)
 	defer l.Close()
-	config.CreateSources([]*config.LogSource{})
+	util.CreateSources([]*sources.LogSource{})
 	destinationsCtx := client.NewDestinationsContext()
 
 	connManager := newConnectionManagerForAddr(l.Addr())

--- a/pkg/logs/diagnostic/message_receiver_test.go
+++ b/pkg/logs/diagnostic/message_receiver_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -217,7 +218,7 @@ func newMessage(name, typ, source, service string) message.Message {
 		Source:  source,
 		Service: service,
 	}
-	src := config.NewLogSource(name, cfg)
+	src := sources.NewLogSource(name, cfg)
 	origin := message.NewOrigin(src)
 	return *message.NewMessage([]byte("a"), origin, "", 0)
 }

--- a/pkg/logs/internal/decoder/auto_multiline_handler.go
+++ b/pkg/logs/internal/decoder/auto_multiline_handler.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/logs/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -57,7 +57,7 @@ type AutoMultilineHandler struct {
 	scoredMatches     []*scoredPattern
 	processFunc       func(message *Message)
 	flushTimeout      time.Duration
-	source            *config.LogSource
+	source            *sources.LogSource
 	timeoutTimer      *time.Timer
 	detectedPattern   *DetectedPattern
 }
@@ -69,7 +69,7 @@ func NewAutoMultilineHandler(
 	matchThreshold float64,
 	matchTimeout time.Duration,
 	flushTimeout time.Duration,
-	source *config.LogSource,
+	source *sources.LogSource,
 	additionalPatterns []*regexp.Regexp,
 	detectedPattern *DetectedPattern,
 ) *AutoMultilineHandler {

--- a/pkg/logs/internal/decoder/decoder.go
+++ b/pkg/logs/internal/decoder/decoder.go
@@ -13,6 +13,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/framer"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/parsers"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/status"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -103,7 +104,7 @@ func NewDecoderWithFraming(source *sources.LogSource, parser parsers.Parser, fra
 			// Since a single source can have multiple file tailers - each with their own decoder instance,
 			// Make sure we keep track of the multiline match count info from all of the decoders so the
 			// status page displays it correctly.
-			if existingInfo, ok := source.GetInfo(lh.countInfo.InfoKey()).(*config.CountInfo); ok {
+			if existingInfo, ok := source.GetInfo(lh.countInfo.InfoKey()).(*status.CountInfo); ok {
 				// override the new decoders info to the instance we are already using
 				lh.countInfo = existingInfo
 			} else {

--- a/pkg/logs/internal/decoder/decoder.go
+++ b/pkg/logs/internal/decoder/decoder.go
@@ -13,6 +13,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/framer"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/parsers"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -80,12 +81,12 @@ type Decoder struct {
 }
 
 // InitializeDecoder returns a properly initialized Decoder
-func InitializeDecoder(source *config.LogSource, parser parsers.Parser) *Decoder {
+func InitializeDecoder(source *sources.LogSource, parser parsers.Parser) *Decoder {
 	return NewDecoderWithFraming(source, parser, framer.UTF8Newline, nil)
 }
 
 // NewDecoderWithFraming initialize a decoder with given endline strategy.
-func NewDecoderWithFraming(source *config.LogSource, parser parsers.Parser, framing framer.Framing, multiLinePattern *regexp.Regexp) *Decoder {
+func NewDecoderWithFraming(source *sources.LogSource, parser parsers.Parser, framing framer.Framing, multiLinePattern *regexp.Regexp) *Decoder {
 	inputChan := make(chan *Input)
 	outputChan := make(chan *Message)
 	lineLimit := defaultContentLenLimit
@@ -145,7 +146,7 @@ func NewDecoderWithFraming(source *config.LogSource, parser parsers.Parser, fram
 	return New(inputChan, outputChan, framer, lineParser, lineHandler, detectedPattern)
 }
 
-func buildAutoMultilineHandlerFromConfig(outputFn func(*Message), lineLimit int, source *config.LogSource, detectedPattern *DetectedPattern) *AutoMultilineHandler {
+func buildAutoMultilineHandlerFromConfig(outputFn func(*Message), lineLimit int, source *sources.LogSource, detectedPattern *DetectedPattern) *AutoMultilineHandler {
 	linesToSample := source.Config.AutoMultiLineSampleSize
 	if linesToSample <= 0 {
 		linesToSample = dd_conf.Datadog.GetInt("logs_config.auto_multi_line_default_sample_size")

--- a/pkg/logs/internal/decoder/decoder_test.go
+++ b/pkg/logs/internal/decoder/decoder_test.go
@@ -17,12 +17,13 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/parsers/kubernetes"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/parsers/noop"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestDecoderWithDockerHeader(t *testing.T) {
-	source := config.NewLogSource("config", &config.LogsConfig{})
+	source := sources.NewLogSource("config", &config.LogsConfig{})
 	d := InitializeDecoder(source, noop.New())
 	d.Start()
 
@@ -55,7 +56,7 @@ func TestDecoderWithDockerHeaderSingleline(t *testing.T) {
 	var lineLen int
 
 	d := InitializeDecoder(
-		config.NewLogSource("", &config.LogsConfig{}), dockerstream.New("abc123"))
+		sources.NewLogSource("", &config.LogsConfig{}), dockerstream.New("abc123"))
 	d.Start()
 	defer d.Stop()
 
@@ -107,7 +108,7 @@ func TestDecoderWithDockerHeaderMultiline(t *testing.T) {
 		},
 	}
 
-	d := InitializeDecoder(config.NewLogSource("", c), dockerstream.New("abc123"))
+	d := InitializeDecoder(sources.NewLogSource("", c), dockerstream.New("abc123"))
 	d.Start()
 	defer d.Stop()
 
@@ -142,7 +143,7 @@ func TestDecoderWithDockerJSONSingleline(t *testing.T) {
 	var line []byte
 	var lineLen int
 
-	d := InitializeDecoder(config.NewLogSource("", &config.LogsConfig{}), dockerfile.New())
+	d := InitializeDecoder(sources.NewLogSource("", &config.LogsConfig{}), dockerfile.New())
 	d.Start()
 	defer d.Stop()
 
@@ -181,7 +182,7 @@ func TestDecoderWithDockerJSONMultiline(t *testing.T) {
 		},
 	}
 
-	d := InitializeDecoder(config.NewLogSource("", c), dockerfile.New())
+	d := InitializeDecoder(sources.NewLogSource("", c), dockerfile.New())
 	d.Start()
 	defer d.Stop()
 
@@ -215,7 +216,7 @@ func TestDecoderWithDockerJSONSplittedByDocker(t *testing.T) {
 	var output *Message
 	var line []byte
 
-	d := InitializeDecoder(config.NewLogSource("", &config.LogsConfig{}), dockerfile.New())
+	d := InitializeDecoder(sources.NewLogSource("", &config.LogsConfig{}), dockerfile.New())
 	d.Start()
 	defer d.Stop()
 
@@ -237,7 +238,7 @@ func TestDecoderWithDockerJSONSplittedByDocker(t *testing.T) {
 }
 
 func TestDecoderWithDecodingParser(t *testing.T) {
-	source := config.NewLogSource("config", &config.LogsConfig{})
+	source := sources.NewLogSource("config", &config.LogsConfig{})
 
 	d := NewDecoderWithFraming(source, encodedtext.New(encodedtext.UTF16LE), framer.UTF16LENewline, nil)
 	d.Start()
@@ -266,7 +267,7 @@ func TestDecoderWithSinglelineKubernetes(t *testing.T) {
 	var line []byte
 	var lineLen int
 
-	d := InitializeDecoder(config.NewLogSource("", &config.LogsConfig{}), kubernetes.New())
+	d := InitializeDecoder(sources.NewLogSource("", &config.LogsConfig{}), kubernetes.New())
 	d.Start()
 	defer d.Stop()
 
@@ -304,7 +305,7 @@ func TestDecoderWithMultilineKubernetes(t *testing.T) {
 			},
 		},
 	}
-	d := InitializeDecoder(config.NewLogSource("", c), kubernetes.New())
+	d := InitializeDecoder(sources.NewLogSource("", c), kubernetes.New())
 	d.Start()
 	defer d.Stop()
 

--- a/pkg/logs/internal/decoder/file_decoder.go
+++ b/pkg/logs/internal/decoder/file_decoder.go
@@ -16,23 +16,24 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/parsers/encodedtext"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/parsers/kubernetes"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/parsers/noop"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 )
 
 // NewDecoderFromSource creates a new decoder from a log source
-func NewDecoderFromSource(source *config.LogSource) *Decoder {
+func NewDecoderFromSource(source *sources.LogSource) *Decoder {
 	return NewDecoderFromSourceWithPattern(source, nil)
 }
 
 // NewDecoderFromSourceWithPattern creates a new decoder from a log source with a multiline pattern
-func NewDecoderFromSourceWithPattern(source *config.LogSource, multiLinePattern *regexp.Regexp) *Decoder {
+func NewDecoderFromSourceWithPattern(source *sources.LogSource, multiLinePattern *regexp.Regexp) *Decoder {
 
 	// TODO: remove those checks and add to source a reference to a tagProvider and a lineParser.
 	var lineParser parsers.Parser
 	framing := framer.UTF8Newline
 	switch source.GetSourceType() {
-	case config.KubernetesSourceType:
+	case sources.KubernetesSourceType:
 		lineParser = kubernetes.New()
-	case config.DockerSourceType:
+	case sources.DockerSourceType:
 		if coreConfig.Datadog.GetBool("logs_config.use_podman_logs") {
 			// podman's on-disk logs are in kubernetes format
 			lineParser = kubernetes.New()

--- a/pkg/logs/internal/decoder/line_handler_benchmark_test.go
+++ b/pkg/logs/internal/decoder/line_handler_benchmark_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 )
 
 func benchmarkSingleLineHandler(b *testing.B, logs int) {
@@ -36,7 +37,7 @@ func benchmarkAutoMultiLineHandler(b *testing.B, logs int, line string) {
 		messages[i] = getDummyMessageWithLF(fmt.Sprintf("%s %d", line, i))
 	}
 
-	source := config.NewLogSource("config", &config.LogsConfig{})
+	source := sources.NewLogSource("config", &config.LogsConfig{})
 	h := NewAutoMultilineHandler(func(*Message) {}, defaultContentLenLimit, 1000, 0.9, 30*time.Second, 1000*time.Millisecond, source, []*regexp.Regexp{}, &DetectedPattern{})
 
 	b.ResetTimer()

--- a/pkg/logs/internal/decoder/line_handler_test.go
+++ b/pkg/logs/internal/decoder/line_handler_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -253,7 +254,7 @@ func TestMultiLineHandlerSendsRawInvalidMessages(t *testing.T) {
 func TestAutoMultiLineHandlerStaysSingleLineMode(t *testing.T) {
 
 	outputFn, outputChan := lineHandlerChans()
-	source := config.NewLogSource("config", &config.LogsConfig{})
+	source := sources.NewLogSource("config", &config.LogsConfig{})
 	detectedPattern := &DetectedPattern{}
 	h := NewAutoMultilineHandler(outputFn, 100, 5, 1.0, 10*time.Millisecond, 10*time.Millisecond, source, []*regexp.Regexp{}, detectedPattern)
 
@@ -268,7 +269,7 @@ func TestAutoMultiLineHandlerStaysSingleLineMode(t *testing.T) {
 
 func TestAutoMultiLineHandlerSwitchesToMultiLineMode(t *testing.T) {
 	outputFn, outputChan := lineHandlerChans()
-	source := config.NewLogSource("config", &config.LogsConfig{})
+	source := sources.NewLogSource("config", &config.LogsConfig{})
 	detectedPattern := &DetectedPattern{}
 	h := NewAutoMultilineHandler(outputFn, 100, 5, 1.0, 10*time.Millisecond, 10*time.Millisecond, source, []*regexp.Regexp{}, detectedPattern)
 
@@ -284,7 +285,7 @@ func TestAutoMultiLineHandlerSwitchesToMultiLineMode(t *testing.T) {
 
 func TestAutoMultiLineHandlerHandelsMessage(t *testing.T) {
 	outputFn, outputChan := lineHandlerChans()
-	source := config.NewLogSource("config", &config.LogsConfig{})
+	source := sources.NewLogSource("config", &config.LogsConfig{})
 	h := NewAutoMultilineHandler(outputFn, 500, 1, 1.0, 10*time.Millisecond, 10*time.Millisecond, source, []*regexp.Regexp{}, &DetectedPattern{})
 
 	h.process(getDummyMessageWithLF("Jul 12, 2021 12:55:15 PM test message 1"))
@@ -302,7 +303,7 @@ func TestAutoMultiLineHandlerHandelsMessage(t *testing.T) {
 
 func TestAutoMultiLineHandlerHandelsMessageConflictingPatterns(t *testing.T) {
 	outputFn, outputChan := lineHandlerChans()
-	source := config.NewLogSource("config", &config.LogsConfig{})
+	source := sources.NewLogSource("config", &config.LogsConfig{})
 	h := NewAutoMultilineHandler(outputFn, 500, 4, 0.75, 10*time.Millisecond, 10*time.Millisecond, source, []*regexp.Regexp{}, &DetectedPattern{})
 
 	// we will match both patterns, but one will win with a threshold of 0.75
@@ -327,7 +328,7 @@ func TestAutoMultiLineHandlerHandelsMessageConflictingPatterns(t *testing.T) {
 
 func TestAutoMultiLineHandlerHandelsMessageConflictingPatternsNoWinner(t *testing.T) {
 	outputFn, outputChan := lineHandlerChans()
-	source := config.NewLogSource("config", &config.LogsConfig{})
+	source := sources.NewLogSource("config", &config.LogsConfig{})
 	h := NewAutoMultilineHandler(outputFn, 500, 4, 0.75, 10*time.Millisecond, 10*time.Millisecond, source, []*regexp.Regexp{}, &DetectedPattern{})
 
 	// we will match both patterns, but neither will win because it doesn't meet the threshold

--- a/pkg/logs/internal/decoder/multiline_handler.go
+++ b/pkg/logs/internal/decoder/multiline_handler.go
@@ -10,7 +10,7 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/logs/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/status"
 )
 
 // MultiLineHandler makes sure that multiple lines from a same content
@@ -26,7 +26,7 @@ type MultiLineHandler struct {
 	linesLen       int
 	status         string
 	timestamp      string
-	countInfo      *config.CountInfo
+	countInfo      *status.CountInfo
 }
 
 // NewMultiLineHandler returns a new MultiLineHandler.
@@ -37,7 +37,7 @@ func NewMultiLineHandler(outputFn func(*Message), newContentRe *regexp.Regexp, f
 		buffer:       bytes.NewBuffer(nil),
 		flushTimeout: flushTimeout,
 		lineLimit:    lineLimit,
-		countInfo:    config.NewCountInfo("MultiLine matches"),
+		countInfo:    status.NewCountInfo("MultiLine matches"),
 	}
 }
 

--- a/pkg/logs/internal/launchers/README.md
+++ b/pkg/logs/internal/launchers/README.md
@@ -1,5 +1,5 @@
 # Launchers
 
-Launchers are responsible for translating sources (config.LogSource) to tailers, and managing their tailers' lifecycle.
+Launchers are responsible for translating sources (sources.LogSource) to tailers, and managing their tailers' lifecycle.
 
 The logs agent maintains a set of current launchers, starting and stopping them at startup and stopping them when the logs-agent stops.

--- a/pkg/logs/internal/launchers/channel/launcher.go
+++ b/pkg/logs/internal/launchers/channel/launcher.go
@@ -11,6 +11,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/launchers"
 	tailer "github.com/DataDog/datadog-agent/pkg/logs/internal/tailers/channel"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 )
 
 // Launcher reacts to sources with Config.Type = Channel, by creating a tailer
@@ -19,7 +20,7 @@ import (
 // WARNING: removing a source does not stop the corresponding tailer.
 type Launcher struct {
 	pipelineProvider pipeline.Provider
-	sources          chan *config.LogSource
+	sources          chan *sources.LogSource
 	tailers          []*tailer.Tailer
 	stop             chan struct{}
 }
@@ -38,7 +39,7 @@ func (l *Launcher) Start(sourceProvider launchers.SourceProvider, pipelineProvid
 	go l.run()
 }
 
-func (l *Launcher) startNewTailer(source *config.LogSource) {
+func (l *Launcher) startNewTailer(source *sources.LogSource) {
 	outputChan := l.pipelineProvider.NextPipelineChan()
 	tailer := tailer.NewTailer(source, source.Config.Channel, outputChan)
 	l.tailers = append(l.tailers, tailer)

--- a/pkg/logs/internal/launchers/docker/container.go
+++ b/pkg/logs/internal/launchers/docker/container.go
@@ -20,8 +20,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 	"github.com/docker/docker/api/types"
 
-	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/service"
+	sourcesPkg "github.com/DataDog/datadog-agent/pkg/logs/sources"
 )
 
 const (
@@ -50,8 +50,8 @@ func NewContainer(container types.ContainerJSON, service *service.Service) *Cont
 
 // FindSource returns the source that most likely matches the container,
 // if no source is found return nil
-func (c *Container) FindSource(sources []*config.LogSource) *config.LogSource {
-	var bestMatch *config.LogSource
+func (c *Container) FindSource(sources []*sourcesPkg.LogSource) *sourcesPkg.LogSource {
+	var bestMatch *sourcesPkg.LogSource
 	for _, source := range sources {
 		if source.Config.Identifier != "" && c.isIdentifierMatch(source.Config.Identifier) {
 			// perfect match between the source and the container
@@ -97,7 +97,7 @@ func (c *Container) getShortImageName(ctx context.Context) (string, error) {
 }
 
 // computeScore returns the matching score between the container and the source.
-func (c *Container) computeScore(source *config.LogSource) int {
+func (c *Container) computeScore(source *sourcesPkg.LogSource) int {
 	score := 0
 	if c.isImageMatch(source.Config.Image) {
 		score++
@@ -112,7 +112,7 @@ func (c *Container) computeScore(source *config.LogSource) int {
 }
 
 // IsMatch returns true if the source matches with the container.
-func (c *Container) IsMatch(source *config.LogSource) bool {
+func (c *Container) IsMatch(source *sourcesPkg.LogSource) bool {
 	if (source.Config.Identifier != "" || c.ContainsADIdentifier()) && !c.isIdentifierMatch(source.Config.Identifier) {
 		// there is only one source matching a container when it contains an autodiscovery identifier,
 		// the one which has an identifier equals to the container identifier.

--- a/pkg/logs/internal/launchers/docker/container_test.go
+++ b/pkg/logs/internal/launchers/docker/container_test.go
@@ -17,17 +17,18 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/service"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 )
 
 func TestFindSourceWithSourceFiltersShouldSucceed(t *testing.T) {
-	var source *config.LogSource
+	var source *sources.LogSource
 	var container *Container
 
-	sources := []*config.LogSource{
-		config.NewLogSource("", &config.LogsConfig{Type: config.DockerType, Image: "myapp"}),
-		config.NewLogSource("", &config.LogsConfig{Type: config.DockerType, Label: "mylabel"}),
-		config.NewLogSource("", &config.LogsConfig{Type: config.DockerType, Image: "myapp", Label: "mylabel"}),
-		config.NewLogSource("", &config.LogsConfig{Type: config.DockerType, Identifier: "1234567890"}),
+	sources := []*sources.LogSource{
+		sources.NewLogSource("", &config.LogsConfig{Type: config.DockerType, Image: "myapp"}),
+		sources.NewLogSource("", &config.LogsConfig{Type: config.DockerType, Label: "mylabel"}),
+		sources.NewLogSource("", &config.LogsConfig{Type: config.DockerType, Image: "myapp", Label: "mylabel"}),
+		sources.NewLogSource("", &config.LogsConfig{Type: config.DockerType, Identifier: "1234567890"}),
 	}
 
 	container = NewContainer(types.ContainerJSON{
@@ -82,12 +83,12 @@ func TestFindSourceWithSourceFiltersShouldSucceed(t *testing.T) {
 }
 
 func TestFindSourceWithNoSourceFilterShouldSucceed(t *testing.T) {
-	var source *config.LogSource
+	var source *sources.LogSource
 	var container *Container
 
-	sources := []*config.LogSource{
-		config.NewLogSource("", &config.LogsConfig{Type: config.DockerType}),
-		config.NewLogSource("", &config.LogsConfig{Type: config.DockerType, Label: "mylabel"}),
+	sources := []*sources.LogSource{
+		sources.NewLogSource("", &config.LogsConfig{Type: config.DockerType}),
+		sources.NewLogSource("", &config.LogsConfig{Type: config.DockerType, Label: "mylabel"}),
 	}
 
 	container = NewContainer(types.ContainerJSON{

--- a/pkg/logs/internal/launchers/docker/launcher.go
+++ b/pkg/logs/internal/launchers/docker/launcher.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/launchers"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/status"
 	tailer "github.com/DataDog/datadog-agent/pkg/logs/internal/tailers/docker"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/util"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/util/containersorpods"
@@ -297,7 +298,7 @@ func (l *Launcher) getFileSource(container *Container, source *sources.LogSource
 }
 
 // newOverridenSource is separated from overrideSource for testing purpose
-func newOverridenSource(standardService, shortName string, status *config.LogStatus) *sources.LogSource {
+func newOverridenSource(standardService, shortName string, status *status.LogStatus) *sources.LogSource {
 	var serviceName string
 	if standardService != "" {
 		serviceName = standardService

--- a/pkg/logs/internal/launchers/docker/launcher.go
+++ b/pkg/logs/internal/launchers/docker/launcher.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/util/containersorpods"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
 	"github.com/DataDog/datadog-agent/pkg/logs/service"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	dockerutilpkg "github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/startstop"
@@ -33,20 +34,20 @@ const (
 )
 
 type sourceInfoPair struct {
-	source *config.LogSource
+	source *sources.LogSource
 	info   *config.MappedInfo
 }
 
 // A Launcher starts and stops new tailers for every new containers discovered by autodiscovery.
 type Launcher struct {
 	pipelineProvider   pipeline.Provider
-	activeSources      []*config.LogSource
+	activeSources      []*sources.LogSource
 	pendingContainers  map[string]*Container
 	tailers            map[string]*tailer.Tailer
 	registry           auditor.Registry
 	erroredContainerID chan string
 	lock               *sync.Mutex
-	collectAllSource   *config.LogSource
+	collectAllSource   *sources.LogSource
 	collectAllInfo     *config.MappedInfo
 	readTimeout        time.Duration               // client read timeout to set on the created tailer
 	serviceNameFunc    func(string, string) string // serviceNameFunc gets the service name from the tagger, it is in a separate field for testing purpose
@@ -54,7 +55,7 @@ type Launcher struct {
 	forceTailingFromFile   bool                      // will ignore known offset and always tail from file
 	tailFromFile           bool                      // If true docker will be tailed from the corresponding log file
 	fileSourcesByContainer map[string]sourceInfoPair // Keep track of locally generated sources
-	sources                *config.LogSources        // To schedule file source when taileing container from file
+	sources                *sources.LogSources       // To schedule file source when taileing container from file
 	services               *service.Services
 	cop                    containersorpods.Chooser
 
@@ -66,7 +67,7 @@ type Launcher struct {
 }
 
 // NewLauncher returns a new launcher
-func NewLauncher(readTimeout time.Duration, sources *config.LogSources, services *service.Services, cop containersorpods.Chooser, tailFromFile, forceTailingFromFile bool) *Launcher {
+func NewLauncher(readTimeout time.Duration, sources *sources.LogSources, services *service.Services, cop containersorpods.Chooser, tailFromFile, forceTailingFromFile bool) *Launcher {
 	launcher := &Launcher{
 		tailers:                make(map[string]*tailer.Tailer),
 		pendingContainers:      make(map[string]*Container),
@@ -208,7 +209,7 @@ func (l *Launcher) run(sourceProvider launchers.SourceProvider, pipelineProvider
 }
 
 // overrideSource create a new source with the image short name if the source is ContainerCollectAll
-func (l *Launcher) overrideSource(container *Container, source *config.LogSource) *config.LogSource {
+func (l *Launcher) overrideSource(container *Container, source *sources.LogSource) *sources.LogSource {
 	standardService := l.serviceNameFunc(container.container.Name, dockerutilpkg.ContainerIDToTaggerEntityName(container.container.ID))
 	if source.Name != config.ContainerCollectAll {
 		if source.Config.Service == "" && standardService != "" {
@@ -237,7 +238,7 @@ func (l *Launcher) overrideSource(container *Container, source *config.LogSource
 }
 
 // getFileSource create a new file source with the image short name if the source is ContainerCollectAll
-func (l *Launcher) getFileSource(container *Container, source *config.LogSource) sourceInfoPair {
+func (l *Launcher) getFileSource(container *Container, source *sources.LogSource) sourceInfoPair {
 	containerID := container.service.Identifier
 
 	// If containerCollectAll is set - we use the global collectAllInfo, otherwise we create a new info for this source
@@ -280,7 +281,7 @@ func (l *Launcher) getFileSource(container *Container, source *config.LogSource)
 	}
 
 	// New file source that inherit most of its parent properties
-	fileSource := config.NewLogSource(source.Name, &config.LogsConfig{
+	fileSource := sources.NewLogSource(source.Name, &config.LogsConfig{
 		Type:            config.FileType,
 		Identifier:      containerID,
 		Path:            getPath(containerID),
@@ -289,14 +290,14 @@ func (l *Launcher) getFileSource(container *Container, source *config.LogSource)
 		Tags:            source.Config.Tags,
 		ProcessingRules: source.Config.ProcessingRules,
 	})
-	fileSource.SetSourceType(config.DockerSourceType)
+	fileSource.SetSourceType(sources.DockerSourceType)
 	fileSource.Status = source.Status
 	fileSource.ParentSource = source
 	return sourceInfoPair{source: fileSource, info: sourceInfo}
 }
 
 // newOverridenSource is separated from overrideSource for testing purpose
-func newOverridenSource(standardService, shortName string, status *config.LogStatus) *config.LogSource {
+func newOverridenSource(standardService, shortName string, status *config.LogStatus) *sources.LogSource {
 	var serviceName string
 	if standardService != "" {
 		serviceName = standardService
@@ -304,7 +305,7 @@ func newOverridenSource(standardService, shortName string, status *config.LogSta
 		serviceName = shortName
 	}
 
-	overridenSource := config.NewLogSource(config.ContainerCollectAll, &config.LogsConfig{
+	overridenSource := sources.NewLogSource(config.ContainerCollectAll, &config.LogsConfig{
 		Type:    config.DockerType,
 		Service: serviceName,
 		Source:  shortName,
@@ -314,7 +315,7 @@ func newOverridenSource(standardService, shortName string, status *config.LogSta
 }
 
 // startTailer starts a new tailer for the container matching with the source.
-func (l *Launcher) startTailer(container *Container, source *config.LogSource) {
+func (l *Launcher) startTailer(container *Container, source *sources.LogSource) {
 	if l.shouldTailFromFile(container) {
 		l.scheduleFileSource(container, source)
 	} else {
@@ -337,7 +338,7 @@ func (l *Launcher) shouldTailFromFile(container *Container) bool {
 	return offset == ""
 }
 
-func (l *Launcher) scheduleFileSource(container *Container, source *config.LogSource) {
+func (l *Launcher) scheduleFileSource(container *Container, source *sources.LogSource) {
 	containerID := container.service.Identifier
 	if _, isTailed := l.fileSourcesByContainer[containerID]; isTailed {
 		log.Warnf("Can't tail twice the same container: %v", dockerutilpkg.ShortContainerID(containerID))
@@ -360,7 +361,7 @@ func (l *Launcher) unscheduleFileSource(containerID string) {
 	}
 }
 
-func (l *Launcher) startSocketTailer(container *Container, source *config.LogSource) {
+func (l *Launcher) startSocketTailer(container *Container, source *sources.LogSource) {
 	containerID := container.service.Identifier
 	if _, isTailed := l.getTailer(containerID); isTailed {
 		log.Warnf("Can't tail twice the same container: %v", dockerutilpkg.ShortContainerID(containerID))
@@ -421,7 +422,7 @@ func (l *Launcher) restartTailer(containerID string) {
 	}
 	backoffDuration := backoffInitialDuration
 	cumulatedBackoff := 0 * time.Second
-	var source *config.LogSource
+	var source *sources.LogSource
 
 	if oldTailer, exists := l.getTailer(containerID); exists {
 		source = oldTailer.Source

--- a/pkg/logs/internal/launchers/docker/launcher.go
+++ b/pkg/logs/internal/launchers/docker/launcher.go
@@ -36,7 +36,7 @@ const (
 
 type sourceInfoPair struct {
 	source *sources.LogSource
-	info   *config.MappedInfo
+	info   *status.MappedInfo
 }
 
 // A Launcher starts and stops new tailers for every new containers discovered by autodiscovery.
@@ -49,7 +49,7 @@ type Launcher struct {
 	erroredContainerID chan string
 	lock               *sync.Mutex
 	collectAllSource   *sources.LogSource
-	collectAllInfo     *config.MappedInfo
+	collectAllInfo     *status.MappedInfo
 	readTimeout        time.Duration               // client read timeout to set on the created tailer
 	serviceNameFunc    func(string, string) string // serviceNameFunc gets the service name from the tagger, it is in a separate field for testing purpose
 
@@ -82,7 +82,7 @@ func NewLauncher(readTimeout time.Duration, sources *sources.LogSources, service
 		forceTailingFromFile:   forceTailingFromFile,
 		tailFromFile:           tailFromFile,
 		fileSourcesByContainer: make(map[string]sourceInfoPair),
-		collectAllInfo:         config.NewMappedInfo("Container Info"),
+		collectAllInfo:         status.NewMappedInfo("Container Info"),
 	}
 
 	if tailFromFile {
@@ -243,7 +243,7 @@ func (l *Launcher) getFileSource(container *Container, source *sources.LogSource
 	containerID := container.service.Identifier
 
 	// If containerCollectAll is set - we use the global collectAllInfo, otherwise we create a new info for this source
-	var sourceInfo *config.MappedInfo
+	var sourceInfo *status.MappedInfo
 
 	// Populate the collectAllSource if we don't have it yet
 	if source.Name == config.ContainerCollectAll && l.collectAllSource == nil {
@@ -251,7 +251,7 @@ func (l *Launcher) getFileSource(container *Container, source *sources.LogSource
 		l.collectAllSource.RegisterInfo(l.collectAllInfo)
 		sourceInfo = l.collectAllInfo
 	} else {
-		sourceInfo = config.NewMappedInfo("Container Info")
+		sourceInfo = status.NewMappedInfo("Container Info")
 		source.RegisterInfo(sourceInfo)
 	}
 

--- a/pkg/logs/internal/launchers/docker/launcher_nodocker.go
+++ b/pkg/logs/internal/launchers/docker/launcher_nodocker.go
@@ -12,11 +12,11 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
-	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/launchers"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/util/containersorpods"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
 	"github.com/DataDog/datadog-agent/pkg/logs/service"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/util/retry"
 )
 
@@ -24,7 +24,7 @@ import (
 type Launcher struct{}
 
 // NewLauncher returns a new Launcher
-func NewLauncher(readTimeout time.Duration, psources *config.LogSources, services *service.Services, cop containersorpods.Chooser, tailFromFile, forceTailingFromFile bool) *Launcher {
+func NewLauncher(readTimeout time.Duration, psources *sources.LogSources, services *service.Services, cop containersorpods.Chooser, tailFromFile, forceTailingFromFile bool) *Launcher {
 	return &Launcher{}
 }
 

--- a/pkg/logs/internal/launchers/docker/launcher_test.go
+++ b/pkg/logs/internal/launchers/docker/launcher_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/status"
 	"github.com/DataDog/datadog-agent/pkg/logs/service"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/stretchr/testify/assert"
@@ -82,21 +83,21 @@ func TestNewOverridenSourceServiceNameOrder(t *testing.T) {
 		name            string
 		standardService string
 		shortName       string
-		status          *config.LogStatus
+		status          *status.LogStatus
 		wantServiceName string
 	}{
 		{
 			name:            "standard svc name",
 			standardService: "stdServiceName",
 			shortName:       "fooName",
-			status:          config.NewLogStatus(),
+			status:          status.NewLogStatus(),
 			wantServiceName: "stdServiceName",
 		},
 		{
 			name:            "image name",
 			standardService: "",
 			shortName:       "fooName",
-			status:          config.NewLogStatus(),
+			status:          status.NewLogStatus(),
 			wantServiceName: "fooName",
 		},
 	}

--- a/pkg/logs/internal/launchers/docker/launcher_test.go
+++ b/pkg/logs/internal/launchers/docker/launcher_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/service"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/docker/docker/api/types"
@@ -24,7 +25,7 @@ func TestOverrideSourceServiceNameOrder(t *testing.T) {
 		name            string
 		sFunc           func(string, string) string
 		container       *Container
-		source          *config.LogSource
+		source          *sources.LogSource
 		wantServiceName string
 	}{
 		{
@@ -38,7 +39,7 @@ func TestOverrideSourceServiceNameOrder(t *testing.T) {
 					},
 				},
 			},
-			source: &config.LogSource{
+			source: &sources.LogSource{
 				Name: "from container",
 				Config: &config.LogsConfig{
 					Service: "configServiceName",
@@ -57,7 +58,7 @@ func TestOverrideSourceServiceNameOrder(t *testing.T) {
 					},
 				},
 			},
-			source: &config.LogSource{
+			source: &sources.LogSource{
 				Name:   "from container",
 				Config: &config.LogsConfig{},
 			},
@@ -119,7 +120,7 @@ func TestGetFileSource(t *testing.T) {
 		name            string
 		sFunc           func(string, string) string
 		container       *Container
-		source          *config.LogSource
+		source          *sources.LogSource
 		wantServiceName string
 		wantSourceName  string
 		wantPath        string
@@ -138,7 +139,7 @@ func TestGetFileSource(t *testing.T) {
 				},
 				service: &service.Service{Identifier: "123456"},
 			},
-			source:          config.NewLogSource("from container", &config.LogsConfig{Service: "configServiceName", Source: "configSourceName", Tags: []string{"foo:bar", "foo:baz"}}),
+			source:          sources.NewLogSource("from container", &config.LogsConfig{Service: "configServiceName", Source: "configSourceName", Tags: []string{"foo:bar", "foo:baz"}}),
 			wantServiceName: "configServiceName",
 			wantSourceName:  "configSourceName",
 			wantPath:        "/var/lib/docker/containers/123456/123456-json.log",
@@ -156,7 +157,7 @@ func TestGetFileSource(t *testing.T) {
 				},
 				service: &service.Service{Identifier: "123456"},
 			},
-			source:          config.NewLogSource("from container", &config.LogsConfig{ProcessingRules: testRules, Source: "stdSourceName"}),
+			source:          sources.NewLogSource("from container", &config.LogsConfig{ProcessingRules: testRules, Source: "stdSourceName"}),
 			wantServiceName: "stdServiceName",
 			wantSourceName:  "stdSourceName",
 			wantPath:        "/var/lib/docker/containers/123456/123456-json.log",

--- a/pkg/logs/internal/launchers/docker/launcher_windows_test.go
+++ b/pkg/logs/internal/launchers/docker/launcher_windows_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/service"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -25,7 +26,7 @@ func TestGetFileSourceOnWindows(t *testing.T) {
 		name            string
 		sFunc           func(string, string) string
 		container       *Container
-		source          *config.LogSource
+		source          *sources.LogSource
 		wantServiceName string
 		wantPath        string
 	}{
@@ -41,7 +42,7 @@ func TestGetFileSourceOnWindows(t *testing.T) {
 				},
 				service: &service.Service{Identifier: "123456"},
 			},
-			source:          config.NewLogSource("from container", &config.LogsConfig{Service: "configServiceName"}),
+			source:          sources.NewLogSource("from container", &config.LogsConfig{Service: "configServiceName"}),
 			wantServiceName: "configServiceName",
 			wantPath:        "c:\\programdata\\docker\\containers\\123456\\123456-json.log",
 		},
@@ -57,7 +58,7 @@ func TestGetFileSourceOnWindows(t *testing.T) {
 				},
 				service: &service.Service{Identifier: "123456"},
 			},
-			source:          config.NewLogSource("from container", &config.LogsConfig{}),
+			source:          sources.NewLogSource("from container", &config.LogsConfig{}),
 			wantServiceName: "stdServiceName",
 			wantPath:        "c:\\programdata\\docker\\containers\\123456\\123456-json.log",
 		},

--- a/pkg/logs/internal/launchers/file/file_provider.go
+++ b/pkg/logs/internal/launchers/file/file_provider.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 
 	tailer "github.com/DataDog/datadog-agent/pkg/logs/internal/tailers/file"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/logs/status"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
@@ -40,7 +41,7 @@ func newFileProvider(filesLimit int) *fileProvider {
 // it cannot return more than filesLimit Files.
 // For now, there is no way to prioritize specific Files over others,
 // they are just returned in reverse lexicographical order, see `searchFiles`
-func (p *fileProvider) filesToTail(sources []*config.LogSource) []*tailer.File {
+func (p *fileProvider) filesToTail(sources []*sources.LogSource) []*tailer.File {
 	var filesToTail []*tailer.File
 	shouldLogErrors := p.shouldLogErrors
 	p.shouldLogErrors = false // Let's log errors on first run only
@@ -92,7 +93,7 @@ func (p *fileProvider) filesToTail(sources []*config.LogSource) []*tailer.File {
 }
 
 // collectFiles returns all the files matching the source path.
-func (p *fileProvider) collectFiles(source *config.LogSource) ([]*tailer.File, error) {
+func (p *fileProvider) collectFiles(source *sources.LogSource) ([]*tailer.File, error) {
 	path := source.Config.Path
 	_, err := os.Stat(path)
 	switch {
@@ -109,7 +110,7 @@ func (p *fileProvider) collectFiles(source *config.LogSource) ([]*tailer.File, e
 }
 
 // searchFiles returns all the files matching the source path pattern.
-func (p *fileProvider) searchFiles(pattern string, source *config.LogSource) ([]*tailer.File, error) {
+func (p *fileProvider) searchFiles(pattern string, source *sources.LogSource) ([]*tailer.File, error) {
 	paths, err := filepath.Glob(pattern)
 	if err != nil {
 		return nil, fmt.Errorf("malformed pattern, could not find any file: %s", pattern)

--- a/pkg/logs/internal/launchers/file/file_provider_test.go
+++ b/pkg/logs/internal/launchers/file/file_provider_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/util"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/logs/status"
 )
 
@@ -27,8 +29,8 @@ type ProviderTestSuite struct {
 }
 
 // newLogSources returns a new log source initialized with the right path.
-func (suite *ProviderTestSuite) newLogSources(path string) []*config.LogSource {
-	return []*config.LogSource{config.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: path})}
+func (suite *ProviderTestSuite) newLogSources(path string) []*sources.LogSource {
+	return []*sources.LogSource{sources.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: path})}
 }
 
 func (suite *ProviderTestSuite) SetupTest() {
@@ -78,7 +80,7 @@ func (suite *ProviderTestSuite) TestFilesToTailReturnsSpecificFile() {
 	path := fmt.Sprintf("%s/1/1.log", suite.testDir)
 	fileProvider := newFileProvider(suite.filesLimit)
 	logSources := suite.newLogSources(path)
-	config.CreateSources(logSources)
+	util.CreateSources(logSources)
 	files := fileProvider.filesToTail(logSources)
 
 	suite.Equal(1, len(files))
@@ -91,7 +93,7 @@ func (suite *ProviderTestSuite) TestFilesToTailReturnsAllFilesFromDirectory() {
 	path := fmt.Sprintf("%s/1/*.log", suite.testDir)
 	fileProvider := newFileProvider(suite.filesLimit)
 	logSources := suite.newLogSources(path)
-	status.InitStatus(config.CreateSources(logSources))
+	status.InitStatus(util.CreateSources(logSources))
 	files := fileProvider.filesToTail(logSources)
 
 	suite.Equal(3, len(files))
@@ -138,7 +140,7 @@ func (suite *ProviderTestSuite) TestFilesToTailReturnsAllFilesFromAnyDirectoryWi
 	path := fmt.Sprintf("%s/*/*1.log", suite.testDir)
 	fileProvider := newFileProvider(suite.filesLimit)
 	logSources := suite.newLogSources(path)
-	config.CreateSources(logSources)
+	util.CreateSources(logSources)
 	files := fileProvider.filesToTail(logSources)
 
 	suite.Equal(2, len(files))
@@ -153,7 +155,7 @@ func (suite *ProviderTestSuite) TestFilesToTailReturnsSpecificFileWithWildcard()
 	path := fmt.Sprintf("%s/1/?.log", suite.testDir)
 	fileProvider := newFileProvider(suite.filesLimit)
 	logSources := suite.newLogSources(path)
-	status.InitStatus(config.CreateSources(logSources))
+	status.InitStatus(util.CreateSources(logSources))
 	files := fileProvider.filesToTail(logSources)
 
 	suite.Equal(3, len(files))
@@ -193,7 +195,7 @@ func (suite *ProviderTestSuite) TestNumberOfFilesToTailDoesNotExceedLimit() {
 	path := fmt.Sprintf("%s/*/*.log", suite.testDir)
 	fileProvider := newFileProvider(suite.filesLimit)
 	logSources := suite.newLogSources(path)
-	status.InitStatus(config.CreateSources(logSources))
+	status.InitStatus(util.CreateSources(logSources))
 	files := fileProvider.filesToTail(logSources)
 	suite.Equal(suite.filesLimit, len(files))
 	suite.Equal([]string{"3 files tailed out of 5 files matching"}, logSources[0].Messages.GetMessages())
@@ -208,11 +210,11 @@ func (suite *ProviderTestSuite) TestNumberOfFilesToTailDoesNotExceedLimit() {
 func (suite *ProviderTestSuite) TestAllWildcardPathsAreUpdated() {
 	filesLimit := 2
 	fileProvider := newFileProvider(filesLimit)
-	logSources := []*config.LogSource{
-		config.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: fmt.Sprintf("%s/1/*.log", suite.testDir)}),
-		config.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: fmt.Sprintf("%s/2/*.log", suite.testDir)}),
+	logSources := []*sources.LogSource{
+		sources.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: fmt.Sprintf("%s/1/*.log", suite.testDir)}),
+		sources.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: fmt.Sprintf("%s/2/*.log", suite.testDir)}),
 	}
-	status.InitStatus(config.CreateSources(logSources))
+	status.InitStatus(util.CreateSources(logSources))
 	files := fileProvider.filesToTail(logSources)
 	suite.Equal(2, len(files))
 	suite.Equal([]string{"2 files tailed out of 3 files matching"}, logSources[0].Messages.GetMessages())
@@ -259,8 +261,8 @@ func (suite *ProviderTestSuite) TestExcludePath() {
 	path := fmt.Sprintf("%s/*/*.log", suite.testDir)
 	excludePaths := []string{fmt.Sprintf("%s/2/*.log", suite.testDir)}
 	fileProvider := newFileProvider(filesLimit)
-	logSources := []*config.LogSource{
-		config.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: path, ExcludePaths: excludePaths}),
+	logSources := []*sources.LogSource{
+		sources.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: path, ExcludePaths: excludePaths}),
 	}
 
 	files := fileProvider.filesToTail(logSources)

--- a/pkg/logs/internal/launchers/file/launcher_test.go
+++ b/pkg/logs/internal/launchers/file/launcher_test.go
@@ -22,9 +22,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/launchers"
 	filetailer "github.com/DataDog/datadog-agent/pkg/logs/internal/tailers/file"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/util"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline/mock"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/logs/status"
 )
 
@@ -39,7 +41,7 @@ type LauncherTestSuite struct {
 
 	outputChan       chan *message.Message
 	pipelineProvider pipeline.Provider
-	source           *config.LogSource
+	source           *sources.LogSource
 	openFilesLimit   int
 	s                *Launcher
 }
@@ -63,13 +65,13 @@ func (suite *LauncherTestSuite) SetupTest() {
 	suite.testRotatedFile = f
 
 	suite.openFilesLimit = 100
-	suite.source = config.NewLogSource("", &config.LogsConfig{Type: config.FileType, Identifier: suite.configID, Path: suite.testPath})
+	suite.source = sources.NewLogSource("", &config.LogsConfig{Type: config.FileType, Identifier: suite.configID, Path: suite.testPath})
 	sleepDuration := 20 * time.Millisecond
 	suite.s = NewLauncher(suite.openFilesLimit, sleepDuration, false, 10*time.Second)
 	suite.s.pipelineProvider = suite.pipelineProvider
 	suite.s.registry = auditor.NewRegistry()
 	suite.s.activeSources = append(suite.s.activeSources, suite.source)
-	status.InitStatus(config.CreateSources([]*config.LogSource{suite.source}))
+	status.InitStatus(util.CreateSources([]*sources.LogSource{suite.source}))
 	suite.s.scan()
 }
 
@@ -225,10 +227,10 @@ func TestLauncherScanStartNewTailer(t *testing.T) {
 		launcher.pipelineProvider = mock.NewMockProvider()
 		launcher.registry = auditor.NewRegistry()
 		outputChan := launcher.pipelineProvider.NextPipelineChan()
-		source := config.NewLogSource("", &config.LogsConfig{Type: config.FileType, Identifier: configID, Path: path})
+		source := sources.NewLogSource("", &config.LogsConfig{Type: config.FileType, Identifier: configID, Path: path})
 		launcher.activeSources = append(launcher.activeSources, source)
 		status.Clear()
-		status.InitStatus(config.CreateSources([]*config.LogSource{source}))
+		status.InitStatus(util.CreateSources([]*sources.LogSource{source}))
 		defer status.Clear()
 
 		// create file
@@ -264,8 +266,8 @@ func TestLauncherWithConcurrentContainerTailer(t *testing.T) {
 	launcher.pipelineProvider = mock.NewMockProvider()
 	launcher.registry = auditor.NewRegistry()
 	outputChan := launcher.pipelineProvider.NextPipelineChan()
-	firstSource := config.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: fmt.Sprintf("%s/*.log", testDir), TailingMode: "beginning", Identifier: "123456789"})
-	secondSource := config.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: fmt.Sprintf("%s/*.log", testDir), TailingMode: "beginning", Identifier: "987654321"})
+	firstSource := sources.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: fmt.Sprintf("%s/*.log", testDir), TailingMode: "beginning", Identifier: "123456789"})
+	secondSource := sources.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: fmt.Sprintf("%s/*.log", testDir), TailingMode: "beginning", Identifier: "987654321"})
 
 	// create/truncate file
 	file, err := os.Create(path)
@@ -312,11 +314,11 @@ func TestLauncherTailFromTheBeginning(t *testing.T) {
 	launcher.pipelineProvider = mock.NewMockProvider()
 	launcher.registry = auditor.NewRegistry()
 	outputChan := launcher.pipelineProvider.NextPipelineChan()
-	sources := []*config.LogSource{
-		config.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: fmt.Sprintf("%s/test.log", testDir), TailingMode: "beginning"}),
-		config.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: fmt.Sprintf("%s/container.log", testDir), TailingMode: "beginning", Identifier: "123456789"}),
+	sources := []*sources.LogSource{
+		sources.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: fmt.Sprintf("%s/test.log", testDir), TailingMode: "beginning"}),
+		sources.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: fmt.Sprintf("%s/container.log", testDir), TailingMode: "beginning", Identifier: "123456789"}),
 		// Same file different container ID
-		config.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: fmt.Sprintf("%s/container.log", testDir), TailingMode: "beginning", Identifier: "987654321"}),
+		sources.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: fmt.Sprintf("%s/container.log", testDir), TailingMode: "beginning", Identifier: "987654321"}),
 	}
 
 	for i, source := range sources {
@@ -378,10 +380,10 @@ func TestLauncherScanWithTooManyFiles(t *testing.T) {
 	launcher := NewLauncher(openFilesLimit, sleepDuration, false, 10*time.Second)
 	launcher.pipelineProvider = mock.NewMockProvider()
 	launcher.registry = auditor.NewRegistry()
-	source := config.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: path})
+	source := sources.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: path})
 	launcher.activeSources = append(launcher.activeSources, source)
 	status.Clear()
-	status.InitStatus(config.CreateSources([]*config.LogSource{source}))
+	status.InitStatus(util.CreateSources([]*sources.LogSource{source}))
 	defer status.Clear()
 
 	// test at scan
@@ -402,8 +404,8 @@ func TestLauncherScanWithTooManyFiles(t *testing.T) {
 func TestContainerIDInContainerLogFile(t *testing.T) {
 	assert := assert.New(t)
 	//func (s *Launcher) shouldIgnore(file *File) bool {
-	logSource := config.NewLogSource("mylogsource", nil)
-	logSource.SetSourceType(config.DockerSourceType)
+	logSource := sources.NewLogSource("mylogsource", nil)
+	logSource.SetSourceType(sources.DockerSourceType)
 	logSource.Config = &config.LogsConfig{
 		Type: config.FileType,
 		Path: "/var/log/pods/file-uuid-foo-bar.log",
@@ -450,6 +452,6 @@ func TestContainerIDInContainerLogFile(t *testing.T) {
 	assert.False(launcher.shouldIgnore(&file), "no container ID found, we don't want to ignore this scanned file")
 }
 
-func getScanKey(path string, source *config.LogSource) string {
+func getScanKey(path string, source *sources.LogSource) string {
 	return filetailer.NewFile(path, source, false).GetScanKey()
 }

--- a/pkg/logs/internal/launchers/journald/launcher.go
+++ b/pkg/logs/internal/launchers/journald/launcher.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/launchers"
 	tailer "github.com/DataDog/datadog-agent/pkg/logs/internal/tailers/journald"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/startstop"
 	"github.com/coreos/go-systemd/sdjournal"
@@ -21,7 +22,7 @@ import (
 
 // Launcher is in charge of starting and stopping new journald tailers
 type Launcher struct {
-	sources          chan *config.LogSource
+	sources          chan *sources.LogSource
 	pipelineProvider pipeline.Provider
 	registry         auditor.Registry
 	tailers          map[string]*tailer.Tailer
@@ -79,7 +80,7 @@ func (l *Launcher) Stop() {
 
 // setupTailer configures and starts a new tailer,
 // returns the tailer or an error.
-func (l *Launcher) setupTailer(source *config.LogSource) (*tailer.Tailer, error) {
+func (l *Launcher) setupTailer(source *sources.LogSource) (*tailer.Tailer, error) {
 	var journal *sdjournal.Journal
 	var err error
 

--- a/pkg/logs/internal/launchers/kubernetes/launcher_nokubelet.go
+++ b/pkg/logs/internal/launchers/kubernetes/launcher_nokubelet.go
@@ -10,11 +10,11 @@ package kubernetes
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
-	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/launchers"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/util/containersorpods"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
 	"github.com/DataDog/datadog-agent/pkg/logs/service"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/util/retry"
 )
 
@@ -22,7 +22,7 @@ import (
 type Launcher struct{}
 
 // NewLauncher returns a new launcher
-func NewLauncher(sources *config.LogSources, services *service.Services, cop containersorpods.Chooser, collectAll bool) *Launcher {
+func NewLauncher(sources *sources.LogSources, services *service.Services, cop containersorpods.Chooser, collectAll bool) *Launcher {
 	return &Launcher{}
 }
 

--- a/pkg/logs/internal/launchers/launchers.go
+++ b/pkg/logs/internal/launchers/launchers.go
@@ -9,8 +9,8 @@ import (
 	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
-	logsConfig "github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 )
 
 // Launchers manages a collection of launchers.
@@ -33,7 +33,7 @@ type Launchers struct {
 
 // NewLaunchers creates a new, empty Launchers instance
 func NewLaunchers(
-	sources *logsConfig.LogSources,
+	sources *sources.LogSources,
 	pipelineProvider pipeline.Provider,
 	registry auditor.Registry,
 ) *Launchers {

--- a/pkg/logs/internal/launchers/listener/launcher.go
+++ b/pkg/logs/internal/launchers/listener/launcher.go
@@ -10,6 +10,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/launchers"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/util/startstop"
 )
 
@@ -17,8 +18,8 @@ import (
 type Launcher struct {
 	pipelineProvider pipeline.Provider
 	frameSize        int
-	tcpSources       chan *config.LogSource
-	udpSources       chan *config.LogSource
+	tcpSources       chan *sources.LogSource
+	udpSources       chan *sources.LogSource
 	listeners        []startstop.StartStoppable
 	stop             chan struct{}
 }

--- a/pkg/logs/internal/launchers/listener/tcp.go
+++ b/pkg/logs/internal/launchers/listener/tcp.go
@@ -13,16 +13,16 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
-	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	tailer "github.com/DataDog/datadog-agent/pkg/logs/internal/tailers/socket"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/util/startstop"
 )
 
 // A TCPListener listens and accepts TCP connections and delegates the read operations to a tailer.
 type TCPListener struct {
 	pipelineProvider pipeline.Provider
-	source           *config.LogSource
+	source           *sources.LogSource
 	idleTimeout      time.Duration
 	frameSize        int
 	listener         net.Listener
@@ -32,7 +32,7 @@ type TCPListener struct {
 }
 
 // NewTCPListener returns an initialized TCPListener
-func NewTCPListener(pipelineProvider pipeline.Provider, source *config.LogSource, frameSize int) *TCPListener {
+func NewTCPListener(pipelineProvider pipeline.Provider, source *sources.LogSource, frameSize int) *TCPListener {
 	var idleTimeout time.Duration
 	if source.Config.IdleTimeout != "" {
 		var err error

--- a/pkg/logs/internal/launchers/listener/tcp_test.go
+++ b/pkg/logs/internal/launchers/listener/tcp_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline/mock"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 )
 
 // use a randomly assigned port
@@ -24,7 +25,7 @@ var tcpTestPort = 0
 func TestTCPShouldReceivesMessages(t *testing.T) {
 	pp := mock.NewMockProvider()
 	msgChan := pp.NextPipelineChan()
-	listener := NewTCPListener(pp, config.NewLogSource("", &config.LogsConfig{Port: tcpTestPort}), 9000)
+	listener := NewTCPListener(pp, sources.NewLogSource("", &config.LogsConfig{Port: tcpTestPort}), 9000)
 	listener.Start()
 
 	conn, err := net.Dial("tcp", fmt.Sprintf("%s", listener.listener.Addr()))
@@ -43,7 +44,7 @@ func TestTCPShouldReceivesMessages(t *testing.T) {
 func TestTCPDoesNotTruncateMessagesThatAreBiggerThanTheReadBufferSize(t *testing.T) {
 	pp := mock.NewMockProvider()
 	msgChan := pp.NextPipelineChan()
-	listener := NewTCPListener(pp, config.NewLogSource("", &config.LogsConfig{Port: tcpTestPort}), 100)
+	listener := NewTCPListener(pp, sources.NewLogSource("", &config.LogsConfig{Port: tcpTestPort}), 100)
 	listener.Start()
 
 	conn, err := net.Dial("tcp", fmt.Sprintf("%s", listener.listener.Addr()))

--- a/pkg/logs/internal/launchers/listener/udp.go
+++ b/pkg/logs/internal/launchers/listener/udp.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
-	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	tailer "github.com/DataDog/datadog-agent/pkg/logs/internal/tailers/socket"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 )
 
 // The UDP listener is limited by the size of its read buffer,
@@ -30,13 +30,13 @@ import (
 // A UDPListener opens a new UDP connection, keeps it alive and delegates the read operations to a tailer.
 type UDPListener struct {
 	pipelineProvider pipeline.Provider
-	source           *config.LogSource
+	source           *sources.LogSource
 	frameSize        int
 	tailer           *tailer.Tailer
 }
 
 // NewUDPListener returns an initialized UDPListener
-func NewUDPListener(pipelineProvider pipeline.Provider, source *config.LogSource, frameSize int) *UDPListener {
+func NewUDPListener(pipelineProvider pipeline.Provider, source *sources.LogSource, frameSize int) *UDPListener {
 	return &UDPListener{
 		pipelineProvider: pipelineProvider,
 		source:           source,

--- a/pkg/logs/internal/launchers/listener/udp_nix_test.go
+++ b/pkg/logs/internal/launchers/listener/udp_nix_test.go
@@ -19,13 +19,14 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline/mock"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 )
 
 func TestUDPShoulProperlyCollectLogSplitPerDatadgram(t *testing.T) {
 	pp := mock.NewMockProvider()
 	msgChan := pp.NextPipelineChan()
 	frameSize := 100
-	listener := NewUDPListener(pp, config.NewLogSource("", &config.LogsConfig{Port: udpTestPort}), frameSize)
+	listener := NewUDPListener(pp, sources.NewLogSource("", &config.LogsConfig{Port: udpTestPort}), frameSize)
 	listener.Start()
 
 	conn, err := net.Dial("udp", listener.tailer.Conn.LocalAddr().String())
@@ -60,7 +61,7 @@ func TestUDPShouldProperlyTruncateBigMessages(t *testing.T) {
 	pp := mock.NewMockProvider()
 	msgChan := pp.NextPipelineChan()
 	frameSize := 100
-	listener := NewUDPListener(pp, config.NewLogSource("", &config.LogsConfig{Port: udpTestPort}), frameSize)
+	listener := NewUDPListener(pp, sources.NewLogSource("", &config.LogsConfig{Port: udpTestPort}), frameSize)
 	listener.Start()
 
 	conn, err := net.Dial("udp", fmt.Sprintf("%s", listener.tailer.Conn.LocalAddr()))
@@ -91,7 +92,7 @@ func TestUDPShoulDropTooBigMessages(t *testing.T) {
 
 	pp := mock.NewMockProvider()
 	msgChan := pp.NextPipelineChan()
-	listener := NewUDPListener(pp, config.NewLogSource("", &config.LogsConfig{Port: udpTestPort}), maxUDPFrameLen)
+	listener := NewUDPListener(pp, sources.NewLogSource("", &config.LogsConfig{Port: udpTestPort}), maxUDPFrameLen)
 	listener.Start()
 
 	conn, err := net.Dial("udp", fmt.Sprintf("%s", listener.tailer.Conn.LocalAddr()))

--- a/pkg/logs/internal/launchers/listener/udp_test.go
+++ b/pkg/logs/internal/launchers/listener/udp_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline/mock"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 )
 
 // use a randomly assigned port
@@ -23,7 +24,7 @@ var udpTestPort = 0
 func TestUDPShouldReceiveMessage(t *testing.T) {
 	pp := mock.NewMockProvider()
 	msgChan := pp.NextPipelineChan()
-	listener := NewUDPListener(pp, config.NewLogSource("", &config.LogsConfig{Port: udpTestPort}), 9000)
+	listener := NewUDPListener(pp, sources.NewLogSource("", &config.LogsConfig{Port: udpTestPort}), 9000)
 	listener.Start()
 
 	conn, err := net.Dial("udp", fmt.Sprintf("%s", listener.tailer.Conn.LocalAddr()))

--- a/pkg/logs/internal/launchers/mock_source_provider.go
+++ b/pkg/logs/internal/launchers/mock_source_provider.go
@@ -6,8 +6,7 @@
 package launchers
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/logs/config"
-	logsConfig "github.com/DataDog/datadog-agent/pkg/logs/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 )
 
 // MockSourceProvider is a fake SourceProvider that can be used to provide fake sources.
@@ -16,22 +15,22 @@ import (
 type MockSourceProvider struct {
 	// SourceChan is the unbuffered channel returned from all source-related methods.
 	// Send LogSources to it to trigger behavior from launchers.
-	SourceChan chan *logsConfig.LogSource
+	SourceChan chan *sources.LogSource
 }
 
 // NewMockSourceProvider creates a new MockSource Provider.
 func NewMockSourceProvider() *MockSourceProvider {
 	return &MockSourceProvider{
-		SourceChan: make(chan *logsConfig.LogSource),
+		SourceChan: make(chan *sources.LogSource),
 	}
 }
 
 // SubscribeForType implements SourceProvider#SubscribeForType.
-func (sp *MockSourceProvider) SubscribeForType(sourceType string) (chan *config.LogSource, chan *config.LogSource) {
+func (sp *MockSourceProvider) SubscribeForType(sourceType string) (chan *sources.LogSource, chan *sources.LogSource) {
 	return sp.SourceChan, sp.SourceChan
 }
 
 // GetAddedForType implements SourceProvider#GetAddedForType.
-func (sp *MockSourceProvider) GetAddedForType(sourceType string) chan *config.LogSource {
+func (sp *MockSourceProvider) GetAddedForType(sourceType string) chan *sources.LogSource {
 	return sp.SourceChan
 }

--- a/pkg/logs/internal/launchers/types.go
+++ b/pkg/logs/internal/launchers/types.go
@@ -7,8 +7,8 @@ package launchers
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
-	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 )
 
 // Launcher implementations launch logs pipelines in response to sources, and
@@ -28,11 +28,11 @@ type Launcher interface {
 
 // SourceProvider is the interface by which launchers subscribe to changes in sources.
 //
-// The *config.LogSources type satisfies this interface.
+// The *sources.LogSources type satisfies this interface.
 type SourceProvider interface {
 	// SubscribeForType returns channels containing the new added and removed sources matching the provided type.
-	SubscribeForType(sourceType string) (added chan *config.LogSource, removed chan *config.LogSource)
+	SubscribeForType(sourceType string) (added chan *sources.LogSource, removed chan *sources.LogSource)
 
 	// GetAddedForType returns channels containing the new added sources matching the provided type.
-	GetAddedForType(sourceType string) chan *config.LogSource
+	GetAddedForType(sourceType string) chan *sources.LogSource
 }

--- a/pkg/logs/internal/launchers/windowsevent/launcher.go
+++ b/pkg/logs/internal/launchers/windowsevent/launcher.go
@@ -13,12 +13,13 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/launchers"
 	tailer "github.com/DataDog/datadog-agent/pkg/logs/internal/tailers/windowsevent"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/util/startstop"
 )
 
 // Launcher is in charge of starting and stopping windows event logs tailers
 type Launcher struct {
-	sources          chan *config.LogSource
+	sources          chan *sources.LogSource
 	pipelineProvider pipeline.Provider
 	tailers          map[string]*tailer.Tailer
 	stop             chan struct{}
@@ -91,7 +92,7 @@ func (l *Launcher) sanitizedConfig(sourceConfig *config.LogsConfig) *tailer.Conf
 }
 
 // setupTailer configures and starts a new tailer
-func (l *Launcher) setupTailer(source *config.LogSource) (*tailer.Tailer, error) {
+func (l *Launcher) setupTailer(source *sources.LogSource) (*tailer.Tailer, error) {
 	sanitizedConfig := l.sanitizedConfig(source.Config)
 	config := &tailer.Config{
 		ChannelPath: sanitizedConfig.ChannelPath,

--- a/pkg/logs/internal/processor/encoder_test.go
+++ b/pkg/logs/internal/processor/encoder_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/pb"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -28,7 +29,7 @@ func TestRawEncoder(t *testing.T) {
 		Tags:           []string{"foo:bar", "baz"},
 	}
 
-	source := config.NewLogSource("", logsConfig)
+	source := sources.NewLogSource("", logsConfig)
 
 	rawMessage := "message"
 	msg := newMessage([]byte(rawMessage), source, message.StatusError)
@@ -60,7 +61,7 @@ func TestRawEncoderDefaults(t *testing.T) {
 
 	logsConfig := &config.LogsConfig{}
 
-	source := config.NewLogSource("", logsConfig)
+	source := sources.NewLogSource("", logsConfig)
 
 	rawMessage := "a"
 	msg := newMessage([]byte(rawMessage), source, "")
@@ -90,7 +91,7 @@ func TestRawEncoderEmpty(t *testing.T) {
 
 	logsConfig := &config.LogsConfig{}
 
-	source := config.NewLogSource("", logsConfig)
+	source := sources.NewLogSource("", logsConfig)
 
 	rawMessage := ""
 	msg := newMessage([]byte(rawMessage), source, "")
@@ -119,7 +120,7 @@ func TestProtoEncoder(t *testing.T) {
 		Tags:           []string{"foo:bar", "baz"},
 	}
 
-	source := config.NewLogSource("", logsConfig)
+	source := sources.NewLogSource("", logsConfig)
 
 	rawMessage := "message"
 	msg := newMessage([]byte(rawMessage), source, message.StatusError)
@@ -151,7 +152,7 @@ func TestProtoEncoderEmpty(t *testing.T) {
 
 	logsConfig := &config.LogsConfig{}
 
-	source := config.NewLogSource("", logsConfig)
+	source := sources.NewLogSource("", logsConfig)
 
 	rawMessage := ""
 	msg := newMessage([]byte(rawMessage), source, "")
@@ -179,7 +180,7 @@ func TestProtoEncoderEmpty(t *testing.T) {
 
 func TestProtoEncoderHandleInvalidUTF8(t *testing.T) {
 	cfg := &config.LogsConfig{}
-	src := config.NewLogSource("", cfg)
+	src := sources.NewLogSource("", cfg)
 	msg := newMessage([]byte(""), src, "")
 	encoded, err := ProtoEncoder.Encode(msg, []byte("a\xfez"))
 	assert.NotNil(t, encoded)
@@ -194,7 +195,7 @@ func TestJsonEncoder(t *testing.T) {
 		Tags:           []string{"foo:bar", "baz"},
 	}
 
-	source := config.NewLogSource("", logsConfig)
+	source := sources.NewLogSource("", logsConfig)
 
 	rawMessage := "message"
 	msg := newMessage([]byte(rawMessage), source, message.StatusError)

--- a/pkg/logs/internal/processor/processor_test.go
+++ b/pkg/logs/internal/processor/processor_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -42,7 +43,7 @@ func TestInclusion(t *testing.T) {
 	var shouldProcess bool
 	var redactedMessage []byte
 
-	source := config.LogSource{Config: &config.LogsConfig{}}
+	source := sources.LogSource{Config: &config.LogsConfig{}}
 	shouldProcess, redactedMessage = p.applyRedactingRules(newMessage([]byte("hello"), &source, ""))
 	assert.Equal(t, false, shouldProcess)
 	assert.Nil(t, redactedMessage)
@@ -70,7 +71,7 @@ func TestExclusionWithInclusion(t *testing.T) {
 	var shouldProcess bool
 	var redactedMessage []byte
 
-	source := config.LogSource{Config: &config.LogsConfig{ProcessingRules: []*config.ProcessingRule{iRule}}}
+	source := sources.LogSource{Config: &config.LogsConfig{ProcessingRules: []*config.ProcessingRule{iRule}}}
 
 	shouldProcess, redactedMessage = p.applyRedactingRules(newMessage([]byte("bob@datadoghq.com"), &source, ""))
 	assert.Equal(t, false, shouldProcess)
@@ -131,7 +132,7 @@ func TestMask(t *testing.T) {
 func TestTruncate(t *testing.T) {
 	p := &Processor{}
 
-	source := config.NewLogSource("", &config.LogsConfig{})
+	source := sources.NewLogSource("", &config.LogsConfig{})
 	var redactedMessage []byte
 
 	_, redactedMessage = p.applyRedactingRules(newMessage([]byte("hello"), source, ""))
@@ -149,10 +150,10 @@ func newProcessingRule(ruleType, replacePlaceholder, pattern string) *config.Pro
 	}
 }
 
-func newSource(ruleType, replacePlaceholder, pattern string) config.LogSource {
-	return config.LogSource{Config: &config.LogsConfig{ProcessingRules: []*config.ProcessingRule{newProcessingRule(ruleType, replacePlaceholder, pattern)}}}
+func newSource(ruleType, replacePlaceholder, pattern string) sources.LogSource {
+	return sources.LogSource{Config: &config.LogsConfig{ProcessingRules: []*config.ProcessingRule{newProcessingRule(ruleType, replacePlaceholder, pattern)}}}
 }
 
-func newMessage(content []byte, source *config.LogSource, status string) *message.Message {
+func newMessage(content []byte, source *sources.LogSource, status string) *message.Message {
 	return message.NewMessageWithSource(content, status, source, 0)
 }

--- a/pkg/logs/internal/status/info.go
+++ b/pkg/logs/internal/status/info.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package config
+package status
 
 import (
 	"fmt"

--- a/pkg/logs/internal/status/status.go
+++ b/pkg/logs/internal/status/status.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package config
+package status
 
 import (
 	"fmt"

--- a/pkg/logs/internal/status/status_test.go
+++ b/pkg/logs/internal/status/status_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package config
+package status
 
 import (
 	"errors"

--- a/pkg/logs/internal/tailers/channel/tailer.go
+++ b/pkg/logs/internal/tailers/channel/tailer.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 )
 
 // serviceEnvVar is the environment variable of the service tag (this is used only for the serverless agent)
@@ -29,14 +30,14 @@ const cloudRunRevisionName = "K_REVISION"
 // This tailer attaches the tags from source.Config.ChannelTags to each
 // message, in addition to the origin tags and tags in source.Config.Tags.
 type Tailer struct {
-	source     *config.LogSource
+	source     *sources.LogSource
 	inputChan  chan *config.ChannelMessage
 	outputChan chan *message.Message
 	done       chan interface{}
 }
 
 // NewTailer returns a new Tailer
-func NewTailer(source *config.LogSource, inputChan chan *config.ChannelMessage, outputChan chan *message.Message) *Tailer {
+func NewTailer(source *sources.LogSource, inputChan chan *config.ChannelMessage, outputChan chan *message.Message) *Tailer {
 	return &Tailer{
 		source:     source,
 		inputChan:  inputChan,

--- a/pkg/logs/internal/tailers/docker/tailer.go
+++ b/pkg/logs/internal/tailers/docker/tailer.go
@@ -25,6 +25,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/parsers/dockerstream"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/tag"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 
 	"github.com/docker/docker/api/types"
 )
@@ -50,7 +51,7 @@ type Tailer struct {
 	outputChan  chan *message.Message
 	decoder     *decoder.Decoder
 	dockerutil  dockerContainerLogInterface
-	Source      *config.LogSource
+	Source      *sources.LogSource
 	tagProvider tag.Provider
 
 	readTimeout   time.Duration
@@ -78,7 +79,7 @@ type Tailer struct {
 }
 
 // NewTailer returns a new Tailer
-func NewTailer(cli *dockerutil.DockerUtil, containerID string, source *config.LogSource, outputChan chan *message.Message, erroredContainerID chan string, readTimeout time.Duration) *Tailer {
+func NewTailer(cli *dockerutil.DockerUtil, containerID string, source *sources.LogSource, outputChan chan *message.Message, erroredContainerID chan string, readTimeout time.Duration) *Tailer {
 	return &Tailer{
 		ContainerID:        containerID,
 		outputChan:         outputChan,

--- a/pkg/logs/internal/tailers/docker/tailer_test.go
+++ b/pkg/logs/internal/tailers/docker/tailer_test.go
@@ -17,10 +17,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/decoder"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/tag"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 
 	"github.com/docker/docker/api/types"
 
@@ -82,7 +82,7 @@ func NewTestDecoder() *decoder.Decoder {
 
 func NewTestTailer(reader io.ReadCloser, dockerClient *fakeDockerClient, cancelFunc context.CancelFunc) *Tailer {
 	containerID := "1234567890abcdef"
-	source := config.NewLogSource("foo", nil)
+	source := sources.NewLogSource("foo", nil)
 	tailer := &Tailer{
 		ContainerID:        containerID,
 		outputChan:         make(chan *message.Message, 100),

--- a/pkg/logs/internal/tailers/file/file.go
+++ b/pkg/logs/internal/tailers/file/file.go
@@ -8,7 +8,7 @@ package file
 import (
 	"fmt"
 
-	"github.com/DataDog/datadog-agent/pkg/logs/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 )
 
 // File represents a file to tail
@@ -21,11 +21,11 @@ type File struct {
 	IsWildcardPath bool
 
 	// Source is the LogSource that led to this File.
-	Source *config.LogSource
+	Source *sources.LogSource
 }
 
 // NewFile returns a new File
-func NewFile(path string, source *config.LogSource, isWildcardPath bool) *File {
+func NewFile(path string, source *sources.LogSource, isWildcardPath bool) *File {
 	return &File{
 		Path:           path,
 		Source:         source,

--- a/pkg/logs/internal/tailers/file/tailer_test.go
+++ b/pkg/logs/internal/tailers/file/tailer_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/decoder"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 )
 
 var chanSize = 10
@@ -39,7 +40,7 @@ type TailerTestSuite struct {
 
 	tailer     *Tailer
 	outputChan chan *message.Message
-	source     *config.LogSource
+	source     *sources.LogSource
 }
 
 func (suite *TailerTestSuite) SetupTest() {
@@ -52,7 +53,7 @@ func (suite *TailerTestSuite) SetupTest() {
 	suite.Nil(err)
 	suite.testFile = f
 	suite.outputChan = make(chan *message.Message, chanSize)
-	suite.source = config.NewLogSource("", &config.LogsConfig{
+	suite.source = sources.NewLogSource("", &config.LogsConfig{
 		Type: config.FileType,
 		Path: suite.testPath,
 	})
@@ -250,7 +251,7 @@ func (suite *TailerTestSuite) TestOriginTagsWhenTailingFiles() {
 
 func (suite *TailerTestSuite) TestDirTagWhenTailingFiles() {
 
-	dirTaggedSource := config.NewLogSource("", &config.LogsConfig{
+	dirTaggedSource := sources.NewLogSource("", &config.LogsConfig{
 		Type: config.FileType,
 		Path: suite.testPath,
 	})
@@ -270,7 +271,7 @@ func (suite *TailerTestSuite) TestDirTagWhenTailingFiles() {
 }
 
 func (suite *TailerTestSuite) TestBuildTagsFileOnly() {
-	dirTaggedSource := config.NewLogSource("", &config.LogsConfig{
+	dirTaggedSource := sources.NewLogSource("", &config.LogsConfig{
 		Type: config.FileType,
 		Path: suite.testPath,
 	})
@@ -286,7 +287,7 @@ func (suite *TailerTestSuite) TestBuildTagsFileOnly() {
 }
 
 func (suite *TailerTestSuite) TestBuildTagsFileDir() {
-	dirTaggedSource := config.NewLogSource("", &config.LogsConfig{
+	dirTaggedSource := sources.NewLogSource("", &config.LogsConfig{
 		Type: config.FileType,
 		Path: suite.testPath,
 	})

--- a/pkg/logs/internal/tailers/journald/docker_test.go
+++ b/pkg/logs/internal/tailers/journald/docker_test.go
@@ -15,10 +15,11 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 )
 
 func TestIsContainerEntry(t *testing.T) {
-	source := config.NewLogSource("", &config.LogsConfig{})
+	source := sources.NewLogSource("", &config.LogsConfig{})
 	tailer := NewTailer(source, nil, nil)
 
 	var entry *sdjournal.JournalEntry
@@ -35,7 +36,7 @@ func TestIsContainerEntry(t *testing.T) {
 }
 
 func TestGetContainerID(t *testing.T) {
-	source := config.NewLogSource("", &config.LogsConfig{})
+	source := sources.NewLogSource("", &config.LogsConfig{})
 	tailer := NewTailer(source, nil, nil)
 
 	entry := &sdjournal.JournalEntry{

--- a/pkg/logs/internal/tailers/journald/tailer.go
+++ b/pkg/logs/internal/tailers/journald/tailer.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/coreos/go-systemd/sdjournal"
 )
@@ -43,7 +44,7 @@ const (
 
 // Tailer collects logs from a journal.
 type Tailer struct {
-	source       *config.LogSource
+	source       *sources.LogSource
 	outputChan   chan *message.Message
 	journal      Journal
 	excludeUnits struct {
@@ -55,7 +56,7 @@ type Tailer struct {
 }
 
 // NewTailer returns a new tailer.
-func NewTailer(source *config.LogSource, outputChan chan *message.Message, journal Journal) *Tailer {
+func NewTailer(source *sources.LogSource, outputChan chan *message.Message, journal Journal) *Tailer {
 	return &Tailer{
 		source:     source,
 		outputChan: outputChan,

--- a/pkg/logs/internal/tailers/socket/tailer.go
+++ b/pkg/logs/internal/tailers/socket/tailer.go
@@ -11,16 +11,16 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
-	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/decoder"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/parsers/noop"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 )
 
 // Tailer reads data from a net.Conn.  It uses a `read` callback to be generic
 // over types of connections.
 type Tailer struct {
-	source     *config.LogSource
+	source     *sources.LogSource
 	Conn       net.Conn
 	outputChan chan *message.Message
 	read       func(*Tailer) ([]byte, error)
@@ -30,7 +30,7 @@ type Tailer struct {
 }
 
 // NewTailer returns a new Tailer
-func NewTailer(source *config.LogSource, conn net.Conn, outputChan chan *message.Message, read func(*Tailer) ([]byte, error)) *Tailer {
+func NewTailer(source *sources.LogSource, conn net.Conn, outputChan chan *message.Message, read func(*Tailer) ([]byte, error)) *Tailer {
 	return &Tailer{
 		source:     source,
 		Conn:       conn,

--- a/pkg/logs/internal/tailers/socket/tailer_test.go
+++ b/pkg/logs/internal/tailers/socket/tailer_test.go
@@ -14,12 +14,13 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 )
 
 func TestReadAndForwardShouldSucceedWithSuccessfulRead(t *testing.T) {
 	msgChan := make(chan *message.Message)
 	r, w := net.Pipe()
-	tailer := NewTailer(config.NewLogSource("", &config.LogsConfig{}), r, msgChan, read)
+	tailer := NewTailer(sources.NewLogSource("", &config.LogsConfig{}), r, msgChan, read)
 	tailer.Start()
 
 	var msg *message.Message
@@ -43,7 +44,7 @@ func TestReadShouldFailWithError(t *testing.T) {
 	msgChan := make(chan *message.Message)
 	r, w := net.Pipe()
 	read := func(*Tailer) ([]byte, error) { return nil, errors.New("") }
-	tailer := NewTailer(config.NewLogSource("", &config.LogsConfig{}), r, msgChan, read)
+	tailer := NewTailer(sources.NewLogSource("", &config.LogsConfig{}), r, msgChan, read)
 	tailer.Start()
 
 	w.Write([]byte("foo\n"))

--- a/pkg/logs/internal/tailers/windowsevent/tailer.go
+++ b/pkg/logs/internal/tailers/windowsevent/tailer.go
@@ -14,8 +14,8 @@ import (
 	"unicode/utf16"
 	"unicode/utf8"
 
-	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/clbanning/mxj"
 )
@@ -49,7 +49,7 @@ type richEvent struct {
 
 // Tailer collects logs from event log.
 type Tailer struct {
-	source     *config.LogSource
+	source     *sources.LogSource
 	config     *Config
 	outputChan chan *message.Message
 	stop       chan struct{}
@@ -59,7 +59,7 @@ type Tailer struct {
 }
 
 // NewTailer returns a new tailer.
-func NewTailer(source *config.LogSource, config *Config, outputChan chan *message.Message) *Tailer {
+func NewTailer(source *sources.LogSource, config *Config, outputChan chan *message.Message) *Tailer {
 	return &Tailer{
 		source:     source,
 		config:     config,

--- a/pkg/logs/internal/util/test_utils.go
+++ b/pkg/logs/internal/util/test_utils.go
@@ -3,11 +3,13 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package config
+package util
+
+import "github.com/DataDog/datadog-agent/pkg/logs/sources"
 
 // ConsumeSources ensures that another component is consuming the channel to prevent
 // the producer to get stuck.
-func consumeSources(sources *LogSources) {
+func consumeSources(sources *sources.LogSources) {
 	go func() {
 		sources := sources.GetAddedForType("foo")
 		for range sources {
@@ -16,8 +18,8 @@ func consumeSources(sources *LogSources) {
 }
 
 // CreateSources creates sources
-func CreateSources(sourcesArray []*LogSource) *LogSources {
-	logSources := NewLogSources()
+func CreateSources(sourcesArray []*sources.LogSource) *sources.LogSources {
+	logSources := sources.NewLogSources()
 	for _, source := range sourcesArray {
 		logSources.AddSource(source)
 	}

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -13,6 +13,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery"
 	"github.com/DataDog/datadog-agent/pkg/logs/client/http"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/metrics"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/metadata/inventories"
 	"go.uber.org/atomic"
 
@@ -79,7 +80,7 @@ func start(ac *autodiscovery.AutoConfig, serverless bool) (*Agent, error) {
 	}
 
 	// setup the sources and the services
-	sources := config.NewLogSources()
+	sources := sources.NewLogSources()
 	services := service.NewServices()
 
 	// setup the server config

--- a/pkg/logs/message/message.go
+++ b/pkg/logs/message/message.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/logs/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/util"
 )
 
@@ -46,7 +46,7 @@ type Lambda struct {
 }
 
 // NewMessageWithSource constructs message with content, status and log source.
-func NewMessageWithSource(content []byte, status string, source *config.LogSource, ingestionTimestamp int64) *Message {
+func NewMessageWithSource(content []byte, status string, source *sources.LogSource, ingestionTimestamp int64) *Message {
 	return NewMessage(content, NewOrigin(source), status, ingestionTimestamp)
 }
 

--- a/pkg/logs/message/origin.go
+++ b/pkg/logs/message/origin.go
@@ -8,13 +8,13 @@ package message
 import (
 	"strings"
 
-	"github.com/DataDog/datadog-agent/pkg/logs/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 )
 
 // Origin represents the Origin of a message
 type Origin struct {
 	Identifier string
-	LogSource  *config.LogSource
+	LogSource  *sources.LogSource
 	Offset     string
 	service    string
 	source     string
@@ -22,7 +22,7 @@ type Origin struct {
 }
 
 // NewOrigin returns a new Origin
-func NewOrigin(source *config.LogSource) *Origin {
+func NewOrigin(source *sources.LogSource) *Origin {
 	return &Origin{
 		LogSource: source,
 	}

--- a/pkg/logs/message/origin_test.go
+++ b/pkg/logs/message/origin_test.go
@@ -9,12 +9,13 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestSetTagsEmpty(t *testing.T) {
 	cfg := &config.LogsConfig{}
-	source := config.NewLogSource("", cfg)
+	source := sources.NewLogSource("", cfg)
 	origin := NewOrigin(source)
 	origin.SetTags([]string{})
 	assert.Equal(t, []string{}, origin.Tags())
@@ -28,7 +29,7 @@ func TestTagsWithConfigTagsOnly(t *testing.T) {
 		SourceCategory: "b",
 		Tags:           []string{"c:d", "e"},
 	}
-	source := config.NewLogSource("", cfg)
+	source := sources.NewLogSource("", cfg)
 	origin := NewOrigin(source)
 	assert.Equal(t, []string{"sourcecategory:b", "c:d", "e"}, origin.Tags())
 	assert.Equal(t, "[dd ddsource=\"a\"][dd ddsourcecategory=\"b\"][dd ddtags=\"c:d,e\"]", string(origin.TagsPayload()))
@@ -40,7 +41,7 @@ func TestSetTagsWithNoConfigTags(t *testing.T) {
 		Source:         "a",
 		SourceCategory: "b",
 	}
-	source := config.NewLogSource("", cfg)
+	source := sources.NewLogSource("", cfg)
 	origin := NewOrigin(source)
 	origin.SetTags([]string{"foo:bar", "baz"})
 	assert.Equal(t, []string{"foo:bar", "baz", "sourcecategory:b"}, origin.Tags())
@@ -54,7 +55,7 @@ func TestSetTagsWithConfigTags(t *testing.T) {
 		SourceCategory: "b",
 		Tags:           []string{"c:d", "e"},
 	}
-	source := config.NewLogSource("", cfg)
+	source := sources.NewLogSource("", cfg)
 	origin := NewOrigin(source)
 	origin.SetTags([]string{"foo:bar", "baz"})
 	assert.Equal(t, []string{"foo:bar", "baz", "sourcecategory:b", "c:d", "e"}, origin.Tags())
@@ -64,11 +65,11 @@ func TestSetTagsWithConfigTags(t *testing.T) {
 
 func TestDefaultSourceValueIsSourceFromConfig(t *testing.T) {
 	var cfg *config.LogsConfig
-	var source *config.LogSource
+	var source *sources.LogSource
 	var origin *Origin
 
 	cfg = &config.LogsConfig{Source: "foo"}
-	source = config.NewLogSource("", cfg)
+	source = sources.NewLogSource("", cfg)
 	origin = NewOrigin(source)
 	assert.Equal(t, "foo", origin.Source())
 
@@ -76,7 +77,7 @@ func TestDefaultSourceValueIsSourceFromConfig(t *testing.T) {
 	assert.Equal(t, "foo", origin.Source())
 
 	cfg = &config.LogsConfig{}
-	source = config.NewLogSource("", cfg)
+	source = sources.NewLogSource("", cfg)
 	origin = NewOrigin(source)
 	assert.Equal(t, "", origin.Source())
 
@@ -86,11 +87,11 @@ func TestDefaultSourceValueIsSourceFromConfig(t *testing.T) {
 
 func TestDefaultServiceValueIsServiceFromConfig(t *testing.T) {
 	var cfg *config.LogsConfig
-	var source *config.LogSource
+	var source *sources.LogSource
 	var origin *Origin
 
 	cfg = &config.LogsConfig{Service: "foo"}
-	source = config.NewLogSource("", cfg)
+	source = sources.NewLogSource("", cfg)
 	origin = NewOrigin(source)
 	assert.Equal(t, "foo", origin.Service())
 
@@ -98,7 +99,7 @@ func TestDefaultServiceValueIsServiceFromConfig(t *testing.T) {
 	assert.Equal(t, "foo", origin.Service())
 
 	cfg = &config.LogsConfig{}
-	source = config.NewLogSource("", cfg)
+	source = sources.NewLogSource("", cfg)
 	origin = NewOrigin(source)
 	assert.Equal(t, "", origin.Service())
 

--- a/pkg/logs/schedulers/README.md
+++ b/pkg/logs/schedulers/README.md
@@ -1,6 +1,6 @@
 # Schedulers
 
-Schedulers are the components responsible for managing log sources (pkg/log/config.LogSource) and services [1].
+Schedulers are the components responsible for managing log sources (pkg/log/sources.LogSource) and services [1].
 These sources and services are then recognized by logs-agent launchers, which create tailers and attach them to the logs-agent pipeline.
 
 In short, schedulers control what is and is not logged, and how it is logged.

--- a/pkg/logs/schedulers/ad/scheduler.go
+++ b/pkg/logs/schedulers/ad/scheduler.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/util/adlistener"
 	"github.com/DataDog/datadog-agent/pkg/logs/schedulers"
 	"github.com/DataDog/datadog-agent/pkg/logs/service"
+	sourcesPkg "github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -178,7 +179,7 @@ func (s *Scheduler) configName(config integration.Config) string {
 
 // toSources creates new sources from an integration config,
 // returns an error if the parsing failed.
-func (s *Scheduler) toSources(config integration.Config) ([]*logsConfig.LogSource, error) {
+func (s *Scheduler) toSources(config integration.Config) ([]*sourcesPkg.LogSource, error) {
 	var configs []*logsConfig.LogsConfig
 	var err error
 
@@ -219,7 +220,7 @@ func (s *Scheduler) toSources(config integration.Config) ([]*logsConfig.LogSourc
 	}
 
 	configName := s.configName(config)
-	var sources []*logsConfig.LogSource
+	var sources []*sourcesPkg.LogSource
 	for _, cfg := range configs {
 		// if no service is set fall back to the global one
 		if cfg.Service == "" && globalServiceDefined {
@@ -239,7 +240,7 @@ func (s *Scheduler) toSources(config integration.Config) ([]*logsConfig.LogSourc
 			}
 		}
 
-		source := logsConfig.NewLogSource(configName, cfg)
+		source := sourcesPkg.NewLogSource(configName, cfg)
 		sources = append(sources, source)
 		if err := cfg.Validate(); err != nil {
 			log.Warnf("Invalid logs configuration: %v", err)

--- a/pkg/logs/schedulers/ad/scheduler_test.go
+++ b/pkg/logs/schedulers/ad/scheduler_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers/names"
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/schedulers"
+	sourcesPkg "github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -41,7 +42,7 @@ func TestScheduleConfigCreatesNewSource(t *testing.T) {
 	logSource := spy.Events[0].Source
 	assert.Equal(t, config.DockerType, logSource.Name)
 	// We use the docker socket, not sourceType here
-	assert.Equal(t, config.SourceType(""), logSource.GetSourceType())
+	assert.Equal(t, sourcesPkg.SourceType(""), logSource.GetSourceType())
 	assert.Equal(t, "foo", logSource.Config.Service)
 	assert.Equal(t, "bar", logSource.Config.Source)
 	assert.Equal(t, config.DockerType, logSource.Config.Type)
@@ -67,7 +68,7 @@ func TestScheduleConfigCreatesNewSourceServiceFallback(t *testing.T) {
 	logSource := spy.Events[0].Source
 	assert.Equal(t, config.DockerType, logSource.Name)
 	// We use the docker socket, not sourceType here
-	assert.Equal(t, config.SourceType(""), logSource.GetSourceType())
+	assert.Equal(t, sourcesPkg.SourceType(""), logSource.GetSourceType())
 	assert.Equal(t, "foo", logSource.Config.Service)
 	assert.Equal(t, "bar", logSource.Config.Source)
 	assert.Equal(t, config.DockerType, logSource.Config.Type)
@@ -93,7 +94,7 @@ func TestScheduleConfigCreatesNewSourceServiceOverride(t *testing.T) {
 	logSource := spy.Events[0].Source
 	assert.Equal(t, config.DockerType, logSource.Name)
 	// We use the docker socket, not sourceType here
-	assert.Equal(t, config.SourceType(""), logSource.GetSourceType())
+	assert.Equal(t, sourcesPkg.SourceType(""), logSource.GetSourceType())
 	assert.Equal(t, "baz", logSource.Config.Service)
 	assert.Equal(t, "bar", logSource.Config.Source)
 	assert.Equal(t, config.DockerType, logSource.Config.Type)
@@ -150,7 +151,7 @@ func TestUnscheduleConfigRemovesSource(t *testing.T) {
 	logSource := spy.Events[0].Source
 	assert.Equal(t, config.DockerType, logSource.Name)
 	// We use the docker socket, not sourceType here
-	assert.Equal(t, config.SourceType(""), logSource.GetSourceType())
+	assert.Equal(t, sourcesPkg.SourceType(""), logSource.GetSourceType())
 	assert.Equal(t, "foo", logSource.Config.Service)
 	assert.Equal(t, "bar", logSource.Config.Source)
 	assert.Equal(t, config.DockerType, logSource.Config.Type)

--- a/pkg/logs/schedulers/base_test.go
+++ b/pkg/logs/schedulers/base_test.go
@@ -8,8 +8,8 @@ package schedulers
 import (
 	"testing"
 
-	logsConfig "github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/service"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/stretchr/testify/require"
 )
 
@@ -29,7 +29,7 @@ func (t *testSched) Stop() {
 func TestSchedulers(t *testing.T) {
 	sch := &testSched{}
 
-	ss := NewSchedulers(logsConfig.NewLogSources(), service.NewServices())
+	ss := NewSchedulers(sources.NewLogSources(), service.NewServices())
 	ss.AddScheduler(sch)
 
 	require.False(t, sch.started)

--- a/pkg/logs/schedulers/cca/scheduler.go
+++ b/pkg/logs/schedulers/cca/scheduler.go
@@ -12,6 +12,7 @@ import (
 	coreConfig "github.com/DataDog/datadog-agent/pkg/config"
 	logsConfig "github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/schedulers"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -39,7 +40,7 @@ func (s *Scheduler) Start(sourceMgr schedulers.SourceManager) {
 		return
 	}
 	// source to collect all logs from all containers
-	source := logsConfig.NewLogSource(logsConfig.ContainerCollectAll, &logsConfig.LogsConfig{
+	source := sources.NewLogSource(logsConfig.ContainerCollectAll, &logsConfig.LogsConfig{
 		Type:    logsConfig.DockerType,
 		Service: "docker",
 		Source:  "docker",

--- a/pkg/logs/schedulers/channel/scheduler.go
+++ b/pkg/logs/schedulers/channel/scheduler.go
@@ -8,6 +8,7 @@ package channel
 import (
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/schedulers"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -30,7 +31,7 @@ type Scheduler struct {
 	extraTags []string
 
 	// logSource is the source currently managed by the scheduler
-	logSource *config.LogSource
+	logSource *sources.LogSource
 
 	// sourceMgr is the schedulers.SourceManager used to add/remove sources
 	sourceMgr schedulers.SourceManager
@@ -65,7 +66,7 @@ func (s *Scheduler) setSource() {
 		s.sourceMgr.RemoveSource(s.logSource)
 	}
 
-	s.logSource = config.NewLogSource(s.sourceName, &config.LogsConfig{
+	s.logSource = sources.NewLogSource(s.sourceName, &config.LogsConfig{
 		Type:        config.StringChannelType,
 		Source:      s.source,
 		ChannelTags: s.extraTags,

--- a/pkg/logs/schedulers/schedulers.go
+++ b/pkg/logs/schedulers/schedulers.go
@@ -8,8 +8,8 @@ package schedulers
 import (
 	"sync"
 
-	logsConfig "github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/service"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 )
 
 // Schedulers manages a collection of schedulers.
@@ -25,7 +25,7 @@ type Schedulers struct {
 }
 
 // NewSchedulers creates a new, empty Schedulers instance
-func NewSchedulers(sources *logsConfig.LogSources, services *service.Services) *Schedulers {
+func NewSchedulers(sources *sources.LogSources, services *service.Services) *Schedulers {
 	return &Schedulers{
 		mgr: &sourceManager{sources, services},
 	}

--- a/pkg/logs/schedulers/source_manager.go
+++ b/pkg/logs/schedulers/source_manager.go
@@ -6,8 +6,8 @@
 package schedulers
 
 import (
-	logsConfig "github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/service"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 )
 
 // sourceManager implements the SourceManager interface.
@@ -15,24 +15,24 @@ import (
 // NOTE: when support for services is removed, this struct will be unnecessary,
 // as config.Sources will satisfy the interface.
 type sourceManager struct {
-	sources  *logsConfig.LogSources
+	sources  *sources.LogSources
 	services *service.Services
 }
 
 var _ SourceManager = &sourceManager{}
 
 // AddSource implements SourceManager#AddSource.
-func (sm *sourceManager) AddSource(source *logsConfig.LogSource) {
+func (sm *sourceManager) AddSource(source *sources.LogSource) {
 	sm.sources.AddSource(source)
 }
 
 // RemoveSource implements SourceManager#RemoveSource.
-func (sm *sourceManager) RemoveSource(source *logsConfig.LogSource) {
+func (sm *sourceManager) RemoveSource(source *sources.LogSource) {
 	sm.sources.RemoveSource(source)
 }
 
 // GetSources implements SourceManager#GetSources.
-func (sm *sourceManager) GetSources() []*logsConfig.LogSource {
+func (sm *sourceManager) GetSources() []*sources.LogSource {
 	return sm.sources.GetSources()
 }
 
@@ -52,7 +52,7 @@ type MockAddRemove struct {
 	Add bool
 
 	// Source is the source that was added or removed, or nil.
-	Source *logsConfig.LogSource
+	Source *sources.LogSource
 
 	// Service is the service that was added or removed, or nil.
 	Service *service.Service
@@ -68,24 +68,24 @@ type MockSourceManager struct {
 	Events []MockAddRemove
 
 	// Sources are the sources returned by GetSources
-	Sources []*logsConfig.LogSource
+	Sources []*sources.LogSource
 }
 
 var _ SourceManager = &MockSourceManager{}
 
 // AddSource implements SourceManager#AddSource.
-func (sm *MockSourceManager) AddSource(source *logsConfig.LogSource) {
+func (sm *MockSourceManager) AddSource(source *sources.LogSource) {
 	sm.Events = append(sm.Events, MockAddRemove{Add: true, Source: source})
 }
 
 // RemoveSource implements SourceManager#RemoveSource.
-func (sm *MockSourceManager) RemoveSource(source *logsConfig.LogSource) {
+func (sm *MockSourceManager) RemoveSource(source *sources.LogSource) {
 	sm.Events = append(sm.Events, MockAddRemove{Add: false, Source: source})
 }
 
 // GetSources implements SourceManager#GetSources.
-func (sm *MockSourceManager) GetSources() []*logsConfig.LogSource {
-	sources := make([]*logsConfig.LogSource, len(sm.Sources))
+func (sm *MockSourceManager) GetSources() []*sources.LogSource {
+	sources := make([]*sources.LogSource, len(sm.Sources))
 	copy(sources, sm.Sources)
 	return sources
 }

--- a/pkg/logs/schedulers/types.go
+++ b/pkg/logs/schedulers/types.go
@@ -6,8 +6,8 @@
 package schedulers
 
 import (
-	logsConfig "github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/service"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 )
 
 // Scheduler implementations manage logs-agent sources.
@@ -30,16 +30,16 @@ type SourceManager interface {
 	// AddSource adds a new source to the logs agent.  The new source is
 	// distributed to all active launchers, which may create appropriate
 	// tailers and begin forwarding messages.
-	AddSource(source *logsConfig.LogSource)
+	AddSource(source *sources.LogSource)
 
 	// RemoveSource removes an existing source from the logs agent.  The
 	// source is recognized by pointer equality.
-	RemoveSource(source *logsConfig.LogSource)
+	RemoveSource(source *sources.LogSource)
 
 	// GetSources returns all the sources currently held.  The result is copied and
 	// will not be modified after it is returned, and represents a "snapshot" of the
 	// state when the function was called.
-	GetSources() []*logsConfig.LogSource
+	GetSources() []*sources.LogSource
 
 	// AddService adds a new service to the logs agent.
 	AddService(service *service.Service)

--- a/pkg/logs/sender/sender_test.go
+++ b/pkg/logs/sender/sender_test.go
@@ -14,10 +14,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/client/tcp"
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/stretchr/testify/assert"
 )
 
-func newMessage(content []byte, source *config.LogSource, status string) *message.Payload {
+func newMessage(content []byte, source *sources.LogSource, status string) *message.Payload {
 	return &message.Payload{
 		Messages: []*message.Message{message.NewMessageWithSource(content, status, source, 0)},
 		Encoded:  content,
@@ -29,7 +30,7 @@ func TestSender(t *testing.T) {
 	l := mock.NewMockLogsIntake(t)
 	defer l.Close()
 
-	source := config.NewLogSource("", &config.LogsConfig{})
+	source := sources.NewLogSource("", &config.LogsConfig{})
 
 	input := make(chan *message.Payload, 1)
 	output := make(chan *message.Payload, 1)

--- a/pkg/logs/sources/source.go
+++ b/pkg/logs/sources/source.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/status"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"go.uber.org/atomic"
 )
@@ -33,7 +34,7 @@ const (
 type LogSource struct {
 	Name     string
 	Config   *config.LogsConfig
-	Status   *config.LogStatus
+	Status   *status.LogStatus
 	inputs   map[string]bool
 	lock     *sync.Mutex
 	Messages *config.Messages
@@ -56,7 +57,7 @@ func NewLogSource(name string, cfg *config.LogsConfig) *LogSource {
 	return &LogSource{
 		Name:             name,
 		Config:           cfg,
-		Status:           config.NewLogStatus(),
+		Status:           status.NewLogStatus(),
 		inputs:           make(map[string]bool),
 		lock:             &sync.Mutex{},
 		Messages:         config.NewMessages(),

--- a/pkg/logs/sources/source.go
+++ b/pkg/logs/sources/source.go
@@ -42,7 +42,7 @@ type LogSource struct {
 	// that reads log lines for this source. E.g, a sourceType == containerd and Config.Type == file means that
 	// the agent is tailing a file to read logs of a containerd container
 	sourceType SourceType
-	info       map[string]config.InfoProvider
+	info       map[string]status.InfoProvider
 	// In the case that the source is overridden, keep a reference to the parent for bubbling up information about the child
 	ParentSource *LogSource
 	// LatencyStats tracks internal stats on the time spent by messages from this source in a processing pipeline, i.e.
@@ -62,7 +62,7 @@ func NewLogSource(name string, cfg *config.LogsConfig) *LogSource {
 		lock:             &sync.Mutex{},
 		Messages:         config.NewMessages(),
 		BytesRead:        atomic.NewInt64(0),
-		info:             make(map[string]config.InfoProvider),
+		info:             make(map[string]status.InfoProvider),
 		LatencyStats:     util.NewStatsTracker(time.Hour*24, time.Hour),
 		hiddenFromStatus: false,
 	}
@@ -108,14 +108,14 @@ func (s *LogSource) GetSourceType() SourceType {
 }
 
 // RegisterInfo registers some info to display on the status page
-func (s *LogSource) RegisterInfo(i config.InfoProvider) {
+func (s *LogSource) RegisterInfo(i status.InfoProvider) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	s.info[i.InfoKey()] = i
 }
 
 // GetInfo gets an InfoProvider instance by the key
-func (s *LogSource) GetInfo(key string) config.InfoProvider {
+func (s *LogSource) GetInfo(key string) status.InfoProvider {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	return s.info[key]

--- a/pkg/logs/sources/source_test.go
+++ b/pkg/logs/sources/source_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package config
+package sources
 
 import (
 	"testing"

--- a/pkg/logs/sources/sources.go
+++ b/pkg/logs/sources/sources.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package config
+package sources
 
 import (
 	"sync"

--- a/pkg/logs/sources/sources_test.go
+++ b/pkg/logs/sources/sources_test.go
@@ -3,11 +3,12 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package config
+package sources
 
 import (
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -15,20 +16,20 @@ func TestAddSource(t *testing.T) {
 	sources := NewLogSources()
 	assert.Equal(t, 0, len(sources.GetSources()))
 
-	sources.AddSource(NewLogSource("foo", &LogsConfig{Type: "boo"}))
+	sources.AddSource(NewLogSource("foo", &config.LogsConfig{Type: "boo"}))
 	assert.Equal(t, 1, len(sources.GetSources()))
 
-	sources.AddSource(NewLogSource("bar", &LogsConfig{Type: "boo"}))
+	sources.AddSource(NewLogSource("bar", &config.LogsConfig{Type: "boo"}))
 	assert.Equal(t, 2, len(sources.GetSources()))
 
-	sources.AddSource(NewLogSource("baz", &LogsConfig{})) // invalid config
+	sources.AddSource(NewLogSource("baz", &config.LogsConfig{})) // invalid config
 	assert.Equal(t, 3, len(sources.GetSources()))
 }
 
 func TestRemoveSource(t *testing.T) {
 	sources := NewLogSources()
-	source1 := NewLogSource("foo", &LogsConfig{Type: "boo"})
-	source2 := NewLogSource("bar", &LogsConfig{Type: "boo"})
+	source1 := NewLogSource("foo", &config.LogsConfig{Type: "boo"})
+	source2 := NewLogSource("bar", &config.LogsConfig{Type: "boo"})
 
 	sources.AddSource(source1)
 	sources.AddSource(source2)
@@ -46,13 +47,13 @@ func TestGetSources(t *testing.T) {
 	sources := NewLogSources()
 	assert.Equal(t, 0, len(sources.GetSources()))
 
-	sources.AddSource(NewLogSource("", &LogsConfig{Type: "boo"}))
+	sources.AddSource(NewLogSource("", &config.LogsConfig{Type: "boo"}))
 	assert.Equal(t, 1, len(sources.GetSources()))
 }
 
 func TestGetAddedForType(t *testing.T) {
 	sources := NewLogSources()
-	source := NewLogSource("foo", &LogsConfig{Type: "foo"})
+	source := NewLogSource("foo", &config.LogsConfig{Type: "foo"})
 
 	stream1 := sources.GetAddedForType("foo")
 	assert.NotNil(t, stream1)
@@ -69,11 +70,11 @@ func TestGetAddedForType(t *testing.T) {
 
 func TestGetAddedForTypeExistingSources(t *testing.T) {
 	sources := NewLogSources()
-	source1 := NewLogSource("one", &LogsConfig{Type: "foo"})
-	source1bar := NewLogSource("one-bar", &LogsConfig{Type: "bar"})
-	source2 := NewLogSource("two", &LogsConfig{Type: "foo"})
-	source2bar := NewLogSource("two-bar", &LogsConfig{Type: "bar"})
-	source3 := NewLogSource("three", &LogsConfig{Type: "foo"})
+	source1 := NewLogSource("one", &config.LogsConfig{Type: "foo"})
+	source1bar := NewLogSource("one-bar", &config.LogsConfig{Type: "bar"})
+	source2 := NewLogSource("two", &config.LogsConfig{Type: "foo"})
+	source2bar := NewLogSource("two-bar", &config.LogsConfig{Type: "bar"})
+	source3 := NewLogSource("three", &config.LogsConfig{Type: "foo"})
 
 	go func() {
 		sources.AddSource(source1bar)
@@ -107,11 +108,11 @@ func TestGetAddedForTypeExistingSources(t *testing.T) {
 
 func TestSubscribeForType(t *testing.T) {
 	sources := NewLogSources()
-	source1 := NewLogSource("one", &LogsConfig{Type: "foo"})
-	source1bar := NewLogSource("one-bar", &LogsConfig{Type: "bar"})
-	source2 := NewLogSource("two", &LogsConfig{Type: "foo"})
-	source2bar := NewLogSource("two-bar", &LogsConfig{Type: "bar"})
-	source3 := NewLogSource("three", &LogsConfig{Type: "foo"})
+	source1 := NewLogSource("one", &config.LogsConfig{Type: "foo"})
+	source1bar := NewLogSource("one-bar", &config.LogsConfig{Type: "bar"})
+	source2 := NewLogSource("two", &config.LogsConfig{Type: "foo"})
+	source2bar := NewLogSource("two-bar", &config.LogsConfig{Type: "bar"})
+	source3 := NewLogSource("three", &config.LogsConfig{Type: "foo"})
 
 	go func() {
 		sources.AddSource(source1bar)

--- a/pkg/logs/status/builder.go
+++ b/pkg/logs/status/builder.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
+	sourcesPkg "github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"go.uber.org/atomic"
 )
 
@@ -18,14 +19,14 @@ import (
 type Builder struct {
 	isRunning   *atomic.Bool
 	endpoints   *config.Endpoints
-	sources     *config.LogSources
+	sources     *sourcesPkg.LogSources
 	warnings    *config.Messages
 	errors      *config.Messages
 	logsExpVars *expvar.Map
 }
 
 // NewBuilder returns a new builder.
-func NewBuilder(isRunning *atomic.Bool, endpoints *config.Endpoints, sources *config.LogSources, warnings *config.Messages, errors *config.Messages, logExpVars *expvar.Map) *Builder {
+func NewBuilder(isRunning *atomic.Bool, endpoints *config.Endpoints, sources *sourcesPkg.LogSources, warnings *config.Messages, errors *config.Messages, logExpVars *expvar.Map) *Builder {
 	return &Builder{
 		isRunning:   isRunning,
 		endpoints:   endpoints,
@@ -106,14 +107,14 @@ func (b *Builder) getIntegrations() []Integration {
 
 // groupSourcesByName groups all logs sources by name so that they get properly displayed
 // on the agent status.
-func (b *Builder) groupSourcesByName() map[string][]*config.LogSource {
-	sources := make(map[string][]*config.LogSource)
+func (b *Builder) groupSourcesByName() map[string][]*sourcesPkg.LogSource {
+	sources := make(map[string][]*sourcesPkg.LogSource)
 	for _, source := range b.sources.GetSources() {
 		if source.IsHiddenFromStatus() {
 			continue
 		}
 		if _, exists := sources[source.Name]; !exists {
-			sources[source.Name] = []*config.LogSource{}
+			sources[source.Name] = []*sourcesPkg.LogSource{}
 		}
 		sources[source.Name] = append(sources[source.Name], source)
 	}

--- a/pkg/logs/status/builder.go
+++ b/pkg/logs/status/builder.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/status"
 	sourcesPkg "github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"go.uber.org/atomic"
 )
@@ -122,7 +123,7 @@ func (b *Builder) groupSourcesByName() map[string][]*sourcesPkg.LogSource {
 }
 
 // toString returns a representation of a status.
-func (b *Builder) toString(status *config.LogStatus) string {
+func (b *Builder) toString(status *status.LogStatus) string {
 	var value string
 	if status.IsPending() {
 		value = "Pending"

--- a/pkg/logs/status/status.go
+++ b/pkg/logs/status/status.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/metrics"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"go.uber.org/atomic"
 )
 
@@ -66,7 +67,7 @@ type Status struct {
 }
 
 // Init instantiates the builder that builds the status on the fly.
-func Init(isRunning *atomic.Bool, endpoints *config.Endpoints, sources *config.LogSources, logExpVars *expvar.Map) {
+func Init(isRunning *atomic.Bool, endpoints *config.Endpoints, sources *sources.LogSources, logExpVars *expvar.Map) {
 	warnings = config.NewMessages()
 	errors = config.NewMessages()
 	builder = NewBuilder(isRunning, endpoints, sources, warnings, errors, logExpVars)

--- a/pkg/logs/status/status_test.go
+++ b/pkg/logs/status/status_test.go
@@ -14,13 +14,15 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/metrics"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/util"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 )
 
 func initStatus() {
-	InitStatus(config.CreateSources([]*config.LogSource{
-		config.NewLogSource("foo", &config.LogsConfig{Type: "foo"}),
-		config.NewLogSource("bar", &config.LogsConfig{Type: "foo"}),
-		config.NewLogSource("foo", &config.LogsConfig{Type: "foo"}),
+	InitStatus(util.CreateSources([]*sources.LogSource{
+		sources.NewLogSource("foo", &config.LogsConfig{Type: "foo"}),
+		sources.NewLogSource("bar", &config.LogsConfig{Type: "foo"}),
+		sources.NewLogSource("foo", &config.LogsConfig{Type: "foo"}),
 	}))
 }
 

--- a/pkg/logs/status/test_utils.go
+++ b/pkg/logs/status/test_utils.go
@@ -8,11 +8,12 @@ package status
 import (
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/metrics"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"go.uber.org/atomic"
 )
 
 // InitStatus initialize a status builder
-func InitStatus(sources *config.LogSources) {
+func InitStatus(sources *sources.LogSources) {
 	var isRunning *atomic.Bool = atomic.NewBool(true)
 	endpoints, _ := config.BuildEndpoints(config.HTTPConnectivityFailure, "test-track", "test-proto", "test-source")
 	Init(isRunning, endpoints, sources, metrics.LogsExpvars)


### PR DESCRIPTION
### What does this PR do?

This moves
 * LogSource and LogSources and related functions into pkg/logs/sources
 * LogStatus and Info-related types and functions into pkg/logs/internal/status

### Motivation

Avoiding some package reference cycles down the road (specifically, allowing the auditor/registry to refer to a status-related type)

### Additional Notes

I left pkg/logs/status where it is -- it's a different kind of status, is global, and has some detailed ties to host metadata that I didn't want to try to untie.

### Describe how to test/QA your changes

This should not have any noticeable effect, as it only renames things.  Validate that the logs agent can still perform a basic logging operation.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
