### PR TITLE
[process-agent] Use a separate domain for event payloads

### DIFF
--- a/cmd/process-agent/collector.go
+++ b/cmd/process-agent/collector.go
@@ -653,7 +653,7 @@ func (l *Collector) logQueuesSize() {
 	processSize, rtProcessSize, eventSize, podSize := l.processResults.Len(), l.rtProcessResults.Len(), l.eventResults.Len(), l.podResults.Len()
 	if processSize > 0 || rtProcessSize > 0 || eventSize > 0 || podSize > 0 {
 		log.Infof(
-			"Delivery queues: process[size=%d, weight=%d], rtprocess [size=%d, weight=%d], event [size=%d, weight=%d], pod[size=%d, weight=%d]",
+			"Delivery queues: process[size=%d, weight=%d], rtprocess[size=%d, weight=%d], event[size=%d, weight=%d], pod[size=%d, weight=%d]",
 			processSize, l.processResults.Weight(),
 			rtProcessSize, l.rtProcessResults.Weight(),
 			eventSize, l.eventResults.Weight(),

--- a/cmd/process-agent/collector.go
+++ b/cmd/process-agent/collector.go
@@ -73,6 +73,7 @@ type Collector struct {
 	processResults   *api.WeightedQueue
 	rtProcessResults *api.WeightedQueue
 	podResults       *api.WeightedQueue
+	eventResults     *api.WeightedQueue
 
 	forwarderRetryQueueMaxBytes int
 
@@ -128,6 +129,9 @@ func NewCollectorWithChecks(cfg *config.AgentConfig, checks []checks.Check, runR
 	podResults := api.NewWeightedQueue(queueSize, int64(cfg.Orchestrator.PodQueueBytes))
 	log.Debugf("Creating pod check queue with max_size=%d and max_weight=%d", podResults.MaxSize(), podResults.MaxWeight())
 
+	eventResults := api.NewWeightedQueue(queueSize, int64(queueBytes))
+	log.Debugf("Creating event check queue with max_size=%d and max_weight=%d", eventResults.MaxSize(), eventResults.MaxWeight())
+
 	dropCheckPayloads := ddconfig.Datadog.GetStringSlice("process_config.drop_check_payloads")
 	if len(dropCheckPayloads) > 0 {
 		log.Debugf("Dropping payloads from checks: %v", dropCheckPayloads)
@@ -146,6 +150,7 @@ func NewCollectorWithChecks(cfg *config.AgentConfig, checks []checks.Check, runR
 		processResults:   processResults,
 		rtProcessResults: rtProcessResults,
 		podResults:       podResults,
+		eventResults:     eventResults,
 
 		forwarderRetryQueueMaxBytes: queueBytes,
 
@@ -253,6 +258,11 @@ func (l *Collector) messagesToResults(start time.Time, name string, messages []m
 			extraHeaders.Set(headers.EVPOriginVersionHeader, version.AgentVersion)
 		}
 
+		if name == checks.ProcessEvents.Name() {
+			extraHeaders.Set(headers.EVPOriginHeader, "process-agent")
+			extraHeaders.Set(headers.EVPOriginVersionHeader, version.AgentVersion)
+		}
+
 		payloads = append(payloads, checkPayload{
 			body:    body,
 			headers: extraHeaders,
@@ -277,6 +287,11 @@ func (l *Collector) run(exit chan struct{}) error {
 		return err
 	}
 
+	processEventsAPIEndpoints, err := getEventsAPIEndpoints()
+	if err != nil {
+		return err
+	}
+
 	eps := make([]string, 0, len(processAPIEndpoints))
 	for _, e := range processAPIEndpoints {
 		eps = append(eps, e.Endpoint.String())
@@ -284,6 +299,10 @@ func (l *Collector) run(exit chan struct{}) error {
 	orchestratorEps := make([]string, 0, len(l.cfg.Orchestrator.OrchestratorEndpoints))
 	for _, e := range l.cfg.Orchestrator.OrchestratorEndpoints {
 		orchestratorEps = append(orchestratorEps, e.Endpoint.String())
+	}
+	eventsEps := make([]string, 0, len(processEventsAPIEndpoints))
+	for _, e := range processEventsAPIEndpoints {
+		eventsEps = append(eventsEps, e.Endpoint.String())
 	}
 
 	var checkNames []string
@@ -298,7 +317,7 @@ func (l *Collector) run(exit chan struct{}) error {
 	}
 	updateEnabledChecks(checkNames)
 	updateDropCheckPayloads(l.dropCheckPayloads)
-	log.Infof("Starting process-agent for host=%s, endpoints=%s, orchestrator endpoints=%s, enabled checks=%v", l.cfg.HostName, eps, orchestratorEps, checkNames)
+	log.Infof("Starting process-agent for host=%s, endpoints=%s, events endpoints=%s orchestrator endpoints=%s, enabled checks=%v", l.cfg.HostName, eps, eventsEps, orchestratorEps, checkNames)
 
 	go util.HandleSignals(exit)
 
@@ -307,6 +326,7 @@ func (l *Collector) run(exit chan struct{}) error {
 		l.processResults.Stop()
 		l.rtProcessResults.Stop()
 		l.podResults.Stop()
+		l.eventResults.Stop()
 	}()
 
 	var wg sync.WaitGroup
@@ -334,14 +354,17 @@ func (l *Collector) run(exit chan struct{}) error {
 			case <-heartbeat.C:
 				statsd.Client.Gauge("datadog.process.agent", 1, tags, 1) //nolint:errcheck
 			case <-queueSizeTicker.C:
-				updateQueueBytes(l.processResults.Weight(), l.rtProcessResults.Weight(), l.podResults.Weight())
-				updateQueueSize(l.processResults.Len(), l.rtProcessResults.Len(), l.podResults.Len())
+				updateQueueBytes(l.processResults.Weight(), l.rtProcessResults.Weight(), l.eventResults.Weight(), l.podResults.Weight())
+				updateQueueSize(l.processResults.Len(), l.rtProcessResults.Len(), l.eventResults.Len(), l.podResults.Len())
 			case <-queueLogTicker.C:
-				processSize, rtProcessSize, podSize := l.processResults.Len(), l.rtProcessResults.Len(), l.podResults.Len()
-				if processSize > 0 || rtProcessSize > 0 || podSize > 0 {
+				processSize, rtProcessSize, eventSize, podSize := l.processResults.Len(), l.rtProcessResults.Len(), l.eventResults.Len(), l.podResults.Len()
+				if processSize > 0 || rtProcessSize > 0 || eventSize > 0 || podSize > 0 {
 					log.Infof(
-						"Delivery queues: process[size=%d, weight=%d], rtprocess [size=%d, weight=%d], pod[size=%d, weight=%d]",
-						processSize, l.processResults.Weight(), rtProcessSize, l.rtProcessResults.Weight(), podSize, l.podResults.Weight(),
+						"Delivery queues: process[size=%d, weight=%d], rtprocess [size=%d, weight=%d], event [size=%d, weight=%d], pod[size=%d, weight=%d]",
+						processSize, l.processResults.Weight(),
+						rtProcessSize, l.rtProcessResults.Weight(),
+						eventSize, l.eventResults.Weight(),
+						podSize, l.podResults.Weight(),
 					)
 				}
 			case <-exit:
@@ -363,6 +386,11 @@ func (l *Collector) run(exit chan struct{}) error {
 	podForwarderOpts.RetryQueuePayloadsTotalMaxSize = l.forwarderRetryQueueMaxBytes // Allow more in-flight requests than the default
 	podForwarder := forwarder.NewDefaultForwarder(podForwarderOpts)
 
+	eventForwarderOpts := forwarder.NewOptionsWithResolvers(resolver.NewSingleDomainResolvers(apicfg.KeysPerDomains(processEventsAPIEndpoints)))
+	eventForwarderOpts.DisableAPIKeyChecking = true
+	eventForwarderOpts.RetryQueuePayloadsTotalMaxSize = l.forwarderRetryQueueMaxBytes // Allow more in-flight requests than the default
+	eventForwarder := forwarder.NewDefaultForwarder(eventForwarderOpts)
+
 	if err := processForwarder.Start(); err != nil {
 		return fmt.Errorf("error starting forwarder: %s", err)
 	}
@@ -373,6 +401,10 @@ func (l *Collector) run(exit chan struct{}) error {
 
 	if err := podForwarder.Start(); err != nil {
 		return fmt.Errorf("error starting pod forwarder: %s", err)
+	}
+
+	if err := eventForwarder.Start(); err != nil {
+		return fmt.Errorf("error starting event forwarder: %s", err)
 	}
 
 	wg.Add(1)
@@ -391,6 +423,12 @@ func (l *Collector) run(exit chan struct{}) error {
 	go func() {
 		defer wg.Done()
 		l.consumePayloads(l.podResults, podForwarder)
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		l.consumePayloads(l.eventResults, eventForwarder)
 	}()
 
 	for _, c := range l.enabledChecks {
@@ -426,6 +464,8 @@ func (l *Collector) resultsQueueForCheck(name string) *api.WeightedQueue {
 		return l.podResults
 	case checks.Process.RealTimeName(), checks.RTContainer.Name():
 		return l.rtProcessResults
+	case checks.ProcessEvents.Name():
+		return l.eventResults
 	}
 	return l.processResults
 }
@@ -631,8 +671,8 @@ func readResponseStatuses(checkName string, responses <-chan forwarder.Response)
 			continue
 		}
 
-		// we don't need to decode the body in case of the pod check
-		if checkName == checks.Pod.Name() {
+		// some checks don't receive a response with a status used to enable RT mode
+		if skipBodyDecoding(checkName) {
 			continue
 		}
 
@@ -656,4 +696,13 @@ func readResponseStatuses(checkName string, responses <-chan forwarder.Response)
 	}
 
 	return statuses
+}
+
+func skipBodyDecoding(checkName string) bool {
+	switch checkName {
+	case checks.Pod.Name(), checks.ProcessEvents.Name():
+		return true
+	default:
+		return false
+	}
 }

--- a/cmd/process-agent/collector_api_test.go
+++ b/cmd/process-agent/collector_api_test.go
@@ -23,6 +23,7 @@ import (
 	apicfg "github.com/DataDog/datadog-agent/pkg/process/util/api/config"
 	"github.com/DataDog/datadog-agent/pkg/process/util/api/headers"
 	"github.com/DataDog/datadog-agent/pkg/version"
+	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -40,6 +41,19 @@ func setProcessEndpointsForTest(config ddconfig.Config, eps ...apicfg.Endpoint) 
 		}
 	}
 	config.Set("process_config.additional_endpoints", additionalEps)
+}
+
+func setProcessEventsEndpointsForTest(config ddconfig.Config, eps ...apicfg.Endpoint) {
+	additionalEps := make(map[string][]string)
+	for i, ep := range eps {
+		if i == 0 {
+			config.Set("api_key", ep.APIKey)
+			config.Set("process_config.events_dd_url", ep.Endpoint)
+		} else {
+			additionalEps[ep.Endpoint.String()] = append(additionalEps[ep.Endpoint.String()], ep.APIKey)
+		}
+	}
+	config.Set("process_config.events_additional_endpoints", additionalEps)
 }
 
 func TestSendConnectionsMessage(t *testing.T) {
@@ -62,6 +76,10 @@ func TestSendConnectionsMessage(t *testing.T) {
 		apiEps, err := getAPIEndpoints()
 		assert.NoError(t, err)
 		assert.Equal(t, apiEps[0].APIKey, req.headers.Get("DD-Api-Key"))
+
+		// process-events specific headers should not be set
+		assert.Equal(t, "", req.headers.Get(headers.EVPOriginHeader))
+		assert.Equal(t, "", req.headers.Get(headers.EVPOriginVersionHeader))
 
 		reqBody, err := process.DecodeMessage(req.body)
 		require.NoError(t, err)
@@ -99,6 +117,10 @@ func TestSendContainerMessage(t *testing.T) {
 		assert.Equal(t, eps[0].APIKey, req.headers.Get("DD-Api-Key"))
 		assert.Equal(t, "1", req.headers.Get(headers.ContainerCountHeader))
 
+		// process-events specific headers should not be set
+		assert.Equal(t, "", req.headers.Get(headers.EVPOriginHeader))
+		assert.Equal(t, "", req.headers.Get(headers.EVPOriginVersionHeader))
+
 		reqBody, err := process.DecodeMessage(req.body)
 		require.NoError(t, err)
 
@@ -133,6 +155,10 @@ func TestSendProcMessage(t *testing.T) {
 		assert.Equal(t, "1", req.headers.Get(headers.ContainerCountHeader))
 		assert.Equal(t, "1", req.headers.Get("X-DD-Agent-Attempts"))
 		assert.NotEmpty(t, req.headers.Get(headers.TimestampHeader))
+
+		// process-events specific headers should not be set
+		assert.Equal(t, "", req.headers.Get(headers.EVPOriginHeader))
+		assert.Equal(t, "", req.headers.Get(headers.EVPOriginVersionHeader))
 
 		reqBody, err := process.DecodeMessage(req.body)
 		require.NoError(t, err)
@@ -169,6 +195,10 @@ func TestSendProcessDiscoveryMessage(t *testing.T) {
 		assert.Equal(t, "0", req.headers.Get(headers.ContainerCountHeader))
 		assert.Equal(t, "1", req.headers.Get("X-DD-Agent-Attempts"))
 		assert.NotEmpty(t, req.headers.Get(headers.TimestampHeader))
+
+		// process-events specific headers should not be set
+		assert.Equal(t, "", req.headers.Get(headers.EVPOriginHeader))
+		assert.Equal(t, "", req.headers.Get(headers.EVPOriginVersionHeader))
 
 		reqBody, err := process.DecodeMessage(req.body)
 		require.NoError(t, err)
@@ -208,7 +238,7 @@ func TestSendProcessEventMessage(t *testing.T) {
 		assert.Equal(t, "/api/v2/proclcycle", req.uri)
 
 		assert.Equal(t, cfg.HostName, req.headers.Get(headers.HostHeader))
-		eps, err := getAPIEndpoints()
+		eps, err := getEventsAPIEndpoints()
 		assert.NoError(t, err)
 		assert.Equal(t, eps[0].APIKey, req.headers.Get("DD-Api-Key"))
 		assert.Equal(t, "0", req.headers.Get(headers.ContainerCountHeader))
@@ -220,12 +250,15 @@ func TestSendProcessEventMessage(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, agentVersion.GetNumber(), req.headers.Get(headers.ProcessVersionHeader))
 
-		reqBody, err := process.DecodeMessage(req.body)
-		require.NoError(t, err)
+		// Check events-specific headers
+		assert.Equal(t, "process-agent", req.headers.Get(headers.EVPOriginHeader))
+		assert.Equal(t, version.AgentVersion, req.headers.Get(headers.EVPOriginVersionHeader))
 
-		b, ok := reqBody.Body.(*process.CollectorProcEvent)
-		require.True(t, ok)
-		assert.Equal(t, m, b)
+		// ProcessEvents payloads are encoded as plain protobuf
+		msg := &process.CollectorProcEvent{}
+		err = proto.Unmarshal(req.body, msg)
+		require.NoError(t, err)
+		assert.Equal(t, m, msg)
 	})
 }
 
@@ -442,7 +475,7 @@ func runCollectorTest(t *testing.T, check checks.Check, cfg *config.AgentConfig,
 
 func runCollectorTestWithAPIKeys(t *testing.T, check checks.Check, cfg *config.AgentConfig, epConfig *endpointConfig, apiKeys, orchAPIKeys []string, mockConfig ddconfig.Config, tc func(cfg *config.AgentConfig, ep *mockEndpoint)) {
 	ep := newMockEndpoint(t, epConfig)
-	collectorAddr, orchestratorAddr := ep.start()
+	collectorAddr, eventsAddr, orchestratorAddr := ep.start()
 	defer ep.stop()
 
 	var eps []apicfg.Endpoint
@@ -450,6 +483,12 @@ func runCollectorTestWithAPIKeys(t *testing.T, check checks.Check, cfg *config.A
 		eps = append(eps, apicfg.Endpoint{APIKey: key, Endpoint: collectorAddr})
 	}
 	setProcessEndpointsForTest(mockConfig, eps...)
+
+	var eventsEps []apicfg.Endpoint
+	for _, key := range apiKeys {
+		eventsEps = append(eventsEps, apicfg.Endpoint{APIKey: key, Endpoint: eventsAddr})
+	}
+	setProcessEventsEndpointsForTest(mockConfig, eventsEps...)
 
 	cfg.Orchestrator.OrchestratorEndpoints = make([]apicfg.Endpoint, len(orchAPIKeys))
 	for index, key := range orchAPIKeys {
@@ -519,6 +558,7 @@ type endpointConfig struct {
 type mockEndpoint struct {
 	t                  *testing.T
 	collectorServer    *http.Server
+	eventsServer       *http.Server
 	orchestratorServer *http.Server
 	stopper            sync.WaitGroup
 	Requests           chan request
@@ -539,20 +579,23 @@ func newMockEndpoint(t *testing.T, config *endpointConfig) *mockEndpoint {
 	collectorMux.HandleFunc("/api/v1/collector", m.handle)
 	collectorMux.HandleFunc("/api/v1/container", m.handle)
 	collectorMux.HandleFunc("/api/v1/discovery", m.handle)
-	collectorMux.HandleFunc("/api/v2/proclcycle", m.handle)
+
+	eventsMux := http.NewServeMux()
+	eventsMux.HandleFunc("/api/v2/proclcycle", m.handleEvents)
 
 	orchestratorMux := http.NewServeMux()
 	orchestratorMux.HandleFunc("/api/v1/validate", m.handleValidate)
 	orchestratorMux.HandleFunc("/api/v2/orch", m.handle)
 
 	m.collectorServer = &http.Server{Addr: ":", Handler: collectorMux}
+	m.eventsServer = &http.Server{Addr: ":", Handler: eventsMux}
 	m.orchestratorServer = &http.Server{Addr: ":", Handler: orchestratorMux}
 
 	return m
 }
 
 // start starts the http endpoints and returns (collector server url, orchestrator server url)
-func (m *mockEndpoint) start() (*url.URL, *url.URL) {
+func (m *mockEndpoint) start() (*url.URL, *url.URL, *url.URL) {
 	addrC := make(chan net.Addr, 1)
 
 	m.stopper.Add(1)
@@ -578,6 +621,20 @@ func (m *mockEndpoint) start() (*url.URL, *url.URL) {
 
 		addrC <- listener.Addr()
 
+		_ = m.eventsServer.Serve(listener)
+	}()
+
+	eventsAddr := <-addrC
+
+	m.stopper.Add(1)
+	go func() {
+		defer m.stopper.Done()
+
+		listener, err := net.Listen("tcp", ":")
+		require.NoError(m.t, err)
+
+		addrC <- listener.Addr()
+
 		_ = m.orchestratorServer.Serve(listener)
 	}()
 
@@ -588,14 +645,20 @@ func (m *mockEndpoint) start() (*url.URL, *url.URL) {
 	collectorEndpoint, err := url.Parse(fmt.Sprintf("http://%s", collectorAddr.String()))
 	require.NoError(m.t, err)
 
+	eventsEndpoint, err := url.Parse(fmt.Sprintf("http://%s", eventsAddr.String()))
+	require.NoError(m.t, err)
+
 	orchestratorEndpoint, err := url.Parse(fmt.Sprintf("http://%s", orchestratorAddr.String()))
 	require.NoError(m.t, err)
 
-	return collectorEndpoint, orchestratorEndpoint
+	return collectorEndpoint, eventsEndpoint, orchestratorEndpoint
 }
 
 func (m *mockEndpoint) stop() {
 	err := m.collectorServer.Close()
+	require.NoError(m.t, err)
+
+	err = m.eventsServer.Close()
 	require.NoError(m.t, err)
 
 	err = m.orchestratorServer.Close()
@@ -649,5 +712,27 @@ func (m *mockEndpoint) handle(w http.ResponseWriter, req *http.Request) {
 	w.WriteHeader(http.StatusAccepted)
 
 	_, err = w.Write(out)
+	require.NoError(m.t, err)
+}
+
+func (m *mockEndpoint) handleEvents(w http.ResponseWriter, req *http.Request) {
+	body, err := ioutil.ReadAll(req.Body)
+	require.NoError(m.t, err)
+
+	err = req.Body.Close()
+	require.NoError(m.t, err)
+
+	m.Requests <- request{headers: req.Header, body: body, uri: req.RequestURI}
+
+	if m.errorCount != m.errorsSent {
+		w.WriteHeader(http.StatusInternalServerError)
+		m.errorsSent++
+		return
+	}
+
+	w.WriteHeader(http.StatusAccepted)
+
+	// process-events endpoint returns an empty body for valid posted payloads
+	_, err = w.Write([]byte{})
 	require.NoError(m.t, err)
 }

--- a/cmd/process-agent/collector_test.go
+++ b/cmd/process-agent/collector_test.go
@@ -326,7 +326,7 @@ func TestNewCollectorProcessQueueBytes(t *testing.T) {
 	}
 }
 
-func TestSkipResponseBody(t *testing.T) {
+func TestIgnoreResponseBody(t *testing.T) {
 	for _, tc := range []struct {
 		checkName string
 		skip      bool
@@ -341,7 +341,7 @@ func TestSkipResponseBody(t *testing.T) {
 		{checkName: checks.ProcessEvents.Name(), skip: true},
 	} {
 		t.Run(tc.checkName, func(t *testing.T) {
-			assert.Equal(t, tc.skip, skipBodyDecoding(tc.checkName))
+			assert.Equal(t, tc.skip, ignoreResponseBody(tc.checkName))
 		})
 	}
 }

--- a/cmd/process-agent/collector_test.go
+++ b/cmd/process-agent/collector_test.go
@@ -329,19 +329,19 @@ func TestNewCollectorProcessQueueBytes(t *testing.T) {
 func TestIgnoreResponseBody(t *testing.T) {
 	for _, tc := range []struct {
 		checkName string
-		skip      bool
+		ignore    bool
 	}{
-		{checkName: checks.Process.Name(), skip: false},
-		{checkName: checks.Process.RealTimeName(), skip: false},
-		{checkName: checks.ProcessDiscovery.Name(), skip: false},
-		{checkName: checks.Container.Name(), skip: false},
-		{checkName: checks.RTContainer.Name(), skip: false},
-		{checkName: checks.Pod.Name(), skip: true},
-		{checkName: checks.Connections.Name(), skip: false},
-		{checkName: checks.ProcessEvents.Name(), skip: true},
+		{checkName: checks.Process.Name(), ignore: false},
+		{checkName: checks.Process.RealTimeName(), ignore: false},
+		{checkName: checks.ProcessDiscovery.Name(), ignore: false},
+		{checkName: checks.Container.Name(), ignore: false},
+		{checkName: checks.RTContainer.Name(), ignore: false},
+		{checkName: checks.Pod.Name(), ignore: true},
+		{checkName: checks.Connections.Name(), ignore: false},
+		{checkName: checks.ProcessEvents.Name(), ignore: true},
 	} {
 		t.Run(tc.checkName, func(t *testing.T) {
-			assert.Equal(t, tc.skip, ignoreResponseBody(tc.checkName))
+			assert.Equal(t, tc.ignore, ignoreResponseBody(tc.checkName))
 		})
 	}
 }

--- a/cmd/process-agent/collector_test.go
+++ b/cmd/process-agent/collector_test.go
@@ -325,3 +325,23 @@ func TestNewCollectorProcessQueueBytes(t *testing.T) {
 		})
 	}
 }
+
+func TestSkipResponseBody(t *testing.T) {
+	for _, tc := range []struct {
+		checkName string
+		skip      bool
+	}{
+		{checkName: checks.Process.Name(), skip: false},
+		{checkName: checks.Process.RealTimeName(), skip: false},
+		{checkName: checks.ProcessDiscovery.Name(), skip: false},
+		{checkName: checks.Container.Name(), skip: false},
+		{checkName: checks.RTContainer.Name(), skip: false},
+		{checkName: checks.Pod.Name(), skip: true},
+		{checkName: checks.Connections.Name(), skip: false},
+		{checkName: checks.ProcessEvents.Name(), skip: true},
+	} {
+		t.Run(tc.checkName, func(t *testing.T) {
+			assert.Equal(t, tc.skip, skipBodyDecoding(tc.checkName))
+		})
+	}
+}

--- a/cmd/process-agent/config.go
+++ b/cmd/process-agent/config.go
@@ -66,10 +66,18 @@ func getChecks(sysCfg *sysconfig.Config, oCfg *oconfig.OrchestratorConfig, canAc
 }
 
 func getAPIEndpoints() (eps []apicfg.Endpoint, err error) {
+	return getAPIEndpointsWithKeys("https://process.", "process_config.process_dd_url", "process_config.additional_endpoints")
+}
+
+func getEventsAPIEndpoints() (eps []apicfg.Endpoint, err error) {
+	return getAPIEndpointsWithKeys("https://process-events.", "process_config.events_dd_url", "process_config.events_additional_endpoints")
+}
+
+func getAPIEndpointsWithKeys(prefix, defaultEpKey, additionalEpsKey string) (eps []apicfg.Endpoint, err error) {
 	// Setup main endpoint
-	mainEndpointURL, err := url.Parse(ddconfig.GetMainEndpoint("https://process.", "process_config.process_dd_url"))
+	mainEndpointURL, err := url.Parse(ddconfig.GetMainEndpoint(prefix, defaultEpKey))
 	if err != nil {
-		return nil, fmt.Errorf("error parsing process_dd_url: %s", err)
+		return nil, fmt.Errorf("error parsing %s: %s", defaultEpKey, err)
 	}
 	eps = append(eps, apicfg.Endpoint{
 		APIKey:   ddconfig.SanitizeAPIKey(ddconfig.Datadog.GetString("api_key")),
@@ -77,10 +85,10 @@ func getAPIEndpoints() (eps []apicfg.Endpoint, err error) {
 	})
 
 	// Optional additional pairs of endpoint_url => []apiKeys to submit to other locations.
-	for endpointURL, apiKeys := range ddconfig.Datadog.GetStringMapStringSlice("process_config.additional_endpoints") {
+	for endpointURL, apiKeys := range ddconfig.Datadog.GetStringMapStringSlice(additionalEpsKey) {
 		u, err := url.Parse(endpointURL)
 		if err != nil {
-			return nil, fmt.Errorf("invalid additional endpoint url '%s': %s", endpointURL, err)
+			return nil, fmt.Errorf("invalid %s url '%s': %s", additionalEpsKey, endpointURL, err)
 		}
 		for _, k := range apiKeys {
 			eps = append(eps, apicfg.Endpoint{

--- a/cmd/process-agent/config_test.go
+++ b/cmd/process-agent/config_test.go
@@ -18,6 +18,14 @@ import (
 	apicfg "github.com/DataDog/datadog-agent/pkg/process/util/api/config"
 )
 
+func mkurl(rawurl string) *url.URL {
+	urlResult, err := url.Parse(rawurl)
+	if err != nil {
+		panic(err)
+	}
+	return urlResult
+}
+
 func TestProcessDiscovery(t *testing.T) {
 	scfg, ocfg := &sysconfig.Config{}, &oconfig.OrchestratorConfig{}
 	cfg := config.Mock(t)
@@ -213,14 +221,6 @@ func TestProcessEventsCheck(t *testing.T) {
 }
 
 func TestGetAPIEndpoints(t *testing.T) {
-	mkurl := func(rawurl string) *url.URL {
-		urlResult, err := url.Parse(rawurl)
-		if err != nil {
-			panic(err)
-		}
-		return urlResult
-	}
-
 	for _, tc := range []struct {
 		name, apiKey, ddURL string
 		additionalEndpoints map[string][]string
@@ -303,23 +303,36 @@ func TestGetAPIEndpoints(t *testing.T) {
 // TestGetAPIEndpointsSite is a test for GetAPIEndpoints. It makes sure that the deprecated `site` setting still works
 func TestGetAPIEndpointsSite(t *testing.T) {
 	for _, tc := range []struct {
-		name, site, ddURL, expectedHostname string
+		name                                     string
+		site                                     string
+		ddURL, eventsDDURL                       string
+		expectedHostname, expectedEventsHostname string
 	}{
 		{
-			name:             "site only",
-			site:             "datadoghq.io",
-			expectedHostname: "process.datadoghq.io",
+			name:                   "site only",
+			site:                   "datadoghq.io",
+			expectedHostname:       "process.datadoghq.io",
+			expectedEventsHostname: "process-events.datadoghq.io",
 		},
 		{
-			name:             "dd_url only",
-			ddURL:            "https://process.datadoghq.eu",
-			expectedHostname: "process.datadoghq.eu",
+			name:                   "dd_url only",
+			ddURL:                  "https://process.datadoghq.eu",
+			expectedHostname:       "process.datadoghq.eu",
+			expectedEventsHostname: "process-events.datadoghq.com",
 		},
 		{
-			name:             "both site and dd_url",
-			site:             "datacathq.eu",
-			ddURL:            "https://burrito.com",
-			expectedHostname: "burrito.com",
+			name:                   "events_dd_url only",
+			eventsDDURL:            "https://process-events.datadoghq.eu",
+			expectedHostname:       "process.datadoghq.com",
+			expectedEventsHostname: "process-events.datadoghq.eu",
+		},
+		{
+			name:                   "both site and dd_url",
+			site:                   "datacathq.eu",
+			ddURL:                  "https://burrito.com",
+			eventsDDURL:            "https://burrito-events.com",
+			expectedHostname:       "burrito.com",
+			expectedEventsHostname: "burrito-events.com",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -330,12 +343,165 @@ func TestGetAPIEndpointsSite(t *testing.T) {
 			if tc.ddURL != "" {
 				cfg.Set("process_config.process_dd_url", tc.ddURL)
 			}
+			if tc.eventsDDURL != "" {
+				cfg.Set("process_config.events_dd_url", tc.eventsDDURL)
+			}
 
 			eps, err := getAPIEndpoints()
 			assert.NoError(t, err)
 
 			mainEndpoint := eps[0]
 			assert.Equal(t, tc.expectedHostname, mainEndpoint.Endpoint.Hostname())
+
+			eventsEps, err := getEventsAPIEndpoints()
+			assert.NoError(t, err)
+
+			mainEventEndpoint := eventsEps[0]
+			assert.Equal(t, tc.expectedEventsHostname, mainEventEndpoint.Endpoint.Hostname())
+		})
+	}
+}
+
+// TestGetConcurrentAPIEndpoints ensures that process and process-events endpoints can be independently set
+func TestGetConcurrentAPIEndpoints(t *testing.T) {
+	for _, tc := range []struct {
+		name                       string
+		ddURL, eventsDDURL, apiKey string
+		additionalEndpoints        map[string][]string
+		additionalEventsEndpoints  map[string][]string
+		expectedEndpoints          []apicfg.Endpoint
+		expectedEventsEndpoints    []apicfg.Endpoint
+	}{
+		{
+			name:   "default",
+			apiKey: "test",
+			expectedEndpoints: []apicfg.Endpoint{
+				{
+					APIKey:   "test",
+					Endpoint: mkurl(config.DefaultProcessEndpoint),
+				},
+			},
+			expectedEventsEndpoints: []apicfg.Endpoint{
+				{
+					APIKey:   "test",
+					Endpoint: mkurl(config.DefaultProcessEventsEndpoint),
+				},
+			},
+		},
+		{
+			name:   "set only process endpoint",
+			ddURL:  "https://process.datadoghq.eu",
+			apiKey: "test",
+			expectedEndpoints: []apicfg.Endpoint{
+				{
+					APIKey:   "test",
+					Endpoint: mkurl("https://process.datadoghq.eu"),
+				},
+			},
+			expectedEventsEndpoints: []apicfg.Endpoint{
+				{
+					APIKey:   "test",
+					Endpoint: mkurl(config.DefaultProcessEventsEndpoint),
+				},
+			},
+		},
+		{
+			name:        "set only process-events endpoint",
+			eventsDDURL: "https://process-events.datadoghq.eu",
+			apiKey:      "test",
+			expectedEndpoints: []apicfg.Endpoint{
+				{
+					APIKey:   "test",
+					Endpoint: mkurl(config.DefaultProcessEndpoint),
+				},
+			},
+			expectedEventsEndpoints: []apicfg.Endpoint{
+				{
+					APIKey:   "test",
+					Endpoint: mkurl("https://process-events.datadoghq.eu"),
+				},
+			},
+		},
+		{
+			name:   "multiple eps",
+			apiKey: "test",
+			additionalEndpoints: map[string][]string{
+				"https://mock.datadoghq.com": {
+					"key1",
+					"key2",
+				},
+				"https://mock2.datadoghq.com": {
+					"key3",
+				},
+			},
+			additionalEventsEndpoints: map[string][]string{
+				"https://mock-events.datadoghq.com": {
+					"key2",
+				},
+				"https://mock2-events.datadoghq.com": {
+					"key3",
+				},
+			},
+			expectedEndpoints: []apicfg.Endpoint{
+				{
+					Endpoint: mkurl(config.DefaultProcessEndpoint),
+					APIKey:   "test",
+				},
+				{
+					Endpoint: mkurl("https://mock.datadoghq.com"),
+					APIKey:   "key1",
+				},
+				{
+					Endpoint: mkurl("https://mock.datadoghq.com"),
+					APIKey:   "key2",
+				},
+				{
+					Endpoint: mkurl("https://mock2.datadoghq.com"),
+					APIKey:   "key3",
+				},
+			},
+			expectedEventsEndpoints: []apicfg.Endpoint{
+				{
+					Endpoint: mkurl(config.DefaultProcessEventsEndpoint),
+					APIKey:   "test",
+				},
+				{
+					Endpoint: mkurl("https://mock-events.datadoghq.com"),
+					APIKey:   "key2",
+				},
+				{
+					Endpoint: mkurl("https://mock2-events.datadoghq.com"),
+					APIKey:   "key3",
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := config.Mock(t)
+			cfg.Set("api_key", tc.apiKey)
+			if tc.ddURL != "" {
+				cfg.Set("process_config.process_dd_url", tc.ddURL)
+			}
+
+			if tc.eventsDDURL != "" {
+				cfg.Set("process_config.events_dd_url", tc.eventsDDURL)
+			}
+
+			if tc.additionalEndpoints != nil {
+				cfg.Set("process_config.additional_endpoints", tc.additionalEndpoints)
+			}
+
+			if tc.additionalEventsEndpoints != nil {
+				cfg.Set("process_config.events_additional_endpoints", tc.additionalEventsEndpoints)
+			}
+
+			eps, err := getAPIEndpoints()
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, tc.expectedEndpoints, eps)
+
+			eventsEps, err := getEventsAPIEndpoints()
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, tc.expectedEventsEndpoints, eventsEps)
 		})
 	}
 }

--- a/cmd/process-agent/info.go
+++ b/cmd/process-agent/info.go
@@ -160,20 +160,28 @@ func updateProcContainerCount(msgs []model.MessageBody) {
 	infoContainerCount = containerCount
 }
 
-type queueSizeInfo struct {
-	processQueueSize   int
-	rtProcessQueueSize int
-	eventQueueSize     int
-	podQueueSize       int
+type queueStats struct {
+	processQueueSize    int
+	rtProcessQueueSize  int
+	eventQueueSize      int
+	podQueueSize        int
+	processQueueBytes   int64
+	rtProcessQueueBytes int64
+	eventQueueBytes     int64
+	podQueueBytes       int64
 }
 
-func updateQueueSize(i *queueSizeInfo) {
+func updateQueueStats(stats *queueStats) {
 	infoMutex.Lock()
 	defer infoMutex.Unlock()
-	infoProcessQueueSize = i.processQueueSize
-	infoRTProcessQueueSize = i.rtProcessQueueSize
-	infoEventQueueSize = i.eventQueueSize
-	infoPodQueueSize = i.podQueueSize
+	infoProcessQueueSize = stats.processQueueSize
+	infoRTProcessQueueSize = stats.rtProcessQueueSize
+	infoEventQueueSize = stats.eventQueueSize
+	infoPodQueueSize = stats.podQueueSize
+	infoProcessQueueBytes = int(stats.processQueueBytes)
+	infoRTProcessQueueBytes = int(stats.rtProcessQueueBytes)
+	infoEventQueueBytes = int(stats.eventQueueBytes)
+	infoPodQueueBytes = int(stats.podQueueBytes)
 }
 
 func updateEnabledChecks(enabledChecks []string) {
@@ -210,22 +218,6 @@ func publishEventQueueSize() interface{} {
 	infoMutex.RLock()
 	defer infoMutex.RUnlock()
 	return infoEventQueueSize
-}
-
-type queueBytesInfo struct {
-	processQueueBytes   int64
-	rtProcessQueueBytes int64
-	eventQueueBytes     int64
-	podQueueBytes       int64
-}
-
-func updateQueueBytes(i *queueBytesInfo) {
-	infoMutex.Lock()
-	defer infoMutex.Unlock()
-	infoProcessQueueBytes = int(i.processQueueBytes)
-	infoRTProcessQueueBytes = int(i.rtProcessQueueBytes)
-	infoEventQueueBytes = int(i.eventQueueBytes)
-	infoPodQueueBytes = int(i.podQueueBytes)
 }
 
 func publishProcessQueueBytes() interface{} {

--- a/cmd/process-agent/info.go
+++ b/cmd/process-agent/info.go
@@ -160,13 +160,20 @@ func updateProcContainerCount(msgs []model.MessageBody) {
 	infoContainerCount = containerCount
 }
 
-func updateQueueSize(processQueueSize, rtProcessQueueSize, eventQueueSize, podQueueSize int) {
+type queueSizeInfo struct {
+	processQueueSize   int
+	rtProcessQueueSize int
+	eventQueueSize     int
+	podQueueSize       int
+}
+
+func updateQueueSize(i *queueSizeInfo) {
 	infoMutex.Lock()
 	defer infoMutex.Unlock()
-	infoProcessQueueSize = processQueueSize
-	infoRTProcessQueueSize = rtProcessQueueSize
-	infoEventQueueSize = eventQueueSize
-	infoPodQueueSize = podQueueSize
+	infoProcessQueueSize = i.processQueueSize
+	infoRTProcessQueueSize = i.rtProcessQueueSize
+	infoEventQueueSize = i.eventQueueSize
+	infoPodQueueSize = i.podQueueSize
 }
 
 func updateEnabledChecks(enabledChecks []string) {
@@ -205,13 +212,20 @@ func publishEventQueueSize() interface{} {
 	return infoEventQueueSize
 }
 
-func updateQueueBytes(processQueueBytes, rtProcessQueueBytes, eventQueueBytes, podQueueBytes int64) {
+type queueBytesInfo struct {
+	processQueueBytes   int64
+	rtProcessQueueBytes int64
+	eventQueueBytes     int64
+	podQueueBytes       int64
+}
+
+func updateQueueBytes(i *queueBytesInfo) {
 	infoMutex.Lock()
 	defer infoMutex.Unlock()
-	infoProcessQueueBytes = int(processQueueBytes)
-	infoRTProcessQueueBytes = int(rtProcessQueueBytes)
-	infoEventQueueBytes = int(eventQueueBytes)
-	infoPodQueueBytes = int(podQueueBytes)
+	infoProcessQueueBytes = int(i.processQueueBytes)
+	infoRTProcessQueueBytes = int(i.rtProcessQueueBytes)
+	infoEventQueueBytes = int(i.eventQueueBytes)
+	infoPodQueueBytes = int(i.podQueueBytes)
 }
 
 func publishProcessQueueBytes() interface{} {

--- a/cmd/process-agent/info_test.go
+++ b/cmd/process-agent/info_test.go
@@ -36,9 +36,11 @@ Processes and Containers Agent (v 0.99.0)
   Number of containers: 0
   Process Queue length: 0
   RTProcess Queue length: 0
+  Event Queue length: 0
   Pod Queue length: 0
   Process Bytes enqueued: 0
   RTProcess Bytes enqueued: 0
+  Event Bytes enqueued: 0
   Pod Bytes enqueued: 0
   Drop Check Payloads: []
 

--- a/pkg/config/process.go
+++ b/pkg/config/process.go
@@ -46,6 +46,9 @@ const (
 	// DefaultProcessEndpoint is the default endpoint for the process agent to send payloads to
 	DefaultProcessEndpoint = "https://process.datadoghq.com"
 
+	// DefaultProcessEventsEndpoint is the default endpoint for the process agent to send event payloads to
+	DefaultProcessEventsEndpoint = "https://process-events.datadoghq.com"
+
 	// DefaultProcessEventStoreMaxItems is the default maximum amount of events that can be stored in the Event Store
 	DefaultProcessEventStoreMaxItems = 200
 
@@ -112,6 +115,7 @@ func setupProcesses(config Config) {
 		"DD_PROCESS_AGENT_URL",
 		"DD_PROCESS_CONFIG_URL",
 	)
+	procBindEnv(config, "process_config.events_dd_url")
 	config.SetKnown("process_config.dd_agent_env")
 	config.SetKnown("process_config.intervals.process_realtime")
 	procBindEnvAndSetDefault(config, "process_config.queue_size", DefaultProcessQueueSize)
@@ -152,6 +156,7 @@ func setupProcesses(config Config) {
 		"DD_PROCESS_AGENT_ADDITIONAL_ENDPOINTS",
 		"DD_PROCESS_ADDITIONAL_ENDPOINTS",
 	)
+	procBindEnvAndSetDefault(config, "process_config.events_additional_endpoints", make(map[string][]string))
 	config.SetKnown("process_config.intervals.connections")
 	procBindEnvAndSetDefault(config, "process_config.expvar_port", DefaultProcessExpVarPort)
 	procBindEnvAndSetDefault(config, "process_config.log_file", DefaultProcessAgentLogFile)

--- a/pkg/config/process_test.go
+++ b/pkg/config/process_test.go
@@ -75,6 +75,10 @@ func TestProcessDefaultConfig(t *testing.T) {
 			defaultValue: make(map[string][]string),
 		},
 		{
+			key:          "process_config.events_additional_endpoints",
+			defaultValue: make(map[string][]string),
+		},
+		{
 			key:          "process_config.internal_profiling.enabled",
 			defaultValue: false,
 		},
@@ -286,6 +290,12 @@ func TestEnvVarOverride(t *testing.T) {
 			expected: "datacat.com",
 		},
 		{
+			key:      "process_config.events_dd_url",
+			env:      "DD_PROCESS_CONFIG_EVENTS_DD_URL",
+			value:    "datacat.com",
+			expected: "datacat.com",
+		},
+		{
 			key:      "process_config.internal_profiling.enabled",
 			env:      "DD_PROCESS_CONFIG_INTERNAL_PROFILING_ENABLED",
 			value:    "true",
@@ -433,6 +443,16 @@ func TestEnvVarOverride(t *testing.T) {
 				"fakeAPIKey",
 			},
 		}, cfg.GetStringMapStringSlice("process_config.additional_endpoints"))
+		reset()
+	})
+
+	t.Run("DD_PROCESS_CONFIG_EVENTS_ADDITIONAL_ENDPOINTS", func(t *testing.T) {
+		reset := setEnvForTest("DD_PROCESS_CONFIG_EVENTS_ADDITIONAL_ENDPOINTS", `{"https://process-events.datadoghq.io": ["fakeAPIKey"]}`)
+		assert.Equal(t, map[string][]string{
+			"https://process-events.datadoghq.io": {
+				"fakeAPIKey",
+			},
+		}, cfg.GetStringMapStringSlice("process_config.events_additional_endpoints"))
 		reset()
 	})
 }

--- a/pkg/process/util/api/payload.go
+++ b/pkg/process/util/api/payload.go
@@ -7,9 +7,10 @@ package api
 
 import (
 	"fmt"
-	"github.com/gogo/protobuf/proto"
 
 	model "github.com/DataDog/agent-payload/v5/process"
+	"github.com/gogo/protobuf/proto"
+
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 )
 

--- a/pkg/process/util/status.go
+++ b/pkg/process/util/status.go
@@ -77,9 +77,11 @@ type ProcessExpvars struct {
 	ContainerCount      int                 `json:"container_count"`
 	ProcessQueueSize    int                 `json:"process_queue_size"`
 	RTProcessQueueSize  int                 `json:"rtprocess_queue_size"`
+	EventQueueSize      int                 `json:"event_queue_size"`
 	PodQueueSize        int                 `json:"pod_queue_size"`
 	ProcessQueueBytes   int                 `json:"process_queue_bytes"`
 	RTProcessQueueBytes int                 `json:"rtprocess_queue_bytes"`
+	EventQueueBytes     int                 `json:"event_queue_bytes"`
 	PodQueueBytes       int                 `json:"pod_queue_bytes"`
 	ContainerID         string              `json:"container_id"`
 	ProxyURL            string              `json:"proxy_url"`

--- a/pkg/status/templates/process-agent.tmpl
+++ b/pkg/status/templates/process-agent.tmpl
@@ -41,9 +41,11 @@ Process Agent
     Number of containers: {{.expvars.container_count}}
     Process Queue length: {{.expvars.process_queue_size}}
     RTProcess Queue length: {{.expvars.rtprocess_queue_size}}
+    Event Queue length: {{.expvars.event_queue_size}}
     Pod Queue length: {{.expvars.pod_queue_size}}
     Process Bytes enqueued: {{.expvars.process_queue_bytes}}
     RTProcess Bytes enqueued: {{.expvars.rtprocess_queue_bytes}}
+    Event Bytes enqueued: {{.expvars.event_queue_bytes}}
     Pod Bytes enqueued: {{.expvars.pod_queue_bytes}}
     Drop Check Payloads: {{.expvars.drop_check_payloads}}
 {{- end }}


### PR DESCRIPTION
### What does this PR do?

This PR creates a separate check queue and forwarder in order to send `process_events` payloads to a separate Datadog domain. The default domain is `https://process-events.datadoghq.com` and it can be overridden and extended with 2 new settings:
* `process_config.events_dd_url`
* `process_config.events_additional_endpoints`

`CollectorProcEvents` are now encoded as plain `protobuf` instead of using the `protobuf+zstd` compression from other `processs-agent` checks.

In addition to that, when sending event payloads, `process-agent` does not read the server response body since it's not used to toggle the realtime mode.

### Motivation


### Additional Notes


### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes

Update `system-probe.yaml` with
```yaml
runtime_security_config:
  event_monitoring:
    enabled: true
```

Update the `datadog.yaml` file with the following settings
```yaml 
process_config:
  event_collection:
    enabled: true
```

When the agent starts, check in the logs that it's creating a separate forwarder to send event payloads to `https://process-events.datadoghq.com`.

Redirect `process-events.datadoghq.com` traffic to your localhost to simulate a connection error. Add the following line to `/etc/hosts`

```
127.0.1.1       process-events.datadoghq.com
```

Check if `process-agent` is logging the increase in the queue size. Look for the same information using

```
./process-agent --info
```

```
./process-agent status
```

```
curl localhost:6062/debug/vars
```

Collect an agent flare and check if the queue info is in the `status.yaml` file.

Repeat the same test now blocking `process.datadoghq.com` traffic. Make sure that the process queue size is increasing.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
