### PR TITLE
Add more endpoints for connectivity diagnose

### DIFF
--- a/pkg/diagnose/connectivity/endpoint_info.go
+++ b/pkg/diagnose/connectivity/endpoint_info.go
@@ -36,11 +36,20 @@ type endpointInfo struct {
 var (
 	apiKeyInQueryString = true
 
-	emptyPayload = []byte("")
+	emptyPayload    = []byte("{}")
+	checkRunPayload = []byte("{\"check\": \"test\", \"status\": 0}")
 
-	// TODO : add more endpoints info and a filtering function to only keep used endpoints
-	v1SeriesEndpointInfo   = endpointInfo{endpoints.V1SeriesEndpoint, "POST", emptyPayload, apiKeyInQueryString}
-	v1ValidateEndpointInfo = endpointInfo{endpoints.V1ValidateEndpoint, "GET", emptyPayload, apiKeyInQueryString}
+	// v1 endpoints
+	v1SeriesEndpointInfo    = endpointInfo{endpoints.V1SeriesEndpoint, "POST", emptyPayload, apiKeyInQueryString}
+	v1CheckRunsEndpointInfo = endpointInfo{endpoints.V1CheckRunsEndpoint, "POST", checkRunPayload, apiKeyInQueryString}
+	v1IntakeEndpointInfo    = endpointInfo{endpoints.V1IntakeEndpoint, "POST", emptyPayload, apiKeyInQueryString}
+	v1ValidateEndpointInfo  = endpointInfo{endpoints.V1ValidateEndpoint, "GET", emptyPayload, false}
+	v1MetadataEndpointInfo  = endpointInfo{endpoints.V1MetadataEndpoint, "POST", emptyPayload, apiKeyInQueryString}
 
-	endpointsInfo = []endpointInfo{v1SeriesEndpointInfo, v1ValidateEndpointInfo}
+	// v2 endpoints
+	SeriesEndpointInfo       = endpointInfo{endpoints.SeriesEndpoint, "POST", emptyPayload, apiKeyInQueryString}
+	SketchSeriesEndpointInfo = endpointInfo{endpoints.SketchSeriesEndpoint, "POST", emptyPayload, apiKeyInQueryString}
+
+	endpointsInfo = []endpointInfo{v1SeriesEndpointInfo, v1CheckRunsEndpointInfo, v1MetadataEndpointInfo, v1IntakeEndpointInfo,
+		SeriesEndpointInfo, SketchSeriesEndpointInfo, v1ValidateEndpointInfo}
 )

--- a/pkg/diagnose/connectivity/endpoint_info.go
+++ b/pkg/diagnose/connectivity/endpoint_info.go
@@ -41,9 +41,9 @@ var (
 	v1MetadataEndpointInfo  = endpointInfo{endpoints.V1MetadataEndpoint, "POST", emptyPayload}
 
 	// v2 endpoints
-	SeriesEndpointInfo       = endpointInfo{endpoints.SeriesEndpoint, "POST", emptyPayload}
-	SketchSeriesEndpointInfo = endpointInfo{endpoints.SketchSeriesEndpoint, "POST", emptyPayload}
+	seriesEndpointInfo       = endpointInfo{endpoints.SeriesEndpoint, "POST", emptyPayload}
+	sketchSeriesEndpointInfo = endpointInfo{endpoints.SketchSeriesEndpoint, "POST", emptyPayload}
 
 	endpointsInfo = []endpointInfo{v1SeriesEndpointInfo, v1CheckRunsEndpointInfo, v1MetadataEndpointInfo, v1IntakeEndpointInfo,
-		SeriesEndpointInfo, SketchSeriesEndpointInfo, v1ValidateEndpointInfo}
+		seriesEndpointInfo, sketchSeriesEndpointInfo, v1ValidateEndpointInfo}
 )

