### PR TITLE
Support disable option metadata inventory

### DIFF
--- a/pkg/metadata/inventories/inventories.go
+++ b/pkg/metadata/inventories/inventories.go
@@ -181,8 +181,8 @@ func createCheckInstanceMetadata(checkID, configProvider string) *CheckInstanceM
 	return &checkInstanceMetadata
 }
 
-// CreatePayload fills and returns the inventory metadata payload
-func CreatePayload(ctx context.Context, hostname string, ac AutoConfigInterface, coll CollectorInterface) *Payload {
+// createPayload fills and returns the inventory metadata payload
+func createPayload(ctx context.Context, hostname string, ac AutoConfigInterface, coll CollectorInterface) *Payload {
 	checkMetadataMutex.Lock()
 	defer checkMetadataMutex.Unlock()
 
@@ -239,7 +239,7 @@ func GetPayload(ctx context.Context, hostname string, ac AutoConfigInterface, co
 	defer lastGetPayloadMutex.Unlock()
 	lastGetPayload = timeNow()
 
-	lastPayload = CreatePayload(ctx, hostname, ac, coll)
+	lastPayload = createPayload(ctx, hostname, ac, coll)
 	return lastPayload
 }
 

--- a/pkg/metadata/inventories_collector.go
+++ b/pkg/metadata/inventories_collector.go
@@ -59,6 +59,11 @@ func (c inventoriesCollector) Init() error {
 
 // SetupInventoriesExpvar init the expvar function for inventories
 func SetupInventoriesExpvar(ac inventories.AutoConfigInterface, coll inventories.CollectorInterface) {
+	if !config.Datadog.GetBool("enable_metadata_collection") {
+		log.Debugf("Metadata collection disabled: inventories payload will not be exposed to expvar")
+		return
+	}
+
 	expvar.Publish("inventories", expvar.Func(func() interface{} {
 		log.Debugf("Creating inventory payload for expvar")
 		p, err := getPayload(context.TODO(), ac, coll)
@@ -72,6 +77,11 @@ func SetupInventoriesExpvar(ac inventories.AutoConfigInterface, coll inventories
 
 // SetupInventories registers the inventories collector into the Scheduler and, if configured, schedules it
 func SetupInventories(sc *Scheduler, ac inventories.AutoConfigInterface, coll inventories.CollectorInterface) error {
+	if !config.Datadog.GetBool("enable_metadata_collection") {
+		log.Debugf("Metadata collection disabled: inventories payload will not be collected nor sent")
+		return nil
+	}
+
 	ic := inventoriesCollector{
 		ac:   ac,
 		coll: coll,

--- a/pkg/metadata/inventories_collector.go
+++ b/pkg/metadata/inventories_collector.go
@@ -24,7 +24,7 @@ type inventoriesCollector struct {
 	sc   *Scheduler
 }
 
-func createPayload(ctx context.Context, ac inventories.AutoConfigInterface, coll inventories.CollectorInterface) (*inventories.Payload, error) {
+func getPayload(ctx context.Context, ac inventories.AutoConfigInterface, coll inventories.CollectorInterface) (*inventories.Payload, error) {
 	hostname, err := util.GetHostname(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to submit inventories metadata payload, no hostname: %s", err)
@@ -39,7 +39,7 @@ func (c inventoriesCollector) Send(ctx context.Context, s serializer.MetricSeria
 		return nil
 	}
 
-	payload, err := createPayload(ctx, c.ac, c.coll)
+	payload, err := getPayload(ctx, c.ac, c.coll)
 	if err != nil {
 		return err
 	}
@@ -61,7 +61,7 @@ func (c inventoriesCollector) Init() error {
 func SetupInventoriesExpvar(ac inventories.AutoConfigInterface, coll inventories.CollectorInterface) {
 	expvar.Publish("inventories", expvar.Func(func() interface{} {
 		log.Debugf("Creating inventory payload for expvar")
-		p, err := createPayload(context.TODO(), ac, coll)
+		p, err := getPayload(context.TODO(), ac, coll)
 		if err != nil {
 			log.Errorf("Could not create inventory payload for expvar: %s", err)
 			return &inventories.Payload{}


### PR DESCRIPTION
### What does this PR do?

Inventories metadata collection can now be disabled through the config `enable_metadata_collection`.

This PR also remove `CreatePayload` from the public API (no need for it to be public).

### Describe how to test/QA your changes

Start the agent with `enable_metadata_collection` set to true (default) and check the inventory payload is sent. You can use the `troubleshooting metadata_inventory` command from the CLI to see the last payload sent (`inventories_min_interval` default to 5 minutes, reduce it to 10s to not wait that long).

Then set `enable_metadata_collection` to false and validate the no payload is sent.

You can also use a fake HTTP server to dump payload sent by the Agent.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
