### PR TITLE
[Serverless] filter out empty logs to prevent snapshot diff flakiness

### DIFF
--- a/pkg/serverless/logs/logs.go
+++ b/pkg/serverless/logs/logs.go
@@ -204,6 +204,11 @@ func shouldProcessLog(ecs *executioncontext.State, message logMessage) bool {
 	if message.logType == logTypePlatformExtension || message.logType == logTypePlatformLogsSubscription {
 		return false
 	}
+	// Making sure that empty logs are not uselessly sent
+	if len(message.stringRecord) == 0 && len(message.objectRecord.requestID) == 0 {
+		return false
+	}
+
 	return true
 }
 

--- a/pkg/serverless/logs/logs_test.go
+++ b/pkg/serverless/logs/logs_test.go
@@ -74,6 +74,44 @@ func TestShouldProcessLog(t *testing.T) {
 	assert.False(t, shouldProcessLog(&executioncontext.State{ARN: emptyARN, LastRequestID: nonEmptyRequestID}, invalidLog1))
 }
 
+func TestShouldNotProcessEmptyLog(t *testing.T) {
+	assert.True(t, shouldProcessLog(
+		&executioncontext.State{
+			ARN:           "arn:aws:lambda:us-east-1:123456789012:function:my-function",
+			LastRequestID: "8286a188-ba32-4475-8077-530cd35c09a9",
+		},
+		logMessage{
+			stringRecord: "aaa",
+			objectRecord: platformObjectRecord{
+				requestID: "",
+			},
+		}),
+	)
+	assert.True(t, shouldProcessLog(
+		&executioncontext.State{
+			ARN:           "arn:aws:lambda:us-east-1:123456789012:function:my-function",
+			LastRequestID: "8286a188-ba32-4475-8077-530cd35c09a9",
+		},
+		logMessage{
+			stringRecord: "",
+			objectRecord: platformObjectRecord{
+				requestID: "aaa",
+			},
+		}),
+	)
+	assert.False(t, shouldProcessLog(
+		&executioncontext.State{
+			ARN:           "arn:aws:lambda:us-east-1:123456789012:function:my-function",
+			LastRequestID: "8286a188-ba32-4475-8077-530cd35c09a9",
+		},
+		logMessage{
+			stringRecord: "",
+			objectRecord: platformObjectRecord{
+				requestID: "",
+			},
+		}),
+	)
+}
 func TestCreateStringRecordForReportLogWithInitDuration(t *testing.T) {
 	var sampleLogMessage = logMessage{
 		objectRecord: platformObjectRecord{

--- a/pkg/serverless/logs/logs_test.go
+++ b/pkg/serverless/logs/logs_test.go
@@ -42,6 +42,9 @@ func TestShouldProcessLog(t *testing.T) {
 
 	validLog := logMessage{
 		logType: logTypePlatformReport,
+		objectRecord: platformObjectRecord{
+			requestID: "8286a188-ba32-4475-8077-530cd35c09a9",
+		},
 	}
 
 	invalidLog0 := logMessage{
@@ -203,6 +206,7 @@ func TestProcessMessageValid(t *testing.T) {
 				maxMemoryUsedMB:  256.0,
 				initDurationMs:   100.0,
 			},
+			requestID: "8286a188-ba32-4475-8077-530cd35c09a9",
 		},
 	}
 	arn := "arn:aws:lambda:us-east-1:123456789012:function:test-function"

--- a/test/integration/serverless/snapshots/log-csharp
+++ b/test/integration/serverless/snapshots/log-csharp
@@ -1,19 +1,6 @@
 [
   {
     "message": {
-      "message": "",
-      "lambda": {
-        "arn": ""
-      }
-    },
-    "status": "info",
-    "hostname": "",
-    "service": "integration-tests-service",
-    "ddsource": "lambda",
-    "ddtags": ""
-  },
-  {
-    "message": {
       "message": "START RequestId: XXX Version: $LATEST",
       "lambda": {
         "arn": "arn:aws:lambda:eu-west-1:601427279990:function:integration-tests-extension-STAGE-log-csharp",


### PR DESCRIPTION
### What does this PR do?

Filter out empty logs message received from Extension Log API

### Motivation

Fix flakiness in snapshot + empty logs are useless

### Describe how to test/QA your changes

Unit tests + integration tests

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
