### PR TITLE
Add telemetry about container event bundling

### DIFF
--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
@@ -26,6 +26,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
@@ -43,6 +44,24 @@ const (
 
 	defaultCacheExpire = 2 * time.Minute
 	defaultCachePurge  = 10 * time.Minute
+)
+
+var (
+	kubeEvents = telemetry.NewCounterWithOpts(
+		kubernetesAPIServerCheckName,
+		"kube_events",
+		[]string{"kind", "component", "type", "reason"},
+		"Number of Kubernetes events received by the check.",
+		telemetry.Options{NoDoubleUnderscoreSep: true},
+	)
+
+	emittedEvents = telemetry.NewCounterWithOpts(
+		kubernetesAPIServerCheckName,
+		"emitted_events",
+		[]string{"kind", "type"},
+		"Number of events emitted by the check.",
+		telemetry.Options{NoDoubleUnderscoreSep: true},
+	)
 )
 
 // KubeASConfig is the config of the API server.
@@ -299,30 +318,54 @@ func (k *KubeASCheck) parseComponentStatus(sender aggregator.Sender, componentsS
 // - extracts some attributes and builds a structure ready to be submitted as a Datadog event (bundle)
 // - formats the bundle and submit the Datadog event
 func (k *KubeASCheck) processEvents(sender aggregator.Sender, events []*v1.Event) error {
-	eventsByObject := make(map[string]*kubernetesEventBundle)
+	bundlesByObject := make(map[bundleID]*kubernetesEventBundle)
 
 	for _, event := range events {
-		id := bundleID(event)
-		bundle, found := eventsByObject[id]
-		if found == false {
-			bundle = newKubernetesEventBundler(event)
-			eventsByObject[id] = bundle
+		if event.InvolvedObject.Kind == "" ||
+			event.InvolvedObject.Name == "" ||
+			event.Reason == "" ||
+			event.Message == "" {
+			continue
 		}
+
+		id := buildBundleID(event)
+
+		bundle, found := bundlesByObject[id]
+		if !found {
+			bundle = newKubernetesEventBundler(event)
+			bundlesByObject[id] = bundle
+		}
+
 		err := bundle.addEvent(event)
 		if err != nil {
 			k.Warnf("Error while bundling events, %s.", err.Error()) //nolint:errcheck
+			continue
 		}
+
+		kubeEvents.Inc(
+			event.InvolvedObject.Kind,
+			event.Source.Component,
+			event.Type,
+			event.Reason,
+		)
 	}
-	hostname, _ := util.GetHostname(context.TODO())
-	clusterName := clustername.GetClusterName(context.TODO(), hostname)
-	for _, bundle := range eventsByObject {
+
+	ctx := context.TODO()
+	hostname, _ := util.GetHostname(ctx)
+	clusterName := clustername.GetClusterName(ctx, hostname)
+
+	for id, bundle := range bundlesByObject {
 		datadogEv, err := bundle.formatEvents(clusterName, k.providerIDCache)
 		if err != nil {
 			k.Warnf("Error while formatting bundled events, %s. Not submitting", err.Error()) //nolint:errcheck
 			continue
 		}
+
 		sender.Event(datadogEv)
+
+		emittedEvents.Inc(id.kind, id.evType)
 	}
+
 	return nil
 }
 
@@ -360,10 +403,20 @@ func (k *KubeASCheck) controlPlaneHealthCheck(ctx context.Context, sender aggreg
 	return nil
 }
 
-// bundleID generates a unique ID to separate k8s events
+type bundleID struct {
+	kind   string
+	uid    string
+	evType string
+}
+
+// buildBundleID generates a unique ID to separate k8s events
 // based on their InvolvedObject UIDs and event Types
-func bundleID(e *v1.Event) string {
-	return fmt.Sprintf("%s/%s", e.InvolvedObject.UID, e.Type)
+func buildBundleID(e *v1.Event) bundleID {
+	return bundleID{
+		kind:   e.InvolvedObject.Kind,
+		uid:    string(e.InvolvedObject.UID),
+		evType: e.Type,
+	}
 }
 
 func init() {

--- a/pkg/collector/corechecks/containers/docker/check.go
+++ b/pkg/collector/corechecks/containers/docker/check.go
@@ -71,7 +71,12 @@ func (d *DockerCheck) Configure(config, initConfig integration.Data, source stri
 	d.instance.Parse(config) //nolint:errcheck
 
 	if len(d.instance.FilteredEventType) == 0 {
-		d.instance.FilteredEventType = []string{"top", "exec_create", "exec_start", "exec_die"}
+		d.instance.FilteredEventType = []string{
+			"top",
+			"exec_create",
+			"exec_start",
+			"exec_die",
+		}
 	}
 
 	// Use the same hostname as the agent so that host tags (like `availability-zone:us-east-1b`)

--- a/pkg/collector/corechecks/containers/docker/events_test.go
+++ b/pkg/collector/corechecks/containers/docker/events_test.go
@@ -148,6 +148,7 @@ func TestAggregateEvents(t *testing.T) {
 					countByAction: map[string]int{
 						"unfiltered_action": 1,
 					},
+					alertType: metrics.EventAlertTypeInfo,
 				},
 			},
 		},
@@ -186,6 +187,7 @@ func TestAggregateEvents(t *testing.T) {
 						"unfiltered_action": 2,
 						"other_action":      1,
 					},
+					alertType: metrics.EventAlertTypeInfo,
 				},
 			},
 		},
@@ -217,12 +219,14 @@ func TestAggregateEvents(t *testing.T) {
 						"unfiltered_action": 2,
 						"other_action":      1,
 					},
+					alertType: metrics.EventAlertTypeInfo,
 				},
 				"other_image": {
 					imageName: "other_image",
 					countByAction: map[string]int{
 						"other_action": 1,
 					},
+					alertType: metrics.EventAlertTypeInfo,
 				},
 			},
 		},


### PR DESCRIPTION
The docker and kubernetesapiserver checks bundle events coming from the
Docker daemon and API Server, respectively, based on a few rules. We
want to monitor how that bundling works, and estimate the impact of a
possible unbundling of those events, so we are adding telemetry to that
effect.

This commit adds the following metrics:

* kubernetes_apiserver_kube_events: kubernetes events processed by the
  check
* kubernetes_apiserver_emitted_events: number of bundles emitted as
  datadog events
* docker_events: docker events processed by the check
* docker_emitted_events: number of bundles emitted as datadog events

### Describe how to test/QA your changes

Check that the telemetry is present (requires `DD_TELEMETRY_ENABLED`), and outputs reasonable values based on the workload. Note that `kubernetes_apiserver` runs in the DCA, while `docker` runs on the core agent.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
