### PR TITLE
Journald tailer support for tailing modes

### DIFF
--- a/pkg/logs/internal/launchers/journald/launcher.go
+++ b/pkg/logs/internal/launchers/journald/launcher.go
@@ -80,8 +80,6 @@ func (l *Launcher) Stop() {
 // setupTailer configures and starts a new tailer,
 // returns the tailer or an error.
 func (l *Launcher) setupTailer(source *config.LogSource) (*tailer.Tailer, error) {
-	tailer := tailer.NewTailer(source, l.pipelineProvider.NextPipelineChan())
-	cursor := l.registry.GetOffset(tailer.Identifier())
 	var journal *sdjournal.Journal
 	var err error
 
@@ -95,7 +93,10 @@ func (l *Launcher) setupTailer(source *config.LogSource) (*tailer.Tailer, error)
 		return nil, err
 	}
 
-	err = tailer.Start(cursor, journal)
+	tailer := tailer.NewTailer(source, l.pipelineProvider.NextPipelineChan(), journal)
+	cursor := l.registry.GetOffset(tailer.Identifier())
+
+	err = tailer.Start(cursor)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/logs/internal/tailers/journald/docker_test.go
+++ b/pkg/logs/internal/tailers/journald/docker_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestIsContainerEntry(t *testing.T) {
 	source := config.NewLogSource("", &config.LogsConfig{})
-	tailer := NewTailer(source, nil)
+	tailer := NewTailer(source, nil, nil)
 
 	var entry *sdjournal.JournalEntry
 
@@ -36,7 +36,7 @@ func TestIsContainerEntry(t *testing.T) {
 
 func TestGetContainerID(t *testing.T) {
 	source := config.NewLogSource("", &config.LogsConfig{})
-	tailer := NewTailer(source, nil)
+	tailer := NewTailer(source, nil, nil)
 
 	entry := &sdjournal.JournalEntry{
 		Fields: map[string]string{

--- a/pkg/logs/internal/tailers/journald/tailer.go
+++ b/pkg/logs/internal/tailers/journald/tailer.go
@@ -55,18 +55,18 @@ type Tailer struct {
 }
 
 // NewTailer returns a new tailer.
-func NewTailer(source *config.LogSource, outputChan chan *message.Message) *Tailer {
+func NewTailer(source *config.LogSource, outputChan chan *message.Message, journal Journal) *Tailer {
 	return &Tailer{
 		source:     source,
 		outputChan: outputChan,
+		journal:    journal,
 		stop:       make(chan struct{}, 1),
 		done:       make(chan struct{}, 1),
 	}
 }
 
 // Start starts tailing the journal from a given offset.
-func (t *Tailer) Start(cursor string, journal Journal) error {
-	t.journal = journal
+func (t *Tailer) Start(cursor string) error {
 	if err := t.setup(); err != nil {
 		t.source.Status.Error(err)
 		return err

--- a/pkg/logs/internal/tailers/journald/tailer.go
+++ b/pkg/logs/internal/tailers/journald/tailer.go
@@ -20,8 +20,8 @@ import (
 	"github.com/coreos/go-systemd/sdjournal"
 )
 
-// JournalShim interfacae to wrap the functions defined in sdjournal.
-type JournalShim interface {
+// Journal interfacae to wrap the functions defined in sdjournal.
+type Journal interface {
 	AddMatch(match string) error
 	AddDisjunction() error
 	SeekTail() error
@@ -45,7 +45,7 @@ const (
 type Tailer struct {
 	source       *config.LogSource
 	outputChan   chan *message.Message
-	journal      JournalShim
+	journal      Journal
 	excludeUnits struct {
 		system map[string]bool
 		user   map[string]bool
@@ -65,7 +65,7 @@ func NewTailer(source *config.LogSource, outputChan chan *message.Message) *Tail
 }
 
 // Start starts tailing the journal from a given offset.
-func (t *Tailer) Start(cursor string, journal JournalShim) error {
+func (t *Tailer) Start(cursor string, journal Journal) error {
 	t.journal = journal
 	if err := t.setup(); err != nil {
 		t.source.Status.Error(err)

--- a/pkg/logs/internal/tailers/journald/tailer_test.go
+++ b/pkg/logs/internal/tailers/journald/tailer_test.go
@@ -400,6 +400,8 @@ func TestTailingMode(t *testing.T) {
 	}{
 		{"default no cursor", &config.LogsConfig{}, "", &MockJournal{m: m, seekTail: 1}},
 		{"default has cursor", &config.LogsConfig{}, "123", &MockJournal{m: m, cursor: "123"}},
+		{"has cursor - seek head", &config.LogsConfig{TailingMode: "beginning"}, "123", &MockJournal{m: m, cursor: "123"}},
+		{"has cursor - seek tail", &config.LogsConfig{TailingMode: "end"}, "123", &MockJournal{m: m, cursor: "123"}},
 		{"has cursor - force head", &config.LogsConfig{TailingMode: "forceBeginning"}, "123", &MockJournal{m: m, seekHead: 1}},
 		{"has cursor - force tail", &config.LogsConfig{TailingMode: "forceEnd"}, "123", &MockJournal{m: m, seekTail: 1}},
 		{"no cursor - force head", &config.LogsConfig{TailingMode: "forceBeginning"}, "", &MockJournal{m: m, seekHead: 1}},

--- a/pkg/logs/internal/tailers/journald/tailer_test.go
+++ b/pkg/logs/internal/tailers/journald/tailer_test.go
@@ -23,13 +23,12 @@ import (
 )
 
 type MockJournal struct {
-	m              *sync.Mutex
-	addDisjunction int
-	seekTail       int
-	seekHead       int
-	cursor         string
-	entry          *sdjournal.JournalEntry
-	next           uint64
+	m        *sync.Mutex
+	seekTail int
+	seekHead int
+	cursor   string
+	entry    *sdjournal.JournalEntry
+	next     uint64
 }
 
 func (m *MockJournal) AddMatch(match string) error {
@@ -435,7 +434,7 @@ func TestTailerCanTailJournal(t *testing.T) {
 	resultMessage := <-tailer.outputChan
 
 	var parsedContent map[string]interface{}
-	json.Unmarshal([]byte(resultMessage.Content), &parsedContent)
+	json.Unmarshal(resultMessage.Content, &parsedContent)
 
 	assert.Equal(t, parsedContent["message"], "foobar")
 	tailer.Stop()

--- a/releasenotes/notes/journald-support-tailing-modes-da9e7d78026e14e4.yaml
+++ b/releasenotes/notes/journald-support-tailing-modes-da9e7d78026e14e4.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Adds support for tailing modes in the journald logs tailer.
+fixes:
+  - |
+    Fix journald byte count on the status page. 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR adds support for the logs config tailing modes: `beginning`, `end`, `forceBeginning`, `forceEnd`. This resolves https://github.com/DataDog/datadog-agent/issues/11072

This PR also: 
- Fixes the `BytesRead` status metric. Previously it was only counting the number of messages NOT the number of bytes. This PR corrects that to count the actual bytes tailed. 
- Fixes the stop mechanism so the tailer can be stopped when the output channel is full or closed. 
- Extends test coverage by mocking out `sdjournal` (needed to test tailing modes - also makes writing future tests easier)

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

https://github.com/DataDog/datadog-agent/issues/11072

### Describe how to test/QA your changes

Run the agent on a host with systemd

1. add a `journald.d/conf.yaml`:
```yaml
logs:
    - type: journald
      start_position: beginning
```
2. start the agent
3. generate some logs like `echo 'test message' | systemd-cat`
4. check `datadog-agent status` and see that bytes were tailed by the journald logs source
5. stop the agent

Repeat the above steps with:
- `start_position: end` (with an existing `registry.json` so it picks up where it left off) - should tail from the cursor in registry
- `start_position: beginning` (with an existing `registry.json` so it picks up where it left off) - should tail from the cursor in registry
- `start_position: end` and delete the `registry.json` first - should start from the end
- `start_position: beginning` and delete the `registry.json` first - should start from the beginning
- `start_position: forceBeginning` (with an existing `registry.json` so it picks up where it left off) - should tail from the beginning, ignoring the cursor from the registry
- `start_position: forceEnd` (with an existing `registry.json` so it picks up where it left off) - should tail from the end, ignoring the cursor from the registry

Note: the expected behavior is [defined in this test case if you want to use it for reference ](https://github.com/DataDog/datadog-agent/pull/12276/files#diff-ba3e4a8eb0a252761c44a86afa797dff7ba94833486ee436e8a0ab794b104438R401)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
