### PR TITLE
cca_in_ad -> do not send service configs

### DIFF
--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -450,14 +450,16 @@ func (ac *AutoConfig) processNewService(ctx context.Context, svc listeners.Servi
 
 	changes := ac.cfgMgr.processNewService(ADIdentifiers, svc)
 
-	// FIXME: schedule new services as well
-	changes.scheduleConfig(integration.Config{
-		LogsConfig:      integration.Data{},
-		ServiceID:       svc.GetServiceID(),
-		TaggerEntity:    svc.GetTaggerEntity(),
-		MetricsExcluded: svc.HasFilter(containers.MetricsFilter),
-		LogsExcluded:    svc.HasFilter(containers.LogsFilter),
-	})
+	if !util.CcaInAD() {
+		// schedule a "service config" for logs-agent's benefit
+		changes.scheduleConfig(integration.Config{
+			LogsConfig:      integration.Data{},
+			ServiceID:       svc.GetServiceID(),
+			TaggerEntity:    svc.GetTaggerEntity(),
+			MetricsExcluded: svc.HasFilter(containers.MetricsFilter),
+			LogsExcluded:    svc.HasFilter(containers.LogsFilter),
+		})
+	}
 
 	ac.applyChanges(changes)
 }
@@ -468,14 +470,16 @@ func (ac *AutoConfig) processDelService(svc listeners.Service) {
 	changes := ac.cfgMgr.processDelService(svc)
 	ac.store.removeTagsHashForService(svc.GetTaggerEntity())
 
-	// FIXME: unschedule remove services as well
-	changes.unscheduleConfig(integration.Config{
-		LogsConfig:      integration.Data{},
-		ServiceID:       svc.GetServiceID(),
-		TaggerEntity:    svc.GetTaggerEntity(),
-		MetricsExcluded: svc.HasFilter(containers.MetricsFilter),
-		LogsExcluded:    svc.HasFilter(containers.LogsFilter),
-	})
+	if !util.CcaInAD() {
+		// unschedule the "service config"
+		changes.unscheduleConfig(integration.Config{
+			LogsConfig:      integration.Data{},
+			ServiceID:       svc.GetServiceID(),
+			TaggerEntity:    svc.GetTaggerEntity(),
+			MetricsExcluded: svc.HasFilter(containers.MetricsFilter),
+			LogsExcluded:    svc.HasFilter(containers.LogsFilter),
+		})
+	}
 
 	ac.applyChanges(changes)
 }


### PR DESCRIPTION
AD has historically sent "service configs" as a way to inform the logs
agent about containers, so that it can implement container_collect_all.
This is no longer necessary when CCA is handled in AD.

### Motivation

Part of the rewrite of the logs-agent's container handling.

### Additional Notes

Please initially ensure, based on the diff, that this cannot possibly have any impact if logs_config.cca_in_ad is false. Then, review the remainder.

@DataDog/container-integrations: please verify that nothing but logs-agent uses these "service configs".  That was the case once, when I checked, but I may have missed a new dependency being added.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Agent-metrics-logs: same as #12320.

Containers: verify that all of the parts of the agent subscribed to AD still behave as expected when containers are created and removed.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
