### PR TITLE
Return empty stats maps when features are disabled

### DIFF
--- a/pkg/network/http/monitor.go
+++ b/pkg/network/http/monitor.go
@@ -187,18 +187,19 @@ func (m *Monitor) GetHTTPStats() map[Key]*RequestStats {
 }
 
 func (m *Monitor) GetStats() map[string]interface{} {
+	empty := map[string]interface{}{}
 	if m == nil {
-		return nil
+		return empty
 	}
 
 	m.mux.Lock()
 	defer m.mux.Unlock()
 	if m.stopped {
-		return nil
+		return empty
 	}
 
 	if m.telemetrySnapshot == nil {
-		return nil
+		return empty
 	}
 
 	return m.telemetrySnapshot.report()

--- a/pkg/network/tracer/gateway_lookup.go
+++ b/pkg/network/tracer/gateway_lookup.go
@@ -174,6 +174,10 @@ func (g *gatewayLookup) Lookup(cs *network.ConnectionStats) *network.Via {
 }
 
 func (g *gatewayLookup) GetStats() map[string]interface{} {
+	if g == nil {
+		return make(map[string]interface{})
+	}
+
 	report := g.statsReporter.Report()
 	report["route_cache"] = g.routeCache.GetStats()
 	return report

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -605,9 +605,7 @@ func (t *Tracer) getStats(comps ...statsComp) (map[string]interface{}, error) {
 		case epbfStats:
 			ret["ebpf"] = t.ebpfTracer.GetTelemetry()
 		case gatewayLookupStats:
-			if t.gwLookup != nil {
-				ret["gateway_lookup"] = t.gwLookup.GetStats()
-			}
+			ret["gateway_lookup"] = t.gwLookup.GetStats()
 		case httpStats:
 			ret["http"] = t.httpMonitor.GetStats()
 		case kprobesStats:


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This is to suppress logs from the agent about missing expvars when features like http are not enabled.

### Motivation
Excessive logs from the agent

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
