### PR TITLE
[corechecks/ksm] Add tags for common k8s labels

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
@@ -112,6 +112,14 @@ func defaultLabelsMapper() map[string]string {
 		"label_failure_domain_beta_kubernetes_io_region": "kube_region",
 		"label_failure_domain_beta_kubernetes_io_zone":   "kube_zone",
 		"ingress": "kube_ingress",
+
+		// Standard Kubernetes labels
+		"label_app_kubernetes_io_name":       "kube_app_name",
+		"label_app_kubernetes_io_instance":   "kube_app_instance",
+		"label_app_kubernetes_io_version":    "kube_app_version",
+		"label_app_kubernetes_io_component":  "kube_app_component",
+		"label_app_kubernetes_io_part_of":    "kube_app_part_of",
+		"label_app_kubernetes_io_managed_by": "kube_app_managed_by",
 	}
 }
 
@@ -121,6 +129,13 @@ func defaultLabelJoins() map[string]*JoinsConfig {
 		"label_tags_datadoghq_com_env",
 		"label_tags_datadoghq_com_service",
 		"label_tags_datadoghq_com_version",
+
+		"label_app_kubernetes_io_name",
+		"label_app_kubernetes_io_instance",
+		"label_app_kubernetes_io_version",
+		"label_app_kubernetes_io_component",
+		"label_app_kubernetes_io_part_of",
+		"label_app_kubernetes_io_managed_by",
 	}
 
 	return map[string]*JoinsConfig{

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
@@ -169,6 +169,61 @@ func TestProcessMetrics(t *testing.T) {
 			},
 		},
 		{
+			name:   "kubernetes standard tags via label join, default label mapper, default label joins (deployment)",
+			config: &KSMConfig{LabelsMapper: defaultLabelsMapper(), LabelJoins: defaultLabelJoins()},
+			metricsToProcess: map[string][]ksmstore.DDMetricsFam{
+				"kube_deployment_status_replicas": {
+					{
+						Type: "*v1.Deployment",
+						Name: "kube_deployment_status_replicas",
+						ListMetrics: []ksmstore.DDMetric{
+							{
+								Labels: map[string]string{"namespace": "default", "deployment": "mysql"},
+								Val:    1,
+							},
+						},
+					},
+				},
+			},
+			metricsToGet: []ksmstore.DDMetricsFam{
+				{
+					Name: "kube_deployment_labels",
+					ListMetrics: []ksmstore.DDMetric{
+						{
+							Labels: map[string]string{
+								"namespace":                          "default",
+								"deployment":                         "mysql",
+								"label_app_kubernetes_io_name":       "mysql",
+								"label_app_kubernetes_io_instance":   "mysql-123",
+								"label_app_kubernetes_io_version":    "5.7",
+								"label_app_kubernetes_io_component":  "db",
+								"label_app_kubernetes_io_part_of":    "my-app",
+								"label_app_kubernetes_io_managed_by": "helm",
+							},
+						},
+					},
+				},
+			},
+			metricTransformers: defaultMetricTransformers(),
+			expected: []metricsExpected{
+				{
+					name: "kubernetes_state.deployment.replicas",
+					val:  1,
+					tags: []string{
+						"kube_namespace:default",
+						"kube_deployment:mysql",
+						"kube_app_name:mysql",
+						"kube_app_instance:mysql-123",
+						"kube_app_version:5.7",
+						"kube_app_component:db",
+						"kube_app_part_of:my-app",
+						"kube_app_managed_by:helm",
+					},
+					hostname: "",
+				},
+			},
+		},
+		{
 			name:   "datadog standard tags via label join, default label mapper, default label joins (statefulset)",
 			config: &KSMConfig{LabelsMapper: defaultLabelsMapper(), LabelJoins: defaultLabelJoins()},
 			metricsToProcess: map[string][]ksmstore.DDMetricsFam{

--- a/releasenotes/notes/k8s-core-common-k8s-labels-a99f2deb5ec30329.yaml
+++ b/releasenotes/notes/k8s-core-common-k8s-labels-a99f2deb5ec30329.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The metrics reported by KSM core now include the tags "kube_app_name",
+    "kube_app_instance", and so on, if they're related to a Kubernetes entity
+    that has a standard label like "app.kubernetes.io/name",
+    "app.kubernetes.io/instance", etc.


### PR DESCRIPTION

### What does this PR do?

Converts standard Kubernetes labels (`app.kubernetes.io/name`, `app.kubernetes.io/instance`, etc.) to tags (`kube_app_name`, `kube_app_instance`, etc.) in the metrics reported by the KSM core check.

This is similar to what we already do in the tagger: https://github.com/DataDog/datadog-agent/blob/0b4ac0ff056c57ad210b41e53acc72eee92c9f22/pkg/tagger/collectors/workloadmeta_extract.go#L37


### Describe how to test/QA your changes

Deploy the agent with KSM core enabled and verify that the metrics reported by KSM core include the `kube_app_name`, `kube_app_instance`, etc tags if they're related with a Kubernetes entity that contains the label `app.kubernetes.io/name`, `app.kubernetes.io/instance`, etc. This is the complete list of labels => tags:
- app.kubernetes.io/name     "kube_app_name"
- app.kubernetes.io/instance":   "kube_app_instance"
- app.kubernetes.io/version":    "kube_app_version"
- app.kubernetes.io/component":  "kube_app_component"
- app.kubernetes.io/part_of":    "kube_app_part_of"
- app.kubernetes.io/managed_by": "kube_app_managed_by"


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
