### PR TITLE
Do not commit changes to runtime integrity hashes to repo

### DIFF
--- a/pkg/ebpf/bytecode/runtime/conntrack.go
+++ b/pkg/ebpf/bytecode/runtime/conntrack.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Conntrack = NewRuntimeAsset("conntrack.c", "5b2058d4530a0b88df94456452591d23f963f3c80819c5d3cfccb8eff8347cd0")
+var Conntrack = NewRuntimeAsset("conntrack.c", "")

--- a/pkg/ebpf/bytecode/runtime/http.go
+++ b/pkg/ebpf/bytecode/runtime/http.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Http = NewRuntimeAsset("http.c", "5a52c2faca6e92c96c19dafaf8a6e5021d1938dbedc8e9ed845afd8ce6f16927")
+var Http = NewRuntimeAsset("http.c", "")

--- a/pkg/ebpf/bytecode/runtime/integrity.go
+++ b/pkg/ebpf/bytecode/runtime/integrity.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -43,6 +44,11 @@ func main() {
 		log.Fatalf("error generating integrity: %s", err)
 	}
 	fmt.Printf("successfully generated from %s => %s\n", inputFile, outputFile)
+
+	err = exec.Command("git", "update-index", "--assume-unchanged", outputFile).Run()
+	if err != nil {
+		log.Printf("error ignoring changes in git: %s", err)
+	}
 }
 
 func genIntegrity(inputFile, outputFile, pkg string) error {

--- a/pkg/ebpf/bytecode/runtime/oom-kill.go
+++ b/pkg/ebpf/bytecode/runtime/oom-kill.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var OomKill = NewRuntimeAsset("oom-kill.c", "2e0ca3089d39a63d6d01176a7df2b0f4e3bd3d371d9b5390a0e674c66b685b43")
+var OomKill = NewRuntimeAsset("oom-kill.c", "")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "4547007f9a65de8ce2facd7d2a1a0071547698f622ce2ebff33dd3f634f0987d")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "")

--- a/pkg/ebpf/bytecode/runtime/tcp-queue-length.go
+++ b/pkg/ebpf/bytecode/runtime/tcp-queue-length.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var TcpQueueLength = NewRuntimeAsset("tcp-queue-length.c", "6961d48574928fd3c137a33e9b3e854f06617a6b05f3d3fa22eb4e1807381070")
+var TcpQueueLength = NewRuntimeAsset("tcp-queue-length.c", "")

--- a/pkg/ebpf/bytecode/runtime/tracer.go
+++ b/pkg/ebpf/bytecode/runtime/tracer.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Tracer = NewRuntimeAsset("tracer.c", "492135c610d9364c749b495d3ba7ae32aea97c1442ffab74fbc0926ad77d8eea")
+var Tracer = NewRuntimeAsset("tracer.c", "")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Ignores changes to the runtime integrity hashes in git. This still leaves a skeleton file in the repo with an empty hash, for linting and build purposes. The builds will still generate the complete hashes and be included in released binaries.

### Motivation

The hashes are not consistently checked-in when the source content is changed. This results in hash files being part of PRs where nothing relevant actually changed, and the owning teams requested for review.

### Additional Notes

New files will need to be manually added, but this is a relatively rare operation.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
