### PR TITLE
Fix panic when container stats are missing

### DIFF
--- a/pkg/collector/corechecks/containers/containerd/check_metrics_extension.go
+++ b/pkg/collector/corechecks/containers/containerd/check_metrics_extension.go
@@ -37,6 +37,11 @@ func (cext *containerdCustomMetricsExtension) Process(tags []string, container *
 		return
 	}
 
+	if containerStats == nil {
+		log.Debugf("Metrics provider returned nil stats for container: %v", container)
+		return
+	}
+
 	if containerStats.IO != nil {
 		for deviceName, deviceStats := range containerStats.IO.Devices {
 			readDeviceTags := taggerUtils.ConcatenateStringTags(tags, "device:"+deviceName, "device_name:"+deviceName, "operation:read")

--- a/pkg/collector/corechecks/containers/docker/check_linux_test.go
+++ b/pkg/collector/corechecks/containers/docker/check_linux_test.go
@@ -106,12 +106,12 @@ func TestDockerNetworkExtension(t *testing.T) {
 	// container4 is a normal docker container connected to 2 networks 0 linked to PID 200
 	container1 := generic.CreateContainerMeta("docker", "kube-host-network")
 	mockCollector.SetContainerEntry(container1.ID, mock.ContainerEntry{
-		ContainerStats: provider.ContainerStats{
+		ContainerStats: &provider.ContainerStats{
 			PID: &provider.ContainerPIDStats{
 				PIDs: []int{100},
 			},
 		},
-		NetworkStats: provider.ContainerNetworkStats{
+		NetworkStats: &provider.ContainerNetworkStats{
 			Interfaces: map[string]provider.InterfaceNetStats{
 				"eth0": {
 					BytesSent:   pointer.Float64Ptr(1),
@@ -158,12 +158,12 @@ func TestDockerNetworkExtension(t *testing.T) {
 
 	container2 := generic.CreateContainerMeta("docker", "kube-app")
 	mockCollector.SetContainerEntry(container2.ID, mock.ContainerEntry{
-		ContainerStats: provider.ContainerStats{
+		ContainerStats: &provider.ContainerStats{
 			PID: &provider.ContainerPIDStats{
 				PIDs: []int{101},
 			},
 		},
-		NetworkStats: provider.ContainerNetworkStats{
+		NetworkStats: &provider.ContainerNetworkStats{
 			Interfaces: map[string]provider.InterfaceNetStats{
 				"eth0": {
 					BytesSent:   pointer.Float64Ptr(5),
@@ -204,12 +204,12 @@ func TestDockerNetworkExtension(t *testing.T) {
 
 	container4 := generic.CreateContainerMeta("docker", "docker-app")
 	mockCollector.SetContainerEntry(container4.ID, mock.ContainerEntry{
-		ContainerStats: provider.ContainerStats{
+		ContainerStats: &provider.ContainerStats{
 			PID: &provider.ContainerPIDStats{
 				PIDs: []int{200},
 			},
 		},
-		NetworkStats: provider.ContainerNetworkStats{
+		NetworkStats: &provider.ContainerNetworkStats{
 			Interfaces: map[string]provider.InterfaceNetStats{
 				"eth0": {
 					BytesSent:   pointer.Float64Ptr(6),

--- a/pkg/collector/corechecks/containers/docker/check_metrics_extension.go
+++ b/pkg/collector/corechecks/containers/docker/check_metrics_extension.go
@@ -37,6 +37,11 @@ func (dn *dockerCustomMetricsExtension) Process(tags []string, container *worklo
 		return
 	}
 
+	if containerStats == nil {
+		log.Debugf("Metrics provider returned nil stats for container: %v", container)
+		return
+	}
+
 	if containerStats.Memory != nil {
 		// Re-implement Docker check behaviour: PrivateWorkingSet is mapped to RSS
 		if containerStats.Memory.PrivateWorkingSet != nil {

--- a/pkg/collector/corechecks/containers/docker/check_network.go
+++ b/pkg/collector/corechecks/containers/docker/check_network.go
@@ -85,9 +85,19 @@ func (dn *dockerNetworkExtension) Process(tags []string, container *workloadmeta
 		return
 	}
 
+	if containerStats == nil {
+		log.Debugf("Metrics provider returned nil stats for container: %v", container)
+		return
+	}
+
 	containerNetworkStats, err := collector.GetContainerNetworkStats(container.Namespace, container.ID, cacheValidity)
 	if err != nil {
 		log.Debugf("Gathering network metrics for container: %v failed, metrics may be missing, err: %v", container, err)
+		return
+	}
+
+	if containerNetworkStats == nil {
+		log.Debugf("Metrics provider returned nil network stats for container: %v", container)
 		return
 	}
 

--- a/pkg/collector/corechecks/containers/generic/processor.go
+++ b/pkg/collector/corechecks/containers/generic/processor.go
@@ -138,6 +138,11 @@ func (p *Processor) processContainer(sender aggregator.Sender, tags []string, co
 		p.sendMetric(sender.Gauge, "container.uptime", pointer.Float64Ptr(uptime.Seconds()), tags)
 	}
 
+	if containerStats == nil {
+		log.Debugf("Metrics provider returned nil stats for container: %v", container)
+		return nil
+	}
+
 	if containerStats.CPU != nil {
 		p.sendMetric(sender.Rate, "container.cpu.usage", containerStats.CPU.Total, tags)
 		p.sendMetric(sender.Rate, "container.cpu.user", containerStats.CPU.User, tags)

--- a/pkg/collector/corechecks/containers/generic/processor_network_test.go
+++ b/pkg/collector/corechecks/containers/generic/processor_network_test.go
@@ -37,7 +37,7 @@ func TestNetworkProcessorExtension(t *testing.T) {
 	container1 := createContainerMeta("docker", "1")
 	fakeTagger.SetTags(containers.BuildTaggerEntityName(container1.ID), "foo", []string{"low:common"}, []string{"orch:common12"}, []string{"id:container1"}, nil)
 	mockCollector.SetContainerEntry(container1.ID, mock.ContainerEntry{
-		NetworkStats: metrics.ContainerNetworkStats{
+		NetworkStats: &metrics.ContainerNetworkStats{
 			BytesSent:   pointer.Float64Ptr(12),
 			BytesRcvd:   pointer.Float64Ptr(12),
 			PacketsSent: pointer.Float64Ptr(12),
@@ -58,7 +58,7 @@ func TestNetworkProcessorExtension(t *testing.T) {
 	container2 := createContainerMeta("docker", "2")
 	fakeTagger.SetTags(containers.BuildTaggerEntityName(container2.ID), "foo", []string{"low:common"}, []string{"orch:common12"}, []string{"id:container2"}, nil)
 	mockCollector.SetContainerEntry(container2.ID, mock.ContainerEntry{
-		NetworkStats: metrics.ContainerNetworkStats{
+		NetworkStats: &metrics.ContainerNetworkStats{
 			BytesSent:   pointer.Float64Ptr(12),
 			BytesRcvd:   pointer.Float64Ptr(12),
 			PacketsSent: pointer.Float64Ptr(12),
@@ -79,7 +79,7 @@ func TestNetworkProcessorExtension(t *testing.T) {
 	container3 := createContainerMeta("docker", "3")
 	fakeTagger.SetTags(containers.BuildTaggerEntityName(container3.ID), "foo", []string{"low:common"}, []string{"orch:standalone3"}, []string{"id:container3"}, nil)
 	mockCollector.SetContainerEntry(container3.ID, mock.ContainerEntry{
-		NetworkStats: metrics.ContainerNetworkStats{
+		NetworkStats: &metrics.ContainerNetworkStats{
 			BytesSent:   pointer.Float64Ptr(3),
 			BytesRcvd:   pointer.Float64Ptr(3),
 			PacketsSent: pointer.Float64Ptr(3),
@@ -98,7 +98,7 @@ func TestNetworkProcessorExtension(t *testing.T) {
 	container4 := createContainerMeta("docker", "4")
 	fakeTagger.SetTags(containers.BuildTaggerEntityName(container4.ID), "foo", []string{"low:common"}, []string{"orch:standalone4"}, []string{"id:container4"}, nil)
 	mockCollector.SetContainerEntry(container4.ID, mock.ContainerEntry{
-		NetworkStats: metrics.ContainerNetworkStats{
+		NetworkStats: &metrics.ContainerNetworkStats{
 			BytesSent:   pointer.Float64Ptr(4),
 			BytesRcvd:   pointer.Float64Ptr(4),
 			PacketsSent: pointer.Float64Ptr(4),
@@ -119,7 +119,7 @@ func TestNetworkProcessorExtension(t *testing.T) {
 	container5 := createContainerMeta("docker", "5")
 	fakeTagger.SetTags(containers.BuildTaggerEntityName(container5.ID), "foo", []string{"low:common"}, []string{"orch:standalone5"}, []string{"id:container5"}, nil)
 	mockCollector.SetContainerEntry(container5.ID, mock.ContainerEntry{
-		NetworkStats: metrics.ContainerNetworkStats{
+		NetworkStats: &metrics.ContainerNetworkStats{
 			BytesSent:   pointer.Float64Ptr(5),
 			BytesRcvd:   pointer.Float64Ptr(5),
 			PacketsSent: pointer.Float64Ptr(5),

--- a/pkg/collector/corechecks/containers/generic/processor_test.go
+++ b/pkg/collector/corechecks/containers/generic/processor_test.go
@@ -34,10 +34,15 @@ func TestProcessorRunFullStatsLinux(t *testing.T) {
 	containersMeta := []*workloadmeta.Container{
 		// Container with full stats
 		createContainerMeta("docker", "cID100"),
+		// Container with no stats (returns nil)
+		createContainerMeta("docker", "cID101"),
 	}
 
 	containersStats := map[string]mock.ContainerEntry{
 		"cID100": mock.GetFullSampleContainerEntry(),
+		"cID101": {
+			ContainerStats: nil,
+		},
 	}
 
 	mockSender, processor, _ := CreateTestProcessor(containersMeta, containersStats, GenericMetricsAdapter{}, nil)
@@ -46,7 +51,7 @@ func TestProcessorRunFullStatsLinux(t *testing.T) {
 
 	expectedTags := []string{"runtime:docker"}
 	mockSender.AssertNumberOfCalls(t, "Rate", 17)
-	mockSender.AssertNumberOfCalls(t, "Gauge", 13)
+	mockSender.AssertNumberOfCalls(t, "Gauge", 14)
 
 	mockSender.AssertMetricInRange(t, "Gauge", "container.uptime", 0, 600, "", expectedTags)
 	mockSender.AssertMetric(t, "Rate", "container.cpu.usage", 100, "", expectedTags)

--- a/pkg/util/containers/v2/metrics/mock/mock.go
+++ b/pkg/util/containers/v2/metrics/mock/mock.go
@@ -64,8 +64,8 @@ func (mp *MetricsProvider) Clear() {
 
 // ContainerEntry allows to customize mock responses
 type ContainerEntry struct {
-	ContainerStats provider.ContainerStats
-	NetworkStats   provider.ContainerNetworkStats
+	ContainerStats *provider.ContainerStats
+	NetworkStats   *provider.ContainerNetworkStats
 	OpenFiles      *uint64
 	Error          error
 }
@@ -107,7 +107,7 @@ func (mp *Collector) Clear() {
 // GetContainerStats returns stats from MockContainerEntry
 func (mp *Collector) GetContainerStats(containerNS, containerID string, cacheValidity time.Duration) (*provider.ContainerStats, error) {
 	if entry, found := mp.containers[containerID]; found {
-		return &entry.ContainerStats, entry.Error
+		return entry.ContainerStats, entry.Error
 	}
 
 	return nil, fmt.Errorf("container not found")
@@ -125,7 +125,7 @@ func (mp *Collector) GetContainerOpenFilesCount(containerNS, containerID string,
 // GetContainerNetworkStats returns stats from MockContainerEntry
 func (mp *Collector) GetContainerNetworkStats(containerNS, containerID string, cacheValidity time.Duration) (*provider.ContainerNetworkStats, error) {
 	if entry, found := mp.containers[containerID]; found {
-		return &entry.NetworkStats, entry.Error
+		return entry.NetworkStats, entry.Error
 	}
 
 	return nil, fmt.Errorf("container not found")

--- a/pkg/util/containers/v2/metrics/mock/mock_samples.go
+++ b/pkg/util/containers/v2/metrics/mock/mock_samples.go
@@ -14,7 +14,7 @@ import (
 func GetFullSampleContainerEntry() ContainerEntry {
 	return ContainerEntry{
 		Error: nil,
-		NetworkStats: metrics.ContainerNetworkStats{
+		NetworkStats: &metrics.ContainerNetworkStats{
 			BytesSent:   pointer.Float64Ptr(42),
 			BytesRcvd:   pointer.Float64Ptr(43),
 			PacketsSent: pointer.Float64Ptr(420),
@@ -28,7 +28,7 @@ func GetFullSampleContainerEntry() ContainerEntry {
 				},
 			},
 		},
-		ContainerStats: metrics.ContainerStats{
+		ContainerStats: &metrics.ContainerStats{
 			CPU: &metrics.ContainerCPUStats{
 				Total:            pointer.Float64Ptr(100),
 				System:           pointer.Float64Ptr(200),

--- a/releasenotes/notes/fix-panic-missing-container-stats-4bdfe8168b3a16b1.yaml
+++ b/releasenotes/notes/fix-panic-missing-container-stats-4bdfe8168b3a16b1.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    Fix `panic` in `container`, `containerd` and `docker` when container stats are temporarily not available
+    Fix `panic` in `container`, `containerd`, and `docker` when container stats are temporarily not available

--- a/releasenotes/notes/fix-panic-missing-container-stats-4bdfe8168b3a16b1.yaml
+++ b/releasenotes/notes/fix-panic-missing-container-stats-4bdfe8168b3a16b1.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix `panic` in `container`, `containerd` and `docker` when container stats are temporarily not available


### PR DESCRIPTION
### What does this PR do?

Fix a `panic` that would happen when container stats are not returned by metrics provider.

### Motivation

Bugfix

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Unfortunately, it appears tricky to reproduce this behaviour (container present in `Running` state in workload but no container stats returned), so I'd only focus on non-regression tests around the `container` and `containerd` checks.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
