### PR TITLE
[kitchen tests] skip chinese NLA windows when running test-signed driver

### DIFF
--- a/release.json
+++ b/release.json
@@ -11,9 +11,9 @@
         "JMXFETCH_VERSION": "0.46.0",
         "JMXFETCH_HASH": "3c41c0660e9c53451dfb51e8dad33bc87b03be1abc1fcd3c856ea81e6b0894ee",
         "MACOS_BUILD_VERSION": "master",
-        "WINDOWS_DDNPM_DRIVER": "release-signed",
+        "WINDOWS_DDNPM_DRIVER": "testsigned",
         "WINDOWS_DDNPM_VERSION": "1.4.3",
-        "WINDOWS_DDNPM_SHASUM": "939960a65f6352b18f21d07b00e543728e93bea123add1f7e8ef283a87197533",
+        "WINDOWS_DDNPM_SHASUM": "62e4de9b8b03916d188adc252550994fe344929d636d0fb46c9002e56febe263",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "nightly-a7": {
@@ -23,9 +23,9 @@
         "JMXFETCH_VERSION": "0.46.0",
         "JMXFETCH_HASH": "3c41c0660e9c53451dfb51e8dad33bc87b03be1abc1fcd3c856ea81e6b0894ee",
         "MACOS_BUILD_VERSION": "master",
-        "WINDOWS_DDNPM_DRIVER": "release-signed",
+        "WINDOWS_DDNPM_DRIVER": "testsigned",
         "WINDOWS_DDNPM_VERSION": "1.4.3",
-        "WINDOWS_DDNPM_SHASUM": "939960a65f6352b18f21d07b00e543728e93bea123add1f7e8ef283a87197533",
+        "WINDOWS_DDNPM_SHASUM": "62e4de9b8b03916d188adc252550994fe344929d636d0fb46c9002e56febe263",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "release-a6": {

--- a/release.json
+++ b/release.json
@@ -11,9 +11,9 @@
         "JMXFETCH_VERSION": "0.46.0",
         "JMXFETCH_HASH": "3c41c0660e9c53451dfb51e8dad33bc87b03be1abc1fcd3c856ea81e6b0894ee",
         "MACOS_BUILD_VERSION": "master",
-        "WINDOWS_DDNPM_DRIVER": "testsigned",
+        "WINDOWS_DDNPM_DRIVER": "release-signed",
         "WINDOWS_DDNPM_VERSION": "1.4.3",
-        "WINDOWS_DDNPM_SHASUM": "62e4de9b8b03916d188adc252550994fe344929d636d0fb46c9002e56febe263",
+        "WINDOWS_DDNPM_SHASUM": "939960a65f6352b18f21d07b00e543728e93bea123add1f7e8ef283a87197533",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "nightly-a7": {
@@ -23,9 +23,9 @@
         "JMXFETCH_VERSION": "0.46.0",
         "JMXFETCH_HASH": "3c41c0660e9c53451dfb51e8dad33bc87b03be1abc1fcd3c856ea81e6b0894ee",
         "MACOS_BUILD_VERSION": "master",
-        "WINDOWS_DDNPM_DRIVER": "testsigned",
+        "WINDOWS_DDNPM_DRIVER": "release-signed",
         "WINDOWS_DDNPM_VERSION": "1.4.3",
-        "WINDOWS_DDNPM_SHASUM": "62e4de9b8b03916d188adc252550994fe344929d636d0fb46c9002e56febe263",
+        "WINDOWS_DDNPM_SHASUM": "939960a65f6352b18f21d07b00e543728e93bea123add1f7e8ef283a87197533",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "release-a6": {

--- a/test/kitchen/tasks/kitchen.py
+++ b/test/kitchen/tasks/kitchen.py
@@ -10,6 +10,7 @@ from invoke.exceptions import Exit
 
 WINDOWS_SKIP_IF_TESTSIGNING = ['.*cn']
 
+
 @task(iterable=['platlist'])
 def genconfig(
     ctx,
@@ -178,9 +179,9 @@ def load_targets(_, targethash, selections, platform):
     commentpattern = re.compile("^comment")
 
     if platform == "windows":
-        if 'WINDOWS_DDNPM_DRIVER' in os.environ.keys() and  os.environ['WINDOWS_DDNPM_DRIVER'] == 'testsigned':
+        if 'WINDOWS_DDNPM_DRIVER' in os.environ.keys() and os.environ['WINDOWS_DDNPM_DRIVER'] == 'testsigned':
             for skip in WINDOWS_SKIP_IF_TESTSIGNING:
-                skiplist.append(re.compile(skip)) 
+                skiplist.append(re.compile(skip))
 
     for selection in selections.split(","):
         selectionpattern = re.compile(f"^{selection}$")
@@ -196,7 +197,7 @@ def load_targets(_, targethash, selections, platform):
                         matched = True
                         break
                 else:
-                    # will only execute if there's not a break in the previous for 
+                    # will only execute if there's not a break in the previous for
                     # loop.
                     matched = True
                     if key not in returnlist:

--- a/test/kitchen/tasks/kitchen.py
+++ b/test/kitchen/tasks/kitchen.py
@@ -1,6 +1,6 @@
 import glob
 import json
-import os.path
+import os
 import re
 import traceback
 
@@ -8,6 +8,7 @@ import requests
 from invoke import task
 from invoke.exceptions import Exit
 
+WINDOWS_SKIP_IF_TESTSIGNING = ['.*cn']
 
 @task(iterable=['platlist'])
 def genconfig(
@@ -90,7 +91,7 @@ def genconfig(
         if osversions.lower() == "all":
             osversions = ".*"
 
-        osimages = load_targets(ctx, ar, osversions)
+        osimages = load_targets(ctx, ar, osversions, platform)
 
         print(f"Chose os targets {osimages}\n")
         for osimage in osimages:
@@ -171,9 +172,16 @@ def should_rerun_failed(_, runlog):
             raise Exit("Seeing some failed tests in log, not advising to rerun", 1)
 
 
-def load_targets(_, targethash, selections):
+def load_targets(_, targethash, selections, platform):
     returnlist = []
+    skiplist = []
     commentpattern = re.compile("^comment")
+
+    if platform == "windows":
+        if 'WINDOWS_DDNPM_DRIVER' in os.environ.keys() and  os.environ['WINDOWS_DDNPM_DRIVER'] == 'testsigned':
+            for skip in WINDOWS_SKIP_IF_TESTSIGNING:
+                skiplist.append(re.compile(skip)) 
+
     for selection in selections.split(","):
         selectionpattern = re.compile(f"^{selection}$")
 
@@ -182,11 +190,19 @@ def load_targets(_, targethash, selections):
             if commentpattern.match(key):
                 continue
             if selectionpattern.search(key):
-                matched = True
-                if key not in returnlist:
-                    returnlist.append(key)
+                for skip in skiplist:
+                    if skip.match(key):
+                        print(f"Matched key {key} to skip list, skipping\n")
+                        matched = True
+                        break
                 else:
-                    print(f"Skipping duplicate target key {key} (matched search {selection})\n")
+                    # will only execute if there's not a break in the previous for 
+                    # loop.
+                    matched = True
+                    if key not in returnlist:
+                        returnlist.append(key)
+                    else:
+                        print(f"Skipping duplicate target key {key} (matched search {selection})\n")
 
         if not matched:
             raise Exit(message=f"Couldn't find any match for target {selection}\n", code=7)


### PR DESCRIPTION
Running the test-signed driver requires running a shell command `bcdedit` in the kitchen tests.
This fails on `cn` versions when checking the output of `bcdedit` commands.

Skip the tests on those versions when using  a testsigned driver


### Additional Notes

### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes

N/A

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
