### PR TITLE
CSPM: do not run docker rules on kubernetes environment

### DIFF
--- a/pkg/compliance/agent/agent_test.go
+++ b/pkg/compliance/agent/agent_test.go
@@ -35,7 +35,7 @@ func (e *tempEnv) leave() {
 	defer os.Chdir(e.prev)
 }
 
-func enterTempEnv(t *testing.T) *tempEnv {
+func enterTempEnv(t *testing.T, k8s bool) *tempEnv {
 	t.Helper()
 	assert := assert.New(t)
 	tempDir, err := os.MkdirTemp("", "compliance-agent-")
@@ -53,7 +53,10 @@ func enterTempEnv(t *testing.T) *tempEnv {
 	prev, _ := os.Getwd()
 	_ = os.Chdir(tempDir)
 
-	os.Setenv("KUBERNETES", "yes")
+	if k8s {
+		t.Setenv("KUBERNETES", "yes")
+	}
+
 	return &tempEnv{
 		dir:  tempDir,
 		prev: prev,
@@ -89,34 +92,17 @@ func eventMatcher(m eventMatch) interface{} {
 	}
 }
 
-func TestRun(t *testing.T) {
+func TestRunK8s(t *testing.T) {
 	assert := assert.New(t)
 
 	opts := aggregator.DefaultDemultiplexerOptions(nil)
 	opts.DontStartForwarders = true
 	aggregator.InitAndStartAgentDemultiplexer(opts, "foo")
 
-	e := enterTempEnv(t)
+	e := enterTempEnv(t, true)
 	defer e.leave()
 
 	reporter := &mocks.Reporter{}
-
-	reporter.On(
-		"Report",
-		mock.MatchedBy(
-			eventMatcher(
-				eventMatch{
-					ruleID:       "cis-docker-1",
-					frameworkID:  "cis-docker",
-					resourceID:   "the-host_daemon",
-					resourceType: "docker_daemon",
-					result:       "passed",
-					path:         "/files/daemon.json",
-					permissions:  0644,
-				},
-			),
-		),
-	).Once()
 
 	reporter.On(
 		"Report",
@@ -148,10 +134,6 @@ func TestRun(t *testing.T) {
 		check.Run()
 	})
 
-	dockerClient := &mocks.DockerClient{}
-	dockerClient.On("Close").Return(nil).Once()
-	defer dockerClient.AssertExpectations(t)
-
 	kubeClient := &mocks.KubeClient{}
 	kubeClient.On("Resource", mock.Anything).Return(nil)
 
@@ -166,7 +148,6 @@ func TestRun(t *testing.T) {
 		&config.Endpoints{},
 		checks.WithHostname("the-host"),
 		checks.WithHostRootMount(e.dir),
-		checks.WithDockerClient(dockerClient),
 		checks.WithNodeLabels(nodeLabels),
 		checks.WithKubernetesClient(kubeClient, "kube_system_uuid"),
 	)
@@ -179,10 +160,84 @@ func TestRun(t *testing.T) {
 	st := agent.builder.GetCheckStatus()
 	assert.Len(st, 2)
 	assert.Equal("cis-docker-1", st[0].RuleID)
-	assert.Equal("passed", st[0].LastEvent.Result)
-
+	assert.Nil(st[0].LastEvent)
 	assert.Equal("cis-kubernetes-1", st[1].RuleID)
 	assert.Equal("failed", st[1].LastEvent.Result)
+
+	v, err := json.Marshal(st)
+	assert.NoError(err)
+
+	// Check the expvar value
+	assert.JSONEq(string(v), status.Get("Checks").String())
+}
+
+func TestRunDocker(t *testing.T) {
+	assert := assert.New(t)
+
+	opts := aggregator.DefaultDemultiplexerOptions(nil)
+	opts.DontStartForwarders = true
+	aggregator.InitAndStartAgentDemultiplexer(opts, "foo")
+
+	e := enterTempEnv(t, false)
+	defer e.leave()
+
+	reporter := &mocks.Reporter{}
+
+	reporter.On(
+		"Report",
+		mock.MatchedBy(
+			eventMatcher(
+				eventMatch{
+					ruleID:       "cis-docker-1",
+					frameworkID:  "cis-docker",
+					resourceID:   "the-host_daemon",
+					resourceType: "docker_daemon",
+					result:       "passed",
+					path:         "/files/daemon.json",
+					permissions:  0644,
+				},
+			),
+		),
+	).Once()
+
+	defer reporter.AssertExpectations(t)
+
+	scheduler := &mocks.Scheduler{}
+	defer scheduler.AssertExpectations(t)
+
+	scheduler.On("Run").Once().Return(nil)
+	scheduler.On("Stop").Once().Return(nil)
+
+	scheduler.On("Enter", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		check := args.Get(0).(check.Check)
+		check.Run()
+	})
+
+	dockerClient := &mocks.DockerClient{}
+	dockerClient.On("Close").Return(nil).Once()
+	defer dockerClient.AssertExpectations(t)
+
+	agent, err := New(
+		reporter,
+		scheduler,
+		e.dir,
+		&config.Endpoints{},
+		checks.WithHostname("the-host"),
+		checks.WithHostRootMount(e.dir),
+		checks.WithDockerClient(dockerClient),
+	)
+	assert.NoError(err)
+
+	err = agent.Run()
+	assert.NoError(err)
+	agent.Stop()
+
+	st := agent.builder.GetCheckStatus()
+	assert.Len(st, 2)
+	assert.Equal("cis-docker-1", st[0].RuleID)
+	assert.Equal("passed", st[0].LastEvent.Result)
+	assert.Equal("cis-kubernetes-1", st[1].RuleID)
+	assert.Nil(st[1].LastEvent)
 
 	v, err := json.Marshal(st)
 	assert.NoError(err)
@@ -198,7 +253,7 @@ func TestRunChecks(t *testing.T) {
 	opts.DontStartForwarders = true
 	aggregator.InitAndStartAgentDemultiplexer(opts, "foo")
 
-	e := enterTempEnv(t)
+	e := enterTempEnv(t, false)
 	defer e.leave()
 
 	reporter := &mocks.Reporter{}
@@ -240,7 +295,7 @@ func TestRunChecks(t *testing.T) {
 
 func TestRunChecksFromFile(t *testing.T) {
 	assert := assert.New(t)
-	e := enterTempEnv(t)
+	e := enterTempEnv(t, true)
 	defer e.leave()
 
 	reporter := &mocks.Reporter{}

--- a/pkg/compliance/agent/agent_test.go
+++ b/pkg/compliance/agent/agent_test.go
@@ -158,11 +158,13 @@ func TestRunK8s(t *testing.T) {
 	agent.Stop()
 
 	st := agent.builder.GetCheckStatus()
-	assert.Len(st, 2)
+	assert.Len(st, 3)
 	assert.Equal("cis-docker-1", st[0].RuleID)
 	assert.Nil(st[0].LastEvent)
-	assert.Equal("cis-kubernetes-1", st[1].RuleID)
-	assert.Equal("failed", st[1].LastEvent.Result)
+	assert.Equal("cis-docker-2", st[1].RuleID)
+	assert.Nil(st[1].LastEvent)
+	assert.Equal("cis-kubernetes-1", st[2].RuleID)
+	assert.Equal("failed", st[2].LastEvent.Result)
 
 	v, err := json.Marshal(st)
 	assert.NoError(err)
@@ -189,6 +191,22 @@ func TestRunDocker(t *testing.T) {
 			eventMatcher(
 				eventMatch{
 					ruleID:       "cis-docker-1",
+					frameworkID:  "cis-docker",
+					resourceID:   "the-host_daemon",
+					resourceType: "docker_daemon",
+					result:       "passed",
+					path:         "/files/daemon.json",
+					permissions:  0644,
+				},
+			),
+		),
+	).Once()
+	reporter.On(
+		"Report",
+		mock.MatchedBy(
+			eventMatcher(
+				eventMatch{
+					ruleID:       "cis-docker-2",
 					frameworkID:  "cis-docker",
 					resourceID:   "the-host_daemon",
 					resourceType: "docker_daemon",
@@ -233,11 +251,13 @@ func TestRunDocker(t *testing.T) {
 	agent.Stop()
 
 	st := agent.builder.GetCheckStatus()
-	assert.Len(st, 2)
+	assert.Len(st, 3)
 	assert.Equal("cis-docker-1", st[0].RuleID)
 	assert.Equal("passed", st[0].LastEvent.Result)
-	assert.Equal("cis-kubernetes-1", st[1].RuleID)
-	assert.Nil(st[1].LastEvent)
+	assert.Equal("cis-docker-2", st[1].RuleID)
+	assert.Equal("passed", st[1].LastEvent.Result)
+	assert.Equal("cis-kubernetes-1", st[2].RuleID)
+	assert.Nil(st[2].LastEvent)
 
 	v, err := json.Marshal(st)
 	assert.NoError(err)

--- a/pkg/compliance/agent/testdata/configs/cis-docker.yaml
+++ b/pkg/compliance/agent/testdata/configs/cis-docker.yaml
@@ -11,5 +11,13 @@ rules:
     - file:
         path: /files/daemon.json
       condition: file.permissions == 0644
+- id: cis-docker-2
+  scope:
+    - docker
+  skipOnKubernetes: true
+  resources:
+    - file:
+        path: /files/daemon.json
+      condition: file.permissions == 0644
 
 

--- a/pkg/compliance/checks/builder.go
+++ b/pkg/compliance/checks/builder.go
@@ -573,6 +573,11 @@ func (b *builder) getRuleResourceReporter(scope compliance.RuleScope, rule compl
 func (b *builder) hostMatcher(scope compliance.RuleScope, ruleID string, hostSelector string) (bool, error) {
 	switch scope {
 	case compliance.DockerScope:
+		if config.IsKubernetes() {
+			log.Infof("rule %s skipped - running on a Kubernetes environment", ruleID)
+			return false, nil
+		}
+
 		if b.dockerClient == nil {
 			log.Infof("rule %s skipped - not running in a docker environment", ruleID)
 			return false, nil

--- a/pkg/compliance/checks/builder.go
+++ b/pkg/compliance/checks/builder.go
@@ -445,7 +445,7 @@ func (b *builder) checkFromRule(meta *compliance.SuiteMeta, rule *compliance.Con
 		return nil, err
 	}
 
-	eligible, err := b.hostMatcher(ruleScope, rule.ID, rule.HostSelector)
+	eligible, err := b.hostMatcher(ruleScope, rule.ID, rule.HostSelector, rule.SkipOnK8s)
 	if err != nil {
 		return nil, err
 	}
@@ -467,7 +467,7 @@ func (b *builder) checkFromRegoRule(meta *compliance.SuiteMeta, rule *compliance
 
 	// skip host match check if rego input is overridden
 	if b.regoInputOverride == nil {
-		eligible, err := b.hostMatcher(ruleScope, rule.ID, rule.HostSelector)
+		eligible, err := b.hostMatcher(ruleScope, rule.ID, rule.HostSelector, rule.SkipOnK8s)
 		if err != nil {
 			return nil, err
 		}
@@ -570,10 +570,10 @@ func (b *builder) getRuleResourceReporter(scope compliance.RuleScope, rule compl
 	}
 }
 
-func (b *builder) hostMatcher(scope compliance.RuleScope, ruleID string, hostSelector string) (bool, error) {
+func (b *builder) hostMatcher(scope compliance.RuleScope, ruleID string, hostSelector string, skipOnK8s bool) (bool, error) {
 	switch scope {
 	case compliance.DockerScope:
-		if config.IsKubernetes() {
+		if skipOnK8s && config.IsKubernetes() {
 			log.Infof("rule %s skipped - running on a Kubernetes environment", ruleID)
 			return false, nil
 		}

--- a/pkg/compliance/rule.go
+++ b/pkg/compliance/rule.go
@@ -20,6 +20,7 @@ type RuleCommon struct {
 	Description  string        `yaml:"description,omitempty"`
 	Scope        RuleScopeList `yaml:"scope,omitempty"`
 	HostSelector string        `yaml:"hostSelector,omitempty"`
+	SkipOnK8s    bool          `yaml:"skipOnKubernetes,omitempty"`
 }
 
 // ConditionFallbackRule defines a rule in a compliance config


### PR DESCRIPTION
### What does this PR do?

This PR makes it so that you can instruct some CSPM docker rules to not run in k8s environments.
For example:
```yaml
schema:
  version: 1.0.0
name: CIS Docker Generic
framework: cis-docker
version: 1.2.0
rules:
- id: cis-docker-2
  scope:
    - docker
  skipOnKubernetes: true
  inputs:
    ...
```

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
