### PR TITLE
[CI] Fix `revive` linter agent-core errors

### DIFF
--- a/pkg/collector/corechecks/embed/jmx/check.go
+++ b/pkg/collector/corechecks/embed/jmx/check.go
@@ -18,7 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// JMXCheck TODO <agent-core>
+// JMXCheck TODO <agent-core> : IML-199
 type JMXCheck struct {
 	id        check.ID
 	name      string
@@ -42,7 +42,7 @@ func newJMXCheck(config integration.Config, source string) *JMXCheck {
 	return check
 }
 
-// Run TODO <agent-core>
+// Run TODO <agent-core> : IML-199
 func (c *JMXCheck) Run() error {
 	err := state.scheduleCheck(c)
 	if err != nil {
@@ -59,56 +59,56 @@ func (c *JMXCheck) Run() error {
 	return nil
 }
 
-// Stop TODO <agent-core>
+// Stop TODO <agent-core> : IML-199
 func (c *JMXCheck) Stop() {
 	close(c.stop)
 	state.unscheduleCheck(c)
 }
 
-// Cancel TODO <agent-core>
+// Cancel TODO <agent-core> : IML-199
 func (c *JMXCheck) Cancel() {}
 
-// String TODO <agent-core>
+// String TODO <agent-core> : IML-199
 func (c *JMXCheck) String() string {
 	return c.name
 }
 
-// Version TODO <agent-core>
+// Version TODO <agent-core> : IML-199
 func (c *JMXCheck) Version() string {
 	return ""
 }
 
-// ConfigSource TODO <agent-core>
+// ConfigSource TODO <agent-core> : IML-199
 func (c *JMXCheck) ConfigSource() string {
 	return c.source
 }
 
-// Configure TODO <agent-core>
+// Configure TODO <agent-core> : IML-199
 func (c *JMXCheck) Configure(config integration.Data, initConfig integration.Data, source string) error {
 	return nil
 }
 
-// Interval TODO <agent-core>
+// Interval TODO <agent-core> : IML-199
 func (c *JMXCheck) Interval() time.Duration {
 	return 0
 }
 
-// ID TODO <agent-core>
+// ID TODO <agent-core> : IML-199
 func (c *JMXCheck) ID() check.ID {
 	return c.id
 }
 
-// IsTelemetryEnabled TODO <agent-core>
+// IsTelemetryEnabled TODO <agent-core> : IML-199
 func (c *JMXCheck) IsTelemetryEnabled() bool {
 	return c.telemetry
 }
 
-// GetWarnings TODO <agent-core>
+// GetWarnings TODO <agent-core> : IML-199
 func (c *JMXCheck) GetWarnings() []error {
 	return []error{}
 }
 
-// GetSenderStats TODO <agent-core>
+// GetSenderStats TODO <agent-core> : IML-199
 func (c *JMXCheck) GetSenderStats() (check.SenderStats, error) {
 	return check.NewSenderStats(), nil
 }

--- a/pkg/collector/corechecks/embed/jmx/check.go
+++ b/pkg/collector/corechecks/embed/jmx/check.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+// JMXCheck TODO <agent-core>
 type JMXCheck struct {
 	id        check.ID
 	name      string
@@ -41,6 +42,7 @@ func newJMXCheck(config integration.Config, source string) *JMXCheck {
 	return check
 }
 
+// Run TODO <agent-core>
 func (c *JMXCheck) Run() error {
 	err := state.scheduleCheck(c)
 	if err != nil {
@@ -57,45 +59,56 @@ func (c *JMXCheck) Run() error {
 	return nil
 }
 
+// Stop TODO <agent-core>
 func (c *JMXCheck) Stop() {
 	close(c.stop)
 	state.unscheduleCheck(c)
 }
 
+// Cancel TODO <agent-core>
 func (c *JMXCheck) Cancel() {}
 
+// String TODO <agent-core>
 func (c *JMXCheck) String() string {
 	return c.name
 }
 
+// Version TODO <agent-core>
 func (c *JMXCheck) Version() string {
 	return ""
 }
 
+// ConfigSource TODO <agent-core>
 func (c *JMXCheck) ConfigSource() string {
 	return c.source
 }
 
+// Configure TODO <agent-core>
 func (c *JMXCheck) Configure(config integration.Data, initConfig integration.Data, source string) error {
 	return nil
 }
 
+// Interval TODO <agent-core>
 func (c *JMXCheck) Interval() time.Duration {
 	return 0
 }
 
+// ID TODO <agent-core>
 func (c *JMXCheck) ID() check.ID {
 	return c.id
 }
 
+// IsTelemetryEnabled TODO <agent-core>
 func (c *JMXCheck) IsTelemetryEnabled() bool {
 	return c.telemetry
 }
 
+// GetWarnings TODO <agent-core>
 func (c *JMXCheck) GetWarnings() []error {
 	return []error{}
 }
 
+// GetSenderStats TODO <agent-core>
 func (c *JMXCheck) GetSenderStats() (check.SenderStats, error) {
 	return check.NewSenderStats(), nil
 }

--- a/pkg/jmxfetch/jmxfetch.go
+++ b/pkg/jmxfetch/jmxfetch.go
@@ -107,6 +107,7 @@ type checkInitCfg struct {
 	JavaOptions    string   `yaml:"java_options,omitempty"`
 }
 
+// Monitor TODO <agent-core>
 func (j *JMXFetch) Monitor() {
 	limiter := newRestartLimiter(config.Datadog.GetInt("jmx_max_restarts"), float64(config.Datadog.GetInt("jmx_restart_interval")))
 	ticker := time.NewTicker(500 * time.Millisecond)

--- a/pkg/jmxfetch/jmxfetch.go
+++ b/pkg/jmxfetch/jmxfetch.go
@@ -107,7 +107,7 @@ type checkInitCfg struct {
 	JavaOptions    string   `yaml:"java_options,omitempty"`
 }
 
-// Monitor TODO <agent-core>
+// Monitor TODO <agent-core> : IML-199
 func (j *JMXFetch) Monitor() {
 	limiter := newRestartLimiter(config.Datadog.GetInt("jmx_max_restarts"), float64(config.Datadog.GetInt("jmx_restart_interval")))
 	ticker := time.NewTicker(500 * time.Millisecond)

--- a/pkg/serializer/internal/stream/compressor.go
+++ b/pkg/serializer/internal/stream/compressor.go
@@ -76,6 +76,7 @@ type Compressor struct {
 	separator           []byte
 }
 
+// NewCompressor TODO <agent-core>
 func NewCompressor(input, output *bytes.Buffer, maxPayloadSize, maxUncompressedSize int, header, footer []byte, separator []byte) (*Compressor, error) {
 	c := &Compressor{
 		header:              header,
@@ -169,6 +170,7 @@ func (c *Compressor) AddItem(data []byte) error {
 	return nil
 }
 
+// Close TODO <agent-core>
 func (c *Compressor) Close() ([]byte, error) {
 	// Flush remaining uncompressed data
 	if c.input.Len() > 0 {

--- a/pkg/serializer/internal/stream/compressor.go
+++ b/pkg/serializer/internal/stream/compressor.go
@@ -76,7 +76,7 @@ type Compressor struct {
 	separator           []byte
 }
 
-// NewCompressor TODO <agent-core>
+// NewCompressor TODO <agent-core> : IML-199
 func NewCompressor(input, output *bytes.Buffer, maxPayloadSize, maxUncompressedSize int, header, footer []byte, separator []byte) (*Compressor, error) {
 	c := &Compressor{
 		header:              header,
@@ -170,7 +170,7 @@ func (c *Compressor) AddItem(data []byte) error {
 	return nil
 }
 
-// Close TODO <agent-core>
+// Close TODO <agent-core> : IML-199
 func (c *Compressor) Close() ([]byte, error) {
 	// Flush remaining uncompressed data
 	if c.input.Len() > 0 {

--- a/pkg/serializer/internal/stream/json_payload_builder.go
+++ b/pkg/serializer/internal/stream/json_payload_builder.go
@@ -70,7 +70,7 @@ type JSONPayloadBuilder struct {
 	mu                            sync.Mutex
 }
 
-// NewJSONPayloadBuilder TODO <agent-core>
+// NewJSONPayloadBuilder TODO <agent-core> : IML-199
 func NewJSONPayloadBuilder(shareAndLockBuffers bool) *JSONPayloadBuilder {
 	if shareAndLockBuffers {
 		return &JSONPayloadBuilder{

--- a/pkg/serializer/internal/stream/json_payload_builder.go
+++ b/pkg/serializer/internal/stream/json_payload_builder.go
@@ -70,6 +70,7 @@ type JSONPayloadBuilder struct {
 	mu                            sync.Mutex
 }
 
+// NewJSONPayloadBuilder TODO <agent-core>
 func NewJSONPayloadBuilder(shareAndLockBuffers bool) *JSONPayloadBuilder {
 	if shareAndLockBuffers {
 		return &JSONPayloadBuilder{


### PR DESCRIPTION
### What does this PR do?

This PR fixes [`revive` linter](https://github.com/mgechev/revive) errors in the `agent-core` team owned code by adding `TODO` comments to exported functions / types.

### Motivation

We used to enforce that exported functions and types are documented. This was done through `revive` but the check was disabled by default when we switched to `golangcli-lint`. Now that we tried to re-enable it we got a lot of errors. This PR addresses these errors and inform the relevant teams for a fix.

### Additional Notes

### Describe how to test/QA your changes

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
