### PR TITLE
Revert docker.mem.in_use to use RSS memory instead of total memory

### DIFF
--- a/pkg/collector/corechecks/containers/docker/check_metrics_extension.go
+++ b/pkg/collector/corechecks/containers/docker/check_metrics_extension.go
@@ -52,9 +52,14 @@ func (dn *dockerCustomMetricsExtension) Process(tags []string, container *worklo
 			dn.sender(dn.aggSender.Gauge, "docker.mem.sw_limit", containerStats.Memory.SwapLimit, tags)
 		}
 
-		if containerStats.Memory.UsageTotal != nil && containerStats.Memory.Limit != nil && *containerStats.Memory.Limit > 0 {
-			memoryPct := *containerStats.Memory.UsageTotal / *containerStats.Memory.Limit
-			dn.sender(dn.aggSender.Gauge, "docker.mem.in_use", &memoryPct, tags)
+		if containerStats.Memory.Limit != nil && *containerStats.Memory.Limit > 0 {
+			if containerStats.Memory.RSS != nil {
+				memoryPct := *containerStats.Memory.RSS / *containerStats.Memory.Limit
+				dn.sender(dn.aggSender.Gauge, "docker.mem.in_use", &memoryPct, tags)
+			} else if containerStats.Memory.CommitBytes != nil {
+				memoryPct := *containerStats.Memory.CommitBytes / *containerStats.Memory.Limit
+				dn.sender(dn.aggSender.Gauge, "docker.mem.in_use", &memoryPct, tags)
+			}
 		}
 	}
 

--- a/pkg/collector/corechecks/containers/docker/check_test.go
+++ b/pkg/collector/corechecks/containers/docker/check_test.go
@@ -82,7 +82,7 @@ func TestDockerCheckGenericPart(t *testing.T) {
 	mockSender.AssertMetric(t, "Gauge", "docker.mem.cache", 200, "", expectedTags)
 	mockSender.AssertMetric(t, "Gauge", "docker.mem.swap", 0, "", expectedTags)
 	mockSender.AssertMetric(t, "Gauge", "docker.mem.failed_count", 10, "", expectedTags)
-	mockSender.AssertMetric(t, "Gauge", "docker.mem.in_use", 1, "", expectedTags)
+	mockSender.AssertMetricInRange(t, "Gauge", "docker.mem.in_use", 0, 1, "", expectedTags)
 	mockSender.AssertMetric(t, "Gauge", "docker.mem.sw_limit", 500, "", expectedTags)
 
 	expectedFooTags := taggerUtils.ConcatenateStringTags(expectedTags, "device:/dev/foo", "device_name:/dev/foo")

--- a/releasenotes/notes/fix-docker-in-use-6a2efc3fa82bb16e.yaml
+++ b/releasenotes/notes/fix-docker-in-use-6a2efc3fa82bb16e.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Revert `docker.mem.in_use` calculation to use RSS Memory instead of total memory.


### PR DESCRIPTION
### What does this PR do?

Revert `docker.mem.in_use` to use RSS memory instead of total memory

### Motivation

Bugfix

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Deploy the Agent on Docker. Deploy a container with a memory limit. `docker.mem.in_use` should be equal to `docker.mem.rss / docker.mem.limit`

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
