### PR TITLE
Add trace-level logs for integration.Configs, log sources

### DIFF
--- a/pkg/autodiscovery/integration/config.go
+++ b/pkg/autodiscovery/integration/config.go
@@ -420,8 +420,9 @@ func (c *Config) FastDigest() uint64 {
 	return h.Sum64()
 }
 
-// Dump returns a multiline string representing this Config value, for debugging purposes.
-func (c *Config) Dump() string {
+// Dump returns a string representing this Config value, for debugging purposes.  If multiline is true,
+// then it contains newlines; otherwise, it is comma-separated.
+func (c *Config) Dump(multiline bool) string {
 	var b strings.Builder
 	dataField := func(data Data) string {
 		if data == nil {
@@ -429,31 +430,37 @@ func (c *Config) Dump() string {
 		}
 		return fmt.Sprintf("[]byte(%#v)", string(data))
 	}
-	fmt.Fprintf(&b, "integration.Config = {\n")
-	fmt.Fprintf(&b, "\tName: %#v,\n", c.Name)
-	if c.Instances == nil {
-		fmt.Fprintf(&b, "\tInstances: nil,\n")
-	} else {
-		fmt.Fprintf(&b, "\tInstances: {\n")
-		for _, inst := range c.Instances {
-			fmt.Fprintf(&b, "\t\t%s,", dataField(inst))
+	ws := func(fmt string) string {
+		if multiline {
+			return "\n\t" + fmt
 		}
-		fmt.Fprintf(&b, "\t}\n")
+		return " " + fmt
 	}
-	fmt.Fprintf(&b, "\tInitConfig: %s,\n", dataField(c.InitConfig))
-	fmt.Fprintf(&b, "\tMetricConfig: %s,\n", dataField(c.MetricConfig))
-	fmt.Fprintf(&b, "\tLogsConfig: %s,\n", dataField(c.LogsConfig))
-	fmt.Fprintf(&b, "\tADIdentifiers: %#v,\n", c.ADIdentifiers)
-	fmt.Fprintf(&b, "\tAdvancedADIdentifiers: %#v,\n", c.AdvancedADIdentifiers)
-	fmt.Fprintf(&b, "\tProvider: %#v,\n", c.Provider)
-	fmt.Fprintf(&b, "\tServiceID: %#v,\n", c.ServiceID)
-	fmt.Fprintf(&b, "\tTaggerEntity: %#v,\n", c.TaggerEntity)
-	fmt.Fprintf(&b, "\tClusterCheck: %t,\n", c.ClusterCheck)
-	fmt.Fprintf(&b, "\tNodeName: %#v,\n", c.NodeName)
-	fmt.Fprintf(&b, "\tSource: %s,\n", c.Source)
-	fmt.Fprintf(&b, "\tIgnoreAutodiscoveryTags: %t,\n", c.IgnoreAutodiscoveryTags)
-	fmt.Fprintf(&b, "\tMetricsExcluded: %t,\n", c.MetricsExcluded)
-	fmt.Fprintf(&b, "\tLogsExcluded: %t,\n", c.LogsExcluded)
-	fmt.Fprintf(&b, "} (digest %s)", c.Digest())
+
+	fmt.Fprintf(&b, "integration.Config = {")
+	fmt.Fprintf(&b, ws("Name: %#v,"), c.Name)
+	if c.Instances == nil {
+		fmt.Fprintf(&b, ws("Instances: nil,"))
+	} else {
+		fmt.Fprintf(&b, ws("Instances: {"))
+		for _, inst := range c.Instances {
+			fmt.Fprintf(&b, ws("%s,"), dataField(inst))
+		}
+		fmt.Fprintf(&b, ws("}"))
+	}
+	fmt.Fprintf(&b, ws("InitConfig: %s,"), dataField(c.InitConfig))
+	fmt.Fprintf(&b, ws("MetricConfig: %s,"), dataField(c.MetricConfig))
+	fmt.Fprintf(&b, ws("LogsConfig: %s,"), dataField(c.LogsConfig))
+	fmt.Fprintf(&b, ws("ADIdentifiers: %#v,"), c.ADIdentifiers)
+	fmt.Fprintf(&b, ws("AdvancedADIdentifiers: %#v,"), c.AdvancedADIdentifiers)
+	fmt.Fprintf(&b, ws("Provider: %#v,"), c.Provider)
+	fmt.Fprintf(&b, ws("ServiceID: %#v,"), c.ServiceID)
+	fmt.Fprintf(&b, ws("TaggerEntity: %#v,"), c.TaggerEntity)
+	fmt.Fprintf(&b, ws("ClusterCheck: %t,"), c.ClusterCheck)
+	fmt.Fprintf(&b, ws("NodeName: %#v,"), c.NodeName)
+	fmt.Fprintf(&b, ws("Source: %s,"), c.Source)
+	fmt.Fprintf(&b, ws("IgnoreAutodiscoveryTags: %t,"), c.IgnoreAutodiscoveryTags)
+	fmt.Fprintf(&b, ws("MetricsExcluded: %t,"), c.MetricsExcluded)
+	fmt.Fprintf(&b, ws("LogsExcluded: %t} (digest %s)"), c.LogsExcluded, c.Digest())
 	return b.String()
 }

--- a/pkg/autodiscovery/integration/config.go
+++ b/pkg/autodiscovery/integration/config.go
@@ -437,16 +437,16 @@ func (c *Config) Dump(multiline bool) string {
 		return " " + fmt
 	}
 
-	fmt.Fprintf(&b, "integration.Config = {")
+	fmt.Fprint(&b, "integration.Config = {")
 	fmt.Fprintf(&b, ws("Name: %#v,"), c.Name)
 	if c.Instances == nil {
-		fmt.Fprintf(&b, ws("Instances: nil,"))
+		fmt.Fprint(&b, ws("Instances: nil,"))
 	} else {
-		fmt.Fprintf(&b, ws("Instances: {"))
+		fmt.Fprint(&b, ws("Instances: {"))
 		for _, inst := range c.Instances {
 			fmt.Fprintf(&b, ws("%s,"), dataField(inst))
 		}
-		fmt.Fprintf(&b, ws("}"))
+		fmt.Fprint(&b, ws("}"))
 	}
 	fmt.Fprintf(&b, ws("InitConfig: %s,"), dataField(c.InitConfig))
 	fmt.Fprintf(&b, ws("MetricConfig: %s,"), dataField(c.MetricConfig))

--- a/pkg/autodiscovery/integration/config_test.go
+++ b/pkg/autodiscovery/integration/config_test.go
@@ -98,7 +98,7 @@ func TestDump(t *testing.T) {
 	config.Name = "foo"
 	config.InitConfig = Data("fooBarBaz: test")
 	config.Instances = []Data{Data("justFoo")}
-	dump := config.Dump()
+	dump := config.Dump(true)
 	assert.Contains(t, dump, `[]byte("justFoo")`)
 }
 

--- a/pkg/autodiscovery/scheduler/meta.go
+++ b/pkg/autodiscovery/scheduler/meta.go
@@ -74,6 +74,7 @@ func (ms *MetaScheduler) Schedule(configs []integration.Config) {
 	ms.m.Lock()
 	defer ms.m.Unlock()
 	for _, config := range configs {
+		log.Tracef("Scheduling %s\n", config.Dump(false))
 		ms.scheduledConfigs[config.Digest()] = config
 	}
 	for _, scheduler := range ms.activeSchedulers {
@@ -86,6 +87,7 @@ func (ms *MetaScheduler) Unschedule(configs []integration.Config) {
 	ms.m.Lock()
 	defer ms.m.Unlock()
 	for _, config := range configs {
+		log.Tracef("Unscheduling %s\n", config.Dump(false))
 		delete(ms.scheduledConfigs, config.Digest())
 	}
 	for _, scheduler := range ms.activeSchedulers {

--- a/pkg/logs/config/integration_config.go
+++ b/pkg/logs/config/integration_config.go
@@ -19,6 +19,7 @@ const (
 	UDPType           = "udp"
 	FileType          = "file"
 	DockerType        = "docker"
+	ContainerdType    = "containerd"
 	JournaldType      = "journald"
 	WindowsEventType  = "windows_event"
 	StringChannelType = "string_channel"
@@ -112,7 +113,7 @@ func (c *LogsConfig) Dump(multiline bool) string {
 		fmt.Fprintf(&b, ws("Identifier: %#v,"), c.Identifier)
 		fmt.Fprintf(&b, ws("ExcludePaths: %#v,"), c.ExcludePaths)
 		fmt.Fprintf(&b, ws("TailingMode: %#v,"), c.TailingMode)
-	case DockerType:
+	case DockerType, ContainerdType:
 		fmt.Fprintf(&b, ws("Image: %#v,"), c.Image)
 		fmt.Fprintf(&b, ws("Label: %#v,"), c.Label)
 		fmt.Fprintf(&b, ws("Name: %#v,"), c.Name)

--- a/pkg/logs/config/integration_config.go
+++ b/pkg/logs/config/integration_config.go
@@ -97,7 +97,7 @@ func (c *LogsConfig) Dump(multiline bool) string {
 		return " " + fmt
 	}
 
-	fmt.Fprintf(&b, ws("&LogsConfig{"))
+	fmt.Fprint(&b, ws("&LogsConfig{"))
 	fmt.Fprintf(&b, ws("Type: %#v,"), c.Type)
 	switch c.Type {
 	case TCPType:
@@ -141,7 +141,7 @@ func (c *LogsConfig) Dump(multiline bool) string {
 	if c.AutoMultiLine != nil {
 		fmt.Fprintf(&b, ws("AutoMultiLine: %t,"), *c.AutoMultiLine)
 	} else {
-		fmt.Fprintf(&b, ws("AutoMultiLine: nil,"))
+		fmt.Fprint(&b, ws("AutoMultiLine: nil,"))
 	}
 	fmt.Fprintf(&b, ws("AutoMultiLineSampleSize: %d,"), c.AutoMultiLineSampleSize)
 	fmt.Fprintf(&b, ws("AutoMultiLineMatchThreshold: %f}"), c.AutoMultiLineMatchThreshold)

--- a/pkg/logs/config/integration_config.go
+++ b/pkg/logs/config/integration_config.go
@@ -84,60 +84,67 @@ type LogsConfig struct {
 }
 
 // Dump dumps the contents of this struct to a string, for debugging purposes.
-func (c *LogsConfig) Dump() string {
-	var b strings.Builder
+func (c *LogsConfig) Dump(multiline bool) string {
 	if c == nil {
 		return "&LogsConfig(nil)"
 	}
-	fmt.Fprintf(&b, "&LogsConfig{\n")
-	fmt.Fprintf(&b, "\tType: %#v,\n", c.Type)
+
+	var b strings.Builder
+	ws := func(fmt string) string {
+		if multiline {
+			return "\n\t" + fmt
+		}
+		return " " + fmt
+	}
+
+	fmt.Fprintf(&b, ws("&LogsConfig{"))
+	fmt.Fprintf(&b, ws("Type: %#v,"), c.Type)
 	switch c.Type {
 	case TCPType:
-		fmt.Fprintf(&b, "\tPort: %d,\n", c.Port)
-		fmt.Fprintf(&b, "\tIdleTimeout: %#v,\n", c.IdleTimeout)
+		fmt.Fprintf(&b, ws("Port: %d,"), c.Port)
+		fmt.Fprintf(&b, ws("IdleTimeout: %#v,"), c.IdleTimeout)
 	case UDPType:
-		fmt.Fprintf(&b, "\tPort: %d,\n", c.Port)
-		fmt.Fprintf(&b, "\tIdleTimeout: %#v,\n", c.IdleTimeout)
+		fmt.Fprintf(&b, ws("Port: %d,"), c.Port)
+		fmt.Fprintf(&b, ws("IdleTimeout: %#v,"), c.IdleTimeout)
 	case FileType:
-		fmt.Fprintf(&b, "\tPath: %#v,\n", c.Path)
-		fmt.Fprintf(&b, "\tEncoding: %#v,\n", c.Encoding)
-		fmt.Fprintf(&b, "\tIdentifier: %#v,\n", c.Identifier)
-		fmt.Fprintf(&b, "\tExcludePaths: %#v,\n", c.ExcludePaths)
-		fmt.Fprintf(&b, "\tTailingMode: %#v,\n", c.TailingMode)
+		fmt.Fprintf(&b, ws("Path: %#v,"), c.Path)
+		fmt.Fprintf(&b, ws("Encoding: %#v,"), c.Encoding)
+		fmt.Fprintf(&b, ws("Identifier: %#v,"), c.Identifier)
+		fmt.Fprintf(&b, ws("ExcludePaths: %#v,"), c.ExcludePaths)
+		fmt.Fprintf(&b, ws("TailingMode: %#v,"), c.TailingMode)
 	case DockerType:
-		fmt.Fprintf(&b, "\tImage: %#v,\n", c.Image)
-		fmt.Fprintf(&b, "\tLabel: %#v,\n", c.Label)
-		fmt.Fprintf(&b, "\tName: %#v,\n", c.Name)
-		fmt.Fprintf(&b, "\tIdentifier: %#v,\n", c.Identifier)
+		fmt.Fprintf(&b, ws("Image: %#v,"), c.Image)
+		fmt.Fprintf(&b, ws("Label: %#v,"), c.Label)
+		fmt.Fprintf(&b, ws("Name: %#v,"), c.Name)
+		fmt.Fprintf(&b, ws("Identifier: %#v,"), c.Identifier)
 	case JournaldType:
-		fmt.Fprintf(&b, "\tPath: %#v,\n", c.Path)
-		fmt.Fprintf(&b, "\tIncludeSystemUnits: %#v,\n", c.IncludeSystemUnits)
-		fmt.Fprintf(&b, "\tExcludeSystemUnits: %#v,\n", c.ExcludeSystemUnits)
-		fmt.Fprintf(&b, "\tIncludeUserUnits: %#v,\n", c.IncludeUserUnits)
-		fmt.Fprintf(&b, "\tExcludeUserUnits: %#v,\n", c.ExcludeUserUnits)
-		fmt.Fprintf(&b, "\tContainerMode: %t,\n", c.ContainerMode)
+		fmt.Fprintf(&b, ws("Path: %#v,"), c.Path)
+		fmt.Fprintf(&b, ws("IncludeSystemUnits: %#v,"), c.IncludeSystemUnits)
+		fmt.Fprintf(&b, ws("ExcludeSystemUnits: %#v,"), c.ExcludeSystemUnits)
+		fmt.Fprintf(&b, ws("IncludeUserUnits: %#v,"), c.IncludeUserUnits)
+		fmt.Fprintf(&b, ws("ExcludeUserUnits: %#v,"), c.ExcludeUserUnits)
+		fmt.Fprintf(&b, ws("ContainerMode: %t,"), c.ContainerMode)
 	case WindowsEventType:
-		fmt.Fprintf(&b, "\tChannelPath: %#v,\n", c.ChannelPath)
-		fmt.Fprintf(&b, "\tQuery: %#v,\n", c.Query)
+		fmt.Fprintf(&b, ws("ChannelPath: %#v,"), c.ChannelPath)
+		fmt.Fprintf(&b, ws("Query: %#v,"), c.Query)
 	case StringChannelType:
-		fmt.Fprintf(&b, "\tChannel: %p,\n", c.Channel)
+		fmt.Fprintf(&b, ws("Channel: %p,"), c.Channel)
 		c.ChannelTagsMutex.Lock()
-		fmt.Fprintf(&b, "\tChannelTags: %#v,\n", c.ChannelTags)
+		fmt.Fprintf(&b, ws("ChannelTags: %#v,"), c.ChannelTags)
 		c.ChannelTagsMutex.Unlock()
 	}
-	fmt.Fprintf(&b, "\tService: %#v,\n", c.Service)
-	fmt.Fprintf(&b, "\tSource: %#v,\n", c.Source)
-	fmt.Fprintf(&b, "\tSourceCategory: %#v,\n", c.SourceCategory)
-	fmt.Fprintf(&b, "\tTags: %#v,\n", c.Tags)
-	fmt.Fprintf(&b, "\tProcessingRules: %#v,\n", c.ProcessingRules)
+	fmt.Fprintf(&b, ws("Service: %#v,"), c.Service)
+	fmt.Fprintf(&b, ws("Source: %#v,"), c.Source)
+	fmt.Fprintf(&b, ws("SourceCategory: %#v,"), c.SourceCategory)
+	fmt.Fprintf(&b, ws("Tags: %#v,"), c.Tags)
+	fmt.Fprintf(&b, ws("ProcessingRules: %#v,"), c.ProcessingRules)
 	if c.AutoMultiLine != nil {
-		fmt.Fprintf(&b, "\tAutoMultiLine: %t,\n", *c.AutoMultiLine)
+		fmt.Fprintf(&b, ws("AutoMultiLine: %t,"), *c.AutoMultiLine)
 	} else {
-		fmt.Fprintf(&b, "\tAutoMultiLine: nil,\n")
+		fmt.Fprintf(&b, ws("AutoMultiLine: nil,"))
 	}
-	fmt.Fprintf(&b, "\tAutoMultiLineSampleSize: %d,\n", c.AutoMultiLineSampleSize)
-	fmt.Fprintf(&b, "\tAutoMultiLineMatchThreshold: %f,\n", c.AutoMultiLineMatchThreshold)
-	fmt.Fprintf(&b, "}")
+	fmt.Fprintf(&b, ws("AutoMultiLineSampleSize: %d,"), c.AutoMultiLineSampleSize)
+	fmt.Fprintf(&b, ws("AutoMultiLineMatchThreshold: %f}"), c.AutoMultiLineMatchThreshold)
 	return b.String()
 }
 

--- a/pkg/logs/config/integration_config_test.go
+++ b/pkg/logs/config/integration_config_test.go
@@ -82,6 +82,6 @@ func TestAutoMultilineEnabled(t *testing.T) {
 
 func TestConfigDump(t *testing.T) {
 	config := LogsConfig{Type: FileType, Path: "/var/log/foo.log"}
-	dump := config.Dump()
+	dump := config.Dump(true)
 	assert.Contains(t, dump, `Path: "/var/log/foo.log",`)
 }

--- a/pkg/logs/service/services.go
+++ b/pkg/logs/service/services.go
@@ -7,6 +7,8 @@ package service
 
 import (
 	"sync"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // Services provides new and removed services.
@@ -29,6 +31,7 @@ func NewServices() *Services {
 
 // AddService sends a new service to all the channels that registered.
 func (s *Services) AddService(service *Service) {
+	log.Tracef("Adding %#v\n", service)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -42,6 +45,7 @@ func (s *Services) AddService(service *Service) {
 
 // RemoveService sends a removed service to all the channels that registered.
 func (s *Services) RemoveService(service *Service) {
+	log.Tracef("Removing %#v\n", service)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 

--- a/pkg/logs/sources/source.go
+++ b/pkg/logs/sources/source.go
@@ -150,8 +150,9 @@ func (s *LogSource) IsHiddenFromStatus() bool {
 	return s.hiddenFromStatus
 }
 
-// Dump provides a multi-line dump of the LogSource contents, for debugging purposes
-func (s *LogSource) Dump() string {
+// Dump provides a dump of the LogSource contents, for debugging purposes.  If
+// multiline is true, the result contains newlines for readability.
+func (s *LogSource) Dump(multiline bool) string {
 	if s == nil {
 		return "&LogSource(nil)"
 	}
@@ -160,18 +161,32 @@ func (s *LogSource) Dump() string {
 	defer s.lock.Unlock()
 
 	var b strings.Builder
-	fmt.Fprintf(&b, "&LogsSource @ %p = {\n", s)
-	fmt.Fprintf(&b, "\tName: %#v,\n", s.Name)
-	fmt.Fprintf(&b, "\tConfig: %s,\n", strings.ReplaceAll(s.Config.Dump(), "\n", "\n\t"))
-	fmt.Fprintf(&b, "\tStatus: %s,\n", strings.ReplaceAll(s.Status.Dump(), "\n", "\n\t"))
-	fmt.Fprintf(&b, "\tinputs: %#v,\n", s.inputs)
-	fmt.Fprintf(&b, "\tMessages: %#v,\n", s.Messages.GetMessages())
-	fmt.Fprintf(&b, "\tsourceType: %#v,\n", s.sourceType)
-	fmt.Fprintf(&b, "\tinfo: %#v,\n", s.info)
-	fmt.Fprintf(&b, "\tparentSource: %p,\n", s.ParentSource)
-	fmt.Fprintf(&b, "\tLatencyStats: %#v,\n", s.LatencyStats)
-	fmt.Fprintf(&b, "\tBytesRead: %d,\n", s.BytesRead.Load())
-	fmt.Fprintf(&b, "\thiddenFromStatus: %t,\n", s.hiddenFromStatus)
-	fmt.Fprintf(&b, "}")
+
+	ws := func(fmt string) string {
+		if multiline {
+			return "\n\t" + fmt
+		}
+		return " " + fmt
+	}
+
+	indent := func(dump string) string {
+		if multiline {
+			return strings.ReplaceAll(dump, "\n", "\n\t")
+		}
+		return dump
+	}
+
+	fmt.Fprintf(&b, ws("&LogsSource @ %p = {"), s)
+	fmt.Fprintf(&b, ws("Name: %#v,"), s.Name)
+	fmt.Fprintf(&b, ws("Config: %s,"), indent(s.Config.Dump(multiline)))
+	fmt.Fprintf(&b, ws("Status: %s,"), indent(s.Status.Dump()))
+	fmt.Fprintf(&b, ws("inputs: %#v,"), s.inputs)
+	fmt.Fprintf(&b, ws("Messages: %#v,"), s.Messages.GetMessages())
+	fmt.Fprintf(&b, ws("sourceType: %#v,"), s.sourceType)
+	fmt.Fprintf(&b, ws("info: %#v,"), s.info)
+	fmt.Fprintf(&b, ws("parentSource: %p,"), s.ParentSource)
+	fmt.Fprintf(&b, ws("LatencyStats: %#v,"), s.LatencyStats)
+	fmt.Fprintf(&b, ws("BytesRead: %d,"), s.BytesRead.Load())
+	fmt.Fprintf(&b, ws("hiddenFromStatus: %t}"), s.hiddenFromStatus)
 	return b.String()
 }

--- a/pkg/logs/sources/source_test.go
+++ b/pkg/logs/sources/source_test.go
@@ -31,7 +31,7 @@ func (s *LogSourceSuite) TestInputs() {
 
 func (s *LogSourceSuite) TestDump() {
 	s.source = NewLogSource("mysource", nil)
-	dump := s.source.Dump()
+	dump := s.source.Dump(true)
 	assert.Contains(s.T(), dump, "mysource")
 }
 

--- a/pkg/logs/sources/sources.go
+++ b/pkg/logs/sources/sources.go
@@ -7,6 +7,8 @@ package sources
 
 import (
 	"sync"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // LogSources serves as the interface between Schedulers and Launchers, distributing
@@ -42,6 +44,7 @@ func NewLogSources() *LogSources {
 // All of the subscribers registered for this source's type (src.Config.Type) will be
 // notified.
 func (s *LogSources) AddSource(source *LogSource) {
+	log.Tracef("Adding %s", source.Dump(false))
 	s.mu.Lock()
 	s.sources = append(s.sources, source)
 	if source.Config == nil || source.Config.Validate() != nil {
@@ -66,6 +69,7 @@ func (s *LogSources) AddSource(source *LogSource) {
 // All of the subscribers registered for this source's type (src.Config.Type) will be
 // notified of its removal.
 func (s *LogSources) RemoveSource(source *LogSource) {
+	log.Tracef("Removing %s", source.Dump(false))
 	s.mu.Lock()
 	var sourceFound bool
 	for i, src := range s.sources {


### PR DESCRIPTION
This logs all integration.Config's scheduled or unscheduled, as well as
LogSources and logs-agent services, all at the trace level.

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

This kind of logging has helped me figure out lots of weird things about AD and the logs agent, so maybe it will be useful for others?  Perhaps also useful for support cases, although catching things in trace logs is hard.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

This will end up calling `.Dump()` a lot even when not logging, which might be a little slow?  Especially for integration.Config's, which will also call `c.Digest()`.  Is this a performance issue?

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
