### PR TITLE
[process-agent] Add the Cleanup method to the Check interface

### DIFF
--- a/cmd/process-agent/app/check.go
+++ b/cmd/process-agent/app/check.go
@@ -126,6 +126,7 @@ func runCheckCmd(cmd *cobra.Command, args []string) error {
 		// Clean up the process check state only after the connections check is executed
 		cleanups = append(cleanups, checks.Process.Cleanup)
 	}
+
 	names := make([]string, 0, len(checks.All))
 	for _, ch := range checks.All {
 		names = append(names, ch.Name())

--- a/cmd/process-agent/collector.go
+++ b/cmd/process-agent/collector.go
@@ -409,6 +409,11 @@ func (l *Collector) run(exit chan struct{}) error {
 	<-exit
 	wg.Wait()
 
+	for _, check := range l.enabledChecks {
+		log.Debugf("Cleaning up %s check", check.Name())
+		check.Cleanup()
+	}
+
 	processForwarder.Stop()
 	rtProcessForwarder.Stop()
 	podForwarder.Stop()

--- a/cmd/process-agent/collector_api_test.go
+++ b/cmd/process-agent/collector_api_test.go
@@ -451,6 +451,8 @@ func (t *testCheck) Run(_ *config.AgentConfig, _ int32) ([]process.MessageBody, 
 	return nil, nil
 }
 
+func (t *testCheck) Cleanup() {}
+
 var _ checks.Check = &testCheck{}
 
 type request struct {

--- a/pkg/process/checks/checks.go
+++ b/pkg/process/checks/checks.go
@@ -19,6 +19,7 @@ type Check interface {
 	Name() string
 	RealTime() bool
 	Run(cfg *config.AgentConfig, groupID int32) ([]model.MessageBody, error)
+	Cleanup()
 }
 
 // RunOptions provides run options for checks

--- a/pkg/process/checks/container.go
+++ b/pkg/process/checks/container.go
@@ -110,6 +110,9 @@ func (c *ContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Me
 	return messages, nil
 }
 
+// Cleanup frees any resource held by the ContainerCheck before the agent exits
+func (c *ContainerCheck) Cleanup() {}
+
 // chunkContainers formats and chunks the ctrList into a slice of chunks using a specific number of chunks.
 func chunkContainers(containers []*model.Container, chunks int) [][]*model.Container {
 	perChunk := (len(containers) / chunks) + 1

--- a/pkg/process/checks/container_rt.go
+++ b/pkg/process/checks/container_rt.go
@@ -81,6 +81,9 @@ func (r *RTContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.
 	return messages, nil
 }
 
+// Cleanup frees any resource held by the RTContainerCheck before the agent exits
+func (r *RTContainerCheck) Cleanup() {}
+
 func convertAndChunkContainers(containers []*model.Container, chunks int) [][]*model.ContainerStat {
 	perChunk := (len(containers) / chunks) + 1
 	chunked := make([][]*model.ContainerStat, chunks)

--- a/pkg/process/checks/net.go
+++ b/pkg/process/checks/net.go
@@ -114,6 +114,9 @@ func (c *ConnectionsCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.
 	return batchConnections(cfg, groupID, c.enrichConnections(conns.Conns), conns.Dns, c.networkID, conns.ConnTelemetryMap, conns.CompilationTelemetryByAsset, conns.Domains, conns.Routes, conns.Tags, conns.AgentConfiguration), nil
 }
 
+// Cleanup frees any resource held by the ConnectionsCheck before the agent exits
+func (c *ConnectionsCheck) Cleanup() {}
+
 func (c *ConnectionsCheck) getConnections() (*model.Connections, error) {
 	tu, err := net.GetRemoteSystemProbeUtil()
 	if err != nil {

--- a/pkg/process/checks/pod.go
+++ b/pkg/process/checks/pod.go
@@ -81,3 +81,6 @@ func (c *PodCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.MessageB
 
 	return messages, nil
 }
+
+// Cleanup frees any resource held by the PodCheck before the agent exits
+func (c *PodCheck) Cleanup() {}

--- a/pkg/process/checks/pod_null.go
+++ b/pkg/process/checks/pod_null.go
@@ -37,3 +37,6 @@ func (c *PodCheck) RealTime() bool { return false }
 func (c *PodCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.MessageBody, error) {
 	return nil, fmt.Errorf("Not implemented")
 }
+
+// Cleanup frees any resource held by the PodCheck before the agent exits
+func (c *PodCheck) Cleanup() {}

--- a/pkg/process/checks/process.go
+++ b/pkg/process/checks/process.go
@@ -111,6 +111,9 @@ func (p *ProcessCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Mess
 	return result.Standard, nil
 }
 
+// Cleanup frees any resource held by the ProcessCheck before the agent exits
+func (p *ProcessCheck) Cleanup() {}
+
 func (p *ProcessCheck) run(cfg *config.AgentConfig, groupID int32, collectRealTime bool) (*RunResult, error) {
 	start := time.Now()
 	cpuTimes, err := cpu.Times(false)

--- a/pkg/process/checks/process_discovery_check.go
+++ b/pkg/process/checks/process_discovery_check.go
@@ -76,6 +76,9 @@ func (d *ProcessDiscoveryCheck) Run(cfg *config.AgentConfig, groupID int32) ([]m
 	return payload, nil
 }
 
+// Cleanup frees any resource held by the ProcessDiscoveryCheck before the agent exits
+func (d *ProcessDiscoveryCheck) Cleanup() {}
+
 func pidMapToProcDiscoveries(pidMap map[int32]*procutil.Process) []*model.ProcessDiscovery {
 	pd := make([]*model.ProcessDiscovery, 0, len(pidMap))
 	for _, proc := range pidMap {

--- a/pkg/process/util/api/payload.go
+++ b/pkg/process/util/api/payload.go
@@ -8,8 +8,6 @@ package api
 import (
 	"fmt"
 
-	"github.com/gogo/protobuf/proto"
-
 	model "github.com/DataDog/agent-payload/v5/process"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 )
@@ -31,29 +29,14 @@ func EncodePayload(m model.MessageBody) ([]byte, error) {
 	typeTag := "type:" + msgType.String()
 	tlmBytesIn.Add(float64(m.Size()), typeTag)
 
-	var encoded []byte
-	// Event messages are encoded as a protobuf without Zstd compression
-	if IsEventPayload(msgType) {
-		encoded, err = proto.Marshal(m)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		encoded, err = model.EncodeMessage(model.Message{
-			Header: model.MessageHeader{
-				Version:  model.MessageV3,
-				Encoding: model.MessageEncodingZstdPB,
-				Type:     msgType,
-			}, Body: m})
-	}
+	encoded, err := model.EncodeMessage(model.Message{
+		Header: model.MessageHeader{
+			Version:  model.MessageV3,
+			Encoding: model.MessageEncodingZstdPB,
+			Type:     msgType,
+		}, Body: m})
 
 	tlmBytesOut.Add(float64(len(encoded)), typeTag)
 
 	return encoded, err
-}
-
-// IsEventPayload returns if a message type should be ingested by the
-// TODO: add test
-func IsEventPayload(t model.MessageType) bool {
-	return t == model.TypeCollectorProcEvent
 }


### PR DESCRIPTION
### What does this PR do?

This PR extends the `Check` interface with a `Cleanup` method. It is used to properly free resources that may be allocated by a check before the `process-agent` collector is shut down.


### Motivation

Have a way to properly stop the event listener and store in process-agent when it's stopped: https://github.com/DataDog/datadog-agent/pull/12390
 
### Additional Notes


### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes

Start the process-agent with logs in DEBUG level and with `process`, `process-discovery`, `container`, `pod` and `connections` checks enabled. In order to run the `process-discovery` and `container` checks, the `process` check should be disabled.

Stop the agent and make sure that the cleanup method for each check is properly called.

Run the `check` command for each supported check and make sure that it's running without any issue.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
