### PR TITLE
Add some minor docs to AD, Logs-Agent

### DIFF
--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -374,9 +374,11 @@ func (ac *AutoConfig) retryListenerCandidates() {
 	}
 }
 
-// AddScheduler allows to register a new scheduler to receive configurations.
+// AddScheduler a new scheduler to receive configurations.
+//
 // Previously scheduled configurations that have not subsequently been
-// unscheduled can be replayed with the replayConfigs flag.
+// unscheduled can be replayed with the replayConfigs flag.  This replay occurs
+// immediately, before the AddScheduler call returns.
 func (ac *AutoConfig) AddScheduler(name string, s scheduler.Scheduler, replayConfigs bool) {
 	ac.m.Lock()
 	defer ac.m.Unlock()

--- a/pkg/autodiscovery/scheduler/meta.go
+++ b/pkg/autodiscovery/scheduler/meta.go
@@ -33,7 +33,11 @@ func NewMetaScheduler() *MetaScheduler {
 	}
 }
 
-// Register a scheduler in the meta scheduler to dispatch to
+// Register a new scheduler to receive configurations.
+//
+// Previously scheduled configurations that have not subsequently been
+// unscheduled can be replayed with the replayConfigs flag.  This replay occurs
+// immediately, before the AddScheduler call returns.
 func (ms *MetaScheduler) Register(name string, s Scheduler, replayConfigs bool) {
 	ms.m.Lock()
 	defer ms.m.Unlock()

--- a/pkg/autodiscovery/scheduler/scheduler.go
+++ b/pkg/autodiscovery/scheduler/scheduler.go
@@ -10,9 +10,17 @@ import (
 )
 
 // Scheduler is the interface that should be implemented if you want to schedule and
-// unschedule integrations
+// unschedule integrations.  Values implementing this interface can be passed to the
+// MetaScheduler's Register method (or AutoConf.AddScheduler).
 type Scheduler interface {
+	// Schedule zero or more new configurations.
 	Schedule([]integration.Config)
+
+	// Unschedule zero or more configurations that were previously scheduled.
 	Unschedule([]integration.Config)
+
+	// Stop the scheduler.  This method is called from the MetaScheduler's Stop
+	// method.  Note that currently-scheduled configs are _not_ unscheduled when
+	// the MetaScheduler stops.
 	Stop()
 }

--- a/pkg/logs/internal/launchers/types.go
+++ b/pkg/logs/internal/launchers/types.go
@@ -31,6 +31,11 @@ type Launcher interface {
 // The *sources.LogSources type satisfies this interface.
 type SourceProvider interface {
 	// SubscribeForType returns channels containing the new added and removed sources matching the provided type.
+	//
+	// Removed sources are pointer-equal to previously-added sources.
+	//
+	// Sources are not automatically removed when the agent shuts down.  Consumers should handle any
+	// required shutdwon of running sources in their own Stop methods.
 	SubscribeForType(sourceType string) (added chan *sources.LogSource, removed chan *sources.LogSource)
 
 	// GetAddedForType returns channels containing the new added sources matching the provided type.


### PR DESCRIPTION
### What does this PR do?

Adds some doc comments.

### Motivation

Make implict assumptions explicit.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
