### PR TITLE
[CWS] Add functional tests for activity dumps

### DIFF
--- a/pkg/security/probe/activity_dump.go
+++ b/pkg/security/probe/activity_dump.go
@@ -481,6 +481,17 @@ func (ad *ActivityDump) findOrCreateProcessActivityNode(entry *model.ProcessCach
 	return node
 }
 
+// FindFirstMatchingNode return the first matching node of requested comm
+func (ad *ActivityDump) FindFirstMatchingNode(comm string) *ProcessActivityNode {
+	for _, node := range ad.ProcessActivityTree {
+		if node.Process.Comm == comm {
+			return node
+		}
+	}
+
+	return nil
+}
+
 // GetSelectorStr returns a string representation of the profile selector
 func (ad *ActivityDump) GetSelectorStr() string {
 	var tags []string

--- a/pkg/security/probe/probe_monitor.go
+++ b/pkg/security/probe/probe_monitor.go
@@ -86,6 +86,11 @@ func (m *Monitor) GetPerfBufferMonitor() *PerfBufferMonitor {
 	return m.perfBufferMonitor
 }
 
+// GetActivityDumpManager returns the activity dump manager
+func (m *Monitor) GetActivityDumpManager() *ActivityDumpManager {
+	return m.activityDumpManager
+}
+
 // Start triggers the goroutine of all the underlying controllers and monitors of the Monitor
 func (m *Monitor) Start(ctx context.Context, wg *sync.WaitGroup) error {
 	delta := 1

--- a/pkg/security/tests/activity_dumps_test.go
+++ b/pkg/security/tests/activity_dumps_test.go
@@ -1,0 +1,184 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build functionaltests
+// +build functionaltests
+
+package tests
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
+)
+
+func TestActivityDumps(t *testing.T) {
+	ruleDefs := []*rules.RuleDefinition{
+		{
+			ID:         "activating_network_probe",
+			Expression: `bind.addr.family == AF_INET && bind.addr.port == 1`,
+		},
+	}
+
+	test, err := newTestModule(t, nil, ruleDefs, testOpts{enableActivityDump: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+	syscallTester, err := loadSyscallTester(t, test, "syscall_tester")
+	if err != nil {
+		t.Fatal(err)
+	}
+	outputDir, _, err := test.Path("test-activity-dump")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(outputDir)
+
+	test.Run(t, "activity-dump-comm-bind", func(t *testing.T, kind wrapperType,
+		cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+
+		outputFiles, err := test.StartActivityDumpComm(t, "syscall_tester", outputDir, []string{"json", "msgp"})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		args := []string{"bind", "AF_INET", "any", "tcp"}
+		envs := []string{}
+		cmd := cmdFunc(syscallTester, args, envs)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatal(fmt.Errorf("%s: %w", out, err))
+		}
+
+		time.Sleep(1 * time.Second) // a quick sleep to let events to be added to the dump
+
+		err = test.StopActivityDumpComm(t, "syscall_tester")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		jsonOK := false
+		msgpOK := false
+		for _, f := range outputFiles {
+			ext := filepath.Ext(f)
+			switch ext {
+			case ".json":
+				if jsonOK == true {
+					t.Fatal("Got more than one JSON file:", outputFiles)
+				}
+				content, err := os.ReadFile(f)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !validateActivityDumpSchema(t, string(content)) {
+					t.Fatal(string(content))
+				}
+				jsonOK = true
+
+			case ".msgp":
+				if msgpOK == true {
+					t.Fatal("Got more than one MSGP file:", outputFiles)
+				}
+				ad, err := test.DecodeMSPActivityDump(t, f)
+				if err != nil {
+					t.Fatal(err)
+				}
+				node := ad.FindFirstMatchingNode("syscall_tester")
+				if node == nil {
+					t.Fatal("Node not found on activity dump")
+				}
+				for _, s := range node.Sockets {
+					if s.Family == "AF_INET" && s.Bind.Port == 4242 && s.Bind.IP == "0.0.0.0" {
+						msgpOK = true
+						break
+					}
+				}
+				if msgpOK == false {
+					t.Fatal("Bound socket not found on activity dump")
+				}
+
+			default:
+				t.Fatal("Unexpected output file")
+			}
+
+		}
+		if jsonOK == false || msgpOK == false {
+			t.Fatal("Some files are missing, got:", outputFiles)
+		}
+	})
+
+	test.Run(t, "activity-dump-comm-dns", func(t *testing.T, kind wrapperType,
+		cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+
+		outputFiles, err := test.StartActivityDumpComm(t, "testsuite", outputDir, []string{"json", "msgp"})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		net.LookupIP("foo.bar")
+
+		time.Sleep(1 * time.Second) // a quick sleep to let events to be added to the dump
+
+		err = test.StopActivityDumpComm(t, "testsuite")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		jsonOK := false
+		msgpOK := false
+		for _, f := range outputFiles {
+			ext := filepath.Ext(f)
+			switch ext {
+			case ".json":
+				if jsonOK == true {
+					t.Fatal("Got more than one JSON file:", outputFiles)
+				}
+				content, err := os.ReadFile(f)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !validateActivityDumpSchema(t, string(content)) {
+					t.Fatal(string(content))
+				}
+				jsonOK = true
+
+			case ".msgp":
+				if msgpOK == true {
+					t.Fatal("Got more than one MSGP file:", outputFiles)
+				}
+				ad, err := test.DecodeMSPActivityDump(t, f)
+				if err != nil {
+					t.Fatal(err)
+				}
+				node := ad.FindFirstMatchingNode("testsuite")
+				if node == nil {
+					t.Fatal("Node not found on activity dump")
+				}
+				for name := range node.DNSNames {
+					if name == "foo.bar" {
+						msgpOK = true
+						break
+					}
+				}
+				if msgpOK == false {
+					t.Fatal("DNS request not found on activity dump")
+				}
+
+			default:
+				t.Fatal("Unexpected output file")
+			}
+
+		}
+		if jsonOK == false || msgpOK == false {
+			t.Fatal("Some files are missing, got:", outputFiles)
+		}
+	})
+}

--- a/pkg/security/tests/activity_dumps_test.go
+++ b/pkg/security/tests/activity_dumps_test.go
@@ -79,7 +79,7 @@ func TestActivityDumps(t *testing.T) {
 					t.Fatal(err)
 				}
 				if !validateActivityDumpSchema(t, string(content)) {
-					t.Fatal(string(content))
+					t.Error(string(content))
 				}
 				jsonOK = true
 
@@ -102,7 +102,7 @@ func TestActivityDumps(t *testing.T) {
 					}
 				}
 				if msgpOK == false {
-					t.Fatal("Bound socket not found on activity dump")
+					t.Error("Bound socket not found on activity dump")
 				}
 
 			default:
@@ -146,7 +146,7 @@ func TestActivityDumps(t *testing.T) {
 					t.Fatal(err)
 				}
 				if !validateActivityDumpSchema(t, string(content)) {
-					t.Fatal(string(content))
+					t.Error(string(content))
 				}
 				jsonOK = true
 
@@ -169,7 +169,7 @@ func TestActivityDumps(t *testing.T) {
 					}
 				}
 				if msgpOK == false {
-					t.Fatal("DNS request not found on activity dump")
+					t.Error("DNS request not found on activity dump")
 				}
 
 			default:

