### PR TITLE
trace-agent/config: proxy config should be loaded after file so it is…

### DIFF
--- a/cmd/trace-agent/config/config.go
+++ b/cmd/trace-agent/config/config.go
@@ -64,9 +64,6 @@ func prepareConfig(path string) (*config.AgentConfig, error) {
 	cfg.LogFilePath = DefaultLogFilePath
 	cfg.DDAgentBin = defaultDDAgentBin
 	cfg.AgentVersion = version.AgentVersion
-	if p := coreconfig.GetProxies(); p != nil {
-		cfg.Proxy = httputils.GetProxyTransportFunc(p)
-	}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	orch := fargate.GetOrchestrator(ctx)
 	cancel()
@@ -77,6 +74,9 @@ func prepareConfig(path string) (*config.AgentConfig, error) {
 	coreconfig.Datadog.SetConfigFile(path)
 	if _, err := coreconfig.Load(); err != nil {
 		return cfg, err
+	}
+	if p := coreconfig.GetProxies(); p != nil {
+		cfg.Proxy = httputils.GetProxyTransportFunc(p)
 	}
 	cfg.ConfigPath = path
 	if coreconfig.Datadog.GetBool("remote_configuration.enabled") && coreconfig.Datadog.GetBool("remote_configuration.apm_sampling.enabled") {

--- a/cmd/trace-agent/config/config_test.go
+++ b/cmd/trace-agent/config/config_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"html/template"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -404,6 +405,12 @@ func TestFullYamlConfig(t *testing.T) {
 	c, err := prepareConfig("./testdata/full.yaml")
 	assert.NoError(err)
 	assert.NoError(applyDatadogConfig(c))
+
+	req, err := http.NewRequest(http.MethodGet, "https://someplace.test", nil)
+	assert.NoError(err)
+	proxyURL, err := c.Proxy(req)
+	assert.NoError(err)
+	assert.Equal("proxy_for_https:1234", proxyURL.Host)
 
 	assert.Equal("mymachine", c.Hostname)
 	assert.Equal("https://user:password@proxy_for_https:1234", c.ProxyURL.String())

--- a/cmd/trace-agent/test/testsuite/proxy_test.go
+++ b/cmd/trace-agent/test/testsuite/proxy_test.go
@@ -1,0 +1,88 @@
+package testsuite
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/cmd/trace-agent/test"
+	"github.com/DataDog/datadog-agent/cmd/trace-agent/test/testsuite/testdata"
+	"github.com/DataDog/datadog-agent/pkg/trace/pb"
+	"github.com/DataDog/datadog-agent/pkg/trace/testutil"
+)
+
+func TestProxy(t *testing.T) {
+	var r test.Runner
+	if err := r.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := r.Shutdown(time.Second); err != nil {
+			t.Log("shutdown: ", err)
+		}
+	}()
+	var proxyt, proxys bool
+	director := func(req *http.Request) {
+		if strings.HasSuffix(req.URL.Path, "/traces") {
+			proxyt = true
+		}
+		if strings.HasSuffix(req.URL.Path, "/stats") {
+			proxys = true
+		}
+	}
+	proxy := httptest.NewServer(&httputil.ReverseProxy{Director: director})
+
+	if err := r.RunAgent([]byte(fmt.Sprintf(`
+hostname: agent-hostname
+apm_config:
+  env: agent-env
+
+proxy:
+  http: %[1]s
+  https: %[1]s
+`, proxy.URL))); err != nil {
+		t.Fatal(err)
+	}
+
+	p := testutil.GeneratePayload(10, &testutil.TraceConfig{
+		MinSpans: 10,
+		Keep:     true,
+	}, nil)
+	if err := r.Post(p); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.PostMsgpack("/v0.6/stats", &testdata.ClientStatsTests[0].In); err != nil {
+		t.Fatal(err)
+	}
+	defer r.KillAgent()
+	timeout := time.After(3 * time.Second)
+	out := r.Out()
+	var gott, gots bool
+	for {
+		select {
+		case p := <-out:
+			switch p.(type) {
+			case pb.StatsPayload:
+				gots = true
+			case pb.AgentPayload:
+				gott = true
+			}
+			if gott && gots {
+				// got traces and got stats
+				if !proxyt {
+					t.Fatal("Did not proxy through for /traces")
+				}
+				if !proxys {
+					t.Fatal("Did not proxy through for /stats")
+				}
+				return
+			}
+		case <-timeout:
+			t.Fatalf("timed out waiting for payloads, log was:\n%s", r.AgentLog())
+		}
+	}
+}

--- a/releasenotes/notes/DoNotIgnoreProxyConfig-e1c8ae3e83fe446e.yaml
+++ b/releasenotes/notes/DoNotIgnoreProxyConfig-e1c8ae3e83fe446e.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes issue where proxy config was ignored by the trace-agent.


### PR DESCRIPTION
… not ignored (#12188)

This is already in 7.36 and in main but missed this release branch

Co-authored-by: Andrew Glaude <ajgajg1134@gmail.com>

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
