### PR TITLE
Add comments about secrets to flare code

### DIFF
--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -160,6 +160,16 @@ func CreateArchive(local bool, distPath, pyChecksPath string, logFilePaths []str
 }
 
 func createArchive(confSearchPaths SearchPaths, local bool, zipFilePath string, logFilePaths []string, pdata ProfileData, ipcError error) (string, error) {
+
+	/** WARNING
+	 *
+	 * When adding data to flares, carefully analyze the what is being added
+	 * and ensure that it contains no credentials or unnecessary user-specific
+	 * data.  The ./pkg/util/scrubber package can be useful for scrubbing
+	 * secrets that match pre-programmed patterns, but it is always better to
+	 * not capture data containing secrets, than to scrub that data.
+	 */
+
 	tempDir, err := createTempDir()
 	if err != nil {
 		return "", err
@@ -981,6 +991,11 @@ func walkConfigFilePaths(tempDir, hostname string, confSearchPaths SearchPaths, 
 
 // writeScrubbedFile writes the given data to the given file, after applying
 // flareScrubber to it.
+//
+// WARNING: while this function applies a scrubber, that scrubber cannot scrub
+// all secrets.  Ensure that the data being written cannot contain user secrets
+// or proprietary information. For example, do not include arbitrary
+// environment variables.
 func writeScrubbedFile(filename string, data []byte) error {
 	scrubbed, err := flareScrubber.ScrubBytes(data)
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?

This PR adds comments to remind developers to think carefully about what information is included in a flare.

This is done both at the top of the createFlare function (to which an additional clause is added when a new file is added to flares) and to the docstring for zipScrubbedFile (in hopes that IDEs will show this warning when adding a new call to the function).

### Motivation

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
