### PR TITLE
[pkg/dogstatsd] Fix linter problem in `mem_based_rate_limiter.go`

### DIFF
--- a/pkg/dogstatsd/listeners/ratelimit/mem_based_rate_limiter.go
+++ b/pkg/dogstatsd/listeners/ratelimit/mem_based_rate_limiter.go
@@ -120,7 +120,7 @@ func NewMemBasedRateLimiter(
 	}, nil
 }
 
-// Wait and try to release the memory. See MemBasedRateLimiter for more information.
+// MayWait waits and tries to release the memory. See MemBasedRateLimiter for more information.
 func (m *MemBasedRateLimiter) MayWait() error {
 	if !m.memoryRateLimiter.keep() {
 		m.telemetry.incNoWait()


### PR DESCRIPTION
### What does this PR do?

Changes the comment on exported function to fit the linter rules

### Motivation

This file had a comment that did not match the expected format for our
linter rules.

### Additional Notes

N/A

### Possible Drawbacks / Trade-offs

N/A

### Describe how to test/QA your changes

CircleCI should not fail the linting stage

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
