### PR TITLE
cca_in_ad -> do not schedule logs services

### DIFF
--- a/pkg/logs/schedulers/ad/scheduler.go
+++ b/pkg/logs/schedulers/ad/scheduler.go
@@ -19,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/schedulers"
 	"github.com/DataDog/datadog-agent/pkg/logs/service"
 	sourcesPkg "github.com/DataDog/datadog-agent/pkg/logs/sources"
+	ddUtil "github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -77,7 +78,7 @@ func (s *Scheduler) Schedule(configs []integration.Config) {
 			for _, source := range sources {
 				s.mgr.AddSource(source)
 			}
-		case s.newService(config):
+		case !ddUtil.CcaInAD() && s.newService(config):
 			entityType, _, err := s.parseEntity(config.TaggerEntity)
 			if err != nil {
 				log.Warnf("Invalid service: %v", err)
@@ -130,7 +131,7 @@ func (s *Scheduler) Unschedule(configs []integration.Config) {
 					s.mgr.RemoveSource(source)
 				}
 			}
-		case s.newService(config):
+		case !ddUtil.CcaInAD() && s.newService(config):
 			// new service to remove
 			entityType, _, err := s.parseEntity(config.TaggerEntity)
 			if err != nil {


### PR DESCRIPTION
When `logs_config.cca_in_ad` is set, the logs-agent no longer concerns
itself with "services" -- only with sources.

### Motivation

Part of the ongoing work to rewrite how the logs agent handles containers and container_collect_all.

### Additional Notes

Please initially verify that it is obvious from the diff that no change in behavior will occur if `logs_config.cca_in_ad` is false.  Then, examine the results if that feature flag is true.  Which are pretty minimal in this case :)

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Enable `logs_config.container_collect_all` and verify that a container without any annotations is logged.  This can be tested in either a kubernetes or docker standalone context.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
