### PR TITLE
[RCM] Error if required fields are missing in ClientGetConfigRequest

### DIFF
--- a/pkg/config/remote/service/service.go
+++ b/pkg/config/remote/service/service.go
@@ -259,16 +259,14 @@ func (s *Service) getClientState() ([]byte, error) {
 func (s *Service) ClientGetConfigs(request *pbgo.ClientGetConfigsRequest) (*pbgo.ClientGetConfigsResponse, error) {
 	s.Lock()
 	defer s.Unlock()
-	if request.Client == nil {
-		return &pbgo.ClientGetConfigsResponse{}, status.Error(codes.InvalidArgument, "client is a required field for client config update requests")
+	err := validateRequest(request)
+	if err != nil {
+		return nil, err
 	}
 	s.clients.seen(request.Client)
 	tufVersions, err := s.uptane.TUFVersionState()
 	if err != nil {
 		return nil, err
-	}
-	if request.Client.State == nil {
-		return &pbgo.ClientGetConfigsResponse{}, status.Error(codes.InvalidArgument, "client.state is a required field for client config update requests")
 	}
 	if tufVersions.DirectorTargets == request.Client.State.TargetsVersion {
 		return &pbgo.ClientGetConfigsResponse{}, nil
@@ -396,4 +394,36 @@ func (s *Service) getTargetFiles(products []rdata.Product, cachedTargetFiles []*
 		}
 	}
 	return configFiles, nil
+}
+
+func validateRequest(request *pbgo.ClientGetConfigsRequest) error {
+	if request.Client == nil {
+		return status.Error(codes.InvalidArgument, "client is a required field for client config update requests")
+	}
+
+	if request.Client.State == nil {
+		return status.Error(codes.InvalidArgument, "client.state is a required field for client config update requests")
+	}
+
+	if request.Client.State.RootVersion <= 0 {
+		return status.Error(codes.InvalidArgument, "client.state.root_version must be >= 1 (clients must start with the base TUF director root)")
+	}
+
+	if request.Client.IsAgent && request.Client.ClientAgent == nil {
+		return status.Error(codes.InvalidArgument, "client.client_agent is a required field for agent client config update requests")
+	}
+
+	if request.Client.IsTracer && request.Client.ClientTracer == nil {
+		return status.Error(codes.InvalidArgument, "client.client_tracer is a required field for tracer client config update requests")
+	}
+
+	if request.Client.IsTracer && request.Client.IsAgent {
+		return status.Error(codes.InvalidArgument, "client.is_tracer and client.is_agent cannot both be true")
+	}
+
+	if !request.Client.IsTracer && !request.Client.IsAgent {
+		return status.Error(codes.InvalidArgument, "agents only support remote config updates from tracer or agent at this time")
+	}
+
+	return nil
 }


### PR DESCRIPTION
We were returning a 200 status code and an empty body if a required
field to request updates was missing. This is an invalid request and
should have an error code instead of 200.

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
