### PR TITLE
[CWS] Use omitempty to differentiate activity dump and process monitoring serializations

### DIFF
--- a/pkg/process/events/model/model_sysprobe.go
+++ b/pkg/process/events/model/model_sysprobe.go
@@ -22,6 +22,11 @@ type ProcessMonitoringEvent struct {
 
 // ProcessMonitoringToProcessEvent converts a ProcessMonitoringEvent to a generic ProcessEvent
 func ProcessMonitoringToProcessEvent(e *ProcessMonitoringEvent) *ProcessEvent {
+	var cmdline []string
+	if e.ArgsEntry != nil {
+		cmdline = e.ArgsEntry.Values
+	}
+
 	return &ProcessEvent{
 		EventType:      e.EventType,
 		CollectionTime: e.CollectionTime,
@@ -32,7 +37,7 @@ func ProcessMonitoringToProcessEvent(e *ProcessMonitoringEvent) *ProcessEvent {
 		Username:       e.User,
 		Group:          e.Group,
 		Exe:            e.FileEvent.PathnameStr, // FileEvent is not a pointer, so it can be directly accessed
-		Cmdline:        e.ScrubbedArgv,
+		Cmdline:        cmdline,
 		ForkTime:       e.ForkTime,
 		ExecTime:       e.ExecTime,
 		ExitTime:       e.ExitTime,
@@ -61,10 +66,12 @@ func ProcessEventToProcessMonitoringEvent(e *ProcessEvent) *ProcessMonitoringEve
 					FileEvent: model.FileEvent{
 						PathnameStr: e.Exe,
 					},
-					ScrubbedArgv: e.Cmdline,
-					ForkTime:     e.ForkTime,
-					ExecTime:     e.ExecTime,
-					ExitTime:     e.ExitTime,
+					ArgsEntry: &model.ArgsEntry{
+						Values: e.Cmdline,
+					},
+					ForkTime: e.ForkTime,
+					ExecTime: e.ExecTime,
+					ExitTime: e.ExitTime,
 				},
 			},
 		},
@@ -102,10 +109,12 @@ func NewMockedProcessMonitoringEvent(evtType string, ts time.Time, pid uint32, e
 					FileEvent: model.FileEvent{
 						PathnameStr: exe,
 					},
-					ScrubbedArgv: args,
-					ForkTime:     forkTime,
-					ExecTime:     execTime,
-					ExitTime:     exitTime,
+					ArgsEntry: &model.ArgsEntry{
+						Values: args,
+					},
+					ForkTime: forkTime,
+					ExecTime: execTime,
+					ExitTime: exitTime,
 				},
 			},
 		},

--- a/pkg/security/probe/activity_dump.go
+++ b/pkg/security/probe/activity_dump.go
@@ -804,6 +804,8 @@ func (pan *ProcessActivityNode) scrubAndReleaseArgsEnvs(resolver *ProcessResolve
 	if pan.Process.EnvsEntry != nil && pan.Process.EnvsEntry.ArgsEnvsCacheEntry != nil {
 		pan.Process.EnvsEntry.Release()
 	}
+	pan.Process.ArgsEntry = nil
+	pan.Process.EnvsEntry = nil
 }
 
 // Matches return true if the process fields used to generate the dump are identical with the provided ProcessCacheEntry

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -301,8 +301,8 @@ type Process struct {
 	ArgsID uint32 `field:"-" msg:"-"`
 	EnvsID uint32 `field:"-" msg:"-"`
 
-	ArgsEntry *ArgsEntry `field:"-" msg:"-"`
-	EnvsEntry *EnvsEntry `field:"-" msg:"-"`
+	ArgsEntry *ArgsEntry `field:"-" msg:"args_entry,omitempty"`
+	EnvsEntry *EnvsEntry `field:"-" msg:"envs_entry,omitempty"`
 
 	// defined to generate accessors, ArgsTruncated and EnvsTruncated are used during by unmarshaller
 	Argv0         string   `field:"argv0,handler:ResolveProcessArgv0,weight:100" msg:"argv0"`                                                                                                                                           // First argument of the process
@@ -311,12 +311,12 @@ type Process struct {
 	ArgsTruncated bool     `field:"args_truncated,handler:ResolveProcessArgsTruncated" msg:"-"`                                                                                                                                         // Indicator of arguments truncation
 	Envs          []string `field:"envs,handler:ResolveProcessEnvs:100" msg:"envs,omitempty"`                                                                                                                                           // Environment variable names of the process
 	Envp          []string `field:"envp,handler:ResolveProcessEnvp:100" msg:"-"`                                                                                                                                                        // Environment variables of the process
-	EnvsTruncated bool     `field:"envs_truncated,handler:ResolveProcessEnvsTruncated" msg:"envs_truncated"`                                                                                                                            // Indicator of environment variables truncation
+	EnvsTruncated bool     `field:"envs_truncated,handler:ResolveProcessEnvsTruncated" msg:"envs_truncated,omitempty"`                                                                                                                  // Indicator of environment variables truncation
 
 	// cache version
 	ScrubbedArgvResolved  bool           `field:"-" msg:"-"`
 	ScrubbedArgv          []string       `field:"-" msg:"argv,omitempty"`
-	ScrubbedArgsTruncated bool           `field:"-" msg:"argv_truncated"`
+	ScrubbedArgsTruncated bool           `field:"-" msg:"argv_truncated,omitempty"`
 	Variables             eval.Variables `field:"-" msg:"-"`
 
 	IsThread bool `field:"is_thread" msg:"is_thread"` // Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

This PR relies on omitempty to differentiate the serialization used by the activity dumps and the serialization used by the Live Process Monitoring product.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Fix a serialization bug for Live Process Monitoring introduced in https://github.com/DataDog/datadog-agent/pull/12084

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
