### PR TITLE
[tasks] Remove the --redo flag of release.build-rc

### DIFF
--- a/tasks/release.py
+++ b/tasks/release.py
@@ -1251,7 +1251,11 @@ Make sure that milestone is open before trying again.""",
     )
 
 
-@task(help={'redo': "Redo the tag & build for the last RC that was tagged, instead of creating tags for the next RC."})
+@task(
+    help={
+        'redo': "The redo functionality was removed because of dangerous --force functionality. Please build another RC."
+    }
+)
 def build_rc(ctx, major_versions="6,7", patch_version=False, redo=False):
     """
     To be done after the PR created by release.create-rc is merged, with the same options
@@ -1269,8 +1273,13 @@ def build_rc(ctx, major_versions="6,7", patch_version=False, redo=False):
     # Get the version of the highest major: needed for tag_version and to know
     # which tag to target when creating the pipeline.
     if redo:
-        # If redo is enabled, we're moving the current RC tag, so we keep the same version
-        new_version = current_version(ctx, max(list_major_versions))
+        raise Exit(
+            color_message(
+                "The redo functionality was removed because of dangerous --force functionality. Please build another RC.",
+                "red",
+            ),
+            code=1,
+        )
     else:
         new_version = next_rc_version(ctx, max(list_major_versions), patch_version)
 
@@ -1310,8 +1319,7 @@ def build_rc(ctx, major_versions="6,7", patch_version=False, redo=False):
     # tag_version only takes the highest version (Agent 7 currently), and creates
     # the tags for all supported versions
     # TODO: make it possible to do Agent 6-only or Agent 7-only tags?
-    # Note: if redo is enabled, then we need to set the --force option to move the tags.
-    tag_version(ctx, str(new_version), force=redo)
+    tag_version(ctx, str(new_version), force=False)
 
     print(color_message(f"Waiting until the {new_version} tag appears in Gitlab", "bold"))
     gitlab_tag = None

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -1251,6 +1251,7 @@ Make sure that milestone is open before trying again.""",
     )
 
 
+@task
 def build_rc(ctx, major_versions="6,7", patch_version=False):
     """
     To be done after the PR created by release.create-rc is merged, with the same options

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -1251,12 +1251,7 @@ Make sure that milestone is open before trying again.""",
     )
 
 
-@task(
-    help={
-        'redo': "The redo functionality was removed because of dangerous --force functionality. Please build another RC."
-    }
-)
-def build_rc(ctx, major_versions="6,7", patch_version=False, redo=False):
+def build_rc(ctx, major_versions="6,7", patch_version=False):
     """
     To be done after the PR created by release.create-rc is merged, with the same options
     as release.create-rc.
@@ -1272,16 +1267,7 @@ def build_rc(ctx, major_versions="6,7", patch_version=False, redo=False):
 
     # Get the version of the highest major: needed for tag_version and to know
     # which tag to target when creating the pipeline.
-    if redo:
-        raise Exit(
-            color_message(
-                "The redo functionality was removed because of dangerous --force functionality. Please build another RC.",
-                "red",
-            ),
-            code=1,
-        )
-    else:
-        new_version = next_rc_version(ctx, max(list_major_versions), patch_version)
+    new_version = next_rc_version(ctx, max(list_major_versions), patch_version)
 
     # Get a string representation of the RC, eg. "6/7.32.0-rc.1"
     versions_string = f"{'/'.join([str(n) for n in list_major_versions[:-1]] + [str(new_version)])}"


### PR DESCRIPTION
### What does this PR do?

Removes the `--redo` flag of the `release.build-rc` flag.

### Motivation

The --redo flag from the build rc task untags and tags a git tag. This is not a safe operation since it can mess up the Go modules proxy if the original tag is stored there. Let's remove it completely and rather suggest doing another RC.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
