### PR TITLE
[prometheus] fix check metrics parsing

### DIFF
--- a/pkg/autodiscovery/common/types/prometheus.go
+++ b/pkg/autodiscovery/common/types/prometheus.go
@@ -38,9 +38,9 @@ var (
 		PrometheusPortAnnotation,
 	}
 	// OpenmetricsDefaultMetricsV1 containers the wildcard pattern to match all metrics
-	OpenmetricsDefaultMetricsV1 = []string{"*"}
+	OpenmetricsDefaultMetricsV1 = []json.RawMessage{json.RawMessage(`"*"`)}
 	// OpenmetricsDefaultMetricsV2 containers the match-all regular expression to match all metrics
-	OpenmetricsDefaultMetricsV2 = []string{".*"}
+	OpenmetricsDefaultMetricsV2 = []json.RawMessage{json.RawMessage(`".*"`)}
 )
 
 func configPrometheusScrapeChecksTransformer(in string) interface{} {
@@ -65,7 +65,7 @@ type PrometheusCheck struct {
 type OpenmetricsInstance struct {
 	PrometheusURL                 string                      `mapstructure:"prometheus_url" yaml:"prometheus_url,omitempty" json:"prometheus_url,omitempty"`
 	Namespace                     string                      `mapstructure:"namespace" yaml:"namespace,omitempty" json:"namespace"`
-	Metrics                       []string                    `mapstructure:"metrics" yaml:"metrics,omitempty" json:"metrics,omitempty"`
+	Metrics                       []json.RawMessage           `mapstructure:"metrics" yaml:"metrics,omitempty" json:"metrics,omitempty"`
 	PromPrefix                    string                      `mapstructure:"prometheus_metrics_prefix" yaml:"prometheus_metrics_prefix,omitempty" json:"prometheus_metrics_prefix,omitempty"`
 	HealthCheck                   *bool                       `mapstructure:"health_service_check" yaml:"health_service_check,omitempty" json:"health_service_check,omitempty"`
 	LabelToHostname               string                      `mapstructure:"label_to_hostname" yaml:"label_to_hostname,omitempty" json:"label_to_hostname,omitempty"`
@@ -149,7 +149,7 @@ func (pc *PrometheusCheck) Init() error {
 
 // initInstances defaults the Instances field in PrometheusCheck
 func (pc *PrometheusCheck) initInstances() {
-	var openmetricsDefaultMetrics []string
+	var openmetricsDefaultMetrics []json.RawMessage
 	version := config.Datadog.GetInt("prometheus_scrape.version")
 	switch version {
 	case 1:
@@ -272,7 +272,7 @@ func (ad *ADConfig) MatchContainer(name string) bool {
 var DefaultPrometheusCheck = &PrometheusCheck{
 	Instances: []*OpenmetricsInstance{
 		{
-			Metrics:   []string{"PLACEHOLDER"},
+			Metrics:   []json.RawMessage{json.RawMessage(`"PLACEHOLDER"`)},
 			Namespace: openmetricsDefaultNS,
 		},
 	},

--- a/pkg/autodiscovery/common/types/prometheus.go
+++ b/pkg/autodiscovery/common/types/prometheus.go
@@ -38,9 +38,9 @@ var (
 		PrometheusPortAnnotation,
 	}
 	// OpenmetricsDefaultMetricsV1 containers the wildcard pattern to match all metrics
-	OpenmetricsDefaultMetricsV1 = []json.RawMessage{json.RawMessage(`"*"`)}
+	OpenmetricsDefaultMetricsV1 = []interface{}{"*"}
 	// OpenmetricsDefaultMetricsV2 containers the match-all regular expression to match all metrics
-	OpenmetricsDefaultMetricsV2 = []json.RawMessage{json.RawMessage(`".*"`)}
+	OpenmetricsDefaultMetricsV2 = []interface{}{".*"}
 )
 
 func configPrometheusScrapeChecksTransformer(in string) interface{} {
@@ -65,7 +65,7 @@ type PrometheusCheck struct {
 type OpenmetricsInstance struct {
 	PrometheusURL                 string                      `mapstructure:"prometheus_url" yaml:"prometheus_url,omitempty" json:"prometheus_url,omitempty"`
 	Namespace                     string                      `mapstructure:"namespace" yaml:"namespace,omitempty" json:"namespace"`
-	Metrics                       []json.RawMessage           `mapstructure:"metrics" yaml:"metrics,omitempty" json:"metrics,omitempty"`
+	Metrics                       []interface{}               `mapstructure:"metrics" yaml:"metrics,omitempty" json:"metrics,omitempty"`
 	PromPrefix                    string                      `mapstructure:"prometheus_metrics_prefix" yaml:"prometheus_metrics_prefix,omitempty" json:"prometheus_metrics_prefix,omitempty"`
 	HealthCheck                   *bool                       `mapstructure:"health_service_check" yaml:"health_service_check,omitempty" json:"health_service_check,omitempty"`
 	LabelToHostname               string                      `mapstructure:"label_to_hostname" yaml:"label_to_hostname,omitempty" json:"label_to_hostname,omitempty"`
@@ -149,7 +149,7 @@ func (pc *PrometheusCheck) Init() error {
 
 // initInstances defaults the Instances field in PrometheusCheck
 func (pc *PrometheusCheck) initInstances() {
-	var openmetricsDefaultMetrics []json.RawMessage
+	var openmetricsDefaultMetrics []interface{}
 	version := config.Datadog.GetInt("prometheus_scrape.version")
 	switch version {
 	case 1:
@@ -272,7 +272,7 @@ func (ad *ADConfig) MatchContainer(name string) bool {
 var DefaultPrometheusCheck = &PrometheusCheck{
 	Instances: []*OpenmetricsInstance{
 		{
-			Metrics:   []json.RawMessage{json.RawMessage(`"PLACEHOLDER"`)},
+			Metrics:   []interface{}{"PLACEHOLDER"},
 			Namespace: openmetricsDefaultNS,
 		},
 	},

--- a/pkg/autodiscovery/common/utils/prometheus_apiserver_test.go
+++ b/pkg/autodiscovery/common/utils/prometheus_apiserver_test.go
@@ -85,7 +85,7 @@ func TestConfigsForService(t *testing.T) {
 				Instances: []*types.OpenmetricsInstance{
 					{
 						OpenMetricsEndpoint: "foo/bar",
-						Metrics:             []string{".*"},
+						Metrics:             []interface{}{".*"},
 						Namespace:           "",
 					},
 				},
@@ -117,7 +117,7 @@ func TestConfigsForService(t *testing.T) {
 				Instances: []*types.OpenmetricsInstance{
 					{
 						PrometheusURL: "foo/bar",
-						Metrics:       []string{"*"},
+						Metrics:       []interface{}{".*"},
 						Namespace:     "",
 					},
 				},
@@ -168,6 +168,38 @@ func TestConfigsForService(t *testing.T) {
 				},
 			},
 			want: nil,
+		},
+		{
+			name: "metrics key value",
+			check: &types.PrometheusCheck{
+				Instances: []*types.OpenmetricsInstance{
+					{
+						PrometheusURL: "foo/bar",
+						Metrics:       []interface{}{map[string]string{"foo": "bar"}},
+						Namespace:     "",
+					},
+				},
+			},
+			version: 2,
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					UID:         k8stypes.UID("foo-uid"),
+					Name:        "svc-foo",
+					Annotations: map[string]string{"prometheus.io/scrape": "true"},
+					Namespace:   "ns",
+				},
+			},
+			want: []integration.Config{
+				{
+					Name:          "openmetrics",
+					InitConfig:    integration.Data("{}"),
+					Instances:     []integration.Data{integration.Data(`{"prometheus_url":"foo/bar","namespace":"","metrics":[{"foo":"bar"}]}`)},
+					ClusterCheck:  true,
+					Provider:      names.PrometheusServices,
+					Source:        "prometheus_services:kube_service://ns/svc-foo",
+					ADIdentifiers: []string{"kube_service://ns/svc-foo"},
+				},
+			},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/autodiscovery/common/utils/prometheus_apiserver_test.go
+++ b/pkg/autodiscovery/common/utils/prometheus_apiserver_test.go
@@ -117,7 +117,7 @@ func TestConfigsForService(t *testing.T) {
 				Instances: []*types.OpenmetricsInstance{
 					{
 						PrometheusURL: "foo/bar",
-						Metrics:       []interface{}{".*"},
+						Metrics:       []interface{}{"*"},
 						Namespace:     "",
 					},
 				},

--- a/pkg/autodiscovery/common/utils/prometheus_kubelet_test.go
+++ b/pkg/autodiscovery/common/utils/prometheus_kubelet_test.go
@@ -105,7 +105,7 @@ func TestConfigsForPod(t *testing.T) {
 				Instances: []*types.OpenmetricsInstance{
 					{
 						OpenMetricsEndpoint: "foo/bar",
-						Metrics:             []string{".*"},
+						Metrics:             []interface{}{".*"},
 						Namespace:           "",
 					},
 				},
@@ -148,7 +148,7 @@ func TestConfigsForPod(t *testing.T) {
 				Instances: []*types.OpenmetricsInstance{
 					{
 						PrometheusURL: "foo/bar",
-						Metrics:       []string{"*"},
+						Metrics:       []interface{}{".*"},
 						Namespace:     "",
 					},
 				},
@@ -398,6 +398,49 @@ func TestConfigsForPod(t *testing.T) {
 					Name:          "openmetrics",
 					InitConfig:    integration.Data("{}"),
 					Instances:     []integration.Data{integration.Data(`{"namespace":"","metrics":[".*"],"openmetrics_endpoint":"http://%%host%%:%%port%%/metrics"}`)},
+					Provider:      names.PrometheusPods,
+					Source:        "prometheus_pods:foo-ctr-id",
+					ADIdentifiers: []string{"foo-ctr-id"},
+				},
+			},
+		},
+		{
+			name: "metrics key value",
+			check: &types.PrometheusCheck{
+				Instances: []*types.OpenmetricsInstance{
+					{
+						PrometheusURL: "foo/bar",
+						Metrics:       []interface{}{map[string]string{"foo": "bar"}},
+						Namespace:     "",
+					},
+				},
+			},
+			version: 2,
+			pod: &kubelet.Pod{
+				Metadata: kubelet.PodMetadata{
+					Name:        "foo-pod",
+					Annotations: map[string]string{"prometheus.io/scrape": "true"},
+				},
+				Status: kubelet.Status{
+					Containers: []kubelet.ContainerStatus{
+						{
+							Name: "foo-ctr",
+							ID:   "foo-ctr-id",
+						},
+					},
+					AllContainers: []kubelet.ContainerStatus{
+						{
+							Name: "foo-ctr",
+							ID:   "foo-ctr-id",
+						},
+					},
+				},
+			},
+			want: []integration.Config{
+				{
+					Name:          "openmetrics",
+					InitConfig:    integration.Data("{}"),
+					Instances:     []integration.Data{integration.Data(`{"prometheus_url":"foo/bar","namespace":"","metrics":[{"foo":"bar"}]}`)},
 					Provider:      names.PrometheusPods,
 					Source:        "prometheus_pods:foo-ctr-id",
 					ADIdentifiers: []string{"foo-ctr-id"},

--- a/pkg/autodiscovery/common/utils/prometheus_kubelet_test.go
+++ b/pkg/autodiscovery/common/utils/prometheus_kubelet_test.go
@@ -148,7 +148,7 @@ func TestConfigsForPod(t *testing.T) {
 				Instances: []*types.OpenmetricsInstance{
 					{
 						PrometheusURL: "foo/bar",
-						Metrics:       []interface{}{".*"},
+						Metrics:       []interface{}{"*"},
 						Namespace:     "",
 					},
 				},

--- a/pkg/autodiscovery/providers/prometheus_common_test.go
+++ b/pkg/autodiscovery/providers/prometheus_common_test.go
@@ -29,7 +29,7 @@ func TestGetPrometheusConfigs(t *testing.T) {
 				{
 					Instances: []*types.OpenmetricsInstance{
 						{
-							Metrics:   []string{"PLACEHOLDER"},
+							Metrics:   []interface{}{"PLACEHOLDER"},
 							Namespace: "",
 						},
 					},
@@ -59,7 +59,7 @@ func TestGetPrometheusConfigs(t *testing.T) {
 				{
 					Instances: []*types.OpenmetricsInstance{
 						{
-							Metrics:   []string{"*"},
+							Metrics:   []interface{}{"*"},
 							Namespace: "",
 							Timeout:   20,
 						},
@@ -91,7 +91,7 @@ func TestGetPrometheusConfigs(t *testing.T) {
 				{
 					Instances: []*types.OpenmetricsInstance{
 						{
-							Metrics:   []string{"*"},
+							Metrics:   []interface{}{"*"},
 							Namespace: "",
 						},
 					},
@@ -113,7 +113,7 @@ func TestGetPrometheusConfigs(t *testing.T) {
 				{
 					Instances: []*types.OpenmetricsInstance{
 						{
-							Metrics:       []string{"foo", "bar"},
+							Metrics:       []interface{}{"foo", "bar"},
 							Namespace:     "custom_ns",
 							IgnoreMetrics: []string{"baz"},
 						},
@@ -131,7 +131,7 @@ func TestGetPrometheusConfigs(t *testing.T) {
 				{
 					Instances: []*types.OpenmetricsInstance{
 						{
-							Metrics:       []string{"foo", "bar"},
+							Metrics:       []interface{}{"foo", "bar"},
 							Namespace:     "custom_ns",
 							IgnoreMetrics: []string{"baz"},
 						},
@@ -177,7 +177,7 @@ func TestGetPrometheusConfigs(t *testing.T) {
 				{
 					Instances: []*types.OpenmetricsInstance{
 						{
-							Metrics:   []string{"*"},
+							Metrics:   []interface{}{"*"},
 							Namespace: "",
 						},
 					},

--- a/releasenotes/notes/fix-prometheus-checks-metrics-07509580eb216c76.yaml
+++ b/releasenotes/notes/fix-prometheus-checks-metrics-07509580eb216c76.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Fix prometheus check Metrics parsing, don't enforce a list of strings
+    Fix prometheus check Metrics parsing by not enforcing a list of strings.

--- a/releasenotes/notes/fix-prometheus-checks-metrics-07509580eb216c76.yaml
+++ b/releasenotes/notes/fix-prometheus-checks-metrics-07509580eb216c76.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix prometheus check Metrics parsing, don't enforce a list of strings


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Makes `PrometheusCheck` Metrics an array of `interface{}` so we don't force individual items to only be strings.

### Motivation

Fixes https://github.com/DataDog/datadog-agent/issues/12317

### Additional Notes

Added a test for the transformation of `PrometheusCheck` to an `Integration.Data`.

There seems to be no tests on the transformation of `DD_PROMETHEUS_SCRAPE_CHECKS` env variable to a prometheus check.

### Possible Drawbacks / Trade-offs

If tests pass, there should be no drawback to this change.

### Describe how to test/QA your changes

Tests included should be enough I guess.

_Edit from the reviewer:_
- _Define `metrics` as a map like the example mentioned in this issue https://github.com/DataDog/datadog-agent/issues/12317_
- _Define `metrics` as a list and make sure there are no regressions_

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
