### PR TITLE
[slack-notifier] Truncate very long job names

### DIFF
--- a/tasks/libs/pipeline_notifications.py
+++ b/tasks/libs/pipeline_notifications.py
@@ -47,7 +47,7 @@ def get_failed_jobs(project_name, pipeline_id):
     return final_failed_jobs
 
 
-def truncate_job_name(job_name, max_char_per_job=32):
+def truncate_job_name(job_name, max_char_per_job=42):
     # Job header should be before the colon, if there is no colon this won't change job_name
     truncated_job_name = job_name.split(":")[0]
     # We also want to avoid it being too long

--- a/tasks/libs/pipeline_notifications.py
+++ b/tasks/libs/pipeline_notifications.py
@@ -47,7 +47,7 @@ def get_failed_jobs(project_name, pipeline_id):
     return final_failed_jobs
 
 
-def truncate_job_name(job_name, max_char_per_job=42):
+def truncate_job_name(job_name, max_char_per_job=48):
     # Job header should be before the colon, if there is no colon this won't change job_name
     truncated_job_name = job_name.split(":")[0]
     # We also want to avoid it being too long

--- a/tasks/libs/pipeline_notifications.py
+++ b/tasks/libs/pipeline_notifications.py
@@ -29,6 +29,8 @@ def get_failed_jobs(project_name, pipeline_id):
     for job_name, jobs in failed_jobs.items():
         # We sort each list per creation date
         jobs.sort(key=lambda x: x["created_at"])
+        # We truncate the job name to increase readability
+        job_name = truncate_job_name(job_name)
         # Check the final job in the list: it contains the current status of the job
         final_status = {
             "name": job_name,
@@ -43,6 +45,14 @@ def get_failed_jobs(project_name, pipeline_id):
             final_failed_jobs.append(final_status)
 
     return final_failed_jobs
+
+
+def truncate_job_name(job_name, max_char_per_job=32):
+    # Job header should be before the colon, if there is no colon this won't change job_name
+    truncated_job_name = job_name.split(":")[0]
+    # We also want to avoid it being too long
+    truncated_job_name = truncated_job_name[:max_char_per_job]
+    return truncated_job_name
 
 
 def read_owners(owners_file):


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR truncates job names on Slack pipelines' notifications.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Some Gitlab job names (especially matrix jobs, for which all matrix variables are appended to the job name) are very long, which makes notification messages really long and unreadable.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

You can locally display the slack notification, e.g for the [pipeline 7410631 ](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/7410631) you can run:

```
CI_PIPELINE_ID=7410631 invoke -e pipeline.notify-failure --notification-type deploy --print-to-stdout
```

This should display a notification message with a small `Failed jobs` section, only keeping the headers (`dev_nightly-a6-windows`, `dev_nightly-a7-windows`...) for all jobs.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
