### PR TITLE
[pkg/otlp] Remove usages of `config.Map.Set`

### DIFF
--- a/pkg/otlp/config.go
+++ b/pkg/otlp/config.go
@@ -45,9 +45,9 @@ func readConfigSection(cfg config.Config, section string) *colConfig.Map {
 	// `GetStringMap` it will fail to cast `interface{}` nil to
 	// `map[string]interface{}` nil; we use `Get` and cast manually.
 	rawVal := cfg.Get(section)
-	cfgMap := colConfig.NewMap()
-	if stringMap, ok := rawVal.(map[string]interface{}); ok {
-		cfgMap = colConfig.NewMapFromStringMap(stringMap)
+	stringMap := map[string]interface{}{}
+	if val, ok := rawVal.(map[string]interface{}); ok {
+		stringMap = val
 	}
 
 	// Step two works around https://github.com/spf13/viper/issues/1012
@@ -57,10 +57,10 @@ func readConfigSection(cfg config.Config, section string) *colConfig.Map {
 	for _, key := range cfg.AllKeys() {
 		if strings.HasPrefix(key, prefix) && cfg.IsSet(key) {
 			mapKey := strings.ReplaceAll(key[len(prefix):], ".", colConfig.KeyDelimiter)
-			cfgMap.Set(mapKey, cfg.Get(key))
+			stringMap[mapKey] = cfg.Get(key)
 		}
 	}
-	return cfgMap
+	return colConfig.NewMapFromStringMap(stringMap)
 }
 
 // FromAgentConfig builds a pipeline configuration from an Agent configuration.

--- a/pkg/otlp/map_provider.go
+++ b/pkg/otlp/map_provider.go
@@ -53,8 +53,9 @@ func buildTracesMap(tracePort uint) (*config.Map, error) {
 		return nil, err
 	}
 	{
-		configMap := config.NewMap()
-		configMap.Set(buildKey("exporters", "otlp", "endpoint"), fmt.Sprintf("%s:%d", "localhost", tracePort))
+		configMap := config.NewMapFromStringMap(map[string]interface{}{
+			buildKey("exporters", "otlp", "endpoint"): fmt.Sprintf("%s:%d", "localhost", tracePort),
+		})
 		err = baseMap.Merge(configMap)
 	}
 	return baseMap, err
@@ -90,8 +91,9 @@ func buildMetricsMap(cfg PipelineConfig) (*config.Map, error) {
 	}
 
 	{
-		configMap := config.NewMap()
-		configMap.Set(buildKey("exporters", "serializer", "metrics"), cfg.Metrics)
+		configMap := config.NewMapFromStringMap(map[string]interface{}{
+			buildKey("exporters", "serializer", "metrics"): cfg.Metrics,
+		})
 		err = baseMap.Merge(configMap)
 	}
 	return baseMap, err


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Remove usages of `config.Map.Set` method.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

It will be removed in a future Collector version, see open-telemetry/opentelemetry-collector#5485

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
