### PR TITLE
Trims leading/trailing whitespace from `auth_token` before using it

### DIFF
--- a/pkg/api/security/security.go
+++ b/pkg/api/security/security.go
@@ -18,6 +18,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -149,7 +150,7 @@ func fetchAuthToken(tokenCreationAllowed bool) (string, error) {
 	}
 
 	// Do some basic validation
-	authToken := string(authTokenRaw)
+	authToken := strings.TrimSpace(string(authTokenRaw))
 	if len(authToken) < authTokenMinimalLen {
 		return "", fmt.Errorf("invalid authentication token: must be at least %d characters in length", authTokenMinimalLen)
 	}


### PR DESCRIPTION
### Motivation
Fixes a bug where `agent status` http requests will fail if there is extra whitespace in the `auth_token` file.


### Additional Notes
Related https://github.com/DataDog/datadog-agent/pull/12338 
### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes
- Add leading or trailing whitespace to the `auth_token` file and ensure that `agent status` still executes correctly.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
