### PR TITLE
add hints when there is a mismatch between http and https when the Agent communicate with an endpoint

### DIFF
--- a/pkg/diagnose/connectivity/hooks.go
+++ b/pkg/diagnose/connectivity/hooks.go
@@ -19,6 +19,7 @@ import (
 	"net/http/httptrace"
 	"strings"
 
+	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
 	"github.com/fatih/color"
 )
 
@@ -79,7 +80,7 @@ func (writer *connectivityHooks) connectDoneHook(network, addr string, err error
 	statusString := color.GreenString("OK")
 	if err != nil {
 		statusString = color.RedString("ERROR")
-		fmt.Fprintf(writer.w, "Unable to connect to the endpoint : %v\n", err)
+		fmt.Fprintf(writer.w, "Unable to connect to the endpoint : %v\n", scrubber.ScrubLine(err.Error()))
 	}
 	fmt.Fprintf(writer.w, "* Connection to the endpoint [%v]\n\n", statusString)
 }
@@ -115,7 +116,7 @@ func (writer *connectivityHooks) dnsDoneHook(di httptrace.DNSDoneInfo) {
 	statusString := color.GreenString("OK")
 	if di.Err != nil {
 		statusString = color.RedString("ERROR")
-		fmt.Fprint(writer.w, dnsColorFunc("Unable to resolve the address : %v\n", di.Err))
+		fmt.Fprint(writer.w, dnsColorFunc("Unable to resolve the address : %v\n", scrubber.ScrubLine(di.Err.Error())))
 	}
 	fmt.Fprintf(writer.w, "* %v [%v]\n\n", dnsColorFunc("DNS Lookup"), statusString)
 }
