### PR TITLE
pkg/otlp: Add `instrumentation_scope_metadata_as_tags`

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -3196,7 +3196,7 @@ api_key:
 
     ## Deprecated - use `instrumentation_scope_metadata_as_tags` instead in favor of
     ## https://github.com/open-telemetry/opentelemetry-proto/releases/tag/v0.15.0
-    ## If both are set, `instrumentation_scope_metadata_as_tags` takes priotiry.
+    ## Both must not be set at the same time.
     ## @param instrumentation_library_metadata_as_tags - boolean - optional - default: false
     ## @env DD_OTLP_CONFIG_METRICS_INSTRUMENTATION_LIBRARY_METADATA_AS_TAGS - boolean - optional - default: false
     ## Set to true to add metadata about the instrumentation library that created a metric.

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -3194,11 +3194,20 @@ api_key:
     #
     # resource_attributes_as_tags: false
 
+    ## Deprecated - use `instrumentation_scope_metadata_as_tags` instead in favor of
+    ## https://github.com/open-telemetry/opentelemetry-proto/releases/tag/v0.15.0
+    ## If both are set, `instrumentation_scope_metadata_as_tags` takes priotiry.
     ## @param instrumentation_library_metadata_as_tags - boolean - optional - default: false
     ## @env DD_OTLP_CONFIG_METRICS_INSTRUMENTATION_LIBRARY_METADATA_AS_TAGS - boolean - optional - default: false
     ## Set to true to add metadata about the instrumentation library that created a metric.
     #
     # instrumentation_library_metadata_as_tags: false
+
+    ## @param instrumentation_scope_metadata_as_tags - boolean - optional - default: false
+    ## @env DD_OTLP_CONFIG_METRICS_INSTRUMENTATION_SCOPE_METADATA_AS_TAGS - boolean - optional - default: false
+    ## Set to true to add metadata about the instrumentation scope that created a metric.
+    #
+    # instrumentation_scope_metadata_as_tags: false
 
     ## @param tag_cardinality - string - optional - default: low
     ## @env DD_OTLP_CONFIG_METRICS_TAG_CARDINALITY - string - optional - default: low

