### PR TITLE
[process-agent] Create the process_events check (after IoT build fix)

### DIFF
--- a/cmd/process-agent/app/check.go
+++ b/cmd/process-agent/app/check.go
@@ -30,14 +30,23 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
 
+var (
+	waitInterval time.Duration
+)
+
+const (
+	defaultWaitInterval = time.Second
+)
+
 func init() {
 	CheckCmd.Flags().BoolVar(&checkOutputJSON, "json", false, "Output check results in JSON")
+	CheckCmd.Flags().DurationVarP(&waitInterval, "wait", "w", defaultWaitInterval, "How long to wait before running the check")
 }
 
 // CheckCmd is a command that runs the process-agent version data
 var CheckCmd = &cobra.Command{
 	Use:   "check",
-	Short: "Run a specific check and print the results. Choose from: process, rtprocess, container, rtcontainer, connections, process_discovery",
+	Short: "Run a specific check and print the results. Choose from: process, rtprocess, container, rtcontainer, connections, process_discovery, process_events",
 
 	Args:         cobra.ExactArgs(1),
 	RunE:         runCheckCmd,
@@ -153,7 +162,8 @@ func runCheck(cfg *config.AgentConfig, ch checks.Check) error {
 		return fmt.Errorf("collection error: %s", err)
 	}
 
-	time.Sleep(1 * time.Second)
+	log.Infof("Waiting %s before running the check", waitInterval.String())
+	time.Sleep(waitInterval)
 
 	if !checkOutputJSON {
 		printResultsBanner(ch.Name())
@@ -185,7 +195,8 @@ func runCheckAsRealTime(cfg *config.AgentConfig, ch checks.CheckWithRealTime) er
 		return fmt.Errorf("collection error: %s", err)
 	}
 
-	time.Sleep(1 * time.Second)
+	log.Infof("Waiting %s before running the check", waitInterval.String())
+	time.Sleep(waitInterval)
 
 	if !checkOutputJSON {
 		printResultsBanner(ch.RealTimeName())

--- a/cmd/process-agent/collector.go
+++ b/cmd/process-agent/collector.go
@@ -537,6 +537,9 @@ func (l *Collector) consumePayloads(results *api.WeightedQueue, fwd forwarder.Fo
 				// A Process Discovery check does not change the RT mode
 				updateRTStatus = false
 				responses, err = fwd.SubmitProcessDiscoveryChecks(forwarderPayload, payload.headers)
+			case checks.ProcessEvents.Name():
+				updateRTStatus = false
+				responses, err = fwd.SubmitProcessEventChecks(forwarderPayload, payload.headers)
 			default:
 				err = fmt.Errorf("unsupported payload type: %s", result.name)
 			}

--- a/cmd/process-agent/collector_api_test.go
+++ b/cmd/process-agent/collector_api_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/config"
 	apicfg "github.com/DataDog/datadog-agent/pkg/process/util/api/config"
 	"github.com/DataDog/datadog-agent/pkg/process/util/api/headers"
+	"github.com/DataDog/datadog-agent/pkg/version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -173,6 +174,56 @@ func TestSendProcessDiscoveryMessage(t *testing.T) {
 		require.NoError(t, err)
 
 		b, ok := reqBody.Body.(*process.CollectorProcDiscovery)
+		require.True(t, ok)
+		assert.Equal(t, m, b)
+	})
+}
+
+func TestSendProcessEventMessage(t *testing.T) {
+	m := &process.CollectorProcEvent{
+		Hostname:  testHostName,
+		GroupId:   1,
+		GroupSize: 1,
+		Events: []*process.ProcessEvent{
+			{
+				Type: process.ProcEventType_exec,
+				Pid:  42,
+				Command: &process.Command{
+					Exe:  "/usr/bin/curl",
+					Args: []string{"curl", "localhost:6062/debug/vars"},
+					Ppid: 1,
+				},
+			},
+		},
+	}
+
+	check := &testCheck{
+		name: checks.ProcessEvents.Name(),
+		data: [][]process.MessageBody{{m}},
+	}
+
+	runCollectorTest(t, check, config.NewDefaultAgentConfig(), &endpointConfig{}, ddconfig.Mock(t), func(cfg *config.AgentConfig, ep *mockEndpoint) {
+		req := <-ep.Requests
+
+		assert.Equal(t, "/api/v2/proclcycle", req.uri)
+
+		assert.Equal(t, cfg.HostName, req.headers.Get(headers.HostHeader))
+		eps, err := getAPIEndpoints()
+		assert.NoError(t, err)
+		assert.Equal(t, eps[0].APIKey, req.headers.Get("DD-Api-Key"))
+		assert.Equal(t, "0", req.headers.Get(headers.ContainerCountHeader))
+		assert.Equal(t, "1", req.headers.Get("X-DD-Agent-Attempts"))
+		assert.NotEmpty(t, req.headers.Get(headers.TimestampHeader))
+		assert.Equal(t, headers.ProtobufContentType, req.headers.Get(headers.ContentTypeHeader))
+
+		agentVersion, err := version.Agent()
+		require.NoError(t, err)
+		assert.Equal(t, agentVersion.GetNumber(), req.headers.Get(headers.ProcessVersionHeader))
+
+		reqBody, err := process.DecodeMessage(req.body)
+		require.NoError(t, err)
+
+		b, ok := reqBody.Body.(*process.CollectorProcEvent)
 		require.True(t, ok)
 		assert.Equal(t, m, b)
 	})
@@ -488,6 +539,7 @@ func newMockEndpoint(t *testing.T, config *endpointConfig) *mockEndpoint {
 	collectorMux.HandleFunc("/api/v1/collector", m.handle)
 	collectorMux.HandleFunc("/api/v1/container", m.handle)
 	collectorMux.HandleFunc("/api/v1/discovery", m.handle)
+	collectorMux.HandleFunc("/api/v2/proclcycle", m.handle)
 
 	orchestratorMux := http.NewServeMux()
 	orchestratorMux.HandleFunc("/api/v1/validate", m.handleValidate)

--- a/cmd/process-agent/config.go
+++ b/cmd/process-agent/config.go
@@ -40,6 +40,10 @@ func getChecks(sysCfg *sysconfig.Config, oCfg *oconfig.OrchestratorConfig, canAc
 		}
 	}
 
+	if ddconfig.Datadog.GetBool("process_config.event_collection.enabled") {
+		checkCfg = append(checkCfg, checks.ProcessEvents)
+	}
+
 	// activate the pod collection if enabled and we have the cluster name set
 	if oCfg.OrchestrationCollectionEnabled {
 		if oCfg.KubeClusterName != "" {

--- a/cmd/process-agent/config_test.go
+++ b/cmd/process-agent/config_test.go
@@ -190,6 +190,28 @@ func TestPodCheck(t *testing.T) {
 	})
 }
 
+func TestProcessEventsCheck(t *testing.T) {
+	scfg, ocfg := &sysconfig.Config{}, &oconfig.OrchestratorConfig{}
+	cfg := config.Mock(t)
+
+	t.Run("default", func(t *testing.T) {
+		enabledChecks := getChecks(scfg, ocfg, false)
+		assert.NotContains(t, enabledChecks, checks.ProcessEvents)
+	})
+
+	t.Run("enabled", func(t *testing.T) {
+		cfg.Set("process_config.event_collection.enabled", true)
+		enabledChecks := getChecks(scfg, ocfg, false)
+		assert.Contains(t, enabledChecks, checks.ProcessEvents)
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		cfg.Set("process_config.event_collection.enabled", false)
+		enabledChecks := getChecks(scfg, ocfg, false)
+		assert.NotContains(t, enabledChecks, checks.ProcessEvents)
+	})
+}
+
 func TestGetAPIEndpoints(t *testing.T) {
 	mkurl := func(rawurl string) *url.URL {
 		urlResult, err := url.Parse(rawurl)

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	code.cloudfoundry.org/bbs v0.0.0-20200403215808-d7bc971db0db
 	code.cloudfoundry.org/garden v0.0.0-20210208153517-580cadd489d2
 	code.cloudfoundry.org/lager v2.0.0+incompatible
-	github.com/DataDog/agent-payload/v5 v5.0.22
+	github.com/DataDog/agent-payload/v5 v5.0.23
 	github.com/DataDog/btf-internals v0.0.0-20220424171854-ebe6bce9afb0
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.37.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/otlp/model v0.37.0-rc.3

--- a/go.sum
+++ b/go.sum
@@ -129,8 +129,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v0.4.1 h1:GaI7EiDXDRfa8VshkTj7Fym7ha+y8/XxIgD2okUIjLw=
 github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/DataDog/agent-payload/v5 v5.0.22 h1:XaMYtdvdjRWLwvoQhZM3Se0YmOeMYgEvdKVLwPsxEaU=
-github.com/DataDog/agent-payload/v5 v5.0.22/go.mod h1:2gapp8p4Vd548JI+axD8kCExklNvVI6AMF5/+IfN/4g=
+github.com/DataDog/agent-payload/v5 v5.0.23 h1:T+xalP3F9XOMZRSokcG4pK1hqyDBbEDPxp68tSBmfhc=
+github.com/DataDog/agent-payload/v5 v5.0.23/go.mod h1:2gapp8p4Vd548JI+axD8kCExklNvVI6AMF5/+IfN/4g=
 github.com/DataDog/btf-internals v0.0.0-20220424171854-ebe6bce9afb0 h1:01FWXvRqmUWsh9dWSWA0PkRK3XSBftQVj/tQ0yq9Z50=
 github.com/DataDog/btf-internals v0.0.0-20220424171854-ebe6bce9afb0/go.mod h1:cBVVIJ/f6XtwFL/U9QI5QDA/LcaiSiI8B4ipyGXzc1s=
 github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3 h1:SobA9WYm4K/MUtWlbKaomWTmnuYp1KhIm8Wlx3vmpsg=

--- a/pkg/config/process.go
+++ b/pkg/config/process.go
@@ -57,6 +57,12 @@ const (
 
 	// DefaultProcessEventStoreStatsInterval is the default frequency at which the event store sends stats about expired events, in seconds
 	DefaultProcessEventStoreStatsInterval = 20
+
+	// DefaultProcessEventsMinCheckInterval is the minimum interval allowed for the process_events check
+	DefaultProcessEventsMinCheckInterval = time.Second
+
+	// DefaultProcessEventsCheckInterval is the default interval used by the process_events check
+	DefaultProcessEventsCheckInterval = 10 * time.Second
 )
 
 // setupProcesses is meant to be called multiple times for different configs, but overrides apply to all configs, so
@@ -170,6 +176,8 @@ func setupProcesses(config Config) {
 	procBindEnvAndSetDefault(config, "process_config.event_collection.store.max_pending_pushes", DefaultProcessEventStoreMaxPendingPushes)
 	procBindEnvAndSetDefault(config, "process_config.event_collection.store.max_pending_pulls", DefaultProcessEventStoreMaxPendingPulls)
 	procBindEnvAndSetDefault(config, "process_config.event_collection.store.stats_interval", DefaultProcessEventStoreStatsInterval)
+	procBindEnvAndSetDefault(config, "process_config.event_collection.enabled", false)
+	procBindEnvAndSetDefault(config, "process_config.event_collection.interval", DefaultProcessEventsCheckInterval)
 
 	processesAddOverrideOnce.Do(func() {
 		AddOverrideFunc(loadProcessTransforms)

--- a/pkg/config/process_test.go
+++ b/pkg/config/process_test.go
@@ -110,6 +110,14 @@ func TestProcessDefaultConfig(t *testing.T) {
 			key:          "process_config.event_collection.store.stats_interval",
 			defaultValue: DefaultProcessEventStoreStatsInterval,
 		},
+		{
+			key:          "process_config.event_collection.enabled",
+			defaultValue: false,
+		},
+		{
+			key:          "process_config.event_collection.interval",
+			defaultValue: DefaultProcessEventsCheckInterval,
+		},
 	} {
 		t.Run(tc.key+" default", func(t *testing.T) {
 			assert.Equal(t, tc.defaultValue, cfg.Get(tc.key))
@@ -386,6 +394,18 @@ func TestEnvVarOverride(t *testing.T) {
 			env:      "DD_PROCESS_CONFIG_EVENT_COLLECTION_STORE_STATS_INTERVAL",
 			value:    "60",
 			expected: 60,
+		},
+		{
+			key:      "process_config.event_collection.enabled",
+			env:      "DD_PROCESS_CONFIG_EVENT_COLLECTION_ENABLED",
+			value:    "true",
+			expected: true,
+		},
+		{
+			key:      "process_config.event_collection.interval",
+			env:      "DD_PROCESS_CONFIG_EVENT_COLLECTION_INTERVAL",
+			value:    "20s",
+			expected: 20 * time.Second,
 		},
 	} {
 		t.Run(tc.env, func(t *testing.T) {

--- a/pkg/forwarder/endpoints/endpoints.go
+++ b/pkg/forwarder/endpoints/endpoints.go
@@ -38,6 +38,8 @@ var (
 	ProcessesEndpoint = transaction.Endpoint{Route: "/api/v1/collector", Name: "process"}
 	// ProcessDiscoveryEndpoint is a v1 endpoint used to sends process discovery checks
 	ProcessDiscoveryEndpoint = transaction.Endpoint{Route: "/api/v1/discovery", Name: "process_discovery"}
+	// ProcessLifecycleEndpoint is a v2 endpoint used to send process lifecycle events
+	ProcessLifecycleEndpoint = transaction.Endpoint{Route: "/api/v2/proclcycle", Name: "process_lifecycle"}
 	// RtProcessesEndpoint is a v1 endpoint used to send real time process checks
 	RtProcessesEndpoint = transaction.Endpoint{Route: "/api/v1/collector", Name: "rtprocess"}
 	// ContainerEndpoint is a v1 endpoint used to send container checks

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -70,6 +70,7 @@ type Forwarder interface {
 	SubmitMetadata(payload Payloads, extra http.Header) error
 	SubmitProcessChecks(payload Payloads, extra http.Header) (chan Response, error)
 	SubmitProcessDiscoveryChecks(payload Payloads, extra http.Header) (chan Response, error)
+	SubmitProcessEventChecks(payload Payloads, extra http.Header) (chan Response, error)
 	SubmitRTProcessChecks(payload Payloads, extra http.Header) (chan Response, error)
 	SubmitContainerChecks(payload Payloads, extra http.Header) (chan Response, error)
 	SubmitRTContainerChecks(payload Payloads, extra http.Header) (chan Response, error)
@@ -590,6 +591,11 @@ func (f *DefaultForwarder) SubmitProcessChecks(payload Payloads, extra http.Head
 // SubmitProcessDiscoveryChecks sends process discovery checks
 func (f *DefaultForwarder) SubmitProcessDiscoveryChecks(payload Payloads, extra http.Header) (chan Response, error) {
 	return f.submitProcessLikePayload(endpoints.ProcessDiscoveryEndpoint, payload, extra, true)
+}
+
+// SubmitProcessEventChecks sends process events checks
+func (f *DefaultForwarder) SubmitProcessEventChecks(payload Payloads, extra http.Header) (chan Response, error) {
+	return f.submitProcessLikePayload(endpoints.ProcessLifecycleEndpoint, payload, extra, true)
 }
 
 // SubmitRTProcessChecks sends real time process checks

--- a/pkg/forwarder/noop_forwarder.go
+++ b/pkg/forwarder/noop_forwarder.go
@@ -52,6 +52,11 @@ func (f NoopForwarder) SubmitProcessDiscoveryChecks(payload Payloads, extra http
 	return nil, nil
 }
 
+// SubmitProcessEventChecks does nothing
+func (f NoopForwarder) SubmitProcessEventChecks(payload Payloads, extra http.Header) (chan Response, error) {
+	return nil, nil
+}
+
 // SubmitRTProcessChecks does nothing.
 func (f NoopForwarder) SubmitRTProcessChecks(payload Payloads, extra http.Header) (chan Response, error) {
 	return nil, nil

--- a/pkg/forwarder/sync_forwarder.go
+++ b/pkg/forwarder/sync_forwarder.go
@@ -122,6 +122,11 @@ func (f *SyncForwarder) SubmitProcessDiscoveryChecks(payload Payloads, extra htt
 	return f.defaultForwarder.submitProcessLikePayload(endpoints.ProcessDiscoveryEndpoint, payload, extra, true)
 }
 
+// SubmitProcessEventChecks sends process events checks
+func (f *SyncForwarder) SubmitProcessEventChecks(payload Payloads, extra http.Header) (chan Response, error) {
+	return f.defaultForwarder.submitProcessLikePayload(endpoints.ProcessLifecycleEndpoint, payload, extra, true)
+}
+
 // SubmitRTProcessChecks sends real time process checks
 func (f *SyncForwarder) SubmitRTProcessChecks(payload Payloads, extra http.Header) (chan Response, error) {
 	return f.defaultForwarder.submitProcessLikePayload(endpoints.RtProcessesEndpoint, payload, extra, false)

--- a/pkg/forwarder/test_common.go
+++ b/pkg/forwarder/test_common.go
@@ -138,6 +138,11 @@ func (tf *MockedForwarder) SubmitProcessDiscoveryChecks(payload Payloads, extra 
 	return nil, tf.Called(payload, extra).Error(0)
 }
 
+// SubmitProcessEventChecks mock
+func (tf *MockedForwarder) SubmitProcessEventChecks(payload Payloads, extra http.Header) (chan Response, error) {
+	return nil, tf.Called(payload, extra).Error(0)
+}
+
 // SubmitRTProcessChecks mock
 func (tf *MockedForwarder) SubmitRTProcessChecks(payload Payloads, extra http.Header) (chan Response, error) {
 	return nil, tf.Called(payload, extra).Error(0)

--- a/pkg/process/checks/checks.go
+++ b/pkg/process/checks/checks.go
@@ -51,4 +51,5 @@ var All = []Check{
 	Connections,
 	Pod,
 	ProcessDiscovery,
+	ProcessEvents,
 }

--- a/pkg/process/checks/process_events_fallback.go
+++ b/pkg/process/checks/process_events_fallback.go
@@ -1,0 +1,42 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !linux || android
+// +build !linux android
+
+package checks
+
+import (
+	"errors"
+
+	model "github.com/DataDog/agent-payload/v5/process"
+
+	"github.com/DataDog/datadog-agent/pkg/process/config"
+)
+
+// ProcessEvents is a ProcessEventsCheck singleton
+var ProcessEvents = &ProcessEventsCheck{}
+
+// ProcessEventsCheck collects process lifecycle events such as exec and exit signals
+type ProcessEventsCheck struct {
+}
+
+// Init initializes the ProcessEventsCheck.
+func (e *ProcessEventsCheck) Init(_ *config.AgentConfig, info *model.SystemInfo) {
+}
+
+// Name returns the name of the ProcessEventsCheck.
+func (e *ProcessEventsCheck) Name() string { return config.ProcessEventsCheckName }
+
+// RealTime returns a value that says whether this check should be run in real time.
+func (e *ProcessEventsCheck) RealTime() bool { return false }
+
+// Run fetches process lifecycle events that have been stored in-memory since the last check run
+func (e *ProcessEventsCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.MessageBody, error) {
+	return nil, errors.New("the process_events check is not supported on this system")
+}
+
+// Cleanup frees any resource held by the ProcessEventsCheck before the agent exits
+func (e *ProcessEventsCheck) Cleanup() {}

--- a/pkg/process/checks/process_events_linux.go
+++ b/pkg/process/checks/process_events_linux.go
@@ -1,0 +1,198 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux && !android
+// +build linux,!android
+
+package checks
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	payload "github.com/DataDog/agent-payload/v5/process"
+
+	"github.com/DataDog/datadog-agent/pkg/process/config"
+	"github.com/DataDog/datadog-agent/pkg/process/events"
+	"github.com/DataDog/datadog-agent/pkg/process/events/model"
+	"github.com/DataDog/datadog-agent/pkg/process/statsd"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// ProcessEvents is a ProcessEventsCheck singleton
+var ProcessEvents = &ProcessEventsCheck{}
+
+// ProcessEventsCheck collects process lifecycle events such as exec and exit signals
+type ProcessEventsCheck struct {
+	initMutex sync.Mutex
+
+	store    events.Store
+	listener *events.SysProbeListener
+	sysInfo  *payload.SystemInfo
+
+	maxBatchSize int
+}
+
+// Init initializes the ProcessEventsCheck.
+func (e *ProcessEventsCheck) Init(_ *config.AgentConfig, info *payload.SystemInfo) {
+	e.initMutex.Lock()
+	defer e.initMutex.Unlock()
+
+	if e.store != nil || e.listener != nil {
+		log.Error("process_events check has already been initialized")
+		return
+	}
+
+	log.Info("Initializing process_events check")
+	e.sysInfo = info
+	e.maxBatchSize = getMaxBatchSize()
+
+	store, err := events.NewRingStore(statsd.Client)
+	if err != nil {
+		log.Errorf("RingStore can't be created: %v", err)
+		return
+	}
+	e.store = store
+
+	listener, err := events.NewListener(func(e *model.ProcessEvent) {
+		// push events to the store asynchronously without checking for errors
+		_ = store.Push(e, nil)
+	})
+	if err != nil {
+		log.Errorf("Event Listener can't be created: %v", err)
+		return
+	}
+	e.listener = listener
+
+	e.start()
+	log.Info("process_events check correctly set up")
+}
+
+// start kicks off process lifecycle events collection and keep them in memory until they're fetched in the next check run
+func (e *ProcessEventsCheck) start() {
+	e.store.Run()
+	e.listener.Run()
+}
+
+// Name returns the name of the ProcessEventsCheck.
+func (e *ProcessEventsCheck) Name() string { return config.ProcessEventsCheckName }
+
+// RealTime returns a value that says whether this check should be run in real time.
+func (e *ProcessEventsCheck) RealTime() bool { return false }
+
+// Run fetches process lifecycle events that have been stored in-memory since the last check run
+func (e *ProcessEventsCheck) Run(cfg *config.AgentConfig, groupID int32) ([]payload.MessageBody, error) {
+	if !e.IsCheckCorrectlySetup() {
+		return nil, errors.New("the process_events check hasn't been correctly initialized")
+	}
+
+	ctx := context.Background()
+	events, err := e.store.Pull(ctx, time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("can't pull events from the Event Store: %v", err)
+	}
+
+	payloadEvents := fmtProcessEvents(events)
+	chunks := chunkProcessEvents(payloadEvents, e.maxBatchSize)
+
+	messages := make([]payload.MessageBody, len(chunks))
+	for c, chunk := range chunks {
+		messages[c] = &payload.CollectorProcEvent{
+			Hostname:  cfg.HostName,
+			Info:      e.sysInfo,
+			Events:    chunk,
+			GroupId:   groupID,
+			GroupSize: int32(len(chunks)),
+		}
+	}
+
+	return messages, nil
+}
+
+// Cleanup frees any resource held by the ProcessEventsCheck before the agent exits
+func (e *ProcessEventsCheck) Cleanup() {
+	log.Info("Cleaning up process_events check")
+	if e.listener != nil {
+		e.listener.Stop()
+	}
+
+	if e.store != nil {
+		e.store.Stop()
+	}
+	log.Info("process_events check cleaned up")
+}
+
+func (e *ProcessEventsCheck) IsCheckCorrectlySetup() bool {
+	return e.store != nil && e.listener != nil
+}
+
+// chunkProcessEvents splits a list of ProcessEvents into chunks according to the given chunk size
+// TODO: Move it to chunker
+func chunkProcessEvents(events []*payload.ProcessEvent, size int) [][]*payload.ProcessEvent {
+	chunkCount := len(events) / size
+	if chunkCount*size < len(events) {
+		chunkCount++
+	}
+	chunks := make([][]*payload.ProcessEvent, 0, chunkCount)
+
+	for i := 0; i < len(events); i += size {
+		end := i + size
+		if end > len(events) {
+			end = len(events)
+		}
+		chunks = append(chunks, events[i:end])
+	}
+
+	return chunks
+}
+
+func fmtProcessEvents(events []*model.ProcessEvent) []*payload.ProcessEvent {
+	payloadEvents := make([]*payload.ProcessEvent, 0, len(events))
+
+	for _, e := range events {
+		pE := &payload.ProcessEvent{
+			CollectionTime: e.CollectionTime.UnixNano(),
+			Pid:            e.Pid,
+			Command: &payload.Command{
+				Exe:  e.Exe,
+				Args: e.Cmdline,
+				Ppid: int32(e.Ppid),
+			},
+			User: &payload.ProcessUser{
+				Name: e.Username,
+				Uid:  int32(e.UID),
+				Gid:  int32(e.GID),
+			},
+		}
+
+		switch e.EventType {
+		case model.Exec:
+			pE.Type = payload.ProcEventType_exec
+			exec := &payload.ProcessExec{
+				ForkTime: e.ForkTime.UnixNano(),
+				ExecTime: e.ExecTime.UnixNano(),
+			}
+			pE.TypedEvent = &payload.ProcessEvent_Exec{Exec: exec}
+		case model.Exit:
+			pE.Type = payload.ProcEventType_exit
+			exit := &payload.ProcessExit{
+				ExecTime: e.ExecTime.UnixNano(),
+				ExitTime: e.ExitTime.UnixNano(),
+				ExitCode: 0,
+			}
+			pE.TypedEvent = &payload.ProcessEvent_Exit{Exit: exit}
+		default:
+			log.Error("Unexpected event type, dropping it")
+			continue
+		}
+
+		payloadEvents = append(payloadEvents, pE)
+	}
+
+	return payloadEvents
+}

--- a/pkg/process/checks/process_events_linux.go
+++ b/pkg/process/checks/process_events_linux.go
@@ -87,7 +87,7 @@ func (e *ProcessEventsCheck) RealTime() bool { return false }
 
 // Run fetches process lifecycle events that have been stored in-memory since the last check run
 func (e *ProcessEventsCheck) Run(cfg *config.AgentConfig, groupID int32) ([]payload.MessageBody, error) {
-	if !e.IsCheckCorrectlySetup() {
+	if !e.isCheckCorrectlySetup() {
 		return nil, errors.New("the process_events check hasn't been correctly initialized")
 	}
 
@@ -127,7 +127,7 @@ func (e *ProcessEventsCheck) Cleanup() {
 	log.Info("process_events check cleaned up")
 }
 
-func (e *ProcessEventsCheck) IsCheckCorrectlySetup() bool {
+func (e *ProcessEventsCheck) isCheckCorrectlySetup() bool {
 	return e.store != nil && e.listener != nil
 }
 

--- a/pkg/process/checks/process_events_linux_test.go
+++ b/pkg/process/checks/process_events_linux_test.go
@@ -1,0 +1,233 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux && !android
+// +build linux,!android
+
+package checks
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	payload "github.com/DataDog/agent-payload/v5/process"
+	"github.com/DataDog/datadog-go/v5/statsd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/process/config"
+	"github.com/DataDog/datadog-agent/pkg/process/events"
+	"github.com/DataDog/datadog-agent/pkg/process/events/model"
+	"github.com/DataDog/datadog-agent/pkg/security/api"
+	"github.com/DataDog/datadog-agent/pkg/security/api/mocks"
+	secmodel "github.com/DataDog/datadog-agent/pkg/security/secl/model"
+)
+
+type eventTestData struct {
+	rawEvent     *model.ProcessMonitoringEvent
+	payloadEvent *payload.ProcessEvent
+}
+
+func parseRFC3339Time(t *testing.T, s string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339Nano, s)
+	require.NoError(t, err)
+	return parsed
+}
+
+func mockedData(t *testing.T) []*eventTestData {
+	t.Helper()
+	return []*eventTestData{
+		{
+			rawEvent: &model.ProcessMonitoringEvent{
+				EventType:      "exec",
+				CollectionTime: parseRFC3339Time(t, "2022-06-12T12:00:10Z"),
+				ProcessCacheEntry: &secmodel.ProcessCacheEntry{
+					ProcessContext: secmodel.ProcessContext{
+						Process: secmodel.Process{
+							PIDContext: secmodel.PIDContext{
+								Pid: 42,
+							},
+							PPid: 1,
+							Credentials: secmodel.Credentials{
+								UID:   100,
+								GID:   100,
+								User:  "user",
+								Group: "mygroup",
+							},
+							FileEvent: secmodel.FileEvent{
+								PathnameStr: "/usr/bin/curl",
+							},
+							ArgsEntry: &secmodel.ArgsEntry{
+								Values: []string{
+									"curl",
+									"localhost:6062/debug/vars",
+								},
+							},
+							ForkTime: parseRFC3339Time(t, "2022-06-12T12:00:01Z"),
+							ExecTime: parseRFC3339Time(t, "2022-06-12T12:00:02Z"),
+							ExitTime: time.Time{},
+						},
+					},
+				},
+			},
+			payloadEvent: &payload.ProcessEvent{
+				Type:           payload.ProcEventType_exec,
+				CollectionTime: parseRFC3339Time(t, "2022-06-12T12:00:10Z").UnixNano(),
+				Pid:            42,
+				Command: &payload.Command{
+					Exe:  "/usr/bin/curl",
+					Args: []string{"curl", "localhost:6062/debug/vars"},
+					Ppid: 1,
+				},
+				User: &payload.ProcessUser{
+					Name: "user",
+					Uid:  100,
+					Gid:  100,
+				},
+				TypedEvent: &payload.ProcessEvent_Exec{
+					Exec: &payload.ProcessExec{
+						ForkTime: parseRFC3339Time(t, "2022-06-12T12:00:01Z").UnixNano(),
+						ExecTime: parseRFC3339Time(t, "2022-06-12T12:00:02Z").UnixNano(),
+					},
+				},
+			},
+		},
+		{
+			rawEvent: &model.ProcessMonitoringEvent{
+				EventType:      "exit",
+				CollectionTime: parseRFC3339Time(t, "2022-06-12T12:00:20Z"),
+				ProcessCacheEntry: &secmodel.ProcessCacheEntry{
+					ProcessContext: secmodel.ProcessContext{
+						Process: secmodel.Process{
+							PIDContext: secmodel.PIDContext{
+								Pid: 42,
+							},
+							PPid: 1,
+							Credentials: secmodel.Credentials{
+								UID:   100,
+								GID:   100,
+								User:  "user",
+								Group: "mygroup",
+							},
+							FileEvent: secmodel.FileEvent{
+								PathnameStr: "/usr/bin/curl",
+							},
+							ArgsEntry: &secmodel.ArgsEntry{
+								Values: []string{
+									"curl",
+									"localhost:6062/debug/vars",
+								},
+							},
+							ForkTime: parseRFC3339Time(t, "2022-06-12T12:00:01Z"),
+							ExecTime: parseRFC3339Time(t, "2022-06-12T12:00:02Z"),
+							ExitTime: parseRFC3339Time(t, "2022-06-12T12:00:12Z"),
+						},
+					},
+				},
+			},
+			payloadEvent: &payload.ProcessEvent{
+				Type:           payload.ProcEventType_exit,
+				CollectionTime: parseRFC3339Time(t, "2022-06-12T12:00:20Z").UnixNano(),
+				Pid:            42,
+				Command: &payload.Command{
+					Exe:  "/usr/bin/curl",
+					Args: []string{"curl", "localhost:6062/debug/vars"},
+					Ppid: 1,
+				},
+				User: &payload.ProcessUser{
+					Name: "user",
+					Uid:  100,
+					Gid:  100,
+				},
+				TypedEvent: &payload.ProcessEvent_Exit{
+					Exit: &payload.ProcessExit{
+						ExecTime: parseRFC3339Time(t, "2022-06-12T12:00:02Z").UnixNano(),
+						ExitTime: parseRFC3339Time(t, "2022-06-12T12:00:12Z").UnixNano(),
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestProcessEventsCheck(t *testing.T) {
+	tests := mockedData(t)
+
+	// Initialize check with a mocked gRPC client
+	ctx := context.Background()
+
+	client := mocks.NewSecurityModuleClient(t)
+	stream := mocks.NewSecurityModule_GetProcessEventsClient(t)
+	client.On("GetProcessEvents", ctx, &api.GetProcessEventParams{}).Return(stream, nil)
+
+	for _, test := range tests {
+		data, err := test.rawEvent.MarshalMsg(nil)
+		require.NoError(t, err)
+
+		stream.On("Recv").Once().Return(&api.SecurityProcessEventMessage{Data: data}, nil)
+	}
+	stream.On("Recv").Return(nil, io.EOF)
+
+	store, err := events.NewRingStore(&statsd.NoOpClient{})
+	require.NoError(t, err)
+
+	listener, err := events.NewSysProbeListener(nil, client, func(e *model.ProcessEvent) {
+		_ = store.Push(e, nil)
+	})
+	require.NoError(t, err)
+
+	check := &ProcessEventsCheck{
+		maxBatchSize: 10,
+		listener:     listener,
+		store:        store,
+	}
+	check.start()
+
+	cfg := &config.AgentConfig{}
+	events := make([]*payload.ProcessEvent, 0)
+	assert.Eventually(t, func() bool {
+		// Run the process_events check until all expected events are collected
+		msgs, err := check.Run(cfg, 0)
+		require.NoError(t, err)
+
+		for _, msg := range msgs {
+			collectorProc, ok := msg.(*payload.CollectorProcEvent)
+			require.True(t, ok)
+			events = append(events, collectorProc.Events...)
+		}
+
+		if len(events) == len(tests) {
+			for i := range events {
+				require.Equal(t, tests[i].payloadEvent, events[i])
+			}
+			return true
+		}
+
+		return false
+
+	}, time.Second, 20*time.Millisecond)
+
+	check.Cleanup()
+}
+
+func TestProcessEventsChunking(t *testing.T) {
+	for _, tc := range []struct {
+		events     int
+		chunkSize  int
+		chunkCount int
+	}{
+		{100, 10, 10},
+		{50, 30, 2},
+		{10, 100, 1},
+		{0, 100, 0},
+	} {
+		events := make([]*payload.ProcessEvent, tc.events)
+		chunks := chunkProcessEvents(events, tc.chunkSize)
+		assert.Len(t, chunks, tc.chunkCount)
+	}
+}

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -40,13 +40,14 @@ const defaultProxyPort = 3128
 
 // Name for check performed by process-agent or system-probe
 const (
-	ProcessCheckName     = "process"
-	RTProcessCheckName   = "rtprocess"
-	ContainerCheckName   = "container"
-	RTContainerCheckName = "rtcontainer"
-	ConnectionsCheckName = "connections"
-	PodCheckName         = "pod"
-	DiscoveryCheckName   = "process_discovery"
+	ProcessCheckName       = "process"
+	RTProcessCheckName     = "rtprocess"
+	ContainerCheckName     = "container"
+	RTContainerCheckName   = "rtcontainer"
+	ConnectionsCheckName   = "connections"
+	PodCheckName           = "pod"
+	DiscoveryCheckName     = "process_discovery"
+	ProcessEventsCheckName = "process_events"
 
 	ProcessCheckDefaultInterval          = 10 * time.Second
 	RTProcessCheckDefaultInterval        = 2 * time.Second
@@ -133,13 +134,14 @@ func NewDefaultAgentConfig() *AgentConfig {
 
 		// Check config
 		CheckIntervals: map[string]time.Duration{
-			ProcessCheckName:     ProcessCheckDefaultInterval,
-			RTProcessCheckName:   RTProcessCheckDefaultInterval,
-			ContainerCheckName:   ContainerCheckDefaultInterval,
-			RTContainerCheckName: RTContainerCheckDefaultInterval,
-			ConnectionsCheckName: ConnectionsCheckDefaultInterval,
-			PodCheckName:         PodCheckDefaultInterval,
-			DiscoveryCheckName:   ProcessDiscoveryCheckDefaultInterval,
+			ProcessCheckName:       ProcessCheckDefaultInterval,
+			RTProcessCheckName:     RTProcessCheckDefaultInterval,
+			ContainerCheckName:     ContainerCheckDefaultInterval,
+			RTContainerCheckName:   RTContainerCheckDefaultInterval,
+			ConnectionsCheckName:   ConnectionsCheckDefaultInterval,
+			PodCheckName:           PodCheckDefaultInterval,
+			DiscoveryCheckName:     ProcessDiscoveryCheckDefaultInterval,
+			ProcessEventsCheckName: config.DefaultProcessEventsCheckInterval,
 		},
 
 		// DataScrubber to hide command line sensitive words

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -56,6 +56,14 @@ func (a *AgentConfig) LoadAgentConfig(path string) error {
 	}
 	a.CheckIntervals[DiscoveryCheckName] = discoveryInterval
 
+	eventsInterval := config.Datadog.GetDuration("process_config.event_collection.interval")
+	if eventsInterval < config.DefaultProcessEventsMinCheckInterval {
+		eventsInterval = config.DefaultProcessEventsCheckInterval
+		_ = log.Warnf("Invalid interval for process_events check (<=%s) using default value of %s",
+			config.DefaultProcessEventsMinCheckInterval.String(), config.DefaultProcessEventsCheckInterval.String())
+	}
+	a.CheckIntervals[ProcessEventsCheckName] = eventsInterval
+
 	if a.CheckIntervals[ProcessCheckName] < a.CheckIntervals[RTProcessCheckName] || a.CheckIntervals[ProcessCheckName]%a.CheckIntervals[RTProcessCheckName] != 0 {
 		// Process check interval must be greater or equal to RTProcess check interval and the intervals must be divisible
 		// in order to be run on the same goroutine

--- a/pkg/process/events/listener_linux.go
+++ b/pkg/process/events/listener_linux.go
@@ -59,11 +59,11 @@ func NewListener(handler EventHandler) (*SysProbeListener, error) {
 	}
 
 	client := api.NewSecurityModuleClient(conn)
-	return newSysProbeListener(conn, client, handler)
+	return NewSysProbeListener(conn, client, handler)
 }
 
-// newSysProbeListener returns a new SysPobeListener
-func newSysProbeListener(conn *grpc.ClientConn, client api.SecurityModuleClient, handler EventHandler) (*SysProbeListener, error) {
+// NewSysProbeListener returns a new SysPobeListener
+func NewSysProbeListener(conn *grpc.ClientConn, client api.SecurityModuleClient, handler EventHandler) (*SysProbeListener, error) {
 	if handler == nil {
 		return nil, errors.New("can't create a Listener without an EventHandler")
 	}

--- a/pkg/process/events/listener_linux_test.go
+++ b/pkg/process/events/listener_linux_test.go
@@ -51,7 +51,7 @@ func TestProcessEventFiltering(t *testing.T) {
 		calledHandlers++
 	}
 
-	l, err := newSysProbeListener(nil, nil, handler)
+	l, err := NewSysProbeListener(nil, nil, handler)
 	require.NoError(t, err)
 
 	for _, e := range rawEvents {
@@ -116,7 +116,7 @@ func TestProcessEventHandling(t *testing.T) {
 
 		i++
 	}
-	l, err := newSysProbeListener(nil, client, handler)
+	l, err := NewSysProbeListener(nil, client, handler)
 	require.NoError(t, err)
 	l.Run()
 
@@ -134,7 +134,7 @@ func TestSecurityModuleClientReconnect(t *testing.T) {
 	client := mocks.NewSecurityModuleClient(t)
 	stream := mocks.NewSecurityModule_GetProcessEventsClient(t)
 
-	l, err := newSysProbeListener(nil, client, func(e *model.ProcessEvent) { return })
+	l, err := NewSysProbeListener(nil, client, func(e *model.ProcessEvent) { return })
 	require.NoError(t, err)
 
 	l.retryInterval = 10 * time.Millisecond // force a fast retry for tests


### PR DESCRIPTION
### What does this PR do?
This PR reverts the revert of https://github.com/DataDog/datadog-agent/pull/12390 since the build errorw have been fixed by https://github.com/DataDog/datadog-agent/pull/12501.

It also unexports the `IsCheckCorrectlySetup` function because it didn't have a comment which breaks the linter check introduced by https://github.com/DataDog/datadog-agent/pull/12312.

### Motivation


### Additional Notes


### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes

Described on https://github.com/DataDog/datadog-agent/pull/12390.

### Reviewer's Checklist


- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
