### PR TITLE
Use go.uber.org/atomic in cmd/system-probe

### DIFF
--- a/cmd/system-probe/modules/network_tracer.go
+++ b/cmd/system-probe/modules/network_tracer.go
@@ -17,7 +17,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
@@ -29,6 +28,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/http/debugging"
 	"github.com/DataDog/datadog-agent/pkg/network/tracer"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"go.uber.org/atomic"
 )
 
 // ErrSysprobeUnsupported is the unsupported error prefix, for error-class matching from callers
@@ -70,7 +70,7 @@ func (nt *networkTracer) GetStats() map[string]interface{} {
 
 // Register all networkTracer endpoints
 func (nt *networkTracer) Register(httpMux *module.Router) error {
-	var runCounter uint64
+	var runCounter = atomic.NewUint64(0)
 
 	httpMux.HandleFunc("/connections", utils.WithConcurrencyLimit(utils.DefaultMaxConcurrentRequests, func(w http.ResponseWriter, req *http.Request) {
 		start := time.Now()
@@ -88,7 +88,7 @@ func (nt *networkTracer) Register(httpMux *module.Router) error {
 		if nt.restartTimer != nil {
 			nt.restartTimer.Reset(inactivityRestartDuration)
 		}
-		count := atomic.AddUint64(&runCounter, 1)
+		count := runCounter.Inc()
 		logRequests(id, count, len(cs.Conns), start)
 	}))
 
@@ -187,7 +187,7 @@ func (nt *networkTracer) Register(httpMux *module.Router) error {
 	// Convenience logging if nothing has made any requests to the system-probe in some time, let's log something.
 	// This should be helpful for customers + support to debug the underlying issue.
 	time.AfterFunc(inactivityLogDuration, func() {
-		if run := atomic.LoadUint64(&runCounter); run == 0 {
+		if runCounter.Load() == 0 {
 			log.Warnf("%v since the agent started without activity, the process-agent may not be configured correctly and/or running", inactivityLogDuration)
 		}
 	})

--- a/cmd/system-probe/modules/oom_kill_probe.go
+++ b/cmd/system-probe/modules/oom_kill_probe.go
@@ -11,7 +11,6 @@ package modules
 import (
 	"fmt"
 	"net/http"
-	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
@@ -20,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/probe"
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"go.uber.org/atomic"
 )
 
 // OOMKillProbe Factory
@@ -36,16 +36,18 @@ var OOMKillProbe = module.Factory{
 	},
 }
 
-var _ module.Module = &oomKillModule{}
+var _ module.Module = &oomKillModule{
+	lastCheck: atomic.NewInt64(0),
+}
 
 type oomKillModule struct {
 	*probe.OOMKillProbe
-	lastCheck int64
+	lastCheck *atomic.Int64
 }
 
 func (o *oomKillModule) Register(httpMux *module.Router) error {
 	httpMux.HandleFunc("/check", utils.WithConcurrencyLimit(utils.DefaultMaxConcurrentRequests, func(w http.ResponseWriter, req *http.Request) {
-		atomic.StoreInt64(&o.lastCheck, time.Now().Unix())
+		o.lastCheck.Store(time.Now().Unix())
 		stats := o.OOMKillProbe.GetAndFlush()
 		utils.WriteAsJSON(w, stats)
 	}))
@@ -55,6 +57,6 @@ func (o *oomKillModule) Register(httpMux *module.Router) error {
 
 func (o *oomKillModule) GetStats() map[string]interface{} {
 	return map[string]interface{}{
-		"last_check": atomic.LoadInt64(&o.lastCheck),
+		"last_check": o.lastCheck.Load(),
 	}
 }

--- a/cmd/system-probe/modules/oom_kill_probe.go
+++ b/cmd/system-probe/modules/oom_kill_probe.go
@@ -32,13 +32,14 @@ var OOMKillProbe = module.Factory{
 		if err != nil {
 			return nil, fmt.Errorf("unable to start the OOM kill probe: %w", err)
 		}
-		return &oomKillModule{OOMKillProbe: okp}, nil
+		return &oomKillModule{
+			OOMKillProbe: okp,
+			lastCheck:    atomic.NewInt64(0),
+		}, nil
 	},
 }
 
-var _ module.Module = &oomKillModule{
-	lastCheck: atomic.NewInt64(0),
-}
+var _ module.Module = &oomKillModule{}
 
 type oomKillModule struct {
 	*probe.OOMKillProbe

--- a/cmd/system-probe/modules/process.go
+++ b/cmd/system-probe/modules/process.go
@@ -14,7 +14,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
@@ -24,6 +23,7 @@ import (
 	reqEncoding "github.com/DataDog/datadog-agent/pkg/process/encoding/request"
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"go.uber.org/atomic"
 )
 
 // ErrProcessUnsupported is an error type indicating that the process module is not support in the running environment
@@ -42,26 +42,28 @@ var Process = module.Factory{
 	},
 }
 
-var _ module.Module = &process{}
+var _ module.Module = &process{
+	lastCheck: atomic.NewInt64(0),
+}
 
 type process struct {
 	probe     procutil.Probe
-	lastCheck int64
+	lastCheck *atomic.Int64
 }
 
 // GetStats returns stats for the module
 func (t *process) GetStats() map[string]interface{} {
 	return map[string]interface{}{
-		"last_check": atomic.LoadInt64(&t.lastCheck),
+		"last_check": t.lastCheck.Load(),
 	}
 }
 
 // Register registers endpoints for the module to expose data
 func (t *process) Register(httpMux *module.Router) error {
-	var runCounter uint64
+	runCounter := atomic.NewUint64(0)
 	httpMux.HandleFunc("/stats", func(w http.ResponseWriter, req *http.Request) {
 		start := time.Now()
-		atomic.StoreInt64(&t.lastCheck, start.Unix())
+		t.lastCheck.Store(start.Unix())
 		pids, err := getPids(req)
 		if err != nil {
 			log.Errorf("Unable to get PIDs from request: %s", err)
@@ -79,7 +81,7 @@ func (t *process) Register(httpMux *module.Router) error {
 		marshaler := encoding.GetMarshaler(contentType)
 		writeStats(w, marshaler, stats)
 
-		count := atomic.AddUint64(&runCounter, 1)
+		count := runCounter.Inc()
 		logProcTracerRequests(count, len(stats), start)
 	}).Methods("POST")
 

--- a/cmd/system-probe/modules/process.go
+++ b/cmd/system-probe/modules/process.go
@@ -38,13 +38,14 @@ var Process = module.Factory{
 
 		// we disable returning zero values for stats to reduce parsing work on process-agent side
 		p := procutil.NewProcessProbe(procutil.WithReturnZeroPermStats(false))
-		return &process{probe: p}, nil
+		return &process{
+			probe:     p,
+			lastCheck: atomic.NewInt64(0),
+		}, nil
 	},
 }
 
-var _ module.Module = &process{
-	lastCheck: atomic.NewInt64(0),
-}
+var _ module.Module = &process{}
 
 type process struct {
 	probe     procutil.Probe

--- a/cmd/system-probe/modules/tcp_queue_tracer.go
+++ b/cmd/system-probe/modules/tcp_queue_tracer.go
@@ -31,13 +31,14 @@ var TCPQueueLength = module.Factory{
 			return nil, fmt.Errorf("unable to start the TCP queue length tracer: %w", err)
 		}
 
-		return &tcpQueueLengthModule{TCPQueueLengthTracer: t}, nil
+		return &tcpQueueLengthModule{
+			TCPQueueLengthTracer: t,
+			lastCheck:            atomic.NewInt64(0),
+		}, nil
 	},
 }
 
-var _ module.Module = &tcpQueueLengthModule{
-	lastCheck: atomic.NewInt64(0),
-}
+var _ module.Module = &tcpQueueLengthModule{}
 
 type tcpQueueLengthModule struct {
 	*probe.TCPQueueLengthTracer


### PR DESCRIPTION
### What does this PR do?

Uses go.uber.com/atomic to ensure alignment of atomic access in cmd/system-probe.

### Motivation

Alignment issues with atomic access.  See #11716.  The uses of atomic were very simple in these modules, and did not have bugs -- but the intent is to eliminate use of `sync/atomic` so that the module's bugs don't tempt us.

### Additional Notes

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Any basic system-probe QA should detect issues here.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
