### PR TITLE
[networks] Add amazon linux 2 for testing in CI

### DIFF
--- a/.gitlab/functional_test/system_probe.yml
+++ b/.gitlab/functional_test/system_probe.yml
@@ -61,6 +61,8 @@ kitchen_test_system_probe_linux_arm64:
         KITCHEN_OSVERS: "debian-10"
       - KITCHEN_PLATFORM: "centos"
         KITCHEN_OSVERS: "centos-78,rhel-83"
+      - KITCHEN_PLATFORM: "amazonlinux"
+        KITCHEN_OSVERS: "amazonlinux2-4-14,amazonlinux2-5-10"
 
 kitchen_test_system_probe_windows_x64:
   extends:

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -57,7 +57,7 @@ const runtimeCompilationEnvVar = "DD_TESTS_RUNTIME_COMPILED"
 func TestMain(m *testing.M) {
 	logLevel := os.Getenv("DD_LOG_LEVEL")
 	if logLevel == "" {
-		logLevel = "debug"
+		logLevel = "warn"
 	}
 	log.SetupLogger(seelog.Default, logLevel)
 	cfg := testConfig()

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -57,7 +57,7 @@ const runtimeCompilationEnvVar = "DD_TESTS_RUNTIME_COMPILED"
 func TestMain(m *testing.M) {
 	logLevel := os.Getenv("DD_LOG_LEVEL")
 	if logLevel == "" {
-		logLevel = "warn"
+		logLevel = "debug"
 	}
 	log.SetupLogger(seelog.Default, logLevel)
 	cfg := testConfig()

--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -98,7 +98,11 @@
             "x86_64": {
                 "amazonlinux2-4-14": "ami-038b3df3312ddf25d",
                 "amazonlinux2-5-10": "ami-033b95fb8079dc481"
-            }
+            },
+	    "arm64": {
+	    	"amazonlinux2-4-14": "ami-090230ed0c6b13c74",
+		"amazonlinux2-5-10": "ami-0e449176cecc3e577"
+	    }
         }
     },
     "windows": {

--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -99,10 +99,10 @@
                 "amazonlinux2-4-14": "ami-038b3df3312ddf25d",
                 "amazonlinux2-5-10": "ami-033b95fb8079dc481"
             },
-	    "arm64": {
-	    	"amazonlinux2-4-14": "ami-090230ed0c6b13c74",
-		"amazonlinux2-5-10": "ami-0e449176cecc3e577"
-	    }
+            "arm64": {
+                "amazonlinux2-4-14": "ami-090230ed0c6b13c74",
+                "amazonlinux2-5-10": "ami-0e449176cecc3e577"
+            }
         }
     },
     "windows": {

--- a/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
+++ b/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
@@ -10,6 +10,8 @@ end
 kernel_version = `uname -r`.strip
 package 'kernel headers' do
   case node[:platform]
+  when 'amazon'
+    package_name "kernel-headers-#{kernel_version}"
   when 'redhat', 'centos', 'fedora'
     package_name "kernel-devel-#{kernel_version}"
   when 'ubuntu', 'debian'

--- a/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
+++ b/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
@@ -30,6 +30,8 @@ package 'conntrack'
 
 package 'netcat' do
   case node[:platform]
+  when 'amazon'
+    package_name 'nmap-ncat'
   when 'redhat', 'centos', 'fedora'
     package_name 'nc'
   else

--- a/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
+++ b/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
@@ -11,7 +11,7 @@ kernel_version = `uname -r`.strip
 package 'kernel headers' do
   case node[:platform]
   when 'amazon'
-    package_name "kernel-headers-#{kernel_version}"
+    package_name "kernel-devel"
   when 'redhat', 'centos', 'fedora'
     package_name "kernel-devel-#{kernel_version}"
   when 'ubuntu', 'debian'

--- a/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
+++ b/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
@@ -21,9 +21,7 @@ end
 kernel_version = `uname -r`.strip
 package 'kernel headers' do
   case node[:platform]
-  when 'amazon'
-    package_name "kernel-devel"
-  when 'redhat', 'centos', 'fedora'
+  when 'redhat', 'centos', 'fedora', 'amazon'
     package_name "kernel-devel-#{kernel_version}"
   when 'ubuntu', 'debian'
     package_name "linux-headers-#{kernel_version}"

--- a/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
+++ b/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
@@ -7,6 +7,17 @@ case node[:platform]
     apt_update
 end
 
+execute "update yum repositories" do
+  command "yum -y update"
+  user "root"
+  case node[:platform]
+  when 'amazon'
+    action :run
+  else
+    action :nothing
+  end
+end
+
 kernel_version = `uname -r`.strip
 package 'kernel headers' do
   case node[:platform]


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR adds amazon linux 2 as testing environments in CI pipeline.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
