### PR TITLE
[winbuildscripts] reno 3.5.0 depend on >=PyYAML-5.3.1

### DIFF
--- a/tasks/winbuildscripts/sysprobe.ps1
+++ b/tasks/winbuildscripts/sysprobe.ps1
@@ -12,7 +12,7 @@ if ($Env:TARGET_ARCH -eq "x64") {
 $Env:BUILD_ROOT=(Get-Location).Path
 $Env:PATH="$Env:BUILD_ROOT\dev\lib;$Env:GOPATH\bin;$Env:Python2_ROOT_DIR;$Env:Python2_ROOT_DIR\Scripts;$Env:Python3_ROOT_DIR;$Env:Python3_ROOT_DIR\Scripts;$Env:PATH"
 
-& $Env:Python3_ROOT_DIR\python.exe -m pip install PyYAML==5.3
+& $Env:Python3_ROOT_DIR\python.exe -m pip install PyYAML==5.3.1
 
 & inv -e deps
 

--- a/tasks/winbuildscripts/unittests.ps1
+++ b/tasks/winbuildscripts/unittests.ps1
@@ -17,7 +17,7 @@ if ($Env:TARGET_ARCH -eq "x64") {
 $Env:BUILD_ROOT=(Get-Location).Path
 $Env:PATH="$Env:BUILD_ROOT\dev\lib;$Env:GOPATH\bin;$Env:Python2_ROOT_DIR;$Env:Python2_ROOT_DIR\Scripts;$Env:Python3_ROOT_DIR;$Env:Python3_ROOT_DIR\Scripts;$Env:PATH"
 
-& $Env:Python3_ROOT_DIR\python.exe -m pip install PyYAML==5.3
+& $Env:Python3_ROOT_DIR\python.exe -m pip install PyYAML==5.3.1
 
 $archflag = "x64"
 if ($Env:TARGET_ARCH -eq "x86") {


### PR DESCRIPTION
### What does this PR do?

Fixing winbuild CI as python reno 3.5.0 depend on PyYAML 5.3.1
### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
