### PR TITLE
pkg/trace/api: ensure best effort setting container tags in OTLP ingest

### DIFF
--- a/pkg/trace/api/otlp.go
+++ b/pkg/trace/api/otlp.go
@@ -339,6 +339,14 @@ func (o *OTLPReceiver) ReceiveResourceSpans(rspans ptrace.ResourceSpans, header 
 		p.TracerPayload.Tags = map[string]string{
 			tagContainersTags: ctags,
 		}
+	} else {
+		// we couldn't obtain any container tags
+		if src.Kind == source.AWSECSFargateKind {
+			// but we have some information from the source provider that we can add
+			p.TracerPayload.Tags = map[string]string{
+				tagContainersTags: src.Tag(),
+			}
+		}
 	}
 	select {
 	case o.out <- &p:


### PR DESCRIPTION
This change makes sure that whenever we are in a containerised
environment (AWS, ECS, Fargate) and we are missing a container ID, we at
least try to add the tag returned by the source provider, if available.