### PR TITLE
Fix `agent check` when `logs_config.cca_in_ad`

### DIFF
--- a/cmd/agent/app/jmx.go
+++ b/cmd/agent/app/jmx.go
@@ -181,7 +181,10 @@ func runJmxCommandConsole(command string) error {
 	}
 
 	common.LoadComponents(context.Background(), config.Datadog.GetString("confd_path"))
+
+	// Set up check collector
 	common.AC.AddScheduler("check", collector.InitCheckScheduler(common.Coll), true)
+	common.Coll.Start()
 
 	if discoveryRetryInterval > discoveryTimeout {
 		fmt.Println("The discovery retry interval", discoveryRetryInterval, "is higher than the discovery timeout", discoveryTimeout)

--- a/cmd/agent/app/jmx.go
+++ b/cmd/agent/app/jmx.go
@@ -182,12 +182,6 @@ func runJmxCommandConsole(command string) error {
 
 	common.LoadComponents(context.Background(), config.Datadog.GetString("confd_path"))
 
-	if discoveryRetryInterval > discoveryTimeout {
-		fmt.Println("The discovery retry interval", discoveryRetryInterval, "is higher than the discovery timeout", discoveryTimeout)
-		fmt.Println("Setting the discovery retry interval to", discoveryTimeout)
-		discoveryRetryInterval = discoveryTimeout
-	}
-
 	// Create the CheckScheduler, but do not attach it to
 	// AutoDiscovery.  NOTE: we do not start common.Coll, either.
 	collector.InitCheckScheduler(common.Coll)

--- a/cmd/agent/app/jmx.go
+++ b/cmd/agent/app/jmx.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/agent/app/standalone"
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/pkg/collector"
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
@@ -180,6 +181,7 @@ func runJmxCommandConsole(command string) error {
 	}
 
 	common.LoadComponents(context.Background(), config.Datadog.GetString("confd_path"))
+	common.AC.AddScheduler("check", collector.InitCheckScheduler(common.Coll), true)
 
 	if discoveryRetryInterval > discoveryTimeout {
 		fmt.Println("The discovery retry interval", discoveryRetryInterval, "is higher than the discovery timeout", discoveryTimeout)

--- a/cmd/agent/app/jmx.go
+++ b/cmd/agent/app/jmx.go
@@ -107,7 +107,7 @@ var (
 func init() {
 	jmxCmd.PersistentFlags().StringVarP(&jmxLogLevel, "log-level", "l", "", "set the log level (default 'debug') (deprecated, use the env var DD_LOG_LEVEL instead)")
 	jmxCmd.PersistentFlags().UintVarP(&discoveryTimeout, "discovery-timeout", "", 5, "max retry duration until Autodiscovery resolves the check template (in seconds)")
-	jmxCmd.PersistentFlags().UintVarP(&discoveryRetryInterval, "discovery-retry-interval", "", 1, "duration between retries until Autodiscovery resolves the check template (in seconds)")
+	jmxCmd.PersistentFlags().UintVarP(&discoveryRetryInterval, "discovery-retry-interval", "", 1, "(unused)")
 	jmxCmd.PersistentFlags().UintVarP(&discoveryMinInstances, "discovery-min-instances", "", 1, "minimum number of config instances to be discovered before running the check(s)")
 
 	// attach list and collect commands to jmx command
@@ -182,20 +182,22 @@ func runJmxCommandConsole(command string) error {
 
 	common.LoadComponents(context.Background(), config.Datadog.GetString("confd_path"))
 
-	// Set up check collector
-	common.AC.AddScheduler("check", collector.InitCheckScheduler(common.Coll), true)
-	common.Coll.Start()
-
 	if discoveryRetryInterval > discoveryTimeout {
 		fmt.Println("The discovery retry interval", discoveryRetryInterval, "is higher than the discovery timeout", discoveryTimeout)
 		fmt.Println("Setting the discovery retry interval to", discoveryTimeout)
 		discoveryRetryInterval = discoveryTimeout
 	}
 
-	// Note: when no checks are selected, cliSelectedChecks will be the empty slice and thus common.SelectedCheckMatcherBuilder
-	//       will return false, leading WaitForConfigs to timeout before returning all AD configs.
-	allConfigs := common.WaitForConfigs(time.Duration(discoveryRetryInterval)*time.Second, time.Duration(discoveryTimeout)*time.Second,
-		common.SelectedCheckMatcherBuilder(cliSelectedChecks, discoveryMinInstances))
+	// Create the CheckScheduler, but do not attach it to
+	// AutoDiscovery.  NOTE: we do not start common.Coll, either.
+	collector.InitCheckScheduler(common.Coll)
+
+	// Note: when no checks are selected, cliSelectedChecks will be the empty slice and thus
+	//       WaitForConfigsFromAD will timeout and return no AD configs.
+	waitCtx, cancelTimeout := context.WithTimeout(
+		context.Background(), time.Duration(discoveryTimeout)*time.Second)
+	allConfigs := common.WaitForConfigsFromAD(waitCtx, cliSelectedChecks, int(discoveryMinInstances))
+	cancelTimeout()
 
 	err = standalone.ExecJMXCommandConsole(command, cliSelectedChecks, logLevel, allConfigs)
 

--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -28,6 +28,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/manager"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/api/healthprobe"
+	"github.com/DataDog/datadog-agent/pkg/collector"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/embed/jmx"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	remoteconfig "github.com/DataDog/datadog-agent/pkg/config/remote/service"
@@ -403,6 +404,7 @@ func StartAgent() error {
 
 	// create and setup the Autoconfig instance
 	common.LoadComponents(common.MainCtx, config.Datadog.GetString("confd_path"))
+	common.AC.AddScheduler("check", collector.InitCheckScheduler(common.Coll), true)
 
 	demux.AddAgentStartupTelemetry(version.AgentVersion)
 

--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -404,7 +404,10 @@ func StartAgent() error {
 
 	// create and setup the Autoconfig instance
 	common.LoadComponents(common.MainCtx, config.Datadog.GetString("confd_path"))
+
+	// Set up check collector
 	common.AC.AddScheduler("check", collector.InitCheckScheduler(common.Coll), true)
+	common.Coll.Start()
 
 	demux.AddAgentStartupTelemetry(version.AgentVersion)
 

--- a/cmd/agent/common/autodiscovery.go
+++ b/cmd/agent/common/autodiscovery.go
@@ -7,7 +7,6 @@ package common
 
 import (
 	"context"
-	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
@@ -247,35 +246,4 @@ func WaitForConfigsFromAD(ctx context.Context, checkNames []string, discoveryMin
 		}
 	}
 	return
-}
-
-// WaitForConfigs retries the collection of Autodiscovery configs until the checkMatcher function (which
-// defines whether the list of integration configs collected is sufficient) returns true or the timeout is reached.
-// Autodiscovery listeners run asynchronously, AC.GetAllConfigs() can fail at the beginning to resolve templated configs
-// depending on non-deterministic factors (system load, network latency, active Autodiscovery listeners and their configurations).
-// This function improves the resiliency of the check command.
-// Note: If the check corresponds to a non-template configuration it should be found on the first try and fast-returned.
-func WaitForConfigs(retryInterval, timeout time.Duration, checkMatcher func([]integration.Config) bool) []integration.Config {
-	allConfigs := AC.GetAllConfigs()
-	if checkMatcher(allConfigs) {
-		return allConfigs
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-
-	retryTicker := time.NewTicker(retryInterval)
-	defer retryTicker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return allConfigs
-		case <-retryTicker.C:
-			allConfigs = AC.GetAllConfigs()
-			if checkMatcher(allConfigs) {
-				return allConfigs
-			}
-		}
-	}
 }

--- a/cmd/agent/common/commands/check.go
+++ b/cmd/agent/common/commands/check.go
@@ -152,6 +152,7 @@ func Check(loggerName config.LoggerName, confFilePath *string, flagNoColor *bool
 			demux := aggregator.InitAndStartAgentDemultiplexer(opts, hostname)
 
 			common.LoadComponents(context.Background(), config.Datadog.GetString("confd_path"))
+			common.AC.AddScheduler("check", collector.InitCheckScheduler(common.Coll), true)
 
 			if config.Datadog.GetBool("inventories_enabled") {
 				metadata.SetupInventoriesExpvar(common.AC, common.Coll)

--- a/cmd/agent/common/commands/check.go
+++ b/cmd/agent/common/commands/check.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
-	"go.uber.org/atomic"
 	"gopkg.in/yaml.v2"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/app/standalone"
@@ -169,8 +168,9 @@ func Check(loggerName config.LoggerName, confFilePath *string, flagNoColor *bool
 			// AutoDiscovery.  NOTE: we do not start common.Coll, either.
 			collector.InitCheckScheduler(common.Coll)
 
-			waitForConfigsFromADCtx, cancelTimeout := context.WithTimeout(context.Background(), time.Duration(discoveryTimeout)*time.Second)
-			allConfigs := waitForConfigsFromAD(waitForConfigsFromADCtx, checkName, int(discoveryMinInstances))
+			waitCtx, cancelTimeout := context.WithTimeout(
+				context.Background(), time.Duration(discoveryTimeout)*time.Second)
+			allConfigs := common.WaitForConfigsFromAD(waitCtx, checkName, int(discoveryMinInstances))
 			cancelTimeout()
 
 			// make sure the checks in cs are not JMX checks
@@ -454,65 +454,6 @@ func Check(loggerName config.LoggerName, confFilePath *string, flagNoColor *bool
 	}
 	setupCmd(cmd)
 	return cmd
-}
-
-// schedulerFunc is a type alias to allow a function to be used as an AD scheduler
-type schedulerFunc func([]integration.Config)
-
-// Schedule implements scheduler.Scheduler#Schedule.
-func (sf schedulerFunc) Schedule(configs []integration.Config) {
-	sf(configs)
-}
-
-// Unschedule implements scheduler.Scheduler#Unschedule.
-func (sf schedulerFunc) Unschedule(configs []integration.Config) {
-	// (do nothing)
-}
-
-// Stop implements scheduler.Scheduler#Stop.
-func (sf schedulerFunc) Stop() {
-}
-
-// waitForConfigsFromAD waits until a count of discoveryMinInstances configs
-// with name checkName are scheduled by AD, and returns the matches.  It does
-// so by subscribing to the AD metascheduler.  If the context is cancelled
-// then any accumulated configs are returned, even if that is fewer than
-// discoveryMinInstances.
-func waitForConfigsFromAD(ctx context.Context, checkName string, discoveryMinInstances int) (configs []integration.Config) {
-	configChan := make(chan integration.Config)
-
-	// signal to the scheduler when we are no longer waiting, so we do not continue
-	// to push items to configChan
-	waiting := atomic.NewBool(true)
-	defer func() {
-		waiting.Store(false)
-		select {
-		case <-configChan:
-		default:
-		}
-	}()
-
-	// add the scheduler in a goroutine, since it will schedule any "catch-up" immediately,
-	// placing items in configChan
-	go common.AC.AddScheduler("check-cmd", schedulerFunc(func(configs []integration.Config) {
-		for _, cfg := range configs {
-			if cfg.Name == checkName {
-				if waiting.Load() {
-					configChan <- cfg
-				}
-			}
-		}
-	}), true)
-
-	for len(configs) < discoveryMinInstances {
-		select {
-		case cfg := <-configChan:
-			configs = append(configs, cfg)
-		case <-ctx.Done():
-			return
-		}
-	}
-	return
 }
 
 func runCheck(c check.Check, demux aggregator.Demultiplexer) *check.Stats {

--- a/cmd/agent/common/commands/check.go
+++ b/cmd/agent/common/commands/check.go
@@ -158,12 +158,6 @@ func Check(loggerName config.LoggerName, confFilePath *string, flagNoColor *bool
 				metadata.SetupInventoriesExpvar(common.AC, common.Coll)
 			}
 
-			if discoveryRetryInterval > discoveryTimeout {
-				fmt.Println("The discovery retry interval", discoveryRetryInterval, "is higher than the discovery timeout", discoveryTimeout)
-				fmt.Println("Setting the discovery retry interval to", discoveryTimeout)
-				discoveryRetryInterval = discoveryTimeout
-			}
-
 			// Create the CheckScheduler, but do not attach it to
 			// AutoDiscovery.  NOTE: we do not start common.Coll, either.
 			collector.InitCheckScheduler(common.Coll)

--- a/cmd/agent/common/commands/check.go
+++ b/cmd/agent/common/commands/check.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
+	"go.uber.org/atomic"
 	"gopkg.in/yaml.v2"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/app/standalone"
@@ -80,7 +81,7 @@ func setupCmd(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&fullSketches, "full-sketches", false, "output sketches with bins information")
 	cmd.Flags().BoolVarP(&saveFlare, "flare", "", false, "save check results to the log dir so it may be reported in a flare")
 	cmd.Flags().UintVarP(&discoveryTimeout, "discovery-timeout", "", 5, "max retry duration until Autodiscovery resolves the check template (in seconds)")
-	cmd.Flags().UintVarP(&discoveryRetryInterval, "discovery-retry-interval", "", 1, "duration between retries until Autodiscovery resolves the check template (in seconds)")
+	cmd.Flags().UintVarP(&discoveryRetryInterval, "discovery-retry-interval", "", 1, "(unused)")
 	cmd.Flags().UintVarP(&discoveryMinInstances, "discovery-min-instances", "", 1, "minimum number of config instances to be discovered before running the check(s)")
 	config.Datadog.BindPFlag("cmd.check.fullsketches", cmd.Flags().Lookup("full-sketches")) //nolint:errcheck
 
@@ -152,8 +153,7 @@ func Check(loggerName config.LoggerName, confFilePath *string, flagNoColor *bool
 			demux := aggregator.InitAndStartAgentDemultiplexer(opts, hostname)
 
 			common.LoadComponents(context.Background(), config.Datadog.GetString("confd_path"))
-			common.AC.AddScheduler("check", collector.InitCheckScheduler(common.Coll), true)
-			// NOTE: we do not start the collector
+			common.AC.LoadAndRun()
 
 			if config.Datadog.GetBool("inventories_enabled") {
 				metadata.SetupInventoriesExpvar(common.AC, common.Coll)
@@ -165,8 +165,13 @@ func Check(loggerName config.LoggerName, confFilePath *string, flagNoColor *bool
 				discoveryRetryInterval = discoveryTimeout
 			}
 
-			allConfigs := common.WaitForConfigs(time.Duration(discoveryRetryInterval)*time.Second, time.Duration(discoveryTimeout)*time.Second,
-				common.SelectedCheckMatcherBuilder([]string{checkName}, discoveryMinInstances))
+			// Create the CheckScheduler, but do not attach it to
+			// AutoDiscovery.  NOTE: we do not start common.Coll, either.
+			collector.InitCheckScheduler(common.Coll)
+
+			waitForConfigsFromADCtx, cancelTimeout := context.WithTimeout(context.Background(), time.Duration(discoveryTimeout)*time.Second)
+			allConfigs := waitForConfigsFromAD(waitForConfigsFromADCtx, checkName, int(discoveryMinInstances))
+			cancelTimeout()
 
 			// make sure the checks in cs are not JMX checks
 			for idx := range allConfigs {
@@ -449,6 +454,65 @@ func Check(loggerName config.LoggerName, confFilePath *string, flagNoColor *bool
 	}
 	setupCmd(cmd)
 	return cmd
+}
+
+// schedulerFunc is a type alias to allow a function to be used as an AD scheduler
+type schedulerFunc func([]integration.Config)
+
+// Schedule implements scheduler.Scheduler#Schedule.
+func (sf schedulerFunc) Schedule(configs []integration.Config) {
+	sf(configs)
+}
+
+// Unschedule implements scheduler.Scheduler#Unschedule.
+func (sf schedulerFunc) Unschedule(configs []integration.Config) {
+	// (do nothing)
+}
+
+// Stop implements scheduler.Scheduler#Stop.
+func (sf schedulerFunc) Stop() {
+}
+
+// waitForConfigsFromAD waits until a count of discoveryMinInstances configs
+// with name checkName are scheduled by AD, and returns the matches.  It does
+// so by subscribing to the AD metascheduler.  If the context is cancelled
+// then any accumulated configs are returned, even if that is fewer than
+// discoveryMinInstances.
+func waitForConfigsFromAD(ctx context.Context, checkName string, discoveryMinInstances int) (configs []integration.Config) {
+	configChan := make(chan integration.Config)
+
+	// signal to the scheduler when we are no longer waiting, so we do not continue
+	// to push items to configChan
+	waiting := atomic.NewBool(true)
+	defer func() {
+		waiting.Store(false)
+		select {
+		case <-configChan:
+		default:
+		}
+	}()
+
+	// add the scheduler in a goroutine, since it will schedule any "catch-up" immediately,
+	// placing items in configChan
+	go common.AC.AddScheduler("check-cmd", schedulerFunc(func(configs []integration.Config) {
+		for _, cfg := range configs {
+			if cfg.Name == checkName {
+				if waiting.Load() {
+					configChan <- cfg
+				}
+			}
+		}
+	}), true)
+
+	for len(configs) < discoveryMinInstances {
+		select {
+		case cfg := <-configChan:
+			configs = append(configs, cfg)
+		case <-ctx.Done():
+			return
+		}
+	}
+	return
 }
 
 func runCheck(c check.Check, demux aggregator.Demultiplexer) *check.Stats {

--- a/cmd/agent/common/commands/check.go
+++ b/cmd/agent/common/commands/check.go
@@ -170,7 +170,7 @@ func Check(loggerName config.LoggerName, confFilePath *string, flagNoColor *bool
 
 			waitCtx, cancelTimeout := context.WithTimeout(
 				context.Background(), time.Duration(discoveryTimeout)*time.Second)
-			allConfigs := common.WaitForConfigsFromAD(waitCtx, checkName, int(discoveryMinInstances))
+			allConfigs := common.WaitForConfigsFromAD(waitCtx, []string{checkName}, int(discoveryMinInstances))
 			cancelTimeout()
 
 			// make sure the checks in cs are not JMX checks

--- a/cmd/agent/common/commands/check.go
+++ b/cmd/agent/common/commands/check.go
@@ -153,6 +153,7 @@ func Check(loggerName config.LoggerName, confFilePath *string, flagNoColor *bool
 
 			common.LoadComponents(context.Background(), config.Datadog.GetString("confd_path"))
 			common.AC.AddScheduler("check", collector.InitCheckScheduler(common.Coll), true)
+			// NOTE: we do not start the collector
 
 			if config.Datadog.GetBool("inventories_enabled") {
 				metadata.SetupInventoriesExpvar(common.AC, common.Coll)

--- a/cmd/agent/common/loader.go
+++ b/cmd/agent/common/loader.go
@@ -38,12 +38,6 @@ func LoadComponents(ctx context.Context, confdPath string) {
 	// NOTICE: this will also setup the Python environment, if available
 	Coll = collector.NewCollector(GetPythonPaths()...)
 
-	// creating the meta scheduler
-	metaScheduler := scheduler.NewMetaScheduler()
-
-	// registering the check scheduler
-	metaScheduler.Register("check", collector.InitCheckScheduler(Coll), false)
-
 	// setup autodiscovery
 	confSearchPaths := []string{
 		confdPath,
@@ -53,5 +47,5 @@ func LoadComponents(ctx context.Context, confdPath string) {
 
 	// setup autodiscovery. must be done after the tagger is initialized
 	// because of subscription to metadata store.
-	AC = setupAutoDiscovery(confSearchPaths, metaScheduler)
+	AC = setupAutoDiscovery(confSearchPaths, scheduler.NewMetaScheduler())
 }

--- a/cmd/cluster-agent-cloudfoundry/app/app.go
+++ b/cmd/cluster-agent-cloudfoundry/app/app.go
@@ -29,6 +29,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/api/healthprobe"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks"
+	"github.com/DataDog/datadog-agent/pkg/collector"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/resolver"
 	"github.com/DataDog/datadog-agent/pkg/forwarder"
@@ -192,6 +193,7 @@ func run(cmd *cobra.Command, args []string) error {
 
 	// create and setup the Autoconfig instance
 	common.LoadComponents(mainCtx, config.Datadog.GetString("confd_path"))
+	common.AC.AddScheduler("check", collector.InitCheckScheduler(common.Coll), true)
 	// start the autoconfig, this will immediately run any configured check
 	common.AC.LoadAndRun()
 

--- a/cmd/cluster-agent-cloudfoundry/app/app.go
+++ b/cmd/cluster-agent-cloudfoundry/app/app.go
@@ -193,7 +193,11 @@ func run(cmd *cobra.Command, args []string) error {
 
 	// create and setup the Autoconfig instance
 	common.LoadComponents(mainCtx, config.Datadog.GetString("confd_path"))
+
+	// Set up check collector
 	common.AC.AddScheduler("check", collector.InitCheckScheduler(common.Coll), true)
+	common.Coll.Start()
+
 	// start the autoconfig, this will immediately run any configured check
 	common.AC.LoadAndRun()
 

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -284,7 +284,11 @@ func start(cmd *cobra.Command, args []string) error {
 	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM)
 	// create and setup the Autoconfig instance
 	common.LoadComponents(mainCtx, config.Datadog.GetString("confd_path"))
+
+	// Set up check collector
 	common.AC.AddScheduler("check", collector.InitCheckScheduler(common.Coll), true)
+	common.Coll.Start()
+
 	// start the autoconfig, this will immediately run any configured check
 	common.AC.LoadAndRun()
 

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -37,6 +37,7 @@ import (
 	admissionpkg "github.com/DataDog/datadog-agent/pkg/clusteragent/admission"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks"
+	"github.com/DataDog/datadog-agent/pkg/collector"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/resolver"
 	"github.com/DataDog/datadog-agent/pkg/forwarder"
@@ -283,6 +284,7 @@ func start(cmd *cobra.Command, args []string) error {
 	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM)
 	// create and setup the Autoconfig instance
 	common.LoadComponents(mainCtx, config.Datadog.GetString("confd_path"))
+	common.AC.AddScheduler("check", collector.InitCheckScheduler(common.Coll), true)
 	// start the autoconfig, this will immediately run any configured check
 	common.AC.LoadAndRun()
 

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -41,18 +41,9 @@ type Collector struct {
 
 // NewCollector create a Collector instance and sets up the Python Environment
 func NewCollector(paths ...string) *Collector {
-	run := runner.NewRunner()
-	sched := scheduler.NewScheduler(run.GetChan())
-
-	// let the runner some visibility into the scheduler
-	run.SetScheduler(sched)
-	sched.Run()
-
 	c := &Collector{
-		scheduler:      sched,
-		runner:         run,
 		checks:         make(map[check.ID]check.Check),
-		state:          atomic.NewUint32(started),
+		state:          atomic.NewUint32(stopped),
 		checkInstances: int64(0),
 	}
 	pyVer, pyHome, pyPath := pySetup(paths...)
@@ -73,6 +64,28 @@ func NewCollector(paths ...string) *Collector {
 	return c
 }
 
+// Start begins the collector's operation.  The scheduler will not run any
+// checks until this has been called.
+func (c *Collector) Start() {
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	if c.state.Load() == started {
+		return
+	}
+
+	run := runner.NewRunner()
+	sched := scheduler.NewScheduler(run.GetChan())
+
+	// let the runner some visibility into the scheduler
+	run.SetScheduler(sched)
+	sched.Run()
+
+	c.scheduler = sched
+	c.runner = run
+	c.state.Store(started)
+}
+
 // Stop halts any component involved in running a Check
 func (c *Collector) Stop() {
 	c.m.Lock()
@@ -82,10 +95,14 @@ func (c *Collector) Stop() {
 		return
 	}
 
-	c.scheduler.Stop() //nolint:errcheck
-	c.scheduler = nil
-	c.runner.Stop()
-	c.runner = nil
+	if c.scheduler != nil {
+		c.scheduler.Stop() //nolint:errcheck
+		c.scheduler = nil
+	}
+	if c.runner != nil {
+		c.runner.Stop()
+		c.runner = nil
+	}
 	c.state.Store(stopped)
 }
 

--- a/pkg/collector/collector_test.go
+++ b/pkg/collector/collector_test.go
@@ -79,6 +79,7 @@ type CollectorTestSuite struct {
 
 func (suite *CollectorTestSuite) SetupTest() {
 	suite.c = NewCollector()
+	suite.c.Start()
 }
 
 func (suite *CollectorTestSuite) TearDownTest() {


### PR DESCRIPTION
### What does this PR do?

In `agent check`, do not start the collector, and do not subscribe the collector to configs from AD.

### Motivation

Fix bugs:
 * `agent check` failures with `logs_config.cca_in_ad: true`.  This had been broken in #11802, which introduced subtle changes to the timing of AD's config scheduling, messing up the delicate balance allowing `agent check` to work.
 * `agent check` would sometimes report that a check was already running
 * `agent check` would sometimes run checks other than the one that was requested

### Additional Notes


### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Run `agent check` in a variety of contexts, once each with `logs_config.cca_in_ad` true and false.

 - for non-templated configs (e.g., `agent check ntp`)
 - for templated configs (e.g., `agent check nginx` with and without a running nginx container)
 - with --discovery-min-instances when there are >1 containers matching a config
 - with --check-rate and check that there are 2 runs in the status output
 - in the cluster agent
 - in the cloudfoundry agent

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
