### PR TITLE
[system-probe] add additional telemetry for dropped connection events

### DIFF
--- a/pkg/network/event_common.go
+++ b/pkg/network/event_common.go
@@ -137,6 +137,7 @@ const (
 	MonotonicConnsClosed            ConnTelemetryType = "conns_closed"
 	MonotonicConntrackRegisters     ConnTelemetryType = "conntrack_registers"
 	MonotonicDNSPacketsProcessed    ConnTelemetryType = "dns_packets_processed"
+	MonotonicPerfLost               ConnTelemetryType = "perf_lost"
 	MonotonicUDPSendsProcessed      ConnTelemetryType = "udp_sends_processed"
 	MonotonicUDPSendsMissed         ConnTelemetryType = "udp_sends_missed"
 	DNSStatsDropped                 ConnTelemetryType = "dns_stats_dropped"
@@ -175,6 +176,7 @@ var (
 		MonotonicUDPSendsProcessed,
 		MonotonicUDPSendsMissed,
 		MonotonicDNSPacketsDropped,
+		MonotonicPerfLost,
 	}
 )
 

--- a/pkg/network/event_common.go
+++ b/pkg/network/event_common.go
@@ -132,6 +132,8 @@ type ConnTelemetryType string
 const (
 	MonotonicKprobesTriggered       ConnTelemetryType = "kprobes_triggered"
 	MonotonicKprobesMissed          ConnTelemetryType = "kprobes_missed"
+	MonotonicClosedConnDropped      ConnTelemetryType = "closed_conn_dropped"
+	MonotonicConnDropped            ConnTelemetryType = "conn_dropped"
 	MonotonicConnsClosed            ConnTelemetryType = "conns_closed"
 	MonotonicConntrackRegisters     ConnTelemetryType = "conntrack_registers"
 	MonotonicDNSPacketsProcessed    ConnTelemetryType = "dns_packets_processed"
@@ -165,6 +167,8 @@ var (
 	MonotonicConnTelemetryTypes = []ConnTelemetryType{
 		MonotonicKprobesTriggered,
 		MonotonicKprobesMissed,
+		MonotonicClosedConnDropped,
+		MonotonicConnDropped,
 		MonotonicConntrackRegisters,
 		MonotonicDNSPacketsProcessed,
 		MonotonicConnsClosed,

--- a/pkg/network/state.go
+++ b/pkg/network/state.go
@@ -606,8 +606,6 @@ func (ns *networkState) RemoveConnections(keys []string) {
 			ns.telemetry.dnsPidCollisions,
 			ns.telemetry.timeSyncCollisions)
 	}
-
-	ns.telemetry = telemetry{}
 }
 
 // GetStats returns a map of statistics about the current network state

--- a/pkg/network/state.go
+++ b/pkg/network/state.go
@@ -247,7 +247,7 @@ func (ns *networkState) saveTelemetry(telemetry map[ConnTelemetryType]int64) {
 }
 
 func (ns *networkState) getTelemetryDelta(id string, telemetry map[ConnTelemetryType]int64) map[ConnTelemetryType]int64 {
-	ns.logMetrics()
+	ns.logTelemetry()
 
 	var res = make(map[ConnTelemetryType]int64)
 	client := ns.getClient(id)
@@ -273,7 +273,7 @@ func (ns *networkState) getTelemetryDelta(id string, telemetry map[ConnTelemetry
 	return res
 }
 
-func (ns *networkState) logMetrics() {
+func (ns *networkState) logTelemetry() {
 	delta := telemetry{
 		closedConnDropped:  ns.telemetry.closedConnDropped - ns.lastTelemetry.closedConnDropped,
 		connDropped:        ns.telemetry.connDropped - ns.lastTelemetry.connDropped,
@@ -285,7 +285,8 @@ func (ns *networkState) logMetrics() {
 	}
 
 	// Flush log line if any metric is non zero
-	if delta.statsResets > 0 || delta.closedConnDropped > 0 || delta.connDropped > 0 || delta.timeSyncCollisions > 0 {
+	if delta.statsResets > 0 || delta.closedConnDropped > 0 || delta.connDropped > 0 || delta.timeSyncCollisions > 0 ||
+		delta.dnsStatsDropped > 0 || delta.httpStatsDropped > 0 || delta.dnsPidCollisions > 0 {
 		s := "state telemetry: "
 		s += " [%d stats stats_resets]"
 		s += " [%d connections dropped due to stats]"

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -415,6 +415,9 @@ func (t *Tracer) getConnTelemetry(mapSize int) map[network.ConnTelemetryType]int
 	if usm, ok := ebpfStats["udp_sends_missed"]; ok {
 		tm[network.MonotonicUDPSendsMissed] = usm
 	}
+	if pl, ok := ebpfStats["closed_conn_polling_lost"]; ok {
+		tm[network.MonotonicPerfLost] = pl
+	}
 
 	stateStats := stats["state"].(map[string]int64)
 	if ccd, ok := stateStats["closed_conn_dropped"]; ok {

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -377,7 +377,7 @@ func (t *Tracer) getConnTelemetry(mapSize int) map[network.ConnTelemetryType]int
 		network.MonotonicConnsClosed:      t.closedConns.Load(),
 	}
 
-	stats, err := t.getStats(conntrackStats, dnsStats, epbfStats, httpStats)
+	stats, err := t.getStats(conntrackStats, dnsStats, epbfStats, httpStats, stateStats)
 	if err != nil {
 		return nil
 	}
@@ -414,6 +414,14 @@ func (t *Tracer) getConnTelemetry(mapSize int) map[network.ConnTelemetryType]int
 	}
 	if usm, ok := ebpfStats["udp_sends_missed"]; ok {
 		tm[network.MonotonicUDPSendsMissed] = usm
+	}
+
+	stateStats := stats["state"].(map[string]int64)
+	if ccd, ok := stateStats["closed_conn_dropped"]; ok {
+		tm[network.MonotonicClosedConnDropped] = ccd
+	}
+	if cd, ok := stateStats["conn_dropped"]; ok {
+		tm[network.MonotonicConnDropped] = cd
 	}
 
 	return tm


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

This PR adds additional telemetry on dropped connection info to be sent to `process-agent`. Those can happen when process-agent's buffers get filled, most of time due to a configuration value being too low. Two cases are are handled:

- When the connection stats buffers is full
- When the perf buffer of the eBPF tracer is full

Those additionnal stats are bundled in `/network_tracer/connections` route of system-probe:

```json
  "connTelemetryMap": {
    "closed_conn_dropped": "830",
    "conn_dropped": "0",
    // ...
    "perf_lost": "505",
    //...
  }
```

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->


### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

The dropped connections stats are now monotonic so that each clients can get the delta on those since the last fetch. Those are part of internal telemetry, and reset each time the route was used, after being used to display a log message (see [`pkg/network/state.go:591`](https://github.com/DataDog/datadog-agent/blob/0d41135e3f3b1ccad6dab846c32fbfdd3699143a/pkg/network/state.go#L580)). Making the internal stats monotonic means once the condition to display this message is true, it always will be. One way to avoid that would be to place in `getTelemetryDelta`, but that would require adding all the other telemetry fields to the route response as well.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

#### `/etc/datadog-agent/system-probe.yaml`

Make the connections stats buffer really small
```yaml
system_probe_config:
  enabled: true
  log_level: "debug"
  max_closed_connections_buffered: 1
```

#### Manual checks of dropped connection info
With a small buffer, just a few networking operations are needed to drop stats (e.g `apt update`). You can then see this by getting the connections route with:

`curl -s --unix-socket /opt/datadog-agent/run/sysprobe.sock http://unix/network_tracer/connections|jq .connTelemetryMap`

#### Checking for perf buffer's drops

This one is harder to make it happen, and to test, so you will probably see the new `perf_lost` field being zero. It can be triggered eventually if you block system-probe long enough with a debugger (can take quite some time, depending on how traffic you machine has). 

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [X] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [X] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
