### PR TITLE
[RCM] Fix storage of backend state in client

### DIFF
--- a/pkg/config/remote/client.go
+++ b/pkg/config/remote/client.go
@@ -258,11 +258,12 @@ func (c *Client) newUpdateRequest() (*pbgo.ClientGetConfigsRequest, error) {
 	req := &pbgo.ClientGetConfigsRequest{
 		Client: &pbgo.Client{
 			State: &pbgo.ClientState{
-				RootVersion:    uint64(state.RootsVersion),
-				TargetsVersion: uint64(state.TargetsVersion),
-				ConfigStates:   pbConfigState,
-				HasError:       hasError,
-				Error:          errMsg,
+				RootVersion:        uint64(state.RootsVersion),
+				TargetsVersion:     uint64(state.TargetsVersion),
+				ConfigStates:       pbConfigState,
+				HasError:           hasError,
+				Error:              errMsg,
+				BackendClientState: state.OpaqueBackendState,
 			},
 			Id:       c.ID,
 			Products: c.products,

--- a/pkg/remoteconfig/state/repository_test.go
+++ b/pkg/remoteconfig/state/repository_test.go
@@ -42,6 +42,7 @@ func TestEmptyUpdate(t *testing.T) {
 	assert.Equal(t, 0, len(state.CachedFiles))
 	assert.EqualValues(t, 0, state.TargetsVersion)
 	assert.EqualValues(t, 1, state.RootsVersion)
+	assert.Nil(t, state.OpaqueBackendState)
 }
 
 func TestUpdateNewConfig(t *testing.T) {
@@ -80,6 +81,7 @@ func TestUpdateNewConfig(t *testing.T) {
 	assert.Equal(t, 1, len(state.CachedFiles))
 	assert.EqualValues(t, 1, state.TargetsVersion)
 	assert.EqualValues(t, 1, state.RootsVersion)
+	assert.Equal(t, testOpaqueBackendStateContents, state.OpaqueBackendState)
 	configState := state.Configs[0]
 	assert.Equal(t, ProductCWSDD, configState.Product)
 	assert.Equal(t, "test", configState.ID)
@@ -131,6 +133,7 @@ func TestUpdateNewConfigThenRemove(t *testing.T) {
 	assert.Equal(t, 0, len(state.CachedFiles))
 	assert.EqualValues(t, 2, state.TargetsVersion)
 	assert.EqualValues(t, 1, state.RootsVersion)
+	assert.Equal(t, testOpaqueBackendStateContents, state.OpaqueBackendState)
 }
 
 func TestUpdateNewConfigThenModify(t *testing.T) {
@@ -181,6 +184,7 @@ func TestUpdateNewConfigThenModify(t *testing.T) {
 	assert.Equal(t, 1, len(state.CachedFiles))
 	assert.EqualValues(t, 2, state.TargetsVersion)
 	assert.EqualValues(t, 1, state.RootsVersion)
+	assert.Equal(t, testOpaqueBackendStateContents, state.OpaqueBackendState)
 	configState := state.Configs[0]
 	assert.Equal(t, ProductCWSDD, configState.Product)
 	assert.Equal(t, "test", configState.ID)
@@ -216,6 +220,7 @@ func TestUpdateWithIncorrectlySignedTargets(t *testing.T) {
 	assert.Equal(t, 0, len(state.CachedFiles))
 	assert.EqualValues(t, 0, state.TargetsVersion)
 	assert.EqualValues(t, 1, state.RootsVersion)
+	assert.Nil(t, state.OpaqueBackendState)
 }
 
 func TestUpdateWithMalformedTargets(t *testing.T) {
@@ -239,6 +244,7 @@ func TestUpdateWithMalformedTargets(t *testing.T) {
 	assert.Equal(t, 0, len(state.CachedFiles))
 	assert.EqualValues(t, 0, state.TargetsVersion)
 	assert.EqualValues(t, 1, state.RootsVersion)
+	assert.Nil(t, state.OpaqueBackendState)
 }
 
 func TestUpdateWithMalformedExtraRoot(t *testing.T) {
@@ -263,6 +269,7 @@ func TestUpdateWithMalformedExtraRoot(t *testing.T) {
 	assert.Equal(t, 0, len(state.CachedFiles))
 	assert.EqualValues(t, 0, state.TargetsVersion)
 	assert.EqualValues(t, 1, state.RootsVersion)
+	assert.Nil(t, state.OpaqueBackendState)
 }
 
 func TestUpdateWithNewRoot(t *testing.T) {
@@ -306,6 +313,7 @@ func TestUpdateWithNewRoot(t *testing.T) {
 	assert.Equal(t, 1, len(state.CachedFiles))
 	assert.EqualValues(t, 1, state.TargetsVersion)
 	assert.EqualValues(t, 2, state.RootsVersion)
+	assert.Equal(t, testOpaqueBackendStateContents, state.OpaqueBackendState)
 	configState := state.Configs[0]
 	assert.Equal(t, ProductCWSDD, configState.Product)
 	assert.Equal(t, "test", configState.ID)
@@ -342,6 +350,7 @@ func TestClientOnlyTakesActionOnFilesInClientConfig(t *testing.T) {
 	assert.Equal(t, 0, len(state.CachedFiles))
 	assert.EqualValues(t, 1, state.TargetsVersion)
 	assert.EqualValues(t, 1, state.RootsVersion)
+	assert.Equal(t, testOpaqueBackendStateContents, state.OpaqueBackendState)
 }
 
 func TestUpdateWithTwoProducts(t *testing.T) {
@@ -393,6 +402,7 @@ func TestUpdateWithTwoProducts(t *testing.T) {
 	assert.Equal(t, 2, len(state.CachedFiles))
 	assert.EqualValues(t, 1, state.TargetsVersion)
 	assert.EqualValues(t, 1, state.RootsVersion)
+	assert.Equal(t, testOpaqueBackendStateContents, state.OpaqueBackendState)
 
 	expectedConfigStateCWSDD := ConfigState{
 		Product: ProductCWSDD,

--- a/pkg/remoteconfig/state/testingutils_test.go
+++ b/pkg/remoteconfig/state/testingutils_test.go
@@ -15,6 +15,10 @@ import (
 	"github.com/theupdateframework/go-tuf/util"
 )
 
+var (
+	testOpaqueBackendStateContents = []byte(`{"foo": "bar"}`)
+)
+
 type testArtifacts struct {
 	key            keys.Signer
 	signedBaseRoot []byte
@@ -75,8 +79,19 @@ func newTestArtifacts() testArtifacts {
 		panic(err)
 	}
 
+	state := struct {
+		State []byte `json:"opaque_backend_state"`
+	}{[]byte(testOpaqueBackendStateContents)}
+
+	b, err := json.Marshal(&state)
+	if err != nil {
+		panic(err)
+	}
+	rm := json.RawMessage(b)
+
 	targets := data.NewTargets()
 	targets.Version = 1
+	targets.Custom = &rm
 
 	return testArtifacts{
 		key:            key,


### PR DESCRIPTION
There was a bug in the communication between the backend and the agent
involving backend state that is supposed to be opaque to the agent and
its clients. (allowing the backend to store whatever it wants downstream
to help optimize the update process or recreate state if needed)

In order to fix the bug, we needed to introduce a new field and change
the data type from json.RawMessage to []byte.

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
