### PR TITLE
pkg/trace/sampler: Fixes Rare Sampler logic

### DIFF
--- a/pkg/trace/sampler/rare_sampler.go
+++ b/pkg/trace/sampler/rare_sampler.go
@@ -71,7 +71,7 @@ func NewRareSampler() *RareSampler {
 // Sample a trace and returns true if trace was sampled (should be kept)
 func (e *RareSampler) Sample(now time.Time, t *pb.TraceChunk, env string) bool {
 	if priority, ok := GetSamplingPriority(t); priority > 0 && ok {
-		e.handlePriorityTrace(now, env, t)
+		e.handlePriorityTrace(now, env, t, priorityTTL)
 		return false
 	}
 	return e.handleTrace(now, env, t)
@@ -82,8 +82,8 @@ func (e *RareSampler) Stop() {
 	e.tickStats.Stop()
 }
 
-func (e *RareSampler) handlePriorityTrace(now time.Time, env string, t *pb.TraceChunk) {
-	expire := now.Add(priorityTTL)
+func (e *RareSampler) handlePriorityTrace(now time.Time, env string, t *pb.TraceChunk, ttl time.Duration) {
+	expire := now.Add(ttl)
 	for _, s := range t.Spans {
 		if !traceutil.HasTopLevel(s) && !traceutil.IsMeasured(s) {
 			continue
@@ -94,17 +94,19 @@ func (e *RareSampler) handlePriorityTrace(now time.Time, env string, t *pb.Trace
 
 func (e *RareSampler) handleTrace(now time.Time, env string, t *pb.TraceChunk) bool {
 	var sampled bool
-	expire := now.Add(defaultTTL)
 	for _, s := range t.Spans {
 		if !traceutil.HasTopLevel(s) && !traceutil.IsMeasured(s) {
 			continue
 		}
-		if !sampled {
-			sampled = e.sampleSpan(now, env, s)
-			continue
+		if sampled = e.sampleSpan(now, env, s); sampled {
+			break
 		}
-		e.addSpan(expire, env, s)
 	}
+
+	if sampled {
+		e.handlePriorityTrace(now, env, t, defaultTTL)
+	}
+
 	return sampled
 }
 

--- a/pkg/trace/sampler/rare_sampler.go
+++ b/pkg/trace/sampler/rare_sampler.go
@@ -102,11 +102,9 @@ func (e *RareSampler) handleTrace(now time.Time, env string, t *pb.TraceChunk) b
 			break
 		}
 	}
-
 	if sampled {
 		e.handlePriorityTrace(now, env, t, defaultTTL)
 	}
-
 	return sampled
 }
 

--- a/pkg/trace/sampler/rare_sampler_test.go
+++ b/pkg/trace/sampler/rare_sampler_test.go
@@ -106,11 +106,46 @@ func TestCardinalityLimit(t *testing.T) {
 	}
 }
 
+func TestMultipleTopeLevels(t *testing.T) {
+	assert := assert.New(t)
+	e := NewRareSampler()
+	e.Stop()
+	now := time.Unix(13829192398, 0)
+	trace1 := getTraceChunkWithSpansAndPriority(
+		[]*pb.Span{
+			&pb.Span{Service: "s1", Resource: "r1", Metrics: map[string]float64{"_top_level": 1}},
+		},
+		PriorityNone,
+	)
+	trace2 := getTraceChunkWithSpansAndPriority(
+		[]*pb.Span{
+			&pb.Span{Service: "s1", Resource: "r1", Metrics: map[string]float64{"_top_level": 1}},
+			&pb.Span{Service: "s1", Resource: "r2", Metrics: map[string]float64{"_top_level": 1}},
+		},
+		PriorityNone,
+	)
+
+	// sampled because of `r1`
+	assert.True(e.Sample(now, trace1, "prod"))
+	assert.EqualValues(1, trace1.Spans[0].Metrics["_dd.rare"])
+
+	// sampled because of `r2`
+	// `r1`'s timestamp gets refreshed
+	assert.True(e.Sample(now.Add(defaultTTL), trace2, "prod"))
+	assert.NotContains(trace2.Spans[0].Metrics, "_dd.rare")
+	assert.EqualValues(1, trace2.Spans[1].Metrics["_dd.rare"])
+
+	// not sampled, because `r1` was sampled on the above
+	assert.False(e.Sample(now.Add(defaultTTL+time.Nanosecond), trace1, "prod"))
+}
+
 func getTraceChunkWithSpanAndPriority(span *pb.Span, priority SamplingPriority) *pb.TraceChunk {
+	return getTraceChunkWithSpansAndPriority([]*pb.Span{span}, priority)
+}
+
+func getTraceChunkWithSpansAndPriority(spans []*pb.Span, priority SamplingPriority) *pb.TraceChunk {
 	return &pb.TraceChunk{
 		Priority: int32(priority),
-		Spans: []*pb.Span{
-			span,
-		},
+		Spans:    spans,
 	}
 }

--- a/pkg/trace/sampler/rare_sampler_test.go
+++ b/pkg/trace/sampler/rare_sampler_test.go
@@ -113,14 +113,14 @@ func TestMultipleTopeLevels(t *testing.T) {
 	now := time.Unix(13829192398, 0)
 	trace1 := getTraceChunkWithSpansAndPriority(
 		[]*pb.Span{
-			&pb.Span{Service: "s1", Resource: "r1", Metrics: map[string]float64{"_top_level": 1}},
+			{Service: "s1", Resource: "r1", Metrics: map[string]float64{"_top_level": 1}},
 		},
 		PriorityNone,
 	)
 	trace2 := getTraceChunkWithSpansAndPriority(
 		[]*pb.Span{
-			&pb.Span{Service: "s1", Resource: "r1", Metrics: map[string]float64{"_top_level": 1}},
-			&pb.Span{Service: "s1", Resource: "r2", Metrics: map[string]float64{"_top_level": 1}},
+			{Service: "s1", Resource: "r1", Metrics: map[string]float64{"_top_level": 1}},
+			{Service: "s1", Resource: "r2", Metrics: map[string]float64{"_top_level": 1}},
 		},
 		PriorityNone,
 	)

--- a/releasenotes/notes/fixes-rare-sampler-7f2167cb7e3337d0.yaml
+++ b/releasenotes/notes/fixes-rare-sampler-7f2167cb7e3337d0.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    APM: Fixed trace rare sampler's oversampling behaviour. With this fix, the rare sampler will sample rare traces more accurately.
+    APM: Fixed trace rare sampler's oversampling behavior. With this fix, the rare sampler will sample rare traces more accurately.

--- a/releasenotes/notes/fixes-rare-sampler-7f2167cb7e3337d0.yaml
+++ b/releasenotes/notes/fixes-rare-sampler-7f2167cb7e3337d0.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Fixed trace rare sampler's oversampling behaviour. With this fix, the rare sampler will sample rare traces more accurately.
+    APM: Fixed trace rare sampler's oversampling behaviour. With this fix, the rare sampler will sample rare traces more accurately.

--- a/releasenotes/notes/fixes-rare-sampler-7f2167cb7e3337d0.yaml
+++ b/releasenotes/notes/fixes-rare-sampler-7f2167cb7e3337d0.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed trace rare sampler's oversampling behaviour. With this fix, the rare sampler will sample rare traces more accurately.


### PR DESCRIPTION
### What does this PR do?
Fixes Rare Sampler.

### Motivation
The current logic of handling traces without priority looks broken.

Let's say we had multiple top levels in the chunk. And, during the iteration, we decided to sample the trace at `span2`. In this case, only `span2`, `span3`, and `span4` will get refreshed in `seenSpans`. Because of this logic, `span1` could get sampled by Rare Sampler again in a short time, even though we've already sampled a trace with it.
```
span1 <- unsampled
span2 <- sampled
span3
span4
```

### Additional Notes
N/A

### Possible Drawbacks / Trade-offs
- increases the number of iterations over spans
- reduces the number of traces sampled with rare sampler

### Describe how to test/QA your changes
- Number of traces kept with rare sampler should get reduced by a small degree

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
