### PR TITLE
[Windows][Installer] Support gMSA accounts

### DIFF
--- a/releasenotes/notes/support_gmsa_accounts-07ddf74f09e8a9d7.yaml
+++ b/releasenotes/notes/support_gmsa_accounts-07ddf74f09e8a9d7.yaml
@@ -1,0 +1,4 @@
+enhancements:
+  - |
+    The Windows installer now supports grouped Managed Service Accounts.
+

--- a/tools/windows/install-help/cal/FinalizeInstall.cpp
+++ b/tools/windows/install-help/cal/FinalizeInstall.cpp
@@ -293,10 +293,6 @@ UINT doFinalizeInstall(CustomActionData &data)
     if (!ddServiceExists)
     {
         WcaLog(LOGMSG_STANDARD, "attempting to install services");
-        if (!passToUse)
-        {
-            passToUse = providedPassword.c_str();
-        }
         int ret = installServices(data, data.Sid(), passToUse);
 
         if (ret != 0)

--- a/tools/windows/install-help/cal/FinalizeInstall.cpp
+++ b/tools/windows/install-help/cal/FinalizeInstall.cpp
@@ -295,14 +295,6 @@ UINT doFinalizeInstall(CustomActionData &data)
         WcaLog(LOGMSG_STANDARD, "attempting to install services");
         if (!passToUse)
         {
-            if (!data.value(propertyDDAgentUserPassword, providedPassword))
-            {
-                // given all the error conditions checked above, this should *never*
-                // happen.  But we'll check anyway
-                WcaLog(LOGMSG_STANDARD, "Don't have password to register service");
-                er = ERROR_INSTALL_FAILURE;
-                goto LExit;
-            }
             passToUse = providedPassword.c_str();
         }
         int ret = installServices(data, data.Sid(), passToUse);

--- a/tools/windows/install-help/cal/LogonCli.cpp
+++ b/tools/windows/install-help/cal/LogonCli.cpp
@@ -1,0 +1,42 @@
+#include "stdafx.h"
+#include "LogonCli.h"
+#include <exception>
+
+LogonCli::LogonCli()
+    : _logonCliDll(LoadLibrary(L"Logoncli.dll"))
+{
+    if (_logonCliDll == nullptr)
+    {
+        throw std::exception("could not load the logoncli DLL");
+    }
+    _fnNetIsServiceAccount =
+        reinterpret_cast<SigNetIsServiceAccount>(GetProcAddress(_logonCliDll, "NetIsServiceAccount"));
+    if (_fnNetIsServiceAccount == nullptr)
+    {
+        throw std::exception("could not find the procedure NetIsServiceAccount in the logoncli DLL");
+    }
+}
+
+LogonCli::LogonCli(LogonCli &&other) noexcept
+    : _logonCliDll(std::move(other._logonCliDll))
+    , _fnNetIsServiceAccount(std::move(other._fnNetIsServiceAccount))
+{
+}
+
+LogonCli &LogonCli::operator=(LogonCli &&other) noexcept
+{
+    _logonCliDll = std::move(other._logonCliDll);
+    _fnNetIsServiceAccount = std::move(other._fnNetIsServiceAccount);
+    return *this;
+}
+
+// ReSharper disable once CppMemberFunctionMayBeConst
+NTSTATUS LogonCli::NetIsServiceAccount(_In_opt_ LPWSTR ServerName, _In_ LPWSTR AccountName, _Out_ BOOL *IsService)
+{
+    return _fnNetIsServiceAccount(ServerName, AccountName, IsService);
+}
+
+LogonCli::~LogonCli()
+{
+    FreeLibrary(_logonCliDll);
+}

--- a/tools/windows/install-help/cal/LogonCli.h
+++ b/tools/windows/install-help/cal/LogonCli.h
@@ -1,0 +1,19 @@
+#pragma once
+#include <Windows.h>
+#include "NonCopyable.h"
+
+class LogonCli : private NonCopyable<LogonCli>
+{
+  private:
+    typedef NTSTATUS (*SigNetIsServiceAccount)(_In_opt_ LPWSTR, _In_ LPWSTR, _Out_ BOOL *);
+    HMODULE _logonCliDll;
+    SigNetIsServiceAccount _fnNetIsServiceAccount;
+
+  public:
+    LogonCli();
+    LogonCli(LogonCli &&other) noexcept;
+    LogonCli &operator=(LogonCli &&) noexcept;
+    ~LogonCli();
+
+    NTSTATUS NetIsServiceAccount(_In_opt_ LPWSTR ServerName, _In_ LPWSTR AccountName, _Out_ BOOL *IsService);
+};

--- a/tools/windows/install-help/cal/NonCopyable.h
+++ b/tools/windows/install-help/cal/NonCopyable.h
@@ -1,0 +1,12 @@
+#pragma once
+// ReSharper disable CppClangTidyCppcoreguidelinesSpecialMemberFunctions
+template <class T> class NonCopyable
+{
+  public:
+    NonCopyable(const NonCopyable &) = delete;
+    T &operator=(const T &) = delete;
+
+  protected:
+    NonCopyable() = default;
+    ~NonCopyable() = default; /// Protected non-virtual destructor
+};

--- a/tools/windows/install-help/cal/caninstall.cpp
+++ b/tools/windows/install-help/cal/caninstall.cpp
@@ -65,7 +65,7 @@ bool canInstall(BOOL isDC, int ddUserExists, int ddServiceExists, const CustomAc
             WcaLog(LOGMSG_STANDARD, "(Configuration Error) Invalid configuration; no DD user, but service exists");
             bRet = false;
         }
-        if (!ddUserExists || !ddServiceExists)
+        if ((!ddUserExists || !ddServiceExists) && !data.IsServiceAccount())
         {
             // case (4) and case (2)
             if (!data.present(propertyDDAgentUserPassword))

--- a/tools/windows/install-help/cal/customaction-tests/CustomActionData_CanInstall.cpp
+++ b/tools/windows/install-help/cal/customaction-tests/CustomActionData_CanInstall.cpp
@@ -45,23 +45,6 @@ TEST_F(CustomActionDataTest, When_ServiceExists_And_NoUser_ReturnsFalse) {
     EXPECT_FALSE(shouldResetPass);
 }
 
-TEST_F(CustomActionDataTest, When_ServiceDoesNotExists_And_UserExists_ButNoPassword_ReturnsFalse) {
-    auto tm = std::make_shared<TargetMachineMock>();
-    ON_CALL(*tm, Detect).WillByDefault(testing::Return(ERROR_SUCCESS));
-    CustomActionData customActionCtx(tm);
-    bool shouldResetPass;
-
-    bool result = canInstall(
-        true    /*isDC*/,
-        false   /*ddUserExists*/,
-        false   /*ddServiceExists*/,
-        customActionCtx,
-        shouldResetPass);
-
-    EXPECT_FALSE(result);
-    EXPECT_FALSE(shouldResetPass);
-}
-
 TEST_F(CustomActionDataTest, When_ServiceExists_And_UserDoesNotExists_WithUserInDifferentDomain_ReturnsFalse) {
     auto tm = std::make_shared<TargetMachineMock>();
     ON_CALL(*tm, Detect).WillByDefault(testing::Return(ERROR_SUCCESS));

--- a/tools/windows/install-help/cal/customaction.vcxproj
+++ b/tools/windows/install-help/cal/customaction.vcxproj
@@ -169,6 +169,7 @@
     <ClCompile Include="doUninstall.cpp" />
     <ClCompile Include="Error.cpp" />
     <ClCompile Include="FinalizeInstall.cpp" />
+    <ClCompile Include="LogonCli.cpp" />
     <ClCompile Include="PropertyReplacer.cpp" />
     <ClCompile Include="rollback.cpp" />
     <ClCompile Include="TargetMachine.cpp" />
@@ -195,6 +196,8 @@
     <ClInclude Include="ddreg.h" />
     <ClInclude Include="Error.h" />
     <ClInclude Include="lmerr_str.h" />
+    <ClInclude Include="LogonCli.h" />
+    <ClInclude Include="NonCopyable.h" />
     <ClInclude Include="PropertyReplacer.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="SID.h" />

--- a/tools/windows/install-help/cal/customaction.vcxproj.filters
+++ b/tools/windows/install-help/cal/customaction.vcxproj.filters
@@ -39,6 +39,9 @@
     <ClCompile Include="TargetMachine.cpp">
       <Filter>helper</Filter>
     </ClCompile>
+    <ClCompile Include="LogonCli.cpp">
+      <Filter>helper</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="customactiondata.h" />
@@ -77,6 +80,12 @@
       <Filter>resources</Filter>
     </ClInclude>
     <ClInclude Include="TargetMachine.h">
+      <Filter>helper</Filter>
+    </ClInclude>
+    <ClInclude Include="LogonCli.h">
+      <Filter>helper</Filter>
+    </ClInclude>
+    <ClInclude Include="NonCopyable.h">
       <Filter>helper</Filter>
     </ClInclude>
   </ItemGroup>

--- a/tools/windows/install-help/cal/customactiondata.cpp
+++ b/tools/windows/install-help/cal/customactiondata.cpp
@@ -23,10 +23,7 @@ CustomActionData::CustomActionData()
 
 CustomActionData::~CustomActionData()
 {
-    if (_logonCli != nullptr)
-    {
-        delete _logonCli;
-    }
+    delete _logonCli;
 }
 
 bool CustomActionData::init(MSIHANDLE hi)

--- a/tools/windows/install-help/cal/customactiondata.cpp
+++ b/tools/windows/install-help/cal/customactiondata.cpp
@@ -23,6 +23,10 @@ CustomActionData::CustomActionData()
 
 CustomActionData::~CustomActionData()
 {
+    if (_logonCli != nullptr)
+    {
+        delete _logonCli;
+    }
 }
 
 bool CustomActionData::init(MSIHANDLE hi)

--- a/tools/windows/install-help/cal/customactiondata.h
+++ b/tools/windows/install-help/cal/customactiondata.h
@@ -15,6 +15,7 @@ class ICustomActionData
     virtual bool isUserDomainUser() const = 0;
     virtual bool isUserLocalUser() const = 0;
     virtual bool DoesUserExist() const = 0;
+    virtual bool IsServiceAccount() const = 0;
     virtual const std::wstring &UnqualifiedUsername() const = 0;
     virtual const std::wstring &Domain() const = 0;
     virtual const std::wstring &FullyQualifiedUsername() const = 0;
@@ -52,6 +53,7 @@ class CustomActionData : ICustomActionData
     bool isUserDomainUser() const override;
     bool isUserLocalUser() const override;
     bool DoesUserExist() const override;
+    bool IsServiceAccount() const override;
     const std::wstring &UnqualifiedUsername() const override;
     const std::wstring &FullyQualifiedUsername() const override;
     const std::wstring &Domain() const override;
@@ -72,6 +74,7 @@ class CustomActionData : ICustomActionData
     bool _doInstallSysprobe;
     bool _ddnpmPresent;
     bool _ddUserExists;
+    bool _isServiceAccount;
     std::shared_ptr<ITargetMachine> _targetMachine;
     std::optional<User> findPreviousUserInfo();
     std::optional<User> findSuppliedUserInfo();

--- a/tools/windows/install-help/cal/customactiondata.h
+++ b/tools/windows/install-help/cal/customactiondata.h
@@ -30,6 +30,8 @@ class ICustomActionData
     }
 };
 
+class LogonCli;
+
 class CustomActionData : ICustomActionData
 {
   private:
@@ -75,6 +77,7 @@ class CustomActionData : ICustomActionData
     bool _ddnpmPresent;
     bool _ddUserExists;
     bool _isServiceAccount;
+    LogonCli *_logonCli;
     std::shared_ptr<ITargetMachine> _targetMachine;
     std::optional<User> findPreviousUserInfo();
     std::optional<User> findSuppliedUserInfo();

--- a/tools/windows/install-help/install-cmd/cmdline.cpp
+++ b/tools/windows/install-help/install-cmd/cmdline.cpp
@@ -67,7 +67,7 @@ bool parseArgs(int argc, wchar_t **argv, std::wstring &calstring)
                 calstring += calargs[(int)a];
                 calstring += L"=";
                 calstring += argv[i];
-                calstring += L";";
+                calstring += L"\n";
                 break;
             }
         }
