### PR TITLE
[CI] Fix `revive` linter integrations-tools-and-libraries errors 

### DIFF
--- a/pkg/autodiscovery/listeners/cloudfoundry.go
+++ b/pkg/autodiscovery/listeners/cloudfoundry.go
@@ -29,6 +29,7 @@ const (
 	CfServiceContainerIP = "container-ip"
 )
 
+// CloudFoundryListener TODO <integrations-tools-and-libraries>: ITL-792
 type CloudFoundryListener struct {
 	sync.RWMutex
 	newService    chan<- Service
@@ -40,6 +41,7 @@ type CloudFoundryListener struct {
 	bbsCache      cloudfoundry.BBSCacheI
 }
 
+// CloudFoundryService TODO <integrations-tools-and-libraries>: ITL-792
 type CloudFoundryService struct {
 	tags           []string
 	adIdentifier   cloudfoundry.ADIdentifier

--- a/pkg/util/cloudproviders/cloudfoundry/cccache.go
+++ b/pkg/util/cloudproviders/cloudfoundry/cccache.go
@@ -86,6 +86,7 @@ type CCCache struct {
 	appsBatchSize        int
 }
 
+// CCClientI TODO <integrations-tools-and-libraries>: ITL-792
 type CCClientI interface {
 	ListV3AppsByQuery(url.Values) ([]cfclient.V3App, error)
 	ListV3OrganizationsByQuery(url.Values) ([]cfclient.V3Organization, error)

--- a/pkg/util/cloudproviders/cloudfoundry/types.go
+++ b/pkg/util/cloudproviders/cloudfoundry/types.go
@@ -131,10 +131,12 @@ type DesiredLRP struct {
 	CustomTags         []string
 }
 
+// CFClient TODO <integrations-tools-and-libraries>: ITL-792
 type CFClient struct {
 	*cfclient.Client
 }
 
+// CFApplication TODO <integrations-tools-and-libraries>: ITL-792
 type CFApplication struct {
 	GUID           string
 	Name           string
@@ -153,6 +155,7 @@ type CFApplication struct {
 	Sidecars       []CFSidecar
 }
 
+// CFSidecar TODO <integrations-tools-and-libraries>: ITL-792
 type CFSidecar struct {
 	Name string
 	GUID string
@@ -163,6 +166,7 @@ type listSidecarsResponse struct {
 	Resources  []CFSidecar         `json:"resources"`
 }
 
+// IsolationSegmentRelationshipResponse TODO <integrations-tools-and-libraries>: ITL-792
 type IsolationSegmentRelationshipResponse struct {
 	Data []struct {
 		GUID string `json:"guid"`
@@ -177,6 +181,7 @@ type IsolationSegmentRelationshipResponse struct {
 	} `json:"links"`
 }
 
+// CFOrgQuota TODO <integrations-tools-and-libraries>: ITL-792
 type CFOrgQuota struct {
 	GUID        string
 	MemoryLimit int
@@ -552,6 +557,7 @@ func (a *CFApplication) extractDataFromV3Org(data *cfclient.V3Organization) {
 	}
 }
 
+// NewCFClient TODO <integrations-tools-and-libraries>: ITL-792
 func NewCFClient(config *cfclient.Config) (client *CFClient, err error) {
 	cfc, err := cfclient.NewClient(config)
 	if err != nil {
@@ -561,6 +567,7 @@ func NewCFClient(config *cfclient.Config) (client *CFClient, err error) {
 	return client, nil
 }
 
+// ListSidecarsByApp TODO <integrations-tools-and-libraries>: ITL-792
 func (c *CFClient) ListSidecarsByApp(query url.Values, appGUID string) ([]CFSidecar, error) {
 	var sidecars []CFSidecar
 
@@ -630,10 +637,12 @@ func (c *CFClient) getIsolationSegmentRelationship(resource, guid string) (strin
 	return data.Data[0].GUID, nil
 }
 
+// GetIsolationSegmentSpaceGUID TODO <integrations-tools-and-libraries>: ITL-792
 func (c *CFClient) GetIsolationSegmentSpaceGUID(guid string) (string, error) {
 	return c.getIsolationSegmentRelationship("spaces", guid)
 }
 
+// GetIsolationSegmentOrganizationGUID TODO <integrations-tools-and-libraries>: ITL-792
 func (c *CFClient) GetIsolationSegmentOrganizationGUID(guid string) (string, error) {
 	return c.getIsolationSegmentRelationship("organizations", guid)
 }


### PR DESCRIPTION
### What does this PR do?

This PR fixes [`revive` linter](https://github.com/mgechev/revive) errors in the `integrations-tools-and-libraries` team owned code by adding `TODO` comments to exported functions / types.

### Motivation

We used to enforce that exported functions and types are documented. This was done through `revive` but the check was disabled by default when we switched to `golangcli-lint`. Now that we tried to re-enable it we got a lot of errors. This PR addresses these errors and inform the relevant teams for a fix.

### Additional Notes

After this PR, the relevant teams will have to fill the `TODO` comments (see [ITL-792](https://datadoghq.atlassian.net/browse/ITL-792)).

### Describe how to test/QA your changes

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
