### PR TITLE
Fixes metrics for log bytes sent

### DIFF
--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -251,7 +251,9 @@ func (d *Destination) unconditionalSend(payload *message.Payload) (err error) {
 		return err
 	}
 	metrics.BytesSent.Add(int64(payload.UnencodedSize))
+	metrics.TlmBytesSent.Add(float64(payload.UnencodedSize))
 	metrics.EncodedBytesSent.Add(int64(len(payload.Encoded)))
+	metrics.TlmEncodedBytesSent.Add(float64(len(payload.Encoded)))
 
 	req, err := http.NewRequest("POST", d.url, bytes.NewReader(payload.Encoded))
 	if err != nil {

--- a/pkg/logs/client/tcp/destination.go
+++ b/pkg/logs/client/tcp/destination.go
@@ -101,8 +101,8 @@ func (d *Destination) sendAndRetry(payload *message.Payload, output chan *messag
 
 		metrics.LogsSent.Add(1)
 		metrics.TlmLogsSent.Inc()
-		metrics.BytesSent.Add(int64(len(payload.Encoded)))
-		metrics.TlmBytesSent.Add(float64(len(payload.Encoded)))
+		metrics.BytesSent.Add(int64(payload.UnencodedSize))
+		metrics.TlmBytesSent.Add(float64(payload.UnencodedSize))
 		metrics.EncodedBytesSent.Add(int64(len(payload.Encoded)))
 		metrics.TlmEncodedBytesSent.Add(float64(len(payload.Encoded)))
 		output <- payload

--- a/pkg/logs/sender/stream_strategy.go
+++ b/pkg/logs/sender/stream_strategy.go
@@ -34,7 +34,7 @@ func (s *streamStrategy) Start() {
 			if msg.Origin != nil {
 				msg.Origin.LogSource.LatencyStats.Add(msg.GetLatency())
 			}
-			s.outputChan <- &message.Payload{Messages: []*message.Message{msg}, Encoded: msg.Content}
+			s.outputChan <- &message.Payload{Messages: []*message.Message{msg}, Encoded: msg.Content, UnencodedSize: len(msg.Content)}
 		}
 		s.done <- struct{}{}
 	}()

--- a/pkg/logs/sender/stream_strategy_test.go
+++ b/pkg/logs/sender/stream_strategy_test.go
@@ -26,6 +26,7 @@ func TestStreamStrategy(t *testing.T) {
 
 	payload := <-output
 	assert.Equal(t, message1, payload.Messages[0])
+	assert.Equal(t, 1, payload.UnencodedSize)
 	assert.Equal(t, content, payload.Encoded)
 
 	content = []byte("b")
@@ -34,6 +35,7 @@ func TestStreamStrategy(t *testing.T) {
 
 	payload = <-output
 	assert.Equal(t, message2, payload.Messages[0])
+	assert.Equal(t, 1, payload.UnencodedSize)
 	assert.Equal(t, content, payload.Encoded)
 	s.Stop()
 }

--- a/releasenotes/notes/fix-log-metrics-b748320e6924033b.yaml
+++ b/releasenotes/notes/fix-log-metrics-b748320e6924033b.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Add missing telemetry metrics for HTTP log bytes sent.


### PR DESCRIPTION
### What does this PR do?

When the telemetry package was introduced in 09957f78be52364182cd6dbebc7364d781c2b334 versions of the logs `(encoded_)bytes_sent` metrics were added to `pkg/logs/client/tcp/destination.go` but not `pkg/logs/client/http/destination.go`

This means that currently the only way to obtain log telemetry that correctly includes http transport is via the legacy expvar metrics.

I also noticed that the tcp version uses the encoded payload size for both the encoded and unencoded byte sizes.  This was confusing to me so I've changed this to explicitly populate UnencodedSize and use it on the metrics.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
