### PR TITLE
[CWS] policy versioning

### DIFF
--- a/cmd/security-agent/app/runtime.go
+++ b/cmd/security-agent/app/runtime.go
@@ -38,6 +38,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -548,7 +549,12 @@ func checkPoliciesInner(dir string) error {
 	model := &model.Model{}
 	ruleSet := rules.NewRuleSet(model, model.NewEvent, &opts)
 
-	provider, err := rules.NewPoliciesDirProvider(cfg.PoliciesDir, false)
+	agentVersion, err := utils.GetAgentSemverVersion()
+	if err != nil {
+		return err
+	}
+
+	provider, err := rules.NewPoliciesDirProvider(cfg.PoliciesDir, false, agentVersion)
 	if err != nil {
 		return err
 	}

--- a/pkg/security/agent/utils.go
+++ b/pkg/security/agent/utils.go
@@ -1,0 +1,21 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package agent
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/version"
+	"github.com/Masterminds/semver"
+)
+
+// GetAgentSemverVersion returns the agent version as a semver version
+func GetAgentSemverVersion() (*semver.Version, error) {
+	av, err := version.Agent()
+	if err != nil {
+		return nil, err
+	}
+
+	return semver.NewVersion(av.GetNumberAndPre())
+}

--- a/pkg/security/rconfig/rconfig.go
+++ b/pkg/security/rconfig/rconfig.go
@@ -42,7 +42,8 @@ func NewRCPolicyProvider(name string, agentVersion *semver.Version) (*RCPolicyPr
 	}
 
 	return &RCPolicyProvider{
-		client: c,
+		client:       c,
+		agentVersion: agentVersion,
 	}, nil
 }
 

--- a/pkg/security/secl/go.mod
+++ b/pkg/security/secl/go.mod
@@ -3,6 +3,7 @@ module github.com/DataDog/datadog-agent/pkg/security/secl
 go 1.17
 
 require (
+	github.com/Masterminds/semver v1.5.0
 	github.com/alecthomas/participle v0.7.1
 	github.com/davecgh/go-spew v1.1.1
 	github.com/fatih/structtag v1.2.0

--- a/pkg/security/secl/go.sum
+++ b/pkg/security/secl/go.sum
@@ -1,3 +1,5 @@
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
+github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/alecthomas/participle v0.7.1 h1:2bN7reTw//5f0cugJcTOnY/NYZcWQOaajW+BwZB5xWs=
 github.com/alecthomas/participle v0.7.1/go.mod h1:HfdmEuwvr12HXQN44HPWXR0lHmVolVYe4dyL6lQ3duY=
 github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1/go.mod h1:xTS7Pm1pD1mvyM075QCDSRqH6qRLXylzS24ZTpRiSzQ=

--- a/pkg/security/secl/rules/policy_dir.go
+++ b/pkg/security/secl/rules/policy_dir.go
@@ -181,7 +181,8 @@ func (p *PoliciesDirProvider) watch(ctx context.Context) {
 func NewPoliciesDirProvider(policiesDir string, watch bool, agentVersion *semver.Version) (*PoliciesDirProvider, error) {
 
 	p := &PoliciesDirProvider{
-		PoliciesDir: policiesDir,
+		PoliciesDir:  policiesDir,
+		agentVersion: agentVersion,
 	}
 
 	if watch {

--- a/pkg/security/secl/rules/policy_loader.go
+++ b/pkg/security/secl/rules/policy_loader.go
@@ -46,7 +46,7 @@ func (p *PolicyLoader) LoadPolicies() ([]*Policy, *multierror.Error) {
 		}
 
 		for _, policy := range policies {
-			if policy.Name == defaultPolicyName {
+			if policy.Name == DefaultPolicyName {
 				defaultPolicy = policy
 			} else {
 				allPolicies = append(allPolicies, policy)

--- a/pkg/security/secl/rules/policy_provider.go
+++ b/pkg/security/secl/rules/policy_provider.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 )
 
-const defaultPolicyName = "default.policy"
+const DefaultPolicyName = "default.policy"
 
 // PolicyProvider defines a rule provider
 type PolicyProvider interface {

--- a/pkg/security/secl/rules/policy_test.go
+++ b/pkg/security/secl/rules/policy_test.go
@@ -77,7 +77,7 @@ func TestMacroMerge(t *testing.T) {
 		},
 	})
 
-	provider, err := NewPoliciesDirProvider(tmpDir, false)
+	provider, err := NewPoliciesDirProvider(tmpDir, false, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -140,7 +140,7 @@ func TestRuleMerge(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	provider, err := NewPoliciesDirProvider(tmpDir, false)
+	provider, err := NewPoliciesDirProvider(tmpDir, false, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -314,7 +314,7 @@ func TestActionSetVariable(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	provider, err := NewPoliciesDirProvider(tmpDir, false)
+	provider, err := NewPoliciesDirProvider(tmpDir, false, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -401,7 +401,7 @@ func TestActionSetVariableConflict(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	provider, err := NewPoliciesDirProvider(tmpDir, false)
+	provider, err := NewPoliciesDirProvider(tmpDir, false, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -432,7 +432,7 @@ func loadPolicy(t *testing.T, testPolicy *PolicyDef) *multierror.Error {
 		t.Fatal(err)
 	}
 
-	provider, err := NewPoliciesDirProvider(tmpDir, false)
+	provider, err := NewPoliciesDirProvider(tmpDir, false, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -68,15 +68,16 @@ var ruleIDPattern = regexp.MustCompile(`^[a-zA-Z0-9_]*$`)
 
 // RuleDefinition holds the definition of a rule
 type RuleDefinition struct {
-	ID          RuleID             `yaml:"id"`
-	Version     string             `yaml:"version"`
-	Expression  string             `yaml:"expression"`
-	Description string             `yaml:"description"`
-	Tags        map[string]string  `yaml:"tags"`
-	Disabled    bool               `yaml:"disabled"`
-	Combine     CombinePolicy      `yaml:"combine"`
-	Actions     []ActionDefinition `yaml:"actions"`
-	Policy      *Policy
+	ID                     RuleID             `yaml:"id"`
+	Version                string             `yaml:"version"`
+	Expression             string             `yaml:"expression"`
+	Description            string             `yaml:"description"`
+	Tags                   map[string]string  `yaml:"tags"`
+	AgentVersionConstraint string             `yaml:"agent_version"`
+	Disabled               bool               `yaml:"disabled"`
+	Combine                CombinePolicy      `yaml:"combine"`
+	Actions                []ActionDefinition `yaml:"actions"`
+	Policy                 *Policy
 }
 
 func checkRuleID(ruleID string) bool {

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -706,7 +706,7 @@ func (tm *testModule) reloadConfiguration() error {
 	log.Debugf("reload configuration with testDir: %s", tm.Root())
 	tm.config.PoliciesDir = tm.Root()
 
-	provider, err := rules.NewPoliciesDirProvider(tm.config.PoliciesDir, false)
+	provider, err := rules.NewPoliciesDirProvider(tm.config.PoliciesDir, false, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/security/utils/utils.go
+++ b/pkg/security/utils/utils.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package agent
+package utils
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/version"


### PR DESCRIPTION
### What does this PR do?

This PR adds a field to rules definition allowing to specify an agent version semver constraint, filtering the loading of the rule.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
