### PR TITLE
Fix TLS Handshakes with leader forwarding, decrease loglevel to warning

### DIFF
--- a/cmd/cluster-agent/api/server.go
+++ b/cmd/cluster-agent/api/server.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cihub/seelog"
 	"github.com/gorilla/mux"
 
 	"github.com/DataDog/datadog-agent/cmd/cluster-agent/api/agent"
@@ -92,11 +93,12 @@ func StartServer() error {
 		tlsConfig.MinVersion = tls.VersionTLS10
 	}
 
+	// Use a stack depth of 4 on top of the default one to get a relevant filename in the stdlib
+	logWriter, _ := config.NewLogWriter(4, seelog.WarnLvl)
+
 	srv := &http.Server{
-		Handler: router,
-		ErrorLog: stdLog.New(&config.ErrorLogWriter{
-			AdditionalDepth: 4, // Use a stack depth of 4 on top of the default one to get a relevant filename in the stdlib
-		}, "Error from the agent http API server: ", 0), // log errors to seelog,
+		Handler:      router,
+		ErrorLog:     stdLog.New(logWriter, "Error from the agent http API server: ", 0), // log errors to seelog,
 		TLSConfig:    &tlsConfig,
 		ReadTimeout:  config.Datadog.GetDuration("cluster_agent.server.read_timeout_seconds") * time.Second,
 		WriteTimeout: config.Datadog.GetDuration("cluster_agent.server.write_timeout_seconds") * time.Second,

--- a/cmd/security-agent/api/server.go
+++ b/cmd/security-agent/api/server.go
@@ -26,6 +26,7 @@ import (
 	compagent "github.com/DataDog/datadog-agent/pkg/compliance/agent"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	secagent "github.com/DataDog/datadog-agent/pkg/security/agent"
+	"github.com/cihub/seelog"
 	"github.com/gorilla/mux"
 )
 
@@ -84,11 +85,12 @@ func (s *Server) Start() error {
 		Certificates: []tls.Certificate{rootTLSCert},
 	}
 
+	// Use a stack depth of 4 on top of the default one to get a relevant filename in the stdlib
+	logWriter, _ := config.NewLogWriter(4, seelog.ErrorLvl)
+
 	srv := &http.Server{
-		Handler: r,
-		ErrorLog: stdLog.New(&config.ErrorLogWriter{
-			AdditionalDepth: 4, // Use a stack depth of 4 on top of the default one to get a relevant filename in the stdlib
-		}, "Error from the agent http API server: ", 0), // log errors to seelog,
+		Handler:      r,
+		ErrorLog:     stdLog.New(logWriter, "Error from the agent http API server: ", 0), // log errors to seelog,
 		TLSConfig:    &tlsConfig,
 		WriteTimeout: config.Datadog.GetDuration("server_timeout") * time.Second,
 	}

--- a/pkg/clusteragent/api/leader_forwarder.go
+++ b/pkg/clusteragent/api/leader_forwarder.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/cihub/seelog"
 )
 
 const (
@@ -26,7 +27,7 @@ const (
 
 // LeaderForwarder allows to forward queries from follower to leader
 type LeaderForwarder struct {
-	transport *http.Transport
+	transport http.RoundTripper
 	logger    *stdLog.Logger
 	proxy     *httputil.ReverseProxy
 	proxyLock sync.RWMutex
@@ -34,7 +35,10 @@ type LeaderForwarder struct {
 }
 
 // NewLeaderForwarder returns a new LeaderForwarder
-func NewLeaderForwarder(apiPort, maxConnections, maxIdleConnections int) *LeaderForwarder {
+func NewLeaderForwarder(apiPort, maxConnections int) *LeaderForwarder {
+	// Use a stack depth of 4 on top of the default one to get a relevant filename in the stdlib
+	logWriter, _ := config.NewLogWriter(4, seelog.DebugLvl)
+
 	lf := &LeaderForwarder{
 		apiPort: strconv.Itoa(apiPort),
 		transport: &http.Transport{
@@ -45,15 +49,15 @@ func NewLeaderForwarder(apiPort, maxConnections, maxIdleConnections int) *Leader
 			}).DialContext,
 			ForceAttemptHTTP2:     false,
 			TLSClientConfig:       &tls.Config{InsecureSkipVerify: true},
-			TLSHandshakeTimeout:   2 * time.Second,
+			TLSHandshakeTimeout:   5 * time.Second,
 			MaxConnsPerHost:       maxConnections,
-			MaxIdleConns:          maxIdleConnections,
-			IdleConnTimeout:       30 * time.Second,
+			MaxIdleConnsPerHost:   maxConnections,
+			MaxIdleConns:          0,
+			IdleConnTimeout:       120 * time.Second,
+			ResponseHeaderTimeout: 5 * time.Second,
 			ExpectContinueTimeout: 1 * time.Second,
 		},
-		logger: stdLog.New(&config.ErrorLogWriter{
-			AdditionalDepth: 4, // Use a stack depth of 4 on top of the default one to get a relevant filename in the stdlib
-		}, "Error while forwarding to leader DCA: ", 0), // log errors to seelog,
+		logger: stdLog.New(logWriter, "Error while forwarding to leader DCA: ", 0), // log errors to seelog,
 	}
 
 	return lf
@@ -77,6 +81,7 @@ func (lf *LeaderForwarder) Forward(rw http.ResponseWriter, req *http.Request) {
 		http.Error(rw, "", http.StatusServiceUnavailable)
 		return
 	}
+
 	currentProxy.ServeHTTP(rw, req)
 }
 
@@ -87,6 +92,7 @@ func (lf *LeaderForwarder) SetLeaderIP(leaderIP string) {
 
 	if leaderIP == "" {
 		lf.proxy = nil
+		return
 	}
 
 	lf.proxy = &httputil.ReverseProxy{

--- a/pkg/clusteragent/clusterchecks/handler.go
+++ b/pkg/clusteragent/clusterchecks/handler.go
@@ -75,7 +75,7 @@ func NewHandler(ac pluggableAutoConfig) (*Handler, error) {
 	}
 
 	if config.Datadog.GetBool("leader_election") {
-		h.leaderForwarder = api.NewLeaderForwarder(h.port, config.Datadog.GetInt("cluster_agent.max_leader_connections"), config.Datadog.GetInt("cluster_agent.max_leader_idle_connections"))
+		h.leaderForwarder = api.NewLeaderForwarder(h.port, config.Datadog.GetInt("cluster_agent.max_leader_connections"))
 		callback, err := getLeaderIPCallback()
 		if err != nil {
 			return nil, err

--- a/pkg/clusteragent/clusterchecks/handler_test.go
+++ b/pkg/clusteragent/clusterchecks/handler_test.go
@@ -153,7 +153,7 @@ func TestHandlerRun(t *testing.T) {
 		dispatcher:           newDispatcher(),
 		leaderStatusCallback: le.get,
 		port:                 5005,
-		leaderForwarder:      api.NewLeaderForwarder(testPort, 10, 1),
+		leaderForwarder:      api.NewLeaderForwarder(testPort, 10),
 	}
 
 	//

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -667,8 +667,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("cluster_agent.serve_nozzle_data", false)
 	config.BindEnvAndSetDefault("cluster_agent.advanced_tagging", false)
 	config.BindEnvAndSetDefault("cluster_agent.token_name", "datadogtoken")
-	config.BindEnvAndSetDefault("cluster_agent.max_leader_connections", 500)
-	config.BindEnvAndSetDefault("cluster_agent.max_leader_idle_connections", 50)
+	config.BindEnvAndSetDefault("cluster_agent.max_leader_connections", 100)
 	config.BindEnvAndSetDefault("cluster_agent.client_reconnect_period_seconds", 1200)
 	config.BindEnvAndSetDefault("metrics_port", "5000")
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2210,15 +2210,10 @@ api_key:
   #
   # kubernetes_service_name: "datadog-cluster-agent"
 
-  ## @param max_leader_connections - integer - optional - default: 500
+  ## @param max_leader_connections - integer - optional - default: 100
   ## Maximum number of connections between a follower and a leader.
   #
-  # max_leader_connections: 500
-
-  ## @param max_leader_idle_connections - integer - optional - default: 50
-  ## Maximum number of idle connections between a follower and a leader.
-  #
-  # max_leader_idle_connections: 50
+  # max_leader_connections: 100
 
   ## @param client_reconnect_period_seconds - integer - optional - default: 1200
   ## Set the refersh period for Agent to Cluster Agent connection (new connection is created, old connection is closed).

--- a/pkg/util/clusteragent/clusteragent.go
+++ b/pkg/util/clusteragent/clusteragent.go
@@ -160,12 +160,14 @@ func (c *DCAClient) initHTTPClient() error {
 			}).DialContext,
 			ForceAttemptHTTP2:     false,
 			TLSClientConfig:       &tls.Config{InsecureSkipVerify: true},
-			TLSHandshakeTimeout:   2 * time.Second,
+			TLSHandshakeTimeout:   5 * time.Second,
 			MaxConnsPerHost:       1,
+			MaxIdleConnsPerHost:   1,
 			IdleConnTimeout:       60 * time.Second,
 			ExpectContinueTimeout: 1 * time.Second,
+			ResponseHeaderTimeout: 3 * time.Second,
 		},
-		Timeout: 3 * time.Second,
+		Timeout: 10 * time.Second,
 	}
 
 	// We need to have a client to perform `GetVersion`, only happens during the first call

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -70,7 +70,6 @@ func SetupJMXLogger(i seelog.LoggerInterface, level string) {
 }
 
 func setupCommonLogger(i seelog.LoggerInterface, level string) *DatadogLogger {
-
 	l := &DatadogLogger{
 		inner: i,
 		extra: make(map[string]seelog.LoggerInterface),
@@ -689,7 +688,7 @@ func JMXError(v ...interface{}) error {
 	return logWithError(seelog.ErrorLvl, func() { JMXError(v...) }, jmxLogger.error, true, v...)
 }
 
-//JMXInfo Logs
+// JMXInfo Logs
 func JMXInfo(v ...interface{}) {
 	log(seelog.InfoLvl, func() { JMXInfo(v...) }, jmxLogger.info, v...)
 }


### PR DESCRIPTION
### What does this PR do?

Change the leader forwarder timeouts and Agent -> Cluster Agent timeouts to make sure we don't put unnecessary pressure on the Cluster Agent on large clusters (thousand of nodes)

### Motivation

Bugfix

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Deploy the Agent+Cluster Agent on a large Kubernetes cluster. Killing the Cluster Agent leader or scaling for 2 -> 1 instance should not trigger high CPU usage and not make skyrocket the number of open files.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
