### PR TITLE
[notifications] Add more infra failure filters

### DIFF
--- a/tasks/libs/pipeline_notifications.py
+++ b/tasks/libs/pipeline_notifications.py
@@ -57,6 +57,7 @@ def get_job_failure_reason(job_log):
         "no basic auth credentials (manager.go:203:0s)",
         # docker / docker-arm runner init failures
         "Docker runner job start script failed",
+        "A disposable runner accepted this job, while it shouldn't have. Runners are meant to run just one job and be terminated."
     ]
 
     for log in infra_failure_logs:

--- a/tasks/libs/pipeline_notifications.py
+++ b/tasks/libs/pipeline_notifications.py
@@ -57,7 +57,7 @@ def get_job_failure_reason(job_log):
         "no basic auth credentials (manager.go:203:0s)",
         # docker / docker-arm runner init failures
         "Docker runner job start script failed",
-        "A disposable runner accepted this job, while it shouldn't have. Runners are meant to run just one job and be terminated."
+        "A disposable runner accepted this job, while it shouldn't have. Runners are meant to run just one job and be terminated.",
     ]
 
     for log in infra_failure_logs:


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Follow-up of #12324, adds one more log filter to check for infrastructure failures.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Catch infrastructure failures.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Run the notification task with a pipeline that exhibits this issue:
```
CI_PIPELINE_ID=8311767 invoke -e pipeline.notify-failure --notification-type deploy --print-to-stdout
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