@@ -85,7 +85,7 @@ bool parseArgs(int argc, wchar_t **argv, std::wstring &calstring)
             calstring += calargs[(int)a];
             calstring += L"=";
             calstring += defaults[(int)a];
-            calstring += L";";
+            calstring += L"\n";
         }
     }
     return true;

--- a/tools/windows/install-help/install-cmd/install-cmd.vcxproj
+++ b/tools/windows/install-help/install-cmd/install-cmd.vcxproj
@@ -181,6 +181,7 @@
     <ClCompile Include="..\cal\customactiondata.cpp" />
     <ClCompile Include="..\cal\ddreg.cpp" />
     <ClCompile Include="..\cal\Error.cpp" />
+    <ClCompile Include="..\cal\Logoncli.cpp" />
     <ClCompile Include="..\cal\FinalizeInstall.cpp" />
     <ClCompile Include="..\cal\stopservices.cpp" />
     <ClCompile Include="..\cal\PropertyReplacer.cpp" />
@@ -212,6 +213,5 @@
     </ResourceCompile>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-  <ImportGroup Label="ExtensionTargets">
-  </ImportGroup>
+  <ImportGroup Label="ExtensionTargets" />
 </Project>

--- a/tools/windows/install-help/install-cmd/install-cmd.vcxproj.filters
+++ b/tools/windows/install-help/install-cmd/install-cmd.vcxproj.filters
@@ -40,6 +40,7 @@
     <ClCompile Include="..\cal\Error.cpp">
       <Filter>cal_imported</Filter>
     </ClCompile>
