### PR TITLE
[networks] Use NAT information to generate `ByteKey`

### DIFF
--- a/pkg/network/event_common.go
+++ b/pkg/network/event_common.go
@@ -266,9 +266,14 @@ func (c ConnectionStats) IsExpired(now uint64, timeout uint64) bool {
 //     4B      2B      2B     .5B     .5B      4/16B        4/16B   = 17/41B
 //    32b     16b     16b      4b      4b     32/128b      32/128b
 // |  PID  | SPORT | DPORT | Family | Type |  SrcAddr  |  DestAddr
-func (c ConnectionStats) ByteKey(buf []byte) ([]byte, error) {
-	laddr, sport := GetNATLocalAddress(c)
-	raddr, dport := GetNATRemoteAddress(c)
+func (c ConnectionStats) ByteKey(buf []byte, useNAT bool) ([]byte, error) {
+	laddr, sport := c.Source, c.SPort
+	raddr, dport := c.Dest, c.DPort
+
+	if useNAT {
+		laddr, sport = GetNATLocalAddress(c)
+		raddr, dport = GetNATRemoteAddress(c)
+	}
 
 	n := 0
 	// Byte-packing to improve creation speed

--- a/pkg/network/event_common.go
+++ b/pkg/network/event_common.go
@@ -260,35 +260,14 @@ func (c ConnectionStats) IsExpired(now uint64, timeout uint64) bool {
 	return c.LastUpdateEpoch+timeout <= now
 }
 
-// ByteKey returns a unique key for this connection represented as a byte array
+// ByteKey returns a unique key for this connection represented as a byte slice
 // It's as following:
 //
 //     4B      2B      2B     .5B     .5B      4/16B        4/16B   = 17/41B
 //    32b     16b     16b      4b      4b     32/128b      32/128b
 // |  PID  | SPORT | DPORT | Family | Type |  SrcAddr  |  DestAddr
-func (c ConnectionStats) ByteKey(buf []byte, useNAT bool) ([]byte, error) {
-	laddr, sport := c.Source, c.SPort
-	raddr, dport := c.Dest, c.DPort
-
-	if useNAT {
-		laddr, sport = GetNATLocalAddress(c)
-		raddr, dport = GetNATRemoteAddress(c)
-	}
-
-	n := 0
-	// Byte-packing to improve creation speed
-	// PID (32 bits) + SPort (16 bits) + DPort (16 bits) = 64 bits
-	p0 := uint64(c.Pid)<<32 | uint64(sport)<<16 | uint64(dport)
-	binary.LittleEndian.PutUint64(buf[0:], p0)
-	n += 8
-
-	// Family (4 bits) + Type (4 bits) = 8 bits
-	buf[n] = uint8(c.Family)<<4 | uint8(c.Type)
-	n++
-
-	n += laddr.WriteTo(buf[n:]) // 4 or 16 bytes
-	n += raddr.WriteTo(buf[n:]) // 4 or 16 bytes
-	return buf[:n], nil
+func (c ConnectionStats) ByteKey(buf []byte) []byte {
+	return generateConnectionKey(c, buf, false)
 }
 
 // IsShortLived returns true when a connection went through its whole lifecycle
@@ -404,4 +383,28 @@ func HTTPKeyTupleFromConn(c ConnectionStats) http.KeyTuple {
 	}
 
 	return http.NewKeyTuple(raddr, laddr, rport, lport)
+}
+
+func generateConnectionKey(c ConnectionStats, buf []byte, useNAT bool) []byte {
+	laddr, sport := c.Source, c.SPort
+	raddr, dport := c.Dest, c.DPort
+	if useNAT {
+		laddr, sport = GetNATLocalAddress(c)
+		raddr, dport = GetNATRemoteAddress(c)
+	}
+
+	n := 0
+	// Byte-packing to improve creation speed
+	// PID (32 bits) + SPort (16 bits) + DPort (16 bits) = 64 bits
+	p0 := uint64(c.Pid)<<32 | uint64(sport)<<16 | uint64(dport)
+	binary.LittleEndian.PutUint64(buf[0:], p0)
+	n += 8
+
+	// Family (4 bits) + Type (4 bits) = 8 bits
+	buf[n] = uint8(c.Family)<<4 | uint8(c.Type)
+	n++
+
+	n += laddr.WriteTo(buf[n:]) // 4 or 16 bytes
+	n += raddr.WriteTo(buf[n:]) // 4 or 16 bytes
+	return buf[:n]
 }

--- a/pkg/network/event_common.go
+++ b/pkg/network/event_common.go
@@ -270,6 +270,14 @@ func (c ConnectionStats) ByteKey(buf []byte) []byte {
 	return generateConnectionKey(c, buf, false)
 }
 
+// ByteKeyNAT returns a unique key for this connection represented as a byte slice.
+// The format is similar to the one emitted by `ByteKey` with the sole difference
+// that the addresses used are translated.
+// Currently this key is used only for the aggregation of ephemeral connections.
+func (c ConnectionStats) ByteKeyNAT(buf []byte) []byte {
+	return generateConnectionKey(c, buf, true)
+}
+
 // IsShortLived returns true when a connection went through its whole lifecycle
 // between two connection checks
 func (c ConnectionStats) IsShortLived() bool {

--- a/pkg/network/event_test.go
+++ b/pkg/network/event_test.go
@@ -57,7 +57,7 @@ func TestBeautifyKey(t *testing.T) {
 			DPort:     443,
 		},
 	} {
-		bk, err := c.ByteKey(buf)
+		bk, err := c.ByteKey(buf, false)
 		require.NoError(t, err)
 		expected := fmt.Sprintf(keyFmt, c.Pid, c.Source.String(), c.SPort, c.Dest.String(), c.DPort, c.Family, c.Type)
 		assert.Equal(t, expected, BeautifyKey(string(bk)))
@@ -70,8 +70,9 @@ func TestConnStatsByteKey(t *testing.T) {
 	addrB := util.AddressFromString("127.0.0.2")
 
 	for _, test := range []struct {
-		a ConnectionStats
-		b ConnectionStats
+		a      ConnectionStats
+		b      ConnectionStats
+		useNAT bool
 	}{
 		{ // Port is different
 			a: ConnectionStats{Source: addrA, Dest: addrB, Pid: 1},
@@ -130,13 +131,14 @@ func TestConnStatsByteKey(t *testing.T) {
 					ReplDstIP: util.AddressFromString("4.4.4.4"),
 				},
 			},
+			useNAT: true,
 		},
 	} {
 		var keyA, keyB string
-		if b, err := test.a.ByteKey(buf); assert.NoError(t, err) {
+		if b, err := test.a.ByteKey(buf, test.useNAT); assert.NoError(t, err) {
 			keyA = string(b)
 		}
-		if b, err := test.b.ByteKey(buf); assert.NoError(t, err) {
+		if b, err := test.b.ByteKey(buf, test.useNAT); assert.NoError(t, err) {
 			keyB = string(b)
 		}
 		assert.NotEqual(t, keyA, keyB)
@@ -180,7 +182,7 @@ func BenchmarkByteKey(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = c.ByteKey(buf)
+		_, _ = c.ByteKey(buf, false)
 	}
 	runtime.KeepAlive(buf)
 }

--- a/pkg/network/event_test.go
+++ b/pkg/network/event_test.go
@@ -113,6 +113,24 @@ func TestConnStatsByteKey(t *testing.T) {
 			a: ConnectionStats{Pid: 1, Source: addrA, Dest: addrB, Family: 1},
 			b: ConnectionStats{Pid: 1, Source: addrA, Dest: addrB, Type: 1},
 		},
+		{ // IPTranslations are different
+			a: ConnectionStats{
+				Source: addrA,
+				Dest:   addrB,
+				IPTranslation: &IPTranslation{
+					ReplSrcIP: util.AddressFromString("1.1.1.1"),
+					ReplDstIP: util.AddressFromString("2.2.2.2"),
+				},
+			},
+			b: ConnectionStats{
+				Source: addrA,
+				Dest:   addrB,
+				IPTranslation: &IPTranslation{
+					ReplSrcIP: util.AddressFromString("3.3.3.3"),
+					ReplDstIP: util.AddressFromString("4.4.4.4"),
+				},
+			},
+		},
 	} {
 		var keyA, keyB string
 		if b, err := test.a.ByteKey(buf); assert.NoError(t, err) {

--- a/pkg/network/state.go
+++ b/pkg/network/state.go
@@ -306,7 +306,7 @@ func (ns *networkState) StoreClosedConnections(closed []ConnectionStats) {
 func (ns *networkState) storeClosedConnections(conns []ConnectionStats) {
 	for _, client := range ns.clients {
 		for _, c := range conns {
-			key := generateConnectionKey(c, ns.buf, true)
+			key := c.ByteKeyNAT(ns.buf)
 
 			i, ok := client.closedConnectionsKeys[closedKey(key)]
 			if ok {

--- a/pkg/network/state_test.go
+++ b/pkg/network/state_test.go
@@ -122,7 +122,7 @@ func TestRemoveConnections(t *testing.T) {
 	}
 
 	buf := make([]byte, ConnectionByteKeyMaxLen)
-	key, err := conn.ByteKey(buf)
+	key, err := conn.ByteKey(buf, false)
 	require.NoError(t, err)
 
 	clientID := "1"

--- a/pkg/network/state_test.go
+++ b/pkg/network/state_test.go
@@ -122,8 +122,7 @@ func TestRemoveConnections(t *testing.T) {
 	}
 
 	buf := make([]byte, ConnectionByteKeyMaxLen)
-	key, err := conn.ByteKey(buf, false)
-	require.NoError(t, err)
+	key := conn.ByteKey(buf)
 
 	clientID := "1"
 	state := newDefaultState().(*networkState)

--- a/pkg/network/state_test.go
+++ b/pkg/network/state_test.go
@@ -1323,6 +1323,109 @@ func TestDNSStatsWithMultipleClients(t *testing.T) {
 	assert.EqualValues(t, 3, rcode)
 }
 
+func TestClosedMergingWithAddressColision(t *testing.T) {
+	const client = "foo"
+
+	c1 := ConnectionStats{
+		Pid:    123,
+		Type:   TCP,
+		Family: AFINET,
+		Source: util.AddressFromString("127.0.0.1"),
+		Dest:   util.AddressFromString("127.0.0.1"),
+		SPort:  1000,
+		DPort:  8080,
+		Monotonic: StatCounters{
+			SentBytes: 100,
+		},
+		IPTranslation: &IPTranslation{
+			ReplSrcIP:   util.AddressFromString("1.1.1.1"),
+			ReplDstIP:   util.AddressFromString("2.2.2.2"),
+			ReplSrcPort: 123,
+			ReplDstPort: 456,
+		},
+	}
+	c2 := ConnectionStats{
+		Pid:    123,
+		Type:   TCP,
+		Family: AFINET,
+		Source: util.AddressFromString("127.0.0.1"),
+		Dest:   util.AddressFromString("127.0.0.1"),
+		SPort:  1000,
+		DPort:  8080,
+		Monotonic: StatCounters{
+			SentBytes: 150,
+		},
+		IPTranslation: &IPTranslation{
+			ReplSrcIP:   util.AddressFromString("3.3.3.3"),
+			ReplDstIP:   util.AddressFromString("4.4.4.4"),
+			ReplSrcPort: 123,
+			ReplDstPort: 456,
+		},
+	}
+
+	t.Run("ephemeral connections", func(t *testing.T) {
+		// tests the state aggregation of *ephemeral* connections that share the
+		// same source/destination addresses but that differ in their NAT
+		// translations. this tends to happen in high-load scenarios with a lot
+		// of connection churn.
+		// note that by *ephemeral* we mean connections whose entire lifecycle
+		// (eg. TCP_ESTABLISHED to TCP_CLOSE) happens whithin two consecutive
+		// connection checks.
+
+		state := newDefaultState()
+		state.RegisterClient(client)
+
+		state.StoreClosedConnections([]ConnectionStats{c1})
+		state.StoreClosedConnections([]ConnectionStats{c2})
+
+		// these two connections will be treated as distinct and won't be aggregated.
+		delta := state.GetDelta(client, latestEpochTime(), nil, nil, nil)
+		connections := delta.Conns
+
+		assert.Len(t, delta.Conns, 2)
+		assert.Condition(t, func() bool {
+			// assert c1 is present
+			for _, c := range connections {
+				if c.IPTranslation != nil && c.IPTranslation.ReplSrcIP == util.AddressFromString("1.1.1.1") {
+					return c.Last.SentBytes == 100
+				}
+			}
+			return false
+		})
+
+		assert.Condition(t, func() bool {
+			// assert c2 is present
+			for _, c := range connections {
+				if c.IPTranslation != nil && c.IPTranslation.ReplSrcIP == util.AddressFromString("3.3.3.3") {
+					return c.Last.SentBytes == 150
+				}
+			}
+			return false
+		})
+	})
+
+	t.Run("long-lived connection", func(t *testing.T) {
+		state := newDefaultState()
+		state.RegisterClient(client)
+
+		// despite having different NAT translations these 2 connections will be
+		// interpreted as one. we do this because over the lifecycle of a long-lived
+		// connection the conntrack entry is looked up multiple times and may change
+		// (usually from a nil to a non-nil value). this behavior stems from a
+		// *limitation* in our connection tracking code and should be revisited
+		// once we find a way to reliably get the NAT translation the *first*
+		// time a connection is seen
+		_ = state.GetDelta(client, latestEpochTime(), []ConnectionStats{c1}, nil, nil)
+		state.StoreClosedConnections([]ConnectionStats{c2})
+
+		// assert that the value returned by the second call to `GetDelta` represents c2 - c1
+		delta := state.GetDelta(client, latestEpochTime(), nil, nil, nil)
+		assert.Len(t, delta.Conns, 1)
+		assert.Equal(t, uint64(50), delta.Conns[0].Last.SentBytes)
+	})
+
+}
+
 func TestHTTPStats(t *testing.T) {
 	c := ConnectionStats{
 		Source: util.AddressFromString("1.1.1.1"),

--- a/pkg/network/tracer/testutil/conntrack.go
+++ b/pkg/network/tracer/testutil/conntrack.go
@@ -37,7 +37,7 @@ func (ctr *delayedConntracker) GetTranslationForConn(c network.ConnectionStats) 
 	ctr.mux.Lock()
 	defer ctr.mux.Unlock()
 
-	key, _ := c.ByteKey(make([]byte, 64))
+	key := c.ByteKey(make([]byte, 64))
 	delays := ctr.delayPerConn[string(key)]
 	if delays < ctr.numDelays {
 		ctr.delayPerConn[string(key)]++

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -530,12 +530,8 @@ func (t *Tracer) removeEntries(entries []network.ConnectionStats) {
 		t.conntracker.DeleteTranslation(*entry)
 
 		// Append the connection key to the keys to remove from the userspace state
-		bk, err := entry.ByteKey(t.buf)
-		if err != nil {
-			log.Warnf("failed to create connection byte_key: %s", err)
-		} else {
-			keys = append(keys, string(bk))
-		}
+		bk := entry.ByteKey(t.buf)
+		keys = append(keys, string(bk))
 	}
 
 	t.state.RemoveConnections(keys)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Use NAT information to generate `ByteKeys` which are used as unique identifiers of TCP connections for the purposes of storage and aggregation inside `network.State`.

This came up when investigating orphan HTTP stats that couldn't be joined to their TCP connection stats.

In the context of a server with high connection churn, there is a chance that 2 or more ephemeral connections sharing the same source and destination addresses (due to port-reuse) will have different NAT translations associated to each.
This PR ensures that these connections ensures that these connections won't be inadvertently merged, since they do differ in their post NAT addresses.


### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
