### PR TITLE
[CWS] Limit memory usage of the reorderer

### DIFF
--- a/pkg/security/ebpf/manager.go
+++ b/pkg/security/ebpf/manager.go
@@ -28,7 +28,7 @@ func NewDefaultOptions() manager.Options {
 		// DefaultPerfRingBufferSize is the default buffer size of the perf buffers
 		// PLEASE NOTE: for the perf ring buffer usage metrics to be accurate, the provided value must have the
 		// following form: (1 + 2^n) * pages. Checkout https://github.com/DataDog/ebpf for more.
-		DefaultPerfRingBufferSize: 4097 * os.Getpagesize(),
+		DefaultPerfRingBufferSize: 257 * os.Getpagesize(),
 
 		VerifierOptions: ebpf.CollectionOptions{
 			Programs: ebpf.ProgramOptions{

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -1347,10 +1347,11 @@ func NewProbe(config *config.Config, statsdClient statsd.ClientInterface) (*Prob
 		p.handleEvent,
 		ExtractEventInfo,
 		ReOrdererOpts{
-			QueueSize:  10000,
-			Rate:       50 * time.Millisecond,
-			Retention:  5,
-			MetricRate: 5 * time.Second,
+			QueueSize:       10000,
+			Rate:            50 * time.Millisecond,
+			Retention:       5,
+			MetricRate:      5 * time.Second,
+			HeapShrinkDelta: 1000,
 		})
 
 	p.scrubber = pconfig.NewDefaultDataScrubber()

--- a/pkg/security/probe/reorderer.go
+++ b/pkg/security/probe/reorderer.go
@@ -121,7 +121,7 @@ func (h *reOrdererHeap) enqueue(cpu uint64, data []byte, tm uint64, generation u
 	h.up(node, len(h.heap)-1, metric)
 }
 
-func (h *reOrdererHeap) dequeue(handler func(cpu uint64, data []byte), generation uint64, metric *ReOrdererMetric) {
+func (h *reOrdererHeap) dequeue(handler func(cpu uint64, data []byte), generation uint64, metric *ReOrdererMetric, opts *ReOrdererOpts) {
 	var n, i int
 	var node *reOrdererNode
 
@@ -141,23 +141,29 @@ func (h *reOrdererHeap) dequeue(handler func(cpu uint64, data []byte), generatio
 
 		h.heap[i] = nil
 
-		heap := make([]*reOrdererNode, i)
-		copy(heap, h.heap[0:i])
-		h.heap = heap
-
 		metric.TotalOp++
 		handler(node.cpu, node.data)
 
 		h.pool.free(node)
+
+		// shrink
+		if cap(h.heap)-len(h.heap) > opts.HeapShrinkDelta {
+			heap := make([]*reOrdererNode, i)
+			copy(heap, h.heap[0:i])
+			h.heap = heap
+		} else {
+			h.heap = h.heap[0:i]
+		}
 	}
 }
 
 // ReOrdererOpts options to pass when creating a new instance of ReOrderer
 type ReOrdererOpts struct {
-	QueueSize  uint64        // size of the chan where the perf data are pushed
-	Rate       time.Duration // delay between two time based iterations
-	Retention  uint64        // bucket to keep before dequeueing
-	MetricRate time.Duration // delay between two metric samples
+	QueueSize       uint64        // size of the chan where the perf data are pushed
+	Rate            time.Duration // delay between two time based iterations
+	Retention       uint64        // bucket to keep before dequeueing
+	MetricRate      time.Duration // delay between two metric samples
+	HeapShrinkDelta int           // delta between cap and len between releasing heap array
 }
 
 func (r *ReOrdererMetric) zero() {
@@ -220,13 +226,12 @@ func (r *ReOrderer) Start(wg *sync.WaitGroup) {
 			} else {
 				r.heap.enqueue(cpu, data, tm, r.generation, &r.metric)
 			}
-			r.heap.dequeue(r.handler, r.generation-r.opts.Retention, &r.metric)
-
+			r.heap.dequeue(r.handler, r.generation-r.opts.Retention, &r.metric, &r.opts)
 		case <-flushTicker.C:
 			r.generation++
 
 			// force dequeue of a generation in case of low event rate
-			r.heap.dequeue(r.handler, r.generation-r.opts.Retention, &r.metric)
+			r.heap.dequeue(r.handler, r.generation-r.opts.Retention, &r.metric, &r.opts)
 		case <-metricTicker.C:
 			r.metric.QueueSize = r.heap.len()
 

--- a/pkg/security/probe/reorderer_test.go
+++ b/pkg/security/probe/reorderer_test.go
@@ -37,7 +37,7 @@ func TestOrder(t *testing.T) {
 			assert.GreaterOrEqual(t, data[0], last)
 		}
 		last = data[0]
-	}, 1, &metric)
+	}, 1, &metric, &ReOrdererOpts{})
 
 	assert.Equal(t, 200, count)
 }
@@ -53,11 +53,11 @@ func TestOrderRetention(t *testing.T) {
 	}
 
 	var count int
-	heap.dequeue(func(cpu uint64, data []byte) { count++ }, 1, &metric)
+	heap.dequeue(func(cpu uint64, data []byte) { count++ }, 1, &metric, &ReOrdererOpts{})
 	assert.Equal(t, 30, count)
-	heap.dequeue(func(cpu uint64, data []byte) { count++ }, 2, &metric)
+	heap.dequeue(func(cpu uint64, data []byte) { count++ }, 2, &metric, &ReOrdererOpts{})
 	assert.Equal(t, 60, count)
-	heap.dequeue(func(cpu uint64, data []byte) { count++ }, 3, &metric)
+	heap.dequeue(func(cpu uint64, data []byte) { count++ }, 3, &metric, &ReOrdererOpts{})
 	assert.Equal(t, 90, count)
 }
 
@@ -71,10 +71,10 @@ func TestOrderGeneration(t *testing.T) {
 	heap.enqueue(0, []byte{byte(1)}, uint64(1), uint64(2), &metric)
 
 	var data []byte
-	heap.dequeue(func(c uint64, d []byte) { data = d }, 1, &metric)
+	heap.dequeue(func(c uint64, d []byte) { data = d }, 1, &metric, &ReOrdererOpts{})
 	assert.Equal(t, 1, int(data[0]))
 
-	heap.dequeue(func(c uint64, d []byte) { data = d }, 2, &metric)
+	heap.dequeue(func(c uint64, d []byte) { data = d }, 2, &metric, &ReOrdererOpts{})
 	assert.Equal(t, 10, int(data[0]))
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Stop sorting elements if the queue size is upper a defined limit and shrink the heap array regularly.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