--- a/pkg/config/otlp.go
+++ b/pkg/config/otlp.go
@@ -70,6 +70,7 @@ func setupOTLPEnvironmentVariables(config Config) {
 	config.BindEnv(OTLPSection + ".metrics.delta_ttl")
 	config.BindEnv(OTLPSection + ".metrics.resource_attributes_as_tags")
 	config.BindEnv(OTLPSection + ".metrics.instrumentation_library_metadata_as_tags")
+	config.BindEnv(OTLPSection + ".metrics.instrumentation_scope_metadata_as_tags")
 	config.BindEnv(OTLPSection + ".metrics.tag_cardinality")
 	config.BindEnv(OTLPSection + ".metrics.histograms.mode")
 	config.BindEnv(OTLPSection + ".metrics.histograms.send_count_sum_metrics")

--- a/pkg/otlp/config_test.go
+++ b/pkg/otlp/config_test.go
@@ -206,10 +206,11 @@ func TestFromEnvironmentVariables(t *testing.T) {
 		{
 			name: "HTTP + gRPC, metrics config",
 			env: map[string]string{
-				"DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT": "0.0.0.0:9995",
-				"DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT": "0.0.0.0:9996",
-				"DD_OTLP_CONFIG_METRICS_DELTA_TTL":                "2400",
-				"DD_OTLP_CONFIG_METRICS_HISTOGRAMS_MODE":          "counters",
+				"DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT":               "0.0.0.0:9995",
+				"DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT":               "0.0.0.0:9996",
+				"DD_OTLP_CONFIG_METRICS_DELTA_TTL":                              "2400",
+				"DD_OTLP_CONFIG_METRICS_HISTOGRAMS_MODE":                        "counters",
+				"DD_OTLP_CONFIG_METRICS_INSTRUMENTATION_SCOPE_METADATA_AS_TAGS": "true",
 			},
 			cfg: PipelineConfig{
 				OTLPReceiverConfig: map[string]interface{}{
@@ -226,9 +227,10 @@ func TestFromEnvironmentVariables(t *testing.T) {
 				TracesEnabled:  true,
 				TracePort:      5003,
 				Metrics: map[string]interface{}{
-					"enabled":         true,
-					"tag_cardinality": "low",
-					"delta_ttl":       "2400",
+					"enabled":                                true,
+					"instrumentation_scope_metadata_as_tags": "true",
+					"tag_cardinality":                        "low",
+					"delta_ttl":                              "2400",
 					"histograms": map[string]interface{}{
 						"mode": "counters",
 					},
@@ -271,6 +273,7 @@ func TestFromAgentConfigMetrics(t *testing.T) {
 					"delta_ttl":                   2400,
 					"resource_attributes_as_tags": true,
 					"instrumentation_library_metadata_as_tags": true,
+					"instrumentation_scope_metadata_as_tags":   true,
 					"tag_cardinality":                          "orchestrator",
 					"histograms": map[string]interface{}{
 						"mode":                   "counters",

--- a/pkg/otlp/internal/serializerexporter/config.go
+++ b/pkg/otlp/internal/serializerexporter/config.go
@@ -148,7 +148,7 @@ type metricsExporterConfig struct {
 
 	// Deprecated: Use InstrumentationScopeMetadataAsTags favor of in favor of
 	// https://github.com/open-telemetry/opentelemetry-proto/releases/tag/v0.15.0
-	// Both  must not be set at the same time.
+	// Both must not be set at the same time.
 	// InstrumentationLibraryMetadataAsTags, if set to true, adds the name and version of the
 	// instrumentation library that created a metric to the metric tags
 	InstrumentationLibraryMetadataAsTags bool `mapstructure:"instrumentation_library_metadata_as_tags"`

--- a/pkg/otlp/internal/serializerexporter/config.go
+++ b/pkg/otlp/internal/serializerexporter/config.go
@@ -148,7 +148,7 @@ type metricsExporterConfig struct {
 
 	// Deprecated: Use InstrumentationScopeMetadataAsTags favor of in favor of
 	// https://github.com/open-telemetry/opentelemetry-proto/releases/tag/v0.15.0
-	// If both are set, InstrumentationScopeMetadataAsTags takes priority.
+	// Both  must not be set at the same time.
 	// InstrumentationLibraryMetadataAsTags, if set to true, adds the name and version of the
 	// instrumentation library that created a metric to the metric tags
 	InstrumentationLibraryMetadataAsTags bool `mapstructure:"instrumentation_library_metadata_as_tags"`

--- a/pkg/otlp/internal/serializerexporter/config.go
+++ b/pkg/otlp/internal/serializerexporter/config.go
@@ -146,9 +146,16 @@ type metricsExporterConfig struct {
 	// resource attributes into metric labels, which are then converted into tags
 	ResourceAttributesAsTags bool `mapstructure:"resource_attributes_as_tags"`
 
+	// Deprecated: Use InstrumentationScopeMetadataAsTags favor of in favor of
+	// https://github.com/open-telemetry/opentelemetry-proto/releases/tag/v0.15.0
+	// If both are set, InstrumentationScopeMetadataAsTags takes priority.
 	// InstrumentationLibraryMetadataAsTags, if set to true, adds the name and version of the
 	// instrumentation library that created a metric to the metric tags
 	InstrumentationLibraryMetadataAsTags bool `mapstructure:"instrumentation_library_metadata_as_tags"`
+
+	// InstrumentationScopeMetadataAsTags, if set to true, adds the name and version of the
+	// instrumentation scope that created a metric to the metric tags
+	InstrumentationScopeMetadataAsTags bool `mapstructure:"instrumentation_scope_metadata_as_tags"`
 }
 
 // Validate configuration

--- a/pkg/otlp/internal/serializerexporter/exporter.go
+++ b/pkg/otlp/internal/serializerexporter/exporter.go
@@ -99,6 +99,10 @@ func translatorFromConfig(logger *zap.Logger, cfg *exporterConfig) (*translator.
 		options = append(options, translator.WithResourceAttributesAsTags())
 	}
 
+	if cfg.Metrics.ExporterConfig.InstrumentationLibraryMetadataAsTags && cfg.Metrics.ExporterConfig.InstrumentationScopeMetadataAsTags {
+		return nil, fmt.Errorf("cannot use both instrumentation_library_metadata_as_tags(deprecated) and instrumentation_scope_metadata_as_tags")
+	}
+
 	if cfg.Metrics.ExporterConfig.InstrumentationLibraryMetadataAsTags {
 		options = append(options, translator.WithInstrumentationLibraryMetadataAsTags())
 	}

--- a/pkg/otlp/internal/serializerexporter/exporter.go
+++ b/pkg/otlp/internal/serializerexporter/exporter.go
@@ -34,6 +34,7 @@ func newDefaultConfig() config.Exporter {
 			ExporterConfig: metricsExporterConfig{
 				ResourceAttributesAsTags:             false,
 				InstrumentationLibraryMetadataAsTags: false,
+				InstrumentationScopeMetadataAsTags:   false,
 			},
 			TagCardinality: collectors.LowCardinalityString,
 			HistConfig: histogramConfig{
@@ -99,6 +100,10 @@ func translatorFromConfig(logger *zap.Logger, cfg *exporterConfig) (*translator.
 	}
 
 	if cfg.Metrics.ExporterConfig.InstrumentationLibraryMetadataAsTags {
+		options = append(options, translator.WithInstrumentationLibraryMetadataAsTags())
+	}
+
+	if cfg.Metrics.ExporterConfig.InstrumentationScopeMetadataAsTags {
 		options = append(options, translator.WithInstrumentationLibraryMetadataAsTags())
 	}
 

--- a/pkg/otlp/map_provider_test.go
+++ b/pkg/otlp/map_provider_test.go
@@ -12,12 +12,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/otlp/internal/testutil"
+	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/config"
-
-	"github.com/DataDog/datadog-agent/pkg/otlp/internal/testutil"
-	"github.com/DataDog/datadog-agent/pkg/serializer"
 )
 
 func TestNewMap(t *testing.T) {
@@ -74,6 +73,7 @@ func TestNewMap(t *testing.T) {
 					"delta_ttl":                                2000,
 					"resource_attributes_as_tags":              true,
 					"instrumentation_library_metadata_as_tags": true,
+					"instrumentation_scope_metadata_as_tags":   true,
 					"histograms": map[string]interface{}{
 						"mode":                   "counters",
 						"send_count_sum_metrics": true,
@@ -108,6 +108,7 @@ func TestNewMap(t *testing.T) {
 							"delta_ttl":                                2000,
 							"resource_attributes_as_tags":              true,
 							"instrumentation_library_metadata_as_tags": true,
+							"instrumentation_scope_metadata_as_tags":   true,
 							"histograms": map[string]interface{}{
 								"mode":                   "counters",
 								"send_count_sum_metrics": true,
@@ -181,6 +182,7 @@ func TestNewMap(t *testing.T) {
 					"delta_ttl":                                1500,
 					"resource_attributes_as_tags":              false,
 					"instrumentation_library_metadata_as_tags": false,
+					"instrumentation_scope_metadata_as_tags":   false,
 					"histograms": map[string]interface{}{
 						"mode":                   "nobuckets",
 						"send_count_sum_metrics": true,
@@ -208,6 +210,7 @@ func TestNewMap(t *testing.T) {
 							"delta_ttl":                                1500,
 							"resource_attributes_as_tags":              false,
 							"instrumentation_library_metadata_as_tags": false,
+							"instrumentation_scope_metadata_as_tags":   false,
 							"histograms": map[string]interface{}{
 								"mode":                   "nobuckets",
 								"send_count_sum_metrics": true,
@@ -249,6 +252,7 @@ func TestUnmarshal(t *testing.T) {
 			"delta_ttl":                                2000,
 			"resource_attributes_as_tags":              true,
 			"instrumentation_library_metadata_as_tags": true,
+			"instrumentation_scope_metadata_as_tags":   true,
 			"histograms": map[string]interface{}{
 				"mode":                   "counters",
 				"send_count_sum_metrics": true,

--- a/pkg/otlp/model/internal/instrumentationscope/metadata.go
+++ b/pkg/otlp/model/internal/instrumentationscope/metadata.go
@@ -1,0 +1,34 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package instrumentationscope
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/otlp/model/internal/utils"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+const (
+	instrumentationScopeTag        = "instrumentation_scope"
+	instrumentationScopeVersionTag = "instrumentation_scope_version"
+)
+
+// TagsFromInstrumentationScopeMetadata takes the name and version of
+// the instrumentation scope and converts them to Datadog tags.
+func TagsFromInstrumentationScopeMetadata(il pcommon.InstrumentationScope) []string {
+	return []string{
+		utils.FormatKeyValueTag(instrumentationScopeTag, il.Name()),
+		utils.FormatKeyValueTag(instrumentationScopeVersionTag, il.Version()),
+	}
+}

--- a/pkg/otlp/model/internal/instrumentationscope/metadata_test.go
+++ b/pkg/otlp/model/internal/instrumentationscope/metadata_test.go
@@ -1,0 +1,45 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package instrumentationscope
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+func TestTagsFromInstrumentationScopeMetadata(t *testing.T) {
+	tests := []struct {
+		name         string
+		version      string
+		expectedTags []string
+	}{
+		{"test-il", "1.0.0", []string{fmt.Sprintf("%s:%s", instrumentationScopeTag, "test-il"), fmt.Sprintf("%s:%s", instrumentationScopeVersionTag, "1.0.0")}},
+		{"test-il", "", []string{fmt.Sprintf("%s:%s", instrumentationScopeTag, "test-il"), fmt.Sprintf("%s:%s", instrumentationScopeVersionTag, "n/a")}},
+		{"", "1.0.0", []string{fmt.Sprintf("%s:%s", instrumentationScopeTag, "n/a"), fmt.Sprintf("%s:%s", instrumentationScopeVersionTag, "1.0.0")}},
+		{"", "", []string{fmt.Sprintf("%s:%s", instrumentationScopeTag, "n/a"), fmt.Sprintf("%s:%s", instrumentationScopeVersionTag, "n/a")}},
+	}
+
+	for _, testInstance := range tests {
+		il := pcommon.NewInstrumentationScope()
+		il.SetName(testInstance.name)
+		il.SetVersion(testInstance.version)
+		tags := TagsFromInstrumentationScopeMetadata(il)
+
+		assert.ElementsMatch(t, testInstance.expectedTags, tags)
+	}
+}

--- a/pkg/otlp/model/translator/config.go
+++ b/pkg/otlp/model/translator/config.go
@@ -25,7 +25,7 @@ type translatorConfig struct {
 	ResourceAttributesAsTags bool
 	// Deprecated: use InstrumentationScopeMetadataAsTags instead in favor of
 	// https://github.com/open-telemetry/opentelemetry-proto/releases/tag/v0.15.0
-	// If both are set, InstrumentationScopeMetadataAsTags takes priority.
+	// Both must be set at the same time.
 	InstrumentationLibraryMetadataAsTags bool
 	InstrumentationScopeMetadataAsTags   bool
 

--- a/pkg/otlp/model/translator/config.go
+++ b/pkg/otlp/model/translator/config.go
@@ -18,12 +18,16 @@ import "fmt"
 
 type translatorConfig struct {
 	// metrics export behavior
-	HistMode                             HistogramMode
-	SendCountSum                         bool
-	Quantiles                            bool
-	SendMonotonic                        bool
-	ResourceAttributesAsTags             bool
+	HistMode                 HistogramMode
+	SendCountSum             bool
+	Quantiles                bool
+	SendMonotonic            bool
+	ResourceAttributesAsTags bool
+	// Deprecated: use InstrumentationScopeMetadataAsTags instead in favor of
+	// https://github.com/open-telemetry/opentelemetry-proto/releases/tag/v0.15.0
+	// If both are set, InstrumentationScopeMetadataAsTags takes priority.
 	InstrumentationLibraryMetadataAsTags bool
+	InstrumentationScopeMetadataAsTags   bool
 
 	// cache configuration
 	sweepInterval int64
@@ -81,6 +85,14 @@ func WithResourceAttributesAsTags() Option {
 func WithInstrumentationLibraryMetadataAsTags() Option {
 	return func(t *translatorConfig) error {
 		t.InstrumentationLibraryMetadataAsTags = true
+		return nil
+	}
+}
+
+// WithInstrumentationScopeMetadataAsTags sets instrumentation scope metadata as tags.
+func WithInstrumentationScopeMetadataAsTags() Option {
+	return func(t *translatorConfig) error {
+		t.InstrumentationScopeMetadataAsTags = true
 		return nil
 	}
 }

--- a/pkg/otlp/model/translator/config.go
+++ b/pkg/otlp/model/translator/config.go
@@ -25,7 +25,7 @@ type translatorConfig struct {
 	ResourceAttributesAsTags bool
 	// Deprecated: use InstrumentationScopeMetadataAsTags instead in favor of
 	// https://github.com/open-telemetry/opentelemetry-proto/releases/tag/v0.15.0
-	// Both must be set at the same time.
+	// Both must not be set at the same time.
 	InstrumentationLibraryMetadataAsTags bool
 	InstrumentationScopeMetadataAsTags   bool
 

--- a/pkg/otlp/model/translator/metrics_translator.go
+++ b/pkg/otlp/model/translator/metrics_translator.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/otlp/model/attributes"
 	"github.com/DataDog/datadog-agent/pkg/otlp/model/internal/instrumentationlibrary"
+	"github.com/DataDog/datadog-agent/pkg/otlp/model/internal/instrumentationscope"
 	"github.com/DataDog/datadog-agent/pkg/quantile"
 	"github.com/DataDog/sketches-go/ddsketch"
 	"github.com/DataDog/sketches-go/ddsketch/mapping"
@@ -552,7 +553,9 @@ func (t *Translator) MapMetrics(ctx context.Context, md pmetric.Metrics, consume
 			metricsArray := ilm.Metrics()
 
 			var additionalTags []string
-			if t.cfg.InstrumentationLibraryMetadataAsTags {
+			if t.cfg.InstrumentationScopeMetadataAsTags {
+				additionalTags = append(attributeTags, instrumentationscope.TagsFromInstrumentationScopeMetadata(ilm.Scope())...)
+			} else if t.cfg.InstrumentationLibraryMetadataAsTags {
 				additionalTags = append(attributeTags, instrumentationlibrary.TagsFromInstrumentationLibraryMetadata(ilm.Scope())...)
 			} else {
 				additionalTags = attributeTags

--- a/pkg/otlp/testdata/metrics/allconfig.yaml
+++ b/pkg/otlp/testdata/metrics/allconfig.yaml
@@ -1,7 +1,7 @@
 otlp_config:
   receiver:
     protocols:
-      http: 
+      http:
         endpoint: localhost:1234
       grpc:
         endpoint: localhost:5678
@@ -10,6 +10,7 @@ otlp_config:
     tag_cardinality: orchestrator
     resource_attributes_as_tags: true
     instrumentation_library_metadata_as_tags: true
+    instrumentation_scope_metadata_as_tags: true
     histograms:
       mode: counters
       send_count_sum_metrics: true

--- a/releasenotes/notes/add-instrumentation_scope_metadata_as_tags-333fd918eba05bcd.yaml
+++ b/releasenotes/notes/add-instrumentation_scope_metadata_as_tags-333fd918eba05bcd.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+deprecations:
+  - |
+    Use `instrumentation_scope_metadata_as_tags` instead of `instrumentation_library_metadata_as_tags`
+    in favor of https://github.com/open-telemetry/opentelemetry-proto/releases/tag/v0.15.0
+    If both are set, `instrumentation_scope_metadata_as_tags` takes priority.

--- a/releasenotes/notes/add-instrumentation_scope_metadata_as_tags-333fd918eba05bcd.yaml
+++ b/releasenotes/notes/add-instrumentation_scope_metadata_as_tags-333fd918eba05bcd.yaml
@@ -10,4 +10,4 @@ deprecations:
   - |
     Use `instrumentation_scope_metadata_as_tags` instead of `instrumentation_library_metadata_as_tags`
     in favor of https://github.com/open-telemetry/opentelemetry-proto/releases/tag/v0.15.0
-    If both are set, `instrumentation_scope_metadata_as_tags` takes priority.
+    Both must not be set at the same time.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Add a new flag named `instrumentation_scope_metadata_as_tags` to deprecate the current flag, [instrumentation_library_metadata_as_tags](https://github.com/DataDog/datadog-agent/blob/3cd1424c0e2a910187fff3a402b8472c86932503/pkg/config/config_template.yaml#L3197-L3201).

### Motivation

Since https://github.com/open-telemetry/opentelemetry-proto/releases/tag/v0.15.0, InstrumentationLibrary had been deprecated and https://github.com/open-telemetry/opentelemetry-collector/pull/5219 removed it eventually.

This is confusing since the rest of the project has moved to the new name, so we should introduce a new flag that uses the instrumentation scope name, and deprecate the current one.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
