### PR TITLE
Redirect klog v2 logs to datadog logger

### DIFF
--- a/cmd/cluster-agent/klog.go
+++ b/cmd/cluster-agent/klog.go
@@ -14,7 +14,8 @@ import (
 	"strconv"
 	"strings"
 
-	"k8s.io/klog"
+	klogv1 "k8s.io/klog"
+	klogv2 "k8s.io/klog/v2"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -24,10 +25,12 @@ import (
 // into ERROR, along with the formatting just being off. To make the
 // conversion, we set a redirectLogger as klog's output, and parse the severity
 // and log message out of every log line.
-// NOTE: on klog v2, used by newer versions of client-go than the one we have
-// right now, this parsing is no longer necessary, as it allows us to use
-// klog.SetLogger() instead of klog.SetOutputBySeverity().
-type redirectLogger struct{}
+// NOTE: on klog v2 this parsing is no longer necessary, as it allows us to use
+// klog.SetLogger() instead of klog.SetOutputBySeverity(). unfortunately we
+// still have some dependencies stuck on v1, so we keep the parsing.
+type redirectLogger struct {
+	stackDepth int
+}
 
 func (l redirectLogger) Write(b []byte) (int, error) {
 	// klog log lines have the following format:
@@ -47,15 +50,15 @@ func (l redirectLogger) Write(b []byte) (int, error) {
 
 	switch b[0] {
 	case 'I':
-		log.InfoStackDepth(6, msg)
+		log.InfoStackDepth(l.stackDepth, msg)
 	case 'W':
-		log.WarnStackDepth(6, msg)
+		log.WarnStackDepth(l.stackDepth, msg)
 	case 'E':
-		log.ErrorStackDepth(6, msg)
+		log.ErrorStackDepth(l.stackDepth, msg)
 	case 'F':
-		log.CriticalStackDepth(6, msg)
+		log.CriticalStackDepth(l.stackDepth, msg)
 	default:
-		log.InfoStackDepth(6, msg)
+		log.InfoStackDepth(l.stackDepth, msg)
 	}
 
 	return 0, nil
@@ -65,7 +68,10 @@ func init() {
 	// klog takes configuration from command line flags or, like we're
 	// doing here, a flagset passed as a parameter
 	flagset := flag.NewFlagSet("", flag.ContinueOnError)
-	klog.InitFlags(flagset)
+
+	// klog v1 and v2 use the same flags, so we only need to init it once,
+	// with either of them (v2 chosen by roll of the dice)
+	klogv2.InitFlags(flagset)
 
 	var err error
 
@@ -94,5 +100,6 @@ func init() {
 	// out of the log instead of having an output for each severity. having
 	// an output just for the lowest level captures the logs on all enabled
 	// severities just once.
-	klog.SetOutputBySeverity("INFO", redirectLogger{})
+	klogv1.SetOutputBySeverity("INFO", redirectLogger{6})
+	klogv2.SetOutputBySeverity("INFO", redirectLogger{7})
 }


### PR DESCRIPTION
This applies the same technique we used for klog v1, for klog v2, now
that we have newer dependencies (namely client-go) that have migrated.

### Describe how to test/QA your changes

Run the DCA. Check that there are no unformatted logs being spat out to STDERR (leader election is a good candidate to look for). Also check that client-go logs show the correct file path in the logs

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
