### PR TITLE
[netflow] Move namespace to device.namespace in payload

### DIFF
--- a/pkg/netflow/flowaggregator/aggregator_test.go
+++ b/pkg/netflow/flowaggregator/aggregator_test.go
@@ -79,7 +79,8 @@ func TestAggregator(t *testing.T) {
   "ether_type": "IPv4",
   "ip_protocol": "TCP",
   "device": {
-    "ip": "127.0.0.1"
+    "ip": "127.0.0.1",
+    "namespace": "my-ns"
   },
   "source": {
     "ip": "10.10.10.10",
@@ -103,7 +104,6 @@ func TestAggregator(t *testing.T) {
       "index": 0
     }
   },
-  "namespace": "my-ns",
   "host": "my-hostname",
   "tcp_flags": [
     "FIN",

--- a/pkg/netflow/flowaggregator/buildpayload.go
+++ b/pkg/netflow/flowaggregator/buildpayload.go
@@ -14,7 +14,8 @@ func buildPayload(aggFlow *common.Flow, hostname string) payload.FlowPayload {
 		SamplingRate: aggFlow.SamplingRate,
 		Direction:    enrichment.RemapDirection(aggFlow.Direction),
 		Device: payload.Device{
-			IP: common.IPBytesToString(aggFlow.DeviceAddr),
+			IP:        common.IPBytesToString(aggFlow.DeviceAddr),
+			Namespace: aggFlow.Namespace,
 		},
 		Start:      aggFlow.StartTimestamp,
 		End:        aggFlow.EndTimestamp,
@@ -44,9 +45,8 @@ func buildPayload(aggFlow *common.Flow, hostname string) payload.FlowPayload {
 				Index: aggFlow.OutputInterface,
 			},
 		},
-		Namespace: aggFlow.Namespace,
-		Host:      hostname,
-		TCPFlags:  enrichment.FormatFCPFlags(aggFlow.TCPFlags),
+		Host:     hostname,
+		TCPFlags: enrichment.FormatFCPFlags(aggFlow.TCPFlags),
 		NextHop: payload.NextHop{
 			IP: common.IPBytesToString(aggFlow.NextHop),
 		},

--- a/pkg/netflow/flowaggregator/buildpayload_test.go
+++ b/pkg/netflow/flowaggregator/buildpayload_test.go
@@ -52,7 +52,8 @@ func Test_buildPayload(t *testing.T) {
 				EtherType:    "IPv4",
 				IPProtocol:   "TCP",
 				Device: payload.Device{
-					IP: "127.0.0.1",
+					IP:        "127.0.0.1",
+					Namespace: "my-namespace",
 				},
 				Source: payload.Endpoint{
 					IP:   "10.10.10.10",
@@ -65,11 +66,10 @@ func Test_buildPayload(t *testing.T) {
 					Mac:  "00:00:00:00:00:14",
 					Mask: "10.10.0.0/20",
 				},
-				Ingress:   payload.ObservationPoint{Interface: payload.Interface{Index: 10}},
-				Egress:    payload.ObservationPoint{Interface: payload.Interface{Index: 20}},
-				Namespace: "my-namespace",
-				Host:      "my-hostname",
-				TCPFlags:  []string{"FIN", "SYN", "ACK"},
+				Ingress:  payload.ObservationPoint{Interface: payload.Interface{Index: 10}},
+				Egress:   payload.ObservationPoint{Interface: payload.Interface{Index: 20}},
+				Host:     "my-hostname",
+				TCPFlags: []string{"FIN", "SYN", "ACK"},
 				NextHop: payload.NextHop{
 					IP: "10.10.10.30",
 				},

--- a/pkg/netflow/payload/payload.go
+++ b/pkg/netflow/payload/payload.go
@@ -7,7 +7,8 @@ package payload
 
 // Device contains device (exporter) details
 type Device struct {
-	IP string `json:"ip"`
+	IP        string `json:"ip"`
+	Namespace string `json:"namespace"`
 }
 
 // Endpoint contains source or destination endpoint details
@@ -49,7 +50,6 @@ type FlowPayload struct {
 	Destination  Endpoint         `json:"destination"`
 	Ingress      ObservationPoint `json:"ingress"`
 	Egress       ObservationPoint `json:"egress"`
-	Namespace    string           `json:"namespace"`
 	Host         string           `json:"host"`
 	TCPFlags     []string         `json:"tcp_flags,omitempty"`
 	NextHop      NextHop          `json:"next_hop,omitempty"`

--- a/pkg/netflow/server_test.go
+++ b/pkg/netflow/server_test.go
@@ -74,7 +74,7 @@ network_devices:
 	assert.Equal(t, "0.0.0.0/0", actualFlow.Destination.Mask)
 	assert.Equal(t, uint32(1), actualFlow.Ingress.Interface.Index)
 	assert.Equal(t, uint32(7), actualFlow.Egress.Interface.Index)
-	assert.Equal(t, "default", actualFlow.Namespace)
+	assert.Equal(t, "default", actualFlow.Device.Namespace)
 	hostname, _ := util.GetHostname(context.TODO())
 	assert.Equal(t, hostname, actualFlow.Host)
 	assert.ElementsMatch(t, []string{"SYN", "RST", "ACK"}, actualFlow.TCPFlags)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

[netflow] Move namespace to device.namespace in payload

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

`namespace` is used to disambiguate devices, hence it makes sense to have it in `device` section.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