--- a/pkg/security/tests/activity_dumps_test.go
+++ b/pkg/security/tests/activity_dumps_test.go
@@ -21,14 +21,7 @@ import (
 )
 
 func TestActivityDumps(t *testing.T) {
-	ruleDefs := []*rules.RuleDefinition{
-		{
-			ID:         "activating_network_probe",
-			Expression: `bind.addr.family == AF_INET && bind.addr.port == 1`,
-		},
-	}
-
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{enableActivityDump: true})
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{}, testOpts{enableActivityDump: true})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/schemas.go
+++ b/pkg/security/tests/schemas.go
@@ -49,14 +49,12 @@ func (v ValidInodeFormatChecker) IsFormat(input interface{}) bool {
 }
 
 //nolint:deadcode,unused
-func validateSchema(t *testing.T, event *sprobe.Event, path string) bool {
+func validateSchema(t *testing.T, json string, path string) bool {
 	fs := http.FS(schemaAssetFS)
 
 	gojsonschema.FormatCheckers.Add("ValidInode", ValidInodeFormatChecker{})
 
-	serialized := event.String()
-
-	documentLoader := gojsonschema.NewStringLoader(serialized)
+	documentLoader := gojsonschema.NewStringLoader(json)
 	schemaLoader := gojsonschema.NewReferenceLoaderFileSystem(path, fs)
 
 	result, err := gojsonschema.Validate(schemaLoader, documentLoader)
@@ -76,96 +74,111 @@ func validateSchema(t *testing.T, event *sprobe.Event, path string) bool {
 }
 
 //nolint:deadcode,unused
+func validateEventSchema(t *testing.T, event *sprobe.Event, path string) bool {
+	return validateSchema(t, event.String(), path)
+}
+
+//nolint:deadcode,unused
+func validateStringSchema(t *testing.T, ad string, path string) bool {
+	return validateSchema(t, ad, path)
+}
+
+//nolint:deadcode,unused
 func validateExecSchema(t *testing.T, event *sprobe.Event) bool {
-	return validateSchema(t, event, "file:///schemas/exec.schema.json")
+	return validateEventSchema(t, event, "file:///schemas/exec.schema.json")
 }
 
 //nolint:deadcode,unused
 func validateOpenSchema(t *testing.T, event *sprobe.Event) bool {
-	return validateSchema(t, event, "file:///schemas/open.schema.json")
+	return validateEventSchema(t, event, "file:///schemas/open.schema.json")
 }
 
 //nolint:deadcode,unused
 func validateRenameSchema(t *testing.T, event *sprobe.Event) bool {
-	return validateSchema(t, event, "file:///schemas/rename.schema.json")
+	return validateEventSchema(t, event, "file:///schemas/rename.schema.json")
 }
 
 //nolint:deadcode,unused
 func validateChmodSchema(t *testing.T, event *sprobe.Event) bool {
-	return validateSchema(t, event, "file:///schemas/chmod.schema.json")
+	return validateEventSchema(t, event, "file:///schemas/chmod.schema.json")
 }
 
 //nolint:deadcode,unused
 func validateChownSchema(t *testing.T, event *sprobe.Event) bool {
-	return validateSchema(t, event, "file:///schemas/chown.schema.json")
+	return validateEventSchema(t, event, "file:///schemas/chown.schema.json")
 }
 
 //nolint:deadcode,unused
 func validateSELinuxSchema(t *testing.T, event *sprobe.Event) bool {
-	return validateSchema(t, event, "file:///schemas/selinux.schema.json")
+	return validateEventSchema(t, event, "file:///schemas/selinux.schema.json")
 }
 
 //nolint:deadcode,unused
 func validateLinkSchema(t *testing.T, event *sprobe.Event) bool {
-	return validateSchema(t, event, "file:///schemas/link.schema.json")
+	return validateEventSchema(t, event, "file:///schemas/link.schema.json")
 }
 
 //nolint:deadcode,unused
 func validateSpanSchema(t *testing.T, event *sprobe.Event) bool {
-	return validateSchema(t, event, "file:///schemas/span.schema.json")
+	return validateEventSchema(t, event, "file:///schemas/span.schema.json")
 }
 
 //nolint:deadcode,unused
 func validateBPFSchema(t *testing.T, event *sprobe.Event) bool {
-	return validateSchema(t, event, "file:///schemas/bpf.schema.json")
+	return validateEventSchema(t, event, "file:///schemas/bpf.schema.json")
 }
 
 //nolint:deadcode,unused
 func validateMMapSchema(t *testing.T, event *sprobe.Event) bool {
-	return validateSchema(t, event, "file:///schemas/mmap.schema.json")
+	return validateEventSchema(t, event, "file:///schemas/mmap.schema.json")
 }
 
 //nolint:deadcode,unused
 func validateMProtectSchema(t *testing.T, event *sprobe.Event) bool {
-	return validateSchema(t, event, "file:///schemas/mprotect.schema.json")
+	return validateEventSchema(t, event, "file:///schemas/mprotect.schema.json")
 }
 
 //nolint:deadcode,unused
 func validatePTraceSchema(t *testing.T, event *sprobe.Event) bool {
-	return validateSchema(t, event, "file:///schemas/ptrace.schema.json")
+	return validateEventSchema(t, event, "file:///schemas/ptrace.schema.json")
 }
 
 //nolint:deadcode,unused
 func validateLoadModuleSchema(t *testing.T, event *sprobe.Event) bool {
-	return validateSchema(t, event, "file:///schemas/load_module.schema.json")
+	return validateEventSchema(t, event, "file:///schemas/load_module.schema.json")
 }
 
 //nolint:deadcode,unused
 func validateLoadModuleNoFileSchema(t *testing.T, event *sprobe.Event) bool {
-	return validateSchema(t, event, "file:///schemas/load_module_no_file.schema.json")
+	return validateEventSchema(t, event, "file:///schemas/load_module_no_file.schema.json")
 }
 
 //nolint:deadcode,unused
 func validateUnloadModuleSchema(t *testing.T, event *sprobe.Event) bool {
-	return validateSchema(t, event, "file:///schemas/unload_module.schema.json")
+	return validateEventSchema(t, event, "file:///schemas/unload_module.schema.json")
 }
 
 //nolint:deadcode,unused
 func validateSignalSchema(t *testing.T, event *sprobe.Event) bool {
-	return validateSchema(t, event, "file:///schemas/signal.schema.json")
+	return validateEventSchema(t, event, "file:///schemas/signal.schema.json")
 }
 
 //nolint:deadcode,unused
 func validateSpliceSchema(t *testing.T, event *sprobe.Event) bool {
-	return validateSchema(t, event, "file:///schemas/splice.schema.json")
+	return validateEventSchema(t, event, "file:///schemas/splice.schema.json")
 }
 
 //nolint:deadcode,unused
 func validateDNSSchema(t *testing.T, event *sprobe.Event) bool {
-	return validateSchema(t, event, "file:///schemas/dns.schema.json")
+	return validateEventSchema(t, event, "file:///schemas/dns.schema.json")
 }
 
 //nolint:deadcode,unused
 func validateBindSchema(t *testing.T, event *sprobe.Event) bool {
-	return validateSchema(t, event, "file:///schemas/bind.schema.json")
+	return validateEventSchema(t, event, "file:///schemas/bind.schema.json")
+}
+
+//nolint:deadcode,unused
+func validateActivityDumpSchema(t *testing.T, ad string) bool {
+	return validateStringSchema(t, ad, "file:///schemas/activity_dump.schema.json")
 }

--- a/pkg/security/tests/schemas/activity_dump.schema.json
+++ b/pkg/security/tests/schemas/activity_dump.schema.json
@@ -231,7 +231,47 @@
                         "type": "object"
                     },
                     "dns": {
-                        "type": "object"
+                        "type": "object",
+                        "patternProperties": {
+                            ".*": {
+                                "type": "object",
+                                "properties": {
+                                    "requests": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string"
+                                                },
+                                                "type": {
+                                                    "type": "integer"
+                                                },
+                                                "class": {
+                                                    "type": "integer"
+                                                },
+                                                "size": {
+                                                    "type": "integer"
+                                                },
+                                                "count": {
+                                                    "type": "integer"
+                                                }
+                                            },
+                                            "required": [
+                                                "name",
+                                                "type",
+                                                "class",
+                                                "size",
+                                                "count"
+                                            ]
+                                        }
+                                    }
+                                },
+                                "required": [
+                                    "requests"
+                                ]
+                            }
+                        }
                     },
                     "sockets": {
                         "type": "array",

--- a/pkg/security/tests/schemas/activity_dump.schema.json
+++ b/pkg/security/tests/schemas/activity_dump.schema.json
@@ -214,11 +214,9 @@
                         "required": [
                             "PIDContext",
                             "argv0",
-                            "argv_truncated",
                             "comm",
                             "cookie",
                             "credentials",
-                            "envs_truncated",
                             "exec_time",
                             "exit_time",
                             "file",

--- a/pkg/security/tests/schemas/activity_dump.schema.json
+++ b/pkg/security/tests/schemas/activity_dump.schema.json
@@ -1,0 +1,335 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "host": {
+            "type": "string"
+        },
+        "source": {
+            "type": "string"
+        },
+        "tags": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "tree": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "process": {
+                        "type": "object",
+                        "properties": {
+                            "PIDContext": {
+                                "type": "object",
+                                "properties": {
+                                    "pid": {
+                                        "type": "integer"
+                                    },
+                                    "tid": {
+                                        "type": "integer"
+                                    }
+                                },
+                                "required": [
+                                    "pid",
+                                    "tid"
+                                ]
+                            },
+                            "file": {
+                                "type": "object",
+                                "properties": {
+                                    "FileFields": {
+                                        "type": "object",
+                                        "properties": {
+                                            "uid": {
+                                                "type": "integer"
+                                            },
+                                            "user": {
+                                                "type": "string"
+                                            },
+                                            "gid": {
+                                                "type": "integer"
+                                            },
+                                            "group": {
+                                                "type": "string"
+                                            },
+                                            "mode": {
+                                                "type": "integer"
+                                            },
+                                            "ctime": {
+                                                "type": "integer"
+                                            },
+                                            "mtime": {
+                                                "type": "integer"
+                                            },
+                                            "mount_id": {
+                                                "type": "integer"
+                                            },
+                                            "inode": {
+                                                "type": "integer"
+                                            },
+                                            "in_upper_layer": {
+                                                "type": "boolean"
+                                            }
+                                        },
+                                        "required": [
+                                            "ctime",
+                                            "gid",
+                                            "in_upper_layer",
+                                            "inode",
+                                            "mode",
+                                            "mount_id",
+                                            "mtime",
+                                            "uid"
+                                        ]
+                                    },
+                                    "path": {
+                                        "type": "string"
+                                    },
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "filesystem": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "FileFields",
+                                    "filesystem",
+                                    "name",
+                                    "path"
+                                ]
+                            },
+                            "container_id": {
+                                "type": "string"
+                            },
+                            "comm": {
+                                "type": "string"
+                            },
+                            "fork_time": {
+                                "type": "string"
+                            },
+                            "exit_time": {
+                                "type": "string"
+                            },
+                            "exec_time": {
+                                "type": "string"
+                            },
+                            "cookie": {
+                                "type": "integer"
+                            },
+                            "ppid": {
+                                "type": "integer"
+                            },
+                            "credentials": {
+                                "type": "object",
+                                "properties": {
+                                    "uid": {
+                                        "type": "integer"
+                                    },
+                                    "gid": {
+                                        "type": "integer"
+                                    },
+                                    "user": {
+                                        "type": "string"
+                                    },
+                                    "group": {
+                                        "type": "string"
+                                    },
+                                    "euid": {
+                                        "type": "integer"
+                                    },
+                                    "egid": {
+                                        "type": "integer"
+                                    },
+                                    "euser": {
+                                        "type": "string"
+                                    },
+                                    "egroup": {
+                                        "type": "string"
+                                    },
+                                    "fsuid": {
+                                        "type": "integer"
+                                    },
+                                    "fsgid": {
+                                        "type": "integer"
+                                    },
+                                    "fsuser": {
+                                        "type": "string"
+                                    },
+                                    "fsgroup": {
+                                        "type": "string"
+                                    },
+                                    "cap_effective": {
+                                        "type": "integer"
+                                    },
+                                    "cap_permitted": {
+                                        "type": "integer"
+                                    }
+                                },
+                                "required": [
+                                    "cap_effective",
+                                    "cap_permitted",
+                                    "egid",
+                                    "egroup",
+                                    "euid",
+                                    "euser",
+                                    "fsgid",
+                                    "fsgroup",
+                                    "fsuid",
+                                    "fsuser",
+                                    "gid",
+                                    "group",
+                                    "uid",
+                                    "user"
+                                ]
+                            },
+                            "argv0": {
+                                "type": "string"
+                            },
+                            "envs": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "envs_truncated": {
+                                "type": "boolean"
+                            },
+                            "argv": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "argv_truncated": {
+                                "type": "boolean"
+                            },
+                            "tty": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "PIDContext",
+                            "argv0",
+                            "argv_truncated",
+                            "comm",
+                            "cookie",
+                            "credentials",
+                            "envs_truncated",
+                            "exec_time",
+                            "exit_time",
+                            "file",
+                            "fork_time",
+                            "ppid"
+                        ]
+                    },
+                    "generation_type": {
+                        "type": "string"
+                    },
+                    "files": {
+                        "type": "object"
+                    },
+                    "dns": {
+                        "type": "object"
+                    },
+                    "sockets": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "family": {
+                                    "type": "string"
+                                },
+                                "bind": {
+                                    "type": "object",
+                                    "properties": {
+                                        "port": {
+                                            "type": "integer"
+                                        },
+                                        "ip": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "port",
+                                        "ip"
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "family"
+                            ]
+                        }
+                    }
+                },
+                "required": [
+                    "files",
+                    "generation_type",
+                    "process"
+                ]
+            }
+        },
+        "DumpMetadata": {
+            "type": "object",
+            "properties": {
+                "agent_version": {
+                    "type": "string"
+                },
+                "agent_commit": {
+                    "type": "string"
+                },
+                "kernel_version": {
+                    "type": "string"
+                },
+                "linux_distribution": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "activity_dump_version": {
+                    "type": "string"
+                },
+                "differentiate_args": {
+                    "type": "boolean"
+                },
+                "comm": {
+                    "type": "string"
+                },
+                "start": {
+                    "type": "string"
+                },
+                "end": {
+                    "type": "string"
+                },
+                "container_id": {
+                    "type": "string"
+                },
+                "activity_dump_size": {
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "activity_dump_version",
+                "agent_commit",
+                "agent_version",
+                "differentiate_args",
+                "end",
+                "kernel_version",
+                "linux_distribution",
+                "name",
+                "start"
+            ]
+        }
+    },
+    "required": [
+        "DumpMetadata",
+        "host",
+        "source",
+        "tags",
+        "tree"
+    ]
+}


### PR DESCRIPTION
### What does this PR do?

This add first functional tests for activity dumps.

This validates only the activity dumps generated manually based on a given comm.

There is two checks, one to validate the DNS request presence, and another one to
validate the presence of bound sockets.

For each of them, we validate the JSON output through a ~generated schema, and the content of the MSGP output.

A lot of work is still to be done:
- Validate AD generation based on cgroups
- Validate the AD content regarding processes (exec) and opened files
- Validate the content of snapshot (not at runtime)
- Validate the generated profiles and graphs
- Validate the core things (compression, timeout, sending, ...)

### Motivation

Make the firsts little step to be able to test activity dumps.

### Describe how to test/QA your changes

inv -e security-agent.functional-tests --testflags "-test.v -test.run TestActivityDumps"

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
