### PR TITLE
Fix `docker_build_cluster_agent_arm64` on `main` branch: Revert "Fix `docker_build_cluster_agent_arm64` job (#12022)"

### DIFF
--- a/.gitlab/container_build/docker_linux.yml
+++ b/.gitlab/container_build/docker_linux.yml
@@ -192,8 +192,6 @@ docker_build_cluster_agent_arm64:
   variables:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/cluster-agent
     BUILD_CONTEXT: Dockerfiles/cluster-agent
-  before_script:
-    - cp -Rvf Dockerfiles/agent/nosys-seccomp Dockerfiles/cluster-agent/
 
 # build the dogstatsd image
 docker_build_dogstatsd_amd64:


### PR DESCRIPTION
This reverts commit 66ecb533d231f55ffafbb2cbc0a632a8798470fd.

### What does this PR do?

#12022 was a fix for #11745.
#11745 has been reverted on `main` by #12433.
So, #12022 need to be reverted as well.

### Motivation

The `docker_build_cluster_agent_arm64` GitLab job is currently broken on `main`.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Check that the `docker_build_cluster_agent_arm64` GitLab CI job is passing.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
