### PR TITLE
Replace a sync/atomic-based lock with sync.Mutex

### DIFF
--- a/cmd/systray/doflare.go
+++ b/cmd/systray/doflare.go
@@ -28,8 +28,6 @@ const (
 	IDD_DIALOG1     = 101
 	IDC_TICKET_EDIT = 1001
 	IDC_EMAIL_EDIT  = 1002
-	notInProgress   = int32(0)
-	isInProgress    = int32(1)
 )
 
 var (


### PR DESCRIPTION
### What does this PR do?

As part of the ongoing [project to remove uses of sync/atomic](https://github.com/DataDog/datadog-agent/pull/11716), this addresses such a use in the systray icon.

### Motivation

See https://github.com/DataDog/datadog-agent/pull/11716.

### Additional Notes

The atomic was being used to implement a lock, but one in which a lock contention was solved by returning early instead of waiting.  Mutex.TryLock can do that!

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Use the systray to start/stop the agent on a Windows system.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
