### PR TITLE
[CWS] fix macro loading

### DIFF
--- a/cmd/security-agent/app/runtime.go
+++ b/cmd/security-agent/app/runtime.go
@@ -535,18 +535,21 @@ func checkPoliciesInner(dir string) error {
 	// enabled all the rules
 	enabled := map[eval.EventType]bool{"*": true}
 
-	var opts rules.Opts
-	opts.
+	var evalOpts eval.Opts
+	evalOpts.
 		WithConstants(model.SECLConstants).
 		WithVariables(model.SECLVariables).
+		WithLegacyFields(model.SECLLegacyFields)
+
+	var opts rules.Opts
+	opts.
 		WithSupportedDiscarders(sprobe.SupportedDiscarders).
 		WithEventTypeEnabled(enabled).
 		WithReservedRuleIDs(sprobe.AllCustomRuleIDs()).
-		WithLegacyFields(model.SECLLegacyFields).
 		WithLogger(&seclog.PatternLogger{})
 
 	model := &model.Model{}
-	ruleSet := rules.NewRuleSet(model, model.NewEvent, &opts)
+	ruleSet := rules.NewRuleSet(model, model.NewEvent, &opts, &evalOpts, &eval.MacroStore{})
 
 	provider, err := rules.NewPoliciesDirProvider(cfg.PoliciesDir, false)
 	if err != nil {

--- a/pkg/security/module/module.go
+++ b/pkg/security/module/module.go
@@ -316,7 +316,7 @@ func (m *Module) LoadPolicies(policyProviders []rules.PolicyProvider, sendLoaded
 
 	// approver ruleset
 	model := &model.Model{}
-	approverRuleSet := rules.NewRuleSet(model, model.NewEvent, &opts, &evalOpts)
+	approverRuleSet := rules.NewRuleSet(model, model.NewEvent, &opts, &evalOpts, &eval.MacroStore{})
 
 	// switch SECLVariables to use the real Event structure and not the mock model.Event one
 	evalOpts.WithVariables(sprobe.SECLVariables)
@@ -325,7 +325,7 @@ func (m *Module) LoadPolicies(policyProviders []rules.PolicyProvider, sendLoaded
 	})
 
 	// standard ruleset
-	ruleSet := m.probe.NewRuleSet(&opts, &evalOpts)
+	ruleSet := m.probe.NewRuleSet(&opts, &evalOpts, &eval.MacroStore{})
 
 	// load policies
 	m.policyLoader.SetProviders(policyProviders)

--- a/pkg/security/probe/approvers_test.go
+++ b/pkg/security/probe/approvers_test.go
@@ -20,15 +20,18 @@ import (
 func TestApproverAncestors1(t *testing.T) {
 	enabled := map[eval.EventType]bool{"*": true}
 
+	var evalOpts eval.Opts
+	evalOpts.
+		WithConstants(model.SECLConstants).
+		WithLegacyFields(model.SECLLegacyFields)
+
 	var opts rules.Opts
 	opts.
-		WithConstants(model.SECLConstants).
 		WithEventTypeEnabled(enabled).
-		WithLegacyFields(model.SECLLegacyFields).
 		WithLogger(&seclog.PatternLogger{})
 
 	m := &model.Model{}
-	rs := rules.NewRuleSet(m, m.NewEvent, &opts)
+	rs := rules.NewRuleSet(m, m.NewEvent, &opts, &evalOpts, &eval.MacroStore{})
 	addRuleExpr(t, rs, `open.file.path == "/etc/passwd" && process.ancestors.file.name == "vipw"`, `open.file.path == "/etc/shadow" && process.ancestors.file.name == "vipw"`)
 
 	capabilities, exists := allCapabilities["open"]
@@ -49,15 +52,18 @@ func TestApproverAncestors1(t *testing.T) {
 func TestApproverAncestors2(t *testing.T) {
 	enabled := map[eval.EventType]bool{"*": true}
 
+	var evalOpts eval.Opts
+	evalOpts.
+		WithConstants(model.SECLConstants).
+		WithLegacyFields(model.SECLLegacyFields)
+
 	var opts rules.Opts
 	opts.
-		WithConstants(model.SECLConstants).
 		WithEventTypeEnabled(enabled).
-		WithLegacyFields(model.SECLLegacyFields).
 		WithLogger(&seclog.PatternLogger{})
 
 	m := &model.Model{}
-	rs := rules.NewRuleSet(m, m.NewEvent, &opts)
+	rs := rules.NewRuleSet(m, m.NewEvent, &opts, &evalOpts, &eval.MacroStore{})
 	addRuleExpr(t, rs, `(open.file.path == "/etc/shadow" || open.file.path == "/etc/gshadow") && process.ancestors.file.path not in ["/usr/bin/dpkg"]`)
 	capabilities, exists := allCapabilities["open"]
 	if !exists {

--- a/pkg/security/probe/discarders_test.go
+++ b/pkg/security/probe/discarders_test.go
@@ -41,56 +41,59 @@ func TestIsParentDiscarder(t *testing.T) {
 
 	enabled := map[eval.EventType]bool{"*": true}
 
+	var evalOpts eval.Opts
+	evalOpts.
+		WithConstants(model.SECLConstants).
+		WithLegacyFields(model.SECLLegacyFields)
+
 	var opts rules.Opts
 	opts.
-		WithConstants(model.SECLConstants).
 		WithEventTypeEnabled(enabled).
-		WithLegacyFields(model.SECLLegacyFields).
 		WithLogger(&seclog.PatternLogger{})
 
-	rs := rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
+	rs := rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
 	addRuleExpr(t, rs, `unlink.file.path =~ "/var/log/*" && unlink.file.path != "/var/log/datadog/system-probe.log"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/log/datadog/system-probe.log", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
 	addRuleExpr(t, rs, `unlink.file.path =~ "/var/log/*" && unlink.file.path != "/var/log/datadog/system-probe.log"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/lib/datadog/system-probe.sock", 1); !is {
 		t.Error("should be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
 	addRuleExpr(t, rs, `unlink.file.path == "/var/log/datadog/system-probe.log"`, `unlink.file.name == "datadog"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/log/datadog/datadog-agent.log", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
 	addRuleExpr(t, rs, `unlink.file.path =~ "/var/log/*" && unlink.file.name =~ ".*"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/lib/.runc/1234", 1); is {
 		t.Error("shouldn't be able to find a parent discarder, due to partial evaluation: true && unlink.file.name =~ '.*'")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
 	addRuleExpr(t, rs, `unlink.file.path == "/etc/conf.d/httpd.conf" || unlink.file.name == "conf.d"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/nginx.conf", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
 	addRuleExpr(t, rs, `unlink.file.path == "/etc/conf.d/httpd.conf" || unlink.file.name == "sys.d"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/sys.d/nginx.conf", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
 	addRuleExpr(t, rs, `unlink.file.name == "conf.d"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/nginx.conf", 1); is {
@@ -98,77 +101,77 @@ func TestIsParentDiscarder(t *testing.T) {
 	}
 
 	// field that doesn't exists shouldn't return any discarders
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
 	addRuleExpr(t, rs, `rename.file.path == "/etc/conf.d/abc"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileRenameEventType, "rename.file.path", "/etc/conf.d/nginx.conf", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
 	addRuleExpr(t, rs, `rename.file.path == "/etc/conf.d/abc"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileRenameEventType, "rename.file.path", "/etc/nginx/nginx.conf", 1); !is {
 		t.Error("should be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
 	addRuleExpr(t, rs, `unlink.file.path =~ "/etc/conf.d/*"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/sys.d/nginx.conf", 1); !is {
 		t.Error("should be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
 	addRuleExpr(t, rs, `unlink.file.path =~ "*/conf.*"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/abc", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
 	addRuleExpr(t, rs, `unlink.file.path =~ "/etc/conf.d/ab*"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/abc", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
 	addRuleExpr(t, rs, `unlink.file.path =~ "*/conf.d/ab*"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/abc", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
 	addRuleExpr(t, rs, `unlink.file.path =~ "*/conf.d"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/abc", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
 	addRuleExpr(t, rs, `unlink.file.path =~ "/etc/*"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/cron.d/log", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
 	addRuleExpr(t, rs, `open.file.path == "/tmp/passwd"`, `open.file.path == "/tmp/secret"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/tmp/runc", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
 	addRuleExpr(t, rs, `open.file.path =~ "/run/secrets/kubernetes.io/serviceaccount/*/token"`, `open.file.path == "/etc/secret"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/tmp/token", 1); !is {
 		t.Error("should be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
 	addRuleExpr(t, rs, `open.file.path =~ "*/token"`, `open.file.path == "/etc/secret"`)
 
 	is, err := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/tmp/token", 1)
@@ -179,28 +182,28 @@ func TestIsParentDiscarder(t *testing.T) {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
 	addRuleExpr(t, rs, `open.file.path =~ "/tmp/dir/no-approver-*"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/tmp/dir/a/test", 1); !is {
 		t.Error("should be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
 	addRuleExpr(t, rs, `open.file.path =~ "/"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/tmp", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
 	addRuleExpr(t, rs, `open.file.path =~ "*/conf.d/aaa"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/tmp/dir/bbb", 1); !is {
 		t.Error("should be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
 	addRuleExpr(t, rs, `open.file.path =~ "/etc/**"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/etc/conf.d/dir/aaa", 1); is {
@@ -213,112 +216,115 @@ func TestIsGrandParentDiscarder(t *testing.T) {
 
 	enabled := map[eval.EventType]bool{"*": true}
 
+	var evalOpts eval.Opts
+	evalOpts.
+		WithConstants(model.SECLConstants).
+		WithLegacyFields(model.SECLLegacyFields)
+
 	var opts rules.Opts
 	opts.
-		WithConstants(model.SECLConstants).
 		WithEventTypeEnabled(enabled).
-		WithLegacyFields(model.SECLLegacyFields).
 		WithLogger(&seclog.PatternLogger{})
 
-	rs := rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
+	rs := rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
 	addRuleExpr(t, rs, `unlink.file.path == "/var/lib/datadog/system-probe.cache"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/run/datadog/system-probe.pid", 2); !is {
 		t.Error("should be a grand parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
 	addRuleExpr(t, rs, `unlink.file.path =~ "/tmp/test"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/lib", 2); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
 	addRuleExpr(t, rs, `unlink.file.path == "/var/run/datadog/system-probe.pid"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/run/pids/system-probe.pid", 2); is {
 		t.Error("shouldn't be a grand parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
 	addRuleExpr(t, rs, `unlink.file.path =~ "/var/lib/datadog/system-probe.cache"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/run/datadog/system-probe.pid", 2); !is {
 		t.Error("should be a grand parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
 	addRuleExpr(t, rs, `unlink.file.path =~ "/var/run/datadog/system-probe.pid"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/run/pids/system-probe.pid", 2); is {
 		t.Error("shouldn't be a grand parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
 	addRuleExpr(t, rs, `unlink.file.path =~ "*/run/datadog/system-probe.pid"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/run/datadog/system-probe.pid", 2); is {
 		t.Error("shouldn't be a grand parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
 	addRuleExpr(t, rs, `unlink.file.path =~ "*/run/datadog/system-probe.pid"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/lib/datadog/system-probe.pid", 2); !is {
 		t.Error("should be a grand parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
 	addRuleExpr(t, rs, `unlink.file.path =~ "/var/*/datadog/system-probe.pid"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/run/datadog/system-probe.pid", 2); is {
 		t.Error("shouldn't be a grand parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
 	addRuleExpr(t, rs, `unlink.file.path =~ "/var/lib/datadog/system-probe.pid"`, `unlink.file.name =~ "run"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/run/datadog/system-probe.pid", 2); is {
 		t.Error("shouldn't be a grand parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
 	addRuleExpr(t, rs, `unlink.file.path =~ "/var/*"`, `unlink.file.name =~ "run"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/run/datadog/system-probe.pid", 2); is {
 		t.Error("shouldn't be a grand parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
 	addRuleExpr(t, rs, `open.file.path =~ "/tmp/dir/*"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/tmp/dir/a/test", 2); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
 	addRuleExpr(t, rs, `unlink.file.name == "dir"`) // + variants
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/tmp/dir/a/test", 2); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
 	addRuleExpr(t, rs, `unlink.file.path == "/tmp/dir/a"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/tmp", 2); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
 	addRuleExpr(t, rs, `unlink.file.path == "/tmp"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/tmp/dir/a", 2); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
 	addRuleExpr(t, rs, `unlink.file.path == "/tmp"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/tmp", 2); is {
@@ -331,14 +337,17 @@ func BenchmarkParentDiscarder(b *testing.B) {
 
 	enabled := map[eval.EventType]bool{"*": true}
 
+	var evalOpts eval.Opts
+	evalOpts.
+		WithConstants(model.SECLConstants).
+		WithLegacyFields(model.SECLLegacyFields)
+
 	var opts rules.Opts
 	opts.
-		WithConstants(model.SECLConstants).
 		WithEventTypeEnabled(enabled).
-		WithLegacyFields(model.SECLLegacyFields).
 		WithLogger(&seclog.PatternLogger{})
 
-	rs := rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
+	rs := rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
 	addRuleExpr(b, rs, `unlink.file.path =~ "/var/log/*" && unlink.file.path != "/var/log/datadog/system-probe.log"`)
 
 	b.ResetTimer()

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -1066,13 +1066,13 @@ func (p *Probe) GetDebugStats() map[string]interface{} {
 }
 
 // NewRuleSet returns a new rule set
-func (p *Probe) NewRuleSet(opts *rules.Opts, evalOpts *eval.Opts) *rules.RuleSet {
+func (p *Probe) NewRuleSet(opts *rules.Opts, evalOpts *eval.Opts, macroStore *eval.MacroStore) *rules.RuleSet {
 	eventCtor := func() eval.Event {
 		return NewEvent(p.resolvers, p.scrubber, p)
 	}
 	opts.WithLogger(&seclog.PatternLogger{})
 
-	return rules.NewRuleSet(&Model{probe: p}, eventCtor, opts, evalOpts)
+	return rules.NewRuleSet(&Model{probe: p}, eventCtor, opts, evalOpts, macroStore)
 }
 
 // QueuedNetworkDeviceError is used to indicate that the new network device was queued until its namespace handle is

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -1066,13 +1066,13 @@ func (p *Probe) GetDebugStats() map[string]interface{} {
 }
 
 // NewRuleSet returns a new rule set
-func (p *Probe) NewRuleSet(opts *rules.Opts) *rules.RuleSet {
+func (p *Probe) NewRuleSet(opts *rules.Opts, evalOpts *eval.Opts) *rules.RuleSet {
 	eventCtor := func() eval.Event {
 		return NewEvent(p.resolvers, p.scrubber, p)
 	}
 	opts.WithLogger(&seclog.PatternLogger{})
 
-	return rules.NewRuleSet(&Model{probe: p}, eventCtor, opts)
+	return rules.NewRuleSet(&Model{probe: p}, eventCtor, opts, evalOpts)
 }
 
 // QueuedNetworkDeviceError is used to indicate that the new network device was queued until its namespace handle is

--- a/pkg/security/secl/compiler/eval/eval.go
+++ b/pkg/security/secl/compiler/eval/eval.go
@@ -64,12 +64,12 @@ type ident struct {
 	Ident *string
 }
 
-type EvalReplacementContext struct {
+type ReplacementContext struct {
 	*Opts
 	*MacroStore
 }
 
-func identToEvaluator(obj *ident, replCtx EvalReplacementContext, state *State) (interface{}, lexer.Position, error) {
+func identToEvaluator(obj *ident, replCtx ReplacementContext, state *State) (interface{}, lexer.Position, error) {
 	if accessor, ok := replCtx.Opts.Constants[*obj.Ident]; ok {
 		return accessor, obj.Pos, nil
 	}
@@ -157,7 +157,7 @@ func identToEvaluator(obj *ident, replCtx EvalReplacementContext, state *State) 
 	return accessor, obj.Pos, nil
 }
 
-func arrayToEvaluator(array *ast.Array, replCtx EvalReplacementContext, state *State) (interface{}, lexer.Position, error) {
+func arrayToEvaluator(array *ast.Array, replCtx ReplacementContext, state *State) (interface{}, lexer.Position, error) {
 	if len(array.Numbers) != 0 {
 		var evaluator IntArrayEvaluator
 		evaluator.AppendValues(array.Numbers...)
@@ -223,7 +223,7 @@ func isVariableName(str string) (string, bool) {
 	return "", false
 }
 
-func evaluatorFromVariable(varname string, pos lexer.Position, replCtx EvalReplacementContext) (interface{}, lexer.Position, error) {
+func evaluatorFromVariable(varname string, pos lexer.Position, replCtx ReplacementContext) (interface{}, lexer.Position, error) {
 	value, exists := replCtx.Opts.Variables[varname]
 	if !exists {
 		return nil, pos, NewError(pos, "variable '%s' doesn't exist", varname)
@@ -232,7 +232,7 @@ func evaluatorFromVariable(varname string, pos lexer.Position, replCtx EvalRepla
 	return value.GetEvaluator(), pos, nil
 }
 
-func stringEvaluatorFromVariable(str string, pos lexer.Position, replCtx EvalReplacementContext) (interface{}, lexer.Position, error) {
+func stringEvaluatorFromVariable(str string, pos lexer.Position, replCtx ReplacementContext) (interface{}, lexer.Position, error) {
 	var evaluators []*StringEvaluator
 
 	doLoc := func(sub string) error {
@@ -313,7 +313,7 @@ func stringEvaluatorFromVariable(str string, pos lexer.Position, replCtx EvalRep
 }
 
 // StringEqualsWrapper makes use of operator overrides
-func StringEqualsWrapper(a *StringEvaluator, b *StringEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
+func StringEqualsWrapper(a *StringEvaluator, b *StringEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
 	var evaluator *BoolEvaluator
 	var err error
 
@@ -332,7 +332,7 @@ func StringEqualsWrapper(a *StringEvaluator, b *StringEvaluator, replCtx EvalRep
 }
 
 // StringArrayContainsWrapper makes use of operator overrides
-func StringArrayContainsWrapper(a *StringEvaluator, b *StringArrayEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
+func StringArrayContainsWrapper(a *StringEvaluator, b *StringArrayEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
 	var evaluator *BoolEvaluator
 	var err error
 
@@ -351,7 +351,7 @@ func StringArrayContainsWrapper(a *StringEvaluator, b *StringArrayEvaluator, rep
 }
 
 // StringValuesContainsWrapper makes use of operator overrides
-func StringValuesContainsWrapper(a *StringEvaluator, b *StringValuesEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
+func StringValuesContainsWrapper(a *StringEvaluator, b *StringValuesEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
 	var evaluator *BoolEvaluator
 	var err error
 
@@ -368,7 +368,7 @@ func StringValuesContainsWrapper(a *StringEvaluator, b *StringValuesEvaluator, r
 }
 
 // StringArrayMatchesWrapper makes use of operator overrides
-func StringArrayMatchesWrapper(a *StringArrayEvaluator, b *StringValuesEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
+func StringArrayMatchesWrapper(a *StringArrayEvaluator, b *StringValuesEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
 	var evaluator *BoolEvaluator
 	var err error
 
@@ -384,7 +384,7 @@ func StringArrayMatchesWrapper(a *StringArrayEvaluator, b *StringValuesEvaluator
 	return evaluator, nil
 }
 
-func nodeToEvaluator(obj interface{}, replCtx EvalReplacementContext, state *State) (interface{}, lexer.Position, error) {
+func nodeToEvaluator(obj interface{}, replCtx ReplacementContext, state *State) (interface{}, lexer.Position, error) {
 	var err error
 	var boolEvaluator *BoolEvaluator
 	var pos lexer.Position

--- a/pkg/security/secl/compiler/eval/eval.go
+++ b/pkg/security/secl/compiler/eval/eval.go
@@ -64,8 +64,13 @@ type ident struct {
 	Ident *string
 }
 
-func identToEvaluator(obj *ident, opts *Opts, state *State) (interface{}, lexer.Position, error) {
-	if accessor, ok := opts.Constants[*obj.Ident]; ok {
+type EvalReplacementContext struct {
+	*Opts
+	*MacroStore
+}
+
+func identToEvaluator(obj *ident, replCtx EvalReplacementContext, state *State) (interface{}, lexer.Position, error) {
+	if accessor, ok := replCtx.Opts.Constants[*obj.Ident]; ok {
 		return accessor, obj.Pos, nil
 	}
 
@@ -81,11 +86,11 @@ func identToEvaluator(obj *ident, opts *Opts, state *State) (interface{}, lexer.
 	}
 
 	// transform extracted field to support legacy SECL fields
-	if opts.LegacyFields != nil {
-		if newField, ok := opts.LegacyFields[field]; ok {
+	if replCtx.Opts.LegacyFields != nil {
+		if newField, ok := replCtx.Opts.LegacyFields[field]; ok {
 			field = newField
 		}
-		if newField, ok := opts.LegacyFields[field]; ok {
+		if newField, ok := replCtx.Opts.LegacyFields[field]; ok {
 			itField = newField
 		}
 	}
@@ -152,7 +157,7 @@ func identToEvaluator(obj *ident, opts *Opts, state *State) (interface{}, lexer.
 	return accessor, obj.Pos, nil
 }
 
-func arrayToEvaluator(array *ast.Array, opts *Opts, state *State) (interface{}, lexer.Position, error) {
+func arrayToEvaluator(array *ast.Array, replCtx EvalReplacementContext, state *State) (interface{}, lexer.Position, error) {
 	if len(array.Numbers) != 0 {
 		var evaluator IntArrayEvaluator
 		evaluator.AppendValues(array.Numbers...)
@@ -169,13 +174,13 @@ func arrayToEvaluator(array *ast.Array, opts *Opts, state *State) (interface{}, 
 		}
 
 		// could be an iterator
-		return identToEvaluator(&ident{Pos: array.Pos, Ident: array.Ident}, opts, state)
+		return identToEvaluator(&ident{Pos: array.Pos, Ident: array.Ident}, replCtx, state)
 	} else if array.Variable != nil {
 		varName, ok := isVariableName(*array.Variable)
 		if !ok {
 			return nil, array.Pos, NewError(array.Pos, "invalid variable name '%s'", *array.Variable)
 		}
-		return evaluatorFromVariable(varName, array.Pos, opts)
+		return evaluatorFromVariable(varName, array.Pos, replCtx)
 	} else if array.CIDR != nil {
 		var values CIDRValues
 		if err := values.AppendCIDR(*array.CIDR); err != nil {
@@ -218,8 +223,8 @@ func isVariableName(str string) (string, bool) {
 	return "", false
 }
 
-func evaluatorFromVariable(varname string, pos lexer.Position, opts *Opts) (interface{}, lexer.Position, error) {
-	value, exists := opts.Variables[varname]
+func evaluatorFromVariable(varname string, pos lexer.Position, replCtx EvalReplacementContext) (interface{}, lexer.Position, error) {
+	value, exists := replCtx.Opts.Variables[varname]
 	if !exists {
 		return nil, pos, NewError(pos, "variable '%s' doesn't exist", varname)
 	}
@@ -227,12 +232,12 @@ func evaluatorFromVariable(varname string, pos lexer.Position, opts *Opts) (inte
 	return value.GetEvaluator(), pos, nil
 }
 
-func stringEvaluatorFromVariable(str string, pos lexer.Position, opts *Opts) (interface{}, lexer.Position, error) {
+func stringEvaluatorFromVariable(str string, pos lexer.Position, replCtx EvalReplacementContext) (interface{}, lexer.Position, error) {
 	var evaluators []*StringEvaluator
 
 	doLoc := func(sub string) error {
 		if varname, ok := isVariableName(sub); ok {
-			value, exists := opts.Variables[varname]
+			value, exists := replCtx.Opts.Variables[varname]
 			if !exists {
 				return NewError(pos, "variable '%s' doesn't exist", varname)
 			}
@@ -308,16 +313,16 @@ func stringEvaluatorFromVariable(str string, pos lexer.Position, opts *Opts) (in
 }
 
 // StringEqualsWrapper makes use of operator overrides
-func StringEqualsWrapper(a *StringEvaluator, b *StringEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func StringEqualsWrapper(a *StringEvaluator, b *StringEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
 	var evaluator *BoolEvaluator
 	var err error
 
 	if a.OpOverrides != nil && a.OpOverrides.StringEquals != nil {
-		evaluator, err = a.OpOverrides.StringEquals(a, b, opts, state)
+		evaluator, err = a.OpOverrides.StringEquals(a, b, replCtx, state)
 	} else if b.OpOverrides != nil && b.OpOverrides.StringEquals != nil {
-		evaluator, err = b.OpOverrides.StringEquals(a, b, opts, state)
+		evaluator, err = b.OpOverrides.StringEquals(a, b, replCtx, state)
 	} else {
-		evaluator, err = StringEquals(a, b, opts, state)
+		evaluator, err = StringEquals(a, b, replCtx, state)
 	}
 	if err != nil {
 		return nil, err
@@ -327,16 +332,16 @@ func StringEqualsWrapper(a *StringEvaluator, b *StringEvaluator, opts *Opts, sta
 }
 
 // StringArrayContainsWrapper makes use of operator overrides
-func StringArrayContainsWrapper(a *StringEvaluator, b *StringArrayEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func StringArrayContainsWrapper(a *StringEvaluator, b *StringArrayEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
 	var evaluator *BoolEvaluator
 	var err error
 
 	if a.OpOverrides != nil && a.OpOverrides.StringArrayContains != nil {
-		evaluator, err = a.OpOverrides.StringArrayContains(a, b, opts, state)
+		evaluator, err = a.OpOverrides.StringArrayContains(a, b, replCtx, state)
 	} else if b.OpOverrides != nil && b.OpOverrides.StringArrayContains != nil {
-		evaluator, err = b.OpOverrides.StringArrayContains(a, b, opts, state)
+		evaluator, err = b.OpOverrides.StringArrayContains(a, b, replCtx, state)
 	} else {
-		evaluator, err = StringArrayContains(a, b, opts, state)
+		evaluator, err = StringArrayContains(a, b, replCtx, state)
 	}
 	if err != nil {
 		return nil, err
@@ -346,14 +351,14 @@ func StringArrayContainsWrapper(a *StringEvaluator, b *StringArrayEvaluator, opt
 }
 
 // StringValuesContainsWrapper makes use of operator overrides
-func StringValuesContainsWrapper(a *StringEvaluator, b *StringValuesEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func StringValuesContainsWrapper(a *StringEvaluator, b *StringValuesEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
 	var evaluator *BoolEvaluator
 	var err error
 
 	if a.OpOverrides != nil && a.OpOverrides.StringValuesContains != nil {
-		evaluator, err = a.OpOverrides.StringValuesContains(a, b, opts, state)
+		evaluator, err = a.OpOverrides.StringValuesContains(a, b, replCtx, state)
 	} else {
-		evaluator, err = StringValuesContains(a, b, opts, state)
+		evaluator, err = StringValuesContains(a, b, replCtx, state)
 	}
 	if err != nil {
 		return nil, err
@@ -363,14 +368,14 @@ func StringValuesContainsWrapper(a *StringEvaluator, b *StringValuesEvaluator, o
 }
 
 // StringArrayMatchesWrapper makes use of operator overrides
-func StringArrayMatchesWrapper(a *StringArrayEvaluator, b *StringValuesEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func StringArrayMatchesWrapper(a *StringArrayEvaluator, b *StringValuesEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
 	var evaluator *BoolEvaluator
 	var err error
 
 	if a.OpOverrides != nil && a.OpOverrides.StringArrayMatches != nil {
-		evaluator, err = a.OpOverrides.StringArrayMatches(a, b, opts, state)
+		evaluator, err = a.OpOverrides.StringArrayMatches(a, b, replCtx, state)
 	} else {
-		evaluator, err = StringArrayMatches(a, b, opts, state)
+		evaluator, err = StringArrayMatches(a, b, replCtx, state)
 	}
 	if err != nil {
 		return nil, err
@@ -379,7 +384,7 @@ func StringArrayMatchesWrapper(a *StringArrayEvaluator, b *StringValuesEvaluator
 	return evaluator, nil
 }
 
-func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, lexer.Position, error) {
+func nodeToEvaluator(obj interface{}, replCtx EvalReplacementContext, state *State) (interface{}, lexer.Position, error) {
 	var err error
 	var boolEvaluator *BoolEvaluator
 	var pos lexer.Position
@@ -387,9 +392,9 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 
 	switch obj := obj.(type) {
 	case *ast.BooleanExpression:
-		return nodeToEvaluator(obj.Expression, opts, state)
+		return nodeToEvaluator(obj.Expression, replCtx, state)
 	case *ast.Expression:
-		cmp, pos, err = nodeToEvaluator(obj.Comparison, opts, state)
+		cmp, pos, err = nodeToEvaluator(obj.Comparison, replCtx, state)
 		if err != nil {
 			return nil, pos, err
 		}
@@ -400,7 +405,7 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 				return nil, obj.Pos, NewTypeError(obj.Pos, reflect.Bool)
 			}
 
-			next, pos, err = nodeToEvaluator(obj.Next, opts, state)
+			next, pos, err = nodeToEvaluator(obj.Next, replCtx, state)
 			if err != nil {
 				return nil, pos, err
 			}
@@ -412,13 +417,13 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 
 			switch *obj.Op {
 			case "||", "or":
-				boolEvaluator, err = Or(cmpBool, nextBool, opts, state)
+				boolEvaluator, err = Or(cmpBool, nextBool, replCtx, state)
 				if err != nil {
 					return nil, obj.Pos, err
 				}
 				return boolEvaluator, obj.Pos, nil
 			case "&&", "and":
-				boolEvaluator, err = And(cmpBool, nextBool, opts, state)
+				boolEvaluator, err = And(cmpBool, nextBool, replCtx, state)
 				if err != nil {
 					return nil, obj.Pos, err
 				}
@@ -428,7 +433,7 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 		}
 		return cmp, obj.Pos, nil
 	case *ast.BitOperation:
-		unary, pos, err = nodeToEvaluator(obj.Unary, opts, state)
+		unary, pos, err = nodeToEvaluator(obj.Unary, replCtx, state)
 		if err != nil {
 			return nil, pos, err
 		}
@@ -439,7 +444,7 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 				return nil, obj.Pos, NewTypeError(obj.Pos, reflect.Int)
 			}
 
-			next, pos, err = nodeToEvaluator(obj.Next, opts, state)
+			next, pos, err = nodeToEvaluator(obj.Next, replCtx, state)
 			if err != nil {
 				return nil, pos, err
 			}
@@ -451,19 +456,19 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 
 			switch *obj.Op {
 			case "&":
-				intEvaluator, err := IntAnd(bitInt, nextInt, opts, state)
+				intEvaluator, err := IntAnd(bitInt, nextInt, replCtx, state)
 				if err != nil {
 					return nil, pos, err
 				}
 				return intEvaluator, obj.Pos, nil
 			case "|":
-				IntEvaluator, err := IntOr(bitInt, nextInt, opts, state)
+				IntEvaluator, err := IntOr(bitInt, nextInt, replCtx, state)
 				if err != nil {
 					return nil, pos, err
 				}
 				return IntEvaluator, obj.Pos, nil
 			case "^":
-				IntEvaluator, err := IntXor(bitInt, nextInt, opts, state)
+				IntEvaluator, err := IntXor(bitInt, nextInt, replCtx, state)
 				if err != nil {
 					return nil, pos, err
 				}
@@ -474,13 +479,13 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 		return unary, obj.Pos, nil
 
 	case *ast.Comparison:
-		unary, pos, err = nodeToEvaluator(obj.BitOperation, opts, state)
+		unary, pos, err = nodeToEvaluator(obj.BitOperation, replCtx, state)
 		if err != nil {
 			return nil, pos, err
 		}
 
 		if obj.ArrayComparison != nil {
-			next, pos, err = nodeToEvaluator(obj.ArrayComparison, opts, state)
+			next, pos, err = nodeToEvaluator(obj.ArrayComparison, replCtx, state)
 			if err != nil {
 				return nil, pos, err
 			}
@@ -489,12 +494,12 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 			case *BoolEvaluator:
 				switch nextBool := next.(type) {
 				case *BoolArrayEvaluator:
-					boolEvaluator, err = ArrayBoolContains(unary, nextBool, opts, state)
+					boolEvaluator, err = ArrayBoolContains(unary, nextBool, replCtx, state)
 					if err != nil {
 						return nil, pos, err
 					}
 					if *obj.ArrayComparison.Op == "notin" {
-						return Not(boolEvaluator, opts, state), obj.Pos, nil
+						return Not(boolEvaluator, replCtx, state), obj.Pos, nil
 					}
 					return boolEvaluator, obj.Pos, nil
 				default:
@@ -503,12 +508,12 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 			case *StringEvaluator:
 				switch nextString := next.(type) {
 				case *StringArrayEvaluator:
-					boolEvaluator, err = StringArrayContainsWrapper(unary, nextString, opts, state)
+					boolEvaluator, err = StringArrayContainsWrapper(unary, nextString, replCtx, state)
 					if err != nil {
 						return nil, pos, err
 					}
 				case *StringValuesEvaluator:
-					boolEvaluator, err = StringValuesContainsWrapper(unary, nextString, opts, state)
+					boolEvaluator, err = StringValuesContainsWrapper(unary, nextString, replCtx, state)
 					if err != nil {
 						return nil, pos, err
 					}
@@ -516,18 +521,18 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 					return nil, pos, NewArrayTypeError(pos, reflect.Array, reflect.String)
 				}
 				if *obj.ArrayComparison.Op == "notin" {
-					return Not(boolEvaluator, opts, state), obj.Pos, nil
+					return Not(boolEvaluator, replCtx, state), obj.Pos, nil
 				}
 				return boolEvaluator, obj.Pos, nil
 			case *StringValuesEvaluator:
 				switch nextStringArray := next.(type) {
 				case *StringArrayEvaluator:
-					boolEvaluator, err = StringArrayMatchesWrapper(nextStringArray, unary, opts, state)
+					boolEvaluator, err = StringArrayMatchesWrapper(nextStringArray, unary, replCtx, state)
 					if err != nil {
 						return nil, pos, err
 					}
 					if *obj.ArrayComparison.Op == "notin" {
-						return Not(boolEvaluator, opts, state), obj.Pos, nil
+						return Not(boolEvaluator, replCtx, state), obj.Pos, nil
 					}
 					return boolEvaluator, obj.Pos, nil
 				default:
@@ -536,12 +541,12 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 			case *StringArrayEvaluator:
 				switch nextStringArray := next.(type) {
 				case *StringValuesEvaluator:
-					boolEvaluator, err = StringArrayMatchesWrapper(unary, nextStringArray, opts, state)
+					boolEvaluator, err = StringArrayMatchesWrapper(unary, nextStringArray, replCtx, state)
 					if err != nil {
 						return nil, pos, err
 					}
 					if *obj.ArrayComparison.Op == "notin" {
-						return Not(boolEvaluator, opts, state), obj.Pos, nil
+						return Not(boolEvaluator, replCtx, state), obj.Pos, nil
 					}
 					return boolEvaluator, obj.Pos, nil
 				default:
@@ -550,12 +555,12 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 			case *IntEvaluator:
 				switch nextInt := next.(type) {
 				case *IntArrayEvaluator:
-					boolEvaluator, err = IntArrayEquals(unary, nextInt, opts, state)
+					boolEvaluator, err = IntArrayEquals(unary, nextInt, replCtx, state)
 					if err != nil {
 						return nil, pos, err
 					}
 					if *obj.ArrayComparison.Op == "notin" {
-						return Not(boolEvaluator, opts, state), obj.Pos, nil
+						return Not(boolEvaluator, replCtx, state), obj.Pos, nil
 					}
 					return boolEvaluator, obj.Pos, nil
 				default:
@@ -564,12 +569,12 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 			case *IntArrayEvaluator:
 				switch nextIntArray := next.(type) {
 				case *IntArrayEvaluator:
-					boolEvaluator, err = IntArrayMatches(unary, nextIntArray, opts, state)
+					boolEvaluator, err = IntArrayMatches(unary, nextIntArray, replCtx, state)
 					if err != nil {
 						return nil, pos, err
 					}
 					if *obj.ArrayComparison.Op == "notin" {
-						return Not(boolEvaluator, opts, state), obj.Pos, nil
+						return Not(boolEvaluator, replCtx, state), obj.Pos, nil
 					}
 					return boolEvaluator, obj.Pos, nil
 				default:
@@ -583,7 +588,7 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 						return nil, pos, NewTypeError(pos, reflect.TypeOf(CIDREvaluator{}).Kind())
 					}
 
-					boolEvaluator, err = CIDREquals(unary, nextIP, opts, state)
+					boolEvaluator, err = CIDREquals(unary, nextIP, replCtx, state)
 					if err != nil {
 						return nil, obj.Pos, err
 					}
@@ -591,39 +596,39 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 					case "in", "allin":
 						return boolEvaluator, obj.Pos, nil
 					case "notin":
-						return Not(boolEvaluator, opts, state), obj.Pos, nil
+						return Not(boolEvaluator, replCtx, state), obj.Pos, nil
 					}
 					return nil, pos, NewOpUnknownError(obj.Pos, *obj.ArrayComparison.Op)
 				case *CIDRValuesEvaluator:
 					switch *obj.ArrayComparison.Op {
 					case "in", "allin":
-						boolEvaluator, err = CIDRValuesContains(unary, nextCIDR, opts, state)
+						boolEvaluator, err = CIDRValuesContains(unary, nextCIDR, replCtx, state)
 						if err != nil {
 							return nil, pos, err
 						}
 						return boolEvaluator, obj.Pos, nil
 					case "notin":
-						boolEvaluator, err = CIDRValuesContains(unary, nextCIDR, opts, state)
+						boolEvaluator, err = CIDRValuesContains(unary, nextCIDR, replCtx, state)
 						if err != nil {
 							return nil, pos, err
 						}
-						return Not(boolEvaluator, opts, state), obj.Pos, nil
+						return Not(boolEvaluator, replCtx, state), obj.Pos, nil
 					}
 					return nil, pos, NewOpUnknownError(obj.Pos, *obj.ArrayComparison.Op)
 				case *CIDRArrayEvaluator:
 					switch *obj.ArrayComparison.Op {
 					case "in", "allin":
-						boolEvaluator, err = CIDRArrayContains(unary, nextCIDR, opts, state)
+						boolEvaluator, err = CIDRArrayContains(unary, nextCIDR, replCtx, state)
 						if err != nil {
 							return nil, pos, err
 						}
 						return boolEvaluator, obj.Pos, nil
 					case "notin":
-						boolEvaluator, err = CIDRArrayContains(unary, nextCIDR, opts, state)
+						boolEvaluator, err = CIDRArrayContains(unary, nextCIDR, replCtx, state)
 						if err != nil {
 							return nil, pos, err
 						}
-						return Not(boolEvaluator, opts, state), obj.Pos, nil
+						return Not(boolEvaluator, replCtx, state), obj.Pos, nil
 					}
 					return nil, pos, NewOpUnknownError(obj.Pos, *obj.ArrayComparison.Op)
 				default:
@@ -634,23 +639,23 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 				case *CIDRValuesEvaluator:
 					switch *obj.ArrayComparison.Op {
 					case "in":
-						boolEvaluator, err = CIDRArrayMatches(unary, nextCIDR, opts, state)
+						boolEvaluator, err = CIDRArrayMatches(unary, nextCIDR, replCtx, state)
 						if err != nil {
 							return nil, pos, err
 						}
 						return boolEvaluator, obj.Pos, nil
 					case "allin":
-						boolEvaluator, err = CIDRArrayMatchesAll(unary, nextCIDR, opts, state)
+						boolEvaluator, err = CIDRArrayMatchesAll(unary, nextCIDR, replCtx, state)
 						if err != nil {
 							return nil, pos, err
 						}
 						return boolEvaluator, obj.Pos, nil
 					case "notin":
-						boolEvaluator, err = CIDRArrayMatches(unary, nextCIDR, opts, state)
+						boolEvaluator, err = CIDRArrayMatches(unary, nextCIDR, replCtx, state)
 						if err != nil {
 							return nil, pos, err
 						}
-						return Not(boolEvaluator, opts, state), obj.Pos, nil
+						return Not(boolEvaluator, replCtx, state), obj.Pos, nil
 					}
 					return nil, pos, NewOpUnknownError(obj.Pos, *obj.ArrayComparison.Op)
 				default:
@@ -661,39 +666,39 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 				case *CIDREvaluator:
 					switch *obj.ArrayComparison.Op {
 					case "in", "allin":
-						boolEvaluator, err = CIDRValuesContains(nextCIDR, unary, opts, state)
+						boolEvaluator, err = CIDRValuesContains(nextCIDR, unary, replCtx, state)
 						if err != nil {
 							return nil, obj.Pos, err
 						}
 						return boolEvaluator, obj.Pos, nil
 					case "notin":
-						boolEvaluator, err = CIDRValuesContains(nextCIDR, unary, opts, state)
+						boolEvaluator, err = CIDRValuesContains(nextCIDR, unary, replCtx, state)
 						if err != nil {
 							return nil, obj.Pos, err
 						}
-						return Not(boolEvaluator, opts, state), obj.Pos, nil
+						return Not(boolEvaluator, replCtx, state), obj.Pos, nil
 					}
 					return nil, pos, NewOpUnknownError(obj.Pos, *obj.ArrayComparison.Op)
 				case *CIDRArrayEvaluator:
 					switch *obj.ArrayComparison.Op {
 					case "allin":
-						boolEvaluator, err = CIDRArrayMatchesAll(nextCIDR, unary, opts, state)
+						boolEvaluator, err = CIDRArrayMatchesAll(nextCIDR, unary, replCtx, state)
 						if err != nil {
 							return nil, obj.Pos, err
 						}
 						return boolEvaluator, obj.Pos, nil
 					case "in":
-						boolEvaluator, err = CIDRArrayMatches(nextCIDR, unary, opts, state)
+						boolEvaluator, err = CIDRArrayMatches(nextCIDR, unary, replCtx, state)
 						if err != nil {
 							return nil, pos, err
 						}
 						return boolEvaluator, obj.Pos, nil
 					case "notin":
-						boolEvaluator, err = CIDRArrayMatches(nextCIDR, unary, opts, state)
+						boolEvaluator, err = CIDRArrayMatches(nextCIDR, unary, replCtx, state)
 						if err != nil {
 							return nil, pos, err
 						}
-						return Not(boolEvaluator, opts, state), obj.Pos, nil
+						return Not(boolEvaluator, replCtx, state), obj.Pos, nil
 					}
 					return nil, pos, NewOpUnknownError(obj.Pos, *obj.ArrayComparison.Op)
 				default:
@@ -703,7 +708,7 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 				return nil, pos, NewTypeError(pos, reflect.Array)
 			}
 		} else if obj.ScalarComparison != nil {
-			next, pos, err = nodeToEvaluator(obj.ScalarComparison, opts, state)
+			next, pos, err = nodeToEvaluator(obj.ScalarComparison, replCtx, state)
 			if err != nil {
 				return nil, pos, err
 			}
@@ -717,13 +722,13 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 
 				switch *obj.ScalarComparison.Op {
 				case "!=":
-					boolEvaluator, err = BoolEquals(unary, nextBool, opts, state)
+					boolEvaluator, err = BoolEquals(unary, nextBool, replCtx, state)
 					if err != nil {
 						return nil, pos, err
 					}
-					return Not(boolEvaluator, opts, state), obj.Pos, nil
+					return Not(boolEvaluator, replCtx, state), obj.Pos, nil
 				case "==":
-					boolEvaluator, err = BoolEquals(unary, nextBool, opts, state)
+					boolEvaluator, err = BoolEquals(unary, nextBool, replCtx, state)
 					if err != nil {
 						return nil, pos, err
 					}
@@ -738,13 +743,13 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 
 				switch *obj.ScalarComparison.Op {
 				case "!=":
-					boolEvaluator, err = BoolArrayEquals(nextBool, unary, opts, state)
+					boolEvaluator, err = BoolArrayEquals(nextBool, unary, replCtx, state)
 					if err != nil {
 						return nil, pos, err
 					}
-					return Not(boolEvaluator, opts, state), obj.Pos, nil
+					return Not(boolEvaluator, replCtx, state), obj.Pos, nil
 				case "==":
-					boolEvaluator, err = BoolArrayEquals(nextBool, unary, opts, state)
+					boolEvaluator, err = BoolArrayEquals(nextBool, unary, replCtx, state)
 					if err != nil {
 						return nil, pos, err
 					}
@@ -759,11 +764,11 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 
 				switch *obj.ScalarComparison.Op {
 				case "!=":
-					boolEvaluator, err = StringEqualsWrapper(unary, nextString, opts, state)
+					boolEvaluator, err = StringEqualsWrapper(unary, nextString, replCtx, state)
 					if err != nil {
 						return nil, obj.Pos, err
 					}
-					return Not(boolEvaluator, opts, state), obj.Pos, nil
+					return Not(boolEvaluator, replCtx, state), obj.Pos, nil
 				case "!~":
 					if nextString.EvalFnc != nil {
 						return nil, obj.Pos, &ErrNonStaticPattern{Field: nextString.Field}
@@ -774,13 +779,13 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 						nextString.ValueType = PatternValueType
 					}
 
-					boolEvaluator, err = StringEqualsWrapper(unary, nextString, opts, state)
+					boolEvaluator, err = StringEqualsWrapper(unary, nextString, replCtx, state)
 					if err != nil {
 						return nil, obj.Pos, err
 					}
-					return Not(boolEvaluator, opts, state), obj.Pos, nil
+					return Not(boolEvaluator, replCtx, state), obj.Pos, nil
 				case "==":
-					boolEvaluator, err = StringEqualsWrapper(unary, nextString, opts, state)
+					boolEvaluator, err = StringEqualsWrapper(unary, nextString, replCtx, state)
 					if err != nil {
 						return nil, obj.Pos, err
 					}
@@ -795,7 +800,7 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 						nextString.ValueType = PatternValueType
 					}
 
-					boolEvaluator, err = StringEqualsWrapper(unary, nextString, opts, state)
+					boolEvaluator, err = StringEqualsWrapper(unary, nextString, replCtx, state)
 					if err != nil {
 						return nil, obj.Pos, err
 					}
@@ -812,13 +817,13 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 
 					switch *obj.ScalarComparison.Op {
 					case "!=":
-						boolEvaluator, err = CIDREquals(unary, nextIP, opts, state)
+						boolEvaluator, err = CIDREquals(unary, nextIP, replCtx, state)
 						if err != nil {
 							return nil, obj.Pos, err
 						}
-						return Not(boolEvaluator, opts, state), obj.Pos, nil
+						return Not(boolEvaluator, replCtx, state), obj.Pos, nil
 					case "==":
-						boolEvaluator, err = CIDREquals(unary, nextIP, opts, state)
+						boolEvaluator, err = CIDREquals(unary, nextIP, replCtx, state)
 						if err != nil {
 							return nil, obj.Pos, err
 						}
@@ -834,13 +839,13 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 
 				switch *obj.ScalarComparison.Op {
 				case "!=":
-					boolEvaluator, err = StringArrayContainsWrapper(nextString, unary, opts, state)
+					boolEvaluator, err = StringArrayContainsWrapper(nextString, unary, replCtx, state)
 					if err != nil {
 						return nil, obj.Pos, err
 					}
-					return Not(boolEvaluator, opts, state), obj.Pos, nil
+					return Not(boolEvaluator, replCtx, state), obj.Pos, nil
 				case "==":
-					boolEvaluator, err = StringArrayContainsWrapper(nextString, unary, opts, state)
+					boolEvaluator, err = StringArrayContainsWrapper(nextString, unary, replCtx, state)
 					if err != nil {
 						return nil, obj.Pos, err
 					}
@@ -855,11 +860,11 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 						nextString.ValueType = PatternValueType
 					}
 
-					boolEvaluator, err = StringArrayContainsWrapper(nextString, unary, opts, state)
+					boolEvaluator, err = StringArrayContainsWrapper(nextString, unary, replCtx, state)
 					if err != nil {
 						return nil, obj.Pos, err
 					}
-					return Not(boolEvaluator, opts, state), obj.Pos, nil
+					return Not(boolEvaluator, replCtx, state), obj.Pos, nil
 				case "=~":
 					if nextString.EvalFnc != nil {
 						return nil, obj.Pos, &ErrNonStaticPattern{Field: nextString.Field}
@@ -870,7 +875,7 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 						nextString.ValueType = PatternValueType
 					}
 
-					boolEvaluator, err = StringArrayContainsWrapper(nextString, unary, opts, state)
+					boolEvaluator, err = StringArrayContainsWrapper(nextString, unary, replCtx, state)
 					if err != nil {
 						return nil, obj.Pos, err
 					}
@@ -882,25 +887,25 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 					if nextInt.isDuration {
 						switch *obj.ScalarComparison.Op {
 						case "<":
-							boolEvaluator, err = DurationLesserThan(unary, nextInt, opts, state)
+							boolEvaluator, err = DurationLesserThan(unary, nextInt, replCtx, state)
 							if err != nil {
 								return nil, obj.Pos, err
 							}
 							return boolEvaluator, obj.Pos, nil
 						case "<=":
-							boolEvaluator, err = DurationLesserOrEqualThan(unary, nextInt, opts, state)
+							boolEvaluator, err = DurationLesserOrEqualThan(unary, nextInt, replCtx, state)
 							if err != nil {
 								return nil, obj.Pos, err
 							}
 							return boolEvaluator, obj.Pos, nil
 						case ">":
-							boolEvaluator, err = DurationGreaterThan(unary, nextInt, opts, state)
+							boolEvaluator, err = DurationGreaterThan(unary, nextInt, replCtx, state)
 							if err != nil {
 								return nil, obj.Pos, err
 							}
 							return boolEvaluator, obj.Pos, nil
 						case ">=":
-							boolEvaluator, err = DurationGreaterOrEqualThan(unary, nextInt, opts, state)
+							boolEvaluator, err = DurationGreaterOrEqualThan(unary, nextInt, replCtx, state)
 							if err != nil {
 								return nil, obj.Pos, err
 							}
@@ -909,38 +914,38 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 					} else {
 						switch *obj.ScalarComparison.Op {
 						case "<":
-							boolEvaluator, err = LesserThan(unary, nextInt, opts, state)
+							boolEvaluator, err = LesserThan(unary, nextInt, replCtx, state)
 							if err != nil {
 								return nil, obj.Pos, err
 							}
 							return boolEvaluator, obj.Pos, nil
 						case "<=":
-							boolEvaluator, err = LesserOrEqualThan(unary, nextInt, opts, state)
+							boolEvaluator, err = LesserOrEqualThan(unary, nextInt, replCtx, state)
 							if err != nil {
 								return nil, obj.Pos, err
 							}
 							return boolEvaluator, obj.Pos, nil
 						case ">":
-							boolEvaluator, err = GreaterThan(unary, nextInt, opts, state)
+							boolEvaluator, err = GreaterThan(unary, nextInt, replCtx, state)
 							if err != nil {
 								return nil, obj.Pos, err
 							}
 							return boolEvaluator, obj.Pos, nil
 						case ">=":
-							boolEvaluator, err = GreaterOrEqualThan(unary, nextInt, opts, state)
+							boolEvaluator, err = GreaterOrEqualThan(unary, nextInt, replCtx, state)
 							if err != nil {
 								return nil, obj.Pos, err
 							}
 							return boolEvaluator, obj.Pos, nil
 						case "!=":
-							boolEvaluator, err = IntEquals(unary, nextInt, opts, state)
+							boolEvaluator, err = IntEquals(unary, nextInt, replCtx, state)
 							if err != nil {
 								return nil, obj.Pos, err
 							}
 
-							return Not(boolEvaluator, opts, state), obj.Pos, nil
+							return Not(boolEvaluator, replCtx, state), obj.Pos, nil
 						case "==":
-							boolEvaluator, err = IntEquals(unary, nextInt, opts, state)
+							boolEvaluator, err = IntEquals(unary, nextInt, replCtx, state)
 							if err != nil {
 								return nil, obj.Pos, err
 							}
@@ -954,37 +959,37 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 
 					switch *obj.ScalarComparison.Op {
 					case "<":
-						boolEvaluator, err = IntArrayLesserThan(unary, nextIntArray, opts, state)
+						boolEvaluator, err = IntArrayLesserThan(unary, nextIntArray, replCtx, state)
 						if err != nil {
 							return nil, obj.Pos, err
 						}
 						return boolEvaluator, obj.Pos, nil
 					case "<=":
-						boolEvaluator, err = IntArrayLesserOrEqualThan(unary, nextIntArray, opts, state)
+						boolEvaluator, err = IntArrayLesserOrEqualThan(unary, nextIntArray, replCtx, state)
 						if err != nil {
 							return nil, obj.Pos, err
 						}
 						return boolEvaluator, obj.Pos, nil
 					case ">":
-						boolEvaluator, err = IntArrayGreaterThan(unary, nextIntArray, opts, state)
+						boolEvaluator, err = IntArrayGreaterThan(unary, nextIntArray, replCtx, state)
 						if err != nil {
 							return nil, obj.Pos, err
 						}
 						return boolEvaluator, obj.Pos, nil
 					case ">=":
-						boolEvaluator, err = IntArrayGreaterOrEqualThan(unary, nextIntArray, opts, state)
+						boolEvaluator, err = IntArrayGreaterOrEqualThan(unary, nextIntArray, replCtx, state)
 						if err != nil {
 							return nil, obj.Pos, err
 						}
 						return boolEvaluator, obj.Pos, nil
 					case "!=":
-						boolEvaluator, err = IntArrayEquals(unary, nextIntArray, opts, state)
+						boolEvaluator, err = IntArrayEquals(unary, nextIntArray, replCtx, state)
 						if err != nil {
 							return nil, obj.Pos, err
 						}
-						return Not(boolEvaluator, opts, state), obj.Pos, nil
+						return Not(boolEvaluator, replCtx, state), obj.Pos, nil
 					case "==":
-						boolEvaluator, err = IntArrayEquals(unary, nextIntArray, opts, state)
+						boolEvaluator, err = IntArrayEquals(unary, nextIntArray, replCtx, state)
 						if err != nil {
 							return nil, obj.Pos, err
 						}
@@ -1002,37 +1007,37 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 
 				switch *obj.ScalarComparison.Op {
 				case "<":
-					boolEvaluator, err = IntArrayGreaterThan(nextInt, unary, opts, state)
+					boolEvaluator, err = IntArrayGreaterThan(nextInt, unary, replCtx, state)
 					if err != nil {
 						return nil, obj.Pos, err
 					}
 					return boolEvaluator, obj.Pos, nil
 				case "<=":
-					boolEvaluator, err = IntArrayGreaterOrEqualThan(nextInt, unary, opts, state)
+					boolEvaluator, err = IntArrayGreaterOrEqualThan(nextInt, unary, replCtx, state)
 					if err != nil {
 						return nil, obj.Pos, err
 					}
 					return boolEvaluator, obj.Pos, nil
 				case ">":
-					boolEvaluator, err = IntArrayLesserThan(nextInt, unary, opts, state)
+					boolEvaluator, err = IntArrayLesserThan(nextInt, unary, replCtx, state)
 					if err != nil {
 						return nil, obj.Pos, err
 					}
 					return boolEvaluator, obj.Pos, nil
 				case ">=":
-					boolEvaluator, err = IntArrayLesserOrEqualThan(nextInt, unary, opts, state)
+					boolEvaluator, err = IntArrayLesserOrEqualThan(nextInt, unary, replCtx, state)
 					if err != nil {
 						return nil, obj.Pos, err
 					}
 					return boolEvaluator, obj.Pos, nil
 				case "!=":
-					boolEvaluator, err = IntArrayEquals(nextInt, unary, opts, state)
+					boolEvaluator, err = IntArrayEquals(nextInt, unary, replCtx, state)
 					if err != nil {
 						return nil, obj.Pos, err
 					}
-					return Not(boolEvaluator, opts, state), obj.Pos, nil
+					return Not(boolEvaluator, replCtx, state), obj.Pos, nil
 				case "==":
-					boolEvaluator, err = IntArrayEquals(nextInt, unary, opts, state)
+					boolEvaluator, err = IntArrayEquals(nextInt, unary, replCtx, state)
 					if err != nil {
 						return nil, obj.Pos, err
 					}
@@ -1045,14 +1050,14 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 		}
 
 	case *ast.ArrayComparison:
-		return nodeToEvaluator(obj.Array, opts, state)
+		return nodeToEvaluator(obj.Array, replCtx, state)
 
 	case *ast.ScalarComparison:
-		return nodeToEvaluator(obj.Next, opts, state)
+		return nodeToEvaluator(obj.Next, replCtx, state)
 
 	case *ast.Unary:
 		if obj.Op != nil {
-			unary, pos, err = nodeToEvaluator(obj.Unary, opts, state)
+			unary, pos, err = nodeToEvaluator(obj.Unary, replCtx, state)
 			if err != nil {
 				return nil, pos, err
 			}
@@ -1064,30 +1069,30 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 					return nil, pos, NewTypeError(pos, reflect.Bool)
 				}
 
-				return Not(unaryBool, opts, state), obj.Pos, nil
+				return Not(unaryBool, replCtx, state), obj.Pos, nil
 			case "-":
 				unaryInt, ok := unary.(*IntEvaluator)
 				if !ok {
 					return nil, pos, NewTypeError(pos, reflect.Int)
 				}
 
-				return Minus(unaryInt, opts, state), pos, nil
+				return Minus(unaryInt, replCtx, state), pos, nil
 			case "^":
 				unaryInt, ok := unary.(*IntEvaluator)
 				if !ok {
 					return nil, pos, NewTypeError(pos, reflect.Int)
 				}
 
-				return IntNot(unaryInt, opts, state), pos, nil
+				return IntNot(unaryInt, replCtx, state), pos, nil
 			}
 			return nil, pos, NewOpUnknownError(obj.Pos, *obj.Op)
 		}
 
-		return nodeToEvaluator(obj.Primary, opts, state)
+		return nodeToEvaluator(obj.Primary, replCtx, state)
 	case *ast.Primary:
 		switch {
 		case obj.Ident != nil:
-			return identToEvaluator(&ident{Pos: obj.Pos, Ident: obj.Ident}, opts, state)
+			return identToEvaluator(&ident{Pos: obj.Pos, Ident: obj.Ident}, replCtx, state)
 		case obj.Number != nil:
 			return &IntEvaluator{
 				Value: *obj.Number,
@@ -1098,7 +1103,7 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 				return nil, obj.Pos, NewError(obj.Pos, "internal variable error '%s'", varname)
 			}
 
-			return evaluatorFromVariable(varname, obj.Pos, opts)
+			return evaluatorFromVariable(varname, obj.Pos, replCtx)
 		case obj.Duration != nil:
 			return &IntEvaluator{
 				Value:      *obj.Duration,
@@ -1109,7 +1114,7 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 
 			// contains variables
 			if len(variableRegex.FindAllIndex([]byte(str), -1)) > 0 {
-				return stringEvaluatorFromVariable(str, obj.Pos, opts)
+				return stringEvaluatorFromVariable(str, obj.Pos, replCtx)
 			}
 
 			return &StringEvaluator{
@@ -1151,12 +1156,12 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 			}
 			return evaluator, obj.Pos, nil
 		case obj.SubExpression != nil:
-			return nodeToEvaluator(obj.SubExpression, opts, state)
+			return nodeToEvaluator(obj.SubExpression, replCtx, state)
 		default:
 			return nil, obj.Pos, NewError(obj.Pos, "unknown primary '%s'", reflect.TypeOf(obj))
 		}
 	case *ast.Array:
-		return arrayToEvaluator(obj, opts, state)
+		return arrayToEvaluator(obj, replCtx, state)
 	}
 
 	return nil, lexer.Position{}, NewError(lexer.Position{}, "unknown entity '%s'", reflect.TypeOf(obj))

--- a/pkg/security/secl/compiler/eval/eval_operators.go
+++ b/pkg/security/secl/compiler/eval/eval_operators.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 )
 
-func Or(a *BoolEvaluator, b *BoolEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
+func Or(a *BoolEvaluator, b *BoolEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
 
 	isDc := a.IsDeterministicFor(state.field) || b.IsDeterministicFor(state.field)
 
@@ -118,7 +118,7 @@ func Or(a *BoolEvaluator, b *BoolEvaluator, replCtx EvalReplacementContext, stat
 	}, nil
 }
 
-func And(a *BoolEvaluator, b *BoolEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
+func And(a *BoolEvaluator, b *BoolEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
 
 	isDc := a.IsDeterministicFor(state.field) || b.IsDeterministicFor(state.field)
 
@@ -230,7 +230,7 @@ func And(a *BoolEvaluator, b *BoolEvaluator, replCtx EvalReplacementContext, sta
 	}, nil
 }
 
-func IntEquals(a *IntEvaluator, b *IntEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
+func IntEquals(a *IntEvaluator, b *IntEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -301,7 +301,7 @@ func IntEquals(a *IntEvaluator, b *IntEvaluator, replCtx EvalReplacementContext,
 	}, nil
 }
 
-func IntAnd(a *IntEvaluator, b *IntEvaluator, replCtx EvalReplacementContext, state *State) (*IntEvaluator, error) {
+func IntAnd(a *IntEvaluator, b *IntEvaluator, replCtx ReplacementContext, state *State) (*IntEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -362,7 +362,7 @@ func IntAnd(a *IntEvaluator, b *IntEvaluator, replCtx EvalReplacementContext, st
 	}, nil
 }
 
-func IntOr(a *IntEvaluator, b *IntEvaluator, replCtx EvalReplacementContext, state *State) (*IntEvaluator, error) {
+func IntOr(a *IntEvaluator, b *IntEvaluator, replCtx ReplacementContext, state *State) (*IntEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -423,7 +423,7 @@ func IntOr(a *IntEvaluator, b *IntEvaluator, replCtx EvalReplacementContext, sta
 	}, nil
 }
 
-func IntXor(a *IntEvaluator, b *IntEvaluator, replCtx EvalReplacementContext, state *State) (*IntEvaluator, error) {
+func IntXor(a *IntEvaluator, b *IntEvaluator, replCtx ReplacementContext, state *State) (*IntEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -484,7 +484,7 @@ func IntXor(a *IntEvaluator, b *IntEvaluator, replCtx EvalReplacementContext, st
 	}, nil
 }
 
-func BoolEquals(a *BoolEvaluator, b *BoolEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
+func BoolEquals(a *BoolEvaluator, b *BoolEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -555,7 +555,7 @@ func BoolEquals(a *BoolEvaluator, b *BoolEvaluator, replCtx EvalReplacementConte
 	}, nil
 }
 
-func GreaterThan(a *IntEvaluator, b *IntEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
+func GreaterThan(a *IntEvaluator, b *IntEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -626,7 +626,7 @@ func GreaterThan(a *IntEvaluator, b *IntEvaluator, replCtx EvalReplacementContex
 	}, nil
 }
 
-func GreaterOrEqualThan(a *IntEvaluator, b *IntEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
+func GreaterOrEqualThan(a *IntEvaluator, b *IntEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -697,7 +697,7 @@ func GreaterOrEqualThan(a *IntEvaluator, b *IntEvaluator, replCtx EvalReplacemen
 	}, nil
 }
 
-func LesserThan(a *IntEvaluator, b *IntEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
+func LesserThan(a *IntEvaluator, b *IntEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -768,7 +768,7 @@ func LesserThan(a *IntEvaluator, b *IntEvaluator, replCtx EvalReplacementContext
 	}, nil
 }
 
-func LesserOrEqualThan(a *IntEvaluator, b *IntEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
+func LesserOrEqualThan(a *IntEvaluator, b *IntEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -839,7 +839,7 @@ func LesserOrEqualThan(a *IntEvaluator, b *IntEvaluator, replCtx EvalReplacement
 	}, nil
 }
 
-func DurationLesserThan(a *IntEvaluator, b *IntEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
+func DurationLesserThan(a *IntEvaluator, b *IntEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -910,7 +910,7 @@ func DurationLesserThan(a *IntEvaluator, b *IntEvaluator, replCtx EvalReplacemen
 	}, nil
 }
 
-func DurationLesserOrEqualThan(a *IntEvaluator, b *IntEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
+func DurationLesserOrEqualThan(a *IntEvaluator, b *IntEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -981,7 +981,7 @@ func DurationLesserOrEqualThan(a *IntEvaluator, b *IntEvaluator, replCtx EvalRep
 	}, nil
 }
 
-func DurationGreaterThan(a *IntEvaluator, b *IntEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
+func DurationGreaterThan(a *IntEvaluator, b *IntEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -1052,7 +1052,7 @@ func DurationGreaterThan(a *IntEvaluator, b *IntEvaluator, replCtx EvalReplaceme
 	}, nil
 }
 
-func DurationGreaterOrEqualThan(a *IntEvaluator, b *IntEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
+func DurationGreaterOrEqualThan(a *IntEvaluator, b *IntEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -1123,7 +1123,7 @@ func DurationGreaterOrEqualThan(a *IntEvaluator, b *IntEvaluator, replCtx EvalRe
 	}, nil
 }
 
-func IntArrayEquals(a *IntEvaluator, b *IntArrayEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
+func IntArrayEquals(a *IntEvaluator, b *IntArrayEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -1201,7 +1201,7 @@ func IntArrayEquals(a *IntEvaluator, b *IntArrayEvaluator, replCtx EvalReplaceme
 	}, nil
 }
 
-func BoolArrayEquals(a *BoolEvaluator, b *BoolArrayEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
+func BoolArrayEquals(a *BoolEvaluator, b *BoolArrayEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -1279,7 +1279,7 @@ func BoolArrayEquals(a *BoolEvaluator, b *BoolArrayEvaluator, replCtx EvalReplac
 	}, nil
 }
 
-func IntArrayGreaterThan(a *IntEvaluator, b *IntArrayEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
+func IntArrayGreaterThan(a *IntEvaluator, b *IntArrayEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -1357,7 +1357,7 @@ func IntArrayGreaterThan(a *IntEvaluator, b *IntArrayEvaluator, replCtx EvalRepl
 	}, nil
 }
 
-func IntArrayGreaterOrEqualThan(a *IntEvaluator, b *IntArrayEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
+func IntArrayGreaterOrEqualThan(a *IntEvaluator, b *IntArrayEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -1435,7 +1435,7 @@ func IntArrayGreaterOrEqualThan(a *IntEvaluator, b *IntArrayEvaluator, replCtx E
 	}, nil
 }
 
-func IntArrayLesserThan(a *IntEvaluator, b *IntArrayEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
+func IntArrayLesserThan(a *IntEvaluator, b *IntArrayEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -1513,7 +1513,7 @@ func IntArrayLesserThan(a *IntEvaluator, b *IntArrayEvaluator, replCtx EvalRepla
 	}, nil
 }
 
-func IntArrayLesserOrEqualThan(a *IntEvaluator, b *IntArrayEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
+func IntArrayLesserOrEqualThan(a *IntEvaluator, b *IntArrayEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 

--- a/pkg/security/secl/compiler/eval/eval_operators.go
+++ b/pkg/security/secl/compiler/eval/eval_operators.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 )
 
-func Or(a *BoolEvaluator, b *BoolEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func Or(a *BoolEvaluator, b *BoolEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
 
 	isDc := a.IsDeterministicFor(state.field) || b.IsDeterministicFor(state.field)
 
@@ -118,7 +118,7 @@ func Or(a *BoolEvaluator, b *BoolEvaluator, opts *Opts, state *State) (*BoolEval
 	}, nil
 }
 
-func And(a *BoolEvaluator, b *BoolEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func And(a *BoolEvaluator, b *BoolEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
 
 	isDc := a.IsDeterministicFor(state.field) || b.IsDeterministicFor(state.field)
 
@@ -230,7 +230,7 @@ func And(a *BoolEvaluator, b *BoolEvaluator, opts *Opts, state *State) (*BoolEva
 	}, nil
 }
 
-func IntEquals(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func IntEquals(a *IntEvaluator, b *IntEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -301,7 +301,7 @@ func IntEquals(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *State) (*Boo
 	}, nil
 }
 
-func IntAnd(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *State) (*IntEvaluator, error) {
+func IntAnd(a *IntEvaluator, b *IntEvaluator, replCtx EvalReplacementContext, state *State) (*IntEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -362,7 +362,7 @@ func IntAnd(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *State) (*IntEva
 	}, nil
 }
 
-func IntOr(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *State) (*IntEvaluator, error) {
+func IntOr(a *IntEvaluator, b *IntEvaluator, replCtx EvalReplacementContext, state *State) (*IntEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -423,7 +423,7 @@ func IntOr(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *State) (*IntEval
 	}, nil
 }
 
-func IntXor(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *State) (*IntEvaluator, error) {
+func IntXor(a *IntEvaluator, b *IntEvaluator, replCtx EvalReplacementContext, state *State) (*IntEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -484,7 +484,7 @@ func IntXor(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *State) (*IntEva
 	}, nil
 }
 
-func BoolEquals(a *BoolEvaluator, b *BoolEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func BoolEquals(a *BoolEvaluator, b *BoolEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -555,7 +555,7 @@ func BoolEquals(a *BoolEvaluator, b *BoolEvaluator, opts *Opts, state *State) (*
 	}, nil
 }
 
-func GreaterThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func GreaterThan(a *IntEvaluator, b *IntEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -626,7 +626,7 @@ func GreaterThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *State) (*B
 	}, nil
 }
 
-func GreaterOrEqualThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func GreaterOrEqualThan(a *IntEvaluator, b *IntEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -697,7 +697,7 @@ func GreaterOrEqualThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *Sta
 	}, nil
 }
 
-func LesserThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func LesserThan(a *IntEvaluator, b *IntEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -768,7 +768,7 @@ func LesserThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *State) (*Bo
 	}, nil
 }
 
-func LesserOrEqualThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func LesserOrEqualThan(a *IntEvaluator, b *IntEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -839,7 +839,7 @@ func LesserOrEqualThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *Stat
 	}, nil
 }
 
-func DurationLesserThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func DurationLesserThan(a *IntEvaluator, b *IntEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -910,7 +910,7 @@ func DurationLesserThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *Sta
 	}, nil
 }
 
-func DurationLesserOrEqualThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func DurationLesserOrEqualThan(a *IntEvaluator, b *IntEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -981,7 +981,7 @@ func DurationLesserOrEqualThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, sta
 	}, nil
 }
 
-func DurationGreaterThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func DurationGreaterThan(a *IntEvaluator, b *IntEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -1052,7 +1052,7 @@ func DurationGreaterThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *St
 	}, nil
 }
 
-func DurationGreaterOrEqualThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func DurationGreaterOrEqualThan(a *IntEvaluator, b *IntEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -1123,7 +1123,7 @@ func DurationGreaterOrEqualThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, st
 	}, nil
 }
 
-func IntArrayEquals(a *IntEvaluator, b *IntArrayEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func IntArrayEquals(a *IntEvaluator, b *IntArrayEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -1201,7 +1201,7 @@ func IntArrayEquals(a *IntEvaluator, b *IntArrayEvaluator, opts *Opts, state *St
 	}, nil
 }
 
-func BoolArrayEquals(a *BoolEvaluator, b *BoolArrayEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func BoolArrayEquals(a *BoolEvaluator, b *BoolArrayEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -1279,7 +1279,7 @@ func BoolArrayEquals(a *BoolEvaluator, b *BoolArrayEvaluator, opts *Opts, state 
 	}, nil
 }
 
-func IntArrayGreaterThan(a *IntEvaluator, b *IntArrayEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func IntArrayGreaterThan(a *IntEvaluator, b *IntArrayEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -1357,7 +1357,7 @@ func IntArrayGreaterThan(a *IntEvaluator, b *IntArrayEvaluator, opts *Opts, stat
 	}, nil
 }
 
-func IntArrayGreaterOrEqualThan(a *IntEvaluator, b *IntArrayEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func IntArrayGreaterOrEqualThan(a *IntEvaluator, b *IntArrayEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -1435,7 +1435,7 @@ func IntArrayGreaterOrEqualThan(a *IntEvaluator, b *IntArrayEvaluator, opts *Opt
 	}, nil
 }
 
-func IntArrayLesserThan(a *IntEvaluator, b *IntArrayEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func IntArrayLesserThan(a *IntEvaluator, b *IntArrayEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -1513,7 +1513,7 @@ func IntArrayLesserThan(a *IntEvaluator, b *IntArrayEvaluator, opts *Opts, state
 	}, nil
 }
 
-func IntArrayLesserOrEqualThan(a *IntEvaluator, b *IntArrayEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func IntArrayLesserOrEqualThan(a *IntEvaluator, b *IntArrayEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 

--- a/pkg/security/secl/compiler/eval/eval_operators.go
+++ b/pkg/security/secl/compiler/eval/eval_operators.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 )
 
-func Or(a *BoolEvaluator, b *BoolEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
+func Or(a *BoolEvaluator, b *BoolEvaluator, state *State) (*BoolEvaluator, error) {
 
 	isDc := a.IsDeterministicFor(state.field) || b.IsDeterministicFor(state.field)
 
@@ -118,7 +118,7 @@ func Or(a *BoolEvaluator, b *BoolEvaluator, replCtx ReplacementContext, state *S
 	}, nil
 }
 
-func And(a *BoolEvaluator, b *BoolEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
+func And(a *BoolEvaluator, b *BoolEvaluator, state *State) (*BoolEvaluator, error) {
 
 	isDc := a.IsDeterministicFor(state.field) || b.IsDeterministicFor(state.field)
 
@@ -230,7 +230,7 @@ func And(a *BoolEvaluator, b *BoolEvaluator, replCtx ReplacementContext, state *
 	}, nil
 }
 
-func IntEquals(a *IntEvaluator, b *IntEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
+func IntEquals(a *IntEvaluator, b *IntEvaluator, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -301,7 +301,7 @@ func IntEquals(a *IntEvaluator, b *IntEvaluator, replCtx ReplacementContext, sta
 	}, nil
 }
 
-func IntAnd(a *IntEvaluator, b *IntEvaluator, replCtx ReplacementContext, state *State) (*IntEvaluator, error) {
+func IntAnd(a *IntEvaluator, b *IntEvaluator, state *State) (*IntEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -362,7 +362,7 @@ func IntAnd(a *IntEvaluator, b *IntEvaluator, replCtx ReplacementContext, state 
 	}, nil
 }
 
-func IntOr(a *IntEvaluator, b *IntEvaluator, replCtx ReplacementContext, state *State) (*IntEvaluator, error) {
+func IntOr(a *IntEvaluator, b *IntEvaluator, state *State) (*IntEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -423,7 +423,7 @@ func IntOr(a *IntEvaluator, b *IntEvaluator, replCtx ReplacementContext, state *
 	}, nil
 }
 
-func IntXor(a *IntEvaluator, b *IntEvaluator, replCtx ReplacementContext, state *State) (*IntEvaluator, error) {
+func IntXor(a *IntEvaluator, b *IntEvaluator, state *State) (*IntEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -484,7 +484,7 @@ func IntXor(a *IntEvaluator, b *IntEvaluator, replCtx ReplacementContext, state 
 	}, nil
 }
 
-func BoolEquals(a *BoolEvaluator, b *BoolEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
+func BoolEquals(a *BoolEvaluator, b *BoolEvaluator, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -555,7 +555,7 @@ func BoolEquals(a *BoolEvaluator, b *BoolEvaluator, replCtx ReplacementContext, 
 	}, nil
 }
 
-func GreaterThan(a *IntEvaluator, b *IntEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
+func GreaterThan(a *IntEvaluator, b *IntEvaluator, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -626,7 +626,7 @@ func GreaterThan(a *IntEvaluator, b *IntEvaluator, replCtx ReplacementContext, s
 	}, nil
 }
 
-func GreaterOrEqualThan(a *IntEvaluator, b *IntEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
+func GreaterOrEqualThan(a *IntEvaluator, b *IntEvaluator, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -697,7 +697,7 @@ func GreaterOrEqualThan(a *IntEvaluator, b *IntEvaluator, replCtx ReplacementCon
 	}, nil
 }
 
-func LesserThan(a *IntEvaluator, b *IntEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
+func LesserThan(a *IntEvaluator, b *IntEvaluator, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -768,7 +768,7 @@ func LesserThan(a *IntEvaluator, b *IntEvaluator, replCtx ReplacementContext, st
 	}, nil
 }
 
-func LesserOrEqualThan(a *IntEvaluator, b *IntEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
+func LesserOrEqualThan(a *IntEvaluator, b *IntEvaluator, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -839,7 +839,7 @@ func LesserOrEqualThan(a *IntEvaluator, b *IntEvaluator, replCtx ReplacementCont
 	}, nil
 }
 
-func DurationLesserThan(a *IntEvaluator, b *IntEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
+func DurationLesserThan(a *IntEvaluator, b *IntEvaluator, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -910,7 +910,7 @@ func DurationLesserThan(a *IntEvaluator, b *IntEvaluator, replCtx ReplacementCon
 	}, nil
 }
 
-func DurationLesserOrEqualThan(a *IntEvaluator, b *IntEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
+func DurationLesserOrEqualThan(a *IntEvaluator, b *IntEvaluator, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -981,7 +981,7 @@ func DurationLesserOrEqualThan(a *IntEvaluator, b *IntEvaluator, replCtx Replace
 	}, nil
 }
 
-func DurationGreaterThan(a *IntEvaluator, b *IntEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
+func DurationGreaterThan(a *IntEvaluator, b *IntEvaluator, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -1052,7 +1052,7 @@ func DurationGreaterThan(a *IntEvaluator, b *IntEvaluator, replCtx ReplacementCo
 	}, nil
 }
 
-func DurationGreaterOrEqualThan(a *IntEvaluator, b *IntEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
+func DurationGreaterOrEqualThan(a *IntEvaluator, b *IntEvaluator, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -1123,7 +1123,7 @@ func DurationGreaterOrEqualThan(a *IntEvaluator, b *IntEvaluator, replCtx Replac
 	}, nil
 }
 
-func IntArrayEquals(a *IntEvaluator, b *IntArrayEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
+func IntArrayEquals(a *IntEvaluator, b *IntArrayEvaluator, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -1201,7 +1201,7 @@ func IntArrayEquals(a *IntEvaluator, b *IntArrayEvaluator, replCtx ReplacementCo
 	}, nil
 }
 
-func BoolArrayEquals(a *BoolEvaluator, b *BoolArrayEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
+func BoolArrayEquals(a *BoolEvaluator, b *BoolArrayEvaluator, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -1279,7 +1279,7 @@ func BoolArrayEquals(a *BoolEvaluator, b *BoolArrayEvaluator, replCtx Replacemen
 	}, nil
 }
 
-func IntArrayGreaterThan(a *IntEvaluator, b *IntArrayEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
+func IntArrayGreaterThan(a *IntEvaluator, b *IntArrayEvaluator, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -1357,7 +1357,7 @@ func IntArrayGreaterThan(a *IntEvaluator, b *IntArrayEvaluator, replCtx Replacem
 	}, nil
 }
 
-func IntArrayGreaterOrEqualThan(a *IntEvaluator, b *IntArrayEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
+func IntArrayGreaterOrEqualThan(a *IntEvaluator, b *IntArrayEvaluator, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -1435,7 +1435,7 @@ func IntArrayGreaterOrEqualThan(a *IntEvaluator, b *IntArrayEvaluator, replCtx R
 	}, nil
 }
 
-func IntArrayLesserThan(a *IntEvaluator, b *IntArrayEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
+func IntArrayLesserThan(a *IntEvaluator, b *IntArrayEvaluator, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -1513,7 +1513,7 @@ func IntArrayLesserThan(a *IntEvaluator, b *IntArrayEvaluator, replCtx Replaceme
 	}, nil
 }
 
-func IntArrayLesserOrEqualThan(a *IntEvaluator, b *IntArrayEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
+func IntArrayLesserOrEqualThan(a *IntEvaluator, b *IntArrayEvaluator, state *State) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 

--- a/pkg/security/secl/compiler/eval/eval_test.go
+++ b/pkg/security/secl/compiler/eval/eval_test.go
@@ -45,7 +45,7 @@ func parseRule(expr string, model Model, opts *Opts) (*Rule, error) {
 		return nil, fmt.Errorf("parsing error: %v", err)
 	}
 
-	replCtx := EvalReplacementContext{
+	replCtx := ReplacementContext{
 		Opts:       opts,
 		MacroStore: &MacroStore{},
 	}
@@ -71,8 +71,8 @@ func eval(t *testing.T, event *testEvent, expr string) (bool, *ast.Rule, error) 
 	return r1, rule.GetAst(), nil
 }
 
-func emptyReplCtx() EvalReplacementContext {
-	return EvalReplacementContext{
+func emptyReplCtx() ReplacementContext {
+	return ReplacementContext{
 		Opts:       &Opts{},
 		MacroStore: &MacroStore{},
 	}
@@ -583,7 +583,7 @@ func TestMacroList(t *testing.T) {
 		"list",
 		`[ "/etc/shadow", "/etc/password" ]`,
 		model,
-		EvalReplacementContext{Opts: opts, MacroStore: macroStore},
+		ReplacementContext{Opts: opts, MacroStore: macroStore},
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -612,7 +612,7 @@ func TestMacroExpression(t *testing.T) {
 		"is_passwd",
 		`open.filename in [ "/etc/shadow", "/etc/passwd" ]`,
 		model,
-		EvalReplacementContext{Opts: opts, MacroStore: macroStore},
+		ReplacementContext{Opts: opts, MacroStore: macroStore},
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -650,7 +650,7 @@ func TestMacroPartial(t *testing.T) {
 		"is_passwd",
 		`open.filename in [ "/etc/shadow", "/etc/passwd" ]`,
 		model,
-		EvalReplacementContext{Opts: opts, MacroStore: macroStore},
+		ReplacementContext{Opts: opts, MacroStore: macroStore},
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -714,7 +714,7 @@ func TestNestedMacros(t *testing.T) {
 		"sensitive_files",
 		`[ "/etc/shadow", "/etc/passwd" ]`,
 		model,
-		EvalReplacementContext{Opts: opts, MacroStore: macroStore},
+		ReplacementContext{Opts: opts, MacroStore: macroStore},
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -725,7 +725,7 @@ func TestNestedMacros(t *testing.T) {
 		"is_sensitive_opened",
 		`open.filename in sensitive_files`,
 		model,
-		EvalReplacementContext{Opts: opts, MacroStore: macroStore},
+		ReplacementContext{Opts: opts, MacroStore: macroStore},
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/security/secl/compiler/eval/macro.go
+++ b/pkg/security/secl/compiler/eval/macro.go
@@ -18,8 +18,8 @@ type MacroID = string
 
 // Macro - Macro object identified by an `ID` containing a SECL `Expression`
 type Macro struct {
-	ID   MacroID
-	Opts *Opts
+	ID    MacroID
+	Store *MacroStore
 
 	evaluator *MacroEvaluator
 	ast       *ast.Macro
@@ -33,17 +33,17 @@ type MacroEvaluator struct {
 }
 
 // NewMacro parses an expression and returns a new macro
-func NewMacro(id, expression string, model Model, opts *Opts) (*Macro, error) {
+func NewMacro(id, expression string, model Model, replCtx EvalReplacementContext) (*Macro, error) {
 	macro := &Macro{
-		ID:   id,
-		Opts: opts,
+		ID:    id,
+		Store: replCtx.MacroStore,
 	}
 
 	if err := macro.Parse(expression); err != nil {
 		return nil, fmt.Errorf("syntax error: %w", err)
 	}
 
-	if err := macro.GenEvaluator(expression, model, opts); err != nil {
+	if err := macro.GenEvaluator(expression, model, replCtx); err != nil {
 		return nil, fmt.Errorf("compilation error: %w", err)
 	}
 
@@ -51,7 +51,7 @@ func NewMacro(id, expression string, model Model, opts *Opts) (*Macro, error) {
 }
 
 // NewStringValuesMacro returns a new macro from an array of strings
-func NewStringValuesMacro(id string, values []string, opts *Opts) (*Macro, error) {
+func NewStringValuesMacro(id string, values []string, macroStore *MacroStore) (*Macro, error) {
 	var evaluator StringValuesEvaluator
 	for _, value := range values {
 		fieldValue := FieldValue{
@@ -68,7 +68,7 @@ func NewStringValuesMacro(id string, values []string, opts *Opts) (*Macro, error
 
 	return &Macro{
 		ID:        id,
-		Opts:      opts,
+		Store:     macroStore,
 		evaluator: &MacroEvaluator{Value: &evaluator},
 	}, nil
 }
@@ -93,9 +93,9 @@ func (m *Macro) Parse(expression string) error {
 	return nil
 }
 
-func macroToEvaluator(macro *ast.Macro, model Model, opts *Opts, field Field) (*MacroEvaluator, error) {
+func macroToEvaluator(macro *ast.Macro, model Model, replCtx EvalReplacementContext, field Field) (*MacroEvaluator, error) {
 	macros := make(map[MacroID]*MacroEvaluator)
-	for id, macro := range opts.Macros {
+	for id, macro := range replCtx.Macros {
 		macros[id] = macro.evaluator
 	}
 	state := NewState(model, field, macros)
@@ -105,11 +105,11 @@ func macroToEvaluator(macro *ast.Macro, model Model, opts *Opts, field Field) (*
 
 	switch {
 	case macro.Expression != nil:
-		eval, _, err = nodeToEvaluator(macro.Expression, opts, state)
+		eval, _, err = nodeToEvaluator(macro.Expression, replCtx, state)
 	case macro.Array != nil:
-		eval, _, err = nodeToEvaluator(macro.Array, opts, state)
+		eval, _, err = nodeToEvaluator(macro.Array, replCtx, state)
 	case macro.Primary != nil:
-		eval, _, err = nodeToEvaluator(macro.Primary, opts, state)
+		eval, _, err = nodeToEvaluator(macro.Primary, replCtx, state)
 	}
 
 	if err != nil {
@@ -129,10 +129,10 @@ func macroToEvaluator(macro *ast.Macro, model Model, opts *Opts, field Field) (*
 }
 
 // GenEvaluator - Compiles and generates the evalutor
-func (m *Macro) GenEvaluator(expression string, model Model, opts *Opts) error {
-	m.Opts = opts
+func (m *Macro) GenEvaluator(expression string, model Model, replCtx EvalReplacementContext) error {
+	m.Store = replCtx.MacroStore
 
-	evaluator, err := macroToEvaluator(m.ast, model, opts, "")
+	evaluator, err := macroToEvaluator(m.ast, model, replCtx, "")
 	if err != nil {
 		if err, ok := err.(*ErrAstToEval); ok {
 			return errors.Wrap(&ErrRuleParse{pos: err.Pos, expr: expression}, "macro syntax error")
@@ -148,7 +148,7 @@ func (m *Macro) GenEvaluator(expression string, model Model, opts *Opts) error {
 func (m *Macro) GetEventTypes() []EventType {
 	eventTypes := m.evaluator.EventTypes
 
-	for _, macro := range m.Opts.Macros {
+	for _, macro := range m.Store.Macros {
 		eventTypes = append(eventTypes, macro.evaluator.EventTypes...)
 	}
 
@@ -159,7 +159,7 @@ func (m *Macro) GetEventTypes() []EventType {
 func (m *Macro) GetFields() []Field {
 	fields := m.evaluator.GetFields()
 
-	for _, macro := range m.Opts.Macros {
+	for _, macro := range m.Store.Macros {
 		fields = append(fields, macro.evaluator.GetFields()...)
 	}
 

--- a/pkg/security/secl/compiler/eval/macro.go
+++ b/pkg/security/secl/compiler/eval/macro.go
@@ -33,7 +33,7 @@ type MacroEvaluator struct {
 }
 
 // NewMacro parses an expression and returns a new macro
-func NewMacro(id, expression string, model Model, replCtx EvalReplacementContext) (*Macro, error) {
+func NewMacro(id, expression string, model Model, replCtx ReplacementContext) (*Macro, error) {
 	macro := &Macro{
 		ID:    id,
 		Store: replCtx.MacroStore,
@@ -93,7 +93,7 @@ func (m *Macro) Parse(expression string) error {
 	return nil
 }
 
-func macroToEvaluator(macro *ast.Macro, model Model, replCtx EvalReplacementContext, field Field) (*MacroEvaluator, error) {
+func macroToEvaluator(macro *ast.Macro, model Model, replCtx ReplacementContext, field Field) (*MacroEvaluator, error) {
 	macros := make(map[MacroID]*MacroEvaluator)
 	for id, macro := range replCtx.Macros {
 		macros[id] = macro.evaluator
@@ -129,7 +129,7 @@ func macroToEvaluator(macro *ast.Macro, model Model, replCtx EvalReplacementCont
 }
 
 // GenEvaluator - Compiles and generates the evalutor
-func (m *Macro) GenEvaluator(expression string, model Model, replCtx EvalReplacementContext) error {
+func (m *Macro) GenEvaluator(expression string, model Model, replCtx ReplacementContext) error {
 	m.Store = replCtx.MacroStore
 
 	evaluator, err := macroToEvaluator(m.ast, model, replCtx, "")

--- a/pkg/security/secl/compiler/eval/macro.go
+++ b/pkg/security/secl/compiler/eval/macro.go
@@ -98,18 +98,18 @@ func macroToEvaluator(macro *ast.Macro, model Model, replCtx ReplacementContext,
 	for id, macro := range replCtx.Macros {
 		macros[id] = macro.evaluator
 	}
-	state := NewState(model, field, macros)
+	state := NewState(model, field, macros, replCtx)
 
 	var eval interface{}
 	var err error
 
 	switch {
 	case macro.Expression != nil:
-		eval, _, err = nodeToEvaluator(macro.Expression, replCtx, state)
+		eval, _, err = nodeToEvaluator(macro.Expression, state)
 	case macro.Array != nil:
-		eval, _, err = nodeToEvaluator(macro.Array, replCtx, state)
+		eval, _, err = nodeToEvaluator(macro.Array, state)
 	case macro.Primary != nil:
-		eval, _, err = nodeToEvaluator(macro.Primary, replCtx, state)
+		eval, _, err = nodeToEvaluator(macro.Primary, state)
 	}
 
 	if err != nil {

--- a/pkg/security/secl/compiler/eval/model_test.go
+++ b/pkg/security/secl/compiler/eval/model_test.go
@@ -400,7 +400,7 @@ func (m *testModel) GetEvaluator(field Field, regID RegisterID) (Evaluator, erro
 			},
 			Field: field,
 			OpOverrides: &OpOverrides{
-				StringValuesContains: func(a *StringEvaluator, b *StringValuesEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
+				StringValuesContains: func(a *StringEvaluator, b *StringValuesEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
 					evaluator := StringValuesEvaluator{
 						EvalFnc: func(ctx *Context) *StringValues {
 							return (*testEvent)(ctx.Object).process.orNameValues()
@@ -409,7 +409,7 @@ func (m *testModel) GetEvaluator(field Field, regID RegisterID) (Evaluator, erro
 
 					return StringValuesContains(a, &evaluator, replCtx, state)
 				},
-				StringEquals: func(a *StringEvaluator, b *StringEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
+				StringEquals: func(a *StringEvaluator, b *StringEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
 					evaluator := StringValuesEvaluator{
 						EvalFnc: func(ctx *Context) *StringValues {
 							return (*testEvent)(ctx.Object).process.orNameValues()
@@ -435,7 +435,7 @@ func (m *testModel) GetEvaluator(field Field, regID RegisterID) (Evaluator, erro
 			},
 			Field: field,
 			OpOverrides: &OpOverrides{
-				StringArrayContains: func(a *StringEvaluator, b *StringArrayEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
+				StringArrayContains: func(a *StringEvaluator, b *StringArrayEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
 					evaluator := StringValuesEvaluator{
 						EvalFnc: func(ctx *Context) *StringValues {
 							return (*testEvent)(ctx.Object).process.orArrayValues()
@@ -444,7 +444,7 @@ func (m *testModel) GetEvaluator(field Field, regID RegisterID) (Evaluator, erro
 
 					return StringArrayMatches(b, &evaluator, replCtx, state)
 				},
-				StringArrayMatches: func(a *StringArrayEvaluator, b *StringValuesEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
+				StringArrayMatches: func(a *StringArrayEvaluator, b *StringValuesEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
 					evaluator := StringValuesEvaluator{
 						EvalFnc: func(ctx *Context) *StringValues {
 							return (*testEvent)(ctx.Object).process.orArrayValues()

--- a/pkg/security/secl/compiler/eval/model_test.go
+++ b/pkg/security/secl/compiler/eval/model_test.go
@@ -400,23 +400,23 @@ func (m *testModel) GetEvaluator(field Field, regID RegisterID) (Evaluator, erro
 			},
 			Field: field,
 			OpOverrides: &OpOverrides{
-				StringValuesContains: func(a *StringEvaluator, b *StringValuesEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+				StringValuesContains: func(a *StringEvaluator, b *StringValuesEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
 					evaluator := StringValuesEvaluator{
 						EvalFnc: func(ctx *Context) *StringValues {
 							return (*testEvent)(ctx.Object).process.orNameValues()
 						},
 					}
 
-					return StringValuesContains(a, &evaluator, opts, state)
+					return StringValuesContains(a, &evaluator, replCtx, state)
 				},
-				StringEquals: func(a *StringEvaluator, b *StringEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+				StringEquals: func(a *StringEvaluator, b *StringEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
 					evaluator := StringValuesEvaluator{
 						EvalFnc: func(ctx *Context) *StringValues {
 							return (*testEvent)(ctx.Object).process.orNameValues()
 						},
 					}
 
-					return StringValuesContains(a, &evaluator, opts, state)
+					return StringValuesContains(a, &evaluator, replCtx, state)
 				},
 			},
 		}, nil
@@ -435,23 +435,23 @@ func (m *testModel) GetEvaluator(field Field, regID RegisterID) (Evaluator, erro
 			},
 			Field: field,
 			OpOverrides: &OpOverrides{
-				StringArrayContains: func(a *StringEvaluator, b *StringArrayEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+				StringArrayContains: func(a *StringEvaluator, b *StringArrayEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
 					evaluator := StringValuesEvaluator{
 						EvalFnc: func(ctx *Context) *StringValues {
 							return (*testEvent)(ctx.Object).process.orArrayValues()
 						},
 					}
 
-					return StringArrayMatches(b, &evaluator, opts, state)
+					return StringArrayMatches(b, &evaluator, replCtx, state)
 				},
-				StringArrayMatches: func(a *StringArrayEvaluator, b *StringValuesEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+				StringArrayMatches: func(a *StringArrayEvaluator, b *StringValuesEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
 					evaluator := StringValuesEvaluator{
 						EvalFnc: func(ctx *Context) *StringValues {
 							return (*testEvent)(ctx.Object).process.orArrayValues()
 						},
 					}
 
-					return StringArrayMatches(a, &evaluator, opts, state)
+					return StringArrayMatches(a, &evaluator, replCtx, state)
 				},
 			},
 		}, nil

--- a/pkg/security/secl/compiler/eval/model_test.go
+++ b/pkg/security/secl/compiler/eval/model_test.go
@@ -400,23 +400,23 @@ func (m *testModel) GetEvaluator(field Field, regID RegisterID) (Evaluator, erro
 			},
 			Field: field,
 			OpOverrides: &OpOverrides{
-				StringValuesContains: func(a *StringEvaluator, b *StringValuesEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
+				StringValuesContains: func(a *StringEvaluator, b *StringValuesEvaluator, state *State) (*BoolEvaluator, error) {
 					evaluator := StringValuesEvaluator{
 						EvalFnc: func(ctx *Context) *StringValues {
 							return (*testEvent)(ctx.Object).process.orNameValues()
 						},
 					}
 
-					return StringValuesContains(a, &evaluator, replCtx, state)
+					return StringValuesContains(a, &evaluator, state)
 				},
-				StringEquals: func(a *StringEvaluator, b *StringEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
+				StringEquals: func(a *StringEvaluator, b *StringEvaluator, state *State) (*BoolEvaluator, error) {
 					evaluator := StringValuesEvaluator{
 						EvalFnc: func(ctx *Context) *StringValues {
 							return (*testEvent)(ctx.Object).process.orNameValues()
 						},
 					}
 
-					return StringValuesContains(a, &evaluator, replCtx, state)
+					return StringValuesContains(a, &evaluator, state)
 				},
 			},
 		}, nil
@@ -435,23 +435,23 @@ func (m *testModel) GetEvaluator(field Field, regID RegisterID) (Evaluator, erro
 			},
 			Field: field,
 			OpOverrides: &OpOverrides{
-				StringArrayContains: func(a *StringEvaluator, b *StringArrayEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
+				StringArrayContains: func(a *StringEvaluator, b *StringArrayEvaluator, state *State) (*BoolEvaluator, error) {
 					evaluator := StringValuesEvaluator{
 						EvalFnc: func(ctx *Context) *StringValues {
 							return (*testEvent)(ctx.Object).process.orArrayValues()
 						},
 					}
 
-					return StringArrayMatches(b, &evaluator, replCtx, state)
+					return StringArrayMatches(b, &evaluator, state)
 				},
-				StringArrayMatches: func(a *StringArrayEvaluator, b *StringValuesEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
+				StringArrayMatches: func(a *StringArrayEvaluator, b *StringValuesEvaluator, state *State) (*BoolEvaluator, error) {
 					evaluator := StringValuesEvaluator{
 						EvalFnc: func(ctx *Context) *StringValues {
 							return (*testEvent)(ctx.Object).process.orArrayValues()
 						},
 					}
 
-					return StringArrayMatches(a, &evaluator, replCtx, state)
+					return StringArrayMatches(a, &evaluator, state)
 				},
 			},
 		}, nil

--- a/pkg/security/secl/compiler/eval/oo_dns_name.go
+++ b/pkg/security/secl/compiler/eval/oo_dns_name.go
@@ -8,7 +8,7 @@ package eval
 var (
 	// DNSNameCmp lower case values before comparing. Important : this operator override doesn't support approvers
 	DNSNameCmp = &OpOverrides{
-		StringEquals: func(a *StringEvaluator, b *StringEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
+		StringEquals: func(a *StringEvaluator, b *StringEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
 			if a.Field != "" {
 				a.StringCmpOpts.ScalarCaseInsensitive = true
 				a.StringCmpOpts.PatternCaseInsensitive = true
@@ -19,7 +19,7 @@ var (
 
 			return StringEquals(a, b, replCtx, state)
 		},
-		StringValuesContains: func(a *StringEvaluator, b *StringValuesEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
+		StringValuesContains: func(a *StringEvaluator, b *StringValuesEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
 			if a.Field != "" {
 				a.StringCmpOpts.ScalarCaseInsensitive = true
 				a.StringCmpOpts.PatternCaseInsensitive = true
@@ -27,7 +27,7 @@ var (
 
 			return StringValuesContains(a, b, replCtx, state)
 		},
-		StringArrayContains: func(a *StringEvaluator, b *StringArrayEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
+		StringArrayContains: func(a *StringEvaluator, b *StringArrayEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
 			if a.Field != "" {
 				a.StringCmpOpts.ScalarCaseInsensitive = true
 				a.StringCmpOpts.PatternCaseInsensitive = true
@@ -38,7 +38,7 @@ var (
 
 			return StringArrayContains(a, b, replCtx, state)
 		},
-		StringArrayMatches: func(a *StringArrayEvaluator, b *StringValuesEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
+		StringArrayMatches: func(a *StringArrayEvaluator, b *StringValuesEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
 			if a.Field != "" {
 				a.StringCmpOpts.ScalarCaseInsensitive = true
 				a.StringCmpOpts.PatternCaseInsensitive = true

--- a/pkg/security/secl/compiler/eval/oo_dns_name.go
+++ b/pkg/security/secl/compiler/eval/oo_dns_name.go
@@ -8,7 +8,7 @@ package eval
 var (
 	// DNSNameCmp lower case values before comparing. Important : this operator override doesn't support approvers
 	DNSNameCmp = &OpOverrides{
-		StringEquals: func(a *StringEvaluator, b *StringEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+		StringEquals: func(a *StringEvaluator, b *StringEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
 			if a.Field != "" {
 				a.StringCmpOpts.ScalarCaseInsensitive = true
 				a.StringCmpOpts.PatternCaseInsensitive = true
@@ -17,17 +17,17 @@ var (
 				b.StringCmpOpts.PatternCaseInsensitive = true
 			}
 
-			return StringEquals(a, b, opts, state)
+			return StringEquals(a, b, replCtx, state)
 		},
-		StringValuesContains: func(a *StringEvaluator, b *StringValuesEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+		StringValuesContains: func(a *StringEvaluator, b *StringValuesEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
 			if a.Field != "" {
 				a.StringCmpOpts.ScalarCaseInsensitive = true
 				a.StringCmpOpts.PatternCaseInsensitive = true
 			}
 
-			return StringValuesContains(a, b, opts, state)
+			return StringValuesContains(a, b, replCtx, state)
 		},
-		StringArrayContains: func(a *StringEvaluator, b *StringArrayEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+		StringArrayContains: func(a *StringEvaluator, b *StringArrayEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
 			if a.Field != "" {
 				a.StringCmpOpts.ScalarCaseInsensitive = true
 				a.StringCmpOpts.PatternCaseInsensitive = true
@@ -36,15 +36,15 @@ var (
 				b.StringCmpOpts.PatternCaseInsensitive = true
 			}
 
-			return StringArrayContains(a, b, opts, state)
+			return StringArrayContains(a, b, replCtx, state)
 		},
-		StringArrayMatches: func(a *StringArrayEvaluator, b *StringValuesEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+		StringArrayMatches: func(a *StringArrayEvaluator, b *StringValuesEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
 			if a.Field != "" {
 				a.StringCmpOpts.ScalarCaseInsensitive = true
 				a.StringCmpOpts.PatternCaseInsensitive = true
 			}
 
-			return StringArrayMatches(a, b, opts, state)
+			return StringArrayMatches(a, b, replCtx, state)
 		},
 	}
 )

--- a/pkg/security/secl/compiler/eval/oo_dns_name.go
+++ b/pkg/security/secl/compiler/eval/oo_dns_name.go
@@ -8,7 +8,7 @@ package eval
 var (
 	// DNSNameCmp lower case values before comparing. Important : this operator override doesn't support approvers
 	DNSNameCmp = &OpOverrides{
-		StringEquals: func(a *StringEvaluator, b *StringEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
+		StringEquals: func(a *StringEvaluator, b *StringEvaluator, state *State) (*BoolEvaluator, error) {
 			if a.Field != "" {
 				a.StringCmpOpts.ScalarCaseInsensitive = true
 				a.StringCmpOpts.PatternCaseInsensitive = true
@@ -17,17 +17,17 @@ var (
 				b.StringCmpOpts.PatternCaseInsensitive = true
 			}
 
-			return StringEquals(a, b, replCtx, state)
+			return StringEquals(a, b, state)
 		},
-		StringValuesContains: func(a *StringEvaluator, b *StringValuesEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
+		StringValuesContains: func(a *StringEvaluator, b *StringValuesEvaluator, state *State) (*BoolEvaluator, error) {
 			if a.Field != "" {
 				a.StringCmpOpts.ScalarCaseInsensitive = true
 				a.StringCmpOpts.PatternCaseInsensitive = true
 			}
 
-			return StringValuesContains(a, b, replCtx, state)
+			return StringValuesContains(a, b, state)
 		},
-		StringArrayContains: func(a *StringEvaluator, b *StringArrayEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
+		StringArrayContains: func(a *StringEvaluator, b *StringArrayEvaluator, state *State) (*BoolEvaluator, error) {
 			if a.Field != "" {
 				a.StringCmpOpts.ScalarCaseInsensitive = true
 				a.StringCmpOpts.PatternCaseInsensitive = true
@@ -36,15 +36,15 @@ var (
 				b.StringCmpOpts.PatternCaseInsensitive = true
 			}
 
-			return StringArrayContains(a, b, replCtx, state)
+			return StringArrayContains(a, b, state)
 		},
-		StringArrayMatches: func(a *StringArrayEvaluator, b *StringValuesEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
+		StringArrayMatches: func(a *StringArrayEvaluator, b *StringValuesEvaluator, state *State) (*BoolEvaluator, error) {
 			if a.Field != "" {
 				a.StringCmpOpts.ScalarCaseInsensitive = true
 				a.StringCmpOpts.PatternCaseInsensitive = true
 			}
 
-			return StringArrayMatches(a, b, replCtx, state)
+			return StringArrayMatches(a, b, state)
 		},
 	}
 )

--- a/pkg/security/secl/compiler/eval/oo_dns_name_test.go
+++ b/pkg/security/secl/compiler/eval/oo_dns_name_test.go
@@ -28,11 +28,11 @@ func TestLowerCaseEquals(t *testing.T) {
 		var ctx Context
 		state := NewState(&testModel{}, "", nil)
 
-		e, err := DNSNameCmp.StringEquals(a, b, nil, state)
+		e, err := DNSNameCmp.StringEquals(a, b, nilReplCtx(), state)
 		assert.Empty(t, err)
 		assert.False(t, e.Eval(&ctx).(bool))
 
-		e, err = DNSNameCmp.StringEquals(b, a, nil, state)
+		e, err = DNSNameCmp.StringEquals(b, a, nilReplCtx(), state)
 		assert.Empty(t, err)
 		assert.False(t, e.Eval(&ctx).(bool))
 	})
@@ -53,11 +53,11 @@ func TestLowerCaseEquals(t *testing.T) {
 		var ctx Context
 		state := NewState(&testModel{}, "", nil)
 
-		e, err := DNSNameCmp.StringEquals(a, b, nil, state)
+		e, err := DNSNameCmp.StringEquals(a, b, nilReplCtx(), state)
 		assert.Empty(t, err)
 		assert.True(t, e.Eval(&ctx).(bool))
 
-		e, err = DNSNameCmp.StringEquals(b, a, nil, state)
+		e, err = DNSNameCmp.StringEquals(b, a, nilReplCtx(), state)
 		assert.Empty(t, err)
 		assert.True(t, e.Eval(&ctx).(bool))
 	})
@@ -78,11 +78,11 @@ func TestLowerCaseEquals(t *testing.T) {
 		var ctx Context
 		state := NewState(&testModel{}, "", nil)
 
-		e, err := DNSNameCmp.StringEquals(a, b, nil, state)
+		e, err := DNSNameCmp.StringEquals(a, b, nilReplCtx(), state)
 		assert.Empty(t, err)
 		assert.True(t, e.Eval(&ctx).(bool))
 
-		e, err = DNSNameCmp.StringEquals(b, a, nil, state)
+		e, err = DNSNameCmp.StringEquals(b, a, nilReplCtx(), state)
 		assert.Empty(t, err)
 		assert.True(t, e.Eval(&ctx).(bool))
 	})
@@ -103,11 +103,11 @@ func TestLowerCaseEquals(t *testing.T) {
 		var ctx Context
 		state := NewState(&testModel{}, "", nil)
 
-		e, err := DNSNameCmp.StringEquals(a, b, nil, state)
+		e, err := DNSNameCmp.StringEquals(a, b, nilReplCtx(), state)
 		assert.Empty(t, err)
 		assert.False(t, e.Eval(&ctx).(bool))
 
-		e, err = DNSNameCmp.StringEquals(b, a, nil, state)
+		e, err = DNSNameCmp.StringEquals(b, a, nilReplCtx(), state)
 		assert.Empty(t, err)
 		assert.False(t, e.Eval(&ctx).(bool))
 	})
@@ -133,7 +133,7 @@ func TestLowerCaseContains(t *testing.T) {
 		var ctx Context
 		state := NewState(&testModel{}, "", nil)
 
-		e, err := DNSNameCmp.StringValuesContains(a, b, nil, state)
+		e, err := DNSNameCmp.StringValuesContains(a, b, nilReplCtx(), state)
 		assert.Empty(t, err)
 		assert.False(t, e.Eval(&ctx).(bool))
 	})
@@ -157,7 +157,7 @@ func TestLowerCaseContains(t *testing.T) {
 		var ctx Context
 		state := NewState(&testModel{}, "", nil)
 
-		e, err := DNSNameCmp.StringValuesContains(a, b, nil, state)
+		e, err := DNSNameCmp.StringValuesContains(a, b, nilReplCtx(), state)
 		assert.Empty(t, err)
 		assert.True(t, e.Eval(&ctx).(bool))
 	})
@@ -181,7 +181,7 @@ func TestLowerCaseContains(t *testing.T) {
 		var ctx Context
 		state := NewState(&testModel{}, "", nil)
 
-		e, err := DNSNameCmp.StringValuesContains(a, b, nil, state)
+		e, err := DNSNameCmp.StringValuesContains(a, b, nilReplCtx(), state)
 		assert.Empty(t, err)
 		assert.True(t, e.Eval(&ctx).(bool))
 	})
@@ -205,7 +205,7 @@ func TestLowerCaseContains(t *testing.T) {
 		var ctx Context
 		state := NewState(&testModel{}, "", nil)
 
-		e, err := DNSNameCmp.StringValuesContains(a, b, nil, state)
+		e, err := DNSNameCmp.StringValuesContains(a, b, nilReplCtx(), state)
 		assert.Empty(t, err)
 		assert.False(t, e.Eval(&ctx).(bool))
 
@@ -215,7 +215,7 @@ func TestLowerCaseContains(t *testing.T) {
 			Values: values,
 		}
 
-		e, err = DNSNameCmp.StringValuesContains(a, b, nil, state)
+		e, err = DNSNameCmp.StringValuesContains(a, b, nilReplCtx(), state)
 		assert.Empty(t, err)
 		assert.True(t, e.Eval(&ctx).(bool))
 	})
@@ -250,7 +250,7 @@ func TestLowerCaseContains(t *testing.T) {
 		var ctx Context
 		state := NewState(&testModel{}, "", nil)
 
-		e, err := DNSNameCmp.StringValuesContains(a, b, nil, state)
+		e, err := DNSNameCmp.StringValuesContains(a, b, nilReplCtx(), state)
 		assert.Empty(t, err)
 		assert.True(t, e.Eval(&ctx).(bool))
 	})
@@ -272,7 +272,7 @@ func TestLowerCaseArrayContains(t *testing.T) {
 		var ctx Context
 		state := NewState(&testModel{}, "", nil)
 
-		e, err := DNSNameCmp.StringArrayContains(a, b, nil, state)
+		e, err := DNSNameCmp.StringArrayContains(a, b, nilReplCtx(), state)
 		assert.Empty(t, err)
 		assert.False(t, e.Eval(&ctx).(bool))
 	})
@@ -292,7 +292,7 @@ func TestLowerCaseArrayContains(t *testing.T) {
 		var ctx Context
 		state := NewState(&testModel{}, "", nil)
 
-		e, err := DNSNameCmp.StringArrayContains(a, b, nil, state)
+		e, err := DNSNameCmp.StringArrayContains(a, b, nilReplCtx(), state)
 		assert.Empty(t, err)
 		assert.True(t, e.Eval(&ctx).(bool))
 	})
@@ -314,8 +314,15 @@ func TestLowerCaseArrayContains(t *testing.T) {
 		var ctx Context
 		state := NewState(&testModel{}, "", nil)
 
-		e, err := DNSNameCmp.StringArrayContains(a, b, nil, state)
+		e, err := DNSNameCmp.StringArrayContains(a, b, nilReplCtx(), state)
 		assert.Empty(t, err)
 		assert.True(t, e.Eval(&ctx).(bool))
 	})
+}
+
+func nilReplCtx() EvalReplacementContext {
+	return EvalReplacementContext{
+		Opts:       nil,
+		MacroStore: nil,
+	}
 }

--- a/pkg/security/secl/compiler/eval/oo_dns_name_test.go
+++ b/pkg/security/secl/compiler/eval/oo_dns_name_test.go
@@ -320,8 +320,8 @@ func TestLowerCaseArrayContains(t *testing.T) {
 	})
 }
 
-func nilReplCtx() EvalReplacementContext {
-	return EvalReplacementContext{
+func nilReplCtx() ReplacementContext {
+	return ReplacementContext{
 		Opts:       nil,
 		MacroStore: nil,
 	}

--- a/pkg/security/secl/compiler/eval/oo_dns_name_test.go
+++ b/pkg/security/secl/compiler/eval/oo_dns_name_test.go
@@ -26,13 +26,13 @@ func TestLowerCaseEquals(t *testing.T) {
 		}
 
 		var ctx Context
-		state := NewState(&testModel{}, "", nil)
+		state := NewState(&testModel{}, "", nil, nilReplCtx())
 
-		e, err := DNSNameCmp.StringEquals(a, b, nilReplCtx(), state)
+		e, err := DNSNameCmp.StringEquals(a, b, state)
 		assert.Empty(t, err)
 		assert.False(t, e.Eval(&ctx).(bool))
 
-		e, err = DNSNameCmp.StringEquals(b, a, nilReplCtx(), state)
+		e, err = DNSNameCmp.StringEquals(b, a, state)
 		assert.Empty(t, err)
 		assert.False(t, e.Eval(&ctx).(bool))
 	})
@@ -51,13 +51,13 @@ func TestLowerCaseEquals(t *testing.T) {
 		}
 
 		var ctx Context
-		state := NewState(&testModel{}, "", nil)
+		state := NewState(&testModel{}, "", nil, nilReplCtx())
 
-		e, err := DNSNameCmp.StringEquals(a, b, nilReplCtx(), state)
+		e, err := DNSNameCmp.StringEquals(a, b, state)
 		assert.Empty(t, err)
 		assert.True(t, e.Eval(&ctx).(bool))
 
-		e, err = DNSNameCmp.StringEquals(b, a, nilReplCtx(), state)
+		e, err = DNSNameCmp.StringEquals(b, a, state)
 		assert.Empty(t, err)
 		assert.True(t, e.Eval(&ctx).(bool))
 	})
@@ -76,13 +76,13 @@ func TestLowerCaseEquals(t *testing.T) {
 		}
 
 		var ctx Context
-		state := NewState(&testModel{}, "", nil)
+		state := NewState(&testModel{}, "", nil, nilReplCtx())
 
-		e, err := DNSNameCmp.StringEquals(a, b, nilReplCtx(), state)
+		e, err := DNSNameCmp.StringEquals(a, b, state)
 		assert.Empty(t, err)
 		assert.True(t, e.Eval(&ctx).(bool))
 
-		e, err = DNSNameCmp.StringEquals(b, a, nilReplCtx(), state)
+		e, err = DNSNameCmp.StringEquals(b, a, state)
 		assert.Empty(t, err)
 		assert.True(t, e.Eval(&ctx).(bool))
 	})
@@ -101,13 +101,13 @@ func TestLowerCaseEquals(t *testing.T) {
 		}
 
 		var ctx Context
-		state := NewState(&testModel{}, "", nil)
+		state := NewState(&testModel{}, "", nil, nilReplCtx())
 
-		e, err := DNSNameCmp.StringEquals(a, b, nilReplCtx(), state)
+		e, err := DNSNameCmp.StringEquals(a, b, state)
 		assert.Empty(t, err)
 		assert.False(t, e.Eval(&ctx).(bool))
 
-		e, err = DNSNameCmp.StringEquals(b, a, nilReplCtx(), state)
+		e, err = DNSNameCmp.StringEquals(b, a, state)
 		assert.Empty(t, err)
 		assert.False(t, e.Eval(&ctx).(bool))
 	})
@@ -131,9 +131,9 @@ func TestLowerCaseContains(t *testing.T) {
 		}
 
 		var ctx Context
-		state := NewState(&testModel{}, "", nil)
+		state := NewState(&testModel{}, "", nil, nilReplCtx())
 
-		e, err := DNSNameCmp.StringValuesContains(a, b, nilReplCtx(), state)
+		e, err := DNSNameCmp.StringValuesContains(a, b, state)
 		assert.Empty(t, err)
 		assert.False(t, e.Eval(&ctx).(bool))
 	})
@@ -155,9 +155,9 @@ func TestLowerCaseContains(t *testing.T) {
 		}
 
 		var ctx Context
-		state := NewState(&testModel{}, "", nil)
+		state := NewState(&testModel{}, "", nil, nilReplCtx())
 
-		e, err := DNSNameCmp.StringValuesContains(a, b, nilReplCtx(), state)
+		e, err := DNSNameCmp.StringValuesContains(a, b, state)
 		assert.Empty(t, err)
 		assert.True(t, e.Eval(&ctx).(bool))
 	})
@@ -179,9 +179,9 @@ func TestLowerCaseContains(t *testing.T) {
 		}
 
 		var ctx Context
-		state := NewState(&testModel{}, "", nil)
+		state := NewState(&testModel{}, "", nil, nilReplCtx())
 
-		e, err := DNSNameCmp.StringValuesContains(a, b, nilReplCtx(), state)
+		e, err := DNSNameCmp.StringValuesContains(a, b, state)
 		assert.Empty(t, err)
 		assert.True(t, e.Eval(&ctx).(bool))
 	})
@@ -203,9 +203,9 @@ func TestLowerCaseContains(t *testing.T) {
 		}
 
 		var ctx Context
-		state := NewState(&testModel{}, "", nil)
+		state := NewState(&testModel{}, "", nil, nilReplCtx())
 
-		e, err := DNSNameCmp.StringValuesContains(a, b, nilReplCtx(), state)
+		e, err := DNSNameCmp.StringValuesContains(a, b, state)
 		assert.Empty(t, err)
 		assert.False(t, e.Eval(&ctx).(bool))
 
@@ -215,7 +215,7 @@ func TestLowerCaseContains(t *testing.T) {
 			Values: values,
 		}
 
-		e, err = DNSNameCmp.StringValuesContains(a, b, nilReplCtx(), state)
+		e, err = DNSNameCmp.StringValuesContains(a, b, state)
 		assert.Empty(t, err)
 		assert.True(t, e.Eval(&ctx).(bool))
 	})
@@ -248,9 +248,9 @@ func TestLowerCaseContains(t *testing.T) {
 		}
 
 		var ctx Context
-		state := NewState(&testModel{}, "", nil)
+		state := NewState(&testModel{}, "", nil, nilReplCtx())
 
-		e, err := DNSNameCmp.StringValuesContains(a, b, nilReplCtx(), state)
+		e, err := DNSNameCmp.StringValuesContains(a, b, state)
 		assert.Empty(t, err)
 		assert.True(t, e.Eval(&ctx).(bool))
 	})
@@ -270,9 +270,9 @@ func TestLowerCaseArrayContains(t *testing.T) {
 		}
 
 		var ctx Context
-		state := NewState(&testModel{}, "", nil)
+		state := NewState(&testModel{}, "", nil, nilReplCtx())
 
-		e, err := DNSNameCmp.StringArrayContains(a, b, nilReplCtx(), state)
+		e, err := DNSNameCmp.StringArrayContains(a, b, state)
 		assert.Empty(t, err)
 		assert.False(t, e.Eval(&ctx).(bool))
 	})
@@ -290,9 +290,9 @@ func TestLowerCaseArrayContains(t *testing.T) {
 		}
 
 		var ctx Context
-		state := NewState(&testModel{}, "", nil)
+		state := NewState(&testModel{}, "", nil, nilReplCtx())
 
-		e, err := DNSNameCmp.StringArrayContains(a, b, nilReplCtx(), state)
+		e, err := DNSNameCmp.StringArrayContains(a, b, state)
 		assert.Empty(t, err)
 		assert.True(t, e.Eval(&ctx).(bool))
 	})
@@ -312,9 +312,9 @@ func TestLowerCaseArrayContains(t *testing.T) {
 		}
 
 		var ctx Context
-		state := NewState(&testModel{}, "", nil)
+		state := NewState(&testModel{}, "", nil, nilReplCtx())
 
-		e, err := DNSNameCmp.StringArrayContains(a, b, nilReplCtx(), state)
+		e, err := DNSNameCmp.StringArrayContains(a, b, state)
 		assert.Empty(t, err)
 		assert.True(t, e.Eval(&ctx).(bool))
 	})

--- a/pkg/security/secl/compiler/eval/oo_glob_cmp.go
+++ b/pkg/security/secl/compiler/eval/oo_glob_cmp.go
@@ -8,7 +8,7 @@ package eval
 var (
 	// GlobCmp replaces a pattern matcher with a glob matcher for *file.path fields.
 	GlobCmp = &OpOverrides{
-		StringEquals: func(a *StringEvaluator, b *StringEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
+		StringEquals: func(a *StringEvaluator, b *StringEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
 			if a.ValueType == PatternValueType {
 				a.ValueType = GlobValueType
 			} else if b.ValueType == PatternValueType {
@@ -17,7 +17,7 @@ var (
 
 			return StringEquals(a, b, replCtx, state)
 		},
-		StringValuesContains: func(a *StringEvaluator, b *StringValuesEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
+		StringValuesContains: func(a *StringEvaluator, b *StringValuesEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
 			if a.ValueType == PatternValueType {
 				a.ValueType = GlobValueType
 			} else {
@@ -35,14 +35,14 @@ var (
 
 			return StringValuesContains(a, b, replCtx, state)
 		},
-		StringArrayContains: func(a *StringEvaluator, b *StringArrayEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
+		StringArrayContains: func(a *StringEvaluator, b *StringArrayEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
 			if a.ValueType == PatternValueType {
 				a.ValueType = GlobValueType
 			}
 
 			return StringArrayContains(a, b, replCtx, state)
 		},
-		StringArrayMatches: func(a *StringArrayEvaluator, b *StringValuesEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
+		StringArrayMatches: func(a *StringArrayEvaluator, b *StringValuesEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
 			var values StringValues
 			for _, v := range b.Values.GetFieldValues() {
 				if v.Type == PatternValueType {

--- a/pkg/security/secl/compiler/eval/oo_glob_cmp.go
+++ b/pkg/security/secl/compiler/eval/oo_glob_cmp.go
@@ -8,16 +8,16 @@ package eval
 var (
 	// GlobCmp replaces a pattern matcher with a glob matcher for *file.path fields.
 	GlobCmp = &OpOverrides{
-		StringEquals: func(a *StringEvaluator, b *StringEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+		StringEquals: func(a *StringEvaluator, b *StringEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
 			if a.ValueType == PatternValueType {
 				a.ValueType = GlobValueType
 			} else if b.ValueType == PatternValueType {
 				b.ValueType = GlobValueType
 			}
 
-			return StringEquals(a, b, opts, state)
+			return StringEquals(a, b, replCtx, state)
 		},
-		StringValuesContains: func(a *StringEvaluator, b *StringValuesEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+		StringValuesContains: func(a *StringEvaluator, b *StringValuesEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
 			if a.ValueType == PatternValueType {
 				a.ValueType = GlobValueType
 			} else {
@@ -33,16 +33,16 @@ var (
 				}
 			}
 
-			return StringValuesContains(a, b, opts, state)
+			return StringValuesContains(a, b, replCtx, state)
 		},
-		StringArrayContains: func(a *StringEvaluator, b *StringArrayEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+		StringArrayContains: func(a *StringEvaluator, b *StringArrayEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
 			if a.ValueType == PatternValueType {
 				a.ValueType = GlobValueType
 			}
 
-			return StringArrayContains(a, b, opts, state)
+			return StringArrayContains(a, b, replCtx, state)
 		},
-		StringArrayMatches: func(a *StringArrayEvaluator, b *StringValuesEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+		StringArrayMatches: func(a *StringArrayEvaluator, b *StringValuesEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
 			var values StringValues
 			for _, v := range b.Values.GetFieldValues() {
 				if v.Type == PatternValueType {
@@ -54,7 +54,7 @@ var (
 				Values: values,
 			}
 
-			return StringArrayMatches(a, b, opts, state)
+			return StringArrayMatches(a, b, replCtx, state)
 		},
 	}
 )

--- a/pkg/security/secl/compiler/eval/oo_glob_cmp.go
+++ b/pkg/security/secl/compiler/eval/oo_glob_cmp.go
@@ -8,16 +8,16 @@ package eval
 var (
 	// GlobCmp replaces a pattern matcher with a glob matcher for *file.path fields.
 	GlobCmp = &OpOverrides{
-		StringEquals: func(a *StringEvaluator, b *StringEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
+		StringEquals: func(a *StringEvaluator, b *StringEvaluator, state *State) (*BoolEvaluator, error) {
 			if a.ValueType == PatternValueType {
 				a.ValueType = GlobValueType
 			} else if b.ValueType == PatternValueType {
 				b.ValueType = GlobValueType
 			}
 
-			return StringEquals(a, b, replCtx, state)
+			return StringEquals(a, b, state)
 		},
-		StringValuesContains: func(a *StringEvaluator, b *StringValuesEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
+		StringValuesContains: func(a *StringEvaluator, b *StringValuesEvaluator, state *State) (*BoolEvaluator, error) {
 			if a.ValueType == PatternValueType {
 				a.ValueType = GlobValueType
 			} else {
@@ -33,16 +33,16 @@ var (
 				}
 			}
 
-			return StringValuesContains(a, b, replCtx, state)
+			return StringValuesContains(a, b, state)
 		},
-		StringArrayContains: func(a *StringEvaluator, b *StringArrayEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
+		StringArrayContains: func(a *StringEvaluator, b *StringArrayEvaluator, state *State) (*BoolEvaluator, error) {
 			if a.ValueType == PatternValueType {
 				a.ValueType = GlobValueType
 			}
 
-			return StringArrayContains(a, b, replCtx, state)
+			return StringArrayContains(a, b, state)
 		},
-		StringArrayMatches: func(a *StringArrayEvaluator, b *StringValuesEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
+		StringArrayMatches: func(a *StringArrayEvaluator, b *StringValuesEvaluator, state *State) (*BoolEvaluator, error) {
 			var values StringValues
 			for _, v := range b.Values.GetFieldValues() {
 				if v.Type == PatternValueType {
@@ -54,7 +54,7 @@ var (
 				Values: values,
 			}
 
-			return StringArrayMatches(a, b, replCtx, state)
+			return StringArrayMatches(a, b, state)
 		},
 	}
 )

--- a/pkg/security/secl/compiler/eval/oo_glob_cmp_test.go
+++ b/pkg/security/secl/compiler/eval/oo_glob_cmp_test.go
@@ -28,11 +28,11 @@ func TestOPOverrideGlobEquals(t *testing.T) {
 		var ctx Context
 		state := NewState(&testModel{}, "", nil)
 
-		e, err := GlobCmp.StringEquals(a, b, nil, state)
+		e, err := GlobCmp.StringEquals(a, b, nilReplCtx(), state)
 		assert.Empty(t, err)
 		assert.False(t, e.Eval(&ctx).(bool))
 
-		e, err = GlobCmp.StringEquals(b, a, nil, state)
+		e, err = GlobCmp.StringEquals(b, a, nilReplCtx(), state)
 		assert.Empty(t, err)
 		assert.False(t, e.Eval(&ctx).(bool))
 	})
@@ -53,11 +53,11 @@ func TestOPOverrideGlobEquals(t *testing.T) {
 		var ctx Context
 		state := NewState(&testModel{}, "", nil)
 
-		e, err := GlobCmp.StringEquals(a, b, nil, state)
+		e, err := GlobCmp.StringEquals(a, b, nilReplCtx(), state)
 		assert.Empty(t, err)
 		assert.True(t, e.Eval(&ctx).(bool))
 
-		e, err = GlobCmp.StringEquals(b, a, nil, state)
+		e, err = GlobCmp.StringEquals(b, a, nilReplCtx(), state)
 		assert.Empty(t, err)
 		assert.True(t, e.Eval(&ctx).(bool))
 	})
@@ -84,7 +84,7 @@ func TestOPOverrideGlobContains(t *testing.T) {
 		var ctx Context
 		state := NewState(&testModel{}, "", nil)
 
-		e, err := GlobCmp.StringValuesContains(a, b, nil, state)
+		e, err := GlobCmp.StringValuesContains(a, b, nilReplCtx(), state)
 		assert.Empty(t, err)
 		assert.False(t, e.Eval(&ctx).(bool))
 	})
@@ -108,7 +108,7 @@ func TestOPOverrideGlobContains(t *testing.T) {
 		var ctx Context
 		state := NewState(&testModel{}, "", nil)
 
-		e, err := GlobCmp.StringValuesContains(a, b, nil, state)
+		e, err := GlobCmp.StringValuesContains(a, b, nilReplCtx(), state)
 		assert.Empty(t, err)
 		assert.True(t, e.Eval(&ctx).(bool))
 	})
@@ -130,7 +130,7 @@ func TestOPOverrideGlobArrayMatches(t *testing.T) {
 		}
 		state := NewState(&testModel{}, "", nil)
 
-		e, err := GlobCmp.StringArrayMatches(a, b, nil, state)
+		e, err := GlobCmp.StringArrayMatches(a, b, nilReplCtx(), state)
 		assert.Empty(t, err)
 		assert.False(t, e.Value)
 	})
@@ -149,7 +149,7 @@ func TestOPOverrideGlobArrayMatches(t *testing.T) {
 		}
 		state := NewState(&testModel{}, "", nil)
 
-		e, err := GlobCmp.StringArrayMatches(a, b, nil, state)
+		e, err := GlobCmp.StringArrayMatches(a, b, nilReplCtx(), state)
 		assert.Empty(t, err)
 		assert.True(t, e.Value)
 	})
@@ -167,7 +167,7 @@ func TestOPOverrideGlobArrayContains(t *testing.T) {
 		}
 		state := NewState(&testModel{}, "", nil)
 
-		e, err := GlobCmp.StringArrayContains(a, b, nil, state)
+		e, err := GlobCmp.StringArrayContains(a, b, nilReplCtx(), state)
 		assert.Empty(t, err)
 		assert.False(t, e.Value)
 	})
@@ -184,7 +184,7 @@ func TestOPOverrideGlobArrayContains(t *testing.T) {
 		}
 		state := NewState(&testModel{}, "", nil)
 
-		e, err := GlobCmp.StringArrayContains(a, b, nil, state)
+		e, err := GlobCmp.StringArrayContains(a, b, nilReplCtx(), state)
 		assert.Empty(t, err)
 		assert.True(t, e.Value)
 	})

--- a/pkg/security/secl/compiler/eval/oo_glob_cmp_test.go
+++ b/pkg/security/secl/compiler/eval/oo_glob_cmp_test.go
@@ -26,13 +26,13 @@ func TestOPOverrideGlobEquals(t *testing.T) {
 		}
 
 		var ctx Context
-		state := NewState(&testModel{}, "", nil)
+		state := NewState(&testModel{}, "", nil, nilReplCtx())
 
-		e, err := GlobCmp.StringEquals(a, b, nilReplCtx(), state)
+		e, err := GlobCmp.StringEquals(a, b, state)
 		assert.Empty(t, err)
 		assert.False(t, e.Eval(&ctx).(bool))
 
-		e, err = GlobCmp.StringEquals(b, a, nilReplCtx(), state)
+		e, err = GlobCmp.StringEquals(b, a, state)
 		assert.Empty(t, err)
 		assert.False(t, e.Eval(&ctx).(bool))
 	})
@@ -51,13 +51,13 @@ func TestOPOverrideGlobEquals(t *testing.T) {
 		}
 
 		var ctx Context
-		state := NewState(&testModel{}, "", nil)
+		state := NewState(&testModel{}, "", nil, nilReplCtx())
 
-		e, err := GlobCmp.StringEquals(a, b, nilReplCtx(), state)
+		e, err := GlobCmp.StringEquals(a, b, state)
 		assert.Empty(t, err)
 		assert.True(t, e.Eval(&ctx).(bool))
 
-		e, err = GlobCmp.StringEquals(b, a, nilReplCtx(), state)
+		e, err = GlobCmp.StringEquals(b, a, state)
 		assert.Empty(t, err)
 		assert.True(t, e.Eval(&ctx).(bool))
 	})
@@ -82,9 +82,9 @@ func TestOPOverrideGlobContains(t *testing.T) {
 		}
 
 		var ctx Context
-		state := NewState(&testModel{}, "", nil)
+		state := NewState(&testModel{}, "", nil, nilReplCtx())
 
-		e, err := GlobCmp.StringValuesContains(a, b, nilReplCtx(), state)
+		e, err := GlobCmp.StringValuesContains(a, b, state)
 		assert.Empty(t, err)
 		assert.False(t, e.Eval(&ctx).(bool))
 	})
@@ -106,9 +106,9 @@ func TestOPOverrideGlobContains(t *testing.T) {
 		}
 
 		var ctx Context
-		state := NewState(&testModel{}, "", nil)
+		state := NewState(&testModel{}, "", nil, nilReplCtx())
 
-		e, err := GlobCmp.StringValuesContains(a, b, nilReplCtx(), state)
+		e, err := GlobCmp.StringValuesContains(a, b, state)
 		assert.Empty(t, err)
 		assert.True(t, e.Eval(&ctx).(bool))
 	})
@@ -128,9 +128,9 @@ func TestOPOverrideGlobArrayMatches(t *testing.T) {
 		b := &StringValuesEvaluator{
 			Values: values,
 		}
-		state := NewState(&testModel{}, "", nil)
+		state := NewState(&testModel{}, "", nil, nilReplCtx())
 
-		e, err := GlobCmp.StringArrayMatches(a, b, nilReplCtx(), state)
+		e, err := GlobCmp.StringArrayMatches(a, b, state)
 		assert.Empty(t, err)
 		assert.False(t, e.Value)
 	})
@@ -147,9 +147,9 @@ func TestOPOverrideGlobArrayMatches(t *testing.T) {
 		b := &StringValuesEvaluator{
 			Values: values,
 		}
-		state := NewState(&testModel{}, "", nil)
+		state := NewState(&testModel{}, "", nil, nilReplCtx())
 
-		e, err := GlobCmp.StringArrayMatches(a, b, nilReplCtx(), state)
+		e, err := GlobCmp.StringArrayMatches(a, b, state)
 		assert.Empty(t, err)
 		assert.True(t, e.Value)
 	})
@@ -165,9 +165,9 @@ func TestOPOverrideGlobArrayContains(t *testing.T) {
 		b := &StringArrayEvaluator{
 			Values: []string{"/2/abc/3"},
 		}
-		state := NewState(&testModel{}, "", nil)
+		state := NewState(&testModel{}, "", nil, nilReplCtx())
 
-		e, err := GlobCmp.StringArrayContains(a, b, nilReplCtx(), state)
+		e, err := GlobCmp.StringArrayContains(a, b, state)
 		assert.Empty(t, err)
 		assert.False(t, e.Value)
 	})
@@ -182,9 +182,9 @@ func TestOPOverrideGlobArrayContains(t *testing.T) {
 			Field:  "dont_forget_me_or_it_wont_compile_a",
 			Values: []string{"/2/abc/3"},
 		}
-		state := NewState(&testModel{}, "", nil)
+		state := NewState(&testModel{}, "", nil, nilReplCtx())
 
-		e, err := GlobCmp.StringArrayContains(a, b, nilReplCtx(), state)
+		e, err := GlobCmp.StringArrayContains(a, b, state)
 		assert.Empty(t, err)
 		assert.True(t, e.Value)
 	})

--- a/pkg/security/secl/compiler/eval/operators.go
+++ b/pkg/security/secl/compiler/eval/operators.go
@@ -12,10 +12,10 @@ import (
 
 // OpOverrides defines operator override functions
 type OpOverrides struct {
-	StringEquals         func(a *StringEvaluator, b *StringEvaluator, opts *Opts, state *State) (*BoolEvaluator, error)
-	StringValuesContains func(a *StringEvaluator, b *StringValuesEvaluator, opts *Opts, state *State) (*BoolEvaluator, error)
-	StringArrayContains  func(a *StringEvaluator, b *StringArrayEvaluator, opts *Opts, state *State) (*BoolEvaluator, error)
-	StringArrayMatches   func(a *StringArrayEvaluator, b *StringValuesEvaluator, opts *Opts, state *State) (*BoolEvaluator, error)
+	StringEquals         func(a *StringEvaluator, b *StringEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error)
+	StringValuesContains func(a *StringEvaluator, b *StringValuesEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error)
+	StringArrayContains  func(a *StringEvaluator, b *StringArrayEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error)
+	StringArrayMatches   func(a *StringArrayEvaluator, b *StringValuesEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error)
 }
 
 // return whether a arithmetic operation is deterministic
@@ -33,7 +33,7 @@ func isArithmDeterministic(a Evaluator, b Evaluator, state *State) bool {
 }
 
 // IntNot - ^int operator
-func IntNot(a *IntEvaluator, opts *Opts, state *State) *IntEvaluator {
+func IntNot(a *IntEvaluator, replCtx EvalReplacementContext, state *State) *IntEvaluator {
 	isDc := a.IsDeterministicFor(state.field)
 
 	if a.EvalFnc != nil {
@@ -58,7 +58,7 @@ func IntNot(a *IntEvaluator, opts *Opts, state *State) *IntEvaluator {
 }
 
 // StringEquals evaluates string
-func StringEquals(a *StringEvaluator, b *StringEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func StringEquals(a *StringEvaluator, b *StringEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
 
 	// default comparison
@@ -158,7 +158,7 @@ func StringEquals(a *StringEvaluator, b *StringEvaluator, opts *Opts, state *Sta
 }
 
 // Not - !true operator
-func Not(a *BoolEvaluator, opts *Opts, state *State) *BoolEvaluator {
+func Not(a *BoolEvaluator, replCtx EvalReplacementContext, state *State) *BoolEvaluator {
 	isDc := a.IsDeterministicFor(state.field)
 
 	if a.EvalFnc != nil {
@@ -187,7 +187,7 @@ func Not(a *BoolEvaluator, opts *Opts, state *State) *BoolEvaluator {
 }
 
 // Minus - -int operator
-func Minus(a *IntEvaluator, opts *Opts, state *State) *IntEvaluator {
+func Minus(a *IntEvaluator, replCtx EvalReplacementContext, state *State) *IntEvaluator {
 	isDc := a.IsDeterministicFor(state.field)
 
 	if a.EvalFnc != nil {
@@ -212,7 +212,7 @@ func Minus(a *IntEvaluator, opts *Opts, state *State) *IntEvaluator {
 }
 
 // StringArrayContains evaluates array of strings against a value
-func StringArrayContains(a *StringEvaluator, b *StringArrayEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func StringArrayContains(a *StringEvaluator, b *StringArrayEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
 
 	op := func(a string, b []string, cmp func(a, b string) bool) bool {
@@ -313,7 +313,7 @@ func StringArrayContains(a *StringEvaluator, b *StringArrayEvaluator, opts *Opts
 }
 
 // StringValuesContains evaluates a string against values
-func StringValuesContains(a *StringEvaluator, b *StringValuesEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func StringValuesContains(a *StringEvaluator, b *StringValuesEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
 
 	if err := b.Compile(a.StringCmpOpts); err != nil {
@@ -382,7 +382,7 @@ func StringValuesContains(a *StringEvaluator, b *StringValuesEvaluator, opts *Op
 }
 
 // StringArrayMatches weak comparison, a least one element of a should be in b. a can't contain regexp
-func StringArrayMatches(a *StringArrayEvaluator, b *StringValuesEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func StringArrayMatches(a *StringArrayEvaluator, b *StringValuesEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
 
 	if err := b.Compile(a.StringCmpOpts); err != nil {
@@ -458,7 +458,7 @@ func StringArrayMatches(a *StringArrayEvaluator, b *StringValuesEvaluator, opts 
 }
 
 // IntArrayMatches weak comparison, a least one element of a should be in b
-func IntArrayMatches(a *IntArrayEvaluator, b *IntArrayEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func IntArrayMatches(a *IntArrayEvaluator, b *IntArrayEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
 
 	arrayOp := func(a []int, b []int) bool {
@@ -532,7 +532,7 @@ func IntArrayMatches(a *IntArrayEvaluator, b *IntArrayEvaluator, opts *Opts, sta
 }
 
 // ArrayBoolContains evaluates array of bool against a value
-func ArrayBoolContains(a *BoolEvaluator, b *BoolArrayEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func ArrayBoolContains(a *BoolEvaluator, b *BoolArrayEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
 
 	arrayOp := func(a bool, b []bool) bool {
@@ -609,7 +609,7 @@ func ArrayBoolContains(a *BoolEvaluator, b *BoolArrayEvaluator, opts *Opts, stat
 }
 
 // CIDREquals evaluates CIDR ranges
-func CIDREquals(a *CIDREvaluator, b *CIDREvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func CIDREquals(a *CIDREvaluator, b *CIDREvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
 
 	if a.EvalFnc != nil && b.EvalFnc != nil {
@@ -679,7 +679,7 @@ func CIDREquals(a *CIDREvaluator, b *CIDREvaluator, opts *Opts, state *State) (*
 }
 
 // CIDRValuesContains evaluates a CIDR against a list of CIDRs
-func CIDRValuesContains(a *CIDREvaluator, b *CIDRValuesEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func CIDRValuesContains(a *CIDREvaluator, b *CIDRValuesEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
 
 	if a.EvalFnc != nil && b.EvalFnc != nil {
@@ -743,7 +743,7 @@ func CIDRValuesContains(a *CIDREvaluator, b *CIDRValuesEvaluator, opts *Opts, st
 	}, nil
 }
 
-func cidrArrayMatches(a *CIDRArrayEvaluator, b *CIDRValuesEvaluator, opts *Opts, state *State, arrayOp func(a *CIDRValues, b []net.IPNet) bool) (*BoolEvaluator, error) {
+func cidrArrayMatches(a *CIDRArrayEvaluator, b *CIDRValuesEvaluator, replCtx EvalReplacementContext, state *State, arrayOp func(a *CIDRValues, b []net.IPNet) bool) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
 
 	if a.EvalFnc != nil && b.EvalFnc != nil {
@@ -806,23 +806,23 @@ func cidrArrayMatches(a *CIDRArrayEvaluator, b *CIDRValuesEvaluator, opts *Opts,
 }
 
 // CIDRArrayMatches weak comparison, at least one element of a should be in b.
-func CIDRArrayMatches(a *CIDRArrayEvaluator, b *CIDRValuesEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func CIDRArrayMatches(a *CIDRArrayEvaluator, b *CIDRValuesEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
 	op := func(values *CIDRValues, ipnets []net.IPNet) bool {
 		return values.Match(ipnets)
 	}
-	return cidrArrayMatches(a, b, opts, state, op)
+	return cidrArrayMatches(a, b, replCtx, state, op)
 }
 
 // CIDRArrayMatchesAll ensures that all values from a and b match.
-func CIDRArrayMatchesAll(a *CIDRArrayEvaluator, b *CIDRValuesEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func CIDRArrayMatchesAll(a *CIDRArrayEvaluator, b *CIDRValuesEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
 	op := func(values *CIDRValues, ipnets []net.IPNet) bool {
 		return values.MatchAll(ipnets)
 	}
-	return cidrArrayMatches(a, b, opts, state, op)
+	return cidrArrayMatches(a, b, replCtx, state, op)
 }
 
 // CIDRArrayContains evaluates a CIDR against a list of CIDRs
-func CIDRArrayContains(a *CIDREvaluator, b *CIDRArrayEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func CIDRArrayContains(a *CIDREvaluator, b *CIDRArrayEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
 
 	arrayOp := func(a *net.IPNet, b []net.IPNet) bool {

--- a/pkg/security/secl/compiler/eval/operators.go
+++ b/pkg/security/secl/compiler/eval/operators.go
@@ -12,10 +12,10 @@ import (
 
 // OpOverrides defines operator override functions
 type OpOverrides struct {
-	StringEquals         func(a *StringEvaluator, b *StringEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error)
-	StringValuesContains func(a *StringEvaluator, b *StringValuesEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error)
-	StringArrayContains  func(a *StringEvaluator, b *StringArrayEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error)
-	StringArrayMatches   func(a *StringArrayEvaluator, b *StringValuesEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error)
+	StringEquals         func(a *StringEvaluator, b *StringEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error)
+	StringValuesContains func(a *StringEvaluator, b *StringValuesEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error)
+	StringArrayContains  func(a *StringEvaluator, b *StringArrayEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error)
+	StringArrayMatches   func(a *StringArrayEvaluator, b *StringValuesEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error)
 }
 
 // return whether a arithmetic operation is deterministic
@@ -33,7 +33,7 @@ func isArithmDeterministic(a Evaluator, b Evaluator, state *State) bool {
 }
 
 // IntNot - ^int operator
-func IntNot(a *IntEvaluator, replCtx EvalReplacementContext, state *State) *IntEvaluator {
+func IntNot(a *IntEvaluator, replCtx ReplacementContext, state *State) *IntEvaluator {
 	isDc := a.IsDeterministicFor(state.field)
 
 	if a.EvalFnc != nil {
@@ -58,7 +58,7 @@ func IntNot(a *IntEvaluator, replCtx EvalReplacementContext, state *State) *IntE
 }
 
 // StringEquals evaluates string
-func StringEquals(a *StringEvaluator, b *StringEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
+func StringEquals(a *StringEvaluator, b *StringEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
 
 	// default comparison
@@ -158,7 +158,7 @@ func StringEquals(a *StringEvaluator, b *StringEvaluator, replCtx EvalReplacemen
 }
 
 // Not - !true operator
-func Not(a *BoolEvaluator, replCtx EvalReplacementContext, state *State) *BoolEvaluator {
+func Not(a *BoolEvaluator, replCtx ReplacementContext, state *State) *BoolEvaluator {
 	isDc := a.IsDeterministicFor(state.field)
 
 	if a.EvalFnc != nil {
@@ -187,7 +187,7 @@ func Not(a *BoolEvaluator, replCtx EvalReplacementContext, state *State) *BoolEv
 }
 
 // Minus - -int operator
-func Minus(a *IntEvaluator, replCtx EvalReplacementContext, state *State) *IntEvaluator {
+func Minus(a *IntEvaluator, replCtx ReplacementContext, state *State) *IntEvaluator {
 	isDc := a.IsDeterministicFor(state.field)
 
 	if a.EvalFnc != nil {
@@ -212,7 +212,7 @@ func Minus(a *IntEvaluator, replCtx EvalReplacementContext, state *State) *IntEv
 }
 
 // StringArrayContains evaluates array of strings against a value
-func StringArrayContains(a *StringEvaluator, b *StringArrayEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
+func StringArrayContains(a *StringEvaluator, b *StringArrayEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
 
 	op := func(a string, b []string, cmp func(a, b string) bool) bool {
@@ -313,7 +313,7 @@ func StringArrayContains(a *StringEvaluator, b *StringArrayEvaluator, replCtx Ev
 }
 
 // StringValuesContains evaluates a string against values
-func StringValuesContains(a *StringEvaluator, b *StringValuesEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
+func StringValuesContains(a *StringEvaluator, b *StringValuesEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
 
 	if err := b.Compile(a.StringCmpOpts); err != nil {
@@ -382,7 +382,7 @@ func StringValuesContains(a *StringEvaluator, b *StringValuesEvaluator, replCtx 
 }
 
 // StringArrayMatches weak comparison, a least one element of a should be in b. a can't contain regexp
-func StringArrayMatches(a *StringArrayEvaluator, b *StringValuesEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
+func StringArrayMatches(a *StringArrayEvaluator, b *StringValuesEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
 
 	if err := b.Compile(a.StringCmpOpts); err != nil {
@@ -458,7 +458,7 @@ func StringArrayMatches(a *StringArrayEvaluator, b *StringValuesEvaluator, replC
 }
 
 // IntArrayMatches weak comparison, a least one element of a should be in b
-func IntArrayMatches(a *IntArrayEvaluator, b *IntArrayEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
+func IntArrayMatches(a *IntArrayEvaluator, b *IntArrayEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
 
 	arrayOp := func(a []int, b []int) bool {
@@ -532,7 +532,7 @@ func IntArrayMatches(a *IntArrayEvaluator, b *IntArrayEvaluator, replCtx EvalRep
 }
 
 // ArrayBoolContains evaluates array of bool against a value
-func ArrayBoolContains(a *BoolEvaluator, b *BoolArrayEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
+func ArrayBoolContains(a *BoolEvaluator, b *BoolArrayEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
 
 	arrayOp := func(a bool, b []bool) bool {
@@ -609,7 +609,7 @@ func ArrayBoolContains(a *BoolEvaluator, b *BoolArrayEvaluator, replCtx EvalRepl
 }
 
 // CIDREquals evaluates CIDR ranges
-func CIDREquals(a *CIDREvaluator, b *CIDREvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
+func CIDREquals(a *CIDREvaluator, b *CIDREvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
 
 	if a.EvalFnc != nil && b.EvalFnc != nil {
@@ -679,7 +679,7 @@ func CIDREquals(a *CIDREvaluator, b *CIDREvaluator, replCtx EvalReplacementConte
 }
 
 // CIDRValuesContains evaluates a CIDR against a list of CIDRs
-func CIDRValuesContains(a *CIDREvaluator, b *CIDRValuesEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
+func CIDRValuesContains(a *CIDREvaluator, b *CIDRValuesEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
 
 	if a.EvalFnc != nil && b.EvalFnc != nil {
@@ -743,7 +743,7 @@ func CIDRValuesContains(a *CIDREvaluator, b *CIDRValuesEvaluator, replCtx EvalRe
 	}, nil
 }
 
-func cidrArrayMatches(a *CIDRArrayEvaluator, b *CIDRValuesEvaluator, replCtx EvalReplacementContext, state *State, arrayOp func(a *CIDRValues, b []net.IPNet) bool) (*BoolEvaluator, error) {
+func cidrArrayMatches(a *CIDRArrayEvaluator, b *CIDRValuesEvaluator, replCtx ReplacementContext, state *State, arrayOp func(a *CIDRValues, b []net.IPNet) bool) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
 
 	if a.EvalFnc != nil && b.EvalFnc != nil {
@@ -806,7 +806,7 @@ func cidrArrayMatches(a *CIDRArrayEvaluator, b *CIDRValuesEvaluator, replCtx Eva
 }
 
 // CIDRArrayMatches weak comparison, at least one element of a should be in b.
-func CIDRArrayMatches(a *CIDRArrayEvaluator, b *CIDRValuesEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
+func CIDRArrayMatches(a *CIDRArrayEvaluator, b *CIDRValuesEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
 	op := func(values *CIDRValues, ipnets []net.IPNet) bool {
 		return values.Match(ipnets)
 	}
@@ -814,7 +814,7 @@ func CIDRArrayMatches(a *CIDRArrayEvaluator, b *CIDRValuesEvaluator, replCtx Eva
 }
 
 // CIDRArrayMatchesAll ensures that all values from a and b match.
-func CIDRArrayMatchesAll(a *CIDRArrayEvaluator, b *CIDRValuesEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
+func CIDRArrayMatchesAll(a *CIDRArrayEvaluator, b *CIDRValuesEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
 	op := func(values *CIDRValues, ipnets []net.IPNet) bool {
 		return values.MatchAll(ipnets)
 	}
@@ -822,7 +822,7 @@ func CIDRArrayMatchesAll(a *CIDRArrayEvaluator, b *CIDRValuesEvaluator, replCtx 
 }
 
 // CIDRArrayContains evaluates a CIDR against a list of CIDRs
-func CIDRArrayContains(a *CIDREvaluator, b *CIDRArrayEvaluator, replCtx EvalReplacementContext, state *State) (*BoolEvaluator, error) {
+func CIDRArrayContains(a *CIDREvaluator, b *CIDRArrayEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
 
 	arrayOp := func(a *net.IPNet, b []net.IPNet) bool {

--- a/pkg/security/secl/compiler/eval/operators.go
+++ b/pkg/security/secl/compiler/eval/operators.go
@@ -12,10 +12,10 @@ import (
 
 // OpOverrides defines operator override functions
 type OpOverrides struct {
-	StringEquals         func(a *StringEvaluator, b *StringEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error)
-	StringValuesContains func(a *StringEvaluator, b *StringValuesEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error)
-	StringArrayContains  func(a *StringEvaluator, b *StringArrayEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error)
-	StringArrayMatches   func(a *StringArrayEvaluator, b *StringValuesEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error)
+	StringEquals         func(a *StringEvaluator, b *StringEvaluator, state *State) (*BoolEvaluator, error)
+	StringValuesContains func(a *StringEvaluator, b *StringValuesEvaluator, state *State) (*BoolEvaluator, error)
+	StringArrayContains  func(a *StringEvaluator, b *StringArrayEvaluator, state *State) (*BoolEvaluator, error)
+	StringArrayMatches   func(a *StringArrayEvaluator, b *StringValuesEvaluator, state *State) (*BoolEvaluator, error)
 }
 
 // return whether a arithmetic operation is deterministic
@@ -33,7 +33,7 @@ func isArithmDeterministic(a Evaluator, b Evaluator, state *State) bool {
 }
 
 // IntNot - ^int operator
-func IntNot(a *IntEvaluator, replCtx ReplacementContext, state *State) *IntEvaluator {
+func IntNot(a *IntEvaluator, state *State) *IntEvaluator {
 	isDc := a.IsDeterministicFor(state.field)
 
 	if a.EvalFnc != nil {
@@ -58,7 +58,7 @@ func IntNot(a *IntEvaluator, replCtx ReplacementContext, state *State) *IntEvalu
 }
 
 // StringEquals evaluates string
-func StringEquals(a *StringEvaluator, b *StringEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
+func StringEquals(a *StringEvaluator, b *StringEvaluator, state *State) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
 
 	// default comparison
@@ -158,7 +158,7 @@ func StringEquals(a *StringEvaluator, b *StringEvaluator, replCtx ReplacementCon
 }
 
 // Not - !true operator
-func Not(a *BoolEvaluator, replCtx ReplacementContext, state *State) *BoolEvaluator {
+func Not(a *BoolEvaluator, state *State) *BoolEvaluator {
 	isDc := a.IsDeterministicFor(state.field)
 
 	if a.EvalFnc != nil {
@@ -187,7 +187,7 @@ func Not(a *BoolEvaluator, replCtx ReplacementContext, state *State) *BoolEvalua
 }
 
 // Minus - -int operator
-func Minus(a *IntEvaluator, replCtx ReplacementContext, state *State) *IntEvaluator {
+func Minus(a *IntEvaluator, state *State) *IntEvaluator {
 	isDc := a.IsDeterministicFor(state.field)
 
 	if a.EvalFnc != nil {
@@ -212,7 +212,7 @@ func Minus(a *IntEvaluator, replCtx ReplacementContext, state *State) *IntEvalua
 }
 
 // StringArrayContains evaluates array of strings against a value
-func StringArrayContains(a *StringEvaluator, b *StringArrayEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
+func StringArrayContains(a *StringEvaluator, b *StringArrayEvaluator, state *State) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
 
 	op := func(a string, b []string, cmp func(a, b string) bool) bool {
@@ -313,7 +313,7 @@ func StringArrayContains(a *StringEvaluator, b *StringArrayEvaluator, replCtx Re
 }
 
 // StringValuesContains evaluates a string against values
-func StringValuesContains(a *StringEvaluator, b *StringValuesEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
+func StringValuesContains(a *StringEvaluator, b *StringValuesEvaluator, state *State) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
 
 	if err := b.Compile(a.StringCmpOpts); err != nil {
@@ -382,7 +382,7 @@ func StringValuesContains(a *StringEvaluator, b *StringValuesEvaluator, replCtx 
 }
 
 // StringArrayMatches weak comparison, a least one element of a should be in b. a can't contain regexp
-func StringArrayMatches(a *StringArrayEvaluator, b *StringValuesEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
+func StringArrayMatches(a *StringArrayEvaluator, b *StringValuesEvaluator, state *State) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
 
 	if err := b.Compile(a.StringCmpOpts); err != nil {
@@ -458,7 +458,7 @@ func StringArrayMatches(a *StringArrayEvaluator, b *StringValuesEvaluator, replC
 }
 
 // IntArrayMatches weak comparison, a least one element of a should be in b
-func IntArrayMatches(a *IntArrayEvaluator, b *IntArrayEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
+func IntArrayMatches(a *IntArrayEvaluator, b *IntArrayEvaluator, state *State) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
 
 	arrayOp := func(a []int, b []int) bool {
@@ -532,7 +532,7 @@ func IntArrayMatches(a *IntArrayEvaluator, b *IntArrayEvaluator, replCtx Replace
 }
 
 // ArrayBoolContains evaluates array of bool against a value
-func ArrayBoolContains(a *BoolEvaluator, b *BoolArrayEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
+func ArrayBoolContains(a *BoolEvaluator, b *BoolArrayEvaluator, state *State) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
 
 	arrayOp := func(a bool, b []bool) bool {
@@ -609,7 +609,7 @@ func ArrayBoolContains(a *BoolEvaluator, b *BoolArrayEvaluator, replCtx Replacem
 }
 
 // CIDREquals evaluates CIDR ranges
-func CIDREquals(a *CIDREvaluator, b *CIDREvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
+func CIDREquals(a *CIDREvaluator, b *CIDREvaluator, state *State) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
 
 	if a.EvalFnc != nil && b.EvalFnc != nil {
@@ -679,7 +679,7 @@ func CIDREquals(a *CIDREvaluator, b *CIDREvaluator, replCtx ReplacementContext, 
 }
 
 // CIDRValuesContains evaluates a CIDR against a list of CIDRs
-func CIDRValuesContains(a *CIDREvaluator, b *CIDRValuesEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
+func CIDRValuesContains(a *CIDREvaluator, b *CIDRValuesEvaluator, state *State) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
 
 	if a.EvalFnc != nil && b.EvalFnc != nil {
@@ -743,7 +743,7 @@ func CIDRValuesContains(a *CIDREvaluator, b *CIDRValuesEvaluator, replCtx Replac
 	}, nil
 }
 
-func cidrArrayMatches(a *CIDRArrayEvaluator, b *CIDRValuesEvaluator, replCtx ReplacementContext, state *State, arrayOp func(a *CIDRValues, b []net.IPNet) bool) (*BoolEvaluator, error) {
+func cidrArrayMatches(a *CIDRArrayEvaluator, b *CIDRValuesEvaluator, state *State, arrayOp func(a *CIDRValues, b []net.IPNet) bool) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
 
 	if a.EvalFnc != nil && b.EvalFnc != nil {
@@ -806,23 +806,23 @@ func cidrArrayMatches(a *CIDRArrayEvaluator, b *CIDRValuesEvaluator, replCtx Rep
 }
 
 // CIDRArrayMatches weak comparison, at least one element of a should be in b.
-func CIDRArrayMatches(a *CIDRArrayEvaluator, b *CIDRValuesEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
+func CIDRArrayMatches(a *CIDRArrayEvaluator, b *CIDRValuesEvaluator, state *State) (*BoolEvaluator, error) {
 	op := func(values *CIDRValues, ipnets []net.IPNet) bool {
 		return values.Match(ipnets)
 	}
-	return cidrArrayMatches(a, b, replCtx, state, op)
+	return cidrArrayMatches(a, b, state, op)
 }
 
 // CIDRArrayMatchesAll ensures that all values from a and b match.
-func CIDRArrayMatchesAll(a *CIDRArrayEvaluator, b *CIDRValuesEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
+func CIDRArrayMatchesAll(a *CIDRArrayEvaluator, b *CIDRValuesEvaluator, state *State) (*BoolEvaluator, error) {
 	op := func(values *CIDRValues, ipnets []net.IPNet) bool {
 		return values.MatchAll(ipnets)
 	}
-	return cidrArrayMatches(a, b, replCtx, state, op)
+	return cidrArrayMatches(a, b, state, op)
 }
 
 // CIDRArrayContains evaluates a CIDR against a list of CIDRs
-func CIDRArrayContains(a *CIDREvaluator, b *CIDRArrayEvaluator, replCtx ReplacementContext, state *State) (*BoolEvaluator, error) {
+func CIDRArrayContains(a *CIDREvaluator, b *CIDRArrayEvaluator, state *State) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
 
 	arrayOp := func(a *net.IPNet, b []net.IPNet) bool {

--- a/pkg/security/secl/compiler/eval/opts.go
+++ b/pkg/security/secl/compiler/eval/opts.go
@@ -11,7 +11,6 @@ type Opts struct {
 	Constants    map[string]interface{}
 	Macros       map[MacroID]*Macro
 	Variables    map[string]VariableValue
-	UserCtx      interface{}
 }
 
 // WithConstants set constants
@@ -49,11 +48,5 @@ func (o *Opts) AddMacro(macro *Macro) *Opts {
 		o.Macros = make(map[string]*Macro)
 	}
 	o.Macros[macro.ID] = macro
-	return o
-}
-
-// WithUserContext set user context
-func (o *Opts) WithUserContext(ctx interface{}) *Opts {
-	o.UserCtx = ctx
 	return o
 }

--- a/pkg/security/secl/compiler/eval/opts.go
+++ b/pkg/security/secl/compiler/eval/opts.go
@@ -5,11 +5,29 @@
 
 package eval
 
+type MacroStore struct {
+	Macros map[MacroID]*Macro
+}
+
+// WithMacros set macros fields
+func (s *MacroStore) WithMacros(macros map[MacroID]*Macro) *MacroStore {
+	s.Macros = macros
+	return s
+}
+
+// AddMacro add a macro
+func (s *MacroStore) AddMacro(macro *Macro) *MacroStore {
+	if s.Macros == nil {
+		s.Macros = make(map[string]*Macro)
+	}
+	s.Macros[macro.ID] = macro
+	return s
+}
+
 // Opts are the options to be passed to the evaluator
 type Opts struct {
 	LegacyFields map[Field]Field
 	Constants    map[string]interface{}
-	Macros       map[MacroID]*Macro
 	Variables    map[string]VariableValue
 }
 
@@ -33,20 +51,5 @@ func (o *Opts) WithVariables(variables map[string]VariableValue) *Opts {
 // WithLegacyFields set legacy fields
 func (o *Opts) WithLegacyFields(fields map[Field]Field) *Opts {
 	o.LegacyFields = fields
-	return o
-}
-
-// WithMacros set macros fields
-func (o *Opts) WithMacros(macros map[MacroID]*Macro) *Opts {
-	o.Macros = macros
-	return o
-}
-
-// AddMacro add a macro
-func (o *Opts) AddMacro(macro *Macro) *Opts {
-	if o.Macros == nil {
-		o.Macros = make(map[string]*Macro)
-	}
-	o.Macros[macro.ID] = macro
 	return o
 }

--- a/pkg/security/secl/compiler/eval/rule.go
+++ b/pkg/security/secl/compiler/eval/rule.go
@@ -22,7 +22,7 @@ type Rule struct {
 	ID             RuleID
 	Expression     string
 	Tags           []string
-	ReplacementCtx EvalReplacementContext
+	ReplacementCtx ReplacementContext
 	Model          Model
 
 	evaluator *RuleEvaluator
@@ -132,7 +132,7 @@ func (r *Rule) Parse() error {
 	return nil
 }
 
-func ruleToEvaluator(rule *ast.Rule, model Model, replCtx EvalReplacementContext) (*RuleEvaluator, error) {
+func ruleToEvaluator(rule *ast.Rule, model Model, replCtx ReplacementContext) (*RuleEvaluator, error) {
 	macros := make(map[MacroID]*MacroEvaluator)
 	for id, macro := range replCtx.Macros {
 		macros[id] = macro.evaluator
@@ -169,7 +169,7 @@ func ruleToEvaluator(rule *ast.Rule, model Model, replCtx EvalReplacementContext
 }
 
 // GenEvaluator - Compile and generates the RuleEvaluator
-func (r *Rule) GenEvaluator(model Model, replCtx EvalReplacementContext) error {
+func (r *Rule) GenEvaluator(model Model, replCtx ReplacementContext) error {
 	r.Model = model
 	r.ReplacementCtx = replCtx
 

--- a/pkg/security/secl/compiler/eval/rule.go
+++ b/pkg/security/secl/compiler/eval/rule.go
@@ -137,9 +137,9 @@ func ruleToEvaluator(rule *ast.Rule, model Model, replCtx ReplacementContext) (*
 	for id, macro := range replCtx.Macros {
 		macros[id] = macro.evaluator
 	}
-	state := NewState(model, "", macros)
+	state := NewState(model, "", macros, replCtx)
 
-	eval, _, err := nodeToEvaluator(rule.BooleanExpression, replCtx, state)
+	eval, _, err := nodeToEvaluator(rule.BooleanExpression, state)
 	if err != nil {
 		return nil, err
 	}
@@ -231,8 +231,8 @@ func (r *Rule) GenPartials() error {
 	}
 
 	for _, field := range r.GetFields() {
-		state := NewState(r.Model, field, macroPartials[field])
-		pEval, _, err := nodeToEvaluator(r.ast.BooleanExpression, r.ReplacementCtx, state)
+		state := NewState(r.Model, field, macroPartials[field], r.ReplacementCtx)
+		pEval, _, err := nodeToEvaluator(r.ast.BooleanExpression, state)
 		if err != nil {
 			return errors.Wrapf(err, "couldn't generate partial for field %s and rule %s", field, r.ID)
 		}

--- a/pkg/security/secl/compiler/eval/state.go
+++ b/pkg/security/secl/compiler/eval/state.go
@@ -28,6 +28,7 @@ type State struct {
 	macros        map[MacroID]*MacroEvaluator
 	registersInfo map[RegisterID]*registerInfo
 	regexpCache   StateRegexpCache
+	replCtx       ReplacementContext
 }
 
 // UpdateFields updates the fields used in the rule
@@ -59,7 +60,7 @@ func (s *State) UpdateFieldValues(field Field, value FieldValue) error {
 }
 
 // NewState returns a new State
-func NewState(model Model, field Field, macros map[MacroID]*MacroEvaluator) *State {
+func NewState(model Model, field Field, macros map[MacroID]*MacroEvaluator, replCtx ReplacementContext) *State {
 	if macros == nil {
 		macros = make(map[MacroID]*MacroEvaluator)
 	}
@@ -70,5 +71,6 @@ func NewState(model Model, field Field, macros map[MacroID]*MacroEvaluator) *Sta
 		events:        make(map[EventType]bool),
 		fieldValues:   make(map[Field][]FieldValue),
 		registersInfo: make(map[RegisterID]*registerInfo),
+		replCtx:       replCtx,
 	}
 }

--- a/pkg/security/secl/compiler/generators/operators/operators.go
+++ b/pkg/security/secl/compiler/generators/operators/operators.go
@@ -43,7 +43,7 @@ import (
 
 {{ range .Operators }}
 
-func {{ .FuncName }}(a *{{ .Arg1Type }}, b *{{ .Arg2Type }}, opts *Opts, state *State) (*{{ .FuncReturnType }}, error) {
+func {{ .FuncName }}(a *{{ .Arg1Type }}, b *{{ .Arg2Type }}, replCtx EvalReplacementContext, state *State) (*{{ .FuncReturnType }}, error) {
 	{{ if or (eq .FuncName "Or") (eq .FuncName "And") }}
 	isDc := a.IsDeterministicFor(state.field) || b.IsDeterministicFor(state.field)
 	{{ else }}
@@ -176,7 +176,7 @@ func {{ .FuncName }}(a *{{ .Arg1Type }}, b *{{ .Arg2Type }}, opts *Opts, state *
 
 {{ range .ArrayOperators }}
 
-func {{ .FuncName }}(a *{{ .Arg1Type }}, b *{{ .Arg2Type }}, opts *Opts, state *State) (*{{ .FuncReturnType }}, error) {
+func {{ .FuncName }}(a *{{ .Arg1Type }}, b *{{ .Arg2Type }}, replCtx EvalReplacementContext, state *State) (*{{ .FuncReturnType }}, error) {
 	{{ if or (eq .FuncName "Or") (eq .FuncName "And") }}
 	isDc := a.IsDeterministicFor(state.field) || b.IsDeterministicFor(state.field)
 	{{ else }}

--- a/pkg/security/secl/compiler/generators/operators/operators.go
+++ b/pkg/security/secl/compiler/generators/operators/operators.go
@@ -43,7 +43,7 @@ import (
 
 {{ range .Operators }}
 
-func {{ .FuncName }}(a *{{ .Arg1Type }}, b *{{ .Arg2Type }}, replCtx EvalReplacementContext, state *State) (*{{ .FuncReturnType }}, error) {
+func {{ .FuncName }}(a *{{ .Arg1Type }}, b *{{ .Arg2Type }}, replCtx ReplacementContext, state *State) (*{{ .FuncReturnType }}, error) {
 	{{ if or (eq .FuncName "Or") (eq .FuncName "And") }}
 	isDc := a.IsDeterministicFor(state.field) || b.IsDeterministicFor(state.field)
 	{{ else }}
@@ -176,7 +176,7 @@ func {{ .FuncName }}(a *{{ .Arg1Type }}, b *{{ .Arg2Type }}, replCtx EvalReplace
 
 {{ range .ArrayOperators }}
 
-func {{ .FuncName }}(a *{{ .Arg1Type }}, b *{{ .Arg2Type }}, replCtx EvalReplacementContext, state *State) (*{{ .FuncReturnType }}, error) {
+func {{ .FuncName }}(a *{{ .Arg1Type }}, b *{{ .Arg2Type }}, replCtx ReplacementContext, state *State) (*{{ .FuncReturnType }}, error) {
 	{{ if or (eq .FuncName "Or") (eq .FuncName "And") }}
 	isDc := a.IsDeterministicFor(state.field) || b.IsDeterministicFor(state.field)
 	{{ else }}

--- a/pkg/security/secl/compiler/generators/operators/operators.go
+++ b/pkg/security/secl/compiler/generators/operators/operators.go
@@ -43,7 +43,7 @@ import (
 
 {{ range .Operators }}
 
-func {{ .FuncName }}(a *{{ .Arg1Type }}, b *{{ .Arg2Type }}, replCtx ReplacementContext, state *State) (*{{ .FuncReturnType }}, error) {
+func {{ .FuncName }}(a *{{ .Arg1Type }}, b *{{ .Arg2Type }}, state *State) (*{{ .FuncReturnType }}, error) {
 	{{ if or (eq .FuncName "Or") (eq .FuncName "And") }}
 	isDc := a.IsDeterministicFor(state.field) || b.IsDeterministicFor(state.field)
 	{{ else }}
@@ -176,7 +176,7 @@ func {{ .FuncName }}(a *{{ .Arg1Type }}, b *{{ .Arg2Type }}, replCtx Replacement
 
 {{ range .ArrayOperators }}
 
-func {{ .FuncName }}(a *{{ .Arg1Type }}, b *{{ .Arg2Type }}, replCtx ReplacementContext, state *State) (*{{ .FuncReturnType }}, error) {
+func {{ .FuncName }}(a *{{ .Arg1Type }}, b *{{ .Arg2Type }}, state *State) (*{{ .FuncReturnType }}, error) {
 	{{ if or (eq .FuncName "Or") (eq .FuncName "And") }}
 	isDc := a.IsDeterministicFor(state.field) || b.IsDeterministicFor(state.field)
 	{{ else }}

--- a/pkg/security/secl/rules/opts.go
+++ b/pkg/security/secl/rules/opts.go
@@ -51,12 +51,6 @@ func (o *Opts) AddMacro(macro *eval.Macro) *Opts {
 	return o
 }
 
-// WithUserContext set user context
-func (o *Opts) WithUserContext(ctx interface{}) *Opts {
-	o.Opts.WithUserContext(ctx)
-	return o
-}
-
 // WithSupportedDiscarders set supported discarders
 func (o *Opts) WithSupportedDiscarders(discarders map[eval.Field]bool) *Opts {
 	o.SupportedDiscarders = discarders

--- a/pkg/security/secl/rules/opts.go
+++ b/pkg/security/secl/rules/opts.go
@@ -19,36 +19,11 @@ type VariableProviderFactory func() VariableProvider
 
 // Opts defines rules set options
 type Opts struct {
-	eval.Opts
 	SupportedDiscarders map[eval.Field]bool
 	ReservedRuleIDs     []RuleID
 	EventTypeEnabled    map[eval.EventType]bool
 	StateScopes         map[Scope]VariableProviderFactory
 	Logger              Logger
-}
-
-// WithConstants set constants
-func (o *Opts) WithConstants(constants map[string]interface{}) *Opts {
-	o.Opts.WithConstants(constants)
-	return o
-}
-
-// WithVariables set variables
-func (o *Opts) WithVariables(variables map[string]eval.VariableValue) *Opts {
-	o.Opts.WithVariables(variables)
-	return o
-}
-
-// WithLegacyFields set legacy fields
-func (o *Opts) WithLegacyFields(fields map[eval.Field]eval.Field) *Opts {
-	o.Opts.WithLegacyFields(fields)
-	return o
-}
-
-// AddMacro add a macro
-func (o *Opts) AddMacro(macro *eval.Macro) *Opts {
-	o.Opts.AddMacro(macro)
-	return o
 }
 
 // WithSupportedDiscarders set supported discarders

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -176,8 +176,8 @@ type RuleSet struct {
 	pool   *eval.ContextPool
 }
 
-func (rs *RuleSet) replCtx() eval.EvalReplacementContext {
-	return eval.EvalReplacementContext{
+func (rs *RuleSet) replCtx() eval.ReplacementContext {
+	return eval.ReplacementContext{
 		Opts:       rs.evalOpts,
 		MacroStore: rs.macroStore,
 	}

--- a/pkg/security/secl/rules/ruleset_test.go
+++ b/pkg/security/secl/rules/ruleset_test.go
@@ -87,6 +87,13 @@ func newRuleSet() *RuleSet {
 	return NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, &opts, &evalOpts, &eval.MacroStore{})
 }
 
+func emptyReplCtx() eval.ReplacementContext {
+	return eval.ReplacementContext{
+		Opts:       &eval.Opts{},
+		MacroStore: &eval.MacroStore{},
+	}
+}
+
 func TestRuleBuckets(t *testing.T) {
 	exprs := []string{
 		`(open.filename =~ "/sbin/*" || open.filename =~ "/usr/sbin/*") && process.uid != 0 && open.flags & O_CREAT > 0`,
@@ -543,7 +550,7 @@ func TestGetRuleEventType(t *testing.T) {
 		ID:         "aaa",
 		Expression: `open.filename == "test"`,
 	}
-	if err := rule.GenEvaluator(&testModel{}, &eval.Opts{}); err != nil {
+	if err := rule.GenEvaluator(&testModel{}, emptyReplCtx()); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/security/secl/rules/ruleset_test.go
+++ b/pkg/security/secl/rules/ruleset_test.go
@@ -75,13 +75,16 @@ func addRuleExpr(t *testing.T, rs *RuleSet, exprs ...string) {
 func newRuleSet() *RuleSet {
 	enabled := map[eval.EventType]bool{"*": true}
 
+	var evalOpts eval.Opts
+	evalOpts.
+		WithConstants(testConstants)
+
 	var opts Opts
 	opts.
-		WithConstants(testConstants).
 		WithSupportedDiscarders(testSupportedDiscarders).
 		WithEventTypeEnabled(enabled)
 
-	return NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, &opts)
+	return NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, &opts, &evalOpts, &eval.MacroStore{})
 }
 
 func TestRuleBuckets(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

The macros are currently store in `Opts`, itself referenced through a pointer in `RuleSet`. Since 2 ruleset are constructed from the same option when loading policies, the macros are appended twice during loading (once for actual loading, once for approvers).
This used to be ignored (maybe involuntarily), but was surfaced since the rework of policy loading (https://github.com/DataDog/datadog-agent/pull/12109)

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
