### PR TITLE
Fix `revert_latest_[67]` GitLab jobs

### DIFF
--- a/.gitlab/maintenance_jobs/docker.yml
+++ b/.gitlab/maintenance_jobs/docker.yml
@@ -14,38 +14,38 @@
 revert_latest_6:
   extends: .docker_publish_job_definition
   rules:
-    !reference [.manual]
+    !reference [.on_main_manual]
   stage: maintenance_jobs
   variables:
     NEW_LATEST_RELEASE_6: ""  # tag name of the non-jmx version, for example "6.21.0"
-    IMG_REGISTRIES: dev
+    IMG_REGISTRIES: public
   parallel:
     matrix:
       - IMG_SOURCES: datadog/agent:${NEW_LATEST_RELEASE_6}
-        IMG_DESTINATIONS: agent-dev:lenaic-6,agent-dev:lenaic-latest-py2
+        IMG_DESTINATIONS: agent:6,agent:latest-py2
       - IMG_SOURCES: datadog/agent:${NEW_LATEST_RELEASE_6}-jmx
-        IMG_DESTINATIONS: agent-dev:lenaic-6-jmx,agent-dev:lenaic-latest-py2-jmx
+        IMG_DESTINATIONS: agent:6-jmx,agent:latest-py2-jmx
 
 revert_latest_7:
   extends: .docker_publish_job_definition
   rules:
-    !reference [.manual]
+    !reference [.on_main_manual]
   stage: maintenance_jobs
   variables:
     NEW_LATEST_RELEASE_7: ""  # tag name of the non-jmx version, for example "7.21.0"
-    IMG_REGISTRIES: dev
+    IMG_REGISTRIES: public
   parallel:
     matrix:
       - IMG_SOURCES: datadog/agent:${NEW_LATEST_RELEASE_7}
-        IMG_DESTINATIONS: agent-dev:lenaic-7,agent-dev:lenaic-latest
+        IMG_DESTINATIONS: agent:7,agent:latest
       - IMG_SOURCES: datadog/agent:${NEW_LATEST_RELEASE_7}-jmx
-        IMG_DESTINATIONS: agent-dev:lenaic-7-jmx,agent-dev:lenaic-latest-jmx
+        IMG_DESTINATIONS: agent:7-jmx,agent:latest-jmx
       - IMG_SOURCES: datadog/agent:${NEW_LATEST_RELEASE_7}-servercore
-        IMG_DESTINATIONS: agent-dev:lenaic-7-servercore,agent-dev:lenaic-latest-servercore
+        IMG_DESTINATIONS: agent:7-servercore,agent:latest-servercore
       - IMG_SOURCES: datadog/agent:${NEW_LATEST_RELEASE_7}-servercore-jmx
-        IMG_DESTINATIONS: agent-dev:lenaic-7-servercore-jmx,agent-dev:lenaic-latest-servercore-jmx
+        IMG_DESTINATIONS: agent:7-servercore-jmx,agent:latest-servercore-jmx
       - IMG_SOURCES: datadog/dogstatsd:${NEW_LATEST_RELEASE_7}
-        IMG_DESTINATIONS: dogstatsd-dev:lenaic-7,dogstatsd-dev:lenaic-latest
+        IMG_DESTINATIONS: dogstatsd:7,dogstatsd:latest
 
 #
 # Use this step to delete a tag of a given image

--- a/.gitlab/maintenance_jobs/docker.yml
+++ b/.gitlab/maintenance_jobs/docker.yml
@@ -14,36 +14,38 @@
 revert_latest_6:
   extends: .docker_publish_job_definition
   rules:
-    !reference [.on_main_manual]
+    !reference [.manual]
   stage: maintenance_jobs
   variables:
     NEW_LATEST_RELEASE_6: ""  # tag name of the non-jmx version, for example "6.21.0"
+    IMG_REGISTRIES: dev
   parallel:
     matrix:
