### PR TITLE
cca_in_ad -> create cca templates and filter them

### DIFF
--- a/pkg/autodiscovery/common/utils/container_collect_all.go
+++ b/pkg/autodiscovery/common/utils/container_collect_all.go
@@ -1,0 +1,26 @@
+package utils
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+// AddContainerCollectAllConfigs adds a config template containing an empty
+// LogsConfig when `logs_config.container_collect_all` is set.  This config
+// will be filtered out during config resolution if another config template
+// also has logs configuration.
+func AddContainerCollectAllConfigs(configs []integration.Config, adIdentifier string) []integration.Config {
+	if !config.Datadog.GetBool("logs_config.container_collect_all") {
+		return configs
+	}
+
+	// create an almost-empty config which just says "please log this
+	// container" to the logs agent.
+	configs = append(configs, integration.Config{
+		Name:          "container_collect_all",
+		ADIdentifiers: []string{adIdentifier},
+		LogsConfig:    []byte("[{}]"),
+	})
+
+	return configs
+}

--- a/pkg/autodiscovery/listeners/service_test.go
+++ b/pkg/autodiscovery/listeners/service_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers/names"
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 	"github.com/stretchr/testify/assert"
 )
@@ -97,5 +98,49 @@ func TestServiceFilterTemplatesOverriddenChecks(t *testing.T) {
 	t.Run("some checkNames, partial match", func(t *testing.T) {
 		assert.Equal(t, []integration.Config{barTpl},
 			filterDrops(&service{entity: entity, checkNames: []string{"bing", "bar"}}, fooTpl, barTpl, fooNonFileTpl, barNonFileTpl))
+	})
+}
+
+func TestServiceFilterTemplatesCCA(t *testing.T) {
+	filterDrops := func(svc *service, configs ...integration.Config) (dropped []integration.Config) {
+		return filterConfigsDropped(svc.filterTemplatesContainerCollectAll, configs...)
+	}
+
+	// this should match what's given in pkg/autodiscovery/common/utils/container_collect_all.go
+	ccaTpl := integration.Config{Name: "container_collect_all", LogsConfig: []byte("{}")}
+	noLogsTpl := integration.Config{Name: "foo"}
+	logsTpl := integration.Config{Name: "foo", LogsConfig: []byte(`{"source":"foo"}`)}
+	nothingDropped := []integration.Config{}
+
+	t.Run("no CCA config", func(t *testing.T) {
+		mockConfig := config.Mock()
+		mockConfig.Set("logs_config.container_collect_all", true)
+
+		assert.Equal(t, nothingDropped,
+			filterDrops(&service{}, logsTpl, noLogsTpl))
+	})
+
+	t.Run("no other logs config", func(t *testing.T) {
+		mockConfig := config.Mock()
+		mockConfig.Set("logs_config.container_collect_all", true)
+
+		assert.Equal(t, nothingDropped,
+			filterDrops(&service{}, noLogsTpl, ccaTpl))
+	})
+
+	t.Run("other logs config", func(t *testing.T) {
+		mockConfig := config.Mock()
+		mockConfig.Set("logs_config.container_collect_all", true)
+
+		assert.Equal(t, []integration.Config{ccaTpl},
+			filterDrops(&service{}, noLogsTpl, logsTpl, ccaTpl))
+	})
+
+	t.Run("other logs config, CCA disabled", func(t *testing.T) {
+		mockConfig := config.Mock()
+		mockConfig.Set("logs_config.container_collect_all", false)
+
+		assert.Equal(t, nothingDropped,
+			filterDrops(&service{}, noLogsTpl, logsTpl, ccaTpl))
 	})
 }

--- a/pkg/autodiscovery/providers/container.go
+++ b/pkg/autodiscovery/providers/container.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers/names"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
+	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
@@ -174,6 +175,10 @@ func (d *ContainerConfigProvider) generateConfigs() ([]integration.Config, error
 
 		for _, err := range errors {
 			log.Errorf("Can't parse template for container %s: %s", containerID, err)
+		}
+
+		if util.CcaInAD() {
+			c = utils.AddContainerCollectAllConfigs(c, containerEntityName)
 		}
 
 		for idx := range c {

--- a/pkg/autodiscovery/providers/kubelet.go
+++ b/pkg/autodiscovery/providers/kubelet.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
+	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
@@ -164,6 +165,10 @@ func (k *KubeletConfigProvider) generateConfigs() ([]integration.Config, error) 
 					errs = append(errs, err)
 				}
 				continue
+			}
+
+			if util.CcaInAD() {
+				c = utils.AddContainerCollectAllConfigs(c, containerEntity)
 			}
 
 			containerIdentifiers[adIdentifier] = struct{}{}


### PR DESCRIPTION
With this change, when logs_config.cca_in_ad is set, AD config providers
for containers will add a `container_collect_all` configuration template
for each container.

It then falls to the config reconciliation process to avoid
double-logging containers that have more-specific configuration.  This
is accomplished with a per-service template filter which drops the
container_collect_all configuration iff there is another template with a
nonempty LogsConfig.

### Motivation

Part of the rewrite of the logs-agent's container handling.

### Additional Notes

Please initially ensure, based on the diff, that this cannot possibly have any impact if `logs_config.cca_in_ad` is false.  Then, review the remainder.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Enable `logs_config.container_collect_all` but not `logs_config.cca_in_ad` and verify that a container is logged.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
