### PR TITLE
[network/ebpf] __always_inline kretprobe do_sys_open / do_sys_openat2

### DIFF
--- a/pkg/ebpf/bytecode/runtime/http.go
+++ b/pkg/ebpf/bytecode/runtime/http.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Http = NewRuntimeAsset("http.c", "b4dd2aa28998f4b6bf5cc475c7df1f573c6e0a9fb8a87c13a0192b967aabd721")
+var Http = NewRuntimeAsset("http.c", "78b620cd822189753e91e38f3c8d86de1eaf3ec67854dfb6e52aa29992f4c350")

--- a/pkg/network/ebpf/c/prebuilt/http.c
+++ b/pkg/network/ebpf/c/prebuilt/http.c
@@ -393,7 +393,7 @@ static __always_inline int fill_path_safe(lib_path_t *path, char *path_argument)
     return 0;
 }
 
-static __always_inline int kprobe__do_sys_open_helper(struct pt_regs* ctx) {
+static __always_inline int do_sys_open_helper_enter(struct pt_regs* ctx) {
     char *path_argument = (char *)PT_REGS_PARM2(ctx);
     lib_path_t path = {0};
     if (bpf_probe_read_user(path.buf, sizeof(path.buf), path_argument) >= 0) {
@@ -423,15 +423,15 @@ static __always_inline int kprobe__do_sys_open_helper(struct pt_regs* ctx) {
 
 SEC("kprobe/do_sys_open")
 int kprobe__do_sys_open(struct pt_regs* ctx) {
-    return kprobe__do_sys_open_helper(ctx);
+    return do_sys_open_helper_enter(ctx);
 }
 
 SEC("kprobe/do_sys_openat2")
 int kprobe__do_sys_openat2(struct pt_regs* ctx) {
-    return kprobe__do_sys_open_helper(ctx);
+    return do_sys_open_helper_enter(ctx);
 }
 
-static inline int kretprobe__do_sys_open_helper(struct pt_regs* ctx) {
+static __always_inline int do_sys_open_helper_exit(struct pt_regs* ctx) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
 
     // If file couldn't be opened, bail out
@@ -471,12 +471,12 @@ cleanup:
 
 SEC("kretprobe/do_sys_open")
 int kretprobe__do_sys_open(struct pt_regs* ctx) {
-    return kretprobe__do_sys_open_helper(ctx);
+    return do_sys_open_helper_exit(ctx);
 }
 
 SEC("kretprobe/do_sys_openat2")
 int kretprobe__do_sys_openat2(struct pt_regs* ctx) {
-    return kretprobe__do_sys_open_helper(ctx);
+    return do_sys_open_helper_exit(ctx);
 }
 
 // This number will be interpreted by elf-loader to set the current running kernel version


### PR DESCRIPTION
### What does this PR do?

Fixing a missing __always_inline that broke 4.4 kernel build


- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
