### PR TITLE
always publish datadog.agent.checks.runs metrics, not just in agent t…

### DIFF
--- a/pkg/collector/check/stats_test.go
+++ b/pkg/collector/check/stats_test.go
@@ -7,8 +7,6 @@ package check
 
 import (
 	"fmt"
-	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -39,18 +37,6 @@ func newMockCheck() Check {
 		stringVal: "checkString",
 		version:   "checkVersion",
 	}
-}
-
-func getTelemetryData() (string, error) {
-	req, err := http.NewRequest("GET", "/", nil)
-	if err != nil {
-		return "", err
-	}
-
-	rec := httptest.NewRecorder()
-	telemetry.Handler().ServeHTTP(rec, req)
-
-	return rec.Body.String(), nil
 }
 
 func TestNewStats(t *testing.T) {

--- a/releasenotes/notes/checks-runs-publish-3accc6aac8c5cf93.yaml
+++ b/releasenotes/notes/checks-runs-publish-3accc6aac8c5cf93.yaml
@@ -1,0 +1,4 @@
+features:
+  - |
+    The agent now generates a metric, ``datadog.agent.checks.runs``, giving the
+    number of runs of each check, by state (``fail`` or ``ok``).

--- a/releasenotes/notes/checks-runs-publish-3accc6aac8c5cf93.yaml
+++ b/releasenotes/notes/checks-runs-publish-3accc6aac8c5cf93.yaml
@@ -1,4 +1,4 @@
 features:
   - |
-    The agent now generates a metric, ``datadog.agent.checks.runs``, giving the
+    The Agent now generates a metric, ``datadog.agent.checks.runs``, giving the
     number of runs of each check, by state (``fail`` or ``ok``).


### PR DESCRIPTION
### What does this PR do?

Adds `datadog.agent.checks.runs` to the built-in agent telemetry sent to the backend

### Motivation

Should help with debugging check-related issues, to see if the checks are running and if they are failing.

### Additional Notes

This removes the same metrics from "agent telemetry", to avoid duplication.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
