### PR TITLE
[CI] Fix `revive` linter errors

### DIFF
--- a/pkg/collector/corechecks/embed/apm.go
+++ b/pkg/collector/corechecks/embed/apm.go
@@ -43,14 +43,17 @@ type APMCheck struct {
 	telemetry   bool
 }
 
+// String TODO <agent-platform>: AP-1715
 func (c *APMCheck) String() string {
 	return "APM Agent"
 }
 
+// Version TODO <agent-platform>: AP-1715
 func (c *APMCheck) Version() string {
 	return ""
 }
 
+// ConfigSource TODO <agent-platform>: AP-1715
 func (c *APMCheck) ConfigSource() string {
 	return c.source
 }

--- a/pkg/collector/corechecks/embed/apm.go
+++ b/pkg/collector/corechecks/embed/apm.go
@@ -43,17 +43,17 @@ type APMCheck struct {
 	telemetry   bool
 }
 
-// String TODO <agent-platform>: AP-1715
+// String displays the Agent name
 func (c *APMCheck) String() string {
 	return "APM Agent"
 }
 
-// Version TODO <agent-platform>: AP-1715
+// Version displays the command's version
 func (c *APMCheck) Version() string {
 	return ""
 }
 
-// ConfigSource TODO <agent-platform>: AP-1715
+// ConfigSource displays the command's source
 func (c *APMCheck) ConfigSource() string {
 	return c.source
 }

--- a/pkg/collector/corechecks/embed/process_agent.go
+++ b/pkg/collector/corechecks/embed/process_agent.go
@@ -44,17 +44,17 @@ type ProcessAgentCheck struct {
 	telemetry   bool
 }
 
-// String TODO <agent-platform>: AP-1715
+// String displays the Agent name
 func (c *ProcessAgentCheck) String() string {
 	return "Process Agent"
 }
 
-// Version TODO <agent-platform>: AP-1715
+// Version displays the command's version
 func (c *ProcessAgentCheck) Version() string {
 	return ""
 }
 
-// ConfigSource TODO <agent-platform>: AP-1715
+// ConfigSource displays the command's source
 func (c *ProcessAgentCheck) ConfigSource() string {
 	return c.source
 }

--- a/pkg/collector/corechecks/embed/process_agent.go
+++ b/pkg/collector/corechecks/embed/process_agent.go
@@ -44,14 +44,17 @@ type ProcessAgentCheck struct {
 	telemetry   bool
 }
 
+// String TODO <agent-platform>: AP-1715
 func (c *ProcessAgentCheck) String() string {
 	return "Process Agent"
 }
 
+// Version TODO <agent-platform>: AP-1715
 func (c *ProcessAgentCheck) Version() string {
 	return ""
 }
 
+// ConfigSource TODO <agent-platform>: AP-1715
 func (c *ProcessAgentCheck) ConfigSource() string {
 	return c.source
 }


### PR DESCRIPTION
### What does this PR do?

This PR fixes [`revive` linter](https://github.com/mgechev/revive) errors by adding `TODO` comments to exported functions / types.

### Motivation

We used to enforce that exported functions and types are documented. This was done through `revive` but the check was disabled by default when we switched to `golangcli-lint`. Now that we tried to re-enable it we got a lot of errors. This PR addresses these errors and inform the relevant teams for a fix.