### PR TITLE
[CWS] Display warning when building with kernel headers < 5.8

### DIFF
--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -32,6 +32,7 @@ KITCHEN_DIR = os.getenv('DD_AGENT_TESTING_DIR') or os.path.normpath(os.path.join
 KITCHEN_ARTIFACT_DIR = os.path.join(KITCHEN_DIR, "site-cookbooks", "dd-system-probe-check", "files", "default", "tests")
 TEST_PACKAGES_LIST = ["./pkg/ebpf/...", "./pkg/network/...", "./pkg/collector/corechecks/ebpf/..."]
 TEST_PACKAGES = " ".join(TEST_PACKAGES_LIST)
+CWS_PREBUILT_MINIMUM_KERNEL_VERSION = [5, 8, 0]
 
 is_windows = sys.platform == "win32"
 
@@ -448,10 +449,18 @@ def get_ebpf_targets():
     return files
 
 
-def get_linux_header_dirs(kernel_release=None):
+def get_linux_header_dirs(kernel_release=None, minimal_kernel_release=None):
     if not kernel_release:
         os_info = os.uname()
         kernel_release = os_info.release
+
+    if kernel_release and minimal_kernel_release:
+        match = re.compile(r'(\d+)\.(\d+)(\.(\d+))?').match(kernel_release)
+        version_tuple = list(map(int, map(lambda x: x or '0', match.group(1, 2, 4))))
+        if version_tuple < minimal_kernel_release:
+            print(
+                f"You need to have kernel headers for at least {'.'.join(map(lambda x: str(x), minimal_kernel_release))} to enable all system-probe features"
+            )
 
     src_kernels_dir = "/usr/src/kernels"
     src_dir = "/usr/src"
@@ -514,7 +523,7 @@ def get_linux_header_dirs(kernel_release=None):
     return dirs
 
 
-def get_ebpf_build_flags(target=None, kernel_release=None):
+def get_ebpf_build_flags(target=None, kernel_release=None, minimal_kernel_release=None):
     bpf_dir = os.path.join(".", "pkg", "ebpf")
     c_dir = os.path.join(bpf_dir, "c")
     if not target:
@@ -547,7 +556,7 @@ def get_ebpf_build_flags(target=None, kernel_release=None):
         ]
     )
 
-    header_dirs = get_linux_header_dirs(kernel_release=kernel_release)
+    header_dirs = get_linux_header_dirs(kernel_release=kernel_release, minimal_kernel_release=minimal_kernel_release)
     for d in header_dirs:
         flags.extend(["-isystem", d])
 
@@ -656,8 +665,8 @@ def build_network_ebpf_files(ctx, build_dir, parallel_build=True, kernel_release
         promise.join()
 
 
-def get_security_agent_build_flags(security_agent_c_dir, kernel_release=None, debug=False):
-    security_flags = get_ebpf_build_flags(kernel_release=kernel_release)
+def get_security_agent_build_flags(security_agent_c_dir, kernel_release=None, minimal_kernel_release=None, debug=False):
+    security_flags = get_ebpf_build_flags(kernel_release=kernel_release, minimal_kernel_release=minimal_kernel_release)
     security_flags.append(f"-I{security_agent_c_dir}")
     if debug:
         security_flags.append("-DDEBUG=1")
@@ -671,7 +680,12 @@ def build_security_offset_guesser_ebpf_files(ctx, build_dir, kernel_release=None
     security_bc_file = os.path.join(build_dir, "runtime-security-offset-guesser.bc")
     security_agent_obj_file = os.path.join(build_dir, "runtime-security-offset-guesser.o")
 
-    security_flags = get_security_agent_build_flags(security_agent_c_dir, kernel_release=kernel_release, debug=debug)
+    security_flags = get_security_agent_build_flags(
+        security_agent_c_dir,
+        kernel_release=kernel_release,
+        minimal_kernel_release=CWS_PREBUILT_MINIMUM_KERNEL_VERSION,
+        debug=debug,
+    )
 
     ctx.run(
         CLANG_CMD.format(
@@ -692,7 +706,12 @@ def build_security_probe_ebpf_files(ctx, build_dir, parallel_build=True, kernel_
     security_bc_file = os.path.join(build_dir, "runtime-security.bc")
     security_agent_obj_file = os.path.join(build_dir, "runtime-security.o")
 
-    security_flags = get_security_agent_build_flags(security_agent_c_dir, kernel_release=kernel_release, debug=debug)
+    security_flags = get_security_agent_build_flags(
+        security_agent_c_dir,
+        kernel_release=kernel_release,
+        minimal_kernel_release=CWS_PREBUILT_MINIMUM_KERNEL_VERSION,
+        debug=debug,
+    )
 
     # compile
     promises = []


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
