### PR TITLE
[CWS] fix cws e2e tests

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1011,6 +1011,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("runtime_security_config.map_dentry_resolution_enabled", true)
 	config.BindEnvAndSetDefault("runtime_security_config.dentry_cache_size", 1024)
 	config.BindEnvAndSetDefault("runtime_security_config.policies.dir", DefaultRuntimePoliciesDir)
+	config.BindEnvAndSetDefault("runtime_security_config.policies.watch_dir", false)
 	config.BindEnvAndSetDefault("runtime_security_config.socket", "/opt/datadog-agent/run/runtime-security.sock")
 	config.BindEnvAndSetDefault("runtime_security_config.enable_approvers", true)
 	config.BindEnvAndSetDefault("runtime_security_config.enable_kernel_filters", true)

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -370,7 +370,7 @@ func (a *APIServer) RunSelfTest(ctx context.Context, params *api.RunSelfTestPara
 		}, nil
 	}
 
-	if err := a.module.RunSelfTest(false); err != nil {
+	if err := a.module.RunSelfTest(false, true); err != nil {
 		return &api.SecuritySelfTestResultMessage{
 			Ok:    false,
 			Error: err.Error(),

--- a/test/e2e/cws-tests/tests/lib/common/app.py
+++ b/test/e2e/cws-tests/tests/lib/common/app.py
@@ -21,7 +21,7 @@ class App:
         response = api_instance.query_metrics(int(time.time()) - 30, int(time.time()), f"{name}{{{','.join(tags)}}}")
         return response
 
-    def wait_for_metric(self, name, tries=15, delay=1, **kw):
+    def wait_for_metric(self, name, tries=30, delay=10, **kw):
         def expect_metric():
             metric = self.query_metric(name, **kw)
             if len(metric.get("series")) == 0:


### PR DESCRIPTION
### What does this PR do?

The main goal was to fix the `check system-probe start` failing in e2e CWS tests.

This PR: 
- reworks the PoliciesDirProvider so that the file watcher is not created if the config tells us it's not needed, this is important since the seccomp profile for the system probe in the public helm charts doesn't allow fanotify
- removes usages of std logger in the PoliciesDirProvider, since it's in the secl package that shouldn't use the std logger (but maybe should use a user provided one, for example a seclog instance ?)
- adds a missing config definition for the watch dir config
- makes it so that we do not do:
```
load self test policies -> load empty policies (from the defer in the self tester) -> load actual RC+dir policies
```
but simply
```
load self test policies -> load actual RC+dir policies
```
- increases the amount of tries and delay between tries when fetching the metric

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
