### PR TITLE
[netflow] Rename exporter to device in payload

### DIFF
--- a/pkg/netflow/common/flow.go
+++ b/pkg/netflow/common/flow.go
@@ -13,7 +13,7 @@ type Flow struct {
 	Direction    uint32
 
 	// Device information
-	ExporterAddr []byte
+	DeviceAddr []byte
 
 	// Flow time
 	StartTimestamp uint64 // in seconds
@@ -62,7 +62,7 @@ type Flow struct {
 func (f *Flow) AggregationHash() uint64 {
 	h := fnv.New64()
 	h.Write([]byte(f.Namespace))             //nolint:errcheck
-	h.Write(f.ExporterAddr)                  //nolint:errcheck
+	h.Write(f.DeviceAddr)                    //nolint:errcheck
 	h.Write(f.SrcAddr)                       //nolint:errcheck
 	h.Write(f.DstAddr)                       //nolint:errcheck
 	h.Write(Uint32ToBytes(f.SrcPort))        //nolint:errcheck

--- a/pkg/netflow/common/flow.go
+++ b/pkg/netflow/common/flow.go
@@ -12,7 +12,7 @@ type Flow struct {
 	SamplingRate uint64
 	Direction    uint32
 
-	// Exporter information
+	// Device information
 	ExporterAddr []byte
 
 	// Flow time

--- a/pkg/netflow/common/flow_test.go
+++ b/pkg/netflow/common/flow_test.go
@@ -9,7 +9,7 @@ func TestFlow_AggregationHash(t *testing.T) {
 	allHash := make(map[uint64]bool)
 	origFlow := Flow{
 		Namespace:      "default",
-		ExporterAddr:   []byte{127, 0, 0, 1},
+		DeviceAddr:     []byte{127, 0, 0, 1},
 		SrcAddr:        []byte{1, 2, 3, 4},
 		DstAddr:        []byte{2, 3, 4, 5},
 		IPProtocol:     6,
@@ -28,7 +28,7 @@ func TestFlow_AggregationHash(t *testing.T) {
 	allHash[flow.AggregationHash()] = true
 
 	flow = origFlow
-	flow.ExporterAddr = []byte{127, 0, 0, 2}
+	flow.DeviceAddr = []byte{127, 0, 0, 2}
 	assert.NotEqual(t, origHash, flow.AggregationHash())
 	allHash[flow.AggregationHash()] = true
 

--- a/pkg/netflow/enrichment/mask.go
+++ b/pkg/netflow/enrichment/mask.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 )
 
+// FormatMask formats mask raw value (uint32) into CIDR format (e.g. `192.1.128.64/26`)
 func FormatMask(ipAddr []byte, maskRawValue uint32) string {
 	maskSuffix := "/" + strconv.Itoa(int(maskRawValue))
 

--- a/pkg/netflow/flowaggregator/aggregator_test.go
+++ b/pkg/netflow/flowaggregator/aggregator_test.go
@@ -39,7 +39,7 @@ func TestAggregator(t *testing.T) {
 	flow := &common.Flow{
 		Namespace:      "my-ns",
 		FlowType:       common.TypeNetFlow9,
-		ExporterAddr:   []byte{127, 0, 0, 1},
+		DeviceAddr:     []byte{127, 0, 0, 1},
 		StartTimestamp: 1234568,
 		EndTimestamp:   1234569,
 		Bytes:          20,

--- a/pkg/netflow/flowaggregator/aggregator_test.go
+++ b/pkg/netflow/flowaggregator/aggregator_test.go
@@ -78,7 +78,7 @@ func TestAggregator(t *testing.T) {
   "packets": 4,
   "ether_type": "IPv4",
   "ip_protocol": "TCP",
-  "exporter": {
+  "device": {
     "ip": "127.0.0.1"
   },
   "source": {

--- a/pkg/netflow/flowaggregator/buildpayload.go
+++ b/pkg/netflow/flowaggregator/buildpayload.go
@@ -13,7 +13,7 @@ func buildPayload(aggFlow *common.Flow, hostname string) payload.FlowPayload {
 		FlowType:     string(aggFlow.FlowType),
 		SamplingRate: aggFlow.SamplingRate,
 		Direction:    enrichment.RemapDirection(aggFlow.Direction),
-		Exporter: payload.Exporter{
+		Device: payload.Device{
 			IP: common.IPBytesToString(aggFlow.ExporterAddr),
 		},
 		Start:      aggFlow.StartTimestamp,

--- a/pkg/netflow/flowaggregator/buildpayload.go
+++ b/pkg/netflow/flowaggregator/buildpayload.go
@@ -14,7 +14,7 @@ func buildPayload(aggFlow *common.Flow, hostname string) payload.FlowPayload {
 		SamplingRate: aggFlow.SamplingRate,
 		Direction:    enrichment.RemapDirection(aggFlow.Direction),
 		Device: payload.Device{
-			IP: common.IPBytesToString(aggFlow.ExporterAddr),
+			IP: common.IPBytesToString(aggFlow.DeviceAddr),
 		},
 		Start:      aggFlow.StartTimestamp,
 		End:        aggFlow.EndTimestamp,

--- a/pkg/netflow/flowaggregator/buildpayload_test.go
+++ b/pkg/netflow/flowaggregator/buildpayload_test.go
@@ -51,7 +51,7 @@ func Test_buildPayload(t *testing.T) {
 				Packets:      2,
 				EtherType:    "IPv4",
 				IPProtocol:   "TCP",
-				Exporter: payload.Exporter{
+				Device: payload.Device{
 					IP: "127.0.0.1",
 				},
 				Source: payload.Endpoint{

--- a/pkg/netflow/flowaggregator/buildpayload_test.go
+++ b/pkg/netflow/flowaggregator/buildpayload_test.go
@@ -20,7 +20,7 @@ func Test_buildPayload(t *testing.T) {
 				FlowType:        common.TypeNetFlow9,
 				SamplingRate:    10,
 				Direction:       1,
-				ExporterAddr:    []byte{127, 0, 0, 1},
+				DeviceAddr:      []byte{127, 0, 0, 1},
 				StartTimestamp:  1234568,
 				EndTimestamp:    1234569,
 				Bytes:           10,

--- a/pkg/netflow/flowaggregator/flowaccumulator_test.go
+++ b/pkg/netflow/flowaggregator/flowaccumulator_test.go
@@ -29,7 +29,7 @@ func Test_flowAccumulator_add(t *testing.T) {
 	// Given
 	flowA1 := &common.Flow{
 		FlowType:       common.TypeNetFlow9,
-		ExporterAddr:   []byte{127, 0, 0, 1},
+		DeviceAddr:     []byte{127, 0, 0, 1},
 		StartTimestamp: 1234568,
 		EndTimestamp:   1234569,
 		Bytes:          20,
@@ -43,7 +43,7 @@ func Test_flowAccumulator_add(t *testing.T) {
 	}
 	flowA2 := &common.Flow{
 		FlowType:       common.TypeNetFlow9,
-		ExporterAddr:   []byte{127, 0, 0, 1},
+		DeviceAddr:     []byte{127, 0, 0, 1},
 		StartTimestamp: 1234578,
 		EndTimestamp:   1234579,
 		Bytes:          10,
@@ -57,7 +57,7 @@ func Test_flowAccumulator_add(t *testing.T) {
 	}
 	flowB1 := &common.Flow{
 		FlowType:       common.TypeNetFlow9,
-		ExporterAddr:   []byte{127, 0, 0, 1},
+		DeviceAddr:     []byte{127, 0, 0, 1},
 		StartTimestamp: 1234568,
 		EndTimestamp:   1234569,
 		Bytes:          10,
@@ -101,7 +101,7 @@ func Test_flowAccumulator_flush(t *testing.T) {
 	// Given
 	flow := &common.Flow{
 		FlowType:       common.TypeNetFlow9,
-		ExporterAddr:   []byte{127, 0, 0, 1},
+		DeviceAddr:     []byte{127, 0, 0, 1},
 		StartTimestamp: 1234568,
 		EndTimestamp:   1234569,
 		Bytes:          20,

--- a/pkg/netflow/goflowlib/convert.go
+++ b/pkg/netflow/goflowlib/convert.go
@@ -13,7 +13,7 @@ func ConvertFlow(srcFlow *flowpb.FlowMessage, namespace string) *common.Flow {
 		FlowType:        convertFlowType(srcFlow.Type),
 		SamplingRate:    srcFlow.SamplingRate,
 		Direction:       srcFlow.FlowDirection,
-		ExporterAddr:    srcFlow.SamplerAddress,
+		DeviceAddr:      srcFlow.SamplerAddress,
 		StartTimestamp:  srcFlow.TimeFlowStart,
 		EndTimestamp:    srcFlow.TimeFlowEnd,
 		Bytes:           srcFlow.Bytes,

--- a/pkg/netflow/goflowlib/convert.go
+++ b/pkg/netflow/goflowlib/convert.go
@@ -13,7 +13,7 @@ func ConvertFlow(srcFlow *flowpb.FlowMessage, namespace string) *common.Flow {
 		FlowType:        convertFlowType(srcFlow.Type),
 		SamplingRate:    srcFlow.SamplingRate,
 		Direction:       srcFlow.FlowDirection,
-		DeviceAddr:      srcFlow.SamplerAddress,
+		DeviceAddr:      srcFlow.SamplerAddress, // Sampler is renamed to Device since it's a device in most cases
 		StartTimestamp:  srcFlow.TimeFlowStart,
 		EndTimestamp:    srcFlow.TimeFlowEnd,
 		Bytes:           srcFlow.Bytes,

--- a/pkg/netflow/goflowlib/convert_test.go
+++ b/pkg/netflow/goflowlib/convert_test.go
@@ -71,7 +71,7 @@ func TestConvertFlow(t *testing.T) {
 		FlowType:        common.TypeNetFlow9,
 		SamplingRate:    10,
 		Direction:       1,
-		ExporterAddr:    []byte{127, 0, 0, 1},
+		DeviceAddr:      []byte{127, 0, 0, 1},
 		StartTimestamp:  1234568,
 		EndTimestamp:    1234569,
 		Bytes:           10,

--- a/pkg/netflow/payload/payload.go
+++ b/pkg/netflow/payload/payload.go
@@ -5,7 +5,7 @@
 
 package payload
 
-// Device contains exporter details
+// Device contains device (exporter) details
 type Device struct {
 	IP string `json:"ip"`
 }
@@ -44,7 +44,7 @@ type FlowPayload struct {
 	Packets      uint64           `json:"packets"`
 	EtherType    string           `json:"ether_type,omitempty"`
 	IPProtocol   string           `json:"ip_protocol"`
-	Device       Device           `json:"exporter"`
+	Device       Device           `json:"device"`
 	Source       Endpoint         `json:"source"`
 	Destination  Endpoint         `json:"destination"`
 	Ingress      ObservationPoint `json:"ingress"`

--- a/pkg/netflow/payload/payload.go
+++ b/pkg/netflow/payload/payload.go
@@ -5,8 +5,8 @@
 
 package payload
 
-// Exporter contains exporter details
-type Exporter struct {
+// Device contains exporter details
+type Device struct {
 	IP string `json:"ip"`
 }
 
@@ -44,7 +44,7 @@ type FlowPayload struct {
 	Packets      uint64           `json:"packets"`
 	EtherType    string           `json:"ether_type,omitempty"`
 	IPProtocol   string           `json:"ip_protocol"`
-	Exporter     Exporter         `json:"exporter"`
+	Device       Device           `json:"exporter"`
 	Source       Endpoint         `json:"source"`
 	Destination  Endpoint         `json:"destination"`
 	Ingress      ObservationPoint `json:"ingress"`

--- a/pkg/netflow/server_test.go
+++ b/pkg/netflow/server_test.go
@@ -63,7 +63,7 @@ network_devices:
 	assert.Equal(t, uint64(194), actualFlow.Bytes)
 	assert.Equal(t, "IPv4", actualFlow.EtherType)
 	assert.Equal(t, "TCP", actualFlow.IPProtocol)
-	assert.Equal(t, "127.0.0.1", actualFlow.Exporter.IP)
+	assert.Equal(t, "127.0.0.1", actualFlow.Device.IP)
 	assert.Equal(t, "10.129.2.1", actualFlow.Source.IP)
 	assert.Equal(t, uint32(49452), actualFlow.Source.Port)
 	assert.Equal(t, "00:00:00:00:00:00", actualFlow.Source.Mac)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

[netflow] Rename exporter to device in payload

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

In most cases the exporter is a device.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
