### PR TITLE
use a mock clock in dogstatsd unit tests

### DIFF
--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -30,6 +30,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/benbjohnson/clock"
 	"go.uber.org/atomic"
 )
 
@@ -184,6 +185,31 @@ type dsdServerDebug struct {
 	metricsCounts metricsCountBuckets
 	// keyGen is used to generate hashes of the metrics received by dogstatsd
 	keyGen *ckey.KeyGenerator
+
+	// clock is used to keep a consistent time state within the debug server whether
+	// we use a real clock in production code or a mock clock for unit testing
+	clock clock.Clock
+}
+
+// newDSDServerDebug creates a new instance of a dsdServerDebug
+func newDSDServerDebug() *dsdServerDebug {
+	return newDSDServerDebugWithClock(clock.New())
+}
+
+// newDSDServerDebugWithClock creates a new instance of a dsdServerDebug with a specific clock
+// It is used to create a dsdServerDebug with a real clock for production code and with a mock clock for testing code
+func newDSDServerDebugWithClock(clock clock.Clock) *dsdServerDebug {
+	return &dsdServerDebug{
+		Enabled: atomic.NewBool(false),
+		Stats:   make(map[ckey.ContextKey]metricStat),
+		metricsCounts: metricsCountBuckets{
+			counts:     [5]uint64{0, 0, 0, 0, 0},
+			metricChan: make(chan struct{}),
+			closeChan:  make(chan struct{}),
+		},
+		keyGen: ckey.NewKeyGenerator(),
+		clock:  clock,
+	}
 }
 
 // metricsCountBuckets is counting the amount of metrics received for the last 5 seconds.
