### PR TITLE
Fix AC.GetAllConfigs

### DIFF
--- a/cmd/agent/app/jmx.go
+++ b/cmd/agent/app/jmx.go
@@ -189,6 +189,7 @@ func runJmxCommandConsole(command string) error {
 
 	// Note: when no checks are selected, cliSelectedChecks will be the empty slice and thus common.SelectedCheckMatcherBuilder
 	//       will return false, leading WaitForConfigs to timeout before returning all AD configs.
+	common.AC.LoadAndRun()
 	allConfigs := common.WaitForConfigs(time.Duration(discoveryRetryInterval)*time.Second, time.Duration(discoveryTimeout)*time.Second,
 		common.SelectedCheckMatcherBuilder(cliSelectedChecks, discoveryMinInstances))
 

--- a/cmd/agent/common/commands/check.go
+++ b/cmd/agent/common/commands/check.go
@@ -163,6 +163,7 @@ func Check(loggerName config.LoggerName, confFilePath *string, flagNoColor *bool
 				discoveryRetryInterval = discoveryTimeout
 			}
 
+			common.AC.LoadAndRun()
 			allConfigs := common.WaitForConfigs(time.Duration(discoveryRetryInterval)*time.Second, time.Duration(discoveryTimeout)*time.Second,
 				common.SelectedCheckMatcherBuilder([]string{checkName}, discoveryMinInstances))
 

--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -229,10 +229,19 @@ func (ac *AutoConfig) WaitUntilRunOnce() {
 	}
 }
 
-// GetAllConfigs queries all the providers and returns all the integration
-// configurations found, resolving the ones it can
+// GetAllConfigs waits until all providers have been polled at least once and
+// resulting configurations have been scheduled, then returns all scheduled
+// configs.  This assumes that `LoadAndRun` has been invoked separately.
 func (ac *AutoConfig) GetAllConfigs() []integration.Config {
-	return ac.getAllConfigs().schedule
+	ac.WaitUntilRunOnce()
+	var configs []integration.Config
+	ac.cfgMgr.mapOverLoadedConfigs(func(byDigest map[string]integration.Config) {
+		configs = make([]integration.Config, 0, len(byDigest))
+		for _, cfg := range byDigest {
+			configs = append(configs, cfg)
+		}
+	})
+	return configs
 }
 
 // getAllConfigs queries all the providers and returns all the integration

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -546,11 +546,6 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("exclude_pause_container", true)
 	config.BindEnvAndSetDefault("ac_include", []string{})
 	config.BindEnvAndSetDefault("ac_exclude", []string{})
-	// ac_load_timeout is used to delay the introduction of sources other than
-	// the ones automatically loaded by the AC, into the logs agent.
-	// It is mainly here to delay the introduction of the container_collect_all
-	// in the logs agent, to avoid it to tail all the available containers.
-	config.BindEnvAndSetDefault("ac_load_timeout", 30000) // in milliseconds
 	config.BindEnvAndSetDefault("container_include", []string{})
 	config.BindEnvAndSetDefault("container_exclude", []string{})
 	config.BindEnvAndSetDefault("container_include_metrics", []string{})


### PR DESCRIPTION
### What does this PR do?

This PR contains a fix to the GetAllConfigs method, which among other things is used by `agent check` to get autoconf config for the requested check.

This function had previously relied on a bug in AutoConfig whereby every call to `getAllConfigs` rescheduled all discovered configs, even if they had already been scheduled.  That bug was fixed with the reconciling config manager, causing GetAllConfigs to only return each config once.

### Motivation

`agent check xxx` doesn't work with the `logs_config.cca_in_ad` feature flag set.

### Additional Notes

Please review commit-by-commit.  In particular, the last commit removes a config parameter which I believe was never used, but I would appreciate additional eyes on that question.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

*With `logs_config.cca_in_ad` both true and false*

Enable `logs_config.cca_in_ad` and run `agent check uptime`.  You should see check output.

Create a temporary config `conf.d/cpu.d/conf.yaml`:
```
ad_identifiers:
 - bash
init_config:
instances:
  - "tags": ["TEST:ING"]
```

Start a bash container (`docker run -ti --rm bash`) and run `agent check cpu`.  You should see check output.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
