### PR TITLE
[CWS] start and close policy providers

### DIFF
--- a/pkg/security/probe/selftests/tester.go
+++ b/pkg/security/probe/selftests/tester.go
@@ -58,6 +58,8 @@ type SelfTester struct {
 	targetTempDir  string
 }
 
+var _ rules.PolicyProvider = (*SelfTester)(nil)
+
 // NewSelfTester returns a new SelfTester, enabled or not
 func NewSelfTester() (*SelfTester, error) {
 	s := &SelfTester{
@@ -154,10 +156,14 @@ func (t *SelfTester) RunSelfTest() ([]string, []string, error) {
 	return success, fails, nil
 }
 
-// Cleanup removes temp directories and files used by the self tester
-func (t *SelfTester) Cleanup() error {
+func (t *SelfTester) Start() {}
+
+// Close removes temp directories and files used by the self tester
+func (t *SelfTester) Close() error {
 	if t.targetTempDir != "" {
-		return os.RemoveAll(t.targetTempDir)
+		err := os.RemoveAll(t.targetTempDir)
+		t.targetTempDir = ""
+		return err
 	}
 	return nil
 }

--- a/pkg/security/rconfig/rconfig.go
+++ b/pkg/security/rconfig/rconfig.go
@@ -30,6 +30,8 @@ type RCPolicyProvider struct {
 	lastConfigs          []client.ConfigCWSDD
 }
 
+var _ rules.PolicyProvider = (*RCPolicyProvider)(nil)
+
 func NewRCPolicyProvider(name string) (*RCPolicyProvider, error) {
 	c, err := remote.NewClient(name, []data.Product{data.ProductCWSDD})
 	if err != nil {
@@ -94,6 +96,7 @@ func (r *RCPolicyProvider) SetOnNewPoliciesReadyCb(cb func()) {
 }
 
 // Stop the client
-func (r *RCPolicyProvider) Stop() {
+func (r *RCPolicyProvider) Close() error {
 	r.client.Close()
+	return nil
 }

--- a/pkg/security/secl/rules/policy_dir.go
+++ b/pkg/security/secl/rules/policy_dir.go
@@ -18,6 +18,8 @@ import (
 
 const policyExtension = ".policy"
 
+var _ PolicyProvider = (*PoliciesDirProvider)(nil)
+
 // PoliciesDirProvider defines a new policy dir provider
 type PoliciesDirProvider struct {
 	PoliciesDir string
@@ -33,6 +35,8 @@ type PoliciesDirProvider struct {
 func (p *PoliciesDirProvider) SetOnNewPoliciesReadyCb(cb func()) {
 	p.onNewPoliciesReadyCb = cb
 }
+
+func (p *PoliciesDirProvider) Start() {}
 
 func (p *PoliciesDirProvider) loadPolicy(filename string) (*Policy, error) {
 	f, err := os.Open(filename)
@@ -121,8 +125,10 @@ func (p *PoliciesDirProvider) LoadPolicies() ([]*Policy, *multierror.Error) {
 }
 
 // Stop implements the policy provider interface
-func (p *PoliciesDirProvider) Stop() {
+func (p *PoliciesDirProvider) Close() error {
 	p.cancelFnc()
+	p.watcher.Close()
+	return nil
 }
 
 func filesEqual(a []string, b []string) bool {

--- a/pkg/security/secl/rules/policy_provider.go
+++ b/pkg/security/secl/rules/policy_provider.go
@@ -15,4 +15,7 @@ const defaultPolicyName = "default.policy"
 type PolicyProvider interface {
 	LoadPolicies() ([]*Policy, *multierror.Error)
 	SetOnNewPoliciesReadyCb(func())
+
+	Start()
+	Close() error
 }


### PR DESCRIPTION
### What does this PR do?

This PR adds `Start` and `Close` methods to the Policy Provider interface. This allows the module to cleanly close policy providers (closing files, watchers etc)

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
