### PR TITLE
pkg/trace/api: forward container ID header in evp_proxy

### DIFF
--- a/pkg/trace/api/evp_proxy.go
+++ b/pkg/trace/api/evp_proxy.go
@@ -151,6 +151,7 @@ func (t *evpProxyTransport) RoundTrip(req *http.Request) (rresp *http.Response, 
 	}
 	req.Header.Set("X-Datadog-Hostname", t.conf.Hostname)
 	req.Header.Set("X-Datadog-AgentDefaultEnv", t.conf.DefaultEnv)
+	req.Header.Set(headerContainerID, containerID)
 
 	// Set target URL and API key header (per domain)
 	req.URL.Scheme = "https"

--- a/pkg/trace/api/evp_proxy_test.go
+++ b/pkg/trace/api/evp_proxy_test.go
@@ -129,12 +129,13 @@ func TestEVPProxyForwarder(t *testing.T) {
 
 		req := httptest.NewRequest("POST", "/mypath/mysubpath?arg=test", bytes.NewReader(randBodyBuf))
 		req.Header.Set("X-Datadog-EVP-Subdomain", "my.subdomain")
-		req.Header.Set("Datadog-Container-ID", "myid")
+		req.Header.Set(headerContainerID, "myid")
 		proxyreqs, resp, logs := sendRequestThroughForwarder(conf, req)
 
 		require.Equal(t, http.StatusOK, resp.StatusCode, "Got: ", fmt.Sprint(resp.StatusCode))
 		require.Len(t, proxyreqs, 1)
 		assert.Equal(t, "container:myid", proxyreqs[0].Header.Get("X-Datadog-Container-Tags"))
+		assert.Equal(t, "myid", proxyreqs[0].Header.Get(headerContainerID))
 		assert.Equal(t, "", logs)
 	})
 


### PR DESCRIPTION
### What does this PR do?
Makes the `evp_proxy` API not only use the container ID to resolve the container tags, but also forward it to the backend.

### Motivation

Some products use this ID in the backend, forward it so they can use this proxy.

