### PR TITLE
Enable Ingresses collection by default

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/ingress.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/ingress.go
@@ -41,7 +41,7 @@ type IngressCollector struct {
 func NewIngressCollector() *IngressCollector {
 	return &IngressCollector{
 		metadata: &collectors.CollectorMetadata{
-			IsStable: false,
+			IsStable: true,
 			Name:     "ingresses",
 			NodeType: orchestrator.K8sIngress,
 		},

--- a/releasenotes-dca/notes/ingress-resource-a8fe3b41f3a0d50a.yaml
+++ b/releasenotes-dca/notes/ingress-resource-a8fe3b41f3a0d50a.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Enable collection of Ingresses by default in the orchestrator check.


### PR DESCRIPTION
### What does this PR do?

Enable Ingresses collection by default

### Motivation

Collect Ingresses

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
