### PR TITLE
SNMP Traps: Remove experimental notice in datadog.yaml

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -3066,7 +3066,7 @@ api_key:
 
   ## @param snmp_traps - custom object - optional
   ## This section configures SNMP traps collection.
-  ## Traps are forwarded as logs to Datadog and can be found with `source:snmp-traps`
+  ## Traps are forwarded as logs and can be found in the logs explorer with a source:snmp-traps query
   #
   # snmp_traps:
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -3065,9 +3065,8 @@ api_key:
   # namespace: default
 
   ## @param snmp_traps - custom object - optional
-  ## This section configures SNMP traps collection. Traps are forwarded as logs to Datadog.
-  ## NOTE: This feature is currently **EXPERIMENTAL**. Both behavior and configuration options may
-  ## change in the future.
+  ## This section configures SNMP traps collection.
+  ## Traps are forwarded as logs to Datadog and can be found with `source:snmp-traps`
   #
   # snmp_traps:
 


### PR DESCRIPTION
The feature is not EXPERIMENTAL anymore