### PR TITLE
Add invoke command for generating kitchen config for system-probe tests

### DIFF
--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -10,7 +10,7 @@ import tempfile
 from subprocess import check_output
 
 from invoke import task
-from invoke.exceptions import Exit
+from invoke.exceptions import Exit, UnexpectedExit
 
 from .build_tags import get_default_build_tags
 from .utils import REPO_PATH, bin_name, get_build_flags, get_version_numeric_only
@@ -230,6 +230,11 @@ def kitchen_prepare(ctx, windows=is_windows):
             if os.path.isdir(extra_path):
                 shutil.copytree(extra_path, os.path.join(target_path, extra))
 
+    if os.path.exists(f"/opt/datadog-agent/embedded/bin/clang-bpf"):
+        shutil.copy(f"/opt/datadog-agent/embedded/bin/clang-bpf", os.path.join(KITCHEN_ARTIFACT_DIR, ".."))
+    if os.path.exists(f"/opt/datadog-agent/embedded/bin/llc-bpf"):
+        shutil.copy(f"/opt/datadog-agent/embedded/bin/llc-bpf", os.path.join(KITCHEN_ARTIFACT_DIR, ".."))
+
 
 @task
 def kitchen_test(ctx, target=None, provider="virtualbox"):
@@ -268,6 +273,44 @@ def kitchen_test(ctx, target=None, provider="virtualbox"):
             env={"KITCHEN_VAGRANT_PROVIDER": provider},
         )
         ctx.run("kitchen test")
+
+
+@task
+def kitchen_genconfig(ctx, ssh_key, platform, osversions=[], image_size=None, provider="azure", arch=CURRENT_ARCH):
+    if arch == "x64":
+        arch = "x86_64"
+    elif arch == "arm64":
+        arch = "arm64"
+    else:
+        raise Exit(f"Unsupported vagrant arch for {arch}", code=1)
+
+    if not image_size and provider == "azure":
+        image_size = "Standard_D2_v2"
+
+    if not image_size:
+        raise UnexpectedExit("Image size must be specified")
+
+    sub_id = ""
+    if provider == "azure":
+        # "compute sandbox" subscription
+        res = ctx.run("az login", hide="out")
+        subs = json.loads(res.stdout)
+        for s in subs:
+            if s["name"] == "compute sandbox":
+                sub_id = s["id"]
+                break
+
+    env={
+        "KITCHEN_RSA_SSH_KEY_PATH": ssh_key,
+    }
+    if sub_id:
+        env["AZURE_SUBSCRIPTION_ID"] = sub_id
+
+    with ctx.cd(KITCHEN_DIR):
+        ctx.run(
+            f"inv -e kitchen.genconfig --platform={platform} --osversions={','.join(osversions)} --provider={provider} --arch={arch} --imagesize={image_size} --testfiles=system-probe-test --platformfile=platforms.json",
+            env=env,
+        )
 
 
 @task

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -276,7 +276,9 @@ def kitchen_test(ctx, target=None, provider="virtualbox"):
 
 
 @task
-def kitchen_genconfig(ctx, ssh_key, platform, osversions=[], image_size=None, provider="azure", arch=None, azure_sub_id=None):
+def kitchen_genconfig(
+    ctx, ssh_key, platform, osversions, image_size=None, provider="azure", arch=None, azure_sub_id=None
+):
     if not arch:
         arch = CURRENT_ARCH
 
@@ -285,7 +287,7 @@ def kitchen_genconfig(ctx, ssh_key, platform, osversions=[], image_size=None, pr
     elif arch == "arm64":
         arch = "arm64"
     else:
-        raise UnexpectedExit("arch must be specified")
+        raise UnexpectedExit("unsupported arch specified")
 
     if not image_size and provider == "azure":
         image_size = "Standard_D2_v2"
@@ -296,7 +298,7 @@ def kitchen_genconfig(ctx, ssh_key, platform, osversions=[], image_size=None, pr
     if azure_sub_id is None and provider == "azure":
         raise Exit("azure subscription id must be specified with --azure-sub-id")
 
-    env={
+    env = {
         "KITCHEN_RSA_SSH_KEY_PATH": ssh_key,
     }
     if azure_sub_id:
@@ -304,7 +306,7 @@ def kitchen_genconfig(ctx, ssh_key, platform, osversions=[], image_size=None, pr
 
     with ctx.cd(KITCHEN_DIR):
         ctx.run(
-            f"inv -e kitchen.genconfig --platform={platform} --osversions={','.join(osversions)} --provider={provider} --arch={arch} --imagesize={image_size} --testfiles=system-probe-test --platformfile=platforms.json",
+            f"inv -e kitchen.genconfig --platform={platform} --osversions={osversions} --provider={provider} --arch={arch} --imagesize={image_size} --testfiles=system-probe-test --platformfile=platforms.json",
             env=env,
         )
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Adds a `inv` command to generate kitchen config for running system-probe tests on azure.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
