### PR TITLE
Add auto multiline lines matched metric telemetry and to status page. 

### DIFF
--- a/pkg/logs/internal/decoder/auto_multiline_handler.go
+++ b/pkg/logs/internal/decoder/auto_multiline_handler.go
@@ -176,7 +176,9 @@ func (h *AutoMultilineHandler) switchToMultilineHandler(r *regexp.Regexp) {
 	h.singleLineHandler = nil
 
 	// Build and start a multiline-handler
-	h.multiLineHandler = NewMultiLineHandler(h.outputFn, r, h.flushTimeout, h.lineLimit)
+	h.multiLineHandler = NewMultiLineHandler(h.outputFn, r, h.flushTimeout, h.lineLimit, true)
+	h.source.RegisterInfo(h.multiLineHandler.countInfo)
+	h.source.RegisterInfo(h.multiLineHandler.linesCombinedInfo)
 	// stay with the multiline handler
 	h.processFunc = h.multiLineHandler.process
 }

--- a/pkg/logs/internal/decoder/auto_multiline_handler.go
+++ b/pkg/logs/internal/decoder/auto_multiline_handler.go
@@ -163,7 +163,7 @@ func (h *AutoMultilineHandler) processAndTry(message *Message) {
 			h.detectedPattern.Set(topMatch.regexp)
 			h.switchToMultilineHandler(topMatch.regexp)
 		} else {
-			log.Debug("No pattern met the line match threshold during multiline autosensing - using single line handler")
+			log.Debugf("No pattern met the line match threshold: %f during multiline auto detection. Top match was %v with a match ratio of: %f - using single line handler", h.matchThreshold, topMatch.regexp.String(), matchRatio)
 			telemetry.GetStatsTelemetryProvider().Count(autoMultiLineTelemetryMetricName, 1, []string{"success:false"})
 			// Stay with the single line handler and no longer attempt to detect multiline matches.
 			h.processFunc = h.singleLineHandler.process

--- a/pkg/logs/internal/decoder/line_handler_benchmark_test.go
+++ b/pkg/logs/internal/decoder/line_handler_benchmark_test.go
@@ -54,7 +54,7 @@ func benchmarkMultiLineHandler(b *testing.B, logs int, line string) {
 		messages[i] = getDummyMessageWithLF(fmt.Sprintf("%s %d", line, i))
 	}
 
-	h := NewMultiLineHandler(func(*Message) {}, regexp.MustCompile(`^[A-Za-z_]+ \d+, \d+ \d+:\d+:\d+ (AM|PM)`), 1000*time.Millisecond, 100)
+	h := NewMultiLineHandler(func(*Message) {}, regexp.MustCompile(`^[A-Za-z_]+ \d+, \d+ \d+:\d+:\d+ (AM|PM)`), 1000*time.Millisecond, 100, false)
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {

--- a/pkg/logs/internal/decoder/line_handler_test.go
+++ b/pkg/logs/internal/decoder/line_handler_test.go
@@ -93,7 +93,7 @@ func TestTrimSingleLine(t *testing.T) {
 func TestMultiLineHandler(t *testing.T) {
 	re := regexp.MustCompile("[0-9]+\\.")
 	outputFn, outputChan := lineHandlerChans()
-	h := NewMultiLineHandler(outputFn, re, 10*time.Millisecond, 20)
+	h := NewMultiLineHandler(outputFn, re, 10*time.Millisecond, 20, false)
 
 	var output *Message
 
@@ -177,7 +177,7 @@ func TestMultiLineHandler(t *testing.T) {
 func TestTrimMultiLine(t *testing.T) {
 	re := regexp.MustCompile("[0-9]+\\.")
 	outputFn, outputChan := lineHandlerChans()
-	h := NewMultiLineHandler(outputFn, re, 10*time.Millisecond, 100)
+	h := NewMultiLineHandler(outputFn, re, 10*time.Millisecond, 100, false)
 
 	var output *Message
 
@@ -206,7 +206,7 @@ func TestTrimMultiLine(t *testing.T) {
 func TestMultiLineHandlerDropsEmptyMessages(t *testing.T) {
 	re := regexp.MustCompile("[0-9]+\\.")
 	outputFn, outputChan := lineHandlerChans()
-	h := NewMultiLineHandler(outputFn, re, 10*time.Millisecond, 100)
+	h := NewMultiLineHandler(outputFn, re, 10*time.Millisecond, 100, false)
 
 	h.process(getDummyMessage(""))
 
@@ -237,7 +237,7 @@ func TestSingleLineHandlerSendsRawInvalidMessages(t *testing.T) {
 func TestMultiLineHandlerSendsRawInvalidMessages(t *testing.T) {
 	re := regexp.MustCompile("[0-9]+\\.")
 	outputFn, outputChan := lineHandlerChans()
-	h := NewMultiLineHandler(outputFn, re, 10*time.Millisecond, 100)
+	h := NewMultiLineHandler(outputFn, re, 10*time.Millisecond, 100, false)
 
 	h.process(getDummyMessage("1.third line"))
 	h.process(getDummyMessage("fourth line"))

--- a/pkg/logs/internal/decoder/multiline_handler.go
+++ b/pkg/logs/internal/decoder/multiline_handler.go
@@ -11,33 +11,44 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/status"
+	"github.com/DataDog/datadog-agent/pkg/telemetry"
 )
+
+// Currently only reported when telemetryEnabled is true. telemetryEnabled is only true when
+// the multi_line handler is used with auto_multi_line_detection enabled.
+const linesCombinedTelemetryMetricName = "datadog.logs_agent.auto_multi_line_lines_combined"
 
 // MultiLineHandler makes sure that multiple lines from a same content
 // are properly put together.
 type MultiLineHandler struct {
-	outputFn       func(*Message)
-	newContentRe   *regexp.Regexp
-	buffer         *bytes.Buffer
-	flushTimeout   time.Duration
-	flushTimer     *time.Timer
-	lineLimit      int
-	shouldTruncate bool
-	linesLen       int
-	status         string
-	timestamp      string
-	countInfo      *status.CountInfo
+	outputFn          func(*Message)
+	newContentRe      *regexp.Regexp
+	buffer            *bytes.Buffer
+	flushTimeout      time.Duration
+	flushTimer        *time.Timer
+	lineLimit         int
+	shouldTruncate    bool
+	linesLen          int
+	status            string
+	timestamp         string
+	countInfo         *status.CountInfo
+	linesCombinedInfo *status.CountInfo
+	telemetryEnabled  bool
+	linesCombined     int
 }
 
 // NewMultiLineHandler returns a new MultiLineHandler.
-func NewMultiLineHandler(outputFn func(*Message), newContentRe *regexp.Regexp, flushTimeout time.Duration, lineLimit int) *MultiLineHandler {
+func NewMultiLineHandler(outputFn func(*Message), newContentRe *regexp.Regexp, flushTimeout time.Duration, lineLimit int, telemetryEnabled bool) *MultiLineHandler {
 	return &MultiLineHandler{
-		outputFn:     outputFn,
-		newContentRe: newContentRe,
-		buffer:       bytes.NewBuffer(nil),
-		flushTimeout: flushTimeout,
-		lineLimit:    lineLimit,
-		countInfo:    status.NewCountInfo("MultiLine matches"),
+		outputFn:          outputFn,
+		newContentRe:      newContentRe,
+		buffer:            bytes.NewBuffer(nil),
+		flushTimeout:      flushTimeout,
+		lineLimit:         lineLimit,
+		countInfo:         status.NewCountInfo("MultiLine matches"),
+		linesCombinedInfo: status.NewCountInfo("Lines Combined"),
+		telemetryEnabled:  telemetryEnabled,
+		linesCombined:     0,
 	}
 }
 
@@ -80,6 +91,7 @@ func (h *MultiLineHandler) process(message *Message) {
 	h.linesLen += message.RawDataLen
 	h.timestamp = message.Timestamp
 	h.status = message.Status
+	h.linesCombined++
 
 	if h.buffer.Len() > 0 {
 		// the buffer already contains some data which means that
@@ -120,6 +132,7 @@ func (h *MultiLineHandler) sendBuffer() {
 	defer func() {
 		h.buffer.Reset()
 		h.linesLen = 0
+		h.linesCombined = 0
 		h.shouldTruncate = false
 	}()
 
@@ -128,6 +141,14 @@ func (h *MultiLineHandler) sendBuffer() {
 	copy(content, data)
 
 	if len(content) > 0 || h.linesLen > 0 {
+		if h.linesCombined > 0 {
+			linesCombined := int32(h.linesCombined - 1)
+			h.linesCombinedInfo.Add(linesCombined)
+			if h.telemetryEnabled {
+				telemetry.GetStatsTelemetryProvider().Count(linesCombinedTelemetryMetricName, float64(linesCombined), []string{})
+			}
+		}
+
 		h.outputFn(NewMessage(content, h.status, h.linesLen, h.timestamp))
 	}
 }

--- a/pkg/logs/internal/decoder/multiline_handler.go
+++ b/pkg/logs/internal/decoder/multiline_handler.go
@@ -142,6 +142,7 @@ func (h *MultiLineHandler) sendBuffer() {
 
 	if len(content) > 0 || h.linesLen > 0 {
 		if h.linesCombined > 0 {
+			// -1 to ignore the line matching the pattern. This leave a count of only combined lines.
 			linesCombined := int32(h.linesCombined - 1)
 			h.linesCombinedInfo.Add(linesCombined)
 			if h.telemetryEnabled {

--- a/releasenotes/notes/auto_multi_line_detection-telemetry-57409b313aa40c2d.yaml
+++ b/releasenotes/notes/auto_multi_line_detection-telemetry-57409b313aa40c2d.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Report lines matched by auto multiline detection as metrics
+    and on the status page. 

--- a/releasenotes/notes/auto_multi_line_detection-telemetry-57409b313aa40c2d.yaml
+++ b/releasenotes/notes/auto_multi_line_detection-telemetry-57409b313aa40c2d.yaml
@@ -9,4 +9,4 @@
 enhancements:
   - |
     Report lines matched by auto multiline detection as metrics
-    and on the status page. 
+    and show on the status page. 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Adding additional telemetry metrics to improve visibility of auto multi line detection. 
This change also makes Lines Matched and Lines Combined show on the status page for auto multi line enabled tailers. 

These numbers can be used for debugging and can also be used to estimate a better match threshold for users that want to change the default auto multiline config. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

1. Start the agent with `auto_mutli_line_detection` enabled (either globally or per source)
2. generate multi-line logs (can use `docker run -it  bfloerschddog/java-excepton-logger`)
3. run `agent status` - make sure you see the following metrics:
```
      Lines Combined: 672   
      MultiLine matches: 18381 
```
4. rotate the file and run `agent status` again - the metrics should NOT restart from 0 and should continue where they left off. 
5. check `datadog.logs_agent.auto_multi_line_lines_combined` is reported in app. 

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
