### PR TITLE
[workloadmeta] Return empty in `ListContainers` instead of err

### DIFF
--- a/pkg/collector/corechecks/containers/containerd/check_test.go
+++ b/pkg/collector/corechecks/containers/containerd/check_test.go
@@ -33,7 +33,7 @@ func TestContainerdCheckGenericPart(t *testing.T) {
 	}
 
 	// Inject mock processor in check
-	mockSender, processor, _ := generic.CreateTestProcessor(containersMeta, nil, containersStats, metricsAdapter{}, getProcessorFilter(nil))
+	mockSender, processor, _ := generic.CreateTestProcessor(containersMeta, containersStats, metricsAdapter{}, getProcessorFilter(nil))
 	processor.RegisterExtension("containerd-custom-metrics", &containerdCustomMetricsExtension{})
 
 	// Create Docker check

--- a/pkg/collector/corechecks/containers/cri/check_test.go
+++ b/pkg/collector/corechecks/containers/cri/check_test.go
@@ -40,7 +40,7 @@ func TestCriCheck(t *testing.T) {
 
 	// Inject mock processor in check
 	mockCri := &crimock.MockCRIClient{}
-	mockSender, processor, _ := generic.CreateTestProcessor(containersMeta, nil, containersStats, metricsAdapter{}, getProcessorFilter(nil))
+	mockSender, processor, _ := generic.CreateTestProcessor(containersMeta, containersStats, metricsAdapter{}, getProcessorFilter(nil))
 	processor.RegisterExtension("cri-custom-metrics", &criCustomMetricsExtension{criGetter: func() (cri.CRIClient, error) { return mockCri, nil }})
 
 	mockCri.On("ListContainerStats").Return(map[string]*criTypes.ContainerStats{

--- a/pkg/collector/corechecks/containers/docker/check_test.go
+++ b/pkg/collector/corechecks/containers/docker/check_test.go
@@ -42,7 +42,7 @@ func TestDockerCheckGenericPart(t *testing.T) {
 	}
 
 	// Inject mock processor in check
-	mockSender, processor, _ := generic.CreateTestProcessor(containersMeta, nil, containersStats, metricsAdapter{}, getProcessorFilter(nil))
+	mockSender, processor, _ := generic.CreateTestProcessor(containersMeta, containersStats, metricsAdapter{}, getProcessorFilter(nil))
 	processor.RegisterExtension("docker-custom-metrics", &dockerCustomMetricsExtension{})
 
 	// Create Docker check

--- a/pkg/collector/corechecks/containers/generic/adapters.go
+++ b/pkg/collector/corechecks/containers/generic/adapters.go
@@ -19,14 +19,14 @@ type MetricsAdapter interface {
 
 // ContainerAccessor abstracts away how to list all known containers
 type ContainerAccessor interface {
-	List() ([]*workloadmeta.Container, error)
+	List() []*workloadmeta.Container
 }
 
 // MetadataContainerAccessor implements ContainerLister interface using Workload meta service
 type MetadataContainerAccessor struct{}
 
 // List returns all known containers
-func (l MetadataContainerAccessor) List() ([]*workloadmeta.Container, error) {
+func (l MetadataContainerAccessor) List() []*workloadmeta.Container {
 	return workloadmeta.GetGlobalStore().ListContainers()
 }
 

--- a/pkg/collector/corechecks/containers/generic/mock.go
+++ b/pkg/collector/corechecks/containers/generic/mock.go
@@ -17,17 +17,15 @@ import (
 // MockContainerAccessor is a dummy ContainerLister for tests
 type MockContainerAccessor struct {
 	containers []*workloadmeta.Container
-	err        error
 }
 
 // List returns the mocked containers
-func (l *MockContainerAccessor) List() ([]*workloadmeta.Container, error) {
-	return l.containers, l.err
+func (l *MockContainerAccessor) List() []*workloadmeta.Container {
+	return l.containers
 }
 
 // CreateTestProcessor returns a ready-to-use Processor
 func CreateTestProcessor(listerContainers []*workloadmeta.Container,
-	listerError error,
 	metricsContainers map[string]mock.ContainerEntry,
 	metricsAdapter MetricsAdapter,
 	containerFilter ContainerFilter) (*mocksender.MockSender, *Processor, ContainerAccessor) {
@@ -42,7 +40,6 @@ func CreateTestProcessor(listerContainers []*workloadmeta.Container,
 
 	mockAccessor := MockContainerAccessor{
 		containers: listerContainers,
-		err:        listerError,
 	}
 
 	mockedSender := mocksender.NewMockSender("generic-container")

--- a/pkg/collector/corechecks/containers/generic/processor.go
+++ b/pkg/collector/corechecks/containers/generic/processor.go
@@ -6,7 +6,6 @@
 package generic
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
@@ -55,9 +54,10 @@ func (p *Processor) RegisterExtension(id string, extension ProcessorExtension) {
 
 // Run executes the check
 func (p *Processor) Run(sender aggregator.Sender, cacheValidity time.Duration) error {
-	allContainers, err := p.ctrLister.List()
-	if err != nil {
-		return fmt.Errorf("cannot list containers from metadata store, container metrics will be missing, err: %w", err)
+	allContainers := p.ctrLister.List()
+
+	if len(allContainers) == 0 {
+		return nil
 	}
 
 	collectorsCache := make(map[workloadmeta.ContainerRuntime]metrics.Collector)

--- a/pkg/collector/corechecks/containers/generic/processor_test.go
+++ b/pkg/collector/corechecks/containers/generic/processor_test.go
@@ -40,7 +40,7 @@ func TestProcessorRunFullStatsLinux(t *testing.T) {
 		"cID100": mock.GetFullSampleContainerEntry(),
 	}
 
-	mockSender, processor, _ := CreateTestProcessor(containersMeta, nil, containersStats, GenericMetricsAdapter{}, nil)
+	mockSender, processor, _ := CreateTestProcessor(containersMeta, containersStats, GenericMetricsAdapter{}, nil)
 	err := processor.Run(mockSender, 0)
 	assert.ErrorIs(t, err, nil)
 
@@ -102,7 +102,7 @@ func TestProcessorRunPartialStats(t *testing.T) {
 		},
 	}
 
-	mockSender, processor, _ := CreateTestProcessor(containersMeta, nil, containersStats, GenericMetricsAdapter{}, nil)
+	mockSender, processor, _ := CreateTestProcessor(containersMeta, containersStats, GenericMetricsAdapter{}, nil)
 	err := processor.Run(mockSender, 0)
 	assert.ErrorIs(t, err, nil)
 

--- a/pkg/compliance/agent/telemetry.go
+++ b/pkg/compliance/agent/telemetry.go
@@ -45,13 +45,11 @@ func (t *telemetry) run(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-metricsTicker.C:
-			if err := t.reportContainers(); err != nil {
-				log.Debugf("Couldn't report containers: %v", err)
-			}
+			t.reportContainers()
 		}
 	}
 }
 
-func (t *telemetry) reportContainers() error {
-	return t.containers.ReportContainers(containersCountMetricName)
+func (t *telemetry) reportContainers() {
+	t.containers.ReportContainers(containersCountMetricName)
 }

--- a/pkg/compliance/agent/telemetry_test.go
+++ b/pkg/compliance/agent/telemetry_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"github.com/DataDog/datadog-agent/pkg/security/common"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func createRandomContainers(store *workloadmeta.MockStore, n int) {
@@ -43,7 +41,7 @@ func TestReportContainersCount(t *testing.T) {
 	containersCount := 10
 	createRandomContainers(fakeStore, containersCount)
 
-	assert.NoError(t, telemetry.reportContainers())
+	telemetry.reportContainers()
 	mockSender.AssertNumberOfCalls(t, "Gauge", containersCount)
 	for i := 0; i < containersCount; i++ {
 		mockSender.AssertCalled(t, "Gauge", containersCountMetricName, 1.0, "", []string{"container_id:" + strconv.Itoa(i)})

--- a/pkg/process/util/containers.go
+++ b/pkg/process/util/containers.go
@@ -95,10 +95,7 @@ func NewDefaultContainerProvider() ContainerProvider {
 
 // GetContainers returns containers found on the machine
 func (p *containerProvider) GetContainers(cacheValidity time.Duration, previousContainers map[string]*ContainerRateMetrics) ([]*model.Container, map[string]*ContainerRateMetrics, map[int]string, error) {
-	containersMetadata, err := p.metadataStore.ListContainers()
-	if err != nil {
-		return nil, nil, nil, err
-	}
+	containersMetadata := p.metadataStore.ListContainers()
 
 	hostCPUCount := float64(system.HostCPUCount())
 	processContainers := make([]*model.Container, 0)

--- a/pkg/security/agent/telemetry.go
+++ b/pkg/security/agent/telemetry.go
@@ -75,5 +75,7 @@ func (t *telemetry) reportContainers() error {
 		return nil
 	}
 
-	return t.containers.ReportContainers(metricName)
+	t.containers.ReportContainers(metricName)
+
+	return nil
 }

--- a/pkg/security/common/telemetry.go
+++ b/pkg/security/common/telemetry.go
@@ -31,11 +31,8 @@ func NewContainersTelemetry() (*ContainersTelemetry, error) {
 
 // ReportContainers sends the metrics about currently running containers
 // This function is critical for CWS/CSPM metering. Please tread carefully.
-func (c *ContainersTelemetry) ReportContainers(metricName string) error {
-	containers, err := c.MetadataStore.ListContainers()
-	if err != nil {
-		return err
-	}
+func (c *ContainersTelemetry) ReportContainers(metricName string) {
+	containers := c.MetadataStore.ListContainers()
 
 	for _, container := range containers {
 		if container.State.Running {
@@ -44,6 +41,4 @@ func (c *ContainersTelemetry) ReportContainers(metricName string) error {
 	}
 
 	c.Sender.Commit()
-
-	return nil
 }

--- a/pkg/util/containers/v2/metrics/docker/collector.go
+++ b/pkg/util/containers/v2/metrics/docker/collector.go
@@ -121,7 +121,7 @@ func (d *dockerCollector) GetContainerIDForPID(pid int, cacheValidity time.Durat
 		return "", err
 	}
 
-	// Use harcoded cacheValidity as input one could be 0
+	// Use hardcoded cacheValidity as input one could be 0
 	cID, found, _ = d.pidCache.Get(currentTime, strPid, time.Second)
 	if found {
 		return cID.(string), nil
@@ -174,11 +174,7 @@ func (d *dockerCollector) refreshPIDCache(currentTime time.Time, cacheValidity t
 	}
 
 	// Full refresh
-	containers, err := d.metadataStore.ListContainers()
-	if err != nil {
-		d.pidCache.Store(currentTime, pidCacheFullRefreshKey, struct{}{}, err)
-		return err
-	}
+	containers := d.metadataStore.ListContainers()
 
 	for _, container := range containers {
 		if container.Runtime == workloadmeta.ContainerRuntimeDocker && container.PID != 0 {

--- a/pkg/workloadmeta/store.go
+++ b/pkg/workloadmeta/store.go
@@ -248,11 +248,8 @@ func (s *store) GetContainer(id string) (*Container, error) {
 }
 
 // ListContainers implements Store#ListContainers.
-func (s *store) ListContainers() ([]*Container, error) {
-	entities, err := s.listEntitiesByKind(KindContainer)
-	if err != nil {
-		return nil, err
-	}
+func (s *store) ListContainers() []*Container {
+	entities := s.listEntitiesByKind(KindContainer)
 
 	// Not very efficient
 	containers := make([]*Container, 0, len(entities))
@@ -260,7 +257,7 @@ func (s *store) ListContainers() ([]*Container, error) {
 		containers = append(containers, entity.(*Container))
 	}
 
-	return containers, nil
+	return containers
 }
 
 // GetKubernetesPod implements Store#GetKubernetesPod
@@ -496,13 +493,13 @@ func (s *store) getEntityByKind(kind Kind, id string) (Entity, error) {
 	return entity.cached, nil
 }
 
-func (s *store) listEntitiesByKind(kind Kind) ([]Entity, error) {
+func (s *store) listEntitiesByKind(kind Kind) []Entity {
 	s.storeMut.RLock()
 	defer s.storeMut.RUnlock()
 
 	entitiesOfKind, ok := s.store[kind]
 	if !ok {
-		return nil, errors.NewNotFound(string(kind))
+		return nil
 	}
 
 	entities := make([]Entity, 0, len(entitiesOfKind))
@@ -510,7 +507,7 @@ func (s *store) listEntitiesByKind(kind Kind) ([]Entity, error) {
 		entities = append(entities, entity.cached)
 	}
 
-	return entities, nil
+	return entities
 }
 
 func (s *store) unsubscribeAll() {

--- a/pkg/workloadmeta/store_test.go
+++ b/pkg/workloadmeta/store_test.go
@@ -555,6 +555,49 @@ func TestSubscribe(t *testing.T) {
 	}
 }
 
+func TestListContainers(t *testing.T) {
+	container := &Container{
+		EntityID: EntityID{
+			Kind: KindContainer,
+			ID:   "abc",
+		},
+	}
+
+	tests := []struct {
+		name               string
+		preEvents          []CollectorEvent
+		expectedContainers []*Container
+	}{
+		{
+			name: "some containers stored",
+			preEvents: []CollectorEvent{
+				{
+					Type:   EventTypeSet,
+					Source: fooSource,
+					Entity: container,
+				},
+			},
+			expectedContainers: []*Container{container},
+		},
+		{
+			name:               "no containers stored",
+			preEvents:          nil,
+			expectedContainers: []*Container{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			testStore := newTestStore()
+			testStore.handleEvents(test.preEvents)
+
+			containers := testStore.ListContainers()
+
+			assert.DeepEqual(t, test.expectedContainers, containers)
+		})
+	}
+}
+
 func newTestStore() *store {
 	return &store{
 		store: make(map[Kind]map[string]*cachedEntity),

--- a/pkg/workloadmeta/testing/store.go
+++ b/pkg/workloadmeta/testing/store.go
@@ -39,11 +39,8 @@ func (s *Store) GetContainer(id string) (*workloadmeta.Container, error) {
 }
 
 // ListContainers returns metadata about all known containers.
-func (s *Store) ListContainers() ([]*workloadmeta.Container, error) {
-	entities, err := s.listEntitiesByKind(workloadmeta.KindContainer)
-	if err != nil {
-		return nil, err
-	}
+func (s *Store) ListContainers() []*workloadmeta.Container {
+	entities := s.listEntitiesByKind(workloadmeta.KindContainer)
 
 	// Not very efficient
 	containers := make([]*workloadmeta.Container, 0, len(entities))
@@ -51,7 +48,7 @@ func (s *Store) ListContainers() ([]*workloadmeta.Container, error) {
 		containers = append(containers, entity.(*workloadmeta.Container))
 	}
 
-	return containers, nil
+	return containers
 }
 
 // GetKubernetesPod returns metadata about a Kubernetes pod.
@@ -163,13 +160,13 @@ func (s *Store) getEntityByKind(kind workloadmeta.Kind, id string) (workloadmeta
 	return entity, nil
 }
 
-func (s *Store) listEntitiesByKind(kind workloadmeta.Kind) ([]workloadmeta.Entity, error) {
+func (s *Store) listEntitiesByKind(kind workloadmeta.Kind) []workloadmeta.Entity {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
 	entitiesOfKind, ok := s.store[kind]
 	if !ok {
-		return nil, errors.NewNotFound(string(kind))
+		return nil
 	}
 
 	entities := make([]workloadmeta.Entity, 0, len(entitiesOfKind))
@@ -177,5 +174,5 @@ func (s *Store) listEntitiesByKind(kind workloadmeta.Kind) ([]workloadmeta.Entit
 		entities = append(entities, entity)
 	}
 
-	return entities, nil
+	return entities
 }

--- a/pkg/workloadmeta/types.go
+++ b/pkg/workloadmeta/types.go
@@ -55,7 +55,7 @@ type Store interface {
 
 	// ListContainers returns metadata about all known containers, equivalent
 	// to all entities with kind KindContainer.
-	ListContainers() ([]*Container, error)
+	ListContainers() []*Container
 
 	// GetKubernetesPod returns metadata about a Kubernetes pod.  It fetches
 	// the entity with kind KindKubernetesPod and the given ID.

--- a/releasenotes/notes/workloadmeta-list-containers-empty-ae8b62e1061b27c6.yaml
+++ b/releasenotes/notes/workloadmeta-list-containers-empty-ae8b62e1061b27c6.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed an issue that made the container check to show an error in the "agent
+    status" output when it was working properly but there were no containers
+    deployed.


### PR DESCRIPTION
### What does this PR do?

Changes the `ListContainers` function of workloadmeta to return an empty array instead of an error when there are no containers stored.

This fixes a bug in the `container`, `containerd`, and `docker` checks. The checks were shown as error or warning in `agent status` when there were no containers deployed.

This change also simplifies a bit the code. Now there's less unnecessary error handling.

### Describe how to test/QA your changes

- For container-integrations: deploy the agent on host, with access to the docker socket but without any deployed containers. Check that `agent status` does not show an error for the `container` check or warnings for the `docker` or `containerd`  checks.
- For processes and agent-security: I think that nothing should break but please check that the functionality that relies on listing containers still works. If possible, try with no containers deployed.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
