### PR TITLE
Add kernel release prefix and coloring to all NPM kitchen test log output

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -712,6 +712,10 @@ variables:
   - changes:
       - pkg/ebpf/**/*
       - pkg/network/**/*
+      - test/kitchen/site-cookbooks/dd-system-probe-check/**/*
+      - test/kitchen/test/integration/system-probe-test/**/*
+      - test/kitchen/test/integration/win-sysprobe-test/**/*
+      - .gitlab/functional_test/system_probe.yml
     when: on_success
   - when: manual
     allow_failure: true

--- a/test/kitchen/drivers/azure-driver.yml
+++ b/test/kitchen/drivers/azure-driver.yml
@@ -126,6 +126,8 @@ platforms:
 %>
 
 - name: <%= platform_name %>
+  attributes:
+    color_idx: <%= idx %>
   driver_config:
     machine_size: <%= size %>
     <% if platform[1] == "urn" %>

--- a/test/kitchen/drivers/ec2-driver.yml
+++ b/test/kitchen/drivers/ec2-driver.yml
@@ -71,6 +71,8 @@ platforms:
 %>
 
 - name: <%= platform_name %>
+  attributes:
+    color_idx: <%= idx %>
   driver:
     <% if windows %>
     connection_timeout: 20

--- a/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/default.rb
@@ -27,6 +27,11 @@ remote_directory testdir do
   end
 end
 
+file ::File.join(testdir, 'color_idx') do
+  content node[:color_idx].to_s
+  mode 644
+end
+
 if platform?('windows')
   include_recipe "::windows"
 else

--- a/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/default.rb
@@ -29,7 +29,9 @@ end
 
 file ::File.join(testdir, 'color_idx') do
   content node[:color_idx].to_s
-  mode 644
+  when !platform?('windows')
+    mode 644
+  end
 end
 
 if platform?('windows')

--- a/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/default.rb
@@ -21,15 +21,14 @@ remote_directory testdir do
   mode '755'
   files_mode '755'
   sensitive true
-  case
-  when !platform?('windows')
+  unless platform?('windows')
     files_owner 'root'
   end
 end
 
 file ::File.join(testdir, 'color_idx') do
   content node[:color_idx].to_s
-  when !platform?('windows')
+  unless platform?('windows')
     mode 644
   end
 end

--- a/test/kitchen/test/integration/system-probe-test/rspec/system-probe-test_spec.rb
+++ b/test/kitchen/test/integration/system-probe-test/rspec/system-probe-test_spec.rb
@@ -8,19 +8,19 @@ def check_output(output, wait_thr)
   test_failures = []
 
   output.each_line do |line|
-    puts line
-    test_failures << line.strip if line =~ GOLANG_TEST_FAILURE
+    puts KernelOut.format(line.strip)
+    test_failures << KernelOut.format(line.strip) if line =~ GOLANG_TEST_FAILURE
   end
 
   if test_failures.empty? && !wait_thr.value.success?
-    test_failures << "Test command exited with status (#{wait_thr.value.exitstatus}) but no failures were captured."
+    test_failures << KernelOut.format("Test command exited with status (#{wait_thr.value.exitstatus}) but no failures were captured.")
   end
 
   test_failures
 end
 
-print `cat /etc/os-release`
-print `uname -a`
+print KernelOut.format(`cat /etc/os-release`)
+print KernelOut.format(`uname -a`)
 
 ##
 ## The main chef recipe (test\kitchen\site-cookbooks\dd-system-probe-check\recipes\default.rb)
@@ -30,7 +30,7 @@ print `uname -a`
 ##
 Dir.glob('/tmp/system-probe-tests/pkg/ebpf/bytecode/build/*.o').each do |f|
   FileUtils.chmod 0644, f, :verbose => true
-end 
+end
 
 Dir.glob('/tmp/system-probe-tests/**/testsuite').each do |f|
   pkg = f.delete_prefix('/tmp/system-probe-tests').delete_suffix('/testsuite')


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

It turns the logs from this:
```
started runtime compiled system-probe tests for /pkg/network/http
=== RUN   TestHttpCompile
--- PASS: TestHttpCompile (0.00s)
=== RUN   TestProcessHTTPTransactions
```

into this:
![Screen Shot 2022-06-24 at 1 42 10 PM](https://user-images.githubusercontent.com/1010430/175664393-e6b6664a-4beb-4821-b01f-91a63140e96f.png)


### Motivation

Since there are multiple versions running at the same time, the output is mixed together. This will help us separate them.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
