### PR TITLE
[pkg/serializer] Fix linter problem in `serializer.go`

### DIFF
--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -337,7 +337,7 @@ func (s *Serializer) SendIterableSeries(serieSource metrics.SerieSource) error {
 	return s.Forwarder.SubmitSeries(seriesPayloads, extraHeaders)
 }
 
-// AreSeriesEnabled returns whether sketches are enabled for serialization
+// AreSketchesEnabled returns whether sketches are enabled for serialization
 func (s *Serializer) AreSketchesEnabled() bool {
 	return s.enableSketches
 }


### PR DESCRIPTION
### What does this PR do?

Fixes the comment on a public method in `pkg/serializer/serializer.go`

### Motivation

This file had a comment that did not match the expected format for our
linter rules on public methods.

### Additional Notes

N/A

### Possible Drawbacks / Trade-offs

N/A

### Describe how to test/QA your changes

CI/CD tests should pass without failures in the linting stage

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
