### PR TITLE
Don't expire contexts for counters we may want to add later

### DIFF
--- a/pkg/aggregator/context_resolver.go
+++ b/pkg/aggregator/context_resolver.go
@@ -153,13 +153,14 @@ func (cr *timestampContextResolver) get(key ckey.ContextKey) (*Context, bool) {
 }
 
 // expireContexts cleans up the contexts that haven't been tracked since the given timestamp
-// and returns the associated contextKeys
-func (cr *timestampContextResolver) expireContexts(expireTimestamp float64) []ckey.ContextKey {
+// and returns the associated contextKeys.
+// keep can be used to retain contexts longer than their natural expiration time based on some condition.
+func (cr *timestampContextResolver) expireContexts(expireTimestamp float64, keep func(ckey.ContextKey) bool) []ckey.ContextKey {
 	var expiredContextKeys []ckey.ContextKey
 
 	// Find expired context keys
 	for contextKey, lastSeen := range cr.lastSeenByKey {
-		if lastSeen < expireTimestamp {
+		if lastSeen < expireTimestamp && (keep == nil || !keep(contextKey)) {
 			expiredContextKeys = append(expiredContextKeys, contextKey)
 		}
 	}

--- a/pkg/aggregator/time_sampler.go
+++ b/pkg/aggregator/time_sampler.go
@@ -211,7 +211,11 @@ func (s *TimeSampler) flush(timestamp float64, series metrics.SerieSink, sketche
 	s.flushSketches(cutoffTime, sketches)
 
 	// expiring contexts
-	s.contextResolver.expireContexts(timestamp - config.Datadog.GetFloat64("dogstatsd_context_expiry_seconds"))
+	s.contextResolver.expireContexts(timestamp-config.Datadog.GetFloat64("dogstatsd_context_expiry_seconds"),
+		func(k ckey.ContextKey) bool {
+			_, ok := s.counterLastSampledByContext[k]
+			return ok
+		})
 	s.lastCutOffTime = cutoffTime
 
 	totalContexts := s.contextResolver.length()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Agent keeps reporting counters for a fixed period of time after the
client app has stopped sending them. Contexts are expired on a
different schedule. When context expiration time is low enough,
granularity of flushes becomes a hindrance, as counters sometimes are
sampled not frequently enough to keep their contexts alive.

This patch prevents active counter contexts from being expired,
regardless of their timestamp in the context resolver. Once the
reporting logic is done with the context, it can be expired using the
regular process though.

### Motivation

Avoid `inconsistent context resolver state` errors when `dogstatsd_context_expiry_seconds` is set to low values.

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

- Run the agent with `DD_LOG_LEVEL=debug DD_LOG_PAYLOADS=true DD_TELEMETRY_ENABLED=true`
- Send dogstatsd gauge and counter. Both values should go through to the app.
- Counter should keep reporting 0 to the app for 300s after the last user sample.
- `datadog.agent.aggregator.dogstatsd_contexts` should return to 0 after 5 minutes.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
