### PR TITLE
[KSM Core] Add ingress metrics

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -759,8 +759,8 @@ func labelsMapperOverride(metricName string) map[string]string {
 		return map[string]string{
 			"host":         "ingress_host",
 			"path":         "ingress_path",
-			"service_name": "ingress_service_name",
-			"service_port": "ingress_service_port",
+			"service_name": "kube_service",
+			"service_port": "kube_service_port",
 		}
 	}
 

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -757,8 +757,8 @@ func labelsMapperOverride(metricName string) map[string]string {
 
 	if strings.HasPrefix(metricName, "kube_ingress") {
 		return map[string]string{
-			"host":         "ingress_host",
-			"path":         "ingress_path",
+			"host":         "kube_ingress_host",
+			"path":         "kube_ingress_path",
 			"service_name": "kube_service",
 			"service_port": "kube_service_port",
 		}

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -698,7 +698,6 @@ func buildDeniedMetricsSet(collectors []string) options.MetricSet {
 		"kube_job_status_.*_time":                          {},
 		"kube_service_spec_external_ip":                    {},
 		"kube_service_status_load_balancer_ingress":        {},
-		"kube_ingress_path":                                {},
 		"kube_statefulset_status_current_revision":         {},
 		"kube_statefulset_status_update_revision":          {},
 		"kube_pod_container_status_last_terminated_reason": {},
@@ -745,17 +744,24 @@ func ownerTags(kind, name string) []string {
 	return tags
 }
 
-// podLabelsMapperOverride defines the label mapper overrides
-// that should be applied on pod metrics only.
-var podLabelsMapperOverride = map[string]string{"phase": "pod_phase"}
-
 // labelsMapperOverride allows overriding the default label mapping for
 // a given metric depending on the metric family.
-// Current use-case:
+// Current use-cases:
 //   - `phase` tag should be mapped to `pod_phase` on pod metrics only.
+//   - Ingress metrics have generic tag names (host/path/service_name/service_port).
+//     It's important to have them in a dedicated mapper override for ingresses.
 func labelsMapperOverride(metricName string) map[string]string {
 	if strings.HasPrefix(metricName, "kube_pod") {
-		return podLabelsMapperOverride
+		return map[string]string{"phase": "pod_phase"}
+	}
+
+	if strings.HasPrefix(metricName, "kube_ingress") {
+		return map[string]string{
+			"host":         "ingress_host",
+			"path":         "ingress_path",
+			"service_name": "ingress_service_name",
+			"service_port": "ingress_service_port",
+		}
 	}
 
 	return nil

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.md
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.md
@@ -362,7 +362,7 @@
 : Number of ingresses. Tags:`kube_namespace`.
 
 `kubernetes_state.ingress.path`
-: Information about the ingress path. Tags:`kube_namespace` `ingress_path` `kube_ingress` `ingress_service_name` `ingress_service_port` `ingress_host` .
+: Information about the ingress path. Tags:`kube_namespace` `kube_ingress_path` `kube_ingress` `kube_service` `kube_service_port` `kube_ingress_host` .
 
 ### Events
 

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.md
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.md
@@ -358,6 +358,12 @@
 `kubernetes_state.service.type`
 : Service types. Tags:`kube_namespace` `kube_service` `type`.
 
+`kubernetes_state.ingress.count`
+: Number of ingresses. Tags:`kube_namespace`.
+
+`kubernetes_state.ingress.path`
+: Information about the ingress path. Tags:`kube_namespace` `ingress_path` `kube_ingress` `ingress_service_name` `ingress_service_port` `ingress_host` .
+
 ### Events
 
 The Kubernetes State Metrics Core check does not include any events.

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators.go
@@ -295,6 +295,11 @@ func defaultMetricAggregators() map[string]metricAggregator {
 			"kube_pod_info",
 			[]string{"node", "namespace", "created_by_kind", "created_by_name"},
 		),
+		"kube_ingress_labels": newCountObjectsAggregator(
+			"ingress.count",
+			"kube_ingress_labels",
+			[]string{"namespace"},
+		),
 		"kube_job_complete": &lastCronJobCompleteAggregator{aggregator: cronJobAggregator},
 		"kube_job_failed":   &lastCronJobFailedAggregator{aggregator: cronJobAggregator},
 	}

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
@@ -82,6 +82,7 @@ func defaultMetricNamesMapper() map[string]string {
 		"kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_minallowed":             "vpa.spec_container_minallowed",
 		"kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_maxallowed":             "vpa.spec_container_maxallowed",
 		"kube_cronjob_spec_suspend":                                                                "cronjob.spec_suspend",
+		"kube_ingress_path":                                                                        "ingress.path",
 	}
 }
 
@@ -110,6 +111,7 @@ func defaultLabelsMapper() map[string]string {
 		"label_topology_kubernetes_io_zone":   "kube_zone",
 		"label_failure_domain_beta_kubernetes_io_region": "kube_region",
 		"label_failure_domain_beta_kubernetes_io_zone":   "kube_zone",
+		"ingress": "kube_ingress",
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
@@ -447,6 +447,34 @@ func TestProcessMetrics(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:   "ingress metric",
+			config: &KSMConfig{LabelsMapper: defaultLabelsMapper()},
+			metricsToProcess: map[string][]ksmstore.DDMetricsFam{
+				"kube_pod_status_phase": {
+					{
+						Type: "*networking.k8s.io/v1.Ingress",
+						Name: "kube_ingress_path",
+						ListMetrics: []ksmstore.DDMetric{
+							{
+								Labels: map[string]string{"namespace": "default", "ingress": "ingress", "service_name": "svc", "service_port": "80", "host": "host", "path": "path"},
+								Val:    1,
+							},
+						},
+					},
+				},
+			},
+			metricsToGet:       []ksmstore.DDMetricsFam{},
+			metricTransformers: defaultMetricTransformers(),
+			expected: []metricsExpected{
+				{
+					name:     "kubernetes_state.ingress.path",
+					val:      1,
+					tags:     []string{"kube_namespace:default", "kube_ingress:ingress", "ingress_service_name:svc", "ingress_service_port:80", "ingress_host:host", "ingress_path:path"},
+					hostname: "",
+				},
+			},
+		},
 	}
 	for _, test := range tests {
 		kubeStateMetricsSCheck := newKSMCheck(core.NewCheckBase(kubeStateMetricsCheckName), test.config)

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
@@ -470,7 +470,7 @@ func TestProcessMetrics(t *testing.T) {
 				{
 					name:     "kubernetes_state.ingress.path",
 					val:      1,
-					tags:     []string{"kube_namespace:default", "kube_ingress:ingress", "kube_service:svc", "kube_service_port:80", "ingress_host:host", "ingress_path:path"},
+					tags:     []string{"kube_namespace:default", "kube_ingress:ingress", "kube_service:svc", "kube_service_port:80", "kube_ingress_host:host", "kube_ingress_path:path"},
 					hostname: "",
 				},
 			},

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
@@ -470,7 +470,7 @@ func TestProcessMetrics(t *testing.T) {
 				{
 					name:     "kubernetes_state.ingress.path",
 					val:      1,
-					tags:     []string{"kube_namespace:default", "kube_ingress:ingress", "ingress_service_name:svc", "ingress_service_port:80", "ingress_host:host", "ingress_path:path"},
+					tags:     []string{"kube_namespace:default", "kube_ingress:ingress", "kube_service:svc", "kube_service_port:80", "ingress_host:host", "ingress_path:path"},
 					hostname: "",
 				},
 			},

--- a/releasenotes-dca/notes/ksm-ingress-1c2d5abfbeca6c2f.yaml
+++ b/releasenotes-dca/notes/ksm-ingress-1c2d5abfbeca6c2f.yaml
@@ -1,5 +1,5 @@
 ---
 enhancements:
   - |
-    The Kubernetes State Metrics Core check now collects 2 ingress metrics:
+    The Kubernetes State Metrics Core check now collects two ingress metrics:
     ``kubernetes_state.ingress.count`` and ``kubernetes_state.ingress.path``.

--- a/releasenotes-dca/notes/ksm-ingress-1c2d5abfbeca6c2f.yaml
+++ b/releasenotes-dca/notes/ksm-ingress-1c2d5abfbeca6c2f.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    The Kubernetes State Metrics Core check now collects 2 ingress metrics:
+    ``kubernetes_state.ingress.count`` and ``kubernetes_state.ingress.path``.

--- a/releasenotes/notes/ksm-ingress-1c2d5abfbeca6c2f.yaml
+++ b/releasenotes/notes/ksm-ingress-1c2d5abfbeca6c2f.yaml
@@ -1,5 +1,5 @@
 ---
 enhancements:
   - |
-    The Kubernetes State Metrics Core check now collects 2 ingress metrics:
+    The Kubernetes State Metrics Core check now collects two ingress metrics:
     ``kubernetes_state.ingress.count`` and ``kubernetes_state.ingress.path``.

--- a/releasenotes/notes/ksm-ingress-1c2d5abfbeca6c2f.yaml
+++ b/releasenotes/notes/ksm-ingress-1c2d5abfbeca6c2f.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    The Kubernetes State Metrics Core check now collects 2 ingress metrics:
+    ``kubernetes_state.ingress.count`` and ``kubernetes_state.ingress.path``.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Collect `kubernetes_state.ingress.count` and `kubernetes_state.ingress.path`.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

FR
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Enable the ingress collector if it's not enabled, make sure the metrics are collected and the tags are remapped as expected

![image](https://user-images.githubusercontent.com/38987709/172817453-7649a77f-3b40-409a-a454-775b74a12868.png)

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
