### PR TITLE
add a new WLM subscriber priority for config providers

### DIFF
--- a/pkg/autodiscovery/providers/container.go
+++ b/pkg/autodiscovery/providers/container.go
@@ -85,7 +85,7 @@ func (d *ContainerConfigProvider) listen() {
 	}()
 	d.Unlock()
 
-	workloadmetaEventsChannel := d.workloadmetaStore.Subscribe("ad-containerprovider", workloadmeta.NormalPriority, workloadmeta.NewFilter(
+	workloadmetaEventsChannel := d.workloadmetaStore.Subscribe("ad-containerprovider", workloadmeta.ConfigProviderPriority, workloadmeta.NewFilter(
 		[]workloadmeta.Kind{workloadmeta.KindContainer},
 		workloadmeta.SourceRuntime,
 		workloadmeta.EventTypeAll,

--- a/pkg/autodiscovery/providers/kubelet.go
+++ b/pkg/autodiscovery/providers/kubelet.go
@@ -77,7 +77,7 @@ func (k *KubeletConfigProvider) listen() {
 	}()
 	k.Unlock()
 
-	ch := k.workloadmetaStore.Subscribe(name, workloadmeta.NormalPriority, workloadmeta.NewFilter(
+	ch := k.workloadmetaStore.Subscribe(name, workloadmeta.ConfigProviderPriority, workloadmeta.NewFilter(
 		[]workloadmeta.Kind{workloadmeta.KindKubernetesPod},
 		workloadmeta.SourceNodeOrchestrator,
 		workloadmeta.EventTypeAll,

--- a/pkg/workloadmeta/types.go
+++ b/pkg/workloadmeta/types.go
@@ -636,6 +636,11 @@ const (
 	// come first.
 	TaggerPriority SubscriberPriority = iota
 
+	// ConfigProviderPriority is the priority for the AD Config Provider.  This
+	// should come before other subscribers so that config provided by entities
+	// is available to those other subscribers.
+	ConfigProviderPriority SubscriberPriority = iota
+
 	// NormalPriority should be used by subscribers on which other components
 	// do not depend.
 	NormalPriority SubscriberPriority = iota


### PR DESCRIPTION
This ensures that config providers learn about new entities before
service listeners.  If the reverse were to occur, then configs a service
might be intially be scheduled without input from config in the entity
(such as labels or annotations), then immediately re-scheduled with that
input.


### Possible Drawbacks / Trade-offs

None

### Describe how to test/QA your changes

Ensure that a check or log annotation on a container is respected, e.g., 

```
docker run -ti --rm --label com.datadoghq.ad.logs='[{"service":"foo"}]' bash
```

(with `logs_enabled: true` and without `logs_config.container_collect_all`)

check in `agent stream-logs` that the logs have service `foo`.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
