### PR TITLE
invoke: Use relative imports instead of importing from tasks

### DIFF
--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -5,8 +5,6 @@ import os
 
 from invoke import Collection
 
-from tasks.utils import generate_config
-
 from . import (
     agent,
     android,
@@ -56,6 +54,7 @@ from .test import (
     lint_teamassignment,
     test,
 )
+from .utils import generate_config
 
 # the root namespace
 ns = Collection()

--- a/tasks/customaction.py
+++ b/tasks/customaction.py
@@ -10,8 +10,7 @@ import sys
 from invoke import task
 from invoke.exceptions import Exit
 
-from tasks.libs.common.color import color_message
-
+from .libs.common.color import color_message
 from .utils import get_version, get_version_numeric_only
 
 # constants

--- a/tasks/dogstatsd.py
+++ b/tasks/dogstatsd.py
@@ -11,9 +11,8 @@ from distutils.dir_util import copy_tree
 from invoke import task
 from invoke.exceptions import Exit
 
-from tasks.flavor import AgentFlavor
-
 from .build_tags import filter_incompatible_tags, get_build_tags, get_default_build_tags
+from .flavor import AgentFlavor
 from .go import deps
 from .utils import (
     REPO_PATH,

--- a/tasks/libs/github_actions_tools.py
+++ b/tasks/libs/github_actions_tools.py
@@ -6,10 +6,9 @@ from time import sleep
 
 from invoke.exceptions import Exit
 
-from tasks.utils import DEFAULT_BRANCH
-
 from .common.color import color_message
 from .common.github_workflows import GithubException, GithubWorkflows, get_github_app_token
+from .utils import DEFAULT_BRANCH
 
 
 def create_or_refresh_macos_build_github_workflows(github_workflows=None):

--- a/tasks/libs/github_actions_tools.py
+++ b/tasks/libs/github_actions_tools.py
@@ -6,9 +6,9 @@ from time import sleep
 
 from invoke.exceptions import Exit
 
+from ..utils import DEFAULT_BRANCH
 from .common.color import color_message
 from .common.github_workflows import GithubException, GithubWorkflows, get_github_app_token
-from .utils import DEFAULT_BRANCH
 
 
 def create_or_refresh_macos_build_github_workflows(github_workflows=None):

--- a/tasks/libs/pipeline_tools.py
+++ b/tasks/libs/pipeline_tools.py
@@ -4,9 +4,9 @@ import platform
 import sys
 from time import sleep, time
 
+from ..utils import DEFAULT_BRANCH
 from .common.color import color_message
 from .common.user_interactions import yes_no_question
-from .utils import DEFAULT_BRANCH
 
 PIPELINE_FINISH_TIMEOUT_SEC = 3600 * 5
 

--- a/tasks/libs/pipeline_tools.py
+++ b/tasks/libs/pipeline_tools.py
@@ -4,10 +4,9 @@ import platform
 import sys
 from time import sleep, time
 
-from tasks.utils import DEFAULT_BRANCH
-
 from .common.color import color_message
 from .common.user_interactions import yes_no_question
+from .utils import DEFAULT_BRANCH
 
 PIPELINE_FINISH_TIMEOUT_SEC = 3600 * 5
 

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -9,14 +9,6 @@ import yaml
 from invoke import task
 from invoke.exceptions import Exit
 
-from tasks.utils import (
-    DEFAULT_BRANCH,
-    get_all_allowed_repo_branches,
-    is_allowed_repo_branch,
-    nightly_entry_for,
-    release_entry_for,
-)
-
 from .libs.common.color import color_message
 from .libs.common.gitlab import Gitlab, get_gitlab_bot_token, get_gitlab_token
 from .libs.pipeline_notifications import (
@@ -34,6 +26,13 @@ from .libs.pipeline_tools import (
     wait_for_pipeline,
 )
 from .libs.types import SlackMessage, TeamMessage
+from .utils import (
+    DEFAULT_BRANCH,
+    get_all_allowed_repo_branches,
+    is_allowed_repo_branch,
+    nightly_entry_for,
+    release_entry_for,
+)
 
 # Tasks to trigger pipelines
 

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -13,16 +13,15 @@ from time import sleep
 from invoke import Failure, task
 from invoke.exceptions import Exit
 
-from tasks.libs.common.color import color_message
-from tasks.libs.common.github_api import GithubAPI, get_github_token
-from tasks.libs.common.gitlab import Gitlab, get_gitlab_token
-from tasks.libs.common.remote_api import APIError
-from tasks.pipeline import run
-from tasks.utils import DEFAULT_BRANCH, get_version, nightly_entry_for, release_entry_for
-
+from .libs.common.color import color_message
+from .libs.common.github_api import GithubAPI, get_github_token
+from .libs.common.gitlab import Gitlab, get_gitlab_token
+from .libs.common.remote_api import APIError
 from .libs.common.user_interactions import yes_no_question
 from .libs.version import Version
 from .modules import DEFAULT_MODULES
+from .pipeline import run
+from .utils import DEFAULT_BRANCH, get_version, nightly_entry_for, release_entry_for
 
 # Generic version regex. Aims to match:
 # - X.Y.Z

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -15,12 +15,11 @@ from typing import Dict, List
 from invoke import task
 from invoke.exceptions import Exit
 
-from tasks.flavor import AgentFlavor
-
 from .agent import integration_tests as agent_integration_tests
 from .build_tags import compute_build_tags_for_flavor
 from .cluster_agent import integration_tests as dca_integration_tests
 from .dogstatsd import integration_tests as dsd_integration_tests
+from .flavor import AgentFlavor
 from .go import golangci_lint
 from .libs.copyright import CopyrightLinter
 from .libs.junit_upload import add_flavor_to_junitxml, junit_upload_from_tgz, produce_junit_tar


### PR DESCRIPTION
### What does this PR do?

Import from other tasks by importing `.<file>` instead of `tasks.<file>`

### Motivation

We had a mix of both methods before and my autocompletion didn't seem to find the imports using `tasks.*`.
