### PR TITLE
[ci] Disable `golang_deps_generate` main branch builds

### DIFF
--- a/.gitlab/source_test.yml
+++ b/.gitlab/source_test.yml
@@ -9,4 +9,3 @@ include:
   - /.gitlab/source_test/macos.yml
   - /.gitlab/source_test/windows.yml
   - /.gitlab/source_test/go_generate_check.yml
-  - /.gitlab/source_test/golang_deps_generate.yml


### PR DESCRIPTION
### What does this PR do?

`golang_deps_generate` is not handling recent changes to `go.mod`
properly (causing a memory exhaustion) and because of that is
breaking the main branch so we will remove it until we have the
problem(s) with this tool resolved.

### Motivation

Failures on main branch.

### Additional Notes

This job is only required for composing/archiving the dep list for releases so
there should be no impact for disabling this task until that point.

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

N/A

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