+    <ClCompile Include="..\cal\Logoncli.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="cmdargs.h" />

--- a/tools/windows/install-help/uninstall-cmd/cmdline.cpp
+++ b/tools/windows/install-help/uninstall-cmd/cmdline.cpp
@@ -53,7 +53,7 @@ bool parseArgs(int argc, wchar_t **argv, std::wstring &calstring)
                 calstring += calargs[(int)a];
                 calstring += L"=";
                 calstring += argv[i];
-                calstring += L";";
+                calstring += L"\n";
                 break;
             }
         }
@@ -71,7 +71,7 @@ bool parseArgs(int argc, wchar_t **argv, std::wstring &calstring)
             calstring += calargs[(int)a];
             calstring += L"=";
             calstring += defaults[(int)a];
-            calstring += L";";
+            calstring += L"\n";
         }
     }
     return true;

--- a/tools/windows/install-help/uninstall-cmd/uninstall-cmd.vcxproj
+++ b/tools/windows/install-help/uninstall-cmd/uninstall-cmd.vcxproj
@@ -183,6 +183,7 @@
     <ClCompile Include="..\cal\delfiles.cpp" />
     <ClCompile Include="..\cal\doUninstall.cpp" />
     <ClCompile Include="..\cal\Error.cpp" />
+    <ClCompile Include="..\cal\Logoncli.cpp" />
     <ClCompile Include="..\cal\PropertyReplacer.cpp" />
     <ClCompile Include="..\cal\stopservices.cpp" />
     <ClCompile Include="..\cal\strings.cpp" />


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR adds support for grouped (& single probably) Managed Service Accounts in the installer.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Support managed service accounts.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
On a server with a Managed Service Account, use the command line to specify it and the Agent should install correctly.
/!\ Specify a $ prefix for the installer to understand that it's a Managed Service Account.

```
msiexec /i ddagent.msi /log install.log DDAGENTUSER_NAME=<managedServiceAccount>$
```

It's also possible to specify the domain where to find the MSA, either using the NETBIOS definition or the DNS domain name:

```
msiexec /i ddagent.msi /log install.log DDAGENTUSER_NAME=<netbios>\<managedServiceAccount>$```
msiexec /i ddagent.msi /log install.log DDAGENTUSER_NAME=<DNS>\<managedServiceAccount>$
```

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
