### PR TITLE
Re-enable SA2001 checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -66,7 +66,6 @@ linters-settings:
              "-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1021", "-ST1022", # These ones are disabled by default on staticcheck
              "-ST1013", # Use HTTP code enums instead of integers
              # Actual issues that should be fixed eventually
-             "-SA2001", # TODO: empty critical section, seems to be used for something?
              "-SA6002", # TODO: Fix sync.Pools
              "-SA4025", # TODO: Fix trace unit test
             ]

--- a/pkg/logs/internal/processor/processor.go
+++ b/pkg/logs/internal/processor/processor.go
@@ -79,6 +79,7 @@ func (p *Processor) run() {
 	for msg := range p.inputChan {
 		p.processMessage(msg)
 		p.mu.Lock() // block here if we're trying to flush synchronously
+		//nolint:staticcheck
 		p.mu.Unlock()
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Ignores a valid usage of lock/unlock in `pkg/logs` and then re-enables the SA2001 rule to run via `golangci`

### Motivation
Re-enable SA2001 lint checks 

### Additional Notes
Other known rule violation was already fixed in https://github.com/DataDog/datadog-agent/pull/11977


### Describe how to test/QA your changes
n/a

### Reviewer's Checklist
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
