### PR TITLE
api: fix flaky TestOTLPReceiveResourceSpans/#07

### DIFF
--- a/pkg/trace/api/otlp_test.go
+++ b/pkg/trace/api/otlp_test.go
@@ -233,6 +233,11 @@ func TestOTLPReceiveResourceSpans(t *testing.T) {
 			},
 			fn: func(out *pb.TracerPayload) {
 				require.Len(out.Chunks, 2)
+				if len(out.Chunks[0].Spans) == 2 {
+					// it seems the chunks ended up in the wrong order; that's fine
+					// switch them to ensure assertions are correct
+					out.Chunks[0], out.Chunks[1] = out.Chunks[1], out.Chunks[0]
+				}
 				require.Equal(uint64(0x90a0b0c0d0e0f10), out.Chunks[0].Spans[0].TraceID)
 				require.Len(out.Chunks[1].Spans, 2)
 			},


### PR DESCRIPTION
The test would sometimes end up sending the trace chunks in the slice
backwards, breaking the assertions. This isn't a functional problem,
just a testing problem.

This change reverses the chunk entries when necessary, so that the order
is as expected by the assertions.