### PR TITLE
[CWS] reduce stack size in activity dump path

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "c3409fa392e961a9d06f2b94ce84ca8548af8be638e8085c1f86e4a3fb70fc94")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "efdaeda4297fe542c714aabfc4b7badb9a0497af8476b75f8b6ad2e95285b302")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "da928ac33c6647b6ef81664bf3b731f7efb8e33decd3defbafbc092ab1200c55")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "c3409fa392e961a9d06f2b94ce84ca8548af8be638e8085c1f86e4a3fb70fc94")

--- a/pkg/security/ebpf/c/activity_dump.h
+++ b/pkg/security/ebpf/c/activity_dump.h
@@ -218,6 +218,7 @@ __attribute__((always_inline)) void fill_activity_dump_discarder_state(void *ctx
         if (!buffer) {
             return;
         }
+        memset(buffer, 0, sizeof(struct ad_container_id_comm));
 
         bpf_probe_read(&buffer->container_id, sizeof(buffer->container_id), proc_entry->container.container_id);
         bpf_probe_read(&buffer->comm, sizeof(buffer->comm), proc_entry->comm);

--- a/pkg/security/ebpf/c/activity_dump.h
+++ b/pkg/security/ebpf/c/activity_dump.h
@@ -195,16 +195,34 @@ __attribute__((always_inline)) void cleanup_traced_state(u32 pid) {
 #define NO_ACTIVITY_DUMP       0
 #define IGNORE_DISCARDER_CHECK 1
 
+struct ad_container_id_comm {
+    char container_id[CONTAINER_ID_LEN];
+    char comm[TASK_COMM_LEN];
+};
+
+struct bpf_map_def SEC("maps/ad_container_id_comm_gen") ad_container_id_comm_gen = {
+    .type = BPF_MAP_TYPE_PERCPU_ARRAY,
+    .key_size = sizeof(u32),
+    .value_size = sizeof(struct ad_container_id_comm),
+    .max_entries = 1,
+    .pinning = 0,
+    .namespace = "",
+};
+
 __attribute__((always_inline)) void fill_activity_dump_discarder_state(void *ctx, struct is_discarded_by_inode_t *params) {
     struct proc_cache_t *proc_entry = get_proc_cache(params->tgid);
     if (proc_entry != NULL) {
         // prepare cgroup and comm (for compatibility with old kernels)
-        char cgroup[CONTAINER_ID_LEN] = {};
-        bpf_probe_read(&cgroup, sizeof(cgroup), proc_entry->container.container_id);
-        char comm[TASK_COMM_LEN] = {};
-        bpf_probe_read(&comm, sizeof(comm), proc_entry->comm);
+        u32 key = 0;
+        struct ad_container_id_comm *buffer = bpf_map_lookup_elem(&ad_container_id_comm_gen, &key);
+        if (!buffer) {
+            return;
+        }
 
-        should_trace_new_process(ctx, params->now, params->tgid, cgroup, comm);
+        bpf_probe_read(&buffer->container_id, sizeof(buffer->container_id), proc_entry->container.container_id);
+        bpf_probe_read(&buffer->comm, sizeof(buffer->comm), proc_entry->comm);
+
+        should_trace_new_process(ctx, params->now, params->tgid, &buffer->container_id[0], &buffer->comm[0]);
     }
 
     u64 timeout = lookup_or_delete_traced_pid_timeout(params->tgid, params->now);

--- a/pkg/security/ebpf/c/dentry_resolver.h
+++ b/pkg/security/ebpf/c/dentry_resolver.h
@@ -112,6 +112,7 @@ int __attribute__((always_inline)) resolve_dentry_tail_call(void *ctx, struct de
         .tgid = bpf_get_current_pid_tgid() >> 32,
         .now = bpf_ktime_get_ns(),
     };
+
     // check if we should ignore the normal discarder check because of an activity dump
     fill_activity_dump_discarder_state(ctx, &params);
 


### PR DESCRIPTION
### What does this PR do?

This PR reduces the stack size for the activity dump kernel side codepath, allowing it to compile with more recent version of clang (the goal being clang 14 for now).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
