### PR TITLE
[CWS] fix regexp parsing

### DIFF
--- a/pkg/security/secl/compiler/ast/secl.go
+++ b/pkg/security/secl/compiler/ast/secl.go
@@ -8,6 +8,7 @@ package ast
 import (
 	"bytes"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/alecthomas/participle"
@@ -39,12 +40,9 @@ any = "\u0000"…"\uffff" .
 )
 
 func unquotePattern(t lexer.Token) (lexer.Token, error) {
-	unquoted, err := strconv.Unquote(t.Value[1:])
-	if err != nil {
-		return t, participle.Errorf(t.Pos, "invalid pattern string %q: %s", t.Value, err)
-	}
+	unquoted := strings.TrimSpace(t.Value[1:])
+	unquoted = unquoted[1 : len(unquoted)-1]
 	t.Value = unquoted
-
 	return t, nil
 }
 

--- a/pkg/security/secl/compiler/ast/secl_test.go
+++ b/pkg/security/secl/compiler/ast/secl_test.go
@@ -194,6 +194,13 @@ func TestRegexp(t *testing.T) {
 	}
 
 	print(t, rule)
+
+	rule, err = ParseRule(`process.name == r"^((?:[A-Za-z\d+]{4})*(?:[A-Za-z\d+]{3}=|[A-Za-z\d+]{2}==)\.)*(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z1-9])$" `)
+	if err != nil {
+		t.Error(err)
+	}
+
+	print(t, rule)
 }
 
 func TestArrayRegexp(t *testing.T) {

--- a/pkg/security/secl/compiler/eval/eval_test.go
+++ b/pkg/security/secl/compiler/eval/eval_test.go
@@ -290,6 +290,9 @@ func TestStringMatcher(t *testing.T) {
 			name:  "/usr/bin/c$t",
 			argv0: "http://example.com",
 		},
+		open: testOpen{
+			filename: "dGVzdA==.dGVzdA==.dGVzdA==.dGVzdA==.dGVzdA==.example.com",
+		},
 	}
 
 	tests := []struct {
@@ -333,6 +336,7 @@ func TestStringMatcher(t *testing.T) {
 		{Expr: `r".*/bin/.*" == process.name`, Expected: true},
 		{Expr: `process.argv0 =~ "http://*"`, Expected: true},
 		{Expr: `process.argv0 =~ "*example.com"`, Expected: true},
+		{Expr: `open.filename == r"^((?:[A-Za-z\d+]{4})*(?:[A-Za-z\d+]{3}=|[A-Za-z\d+]{2}==)\.)*(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$"`, Expected: true},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

the strconv.Unquote method doesn't parse properly some regexp. This PR fixes this problem.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
