### PR TITLE
[process-agent] Collect Container ID for process events

### DIFF
--- a/cmd/process-agent/app/events.go
+++ b/cmd/process-agent/app/events.go
@@ -218,6 +218,7 @@ func fmtProcessEvents(events []*model.ProcessEvent) []*payload.ProcessEvent {
 		pE := &payload.ProcessEvent{
 			CollectionTime: e.CollectionTime.UnixNano(),
 			Pid:            e.Pid,
+			ContainerId:    e.ContainerID,
 			Command: &payload.Command{
 				Exe:  e.Exe,
 				Args: e.Cmdline,

--- a/pkg/process/checks/process_events_linux.go
+++ b/pkg/process/checks/process_events_linux.go
@@ -159,6 +159,7 @@ func fmtProcessEvents(events []*model.ProcessEvent) []*payload.ProcessEvent {
 		pE := &payload.ProcessEvent{
 			CollectionTime: e.CollectionTime.UnixNano(),
 			Pid:            e.Pid,
+			ContainerId:    e.ContainerID,
 			Command: &payload.Command{
 				Exe:  e.Exe,
 				Args: e.Cmdline,

--- a/pkg/process/checks/process_events_linux_test.go
+++ b/pkg/process/checks/process_events_linux_test.go
@@ -45,7 +45,8 @@ func mockedData(t *testing.T) []*eventTestData {
 							PIDContext: secmodel.PIDContext{
 								Pid: 42,
 							},
-							PPid: 1,
+							ContainerID: "0123456789abcdef",
+							PPid:        1,
 							Credentials: secmodel.Credentials{
 								UID:   100,
 								GID:   100,
@@ -72,6 +73,7 @@ func mockedData(t *testing.T) []*eventTestData {
 				Type:           payload.ProcEventType_exec,
 				CollectionTime: parseRFC3339Time(t, "2022-06-12T12:00:10Z").UnixNano(),
 				Pid:            42,
+				ContainerId:    "0123456789abcdef",
 				Command: &payload.Command{
 					Exe:  "/usr/bin/curl",
 					Args: []string{"curl", "localhost:6062/debug/vars"},
@@ -100,7 +102,8 @@ func mockedData(t *testing.T) []*eventTestData {
 							PIDContext: secmodel.PIDContext{
 								Pid: 42,
 							},
-							PPid: 1,
+							ContainerID: "0123456789abcdef",
+							PPid:        1,
 							Credentials: secmodel.Credentials{
 								UID:   100,
 								GID:   100,
@@ -127,6 +130,7 @@ func mockedData(t *testing.T) []*eventTestData {
 				Type:           payload.ProcEventType_exit,
 				CollectionTime: parseRFC3339Time(t, "2022-06-12T12:00:20Z").UnixNano(),
 				Pid:            42,
+				ContainerId:    "0123456789abcdef",
 				Command: &payload.Command{
 					Exe:  "/usr/bin/curl",
 					Args: []string{"curl", "localhost:6062/debug/vars"},

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -59,7 +59,7 @@ func (a *AgentConfig) LoadAgentConfig(path string) error {
 	eventsInterval := config.Datadog.GetDuration("process_config.event_collection.interval")
 	if eventsInterval < config.DefaultProcessEventsMinCheckInterval {
 		eventsInterval = config.DefaultProcessEventsCheckInterval
-		_ = log.Warnf("Invalid interval for process_events check (<=%s) using default value of %s",
+		_ = log.Warnf("Invalid interval for process_events check (< %s) using default value of %s",
 			config.DefaultProcessEventsMinCheckInterval.String(), config.DefaultProcessEventsCheckInterval.String())
 	}
 	a.CheckIntervals[ProcessEventsCheckName] = eventsInterval

--- a/pkg/process/events/listener_linux_test.go
+++ b/pkg/process/events/listener_linux_test.go
@@ -76,6 +76,7 @@ func TestProcessEventHandling(t *testing.T) {
 		EventType:      model.Exec,
 		CollectionTime: now,
 		Pid:            32,
+		ContainerID:    "01234567890abcdef",
 		Ppid:           1,
 		UID:            124,
 		GID:            2,

--- a/pkg/process/events/model/model_common.go
+++ b/pkg/process/events/model/model_common.go
@@ -26,6 +26,7 @@ type ProcessEvent struct {
 	EventType      string    `json:"event_type"`
 	CollectionTime time.Time `json:"collection_time"`
 	Pid            uint32    `json:"pid"`
+	ContainerID    string    `json:"container_id"`
 	Ppid           uint32    `json:"ppid"`
 	UID            uint32    `json:"uid"`
 	GID            uint32    `json:"gid"`
@@ -54,6 +55,7 @@ func NewMockedProcessEvent(evtType string, ts time.Time, pid uint32, exe string,
 		EventType:      evtType,
 		CollectionTime: time.Now(),
 		Pid:            pid,
+		ContainerID:    "01234567890abcedf",
 		Ppid:           1,
 		UID:            100,
 		GID:            100,
@@ -75,6 +77,7 @@ func AssertProcessEvents(t *testing.T, expected, actual *ProcessEvent) {
 	assert.Equal(t, expected.EventType, actual.EventType)
 	assert.WithinDuration(t, expected.CollectionTime, actual.CollectionTime, 0)
 	assert.Equal(t, expected.Pid, actual.Pid)
+	assert.Equal(t, expected.ContainerID, actual.ContainerID)
 	assert.Equal(t, expected.Ppid, actual.Ppid)
 	assert.Equal(t, expected.UID, actual.UID)
 	assert.Equal(t, expected.GID, actual.GID)

--- a/pkg/process/events/model/model_sysprobe.go
+++ b/pkg/process/events/model/model_sysprobe.go
@@ -31,6 +31,7 @@ func ProcessMonitoringToProcessEvent(e *ProcessMonitoringEvent) *ProcessEvent {
 		EventType:      e.EventType,
 		CollectionTime: e.CollectionTime,
 		Pid:            e.Pid,
+		ContainerID:    e.ContainerID,
 		Ppid:           e.PPid,
 		UID:            e.UID,
 		GID:            e.GID,
@@ -56,7 +57,8 @@ func ProcessEventToProcessMonitoringEvent(e *ProcessEvent) *ProcessMonitoringEve
 					PIDContext: model.PIDContext{
 						Pid: e.Pid,
 					},
-					PPid: e.Ppid,
+					ContainerID: e.ContainerID,
+					PPid:        e.Ppid,
 					Credentials: model.Credentials{
 						UID:   e.UID,
 						GID:   e.GID,


### PR DESCRIPTION
### What does this PR do?

This PR adds the `ContainerID` field to the `ProcessEvent` model and populates it with the corresponding field received from `system-probe`.

### Motivation

Collect ContainerID for exec and exit events.

### Additional Notes


### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes

Start listening for process events with `sudo ./process-agent/events listen`. Start and stop a container and verify that the exec and exit events are correctly populated with the containerID.

Repeat the same test with `sudo ./process-agent check process_events -w 10s`.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
