### PR TITLE
Use go.uber.org/atomic in pkg/netflow

### DIFF
--- a/pkg/netflow/flowaggregator/aggregator_test.go
+++ b/pkg/netflow/flowaggregator/aggregator_test.go
@@ -4,15 +4,15 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"sync"
+	"testing"
+	"time"
+
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"github.com/DataDog/datadog-agent/pkg/netflow/common"
 	"github.com/DataDog/datadog-agent/pkg/netflow/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"sync"
-	"sync/atomic"
-	"testing"
-	"time"
 )
 
 func TestAggregator(t *testing.T) {
@@ -159,7 +159,7 @@ func waitForFlowsToBeFlushed(aggregator *FlowAggregator, timeoutDuration time.Du
 			return fmt.Errorf("timeout error waiting for events")
 		// Got a tick, we should check on doSomething()
 		case <-tick:
-			if atomic.LoadUint64(&aggregator.flushedFlowCount) >= minEvents {
+			if aggregator.flushedFlowCount.Load() >= minEvents {
 				return nil
 			}
 		}


### PR DESCRIPTION
### What does this PR do?

Uses go.uber.com/atomic to ensure alignment of atomic access in pkg/netflow.  The changes are quite simple.

### Motivation

Alignment issues with atomic access.  See #11716 

### Additional Notes

This should be a consequence-free change.  In most of the diff this is easy to validate visually.  The part that's a little hard to see is whether the pointer to the atomic value is initialized when it is used.  Please verify this carefully for the production code.  It's more complex for `_test.go` files, but those are exercised in CI so need less inspection.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Verify that basic check collection still works in a simple agent.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
