### PR TITLE
[Serverless] Prepare v23 - cherry-pick handleRuntimeDone panic

### DIFF
--- a/pkg/serverless/serverless.go
+++ b/pkg/serverless/serverless.go
@@ -184,6 +184,7 @@ func callInvocationHandler(daemon *daemon.Daemon, arn string, deadlineMs int64, 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	doneChannel := make(chan bool)
+	daemon.TellDaemonRuntimeStarted()
 	go invocationHandler(doneChannel, daemon, arn, requestID)
 	select {
 	case <-ctx.Done():
@@ -201,7 +202,6 @@ func callInvocationHandler(daemon *daemon.Daemon, arn string, deadlineMs int64, 
 }
 
 func handleInvocation(doneChannel chan bool, daemon *daemon.Daemon, arn string, requestID string) {
-	daemon.TellDaemonRuntimeStarted()
 	log.Debug("Received invocation event...")
 	daemon.ExecutionContext.SetFromInvocation(arn, requestID)
 	daemon.ComputeGlobalTags(config.GetConfiguredTags(true))

--- a/pkg/serverless/serverless_test.go
+++ b/pkg/serverless/serverless_test.go
@@ -8,6 +8,7 @@ package serverless
 import (
 	"fmt"
 	"os"
+	"runtime/debug"
 	"sort"
 	"testing"
 	"time"
@@ -56,6 +57,30 @@ func TestHandleInvocationShouldSetExtraTags(t *testing.T) {
 	ecs := d.ExecutionContext.GetCurrentState()
 	assert.Equal(t, "arn:aws:lambda:us-east-1:123456789012:function:my-function", ecs.ARN)
 	assert.Equal(t, "myRequestID", ecs.LastRequestID)
+}
+
+func TestHandleInvocationShouldNotSIGSEGVWhenTimedOut(t *testing.T) {
+	currentPanicOnFaultBehavior := debug.SetPanicOnFault(true)
+	defer debug.SetPanicOnFault(currentPanicOnFaultBehavior)
+	defer func() {
+		r := recover()
+		if r != nil {
+			assert.Fail(t, "Expected no panic, instead got ", r)
+		}
+	}()
+	for i := 0; i < 10; i++ { // each one of these takes about a second on my laptop
+		fmt.Printf("Running this test the %d time\n", i)
+		d := daemon.StartDaemon("http://localhost:8124")
+		d.WaitForDaemon()
+
+		//deadline = current time - 20 ms
+		deadlineMs := (time.Now().UnixNano())/1000000 - 20
+
+		callInvocationHandler(d, "arn:aws:lambda:us-east-1:123456789012:function:my-function", deadlineMs, 0, "myRequestID", handleInvocation)
+		d.Stop()
+	}
+	//before 8682842e9202a4984a38b00fdf427837c9e2d46b, if this was the Daemon's first invocation, the Go scheduler (trickster spirit)
+	//might try to execute TellDaemonRuntimeDone before TellDaemonRuntimeStarted, which would result in a SIGSEGV. Now this should never happen.
 }
 
 func TestComputeTimeout(t *testing.T) {


### PR DESCRIPTION
Cherry-picking 8ae4410c99edd24200f88bbf3c9b8976434e2ac4 from https://github.com/DataDog/datadog-agent/pull/12287 to prepare the v23 release (v22 + this hotfix)