### PR TITLE
[AD] Re-introduce autodiscovery_scheduled_configs telemetry

### DIFF
--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/listeners"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/scheduler"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
@@ -504,9 +505,34 @@ func (ac *AutoConfig) GetAutodiscoveryErrors() map[string]map[string]providers.E
 // applyChanges applies a configChanges object. This always unschedules first.
 func (ac *AutoConfig) applyChanges(changes configChanges) {
 	if len(changes.unschedule) > 0 {
+		for _, conf := range changes.unschedule {
+			telemetry.ScheduledConfigs.Dec(conf.Provider, configType(conf))
+		}
+
 		ac.scheduler.Unschedule(changes.unschedule)
 	}
+
 	if len(changes.schedule) > 0 {
+		for _, conf := range changes.schedule {
+			telemetry.ScheduledConfigs.Inc(conf.Provider, configType(conf))
+		}
+
 		ac.scheduler.Schedule(changes.schedule)
 	}
+}
+
+func configType(c integration.Config) string {
+	if c.IsLogConfig() {
+		return "logs"
+	}
+
+	if c.IsCheckConfig() {
+		return "check"
+	}
+
+	if c.ClusterCheck {
+		return "clustercheck"
+	}
+
+	return "unknown"
 }

--- a/pkg/autodiscovery/telemetry/telemetry.go
+++ b/pkg/autodiscovery/telemetry/telemetry.go
@@ -25,6 +25,15 @@ var (
 )
 
 var (
+	// ScheduledConfigs tracks how many configs are scheduled.
+	ScheduledConfigs = telemetry.NewGaugeWithOpts(
+		subsystem,
+		"scheduled_configs",
+		[]string{"provider", "type"},
+		"Number of configs scheduled in Autodiscovery by provider and type.",
+		commonOpts,
+	)
+
 	// WatchedResources tracks how many resources are watched by AD listeners.
 	WatchedResources = telemetry.NewGaugeWithOpts(
 		subsystem,


### PR DESCRIPTION
### What does this PR do?

This was reverted in #10499 due to a bug in AD scheduling. This has
since been fixed in #11639, so I'm re-introducing equivalent changes as
to what #10499 reverted.

### Describe how to test/QA your changes

Same as #10243, but only for the `autodiscovery_scheduled_configs` bits. Also observe a cluster with a lot of workload churn (or a busy staging cluster) and ensure that the telemetry stays stable (and definitely does not go below zero).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
