### PR TITLE
Bump `fake-datadog` and add support for multiarch push

### DIFF
--- a/test/e2e/argo-workflows/templates/fake-datadog.yaml
+++ b/test/e2e/argo-workflows/templates/fake-datadog.yaml
@@ -59,7 +59,7 @@ spec:
               spec:
                 containers:
                 - name: api
-                  image: datadog/fake-datadog:20210705
+                  image: datadog/fake-datadog:20220621
                 - name: mongo
                   image: mongo:4.4.1
 

--- a/test/e2e/containers/fake_datadog/Makefile
+++ b/test/e2e/containers/fake_datadog/Makefile
@@ -1,6 +1,6 @@
 TAG?=$(shell date '+%Y%m%d')
 
-.PHONY: venv pip build default push
+.PHONY: venv pip build default push multiarch
 
 default: pip
 
@@ -12,6 +12,9 @@ pip: venv
 
 build:
 	docker build --force-rm -t datadog/fake-datadog:$(TAG) .
+
+multiarch:
+	docker buildx build --platform linux/amd64,linux/arm64 -t datadog/fake-datadog:$(TAG) . --push
 
 push:
 	docker push datadog/fake-datadog:$(TAG)


### PR DESCRIPTION
### What does this PR do?

This PR:
- adds support to build/push multiarch images, using buildx (available by defaults on macOS docker desktop)
- bumps the image tag of `datadog/fake-datadog` used in e2e tests
 
### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
