### PR TITLE
[CWS] Ignore invalid entries in /proc/modules

### DIFF
--- a/pkg/security/utils/proc.go
+++ b/pkg/security/utils/proc.go
@@ -294,12 +294,14 @@ func FetchLoadedModules() (map[string]ProcFSModule, error) {
 
 		newModule.Size, err = strconv.Atoi(split[1])
 		if err != nil {
-			continue
+			// set to 0 by default
+			newModule.Size = 0
 		}
 
 		newModule.InstancesCount, err = strconv.Atoi(split[2])
 		if err != nil {
-			continue
+			// set to 0 by default
+			newModule.InstancesCount = 0
 		}
 
 		if split[3] != "-" {
@@ -312,7 +314,8 @@ func FetchLoadedModules() (map[string]ProcFSModule, error) {
 
 		newModule.Address, err = strconv.ParseInt(strings.Trim(split[5], "0x"), 16, 64)
 		if err != nil {
-			continue
+			// set to 0 by default
+			newModule.Address = 0
 		}
 
 		output[newModule.Name] = newModule


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

This PR ignores invalid or empty entries in /proc/modules and set the default values to 0.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

When `kernel.kptr_restrict` is set to [2](https://lwn.net/Articles/420403/), the agent fails to parse the empty addresses in /proc/modules. This leads to making `system-probe` believe that the `veth` module isn't loaded, and thus prevents some hook points to be attached. Eventually, this explains why veth pairs are not properly discovered at runtime.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
