### PR TITLE
[CI] Fix `revive` linter container-integrations errors

### DIFF
--- a/pkg/autodiscovery/listeners/kube_endpoints.go
+++ b/pkg/autodiscovery/listeners/kube_endpoints.go
@@ -65,7 +65,7 @@ func init() {
 	Register(kubeEndpointsName, NewKubeEndpointsListener)
 }
 
-// NewKubeEndpointsListener TODO <container-integrations>: CONT-3353
+// NewKubeEndpointsListener returns the kube endpoints implementation of the ServiceListener interface
 func NewKubeEndpointsListener(conf Config) (ServiceListener, error) {
 	// Using GetAPIClient (no wait) as Client should already be initialized by Cluster Agent main entrypoint before
 	ac, err := apiserver.GetAPIClient()
@@ -94,7 +94,7 @@ func NewKubeEndpointsListener(conf Config) (ServiceListener, error) {
 	}, nil
 }
 
-// Listen TODO <container-integrations>: CONT-3353
+// Listen starts watching service and endpoint events
 func (l *KubeEndpointsListener) Listen(newSvc chan<- Service, delSvc chan<- Service) {
 	// setup the I/O channels
 	l.newService = newSvc

--- a/pkg/autodiscovery/listeners/kube_endpoints.go
+++ b/pkg/autodiscovery/listeners/kube_endpoints.go
@@ -65,6 +65,7 @@ func init() {
 	Register(kubeEndpointsName, NewKubeEndpointsListener)
 }
 
+// NewKubeEndpointsListener TODO <container-integrations>: CONT-3353
 func NewKubeEndpointsListener(conf Config) (ServiceListener, error) {
 	// Using GetAPIClient (no wait) as Client should already be initialized by Cluster Agent main entrypoint before
 	ac, err := apiserver.GetAPIClient()
@@ -93,6 +94,7 @@ func NewKubeEndpointsListener(conf Config) (ServiceListener, error) {
 	}, nil
 }
 
+// Listen TODO <container-integrations>: CONT-3353
 func (l *KubeEndpointsListener) Listen(newSvc chan<- Service, delSvc chan<- Service) {
 	// setup the I/O channels
 	l.newService = newSvc

--- a/pkg/autodiscovery/listeners/kube_services.go
+++ b/pkg/autodiscovery/listeners/kube_services.go
@@ -80,7 +80,7 @@ func isServiceAnnotated(ksvc *v1.Service, annotationKey string) bool {
 	return false
 }
 
-// NewKubeServiceListener TODO <container-integrations>: CONT-3353
+// NewKubeServiceListener returns the kube service implementation of the ServiceListener interface
 func NewKubeServiceListener(conf Config) (ServiceListener, error) {
 	// Using GetAPIClient (no wait) as Client should already be initialized by Cluster Agent main entrypoint before
 	ac, err := apiserver.GetAPIClient()
@@ -101,7 +101,7 @@ func NewKubeServiceListener(conf Config) (ServiceListener, error) {
 	}, nil
 }
 
-// Listen TODO <container-integrations>: CONT-3353
+// Listen starts watching service events
 func (l *KubeServiceListener) Listen(newSvc chan<- Service, delSvc chan<- Service) {
 	// setup the I/O channels
 	l.newService = newSvc

--- a/pkg/autodiscovery/listeners/kube_services.go
+++ b/pkg/autodiscovery/listeners/kube_services.go
@@ -80,6 +80,7 @@ func isServiceAnnotated(ksvc *v1.Service, annotationKey string) bool {
 	return false
 }
 
+// NewKubeServiceListener TODO <container-integrations>: CONT-3353
 func NewKubeServiceListener(conf Config) (ServiceListener, error) {
 	// Using GetAPIClient (no wait) as Client should already be initialized by Cluster Agent main entrypoint before
 	ac, err := apiserver.GetAPIClient()
@@ -100,6 +101,7 @@ func NewKubeServiceListener(conf Config) (ServiceListener, error) {
 	}, nil
 }
 
+// Listen TODO <container-integrations>: CONT-3353
 func (l *KubeServiceListener) Listen(newSvc chan<- Service, delSvc chan<- Service) {
 	// setup the I/O channels
 	l.newService = newSvc

--- a/pkg/autodiscovery/providers/prometheus_services.go
+++ b/pkg/autodiscovery/providers/prometheus_services.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-// ServiceAPI TODO <container-integrations>: CONT-3353
+// ServiceAPI abstracts the dependency on the Kubernetes API (useful for testing)
 type ServiceAPI interface {
 	// List lists all Services
 	ListServices() ([]*v1.Service, error)

--- a/pkg/autodiscovery/providers/prometheus_services.go
+++ b/pkg/autodiscovery/providers/prometheus_services.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+// ServiceAPI TODO <container-integrations>: CONT-3353
 type ServiceAPI interface {
 	// List lists all Services
 	ListServices() ([]*v1.Service, error)

--- a/pkg/clusteragent/admission/controllers/secret/config.go
+++ b/pkg/clusteragent/admission/controllers/secret/config.go
@@ -44,17 +44,18 @@ func NewConfig(ns, name, svc string, cert CertConfig) Config {
 	}
 }
 
-// GetName TODO <container-integrations>: CONT-3353
+// GetName returns the secret object name
 func (s *Config) GetName() string { return s.name }
 
-// GetNs TODO <container-integrations>: CONT-3353
+// GetNs returns secret object namespace
 func (s *Config) GetNs() string { return s.ns }
 
-// GetSvc TODO <container-integrations>: CONT-3353
+// GetSvc returns the name of the targeted service
 func (s *Config) GetSvc() string { return s.svc }
 
-// GetCertExpiration TODO <container-integrations>: CONT-3353
+// GetCertExpiration returns the certificate's expiration threshold
+// (how long before its expiration a certificate should be refreshed)
 func (s *Config) GetCertExpiration() time.Duration { return s.cert.expirationThreshold }
 
-// GetCertValidityBound TODO <container-integrations>: CONT-3353
+// GetCertValidityBound returns the validity bound of the certificate
 func (s *Config) GetCertValidityBound() time.Duration { return s.cert.validityBound }

--- a/pkg/clusteragent/admission/controllers/secret/config.go
+++ b/pkg/clusteragent/admission/controllers/secret/config.go
@@ -44,8 +44,17 @@ func NewConfig(ns, name, svc string, cert CertConfig) Config {
 	}
 }
 
-func (s *Config) GetName() string                     { return s.name }
-func (s *Config) GetNs() string                       { return s.ns }
-func (s *Config) GetSvc() string                      { return s.svc }
-func (s *Config) GetCertExpiration() time.Duration    { return s.cert.expirationThreshold }
+// GetName TODO <container-integrations>: CONT-3353
+func (s *Config) GetName() string { return s.name }
+
+// GetNs TODO <container-integrations>: CONT-3353
+func (s *Config) GetNs() string { return s.ns }
+
+// GetSvc TODO <container-integrations>: CONT-3353
+func (s *Config) GetSvc() string { return s.svc }
+
+// GetCertExpiration TODO <container-integrations>: CONT-3353
+func (s *Config) GetCertExpiration() time.Duration { return s.cert.expirationThreshold }
+
+// GetCertValidityBound TODO <container-integrations>: CONT-3353
 func (s *Config) GetCertValidityBound() time.Duration { return s.cert.validityBound }

--- a/pkg/clusteragent/clusterchecks/dispatcher_rebalance.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_rebalance.go
@@ -23,30 +23,18 @@ import (
 // the 0.9 value is tentative and could be changed
 const tolerationMargin float64 = 0.9
 
-// Weight TODO <container-integrations>: CONT-3353
+// Weight holds a node name and the corresponding busyness score
 type Weight struct {
 	nodeName string
 	busyness int
 }
 
-// Weights TODO <container-integrations>: CONT-3353
+// Weights is an array of node weights
 type Weights []Weight
 
 func (w Weights) Len() int           { return len(w) }
 func (w Weights) Less(i, j int) bool { return w[i].busyness > w[j].busyness }
 func (w Weights) Swap(i, j int)      { w[i], w[j] = w[j], w[i] }
-
-// RebalancingDecision TODO <container-integrations>: CONT-3353
-type RebalancingDecision struct {
-	CheckID     string
-	CheckWeight int
-
-	SourceNodeName string
-	SourceDiff     int
-
-	DestNodeName string
-	DestDiff     int
-}
 
 func (d *dispatcher) calculateAvg() (int, error) {
 	busyness := 0

--- a/pkg/clusteragent/clusterchecks/dispatcher_rebalance.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_rebalance.go
@@ -23,17 +23,20 @@ import (
 // the 0.9 value is tentative and could be changed
 const tolerationMargin float64 = 0.9
 
+// Weight TODO <container-integrations>: CONT-3353
 type Weight struct {
 	nodeName string
 	busyness int
 }
 
+// Weights TODO <container-integrations>: CONT-3353
 type Weights []Weight
 
 func (w Weights) Len() int           { return len(w) }
 func (w Weights) Less(i, j int) bool { return w[i].busyness > w[j].busyness }
 func (w Weights) Swap(i, j int)      { w[i], w[j] = w[j], w[i] }
 
+// RebalancingDecision TODO <container-integrations>: CONT-3353
 type RebalancingDecision struct {
 	CheckID     string
 	CheckWeight int

--- a/pkg/clusteragent/clusterchecks/handler_api.go
+++ b/pkg/clusteragent/clusterchecks/handler_api.go
@@ -18,7 +18,7 @@ import (
 
 var errNotReady = errors.New("Startup in progress")
 
-// RejectOrForward performs some checks on incoming queries that should go to a leader:
+// RejectOrForwardLeaderQuery performs some checks on incoming queries that should go to a leader:
 // - Forward to leader if we are a follower
 // - Reject with "not ready" if leader election status is unknown
 func (h *Handler) RejectOrForwardLeaderQuery(rw http.ResponseWriter, req *http.Request) bool {
@@ -98,6 +98,7 @@ func (h *Handler) GetAllEndpointsCheckConfigs() (types.ConfigResponse, error) {
 	return response, err
 }
 
+// RebalanceClusterChecks TODO <container-integrations>: CONT-3353
 func (h *Handler) RebalanceClusterChecks() ([]types.RebalanceResponse, error) {
 	if !h.dispatcher.advancedDispatching {
 		return nil, fmt.Errorf("no checks to rebalance: advanced dispatching is not enabled")

--- a/pkg/clusteragent/clusterchecks/handler_api.go
+++ b/pkg/clusteragent/clusterchecks/handler_api.go
@@ -98,7 +98,7 @@ func (h *Handler) GetAllEndpointsCheckConfigs() (types.ConfigResponse, error) {
 	return response, err
 }
 
-// RebalanceClusterChecks TODO <container-integrations>: CONT-3353
+// RebalanceClusterChecks triggers an attempt to rebalance cluster checks
 func (h *Handler) RebalanceClusterChecks() ([]types.RebalanceResponse, error) {
 	if !h.dispatcher.advancedDispatching {
 		return nil, fmt.Errorf("no checks to rebalance: advanced dispatching is not enabled")

--- a/pkg/clusteragent/custommetrics/store.go
+++ b/pkg/clusteragent/custommetrics/store.go
@@ -52,6 +52,7 @@ func ExternalMetricValueKeyFunc(val ExternalMetricValue) string {
 	return strings.Join(parts, keyDelimeter)
 }
 
+// DeprecatedExternalMetricValueKeyFunc TODO <container-integrations>: CONT-3353
 func DeprecatedExternalMetricValueKeyFunc(val DeprecatedExternalMetricValue) string {
 	parts := []string{
 		"external_metric",

--- a/pkg/clusteragent/custommetrics/store.go
+++ b/pkg/clusteragent/custommetrics/store.go
@@ -52,7 +52,7 @@ func ExternalMetricValueKeyFunc(val ExternalMetricValue) string {
 	return strings.Join(parts, keyDelimeter)
 }
 
-// DeprecatedExternalMetricValueKeyFunc TODO <container-integrations>: CONT-3353
+// DeprecatedExternalMetricValueKeyFunc generates identifiers for DeprecatedExternalMetricValue objects
 func DeprecatedExternalMetricValueKeyFunc(val DeprecatedExternalMetricValue) string {
 	parts := []string{
 		"external_metric",

--- a/pkg/clusteragent/custommetrics/types.go
+++ b/pkg/clusteragent/custommetrics/types.go
@@ -8,6 +8,7 @@
 
 package custommetrics
 
+// ExternalMetricValue TODO <container-integrations>: CONT-3353
 type ExternalMetricValue struct {
 	MetricName string            `json:"metricName"`
 	Labels     map[string]string `json:"labels"`
@@ -17,6 +18,7 @@ type ExternalMetricValue struct {
 	Valid      bool              `json:"valid"`
 }
 
+// DeprecatedExternalMetricValue TODO <container-integrations>: CONT-3353
 type DeprecatedExternalMetricValue struct {
 	MetricName string            `json:"metricName"`
 	Labels     map[string]string `json:"labels"`
@@ -34,6 +36,7 @@ type ObjectReference struct {
 	UID       string `json:"uid"`
 }
 
+// MetricsBundle TODO <container-integrations>: CONT-3353
 type MetricsBundle struct {
 	External   []ExternalMetricValue
 	Deprecated []DeprecatedExternalMetricValue

--- a/pkg/clusteragent/custommetrics/types.go
+++ b/pkg/clusteragent/custommetrics/types.go
@@ -8,7 +8,7 @@
 
 package custommetrics
 
-// ExternalMetricValue TODO <container-integrations>: CONT-3353
+// ExternalMetricValue represents external metrics for any autoscaler (HPA, WPA)
 type ExternalMetricValue struct {
 	MetricName string            `json:"metricName"`
 	Labels     map[string]string `json:"labels"`
@@ -18,7 +18,7 @@ type ExternalMetricValue struct {
 	Valid      bool              `json:"valid"`
 }
 
-// DeprecatedExternalMetricValue TODO <container-integrations>: CONT-3353
+// DeprecatedExternalMetricValue represents external metrics for HPA only
 type DeprecatedExternalMetricValue struct {
 	MetricName string            `json:"metricName"`
 	Labels     map[string]string `json:"labels"`
@@ -36,7 +36,7 @@ type ObjectReference struct {
 	UID       string `json:"uid"`
 }
 
-// MetricsBundle TODO <container-integrations>: CONT-3353
+// MetricsBundle holds external metrics
 type MetricsBundle struct {
 	External   []ExternalMetricValue
 	Deprecated []DeprecatedExternalMetricValue

--- a/pkg/clusteragent/externalmetrics/autoscaler_watcher.go
+++ b/pkg/clusteragent/externalmetrics/autoscaler_watcher.go
@@ -36,6 +36,7 @@ const (
 	autoscalerHPAKindKey        string = "hpa"
 )
 
+// AutoscalerWatcher TODO <container-integrations>: CONT-3353
 type AutoscalerWatcher struct {
 	refreshPeriod           int64
 	autogenExpirationPeriod time.Duration
@@ -103,6 +104,7 @@ func NewAutoscalerWatcher(refreshPeriod, autogenExpirationPeriodHours int64, aut
 	return autoscalerWatcher, nil
 }
 
+// Run TODO <container-integrations>: CONT-3353
 func (w *AutoscalerWatcher) Run(stopCh <-chan struct{}) {
 	log.Infof("Starting AutoscalerWatcher (waiting for cache sync)")
 	if w.autoscalerListerSynced != nil {

--- a/pkg/clusteragent/externalmetrics/autoscaler_watcher.go
+++ b/pkg/clusteragent/externalmetrics/autoscaler_watcher.go
@@ -36,7 +36,7 @@ const (
 	autoscalerHPAKindKey        string = "hpa"
 )
 
-// AutoscalerWatcher TODO <container-integrations>: CONT-3353
+// AutoscalerWatcher watches autoscaling objects and reconciles the corresponding external metrics
 type AutoscalerWatcher struct {
 	refreshPeriod           int64
 	autogenExpirationPeriod time.Duration
@@ -104,7 +104,7 @@ func NewAutoscalerWatcher(refreshPeriod, autogenExpirationPeriodHours int64, aut
 	return autoscalerWatcher, nil
 }
 
-// Run TODO <container-integrations>: CONT-3353
+// Run starts the autoscaling reconciliation loop
 func (w *AutoscalerWatcher) Run(stopCh <-chan struct{}) {
 	log.Infof("Starting AutoscalerWatcher (waiting for cache sync)")
 	if w.autoscalerListerSynced != nil {

--- a/pkg/clusteragent/externalmetrics/metrics_retriever.go
+++ b/pkg/clusteragent/externalmetrics/metrics_retriever.go
@@ -25,6 +25,7 @@ const (
 	metricRetrieverStoreID            string = "mr"
 )
 
+// MetricsRetriever TODO <container-integrations>: CONT-3353
 type MetricsRetriever struct {
 	refreshPeriod int64
 	metricsMaxAge int64
@@ -33,6 +34,7 @@ type MetricsRetriever struct {
 	isLeader      func() bool
 }
 
+// NewMetricsRetriever TODO <container-integrations>: CONT-3353
 func NewMetricsRetriever(refreshPeriod, metricsMaxAge int64, processor autoscalers.ProcessorInterface, isLeader func() bool, store *DatadogMetricsInternalStore) (*MetricsRetriever, error) {
 	return &MetricsRetriever{
 		refreshPeriod: refreshPeriod,
@@ -43,6 +45,7 @@ func NewMetricsRetriever(refreshPeriod, metricsMaxAge int64, processor autoscale
 	}, nil
 }
 
+// Run TODO <container-integrations>: CONT-3353
 func (mr *MetricsRetriever) Run(stopCh <-chan struct{}) {
 	log.Infof("Starting MetricsRetriever")
 	tickerRefreshProcess := time.NewTicker(time.Duration(mr.refreshPeriod) * time.Second)

--- a/pkg/clusteragent/externalmetrics/metrics_retriever.go
+++ b/pkg/clusteragent/externalmetrics/metrics_retriever.go
@@ -25,7 +25,7 @@ const (
 	metricRetrieverStoreID            string = "mr"
 )
 
-// MetricsRetriever TODO <container-integrations>: CONT-3353
+// MetricsRetriever is responsible for querying and storing external metrics
 type MetricsRetriever struct {
 	refreshPeriod int64
 	metricsMaxAge int64
@@ -34,7 +34,7 @@ type MetricsRetriever struct {
 	isLeader      func() bool
 }
 
-// NewMetricsRetriever TODO <container-integrations>: CONT-3353
+// NewMetricsRetriever returns a new MetricsRetriever
 func NewMetricsRetriever(refreshPeriod, metricsMaxAge int64, processor autoscalers.ProcessorInterface, isLeader func() bool, store *DatadogMetricsInternalStore) (*MetricsRetriever, error) {
 	return &MetricsRetriever{
 		refreshPeriod: refreshPeriod,
@@ -45,7 +45,7 @@ func NewMetricsRetriever(refreshPeriod, metricsMaxAge int64, processor autoscale
 	}, nil
 }
 
-// Run TODO <container-integrations>: CONT-3353
+// Run starts retrieving external metrics
 func (mr *MetricsRetriever) Run(stopCh <-chan struct{}) {
 	log.Infof("Starting MetricsRetriever")
 	tickerRefreshProcess := time.NewTicker(time.Duration(mr.refreshPeriod) * time.Second)

--- a/pkg/clusteragent/externalmetrics/provider.go
+++ b/pkg/clusteragent/externalmetrics/provider.go
@@ -37,6 +37,7 @@ type datadogMetricProvider struct {
 	autogenNamespace string
 }
 
+// NewDatadogMetricProvider TODO <container-integrations>: CONT-3353
 func NewDatadogMetricProvider(ctx context.Context, apiCl *apiserver.APIClient) (provider.ExternalMetricsProvider, error) {
 	if apiCl == nil {
 		return nil, fmt.Errorf("Impossible to create DatadogMetricProvider without valid APIClient")

--- a/pkg/clusteragent/externalmetrics/provider.go
+++ b/pkg/clusteragent/externalmetrics/provider.go
@@ -37,7 +37,7 @@ type datadogMetricProvider struct {
 	autogenNamespace string
 }
 
-// NewDatadogMetricProvider TODO <container-integrations>: CONT-3353
+// NewDatadogMetricProvider configures and returns a new datadogMetricProvider
 func NewDatadogMetricProvider(ctx context.Context, apiCl *apiserver.APIClient) (provider.ExternalMetricsProvider, error) {
 	if apiCl == nil {
 		return nil, fmt.Errorf("Impossible to create DatadogMetricProvider without valid APIClient")

--- a/pkg/clusteragent/externalmetrics/status.go
+++ b/pkg/clusteragent/externalmetrics/status.go
@@ -14,6 +14,7 @@ import (
 
 var datadogClient autoscalers.DatadogClient
 
+// GetStatus TODO <container-integrations>: CONT-3353
 func GetStatus() map[string]interface{} {
 	return autoscalers.GetStatus(datadogClient)
 }

--- a/pkg/clusteragent/externalmetrics/status.go
+++ b/pkg/clusteragent/externalmetrics/status.go
@@ -14,7 +14,7 @@ import (
 
 var datadogClient autoscalers.DatadogClient
 
-// GetStatus TODO <container-integrations>: CONT-3353
+// GetStatus returns the status of the autoscalers
 func GetStatus() map[string]interface{} {
 	return autoscalers.GetStatus(datadogClient)
 }

--- a/pkg/clusteragent/externalmetrics/store.go
+++ b/pkg/clusteragent/externalmetrics/store.go
@@ -19,7 +19,7 @@ const (
 	deleteOperation
 )
 
-// DatadogMetricInternalObserverFunc TODO <container-integrations>: CONT-3353
+// DatadogMetricInternalObserverFunc represents observer functions of the datadog metrics store
 type DatadogMetricInternalObserverFunc func(string, string)
 
 // DatadogMetricInternalObserver allows to define functions to watch changes in Store

--- a/pkg/clusteragent/externalmetrics/store.go
+++ b/pkg/clusteragent/externalmetrics/store.go
@@ -19,6 +19,7 @@ const (
 	deleteOperation
 )
 
+// DatadogMetricInternalObserverFunc TODO <container-integrations>: CONT-3353
 type DatadogMetricInternalObserverFunc func(string, string)
 
 // DatadogMetricInternalObserver allows to define functions to watch changes in Store

--- a/pkg/clusteragent/externalmetrics/utils.go
+++ b/pkg/clusteragent/externalmetrics/utils.go
@@ -102,6 +102,7 @@ func setQueryConfigValues(aggregator string, rollup int) {
 	queryConfigRollup = rollup
 }
 
+// UnstructuredIntoDDM TODO <container-integrations>: CONT-3353
 func UnstructuredIntoDDM(obj interface{}, structDest *v1alpha1.DatadogMetric) error {
 	unstrObj, ok := obj.(*unstructured.Unstructured)
 	if !ok {
@@ -110,6 +111,7 @@ func UnstructuredIntoDDM(obj interface{}, structDest *v1alpha1.DatadogMetric) er
 	return runtime.DefaultUnstructuredConverter.FromUnstructured(unstrObj.UnstructuredContent(), structDest)
 }
 
+// UnstructuredFromDDM TODO <container-integrations>: CONT-3353
 func UnstructuredFromDDM(structIn *v1alpha1.DatadogMetric, unstructOut *unstructured.Unstructured) error {
 	content, err := runtime.DefaultUnstructuredConverter.ToUnstructured(structIn)
 	if err != nil {

--- a/pkg/clusteragent/externalmetrics/utils.go
+++ b/pkg/clusteragent/externalmetrics/utils.go
@@ -102,7 +102,7 @@ func setQueryConfigValues(aggregator string, rollup int) {
 	queryConfigRollup = rollup
 }
 
-// UnstructuredIntoDDM TODO <container-integrations>: CONT-3353
+// UnstructuredIntoDDM converts an unstructured object into a DatadogMetric
 func UnstructuredIntoDDM(obj interface{}, structDest *v1alpha1.DatadogMetric) error {
 	unstrObj, ok := obj.(*unstructured.Unstructured)
 	if !ok {
@@ -111,7 +111,7 @@ func UnstructuredIntoDDM(obj interface{}, structDest *v1alpha1.DatadogMetric) er
 	return runtime.DefaultUnstructuredConverter.FromUnstructured(unstrObj.UnstructuredContent(), structDest)
 }
 
-// UnstructuredFromDDM TODO <container-integrations>: CONT-3353
+// UnstructuredFromDDM converts a DatadogMetric object into an Unstructured
 func UnstructuredFromDDM(structIn *v1alpha1.DatadogMetric, unstructOut *unstructured.Unstructured) error {
 	content, err := runtime.DefaultUnstructuredConverter.ToUnstructured(structIn)
 	if err != nil {

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -609,6 +609,7 @@ func (k *KSMCheck) sendTelemetry(s aggregator.Sender) {
 	}
 }
 
+// KubeStateMetricsFactory TODO <container-integrations>: CONT-3353
 func KubeStateMetricsFactory() check.Check {
 	return newKSMCheck(
 		core.NewCheckBase(kubeStateMetricsCheckName),

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -609,7 +609,7 @@ func (k *KSMCheck) sendTelemetry(s aggregator.Sender) {
 	}
 }
 
-// KubeStateMetricsFactory TODO <container-integrations>: CONT-3353
+// KubeStateMetricsFactory returns a new KSMCheck
 func KubeStateMetricsFactory() check.Check {
 	return newKSMCheck(
 		core.NewCheckBase(kubeStateMetricsCheckName),

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
@@ -84,6 +84,7 @@ func (c *KubeASConfig) parse(data []byte) error {
 	return yaml.Unmarshal(data, c)
 }
 
+// NewKubeASCheck TODO <container-integrations>: CONT-3353
 func NewKubeASCheck(base core.CheckBase, instance *KubeASConfig) *KubeASCheck {
 	return &KubeASCheck{
 		CheckBase:       base,

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
@@ -84,7 +84,7 @@ func (c *KubeASConfig) parse(data []byte) error {
 	return yaml.Unmarshal(data, c)
 }
 
-// NewKubeASCheck TODO <container-integrations>: CONT-3353
+// NewKubeASCheck returns a new KubeASCheck
 func NewKubeASCheck(base core.CheckBase, instance *KubeASConfig) *KubeASCheck {
 	return &KubeASCheck{
 		CheckBase:       base,

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/processor.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/processor.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+// ProcessorContext TODO <container-app>: CONT-3353
 type ProcessorContext struct {
 	APIClient  *apiserver.APIClient
 	Cfg        *config.OrchestratorConfig

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/processor.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/processor.go
@@ -19,7 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-// ProcessorContext TODO <container-app>: CONT-3353
+// ProcessorContext holds resource processing attributes
 type ProcessorContext struct {
 	APIClient  *apiserver.APIClient
 	Cfg        *config.OrchestratorConfig

--- a/pkg/collector/corechecks/containers/docker/config.go
+++ b/pkg/collector/corechecks/containers/docker/config.go
@@ -16,7 +16,7 @@ const (
 	DockerExit      = "docker.exit"
 )
 
-// DockerConfig TODO <container-integrations>: CONT-3353
+// DockerConfig holds the docker check configuration
 type DockerConfig struct {
 	CollectContainerSize     bool               `yaml:"collect_container_size"`
 	CollectContainerSizeFreq uint64             `yaml:"collect_container_size_frequency"`
@@ -32,7 +32,7 @@ type DockerConfig struct {
 	CappedMetrics            map[string]float64 `yaml:"capped_metrics"`
 }
 
-// Parse TODO <container-integrations>: CONT-3353
+// Parse reads the docker check configuration
 func (c *DockerConfig) Parse(data []byte) error {
 	// default values
 	c.CollectEvent = true

--- a/pkg/collector/corechecks/containers/docker/config.go
+++ b/pkg/collector/corechecks/containers/docker/config.go
@@ -16,6 +16,7 @@ const (
 	DockerExit      = "docker.exit"
 )
 
+// DockerConfig TODO <container-integrations>: CONT-3353
 type DockerConfig struct {
 	CollectContainerSize     bool               `yaml:"collect_container_size"`
 	CollectContainerSizeFreq uint64             `yaml:"collect_container_size_frequency"`
@@ -31,6 +32,7 @@ type DockerConfig struct {
 	CappedMetrics            map[string]float64 `yaml:"capped_metrics"`
 }
 
+// Parse TODO <container-integrations>: CONT-3353
 func (c *DockerConfig) Parse(data []byte) error {
 	// default values
 	c.CollectEvent = true

--- a/pkg/kubestatemetrics/builder/builder.go
+++ b/pkg/kubestatemetrics/builder/builder.go
@@ -103,12 +103,12 @@ func (b *Builder) WithContext(ctx context.Context) {
 	b.ctx = ctx
 }
 
-// DefaultGenerateStoreFunc returns default buildStore function
+// DefaultGenerateStoresFunc returns default buildStore function
 func (b *Builder) DefaultGenerateStoresFunc() ksmtypes.BuildStoresFunc {
 	return b.GenerateStores
 }
 
-// WithGenerateStoreFunc configures a constom generate store function
+// WithGenerateStoresFunc configures a constom generate store function
 func (b *Builder) WithGenerateStoresFunc(f ksmtypes.BuildStoresFunc) {
 	b.ksmBuilder.WithGenerateStoresFunc(f)
 }

--- a/pkg/util/containerd/containerd_util.go
+++ b/pkg/util/containerd/containerd_util.go
@@ -104,24 +104,29 @@ func NewContainerdUtil() (ContainerdItf, error) {
 	return containerdUtil, nil
 }
 
+// CheckConnectivity TODO <container-integrations>: CONT-3353
 func (c *ContainerdUtil) CheckConnectivity() *retry.Error {
 	return c.initRetry.TriggerRetry()
 }
 
+// CurrentNamespace TODO <container-integrations>: CONT-3353
 func (c *ContainerdUtil) CurrentNamespace() string {
 	return c.namespace
 }
 
+// SetCurrentNamespace TODO <container-integrations>: CONT-3353
 func (c *ContainerdUtil) SetCurrentNamespace(namespace string) {
 	c.namespace = namespace
 }
 
+// Namespaces TODO <container-integrations>: CONT-3353
 func (c *ContainerdUtil) Namespaces(ctx context.Context) ([]string, error) {
 	ctx, cancel := context.WithTimeout(ctx, c.queryTimeout)
 	defer cancel()
 	return c.cl.NamespaceService().List(ctx)
 }
 
+// CallWithClientContext TODO <container-integrations>: CONT-3353
 func (c *ContainerdUtil) CallWithClientContext(f func(context.Context) error) error {
 	ctx, cancel := context.WithTimeout(context.Background(), c.queryTimeout)
 	defer cancel()
@@ -201,6 +206,7 @@ func (c *ContainerdUtil) Containers() ([]containerd.Container, error) {
 	return c.cl.Containers(ctxNamespace)
 }
 
+// EnvVars TODO <container-integrations>: CONT-3353
 func (c *ContainerdUtil) EnvVars(ctn containerd.Container) (map[string]string, error) {
 	spec, err := c.Spec(ctn)
 	if err != nil {

--- a/pkg/util/containerd/containerd_util.go
+++ b/pkg/util/containerd/containerd_util.go
@@ -104,29 +104,29 @@ func NewContainerdUtil() (ContainerdItf, error) {
 	return containerdUtil, nil
 }
 
-// CheckConnectivity TODO <container-integrations>: CONT-3353
+// CheckConnectivity tries to connect to containerd api
 func (c *ContainerdUtil) CheckConnectivity() *retry.Error {
 	return c.initRetry.TriggerRetry()
 }
 
-// CurrentNamespace TODO <container-integrations>: CONT-3353
+// CurrentNamespace returns the current containerd namespace
 func (c *ContainerdUtil) CurrentNamespace() string {
 	return c.namespace
 }
 
-// SetCurrentNamespace TODO <container-integrations>: CONT-3353
+// SetCurrentNamespace sets the current containerd namespace
 func (c *ContainerdUtil) SetCurrentNamespace(namespace string) {
 	c.namespace = namespace
 }
 
-// Namespaces TODO <container-integrations>: CONT-3353
+// Namespaces lists the containerd namespaces
 func (c *ContainerdUtil) Namespaces(ctx context.Context) ([]string, error) {
 	ctx, cancel := context.WithTimeout(ctx, c.queryTimeout)
 	defer cancel()
 	return c.cl.NamespaceService().List(ctx)
 }
 
-// CallWithClientContext TODO <container-integrations>: CONT-3353
+// CallWithClientContext allows passing an additional context when calling the containerd api
 func (c *ContainerdUtil) CallWithClientContext(f func(context.Context) error) error {
 	ctx, cancel := context.WithTimeout(context.Background(), c.queryTimeout)
 	defer cancel()
@@ -206,7 +206,7 @@ func (c *ContainerdUtil) Containers() ([]containerd.Container, error) {
 	return c.cl.Containers(ctxNamespace)
 }
 
-// EnvVars TODO <container-integrations>: CONT-3353
+// EnvVars returns the env variables of a containerd container
 func (c *ContainerdUtil) EnvVars(ctn containerd.Container) (map[string]string, error) {
 	spec, err := c.Spec(ctn)
 	if err != nil {

--- a/pkg/util/containerd/fake/containerd_util.go
+++ b/pkg/util/containerd/fake/containerd_util.go
@@ -49,102 +49,127 @@ type MockedContainerdClient struct {
 	MockIsSandbox             func(ctn containerd.Container) (bool, error)
 }
 
+// Close TODO <container-integrations>: CONT-3353
 func (client *MockedContainerdClient) Close() error {
 	return client.MockClose()
 }
 
+// CheckConnectivity TODO <container-integrations>: CONT-3353
 func (client *MockedContainerdClient) CheckConnectivity() *retry.Error {
 	return client.MockCheckConnectivity()
 }
 
+// ListImages TODO <container-integrations>: CONT-3353
 func (client *MockedContainerdClient) ListImages() ([]containerd.Image, error) {
 	return client.MockListImages()
 }
 
+// Image TODO <container-integrations>: CONT-3353
 func (client *MockedContainerdClient) Image(ctn containerd.Container) (containerd.Image, error) {
 	return client.MockImage(ctn)
 }
 
+// ImageSize TODO <container-integrations>: CONT-3353
 func (client *MockedContainerdClient) ImageSize(ctn containerd.Container) (int64, error) {
 	return client.MockImageSize(ctn)
 }
 
+// Labels TODO <container-integrations>: CONT-3353
 func (client *MockedContainerdClient) Labels(ctn containerd.Container) (map[string]string, error) {
 	return client.MockLabels(ctn)
 }
 
+// LabelsWithContext TODO <container-integrations>: CONT-3353
 func (client *MockedContainerdClient) LabelsWithContext(ctx context.Context, ctn containerd.Container) (map[string]string, error) {
 	return client.MockLabelsWithContext(ctx, ctn)
 }
 
+// Info TODO <container-integrations>: CONT-3353
 func (client *MockedContainerdClient) Info(ctn containerd.Container) (containers.Container, error) {
 	return client.MockInfo(ctn)
 }
 
+// TaskMetrics TODO <container-integrations>: CONT-3353
 func (client *MockedContainerdClient) TaskMetrics(ctn containerd.Container) (*types.Metric, error) {
 	return client.MockTaskMetrics(ctn)
 }
 
+// TaskPids TODO <container-integrations>: CONT-3353
 func (client *MockedContainerdClient) TaskPids(ctn containerd.Container) ([]containerd.ProcessInfo, error) {
 	return client.MockTaskPids(ctn)
 }
 
+// Metadata TODO <container-integrations>: CONT-3353
 func (client *MockedContainerdClient) Metadata() (containerd.Version, error) {
 	return client.MockMetadata()
 }
 
+// CurrentNamespace TODO <container-integrations>: CONT-3353
 func (client *MockedContainerdClient) CurrentNamespace() string {
 	return client.MockCurrentNamespace()
 }
 
+// SetCurrentNamespace TODO <container-integrations>: CONT-3353
 func (client *MockedContainerdClient) SetCurrentNamespace(namespace string) {
 	client.MockSetCurrentNamespace(namespace)
 }
 
+// Namespaces TODO <container-integrations>: CONT-3353
 func (client *MockedContainerdClient) Namespaces(ctx context.Context) ([]string, error) {
 	return client.MockNamespaces(ctx)
 }
 
+// Containers TODO <container-integrations>: CONT-3353
 func (client *MockedContainerdClient) Containers() ([]containerd.Container, error) {
 	return client.MockContainers()
 }
 
+// Container TODO <container-integrations>: CONT-3353
 func (client *MockedContainerdClient) Container(id string) (containerd.Container, error) {
 	return client.MockContainer(id)
 }
 
+// ContainerWithContext TODO <container-integrations>: CONT-3353
 func (client *MockedContainerdClient) ContainerWithContext(ctx context.Context, id string) (containerd.Container, error) {
 	return client.MockContainerWithCtx(ctx, id)
 }
 
+// GetEvents TODO <container-integrations>: CONT-3353
 func (client *MockedContainerdClient) GetEvents() containerd.EventService {
 	return client.MockEvents()
 }
 
+// Spec TODO <container-integrations>: CONT-3353
 func (client *MockedContainerdClient) Spec(ctn containerd.Container) (*oci.Spec, error) {
 	return client.MockSpec(ctn)
 }
 
+// SpecWithContext TODO <container-integrations>: CONT-3353
 func (client *MockedContainerdClient) SpecWithContext(ctx context.Context, ctn containerd.Container) (*oci.Spec, error) {
 	return client.MockSpecWithContext(ctx, ctn)
 }
 
+// EnvVars TODO <container-integrations>: CONT-3353
 func (client *MockedContainerdClient) EnvVars(ctn containerd.Container) (map[string]string, error) {
 	return client.MockEnvVars(ctn)
 }
 
+// Status TODO <container-integrations>: CONT-3353
 func (client *MockedContainerdClient) Status(ctn containerd.Container) (containerd.ProcessStatus, error) {
 	return client.MockStatus(ctn)
 }
 
+// CallWithClientContext TODO <container-integrations>: CONT-3353
 func (client *MockedContainerdClient) CallWithClientContext(f func(context.Context) error) error {
 	return client.MockCallWithClientContext(f)
 }
 
+// Annotations TODO <container-integrations>: CONT-3353
 func (client *MockedContainerdClient) Annotations(ctn containerd.Container) (map[string]string, error) {
 	return client.MockAnnotations(ctn)
 }
 
+// IsSandbox TODO <container-integrations>: CONT-3353
 func (client *MockedContainerdClient) IsSandbox(ctn containerd.Container) (bool, error) {
 	return client.MockIsSandbox(ctn)
 }

--- a/pkg/util/containerd/fake/containerd_util.go
+++ b/pkg/util/containerd/fake/containerd_util.go
@@ -49,127 +49,127 @@ type MockedContainerdClient struct {
 	MockIsSandbox             func(ctn containerd.Container) (bool, error)
 }
 
-// Close TODO <container-integrations>: CONT-3353
+// Close is a mock method
 func (client *MockedContainerdClient) Close() error {
 	return client.MockClose()
 }
 
-// CheckConnectivity TODO <container-integrations>: CONT-3353
+// CheckConnectivity is a mock method
 func (client *MockedContainerdClient) CheckConnectivity() *retry.Error {
 	return client.MockCheckConnectivity()
 }
 
-// ListImages TODO <container-integrations>: CONT-3353
+// ListImages is a mock method
 func (client *MockedContainerdClient) ListImages() ([]containerd.Image, error) {
 	return client.MockListImages()
 }
 
-// Image TODO <container-integrations>: CONT-3353
+// Image is a mock method
 func (client *MockedContainerdClient) Image(ctn containerd.Container) (containerd.Image, error) {
 	return client.MockImage(ctn)
 }
 
-// ImageSize TODO <container-integrations>: CONT-3353
+// ImageSize is a mock method
 func (client *MockedContainerdClient) ImageSize(ctn containerd.Container) (int64, error) {
 	return client.MockImageSize(ctn)
 }
 
-// Labels TODO <container-integrations>: CONT-3353
+// Labels is a mock method
 func (client *MockedContainerdClient) Labels(ctn containerd.Container) (map[string]string, error) {
 	return client.MockLabels(ctn)
 }
 
-// LabelsWithContext TODO <container-integrations>: CONT-3353
+// LabelsWithContext is a mock method
 func (client *MockedContainerdClient) LabelsWithContext(ctx context.Context, ctn containerd.Container) (map[string]string, error) {
 	return client.MockLabelsWithContext(ctx, ctn)
 }
 
-// Info TODO <container-integrations>: CONT-3353
+// Info is a mock method
 func (client *MockedContainerdClient) Info(ctn containerd.Container) (containers.Container, error) {
 	return client.MockInfo(ctn)
 }
 
-// TaskMetrics TODO <container-integrations>: CONT-3353
+// TaskMetrics is a mock method
 func (client *MockedContainerdClient) TaskMetrics(ctn containerd.Container) (*types.Metric, error) {
 	return client.MockTaskMetrics(ctn)
 }
 
-// TaskPids TODO <container-integrations>: CONT-3353
+// TaskPids is a mock method
 func (client *MockedContainerdClient) TaskPids(ctn containerd.Container) ([]containerd.ProcessInfo, error) {
 	return client.MockTaskPids(ctn)
 }
 
-// Metadata TODO <container-integrations>: CONT-3353
+// Metadata is a mock method
 func (client *MockedContainerdClient) Metadata() (containerd.Version, error) {
 	return client.MockMetadata()
 }
 
-// CurrentNamespace TODO <container-integrations>: CONT-3353
+// CurrentNamespace is a mock method
 func (client *MockedContainerdClient) CurrentNamespace() string {
 	return client.MockCurrentNamespace()
 }
 
-// SetCurrentNamespace TODO <container-integrations>: CONT-3353
+// SetCurrentNamespace is a mock method
 func (client *MockedContainerdClient) SetCurrentNamespace(namespace string) {
 	client.MockSetCurrentNamespace(namespace)
 }
 
-// Namespaces TODO <container-integrations>: CONT-3353
+// Namespaces is a mock method
 func (client *MockedContainerdClient) Namespaces(ctx context.Context) ([]string, error) {
 	return client.MockNamespaces(ctx)
 }
 
-// Containers TODO <container-integrations>: CONT-3353
+// Containers is a mock method
 func (client *MockedContainerdClient) Containers() ([]containerd.Container, error) {
 	return client.MockContainers()
 }
 
-// Container TODO <container-integrations>: CONT-3353
+// Container is a mock method
 func (client *MockedContainerdClient) Container(id string) (containerd.Container, error) {
 	return client.MockContainer(id)
 }
 
-// ContainerWithContext TODO <container-integrations>: CONT-3353
+// ContainerWithContext is a mock method
 func (client *MockedContainerdClient) ContainerWithContext(ctx context.Context, id string) (containerd.Container, error) {
 	return client.MockContainerWithCtx(ctx, id)
 }
 
-// GetEvents TODO <container-integrations>: CONT-3353
+// GetEvents is a mock method
 func (client *MockedContainerdClient) GetEvents() containerd.EventService {
 	return client.MockEvents()
 }
 
-// Spec TODO <container-integrations>: CONT-3353
+// Spec is a mock method
 func (client *MockedContainerdClient) Spec(ctn containerd.Container) (*oci.Spec, error) {
 	return client.MockSpec(ctn)
 }
 
-// SpecWithContext TODO <container-integrations>: CONT-3353
+// SpecWithContext is a mock method
 func (client *MockedContainerdClient) SpecWithContext(ctx context.Context, ctn containerd.Container) (*oci.Spec, error) {
 	return client.MockSpecWithContext(ctx, ctn)
 }
 
-// EnvVars TODO <container-integrations>: CONT-3353
+// EnvVars is a mock method
 func (client *MockedContainerdClient) EnvVars(ctn containerd.Container) (map[string]string, error) {
 	return client.MockEnvVars(ctn)
 }
 
-// Status TODO <container-integrations>: CONT-3353
+// Status is a mock method
 func (client *MockedContainerdClient) Status(ctn containerd.Container) (containerd.ProcessStatus, error) {
 	return client.MockStatus(ctn)
 }
 
-// CallWithClientContext TODO <container-integrations>: CONT-3353
+// CallWithClientContext is a mock method
 func (client *MockedContainerdClient) CallWithClientContext(f func(context.Context) error) error {
 	return client.MockCallWithClientContext(f)
 }
 
-// Annotations TODO <container-integrations>: CONT-3353
+// Annotations is a mock method
 func (client *MockedContainerdClient) Annotations(ctn containerd.Container) (map[string]string, error) {
 	return client.MockAnnotations(ctn)
 }
 
-// IsSandbox TODO <container-integrations>: CONT-3353
+// IsSandbox is a mock method
 func (client *MockedContainerdClient) IsSandbox(ctn containerd.Container) (bool, error) {
 	return client.MockIsSandbox(ctn)
 }

--- a/pkg/util/containers/cri/crimock/criutil.go
+++ b/pkg/util/containers/cri/crimock/criutil.go
@@ -36,10 +36,12 @@ func (m *MockCRIClient) GetContainerStatus(containerID string) (*pb.ContainerSta
 	return args.Get(0).(*pb.ContainerStatus), args.Error(1)
 }
 
+// GetRuntime TODO <container-integrations>: CONT-3353
 func (m *MockCRIClient) GetRuntime() string {
 	return "fakeruntime"
 }
 
+// GetRuntimeVersion TODO <container-integrations>: CONT-3353
 func (m *MockCRIClient) GetRuntimeVersion() string {
 	return "1.0"
 }

--- a/pkg/util/containers/cri/crimock/criutil.go
+++ b/pkg/util/containers/cri/crimock/criutil.go
@@ -36,12 +36,12 @@ func (m *MockCRIClient) GetContainerStatus(containerID string) (*pb.ContainerSta
 	return args.Get(0).(*pb.ContainerStatus), args.Error(1)
 }
 
-// GetRuntime TODO <container-integrations>: CONT-3353
+// GetRuntime is a mock of GetRuntime
 func (m *MockCRIClient) GetRuntime() string {
 	return "fakeruntime"
 }
 
-// GetRuntimeVersion TODO <container-integrations>: CONT-3353
+// GetRuntimeVersion is a mock of GetRuntimeVersion
 func (m *MockCRIClient) GetRuntimeVersion() string {
 	return "1.0"
 }

--- a/pkg/util/containers/cri/util.go
+++ b/pkg/util/containers/cri/util.go
@@ -29,6 +29,7 @@ var (
 	once          sync.Once
 )
 
+// CRIClient TODO <container-integrations>: CONT-3353
 type CRIClient interface {
 	ListContainerStats() (map[string]*pb.ContainerStats, error)
 	GetContainerStats(containerID string) (*pb.ContainerStats, error)
@@ -151,10 +152,12 @@ func (c *CRIUtil) GetContainerStatus(containerID string) (*pb.ContainerStatus, e
 	return r.Status, nil
 }
 
+// GetRuntime TODO <container-integrations>: CONT-3353
 func (c *CRIUtil) GetRuntime() string {
 	return c.runtime
 }
 
+// GetRuntimeVersion TODO <container-integrations>: CONT-3353
 func (c *CRIUtil) GetRuntimeVersion() string {
 	return c.runtimeVersion
 }

--- a/pkg/util/containers/cri/util.go
+++ b/pkg/util/containers/cri/util.go
@@ -29,7 +29,7 @@ var (
 	once          sync.Once
 )
 
-// CRIClient TODO <container-integrations>: CONT-3353
+// CRIClient abstracts the CRI client methods
 type CRIClient interface {
 	ListContainerStats() (map[string]*pb.ContainerStats, error)
 	GetContainerStats(containerID string) (*pb.ContainerStats, error)
@@ -152,12 +152,12 @@ func (c *CRIUtil) GetContainerStatus(containerID string) (*pb.ContainerStatus, e
 	return r.Status, nil
 }
 
-// GetRuntime TODO <container-integrations>: CONT-3353
+// GetRuntime returns the CRI runtime
 func (c *CRIUtil) GetRuntime() string {
 	return c.runtime
 }
 
-// GetRuntimeVersion TODO <container-integrations>: CONT-3353
+// GetRuntimeVersion returns the CRI runtime version
 func (c *CRIUtil) GetRuntimeVersion() string {
 	return c.runtimeVersion
 }

--- a/pkg/util/docker/client_mock.go
+++ b/pkg/util/docker/client_mock.go
@@ -16,7 +16,7 @@ import (
 	"github.com/docker/docker/api/types"
 )
 
-// DockerClient is a mock implementation of docker.Client interface
+// MockClient is a mock implementation of docker.Client interface
 // Should probably be generated at some point
 type MockClient struct {
 	FakeContainerList               []types.Container
@@ -30,30 +30,37 @@ type MockClient struct {
 	FakeError                       error
 }
 
+// RawContainerList TODO <container-integrations>: CONT-3353
 func (d *MockClient) RawContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error) {
 	return d.FakeContainerList, d.FakeError
 }
 
+// ResolveImageName TODO <container-integrations>: CONT-3353
 func (d *MockClient) ResolveImageName(ctx context.Context, image string) (string, error) {
 	return d.FakeImageNameMapping[image], d.FakeError
 }
 
+// Images TODO <container-integrations>: CONT-3353
 func (d *MockClient) Images(ctx context.Context, includeIntermediate bool) ([]types.ImageSummary, error) {
 	return d.FakeImages, d.FakeError
 }
 
+// GetPreferredImageName TODO <container-integrations>: CONT-3353
 func (d *MockClient) GetPreferredImageName(imageID string, repoTags []string, repoDigests []string) string {
 	return d.FakeImageNameMapping[imageID]
 }
 
+// GetStorageStats TODO <container-integrations>: CONT-3353
 func (d *MockClient) GetStorageStats(ctx context.Context) ([]*StorageStats, error) {
 	return d.FakeStorageStats, d.FakeError
 }
 
+// CountVolumes TODO <container-integrations>: CONT-3353
 func (d *MockClient) CountVolumes(ctx context.Context) (int, int, error) {
 	return d.FakeAttachedVolumes, d.FakeDandlingVolumes, d.FakeError
 }
 
+// LatestContainerEvents TODO <container-integrations>: CONT-3353
 func (d *MockClient) LatestContainerEvents(ctx context.Context, since time.Time, filter *containers.Filter) ([]*ContainerEvent, time.Time, error) {
 	return d.FakeContainerEvents, d.FakeLastContainerEventTimestamp, d.FakeError
 }

--- a/pkg/util/docker/client_mock.go
+++ b/pkg/util/docker/client_mock.go
@@ -30,37 +30,37 @@ type MockClient struct {
 	FakeError                       error
 }
 
-// RawContainerList TODO <container-integrations>: CONT-3353
+// RawContainerList is a mock method
 func (d *MockClient) RawContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error) {
 	return d.FakeContainerList, d.FakeError
 }
 
-// ResolveImageName TODO <container-integrations>: CONT-3353
+// ResolveImageName is a mock method
 func (d *MockClient) ResolveImageName(ctx context.Context, image string) (string, error) {
 	return d.FakeImageNameMapping[image], d.FakeError
 }
 
-// Images TODO <container-integrations>: CONT-3353
+// Images is a mock method
 func (d *MockClient) Images(ctx context.Context, includeIntermediate bool) ([]types.ImageSummary, error) {
 	return d.FakeImages, d.FakeError
 }
 
-// GetPreferredImageName TODO <container-integrations>: CONT-3353
+// GetPreferredImageName is a mock method
 func (d *MockClient) GetPreferredImageName(imageID string, repoTags []string, repoDigests []string) string {
 	return d.FakeImageNameMapping[imageID]
 }
 
-// GetStorageStats TODO <container-integrations>: CONT-3353
+// GetStorageStats is a mock method
 func (d *MockClient) GetStorageStats(ctx context.Context) ([]*StorageStats, error) {
 	return d.FakeStorageStats, d.FakeError
 }
 
-// CountVolumes TODO <container-integrations>: CONT-3353
+// CountVolumes is a mock method
 func (d *MockClient) CountVolumes(ctx context.Context) (int, int, error) {
 	return d.FakeAttachedVolumes, d.FakeDandlingVolumes, d.FakeError
 }
 
-// LatestContainerEvents TODO <container-integrations>: CONT-3353
+// LatestContainerEvents is a mock method
 func (d *MockClient) LatestContainerEvents(ctx context.Context, since time.Time, filter *containers.Filter) ([]*ContainerEvent, time.Time, error) {
 	return d.FakeContainerEvents, d.FakeLastContainerEventTimestamp, d.FakeError
 }

--- a/pkg/util/docker/containers.go
+++ b/pkg/util/docker/containers.go
@@ -191,6 +191,7 @@ func (d *DockerUtil) getContainerMetrics(ctn *containers.Container) {
 	}
 }
 
+// ContainerLogs TODO <container-integrations>: CONT-3353
 func (d *DockerUtil) ContainerLogs(ctx context.Context, container string, options types.ContainerLogsOptions) (io.ReadCloser, error) {
 	return d.cli.ContainerLogs(ctx, container, options)
 }

--- a/pkg/util/docker/containers.go
+++ b/pkg/util/docker/containers.go
@@ -191,7 +191,7 @@ func (d *DockerUtil) getContainerMetrics(ctn *containers.Container) {
 	}
 }
 
-// ContainerLogs TODO <container-integrations>: CONT-3353
+// ContainerLogs returns a container logs reader
 func (d *DockerUtil) ContainerLogs(ctx context.Context, container string, options types.ContainerLogsOptions) (io.ReadCloser, error) {
 	return d.cli.ContainerLogs(ctx, container, options)
 }

--- a/pkg/util/docker/docker_util.go
+++ b/pkg/util/docker/docker_util.go
@@ -171,6 +171,7 @@ func (d *DockerUtil) RawContainerListWithFilter(ctx context.Context, options typ
 	return filtered, nil
 }
 
+// GetHostname TODO <container-integrations>: CONT-3353
 func (d *DockerUtil) GetHostname(ctx context.Context) (string, error) {
 	ctx, cancel := context.WithTimeout(ctx, d.queryTimeout)
 	defer cancel()
@@ -352,6 +353,7 @@ func (d *DockerUtil) AllContainerLabels(ctx context.Context) (map[string]map[str
 	return labelMap, nil
 }
 
+// GetContainerStats TODO <container-integrations>: CONT-3353
 func (d *DockerUtil) GetContainerStats(ctx context.Context, containerID string) (*types.StatsJSON, error) {
 	ctx, cancel := context.WithTimeout(ctx, d.queryTimeout)
 	defer cancel()

--- a/pkg/util/docker/docker_util.go
+++ b/pkg/util/docker/docker_util.go
@@ -171,7 +171,7 @@ func (d *DockerUtil) RawContainerListWithFilter(ctx context.Context, options typ
 	return filtered, nil
 }
 
-// GetHostname TODO <container-integrations>: CONT-3353
+// GetHostname returns the hostname from the docker api
 func (d *DockerUtil) GetHostname(ctx context.Context) (string, error) {
 	ctx, cancel := context.WithTimeout(ctx, d.queryTimeout)
 	defer cancel()
@@ -353,7 +353,7 @@ func (d *DockerUtil) AllContainerLabels(ctx context.Context) (map[string]map[str
 	return labelMap, nil
 }
 
-// GetContainerStats TODO <container-integrations>: CONT-3353
+// GetContainerStats returns docker container stats
 func (d *DockerUtil) GetContainerStats(ctx context.Context, containerID string) (*types.StatsJSON, error) {
 	ctx, cancel := context.WithTimeout(ctx, d.queryTimeout)
 	defer cancel()

--- a/pkg/util/docker/fake/system_api_client.go
+++ b/pkg/util/docker/fake/system_api_client.go
@@ -16,32 +16,32 @@ import (
 	"github.com/docker/docker/api/types/registry"
 )
 
-// SystemAPIClient TODO <container-integrations>: CONT-3353
+// SystemAPIClient is a mock
 type SystemAPIClient struct {
 	InfoFunc func() (types.Info, error)
 }
 
-// Events TODO <container-integrations>: CONT-3353
+// Events is a mock method
 func (c *SystemAPIClient) Events(ctx context.Context, options types.EventsOptions) (<-chan events.Message, <-chan error) {
 	return nil, nil
 }
 
-// Info TODO <container-integrations>: CONT-3353
+// Info is a mock method
 func (c *SystemAPIClient) Info(ctx context.Context) (types.Info, error) {
 	return c.InfoFunc()
 }
 
-// RegistryLogin TODO <container-integrations>: CONT-3353
+// RegistryLogin is a mock method
 func (c *SystemAPIClient) RegistryLogin(ctx context.Context, auth types.AuthConfig) (registry.AuthenticateOKBody, error) {
 	return registry.AuthenticateOKBody{}, nil
 }
 
-// DiskUsage TODO <container-integrations>: CONT-3353
+// DiskUsage is a mock method
 func (c *SystemAPIClient) DiskUsage(ctx context.Context) (types.DiskUsage, error) {
 	return types.DiskUsage{}, nil
 }
 
-// Ping TODO <container-integrations>: CONT-3353
+// Ping is a mock method
 func (c *SystemAPIClient) Ping(ctx context.Context) (types.Ping, error) {
 	return types.Ping{}, nil
 }

--- a/pkg/util/docker/fake/system_api_client.go
+++ b/pkg/util/docker/fake/system_api_client.go
@@ -16,26 +16,32 @@ import (
 	"github.com/docker/docker/api/types/registry"
 )
 
+// SystemAPIClient TODO <container-integrations>: CONT-3353
 type SystemAPIClient struct {
 	InfoFunc func() (types.Info, error)
 }
 
+// Events TODO <container-integrations>: CONT-3353
 func (c *SystemAPIClient) Events(ctx context.Context, options types.EventsOptions) (<-chan events.Message, <-chan error) {
 	return nil, nil
 }
 
+// Info TODO <container-integrations>: CONT-3353
 func (c *SystemAPIClient) Info(ctx context.Context) (types.Info, error) {
 	return c.InfoFunc()
 }
 
+// RegistryLogin TODO <container-integrations>: CONT-3353
 func (c *SystemAPIClient) RegistryLogin(ctx context.Context, auth types.AuthConfig) (registry.AuthenticateOKBody, error) {
 	return registry.AuthenticateOKBody{}, nil
 }
 
+// DiskUsage TODO <container-integrations>: CONT-3353
 func (c *SystemAPIClient) DiskUsage(ctx context.Context) (types.DiskUsage, error) {
 	return types.DiskUsage{}, nil
 }
 
+// Ping TODO <container-integrations>: CONT-3353
 func (c *SystemAPIClient) Ping(ctx context.Context) (types.Ping, error) {
 	return types.Ping{}, nil
 }

--- a/pkg/util/docker/network_test_linux.go
+++ b/pkg/util/docker/network_test_linux.go
@@ -22,7 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/testutil"
 )
 
-// TestFindDockerNetworks TODO <container-integrations>: CONT-3353
+// TestFindDockerNetworks tests findDockerNetworks
 func TestFindDockerNetworks(t *testing.T) {
 	dummyProcDir, err := testutil.NewTempFolder("test-find-docker-networks")
 	assert.Nil(t, err)
@@ -187,7 +187,7 @@ func TestFindDockerNetworks(t *testing.T) {
 	}
 }
 
-// TestParseContainerNetworkMode TODO <container-integrations>: CONT-3353
+// TestParseContainerNetworkMode tests parseContainerNetworkMode
 func TestParseContainerNetworkMode(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/pkg/util/docker/network_test_linux.go
+++ b/pkg/util/docker/network_test_linux.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/testutil"
 )
 
+// TestFindDockerNetworks TODO <container-integrations>: CONT-3353
 func TestFindDockerNetworks(t *testing.T) {
 	dummyProcDir, err := testutil.NewTempFolder("test-find-docker-networks")
 	assert.Nil(t, err)
@@ -186,6 +187,7 @@ func TestFindDockerNetworks(t *testing.T) {
 	}
 }
 
+// TestParseContainerNetworkMode TODO <container-integrations>: CONT-3353
 func TestParseContainerNetworkMode(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -186,6 +186,7 @@ func getClientConfig(timeout time.Duration) (*rest.Config, error) {
 	return clientConfig, nil
 }
 
+// GetKubeClient TODO <container-integrations>: CONT-3353
 func GetKubeClient(timeout time.Duration) (kubernetes.Interface, error) {
 	// TODO: Remove custom warning logger when we remove usage of ComponentStatus
 	rest.SetDefaultWarningHandler(CustomWarningLogger{})

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -186,7 +186,7 @@ func getClientConfig(timeout time.Duration) (*rest.Config, error) {
 	return clientConfig, nil
 }
 
-// GetKubeClient TODO <container-integrations>: CONT-3353
+// GetKubeClient returns a kubernetes API server client
 func GetKubeClient(timeout time.Duration) (kubernetes.Interface, error) {
 	// TODO: Remove custom warning logger when we remove usage of ComponentStatus
 	rest.SetDefaultWarningHandler(CustomWarningLogger{})

--- a/pkg/util/kubernetes/apiserver/controllers.go
+++ b/pkg/util/kubernetes/apiserver/controllers.go
@@ -52,7 +52,7 @@ var controllerCatalog = map[controllerName]controllerFuncs{
 	},
 }
 
-// ControllerContext TODO <container-integrations>: CONT-3353
+// ControllerContext holds all the attributes needed by the controllers
 type ControllerContext struct {
 	informers          map[InformerName]cache.SharedInformer
 	InformerFactory    informers.SharedInformerFactory

--- a/pkg/util/kubernetes/apiserver/controllers.go
+++ b/pkg/util/kubernetes/apiserver/controllers.go
@@ -52,6 +52,7 @@ var controllerCatalog = map[controllerName]controllerFuncs{
 	},
 }
 
+// ControllerContext TODO <container-integrations>: CONT-3353
 type ControllerContext struct {
 	informers          map[InformerName]cache.SharedInformer
 	InformerFactory    informers.SharedInformerFactory

--- a/pkg/util/kubernetes/apiserver/endpoints.go
+++ b/pkg/util/kubernetes/apiserver/endpoints.go
@@ -38,7 +38,7 @@ func SearchTargetPerName(endpoints *v1.Endpoints, targetName string) (v1.Endpoin
 	return v1.EndpointAddress{}, dderrors.NewNotFound("target named " + targetName)
 }
 
-// EntityForEndpoints TODO <container-integrations>: CONT-3353
+// EntityForEndpoints builds entity strings for Endpoints
 func EntityForEndpoints(namespace, name, ip string) string {
 	return fmt.Sprintf("%s%s/%s/%s", kubeEndpointIDPrefix, namespace, name, ip)
 }

--- a/pkg/util/kubernetes/apiserver/endpoints.go
+++ b/pkg/util/kubernetes/apiserver/endpoints.go
@@ -38,6 +38,7 @@ func SearchTargetPerName(endpoints *v1.Endpoints, targetName string) (v1.Endpoin
 	return v1.EndpointAddress{}, dderrors.NewNotFound("target named " + targetName)
 }
 
+// EntityForEndpoints TODO <container-integrations>: CONT-3353
 func EntityForEndpoints(namespace, name, ip string) string {
 	return fmt.Sprintf("%s%s/%s/%s", kubeEndpointIDPrefix, namespace, name, ip)
 }

--- a/pkg/util/kubernetes/apiserver/hpa_controller.go
+++ b/pkg/util/kubernetes/apiserver/hpa_controller.go
@@ -33,7 +33,7 @@ const (
 	maxRetries = 10
 )
 
-// PollerConfig TODO <container-integrations>: CONT-3353
+// PollerConfig holds the configuration of the metrics poller
 type PollerConfig struct {
 	gcPeriodSeconds int
 	refreshPeriod   int

--- a/pkg/util/kubernetes/apiserver/hpa_controller.go
+++ b/pkg/util/kubernetes/apiserver/hpa_controller.go
@@ -33,6 +33,7 @@ const (
 	maxRetries = 10
 )
 
+// PollerConfig TODO <container-integrations>: CONT-3353
 type PollerConfig struct {
 	gcPeriodSeconds int
 	refreshPeriod   int

--- a/pkg/util/kubernetes/apiserver/metadata_controller.go
+++ b/pkg/util/kubernetes/apiserver/metadata_controller.go
@@ -49,6 +49,7 @@ type MetadataController struct {
 	queue workqueue.RateLimitingInterface
 }
 
+// NewMetadataController TODO <container-integrations>: CONT-3353
 func NewMetadataController(nodeInformer coreinformers.NodeInformer, namespaceInformer coreinformers.NamespaceInformer, endpointsInformer coreinformers.EndpointsInformer) *MetadataController {
 	m := &MetadataController{
 		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "endpoints"),
@@ -75,6 +76,7 @@ func NewMetadataController(nodeInformer coreinformers.NodeInformer, namespaceInf
 	return m
 }
 
+// Run TODO <container-integrations>: CONT-3353
 func (m *MetadataController) Run(stopCh <-chan struct{}) {
 	defer m.queue.ShutDown()
 

--- a/pkg/util/kubernetes/apiserver/metadata_controller.go
+++ b/pkg/util/kubernetes/apiserver/metadata_controller.go
@@ -49,7 +49,7 @@ type MetadataController struct {
 	queue workqueue.RateLimitingInterface
 }
 
-// NewMetadataController TODO <container-integrations>: CONT-3353
+// NewMetadataController returns a new metadata controller
 func NewMetadataController(nodeInformer coreinformers.NodeInformer, namespaceInformer coreinformers.NamespaceInformer, endpointsInformer coreinformers.EndpointsInformer) *MetadataController {
 	m := &MetadataController{
 		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "endpoints"),
@@ -76,7 +76,7 @@ func NewMetadataController(nodeInformer coreinformers.NodeInformer, namespaceInf
 	return m
 }
 
-// Run TODO <container-integrations>: CONT-3353
+// Run starts the metadata controller reconciler loop
 func (m *MetadataController) Run(stopCh <-chan struct{}) {
 	defer m.queue.ShutDown()
 

--- a/pkg/util/kubernetes/apiserver/services.go
+++ b/pkg/util/kubernetes/apiserver/services.go
@@ -32,7 +32,7 @@ func (metaBundle *metadataMapperBundle) DeepCopy(old *metadataMapperBundle) *met
 	return metaBundle
 }
 
-// EntityForService TODO <container-integrations>: CONT-3353
+// EntityForService builds entity strings for Service objects
 func EntityForService(svc *v1.Service) string {
 	if svc == nil {
 		return ""
@@ -41,7 +41,7 @@ func EntityForService(svc *v1.Service) string {
 	return EntityForServiceWithNames(svc.ObjectMeta.Namespace, svc.ObjectMeta.Name)
 }
 
-// EntityForServiceWithNames TODO <container-integrations>: CONT-3353
+// EntityForServiceWithNames builds entity strings for Service objects based on the name and the namespace
 func EntityForServiceWithNames(namespace, name string) string {
 	return fmt.Sprintf("%s%s/%s", kubeServiceIDPrefix, namespace, name)
 }

--- a/pkg/util/kubernetes/apiserver/services.go
+++ b/pkg/util/kubernetes/apiserver/services.go
@@ -32,6 +32,7 @@ func (metaBundle *metadataMapperBundle) DeepCopy(old *metadataMapperBundle) *met
 	return metaBundle
 }
 
+// EntityForService TODO <container-integrations>: CONT-3353
 func EntityForService(svc *v1.Service) string {
 	if svc == nil {
 		return ""
@@ -40,6 +41,7 @@ func EntityForService(svc *v1.Service) string {
 	return EntityForServiceWithNames(svc.ObjectMeta.Namespace, svc.ObjectMeta.Name)
 }
 
+// EntityForServiceWithNames TODO <container-integrations>: CONT-3353
 func EntityForServiceWithNames(namespace, name string) string {
 	return fmt.Sprintf("%s%s/%s", kubeServiceIDPrefix, namespace, name)
 }

--- a/pkg/util/kubernetes/apiserver/status.go
+++ b/pkg/util/kubernetes/apiserver/status.go
@@ -14,7 +14,7 @@ import (
 
 var dogCl autoscalers.DatadogClient
 
-// GetStatus TODO <container-integrations>: CONT-3353
+// GetStatus returns the status of the autoscalers
 func GetStatus() map[string]interface{} {
 	return autoscalers.GetStatus(dogCl)
 }

--- a/pkg/util/kubernetes/apiserver/status.go
+++ b/pkg/util/kubernetes/apiserver/status.go
@@ -14,6 +14,7 @@ import (
 
 var dogCl autoscalers.DatadogClient
 
+// GetStatus TODO <container-integrations>: CONT-3353
 func GetStatus() map[string]interface{} {
 	return autoscalers.GetStatus(dogCl)
 }

--- a/pkg/util/kubernetes/apiserver/util.go
+++ b/pkg/util/kubernetes/apiserver/util.go
@@ -47,7 +47,7 @@ func SyncInformers(informers map[InformerName]cache.SharedInformer, extraWait ti
 	return g.Wait()
 }
 
-// UnstructuredIntoWPA TODO <container-integrations>: CONT-3353
+// UnstructuredIntoWPA converts an unstructured into a WPA
 func UnstructuredIntoWPA(obj interface{}, structDest *v1alpha1.WatermarkPodAutoscaler) error {
 	unstrObj, ok := obj.(*unstructured.Unstructured)
 	if !ok {
@@ -56,7 +56,7 @@ func UnstructuredIntoWPA(obj interface{}, structDest *v1alpha1.WatermarkPodAutos
 	return runtime.DefaultUnstructuredConverter.FromUnstructured(unstrObj.UnstructuredContent(), structDest)
 }
 
-// UnstructuredFromWPA TODO <container-integrations>: CONT-3353
+// UnstructuredFromWPA converts a WPA object into an Unstructured
 func UnstructuredFromWPA(structIn *v1alpha1.WatermarkPodAutoscaler, unstructOut *unstructured.Unstructured) error {
 	content, err := runtime.DefaultUnstructuredConverter.ToUnstructured(structIn)
 	if err != nil {

--- a/pkg/util/kubernetes/apiserver/util.go
+++ b/pkg/util/kubernetes/apiserver/util.go
@@ -47,6 +47,7 @@ func SyncInformers(informers map[InformerName]cache.SharedInformer, extraWait ti
 	return g.Wait()
 }
 
+// UnstructuredIntoWPA TODO <container-integrations>: CONT-3353
 func UnstructuredIntoWPA(obj interface{}, structDest *v1alpha1.WatermarkPodAutoscaler) error {
 	unstrObj, ok := obj.(*unstructured.Unstructured)
 	if !ok {
@@ -55,6 +56,7 @@ func UnstructuredIntoWPA(obj interface{}, structDest *v1alpha1.WatermarkPodAutos
 	return runtime.DefaultUnstructuredConverter.FromUnstructured(unstrObj.UnstructuredContent(), structDest)
 }
 
+// UnstructuredFromWPA TODO <container-integrations>: CONT-3353
 func UnstructuredFromWPA(structIn *v1alpha1.WatermarkPodAutoscaler, unstructOut *unstructured.Unstructured) error {
 	content, err := runtime.DefaultUnstructuredConverter.ToUnstructured(structIn)
 	if err != nil {

--- a/pkg/util/kubernetes/apiserver/warning_handler.go
+++ b/pkg/util/kubernetes/apiserver/warning_handler.go
@@ -16,6 +16,7 @@ import (
 
 var supressedWarning = regexp.MustCompile(`.*is deprecated in v.*`)
 
+// CustomWarningLogger TODO <container-integrations>: CONT-3353
 type CustomWarningLogger struct{}
 
 // HandleWarningHeader suppresses some warning logs

--- a/pkg/util/kubernetes/apiserver/warning_handler.go
+++ b/pkg/util/kubernetes/apiserver/warning_handler.go
@@ -16,7 +16,7 @@ import (
 
 var supressedWarning = regexp.MustCompile(`.*is deprecated in v.*`)
 
-// CustomWarningLogger TODO <container-integrations>: CONT-3353
+// CustomWarningLogger is a custom logger to wrap warning logs
 type CustomWarningLogger struct{}
 
 // HandleWarningHeader suppresses some warning logs

--- a/pkg/util/kubernetes/autoscalers/datadogclient.go
+++ b/pkg/util/kubernetes/autoscalers/datadogclient.go
@@ -25,7 +25,7 @@ const (
 	metricsEndpointConfig = "external_metrics_provider.endpoint"
 )
 
-// NewDatadogClient TODO <container-integrations>: CONT-3353
+// NewDatadogClient configures and returns a new DatadogClient
 func NewDatadogClient() (DatadogClient, error) {
 	if config.Datadog.IsSet("external_metrics_provider.endpoints") {
 		var endpoints []config.Endpoint
@@ -212,7 +212,7 @@ func (cl *datadogFallbackClient) GetRateLimitStats() map[string]datadog.RateLimi
 	return map[string]datadog.RateLimit{}
 }
 
-// GetStatus TODO <container-integrations>: CONT-3353
+// GetStatus returns the status of the DatadogClient
 func GetStatus(datadogClient DatadogClient) map[string]interface{} {
 	status := make(map[string]interface{})
 

--- a/pkg/util/kubernetes/autoscalers/datadogclient.go
+++ b/pkg/util/kubernetes/autoscalers/datadogclient.go
@@ -25,6 +25,7 @@ const (
 	metricsEndpointConfig = "external_metrics_provider.endpoint"
 )
 
+// NewDatadogClient TODO <container-integrations>: CONT-3353
 func NewDatadogClient() (DatadogClient, error) {
 	if config.Datadog.IsSet("external_metrics_provider.endpoints") {
 		var endpoints []config.Endpoint
@@ -211,6 +212,7 @@ func (cl *datadogFallbackClient) GetRateLimitStats() map[string]datadog.RateLimi
 	return map[string]datadog.RateLimit{}
 }
 
+// GetStatus TODO <container-integrations>: CONT-3353
 func GetStatus(datadogClient DatadogClient) map[string]interface{} {
 	status := make(map[string]interface{})
 

--- a/pkg/util/kubernetes/autoscalers/datadogexternal.go
+++ b/pkg/util/kubernetes/autoscalers/datadogexternal.go
@@ -45,7 +45,7 @@ var (
 		telemetry.Options{NoDoubleUnderscoreSep: true})
 )
 
-// Point TODO <container-integrations>: CONT-3353
+// Point represents a metric data point
 type Point struct {
 	Value     float64
 	Timestamp int64

--- a/pkg/util/kubernetes/autoscalers/datadogexternal.go
+++ b/pkg/util/kubernetes/autoscalers/datadogexternal.go
@@ -45,6 +45,7 @@ var (
 		telemetry.Options{NoDoubleUnderscoreSep: true})
 )
 
+// Point TODO <container-integrations>: CONT-3353
 type Point struct {
 	Value     float64
 	Timestamp int64

--- a/pkg/util/kubernetes/autoscalers/processor.go
+++ b/pkg/util/kubernetes/autoscalers/processor.go
@@ -35,7 +35,7 @@ const (
 	extraQueryCharacters = 16
 )
 
-// DatadogClient TODO <container-integrations>: CONT-3353
+// DatadogClient abstracts the dependency on the Datadog api
 type DatadogClient interface {
 	QueryMetrics(from, to int64, query string) ([]datadog.Series, error)
 	GetRateLimitStats() map[string]datadog.RateLimit

--- a/pkg/util/kubernetes/autoscalers/processor.go
+++ b/pkg/util/kubernetes/autoscalers/processor.go
@@ -35,6 +35,7 @@ const (
 	extraQueryCharacters = 16
 )
 
+// DatadogClient TODO <container-integrations>: CONT-3353
 type DatadogClient interface {
 	QueryMetrics(from, to int64, query string) ([]datadog.Series, error)
 	GetRateLimitStats() map[string]datadog.RateLimit

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -87,7 +87,7 @@ func (ku *KubeUtil) init() error {
 	return nil
 }
 
-// NewKubeUtil TODO <container-integrations>: CONT-3353
+// NewKubeUtil returns a new KubeUtil
 func NewKubeUtil() *KubeUtil {
 	ku := &KubeUtil{
 		rawConnectionInfo:    make(map[string]string),
@@ -342,7 +342,7 @@ func (ku *KubeUtil) GetSpecForContainerName(pod *Pod, containerName string) (Con
 	return ContainerSpec{}, errors.NewNotFound(fmt.Sprintf("container %s in pod", containerName))
 }
 
-// GetPodFromUID TODO <container-integrations>: CONT-3353
+// GetPodFromUID fetches pods by UID
 func (ku *KubeUtil) GetPodFromUID(ctx context.Context, podUID string) (*Pod, error) {
 	if podUID == "" {
 		return nil, fmt.Errorf("pod UID is empty")
@@ -380,7 +380,7 @@ func (ku *KubeUtil) GetPodForEntityID(ctx context.Context, entityID string) (*Po
 	return ku.GetPodForContainerID(ctx, entityID)
 }
 
-// GetLocalStatsSummary TODO <container-integrations>: CONT-3353
+// GetLocalStatsSummary returns node and pod stats from kubelet
 func (ku *KubeUtil) GetLocalStatsSummary(ctx context.Context) (*kubeletv1alpha1.Summary, error) {
 	data, code, err := ku.QueryKubelet(ctx, kubeletStatsSummary)
 	if err != nil {

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -87,6 +87,7 @@ func (ku *KubeUtil) init() error {
 	return nil
 }
 
+// NewKubeUtil TODO <container-integrations>: CONT-3353
 func NewKubeUtil() *KubeUtil {
 	ku := &KubeUtil{
 		rawConnectionInfo:    make(map[string]string),
@@ -341,6 +342,7 @@ func (ku *KubeUtil) GetSpecForContainerName(pod *Pod, containerName string) (Con
 	return ContainerSpec{}, errors.NewNotFound(fmt.Sprintf("container %s in pod", containerName))
 }
 
+// GetPodFromUID TODO <container-integrations>: CONT-3353
 func (ku *KubeUtil) GetPodFromUID(ctx context.Context, podUID string) (*Pod, error) {
 	if podUID == "" {
 		return nil, fmt.Errorf("pod UID is empty")
@@ -378,6 +380,7 @@ func (ku *KubeUtil) GetPodForEntityID(ctx context.Context, entityID string) (*Po
 	return ku.GetPodForContainerID(ctx, entityID)
 }
 
+// GetLocalStatsSummary TODO <container-integrations>: CONT-3353
 func (ku *KubeUtil) GetLocalStatsSummary(ctx context.Context) (*kubeletv1alpha1.Summary, error) {
 	data, code, err := ku.QueryKubelet(ctx, kubeletStatsSummary)
 	if err != nil {

--- a/pkg/util/kubernetes/kubelet/mock/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/mock/kubelet.go
@@ -49,7 +49,7 @@ func (km *KubeletMock) QueryKubelet(ctx context.Context, path string) ([]byte, i
 	return nil, http.StatusNotFound, nil
 }
 
-// GetLocalStatsSummary TODO <container-integrations>: CONT-3353
+// GetLocalStatsSummary is a mock method
 func (km *KubeletMock) GetLocalStatsSummary(ctx context.Context) (*kubeletv1alpha1.Summary, error) {
 	data, rc, err := km.QueryKubelet(ctx, "/stats/summary")
 	if err != nil {

--- a/pkg/util/kubernetes/kubelet/mock/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/mock/kubelet.go
@@ -49,6 +49,7 @@ func (km *KubeletMock) QueryKubelet(ctx context.Context, path string) ([]byte, i
 	return nil, http.StatusNotFound, nil
 }
 
+// GetLocalStatsSummary TODO <container-integrations>: CONT-3353
 func (km *KubeletMock) GetLocalStatsSummary(ctx context.Context) (*kubeletv1alpha1.Summary, error) {
 	data, rc, err := km.QueryKubelet(ctx, "/stats/summary")
 	if err != nil {

--- a/pkg/util/podman/container.go
+++ b/pkg/util/podman/container.go
@@ -40,6 +40,7 @@ import (
 // - Deleted the `EnvSecrets` field of the `ContainerMiscConfig` struct.
 // - The `Container` struct only contains the 2 attributes that we need.
 
+// Container TODO <container-integrations>: CONT-3353
 type Container struct {
 	Config *ContainerConfig
 	State  *ContainerState

--- a/pkg/util/podman/container.go
+++ b/pkg/util/podman/container.go
@@ -40,7 +40,7 @@ import (
 // - Deleted the `EnvSecrets` field of the `ContainerMiscConfig` struct.
 // - The `Container` struct only contains the 2 attributes that we need.
 
-// Container TODO <container-integrations>: CONT-3353
+// Container holds the configuration and the state of a container
 type Container struct {
 	Config *ContainerConfig
 	State  *ContainerState

--- a/pkg/util/podman/db_client.go
+++ b/pkg/util/podman/db_client.go
@@ -37,7 +37,7 @@ import (
 )
 
 const (
-	// DefaultDBPath TODO <container-integrations>: CONT-3353
+	// DefaultDBPath is the default path of podman's state database
 	DefaultDBPath = "/var/lib/containers/storage/libpod/bolt_state.db"
 	ctrName       = "ctr"
 	allCtrsName   = "all-ctrs"
@@ -52,7 +52,7 @@ var (
 	stateKey   = []byte(stateName)
 )
 
-// DBClient TODO <container-integrations>: CONT-3353
+// DBClient is a client for the podman's state database
 type DBClient struct {
 	DBPath string
 }

--- a/pkg/util/podman/db_client.go
+++ b/pkg/util/podman/db_client.go
@@ -37,6 +37,7 @@ import (
 )
 
 const (
+	// DefaultDBPath TODO <container-integrations>: CONT-3353
 	DefaultDBPath = "/var/lib/containers/storage/libpod/bolt_state.db"
 	ctrName       = "ctr"
 	allCtrsName   = "all-ctrs"
@@ -51,6 +52,7 @@ var (
 	stateKey   = []byte(stateName)
 )
 
+// DBClient TODO <container-integrations>: CONT-3353
 type DBClient struct {
 	DBPath string
 }

--- a/pkg/workloadmeta/collectors/internal/containerd/containerd.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/containerd.go
@@ -36,12 +36,18 @@ const (
 
 	// These are not all the task-related topics, but enough to detect changes
 	// in the state of the container (only need to know if it's running or not).
-	// TaskStartTopic TODO <container-integrations>: CONT-3353
-	TaskStartTopic   = "/tasks/start"
-	TaskOOMTopic     = "/tasks/oom"
-	TaskExitTopic    = "/tasks/exit"
-	TaskDeleteTopic  = "/tasks/delete"
-	TaskPausedTopic  = "/tasks/paused"
+
+	// TaskStartTopic represents task start events
+	TaskStartTopic = "/tasks/start"
+	// TaskOOMTopic represents task oom events
+	TaskOOMTopic = "/tasks/oom"
+	// TaskExitTopic represents task exit events
+	TaskExitTopic = "/tasks/exit"
+	// TaskDeleteTopic represents task delete events
+	TaskDeleteTopic = "/tasks/delete"
+	// TaskPausedTopic represents task paused events
+	TaskPausedTopic = "/tasks/paused"
+	// TaskResumedTopic represents task resumed events
 	TaskResumedTopic = "/tasks/resumed"
 )
 

--- a/pkg/workloadmeta/collectors/internal/containerd/containerd.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/containerd.go
@@ -36,7 +36,7 @@ const (
 
 	// These are not all the task-related topics, but enough to detect changes
 	// in the state of the container (only need to know if it's running or not).
-
+	// TaskStartTopic TODO <container-integrations>: CONT-3353
 	TaskStartTopic   = "/tasks/start"
 	TaskOOMTopic     = "/tasks/oom"
 	TaskExitTopic    = "/tasks/exit"


### PR DESCRIPTION
*This PR follows a first PR (#12135) about these errors*

### What does this PR do?

This PR fixes [`revive` linter](https://github.com/mgechev/revive) errors in the `container-integrations` team owned code by adding `TODO` comments to exported functions / types.

### Motivation

We used to enforce that exported functions and types are documented. This was done through `revive` but the check was disabled by default when we switched to `golangcli-lint`. Now that we tried to re-enable it we got a lot of errors. This PR addresses these errors and inform the relevant teams for a fix.

### Additional Notes

After this PR, the relevant teams will have to fill the `TODO` comments (see [CONT-3353](https://datadoghq.atlassian.net/jira/software/projects/CONT/boards/167/backlog?selectedIssue=CONT-3353)).

### Describe how to test/QA your changes

You can try to run `revive ./...` in the edited files folder. You shouldn't have errors anymore.

You can also just check that the CI didn't raise an error.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
