### PR TITLE
[gitlab] Run A6 kitchen tests by default

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -687,11 +687,29 @@ variables:
 # Default kitchen tests are also run on dev branches
 # In that case, the target OS versions is a subset of the
 # available versions, stored in DEFAULT_KITCHEN_OSVERS
+.on_default_kitchen_tests_a6:
+  - <<: *if_not_version_6
+    when: never
+  - <<: *if_kitchen
+  - <<: *if_default_kitchen
+    variables:
+      KITCHEN_OSVERS: $DEFAULT_KITCHEN_OSVERS
+
 .on_default_kitchen_tests_a7:
   - <<: *if_not_version_7
     when: never
   - <<: *if_kitchen
   - <<: *if_default_kitchen
+    variables:
+      KITCHEN_OSVERS: $DEFAULT_KITCHEN_OSVERS
+
+.on_default_kitchen_tests_a6_always:
+  - <<: *if_not_version_6
+    when: never
+  - <<: *if_kitchen
+    when: always
+  - <<: *if_default_kitchen
+    when: always
     variables:
       KITCHEN_OSVERS: $DEFAULT_KITCHEN_OSVERS
 

--- a/.gitlab/kitchen_cleanup.yml
+++ b/.gitlab/kitchen_cleanup.yml
@@ -11,7 +11,7 @@
 kitchen_cleanup_s3-a6:
   extends: .kitchen_cleanup_s3_common
   rules:
-    !reference [.on_kitchen_tests_a6]
+    !reference [.on_default_kitchen_tests_a6]
   dependencies: ["agent_deb-x64-a6", "agent_heroku_deb-x64-a6"]
   variables:
     AGENT_MAJOR_VERSION: 6
@@ -29,7 +29,7 @@ kitchen_cleanup_s3-a7:
 kitchen_cleanup_azure-a6:
   extends: .kitchen_cleanup_azure_common
   rules:
-    !reference [.on_kitchen_tests_a6_always]
+    !reference [.on_default_kitchen_tests_a6_always]
   variables:
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a6
 

--- a/.gitlab/kitchen_deploy.yml
+++ b/.gitlab/kitchen_deploy.yml
@@ -47,7 +47,7 @@
 
 deploy_deb_testing-a6_x64:
   rules:
-    !reference [.on_kitchen_tests_a6]
+    !reference [.on_default_kitchen_tests_a6]
   extends:
     - .deploy_deb_testing-a6
   needs: ["agent_deb-x64-a6", "agent_heroku_deb-x64-a6", "tests_deb-x64-py2", "tests_deb-x64-py3"]
@@ -120,7 +120,7 @@ deploy_deb_testing-a7_arm64:
 
 deploy_rpm_testing-a6:
   rules:
-    !reference [.on_kitchen_tests_a6]
+    !reference [.on_default_kitchen_tests_a6]
   stage: kitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   tags: ["runner:main"]
@@ -152,7 +152,7 @@ deploy_rpm_testing-a7:
 
 deploy_suse_rpm_testing-a6:
   rules:
-    !reference [.on_kitchen_tests_a6]
+    !reference [.on_default_kitchen_tests_a6]
   stage: kitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   tags: ["runner:main"]
@@ -184,7 +184,7 @@ deploy_suse_rpm_testing-a7:
 
 deploy_windows_testing-a6:
   rules:
-    !reference [.on_kitchen_tests_a6]
+    !reference [.on_default_kitchen_tests_a6]
   stage: kitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   tags: ["runner:main"]

--- a/.gitlab/kitchen_testing/centos.yml
+++ b/.gitlab/kitchen_testing/centos.yml
@@ -101,6 +101,8 @@ kitchen_centos_install_script_agent-a7:
     - .kitchen_test_install_script_agent
 
 kitchen_centos_fips_install_script_agent-a6:
+  rules:
+    !reference [.on_default_kitchen_tests_a6]
   extends:
     - .kitchen_scenario_centos_8_fips_a6
     - .kitchen_test_install_script_agent

--- a/.gitlab/kitchen_testing/debian.yml
+++ b/.gitlab/kitchen_testing/debian.yml
@@ -63,6 +63,8 @@
 # ----------------------------------------------
 
 kitchen_debian_install_script_agent-a6_x64:
+  rules:
+    !reference [.on_default_kitchen_tests_a6]
   extends:
     - .kitchen_scenario_debian_a6_x64
     - .kitchen_test_install_script_agent

--- a/.gitlab/kitchen_testing/suse.yml
+++ b/.gitlab/kitchen_testing/suse.yml
@@ -39,6 +39,8 @@
 # ----------------------------------------------
 
 kitchen_suse_install_script_agent-a6:
+  rules:
+    !reference [.on_default_kitchen_tests_a6]
   extends:
     - .kitchen_scenario_suse_a6
     - .kitchen_test_install_script_agent

--- a/.gitlab/kitchen_testing/ubuntu.yml
+++ b/.gitlab/kitchen_testing/ubuntu.yml
@@ -62,6 +62,8 @@
 # ----------------------------------------------
 
 kitchen_ubuntu_install_script_agent-a6_x64:
+  rules:
+    !reference [.on_default_kitchen_tests_a6]
   extends:
     - .kitchen_scenario_ubuntu_a6_x64
     - .kitchen_test_install_script_agent

--- a/.gitlab/kitchen_testing/windows.yml
+++ b/.gitlab/kitchen_testing/windows.yml
@@ -136,6 +136,8 @@ kitchen_windows_installer_agent-a7:
     - .kitchen_test_windows_installer_agent
 
 kitchen_windows_chef_agent-a6:
+  rules:
+    !reference [.on_default_kitchen_tests_a6]
   extends:
     - .kitchen_scenario_windows_a6
     - .kitchen_test_chef_agent


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

On branch pipelines, also run some default Agent 6 kitchen tests.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Would have caught issues that are specific to Agent 6, eg. #12123 (reverted in #12299).

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

May overload our testing infrastructure, so this will need to be monitored.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Check that A6 kitchen tests run and succeed on this branch.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
