### PR TITLE
[CWS] fix listeners race

### DIFF
--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -71,7 +71,7 @@ tests_ebpf_x64:
     - invoke -e security-agent.build-embed-syscall-tester
     - invoke -e security-agent.build-embed-latency-tools
     # Compile runtime security functional tests to be executed in kitchen tests
-    - inv -e security-agent.build-functional-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/testsuite --build-flags "-race" --nikos-embedded-path=$NIKOS_EMBEDDED_PATH
+    - inv -e security-agent.build-functional-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/testsuite --race --nikos-embedded-path=$NIKOS_EMBEDDED_PATH
     # Compile runtime security stress tests to be executed in kitchen tests
     - inv -e security-agent.build-stress-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/stresssuite
     # Copy nikos archive to be extracted in kitchen tests
@@ -105,7 +105,7 @@ tests_ebpf_arm64:
     - invoke -e security-agent.build-embed-syscall-tester --arch arm64
     - invoke -e security-agent.build-embed-latency-tools
     # Compile runtime security functional tests to be executed in kitchen tests
-    - inv -e security-agent.build-functional-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/testsuite --build-flags "-race" --nikos-embedded-path=$NIKOS_EMBEDDED_PATH
+    - inv -e security-agent.build-functional-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/testsuite --race --nikos-embedded-path=$NIKOS_EMBEDDED_PATH
     # Compile runtime security stress tests to be executed in kitchen tests
     - inv -e security-agent.build-stress-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/stresssuite
     # Copy nikos archive to be extracted in kitchen tests

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -300,6 +300,7 @@ def build_functional_tests(
     bundle_ebpf=True,
     static=False,
     skip_linters=False,
+    race=False,
 ):
     ldflags, _, env = get_build_flags(
         ctx, major_version=major_version, nikos_embedded_path=nikos_embedded_path, static=static
@@ -327,6 +328,9 @@ def build_functional_tests(
     # linters have a hard time with dnf, so we add the build tag after running them
     if nikos_embedded_path:
         build_tags.append("dnf")
+
+    if race:
+        build_flags += " -race"
 
     build_tags = ",".join(build_tags)
     cmd = 'go test -mod=mod -tags {build_tags} -ldflags="{ldflags}" -c -o {output} '
@@ -418,7 +422,7 @@ def functional_tests(
         output=output,
         bundle_ebpf=bundle_ebpf,
         skip_linters=skip_linters,
-        build_flags="-race" if race else "",
+        race=race,
     )
 
     run_functional_tests(

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -401,6 +401,7 @@ def stress_tests(
 def functional_tests(
     ctx,
     verbose=False,
+    race=False,
     go_version=None,
     arch=CURRENT_ARCH,
     major_version='7',
@@ -417,6 +418,7 @@ def functional_tests(
         output=output,
         bundle_ebpf=bundle_ebpf,
         skip_linters=skip_linters,
+        build_flags="-race" if race else "",
     )
 
     run_functional_tests(


### PR DESCRIPTION
### What does this PR do?

This PR fixes:
```
==================
       WARNING: DATA RACE
       Read at 0x00c000abe158 by goroutine 52:
         github.com/DataDog/datadog-agent/pkg/security/secl/rules.(*RuleSet).NotifyDiscarderFound()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/secl/rules/ruleset.go:368 +0x64
         github.com/DataDog/datadog-agent/pkg/security/secl/rules.(*RuleSet).Evaluate()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/secl/rules/ruleset.go:547 +0x971
         github.com/DataDog/datadog-agent/pkg/security/module.(*Module).HandleEvent()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/module/module.go:429 +0x79
         github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).DispatchEvent()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe.go:318 +0x286
         github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).handleEvent()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe.go:757 +0x7150
         github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).handleEvent-fm()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe.go:399 +0x6d
         github.com/DataDog/datadog-agent/pkg/security/probe.(*reOrdererHeap).dequeue()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/reorderer.go:145 +0x746
         github.com/DataDog/datadog-agent/pkg/security/probe.(*ReOrderer).Start()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/reorderer.go:234 +0x71e
         github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).Start·dwrap·52()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe.go:304 +0x47
       
       Previous write at 0x00c000abe158 by goroutine 37:
         [failed to restore the stack]
       
       Goroutine 52 (running) created at:
         github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).Start()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe.go:304 +0x110
         github.com/DataDog/datadog-agent/pkg/security/module.(*Module).Start()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/module/module.go:144 +0xe6
         github.com/DataDog/datadog-agent/pkg/security/tests.newTestModule()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/module_tester.go:687 +0x1524
         github.com/DataDog/datadog-agent/pkg/security/tests.TestDentryResolutionMap()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/dentry_test.go:73 +0x2b1
         testing.tRunner()
             /root/.gimme/versions/go1.17.11.linux.amd64/src/testing/testing.go:1259 +0x22f
         testing.(*T).Run·dwrap·21()
             /root/.gimme/versions/go1.17.11.linux.amd64/src/testing/testing.go:1306 +0x47
       
       Goroutine 37 (running) created at:
         testing.(*T).Run()
             /root/.gimme/versions/go1.17.11.linux.amd64/src/testing/testing.go:1306 +0x726
         testing.runTests.func1()
             /root/.gimme/versions/go1.17.11.linux.amd64/src/testing/testing.go:1598 +0x99
         testing.tRunner()
             /root/.gimme/versions/go1.17.11.linux.amd64/src/testing/testing.go:1259 +0x22f
         testing.runTests()
             /root/.gimme/versions/go1.17.11.linux.amd64/src/testing/testing.go:1596 +0x7ca
         testing.(*M).Run()
             /root/.gimme/versions/go1.17.11.linux.amd64/src/testing/testing.go:1504 +0x9d1
         main.main()
             _testmain.go:191 +0x22b
       ==================
```

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
