### PR TITLE
Use go.uber.org/atomic in pkg/security

### DIFF
--- a/pkg/security/agent/agent.go
+++ b/pkg/security/agent/agent.go
@@ -12,12 +12,11 @@ import (
 	"fmt"
 	"io"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/cenkalti/backoff"
 	"github.com/pkg/errors"
-	uatomic "go.uber.org/atomic"
+	"go.uber.org/atomic"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -34,11 +33,11 @@ type RuntimeSecurityAgent struct {
 	hostname             string
 	reporter             common.RawReporter
 	client               *RuntimeSecurityClient
-	running              uatomic.Bool
+	running              *atomic.Bool
 	wg                   sync.WaitGroup
-	connected            uatomic.Bool
-	eventReceived        uint64
-	activityDumpReceived uint64
+	connected            *atomic.Bool
+	eventReceived        *atomic.Uint64
+	activityDumpReceived *atomic.Uint64
 	telemetry            *telemetry
 	endpoints            *config.Endpoints
 	cancel               context.CancelFunc
@@ -65,10 +64,14 @@ func NewRuntimeSecurityAgent(hostname string) (*RuntimeSecurityAgent, error) {
 	}
 
 	return &RuntimeSecurityAgent{
-		client:    client,
-		hostname:  hostname,
-		telemetry: telemetry,
-		storage:   storage,
+		client:               client,
+		hostname:             hostname,
+		telemetry:            telemetry,
+		storage:              storage,
+		running:              atomic.NewBool(false),
+		connected:            atomic.NewBool(false),
+		eventReceived:        atomic.NewUint64(0),
+		activityDumpReceived: atomic.NewUint64(0),
 	}, nil
 }
 
@@ -145,7 +148,7 @@ func (rsa *RuntimeSecurityAgent) StartEventListener() {
 			}
 			log.Tracef("Got message from rule `%s` for event `%s`", in.RuleID, string(in.Data))
 
-			atomic.AddUint64(&rsa.eventReceived, 1)
+			rsa.eventReceived.Inc()
 
 			// Dispatch security event
 			rsa.DispatchEvent(in)
@@ -175,7 +178,7 @@ func (rsa *RuntimeSecurityAgent) StartActivityDumpListener() {
 			}
 			log.Tracef("Got activity dump [%s]", msg.GetDump().GetMetadata().GetName())
 
-			atomic.AddUint64(&rsa.activityDumpReceived, 1)
+			rsa.activityDumpReceived.Inc()
 
 			// Dispatch activity dump
 			rsa.DispatchActivityDump(msg)
@@ -231,8 +234,8 @@ func (rsa *RuntimeSecurityAgent) DispatchActivityDump(msg *api.ActivityDumpStrea
 func (rsa *RuntimeSecurityAgent) GetStatus() map[string]interface{} {
 	base := map[string]interface{}{
 		"connected":            rsa.connected.Load(),
-		"eventReceived":        atomic.LoadUint64(&rsa.eventReceived),
-		"activityDumpReceived": atomic.LoadUint64(&rsa.activityDumpReceived),
+		"eventReceived":        rsa.eventReceived.Load(),
+		"activityDumpReceived": rsa.activityDumpReceived.Load(),
 	}
 
 	if rsa.endpoints != nil {

--- a/pkg/security/probe/load_controller.go
+++ b/pkg/security/probe/load_controller.go
@@ -11,11 +11,11 @@ package probe
 import (
 	"context"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/hashicorp/golang-lru/simplelru"
 	"github.com/pkg/errors"
+	"go.uber.org/atomic"
 	"golang.org/x/time/rate"
 
 	seclog "github.com/DataDog/datadog-agent/pkg/security/log"
@@ -38,9 +38,9 @@ type LoadController struct {
 	sync.RWMutex
 	probe *Probe
 
-	eventsTotal        int64
+	eventsTotal        *atomic.Int64
 	eventsCounters     *simplelru.LRU
-	pidDiscardersCount int64
+	pidDiscardersCount *atomic.Int64
 
 	EventsCountThreshold int64
 	DiscarderTimeout     time.Duration
@@ -59,7 +59,9 @@ func NewLoadController(probe *Probe) (*LoadController, error) {
 	lc := &LoadController{
 		probe: probe,
 
-		eventsCounters: lru,
+		eventsTotal:        atomic.NewInt64(0),
+		eventsCounters:     lru,
+		pidDiscardersCount: atomic.NewInt64(0),
 
 		EventsCountThreshold: probe.config.LoadControllerEventsCountThreshold,
 		DiscarderTimeout:     probe.config.LoadControllerDiscarderTimeout,
@@ -73,7 +75,7 @@ func NewLoadController(probe *Probe) (*LoadController, error) {
 // SendStats sends load controller stats
 func (lc *LoadController) SendStats() error {
 	// send load_controller.pids_discarder metric
-	if count := atomic.SwapInt64(&lc.pidDiscardersCount, 0); count > 0 {
+	if count := lc.pidDiscardersCount.Swap(0); count > 0 {
 		if err := lc.probe.statsdClient.Count(metrics.MetricLoadControllerPidDiscarder, count, []string{}, 1.0); err != nil {
 			return errors.Wrap(err, "couldn't send load_controller.pids_discarder metric")
 		}
@@ -99,13 +101,12 @@ func (lc *LoadController) GenericCount(event *Event) {
 
 	entry, ok := lc.eventsCounters.Get(eventCounterLRUKey{Pid: event.ProcessContext.Pid, Cookie: event.ProcessContext.Cookie})
 	if ok {
-		counter := entry.(*uint64)
-		atomic.AddUint64(counter, 1)
+		counter := entry.(*atomic.Uint64)
+		counter.Inc()
 	} else {
-		counter := uint64(1)
-		lc.eventsCounters.Add(eventCounterLRUKey{Pid: event.ProcessContext.Pid, Cookie: event.ProcessContext.Cookie}, &counter)
+		lc.eventsCounters.Add(eventCounterLRUKey{Pid: event.ProcessContext.Pid, Cookie: event.ProcessContext.Cookie}, atomic.NewUint64(1))
 	}
-	newTotal := atomic.AddInt64(&lc.eventsTotal, 1)
+	newTotal := lc.eventsTotal.Inc()
 
 	if newTotal >= lc.EventsCountThreshold {
 		lc.discardNoisiestProcess()
@@ -116,17 +117,17 @@ func (lc *LoadController) GenericCount(event *Event) {
 func (lc *LoadController) discardNoisiestProcess() {
 	// iterate over the LRU map to retrieve the noisiest process & event_type tuple
 	var maxKey eventCounterLRUKey
-	var maxCount *uint64
+	var maxCount *atomic.Uint64
 	for _, key := range lc.eventsCounters.Keys() {
 		entry, ok := lc.eventsCounters.Peek(key)
 		if !ok || entry == nil {
 			continue
 		}
-		tmpCount := entry.(*uint64)
+		tmpCount := entry.(*atomic.Uint64)
 		tmpKey := key.(eventCounterLRUKey)
 
 		// update max if necessary
-		if maxCount == nil || *maxCount < *tmpCount {
+		if maxCount == nil || maxCount.Load() < tmpCount.Load() {
 			maxCount = tmpCount
 			maxKey = tmpKey
 		}
@@ -143,11 +144,13 @@ func (lc *LoadController) discardNoisiestProcess() {
 		return
 	}
 
-	// update current total and remove biggest entry from cache
-	oldMaxCount := atomic.SwapUint64(maxCount, 0)
-	atomic.AddInt64(&lc.eventsTotal, -int64(oldMaxCount))
+	// update current total and remove biggest entry from cache.  Note that there
+	// is a chance of the maxCount value being incremented between these two atomic
+	// operations, but that's OK -- the event is still counted.
+	oldMaxCount := maxCount.Swap(0)
+	lc.eventsTotal.Sub(int64(oldMaxCount))
 
-	atomic.AddInt64(&lc.pidDiscardersCount, 1)
+	lc.pidDiscardersCount.Inc()
 
 	if lc.NoisyProcessCustomEventRate.Allow() {
 		process := lc.probe.resolvers.ProcessResolver.Resolve(maxKey.Pid, maxKey.Pid)
@@ -179,8 +182,8 @@ func (lc *LoadController) cleanupCounter(pid uint32, cookie uint32) {
 	key := eventCounterLRUKey{Pid: pid, Cookie: cookie}
 	entry, ok := lc.eventsCounters.Get(key)
 	if ok {
-		counter := int64(*entry.(*uint64))
-		atomic.AddInt64(&lc.eventsTotal, -counter)
+		counter := entry.(*atomic.Uint64)
+		lc.eventsTotal.Sub(int64(counter.Load()))
 		lc.eventsCounters.Remove(key)
 	}
 }
@@ -192,7 +195,7 @@ func (lc *LoadController) cleanup() {
 
 	// purge counters
 	lc.eventsCounters.Purge()
-	atomic.SwapInt64(&lc.eventsTotal, 0)
+	lc.eventsTotal.Store(0)
 }
 
 // Start resets the internal counters periodically

--- a/pkg/security/probe/namespace_resolver.go
+++ b/pkg/security/probe/namespace_resolver.go
@@ -15,7 +15,6 @@ import (
 	"os"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
@@ -23,6 +22,7 @@ import (
 	"github.com/DataDog/gopsutil/process"
 	"github.com/hashicorp/golang-lru/simplelru"
 	"github.com/vishvananda/netlink"
+	"go.uber.org/atomic"
 	"golang.org/x/sys/unix"
 
 	"github.com/DataDog/datadog-agent/pkg/security/api"
@@ -192,7 +192,7 @@ func (nn *NetworkNamespace) hasValidHandle() bool {
 // NamespaceResolver is used to store namespace handles
 type NamespaceResolver struct {
 	sync.RWMutex
-	state  int64
+	state  *atomic.Int64
 	probe  *Probe
 	client statsd.ClientInterface
 
@@ -202,6 +202,7 @@ type NamespaceResolver struct {
 // NewNamespaceResolver returns a new instance of NamespaceResolver
 func NewNamespaceResolver(probe *Probe) (*NamespaceResolver, error) {
 	nr := &NamespaceResolver{
+		state:  atomic.NewInt64(0),
 		probe:  probe,
 		client: probe.statsdClient,
 	}
@@ -220,12 +221,12 @@ func NewNamespaceResolver(probe *Probe) (*NamespaceResolver, error) {
 
 // SetState sets state of the namespace resolver
 func (nr *NamespaceResolver) SetState(state int64) {
-	atomic.StoreInt64(&nr.state, state)
+	nr.state.Store(state)
 }
 
 // GetState returns the state of the namespace resolver
 func (nr *NamespaceResolver) GetState() int64 {
-	return atomic.LoadInt64(&nr.state)
+	return nr.state.Load()
 }
 
 // SaveNetworkNamespaceHandle inserts the provided process network namespace in the list of tracked network. Returns

--- a/pkg/security/probe/perf_buffer_monitor.go
+++ b/pkg/security/probe/perf_buffer_monitor.go
@@ -10,11 +10,11 @@ package probe
 
 import (
 	"fmt"
-	"sync/atomic"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 	lib "github.com/cilium/ebpf"
 	"github.com/pkg/errors"
+	"go.uber.org/atomic"
 
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/probes"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
@@ -25,9 +25,9 @@ import (
 
 // PerfMapStats contains the collected metrics for one event and one cpu in a perf buffer statistics map
 type PerfMapStats struct {
-	Bytes uint64
-	Count uint64
-	Lost  uint64
+	Bytes *atomic.Uint64
+	Count *atomic.Uint64
+	Lost  *atomic.Uint64
 }
 
 // UnmarshalBinary parses a map entry and populates the current PerfMapStats instance
@@ -35,9 +35,9 @@ func (s *PerfMapStats) UnmarshalBinary(data []byte) error {
 	if len(data) < 24 {
 		return model.ErrNotEnoughData
 	}
-	s.Bytes = model.ByteOrder.Uint64(data[0:8])
-	s.Count = model.ByteOrder.Uint64(data[8:16])
-	s.Lost = model.ByteOrder.Uint64(data[16:24])
+	s.Bytes = atomic.NewUint64(model.ByteOrder.Uint64(data[0:8]))
+	s.Count = atomic.NewUint64(model.ByteOrder.Uint64(data[8:16]))
+	s.Lost = atomic.NewUint64(model.ByteOrder.Uint64(data[16:24]))
 	return nil
 }
 
@@ -62,15 +62,17 @@ type PerfBufferMonitor struct {
 	stats map[string][][model.MaxKernelEventType]PerfMapStats
 	// kernelStats holds the aggregated kernel space metrics
 	kernelStats map[string][][model.MaxKernelEventType]PerfMapStats
-	// readLostEvents is the count of lost events, collected by reading the perf buffer
-	readLostEvents map[string][]uint64
+	// readLostEvents is the count of lost events, collected by reading the perf buffer.  Note that the
+	// slices of Uint64 are properly aligned for atomic access, and are not moved after creation (they
+	// are indexed by cpuid)
+	readLostEvents map[string][]atomic.Uint64
 	// sortingErrorStats holds the count of events that indicate that at least 1 event is miss ordered
-	sortingErrorStats map[string][model.MaxKernelEventType]*int64
+	sortingErrorStats map[string][model.MaxKernelEventType]*atomic.Int64
 
 	// lastTimestamp is used to track the timestamp of the last event retrieved from the perf map
 	lastTimestamp uint64
 	// shouldBumpGeneration is used to track if the dentry cache generations should be bumped
-	shouldBumpGeneration uint64
+	shouldBumpGeneration *atomic.Bool
 }
 
 // NewPerfBufferMonitor instantiates a new event statistics counter
@@ -85,8 +87,10 @@ func NewPerfBufferMonitor(p *Probe) (*PerfBufferMonitor, error) {
 
 		stats:             make(map[string][][model.MaxKernelEventType]PerfMapStats),
 		kernelStats:       make(map[string][][model.MaxKernelEventType]PerfMapStats),
-		readLostEvents:    make(map[string][]uint64),
-		sortingErrorStats: make(map[string][model.MaxKernelEventType]*int64),
+		readLostEvents:    make(map[string][]atomic.Uint64),
+		sortingErrorStats: make(map[string][model.MaxKernelEventType]*atomic.Int64),
+
+		shouldBumpGeneration: atomic.NewBool(false),
 	}
 	numCPU, err := utils.NumCPU()
 	if err != nil {
@@ -130,18 +134,17 @@ func NewPerfBufferMonitor(p *Probe) (*PerfBufferMonitor, error) {
 	// Prepare user space counters
 	for mapName, size := range maps {
 		var stats, kernelStats [][model.MaxKernelEventType]PerfMapStats
-		var usrLostEvents []uint64
-		var sortingErrorStats [model.MaxKernelEventType]*int64
+		var usrLostEvents []atomic.Uint64
+		var sortingErrorStats [model.MaxKernelEventType]*atomic.Int64
 
 		for i := 0; i < pbm.numCPU; i++ {
 			stats = append(stats, [model.MaxKernelEventType]PerfMapStats{})
 			kernelStats = append(kernelStats, [model.MaxKernelEventType]PerfMapStats{})
-			usrLostEvents = append(usrLostEvents, 0)
+			usrLostEvents = append(usrLostEvents, atomic.Uint64{})
 		}
 
 		for i := 0; i < int(model.MaxKernelEventType); i++ {
-			zero := int64(0)
-			sortingErrorStats[i] = &zero
+			sortingErrorStats[i] = atomic.NewInt64(0)
 		}
 
 		pbm.stats[mapName] = stats
@@ -160,7 +163,7 @@ func NewPerfBufferMonitor(p *Probe) (*PerfBufferMonitor, error) {
 
 // getLostCount is an internal function, it can segfault if its parameters are incorrect.
 func (pbm *PerfBufferMonitor) getLostCount(perfMap string, cpu int) uint64 {
-	return atomic.LoadUint64(&pbm.readLostEvents[perfMap][cpu])
+	return pbm.readLostEvents[perfMap][cpu].Load()
 }
 
 // GetLostCount returns the number of lost events for a given map and cpu. If a cpu of -1 is provided, the function will
@@ -182,7 +185,7 @@ func (pbm *PerfBufferMonitor) GetLostCount(perfMap string, cpu int) uint64 {
 
 // getKernelLostCount is an internal function, it can segfault if its parameters are incorrect.
 func (pbm *PerfBufferMonitor) getKernelLostCount(eventType model.EventType, perfMap string, cpu int) uint64 {
-	return atomic.LoadUint64(&pbm.kernelStats[perfMap][cpu][eventType].Lost)
+	return pbm.kernelStats[perfMap][cpu][eventType].Lost.Load()
 }
 
 // GetKernelLostCount returns the number of lost events for a given map and cpu. If a cpu of -1 is provided, the function will
@@ -217,7 +220,7 @@ func (pbm *PerfBufferMonitor) GetKernelLostCount(perfMap string, cpu int, evtTyp
 
 // getAndResetReadLostCount is an internal function, it can segfault if its parameters are incorrect.
 func (pbm *PerfBufferMonitor) getAndResetReadLostCount(perfMap string, cpu int) uint64 {
-	return atomic.SwapUint64(&pbm.readLostEvents[perfMap][cpu], 0)
+	return pbm.readLostEvents[perfMap][cpu].Swap(0)
 }
 
 // GetAndResetLostCount returns the number of lost events and resets the counter for a given map and cpu. If a cpu of -1 is
@@ -239,37 +242,37 @@ func (pbm *PerfBufferMonitor) GetAndResetLostCount(perfMap string, cpu int) uint
 
 // getEventCount is an internal function, it can segfault if its parameters are incorrect.
 func (pbm *PerfBufferMonitor) getEventCount(eventType model.EventType, perfMap string, cpu int) uint64 {
-	return atomic.LoadUint64(&pbm.stats[perfMap][cpu][eventType].Count)
+	return pbm.stats[perfMap][cpu][eventType].Count.Load()
 }
 
 // getEventBytes is an internal function, it can segfault if its parameters are incorrect.
 func (pbm *PerfBufferMonitor) getEventBytes(eventType model.EventType, perfMap string, cpu int) uint64 {
-	return atomic.LoadUint64(&pbm.stats[perfMap][cpu][eventType].Bytes)
+	return pbm.stats[perfMap][cpu][eventType].Bytes.Load()
 }
 
 // getKernelEventCount is an internal function, it can segfault if its parameters are incorrect.
 func (pbm *PerfBufferMonitor) getKernelEventCount(eventType model.EventType, perfMap string, cpu int) uint64 {
-	return atomic.LoadUint64(&pbm.kernelStats[perfMap][cpu][eventType].Count)
+	return pbm.kernelStats[perfMap][cpu][eventType].Count.Load()
 }
 
 // getEventBytes is an internal function, it can segfault if its parameters are incorrect.
 func (pbm *PerfBufferMonitor) getKernelEventBytes(eventType model.EventType, perfMap string, cpu int) uint64 {
-	return atomic.LoadUint64(&pbm.kernelStats[perfMap][cpu][eventType].Bytes)
+	return pbm.kernelStats[perfMap][cpu][eventType].Bytes.Load()
 }
 
 // getKernelEventCount is an internal function, it can segfault if its parameters are incorrect.
 func (pbm *PerfBufferMonitor) swapKernelEventCount(eventType model.EventType, perfMap string, cpu int, value uint64) uint64 {
-	return atomic.SwapUint64(&pbm.kernelStats[perfMap][cpu][eventType].Count, value)
+	return pbm.kernelStats[perfMap][cpu][eventType].Count.Swap(value)
 }
 
 // getKernelEventBytes is an internal function, it can segfault if its parameters are incorrect.
 func (pbm *PerfBufferMonitor) swapKernelEventBytes(eventType model.EventType, perfMap string, cpu int, value uint64) uint64 {
-	return atomic.SwapUint64(&pbm.kernelStats[perfMap][cpu][eventType].Bytes, value)
+	return pbm.kernelStats[perfMap][cpu][eventType].Bytes.Swap(value)
 }
 
 // getKernelLostCount is an internal function, it can segfault if its parameters are incorrect.
 func (pbm *PerfBufferMonitor) swapKernelLostCount(eventType model.EventType, perfMap string, cpu int, value uint64) uint64 {
-	return atomic.SwapUint64(&pbm.kernelStats[perfMap][cpu][eventType].Lost, value)
+	return pbm.kernelStats[perfMap][cpu][eventType].Lost.Swap(value)
 }
 
 // GetEventStats returns the number of received events of the specified type
@@ -295,20 +298,20 @@ func (pbm *PerfBufferMonitor) GetEventStats(eventType model.EventType, perfMap s
 		switch {
 		case cpu == -1:
 			for i := range pbm.stats[m] {
-				stats.Count += pbm.getEventCount(eventType, perfMap, i)
-				stats.Bytes += pbm.getEventBytes(eventType, perfMap, i)
+				stats.Count.Add(pbm.getEventCount(eventType, perfMap, i))
+				stats.Bytes.Add(pbm.getEventBytes(eventType, perfMap, i))
 
-				kernelStats.Count += pbm.getKernelEventCount(eventType, perfMap, i)
-				kernelStats.Bytes += pbm.getKernelEventBytes(eventType, perfMap, i)
-				kernelStats.Lost += pbm.getKernelLostCount(eventType, perfMap, i)
+				kernelStats.Count.Add(pbm.getKernelEventCount(eventType, perfMap, i))
+				kernelStats.Bytes.Add(pbm.getKernelEventBytes(eventType, perfMap, i))
+				kernelStats.Lost.Add(pbm.getKernelLostCount(eventType, perfMap, i))
 			}
 		case cpu >= 0 && pbm.numCPU > cpu:
-			stats.Count += pbm.getEventCount(eventType, perfMap, cpu)
-			stats.Bytes += pbm.getEventBytes(eventType, perfMap, cpu)
+			stats.Count.Add(pbm.getEventCount(eventType, perfMap, cpu))
+			stats.Bytes.Add(pbm.getEventBytes(eventType, perfMap, cpu))
 
-			kernelStats.Count += pbm.getKernelEventCount(eventType, perfMap, cpu)
-			kernelStats.Bytes += pbm.getKernelEventBytes(eventType, perfMap, cpu)
-			kernelStats.Lost += pbm.getKernelLostCount(eventType, perfMap, cpu)
+			kernelStats.Count.Add(pbm.getKernelEventCount(eventType, perfMap, cpu))
+			kernelStats.Bytes.Add(pbm.getKernelEventBytes(eventType, perfMap, cpu))
+			kernelStats.Lost.Add(pbm.getKernelLostCount(eventType, perfMap, cpu))
 		}
 
 	}
@@ -317,17 +320,17 @@ func (pbm *PerfBufferMonitor) GetEventStats(eventType model.EventType, perfMap s
 
 // getAndResetEventCount is an internal function, it can segfault if its parameters are incorrect.
 func (pbm *PerfBufferMonitor) getAndResetEventCount(eventType model.EventType, perfMap string, cpu int) uint64 {
-	return atomic.SwapUint64(&pbm.stats[perfMap][cpu][eventType].Count, 0)
+	return pbm.stats[perfMap][cpu][eventType].Count.Swap(0)
 }
 
 // getAndResetEventBytes is an internal function, it can segfault if its parameters are incorrect.
 func (pbm *PerfBufferMonitor) getAndResetEventBytes(eventType model.EventType, perfMap string, cpu int) uint64 {
-	return atomic.SwapUint64(&pbm.stats[perfMap][cpu][eventType].Bytes, 0)
+	return pbm.stats[perfMap][cpu][eventType].Bytes.Swap(0)
 }
 
 // getAndResetSortingErrorCount is an internal function, it can segfault if its parameters are incorrect.
 func (pbm *PerfBufferMonitor) getAndResetSortingErrorCount(eventType model.EventType, perfMap string) int64 {
-	return atomic.SwapInt64(pbm.sortingErrorStats[perfMap][eventType], 0)
+	return pbm.sortingErrorStats[perfMap][eventType].Swap(0)
 }
 
 // CountLostEvent adds `count` to the counter of lost events
@@ -336,15 +339,15 @@ func (pbm *PerfBufferMonitor) CountLostEvent(count uint64, mapName string, cpu i
 	if (pbm.readLostEvents[mapName] == nil) || (len(pbm.readLostEvents[mapName]) <= cpu) {
 		return
 	}
-	atomic.AddUint64(&pbm.readLostEvents[mapName][cpu], count)
+	pbm.readLostEvents[mapName][cpu].Add(count)
 }
 
 // CountEvent adds `count` to the counter of received events of the specified type
 func (pbm *PerfBufferMonitor) CountEvent(eventType model.EventType, timestamp uint64, count uint64, size uint64, mapName string, cpu int) {
 	// check event order
 	if timestamp < pbm.lastTimestamp && pbm.lastTimestamp != 0 {
-		atomic.AddInt64(pbm.sortingErrorStats[mapName][eventType], 1)
-		atomic.SwapUint64(&pbm.shouldBumpGeneration, 1)
+		pbm.sortingErrorStats[mapName][eventType].Inc()
+		pbm.shouldBumpGeneration.Store(true)
 	} else {
 		pbm.lastTimestamp = timestamp
 	}
@@ -354,8 +357,8 @@ func (pbm *PerfBufferMonitor) CountEvent(eventType model.EventType, timestamp ui
 		return
 	}
 
-	atomic.AddUint64(&pbm.stats[mapName][cpu][eventType].Count, count)
-	atomic.AddUint64(&pbm.stats[mapName][cpu][eventType].Bytes, size)
+	pbm.stats[mapName][cpu][eventType].Count.Add(count)
+	pbm.stats[mapName][cpu][eventType].Bytes.Add(size)
 }
 
 func (pbm *PerfBufferMonitor) sendEventsAndBytesReadStats(client statsd.ClientInterface) error {
@@ -463,19 +466,19 @@ func (pbm *PerfBufferMonitor) collectAndSendKernelStats(client statsd.ClientInte
 				}
 
 				// Update stats to avoid sending twice the same data points
-				if tmpCount = pbm.swapKernelEventBytes(evtType, perfMapName, cpu, stats.Bytes); tmpCount <= stats.Bytes {
-					stats.Bytes -= tmpCount
+				if tmpCount = pbm.swapKernelEventBytes(evtType, perfMapName, cpu, stats.Bytes.Load()); tmpCount <= stats.Bytes.Load() {
+					stats.Bytes.Sub(tmpCount)
 				}
-				if tmpCount = pbm.swapKernelEventCount(evtType, perfMapName, cpu, stats.Count); tmpCount <= stats.Count {
-					stats.Count -= tmpCount
+				if tmpCount = pbm.swapKernelEventCount(evtType, perfMapName, cpu, stats.Count.Load()); tmpCount <= stats.Count.Load() {
+					stats.Count.Sub(tmpCount)
 				}
-				if tmpCount = pbm.swapKernelLostCount(evtType, perfMapName, cpu, stats.Lost); tmpCount <= stats.Lost {
-					stats.Lost -= tmpCount
+				if tmpCount = pbm.swapKernelLostCount(evtType, perfMapName, cpu, stats.Lost.Load()); tmpCount <= stats.Lost.Load() {
+					stats.Lost.Sub(tmpCount)
 				}
 
 				// purge dentry resolver generation if needed
 				if evtType == model.FileRenameEventType || evtType == model.FileUnlinkEventType || evtType == model.FileRmdirEventType {
-					atomic.SwapUint64(&pbm.shouldBumpGeneration, 1)
+					pbm.shouldBumpGeneration.Store(true)
 				}
 
 				if client != nil {
@@ -483,8 +486,8 @@ func (pbm *PerfBufferMonitor) collectAndSendKernelStats(client statsd.ClientInte
 						return err
 					}
 				}
-				total += stats.Lost
-				perEvent[evtType.String()] += stats.Lost
+				total += stats.Lost.Load()
+				perEvent[evtType.String()] += stats.Lost.Load()
 			}
 		}
 		if iterator.Err() != nil {
@@ -507,20 +510,20 @@ func (pbm *PerfBufferMonitor) collectAndSendKernelStats(client statsd.ClientInte
 }
 
 func (pbm *PerfBufferMonitor) sendKernelStats(client statsd.ClientInterface, stats PerfMapStats, tags []string) error {
-	if stats.Count > 0 {
-		if err := client.Count(metrics.MetricPerfBufferEventsWrite, int64(stats.Count), tags, 1.0); err != nil {
+	if stats.Count.Load() > 0 {
+		if err := client.Count(metrics.MetricPerfBufferEventsWrite, int64(stats.Count.Load()), tags, 1.0); err != nil {
 			return err
 		}
 	}
 
-	if stats.Bytes > 0 {
-		if err := client.Count(metrics.MetricPerfBufferBytesWrite, int64(stats.Bytes), tags, 1.0); err != nil {
+	if stats.Bytes.Load() > 0 {
+		if err := client.Count(metrics.MetricPerfBufferBytesWrite, int64(stats.Bytes.Load()), tags, 1.0); err != nil {
 			return err
 		}
 	}
 
-	if stats.Lost > 0 {
-		if err := client.Count(metrics.MetricPerfBufferLostWrite, int64(stats.Lost), tags, 1.0); err != nil {
+	if stats.Lost.Load() > 0 {
+		if err := client.Count(metrics.MetricPerfBufferLostWrite, int64(stats.Lost.Load()), tags, 1.0); err != nil {
 			return err
 		}
 	}
@@ -534,7 +537,7 @@ func (pbm *PerfBufferMonitor) SendStats() error {
 		return err
 	}
 
-	if atomic.SwapUint64(&pbm.shouldBumpGeneration, 0) == 1 {
+	if pbm.shouldBumpGeneration.Swap(false) {
 		pbm.probe.resolvers.DentryResolver.BumpCacheGenerations()
 	}
 

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -17,7 +17,6 @@ import (
 	"path"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"syscall"
 	"time"
 	"unsafe"
@@ -27,6 +26,7 @@ import (
 	lib "github.com/cilium/ebpf"
 	"github.com/hashicorp/golang-lru/simplelru"
 	"github.com/pkg/errors"
+	"go.uber.org/atomic"
 
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
 	seclog "github.com/DataDog/datadog-agent/pkg/security/log"
@@ -91,18 +91,18 @@ type ProcessResolverOpts struct{}
 // ProcessResolver resolved process context
 type ProcessResolver struct {
 	sync.RWMutex
-	state            int64
+	state            *atomic.Int64
 	probe            *Probe
 	resolvers        *Resolvers
 	execFileCacheMap *lib.Map
 	procCacheMap     *lib.Map
 	pidCacheMap      *lib.Map
-	cacheSize        int64
+	cacheSize        *atomic.Int64
 	opts             ProcessResolverOpts
-	hitsStats        map[string]*int64
-	missStats        int64
-	addedEntries     int64
-	flushedEntries   int64
+	hitsStats        map[string]*atomic.Int64
+	missStats        *atomic.Int64
+	addedEntries     *atomic.Int64
+	flushedEntries   *atomic.Int64
 
 	entryCache    map[uint32]*model.ProcessCacheEntry
 	argsEnvsCache *simplelru.LRU
@@ -210,7 +210,7 @@ func NewProcessCacheEntryPool(p *ProcessResolver) *ProcessCacheEntryPool {
 				pce.EnvsEntry.ArgsEnvsCacheEntry.Release()
 			}
 
-			atomic.AddInt64(&p.cacheSize, -1)
+			p.cacheSize.Dec()
 
 			pcep.Put(pce)
 		})
@@ -226,7 +226,7 @@ func (p *ProcessResolver) DequeueExited() {
 
 	delEntry := func(pid uint32, exitTime time.Time) {
 		p.deleteEntry(pid, exitTime)
-		atomic.AddInt64(&p.flushedEntries, 1)
+		p.flushedEntries.Inc()
 	}
 
 	now := time.Now()
@@ -269,37 +269,37 @@ func (p *ProcessResolver) SendStats() error {
 		return errors.Wrap(err, "failed to send process_resolver reference_count metric")
 	}
 
-	if count = atomic.SwapInt64(p.hitsStats[metrics.CacheTag], 0); count > 0 {
+	if count = p.hitsStats[metrics.CacheTag].Swap(0); count > 0 {
 		if err = p.probe.statsdClient.Count(metrics.MetricProcessResolverCacheHits, count, []string{metrics.CacheTag}, 1.0); err != nil {
 			return errors.Wrap(err, "failed to send process_resolver cache hits metric")
 		}
 	}
 
-	if count = atomic.SwapInt64(p.hitsStats[metrics.KernelMapsTag], 0); count > 0 {
+	if count = p.hitsStats[metrics.KernelMapsTag].Swap(0); count > 0 {
 		if err = p.probe.statsdClient.Count(metrics.MetricProcessResolverCacheHits, count, []string{metrics.KernelMapsTag}, 1.0); err != nil {
 			return errors.Wrap(err, "failed to send process_resolver kernel maps hits metric")
 		}
 	}
 
-	if count = atomic.SwapInt64(p.hitsStats[metrics.ProcFSTag], 0); count > 0 {
+	if count = p.hitsStats[metrics.ProcFSTag].Swap(0); count > 0 {
 		if err = p.probe.statsdClient.Count(metrics.MetricProcessResolverCacheHits, count, []string{metrics.ProcFSTag}, 1.0); err != nil {
 			return errors.Wrap(err, "failed to send process_resolver procfs hits metric")
 		}
 	}
 
-	if count = atomic.SwapInt64(&p.missStats, 0); count > 0 {
+	if count = p.missStats.Swap(0); count > 0 {
 		if err = p.probe.statsdClient.Count(metrics.MetricProcessResolverCacheMiss, count, []string{}, 1.0); err != nil {
 			return errors.Wrap(err, "failed to send process_resolver misses metric")
 		}
 	}
 
-	if count = atomic.SwapInt64(&p.addedEntries, 0); count > 0 {
+	if count = p.addedEntries.Swap(0); count > 0 {
 		if err = p.probe.statsdClient.Count(metrics.MetricProcessResolverAdded, count, []string{}, 1.0); err != nil {
 			return errors.Wrap(err, "failed to send process_resolver added entries metric")
 		}
 	}
 
-	if count = atomic.SwapInt64(&p.flushedEntries, 0); count > 0 {
+	if count = p.flushedEntries.Swap(0); count > 0 {
 		if err = p.probe.statsdClient.Count(metrics.MetricProcessResolverFlushed, count, []string{}, 1.0); err != nil {
 			return errors.Wrap(err, "failed to send process_resolver flushed entries metric")
 		}
@@ -466,8 +466,8 @@ func (p *ProcessResolver) insertEntry(entry, prev *model.ProcessCacheEntry) {
 		prev.Release()
 	}
 
-	atomic.AddInt64(&p.addedEntries, 1)
-	atomic.AddInt64(&p.cacheSize, 1)
+	p.addedEntries.Inc()
+	p.cacheSize.Inc()
 }
 
 func (p *ProcessResolver) insertForkEntry(entry *model.ProcessCacheEntry) {
@@ -528,27 +528,27 @@ func (p *ProcessResolver) Resolve(pid, tid uint32) *model.ProcessCacheEntry {
 
 func (p *ProcessResolver) resolve(pid, tid uint32) *model.ProcessCacheEntry {
 	if entry := p.resolveFromCache(pid, tid); entry != nil {
-		atomic.AddInt64(p.hitsStats[metrics.CacheTag], 1)
+		p.hitsStats[metrics.CacheTag].Inc()
 		return entry
 	}
 
-	if atomic.LoadInt64(&p.state) != snapshotted {
+	if p.state.Load() != snapshotted {
 		return nil
 	}
 
 	// fallback to the kernel maps directly, the perf event may be delayed / may have been lost
 	if entry := p.resolveWithKernelMaps(pid, tid); entry != nil {
-		atomic.AddInt64(p.hitsStats[metrics.KernelMapsTag], 1)
+		p.hitsStats[metrics.KernelMapsTag].Inc()
 		return entry
 	}
 
 	// fallback to /proc, the in-kernel LRU may have deleted the entry
 	if entry := p.resolveWithProcfs(pid, procResolveMaxDepth); entry != nil {
-		atomic.AddInt64(p.hitsStats[metrics.ProcFSTag], 1)
+		p.hitsStats[metrics.ProcFSTag].Inc()
 		return entry
 	}
 
-	atomic.AddInt64(&p.missStats, 1)
+	p.missStats.Inc()
 	return nil
 }
 
@@ -1126,12 +1126,12 @@ func (p *ProcessResolver) GetCacheSize() float64 {
 
 // GetEntryCacheSize returns the cache size of the process resolver
 func (p *ProcessResolver) GetEntryCacheSize() float64 {
-	return float64(atomic.LoadInt64(&p.cacheSize))
+	return float64(p.cacheSize.Load())
 }
 
 // SetState sets the process resolver state
 func (p *ProcessResolver) SetState(state int64) {
-	atomic.StoreInt64(&p.state, state)
+	p.state.Store(state)
 }
 
 // Walk iterates through the entire tree and call the provided callback on each entry
@@ -1168,18 +1168,21 @@ func NewProcessResolver(probe *Probe, resolvers *Resolvers, opts ProcessResolver
 	}
 
 	p := &ProcessResolver{
-		probe:         probe,
-		resolvers:     resolvers,
-		entryCache:    make(map[uint32]*model.ProcessCacheEntry),
-		opts:          opts,
-		argsEnvsCache: argsEnvsCache,
-		state:         snapshotting,
-		argsEnvsPool:  NewArgsEnvsPool(maxArgsEnvResidents),
-		hitsStats:     map[string]*int64{},
+		probe:          probe,
+		resolvers:      resolvers,
+		entryCache:     make(map[uint32]*model.ProcessCacheEntry),
+		opts:           opts,
+		argsEnvsCache:  argsEnvsCache,
+		state:          atomic.NewInt64(snapshotting),
+		argsEnvsPool:   NewArgsEnvsPool(maxArgsEnvResidents),
+		hitsStats:      map[string]*atomic.Int64{},
+		cacheSize:      atomic.NewInt64(0),
+		missStats:      atomic.NewInt64(0),
+		addedEntries:   atomic.NewInt64(0),
+		flushedEntries: atomic.NewInt64(0),
 	}
 	for _, t := range metrics.AllTypesTags {
-		zero := int64(0)
-		p.hitsStats[t] = &zero
+		p.hitsStats[t] = atomic.NewInt64(0)
 	}
 	p.processCacheEntryPool = NewProcessCacheEntryPool(p)
 

--- a/pkg/security/probe/process_resolver_test.go
+++ b/pkg/security/probe/process_resolver_test.go
@@ -10,7 +10,6 @@ package probe
 
 import (
 	"fmt"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -22,11 +21,11 @@ import (
 func testCacheSize(t *testing.T, resolver *ProcessResolver) {
 	err := retry.Do(
 		func() error {
-			if atomic.LoadInt64(&resolver.cacheSize) == 0 {
+			if resolver.cacheSize.Load() == 0 {
 				return nil
 			}
 
-			return fmt.Errorf("cache size error: %d", atomic.LoadInt64(&resolver.cacheSize))
+			return fmt.Errorf("cache size error: %d", resolver.cacheSize.Load())
 		},
 	)
 	assert.Nil(t, err)
@@ -49,7 +48,7 @@ func TestFork1st(t *testing.T) {
 	resolver.AddForkEntry(parent)
 	assert.Equal(t, parent, resolver.entryCache[parent.Pid])
 	assert.Equal(t, 1, len(resolver.entryCache))
-	assert.EqualValues(t, 1, atomic.LoadInt64(&resolver.cacheSize))
+	assert.EqualValues(t, 1, resolver.cacheSize.Load())
 
 	// parent
 	//     \ child
@@ -57,7 +56,7 @@ func TestFork1st(t *testing.T) {
 	assert.Equal(t, child, resolver.entryCache[child.Pid])
 	assert.Equal(t, 2, len(resolver.entryCache))
 	assert.Equal(t, parent, child.Ancestor)
-	assert.EqualValues(t, 2, atomic.LoadInt64(&resolver.cacheSize))
+	assert.EqualValues(t, 2, resolver.cacheSize.Load())
 
 	// parent
 	resolver.DeleteEntry(child.Pid, time.Now())
@@ -88,7 +87,7 @@ func TestFork2nd(t *testing.T) {
 	resolver.AddForkEntry(parent)
 	assert.Equal(t, parent, resolver.entryCache[parent.Pid])
 	assert.Equal(t, 1, len(resolver.entryCache))
-	assert.EqualValues(t, 1, atomic.LoadInt64(&resolver.cacheSize))
+	assert.EqualValues(t, 1, resolver.cacheSize.Load())
 
 	// parent
 	//     \ child
@@ -96,7 +95,7 @@ func TestFork2nd(t *testing.T) {
 	assert.Equal(t, child, resolver.entryCache[child.Pid])
 	assert.Equal(t, 2, len(resolver.entryCache))
 	assert.Equal(t, parent, child.Ancestor)
-	assert.EqualValues(t, 2, atomic.LoadInt64(&resolver.cacheSize))
+	assert.EqualValues(t, 2, resolver.cacheSize.Load())
 
 	// [parent]
 	//     \ child
@@ -133,7 +132,7 @@ func TestForkExec(t *testing.T) {
 	resolver.AddForkEntry(parent)
 	assert.Equal(t, parent, resolver.entryCache[parent.Pid])
 	assert.Equal(t, 1, len(resolver.entryCache))
-	assert.EqualValues(t, 1, atomic.LoadInt64(&resolver.cacheSize))
+	assert.EqualValues(t, 1, resolver.cacheSize.Load())
 
 	// parent
 	//     \ child
@@ -141,7 +140,7 @@ func TestForkExec(t *testing.T) {
 	assert.Equal(t, child, resolver.entryCache[child.Pid])
 	assert.Equal(t, 2, len(resolver.entryCache))
 	assert.Equal(t, parent, child.Ancestor)
-	assert.EqualValues(t, 2, atomic.LoadInt64(&resolver.cacheSize))
+	assert.EqualValues(t, 2, resolver.cacheSize.Load())
 
 	// parent
 	//     \ [child] -> exec
@@ -150,7 +149,7 @@ func TestForkExec(t *testing.T) {
 	assert.Equal(t, 2, len(resolver.entryCache))
 	assert.Equal(t, child, exec.Ancestor)
 	assert.Equal(t, parent, exec.Ancestor.Ancestor)
-	assert.EqualValues(t, 3, atomic.LoadInt64(&resolver.cacheSize))
+	assert.EqualValues(t, 3, resolver.cacheSize.Load())
 
 	// [parent]
 	//     \ [child] -> exec
@@ -189,7 +188,7 @@ func TestOrphanExec(t *testing.T) {
 	resolver.AddForkEntry(parent)
 	assert.Equal(t, parent, resolver.entryCache[parent.Pid])
 	assert.Equal(t, 1, len(resolver.entryCache))
-	assert.EqualValues(t, 1, atomic.LoadInt64(&resolver.cacheSize))
+	assert.EqualValues(t, 1, resolver.cacheSize.Load())
 
 	// parent
 	//     \ child
@@ -197,7 +196,7 @@ func TestOrphanExec(t *testing.T) {
 	assert.Equal(t, child, resolver.entryCache[child.Pid])
 	assert.Equal(t, 2, len(resolver.entryCache))
 	assert.Equal(t, parent, child.Ancestor)
-	assert.EqualValues(t, 2, atomic.LoadInt64(&resolver.cacheSize))
+	assert.EqualValues(t, 2, resolver.cacheSize.Load())
 
 	// [parent]
 	//     \ child
@@ -213,7 +212,7 @@ func TestOrphanExec(t *testing.T) {
 	assert.Equal(t, 1, len(resolver.entryCache))
 	assert.Equal(t, child, exec.Ancestor)
 	assert.Equal(t, parent, exec.Ancestor.Ancestor)
-	assert.EqualValues(t, 3, atomic.LoadInt64(&resolver.cacheSize))
+	assert.EqualValues(t, 3, resolver.cacheSize.Load())
 
 	// nothing
 	resolver.DeleteEntry(exec.Pid, time.Now())
@@ -248,7 +247,7 @@ func TestForkExecExec(t *testing.T) {
 	resolver.AddForkEntry(parent)
 	assert.Equal(t, parent, resolver.entryCache[parent.Pid])
 	assert.Equal(t, 1, len(resolver.entryCache))
-	assert.EqualValues(t, 1, atomic.LoadInt64(&resolver.cacheSize))
+	assert.EqualValues(t, 1, resolver.cacheSize.Load())
 
 	// parent
 	//     \ child
@@ -256,7 +255,7 @@ func TestForkExecExec(t *testing.T) {
 	assert.Equal(t, child, resolver.entryCache[child.Pid])
 	assert.Equal(t, 2, len(resolver.entryCache))
 	assert.Equal(t, parent, child.Ancestor)
-	assert.EqualValues(t, 2, atomic.LoadInt64(&resolver.cacheSize))
+	assert.EqualValues(t, 2, resolver.cacheSize.Load())
 
 	// [parent]
 	//     \ child
@@ -272,7 +271,7 @@ func TestForkExecExec(t *testing.T) {
 	assert.Equal(t, 1, len(resolver.entryCache))
 	assert.Equal(t, child, exec1.Ancestor)
 	assert.Equal(t, parent, exec1.Ancestor.Ancestor)
-	assert.EqualValues(t, 3, atomic.LoadInt64(&resolver.cacheSize))
+	assert.EqualValues(t, 3, resolver.cacheSize.Load())
 
 	// [parent]
 	//     \ [child] -> [exec1] -> exec2
@@ -282,7 +281,7 @@ func TestForkExecExec(t *testing.T) {
 	assert.Equal(t, exec1, exec2.Ancestor)
 	assert.Equal(t, child, exec2.Ancestor.Ancestor)
 	assert.Equal(t, parent, exec2.Ancestor.Ancestor.Ancestor)
-	assert.EqualValues(t, 4, atomic.LoadInt64(&resolver.cacheSize))
+	assert.EqualValues(t, 4, resolver.cacheSize.Load())
 
 	// nothing
 	resolver.DeleteEntry(exec2.Pid, time.Now())
@@ -319,7 +318,7 @@ func TestForkReuse(t *testing.T) {
 	resolver.AddForkEntry(parent1)
 	assert.Equal(t, parent1, resolver.entryCache[parent1.Pid])
 	assert.Equal(t, 1, len(resolver.entryCache))
-	assert.EqualValues(t, 1, atomic.LoadInt64(&resolver.cacheSize))
+	assert.EqualValues(t, 1, resolver.cacheSize.Load())
 
 	// parent1
 	//     \ child1
@@ -327,7 +326,7 @@ func TestForkReuse(t *testing.T) {
 	assert.Equal(t, child1, resolver.entryCache[child1.Pid])
 	assert.Equal(t, 2, len(resolver.entryCache))
 	assert.Equal(t, parent1, child1.Ancestor)
-	assert.EqualValues(t, 2, atomic.LoadInt64(&resolver.cacheSize))
+	assert.EqualValues(t, 2, resolver.cacheSize.Load())
 
 	// [parent1]
 	//     \ child1
@@ -343,7 +342,7 @@ func TestForkReuse(t *testing.T) {
 	assert.Equal(t, 1, len(resolver.entryCache))
 	assert.Equal(t, child1, exec1.Ancestor)
 	assert.Equal(t, parent1, exec1.Ancestor.Ancestor)
-	assert.EqualValues(t, 3, atomic.LoadInt64(&resolver.cacheSize))
+	assert.EqualValues(t, 3, resolver.cacheSize.Load())
 
 	// [parent1:pid1]
 	//     \ [child1] -> exec1
@@ -352,7 +351,7 @@ func TestForkReuse(t *testing.T) {
 	resolver.AddForkEntry(parent2)
 	assert.Equal(t, parent2, resolver.entryCache[parent2.Pid])
 	assert.Equal(t, 2, len(resolver.entryCache))
-	assert.EqualValues(t, 4, atomic.LoadInt64(&resolver.cacheSize))
+	assert.EqualValues(t, 4, resolver.cacheSize.Load())
 
 	// [parent1:pid1]
 	//     \ [child1] -> exec1
@@ -363,7 +362,7 @@ func TestForkReuse(t *testing.T) {
 	assert.Equal(t, child2, resolver.entryCache[child2.Pid])
 	assert.Equal(t, 3, len(resolver.entryCache))
 	assert.Equal(t, parent2, child2.Ancestor)
-	assert.EqualValues(t, 5, atomic.LoadInt64(&resolver.cacheSize))
+	assert.EqualValues(t, 5, resolver.cacheSize.Load())
 
 	// parent2:pid1
 	//     \ child2

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -814,10 +814,10 @@ func GetStatusMetrics(probe *sprobe.Probe) string {
 
 	for i := model.UnknownEventType + 1; i < model.MaxKernelEventType; i++ {
 		stats, kernelStats := perfBufferMonitor.GetEventStats(i, "events", -1)
-		if stats.Count == 0 && kernelStats.Count == 0 && kernelStats.Lost == 0 {
+		if stats.Count.Load() == 0 && kernelStats.Count.Load() == 0 && kernelStats.Lost.Load() == 0 {
 			continue
 		}
-		status.WriteString(fmt.Sprintf(", %s user:%d kernel:%d lost:%d", i, stats.Count, kernelStats.Count, kernelStats.Lost))
+		status.WriteString(fmt.Sprintf(", %s user:%d kernel:%d lost:%d", i, stats.Count.Load(), kernelStats.Count.Load(), kernelStats.Lost.Load()))
 	}
 
 	return status.String()


### PR DESCRIPTION
 ### What does this PR do?

Uses go.uber.com/atomic to ensure alignment of atomic access in cmd/system-probe.

### Motivation

Alignment issues with atomic access, and enforcing atomic access to atomic variables.  See #11716.

### Additional Notes

At several points, especially in perf_buffer_monitor.go, atomic values were accessed non-atomically.  All accesses are now atomic.

There were a few places where alignment wasn't guaranteed, but since most struct fields are 32-bit-aligned, the chances are 50/50 that a given 64-bit atomic variable was properly aligned.  Adding another field to any of these structs might have introduced alignment issues.

### Possible Drawbacks / Trade-offs

Many of the `uint64` and `int64` struct fields that were treated atomically are now a pointer.  I believe, based on a guess from the type name, that these structs are few in number and not allocated frequently, so additional pointer allocations should not create memory- or cpu-performance issues.  But, please look over the patches with this in mind and verify my assumption.

### Describe how to test/QA your changes

Any basic security-agent QA should detect issues here.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
