### PR TITLE
[RCM] Add a method to pull only the TUF version state

### DIFF
--- a/pkg/config/remote/service/service.go
+++ b/pkg/config/remote/service/service.go
@@ -73,6 +73,8 @@ type uptaneClient interface {
 	TargetFile(path string) ([]byte, error)
 	TargetsMeta() ([]byte, error)
 	TargetsCustom() ([]byte, error)
+	DirectorVersionState() (uint64, uint64, error)
+	TUFVersionState() (uptane.TUFVersions, error)
 }
 
 // NewService instantiates a new remote configuration management service
@@ -194,12 +196,12 @@ func (s *Service) refresh() error {
 	defer s.Unlock()
 	activeClients := s.clients.activeClients()
 	s.refreshProducts(activeClients)
-	previousState, err := s.uptane.State()
+	previousState, err := s.uptane.TUFVersionState()
 	if err != nil {
-		log.Warnf("could not get previous state: %v", err)
+		log.Warnf("could not get previous TUF version state: %v", err)
 	}
 	if s.forceRefresh() || err != nil {
-		previousState = uptane.State{}
+		previousState = uptane.TUFVersions{}
 	}
 	clientState, err := s.getClientState()
 	if err != nil {
@@ -257,17 +259,17 @@ func (s *Service) ClientGetConfigs(request *pbgo.ClientGetConfigsRequest) (*pbgo
 	s.Lock()
 	defer s.Unlock()
 	s.clients.seen(request.Client)
-	state, err := s.uptane.State()
+	rootVersion, targetVersion, err := s.uptane.DirectorVersionState()
 	if err != nil {
 		return nil, err
 	}
 	if request.Client.State == nil {
 		return &pbgo.ClientGetConfigsResponse{}, nil
 	}
-	if state.DirectorTargetsVersion() == request.Client.State.TargetsVersion {
+	if targetVersion == request.Client.State.TargetsVersion {
 		return &pbgo.ClientGetConfigsResponse{}, nil
 	}
-	roots, err := s.getNewDirectorRoots(request.Client.State.RootVersion, state.DirectorRootVersion())
+	roots, err := s.getNewDirectorRoots(request.Client.State.RootVersion, rootVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/config/remote/service/service.go
+++ b/pkg/config/remote/service/service.go
@@ -73,7 +73,6 @@ type uptaneClient interface {
 	TargetFile(path string) ([]byte, error)
 	TargetsMeta() ([]byte, error)
 	TargetsCustom() ([]byte, error)
-	DirectorVersionState() (uint64, uint64, error)
 	TUFVersionState() (uptane.TUFVersions, error)
 }
 
@@ -259,17 +258,17 @@ func (s *Service) ClientGetConfigs(request *pbgo.ClientGetConfigsRequest) (*pbgo
 	s.Lock()
 	defer s.Unlock()
 	s.clients.seen(request.Client)
-	rootVersion, targetVersion, err := s.uptane.DirectorVersionState()
+	tufVersions, err := s.uptane.TUFVersionState()
 	if err != nil {
 		return nil, err
 	}
 	if request.Client.State == nil {
 		return &pbgo.ClientGetConfigsResponse{}, nil
 	}
-	if targetVersion == request.Client.State.TargetsVersion {
+	if tufVersions.DirectorTargets == request.Client.State.TargetsVersion {
 		return &pbgo.ClientGetConfigsResponse{}, nil
 	}
-	roots, err := s.getNewDirectorRoots(request.Client.State.RootVersion, rootVersion)
+	roots, err := s.getNewDirectorRoots(request.Client.State.RootVersion, tufVersions.DirectorRoot)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/config/remote/service/util.go
+++ b/pkg/config/remote/service/util.go
@@ -51,7 +51,7 @@ func parseRemoteConfigKey(serializedKey string) (*msgpgo.RemoteConfigKey, error)
 	return &key, nil
 }
 
-func buildLatestConfigsRequest(hostname string, state uptane.State, activeClients []*pbgo.Client, products map[data.Product]struct{}, newProducts map[data.Product]struct{}, clientState []byte) *pbgo.LatestConfigsRequest {
+func buildLatestConfigsRequest(hostname string, state uptane.TUFVersions, activeClients []*pbgo.Client, products map[data.Product]struct{}, newProducts map[data.Product]struct{}, clientState []byte) *pbgo.LatestConfigsRequest {
 	productsList := make([]data.Product, len(products))
 	i := 0
 	for k := range products {
@@ -69,9 +69,9 @@ func buildLatestConfigsRequest(hostname string, state uptane.State, activeClient
 		AgentVersion:                 version.AgentVersion,
 		Products:                     data.ProductListToString(productsList),
 		NewProducts:                  data.ProductListToString(newProductsList),
-		CurrentConfigSnapshotVersion: state.ConfigSnapshotVersion(),
-		CurrentConfigRootVersion:     state.ConfigRootVersion(),
-		CurrentDirectorRootVersion:   state.DirectorRootVersion(),
+		CurrentConfigSnapshotVersion: state.ConfigSnapshot,
+		CurrentConfigRootVersion:     state.ConfigRoot,
+		CurrentDirectorRootVersion:   state.DirectorRoot,
 		ActiveClients:                activeClients,
 		BackendClientState:           clientState,
 	}

--- a/pkg/config/remote/uptane/client_state.go
+++ b/pkg/config/remote/uptane/client_state.go
@@ -54,6 +54,62 @@ func (s *State) DirectorTargetsVersion() uint64 {
 	return meta.Version
 }
 
+type TUFVersions struct {
+	DirectorRoot    uint64
+	DirectorTargets uint64
+	ConfigRoot      uint64
+	ConfigSnapshot  uint64
+}
+
+func (c *Client) TUFVersionState() (TUFVersions, error) {
+	c.Lock()
+	defer c.Unlock()
+
+	drv, err := c.directorLocalStore.GetMetaVersion("root.json")
+	if err != nil {
+		return TUFVersions{}, err
+	}
+
+	dtv, err := c.directorLocalStore.GetMetaVersion("targets.json")
+	if err != nil {
+		return TUFVersions{}, err
+	}
+
+	crv, err := c.configLocalStore.GetMetaVersion("root.json")
+	if err != nil {
+		return TUFVersions{}, err
+	}
+
+	csv, err := c.configLocalStore.GetMetaVersion("snapshot.json")
+	if err != nil {
+		return TUFVersions{}, err
+	}
+
+	return TUFVersions{
+		DirectorRoot:    drv,
+		DirectorTargets: dtv,
+		ConfigRoot:      crv,
+		ConfigSnapshot:  csv,
+	}, nil
+}
+
+func (c *Client) DirectorVersionState() (uint64, uint64, error) {
+	c.Lock()
+	defer c.Unlock()
+
+	rv, err := c.directorLocalStore.GetMetaVersion("root.json")
+	if err != nil {
+		return 0, 0, err
+	}
+
+	tv, err := c.directorLocalStore.GetMetaVersion("targets.json")
+	if err != nil {
+		return 0, 0, err
+	}
+
+	return rv, tv, nil
+}
+
 // State returns the state of the uptane client
 func (c *Client) State() (State, error) {
 	c.Lock()

--- a/pkg/config/remote/uptane/client_state.go
+++ b/pkg/config/remote/uptane/client_state.go
@@ -93,23 +93,6 @@ func (c *Client) TUFVersionState() (TUFVersions, error) {
 	}, nil
 }
 
-func (c *Client) DirectorVersionState() (uint64, uint64, error) {
-	c.Lock()
-	defer c.Unlock()
-
-	rv, err := c.directorLocalStore.GetMetaVersion("root.json")
-	if err != nil {
-		return 0, 0, err
-	}
-
-	tv, err := c.directorLocalStore.GetMetaVersion("targets.json")
-	if err != nil {
-		return 0, 0, err
-	}
-
-	return rv, tv, nil
-}
-
 // State returns the state of the uptane client
 func (c *Client) State() (State, error) {
 	c.Lock()

--- a/pkg/config/remote/uptane/client_state.go
+++ b/pkg/config/remote/uptane/client_state.go
@@ -65,22 +65,22 @@ func (c *Client) TUFVersionState() (TUFVersions, error) {
 	c.Lock()
 	defer c.Unlock()
 
-	drv, err := c.directorLocalStore.GetMetaVersion("root.json")
+	drv, err := c.directorLocalStore.GetMetaVersion(metaRoot)
 	if err != nil {
 		return TUFVersions{}, err
 	}
 
-	dtv, err := c.directorLocalStore.GetMetaVersion("targets.json")
+	dtv, err := c.directorLocalStore.GetMetaVersion(metaTargets)
 	if err != nil {
 		return TUFVersions{}, err
 	}
 
-	crv, err := c.configLocalStore.GetMetaVersion("root.json")
+	crv, err := c.configLocalStore.GetMetaVersion(metaRoot)
 	if err != nil {
 		return TUFVersions{}, err
 	}
 
-	csv, err := c.configLocalStore.GetMetaVersion("snapshot.json")
+	csv, err := c.configLocalStore.GetMetaVersion(metaSnapshot)
 	if err != nil {
 		return TUFVersions{}, err
 	}


### PR DESCRIPTION
Pulling the full state is a non-trivial operation, and we were doing it
on every update request from an agent/tracer client. These clients ask
for updates quite frequently and this was causing the agent to use
more CPU than intended for remote configuration updates.

To fix this, we split out full state checks (which ARE needed for the
agent's CLI for users to query the remote config state) from TUF Version
state checks, which is all that is needed for trace/agent client updates
as well as getting updates from the remote configuration backend.

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