@@ -131,7 +132,7 @@ func (writer *connectivityHooks) tlsHandshakeDoneHook(cs tls.ConnectionState, er
 	statusString := color.GreenString("OK")
 	if err != nil {
 		statusString = color.RedString("ERROR")
-		fmt.Fprint(writer.w, tlsColorFunc("Unable to achieve the TLS Handshake : %v\n", err))
+		fmt.Fprint(writer.w, tlsColorFunc("Unable to achieve the TLS Handshake : %v\n", scrubber.ScrubLine(err.Error())))
 
 		writer.getTLSHandshakeHints(err)
 	}

--- a/pkg/diagnose/connectivity/trace_request.go
+++ b/pkg/diagnose/connectivity/trace_request.go
@@ -140,7 +140,7 @@ func noResponseHints(writer io.Writer, err error) {
 	endpoint := config.GetMainInfraEndpoint()
 	parsedURL, parseErr := url.Parse(endpoint)
 	if parseErr != nil {
-		fmt.Fprintf(writer, "Could not parse url '%v' : %v", scrubber.ScrubLine(endpoint), parseErr)
+		fmt.Fprintf(writer, "Could not parse url '%v' : %v", scrubber.ScrubLine(endpoint), scrubber.ScrubLine(parseErr.Error()))
 		return
 	}
 

--- a/pkg/diagnose/connectivity/trace_request.go
+++ b/pkg/diagnose/connectivity/trace_request.go
@@ -119,9 +119,8 @@ func createEndpointURL(domain string, endpointInfo endpointInfo) string {
 func verifyEndpointResponse(writer io.Writer, statusCode int, responseBody []byte, err error) {
 
 	if err != nil {
-		fmt.Fprintf(writer, "could not get a response from the endpoint : %v\n", scrubber.ScrubLine(err.Error()))
+		fmt.Fprintf(writer, "could not get a response from the endpoint : %v ====> %v\n", scrubber.ScrubLine(err.Error()), color.RedString("FAIL"))
 		noResponseHints(writer, err)
-		fmt.Fprintf(writer, "Could not get a valid response from the backend ====> %v\n", color.RedString("FAIL"))
 		return
 	}
 

--- a/pkg/diagnose/connectivity/trace_request.go
+++ b/pkg/diagnose/connectivity/trace_request.go
@@ -15,6 +15,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptrace"
+	"net/url"
+	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/resolver"
@@ -112,10 +114,14 @@ func createEndpointURL(domain string, endpointInfo endpointInfo) string {
 	return domain + endpointInfo.Endpoint.Route
 }
 
+// vertifyEndpointResponse interprets the endpoint response and displays information on if the connectivity
+// check was successful or not
 func verifyEndpointResponse(writer io.Writer, statusCode int, responseBody []byte, err error) {
 
 	if err != nil {
 		fmt.Fprintf(writer, "could not get a response from the endpoint : %v\n", scrubber.ScrubLine(err.Error()))
+		noResponseHints(writer, err)
+		fmt.Fprintf(writer, "Could not get a valid response from the backend ====> %v\n", color.RedString("FAIL"))
 		return
 	}
 
@@ -125,4 +131,23 @@ func verifyEndpointResponse(writer io.Writer, statusCode int, responseBody []byt
 		fmt.Fprintf(writer, "Received response : '%v'\n", scrubber.ScrubLine(string(responseBody)))
 	}
 	fmt.Fprintf(writer, "Received status code %v from the endpoint ====> %v\n", statusCode, scrubber.ScrubLine(statusString))
+}
+
+// noResponseHints aims to give hints when the endpoint did not respond.
+// For instance, when sending an HTTP request to a HAProxy endpoint configured for HTTPS
+// the endpoint send an empty response. As the error 'EOF' is not very informative, it can
+// be interesting to 'wrap' this error to display more context.
+func noResponseHints(writer io.Writer, err error) {
+	endpoint := config.GetMainInfraEndpoint()
+	parsedURL, parseErr := url.Parse(endpoint)
+	if parseErr != nil {
+		fmt.Fprintf(writer, "Could not parse url '%v' : %v", scrubber.ScrubLine(endpoint), parseErr)
+		return
+	}
+
+	if parsedURL.Scheme == "http" {
+		if strings.Contains(err.Error(), "EOF") {
+			fmt.Fprintln(writer, hintColorFunc("Hint: received an empty reply from the server. You are maybe trying to contact an HTTPS endpoint using an HTTP url : '%v'", scrubber.ScrubLine(endpoint)))
+		}
+	}
 }


### PR DESCRIPTION

### What does this PR do?

Add more information on the diagnose connectivity function.

### Motivation

Some errors returned by Golang network package are not clear enough so we want to add more context when we encounter them.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

There is 2 new 'debug' print added in this PR that we need to check.

- The first one is displayed when the Agent is using HTTPS to communicate with a HTTP endpoint
- The second one is displayed when the Agent is using HTTP to communicate with a HTTPS endpoint in some case (for instance when using HAProxy because it sends an empty reply)

#### 1) HAProxy Setup

Setup HAProxy using this documentation https://docs.datadoghq.com/agent/proxy/?tabs=agentv6v7#haproxy

You will need a Certificate to enable ssl for HAProxy. There are several ways to create a certificate like [this one](https://gist.github.com/fntlnz/cf14feb5a46b2eda428e000157447309) but I think the easiest way is to use `mkcert`.

- Run `mkcert test.com` : it should create 2 files `test.com-key.pem` and `test.com.pem`
- HAProxy need a file with the content of both files above : run `cat test.com.pem test.com-key.pem > test.com.cert` (or `sudo sh -c "cat test.com.pem test.com-key.pem > test.com.cert"` if you have permission issues)
- Now you can use `test.com.cert` as a certificate for HAProxy. It doesn't matter if this certificate is not trust by the Agent host.

#### 2) Agent  configuration

- Be sure that `dd_url` is correctly set (details [here](https://docs.datadoghq.com/agent/proxy/?tabs=agentv6v7#datadog-agent-configuration))

#### 3) Run the diagnose command

##### Agent HTTPS -> HAProxy HTTP : 
- `datadog.yaml`: set `dd_url` to `https:<address>:<port>`. Here the `s` in `https` is important and the port is probably `3834` if you followed the documentation.
- `haproxy.cfg` : verify that the frontend that binds the port `3834` do not have ssl enabled. It should look like this : 
```
frontend metrics-forwarder
     bind *:3834 
    ....
```
- Run `datadog-agent diagnose datadog-connectivity`
- Check that this line is in the output `Hint: you are trying to communicate using HTTPS with an endpoint that does not seem to be configured for HTTPS. If you are using a proxy, please verify that it is configured for HTTPS connections.`



##### Agent HTTP -> HAProxy HTTPS : 

- `datadog.yaml`: set `dd_url` to `http:<address>:<port>`. The port is probably `3834` if you followed the documentation.
- `haproxy.cfg` : verify that the frontend that binds the port `3834`  **HAVE** ssl enabled. It should look like this : 
```
frontend metrics-forwarder
     bind *:3834 ssl cert <path/to/cert>
    ....
```
- Run `datadog-agent diagnose datadog-connectivity`
- Check that this line is in the output `Hint: received an empty reply from the server. You are maybe trying to contact an HTTPS endpoint using an HTTP url : '<dd_url>'`


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
