### PR TITLE
[CSPM] fix expected findings, with host-selectors reintroduction

### DIFF
--- a/test/e2e/cws-tests/tests/test_e2e_cspm_kubernetes.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cspm_kubernetes.py
@@ -17,18 +17,10 @@ class TestE2EKubernetes(unittest.TestCase):
 
     namespace = "default"
     in_cluster = False
-    expectedFindings = {
+    expectedFindingsMasterEtcdNode = {
         "cis-kubernetes-1.5.1-1.1.12": [
             {
                 "result": "failed",
-            }
-        ],
-        "cis-kubernetes-1.5.1-4.2.6": [
-            {
-                "agent_rule_id": "cis-kubernetes-1.5.1-4.2.6",
-                "agent_framework_id": "cis-kubernetes",
-                "result": "failed",
-                "resource_type": "kubernetes_worker_node",
             }
         ],
         "cis-kubernetes-1.5.1-1.2.16": [
@@ -121,6 +113,16 @@ class TestE2EKubernetes(unittest.TestCase):
                 "result": "failed",
             }
         ],
+    }
+    expectedFindingsWorkerNode = {
+        "cis-kubernetes-1.5.1-4.2.6": [
+            {
+                "agent_rule_id": "cis-kubernetes-1.5.1-4.2.6",
+                "agent_framework_id": "cis-kubernetes",
+                "result": "failed",
+                "resource_type": "kubernetes_worker_node",
+            }
+        ],
         "cis-kubernetes-1.5.1-4.1.1": [
             {
                 "result": "error",
@@ -211,7 +213,7 @@ class TestE2EKubernetes(unittest.TestCase):
             output = self.kubernetes_helper.exec_command(agent_name, ["bash", "-c", "cat /tmp/reports"])
             # if the output is JSON, it automatically calls json.loads on it. Yeah, I know... I've felt the same too
             findings = eval(output)
-            expect_findings(self, findings, TestE2EKubernetes.expectedFindings)
+            expect_findings(self, findings, TestE2EKubernetes.expectedFindingsWorkerNode)
 
         with Step(msg="wait for intake (~1m)", emoji=":alarm_clock:"):
             time.sleep(1 * 60)


### PR DESCRIPTION
### What does this PR do?

With the reintroduction of host selectors, the e2e are failing because some expected findings are no longer present. This PR fixes this

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
