### PR TITLE
[pkg/otlp/model] Partial sync with Datadog exporter codebase

### DIFF
--- a/pkg/otlp/model/attributes/azure/azure.go
+++ b/pkg/otlp/model/attributes/azure/azure.go
@@ -33,11 +33,11 @@ type HostInfo struct {
 
 // HostInfoFromAttributes gets Azure host info from attributes following
 // OpenTelemetry semantic conventions
-func HostInfoFromAttributes(attrs pcommon.Map) (hostInfo *HostInfo) {
+func HostInfoFromAttributes(attrs pcommon.Map, usePreviewRules bool) (hostInfo *HostInfo) {
 	hostInfo = &HostInfo{}
 
 	// Add Azure VM ID as a host alias if available for compatibility with Azure integration
-	if vmID, ok := attrs.Get(conventions.AttributeHostID); ok {
+	if vmID, ok := attrs.Get(conventions.AttributeHostID); ok && !usePreviewRules {
 		hostInfo.HostAliases = append(hostInfo.HostAliases, vmID.StringVal())
 	}
 
@@ -45,7 +45,11 @@ func HostInfoFromAttributes(attrs pcommon.Map) (hostInfo *HostInfo) {
 }
 
 // HostnameFromAttributes gets the Azure hostname from attributes
-func HostnameFromAttributes(attrs pcommon.Map) (string, bool) {
+func HostnameFromAttributes(attrs pcommon.Map, usePreviewRules bool) (string, bool) {
+	if vmID, ok := attrs.Get(conventions.AttributeHostID); usePreviewRules && ok {
+		return vmID.StringVal(), true
+	}
+
 	if hostname, ok := attrs.Get(conventions.AttributeHostName); ok {
 		return hostname.StringVal(), true
 	}

--- a/pkg/otlp/model/attributes/azure/azure_test.go
+++ b/pkg/otlp/model/attributes/azure/azure_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
 
 	"github.com/DataDog/datadog-agent/pkg/otlp/model/internal/testutils"
@@ -38,22 +39,55 @@ var (
 )
 
 func TestHostInfoFromAttributes(t *testing.T) {
-	hostInfo := HostInfoFromAttributes(testAttrs)
-	require.NotNil(t, hostInfo)
-	assert.ElementsMatch(t, hostInfo.HostAliases, []string{testVMID})
+	tests := []struct {
+		name       string
+		attrs      pcommon.Map
+		usePreview bool
 
-	emptyHostInfo := HostInfoFromAttributes(testEmpty)
-	require.NotNil(t, emptyHostInfo)
-	assert.ElementsMatch(t, emptyHostInfo.HostAliases, []string{})
-}
+		ok       bool
+		hostname string
+		aliases  []string
+	}{
+		{
+			name:  "all attributes",
+			attrs: testAttrs,
 
-func TestHostnameFromAttributes(t *testing.T) {
-	hostname, ok := HostnameFromAttributes(testAttrs)
-	assert.True(t, ok)
-	assert.Equal(t, hostname, testHostname)
+			ok:       true,
+			hostname: testHostname,
+			aliases:  []string{testVMID},
+		},
+		{
+			name:  "empty",
+			attrs: testEmpty,
+		},
+		{
+			name:       "all attributes with preview",
+			attrs:      testAttrs,
+			usePreview: true,
 
-	_, ok = HostnameFromAttributes(testEmpty)
-	assert.False(t, ok)
+			ok:       true,
+			hostname: testVMID,
+		},
+		{
+			name:       "empty with preview",
+			attrs:      testEmpty,
+			usePreview: true,
+		},
+	}
+
+	for _, testInstance := range tests {
+		t.Run(testInstance.name, func(t *testing.T) {
+			hostInfo := HostInfoFromAttributes(testInstance.attrs, testInstance.usePreview)
+			require.NotNil(t, hostInfo)
+			assert.ElementsMatch(t, testInstance.aliases, hostInfo.HostAliases)
+			hostname, ok := HostnameFromAttributes(testInstance.attrs, testInstance.usePreview)
+
+			assert.Equal(t, testInstance.ok, ok)
+			if testInstance.ok || ok {
+				assert.Equal(t, testInstance.hostname, hostname)
+			}
+		})
+	}
 }
 
 func TestClusterNameFromAttributes(t *testing.T) {

--- a/pkg/otlp/model/attributes/ec2/ec2.go
+++ b/pkg/otlp/model/attributes/ec2/ec2.go
@@ -48,9 +48,10 @@ func isDefaultHostname(hostname string) bool {
 
 // HostnameFromAttributes gets a valid hostname from labels
 // if available
-func HostnameFromAttributes(attrs pcommon.Map) (string, bool) {
+func HostnameFromAttributes(attrs pcommon.Map, usePreviewRules bool) (string, bool) {
 	hostName, ok := attrs.Get(conventions.AttributeHostName)
-	if ok && !isDefaultHostname(hostName.StringVal()) {
+	// With hostname preview rules, return the EC2 instance id always.
+	if !usePreviewRules && ok && !isDefaultHostname(hostName.StringVal()) {
 		return hostName.StringVal(), true
 	}
 

--- a/pkg/otlp/model/attributes/ec2/ec2_test.go
+++ b/pkg/otlp/model/attributes/ec2/ec2_test.go
@@ -44,7 +44,11 @@ func TestHostnameFromAttributes(t *testing.T) {
 		conventions.AttributeHostID:        testInstanceID,
 		conventions.AttributeHostName:      testIP,
 	})
-	hostname, ok := HostnameFromAttributes(attrs)
+	hostname, ok := HostnameFromAttributes(attrs, false)
+	assert.True(t, ok)
+	assert.Equal(t, hostname, testInstanceID)
+
+	hostname, ok = HostnameFromAttributes(attrs, true)
 	assert.True(t, ok)
 	assert.Equal(t, hostname, testInstanceID)
 }

--- a/pkg/otlp/model/attributes/gcp/gcp.go
+++ b/pkg/otlp/model/attributes/gcp/gcp.go
@@ -16,6 +16,7 @@ package gcp
 
 import (
 	"fmt"
+	"strings"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
@@ -27,9 +28,37 @@ type HostInfo struct {
 	GCPTags     []string
 }
 
+func getGCPIntegrationHostname(attrs pcommon.Map) (string, bool) {
+	hostName, ok := attrs.Get(conventions.AttributeHostName)
+	if !ok {
+		// We need the hostname.
+		return "", false
+	}
+
+	name := hostName.StringVal()
+	if strings.Count(name, ".") >= 3 {
+		// Unless the host.name attribute has been tampered with, use the same logic as the Agent to
+		// extract the hostname: https://github.com/DataDog/datadog-agent/blob/7.36.0/pkg/util/cloudproviders/gce/gce.go#L106
+		name = strings.SplitN(name, ".", 2)[0]
+	}
+
+	cloudAccount, ok := attrs.Get(conventions.AttributeCloudAccountID)
+	if !ok {
+		// We need the project ID.
+		return "", false
+	}
+
+	alias := fmt.Sprintf("%s.%s", name, cloudAccount.StringVal())
+	return alias, true
+}
+
 // HostnameFromAttributes gets a valid hostname from labels
 // if available
-func HostnameFromAttributes(attrs pcommon.Map) (string, bool) {
+func HostnameFromAttributes(attrs pcommon.Map, usePreviewRules bool) (string, bool) {
+	if usePreviewRules {
+		return getGCPIntegrationHostname(attrs)
+	}
+
 	if hostName, ok := attrs.Get(conventions.AttributeHostName); ok {
 		return hostName.StringVal(), true
 	}
@@ -39,13 +68,10 @@ func HostnameFromAttributes(attrs pcommon.Map) (string, bool) {
 
 // HostInfoFromAttributes gets GCP host info from attributes following
 // OpenTelemetry semantic conventions
-func HostInfoFromAttributes(attrs pcommon.Map) (hostInfo *HostInfo) {
+func HostInfoFromAttributes(attrs pcommon.Map, usePreviewRules bool) (hostInfo *HostInfo) {
 	hostInfo = &HostInfo{}
 
 	if hostID, ok := attrs.Get(conventions.AttributeHostID); ok {
-		// Add host id as a host alias to preserve backwards compatibility
-		// The Datadog Agent does not do this
-		hostInfo.HostAliases = append(hostInfo.HostAliases, hostID.StringVal())
 		hostInfo.GCPTags = append(hostInfo.GCPTags, fmt.Sprintf("instance-id:%s", hostID.StringVal()))
 	}
 
@@ -59,6 +85,10 @@ func HostInfoFromAttributes(attrs pcommon.Map) (hostInfo *HostInfo) {
 
 	if cloudAccount, ok := attrs.Get(conventions.AttributeCloudAccountID); ok {
 		hostInfo.GCPTags = append(hostInfo.GCPTags, fmt.Sprintf("project:%s", cloudAccount.StringVal()))
+	}
+
+	if alias, ok := getGCPIntegrationHostname(attrs); ok && !usePreviewRules {
+		hostInfo.HostAliases = append(hostInfo.HostAliases, alias)
 	}
 
 	return

--- a/pkg/otlp/model/attributes/gcp/gcp_test.go
+++ b/pkg/otlp/model/attributes/gcp/gcp_test.go
@@ -14,39 +14,28 @@
 package gcp
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
 
 	"github.com/DataDog/datadog-agent/pkg/otlp/model/internal/testutils"
 )
 
 const (
-	testHostname     = "hostname"
-	testHostID       = "hostID"
-	testCloudZone    = "zone"
-	testHostType     = "machineType"
-	testCloudAccount = "projectID"
+	testShortHostname = "hostname"
+	testHostID        = "hostID"
+	testCloudZone     = "zone"
+	testHostType      = "machineType"
+	testCloudAccount  = "projectID"
+	testHostname      = testShortHostname + ".c." + testCloudAccount + ".internal"
+	testBadHostname   = "badhostname"
 )
 
-func TestHostnameFromAttributes(t *testing.T) {
-	attrs := testutils.NewAttributeMap(map[string]string{
-		conventions.AttributeCloudProvider: conventions.AttributeCloudProviderGCP,
-		conventions.AttributeHostID:        testHostID,
-		conventions.AttributeHostName:      testHostname,
-	})
-	hostname, ok := HostnameFromAttributes(attrs)
-	assert.True(t, ok)
-	assert.Equal(t, hostname, testHostname)
-
-	attrs = testutils.NewAttributeMap(map[string]string{})
-	_, ok = HostnameFromAttributes(attrs)
-	assert.False(t, ok)
-}
-
-func TestHostInfoFromAttributes(t *testing.T) {
-	attrs := testutils.NewAttributeMap(map[string]string{
+var (
+	testFullMap = testutils.NewAttributeMap(map[string]string{
 		conventions.AttributeCloudProvider:         conventions.AttributeCloudProviderGCP,
 		conventions.AttributeHostID:                testHostID,
 		conventions.AttributeHostName:              testHostname,
@@ -54,8 +43,84 @@ func TestHostInfoFromAttributes(t *testing.T) {
 		conventions.AttributeHostType:              testHostType,
 		conventions.AttributeCloudAccountID:        testCloudAccount,
 	})
-	hostInfo := HostInfoFromAttributes(attrs)
-	assert.ElementsMatch(t, hostInfo.HostAliases, []string{testHostID})
-	assert.ElementsMatch(t, hostInfo.GCPTags,
-		[]string{"instance-id:hostID", "zone:zone", "instance-type:machineType", "project:projectID"})
+
+	testFullBadMap = testutils.NewAttributeMap(map[string]string{
+		conventions.AttributeCloudProvider:         conventions.AttributeCloudProviderGCP,
+		conventions.AttributeHostID:                testHostID,
+		conventions.AttributeHostName:              testBadHostname,
+		conventions.AttributeCloudAvailabilityZone: testCloudZone,
+		conventions.AttributeHostType:              testHostType,
+		conventions.AttributeCloudAccountID:        testCloudAccount,
+	})
+
+	testGCPIntegrationHostname    = fmt.Sprintf("%s.%s", testShortHostname, testCloudAccount)
+	testGCPIntegrationBadHostname = fmt.Sprintf("%s.%s", testBadHostname, testCloudAccount)
+)
+
+func TestInfoFromAttributes(t *testing.T) {
+	tags := []string{"instance-id:hostID", "zone:zone", "instance-type:machineType", "project:projectID"}
+	tests := []struct {
+		name       string
+		attrs      pcommon.Map
+		usePreview bool
+
+		ok          bool
+		hostname    string
+		hostAliases []string
+		gcpTags     []string
+	}{
+		{
+			name:        "no preview",
+			attrs:       testFullMap,
+			ok:          true,
+			hostname:    testHostname,
+			hostAliases: []string{testGCPIntegrationHostname},
+			gcpTags:     tags,
+		},
+		{
+			name:  "no hostname, no preview",
+			attrs: testutils.NewAttributeMap(map[string]string{}),
+		},
+		{
+			name:       "preview",
+			attrs:      testFullMap,
+			usePreview: true,
+			ok:         true,
+			hostname:   testGCPIntegrationHostname,
+			gcpTags:    tags,
+		},
+		{
+			name:        "bad hostname, no preview",
+			attrs:       testFullBadMap,
+			ok:          true,
+			hostname:    testBadHostname,
+			hostAliases: []string{testGCPIntegrationBadHostname},
+			gcpTags:     tags,
+		},
+		{
+			name:       "bad hostname, preview",
+			attrs:      testFullBadMap,
+			usePreview: true,
+			ok:         true,
+			hostname:   testGCPIntegrationBadHostname,
+			gcpTags:    tags,
+		},
+		{
+			name:       "no hostname, preview",
+			attrs:      testutils.NewAttributeMap(map[string]string{}),
+			usePreview: true,
+		},
+	}
+
+	for _, testInstance := range tests {
+		t.Run(testInstance.name, func(t *testing.T) {
+			hostname, ok := HostnameFromAttributes(testInstance.attrs, testInstance.usePreview)
+			assert.Equal(t, testInstance.ok, ok)
+			assert.Equal(t, testInstance.hostname, hostname)
+
+			hostInfo := HostInfoFromAttributes(testInstance.attrs, testInstance.usePreview)
+			assert.ElementsMatch(t, testInstance.hostAliases, hostInfo.HostAliases)
+			assert.ElementsMatch(t, testInstance.gcpTags, hostInfo.GCPTags)
+		})
+	}
 }

--- a/pkg/otlp/model/attributes/hostname.go
+++ b/pkg/otlp/model/attributes/hostname.go
@@ -54,9 +54,8 @@ func getClusterName(attrs pcommon.Map) (string, bool) {
 //   5. the cloud provider host ID and
 //   6. the host.name attribute.
 //
-//  It returns a boolean value indicated if any name was found. In some environments (such as Fargate)
-//  it may be possible to return an empty value and true.
-func HostnameFromAttributes(attrs pcommon.Map) (hostname string, ok bool) {
+//  It returns a boolean value indicated if any name was found
+func HostnameFromAttributes(attrs pcommon.Map, usePreviewRules bool) (string, bool) {
 	// Check if the host is localhost or 0.0.0.0, if so discard it.
 	// We don't do the more strict validation done for metadata,
 	// to avoid breaking users existing invalid-but-accepted hostnames.
@@ -69,14 +68,14 @@ func HostnameFromAttributes(attrs pcommon.Map) (hostname string, ok bool) {
 		"ip6-localhost":           {},
 	}
 
-	candidateHost, ok := unsanitizedHostnameFromAttributes(attrs)
+	candidateHost, ok := unsanitizedHostnameFromAttributes(attrs, usePreviewRules)
 	if _, invalid := invalidHosts[candidateHost]; invalid {
 		return "", false
 	}
 	return candidateHost, ok
 }
 
-func unsanitizedHostnameFromAttributes(attrs pcommon.Map) (string, bool) {
+func unsanitizedHostnameFromAttributes(attrs pcommon.Map, usePreviewRules bool) (string, bool) {
 	// Custom hostname: useful for overriding in k8s/cloud envs
 	if customHostname, ok := attrs.Get(AttributeDatadogHostname); ok {
 		return customHostname.StringVal(), true
@@ -97,11 +96,11 @@ func unsanitizedHostnameFromAttributes(attrs pcommon.Map) (string, bool) {
 
 	cloudProvider, ok := attrs.Get(conventions.AttributeCloudProvider)
 	if ok && cloudProvider.StringVal() == conventions.AttributeCloudProviderAWS {
-		return ec2.HostnameFromAttributes(attrs)
+		return ec2.HostnameFromAttributes(attrs, usePreviewRules)
 	} else if ok && cloudProvider.StringVal() == conventions.AttributeCloudProviderGCP {
-		return gcp.HostnameFromAttributes(attrs)
+		return gcp.HostnameFromAttributes(attrs, usePreviewRules)
 	} else if ok && cloudProvider.StringVal() == conventions.AttributeCloudProviderAzure {
-		return azure.HostnameFromAttributes(attrs)
+		return azure.HostnameFromAttributes(attrs, usePreviewRules)
 	}
 
 	// host id from cloud provider
@@ -114,9 +113,11 @@ func unsanitizedHostnameFromAttributes(attrs pcommon.Map) (string, bool) {
 		return hostName.StringVal(), true
 	}
 
-	// container id (e.g. from Docker)
-	if containerID, ok := attrs.Get(conventions.AttributeContainerID); ok {
-		return containerID.StringVal(), true
+	if !usePreviewRules {
+		// container id (e.g. from Docker)
+		if containerID, ok := attrs.Get(conventions.AttributeContainerID); ok {
+			return containerID.StringVal(), true
+		}
 	}
 
 	return "", false

--- a/pkg/otlp/model/attributes/hostname_test.go
+++ b/pkg/otlp/model/attributes/hostname_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
 
 	"github.com/DataDog/datadog-agent/pkg/otlp/model/attributes/azure"
@@ -25,100 +26,160 @@ import (
 )
 
 const (
-	testHostID      = "example-host-id"
-	testHostName    = "example-host-name"
-	testContainerID = "example-container-id"
-	testClusterName = "clusterName"
-	testNodeName    = "nodeName"
-	testCustomName  = "example-custom-host-name"
+	testHostID                 = "example-host-id"
+	testHostName               = "example-host-name"
+	testContainerID            = "example-container-id"
+	testClusterName            = "clusterName"
+	testNodeName               = "nodeName"
+	testCustomName             = "example-custom-host-name"
+	testCloudAccount           = "projectID"
+	testGCPHostname            = testHostName + ".c." + testCloudAccount + ".internal"
+	testGCPIntegrationHostname = testHostName + "." + testCloudAccount
 )
 
 func TestHostnameFromAttributes(t *testing.T) {
-	// Custom hostname
-	attrs := testutils.NewAttributeMap(map[string]string{
-		AttributeDatadogHostname:            testCustomName,
-		AttributeK8sNodeName:                testNodeName,
-		conventions.AttributeK8SClusterName: testClusterName,
-		conventions.AttributeContainerID:    testContainerID,
-		conventions.AttributeHostID:         testHostID,
-		conventions.AttributeHostName:       testHostName,
-	})
-	hostname, ok := HostnameFromAttributes(attrs)
-	assert.True(t, ok)
-	assert.Equal(t, hostname, testCustomName)
+	tests := []struct {
+		name       string
+		attrs      pcommon.Map
+		usePreview bool
 
-	// Container ID
-	attrs = testutils.NewAttributeMap(map[string]string{
-		conventions.AttributeContainerID: testContainerID,
-	})
-	hostname, ok = HostnameFromAttributes(attrs)
-	assert.True(t, ok)
-	assert.Equal(t, hostname, testContainerID)
+		ok       bool
+		hostname string
+	}{
+		{
+			name: "custom hostname",
+			attrs: testutils.NewAttributeMap(map[string]string{
+				AttributeDatadogHostname:            testCustomName,
+				AttributeK8sNodeName:                testNodeName,
+				conventions.AttributeK8SClusterName: testClusterName,
+				conventions.AttributeContainerID:    testContainerID,
+				conventions.AttributeHostID:         testHostID,
+				conventions.AttributeHostName:       testHostName,
+			}),
+			ok:       true,
+			hostname: testCustomName,
+		},
+		{
+			name: "container ID",
+			attrs: testutils.NewAttributeMap(map[string]string{
+				conventions.AttributeContainerID: testContainerID,
+			}),
+			ok:       true,
+			hostname: testContainerID,
+		},
+		{
+			name: "container ID, preview",
+			attrs: testutils.NewAttributeMap(map[string]string{
+				conventions.AttributeContainerID: testContainerID,
+			}),
+			usePreview: true,
+		},
+		{
+			name: "AWS EC2",
+			attrs: testutils.NewAttributeMap(map[string]string{
+				conventions.AttributeCloudProvider: conventions.AttributeCloudProviderAWS,
+				conventions.AttributeHostID:        testHostID,
+				conventions.AttributeHostName:      testHostName,
+			}),
+			ok:       true,
+			hostname: testHostName,
+		},
+		{
+			name: "AWS EC2, preview",
+			attrs: testutils.NewAttributeMap(map[string]string{
+				conventions.AttributeCloudProvider: conventions.AttributeCloudProviderAWS,
+				conventions.AttributeHostID:        testHostID,
+				conventions.AttributeHostName:      testHostName,
+			}),
+			ok:         true,
+			hostname:   testHostID,
+			usePreview: true,
+		},
+		{
+			name: "ECS Fargate",
+			attrs: testutils.NewAttributeMap(map[string]string{
+				conventions.AttributeCloudProvider:      conventions.AttributeCloudProviderAWS,
+				conventions.AttributeCloudPlatform:      conventions.AttributeCloudPlatformAWSECS,
+				conventions.AttributeAWSECSTaskARN:      "example-task-ARN",
+				conventions.AttributeAWSECSTaskFamily:   "example-task-family",
+				conventions.AttributeAWSECSTaskRevision: "example-task-revision",
+				conventions.AttributeAWSECSLaunchtype:   conventions.AttributeAWSECSLaunchtypeFargate,
+			}),
+			ok:       true,
+			hostname: "",
+		},
+		{
+			name: "GCP",
+			attrs: testutils.NewAttributeMap(map[string]string{
+				conventions.AttributeCloudProvider: conventions.AttributeCloudProviderGCP,
+				conventions.AttributeHostID:        testHostID,
+				conventions.AttributeHostName:      testGCPHostname,
+			}),
+			ok:       true,
+			hostname: testGCPHostname,
+		},
+		{
+			name: "GCP, preview",
+			attrs: testutils.NewAttributeMap(map[string]string{
+				conventions.AttributeCloudProvider:  conventions.AttributeCloudProviderGCP,
+				conventions.AttributeHostID:         testHostID,
+				conventions.AttributeHostName:       testGCPHostname,
+				conventions.AttributeCloudAccountID: testCloudAccount,
+			}),
+			usePreview: true,
+			ok:         true,
+			hostname:   testGCPIntegrationHostname,
+		},
+		{
+			name: "azure",
+			attrs: testutils.NewAttributeMap(map[string]string{
+				conventions.AttributeCloudProvider: conventions.AttributeCloudProviderAzure,
+				conventions.AttributeHostID:        testHostID,
+				conventions.AttributeHostName:      testHostName,
+			}),
+			ok:       true,
+			hostname: testHostName,
+		},
+		{
+			name: "azure, preview",
+			attrs: testutils.NewAttributeMap(map[string]string{
+				conventions.AttributeCloudProvider: conventions.AttributeCloudProviderAzure,
+				conventions.AttributeHostID:        testHostID,
+				conventions.AttributeHostName:      testHostName,
+			}),
+			usePreview: true,
+			ok:         true,
+			hostname:   testHostID,
+		},
+		{
+			name: "host id v. hostname",
+			attrs: testutils.NewAttributeMap(map[string]string{
+				conventions.AttributeHostID:   testHostID,
+				conventions.AttributeHostName: testHostName,
+			}),
+			ok:       true,
+			hostname: testHostID,
+		},
+		{
+			name:  "no hostname",
+			attrs: testutils.NewAttributeMap(map[string]string{}),
+		},
+		{
+			name: "localhost",
+			attrs: testutils.NewAttributeMap(map[string]string{
+				AttributeDatadogHostname: "127.0.0.1",
+			}),
+		},
+	}
 
-	// AWS cloud provider means relying on the EC2 function
-	attrs = testutils.NewAttributeMap(map[string]string{
-		conventions.AttributeCloudProvider: conventions.AttributeCloudProviderAWS,
-		conventions.AttributeHostID:        testHostID,
-		conventions.AttributeHostName:      testHostName,
-	})
-	hostname, ok = HostnameFromAttributes(attrs)
-	assert.True(t, ok)
-	assert.Equal(t, hostname, testHostName)
+	for _, testInstance := range tests {
+		t.Run(testInstance.name, func(t *testing.T) {
+			hostname, ok := HostnameFromAttributes(testInstance.attrs, testInstance.usePreview)
+			assert.Equal(t, testInstance.ok, ok)
+			assert.Equal(t, testInstance.hostname, hostname)
+		})
 
-	// AWS cloud provider means relying on the EC2 function
-	attrs = testutils.NewAttributeMap(map[string]string{
-		conventions.AttributeCloudProvider:      conventions.AttributeCloudProviderAWS,
-		conventions.AttributeCloudPlatform:      conventions.AttributeCloudPlatformAWSECS,
-		conventions.AttributeAWSECSTaskARN:      "example-task-ARN",
-		conventions.AttributeAWSECSTaskFamily:   "example-task-family",
-		conventions.AttributeAWSECSTaskRevision: "example-task-revision",
-		conventions.AttributeAWSECSLaunchtype:   conventions.AttributeAWSECSLaunchtypeFargate,
-	})
-	hostname, ok = HostnameFromAttributes(attrs)
-	assert.True(t, ok)
-	assert.Empty(t, hostname)
-
-	// GCP cloud provider means relying on the GCP function
-	attrs = testutils.NewAttributeMap(map[string]string{
-		conventions.AttributeCloudProvider: conventions.AttributeCloudProviderGCP,
-		conventions.AttributeHostID:        testHostID,
-		conventions.AttributeHostName:      testHostName,
-	})
-	hostname, ok = HostnameFromAttributes(attrs)
-	assert.True(t, ok)
-	assert.Equal(t, hostname, testHostName)
-
-	// Azure cloud provider means relying on the Azure function
-	attrs = testutils.NewAttributeMap(map[string]string{
-		conventions.AttributeCloudProvider: conventions.AttributeCloudProviderAzure,
-		conventions.AttributeHostID:        testHostID,
-		conventions.AttributeHostName:      testHostName,
-	})
-	hostname, ok = HostnameFromAttributes(attrs)
-	assert.True(t, ok)
-	assert.Equal(t, hostname, testHostName)
-
-	// Host Id takes preference
-	attrs = testutils.NewAttributeMap(map[string]string{
-		conventions.AttributeHostID:   testHostID,
-		conventions.AttributeHostName: testHostName,
-	})
-	hostname, ok = HostnameFromAttributes(attrs)
-	assert.True(t, ok)
-	assert.Equal(t, hostname, testHostID)
-
-	// No labels means no hostname
-	attrs = testutils.NewAttributeMap(map[string]string{})
-	hostname, ok = HostnameFromAttributes(attrs)
-	assert.False(t, ok)
-	assert.Empty(t, hostname)
-
-	attrs = testutils.NewAttributeMap(map[string]string{
-		AttributeDatadogHostname: "127.0.0.1",
-	})
-	hostname, ok = HostnameFromAttributes(attrs)
-	assert.False(t, ok)
-	assert.Empty(t, hostname)
+	}
 }
 
 func TestGetClusterName(t *testing.T) {
@@ -163,7 +224,7 @@ func TestHostnameKubernetes(t *testing.T) {
 		conventions.AttributeHostID:         testHostID,
 		conventions.AttributeHostName:       testHostName,
 	})
-	hostname, ok := HostnameFromAttributes(attrs)
+	hostname, ok := HostnameFromAttributes(attrs, false)
 	assert.True(t, ok)
 	assert.Equal(t, hostname, "nodeName-clusterName")
 
@@ -174,7 +235,7 @@ func TestHostnameKubernetes(t *testing.T) {
 		conventions.AttributeHostID:      testHostID,
 		conventions.AttributeHostName:    testHostName,
 	})
-	hostname, ok = HostnameFromAttributes(attrs)
+	hostname, ok = HostnameFromAttributes(attrs, false)
 	assert.True(t, ok)
 	assert.Equal(t, hostname, "nodeName")
 
@@ -185,7 +246,7 @@ func TestHostnameKubernetes(t *testing.T) {
 		conventions.AttributeHostID:         testHostID,
 		conventions.AttributeHostName:       testHostName,
 	})
-	hostname, ok = HostnameFromAttributes(attrs)
+	hostname, ok = HostnameFromAttributes(attrs, false)
 	assert.True(t, ok)
 	// cluster name gets ignored, fallback to next option
 	assert.Equal(t, hostname, testHostID)

--- a/pkg/otlp/model/translator/config.go
+++ b/pkg/otlp/model/translator/config.go
@@ -30,7 +30,8 @@ type translatorConfig struct {
 	deltaTTL      int64
 
 	// hostname provider configuration
-	fallbackHostnameProvider HostnameProvider
+	previewHostnameFromAttributes bool
+	fallbackHostnameProvider      HostnameProvider
 }
 
 // Option is a translator creation option.
@@ -57,6 +58,14 @@ func WithDeltaTTL(deltaTTL int64) Option {
 func WithFallbackHostnameProvider(provider HostnameProvider) Option {
 	return func(t *translatorConfig) error {
 		t.fallbackHostnameProvider = provider
+		return nil
+	}
+}
+
+// WithPreviewHostnameFromAttributes enables the preview hostname algorithm.
+func WithPreviewHostnameFromAttributes() Option {
+	return func(t *translatorConfig) error {
+		t.previewHostnameFromAttributes = true
 		return nil
 	}
 }

--- a/pkg/otlp/model/translator/metrics_translator.go
+++ b/pkg/otlp/model/translator/metrics_translator.go
@@ -522,7 +522,7 @@ func (t *Translator) MapMetrics(ctx context.Context, md pmetric.Metrics, consume
 		// Fetch tags from attributes.
 		attributeTags := attributes.TagsFromAttributes(rm.Resource().Attributes())
 
-		host, ok := attributes.HostnameFromAttributes(rm.Resource().Attributes())
+		host, ok := attributes.HostnameFromAttributes(rm.Resource().Attributes(), t.cfg.previewHostnameFromAttributes)
 		if !ok {
 			var err error
 			host, err = t.cfg.fallbackHostnameProvider.Hostname(context.Background())
@@ -579,7 +579,7 @@ func (t *Translator) MapMetrics(ctx context.Context, md pmetric.Metrics, consume
 						}
 					case pmetric.MetricAggregationTemporalityDelta:
 						t.mapNumberMetrics(ctx, consumer, baseDims, Count, md.Sum().DataPoints())
-					default: // pmetric.AggregationTemporalityUnspecified or any other not supported type
+					default: // pmetric.MetricAggregationTemporalityUnspecified or any other not supported type
 						t.logger.Debug("Unknown or unsupported aggregation temporality",
 							zap.String(metricName, md.Name()),
 							zap.Any("aggregation temporality", md.Sum().AggregationTemporality()),
@@ -591,7 +591,7 @@ func (t *Translator) MapMetrics(ctx context.Context, md pmetric.Metrics, consume
 					case pmetric.MetricAggregationTemporalityCumulative, pmetric.MetricAggregationTemporalityDelta:
 						delta := md.Histogram().AggregationTemporality() == pmetric.MetricAggregationTemporalityDelta
 						t.mapHistogramMetrics(ctx, consumer, baseDims, md.Histogram().DataPoints(), delta)
-					default: // pmetric.AggregationTemporalityUnspecified or any other not supported type
+					default: // pmetric.MetricAggregationTemporalityUnspecified or any other not supported type
 						t.logger.Debug("Unknown or unsupported aggregation temporality",
 							zap.String("metric name", md.Name()),
 							zap.Any("aggregation temporality", md.Histogram().AggregationTemporality()),
@@ -603,7 +603,7 @@ func (t *Translator) MapMetrics(ctx context.Context, md pmetric.Metrics, consume
 					case pmetric.MetricAggregationTemporalityDelta:
 						delta := md.ExponentialHistogram().AggregationTemporality() == pmetric.MetricAggregationTemporalityDelta
 						t.mapExponentialHistogramMetrics(ctx, consumer, baseDims, md.ExponentialHistogram().DataPoints(), delta)
-					default: // pmetric.MetricAggregationTemporalityCumulative, pmetric.AggregationTemporalityUnspecified or any other not supported type
+					default: // pmetric.MetricAggregationTemporalityCumulative, pmetric.MetricAggregationTemporalityUnspecified or any other not supported type
 						t.logger.Debug("Unknown or unsupported aggregation temporality",
 							zap.String("metric name", md.Name()),
 							zap.Any("aggregation temporality", md.ExponentialHistogram().AggregationTemporality()),

--- a/pkg/trace/api/otlp.go
+++ b/pkg/trace/api/otlp.go
@@ -226,7 +226,7 @@ func (o *OTLPReceiver) ReceiveResourceSpans(rspans ptrace.ResourceSpans, header 
 		rattr[k] = v.AsString()
 		return true
 	})
-	hostname, hostok := attributes.HostnameFromAttributes(attr, false)
+	hostname, hostok := attributes.HostnameFromAttributes(attr, o.conf.OTLPReceiver.UsePreviewHostnameLogic)
 	hostFromMap := func(m map[string]string, key string) {
 		// hostFromMap sets the hostname to m[key] if it is set.
 		if v, ok := m[key]; ok {

--- a/pkg/trace/api/otlp.go
+++ b/pkg/trace/api/otlp.go
@@ -226,7 +226,7 @@ func (o *OTLPReceiver) ReceiveResourceSpans(rspans ptrace.ResourceSpans, header 
 		rattr[k] = v.AsString()
 		return true
 	})
-	hostname, hostok := attributes.HostnameFromAttributes(attr)
+	hostname, hostok := attributes.HostnameFromAttributes(attr, false)
 	hostFromMap := func(m map[string]string, key string) {
 		// hostFromMap sets the hostname to m[key] if it is set.
 		if v, ok := m[key]; ok {

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -59,6 +59,12 @@ type OTLP struct {
 	// MaxRequestBytes specifies the maximum number of bytes that will be read
 	// from an incoming HTTP request.
 	MaxRequestBytes int64 `mapstructure:"-"`
+
+	// UsePreviewHostnameLogic specifies wether to use the 'preview' OpenTelemetry attributes to hostname rules,
+	// controlled in the Datadog exporter by the `exporter.datadog.hostname.preview` feature flag.
+	// The 'preview' rules change the canonical hostname chosen in cloud providers to be consistent with the
+	// one sent by Datadog cloud integrations.
+	UsePreviewHostnameLogic bool `mapstructure:"-"`
 }
 
 // ObfuscationConfig holds the configuration for obfuscating sensitive data


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Partially syncs `pkg/otlp/model` module with Datadog exporter copy.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

I introduced a breaking change on this module which needs a sync here.
The exponential histogram implementation remains out of sync, pending unifying the tests.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

This depends on #12343.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
