### PR TITLE
Fix Windows container startup and `agent status` hang (#12275)

### DIFF
--- a/pkg/util/cloudproviders/kubernetes/kubernetes.go
+++ b/pkg/util/cloudproviders/kubernetes/kubernetes.go
@@ -23,6 +23,10 @@ var (
 
 // GetHostAliases returns the host aliases from the Kubernetes node annotations
 func GetHostAliases(ctx context.Context) ([]string, error) {
+	if !config.IsFeaturePresent(config.Kubernetes) {
+		return []string{}, nil
+	}
+
 	aliases := []string{}
 
 	annotations, err := hostinfo.GetNodeAnnotations(ctx)

--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -92,10 +92,12 @@ func isOSHostnameUsable(ctx context.Context) (osHostnameUsable bool) {
 	// Check hostNetwork from kubernetes
 	// because kubernetes sets UTS namespace to host if and only if hostNetwork = true:
 	// https://github.com/kubernetes/kubernetes/blob/cf16e4988f58a5b816385898271e70c3346b9651/pkg/kubelet/dockershim/security_context.go#L203-L205
-	hostNetwork, err := isAgentKubeHostNetwork()
-	if err == nil && !hostNetwork {
-		log.Debug("Agent is running in a POD without hostNetwork: OS-provided hostnames cannot be used for hostname resolution.")
-		return false
+	if config.IsFeaturePresent(config.Kubernetes) {
+		hostNetwork, err := isAgentKubeHostNetwork()
+		if err == nil && !hostNetwork {
+			log.Debug("Agent is running in a POD without hostNetwork: OS-provided hostnames cannot be used for hostname resolution.")
+			return false
+		}
 	}
 
 	return true

--- a/pkg/util/kubernetes/clustername/clustername.go
+++ b/pkg/util/kubernetes/clustername/clustername.go
@@ -108,7 +108,7 @@ func getClusterName(ctx context.Context, data *clusterNameData, hostname string)
 			}
 		}
 
-		if data.clusterName == "" {
+		if data.clusterName == "" && config.IsFeaturePresent(config.Kubernetes) {
 			clusterName, err := hostinfo.GetNodeClusterNameLabel(ctx)
 			if err != nil {
 				log.Debugf("Unable to auto discover the cluster name from node label : %s", err)

--- a/test/integration/util/kube_apiserver/apiserver_test.go
+++ b/test/integration/util/kube_apiserver/apiserver_test.go
@@ -43,6 +43,9 @@ func TestSuiteKube(t *testing.T) {
 	mockConfig := config.Mock()
 	s := &testSuite{}
 
+	// Env detection
+	config.DetectFeatures()
+
 	// Start compose stack
 	compose, err := initAPIServerCompose()
 	require.Nil(t, err)


### PR DESCRIPTION
### What does this PR do?

* Fix containerised docker agent start on Windows
* Fix `agent status` hang when started on a docker host without Kubernetes

### Motivation

Dockerized agent doesn’t start properly on Windows.

### Additional Notes

See #12275

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Start the agent on Linux with

```
docker run --name dd-agent --rm --volume /var/run/docker.sock:/var/run/docker.sock:ro --volume /proc/:/host/proc/:ro --volume /sys/fs/cgroup/:/host/sys/fs/cgroup:ro --env DD_API_KEY="${DD_API_KEY:?You must set DD_API_KEY environment variable}" --env DD_LOGS_ENABLED=true --env DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true gcr.io/datadoghq/agent:7.37.0-rc.6
```
and verify that `agent status` returns promptly with

```
docker exec -ti dd-agent agent status
```

Start the agent on Windows with

```
docker run --rm --name dd-agent -e DD_API_KEY=$DD_API_KEY -v \\.\pipe\docker_engine:\\.\pipe\docker_engine public.ecr.aws/datadog/agent:7.37.0-rc.6
```
and verify that it starts properly.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