@@ -202,7 +228,7 @@ func NewServer(demultiplexer aggregator.Demultiplexer, serverless bool) (*Server
 	once.Do(initLatencyTelemetry)
 
 	var stats *util.Stats
-	if config.Datadog.GetBool("dogstatsd_stats_enable") == true {
+	if config.Datadog.GetBool("dogstatsd_stats_enable") {
 		buff := config.Datadog.GetInt("dogstatsd_stats_buffer")
 		s, err := util.NewStats(uint32(buff))
 		if err != nil {
@@ -213,7 +239,7 @@ func NewServer(demultiplexer aggregator.Demultiplexer, serverless bool) (*Server
 	}
 
 	metricsStatsEnabled := false
-	if config.Datadog.GetBool("dogstatsd_metrics_stats_enable") == true {
+	if config.Datadog.GetBool("dogstatsd_metrics_stats_enable") {
 		log.Info("Dogstatsd: metrics statistics will be stored.")
 		metricsStatsEnabled = true
 	}
@@ -334,20 +360,11 @@ func NewServer(demultiplexer aggregator.Demultiplexer, serverless bool) (*Server
 		eolTerminationNamedPipe:   eolTerminationNamedPipe,
 		entityIDPrecedenceEnabled: entityIDPrecedenceEnabled,
 		disableVerboseLogs:        config.Datadog.GetBool("dogstatsd_disable_verbose_logs"),
-		Debug: &dsdServerDebug{
-			Enabled: atomic.NewBool(false),
-			Stats:   make(map[ckey.ContextKey]metricStat),
-			metricsCounts: metricsCountBuckets{
-				counts:     [5]uint64{0, 0, 0, 0, 0},
-				metricChan: make(chan struct{}),
-				closeChan:  make(chan struct{}),
-			},
-			keyGen: ckey.NewKeyGenerator(),
-		},
-		TCapture:           capture,
-		UdsListenerRunning: udsListenerRunning,
-		cachedTlmOriginIds: make(map[string]cachedTagsOriginMap),
-		ServerlessMode:     serverless,
+		Debug:                     newDSDServerDebug(),
+		TCapture:                  capture,
+		UdsListenerRunning:        udsListenerRunning,
+		cachedTlmOriginIds:        make(map[string]cachedTagsOriginMap),
+		ServerlessMode:            serverless,
 	}
 
 	// packets forwarding
@@ -718,7 +735,7 @@ func (s *Server) Stop() {
 //
 // It can help troubleshooting clients with bad behaviors.
 func (s *Server) storeMetricStats(sample metrics.MetricSample) {
-	now := time.Now()
+	now := s.Debug.clock.Now()
 	s.Debug.Lock()
 	defer s.Debug.Unlock()
 
@@ -755,21 +772,21 @@ func (s *Server) EnableMetricsStats() {
 
 	s.Debug.Enabled.Store(true)
 	go func() {
-		ticker := time.NewTicker(time.Millisecond * 100)
+		ticker := s.Debug.clock.Ticker(time.Millisecond * 100)
 		var closed bool
 		log.Debug("Starting the DogStatsD debug loop.")
 		for {
 			select {
 			case <-ticker.C:
-				sec := time.Now().Truncate(time.Second)
+				sec := s.Debug.clock.Now().Truncate(time.Second)
 				if sec.After(s.Debug.metricsCounts.currentSec) {
 					s.Debug.metricsCounts.currentSec = sec
-
 					if s.hasSpike() {
 						log.Warnf("A burst of metrics has been detected by DogStatSd: here is the last 5 seconds count of metrics: %v", s.Debug.metricsCounts.counts)
 					}
 
 					s.Debug.metricsCounts.bucketIdx++
+
 					if s.Debug.metricsCounts.bucketIdx >= len(s.Debug.metricsCounts.counts) {
 						s.Debug.metricsCounts.bucketIdx = 0
 					}
@@ -801,10 +818,8 @@ func (s *Server) hasSpike() bool {
 		sum += v
 	}
 	sum -= s.Debug.metricsCounts.counts[s.Debug.metricsCounts.bucketIdx]
-	if s.Debug.metricsCounts.counts[s.Debug.metricsCounts.bucketIdx] > sum {
-		return true
-	}
-	return false
+
+	return s.Debug.metricsCounts.counts[s.Debug.metricsCounts.bucketIdx] > sum
 }
 
 // DisableMetricsStats disables the debug mode of the DogStatsD server and

--- a/pkg/dogstatsd/server_test.go
+++ b/pkg/dogstatsd/server_test.go
@@ -640,7 +640,6 @@ func TestDebugStats(t *testing.T) {
 	// test ingestion and ingestion time
 	s.storeMetricStats(sample1)
 	s.storeMetricStats(sample2)
-	time.Sleep(10 * time.Millisecond)
 	s.storeMetricStats(sample1)
 
 	data, err := s.GetJSONDebugStats()
@@ -656,7 +655,6 @@ func TestDebugStats(t *testing.T) {
 	require.True(t, stats[hash1].LastSeen.After(stats[hash2].LastSeen), "some.metric1 should have appeared again after some.metric2")
 
 	s.storeMetricStats(sample3)
-	time.Sleep(10 * time.Millisecond)
 	s.storeMetricStats(sample1)
 
 	s.storeMetricStats(sample4)

--- a/pkg/dogstatsd/server_test.go
+++ b/pkg/dogstatsd/server_test.go
@@ -618,6 +618,8 @@ func TestDebugStats(t *testing.T) {
 	demux := mockDemultiplexer()
 	defer demux.Stop(false)
 	s, err := NewServer(demux, false)
+	clk := clock.NewMock()
+	s.Debug = newDSDServerDebugWithClock(clk)
 	require.NoError(t, err, "cannot start DSD")
 	defer s.Stop()
 
@@ -640,6 +642,7 @@ func TestDebugStats(t *testing.T) {
 	// test ingestion and ingestion time
 	s.storeMetricStats(sample1)
 	s.storeMetricStats(sample2)
+	clk.Add(10 * time.Millisecond)
 	s.storeMetricStats(sample1)
 
 	data, err := s.GetJSONDebugStats()
@@ -655,6 +658,7 @@ func TestDebugStats(t *testing.T) {
 	require.True(t, stats[hash1].LastSeen.After(stats[hash2].LastSeen), "some.metric1 should have appeared again after some.metric2")
 
 	s.storeMetricStats(sample3)
+	clk.Add(10 * time.Millisecond)
 	s.storeMetricStats(sample1)
 
 	s.storeMetricStats(sample4)

--- a/pkg/dogstatsd/server_test.go
+++ b/pkg/dogstatsd/server_test.go
@@ -592,12 +592,10 @@ func TestDebugStatsSpike(t *testing.T) {
 
 	// stop the debug loop to avoid data race
 	s.DisableMetricsStats()
-	time.Sleep(1 * time.Millisecond)
-
-	assert.True(s.hasSpike())
+	assert.Eventually(s.hasSpike, 10*time.Millisecond, 2*time.Millisecond)
 
 	s.EnableMetricsStats()
-	// This sleep is necessary as we need to wait for the goroutine function wihtin 'EnableMetricsStats' to start.
+	// This sleep is necessary as we need to wait for the goroutine function within 'EnableMetricsStats' to start.
 	// If we remove the sleep, the debug loop ticker will not be triggered by the clk.Add() call and the 500 samples
 	// added with 'send(500)' will be considered as if they had been added in the same second as the previous 500 samples.
 	// This will lead to a spike because we have 1000 samples in 1 second instead of having 500 and 500 in 2 different seconds.
@@ -608,10 +606,12 @@ func TestDebugStatsSpike(t *testing.T) {
 
 	// stop the debug loop to avoid data race
 	s.DisableMetricsStats()
-	time.Sleep(1 * time.Millisecond)
 
+	hasNoSpike := func() bool {
+		return !s.hasSpike()
+	}
 	// it is no more considered a spike because we had another second with 500 metrics
-	assert.False(s.hasSpike())
+	assert.Eventually(hasNoSpike, 10*time.Millisecond, 2*time.Millisecond)
 }
 
 func TestDebugStats(t *testing.T) {

--- a/pkg/dogstatsd/server_test.go
+++ b/pkg/dogstatsd/server_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -557,7 +558,11 @@ func TestDebugStatsSpike(t *testing.T) {
 	assert := assert.New(t)
 	demux := mockDemultiplexer()
 	defer demux.Stop(false)
+
 	s, err := NewServer(demux, false)
+	clk := clock.NewMock()
+	s.Debug = newDSDServerDebugWithClock(clk)
+
 	require.NoError(t, err, "cannot start DSD")
 	defer s.Stop()
 	require.NoError(t, err, "cannot start DSD")
@@ -572,27 +577,39 @@ func TestDebugStatsSpike(t *testing.T) {
 	}
 
 	send(10)
-	time.Sleep(1050 * time.Millisecond)
+
+	clk.Add(1050 * time.Millisecond)
 	send(10)
-	time.Sleep(1050 * time.Millisecond)
+
+	clk.Add(1050 * time.Millisecond)
 	send(10)
-	time.Sleep(1050 * time.Millisecond)
+
+	clk.Add(1050 * time.Millisecond)
 	send(10)
-	time.Sleep(1050 * time.Millisecond)
+
+	clk.Add(1050 * time.Millisecond)
 	send(500)
 
 	// stop the debug loop to avoid data race
 	s.DisableMetricsStats()
-	time.Sleep(500 * time.Millisecond)
+	time.Sleep(1 * time.Millisecond)
+
 	assert.True(s.hasSpike())
 
 	s.EnableMetricsStats()
-	time.Sleep(1050 * time.Millisecond)
+	// This sleep is necessary as we need to wait for the goroutine function wihtin 'EnableMetricsStats' to start.
+	// If we remove the sleep, the debug loop ticker will not be triggered by the clk.Add() call and the 500 samples
+	// added with 'send(500)' will be considered as if they had been added in the same second as the previous 500 samples.
+	// This will lead to a spike because we have 1000 samples in 1 second instead of having 500 and 500 in 2 different seconds.
+	time.Sleep(1 * time.Millisecond)
+
+	clk.Add(1050 * time.Millisecond)
 	send(500)
 
 	// stop the debug loop to avoid data race
 	s.DisableMetricsStats()
-	time.Sleep(500 * time.Millisecond)
+	time.Sleep(1 * time.Millisecond)
+
 	// it is no more considered a spike because we had another second with 500 metrics
 	assert.False(s.hasSpike())
 }


### PR DESCRIPTION

### What does this PR do?

This PR replaces several `time.Sleep()` in DogStatsD unit tests by a mock clock.

### Motivation

Running 'time dependent' tests faster  

### Additional Notes

There are still some `time.Sleep` remaining in the unit tests but I don't think they can be mock as they are used to wait for runtime (async, I/O, ...)

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

- Run the DogStatsD unit tests
- Set the `dogstatsd_metrics_stats_enabled` option to `true` and verify that the `datadog-agent dogstatsd-stats` command outputs stats


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
