### PR TITLE
pkg/trace/api: add generic EVP Proxy API

### DIFF
--- a/cmd/trace-agent/config/config.go
+++ b/cmd/trace-agent/config/config.go
@@ -401,16 +401,16 @@ func applyDatadogConfig(c *config.AgentConfig) error {
 	if k := "apm_config.debugger_api_key"; coreconfig.Datadog.IsSet(k) {
 		c.DebuggerProxy.APIKey = coreconfig.Datadog.GetString(k)
 	}
-	if k := "evpiproxy_config.enabled"; coreconfig.Datadog.IsSet(k) {
+	if k := "evp_proxy_config.enabled"; coreconfig.Datadog.IsSet(k) {
 		c.EVPIntakeProxy.Enabled = coreconfig.Datadog.GetBool(k)
 	}
-	if k := "evpiproxy_config.evpiproxy_dd_url"; coreconfig.Datadog.IsSet(k) {
+	if k := "evp_proxy_config.evp_proxy_dd_url"; coreconfig.Datadog.IsSet(k) {
 		c.EVPIntakeProxy.DDURL = coreconfig.Datadog.GetString(k)
 	}
-	if k := "evpiproxy_config.evpiproxy_api_key"; coreconfig.Datadog.IsSet(k) {
+	if k := "evp_proxy_config.evp_proxy_api_key"; coreconfig.Datadog.IsSet(k) {
 		c.EVPIntakeProxy.APIKey = coreconfig.Datadog.GetString(k)
 	}
-	if k := "evpiproxy_config.evpiproxy_additional_endpoints"; coreconfig.Datadog.IsSet(k) {
+	if k := "evp_proxy_config.evp_proxy_additional_endpoints"; coreconfig.Datadog.IsSet(k) {
 		c.EVPIntakeProxy.AdditionalEndpoints = coreconfig.Datadog.GetStringMapStringSlice(k)
 	}
 	return nil

--- a/cmd/trace-agent/config/config.go
+++ b/cmd/trace-agent/config/config.go
@@ -402,17 +402,13 @@ func applyDatadogConfig(c *config.AgentConfig) error {
 		c.DebuggerProxy.APIKey = coreconfig.Datadog.GetString(k)
 	}
 	if k := "evpiproxy_config.enabled"; coreconfig.Datadog.IsSet(k) {
-		c.EvpIntakeProxy.Enabled = c.Enabled && coreconfig.Datadog.GetBool(k)
+		c.EvpIntakeProxy.Enabled = coreconfig.Datadog.GetBool(k)
 	}
 	if k := "evpiproxy_config.evpiproxy_dd_url"; coreconfig.Datadog.IsSet(k) {
 		c.EvpIntakeProxy.DDURL = coreconfig.Datadog.GetString(k)
-	} else {
-		c.EvpIntakeProxy.DDURL = c.Site
 	}
 	if k := "evpiproxy_config.evpiproxy_api_key"; coreconfig.Datadog.IsSet(k) {
 		c.EvpIntakeProxy.APIKey = coreconfig.Datadog.GetString(k)
-	} else {
-		c.EvpIntakeProxy.APIKey = c.APIKey()
 	}
 	if k := "evpiproxy_config.evpiproxy_additional_endpoints"; coreconfig.Datadog.IsSet(k) {
 		c.EvpIntakeProxy.AdditionalEndpoints = coreconfig.Datadog.GetStringMapStringSlice(k)

--- a/cmd/trace-agent/config/config.go
+++ b/cmd/trace-agent/config/config.go
@@ -413,6 +413,9 @@ func applyDatadogConfig(c *config.AgentConfig) error {
 	if k := "evp_proxy_config.additional_endpoints"; coreconfig.Datadog.IsSet(k) {
 		c.EVPProxy.AdditionalEndpoints = coreconfig.Datadog.GetStringMapStringSlice(k)
 	}
+	if k := "evp_proxy_config.max_payload_size"; coreconfig.Datadog.IsSet(k) {
+		c.EVPProxy.MaxPayloadSize = coreconfig.Datadog.GetInt64(k)
+	}
 	return nil
 }
 

--- a/cmd/trace-agent/config/config.go
+++ b/cmd/trace-agent/config/config.go
@@ -402,16 +402,16 @@ func applyDatadogConfig(c *config.AgentConfig) error {
 		c.DebuggerProxy.APIKey = coreconfig.Datadog.GetString(k)
 	}
 	if k := "evpiproxy_config.enabled"; coreconfig.Datadog.IsSet(k) {
-		c.EvpIntakeProxy.Enabled = coreconfig.Datadog.GetBool(k)
+		c.EVPIntakeProxy.Enabled = coreconfig.Datadog.GetBool(k)
 	}
 	if k := "evpiproxy_config.evpiproxy_dd_url"; coreconfig.Datadog.IsSet(k) {
-		c.EvpIntakeProxy.DDURL = coreconfig.Datadog.GetString(k)
+		c.EVPIntakeProxy.DDURL = coreconfig.Datadog.GetString(k)
 	}
 	if k := "evpiproxy_config.evpiproxy_api_key"; coreconfig.Datadog.IsSet(k) {
-		c.EvpIntakeProxy.APIKey = coreconfig.Datadog.GetString(k)
+		c.EVPIntakeProxy.APIKey = coreconfig.Datadog.GetString(k)
 	}
 	if k := "evpiproxy_config.evpiproxy_additional_endpoints"; coreconfig.Datadog.IsSet(k) {
-		c.EvpIntakeProxy.AdditionalEndpoints = coreconfig.Datadog.GetStringMapStringSlice(k)
+		c.EVPIntakeProxy.AdditionalEndpoints = coreconfig.Datadog.GetStringMapStringSlice(k)
 	}
 	return nil
 }

--- a/cmd/trace-agent/config/config.go
+++ b/cmd/trace-agent/config/config.go
@@ -401,6 +401,22 @@ func applyDatadogConfig(c *config.AgentConfig) error {
 	if k := "apm_config.debugger_api_key"; coreconfig.Datadog.IsSet(k) {
 		c.DebuggerProxy.APIKey = coreconfig.Datadog.GetString(k)
 	}
+	if k := "evpiproxy_config.enabled"; coreconfig.Datadog.IsSet(k) {
+		c.EvpIntakeProxy.Enabled = c.Enabled && coreconfig.Datadog.GetBool(k)
+	}
+	if k := "evpiproxy_config.evpiproxy_dd_url"; coreconfig.Datadog.IsSet(k) {
+		c.EvpIntakeProxy.DDURL = coreconfig.Datadog.GetString(k)
+	} else {
+		c.EvpIntakeProxy.DDURL = c.Site
+	}
+	if k := "evpiproxy_config.evpiproxy_api_key"; coreconfig.Datadog.IsSet(k) {
+		c.EvpIntakeProxy.APIKey = coreconfig.Datadog.GetString(k)
+	} else {
+		c.EvpIntakeProxy.APIKey = c.APIKey()
+	}
+	if k := "evpiproxy_config.evpiproxy_additional_endpoints"; coreconfig.Datadog.IsSet(k) {
+		c.EvpIntakeProxy.AdditionalEndpoints = coreconfig.Datadog.GetStringMapStringSlice(k)
+	}
 	return nil
 }
 

--- a/cmd/trace-agent/config/config.go
+++ b/cmd/trace-agent/config/config.go
@@ -402,16 +402,16 @@ func applyDatadogConfig(c *config.AgentConfig) error {
 		c.DebuggerProxy.APIKey = coreconfig.Datadog.GetString(k)
 	}
 	if k := "evp_proxy_config.enabled"; coreconfig.Datadog.IsSet(k) {
-		c.EVPIntakeProxy.Enabled = coreconfig.Datadog.GetBool(k)
+		c.EVPProxy.Enabled = coreconfig.Datadog.GetBool(k)
 	}
 	if k := "evp_proxy_config.evp_proxy_dd_url"; coreconfig.Datadog.IsSet(k) {
-		c.EVPIntakeProxy.DDURL = coreconfig.Datadog.GetString(k)
+		c.EVPProxy.DDURL = coreconfig.Datadog.GetString(k)
 	}
 	if k := "evp_proxy_config.evp_proxy_api_key"; coreconfig.Datadog.IsSet(k) {
-		c.EVPIntakeProxy.APIKey = coreconfig.Datadog.GetString(k)
+		c.EVPProxy.APIKey = coreconfig.Datadog.GetString(k)
 	}
 	if k := "evp_proxy_config.evp_proxy_additional_endpoints"; coreconfig.Datadog.IsSet(k) {
-		c.EVPIntakeProxy.AdditionalEndpoints = coreconfig.Datadog.GetStringMapStringSlice(k)
+		c.EVPProxy.AdditionalEndpoints = coreconfig.Datadog.GetStringMapStringSlice(k)
 	}
 	return nil
 }

--- a/cmd/trace-agent/config/config.go
+++ b/cmd/trace-agent/config/config.go
@@ -404,13 +404,13 @@ func applyDatadogConfig(c *config.AgentConfig) error {
 	if k := "evp_proxy_config.enabled"; coreconfig.Datadog.IsSet(k) {
 		c.EVPProxy.Enabled = coreconfig.Datadog.GetBool(k)
 	}
-	if k := "evp_proxy_config.evp_proxy_dd_url"; coreconfig.Datadog.IsSet(k) {
+	if k := "evp_proxy_config.dd_url"; coreconfig.Datadog.IsSet(k) {
 		c.EVPProxy.DDURL = coreconfig.Datadog.GetString(k)
 	}
-	if k := "evp_proxy_config.evp_proxy_api_key"; coreconfig.Datadog.IsSet(k) {
+	if k := "evp_proxy_config.api_key"; coreconfig.Datadog.IsSet(k) {
 		c.EVPProxy.APIKey = coreconfig.Datadog.GetString(k)
 	}
-	if k := "evp_proxy_config.evp_proxy_additional_endpoints"; coreconfig.Datadog.IsSet(k) {
+	if k := "evp_proxy_config.additional_endpoints"; coreconfig.Datadog.IsSet(k) {
 		c.EVPProxy.AdditionalEndpoints = coreconfig.Datadog.GetStringMapStringSlice(k)
 	}
 	return nil

--- a/pkg/trace/api/endpoints.go
+++ b/pkg/trace/api/endpoints.go
@@ -113,7 +113,7 @@ var endpoints = []Endpoint{
 		Handler: func(r *HTTPReceiver) http.Handler { return http.StripPrefix("/appsec/proxy", r.appsecHandler) },
 	},
 	{
-		Pattern: "/evp_proxy/v1/input/",
+		Pattern: "/evp_proxy/v1/",
 		Handler: func(r *HTTPReceiver) http.Handler { return r.evpProxyHandler() },
 	},
 	{

--- a/pkg/trace/api/endpoints.go
+++ b/pkg/trace/api/endpoints.go
@@ -113,7 +113,7 @@ var endpoints = []Endpoint{
 		Handler: func(r *HTTPReceiver) http.Handler { return http.StripPrefix("/appsec/proxy", r.appsecHandler) },
 	},
 	{
-		Pattern: "/evp_intake_proxy/v1/input/",
+		Pattern: "/evp_proxy/v1/input/",
 		Handler: func(r *HTTPReceiver) http.Handler { return r.evpIntakeHandler() },
 	},
 	{

--- a/pkg/trace/api/endpoints.go
+++ b/pkg/trace/api/endpoints.go
@@ -113,7 +113,7 @@ var endpoints = []Endpoint{
 		Handler: func(r *HTTPReceiver) http.Handler { return http.StripPrefix("/appsec/proxy", r.appsecHandler) },
 	},
 	{
-		Pattern: "/evpIntakeProxy/v1/",
+		Pattern: "/evp_intake_proxy/v1/input/",
 		Handler: func(r *HTTPReceiver) http.Handler { return r.evpIntakeHandler() },
 	},
 	{

--- a/pkg/trace/api/endpoints.go
+++ b/pkg/trace/api/endpoints.go
@@ -114,7 +114,7 @@ var endpoints = []Endpoint{
 	},
 	{
 		Pattern: "/evp_proxy/v1/input/",
-		Handler: func(r *HTTPReceiver) http.Handler { return r.evpIntakeHandler() },
+		Handler: func(r *HTTPReceiver) http.Handler { return r.evpProxyHandler() },
 	},
 	{
 		Pattern: "/debugger/v1/input",

--- a/pkg/trace/api/endpoints.go
+++ b/pkg/trace/api/endpoints.go
@@ -113,6 +113,10 @@ var endpoints = []Endpoint{
 		Handler: func(r *HTTPReceiver) http.Handler { return http.StripPrefix("/appsec/proxy", r.appsecHandler) },
 	},
 	{
+		Pattern: "/evpIntakeProxy/v1/",
+		Handler: func(r *HTTPReceiver) http.Handler { return r.evpIntakeHandler() },
+	},
+	{
 		Pattern: "/debugger/v1/input",
 		Handler: func(r *HTTPReceiver) http.Handler { return r.debuggerProxyHandler() },
 	},

--- a/pkg/trace/api/evp_intake_proxy.go
+++ b/pkg/trace/api/evp_intake_proxy.go
@@ -108,6 +108,9 @@ func evpProxyErrorHandler(message string) http.Handler {
 // See also evpProxyTransport below.
 func evpProxyForwarder(conf *config.AgentConfig, endpoints []config.Endpoint, transport http.RoundTripper, logger *stdlog.Logger) http.Handler {
 	director := func(req *http.Request) {
+		if req == nil {
+			return
+		}
 
 		containerID := req.Header.Get("Datadog-Container-ID")
 		contentType := req.Header.Get("Content-Type")
@@ -153,24 +156,32 @@ type evpProxyTransport struct {
 }
 
 func (t *evpProxyTransport) RoundTrip(req *http.Request) (rresp *http.Response, rerr error) {
-	if req.Body != nil && t.maxPayloadSize > 0 {
-		req.Body = apiutil.NewLimitedReader(req.Body, t.maxPayloadSize)
-	}
 
 	// Metrics with stats for debugging
 	beginTime := time.Now()
 	metricTags := []string{}
-	if ct := req.Header.Get("Content-Type"); ct != "" {
-		metricTags = append(metricTags, "content_type:"+ct)
-	}
+	var contentLength int64
 	defer func() {
 		metrics.Count("datadog.trace_agent.evp_proxy.request", 1, metricTags, 1)
-		metrics.Count("datadog.trace_agent.evp_proxy.request_bytes", req.ContentLength, metricTags, 1)
+		metrics.Count("datadog.trace_agent.evp_proxy.request_bytes", contentLength, metricTags, 1)
 		metrics.Timing("datadog.trace_agent.evp_proxy.request_duration_ms", time.Since(beginTime), metricTags, 1)
 		if rerr != nil {
 			metrics.Count("datadog.trace_agent.evp_proxy.request_error", 1, metricTags, 1)
 		}
 	}()
+
+	if req == nil || req.URL == nil {
+		return nil, fmt.Errorf("EVPProxy: invalid request")
+	}
+
+	if req.Body != nil && t.maxPayloadSize > 0 {
+		req.Body = apiutil.NewLimitedReader(req.Body, t.maxPayloadSize)
+	}
+
+	if ct := req.Header.Get("Content-Type"); ct != "" {
+		metricTags = append(metricTags, "content_type:"+ct)
+	}
+	contentLength = req.ContentLength
 
 	// Parse request path: The first component is the target subdomain, the rest is the target path.
 	inputPath := req.URL.Path

--- a/pkg/trace/api/evp_intake_proxy.go
+++ b/pkg/trace/api/evp_intake_proxy.go
@@ -78,7 +78,7 @@ func evpIntakeEndpointsFromConfig(conf *config.AgentConfig) []config.Endpoint {
 	return endpoints
 }
 
-// evpIntakeHandler returns an HTTP handler for the /evp_intake_proxy API.
+// evpIntakeHandler returns an HTTP handler for the /evp_proxy API.
 // Depending on the config, this is a proxying handler or a noop handler.
 func (r *HTTPReceiver) evpIntakeHandler() http.Handler {
 	// r.conf is populated by cmd/trace-agent/config/config.go
@@ -89,7 +89,7 @@ func (r *HTTPReceiver) evpIntakeHandler() http.Handler {
 	transport := r.conf.NewHTTPTransport()
 	logger := stdlog.New(log.NewThrottled(5, 10*time.Second), "EVPIntakeProxy: ", 0) // limit to 5 messages every 10 seconds
 	handler := evpIntakeReverseProxyHandler(r.conf, endpoints, transport, logger)
-	return http.StripPrefix("/evp_intake_proxy/v1/input", handler)
+	return http.StripPrefix("/evp_proxy/v1/input", handler)
 }
 
 // evpIntakeErrorHandler returns an HTTP handler that will always return
@@ -156,11 +156,11 @@ func (t *evpIntakeProxyTransport) RoundTrip(req *http.Request) (rresp *http.Resp
 	beginTime := time.Now()
 	metricTags := []string{}
 	defer func() {
-		metrics.Count("datadog.trace_agent.evpiproxy.request", 1, metricTags, 1)
-		metrics.Count("datadog.trace_agent.evpiproxy.request_bytes", req.ContentLength, metricTags, 1)
-		metrics.Timing("datadog.trace_agent.evpiproxy.request_duration_ms", time.Since(beginTime), metricTags, 1)
+		metrics.Count("datadog.trace_agent.evp_proxy.request", 1, metricTags, 1)
+		metrics.Count("datadog.trace_agent.evp_proxy.request_bytes", req.ContentLength, metricTags, 1)
+		metrics.Timing("datadog.trace_agent.evp_proxy.request_duration_ms", time.Since(beginTime), metricTags, 1)
 		if rerr != nil {
-			metrics.Count("datadog.trace_agent.evpiproxy.request_error", 1, metricTags, 1)
+			metrics.Count("datadog.trace_agent.evp_proxy.request_error", 1, metricTags, 1)
 		}
 	}()
 

--- a/pkg/trace/api/evp_intake_proxy.go
+++ b/pkg/trace/api/evp_intake_proxy.go
@@ -209,18 +209,18 @@ func (t *evpProxyTransport) RoundTrip(req *http.Request) (rresp *http.Response, 
 	}
 
 	// There's more than one destination endpoint
-	var slurp *[]byte
+	var slurp []byte
 	if req.Body != nil {
 		body, err := ioutil.ReadAll(req.Body)
 		if err != nil {
 			return nil, err
 		}
-		slurp = &body
+		slurp = body
 	}
 	for i, endpointDomain := range t.endpoints {
 		newreq := req.Clone(req.Context())
 		if slurp != nil {
-			newreq.Body = ioutil.NopCloser(bytes.NewReader(*slurp))
+			newreq.Body = ioutil.NopCloser(bytes.NewReader(slurp))
 		}
 		setTarget(newreq, endpointDomain.Host, endpointDomain.APIKey)
 		if i == 0 {

--- a/pkg/trace/api/evp_intake_proxy.go
+++ b/pkg/trace/api/evp_intake_proxy.go
@@ -195,7 +195,7 @@ func (t *evpProxyTransport) RoundTrip(req *http.Request) (rresp *http.Response, 
 
 	req.URL.Scheme = "https"
 	setTarget := func(r *http.Request, host, apiKey string) {
-		targetHost := subdomain + "." + host
+		targetHost := subdomain + ".evp." + host
 		r.Host = targetHost
 		r.URL.Host = targetHost
 		r.Header.Set("DD-API-KEY", apiKey)

--- a/pkg/trace/api/evp_intake_proxy.go
+++ b/pkg/trace/api/evp_intake_proxy.go
@@ -154,6 +154,9 @@ func (t *evpProxyTransport) RoundTrip(req *http.Request) (rresp *http.Response, 
 	userAgent := req.Header.Get("User-Agent")
 
 	// Sanitize the input
+	if len(subdomain) == 0 {
+		return nil, fmt.Errorf("EVPProxy: no subdomain specified")
+	}
 	if !isValidSubdomain(subdomain) {
 		return nil, fmt.Errorf("EVPProxy: invalid subdomain: %s", subdomain)
 	}

--- a/pkg/trace/api/evp_intake_proxy.go
+++ b/pkg/trace/api/evp_intake_proxy.go
@@ -196,7 +196,7 @@ func (t *evpProxyTransport) RoundTrip(req *http.Request) (rresp *http.Response, 
 	// Configure target URL
 	req.URL.Scheme = "https"
 	setTarget := func(r *http.Request, host, apiKey string) {
-		targetHost := subdomain + ".evp." + host
+		targetHost := subdomain + "." + host
 		r.Host = targetHost
 		r.URL.Host = targetHost
 		r.Header.Set("DD-API-KEY", apiKey)

--- a/pkg/trace/api/evp_intake_proxy.go
+++ b/pkg/trace/api/evp_intake_proxy.go
@@ -155,6 +155,9 @@ func (t *evpProxyTransport) RoundTrip(req *http.Request) (rresp *http.Response, 
 	// Metrics with stats for debugging
 	beginTime := time.Now()
 	metricTags := []string{}
+	if ct := req.Header.Get("Content-Type"); ct != "" {
+		metricTags = append(metricTags, "content_type:"+ct)
+	}
 	defer func() {
 		metrics.Count("datadog.trace_agent.evp_proxy.request", 1, metricTags, 1)
 		metrics.Count("datadog.trace_agent.evp_proxy.request_bytes", req.ContentLength, metricTags, 1)

--- a/pkg/trace/api/evp_intake_proxy.go
+++ b/pkg/trace/api/evp_intake_proxy.go
@@ -90,7 +90,7 @@ func (r *HTTPReceiver) evpProxyHandler() http.Handler {
 	transport := r.conf.NewHTTPTransport()
 	logger := stdlog.New(log.NewThrottled(5, 10*time.Second), "EVPProxy: ", 0) // limit to 5 messages every 10 seconds
 	handler := evpProxyForwarder(r.conf, endpoints, transport, logger)
-	return http.StripPrefix("/evp_proxy/v1/input", handler)
+	return http.StripPrefix("/evp_proxy/v1", handler)
 }
 
 // evpProxyErrorHandler returns an HTTP handler that will always return

--- a/pkg/trace/api/evp_intake_proxy.go
+++ b/pkg/trace/api/evp_intake_proxy.go
@@ -193,6 +193,7 @@ func (t *evpProxyTransport) RoundTrip(req *http.Request) (rresp *http.Response, 
 		return nil, fmt.Errorf("EVPProxy: invalid query string: %s", req.URL.RawQuery)
 	}
 
+	// Configure target URL
 	req.URL.Scheme = "https"
 	setTarget := func(r *http.Request, host, apiKey string) {
 		targetHost := subdomain + ".evp." + host
@@ -201,13 +202,13 @@ func (t *evpProxyTransport) RoundTrip(req *http.Request) (rresp *http.Response, 
 		r.Header.Set("DD-API-KEY", apiKey)
 	}
 
+	// Special case if we only have one endpoint
 	if len(t.endpoints) == 1 {
 		setTarget(req, t.endpoints[0].Host, t.endpoints[0].APIKey)
 		return t.transport.RoundTrip(req)
 	}
 
 	// There's more than one destination endpoint
-
 	var slurp *[]byte
 	if req.Body != nil {
 		body, err := ioutil.ReadAll(req.Body)

--- a/pkg/trace/api/evp_intake_proxy.go
+++ b/pkg/trace/api/evp_intake_proxy.go
@@ -1,0 +1,211 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package api
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	stdlog "log"
+	"net/http"
+	"net/http/httputil"
+	"strings"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/trace/config"
+	"github.com/DataDog/datadog-agent/pkg/trace/info"
+	"github.com/DataDog/datadog-agent/pkg/trace/log"
+)
+
+const (
+	validSubdomainSymbols       = "_-."
+	validPathSymbols            = "/_-+"
+	validPathQueryStringSymbols = "/_-+@?&=.:\""
+)
+
+func isValidSubdomain(s string) bool {
+	for _, c := range s {
+		if (c < 'a' || c > 'z') && (c < 'A' || c > 'Z') && (c < '0' || c > '9') && !strings.ContainsRune(validSubdomainSymbols, c) {
+			return false
+		}
+	}
+	return true
+}
+
+func isValidPath(s string) bool {
+	for _, c := range s {
+		if (c < 'a' || c > 'z') && (c < 'A' || c > 'Z') && (c < '0' || c > '9') && !strings.ContainsRune(validPathSymbols, c) {
+			return false
+		}
+	}
+	return true
+}
+
+func isValidQueryString(s string) bool {
+	for _, c := range s {
+		if (c < 'a' || c > 'z') && (c < 'A' || c > 'Z') && (c < '0' || c > '9') && !strings.ContainsRune(validPathQueryStringSymbols, c) {
+			return false
+		}
+	}
+	return true
+}
+
+// evpIntakeEndpointsFromConfig returns the configured list of endpoints to forward payloads to.
+func evpIntakeEndpointsFromConfig(conf *config.AgentConfig) []config.Endpoint {
+	mainEndpoint := config.Endpoint{
+		Host:   conf.EvpIntakeProxy.DDURL,
+		APIKey: conf.EvpIntakeProxy.APIKey,
+	}
+	endpoints := []config.Endpoint{mainEndpoint}
+	for host, keys := range conf.EvpIntakeProxy.AdditionalEndpoints {
+		for _, key := range keys {
+			endpoints = append(endpoints, config.Endpoint{
+				Host:   host,
+				APIKey: key,
+			})
+		}
+	}
+	return endpoints
+}
+
+// evpIntakeHandler returns an HTTP handler for the /evpIntakeProxy API.
+// Depending on the config, this is a proxying handler or a noop handler.
+func (r *HTTPReceiver) evpIntakeHandler() http.Handler {
+
+	// r.conf is populated by cmd/trace-agent/config/config.go
+	if !r.conf.EvpIntakeProxy.Enabled {
+		return evpIntakeErrorHandler("Has been disabled in config")
+	}
+
+	endpoints := evpIntakeEndpointsFromConfig(r.conf)
+	reverseProxyHandler := evpIntakeReverseProxyHandler(r.conf, endpoints)
+	return http.StripPrefix("/evpIntakeProxy/v1/", reverseProxyHandler)
+}
+
+// evpIntakeErrorHandler returns an HTTP handler that will always return
+// http.StatusMethodNotAllowed along with a clarification.
+func evpIntakeErrorHandler(message string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		msg := fmt.Sprintf("EvpIntakeProxy is disabled: %v", message)
+		http.Error(w, msg, http.StatusMethodNotAllowed)
+	})
+}
+
+// evpIntakeReverseProxyHandler creates an http.ReverseProxy which can forward payloads
+// to one or more endpoints, based on the request received and the Agent configuration.
+// Headers are not proxied, instead we add our own known set of headers.
+// See also evpIntakeProxyTransport below.
+func evpIntakeReverseProxyHandler(conf *config.AgentConfig, endpoints []config.Endpoint) http.Handler {
+	director := func(req *http.Request) {
+
+		containerID := req.Header.Get(headerContainerID)
+		contentType := req.Header.Get("Content-Type")
+		userAgent := req.Header.Get("User-Agent")
+
+		// Clear all received headers
+		req.Header = http.Header{}
+
+		// Standard headers
+		req.Header.Set("Via", fmt.Sprintf("trace-agent %s", info.Version))
+		if contentType != "" {
+			req.Header.Set("Content-Type", contentType)
+		}
+		req.Header.Set("User-Agent", userAgent) // Set even if an empty string so Go doesn't set its default
+		req.Header["X-Forwarded-For"] = nil     // Prevent setting X-Forwarded-For
+
+		// Datadog headers
+		if ctags := getContainerTags(conf.ContainerTags, containerID); ctags != "" {
+			req.Header.Set("X-Datadog-Container-Tags", ctags)
+		}
+		req.Header.Set("X-Datadog-Hostname", conf.Hostname)
+		req.Header.Set("X-Datadog-AgentDefaultEnv", conf.DefaultEnv)
+
+		// URL, Host and the API key header are set in the transport for each outbound request
+	}
+	transport := conf.NewHTTPTransport()
+	logger := log.NewThrottled(5, 10*time.Second) // limit to 5 messages every 10 seconds
+	return &httputil.ReverseProxy{
+		Director:  director,
+		ErrorLog:  stdlog.New(logger, "EvpIntakeProxy: ", 0),
+		Transport: &evpIntakeProxyTransport{transport, endpoints},
+	}
+}
+
+// evpIntakeProxyTransport sends HTTPS requests to multiple targets using an
+// underlying http.RoundTripper. API keys are set separately for each target.
+// When multiple endpoints are in use the response from the first endpoint
+// is proxied back to the client, while for all aditional endpoints the
+// response is discarded.
+type evpIntakeProxyTransport struct {
+	transport http.RoundTripper
+	endpoints []config.Endpoint
+}
+
+func (t *evpIntakeProxyTransport) RoundTrip(req *http.Request) (rresp *http.Response, rerr error) {
+
+	// Parse request path: The first component is the target subdomain, the rest is the target path.
+	inputPath := req.URL.Path
+	subdomainAndPath := strings.SplitN(inputPath, "/", 2)
+	if len(subdomainAndPath) != 2 || subdomainAndPath[0] == "" || subdomainAndPath[1] == "" {
+		return nil, fmt.Errorf("EvpIntakeProxy: invalid path: '%s'", inputPath)
+	}
+	subdomain := subdomainAndPath[0]
+	path := subdomainAndPath[1]
+
+	// Sanitize the input
+	if !isValidSubdomain(subdomain) {
+		return nil, fmt.Errorf("EvpIntakeProxy: invalid subdomain: %s", subdomain)
+	}
+	if !isValidPath(path) {
+		return nil, fmt.Errorf("EvpIntakeProxy: invalid target path: %s", path)
+	}
+	if !isValidQueryString(req.URL.RawQuery) {
+		return nil, fmt.Errorf("EvpIntakeProxy: invalid query string: %s", req.URL.RawQuery)
+	}
+
+	req.URL.Scheme = "https"
+	req.URL.Path = "/" + path
+
+	setTarget := func(r *http.Request, host, apiKey string) {
+		targetHost := subdomain + "." + host
+		r.Host = targetHost
+		r.URL.Host = targetHost
+		r.Header.Set("DD-API-KEY", apiKey)
+	}
+
+	if len(t.endpoints) == 1 {
+		setTarget(req, t.endpoints[0].Host, t.endpoints[0].APIKey)
+		return t.transport.RoundTrip(req)
+	}
+
+	// There's more than one destination endpoint
+
+	slurp, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	for i, endpointDomain := range t.endpoints {
+		newreq := req.Clone(req.Context())
+		newreq.Body = ioutil.NopCloser(bytes.NewReader(slurp))
+		setTarget(newreq, endpointDomain.Host, endpointDomain.APIKey)
+		if i == 0 {
+			// given the way we construct the list of targets the main endpoint
+			// will be the first one called, we return its response and error
+			rresp, rerr = t.transport.RoundTrip(newreq)
+			continue
+		}
+
+		if resp, err := t.transport.RoundTrip(newreq); err == nil {
+			// we discard responses for all subsequent requests
+			io.Copy(ioutil.Discard, resp.Body) //nolint:errcheck
+			resp.Body.Close()
+		} else {
+			log.Error(err)
+		}
+	}
+	return rresp, rerr
+}

--- a/pkg/trace/api/evp_intake_proxy_test.go
+++ b/pkg/trace/api/evp_intake_proxy_test.go
@@ -57,7 +57,6 @@ func sendRequestThroughForwarder(conf *config.AgentConfig, inReq *http.Request) 
 }
 
 func TestEVPProxyForwarder(t *testing.T) {
-
 	randBodyBuf := make([]byte, 1024)
 	rand.Read(randBodyBuf)
 
@@ -126,7 +125,7 @@ func TestEVPProxyForwarder(t *testing.T) {
 			return []string{"container:" + cid}, nil
 		}
 
-		req := httptest.NewRequest("POST", "/mypath/mysubpath?arg=test", nil)
+		req := httptest.NewRequest("POST", "/mypath/mysubpath?arg=test", bytes.NewReader(randBodyBuf))
 		req.Header.Set("X-Datadog-EVP-Subdomain", "my.subdomain")
 		req.Header.Set("Datadog-Container-ID", "myid")
 		proxyreqs, resp, logs := sendRequestThroughForwarder(conf, req)
@@ -144,7 +143,7 @@ func TestEVPProxyForwarder(t *testing.T) {
 		conf.EVPProxy.AdditionalEndpoints = map[string][]string{
 			"datadoghq.eu": {"test_api_key_1", "test_api_key_2"},
 		}
-		req := httptest.NewRequest("POST", "/mypath/mysubpath?arg=test", nil)
+		req := httptest.NewRequest("POST", "/mypath/mysubpath?arg=test", bytes.NewReader(randBodyBuf))
 		req.Header.Set("X-Datadog-EVP-Subdomain", "my.subdomain")
 		proxyreqs, resp, logs := sendRequestThroughForwarder(conf, req)
 
@@ -177,7 +176,7 @@ func TestEVPProxyForwarder(t *testing.T) {
 		conf.Site = "us3.datadoghq.com"
 		conf.Endpoints[0].APIKey = "test_api_key"
 
-		req := httptest.NewRequest("POST", "/mypath/mysubpath", nil)
+		req := httptest.NewRequest("POST", "/mypath/mysubpath", bytes.NewReader(randBodyBuf))
 		proxyreqs, resp, logs := sendRequestThroughForwarder(conf, req)
 
 		require.Len(t, proxyreqs, 0)
@@ -199,7 +198,7 @@ func TestEVPProxyForwarder(t *testing.T) {
 		conf.Site = "us3.datadoghq.com"
 		conf.Endpoints[0].APIKey = "test_api_key"
 
-		req := httptest.NewRequest("POST", "/mypath/mysubpath", nil)
+		req := httptest.NewRequest("POST", "/mypath/mysubpath", bytes.NewReader(randBodyBuf))
 		req.Header.Set("X-Datadog-EVP-Subdomain", "/google.com%3Fattack=")
 		proxyreqs, resp, logs := sendRequestThroughForwarder(conf, req)
 
@@ -222,7 +221,7 @@ func TestEVPProxyForwarder(t *testing.T) {
 		conf.Site = "us3.datadoghq.com"
 		conf.Endpoints[0].APIKey = "test_api_key"
 
-		req := httptest.NewRequest("POST", "/mypath/my%20subpath", nil)
+		req := httptest.NewRequest("POST", "/mypath/my%20subpath", bytes.NewReader(randBodyBuf))
 		req.Header.Set("X-Datadog-EVP-Subdomain", "my.subdomain")
 		proxyreqs, resp, logs := sendRequestThroughForwarder(conf, req)
 
@@ -248,7 +247,7 @@ func TestEVPProxyForwarder(t *testing.T) {
 		conf.Site = "us3.datadoghq.com"
 		conf.Endpoints[0].APIKey = "test_api_key"
 
-		req := httptest.NewRequest("POST", "/mypath/mysubpath?test=bad%20arg", nil)
+		req := httptest.NewRequest("POST", "/mypath/mysubpath?test=bad%20arg", bytes.NewReader(randBodyBuf))
 		req.Header.Set("X-Datadog-EVP-Subdomain", "my.subdomain")
 		proxyreqs, resp, logs := sendRequestThroughForwarder(conf, req)
 

--- a/pkg/trace/api/evp_intake_proxy_test.go
+++ b/pkg/trace/api/evp_intake_proxy_test.go
@@ -32,7 +32,7 @@ func (r roundTripperMock) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 // sendRequestThroughForwarder sends a request through the evpProxyForwarder handler and returns the forwarded
-// request(s), their response and the log output. The path for inReq shouldn't have the /evp_proxy/v1/input
+// request(s), their response and the log output. The path for inReq shouldn't have the /evp_proxy/v1
 // prefix since it is passed directly to the inner proxy handler and not the trace-agent API handler.
 func sendRequestThroughForwarder(conf *config.AgentConfig, inReq *http.Request) (outReqs []*http.Request, resp *http.Response, logs string) {
 	mockRoundTripper := roundTripperMock(func(req *http.Request) (*http.Response, error) {
@@ -303,7 +303,7 @@ func TestEVPProxyHandler(t *testing.T) {
 		require.NotNil(t, handler)
 
 		rec := httptest.NewRecorder()
-		req := httptest.NewRequest("POST", "/evp_proxy/v1/input/mypath", nil)
+		req := httptest.NewRequest("POST", "/evp_proxy/v1/mypath", nil)
 		req.Header.Set("X-Datadog-EVP-Subdomain", "my.subdomain")
 		handler.ServeHTTP(rec, req)
 		require.Equal(t, http.StatusMethodNotAllowed, rec.Code)

--- a/pkg/trace/api/evp_intake_proxy_test.go
+++ b/pkg/trace/api/evp_intake_proxy_test.go
@@ -1,0 +1,50 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package api
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type roundTripperMock func(*http.Request) (*http.Response, error)
+
+func (r roundTripperMock) RoundTrip(req *http.Request) (*http.Response, error) {
+	return r(req)
+}
+
+func TestEvpIntakeReverseProxyHandler(t *testing.T) {
+
+	conf := newTestReceiverConfig()
+	conf.Site = "my.site.com"
+	conf.Endpoints[0].APIKey = "test_api_key"
+
+	request := httptest.NewRequest("POST", "/mysubdomain/mypath/mysubpath", nil)
+
+	responseBody := []byte("{\"potato\": true}")
+	mockRoundTripper := roundTripperMock(func(req *http.Request) (*http.Response, error) {
+		require.Equal(t, req.Host, "mysubdomain.my.site.com")
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBody)),
+		}, nil
+	})
+
+	handler := evpIntakeReverseProxyHandler(conf, evpIntakeEndpointsFromConfig(conf), mockRoundTripper)
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, request)
+	out, _ := ioutil.ReadAll(rec.Body)
+	require.Equal(t, http.StatusOK, rec.Code, "Got: ", fmt.Sprint(rec.Code))
+	require.Equal(t, responseBody, out, "Got: ", string(out))
+}

--- a/pkg/trace/api/evp_intake_proxy_test.go
+++ b/pkg/trace/api/evp_intake_proxy_test.go
@@ -83,8 +83,8 @@ func TestEVPProxyForwarder(t *testing.T) {
 		require.Equal(t, http.StatusOK, resp.StatusCode, "Got: ", fmt.Sprint(resp.StatusCode))
 		require.Len(t, proxyreqs, 1)
 		proxyreq := proxyreqs[0]
-		assert.Equal(t, "my.subdomain.evp.us3.datadoghq.com", proxyreq.Host)
-		assert.Equal(t, "my.subdomain.evp.us3.datadoghq.com", proxyreq.URL.Host)
+		assert.Equal(t, "my.subdomain.us3.datadoghq.com", proxyreq.Host)
+		assert.Equal(t, "my.subdomain.us3.datadoghq.com", proxyreq.URL.Host)
 		assert.Equal(t, "/mypath/mysubpath", proxyreq.URL.Path)
 		assert.Equal(t, "arg=test", proxyreq.URL.RawQuery)
 		assert.Equal(t, "test_api_key", proxyreq.Header.Get("DD-API-KEY"))
@@ -149,20 +149,20 @@ func TestEVPProxyForwarder(t *testing.T) {
 		require.Equal(t, http.StatusOK, resp.StatusCode, "Got: ", fmt.Sprint(resp.StatusCode))
 		require.Len(t, proxyreqs, 3)
 
-		assert.Equal(t, "my.subdomain.evp.us3.datadoghq.com", proxyreqs[0].Host)
-		assert.Equal(t, "my.subdomain.evp.us3.datadoghq.com", proxyreqs[0].URL.Host)
+		assert.Equal(t, "my.subdomain.us3.datadoghq.com", proxyreqs[0].Host)
+		assert.Equal(t, "my.subdomain.us3.datadoghq.com", proxyreqs[0].URL.Host)
 		assert.Equal(t, "/mypath/mysubpath", proxyreqs[0].URL.Path)
 		assert.Equal(t, "arg=test", proxyreqs[0].URL.RawQuery)
 		assert.Equal(t, "test_api_key", proxyreqs[0].Header.Get("DD-API-KEY"))
 
-		assert.Equal(t, "my.subdomain.evp.datadoghq.eu", proxyreqs[1].Host)
-		assert.Equal(t, "my.subdomain.evp.datadoghq.eu", proxyreqs[1].URL.Host)
+		assert.Equal(t, "my.subdomain.datadoghq.eu", proxyreqs[1].Host)
+		assert.Equal(t, "my.subdomain.datadoghq.eu", proxyreqs[1].URL.Host)
 		assert.Equal(t, "/mypath/mysubpath", proxyreqs[1].URL.Path)
 		assert.Equal(t, "arg=test", proxyreqs[1].URL.RawQuery)
 		assert.Equal(t, "test_api_key_1", proxyreqs[1].Header.Get("DD-API-KEY"))
 
-		assert.Equal(t, "my.subdomain.evp.datadoghq.eu", proxyreqs[2].Host)
-		assert.Equal(t, "my.subdomain.evp.datadoghq.eu", proxyreqs[2].URL.Host)
+		assert.Equal(t, "my.subdomain.datadoghq.eu", proxyreqs[2].Host)
+		assert.Equal(t, "my.subdomain.datadoghq.eu", proxyreqs[2].URL.Host)
 		assert.Equal(t, "test_api_key_2", proxyreqs[2].Header.Get("DD-API-KEY"))
 
 		assert.Equal(t, "", logs)

--- a/pkg/trace/api/evp_intake_proxy_test.go
+++ b/pkg/trace/api/evp_intake_proxy_test.go
@@ -83,8 +83,8 @@ func TestEVPProxyForwarder(t *testing.T) {
 		require.Equal(t, http.StatusOK, resp.StatusCode, "Got: ", fmt.Sprint(resp.StatusCode))
 		require.Len(t, proxyreqs, 1)
 		proxyreq := proxyreqs[0]
-		assert.Equal(t, "my.subdomain.us3.datadoghq.com", proxyreq.Host)
-		assert.Equal(t, "my.subdomain.us3.datadoghq.com", proxyreq.URL.Host)
+		assert.Equal(t, "my.subdomain.evp.us3.datadoghq.com", proxyreq.Host)
+		assert.Equal(t, "my.subdomain.evp.us3.datadoghq.com", proxyreq.URL.Host)
 		assert.Equal(t, "/mypath/mysubpath", proxyreq.URL.Path)
 		assert.Equal(t, "arg=test", proxyreq.URL.RawQuery)
 		assert.Equal(t, "test_api_key", proxyreq.Header.Get("DD-API-KEY"))
@@ -149,20 +149,20 @@ func TestEVPProxyForwarder(t *testing.T) {
 		require.Equal(t, http.StatusOK, resp.StatusCode, "Got: ", fmt.Sprint(resp.StatusCode))
 		require.Len(t, proxyreqs, 3)
 
-		assert.Equal(t, "my.subdomain.us3.datadoghq.com", proxyreqs[0].Host)
-		assert.Equal(t, "my.subdomain.us3.datadoghq.com", proxyreqs[0].URL.Host)
+		assert.Equal(t, "my.subdomain.evp.us3.datadoghq.com", proxyreqs[0].Host)
+		assert.Equal(t, "my.subdomain.evp.us3.datadoghq.com", proxyreqs[0].URL.Host)
 		assert.Equal(t, "/mypath/mysubpath", proxyreqs[0].URL.Path)
 		assert.Equal(t, "arg=test", proxyreqs[0].URL.RawQuery)
 		assert.Equal(t, "test_api_key", proxyreqs[0].Header.Get("DD-API-KEY"))
 
-		assert.Equal(t, "my.subdomain.datadoghq.eu", proxyreqs[1].Host)
-		assert.Equal(t, "my.subdomain.datadoghq.eu", proxyreqs[1].URL.Host)
+		assert.Equal(t, "my.subdomain.evp.datadoghq.eu", proxyreqs[1].Host)
+		assert.Equal(t, "my.subdomain.evp.datadoghq.eu", proxyreqs[1].URL.Host)
 		assert.Equal(t, "/mypath/mysubpath", proxyreqs[1].URL.Path)
 		assert.Equal(t, "arg=test", proxyreqs[1].URL.RawQuery)
 		assert.Equal(t, "test_api_key_1", proxyreqs[1].Header.Get("DD-API-KEY"))
 
-		assert.Equal(t, "my.subdomain.datadoghq.eu", proxyreqs[2].Host)
-		assert.Equal(t, "my.subdomain.datadoghq.eu", proxyreqs[2].URL.Host)
+		assert.Equal(t, "my.subdomain.evp.datadoghq.eu", proxyreqs[2].Host)
+		assert.Equal(t, "my.subdomain.evp.datadoghq.eu", proxyreqs[2].URL.Host)
 		assert.Equal(t, "test_api_key_2", proxyreqs[2].Header.Get("DD-API-KEY"))
 
 		assert.Equal(t, "", logs)

--- a/pkg/trace/api/evp_intake_proxy_test.go
+++ b/pkg/trace/api/evp_intake_proxy_test.go
@@ -49,7 +49,7 @@ func sendRequestThroughForwarder(conf *config.AgentConfig, inReq *http.Request) 
 			Body:       ioutil.NopCloser(bytes.NewBuffer([]byte("ok_resprino"))),
 		}, nil
 	})
-	handler := evpProxyForwarder(conf, evpProxyEndpointsFromConfig(conf))
+	handler := evpProxyForwarder(conf)
 	var loggerBuffer bytes.Buffer
 	handler.(*httputil.ReverseProxy).ErrorLog = log.New(io.Writer(&loggerBuffer), "", 0)
 	handler.(*httputil.ReverseProxy).Transport.(*evpProxyTransport).transport = mockRoundTripper
@@ -66,7 +66,7 @@ func TestEVPProxyForwarder(t *testing.T) {
 	defer func(old metrics.StatsClient) { metrics.Client = old }(metrics.Client)
 	metrics.Client = stats
 
-	t.Run("happy case", func(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
 		stats.Reset()
 
 		conf := newTestReceiverConfig()
@@ -119,7 +119,7 @@ func TestEVPProxyForwarder(t *testing.T) {
 		assert.ElementsMatch(t, expectedTags, stats.CountCalls[1].Tags)
 	})
 
-	t.Run("with containerid", func(t *testing.T) {
+	t.Run("containerID", func(t *testing.T) {
 		conf := newTestReceiverConfig()
 		conf.Site = "us3.datadoghq.com"
 		conf.Endpoints[0].APIKey = "test_api_key"
@@ -138,7 +138,7 @@ func TestEVPProxyForwarder(t *testing.T) {
 		assert.Equal(t, "", logs)
 	})
 
-	t.Run("dual shipping", func(t *testing.T) {
+	t.Run("dual-shipping", func(t *testing.T) {
 		conf := newTestReceiverConfig()
 		conf.Site = "us3.datadoghq.com"
 		conf.Endpoints[0].APIKey = "test_api_key"
@@ -171,7 +171,7 @@ func TestEVPProxyForwarder(t *testing.T) {
 		assert.Equal(t, "", logs)
 	})
 
-	t.Run("no subdomain", func(t *testing.T) {
+	t.Run("no-subdomain", func(t *testing.T) {
 		stats.Reset()
 
 		conf := newTestReceiverConfig()
@@ -193,7 +193,7 @@ func TestEVPProxyForwarder(t *testing.T) {
 		assert.Len(t, stats.CountCalls[2].Tags, 0)
 	})
 
-	t.Run("invalid subdomain", func(t *testing.T) {
+	t.Run("invalid-subdomain", func(t *testing.T) {
 		stats.Reset()
 
 		conf := newTestReceiverConfig()
@@ -216,7 +216,7 @@ func TestEVPProxyForwarder(t *testing.T) {
 		assert.Len(t, stats.CountCalls[2].Tags, 0)
 	})
 
-	t.Run("invalid path", func(t *testing.T) {
+	t.Run("invalid-path", func(t *testing.T) {
 		stats.Reset()
 
 		conf := newTestReceiverConfig()
@@ -242,7 +242,7 @@ func TestEVPProxyForwarder(t *testing.T) {
 		assert.ElementsMatch(t, expectedTags, stats.CountCalls[2].Tags)
 	})
 
-	t.Run("invalid query string", func(t *testing.T) {
+	t.Run("invalid-query", func(t *testing.T) {
 		stats.Reset()
 
 		conf := newTestReceiverConfig()
@@ -268,7 +268,7 @@ func TestEVPProxyForwarder(t *testing.T) {
 		assert.ElementsMatch(t, expectedTags, stats.CountCalls[2].Tags)
 	})
 
-	t.Run("max payload size reached", func(t *testing.T) {
+	t.Run("maxpayloadsize", func(t *testing.T) {
 		stats.Reset()
 
 		conf := newTestReceiverConfig()
@@ -295,7 +295,7 @@ func TestEVPProxyForwarder(t *testing.T) {
 		assert.ElementsMatch(t, expectedTags, stats.CountCalls[2].Tags)
 	})
 
-	t.Run("config override ddurl and apikey", func(t *testing.T) {
+	t.Run("ddurl", func(t *testing.T) {
 		conf := newTestReceiverConfig()
 		conf.Site = "us3.datadoghq.com"
 		conf.Endpoints[0].APIKey = "test_api_key"

--- a/pkg/trace/api/evp_intake_proxy_test.go
+++ b/pkg/trace/api/evp_intake_proxy_test.go
@@ -140,7 +140,7 @@ func TestEVPProxyForwarder(t *testing.T) {
 		conf.Site = "us3.datadoghq.com"
 		conf.Endpoints[0].APIKey = "test_api_key"
 		conf.EVPProxy.AdditionalEndpoints = map[string][]string{
-			"datadoghq.eu": []string{"test_api_key_1", "test_api_key_2"},
+			"datadoghq.eu": {"test_api_key_1", "test_api_key_2"},
 		}
 		req := httptest.NewRequest("POST", "/my.subdomain/mypath/mysubpath?arg=test", nil)
 		req.Header.Set("X-Datadog-Agent", "test_user_agent")

--- a/pkg/trace/api/evp_intake_proxy_test.go
+++ b/pkg/trace/api/evp_intake_proxy_test.go
@@ -29,7 +29,7 @@ func (r roundTripperMock) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 // sendRequestThroughHandler sends a request through the evpIntakeReverseProxy handler and returns the forwarded
-// request(s), their response and the log output. The path for inReq shouldn't have the /evp_intake_proxy/v1/input
+// request(s), their response and the log output. The path for inReq shouldn't have the /evp_proxy/v1/input
 // prefix since it is passed directly to the inner proxy handler and not the trace-agent API handler.
 func sendRequestThroughHandler(conf *config.AgentConfig, inReq *http.Request) (outReqs []*http.Request, resp *http.Response, logs string) {
 	mockRoundTripper := roundTripperMock(func(req *http.Request) (*http.Response, error) {
@@ -198,6 +198,6 @@ func TestEVPIntakeHandlerDisabled(t *testing.T) {
 	require.NotNil(t, handler)
 
 	rec := httptest.NewRecorder()
-	handler.ServeHTTP(rec, httptest.NewRequest("POST", "/evp_intake_proxy/v1/input/mysubdomain/mypath", nil))
+	handler.ServeHTTP(rec, httptest.NewRequest("POST", "/evp_proxy/v1/input/mysubdomain/mypath", nil))
 	require.Equal(t, http.StatusMethodNotAllowed, rec.Code)
 }

--- a/pkg/trace/api/evp_intake_proxy_test.go
+++ b/pkg/trace/api/evp_intake_proxy_test.go
@@ -8,12 +8,17 @@ package api
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"net/http/httptest"
 
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/trace/config"
+	"github.com/DataDog/datadog-agent/pkg/trace/info"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -23,28 +28,147 @@ func (r roundTripperMock) RoundTrip(req *http.Request) (*http.Response, error) {
 	return r(req)
 }
 
-func TestEvpIntakeReverseProxyHandler(t *testing.T) {
-
-	conf := newTestReceiverConfig()
-	conf.Site = "my.site.com"
-	conf.Endpoints[0].APIKey = "test_api_key"
-
-	request := httptest.NewRequest("POST", "/mysubdomain/mypath/mysubpath", nil)
-
-	responseBody := []byte("{\"potato\": true}")
+// sendRequestThroughHandler sends a request through the evpIntakeReverseProxy handler and returns the forwarded request(s), their response and the log output.
+// The path for inReq shouldn't have the /evpIntakeProxy/v1 prefix since it is passed directly to the inner proxy handler and not the trace-agent API handler.
+func sendRequestThroughHandler(conf *config.AgentConfig, inReq *http.Request) (outReqs []*http.Request, response *http.Response, loggerOut string) {
 	mockRoundTripper := roundTripperMock(func(req *http.Request) (*http.Response, error) {
-		require.Equal(t, req.Host, "mysubdomain.my.site.com")
+		outReqs = append(outReqs, req)
+		// If we got here it means the proxy didn't raise an error earlier, return an ok response
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBody)),
+			Body:       ioutil.NopCloser(bytes.NewBuffer([]byte("ok_responserino"))),
 		}, nil
 	})
-
-	handler := evpIntakeReverseProxyHandler(conf, evpIntakeEndpointsFromConfig(conf), mockRoundTripper)
-
+	var loggerBuffer bytes.Buffer
+	mockLogger := log.New(io.Writer(&loggerBuffer), "", 0)
+	handler := evpIntakeReverseProxyHandler(conf, evpIntakeEndpointsFromConfig(conf), mockRoundTripper, mockLogger)
 	rec := httptest.NewRecorder()
-	handler.ServeHTTP(rec, request)
-	out, _ := ioutil.ReadAll(rec.Body)
-	require.Equal(t, http.StatusOK, rec.Code, "Got: ", fmt.Sprint(rec.Code))
-	require.Equal(t, responseBody, out, "Got: ", string(out))
+	handler.ServeHTTP(rec, inReq)
+	return outReqs, rec.Result(), loggerBuffer.String()
+}
+
+func TestEvpIntakeReverseProxyHandlerOk(t *testing.T) {
+	conf := newTestReceiverConfig()
+	conf.Hostname = "test_hostname"
+	conf.DefaultEnv = "test_env"
+	conf.Site = "us3.datadoghq.com"
+	conf.Endpoints[0].APIKey = "test_api_key"
+
+	request := httptest.NewRequest("POST", "/mysubdomain/mypath/mysubpath?arg=test", nil)
+	request.Header.Set("User-Agent", "test_user_agent")
+	request.Header.Set("Content-Type", "text/json")
+	request.Header.Set("Unexpected-Header", "To-Be-Discarded")
+	proxiedRequests, response, loggerOut := sendRequestThroughHandler(conf, request)
+
+	require.Equal(t, http.StatusOK, response.StatusCode, "Got: ", fmt.Sprint(response.StatusCode))
+	require.Equal(t, 1, len(proxiedRequests))
+	proxiedRequest := proxiedRequests[0]
+	assert.Equal(t, "mysubdomain.us3.datadoghq.com", proxiedRequest.Host)
+	assert.Equal(t, "mysubdomain.us3.datadoghq.com", proxiedRequest.URL.Host)
+	assert.Equal(t, "/mypath/mysubpath", proxiedRequest.URL.Path)
+	assert.Equal(t, "arg=test", proxiedRequest.URL.RawQuery)
+	assert.Equal(t, "test_api_key", proxiedRequest.Header.Get("DD-API-KEY"))
+	assert.Equal(t, conf.Hostname, proxiedRequest.Header.Get("X-Datadog-Hostname"))
+	assert.Equal(t, conf.DefaultEnv, proxiedRequest.Header.Get("X-Datadog-AgentDefaultEnv"))
+	assert.Equal(t, fmt.Sprintf("trace-agent %s", info.Version), proxiedRequest.Header.Get("Via"))
+	assert.Equal(t, "test_user_agent", proxiedRequest.Header.Get("User-Agent"))
+	assert.Equal(t, "text/json", proxiedRequest.Header.Get("Content-Type"))
+	assert.NotContains(t, proxiedRequest.Header, "Unexpected-Header")
+	assert.NotContains(t, proxiedRequest.Header, "X-Datadog-Container-Tags")
+	assert.Equal(t, "", loggerOut)
+}
+
+func TestEvpIntakeReverseProxyHandlerWithContainerId(t *testing.T) {
+	conf := newTestReceiverConfig()
+	conf.Site = "us3.datadoghq.com"
+	conf.Endpoints[0].APIKey = "test_api_key"
+	conf.ContainerTags = func(cid string) ([]string, error) {
+		return []string{"container:" + cid}, nil
+	}
+
+	request := httptest.NewRequest("POST", "/mysubdomain/mypath/mysubpath?arg=test", nil)
+	request.Header.Set("Datadog-Container-ID", "myid")
+	proxiedRequests, response, loggerOut := sendRequestThroughHandler(conf, request)
+
+	require.Equal(t, http.StatusOK, response.StatusCode, "Got: ", fmt.Sprint(response.StatusCode))
+	require.Equal(t, 1, len(proxiedRequests))
+	assert.Equal(t, "container:myid", proxiedRequests[0].Header.Get("X-Datadog-Container-Tags"))
+	assert.Equal(t, "", loggerOut)
+}
+
+func TestEvpIntakeReverseProxyHandlerMultipleEndpoints(t *testing.T) {
+	conf := newTestReceiverConfig()
+	conf.Site = "us3.datadoghq.com"
+	conf.Endpoints[0].APIKey = "test_api_key"
+	conf.EvpIntakeProxy.AdditionalEndpoints = map[string][]string{
+		"datadoghq.com": []string{"test_api_key_1", "test_api_key_2"},
+		"datadoghq.eu":  []string{"test_api_key_eu"},
+	}
+	request := httptest.NewRequest("POST", "/mysubdomain/mypath/mysubpath?arg=test", nil)
+	request.Header.Set("X-Datadog-Agent", "test_user_agent")
+	proxiedRequests, response, loggerOut := sendRequestThroughHandler(conf, request)
+
+	require.Equal(t, http.StatusOK, response.StatusCode, "Got: ", fmt.Sprint(response.StatusCode))
+	require.Equal(t, 4, len(proxiedRequests))
+
+	assert.Equal(t, "mysubdomain.us3.datadoghq.com", proxiedRequests[0].Host)
+	assert.Equal(t, "mysubdomain.us3.datadoghq.com", proxiedRequests[0].URL.Host)
+	assert.Equal(t, "/mypath/mysubpath", proxiedRequests[0].URL.Path)
+	assert.Equal(t, "arg=test", proxiedRequests[0].URL.RawQuery)
+	assert.Equal(t, "test_api_key", proxiedRequests[0].Header.Get("DD-API-KEY"))
+
+	assert.Equal(t, "mysubdomain.datadoghq.com", proxiedRequests[1].Host)
+	assert.Equal(t, "mysubdomain.datadoghq.com", proxiedRequests[1].URL.Host)
+	assert.Equal(t, "/mypath/mysubpath", proxiedRequests[1].URL.Path)
+	assert.Equal(t, "arg=test", proxiedRequests[1].URL.RawQuery)
+	assert.Equal(t, "test_api_key_1", proxiedRequests[1].Header.Get("DD-API-KEY"))
+
+	assert.Equal(t, "mysubdomain.datadoghq.com", proxiedRequests[2].Host)
+	assert.Equal(t, "mysubdomain.datadoghq.com", proxiedRequests[2].URL.Host)
+	assert.Equal(t, "test_api_key_2", proxiedRequests[2].Header.Get("DD-API-KEY"))
+
+	assert.Equal(t, "mysubdomain.datadoghq.eu", proxiedRequests[3].Host)
+	assert.Equal(t, "mysubdomain.datadoghq.eu", proxiedRequests[3].URL.Host)
+	assert.Equal(t, "test_api_key_eu", proxiedRequests[3].Header.Get("DD-API-KEY"))
+
+	assert.Equal(t, "", loggerOut)
+}
+
+func TestEvpIntakeReverseProxyHandlerInvalidSubdomain(t *testing.T) {
+	conf := newTestReceiverConfig()
+	conf.Site = "us3.datadoghq.com"
+	conf.Endpoints[0].APIKey = "test_api_key"
+
+	request := httptest.NewRequest("POST", "/google.com%3Fattack=/mypath/mysubpath", nil)
+	proxiedRequests, response, loggerOut := sendRequestThroughHandler(conf, request)
+
+	require.Equal(t, 0, len(proxiedRequests))
+	require.Equal(t, http.StatusBadGateway, response.StatusCode, "Got: ", fmt.Sprint(response.StatusCode))
+	require.Contains(t, loggerOut, "invalid subdomain")
+}
+
+func TestEvpIntakeReverseProxyHandlerInvalidPath(t *testing.T) {
+	conf := newTestReceiverConfig()
+	conf.Site = "us3.datadoghq.com"
+	conf.Endpoints[0].APIKey = "test_api_key"
+
+	request := httptest.NewRequest("POST", "/mysubdomain/mypath/my%20subpath", nil)
+	proxiedRequests, response, loggerOut := sendRequestThroughHandler(conf, request)
+
+	require.Equal(t, 0, len(proxiedRequests))
+	require.Equal(t, http.StatusBadGateway, response.StatusCode, "Got: ", fmt.Sprint(response.StatusCode))
+	require.Contains(t, loggerOut, "invalid target path")
+}
+
+func TestEvpIntakeReverseProxyHandlerInvalidQuery(t *testing.T) {
+	conf := newTestReceiverConfig()
+	conf.Site = "us3.datadoghq.com"
+	conf.Endpoints[0].APIKey = "test_api_key"
+
+	request := httptest.NewRequest("POST", "/mysubdomain/mypath/mysubpath?test=bad%20arg", nil)
+	proxiedRequests, response, loggerOut := sendRequestThroughHandler(conf, request)
+
+	require.Equal(t, 0, len(proxiedRequests))
+	require.Equal(t, http.StatusBadGateway, response.StatusCode, "Got: ", fmt.Sprint(response.StatusCode))
+	require.Contains(t, loggerOut, "invalid query string")
 }

--- a/pkg/trace/api/evp_intake_proxy_test.go
+++ b/pkg/trace/api/evp_intake_proxy_test.go
@@ -28,10 +28,10 @@ func (r roundTripperMock) RoundTrip(req *http.Request) (*http.Response, error) {
 	return r(req)
 }
 
-// sendRequestThroughHandler sends a request through the evpIntakeReverseProxy handler and returns the forwarded
+// sendRequestThroughForwarder sends a request through the evpProxyForwarder handler and returns the forwarded
 // request(s), their response and the log output. The path for inReq shouldn't have the /evp_proxy/v1/input
 // prefix since it is passed directly to the inner proxy handler and not the trace-agent API handler.
-func sendRequestThroughHandler(conf *config.AgentConfig, inReq *http.Request) (outReqs []*http.Request, resp *http.Response, logs string) {
+func sendRequestThroughForwarder(conf *config.AgentConfig, inReq *http.Request) (outReqs []*http.Request, resp *http.Response, logs string) {
 	mockRoundTripper := roundTripperMock(func(req *http.Request) (*http.Response, error) {
 		outReqs = append(outReqs, req)
 		// If we got here it means the proxy didn't raise an error earlier, return an ok resp
@@ -42,13 +42,13 @@ func sendRequestThroughHandler(conf *config.AgentConfig, inReq *http.Request) (o
 	})
 	var loggerBuffer bytes.Buffer
 	mockLogger := log.New(io.Writer(&loggerBuffer), "", 0)
-	handler := evpIntakeReverseProxyHandler(conf, evpIntakeEndpointsFromConfig(conf), mockRoundTripper, mockLogger)
+	handler := evpProxyForwarder(conf, evpProxyEndpointsFromConfig(conf), mockRoundTripper, mockLogger)
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, inReq)
 	return outReqs, rec.Result(), loggerBuffer.String()
 }
 
-func TestEVPIntakeReverseProxyHandlerOk(t *testing.T) {
+func TestEVPProxyForwarderOk(t *testing.T) {
 	conf := newTestReceiverConfig()
 	conf.Hostname = "test_hostname"
 	conf.DefaultEnv = "test_env"
@@ -59,7 +59,7 @@ func TestEVPIntakeReverseProxyHandlerOk(t *testing.T) {
 	req.Header.Set("User-Agent", "test_user_agent")
 	req.Header.Set("Content-Type", "text/json")
 	req.Header.Set("Unexpected-Header", "To-Be-Discarded")
-	proxyreqs, resp, logs := sendRequestThroughHandler(conf, req)
+	proxyreqs, resp, logs := sendRequestThroughForwarder(conf, req)
 
 	require.Equal(t, http.StatusOK, resp.StatusCode, "Got: ", fmt.Sprint(resp.StatusCode))
 	require.Equal(t, 1, len(proxyreqs))
@@ -79,7 +79,7 @@ func TestEVPIntakeReverseProxyHandlerOk(t *testing.T) {
 	assert.Equal(t, "", logs)
 }
 
-func TestEVPIntakeReverseProxyHandlerWithContainerId(t *testing.T) {
+func TestEVPProxyForwarderWithContainerId(t *testing.T) {
 	conf := newTestReceiverConfig()
 	conf.Site = "us3.datadoghq.com"
 	conf.Endpoints[0].APIKey = "test_api_key"
@@ -89,7 +89,7 @@ func TestEVPIntakeReverseProxyHandlerWithContainerId(t *testing.T) {
 
 	req := httptest.NewRequest("POST", "/mysubdomain/mypath/mysubpath?arg=test", nil)
 	req.Header.Set("Datadog-Container-ID", "myid")
-	proxyreqs, resp, logs := sendRequestThroughHandler(conf, req)
+	proxyreqs, resp, logs := sendRequestThroughForwarder(conf, req)
 
 	require.Equal(t, http.StatusOK, resp.StatusCode, "Got: ", fmt.Sprint(resp.StatusCode))
 	require.Equal(t, 1, len(proxyreqs))
@@ -97,16 +97,16 @@ func TestEVPIntakeReverseProxyHandlerWithContainerId(t *testing.T) {
 	assert.Equal(t, "", logs)
 }
 
-func TestEVPIntakeReverseProxyHandlerMultipleEndpoints(t *testing.T) {
+func TestEVPProxyForwarderMultipleEndpoints(t *testing.T) {
 	conf := newTestReceiverConfig()
 	conf.Site = "us3.datadoghq.com"
 	conf.Endpoints[0].APIKey = "test_api_key"
-	conf.EVPIntakeProxy.AdditionalEndpoints = map[string][]string{
+	conf.EVPProxy.AdditionalEndpoints = map[string][]string{
 		"datadoghq.eu": []string{"test_api_key_1", "test_api_key_2"},
 	}
 	req := httptest.NewRequest("POST", "/mysubdomain/mypath/mysubpath?arg=test", nil)
 	req.Header.Set("X-Datadog-Agent", "test_user_agent")
-	proxyreqs, resp, logs := sendRequestThroughHandler(conf, req)
+	proxyreqs, resp, logs := sendRequestThroughForwarder(conf, req)
 
 	require.Equal(t, http.StatusOK, resp.StatusCode, "Got: ", fmt.Sprint(resp.StatusCode))
 	require.Equal(t, 3, len(proxyreqs))
@@ -130,71 +130,71 @@ func TestEVPIntakeReverseProxyHandlerMultipleEndpoints(t *testing.T) {
 	assert.Equal(t, "", logs)
 }
 
-func TestEVPIntakeReverseProxyHandlerInvalidSubdomain(t *testing.T) {
+func TestEVPProxyForwarderInvalidSubdomain(t *testing.T) {
 	conf := newTestReceiverConfig()
 	conf.Site = "us3.datadoghq.com"
 	conf.Endpoints[0].APIKey = "test_api_key"
 
 	req := httptest.NewRequest("POST", "/google.com%3Fattack=/mypath/mysubpath", nil)
-	proxyreqs, resp, logs := sendRequestThroughHandler(conf, req)
+	proxyreqs, resp, logs := sendRequestThroughForwarder(conf, req)
 
 	require.Equal(t, 0, len(proxyreqs))
 	require.Equal(t, http.StatusBadGateway, resp.StatusCode, "Got: ", fmt.Sprint(resp.StatusCode))
 	require.Contains(t, logs, "invalid subdomain")
 }
 
-func TestEVPIntakeReverseProxyHandlerInvalidPath(t *testing.T) {
+func TestEVPProxyForwarderInvalidPath(t *testing.T) {
 	conf := newTestReceiverConfig()
 	conf.Site = "us3.datadoghq.com"
 	conf.Endpoints[0].APIKey = "test_api_key"
 
 	req := httptest.NewRequest("POST", "/mysubdomain/mypath/my%20subpath", nil)
-	proxyreqs, resp, logs := sendRequestThroughHandler(conf, req)
+	proxyreqs, resp, logs := sendRequestThroughForwarder(conf, req)
 
 	require.Equal(t, 0, len(proxyreqs))
 	require.Equal(t, http.StatusBadGateway, resp.StatusCode, "Got: ", fmt.Sprint(resp.StatusCode))
 	require.Contains(t, logs, "invalid target path")
 }
 
-func TestEVPIntakeReverseProxyHandlerInvalidQuery(t *testing.T) {
+func TestEVPProxyForwarderInvalidQuery(t *testing.T) {
 	conf := newTestReceiverConfig()
 	conf.Site = "us3.datadoghq.com"
 	conf.Endpoints[0].APIKey = "test_api_key"
 
 	req := httptest.NewRequest("POST", "/mysubdomain/mypath/mysubpath?test=bad%20arg", nil)
-	proxyreqs, resp, logs := sendRequestThroughHandler(conf, req)
+	proxyreqs, resp, logs := sendRequestThroughForwarder(conf, req)
 
 	require.Equal(t, 0, len(proxyreqs))
 	require.Equal(t, http.StatusBadGateway, resp.StatusCode, "Got: ", fmt.Sprint(resp.StatusCode))
 	require.Contains(t, logs, "invalid query string")
 }
 
-func TestEVPIntakeEndpointsFromConfigOverride(t *testing.T) {
+func TestEVPProxyEndpointsFromConfigOverride(t *testing.T) {
 	conf := newTestReceiverConfig()
 	conf.Site = "us3.datadoghq.com"
 	conf.Endpoints[0].APIKey = "test_api_key"
-	conf.EVPIntakeProxy.DDURL = "override.datadoghq.com"
-	conf.EVPIntakeProxy.APIKey = "override_api_key"
+	conf.EVPProxy.DDURL = "override.datadoghq.com"
+	conf.EVPProxy.APIKey = "override_api_key"
 
-	endpoints := evpIntakeEndpointsFromConfig(conf)
+	endpoints := evpProxyEndpointsFromConfig(conf)
 
 	require.Equal(t, 1, len(endpoints))
 	require.Equal(t, endpoints[0].Host, "override.datadoghq.com")
 	require.Equal(t, endpoints[0].APIKey, "override_api_key")
 }
 
-func TestEVPIntakeHandler(t *testing.T) {
+func TestEVPProxyHandler(t *testing.T) {
 	cfg := config.New()
 	receiver := &HTTPReceiver{conf: cfg}
-	handler := receiver.evpIntakeHandler()
+	handler := receiver.evpProxyHandler()
 	require.NotNil(t, handler)
 }
 
-func TestEVPIntakeHandlerDisabled(t *testing.T) {
+func TestEVPProxyHandlerDisabled(t *testing.T) {
 	cfg := config.New()
-	cfg.EVPIntakeProxy.Enabled = false
+	cfg.EVPProxy.Enabled = false
 	receiver := &HTTPReceiver{conf: cfg}
-	handler := receiver.evpIntakeHandler()
+	handler := receiver.evpProxyHandler()
 	require.NotNil(t, handler)
 
 	rec := httptest.NewRecorder()

--- a/pkg/trace/api/evp_intake_proxy_test.go
+++ b/pkg/trace/api/evp_intake_proxy_test.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
+	"math/rand"
 	"net/http"
 	"net/http/httptest"
 
@@ -18,6 +19,8 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/info"
+	"github.com/DataDog/datadog-agent/pkg/trace/metrics"
+	"github.com/DataDog/datadog-agent/pkg/trace/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -49,24 +52,34 @@ func sendRequestThroughForwarder(conf *config.AgentConfig, inReq *http.Request) 
 }
 
 func TestEVPProxyForwarder(t *testing.T) {
+
+	randBodyBuf := make([]byte, 1024)
+	rand.Read(randBodyBuf)
+
+	stats := &testutil.TestStatsClient{}
+	defer func(old metrics.StatsClient) { metrics.Client = old }(metrics.Client)
+	metrics.Client = stats
+
 	t.Run("happy case", func(t *testing.T) {
+		stats.Reset()
+
 		conf := newTestReceiverConfig()
 		conf.Hostname = "test_hostname"
 		conf.DefaultEnv = "test_env"
 		conf.Site = "us3.datadoghq.com"
 		conf.Endpoints[0].APIKey = "test_api_key"
 
-		req := httptest.NewRequest("POST", "/mysubdomain/mypath/mysubpath?arg=test", nil)
+		req := httptest.NewRequest("POST", "/my.subdomain/mypath/mysubpath?arg=test", bytes.NewReader(randBodyBuf))
 		req.Header.Set("User-Agent", "test_user_agent")
 		req.Header.Set("Content-Type", "text/json")
 		req.Header.Set("Unexpected-Header", "To-Be-Discarded")
 		proxyreqs, resp, logs := sendRequestThroughForwarder(conf, req)
 
 		require.Equal(t, http.StatusOK, resp.StatusCode, "Got: ", fmt.Sprint(resp.StatusCode))
-		require.Equal(t, 1, len(proxyreqs))
+		require.Len(t, proxyreqs, 1)
 		proxyreq := proxyreqs[0]
-		assert.Equal(t, "mysubdomain.us3.datadoghq.com", proxyreq.Host)
-		assert.Equal(t, "mysubdomain.us3.datadoghq.com", proxyreq.URL.Host)
+		assert.Equal(t, "my.subdomain.us3.datadoghq.com", proxyreq.Host)
+		assert.Equal(t, "my.subdomain.us3.datadoghq.com", proxyreq.URL.Host)
 		assert.Equal(t, "/mypath/mysubpath", proxyreq.URL.Path)
 		assert.Equal(t, "arg=test", proxyreq.URL.RawQuery)
 		assert.Equal(t, "test_api_key", proxyreq.Header.Get("DD-API-KEY"))
@@ -78,6 +91,25 @@ func TestEVPProxyForwarder(t *testing.T) {
 		assert.NotContains(t, proxyreq.Header, "Unexpected-Header")
 		assert.NotContains(t, proxyreq.Header, "X-Datadog-Container-Tags")
 		assert.Equal(t, "", logs)
+
+		// check metrics
+		expectedTags := []string{
+			"content_type:text/json",
+			"subdomain:my.subdomain",
+		}
+		require.Len(t, stats.TimingCalls, 1)
+		assert.Equal(t, "datadog.trace_agent.evp_proxy.request_duration_ms", stats.TimingCalls[0].Name)
+		assert.ElementsMatch(t, expectedTags, stats.TimingCalls[0].Tags)
+		assert.Equal(t, float64(1), stats.TimingCalls[0].Rate)
+		require.Len(t, stats.CountCalls, 2)
+		assert.Equal(t, "datadog.trace_agent.evp_proxy.request", stats.CountCalls[0].Name)
+		assert.Equal(t, float64(1), stats.CountCalls[0].Value)
+		assert.Equal(t, float64(1), stats.CountCalls[0].Rate)
+		assert.ElementsMatch(t, expectedTags, stats.CountCalls[0].Tags)
+		assert.Equal(t, "datadog.trace_agent.evp_proxy.request_bytes", stats.CountCalls[1].Name)
+		assert.Equal(t, float64(1024), stats.CountCalls[1].Value)
+		assert.Equal(t, float64(1), stats.CountCalls[1].Rate)
+		assert.ElementsMatch(t, expectedTags, stats.CountCalls[1].Tags)
 	})
 
 	t.Run("with containerid", func(t *testing.T) {
@@ -88,12 +120,12 @@ func TestEVPProxyForwarder(t *testing.T) {
 			return []string{"container:" + cid}, nil
 		}
 
-		req := httptest.NewRequest("POST", "/mysubdomain/mypath/mysubpath?arg=test", nil)
+		req := httptest.NewRequest("POST", "/my.subdomain/mypath/mysubpath?arg=test", nil)
 		req.Header.Set("Datadog-Container-ID", "myid")
 		proxyreqs, resp, logs := sendRequestThroughForwarder(conf, req)
 
 		require.Equal(t, http.StatusOK, resp.StatusCode, "Got: ", fmt.Sprint(resp.StatusCode))
-		require.Equal(t, 1, len(proxyreqs))
+		require.Len(t, proxyreqs, 1)
 		assert.Equal(t, "container:myid", proxyreqs[0].Header.Get("X-Datadog-Container-Tags"))
 		assert.Equal(t, "", logs)
 	})
@@ -105,33 +137,35 @@ func TestEVPProxyForwarder(t *testing.T) {
 		conf.EVPProxy.AdditionalEndpoints = map[string][]string{
 			"datadoghq.eu": []string{"test_api_key_1", "test_api_key_2"},
 		}
-		req := httptest.NewRequest("POST", "/mysubdomain/mypath/mysubpath?arg=test", nil)
+		req := httptest.NewRequest("POST", "/my.subdomain/mypath/mysubpath?arg=test", nil)
 		req.Header.Set("X-Datadog-Agent", "test_user_agent")
 		proxyreqs, resp, logs := sendRequestThroughForwarder(conf, req)
 
 		require.Equal(t, http.StatusOK, resp.StatusCode, "Got: ", fmt.Sprint(resp.StatusCode))
-		require.Equal(t, 3, len(proxyreqs))
+		require.Len(t, proxyreqs, 3)
 
-		assert.Equal(t, "mysubdomain.us3.datadoghq.com", proxyreqs[0].Host)
-		assert.Equal(t, "mysubdomain.us3.datadoghq.com", proxyreqs[0].URL.Host)
+		assert.Equal(t, "my.subdomain.us3.datadoghq.com", proxyreqs[0].Host)
+		assert.Equal(t, "my.subdomain.us3.datadoghq.com", proxyreqs[0].URL.Host)
 		assert.Equal(t, "/mypath/mysubpath", proxyreqs[0].URL.Path)
 		assert.Equal(t, "arg=test", proxyreqs[0].URL.RawQuery)
 		assert.Equal(t, "test_api_key", proxyreqs[0].Header.Get("DD-API-KEY"))
 
-		assert.Equal(t, "mysubdomain.datadoghq.eu", proxyreqs[1].Host)
-		assert.Equal(t, "mysubdomain.datadoghq.eu", proxyreqs[1].URL.Host)
+		assert.Equal(t, "my.subdomain.datadoghq.eu", proxyreqs[1].Host)
+		assert.Equal(t, "my.subdomain.datadoghq.eu", proxyreqs[1].URL.Host)
 		assert.Equal(t, "/mypath/mysubpath", proxyreqs[1].URL.Path)
 		assert.Equal(t, "arg=test", proxyreqs[1].URL.RawQuery)
 		assert.Equal(t, "test_api_key_1", proxyreqs[1].Header.Get("DD-API-KEY"))
 
-		assert.Equal(t, "mysubdomain.datadoghq.eu", proxyreqs[2].Host)
-		assert.Equal(t, "mysubdomain.datadoghq.eu", proxyreqs[2].URL.Host)
+		assert.Equal(t, "my.subdomain.datadoghq.eu", proxyreqs[2].Host)
+		assert.Equal(t, "my.subdomain.datadoghq.eu", proxyreqs[2].URL.Host)
 		assert.Equal(t, "test_api_key_2", proxyreqs[2].Header.Get("DD-API-KEY"))
 
 		assert.Equal(t, "", logs)
 	})
 
 	t.Run("invalid subdomain", func(t *testing.T) {
+		stats.Reset()
+
 		conf := newTestReceiverConfig()
 		conf.Site = "us3.datadoghq.com"
 		conf.Endpoints[0].APIKey = "test_api_key"
@@ -139,35 +173,103 @@ func TestEVPProxyForwarder(t *testing.T) {
 		req := httptest.NewRequest("POST", "/google.com%3Fattack=/mypath/mysubpath", nil)
 		proxyreqs, resp, logs := sendRequestThroughForwarder(conf, req)
 
-		require.Equal(t, 0, len(proxyreqs))
+		require.Len(t, proxyreqs, 0)
 		require.Equal(t, http.StatusBadGateway, resp.StatusCode, "Got: ", fmt.Sprint(resp.StatusCode))
 		require.Contains(t, logs, "invalid subdomain")
+
+		// check metrics
+		require.Len(t, stats.TimingCalls, 1)
+		assert.Equal(t, "datadog.trace_agent.evp_proxy.request_duration_ms", stats.TimingCalls[0].Name)
+		assert.Len(t, stats.TimingCalls[0].Tags, 0)
+		assert.Equal(t, float64(1), stats.TimingCalls[0].Rate)
+		require.Len(t, stats.CountCalls, 3)
+		assert.Equal(t, "datadog.trace_agent.evp_proxy.request", stats.CountCalls[0].Name)
+		assert.Equal(t, float64(1), stats.CountCalls[0].Value)
+		assert.Equal(t, float64(1), stats.CountCalls[0].Rate)
+		assert.Len(t, stats.CountCalls[0].Tags, 0)
+		assert.Equal(t, "datadog.trace_agent.evp_proxy.request_bytes", stats.CountCalls[1].Name)
+		assert.Equal(t, float64(0), stats.CountCalls[1].Value)
+		assert.Equal(t, float64(1), stats.CountCalls[1].Rate)
+		assert.Len(t, stats.CountCalls[1].Tags, 0)
+		assert.Equal(t, "datadog.trace_agent.evp_proxy.request_error", stats.CountCalls[2].Name)
+		assert.Equal(t, float64(1), stats.CountCalls[2].Value)
+		assert.Equal(t, float64(1), stats.CountCalls[2].Rate)
+		assert.Len(t, stats.CountCalls[2].Tags, 0)
 	})
 
 	t.Run("invalid path", func(t *testing.T) {
+		stats.Reset()
+
 		conf := newTestReceiverConfig()
 		conf.Site = "us3.datadoghq.com"
 		conf.Endpoints[0].APIKey = "test_api_key"
 
-		req := httptest.NewRequest("POST", "/mysubdomain/mypath/my%20subpath", nil)
+		req := httptest.NewRequest("POST", "/my.subdomain/mypath/my%20subpath", nil)
 		proxyreqs, resp, logs := sendRequestThroughForwarder(conf, req)
 
-		require.Equal(t, 0, len(proxyreqs))
+		require.Len(t, proxyreqs, 0)
 		require.Equal(t, http.StatusBadGateway, resp.StatusCode, "Got: ", fmt.Sprint(resp.StatusCode))
 		require.Contains(t, logs, "invalid target path")
+
+		// check metrics
+		expectedTags := []string{
+			"subdomain:my.subdomain",
+		}
+		require.Len(t, stats.TimingCalls, 1)
+		assert.Equal(t, "datadog.trace_agent.evp_proxy.request_duration_ms", stats.TimingCalls[0].Name)
+		assert.ElementsMatch(t, expectedTags, stats.TimingCalls[0].Tags)
+		assert.Equal(t, float64(1), stats.TimingCalls[0].Rate)
+		require.Len(t, stats.CountCalls, 3)
+		assert.Equal(t, "datadog.trace_agent.evp_proxy.request", stats.CountCalls[0].Name)
+		assert.Equal(t, float64(1), stats.CountCalls[0].Value)
+		assert.Equal(t, float64(1), stats.CountCalls[0].Rate)
+		assert.ElementsMatch(t, expectedTags, stats.CountCalls[0].Tags)
+		assert.Equal(t, "datadog.trace_agent.evp_proxy.request_bytes", stats.CountCalls[1].Name)
+		assert.Equal(t, float64(0), stats.CountCalls[1].Value)
+		assert.Equal(t, float64(1), stats.CountCalls[1].Rate)
+		assert.ElementsMatch(t, expectedTags, stats.CountCalls[1].Tags)
+		assert.Equal(t, "datadog.trace_agent.evp_proxy.request_error", stats.CountCalls[2].Name)
+		assert.Equal(t, float64(1), stats.CountCalls[2].Value)
+		assert.Equal(t, float64(1), stats.CountCalls[2].Rate)
+		assert.ElementsMatch(t, expectedTags, stats.CountCalls[2].Tags)
 	})
 
 	t.Run("invalid query string", func(t *testing.T) {
+		stats.Reset()
+
 		conf := newTestReceiverConfig()
 		conf.Site = "us3.datadoghq.com"
 		conf.Endpoints[0].APIKey = "test_api_key"
 
-		req := httptest.NewRequest("POST", "/mysubdomain/mypath/mysubpath?test=bad%20arg", nil)
+		req := httptest.NewRequest("POST", "/my.subdomain/mypath/mysubpath?test=bad%20arg", nil)
 		proxyreqs, resp, logs := sendRequestThroughForwarder(conf, req)
 
-		require.Equal(t, 0, len(proxyreqs))
+		require.Len(t, proxyreqs, 0)
+
 		require.Equal(t, http.StatusBadGateway, resp.StatusCode, "Got: ", fmt.Sprint(resp.StatusCode))
 		require.Contains(t, logs, "invalid query string")
+
+		// check metrics
+		expectedTags := []string{
+			"subdomain:my.subdomain",
+		}
+		require.Len(t, stats.TimingCalls, 1)
+		assert.Equal(t, "datadog.trace_agent.evp_proxy.request_duration_ms", stats.TimingCalls[0].Name)
+		assert.ElementsMatch(t, expectedTags, stats.TimingCalls[0].Tags)
+		assert.Equal(t, float64(1), stats.TimingCalls[0].Rate)
+		require.Len(t, stats.CountCalls, 3)
+		assert.Equal(t, "datadog.trace_agent.evp_proxy.request", stats.CountCalls[0].Name)
+		assert.Equal(t, float64(1), stats.CountCalls[0].Value)
+		assert.Equal(t, float64(1), stats.CountCalls[0].Rate)
+		assert.ElementsMatch(t, expectedTags, stats.CountCalls[0].Tags)
+		assert.Equal(t, "datadog.trace_agent.evp_proxy.request_bytes", stats.CountCalls[1].Name)
+		assert.Equal(t, float64(0), stats.CountCalls[1].Value)
+		assert.Equal(t, float64(1), stats.CountCalls[1].Rate)
+		assert.ElementsMatch(t, expectedTags, stats.CountCalls[1].Tags)
+		assert.Equal(t, "datadog.trace_agent.evp_proxy.request_error", stats.CountCalls[2].Name)
+		assert.Equal(t, float64(1), stats.CountCalls[2].Value)
+		assert.Equal(t, float64(1), stats.CountCalls[2].Rate)
+		assert.ElementsMatch(t, expectedTags, stats.CountCalls[2].Tags)
 	})
 
 	t.Run("config override ddurl and apikey", func(t *testing.T) {
@@ -179,9 +281,9 @@ func TestEVPProxyForwarder(t *testing.T) {
 
 		endpoints := evpProxyEndpointsFromConfig(conf)
 
-		require.Equal(t, 1, len(endpoints))
-		require.Equal(t, endpoints[0].Host, "override.datadoghq.com")
-		require.Equal(t, endpoints[0].APIKey, "override_api_key")
+		require.Len(t, endpoints, 1)
+		assert.Equal(t, endpoints[0].Host, "override.datadoghq.com")
+		assert.Equal(t, endpoints[0].APIKey, "override_api_key")
 	})
 }
 
@@ -201,7 +303,7 @@ func TestEVPProxyHandler(t *testing.T) {
 		require.NotNil(t, handler)
 
 		rec := httptest.NewRecorder()
-		handler.ServeHTTP(rec, httptest.NewRequest("POST", "/evp_proxy/v1/input/mysubdomain/mypath", nil))
+		handler.ServeHTTP(rec, httptest.NewRequest("POST", "/evp_proxy/v1/input/my.subdomain/mypath", nil))
 		require.Equal(t, http.StatusMethodNotAllowed, rec.Code)
 	})
 }

--- a/pkg/trace/api/info_test.go
+++ b/pkg/trace/api/info_test.go
@@ -128,7 +128,7 @@ func TestInfoHandler(t *testing.T) {
 		"/v0.6/stats",
 		"/v0.1/pipeline_stats",
 		"/appsec/proxy/",
-		"/evp_intake_proxy/v1/input/",
+		"/evp_proxy/v1/input/",
 		"/debugger/v1/input"
 	],
 	"feature_flags": [
@@ -188,7 +188,7 @@ func TestInfoHandler(t *testing.T) {
 		"/v0.6/stats",
 		"/v0.1/pipeline_stats",
 		"/appsec/proxy/",
-		"/evp_intake_proxy/v1/input/",
+		"/evp_proxy/v1/input/",
 		"/debugger/v1/input"
 	],
 	"feature_flags": [

--- a/pkg/trace/api/info_test.go
+++ b/pkg/trace/api/info_test.go
@@ -128,6 +128,7 @@ func TestInfoHandler(t *testing.T) {
 		"/v0.6/stats",
 		"/v0.1/pipeline_stats",
 		"/appsec/proxy/",
+		"/evpIntakeProxy/v1",
 		"/debugger/v1/input"
 	],
 	"feature_flags": [
@@ -187,6 +188,7 @@ func TestInfoHandler(t *testing.T) {
 		"/v0.6/stats",
 		"/v0.1/pipeline_stats",
 		"/appsec/proxy/",
+		"/evpIntakeProxy/v1",
 		"/debugger/v1/input"
 	],
 	"feature_flags": [

--- a/pkg/trace/api/info_test.go
+++ b/pkg/trace/api/info_test.go
@@ -128,7 +128,7 @@ func TestInfoHandler(t *testing.T) {
 		"/v0.6/stats",
 		"/v0.1/pipeline_stats",
 		"/appsec/proxy/",
-		"/evpIntakeProxy/v1",
+		"/evpIntakeProxy/v1/",
 		"/debugger/v1/input"
 	],
 	"feature_flags": [
@@ -188,7 +188,7 @@ func TestInfoHandler(t *testing.T) {
 		"/v0.6/stats",
 		"/v0.1/pipeline_stats",
 		"/appsec/proxy/",
-		"/evpIntakeProxy/v1",
+		"/evpIntakeProxy/v1/",
 		"/debugger/v1/input"
 	],
 	"feature_flags": [

--- a/pkg/trace/api/info_test.go
+++ b/pkg/trace/api/info_test.go
@@ -128,7 +128,7 @@ func TestInfoHandler(t *testing.T) {
 		"/v0.6/stats",
 		"/v0.1/pipeline_stats",
 		"/appsec/proxy/",
-		"/evpIntakeProxy/v1/",
+		"/evp_intake_proxy/v1/input/",
 		"/debugger/v1/input"
 	],
 	"feature_flags": [
@@ -188,7 +188,7 @@ func TestInfoHandler(t *testing.T) {
 		"/v0.6/stats",
 		"/v0.1/pipeline_stats",
 		"/appsec/proxy/",
-		"/evpIntakeProxy/v1/",
+		"/evp_intake_proxy/v1/input/",
 		"/debugger/v1/input"
 	],
 	"feature_flags": [

--- a/pkg/trace/api/info_test.go
+++ b/pkg/trace/api/info_test.go
@@ -128,7 +128,7 @@ func TestInfoHandler(t *testing.T) {
 		"/v0.6/stats",
 		"/v0.1/pipeline_stats",
 		"/appsec/proxy/",
-		"/evp_proxy/v1/input/",
+		"/evp_proxy/v1/",
 		"/debugger/v1/input"
 	],
 	"feature_flags": [
@@ -188,7 +188,7 @@ func TestInfoHandler(t *testing.T) {
 		"/v0.6/stats",
 		"/v0.1/pipeline_stats",
 		"/appsec/proxy/",
-		"/evp_proxy/v1/input/",
+		"/evp_proxy/v1/",
 		"/debugger/v1/input"
 	],
 	"feature_flags": [

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -480,7 +480,6 @@ func New() *AgentConfig {
 		},
 		EvpIntakeProxy: EvpIntakeProxy{
 			Enabled: true,
-			DDURL:   "datadoghq.com",
 		},
 	}
 }

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -262,6 +262,8 @@ type EVPProxy struct {
 	APIKey string
 	// AdditionalEndpoints is a map of additional domain URLs to API keys.
 	AdditionalEndpoints map[string][]string
+	// MaxPayloadSize indicates the size at which payloads will be rejected, in bytes
+	MaxPayloadSize int64
 }
 
 // DebuggerProxyConfig ...
@@ -479,7 +481,8 @@ func New() *AgentConfig {
 			MaxPayloadSize: 5 * 1024 * 1024,
 		},
 		EVPProxy: EVPProxy{
-			Enabled: true,
+			Enabled:        true,
+			MaxPayloadSize: 5 * 1024 * 1024,
 		},
 	}
 }

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -252,6 +252,18 @@ type ProfilingProxyConfig struct {
 	AdditionalEndpoints map[string][]string
 }
 
+// EvpIntakeProxy ...
+type EvpIntakeProxy struct {
+	// Enabled reports whether EvpIntakeProxy is enabled (defaults to apm_config.enabled).
+	Enabled bool
+	// DDURL is the main domain URL (defaults to the Site)
+	DDURL string
+	// APIKey is the main API Key (defaults to the main API key)
+	APIKey string
+	// AdditionalEndpoints is a map of additional domain URLs to API keys.
+	AdditionalEndpoints map[string][]string
+}
+
 // DebuggerProxyConfig ...
 type DebuggerProxyConfig struct {
 	// DDURL ...
@@ -374,6 +386,9 @@ type AgentConfig struct {
 	AppSec AppSecConfig
 
 	// DebuggerProxy contains the settings for the Live Debugger proxy.
+	EvpIntakeProxy EvpIntakeProxy
+
+	// DebuggerProxy contains the settings for the Live Debugger proxy.
 	DebuggerProxy DebuggerProxyConfig
 
 	// Proxy specifies a function to return a proxy for a given Request.
@@ -462,6 +477,10 @@ func New() *AgentConfig {
 		AppSec: AppSecConfig{
 			Enabled:        true,
 			MaxPayloadSize: 5 * 1024 * 1024,
+		},
+		EvpIntakeProxy: EvpIntakeProxy{
+			Enabled: true,
+			DDURL:   "datadoghq.com",
 		},
 	}
 }

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -254,15 +254,15 @@ type ProfilingProxyConfig struct {
 
 // EVPProxy contains the settings for the EVPProxy proxy.
 type EVPProxy struct {
-	// Enabled reports whether EVPProxy is enabled (true by default)
+	// Enabled reports whether EVPProxy is enabled (true by default).
 	Enabled bool
-	// DDURL is the main domain URL (defaults to the Site)
+	// DDURL is the Datadog site to forward payloads to (defaults to the Site setting if not set).
 	DDURL string
-	// APIKey is the main API Key (defaults to the main API key)
+	// APIKey is the main API Key (defaults to the main API key).
 	APIKey string
-	// AdditionalEndpoints is a map of additional domain URLs to API keys.
+	// AdditionalEndpoints is a map of additional Datadog sites to API keys.
 	AdditionalEndpoints map[string][]string
-	// MaxPayloadSize indicates the size at which payloads will be rejected, in bytes
+	// MaxPayloadSize indicates the size at which payloads will be rejected, in bytes.
 	MaxPayloadSize int64
 }
 

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -252,9 +252,9 @@ type ProfilingProxyConfig struct {
 	AdditionalEndpoints map[string][]string
 }
 
-// EvpIntakeProxy ...
-type EvpIntakeProxy struct {
-	// Enabled reports whether EvpIntakeProxy is enabled (defaults to apm_config.enabled).
+// EVPIntakeProxy contains the settings for the EVPIntake proxy.
+type EVPIntakeProxy struct {
+	// Enabled reports whether EVPIntakeProxy is enabled (true by default)
 	Enabled bool
 	// DDURL is the main domain URL (defaults to the Site)
 	DDURL string
@@ -385,8 +385,8 @@ type AgentConfig struct {
 	// AppSec contains AppSec configuration.
 	AppSec AppSecConfig
 
-	// DebuggerProxy contains the settings for the Live Debugger proxy.
-	EvpIntakeProxy EvpIntakeProxy
+	// EVPIntakeProxy contains the settings for the EVPIntake proxy.
+	EVPIntakeProxy EVPIntakeProxy
 
 	// DebuggerProxy contains the settings for the Live Debugger proxy.
 	DebuggerProxy DebuggerProxyConfig
@@ -478,7 +478,7 @@ func New() *AgentConfig {
 			Enabled:        true,
 			MaxPayloadSize: 5 * 1024 * 1024,
 		},
-		EvpIntakeProxy: EvpIntakeProxy{
+		EVPIntakeProxy: EVPIntakeProxy{
 			Enabled: true,
 		},
 	}

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -252,9 +252,9 @@ type ProfilingProxyConfig struct {
 	AdditionalEndpoints map[string][]string
 }
 
-// EVPIntakeProxy contains the settings for the EVPIntake proxy.
-type EVPIntakeProxy struct {
-	// Enabled reports whether EVPIntakeProxy is enabled (true by default)
+// EVPProxy contains the settings for the EVPProxy proxy.
+type EVPProxy struct {
+	// Enabled reports whether EVPProxy is enabled (true by default)
 	Enabled bool
 	// DDURL is the main domain URL (defaults to the Site)
 	DDURL string
@@ -385,8 +385,8 @@ type AgentConfig struct {
 	// AppSec contains AppSec configuration.
 	AppSec AppSecConfig
 
-	// EVPIntakeProxy contains the settings for the EVPIntake proxy.
-	EVPIntakeProxy EVPIntakeProxy
+	// EVPProxy contains the settings for the EVPProxy proxy.
+	EVPProxy EVPProxy
 
 	// DebuggerProxy contains the settings for the Live Debugger proxy.
 	DebuggerProxy DebuggerProxyConfig
@@ -478,7 +478,7 @@ func New() *AgentConfig {
 			Enabled:        true,
 			MaxPayloadSize: 5 * 1024 * 1024,
 		},
-		EVPIntakeProxy: EVPIntakeProxy{
+		EVPProxy: EVPProxy{
 			Enabled: true,
 		},
 	}

--- a/releasenotes/notes/trace-agent-evp-forwarding-api-000a992cbfe7c14b.yaml
+++ b/releasenotes/notes/trace-agent-evp-forwarding-api-000a992cbfe7c14b.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Add support for new types of CI Visibility payloads to the Trace Agent, so
+    features that until now were Agentless-only are available as well when using
+    the Agent.


### PR DESCRIPTION
### What does this PR do?

Adds a generic forwarding proxy API that can forward payloads to any intake endpoint given its path and subdomain (the domain is always set to the configured Datadog site(s)).

The proxy discards all input headers (except for `User-Agent` and `Content-Type`) and adds its own with the API key for the given site, the hostname configured in the Agent and the container tags if the request comes from a container. 

The proxy doesn't deserialize the payloads.

The code is mostly based on the [profiling proxy API](https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/api/profiles.go) and the [appsec proxy API](https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/appsec/appsec.go).

### Motivation

The Tracing Libraries add support for new products (profiling, appsec, ci visibility...) and need the Trace Agent to send their payloads to different endpoints. The goal of this PR is to add a generic API that can be reused for different types of payloads and endpoints instead of adding new specific forwarding APIs. The first user will be CI Visibility.

While the Tracing Libraries can send some of these payloads directly to the backend endpoints, sending them through the Agent has some advantages: you don't need to configure your Tracing Libraries with your API key or proxy settings, the hostname will match with everything else sent from the same Agent, container tags can be set...

### Additional Notes

* Naming is hard. I'm calling this EVPProxy. The api URL is `/evp_proxy` and the config settings are under `evp_proxy_conf`. I'm not sure this is the best name, but it achieves two goals: it is generic and it doesn't expose the name of internal backend components.

* Inconsistencies in header names (`Datadog-Container-ID` vs `X-Datadog-Hostname` vs `DD-API-KEY`) are to keep them consistent with other Trace Agent and backend APIs.

* Someone with access to this API (eg: a local user on a machine running the Agent) can make the Agent send a payload with the Agent API key to the current Datadog site (eg: *.datadoghq.com). This assumes this is always safe to do.

* The new configuration options are not documented. This was already the case for the profiling API settings and we can reconsider it if we see valid use cases for tweaking these settings.

### Describe how to test/QA your changes

In addition to the tests added, I tested this manually by [hacking the JS Tracing Library](https://github.com/DataDog/dd-trace-js/commit/2fc39c1b8e688872a041bb07c6b1e50ab3a726a3) so it sends CI Visibility payloads to the Agent instead of directly to the backend API.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
