### PR TITLE
feat(flare): add diagnose datadog-connectivity output to the flare archive

### DIFF
--- a/cmd/agent/app/diagnose.go
+++ b/cmd/agent/app/diagnose.go
@@ -66,7 +66,7 @@ func doDiagnoseDatadogConnectivity(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return connectivity.RunDatadogConnectivityDiagnose(noTrace)
+	return connectivity.RunDatadogConnectivityDiagnose(color.Output, noTrace)
 }
 
 func configAndLogSetup() error {

--- a/pkg/diagnose/connectivity/hooks.go
+++ b/pkg/diagnose/connectivity/hooks.go
@@ -15,6 +15,7 @@ package connectivity
 import (
 	"crypto/tls"
 	"fmt"
+	"io"
 	"net/http/httptrace"
 
 	"github.com/fatih/color"
@@ -25,24 +26,25 @@ import (
 // During a request, the http.Client will call the functions of the ClientTrace at specific moments
 // This is useful to get extra information about what is happening and if there are errors during
 // connection establishment, DNS resolution or TLS handshake for instance
-func createDiagnoseTrace() *httptrace.ClientTrace {
+func createDiagnoseTrace(writer *writerWrapper) *httptrace.ClientTrace {
+
 	return &httptrace.ClientTrace{
 
 		// Hooks called before and after creating or retrieving a connection
-		GetConn: getConnHook,
-		GotConn: gotConnHook,
+		GetConn: writer.getConnHook,
+		GotConn: writer.gotConnHook,
 
 		// Hooks for connection establishment
-		ConnectStart: connectStartHook,
-		ConnectDone:  connectDoneHook,
+		ConnectStart: writer.connectStartHook,
+		ConnectDone:  writer.connectDoneHook,
 
 		// Hooks for DNS resolution
-		DNSStart: dnsStartHook,
-		DNSDone:  dnsDoneHook,
+		DNSStart: writer.dnsStartHook,
+		DNSDone:  writer.dnsDoneHook,
 
 		// Hooks for TLS Handshake
-		TLSHandshakeStart: tlsHandshakeStartHook,
-		TLSHandshakeDone:  tlsHandshakeDoneHook,
+		TLSHandshakeStart: writer.tlsHandshakeStartHook,
+		TLSHandshakeDone:  writer.tlsHandshakeDoneHook,
 	}
 }
 
@@ -51,29 +53,36 @@ var (
 	tlsColorFunc = color.YellowString
 )
 
+// writeWrapper is used to pass a io.Writer variable to the hooks so that they
+// can output into a terminal if the command is used via CLI or into a buffer
+// when requesting a flare
+type writerWrapper struct {
+	w io.Writer
+}
+
 // connectStartHook is called when the http.Client is establishing a new connection to 'addr'
 // However, it is not called when a connection is reused (see gotConnHook)
-func connectStartHook(network, addr string) {
-	fmt.Printf("~~~ Starting a new connection ~~~\n")
+func (writer *writerWrapper) connectStartHook(network, addr string) {
+	fmt.Fprintf(writer.w, "~~~ Starting a new connection ~~~\n")
 }
 
 // connectDoneHook is called when the new connection to 'addr' completes
 // It displays the error message if there is one and indicates if this step was successful
-func connectDoneHook(network, addr string, err error) {
+func (writer *writerWrapper) connectDoneHook(network, addr string, err error) {
 	statusString := color.GreenString("OK")
 	if err != nil {
 		statusString = color.RedString("ERROR")
-		fmt.Printf("Unable to connect to the endpoint : %v\n", err)
+		fmt.Fprintf(writer.w, "Unable to connect to the endpoint : %v\n", err)
 	}
-	fmt.Printf("* Connection to the endpoint [%v]\n\n", statusString)
+	fmt.Fprintf(writer.w, "* Connection to the endpoint [%v]\n\n", statusString)
 }
 
 // getConnHook is called before getting a new connection.
 // This is called before :
 // 		- Creating a new connection 		: getConnHook ---> connectStartHook
 //		- Retrieving an existing connection : getConnHook ---> gotConnHook
-func getConnHook(hostPort string) {
-	fmt.Printf("=== Retrieving or creating a new connection ===\n")
+func (writer *writerWrapper) getConnHook(hostPort string) {
+	fmt.Fprintf(writer.w, "=== Retrieving or creating a new connection ===\n")
 }
 
 // gotConnHook is called after a successful connection is obtained.
@@ -82,40 +91,40 @@ func getConnHook(hostPort string) {
 // 		- Previous connection retrieved : getConnHook     ---> gotConnHook
 // This function only displays when a connection is retrieved.
 // Information about new connection are reported by connectDoneHook
-func gotConnHook(gci httptrace.GotConnInfo) {
+func (writer *writerWrapper) gotConnHook(gci httptrace.GotConnInfo) {
 	if gci.Reused {
-		fmt.Print(color.CyanString("Reusing a previous connection that was idle for %v\n", gci.IdleTime))
+		fmt.Fprint(writer.w, color.CyanString("Reusing a previous connection that was idle for %v\n", gci.IdleTime))
 	}
 }
 
 // dnsStartHook is called when starting the DNS lookup
-func dnsStartHook(di httptrace.DNSStartInfo) {
-	fmt.Print(dnsColorFunc("--- Starting DNS lookup to resolve '%v' ---\n", di.Host))
+func (writer *writerWrapper) dnsStartHook(di httptrace.DNSStartInfo) {
+	fmt.Fprint(writer.w, dnsColorFunc("--- Starting DNS lookup to resolve '%v' ---\n", di.Host))
 }
 
 // dnsDoneHook is called after the DNS lookup
 // It displays the error message if there is one and indicates if this step was successful
-func dnsDoneHook(di httptrace.DNSDoneInfo) {
+func (writer *writerWrapper) dnsDoneHook(di httptrace.DNSDoneInfo) {
 	statusString := color.GreenString("OK")
 	if di.Err != nil {
 		statusString = color.RedString("ERROR")
-		fmt.Print(dnsColorFunc("Unable to resolve the address : %v\n", di.Err))
+		fmt.Fprint(writer.w, dnsColorFunc("Unable to resolve the address : %v\n", di.Err))
 	}
-	fmt.Printf("* %v [%v]\n\n", dnsColorFunc("DNS Lookup"), statusString)
+	fmt.Fprintf(writer.w, "* %v [%v]\n\n", dnsColorFunc("DNS Lookup"), statusString)
 }
 
 // tlsHandshakeStartHook is called when starting the TLS Handshake
-func tlsHandshakeStartHook() {
-	fmt.Print(tlsColorFunc("### Starting TLS Handshake ###\n"))
+func (writer *writerWrapper) tlsHandshakeStartHook() {
+	fmt.Fprint(writer.w, tlsColorFunc("### Starting TLS Handshake ###\n"))
 }
 
 // tlsHandshakeDoneHook is called after the TLS Handshake
 // It displays the error message if there is one and indicates if this step was successful
-func tlsHandshakeDoneHook(cs tls.ConnectionState, err error) {
+func (writer *writerWrapper) tlsHandshakeDoneHook(cs tls.ConnectionState, err error) {
 	statusString := color.GreenString("OK")
 	if err != nil {
 		statusString = color.RedString("ERROR")
-		fmt.Print(tlsColorFunc("Unable to achieve the TLS Handshake : %v\n", err))
+		fmt.Fprint(writer.w, tlsColorFunc("Unable to achieve the TLS Handshake : %v\n", err))
 	}
-	fmt.Printf("* %v [%v]\n\n", tlsColorFunc("TLS Handshake"), statusString)
+	fmt.Fprintf(writer.w, "* %v [%v]\n\n", tlsColorFunc("TLS Handshake"), statusString)
 }

--- a/pkg/diagnose/connectivity/trace_request.go
+++ b/pkg/diagnose/connectivity/trace_request.go
@@ -26,7 +26,10 @@ import (
 
 // RunDatadogConnectivityDiagnose sends requests to all known endpoints for all domains
 // to check if there are connectivity issues between Datadog and these endpoints
-func RunDatadogConnectivityDiagnose(noTrace bool) error {
+func RunDatadogConnectivityDiagnose(w io.Writer, noTrace bool) error {
+
+	writer := &writerWrapper{w: w}
+
 	// Create domain resolvers
 	keysPerDomain, err := config.GetMultipleEndpoints()
 	if err != nil {
@@ -38,16 +41,16 @@ func RunDatadogConnectivityDiagnose(noTrace bool) error {
 	client := forwarder.NewHTTPClient()
 
 	// Send requests to all endpoints for all domains
-	fmt.Println("\n================ Starting connectivity diagnosis ================")
+	fmt.Fprintln(writer.w, "\n================ Starting connectivity diagnosis ================")
 	for _, domainResolver := range domainResolvers {
-		sendRequestToAllEndpointOfADomain(client, domainResolver, noTrace)
+		sendRequestToAllEndpointOfADomain(writer, client, domainResolver, noTrace)
 	}
 
 	return nil
 }
 
 // sendRequestToAllEndpointOfADomain sends HTTP request on all endpoints for a given domain
-func sendRequestToAllEndpointOfADomain(client *http.Client, domainResolver resolver.DomainResolver, noTrace bool) {
+func sendRequestToAllEndpointOfADomain(writer *writerWrapper, client *http.Client, domainResolver resolver.DomainResolver, noTrace bool) {
 
 	// Go through all API Keys of a domain and send an HTTP request on each endpoint
 	for _, apiKey := range domainResolver.GetAPIKeys() {
@@ -58,24 +61,24 @@ func sendRequestToAllEndpointOfADomain(client *http.Client, domainResolver resol
 
 			ctx := context.Background()
 			if !noTrace {
-				ctx = httptrace.WithClientTrace(context.Background(), createDiagnoseTrace())
+				ctx = httptrace.WithClientTrace(context.Background(), createDiagnoseTrace(writer))
 			}
 
-			statusCode, responseBody, err := sendHTTPRequestToEndpoint(ctx, client, domain, endpointInfo, apiKey)
+			statusCode, responseBody, err := sendHTTPRequestToEndpoint(writer, ctx, client, domain, endpointInfo, apiKey)
 
 			// Check if there is a response and if it's valid
-			verifyEndpointResponse(statusCode, responseBody, err)
+			verifyEndpointResponse(writer, statusCode, responseBody, err)
 		}
 	}
 }
 
 // sendHTTPRequestToEndpoint creates an URL based on the domain and the endpoint information
 // then sends an HTTP Request with the method and payload inside the endpoint information
-func sendHTTPRequestToEndpoint(ctx context.Context, client *http.Client, domain string, endpointInfo endpointInfo, apiKey string) (int, []byte, error) {
+func sendHTTPRequestToEndpoint(writer *writerWrapper, ctx context.Context, client *http.Client, domain string, endpointInfo endpointInfo, apiKey string) (int, []byte, error) {
 	url := createEndpointURL(domain, endpointInfo)
 	logURL := scrubber.ScrubLine(url)
 
-	fmt.Printf("\n======== '%v' ========\n", color.BlueString(logURL))
+	fmt.Fprintf(writer.w, "\n======== '%v' ========\n", color.BlueString(logURL))
 
 	// Create a request for the backend
 	reader := bytes.NewReader(endpointInfo.Payload)
@@ -100,7 +103,7 @@ func sendHTTPRequestToEndpoint(ctx context.Context, client *http.Client, domain 
 	// Get the endpoint response
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return 0, nil, fmt.Errorf("fail to read the response Body: %s", err)
+		return 0, nil, fmt.Errorf("fail to read the response Body: %s", scrubber.ScrubLine(err.Error()))
 	}
 
 	return resp.StatusCode, body, nil
@@ -111,17 +114,17 @@ func createEndpointURL(domain string, endpointInfo endpointInfo) string {
 	return domain + endpointInfo.Endpoint.Route
 }
 
-func verifyEndpointResponse(statusCode int, responseBody []byte, err error) {
+func verifyEndpointResponse(writer *writerWrapper, statusCode int, responseBody []byte, err error) {
 
 	if err != nil {
-		fmt.Printf("could not get a response from the endpoint : %v\n", err)
+		fmt.Fprintf(writer.w, "could not get a response from the endpoint : %v\n", scrubber.ScrubLine(err.Error()))
 		return
 	}
 
 	statusString := color.GreenString("PASS")
 	if statusCode >= 400 {
 		statusString = color.RedString("FAIL")
-		fmt.Printf("Received response : '%v'\n", string(responseBody))
+		fmt.Fprintf(writer.w, "Received response : '%v'\n", scrubber.ScrubLine(string(responseBody)))
 	}
-	fmt.Printf("Received status code %v from the endpoint ====> %v\n", statusCode, statusString)
+	fmt.Fprintf(writer.w, "Received status code %v from the endpoint ====> %v\n", statusCode, scrubber.ScrubLine(statusString))
 }

--- a/pkg/diagnose/connectivity/trace_request.go
+++ b/pkg/diagnose/connectivity/trace_request.go
@@ -64,7 +64,7 @@ func sendRequestToAllEndpointOfADomain(writer *writerWrapper, client *http.Clien
 				ctx = httptrace.WithClientTrace(context.Background(), createDiagnoseTrace(writer))
 			}
 
-			statusCode, responseBody, err := sendHTTPRequestToEndpoint(writer, ctx, client, domain, endpointInfo, apiKey)
+			statusCode, responseBody, err := sendHTTPRequestToEndpoint(ctx, writer, client, domain, endpointInfo, apiKey)
 
 			// Check if there is a response and if it's valid
 			verifyEndpointResponse(writer, statusCode, responseBody, err)
@@ -74,7 +74,7 @@ func sendRequestToAllEndpointOfADomain(writer *writerWrapper, client *http.Clien
 
 // sendHTTPRequestToEndpoint creates an URL based on the domain and the endpoint information
 // then sends an HTTP Request with the method and payload inside the endpoint information
-func sendHTTPRequestToEndpoint(writer *writerWrapper, ctx context.Context, client *http.Client, domain string, endpointInfo endpointInfo, apiKey string) (int, []byte, error) {
+func sendHTTPRequestToEndpoint(ctx context.Context, writer *writerWrapper, client *http.Client, domain string, endpointInfo endpointInfo, apiKey string) (int, []byte, error) {
 	url := createEndpointURL(domain, endpointInfo)
 	logURL := scrubber.ScrubLine(url)
 

--- a/pkg/diagnose/connectivity/trace_request_test.go
+++ b/pkg/diagnose/connectivity/trace_request_test.go
@@ -45,16 +45,15 @@ func TestSendHTTPRequestToEndpoint(t *testing.T) {
 	defer ts1.Close()
 
 	client := forwarder.NewHTTPClient()
-	writer := &writerWrapper{w: color.Output}
 
 	// With the correct API Key, it should be a 200
-	statusCodeWithKey, responseBodyWithKey, errWithKey := sendHTTPRequestToEndpoint(context.Background(), writer, client, ts1.URL, endpointInfoTest, apiKey1)
+	statusCodeWithKey, responseBodyWithKey, errWithKey := sendHTTPRequestToEndpoint(context.Background(), color.Output, client, ts1.URL, endpointInfoTest, apiKey1)
 	assert.Nil(t, errWithKey)
 	assert.Equal(t, statusCodeWithKey, 200)
 	assert.Equal(t, string(responseBodyWithKey), "OK")
 
 	// With the wrong API Key, it should be a 400
-	statusCode, responseBody, err := sendHTTPRequestToEndpoint(context.Background(), writer, client, ts1.URL, endpointInfoTest, apiKey2)
+	statusCode, responseBody, err := sendHTTPRequestToEndpoint(context.Background(), color.Output, client, ts1.URL, endpointInfoTest, apiKey2)
 	assert.Nil(t, err)
 	assert.Equal(t, statusCode, 400)
 	assert.Equal(t, string(responseBody), "Bad Request")

--- a/pkg/diagnose/connectivity/trace_request_test.go
+++ b/pkg/diagnose/connectivity/trace_request_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/forwarder"
 	"github.com/DataDog/datadog-agent/pkg/forwarder/endpoints"
+	"github.com/fatih/color"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -44,15 +45,16 @@ func TestSendHTTPRequestToEndpoint(t *testing.T) {
 	defer ts1.Close()
 
 	client := forwarder.NewHTTPClient()
+	writer := &writerWrapper{w: color.Output}
 
 	// With the correct API Key, it should be a 200
-	statusCodeWithKey, responseBodyWithKey, errWithKey := sendHTTPRequestToEndpoint(context.Background(), client, ts1.URL, endpointInfoTest, apiKey1)
+	statusCodeWithKey, responseBodyWithKey, errWithKey := sendHTTPRequestToEndpoint(writer, context.Background(), client, ts1.URL, endpointInfoTest, apiKey1)
 	assert.Nil(t, errWithKey)
 	assert.Equal(t, statusCodeWithKey, 200)
 	assert.Equal(t, string(responseBodyWithKey), "OK")
 
 	// With the wrong API Key, it should be a 400
-	statusCode, responseBody, err := sendHTTPRequestToEndpoint(context.Background(), client, ts1.URL, endpointInfoTest, apiKey2)
+	statusCode, responseBody, err := sendHTTPRequestToEndpoint(writer, context.Background(), client, ts1.URL, endpointInfoTest, apiKey2)
 	assert.Nil(t, err)
 	assert.Equal(t, statusCode, 400)
 	assert.Equal(t, string(responseBody), "Bad Request")

--- a/pkg/diagnose/connectivity/trace_request_test.go
+++ b/pkg/diagnose/connectivity/trace_request_test.go
@@ -48,13 +48,13 @@ func TestSendHTTPRequestToEndpoint(t *testing.T) {
 	writer := &writerWrapper{w: color.Output}
 
 	// With the correct API Key, it should be a 200
-	statusCodeWithKey, responseBodyWithKey, errWithKey := sendHTTPRequestToEndpoint(writer, context.Background(), client, ts1.URL, endpointInfoTest, apiKey1)
+	statusCodeWithKey, responseBodyWithKey, errWithKey := sendHTTPRequestToEndpoint(context.Background(), writer, client, ts1.URL, endpointInfoTest, apiKey1)
 	assert.Nil(t, errWithKey)
 	assert.Equal(t, statusCodeWithKey, 200)
 	assert.Equal(t, string(responseBodyWithKey), "OK")
 
 	// With the wrong API Key, it should be a 400
-	statusCode, responseBody, err := sendHTTPRequestToEndpoint(writer, context.Background(), client, ts1.URL, endpointInfoTest, apiKey2)
+	statusCode, responseBody, err := sendHTTPRequestToEndpoint(context.Background(), writer, client, ts1.URL, endpointInfoTest, apiKey2)
 	assert.Nil(t, err)
 	assert.Equal(t, statusCode, 400)
 	assert.Equal(t, string(responseBody), "Bad Request")


### PR DESCRIPTION
### What does this PR do?

This PR adds the output of `diagnose datadog-connectivity` command in the flare archive with some code refactor in the `archive.go` file. 

### Motivation

Having more information in the flare for troubleshooting 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

- Run `datadog-agent --no-color diagnose datadog-connectivity` and `datadog-agent diagnose datadog-connectivity` and verify that you get an output.
- Run `datadog-agent flare` and verify that there is a new `connectivity.log` file, in the archive, containing the same output as the command above, and also that the other files are still here with a content similar to before.


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
