### PR TITLE
[Backport][7.37.x] Backport 12239

### DIFF
--- a/pkg/collector/python/datadog_agent.go
+++ b/pkg/collector/python/datadog_agent.go
@@ -233,6 +233,10 @@ type sqlConfig struct {
 	CollectComments bool `json:"collect_comments"`
 	// ReplaceDigits specifies whether digits in table names and identifiers should be obfuscated.
 	ReplaceDigits bool `json:"replace_digits"`
+	// KeepSQLAlias specifies whether or not to strip sql aliases while obfuscating.
+	KeepSQLAlias bool `json:"keep_sql_alias"`
+	// DollarQuotedFunc specifies whether or not to remove $func$ strings in postgres.
+	DollarQuotedFunc bool `json:"dollar_quoted_func"`
 	// ReturnJSONMetadata specifies whether the stub will return metadata as JSON.
 	ReturnJSONMetadata bool `json:"return_json_metadata"`
 }
@@ -253,11 +257,13 @@ func ObfuscateSQL(rawQuery, opts *C.char, errResult **C.char) *C.char {
 	}
 	s := C.GoString(rawQuery)
 	obfuscatedQuery, err := lazyInitObfuscator().ObfuscateSQLStringWithOptions(s, &obfuscate.SQLConfig{
-		DBMS:            sqlOpts.DBMS,
-		TableNames:      sqlOpts.TableNames,
-		CollectCommands: sqlOpts.CollectCommands,
-		CollectComments: sqlOpts.CollectComments,
-		ReplaceDigits:   sqlOpts.ReplaceDigits,
+		DBMS:             sqlOpts.DBMS,
+		TableNames:       sqlOpts.TableNames,
+		CollectCommands:  sqlOpts.CollectCommands,
+		CollectComments:  sqlOpts.CollectComments,
+		ReplaceDigits:    sqlOpts.ReplaceDigits,
+		KeepSQLAlias:     sqlOpts.KeepSQLAlias,
+		DollarQuotedFunc: sqlOpts.DollarQuotedFunc,
 	})
 	if err != nil {
 		// memory will be freed by caller

--- a/pkg/obfuscate/obfuscate.go
+++ b/pkg/obfuscate/obfuscate.go
@@ -116,14 +116,14 @@ type SQLConfig struct {
 	ReplaceDigits bool `json:"replace_digits"`
 
 	// KeepSQLAlias reports whether SQL aliases ("AS") should be truncated.
-	KeepSQLAlias bool
+	KeepSQLAlias bool `json:"keep_sql_alias"`
 
 	// DollarQuotedFunc reports whether to treat "$func$" delimited dollar-quoted strings
 	// differently and not obfuscate them as a string. To read more about dollar quoted
 	// strings see:
 	//
 	// https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-DOLLAR-QUOTING
-	DollarQuotedFunc bool
+	DollarQuotedFunc bool `json:"dollar_quoted_func"`
 
 	// Cache reports whether the obfuscator should use a LRU look-up cache for SQL obfuscations.
 	Cache bool

--- a/rtloader/test/datadog_agent/datadog_agent.go
+++ b/rtloader/test/datadog_agent/datadog_agent.go
@@ -256,6 +256,10 @@ type sqlConfig struct {
 	CollectComments bool `json:"collect_comments"`
 	// ReplaceDigits specifies whether digits in table names and identifiers should be obfuscated.
 	ReplaceDigits bool `json:"replace_digits"`
+	// KeepSQLAlias specifies whether or not to strip sql aliases while obfuscating.
+	KeepSQLAlias bool `json:"keep_sql_alias"`
+	// DollarQuotedFunc specifies whether or not to remove $func$ strings in postgres.
+	DollarQuotedFunc bool `json:"dollar_quoted_func"`
 	// ReturnJSONMetadata specifies whether the stub will return metadata as JSON.
 	ReturnJSONMetadata bool `json:"return_json_metadata"`
 }


### PR DESCRIPTION
### What does this PR do?
Backport #12239 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
