### PR TITLE
fix(tests): don't use assert.Eventually() in dsd debug loop unit tests as it still breaks the CI

### DIFF
--- a/pkg/dogstatsd/server_test.go
+++ b/pkg/dogstatsd/server_test.go
@@ -594,14 +594,14 @@ func TestDebugStatsSpike(t *testing.T) {
 	s.DisableMetricsStats()
 	time.Sleep(500 * time.Millisecond)
 
-	assert.Eventually(s.hasSpike, 10*time.Millisecond, 2*time.Millisecond)
+	assert.True(s.hasSpike())
 
 	s.EnableMetricsStats()
 	// This sleep is necessary as we need to wait for the goroutine function within 'EnableMetricsStats' to start.
 	// If we remove the sleep, the debug loop ticker will not be triggered by the clk.Add() call and the 500 samples
 	// added with 'send(500)' will be considered as if they had been added in the same second as the previous 500 samples.
 	// This will lead to a spike because we have 1000 samples in 1 second instead of having 500 and 500 in 2 different seconds.
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(1050 * time.Millisecond)
 
 	clk.Add(1050 * time.Millisecond)
 	send(500)
@@ -610,11 +610,8 @@ func TestDebugStatsSpike(t *testing.T) {
 	s.DisableMetricsStats()
 	time.Sleep(500 * time.Millisecond)
 
-	hasNoSpike := func() bool {
-		return !s.hasSpike()
-	}
 	// it is no more considered a spike because we had another second with 500 metrics
-	assert.Eventually(hasNoSpike, 10*time.Millisecond, 2*time.Millisecond)
+	assert.False(s.hasSpike())
 }
 
 func TestDebugStats(t *testing.T) {


### PR DESCRIPTION


<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Hopefully it fixes flaky DSD tests on windows CI

### Motivation

CI still broken on main after a fix attempt https://github.com/DataDog/datadog-agent/pull/12453

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
