### PR TITLE
[AD] Sort tags on resolved config's integration.Data

### DIFF
--- a/pkg/autodiscovery/configresolver/configresolver.go
+++ b/pkg/autodiscovery/configresolver/configresolver.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -463,15 +464,22 @@ func tagsAdder(tags []string) func(interface{}) error {
 					}
 				}
 			}
+
 			for _, t := range tags {
 				tagSet[t] = struct{}{}
 			}
-			typedTree["tags"] = make([]string, len(tagSet))
+
+			allTags := make([]string, len(tagSet))
+
 			i := 0
 			for k := range tagSet {
-				typedTree["tags"].([]string)[i] = k
+				allTags[i] = k
 				i++
 			}
+
+			sort.Strings(allTags)
+
+			typedTree["tags"] = allTags
 		}
 		return nil
 	}

--- a/pkg/autodiscovery/configresolver/configresolver_test.go
+++ b/pkg/autodiscovery/configresolver/configresolver_test.go
@@ -811,7 +811,7 @@ func TestResolve(t *testing.T) {
 			out: integration.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []integration.Data{integration.Data("host: 127.0.0.1\ntags:\n- statictag:TEST\n- foo:bar\n")},
+				Instances:     []integration.Data{integration.Data("host: 127.0.0.1\ntags:\n- foo:bar\n- statictag:TEST\n")},
 				ServiceID:     "a5901276aed1",
 			},
 		},


### PR DESCRIPTION
### What does this PR do?

This fixes a [flaky test](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/145953755#L1060) due to unstable sorting order of hash keys in Go. It probably also makes this resolution more stable if it ever has to merge in different tags at runtime, by producing the same digest [1].

[1] That is, if the digest itself didn't have to handle tag ordering in the first place (see [pkg/autodiscovery/integration/config.go](https://github.com/DataDog/datadog-agent/blob/main/pkg/autodiscovery/integration/config.go#L366-L380) and tell me how fun that code is). That can probably go away now, for a nice performance improvement, but that's a PR for another day.

### Describe how to test/QA your changes

No QA needed. Do note that this adds a somewhat expensive operation (sorting a list of strings) to resolving configs, but it's already an expensive operation by marshalling and unmarshalling yaml a whole bunch, so I'm expecting it to be a drop in the bucket.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
