### PR TITLE
SNMP Traps: Remove experimental notice in datadog.yaml (#12254)

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -3055,9 +3055,8 @@ api_key:
   # namespace: default
 
   ## @param snmp_traps - custom object - optional
-  ## This section configures SNMP traps collection. Traps are forwarded as logs to Datadog.
-  ## NOTE: This feature is currently **EXPERIMENTAL**. Both behavior and configuration options may
-  ## change in the future.
+  ## This section configures SNMP traps collection.
+  ## Traps are forwarded as logs and can be found in the logs explorer with a source:snmp-traps query
   #
   # snmp_traps:
 


### PR DESCRIPTION
Backport of https://github.com/DataDog/datadog-agent/pull/12254/s

* SNMP Traps: Remove experimental notice in datadog.yaml
