### PR TITLE
Fix `agent status` hang

### DIFF
--- a/pkg/util/cloudproviders/kubernetes/kubernetes.go
+++ b/pkg/util/cloudproviders/kubernetes/kubernetes.go
@@ -23,6 +23,10 @@ var (
 
 // GetHostAliases returns the host aliases from the Kubernetes node annotations
 func GetHostAliases(ctx context.Context) ([]string, error) {
+	if !config.IsFeaturePresent(config.Kubernetes) {
+		return []string{}, nil
+	}
+
 	aliases := []string{}
 
 	annotations, err := hostinfo.GetNodeAnnotations(ctx)

--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -92,10 +92,12 @@ func isOSHostnameUsable(ctx context.Context) (osHostnameUsable bool) {
 	// Check hostNetwork from kubernetes
 	// because kubernetes sets UTS namespace to host if and only if hostNetwork = true:
 	// https://github.com/kubernetes/kubernetes/blob/cf16e4988f58a5b816385898271e70c3346b9651/pkg/kubelet/dockershim/security_context.go#L203-L205
-	hostNetwork, err := isAgentKubeHostNetwork()
-	if err == nil && !hostNetwork {
-		log.Debug("Agent is running in a POD without hostNetwork: OS-provided hostnames cannot be used for hostname resolution.")
-		return false
+	if config.IsFeaturePresent(config.Kubernetes) {
+		hostNetwork, err := isAgentKubeHostNetwork()
+		if err == nil && !hostNetwork {
+			log.Debug("Agent is running in a POD without hostNetwork: OS-provided hostnames cannot be used for hostname resolution.")
+			return false
+		}
 	}
 
 	return true

--- a/pkg/util/kubernetes/clustername/clustername.go
+++ b/pkg/util/kubernetes/clustername/clustername.go
@@ -108,7 +108,7 @@ func getClusterName(ctx context.Context, data *clusterNameData, hostname string)
 			}
 		}
 
-		if data.clusterName == "" {
+		if data.clusterName == "" && config.IsFeaturePresent(config.Kubernetes) {
 			clusterName, err := hostinfo.GetNodeClusterNameLabel(ctx)
 			if err != nil {
 				log.Debugf("Unable to auto discover the cluster name from node label : %s", err)

--- a/test/integration/util/kube_apiserver/apiserver_test.go
+++ b/test/integration/util/kube_apiserver/apiserver_test.go
@@ -43,6 +43,9 @@ func TestSuiteKube(t *testing.T) {
 	mockConfig := config.Mock()
 	s := &testSuite{}
 
+	// Env detection
+	config.DetectFeatures()
+
 	// Start compose stack
 	compose, err := initAPIServerCompose()
 	require.Nil(t, err)


### PR DESCRIPTION
### What does this PR do?

Fix `agent status` hang when `agent` is started as a plain docker container (without Kubernetes).

### Motivation

When the agent is started as a “plain” docker container without Kubernetes, `agent status` hangs and never replies.
On Linux, the only effect is that `agent status` hangs forever.

```
$ docker exec -ti dd-agent agent status
Getting the status from the agent.
```
(and never returns)

On Windows, the container startup times-out and the container is killed.

```
PS C:\> docker run --rm --name dd-agent -e DD_API_KEY=$DD_API_KEY -v \\.\pipe\docker_engine:\\.\pipe\docker_engine public.ecr.aws/datadog/agent:7.37.0-rc.4
[ENTRYPOINT][INFO] Running init script: entrypoint-ps1\01-check-apikey.ps1
[ENTRYPOINT][INFO] Running init script: entrypoint-ps1\02-set-env-vars.ps1
Setting ENV var: DD_API_KEY to machine scope
[ENTRYPOINT][INFO] Running init script: entrypoint-ps1\50-ci.ps1
[ENTRYPOINT][INFO] Running init script: entrypoint-ps1\50-kubernetes.ps1
[ENTRYPOINT][INFO] Running init script: entrypoint-ps1\51-docker.ps1
[ENTRYPOINT][INFO] Running init script: entrypoint-ps1\59-default.ps1
[ENTRYPOINT][INFO] Running init script: entrypoint-ps1\60-disable-infra.ps1
[ENTRYPOINT][INFO] Running init script: entrypoint-ps1\89-copy-customfiles.ps1
[ENTRYPOINT][INFO] Starting service datadogagent
[ENTRYPOINT][ERROR] Timeout while starting the service
PS C:\>
```

### Additional Notes

Here are the stacktraces that show where `agent status` hang:

```
  Goroutine 815 - User: .usr/lib/go-1.18/src/runtime/sema.go:71 sync.runtime_SemacquireMutex (0x17ff7e5) [semacquire 459516h12m51.276174455s]
         0  0x00000000017d2312 in runtime.gopark
             at .usr/lib/go-1.18/src/runtime/proc.go:362
         1  0x00000000017d23aa in runtime.goparkunlock
             at .usr/lib/go-1.18/src/runtime/proc.go:367
         2  0x00000000017e3212 in runtime.semacquire1
             at .usr/lib/go-1.18/src/runtime/sema.go:144
         3  0x00000000017ff7e5 in sync.runtime_SemacquireMutex
             at .usr/lib/go-1.18/src/runtime/sema.go:71
         4  0x0000000001815a91 in sync.(*Mutex).lockSlow
             at .usr/lib/go-1.18/src/sync/mutex.go:162
         5  0x0000000001815751 in sync.(*Mutex).Lock
             at .usr/lib/go-1.18/src/sync/mutex.go:81
         6  0x00000000034b5747 in github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet.GetKubeUtilWithRetrier
             at .home/lenaic/devel/DataDog/datadog-agent/pkg/util/kubernetes/kubelet/kubelet.go:120
         7  0x00000000034b5bb8 in github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet.GetKubeUtil
             at .home/lenaic/devel/DataDog/datadog-agent/pkg/util/kubernetes/kubelet/kubelet.go:142
         8  0x0000000003b2995f in github.com/DataDog/datadog-agent/pkg/util/kubernetes/hostinfo.GetNodeAnnotations
             at .home/lenaic/devel/DataDog/datadog-agent/pkg/util/kubernetes/hostinfo/node_annotations.go:21
         9  0x00000000049a1405 in github.com/DataDog/datadog-agent/pkg/util/cloudproviders/kubernetes.GetHostAliases
             at .home/lenaic/devel/DataDog/datadog-agent/pkg/util/cloudproviders/kubernetes/kubernetes.go:28
        10  0x00000000049a43e2 in github.com/DataDog/datadog-agent/pkg/util/cloudproviders.GetHostAliases
             at .home/lenaic/devel/DataDog/datadog-agent/pkg/util/cloudproviders/cloudproviders.go:109
        11  0x00000000049a630a in github.com/DataDog/datadog-agent/pkg/metadata/host.getMeta
             at .home/lenaic/devel/DataDog/datadog-agent/pkg/metadata/host/host.go:145
        12  0x00000000049a4f94 in github.com/DataDog/datadog-agent/pkg/metadata/host.GetPayload
             at .home/lenaic/devel/DataDog/datadog-agent/pkg/metadata/host/host.go:52
        13  0x00000000049a54de in github.com/DataDog/datadog-agent/pkg/metadata/host.GetPayloadFromCache
             at .home/lenaic/devel/DataDog/datadog-agent/pkg/metadata/host/host.go:84
        14  0x0000000004d2f506 in github.com/DataDog/datadog-agent/pkg/status.getCommonStatus
             at .home/lenaic/devel/DataDog/datadog-agent/pkg/status/status.go:313
        15  0x0000000004d2cbd8 in github.com/DataDog/datadog-agent/pkg/status.GetStatus
             at .home/lenaic/devel/DataDog/datadog-agent/pkg/status/status.go:43
        16  0x0000000004ef86d1 in github.com/DataDog/datadog-agent/cmd/agent/api/internal/agent.getStatus
             at .home/lenaic/devel/DataDog/datadog-agent/cmd/agent/api/internal/agent/agent.go:182
        17  0x0000000001f44163 in net/http.HandlerFunc.ServeHTTP
             at .usr/lib/go-1.18/src/net/http/server.go:2084
        18  0x0000000004f00462 in github.com/DataDog/datadog-agent/cmd/agent/api.validateToken.func1
             at .home/lenaic/devel/DataDog/datadog-agent/cmd/agent/api/security.go:42
        19  0x0000000001f44163 in net/http.HandlerFunc.ServeHTTP
             at .usr/lib/go-1.18/src/net/http/server.go:2084
        20  0x000000000463939d in github.com/gorilla/mux.(*Router).ServeHTTP
             at .home/lenaic/go/pkg/mod/github.com/gorilla/mux@v1.8.0/mux.go:210
        21  0x0000000001f448cf in net/http.StripPrefix.func1
             at .usr/lib/go-1.18/src/net/http/server.go:2127
        22  0x0000000001f44163 in net/http.HandlerFunc.ServeHTTP
             at .usr/lib/go-1.18/src/net/http/server.go:2084
        23  0x0000000001f47095 in net/http.(*ServeMux).ServeHTTP
             at .usr/lib/go-1.18/src/net/http/server.go:2462
        24  0x0000000004f015c2 in github.com/DataDog/datadog-agent/cmd/agent/api.timeoutHandlerFunc.func1
             at .home/lenaic/devel/DataDog/datadog-agent/cmd/agent/api/server.go:63
        25  0x0000000001f44163 in net/http.HandlerFunc.ServeHTTP
             at .usr/lib/go-1.18/src/net/http/server.go:2084
        26  0x0000000004f013a8 in github.com/DataDog/datadog-agent/cmd/agent/api.grpcHandlerFunc.func1
             at .home/lenaic/devel/DataDog/datadog-agent/cmd/agent/api/server.go:49
        27  0x0000000001f44163 in net/http.HandlerFunc.ServeHTTP
             at .usr/lib/go-1.18/src/net/http/server.go:2084
        28  0x0000000001f49614 in net/http.serverHandler.ServeHTTP
             at .usr/lib/go-1.18/src/net/http/server.go:2916
        29  0x0000000001f42fbc in net/http.(*conn).serve
             at .usr/lib/go-1.18/src/net/http/server.go:1966
        30  0x0000000001f4a485 in net/http.(*Server).Serve.func3
             at .usr/lib/go-1.18/src/net/http/server.go:3071
        31  0x0000000001803a41 in runtime.goexit
             at .usr/lib/go-1.18/src/runtime/asm_amd64.s:1571
```

```
  Goroutine 636 - User: .usr/lib/go-1.18/src/runtime/sema.go:71 sync.runtime_SemacquireMutex (0x17ff7e5) [semacquire]
         0  0x00000000017d2312 in runtime.gopark
             at .usr/lib/go-1.18/src/runtime/proc.go:362
         1  0x00000000017d23aa in runtime.goparkunlock
             at .usr/lib/go-1.18/src/runtime/proc.go:367
         2  0x00000000017e3212 in runtime.semacquire1
             at .usr/lib/go-1.18/src/runtime/sema.go:144
         3  0x00000000017ff7e5 in sync.runtime_SemacquireMutex
             at .usr/lib/go-1.18/src/runtime/sema.go:71
         4  0x0000000001815a91 in sync.(*Mutex).lockSlow
             at .usr/lib/go-1.18/src/sync/mutex.go:162
         5  0x0000000001815751 in sync.(*Mutex).Lock
             at .usr/lib/go-1.18/src/sync/mutex.go:81
         6  0x0000000003b2b455 in github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername.getClusterName
             at .home/lenaic/devel/DataDog/datadog-agent/pkg/util/kubernetes/clustername/clustername.go:69
         7  0x0000000003b2c24e in github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername.GetClusterName
             at .home/lenaic/devel/DataDog/datadog-agent/pkg/util/kubernetes/clustername/clustername.go:135
         8  0x00000000049a9aca in github.com/DataDog/datadog-agent/pkg/metadata/host.GetHostTags
             at .home/lenaic/devel/DataDog/datadog-agent/pkg/metadata/host/host_tags.go:88
         9  0x00000000049a5096 in github.com/DataDog/datadog-agent/pkg/metadata/host.GetPayload
             at .home/lenaic/devel/DataDog/datadog-agent/pkg/metadata/host/host.go:61
        10  0x00000000049a555e in github.com/DataDog/datadog-agent/pkg/metadata/host.GetPayloadFromCache
             at .home/lenaic/devel/DataDog/datadog-agent/pkg/metadata/host/host.go:84
        11  0x0000000004d2f586 in github.com/DataDog/datadog-agent/pkg/status.getCommonStatus
             at .home/lenaic/devel/DataDog/datadog-agent/pkg/status/status.go:313
        12  0x0000000004d2cc58 in github.com/DataDog/datadog-agent/pkg/status.GetStatus
             at .home/lenaic/devel/DataDog/datadog-agent/pkg/status/status.go:43
        13  0x0000000004ef8751 in github.com/DataDog/datadog-agent/cmd/agent/api/internal/agent.getStatus
             at .home/lenaic/devel/DataDog/datadog-agent/cmd/agent/api/internal/agent/agent.go:182
        14  0x0000000001f44163 in net/http.HandlerFunc.ServeHTTP
             at .usr/lib/go-1.18/src/net/http/server.go:2084
        15  0x0000000004f004e2 in github.com/DataDog/datadog-agent/cmd/agent/api.validateToken.func1
             at .home/lenaic/devel/DataDog/datadog-agent/cmd/agent/api/security.go:42
        16  0x0000000001f44163 in net/http.HandlerFunc.ServeHTTP
             at .usr/lib/go-1.18/src/net/http/server.go:2084
        17  0x000000000463939d in github.com/gorilla/mux.(*Router).ServeHTTP
             at .home/lenaic/go/pkg/mod/github.com/gorilla/mux@v1.8.0/mux.go:210
        18  0x0000000001f448cf in net/http.StripPrefix.func1
             at .usr/lib/go-1.18/src/net/http/server.go:2127
        19  0x0000000001f44163 in net/http.HandlerFunc.ServeHTTP
             at .usr/lib/go-1.18/src/net/http/server.go:2084
        20  0x0000000001f47095 in net/http.(*ServeMux).ServeHTTP
             at .usr/lib/go-1.18/src/net/http/server.go:2462
        21  0x0000000004f01642 in github.com/DataDog/datadog-agent/cmd/agent/api.timeoutHandlerFunc.func1
             at .home/lenaic/devel/DataDog/datadog-agent/cmd/agent/api/server.go:63
        22  0x0000000001f44163 in net/http.HandlerFunc.ServeHTTP
             at .usr/lib/go-1.18/src/net/http/server.go:2084
        23  0x0000000004f01428 in github.com/DataDog/datadog-agent/cmd/agent/api.grpcHandlerFunc.func1
             at .home/lenaic/devel/DataDog/datadog-agent/cmd/agent/api/server.go:49
        24  0x0000000001f44163 in net/http.HandlerFunc.ServeHTTP
             at .usr/lib/go-1.18/src/net/http/server.go:2084
        25  0x0000000001f49614 in net/http.serverHandler.ServeHTTP
             at .usr/lib/go-1.18/src/net/http/server.go:2916
        26  0x0000000001f42fbc in net/http.(*conn).serve
             at .usr/lib/go-1.18/src/net/http/server.go:1966
        27  0x0000000001f4a485 in net/http.(*Server).Serve.func3
             at .usr/lib/go-1.18/src/net/http/server.go:3071
        28  0x0000000001803a41 in runtime.goexit
             at .usr/lib/go-1.18/src/runtime/asm_amd64.s:1571
```

```
  Goroutine 671 - User: .usr/lib/go-1.18/src/net/http/transport.go:2620 net/http.(*persistConn).roundTrip (0x1f7126c) [select 459516h12m0.496886384s]
         0  0x00000000017d2312 in runtime.gopark
             at .usr/lib/go-1.18/src/runtime/proc.go:362
         1  0x00000000017e2565 in runtime.selectgo
             at .usr/lib/go-1.18/src/runtime/select.go:328
         2  0x0000000001f7126c in net/http.(*persistConn).roundTrip
             at .usr/lib/go-1.18/src/net/http/transport.go:2620
         3  0x0000000001f606ab in net/http.(*Transport).roundTrip
             at .usr/lib/go-1.18/src/net/http/transport.go:594
         4  0x0000000001f3734f in net/http.(*Transport).RoundTrip
             at .usr/lib/go-1.18/src/net/http/roundtrip.go:17
         5  0x0000000001ed64a4 in net/http.send
             at .usr/lib/go-1.18/src/net/http/client.go:252
         6  0x0000000001ed5d05 in net/http.(*Client).send
             at .usr/lib/go-1.18/src/net/http/client.go:176
         7  0x0000000001ed9c96 in net/http.(*Client).do
             at .usr/lib/go-1.18/src/net/http/client.go:725
         8  0x0000000001ed8a6f in net/http.(*Client).Do
             at .usr/lib/go-1.18/src/net/http/client.go:593
         9  0x0000000003504597 in github.com/DataDog/datadog-agent/pkg/api/util.DoGet
             at .home/lenaic/devel/DataDog/datadog-agent/pkg/api/util/doget.go:54
        10  0x0000000004d32ec5 in github.com/DataDog/datadog-agent/pkg/status.GetProcessAgentStatus
             at .home/lenaic/devel/DataDog/datadog-agent/pkg/status/status_process_agent.go:47
        11  0x0000000004d2d929 in github.com/DataDog/datadog-agent/pkg/status.GetStatus
             at .home/lenaic/devel/DataDog/datadog-agent/pkg/status/status.go:81
        12  0x0000000004ef8791 in github.com/DataDog/datadog-agent/cmd/agent/api/internal/agent.getStatus
             at .home/lenaic/devel/DataDog/datadog-agent/cmd/agent/api/internal/agent/agent.go:182
        13  0x0000000001f44163 in net/http.HandlerFunc.ServeHTTP
             at .usr/lib/go-1.18/src/net/http/server.go:2084
        14  0x0000000004f00522 in github.com/DataDog/datadog-agent/cmd/agent/api.validateToken.func1
             at .home/lenaic/devel/DataDog/datadog-agent/cmd/agent/api/security.go:42
        15  0x0000000001f44163 in net/http.HandlerFunc.ServeHTTP
             at .usr/lib/go-1.18/src/net/http/server.go:2084
        16  0x00000000046393dd in github.com/gorilla/mux.(*Router).ServeHTTP
             at .home/lenaic/go/pkg/mod/github.com/gorilla/mux@v1.8.0/mux.go:210
        17  0x0000000001f448cf in net/http.StripPrefix.func1
             at .usr/lib/go-1.18/src/net/http/server.go:2127
        18  0x0000000001f44163 in net/http.HandlerFunc.ServeHTTP
             at .usr/lib/go-1.18/src/net/http/server.go:2084
        19  0x0000000001f47095 in net/http.(*ServeMux).ServeHTTP
             at .usr/lib/go-1.18/src/net/http/server.go:2462
        20  0x0000000004f01682 in github.com/DataDog/datadog-agent/cmd/agent/api.timeoutHandlerFunc.func1
             at .home/lenaic/devel/DataDog/datadog-agent/cmd/agent/api/server.go:63
        21  0x0000000001f44163 in net/http.HandlerFunc.ServeHTTP
             at .usr/lib/go-1.18/src/net/http/server.go:2084
        22  0x0000000004f01468 in github.com/DataDog/datadog-agent/cmd/agent/api.grpcHandlerFunc.func1
             at .home/lenaic/devel/DataDog/datadog-agent/cmd/agent/api/server.go:49
        23  0x0000000001f44163 in net/http.HandlerFunc.ServeHTTP
             at .usr/lib/go-1.18/src/net/http/server.go:2084
        24  0x0000000001f49614 in net/http.serverHandler.ServeHTTP
             at .usr/lib/go-1.18/src/net/http/server.go:2916
        25  0x0000000001f42fbc in net/http.(*conn).serve
             at .usr/lib/go-1.18/src/net/http/server.go:1966
        26  0x0000000001f4a485 in net/http.(*Server).Serve.func3
             at .usr/lib/go-1.18/src/net/http/server.go:3071
        27  0x0000000001803a41 in runtime.goexit
             at .usr/lib/go-1.18/src/runtime/asm_amd64.s:1571
```

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Start the agent on Linux with
```
docker run --name dd-agent --rm --volume /var/run/docker.sock:/var/run/docker.sock:ro --volume /proc/:/host/proc/:ro --volume /sys/fs/cgroup/:/host/sys/fs/cgroup:ro --env DD_API_KEY="${DD_API_KEY:?You must set DD_API_KEY environment variable}" --env DD_LOGS_ENABLED=true --env DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true gcr.io/datadoghq/agent:7.37.0-rc.5
```

and verify that `agent status` returns promptly with

```
docker exec -ti dd-agent agent status
```

Start the agent on Windows with
```
docker run --rm --name dd-agent -e DD_API_KEY=$DD_API_KEY -v \\.\pipe\docker_engine:\\.\pipe\docker_engine public.ecr.aws/datadog/agent:7.37.0-rc.5
```

and verify that it starts properly.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