--- a/pkg/diagnose/connectivity/endpoint_info.go
+++ b/pkg/diagnose/connectivity/endpoint_info.go
@@ -27,28 +27,22 @@ type endpointInfo struct {
 
 	// Payload is the HTTP request body we want to send to the endpoint.
 	Payload []byte
-
-	// ApiKeyInQueryString is set to true if the API Key has to be in the query string
-	// i.e. https://domain/endpoint?api_key=***************************XXXXX
-	APIKeyInQueryString bool
 }
 
 var (
-	apiKeyInQueryString = true
-
 	emptyPayload    = []byte("{}")
 	checkRunPayload = []byte("{\"check\": \"test\", \"status\": 0}")
 
 	// v1 endpoints
-	v1SeriesEndpointInfo    = endpointInfo{endpoints.V1SeriesEndpoint, "POST", emptyPayload, apiKeyInQueryString}
-	v1CheckRunsEndpointInfo = endpointInfo{endpoints.V1CheckRunsEndpoint, "POST", checkRunPayload, apiKeyInQueryString}
-	v1IntakeEndpointInfo    = endpointInfo{endpoints.V1IntakeEndpoint, "POST", emptyPayload, apiKeyInQueryString}
-	v1ValidateEndpointInfo  = endpointInfo{endpoints.V1ValidateEndpoint, "GET", emptyPayload, false}
-	v1MetadataEndpointInfo  = endpointInfo{endpoints.V1MetadataEndpoint, "POST", emptyPayload, apiKeyInQueryString}
+	v1SeriesEndpointInfo    = endpointInfo{endpoints.V1SeriesEndpoint, "POST", emptyPayload}
+	v1CheckRunsEndpointInfo = endpointInfo{endpoints.V1CheckRunsEndpoint, "POST", checkRunPayload}
+	v1IntakeEndpointInfo    = endpointInfo{endpoints.V1IntakeEndpoint, "POST", emptyPayload}
+	v1ValidateEndpointInfo  = endpointInfo{endpoints.V1ValidateEndpoint, "GET", emptyPayload}
+	v1MetadataEndpointInfo  = endpointInfo{endpoints.V1MetadataEndpoint, "POST", emptyPayload}
 
 	// v2 endpoints
-	SeriesEndpointInfo       = endpointInfo{endpoints.SeriesEndpoint, "POST", emptyPayload, apiKeyInQueryString}
-	SketchSeriesEndpointInfo = endpointInfo{endpoints.SketchSeriesEndpoint, "POST", emptyPayload, apiKeyInQueryString}
+	SeriesEndpointInfo       = endpointInfo{endpoints.SeriesEndpoint, "POST", emptyPayload}
+	SketchSeriesEndpointInfo = endpointInfo{endpoints.SketchSeriesEndpoint, "POST", emptyPayload}
 
 	endpointsInfo = []endpointInfo{v1SeriesEndpointInfo, v1CheckRunsEndpointInfo, v1MetadataEndpointInfo, v1IntakeEndpointInfo,
 		SeriesEndpointInfo, SketchSeriesEndpointInfo, v1ValidateEndpointInfo}

--- a/pkg/diagnose/connectivity/trace_request.go
+++ b/pkg/diagnose/connectivity/trace_request.go
@@ -72,7 +72,7 @@ func sendRequestToAllEndpointOfADomain(client *http.Client, domainResolver resol
 // sendHTTPRequestToEndpoint creates an URL based on the domain and the endpoint information
 // then sends an HTTP Request with the method and payload inside the endpoint information
 func sendHTTPRequestToEndpoint(ctx context.Context, client *http.Client, domain string, endpointInfo endpointInfo, apiKey string) (int, []byte, error) {
-	url := createEndpointURL(domain, endpointInfo, apiKey)
+	url := createEndpointURL(domain, endpointInfo)
 	logURL := scrubber.ScrubLine(url)
 
 	fmt.Printf("\n======== '%v' ========\n", color.BlueString(logURL))
@@ -106,15 +106,9 @@ func sendHTTPRequestToEndpoint(ctx context.Context, client *http.Client, domain 
 	return resp.StatusCode, body, nil
 }
 
-// createEndpointUrl joins a domain with an endpoint and adds the apiKey to the query
-// string if it is necessary for the given endpoint
-func createEndpointURL(domain string, endpointInfo endpointInfo, apiKey string) string {
+// createEndpointUrl joins a domain with an endpoint
+func createEndpointURL(domain string, endpointInfo endpointInfo) string {
 	url := domain + endpointInfo.Endpoint.Route
-
-	if endpointInfo.APIKeyInQueryString {
-		url = fmt.Sprintf("%s?api_key=%s", url, apiKey)
-	}
-
 	return url
 }
 

--- a/pkg/diagnose/connectivity/trace_request.go
+++ b/pkg/diagnose/connectivity/trace_request.go
@@ -119,7 +119,7 @@ func verifyEndpointResponse(statusCode int, responseBody []byte, err error) {
 	}
 
 	statusString := color.GreenString("PASS")
-	if statusCode >= http.StatusBadRequest {
+	if statusCode >= 400 {
 		statusString = color.RedString("FAIL")
 		fmt.Printf("Received response : '%v'\n", string(responseBody))
 	}

--- a/pkg/diagnose/connectivity/trace_request.go
+++ b/pkg/diagnose/connectivity/trace_request.go
@@ -108,8 +108,7 @@ func sendHTTPRequestToEndpoint(ctx context.Context, client *http.Client, domain 
 
 // createEndpointUrl joins a domain with an endpoint
 func createEndpointURL(domain string, endpointInfo endpointInfo) string {
-	url := domain + endpointInfo.Endpoint.Route
-	return url
+	return domain + endpointInfo.Endpoint.Route
 }
 
 func verifyEndpointResponse(statusCode int, responseBody []byte, err error) {

--- a/pkg/diagnose/connectivity/trace_request.go
+++ b/pkg/diagnose/connectivity/trace_request.go
@@ -87,6 +87,9 @@ func sendHTTPRequestToEndpoint(ctx context.Context, client *http.Client, domain 
 
 	// Add tracing and send the request
 	req = req.WithContext(ctx)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("DD-API-KEY", apiKey)
+
 	resp, err := client.Do(req)
 
 	if err != nil {
@@ -123,7 +126,7 @@ func verifyEndpointResponse(statusCode int, responseBody []byte, err error) {
 	}
 
 	statusString := color.GreenString("PASS")
-	if statusCode != http.StatusOK {
+	if statusCode >= http.StatusBadRequest {
 		statusString = color.RedString("FAIL")
 		fmt.Printf("Received response : '%v'\n", string(responseBody))
 	}


### PR DESCRIPTION

### What does this PR do?

This PR adds the remaining metrics endpoints, used by the forwarder, in the `diagnose datadog-connectivity` command.

### Motivation

Being able to troubleshoot more endpoints

### Additional Notes

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Run `diagnose datadog-connectivity` and verify that there is an output for the following endpoints : 

- `api/v1/check_run`
- `api/v1/metadata`
- `intake/`
- `api/v2/series`
- `api/beta/sketches`
- `api/v1/validate`


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
