### PR TITLE
[process-agent][event-listener] Fix unreachable code

### DIFF
--- a/pkg/process/events/listener_linux.go
+++ b/pkg/process/events/listener_linux.go
@@ -92,10 +92,12 @@ func (l *SysProbeListener) run() {
 	l.connected.Store(false)
 	logTicker := newLogBackoffTicker()
 
-	for {
+	running := true
+	for running {
 		select {
 		case <-l.exit:
-			return
+			running = false
+			continue
 		default:
 			stream, err := l.client.GetProcessEvents(context.Background(), &api.GetProcessEventParams{})
 			if err != nil {
@@ -123,7 +125,9 @@ func (l *SysProbeListener) run() {
 				select {
 				// If an exit signal is sent, stop consuming from the stream and return
 				case <-l.exit:
-					return
+					readStream = false
+					running = false
+					continue
 				default:
 					in, err := stream.Recv()
 					if err == io.EOF || in == nil {


### PR DESCRIPTION
### What does this PR do?

A linter test is failing because the following line in unreachable:
https://github.com/DataDog/datadog-agent/blame/main/pkg/process/events/listener_linux.go#L139

This PR updates the `run` method to remove any return statement from the for loop and make sure that this log line is reachead.

### Motivation

Fix failing tests.

### Additional Notes


### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes

This should be covered by unit tests.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