-      - IMG_SOURCES: datadog/agent-amd64:${NEW_LATEST_RELEASE_6},datadog/agent-arm64:${NEW_LATEST_RELEASE_6}
-        IMG_DESTINATIONS: agent:6,agent:latest-py2
-      - IMG_SOURCES: datadog/agent-amd64:${NEW_LATEST_RELEASE_6}-jmx,datadog/agent-arm64:${NEW_LATEST_RELEASE_6}-jmx
-        IMG_DESTINATIONS: agent:6-jmx,agent:latest-py2-jmx
+      - IMG_SOURCES: datadog/agent:${NEW_LATEST_RELEASE_6}
+        IMG_DESTINATIONS: agent-dev:lenaic-6,agent-dev:lenaic-latest-py2
+      - IMG_SOURCES: datadog/agent:${NEW_LATEST_RELEASE_6}-jmx
+        IMG_DESTINATIONS: agent-dev:lenaic-6-jmx,agent-dev:lenaic-latest-py2-jmx
 
 revert_latest_7:
   extends: .docker_publish_job_definition
   rules:
-    !reference [.on_main_manual]
+    !reference [.manual]
   stage: maintenance_jobs
   variables:
     NEW_LATEST_RELEASE_7: ""  # tag name of the non-jmx version, for example "7.21.0"
+    IMG_REGISTRIES: dev
   parallel:
     matrix:
-      - IMG_SOURCES: datadog/agent-amd64:${NEW_LATEST_RELEASE_7},datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win1809,datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win1909,datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win2004,datadog/agent-arm64:${NEW_LATEST_RELEASE_7}
-        IMG_DESTINATIONS: agent:7,agent:latest
-      - IMG_SOURCES: datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx,datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1809,datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1909,datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win2004,datadog/agent-arm64:${NEW_LATEST_RELEASE_7}-jmx
-        IMG_DESTINATIONS: agent:7-jmx,agent:latest-jmx
-      - IMG_SOURCES: datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win1809-servercore,datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win1909-servercore,datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win2004-servercore
-        IMG_DESTINATIONS: agent:7-servercore,agent:latest-servercore
-      - IMG_SOURCES: datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1809-servercore,datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1909-servercore,datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win2004-servercore
-        IMG_DESTINATIONS: agent:7-servercore-jmx,agent:latest-servercore-jmx
+      - IMG_SOURCES: datadog/agent:${NEW_LATEST_RELEASE_7}
+        IMG_DESTINATIONS: agent-dev:lenaic-7,agent-dev:lenaic-latest
+      - IMG_SOURCES: datadog/agent:${NEW_LATEST_RELEASE_7}-jmx
+        IMG_DESTINATIONS: agent-dev:lenaic-7-jmx,agent-dev:lenaic-latest-jmx
+      - IMG_SOURCES: datadog/agent:${NEW_LATEST_RELEASE_7}-servercore
+        IMG_DESTINATIONS: agent-dev:lenaic-7-servercore,agent-dev:lenaic-latest-servercore
+      - IMG_SOURCES: datadog/agent:${NEW_LATEST_RELEASE_7}-servercore-jmx
+        IMG_DESTINATIONS: agent-dev:lenaic-7-servercore-jmx,agent-dev:lenaic-latest-servercore-jmx
       - IMG_SOURCES: datadog/dogstatsd:${NEW_LATEST_RELEASE_7}
-        IMG_DESTINATIONS: dogstatsd:7,dogstatsd:latest
+        IMG_DESTINATIONS: dogstatsd-dev:lenaic-7,dogstatsd-dev:lenaic-latest
 
 #
 # Use this step to delete a tag of a given image


### PR DESCRIPTION
### What does this PR do?

Fix `revert_latest_[67]` GitLab jobs.

### Motivation

We don’t publish arch-specific mono-arch images in `datadog/agent-amd64` and `datadog/agent-arm64` anymore. Or at least, those images are not tagged anymore. They are only referenced by the multi-arch `datadog/agent` image.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
