### PR TITLE
Revert "pkg/trace: use go.uber.com/atomic (#12120)"

### DIFF
--- a/docs/dev/atomics.md
+++ b/docs/dev/atomics.md
@@ -48,9 +48,6 @@ If the additional pointer allocation poses an undue performance burden, include 
  * that it must remain in that position; and
  * why a pointer was not suitable.
 
-Note that pointers to atomic types marshal correctly to JSON as their enclosed value.
-Unmarshaling does the reverse, except that missing values are represented as nil, rather than an atomic type with zero value.
-
 ### Why
 
 There are two main issues with the built-in `sync/atomic` package:

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -8,6 +8,7 @@ package agent
 import (
 	"context"
 	"runtime"
+	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/obfuscate"
@@ -216,11 +217,11 @@ func (a *Agent) Process(p *api.Payload) {
 		}
 
 		tracen := int64(len(chunk.Spans))
-		ts.SpansReceived.Add(tracen)
+		atomic.AddInt64(&ts.SpansReceived, tracen)
 		err := normalizeTrace(p.Source, chunk.Spans)
 		if err != nil {
 			log.Debugf("Dropping invalid trace: %s", err)
-			ts.SpansDropped.Add(tracen)
+			atomic.AddInt64(&ts.SpansDropped, tracen)
 			p.RemoveChunk(i)
 			continue
 		}
@@ -230,16 +231,16 @@ func (a *Agent) Process(p *api.Payload) {
 		normalizeChunk(chunk, root)
 		if !a.Blacklister.Allows(root) {
 			log.Debugf("Trace rejected by ignore resources rules. root: %v", root)
-			ts.TracesFiltered.Inc()
-			ts.SpansFiltered.Add(tracen)
+			atomic.AddInt64(&ts.TracesFiltered, 1)
+			atomic.AddInt64(&ts.SpansFiltered, tracen)
 			p.RemoveChunk(i)
 			continue
 		}
 
 		if filteredByTags(root, a.conf.RequireTags, a.conf.RejectTags) {
 			log.Debugf("Trace rejected as it fails to meet tag requirements. root: %v", root)
-			ts.TracesFiltered.Inc()
-			ts.SpansFiltered.Add(tracen)
+			atomic.AddInt64(&ts.TracesFiltered, 1)
+			atomic.AddInt64(&ts.SpansFiltered, tracen)
 			p.RemoveChunk(i)
 			continue
 		}
@@ -437,7 +438,7 @@ func (a *Agent) sample(now time.Time, ts *info.TagStats, pt traceutil.ProcessedT
 	if hasPriority {
 		ts.TracesPerSamplingPriority.CountSamplingPriority(priority)
 	} else {
-		ts.TracesPriorityNone.Inc()
+		atomic.AddInt64(&ts.TracesPriorityNone, 1)
 	}
 
 	if priority < 0 {
@@ -454,8 +455,8 @@ func (a *Agent) sample(now time.Time, ts *info.TagStats, pt traceutil.ProcessedT
 	}
 	numEvents, numExtracted := a.EventProcessor.Process(pt.Root, filteredChunk)
 
-	ts.EventsExtracted.Add(numExtracted)
-	ts.EventsSampled.Add(numEvents)
+	atomic.AddInt64(&ts.EventsExtracted, numExtracted)
+	atomic.AddInt64(&ts.EventsSampled, numEvents)
 
 	return numEvents, sampled, filteredChunk
 }

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -136,8 +136,8 @@ func TestProcess(t *testing.T) {
 			TracerPayload: testutil.TracerPayloadWithChunk(testutil.TraceChunkWithSpan(spanValid)),
 			Source:        info.NewReceiverStats().GetTagStats(info.Tags{}),
 		})
-		assert.EqualValues(0, want.TracesFiltered.Load())
-		assert.EqualValues(0, want.SpansFiltered.Load())
+		assert.EqualValues(0, want.TracesFiltered)
+		assert.EqualValues(0, want.SpansFiltered)
 
 		agnt.Process(&api.Payload{
 			TracerPayload: testutil.TracerPayloadWithChunk(testutil.TraceChunkWithSpans([]*pb.Span{
@@ -146,8 +146,8 @@ func TestProcess(t *testing.T) {
 			})),
 			Source: want,
 		})
-		assert.EqualValues(1, want.TracesFiltered.Load())
-		assert.EqualValues(2, want.SpansFiltered.Load())
+		assert.EqualValues(1, want.TracesFiltered)
+		assert.EqualValues(2, want.SpansFiltered)
 	})
 
 	t.Run("BlacklistPayload", func(t *testing.T) {
@@ -190,8 +190,8 @@ func TestProcess(t *testing.T) {
 			}),
 			Source: want,
 		})
-		assert.EqualValues(1, want.TracesFiltered.Load())
-		assert.EqualValues(2, want.SpansFiltered.Load())
+		assert.EqualValues(1, want.TracesFiltered)
+		assert.EqualValues(2, want.SpansFiltered)
 		var span *pb.Span
 		select {
 		case ss := <-agnt.TraceWriter.In:
@@ -246,7 +246,7 @@ func TestProcess(t *testing.T) {
 		}
 
 		samplingPriorityTagValues := want.TracesPerSamplingPriority.TagValues()
-		assert.EqualValues(t, 1, want.TracesPriorityNone.Load())
+		assert.EqualValues(t, 1, want.TracesPriorityNone)
 		assert.EqualValues(t, 2, samplingPriorityTagValues["-1"])
 		assert.EqualValues(t, 3, samplingPriorityTagValues["0"])
 		assert.EqualValues(t, 4, samplingPriorityTagValues["1"])

--- a/pkg/trace/agent/normalizer.go
+++ b/pkg/trace/agent/normalizer.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/config/features"
@@ -40,23 +41,23 @@ var (
 // is invalid beyond repair
 func normalize(ts *info.TagStats, s *pb.Span) error {
 	if s.TraceID == 0 {
-		ts.TracesDropped.TraceIDZero.Inc()
+		atomic.AddInt64(&ts.TracesDropped.TraceIDZero, 1)
 		return fmt.Errorf("TraceID is zero (reason:trace_id_zero): %s", s)
 	}
 	if s.SpanID == 0 {
-		ts.TracesDropped.SpanIDZero.Inc()
+		atomic.AddInt64(&ts.TracesDropped.SpanIDZero, 1)
 		return fmt.Errorf("SpanID is zero (reason:span_id_zero): %s", s)
 	}
 	svc, err := traceutil.NormalizeService(s.Service, ts.Lang)
 	switch err {
 	case traceutil.ErrEmpty:
-		ts.SpansMalformed.ServiceEmpty.Inc()
+		atomic.AddInt64(&ts.SpansMalformed.ServiceEmpty, 1)
 		log.Debugf("Fixing malformed trace. Service is empty (reason:service_empty), setting span.service=%s: %s", s.Service, s)
 	case traceutil.ErrTooLong:
-		ts.SpansMalformed.ServiceTruncate.Inc()
+		atomic.AddInt64(&ts.SpansMalformed.ServiceTruncate, 1)
 		log.Debugf("Fixing malformed trace. Service is too long (reason:service_truncate), truncating span.service to length=%d: %s", traceutil.MaxServiceLen, s)
 	case traceutil.ErrInvalid:
-		ts.SpansMalformed.ServiceInvalid.Inc()
+		atomic.AddInt64(&ts.SpansMalformed.ServiceInvalid, 1)
 		log.Debugf("Fixing malformed trace. Service is invalid (reason:service_invalid), replacing invalid span.service=%s with fallback span.service=%s: %s", s.Service, svc, s)
 	}
 	s.Service = svc
@@ -75,18 +76,18 @@ func normalize(ts *info.TagStats, s *pb.Span) error {
 	s.Name, err = traceutil.NormalizeName(s.Name)
 	switch err {
 	case traceutil.ErrEmpty:
-		ts.SpansMalformed.SpanNameEmpty.Inc()
+		atomic.AddInt64(&ts.SpansMalformed.SpanNameEmpty, 1)
 		log.Debugf("Fixing malformed trace. Name is empty (reason:span_name_empty), setting span.name=%s: %s", s.Name, s)
 	case traceutil.ErrTooLong:
-		ts.SpansMalformed.SpanNameTruncate.Inc()
+		atomic.AddInt64(&ts.SpansMalformed.SpanNameTruncate, 1)
 		log.Debugf("Fixing malformed trace. Name is too long (reason:span_name_truncate), truncating span.name to length=%d: %s", traceutil.MaxServiceLen, s)
 	case traceutil.ErrInvalid:
-		ts.SpansMalformed.SpanNameInvalid.Inc()
+		atomic.AddInt64(&ts.SpansMalformed.SpanNameInvalid, 1)
 		log.Debugf("Fixing malformed trace. Name is invalid (reason:span_name_invalid), setting span.name=%s: %s", s.Name, s)
 	}
 
 	if s.Resource == "" {
-		ts.SpansMalformed.ResourceEmpty.Inc()
+		atomic.AddInt64(&ts.SpansMalformed.ResourceEmpty, 1)
 		log.Debugf("Fixing malformed trace. Resource is empty (reason:resource_empty), setting span.resource=%s: %s", s.Name, s)
 		s.Resource = s.Name
 	}
@@ -105,17 +106,17 @@ func normalize(ts *info.TagStats, s *pb.Span) error {
 	// if s.Start is very little, less than year 2000 probably a unit issue so discard
 	// (or it is "le bug de l'an 2000")
 	if s.Duration < 0 {
-		ts.SpansMalformed.InvalidDuration.Inc()
+		atomic.AddInt64(&ts.SpansMalformed.InvalidDuration, 1)
 		log.Debugf("Fixing malformed trace. Duration is invalid (reason:invalid_duration), setting span.duration=0: %s", s)
 		s.Duration = 0
 	}
 	if s.Duration > math.MaxInt64-s.Start {
-		ts.SpansMalformed.InvalidDuration.Inc()
+		atomic.AddInt64(&ts.SpansMalformed.InvalidDuration, 1)
 		log.Debugf("Fixing malformed trace. Duration is too large and causes overflow (reason:invalid_duration), setting span.duration=0: %s", s)
 		s.Duration = 0
 	}
 	if s.Start < Year2000NanosecTS {
-		ts.SpansMalformed.InvalidStartDate.Inc()
+		atomic.AddInt64(&ts.SpansMalformed.InvalidStartDate, 1)
 		log.Debugf("Fixing malformed trace. Start date is invalid (reason:invalid_start_date), setting span.start=time.now(): %s", s)
 		now := time.Now().UnixNano()
 		s.Start = now - s.Duration
@@ -125,7 +126,7 @@ func normalize(ts *info.TagStats, s *pb.Span) error {
 	}
 
 	if len(s.Type) > MaxTypeLen {
-		ts.SpansMalformed.TypeTruncate.Inc()
+		atomic.AddInt64(&ts.SpansMalformed.TypeTruncate, 1)
 		log.Debugf("Fixing malformed trace. Type is too long (reason:type_truncate), truncating span.type to length=%d: %s", MaxTypeLen, s)
 		s.Type = traceutil.TruncateUTF8(s.Type, MaxTypeLen)
 	}
@@ -134,7 +135,7 @@ func normalize(ts *info.TagStats, s *pb.Span) error {
 	}
 	if sc, ok := s.Meta["http.status_code"]; ok {
 		if !isValidStatusCode(sc) {
-			ts.SpansMalformed.InvalidHTTPStatusCode.Inc()
+			atomic.AddInt64(&ts.SpansMalformed.InvalidHTTPStatusCode, 1)
 			log.Debugf("Fixing malformed trace. HTTP status code is invalid (reason:invalid_http_status_code), dropping invalid http.status_code=%s: %s", sc, s)
 			delete(s.Meta, "http.status_code")
 		}
@@ -176,7 +177,7 @@ func normalizeChunk(chunk *pb.TraceChunk, root *pb.Span) {
 //   - a reason tag explaining the reason the traces failed normalization
 func normalizeTrace(ts *info.TagStats, t pb.Trace) error {
 	if len(t) == 0 {
-		ts.TracesDropped.EmptyTrace.Inc()
+		atomic.AddInt64(&ts.TracesDropped.EmptyTrace, 1)
 		return errors.New("trace is empty (reason:empty_trace)")
 	}
 
@@ -185,14 +186,14 @@ func normalizeTrace(ts *info.TagStats, t pb.Trace) error {
 
 	for _, span := range t {
 		if span.TraceID != firstSpan.TraceID {
-			ts.TracesDropped.ForeignSpan.Inc()
+			atomic.AddInt64(&ts.TracesDropped.ForeignSpan, 1)
 			return fmt.Errorf("trace has foreign span (reason:foreign_span): %s", span)
 		}
 		if err := normalize(ts, span); err != nil {
 			return err
 		}
 		if _, ok := spanIDs[span.SpanID]; ok {
-			ts.SpansMalformed.DuplicateSpanID.Inc()
+			atomic.AddInt64(&ts.SpansMalformed.DuplicateSpanID, 1)
 			log.Debugf("Found malformed trace with duplicate span ID (reason:duplicate_span_id): %s", span)
 		}
 		spanIDs[span.SpanID] = struct{}{}

--- a/pkg/trace/agent/normalizer_test.go
+++ b/pkg/trace/agent/normalizer_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/testutil"
 	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/atomic"
 )
 
 func newTestSpan() *pb.Span {
@@ -80,7 +79,7 @@ func TestNormalizeEmptyServiceNoLang(t *testing.T) {
 	s.Service = ""
 	assert.NoError(t, normalize(ts, s))
 	assert.Equal(t, traceutil.DefaultServiceName, s.Service)
-	assert.Equal(t, tsMalformed(&info.SpansMalformed{ServiceEmpty: *atomic.NewInt64(1)}), ts)
+	assert.Equal(t, tsMalformed(&info.SpansMalformed{ServiceEmpty: 1}), ts)
 }
 
 func TestNormalizeEmptyServiceWithLang(t *testing.T) {
@@ -90,7 +89,7 @@ func TestNormalizeEmptyServiceWithLang(t *testing.T) {
 	ts.Lang = "java"
 	assert.NoError(t, normalize(ts, s))
 	assert.Equal(t, s.Service, fmt.Sprintf("unnamed-%s-service", ts.Lang))
-	tsExpected := tsMalformed(&info.SpansMalformed{ServiceEmpty: *atomic.NewInt64(1)})
+	tsExpected := tsMalformed(&info.SpansMalformed{ServiceEmpty: 1})
 	tsExpected.Lang = ts.Lang
 	assert.Equal(t, tsExpected, ts)
 }
@@ -101,7 +100,7 @@ func TestNormalizeLongService(t *testing.T) {
 	s.Service = strings.Repeat("CAMEMBERT", 100)
 	assert.NoError(t, normalize(ts, s))
 	assert.Equal(t, s.Service, s.Service[:traceutil.MaxServiceLen])
-	assert.Equal(t, tsMalformed(&info.SpansMalformed{ServiceTruncate: *atomic.NewInt64(1)}), ts)
+	assert.Equal(t, tsMalformed(&info.SpansMalformed{ServiceTruncate: 1}), ts)
 }
 
 func TestNormalizeNamePassThru(t *testing.T) {
@@ -119,7 +118,7 @@ func TestNormalizeEmptyName(t *testing.T) {
 	s.Name = ""
 	assert.NoError(t, normalize(ts, s))
 	assert.Equal(t, s.Name, traceutil.DefaultSpanName)
-	assert.Equal(t, tsMalformed(&info.SpansMalformed{SpanNameEmpty: *atomic.NewInt64(1)}), ts)
+	assert.Equal(t, tsMalformed(&info.SpansMalformed{SpanNameEmpty: 1}), ts)
 }
 
 func TestNormalizeLongName(t *testing.T) {
@@ -128,7 +127,7 @@ func TestNormalizeLongName(t *testing.T) {
 	s.Name = strings.Repeat("CAMEMBERT", 100)
 	assert.NoError(t, normalize(ts, s))
 	assert.Equal(t, s.Name, s.Name[:traceutil.MaxNameLen])
-	assert.Equal(t, tsMalformed(&info.SpansMalformed{SpanNameTruncate: *atomic.NewInt64(1)}), ts)
+	assert.Equal(t, tsMalformed(&info.SpansMalformed{SpanNameTruncate: 1}), ts)
 }
 
 func TestNormalizeNameNoAlphanumeric(t *testing.T) {
@@ -137,7 +136,7 @@ func TestNormalizeNameNoAlphanumeric(t *testing.T) {
 	s.Name = "/"
 	assert.NoError(t, normalize(ts, s))
 	assert.Equal(t, s.Name, traceutil.DefaultSpanName)
-	assert.Equal(t, tsMalformed(&info.SpansMalformed{SpanNameInvalid: *atomic.NewInt64(1)}), ts)
+	assert.Equal(t, tsMalformed(&info.SpansMalformed{SpanNameInvalid: 1}), ts)
 }
 
 func TestNormalizeNameForMetrics(t *testing.T) {
@@ -171,7 +170,7 @@ func TestNormalizeEmptyResource(t *testing.T) {
 	s.Resource = ""
 	assert.NoError(t, normalize(ts, s))
 	assert.Equal(t, s.Resource, s.Name)
-	assert.Equal(t, tsMalformed(&info.SpansMalformed{ResourceEmpty: *atomic.NewInt64(1)}), ts)
+	assert.Equal(t, tsMalformed(&info.SpansMalformed{ResourceEmpty: 1}), ts)
 }
 
 func TestNormalizeTraceIDPassThru(t *testing.T) {
@@ -188,7 +187,7 @@ func TestNormalizeNoTraceID(t *testing.T) {
 	s := newTestSpan()
 	s.TraceID = 0
 	assert.Error(t, normalize(ts, s))
-	assert.Equal(t, tsDropped(&info.TracesDropped{TraceIDZero: *atomic.NewInt64(1)}), ts)
+	assert.Equal(t, tsDropped(&info.TracesDropped{TraceIDZero: 1}), ts)
 }
 
 func TestNormalizeComponent2Name(t *testing.T) {
@@ -235,7 +234,7 @@ func TestNormalizeNoSpanID(t *testing.T) {
 	s := newTestSpan()
 	s.SpanID = 0
 	assert.Error(t, normalize(ts, s))
-	assert.Equal(t, tsDropped(&info.TracesDropped{SpanIDZero: *atomic.NewInt64(1)}), ts)
+	assert.Equal(t, tsDropped(&info.TracesDropped{SpanIDZero: 1}), ts)
 }
 
 func TestNormalizeStart(t *testing.T) {
@@ -256,7 +255,7 @@ func TestNormalizeStart(t *testing.T) {
 		assert.NoError(t, normalize(ts, s))
 		assert.True(t, s.Start >= minStart)
 		assert.True(t, s.Start <= time.Now().UnixNano()-s.Duration)
-		assert.Equal(t, tsMalformed(&info.SpansMalformed{InvalidStartDate: *atomic.NewInt64(1)}), ts)
+		assert.Equal(t, tsMalformed(&info.SpansMalformed{InvalidStartDate: 1}), ts)
 	})
 
 	t.Run("too-small-with-large-duration", func(t *testing.T) {
@@ -266,7 +265,7 @@ func TestNormalizeStart(t *testing.T) {
 		s.Duration = time.Now().UnixNano() * 2
 		minStart := time.Now().UnixNano()
 		assert.NoError(t, normalize(ts, s))
-		assert.Equal(t, tsMalformed(&info.SpansMalformed{InvalidStartDate: *atomic.NewInt64(1)}), ts)
+		assert.Equal(t, tsMalformed(&info.SpansMalformed{InvalidStartDate: 1}), ts)
 		assert.True(t, s.Start >= minStart, "start should have been reset to current time")
 		assert.True(t, s.Start <= time.Now().UnixNano(), "start should have been reset to current time")
 	})
@@ -296,7 +295,7 @@ func TestNormalizeNegativeDuration(t *testing.T) {
 	s.Duration = -50
 	assert.NoError(t, normalize(ts, s))
 	assert.EqualValues(t, s.Duration, 0)
-	assert.Equal(t, tsMalformed(&info.SpansMalformed{InvalidDuration: *atomic.NewInt64(1)}), ts)
+	assert.Equal(t, tsMalformed(&info.SpansMalformed{InvalidDuration: 1}), ts)
 }
 
 func TestNormalizeLargeDuration(t *testing.T) {
@@ -305,7 +304,7 @@ func TestNormalizeLargeDuration(t *testing.T) {
 	s.Duration = int64(math.MaxInt64)
 	assert.NoError(t, normalize(ts, s))
 	assert.EqualValues(t, s.Duration, 0)
-	assert.Equal(t, tsMalformed(&info.SpansMalformed{InvalidDuration: *atomic.NewInt64(1)}), ts)
+	assert.Equal(t, tsMalformed(&info.SpansMalformed{InvalidDuration: 1}), ts)
 }
 
 func TestNormalizeErrorPassThru(t *testing.T) {
@@ -358,7 +357,7 @@ func TestNormalizeTypeTooLong(t *testing.T) {
 	s := newTestSpan()
 	s.Type = strings.Repeat("sql", 1000)
 	assert.NoError(t, normalize(ts, s))
-	assert.Equal(t, tsMalformed(&info.SpansMalformed{TypeTruncate: *atomic.NewInt64(1)}), ts)
+	assert.Equal(t, tsMalformed(&info.SpansMalformed{TypeTruncate: 1}), ts)
 }
 
 func TestNormalizeServiceTag(t *testing.T) {
@@ -398,7 +397,7 @@ func TestNormalizeTraceEmpty(t *testing.T) {
 	ts, trace := newTagStats(), pb.Trace{}
 	err := normalizeTrace(ts, trace)
 	assert.Error(t, err)
-	assert.Equal(t, tsDropped(&info.TracesDropped{EmptyTrace: *atomic.NewInt64(1)}), ts)
+	assert.Equal(t, tsDropped(&info.TracesDropped{EmptyTrace: 1}), ts)
 }
 
 func TestNormalizeTraceTraceIdMismatch(t *testing.T) {
@@ -410,7 +409,7 @@ func TestNormalizeTraceTraceIdMismatch(t *testing.T) {
 	trace := pb.Trace{span1, span2}
 	err := normalizeTrace(ts, trace)
 	assert.Error(t, err)
-	assert.Equal(t, tsDropped(&info.TracesDropped{ForeignSpan: *atomic.NewInt64(1)}), ts)
+	assert.Equal(t, tsDropped(&info.TracesDropped{ForeignSpan: 1}), ts)
 }
 
 func TestNormalizeTraceInvalidSpan(t *testing.T) {
@@ -421,7 +420,7 @@ func TestNormalizeTraceInvalidSpan(t *testing.T) {
 	trace := pb.Trace{span1, span2}
 	err := normalizeTrace(ts, trace)
 	assert.NoError(t, err)
-	assert.Equal(t, tsMalformed(&info.SpansMalformed{SpanNameEmpty: *atomic.NewInt64(1)}), ts)
+	assert.Equal(t, tsMalformed(&info.SpansMalformed{SpanNameEmpty: 1}), ts)
 }
 
 func TestNormalizeTraceDuplicateSpanID(t *testing.T) {
@@ -432,7 +431,7 @@ func TestNormalizeTraceDuplicateSpanID(t *testing.T) {
 	trace := pb.Trace{span1, span2}
 	err := normalizeTrace(ts, trace)
 	assert.NoError(t, err)
-	assert.Equal(t, tsMalformed(&info.SpansMalformed{DuplicateSpanID: *atomic.NewInt64(1)}), ts)
+	assert.Equal(t, tsMalformed(&info.SpansMalformed{DuplicateSpanID: 1}), ts)
 }
 
 func TestNormalizeTrace(t *testing.T) {

--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -408,7 +408,7 @@ func TestReceiverDecodingError(t *testing.T) {
 		resp, err := client.Do(req)
 		assert.NoError(err)
 		assert.Equal(400, resp.StatusCode)
-		assert.EqualValues(0, r.Stats.GetTagStats(info.Tags{EndpointVersion: "v0.4"}).TracesDropped.DecodingError.Load())
+		assert.EqualValues(0, r.Stats.GetTagStats(info.Tags{EndpointVersion: "v0.4"}).TracesDropped.DecodingError)
 	})
 
 	t.Run("with-header", func(t *testing.T) {
@@ -421,7 +421,7 @@ func TestReceiverDecodingError(t *testing.T) {
 		resp, err := client.Do(req)
 		assert.NoError(err)
 		assert.Equal(400, resp.StatusCode)
-		assert.EqualValues(traceCount, r.Stats.GetTagStats(info.Tags{EndpointVersion: "v0.4"}).TracesDropped.DecodingError.Load())
+		assert.EqualValues(traceCount, r.Stats.GetTagStats(info.Tags{EndpointVersion: "v0.4"}).TracesDropped.DecodingError)
 	})
 }
 
@@ -451,7 +451,7 @@ func TestReceiverUnexpectedEOF(t *testing.T) {
 	assert.NoError(err)
 
 	assert.Equal(400, resp.StatusCode)
-	assert.EqualValues(traceCount, r.Stats.GetTagStats(info.Tags{EndpointVersion: "v0.5"}).TracesDropped.EOF.Load())
+	assert.EqualValues(traceCount, r.Stats.GetTagStats(info.Tags{EndpointVersion: "v0.5"}).TracesDropped.EOF)
 }
 
 func TestTraceCount(t *testing.T) {
@@ -751,8 +751,8 @@ func TestHandleTraces(t *testing.T) {
 	for _, lang := range langs {
 		ts, ok := rs.Stats[info.Tags{Lang: lang, EndpointVersion: "v0.4"}]
 		assert.True(ok)
-		assert.Equal(int64(20), ts.TracesReceived.Load())
-		assert.Equal(int64(61822), ts.TracesBytes.Load())
+		assert.Equal(int64(20), ts.TracesReceived)
+		assert.Equal(int64(61822), ts.TracesBytes)
 	}
 	// make sure we have all our languages registered
 	assert.Equal("C#|go|java|python|ruby", receiver.Languages())

--- a/pkg/trace/api/listener.go
+++ b/pkg/trace/api/listener.go
@@ -8,22 +8,22 @@ package api
 import (
 	"errors"
 	"net"
+	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/log"
 	"github.com/DataDog/datadog-agent/pkg/trace/metrics"
-	"go.uber.org/atomic"
 )
 
 // measuredListener wraps an existing net.Listener and emits metrics upon accepting connections.
 type measuredListener struct {
 	net.Listener
 
-	name     string         // metric name to emit
-	accepted *atomic.Uint32 // accepted connection count
-	timedout *atomic.Uint32 // timedout connection count
-	errored  *atomic.Uint32 // errored connection count
-	exit     chan struct{}  // exit signal channel (on Close call)
+	name     string        // metric name to emit
+	accepted uint32        // accepted connection count
+	timedout uint32        // timedout connection count
+	errored  uint32        // errored connection count
+	exit     chan struct{} // exit signal channel (on Close call)
 }
 
 // NewMeasuredListener wraps ln and emits metrics every 10 seconds. The metric name is
@@ -33,9 +33,6 @@ func NewMeasuredListener(ln net.Listener, name string) net.Listener {
 	ml := &measuredListener{
 		Listener: ln,
 		name:     "datadog.trace_agent.receiver." + name,
-		accepted: atomic.NewUint32(0),
-		timedout: atomic.NewUint32(0),
-		errored:  atomic.NewUint32(0),
 		exit:     make(chan struct{}),
 	}
 	go ml.run()
@@ -57,12 +54,12 @@ func (ln *measuredListener) run() {
 }
 
 func (ln *measuredListener) flushMetrics() {
-	for tag, stat := range map[string]*atomic.Uint32{
-		"status:accepted": ln.accepted,
-		"status:timedout": ln.timedout,
-		"status:errored":  ln.errored,
+	for tag, stat := range map[string]*uint32{
+		"status:accepted": &ln.accepted,
+		"status:timedout": &ln.timedout,
+		"status:errored":  &ln.errored,
 	} {
-		if v := int64(stat.Swap(0)); v > 0 {
+		if v := int64(atomic.SwapUint32(stat, 0)); v > 0 {
 			metrics.Count(ln.name, v, []string{tag}, 1)
 		}
 	}
@@ -73,12 +70,12 @@ func (ln *measuredListener) Accept() (net.Conn, error) {
 	conn, err := ln.Listener.Accept()
 	if err != nil {
 		if ne, ok := err.(net.Error); ok && ne.Timeout() && !ne.Temporary() {
-			ln.timedout.Inc()
+			atomic.AddUint32(&ln.timedout, 1)
 		} else {
-			ln.errored.Inc()
+			atomic.AddUint32(&ln.errored, 1)
 		}
 	} else {
-		ln.accepted.Inc()
+		atomic.AddUint32(&ln.accepted, 1)
 	}
 	log.Tracef("Accepted connection named %q.", ln.name)
 	return conn, err
@@ -100,15 +97,15 @@ func (ln measuredListener) Addr() net.Addr { return ln.Listener.Addr() }
 type rateLimitedListener struct {
 	*net.TCPListener
 
-	lease  *atomic.Int32  // connections allowed until refresh
-	exit   chan struct{}  // exit notification channel
-	closed *atomic.Uint32 // closed will be non-zero if the listener was closed
+	lease  int32         // connections allowed until refresh
+	exit   chan struct{} // exit notification channel
+	closed uint32        // closed will be non-zero if the listener was closed
 
 	// stats
-	accepted *atomic.Uint32
-	rejected *atomic.Uint32
-	timedout *atomic.Uint32
-	errored  *atomic.Uint32
+	accepted uint32
+	rejected uint32
+	timedout uint32
+	errored  uint32
 }
 
 // newRateLimitedListener returns a new wrapped listener, which is non-initialized
@@ -120,14 +117,9 @@ func newRateLimitedListener(l net.Listener, conns int) (*rateLimitedListener, er
 	}
 
 	return &rateLimitedListener{
-		lease:       atomic.NewInt32(int32(conns)),
+		lease:       int32(conns),
 		TCPListener: tcpL,
 		exit:        make(chan struct{}),
-		closed:      atomic.NewUint32(0),
-		accepted:    atomic.NewUint32(0),
-		rejected:    atomic.NewUint32(0),
-		timedout:    atomic.NewUint32(0),
-		errored:     atomic.NewUint32(0),
 	}, nil
 }
 
@@ -145,17 +137,17 @@ func (sl *rateLimitedListener) Refresh(conns int) {
 		case <-sl.exit:
 			return
 		case <-tickStats.C:
-			for tag, stat := range map[string]*atomic.Uint32{
-				"status:accepted": sl.accepted,
-				"status:rejected": sl.rejected,
-				"status:timedout": sl.timedout,
-				"status:errored":  sl.errored,
+			for tag, stat := range map[string]*uint32{
+				"status:accepted": &sl.accepted,
+				"status:rejected": &sl.rejected,
+				"status:timedout": &sl.timedout,
+				"status:errored":  &sl.errored,
 			} {
-				v := int64(stat.Swap(0))
+				v := int64(atomic.SwapUint32(stat, 0))
 				metrics.Count("datadog.trace_agent.receiver.tcp_connections", v, []string{tag}, 1)
 			}
 		case <-t.C:
-			sl.lease.Store(int32(conns))
+			atomic.StoreInt32(&sl.lease, int32(conns))
 			log.Debugf("Refreshed the connection lease: %d conns available", conns)
 		}
 	}
@@ -176,9 +168,9 @@ func (e *rateLimitedError) Timeout() bool { return false }
 
 // Accept reimplements the regular Accept but adds rate limiting.
 func (sl *rateLimitedListener) Accept() (net.Conn, error) {
-	if sl.lease.Load() <= 0 {
+	if atomic.LoadInt32(&sl.lease) <= 0 {
 		// we've reached our cap for this lease period; reject the request
-		sl.rejected.Inc()
+		atomic.AddUint32(&sl.rejected, 1)
 		return nil, &rateLimitedError{}
 	}
 	for {
@@ -195,16 +187,16 @@ func (sl *rateLimitedListener) Accept() (net.Conn, error) {
 				} else {
 					// don't count temporary errors; they usually signify expired deadlines
 					// see (golang/go/src/internal/poll/fd.go).TimeoutError
-					sl.timedout.Inc()
+					atomic.AddUint32(&sl.timedout, 1)
 				}
 			} else {
-				sl.errored.Inc()
+				atomic.AddUint32(&sl.errored, 1)
 			}
 			return conn, err
 		}
 
-		sl.lease.Dec()
-		sl.accepted.Inc()
+		atomic.AddInt32(&sl.lease, -1)
+		atomic.AddUint32(&sl.accepted, 1)
 
 		return conn, nil
 	}
@@ -212,7 +204,7 @@ func (sl *rateLimitedListener) Accept() (net.Conn, error) {
 
 // Close wraps the Close method of the underlying tcp listener
 func (sl *rateLimitedListener) Close() error {
-	if !sl.closed.CAS(0, 1) {
+	if !atomic.CompareAndSwapUint32(&sl.closed, 0, 1) {
 		// already closed; avoid multiple calls if we're on go1.10
 		// https://golang.org/issue/24803
 		return nil

--- a/pkg/trace/api/responses.go
+++ b/pkg/trace/api/responses.go
@@ -11,13 +11,13 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"sync/atomic"
 
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state/products/apmsampling"
 	"github.com/DataDog/datadog-agent/pkg/trace/api/apiutil"
 	"github.com/DataDog/datadog-agent/pkg/trace/log"
 	"github.com/DataDog/datadog-agent/pkg/trace/metrics"
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
-	"go.uber.org/atomic"
 )
 
 const (
@@ -75,22 +75,19 @@ func httpOK(w http.ResponseWriter) (n uint64, ok bool) {
 
 type writeCounter struct {
 	w io.Writer
-	n *atomic.Uint64
+	n uint64
 }
 
 func newWriteCounter(w io.Writer) *writeCounter {
-	return &writeCounter{
-		w: w,
-		n: atomic.NewUint64(0),
-	}
+	return &writeCounter{w: w}
 }
 
 func (wc *writeCounter) Write(p []byte) (n int, err error) {
-	wc.n.Add(uint64(len(p)))
+	atomic.AddUint64(&wc.n, uint64(len(p)))
 	return wc.w.Write(p)
 }
 
-func (wc *writeCounter) N() uint64 { return wc.n.Load() }
+func (wc *writeCounter) N() uint64 { return atomic.LoadUint64(&wc.n) }
 
 // httpRateByService outputs, as a JSON, the recommended sampling rates for all services.
 // It returns the number of bytes written and a boolean specifying whether the write was

--- a/pkg/trace/atomic/float.go
+++ b/pkg/trace/atomic/float.go
@@ -1,0 +1,59 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package atomic
+
+import (
+	"math"
+	"sync/atomic"
+)
+
+// The atomic float64 is copied from: https://github.com/uber-go/atomic/blob/master/atomic.go#L267
+
+// Float64 is an atomic wrapper around float64.
+type Float64 struct {
+	v uint64
+}
+
+// NewFloat creates a Float64.
+func NewFloat(f float64) *Float64 {
+	return &Float64{math.Float64bits(f)}
+}
+
+// Load atomically loads the wrapped value.
+func (f *Float64) Load() float64 {
+	return math.Float64frombits(atomic.LoadUint64(&f.v))
+}
+
+// Store atomically stores the passed value.
+func (f *Float64) Store(s float64) {
+	atomic.StoreUint64(&f.v, math.Float64bits(s))
+}
+
+// Swap atomically swaps the passed value and returns the old one.
+func (f *Float64) Swap(s float64) (old float64) {
+	return math.Float64frombits(atomic.SwapUint64(&f.v, math.Float64bits(s)))
+}
+
+// Add atomically adds to the wrapped float64 and returns the new value.
+func (f *Float64) Add(s float64) float64 {
+	for {
+		old := f.Load()
+		new := old + s
+		if f.CAS(old, new) {
+			return new
+		}
+	}
+}
+
+// Sub atomically subtracts from the wrapped float64 and returns the new value.
+func (f *Float64) Sub(s float64) float64 {
+	return f.Add(-s)
+}
+
+// CAS is an atomic compare-and-swap.
+func (f *Float64) CAS(old, new float64) bool {
+	return atomic.CompareAndSwapUint64(&f.v, math.Float64bits(old), math.Float64bits(new))
+}

--- a/pkg/trace/atomic/float_test.go
+++ b/pkg/trace/atomic/float_test.go
@@ -1,0 +1,28 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package atomic
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFloat64(t *testing.T) {
+	f := NewFloat(1.0)
+	assert := assert.New(t)
+	assert.Equal(f.Load(), 1.0)
+	f.Store(2.0)
+	assert.Equal(f.Load(), 2.0)
+	assert.Equal(f.Swap(3.0), 2.0)
+	assert.Equal(f.Load(), 3.0)
+	assert.Equal(f.Add(1.0), 4.0)
+	assert.Equal(f.Load(), 4.0)
+	assert.Equal(f.Add(1.0), 5.0)
+	assert.Equal(f.Load(), 5.0)
+	assert.Equal(f.Sub(3.0), 2.0)
+	assert.Equal(f.Load(), 2.0)
+}

--- a/pkg/trace/go.mod
+++ b/pkg/trace/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/vmihailenco/msgpack/v4 v4.3.12
 	go.opentelemetry.io/collector/pdata v0.54.0
 	go.opentelemetry.io/collector/semconv v0.54.0
-	go.uber.org/atomic v1.9.0
 	golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba
 	google.golang.org/grpc v1.47.0
@@ -46,6 +45,7 @@ require (
 	github.com/tklauser/numcpus v0.4.0 // indirect
 	github.com/vmihailenco/tagparser v0.1.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
+	go.uber.org/atomic v1.9.0 // indirect
 	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/appengine v1.6.5 // indirect

--- a/pkg/trace/info/info.go
+++ b/pkg/trace/info/info.go
@@ -80,10 +80,10 @@ const (
 
   --- Writer stats (1 min) ---
 
-  Traces: {{.Status.TraceWriter.Payloads}} payloads, {{.Status.TraceWriter.Traces}} traces, {{if gt .Status.TraceWriter.Events.Load 0}}{{.Status.TraceWriter.Events.Load}} events, {{end}}{{.Status.TraceWriter.Bytes}} bytes
-  {{if gt .Status.TraceWriter.Errors.Load 0}}WARNING: Traces API errors (1 min): {{.Status.TraceWriter.Errors.Load}}{{end}}
-  Stats: {{.Status.StatsWriter.Payloads.Load}} payloads, {{.Status.StatsWriter.StatsBuckets.Load}} stats buckets, {{.Status.StatsWriter.Bytes.Load}} bytes
-  {{if gt .Status.StatsWriter.Errors.Load 0}}WARNING: Stats API errors (1 min): {{.Status.StatsWriter.Errors.Load}}{{end}}
+  Traces: {{.Status.TraceWriter.Payloads}} payloads, {{.Status.TraceWriter.Traces}} traces, {{if gt .Status.TraceWriter.Events 0}}{{.Status.TraceWriter.Events}} events, {{end}}{{.Status.TraceWriter.Bytes}} bytes
+  {{if gt .Status.TraceWriter.Errors 0}}WARNING: Traces API errors (1 min): {{.Status.TraceWriter.Errors}}{{end}}
+  Stats: {{.Status.StatsWriter.Payloads}} payloads, {{.Status.StatsWriter.StatsBuckets}} stats buckets, {{.Status.StatsWriter.Bytes}} bytes
+  {{if gt .Status.StatsWriter.Errors 0}}WARNING: Stats API errors (1 min): {{.Status.StatsWriter.Errors}}{{end}}
 `
 
 	notRunningTmplSrc = `{{.Banner}}

--- a/pkg/trace/info/info_test.go
+++ b/pkg/trace/info/info_test.go
@@ -294,12 +294,8 @@ func TestInfoReceiverStats(t *testing.T) {
 	stats := NewReceiverStats()
 	t1 := &TagStats{
 		Tags{Lang: "python"},
-		Stats{},
+		Stats{TracesReceived: 23, TracesBytes: 3244, SpansReceived: 213, SpansDropped: 14},
 	}
-	t1.Stats.TracesReceived.Store(23)
-	t1.Stats.TracesBytes.Store(3244)
-	t1.Stats.SpansReceived.Store(213)
-	t1.Stats.SpansDropped.Store(14)
 	t2 := &TagStats{
 		Tags{Lang: "go"},
 		Stats{},
@@ -339,7 +335,7 @@ func TestInfoReceiverStats(t *testing.T) {
 	default:
 		t.Errorf("bad stats type: %v", s)
 	}
-	stats.Stats[t1.Tags].TracesReceived.Inc()
+	stats.Stats[t1.Tags].TracesReceived++
 	UpdateReceiverStats(stats)
 	s = publishReceiverStats()
 	switch s := s.(type) {

--- a/pkg/trace/info/stats.go
+++ b/pkg/trace/info/stats.go
@@ -11,9 +11,9 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
-	"go.uber.org/atomic"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/log"
 	"github.com/DataDog/datadog-agent/pkg/trace/metrics"
@@ -134,19 +134,19 @@ func (ts *TagStats) AsTags() []string {
 
 func (ts *TagStats) publish() {
 	// Atomically load the stats from ts
-	tracesReceived := ts.TracesReceived.Load()
-	tracesFiltered := ts.TracesFiltered.Load()
-	tracesPriorityNone := ts.TracesPriorityNone.Load()
-	clientDroppedP0Spans := ts.ClientDroppedP0Spans.Load()
-	clientDroppedP0Traces := ts.ClientDroppedP0Traces.Load()
-	tracesBytes := ts.TracesBytes.Load()
-	spansReceived := ts.SpansReceived.Load()
-	spansDropped := ts.SpansDropped.Load()
-	spansFiltered := ts.SpansFiltered.Load()
-	eventsExtracted := ts.EventsExtracted.Load()
-	eventsSampled := ts.EventsSampled.Load()
-	requestsMade := ts.PayloadAccepted.Load()
-	requestsRejected := ts.PayloadRefused.Load()
+	tracesReceived := atomic.LoadInt64(&ts.TracesReceived)
+	tracesFiltered := atomic.LoadInt64(&ts.TracesFiltered)
+	tracesPriorityNone := atomic.LoadInt64(&ts.TracesPriorityNone)
+	clientDroppedP0Spans := atomic.LoadInt64(&ts.ClientDroppedP0Spans)
+	clientDroppedP0Traces := atomic.LoadInt64(&ts.ClientDroppedP0Traces)
+	tracesBytes := atomic.LoadInt64(&ts.TracesBytes)
+	spansReceived := atomic.LoadInt64(&ts.SpansReceived)
+	spansDropped := atomic.LoadInt64(&ts.SpansDropped)
+	spansFiltered := atomic.LoadInt64(&ts.SpansFiltered)
+	eventsExtracted := atomic.LoadInt64(&ts.EventsExtracted)
+	eventsSampled := atomic.LoadInt64(&ts.EventsSampled)
+	requestsMade := atomic.LoadInt64(&ts.PayloadAccepted)
+	requestsRejected := atomic.LoadInt64(&ts.PayloadRefused)
 
 	// Publish the stats
 	tags := ts.Tags.toArray()
@@ -198,40 +198,37 @@ func mapToString(m map[string]int64) string {
 
 // TracesDropped contains counts for reasons traces have been dropped
 type TracesDropped struct {
-	// all atomic values are included as values in this struct, to simplify umarshaling and
-	// initialization of the type.  The atomic values _must_ occur first in the struct.
-
 	// DecodingError is when the agent fails to decode a trace payload
-	DecodingError atomic.Int64
+	DecodingError int64
 	// PayloadTooLarge specifies the number of traces dropped due to the payload
 	// being too large to be accepted.
-	PayloadTooLarge atomic.Int64
+	PayloadTooLarge int64
 	// EmptyTrace is when the trace contains no spans
-	EmptyTrace atomic.Int64
+	EmptyTrace int64
 	// TraceIDZero is when any spans in a trace have TraceId=0
-	TraceIDZero atomic.Int64
+	TraceIDZero int64
 	// SpanIDZero is when any span has SpanId=0
-	SpanIDZero atomic.Int64
+	SpanIDZero int64
 	// ForeignSpan is when a span in a trace has a TraceId that is different than the first span in the trace
-	ForeignSpan atomic.Int64
+	ForeignSpan int64
 	// Timeout is when a request times out.
-	Timeout atomic.Int64
+	Timeout int64
 	// EOF is when an unexpected EOF is encountered, this can happen because the client has aborted
 	// or because a bad payload (i.e. shorter than claimed in Content-Length) was sent.
-	EOF atomic.Int64
+	EOF int64
 }
 
 // tagValues converts TracesDropped into a map representation with keys matching standardized names for all reasons
 func (s *TracesDropped) tagValues() map[string]int64 {
 	return map[string]int64{
-		"payload_too_large": s.PayloadTooLarge.Load(),
-		"decoding_error":    s.DecodingError.Load(),
-		"empty_trace":       s.EmptyTrace.Load(),
-		"trace_id_zero":     s.TraceIDZero.Load(),
-		"span_id_zero":      s.SpanIDZero.Load(),
-		"foreign_span":      s.ForeignSpan.Load(),
-		"timeout":           s.Timeout.Load(),
-		"unexpected_eof":    s.EOF.Load(),
+		"payload_too_large": atomic.LoadInt64(&s.PayloadTooLarge),
+		"decoding_error":    atomic.LoadInt64(&s.DecodingError),
+		"empty_trace":       atomic.LoadInt64(&s.EmptyTrace),
+		"trace_id_zero":     atomic.LoadInt64(&s.TraceIDZero),
+		"span_id_zero":      atomic.LoadInt64(&s.SpanIDZero),
+		"foreign_span":      atomic.LoadInt64(&s.ForeignSpan),
+		"timeout":           atomic.LoadInt64(&s.Timeout),
+		"unexpected_eof":    atomic.LoadInt64(&s.EOF),
 	}
 }
 
@@ -241,50 +238,47 @@ func (s *TracesDropped) String() string {
 
 // SpansMalformed contains counts for reasons malformed spans have been accepted after applying automatic fixes
 type SpansMalformed struct {
-	// all atomic values are included as values in this struct, to simplify umarshaling and
-	// initialization of the type.  The atomic values _must_ occur first in the struct.
-
 	// DuplicateSpanID is when one or more spans in a trace have the same SpanId
-	DuplicateSpanID atomic.Int64
+	DuplicateSpanID int64
 	// ServiceEmpty is when a span has an empty Service field
-	ServiceEmpty atomic.Int64
+	ServiceEmpty int64
 	// ServiceTruncate is when a span's Service is truncated for exceeding the max length
-	ServiceTruncate atomic.Int64
+	ServiceTruncate int64
 	// ServiceInvalid is when a span's Service doesn't conform to Datadog tag naming standards
-	ServiceInvalid atomic.Int64
+	ServiceInvalid int64
 	// SpanNameEmpty is when a span's Name is empty
-	SpanNameEmpty atomic.Int64
+	SpanNameEmpty int64
 	// SpanNameTruncate is when a span's Name is truncated for exceeding the max length
-	SpanNameTruncate atomic.Int64
+	SpanNameTruncate int64
 	// SpanNameInvalid is when a span's Name doesn't conform to Datadog tag naming standards
-	SpanNameInvalid atomic.Int64
+	SpanNameInvalid int64
 	// ResourceEmpty is when a span's Resource is empty
-	ResourceEmpty atomic.Int64
+	ResourceEmpty int64
 	// TypeTruncate is when a span's Type is truncated for exceeding the max length
-	TypeTruncate atomic.Int64
+	TypeTruncate int64
 	// InvalidStartDate is when a span's Start date is invalid
-	InvalidStartDate atomic.Int64
+	InvalidStartDate int64
 	// InvalidDuration is when a span's Duration is invalid
-	InvalidDuration atomic.Int64
+	InvalidDuration int64
 	// InvalidHTTPStatusCode is when a span's metadata contains an invalid http status code
-	InvalidHTTPStatusCode atomic.Int64
+	InvalidHTTPStatusCode int64
 }
 
 // tagValues converts SpansMalformed into a map representation with keys matching standardized names for all reasons
 func (s *SpansMalformed) tagValues() map[string]int64 {
 	return map[string]int64{
-		"duplicate_span_id":        s.DuplicateSpanID.Load(),
-		"service_empty":            s.ServiceEmpty.Load(),
-		"service_truncate":         s.ServiceTruncate.Load(),
-		"service_invalid":          s.ServiceInvalid.Load(),
-		"span_name_empty":          s.SpanNameEmpty.Load(),
-		"span_name_truncate":       s.SpanNameTruncate.Load(),
-		"span_name_invalid":        s.SpanNameInvalid.Load(),
-		"resource_empty":           s.ResourceEmpty.Load(),
-		"type_truncate":            s.TypeTruncate.Load(),
-		"invalid_start_date":       s.InvalidStartDate.Load(),
-		"invalid_duration":         s.InvalidDuration.Load(),
-		"invalid_http_status_code": s.InvalidHTTPStatusCode.Load(),
+		"duplicate_span_id":        atomic.LoadInt64(&s.DuplicateSpanID),
+		"service_empty":            atomic.LoadInt64(&s.ServiceEmpty),
+		"service_truncate":         atomic.LoadInt64(&s.ServiceTruncate),
+		"service_invalid":          atomic.LoadInt64(&s.ServiceInvalid),
+		"span_name_empty":          atomic.LoadInt64(&s.SpanNameEmpty),
+		"span_name_truncate":       atomic.LoadInt64(&s.SpanNameTruncate),
+		"span_name_invalid":        atomic.LoadInt64(&s.SpanNameInvalid),
+		"resource_empty":           atomic.LoadInt64(&s.ResourceEmpty),
+		"type_truncate":            atomic.LoadInt64(&s.TypeTruncate),
+		"invalid_start_date":       atomic.LoadInt64(&s.InvalidStartDate),
+		"invalid_duration":         atomic.LoadInt64(&s.InvalidDuration),
+		"invalid_http_status_code": atomic.LoadInt64(&s.InvalidHTTPStatusCode),
 	}
 }
 
@@ -300,27 +294,27 @@ const maxAbsPriority = 10
 type samplingPriorityStats struct {
 	// counts holds counters for each priority in position maxAbsPriorityValue + priority.
 	// Priority values are expected to be in the range [-10, 10].
-	counts [maxAbsPriority*2 + 1]atomic.Int64
+	counts [maxAbsPriority*2 + 1]int64
 }
 
 // CountSamplingPriority increments the counter of observed traces with the given sampling priority by 1
 func (s *samplingPriorityStats) CountSamplingPriority(p sampler.SamplingPriority) {
 	if p >= (-1*maxAbsPriority) && p <= maxAbsPriority {
-		s.counts[maxAbsPriority+p].Inc()
+		atomic.AddInt64(&s.counts[maxAbsPriority+p], 1)
 	}
 }
 
 // reset sets stats to 0
 func (s *samplingPriorityStats) reset() {
 	for i := range s.counts {
-		s.counts[i].Store(0)
+		atomic.StoreInt64(&s.counts[i], 0)
 	}
 }
 
 // update absorbs recent stats on top of existing ones.
 func (s *samplingPriorityStats) update(recent *samplingPriorityStats) {
 	for i := range s.counts {
-		s.counts[i].Add(recent.counts[i].Load())
+		atomic.AddInt64(&s.counts[i], atomic.LoadInt64(&recent.counts[i]))
 	}
 }
 
@@ -328,7 +322,7 @@ func (s *samplingPriorityStats) update(recent *samplingPriorityStats) {
 func (s *samplingPriorityStats) TagValues() map[string]int64 {
 	stats := make(map[string]int64)
 	for i := range s.counts {
-		count := s.counts[i].Load()
+		count := atomic.LoadInt64(&s.counts[i])
 		if count > 0 {
 			stats[strconv.Itoa(i-maxAbsPriority)] = count
 		}
@@ -341,41 +335,38 @@ func (s *samplingPriorityStats) TagValues() map[string]int64 {
 //
 // Use NewStats to initialise.
 type Stats struct {
-	// all atomic values are included as values in this struct, to simplify umarshaling and
-	// initialization of the type.  The atomic values _must_ occur first in the struct.
-
 	// TracesReceived is the total number of traces received, including the dropped ones.
-	TracesReceived atomic.Int64
-	// TracesFiltered is the number of traces filtered.
-	TracesFiltered atomic.Int64
-	// TracesPriorityNone is the number of traces with no sampling priority.
-	TracesPriorityNone atomic.Int64
-	// TracesPerPriority holds counters for each priority in position MaxAbsPriorityValue + priority.
-	TracesPerSamplingPriority samplingPriorityStats
-	// ClientDroppedP0Traces number of P0 traces dropped by client.
-	ClientDroppedP0Traces atomic.Int64
-	// ClientDroppedP0Spans number of P0 spans dropped by client.
-	ClientDroppedP0Spans atomic.Int64
-	// TracesBytes is the amount of data received on the traces endpoint (raw data, encoded, compressed).
-	TracesBytes atomic.Int64
-	// SpansReceived is the total number of spans received, including the dropped ones.
-	SpansReceived atomic.Int64
-	// SpansDropped is the number of spans dropped.
-	SpansDropped atomic.Int64
-	// SpansFiltered is the number of spans filtered.
-	SpansFiltered atomic.Int64
-	// EventsExtracted is the total number of APM events extracted from traces.
-	EventsExtracted atomic.Int64
-	// EventsSampled is the total number of APM events sampled.
-	EventsSampled atomic.Int64
-	// PayloadAccepted counts the number of payloads that have been accepted by the HTTP handler.
-	PayloadAccepted atomic.Int64
-	// PayloadRefused counts the number of payloads that have been rejected by the rate limiter.
-	PayloadRefused atomic.Int64
+	TracesReceived int64
 	// TracesDropped contains stats about the count of dropped traces by reason
 	TracesDropped *TracesDropped
 	// SpansMalformed contains stats about the count of malformed traces by reason
 	SpansMalformed *SpansMalformed
+	// TracesFiltered is the number of traces filtered.
+	TracesFiltered int64
+	// TracesPriorityNone is the number of traces with no sampling priority.
+	TracesPriorityNone int64
+	// TracesPerPriority holds counters for each priority in position MaxAbsPriorityValue + priority.
+	TracesPerSamplingPriority samplingPriorityStats
+	// ClientDroppedP0Traces number of P0 traces dropped by client.
+	ClientDroppedP0Traces int64
+	// ClientDroppedP0Spans number of P0 spans dropped by client.
+	ClientDroppedP0Spans int64
+	// TracesBytes is the amount of data received on the traces endpoint (raw data, encoded, compressed).
+	TracesBytes int64
+	// SpansReceived is the total number of spans received, including the dropped ones.
+	SpansReceived int64
+	// SpansDropped is the number of spans dropped.
+	SpansDropped int64
+	// SpansFiltered is the number of spans filtered.
+	SpansFiltered int64
+	// EventsExtracted is the total number of APM events extracted from traces.
+	EventsExtracted int64
+	// EventsSampled is the total number of APM events sampled.
+	EventsSampled int64
+	// PayloadAccepted counts the number of payloads that have been accepted by the HTTP handler.
+	PayloadAccepted int64
+	// PayloadRefused counts the number of payloads that have been rejected by the rate limiter.
+	PayloadRefused int64
 }
 
 // NewStats returns new, ready to use stats.
@@ -387,81 +378,81 @@ func NewStats() Stats {
 }
 
 func (s *Stats) update(recent *Stats) {
-	s.TracesReceived.Add(recent.TracesReceived.Load())
-	s.TracesDropped.DecodingError.Add(recent.TracesDropped.DecodingError.Load())
-	s.TracesDropped.EmptyTrace.Add(recent.TracesDropped.EmptyTrace.Load())
-	s.TracesDropped.TraceIDZero.Add(recent.TracesDropped.TraceIDZero.Load())
-	s.TracesDropped.SpanIDZero.Add(recent.TracesDropped.SpanIDZero.Load())
-	s.TracesDropped.ForeignSpan.Add(recent.TracesDropped.ForeignSpan.Load())
-	s.TracesDropped.PayloadTooLarge.Add(recent.TracesDropped.PayloadTooLarge.Load())
-	s.TracesDropped.Timeout.Add(recent.TracesDropped.Timeout.Load())
-	s.TracesDropped.EOF.Add(recent.TracesDropped.EOF.Load())
-	s.SpansMalformed.DuplicateSpanID.Add(recent.SpansMalformed.DuplicateSpanID.Load())
-	s.SpansMalformed.ServiceEmpty.Add(recent.SpansMalformed.ServiceEmpty.Load())
-	s.SpansMalformed.ServiceTruncate.Add(recent.SpansMalformed.ServiceTruncate.Load())
-	s.SpansMalformed.ServiceInvalid.Add(recent.SpansMalformed.ServiceInvalid.Load())
-	s.SpansMalformed.SpanNameEmpty.Add(recent.SpansMalformed.SpanNameEmpty.Load())
-	s.SpansMalformed.SpanNameTruncate.Add(recent.SpansMalformed.SpanNameTruncate.Load())
-	s.SpansMalformed.SpanNameInvalid.Add(recent.SpansMalformed.SpanNameInvalid.Load())
-	s.SpansMalformed.ResourceEmpty.Add(recent.SpansMalformed.ResourceEmpty.Load())
-	s.SpansMalformed.TypeTruncate.Add(recent.SpansMalformed.TypeTruncate.Load())
-	s.SpansMalformed.InvalidStartDate.Add(recent.SpansMalformed.InvalidStartDate.Load())
-	s.SpansMalformed.InvalidDuration.Add(recent.SpansMalformed.InvalidDuration.Load())
-	s.SpansMalformed.InvalidHTTPStatusCode.Add(recent.SpansMalformed.InvalidHTTPStatusCode.Load())
-	s.TracesFiltered.Add(recent.TracesFiltered.Load())
-	s.TracesPriorityNone.Add(recent.TracesPriorityNone.Load())
-	s.ClientDroppedP0Traces.Add(recent.ClientDroppedP0Traces.Load())
-	s.ClientDroppedP0Spans.Add(recent.ClientDroppedP0Spans.Load())
-	s.TracesBytes.Add(recent.TracesBytes.Load())
-	s.SpansReceived.Add(recent.SpansReceived.Load())
-	s.SpansDropped.Add(recent.SpansDropped.Load())
-	s.SpansFiltered.Add(recent.SpansFiltered.Load())
-	s.EventsExtracted.Add(recent.EventsExtracted.Load())
-	s.EventsSampled.Add(recent.EventsSampled.Load())
-	s.PayloadAccepted.Add(recent.PayloadAccepted.Load())
-	s.PayloadRefused.Add(recent.PayloadRefused.Load())
+	atomic.AddInt64(&s.TracesReceived, atomic.LoadInt64(&recent.TracesReceived))
+	atomic.AddInt64(&s.TracesDropped.DecodingError, atomic.LoadInt64(&recent.TracesDropped.DecodingError))
+	atomic.AddInt64(&s.TracesDropped.EmptyTrace, atomic.LoadInt64(&recent.TracesDropped.EmptyTrace))
+	atomic.AddInt64(&s.TracesDropped.TraceIDZero, atomic.LoadInt64(&recent.TracesDropped.TraceIDZero))
+	atomic.AddInt64(&s.TracesDropped.SpanIDZero, atomic.LoadInt64(&recent.TracesDropped.SpanIDZero))
+	atomic.AddInt64(&s.TracesDropped.ForeignSpan, atomic.LoadInt64(&recent.TracesDropped.ForeignSpan))
+	atomic.AddInt64(&s.TracesDropped.PayloadTooLarge, atomic.LoadInt64(&recent.TracesDropped.PayloadTooLarge))
+	atomic.AddInt64(&s.TracesDropped.Timeout, atomic.LoadInt64(&recent.TracesDropped.Timeout))
+	atomic.AddInt64(&s.TracesDropped.EOF, atomic.LoadInt64(&recent.TracesDropped.EOF))
+	atomic.AddInt64(&s.SpansMalformed.DuplicateSpanID, atomic.LoadInt64(&recent.SpansMalformed.DuplicateSpanID))
+	atomic.AddInt64(&s.SpansMalformed.ServiceEmpty, atomic.LoadInt64(&recent.SpansMalformed.ServiceEmpty))
+	atomic.AddInt64(&s.SpansMalformed.ServiceTruncate, atomic.LoadInt64(&recent.SpansMalformed.ServiceTruncate))
+	atomic.AddInt64(&s.SpansMalformed.ServiceInvalid, atomic.LoadInt64(&recent.SpansMalformed.ServiceInvalid))
+	atomic.AddInt64(&s.SpansMalformed.SpanNameEmpty, atomic.LoadInt64(&recent.SpansMalformed.SpanNameEmpty))
+	atomic.AddInt64(&s.SpansMalformed.SpanNameTruncate, atomic.LoadInt64(&recent.SpansMalformed.SpanNameTruncate))
+	atomic.AddInt64(&s.SpansMalformed.SpanNameInvalid, atomic.LoadInt64(&recent.SpansMalformed.SpanNameInvalid))
+	atomic.AddInt64(&s.SpansMalformed.ResourceEmpty, atomic.LoadInt64(&recent.SpansMalformed.ResourceEmpty))
+	atomic.AddInt64(&s.SpansMalformed.TypeTruncate, atomic.LoadInt64(&recent.SpansMalformed.TypeTruncate))
+	atomic.AddInt64(&s.SpansMalformed.InvalidStartDate, atomic.LoadInt64(&recent.SpansMalformed.InvalidStartDate))
+	atomic.AddInt64(&s.SpansMalformed.InvalidDuration, atomic.LoadInt64(&recent.SpansMalformed.InvalidDuration))
+	atomic.AddInt64(&s.SpansMalformed.InvalidHTTPStatusCode, atomic.LoadInt64(&recent.SpansMalformed.InvalidHTTPStatusCode))
+	atomic.AddInt64(&s.TracesFiltered, atomic.LoadInt64(&recent.TracesFiltered))
+	atomic.AddInt64(&s.TracesPriorityNone, atomic.LoadInt64(&recent.TracesPriorityNone))
+	atomic.AddInt64(&s.ClientDroppedP0Traces, atomic.LoadInt64(&recent.ClientDroppedP0Traces))
+	atomic.AddInt64(&s.ClientDroppedP0Spans, atomic.LoadInt64(&recent.ClientDroppedP0Spans))
+	atomic.AddInt64(&s.TracesBytes, atomic.LoadInt64(&recent.TracesBytes))
+	atomic.AddInt64(&s.SpansReceived, atomic.LoadInt64(&recent.SpansReceived))
+	atomic.AddInt64(&s.SpansDropped, atomic.LoadInt64(&recent.SpansDropped))
+	atomic.AddInt64(&s.SpansFiltered, atomic.LoadInt64(&recent.SpansFiltered))
+	atomic.AddInt64(&s.EventsExtracted, atomic.LoadInt64(&recent.EventsExtracted))
+	atomic.AddInt64(&s.EventsSampled, atomic.LoadInt64(&recent.EventsSampled))
+	atomic.AddInt64(&s.PayloadAccepted, atomic.LoadInt64(&recent.PayloadAccepted))
+	atomic.AddInt64(&s.PayloadRefused, atomic.LoadInt64(&recent.PayloadRefused))
 	s.TracesPerSamplingPriority.update(&recent.TracesPerSamplingPriority)
 }
 
 func (s *Stats) reset() {
-	s.TracesReceived.Store(0)
-	s.TracesDropped.PayloadTooLarge.Store(0)
-	s.TracesDropped.DecodingError.Store(0)
-	s.TracesDropped.EmptyTrace.Store(0)
-	s.TracesDropped.TraceIDZero.Store(0)
-	s.TracesDropped.SpanIDZero.Store(0)
-	s.TracesDropped.ForeignSpan.Store(0)
-	s.TracesDropped.Timeout.Store(0)
-	s.TracesDropped.EOF.Store(0)
-	s.SpansMalformed.DuplicateSpanID.Store(0)
-	s.SpansMalformed.ServiceEmpty.Store(0)
-	s.SpansMalformed.ServiceTruncate.Store(0)
-	s.SpansMalformed.ServiceInvalid.Store(0)
-	s.SpansMalformed.SpanNameEmpty.Store(0)
-	s.SpansMalformed.SpanNameTruncate.Store(0)
-	s.SpansMalformed.SpanNameInvalid.Store(0)
-	s.SpansMalformed.ResourceEmpty.Store(0)
-	s.SpansMalformed.TypeTruncate.Store(0)
-	s.SpansMalformed.InvalidStartDate.Store(0)
-	s.SpansMalformed.InvalidDuration.Store(0)
-	s.SpansMalformed.InvalidHTTPStatusCode.Store(0)
-	s.TracesFiltered.Store(0)
-	s.TracesPriorityNone.Store(0)
-	s.ClientDroppedP0Traces.Store(0)
-	s.ClientDroppedP0Spans.Store(0)
-	s.TracesBytes.Store(0)
-	s.SpansReceived.Store(0)
-	s.SpansDropped.Store(0)
-	s.SpansFiltered.Store(0)
-	s.EventsExtracted.Store(0)
-	s.EventsSampled.Store(0)
-	s.PayloadAccepted.Store(0)
-	s.PayloadRefused.Store(0)
+	atomic.StoreInt64(&s.TracesReceived, 0)
+	atomic.StoreInt64(&s.TracesDropped.PayloadTooLarge, 0)
+	atomic.StoreInt64(&s.TracesDropped.DecodingError, 0)
+	atomic.StoreInt64(&s.TracesDropped.EmptyTrace, 0)
+	atomic.StoreInt64(&s.TracesDropped.TraceIDZero, 0)
+	atomic.StoreInt64(&s.TracesDropped.SpanIDZero, 0)
+	atomic.StoreInt64(&s.TracesDropped.ForeignSpan, 0)
+	atomic.StoreInt64(&s.TracesDropped.Timeout, 0)
+	atomic.StoreInt64(&s.TracesDropped.EOF, 0)
+	atomic.StoreInt64(&s.SpansMalformed.DuplicateSpanID, 0)
+	atomic.StoreInt64(&s.SpansMalformed.ServiceEmpty, 0)
+	atomic.StoreInt64(&s.SpansMalformed.ServiceTruncate, 0)
+	atomic.StoreInt64(&s.SpansMalformed.ServiceInvalid, 0)
+	atomic.StoreInt64(&s.SpansMalformed.SpanNameEmpty, 0)
+	atomic.StoreInt64(&s.SpansMalformed.SpanNameTruncate, 0)
+	atomic.StoreInt64(&s.SpansMalformed.SpanNameInvalid, 0)
+	atomic.StoreInt64(&s.SpansMalformed.ResourceEmpty, 0)
+	atomic.StoreInt64(&s.SpansMalformed.TypeTruncate, 0)
+	atomic.StoreInt64(&s.SpansMalformed.InvalidStartDate, 0)
+	atomic.StoreInt64(&s.SpansMalformed.InvalidDuration, 0)
+	atomic.StoreInt64(&s.SpansMalformed.InvalidHTTPStatusCode, 0)
+	atomic.StoreInt64(&s.TracesFiltered, 0)
+	atomic.StoreInt64(&s.TracesPriorityNone, 0)
+	atomic.StoreInt64(&s.ClientDroppedP0Traces, 0)
+	atomic.StoreInt64(&s.ClientDroppedP0Spans, 0)
+	atomic.StoreInt64(&s.TracesBytes, 0)
+	atomic.StoreInt64(&s.SpansReceived, 0)
+	atomic.StoreInt64(&s.SpansDropped, 0)
+	atomic.StoreInt64(&s.SpansFiltered, 0)
+	atomic.StoreInt64(&s.EventsExtracted, 0)
+	atomic.StoreInt64(&s.EventsSampled, 0)
+	atomic.StoreInt64(&s.PayloadAccepted, 0)
+	atomic.StoreInt64(&s.PayloadRefused, 0)
 	s.TracesPerSamplingPriority.reset()
 }
 
 func (s *Stats) isEmpty() bool {
-	tracesBytes := s.TracesBytes.Load()
+	tracesBytes := atomic.LoadInt64(&s.TracesBytes)
 
 	return tracesBytes == 0
 }
@@ -469,12 +460,12 @@ func (s *Stats) isEmpty() bool {
 // infoString returns a string representation of the Stats struct containing standard operational stats (not problems)
 func (s *Stats) infoString() string {
 	// Atomically load the stats
-	tracesReceived := s.TracesReceived.Load()
-	tracesFiltered := s.TracesFiltered.Load()
+	tracesReceived := atomic.LoadInt64(&s.TracesReceived)
+	tracesFiltered := atomic.LoadInt64(&s.TracesFiltered)
 	// Omitting priority information, use expvar or metrics for debugging purpose
-	tracesBytes := s.TracesBytes.Load()
-	eventsExtracted := s.EventsExtracted.Load()
-	eventsSampled := s.EventsSampled.Load()
+	tracesBytes := atomic.LoadInt64(&s.TracesBytes)
+	eventsExtracted := atomic.LoadInt64(&s.EventsExtracted)
+	eventsSampled := atomic.LoadInt64(&s.EventsSampled)
 
 	return fmt.Sprintf("traces received: %d, traces filtered: %d, "+
 		"traces amount: %d bytes, events extracted: %d, events sampled: %d",

--- a/pkg/trace/info/stats_test.go
+++ b/pkg/trace/info/stats_test.go
@@ -8,22 +8,23 @@ package info
 import (
 	"fmt"
 	"reflect"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/metrics"
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
-	"go.uber.org/atomic"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestTracesDropped(t *testing.T) {
-	s := TracesDropped{}
-	s.DecodingError.Store(1)
-	s.ForeignSpan.Store(1)
-	s.TraceIDZero.Store(1)
-	s.SpanIDZero.Store(1)
+	s := TracesDropped{
+		DecodingError: 1,
+		ForeignSpan:   1,
+		TraceIDZero:   1,
+		SpanIDZero:    1,
+	}
 
 	t.Run("tagValues", func(t *testing.T) {
 		assert.Equal(t, map[string]int64{
@@ -44,12 +45,13 @@ func TestTracesDropped(t *testing.T) {
 }
 
 func TestSpansMalformed(t *testing.T) {
-	s := SpansMalformed{}
-	s.ServiceEmpty.Store(1)
-	s.ResourceEmpty.Store(1)
-	s.ServiceInvalid.Store(1)
-	s.SpanNameTruncate.Store(1)
-	s.TypeTruncate.Store(1)
+	s := SpansMalformed{
+		ServiceEmpty:     1,
+		ResourceEmpty:    1,
+		ServiceInvalid:   1,
+		SpanNameTruncate: 1,
+		TypeTruncate:     1,
+	}
 
 	t.Run("tagValues", func(t *testing.T) {
 		assert.Equal(t, map[string]int64{
@@ -92,10 +94,9 @@ func TestStatsTags(t *testing.T) {
 }
 
 func TestSamplingPriorityStats(t *testing.T) {
-	s := samplingPriorityStats{}
-	s.counts[0].Store(1)
-	s.counts[10].Store(2)
-	s.counts[20].Store(3)
+	s := samplingPriorityStats{
+		[21]int64{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3},
+	}
 
 	t.Run("TagValues", func(t *testing.T) {
 		assert.Equal(t, map[string]int64{
@@ -142,14 +143,12 @@ func TestSamplingPriorityStats(t *testing.T) {
 		}, s2.TagValues())
 	})
 
-	s3 := samplingPriorityStats{}
-	s3.counts[0].Store(1)
-	s3.counts[10].Store(2)
-	s3.counts[20].Store(3)
-	s4 := samplingPriorityStats{}
-	s4.counts[1].Store(1)
-	s4.counts[10].Store(5)
-	s4.counts[19].Store(10)
+	s3 := samplingPriorityStats{
+		[21]int64{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3},
+	}
+	s4 := samplingPriorityStats{
+		[21]int64{0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0},
+	}
 	t.Run("update", func(t *testing.T) {
 		s3.update(&s4)
 		assert.Equal(t, map[string]int64{
@@ -165,7 +164,7 @@ func TestSamplingPriorityStats(t *testing.T) {
 var _ metrics.StatsClient = (*testStatsClient)(nil)
 
 type testStatsClient struct {
-	counts atomic.Int64
+	counts int64
 }
 
 func (ts *testStatsClient) Gauge(name string, value float64, tags []string, rate float64) error {
@@ -173,7 +172,7 @@ func (ts *testStatsClient) Gauge(name string, value float64, tags []string, rate
 }
 
 func (ts *testStatsClient) Count(name string, value int64, tags []string, rate float64) error {
-	ts.counts.Inc()
+	atomic.AddInt64(&ts.counts, 1)
 	return nil
 }
 
@@ -201,53 +200,36 @@ func TestReceiverStats(t *testing.T) {
 		EndpointVersion: "v0.4",
 	}
 	testStats := func() *ReceiverStats {
-		stats := Stats{}
-		stats.TracesReceived.Store(1)
-		stats.TracesFiltered.Store(4)
-		stats.TracesPriorityNone.Store(5)
-		stats.TracesPerSamplingPriority = samplingPriorityStats{}
-		stats.TracesPerSamplingPriority.counts[maxAbsPriority+0].Store(1)
-		stats.TracesPerSamplingPriority.counts[maxAbsPriority+1].Store(2)
-		stats.TracesPerSamplingPriority.counts[maxAbsPriority+2].Store(3)
-		stats.TracesPerSamplingPriority.counts[maxAbsPriority+3].Store(4)
-		stats.TracesPerSamplingPriority.counts[maxAbsPriority+4].Store(5)
-		stats.ClientDroppedP0Traces.Store(7)
-		stats.ClientDroppedP0Spans.Store(8)
-		stats.TracesBytes.Store(9)
-		stats.SpansReceived.Store(10)
-		stats.SpansDropped.Store(11)
-		stats.SpansFiltered.Store(12)
-		stats.EventsExtracted.Store(13)
-		stats.EventsSampled.Store(14)
-		stats.PayloadAccepted.Store(15)
-		stats.PayloadRefused.Store(16)
-		stats.TracesDropped = &TracesDropped{}
-		stats.TracesDropped.DecodingError.Store(1)
-		stats.TracesDropped.PayloadTooLarge.Store(2)
-		stats.TracesDropped.EmptyTrace.Store(3)
-		stats.TracesDropped.TraceIDZero.Store(4)
-		stats.TracesDropped.SpanIDZero.Store(5)
-		stats.TracesDropped.ForeignSpan.Store(6)
-		stats.TracesDropped.Timeout.Store(7)
-		stats.TracesDropped.EOF.Store(8)
-		stats.SpansMalformed = &SpansMalformed{}
-		stats.SpansMalformed.DuplicateSpanID.Store(1)
-		stats.SpansMalformed.ServiceEmpty.Store(2)
-		stats.SpansMalformed.ServiceTruncate.Store(3)
-		stats.SpansMalformed.ServiceInvalid.Store(4)
-		stats.SpansMalformed.SpanNameEmpty.Store(5)
-		stats.SpansMalformed.SpanNameTruncate.Store(6)
-		stats.SpansMalformed.SpanNameInvalid.Store(7)
-		stats.SpansMalformed.ResourceEmpty.Store(8)
-		stats.SpansMalformed.TypeTruncate.Store(9)
-		stats.SpansMalformed.InvalidStartDate.Store(10)
-		stats.SpansMalformed.InvalidDuration.Store(11)
-		stats.SpansMalformed.InvalidHTTPStatusCode.Store(12)
 		return &ReceiverStats{
 			Stats: map[Tags]*TagStats{
 				tags: {
-					Tags:  tags,
-					Stats: stats,
+					Tags: tags,
+					Stats: Stats{
+						TracesReceived:     1,
+						TracesDropped:      &TracesDropped{1, 2, 3, 4, 5, 6, 7, 8},
+						SpansMalformed:     &SpansMalformed{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
+						TracesFiltered:     4,
+						TracesPriorityNone: 5,
+						TracesPerSamplingPriority: samplingPriorityStats{
+							[maxAbsPriority*2 + 1]int64{
+								maxAbsPriority + 0: 1,
+								maxAbsPriority + 1: 2,
+								maxAbsPriority + 2: 3,
+								maxAbsPriority + 3: 4,
+								maxAbsPriority + 4: 5,
+							},
+						},
+						ClientDroppedP0Traces: 7,
+						ClientDroppedP0Spans:  8,
+						TracesBytes:           9,
+						SpansReceived:         10,
+						SpansDropped:          11,
+						SpansFiltered:         12,
+						EventsExtracted:       13,
+						EventsSampled:         14,
+						PayloadAccepted:       15,
+						PayloadRefused:        16,
+					},
 				},
 			},
 		}
@@ -255,7 +237,7 @@ func TestReceiverStats(t *testing.T) {
 
 	t.Run("Publish", func(t *testing.T) {
 		testStats().Publish()
-		assert.EqualValues(t, statsclient.counts.Load(), 39)
+		assert.EqualValues(t, atomic.LoadInt64(&statsclient.counts), 39)
 	})
 
 	t.Run("reset", func(t *testing.T) {

--- a/pkg/trace/info/writer.go
+++ b/pkg/trace/info/writer.go
@@ -5,40 +5,30 @@
 
 package info
 
-import "go.uber.org/atomic"
-
 // TraceWriterInfo represents statistics from the trace writer.
 type TraceWriterInfo struct {
-	// all atomic values are included as values in this struct, to simplify
-	// initialization of the type.  The atomic values _must_ occur first in the
-	// struct.
-
-	Payloads          atomic.Int64
-	Traces            atomic.Int64
-	Events            atomic.Int64
-	Spans             atomic.Int64
-	Errors            atomic.Int64
-	Retries           atomic.Int64
-	Bytes             atomic.Int64
-	BytesUncompressed atomic.Int64
-	BytesEstimated    atomic.Int64
-	SingleMaxSize     atomic.Int64
+	Payloads          int64
+	Traces            int64
+	Events            int64
+	Spans             int64
+	Errors            int64
+	Retries           int64
+	Bytes             int64
+	BytesUncompressed int64
+	BytesEstimated    int64
+	SingleMaxSize     int64
 }
 
 // StatsWriterInfo represents statistics from the stats writer.
 type StatsWriterInfo struct {
-	// all atomic values are included as values in this struct, to simplify
-	// initialization of the type.  The atomic values _must_ occur first in the
-	// struct.
-
-	Payloads       atomic.Int64
-	ClientPayloads atomic.Int64
-	StatsBuckets   atomic.Int64
-	StatsEntries   atomic.Int64
-	Errors         atomic.Int64
-	Retries        atomic.Int64
-	Splits         atomic.Int64
-	Bytes          atomic.Int64
+	Payloads       int64
+	ClientPayloads int64
+	StatsBuckets   int64
+	StatsEntries   int64
+	Errors         int64
+	Retries        int64
+	Splits         int64
+	Bytes          int64
 }
 
 // UpdateTraceWriterInfo updates internal trace writer stats

--- a/pkg/trace/log/throttled.go
+++ b/pkg/trace/log/throttled.go
@@ -6,36 +6,31 @@
 package log
 
 import (
+	"sync/atomic"
 	"time"
-
-	"go.uber.org/atomic"
 )
 
 // NewThrottled returns a new throttled logger. The returned logger will allow up to n calls in
 // a time period of length d.
 func NewThrottled(n int, d time.Duration) *ThrottledLogger {
-	return &ThrottledLogger{
-		n: uint64(n),
-		c: atomic.NewUint64(0),
-		d: d,
-	}
+	return &ThrottledLogger{n: uint64(n), d: d}
 }
 
 // ThrottledLogger limits the number of log calls during a time window. To create a new logger
 // use NewThrottled.
 type ThrottledLogger struct {
-	n uint64         // number of log calls allowed during interval d
-	c *atomic.Uint64 // number of log calls performed during an interval d
+	n uint64 // number of log calls allowed during interval d
+	c uint64 // number of log calls performed during an interval d; atomic value
 	d time.Duration
 }
 
 type loggerFunc func(format string, params ...interface{})
 
 func (tl *ThrottledLogger) log(logFunc loggerFunc, format string, params ...interface{}) {
-	c := tl.c.Inc() - 1
+	c := atomic.AddUint64(&tl.c, 1) - 1
 	if c == 0 {
 		// first call, trigger the reset
-		time.AfterFunc(tl.d, func() { tl.c.Store(0) })
+		time.AfterFunc(tl.d, func() { atomic.StoreUint64(&tl.c, 0) })
 	}
 	if c >= tl.n {
 		if c == tl.n {

--- a/pkg/trace/metrics/client_test.go
+++ b/pkg/trace/metrics/client_test.go
@@ -6,39 +6,39 @@
 package metrics
 
 import (
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/atomic"
 )
 
 type testStatsClient struct {
-	counts atomic.Int64
+	counts int64
 }
 
 func (ts *testStatsClient) Gauge(name string, value float64, tags []string, rate float64) error {
-	ts.counts.Inc()
+	atomic.AddInt64(&ts.counts, 1)
 	return nil
 }
 
 func (ts *testStatsClient) Count(name string, value int64, tags []string, rate float64) error {
-	ts.counts.Inc()
+	atomic.AddInt64(&ts.counts, 1)
 	return nil
 }
 
 func (ts *testStatsClient) Histogram(name string, value float64, tags []string, rate float64) error {
-	ts.counts.Inc()
+	atomic.AddInt64(&ts.counts, 1)
 	return nil
 }
 
 func (ts *testStatsClient) Timing(name string, value time.Duration, tags []string, rate float64) error {
-	ts.counts.Inc()
+	atomic.AddInt64(&ts.counts, 1)
 	return nil
 }
 
 func (ts *testStatsClient) Flush() error {
-	ts.counts.Inc()
+	atomic.AddInt64(&ts.counts, 1)
 	return nil
 }
 
@@ -62,6 +62,6 @@ func TestForwarding(t *testing.T) {
 		assert.NoError(t, Histogram("stat", 1, nil, 1))
 		assert.NoError(t, Timing("stat", time.Second, nil, 1))
 		assert.NoError(t, Flush())
-		assert.Equal(t, testclient.counts.Load(), int64(5))
+		assert.Equal(t, atomic.LoadInt64(&testclient.counts), int64(5))
 	})
 }

--- a/pkg/trace/metrics/timing/timing.go
+++ b/pkg/trace/metrics/timing/timing.go
@@ -13,8 +13,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/trace/atomic"
 	"github.com/DataDog/datadog-agent/pkg/trace/metrics"
-	"go.uber.org/atomic"
 )
 
 // AutoreportInterval specifies the interval at which the default set reports.
@@ -123,9 +123,9 @@ type counter struct {
 func newCounter(name string) *counter {
 	return &counter{
 		name:  name,
-		count: atomic.NewFloat64(0),
-		max:   atomic.NewFloat64(0),
-		sum:   atomic.NewFloat64(0),
+		count: atomic.NewFloat(0),
+		max:   atomic.NewFloat(0),
+		sum:   atomic.NewFloat(0),
 	}
 }
 

--- a/pkg/trace/sampler/dynamic_config.go
+++ b/pkg/trace/sampler/dynamic_config.go
@@ -9,10 +9,10 @@ import (
 	"math"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state/products/apmsampling"
-	"go.uber.org/atomic"
 )
 
 // DynamicConfig contains configuration items which may change
@@ -114,8 +114,8 @@ func (rbs *RateByService) GetNewState(version string) State {
 	return ret
 }
 
-var localVersion atomic.Int64
+var localVersion int64
 
 func newVersion() string {
-	return strconv.FormatInt(time.Now().Unix(), 16) + "-" + strconv.FormatInt(localVersion.Inc(), 16)
+	return strconv.FormatInt(time.Now().Unix(), 16) + "-" + strconv.FormatInt(atomic.AddInt64(&localVersion, 1), 16)
 }

--- a/pkg/trace/sampler/prioritysampler_test.go
+++ b/pkg/trace/sampler/prioritysampler_test.go
@@ -11,11 +11,11 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state/products/apmsampling"
+	"github.com/DataDog/datadog-agent/pkg/trace/atomic"
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 )
 
 func randomTraceID() uint64 {
@@ -70,7 +70,7 @@ func TestPrioritySample(t *testing.T) {
 	s := getTestPrioritySampler()
 
 	assert.Equal(float32(0), s.localRates.totalSeen, "checking fresh backend total score is 0")
-	assert.Equal(int64(0), s.localRates.totalKept.Load(), "checkeing fresh backend sampled score is 0")
+	assert.Equal(int64(0), s.localRates.totalKept, "checkeing fresh backend sampled score is 0")
 
 	s = getTestPrioritySampler()
 	chunk, root := getTestTraceWithService(t, "my-service", s)
@@ -79,7 +79,7 @@ func TestPrioritySample(t *testing.T) {
 	sampled := s.Sample(time.Now(), chunk, root, env, 0)
 	assert.False(sampled, "trace with negative priority is dropped")
 	assert.Equal(float32(0), s.localRates.totalSeen, "sampling a priority -1 trace should *NOT* impact sampler backend")
-	assert.Equal(int64(0), s.localRates.totalKept.Load(), "sampling a priority -1 trace should *NOT* impact sampler backend")
+	assert.Equal(int64(0), s.localRates.totalKept, "sampling a priority -1 trace should *NOT* impact sampler backend")
 
 	s = getTestPrioritySampler()
 	chunk, root = getTestTraceWithService(t, "my-service", s)
@@ -88,7 +88,7 @@ func TestPrioritySample(t *testing.T) {
 	sampled = s.Sample(time.Now(), chunk, root, env, 0)
 	assert.False(sampled, "trace with priority 0 is dropped")
 	assert.True(float32(0) < s.localRates.totalSeen, "sampling a priority 0 trace should increase total score")
-	assert.Equal(int64(0), s.localRates.totalKept.Load(), "sampling a priority 0 trace should *NOT* increase sampled score")
+	assert.Equal(int64(0), s.localRates.totalKept, "sampling a priority 0 trace should *NOT* increase sampled score")
 
 	s = getTestPrioritySampler()
 	chunk, root = getTestTraceWithService(t, "my-service", s)
@@ -97,7 +97,7 @@ func TestPrioritySample(t *testing.T) {
 	sampled = s.Sample(time.Now(), chunk, root, env, 0)
 	assert.True(sampled, "trace with priority 1 is kept")
 	assert.True(float32(0) < s.localRates.totalSeen, "sampling a priority 0 trace should increase total score")
-	assert.True(int64(0) < s.localRates.totalKept.Load(), "sampling a priority 0 trace should increase sampled score")
+	assert.True(int64(0) < s.localRates.totalKept, "sampling a priority 0 trace should increase sampled score")
 
 	s = getTestPrioritySampler()
 	chunk, root = getTestTraceWithService(t, "my-service", s)
@@ -106,7 +106,7 @@ func TestPrioritySample(t *testing.T) {
 	sampled = s.Sample(time.Now(), chunk, root, env, 0)
 	assert.True(sampled, "trace with priority 2 is kept")
 	assert.Equal(float32(0), s.localRates.totalSeen, "sampling a priority 2 trace should *NOT* increase total score")
-	assert.Equal(int64(0), s.localRates.totalKept.Load(), "sampling a priority 2 trace should *NOT* increase sampled score")
+	assert.Equal(int64(0), s.localRates.totalKept, "sampling a priority 2 trace should *NOT* increase sampled score")
 
 	s = getTestPrioritySampler()
 	chunk, root = getTestTraceWithService(t, "my-service", s)
@@ -115,7 +115,7 @@ func TestPrioritySample(t *testing.T) {
 	sampled = s.Sample(time.Now(), chunk, root, env, 0)
 	assert.True(sampled, "trace with high priority is kept")
 	assert.Equal(float32(0), s.localRates.totalSeen, "sampling a high priority trace should *NOT* increase total score")
-	assert.Equal(int64(0), s.localRates.totalKept.Load(), "sampling a high priority trace should *NOT* increase sampled score")
+	assert.Equal(int64(0), s.localRates.totalKept, "sampling a high priority trace should *NOT* increase sampled score")
 
 	chunk.Priority = int32(PriorityNone)
 	sampled = s.Sample(time.Now(), chunk, root, env, 0)
@@ -206,7 +206,7 @@ func TestPrioritySamplerTPSFeedbackLoop(t *testing.T) {
 		s.remoteRates.onUpdate(configGenerator(generatedConfigVersion, testCasesRates))
 
 		t.Logf("testing targetTPS=%0.1f generatedTPS=%0.1f localRate=%v clientDrop=%v", tc.targetTPS, tc.generatedTPS, tc.localRate, tc.clientDrop)
-		s.localRates.targetTPS = atomic.NewFloat64(tc.targetTPS)
+		s.localRates.targetTPS = atomic.NewFloat(tc.targetTPS)
 
 		var sampledCount, handledCount int
 		const warmUpDuration, testDuration = 2, 10

--- a/pkg/trace/sampler/rare_sampler.go
+++ b/pkg/trace/sampler/rare_sampler.go
@@ -7,13 +7,13 @@ package sampler
 
 import (
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/metrics"
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
-	"go.uber.org/atomic"
 	"golang.org/x/time/rate"
 )
 
@@ -34,9 +34,10 @@ const (
 // The resulting sampled traces will likely be incomplete and will be flagged with
 // a exceptioKey metric set at 1.
 type RareSampler struct {
-	hits    *atomic.Int64
-	misses  *atomic.Int64
-	shrinks *atomic.Int64
+	// Variables access through the 'atomic' package must be 64bits aligned.
+	hits    int64
+	misses  int64
+	shrinks int64
 	mu      sync.RWMutex
 
 	tickStats   *time.Ticker
@@ -51,9 +52,6 @@ type RareSampler struct {
 // of env, service, name, resource, http-status, error type for each top level or measured spans
 func NewRareSampler(conf *config.AgentConfig) *RareSampler {
 	e := &RareSampler{
-		hits:        atomic.NewInt64(0),
-		misses:      atomic.NewInt64(0),
-		shrinks:     atomic.NewInt64(0),
 		limiter:     rate.NewLimiter(rate.Limit(conf.RareSamplerTPS), rareSamplerBurst),
 		ttl:         conf.RareSamplerCooldownPeriod,
 		priorityTTL: priorityTTL,
@@ -131,10 +129,10 @@ func (e *RareSampler) sampleSpan(now time.Time, env string, s *pb.Span) bool {
 		sampled = e.limiter.Allow()
 		if sampled {
 			ss.add(now.Add(e.ttl), s)
-			e.hits.Inc()
+			atomic.AddInt64(&e.hits, 1)
 			traceutil.SetMetric(s, rareKey, 1)
 		} else {
-			e.misses.Inc()
+			atomic.AddInt64(&e.misses, 1)
 		}
 	}
 	return sampled
@@ -149,7 +147,7 @@ func (e *RareSampler) loadSeenSpans(shardSig Signature) *seenSpans {
 	}
 	s = &seenSpans{
 		expires:             make(map[spanHash]time.Time),
-		totalSamplerShrinks: e.shrinks,
+		totalSamplerShrinks: &e.shrinks,
 		cardinality:         e.cardinality,
 	}
 	e.mu.Lock()
@@ -159,9 +157,9 @@ func (e *RareSampler) loadSeenSpans(shardSig Signature) *seenSpans {
 }
 
 func (e *RareSampler) report() {
-	metrics.Count("datadog.trace_agent.sampler.rare.hits", e.hits.Swap(0), nil, 1)
-	metrics.Count("datadog.trace_agent.sampler.rare.misses", e.misses.Swap(0), nil, 1)
-	metrics.Gauge("datadog.trace_agent.sampler.rare.shrinks", float64(e.shrinks.Load()), nil, 1)
+	metrics.Count("datadog.trace_agent.sampler.rare.hits", atomic.SwapInt64(&e.hits, 0), nil, 1)
+	metrics.Count("datadog.trace_agent.sampler.rare.misses", atomic.SwapInt64(&e.misses, 0), nil, 1)
+	metrics.Gauge("datadog.trace_agent.sampler.rare.shrinks", float64(atomic.LoadInt64(&e.shrinks)), nil, 1)
 }
 
 // seenSpans keeps record of a set of spans.
@@ -172,7 +170,7 @@ type seenSpans struct {
 	// shrunk caracterize seenSpans when it's limited in size by capacityLimit.
 	shrunk bool
 	// totalSamplerShrinks is the reference to the total number of shrinks reported by RareSampler.
-	totalSamplerShrinks *atomic.Int64
+	totalSamplerShrinks *int64
 	// cardinality limits the number of spans considered per combination of (env, service).
 	cardinality int
 }
@@ -206,7 +204,7 @@ func (ss *seenSpans) shrink() {
 	}
 	ss.expires = newExpires
 	ss.shrunk = true
-	ss.totalSamplerShrinks.Inc()
+	atomic.AddInt64(ss.totalSamplerShrinks, 1)
 }
 
 func (ss *seenSpans) getExpire(h spanHash) (time.Time, bool) {

--- a/pkg/trace/sampler/remote_rates.go
+++ b/pkg/trace/sampler/remote_rates.go
@@ -7,6 +7,7 @@ package sampler
 
 import (
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
@@ -15,7 +16,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/log"
 	"github.com/DataDog/datadog-agent/pkg/trace/metrics"
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
-	"go.uber.org/atomic"
 )
 
 const (
@@ -35,9 +35,9 @@ type RemoteRates struct {
 	// tpsTargets contains the latest tps targets available per (env, service)
 	// this map may include signatures (env, service) not seen by this agent.
 	tpsTargets         map[Signature]apmsampling.TargetTPS
-	mu                 sync.RWMutex   // protects concurrent access to samplers and tpsTargets
-	tpsVersion         *atomic.Uint64 // version of the loaded tpsTargets
-	duplicateTargetTPS *atomic.Uint64 // count of duplicate received targetTPS
+	mu                 sync.RWMutex // protects concurrent access to samplers and tpsTargets
+	tpsVersion         uint64       // version of the loaded tpsTargets
+	duplicateTargetTPS uint64       // count of duplicate received targetTPS
 
 	client config.RemoteClient
 }
@@ -52,11 +52,9 @@ func newRemoteRates(client config.RemoteClient, maxTPS float64, agentVersion str
 		return nil
 	}
 	return &RemoteRates{
-		client:             client,
-		maxSigTPS:          maxTPS,
-		samplers:           make(map[Signature]*remoteSampler),
-		tpsVersion:         atomic.NewUint64(0),
-		duplicateTargetTPS: atomic.NewUint64(0),
+		client:    client,
+		maxSigTPS: maxTPS,
+		samplers:  make(map[Signature]*remoteSampler),
 	}
 }
 
@@ -85,7 +83,7 @@ func (r *RemoteRates) onUpdate(update map[string]state.APMSamplingConfig) {
 		}
 	}
 	r.updateTPS(tpsTargets)
-	r.tpsVersion.Store(version)
+	atomic.StoreUint64(&r.tpsVersion, version)
 }
 
 // addTargetTPS keeping the highest rank if 2 targetTPS of the same signature are added
@@ -101,7 +99,7 @@ func (r *RemoteRates) addTargetTPS(tpsTargets map[Signature]apmsampling.TargetTP
 		return
 	}
 	if new.Rank == stored.Rank {
-		r.duplicateTargetTPS.Inc()
+		atomic.AddUint64(&r.duplicateTargetTPS, 1)
 	}
 }
 
@@ -186,7 +184,7 @@ func (r *RemoteRates) countSample(root *pb.Span, sig Signature) {
 	}
 	s.countSample()
 	root.Metrics[tagRemoteTPS] = s.targetTPS.Load()
-	root.Metrics[tagRemoteVersion] = float64(r.tpsVersion.Load())
+	root.Metrics[tagRemoteVersion] = float64(atomic.LoadUint64(&r.tpsVersion))
 }
 
 // getSignatureSampleRate returns the sampling rate to apply for a registered signature.
@@ -217,7 +215,7 @@ func (r *RemoteRates) report() {
 	defer r.mu.RUnlock()
 	metrics.Gauge("datadog.trace_agent.remote.samplers", float64(len(r.samplers)), nil, 1)
 	metrics.Gauge("datadog.trace_agent.remote.sig_targets", float64(len(r.tpsTargets)), nil, 1)
-	if duplicateTargetTPS := r.duplicateTargetTPS.Swap(0); duplicateTargetTPS != 0 {
+	if duplicateTargetTPS := atomic.SwapUint64(&r.duplicateTargetTPS, 0); duplicateTargetTPS != 0 {
 		metrics.Count("datadog.trace_agent.remote.duplicate_target_tps", int64(duplicateTargetTPS), nil, 1)
 	}
 }

--- a/pkg/trace/sampler/remote_rates_test.go
+++ b/pkg/trace/sampler/remote_rates_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 )
 
 const maxRemoteTPS = 12377
@@ -30,10 +29,8 @@ func TestRemoteConfInit(t *testing.T) {
 
 func newTestRemoteRates() *RemoteRates {
 	return &RemoteRates{
-		maxSigTPS:          maxRemoteTPS,
-		samplers:           make(map[Signature]*remoteSampler),
-		tpsVersion:         atomic.NewUint64(0),
-		duplicateTargetTPS: atomic.NewUint64(0),
+		maxSigTPS: maxRemoteTPS,
+		samplers:  make(map[Signature]*remoteSampler),
 	}
 }
 

--- a/pkg/trace/sampler/scoresampler_test.go
+++ b/pkg/trace/sampler/scoresampler_test.go
@@ -12,10 +12,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/trace/atomic"
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/atomic"
 )
 
 const defaultEnv = "testEnv"
@@ -110,7 +110,7 @@ func TestTargetTPS(t *testing.T) {
 	initPeriods := 2
 	periods := 10
 
-	s.targetTPS = atomic.NewFloat64(targetTPS)
+	s.targetTPS = atomic.NewFloat(targetTPS)
 	periodSeconds := bucketDuration.Seconds()
 	tracesPerPeriod := generatedTPS * periodSeconds
 

--- a/pkg/trace/writer/sender_test.go
+++ b/pkg/trace/writer/sender_test.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/atomic"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/log"
@@ -107,17 +106,9 @@ func TestSender(t *testing.T) {
 	})
 
 	t.Run("Push", func(t *testing.T) {
-		s := &sender{
-			cfg:      &senderConfig{},
-			queue:    make(chan *payload, 4),
-			inflight: atomic.NewInt32(0),
-			attempt:  atomic.NewInt32(0),
-		}
+		s := &sender{cfg: &senderConfig{}, queue: make(chan *payload, 4)}
 		p := func(n string) *payload {
-			return &payload{
-				body:    bytes.NewBufferString(n),
-				retries: atomic.NewInt32(0),
-			}
+			return &payload{body: bytes.NewBufferString(n)}
 		}
 
 		s.Push(p("1"))

--- a/pkg/trace/writer/stats.go
+++ b/pkg/trace/writer/stats.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"math"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
@@ -188,9 +189,9 @@ func (w *StatsWriter) buildPayloads(sp pb.StatsPayload, maxEntriesPerPayload int
 	var nbEntries, nbBuckets int
 	addPayload := func() {
 		log.Debugf("Flushing %d entries (buckets=%d client_payloads=%d)", nbEntries, nbBuckets, len(current.Stats))
-		w.stats.StatsBuckets.Add(int64(nbBuckets))
-		w.stats.ClientPayloads.Add(int64(len(current.Stats)))
-		w.stats.StatsEntries.Add(int64(nbEntries))
+		atomic.AddInt64(&w.stats.StatsBuckets, int64(nbBuckets))
+		atomic.AddInt64(&w.stats.ClientPayloads, int64(len(current.Stats)))
+		atomic.AddInt64(&w.stats.StatsEntries, int64(nbEntries))
 		grouped = append(grouped, current)
 		current.Stats = nil
 		nbEntries = 0
@@ -209,7 +210,7 @@ func (w *StatsWriter) buildPayloads(sp pb.StatsPayload, maxEntriesPerPayload int
 		addPayload()
 	}
 	if len(grouped) > 1 {
-		w.stats.Splits.Inc()
+		atomic.AddInt64(&w.stats.Splits, 1)
 	}
 	return grouped
 }
@@ -317,14 +318,14 @@ func splitPayload(p pb.ClientStatsPayload, maxEntriesPerPayload int) []clientSta
 var _ eventRecorder = (*StatsWriter)(nil)
 
 func (w *StatsWriter) report() {
-	metrics.Count("datadog.trace_agent.stats_writer.client_payloads", w.stats.ClientPayloads.Swap(0), nil, 1)
-	metrics.Count("datadog.trace_agent.stats_writer.payloads", w.stats.Payloads.Swap(0), nil, 1)
-	metrics.Count("datadog.trace_agent.stats_writer.stats_buckets", w.stats.StatsBuckets.Swap(0), nil, 1)
-	metrics.Count("datadog.trace_agent.stats_writer.stats_entries", w.stats.StatsEntries.Swap(0), nil, 1)
-	metrics.Count("datadog.trace_agent.stats_writer.bytes", w.stats.Bytes.Swap(0), nil, 1)
-	metrics.Count("datadog.trace_agent.stats_writer.retries", w.stats.Retries.Swap(0), nil, 1)
-	metrics.Count("datadog.trace_agent.stats_writer.splits", w.stats.Splits.Swap(0), nil, 1)
-	metrics.Count("datadog.trace_agent.stats_writer.errors", w.stats.Errors.Swap(0), nil, 1)
+	metrics.Count("datadog.trace_agent.stats_writer.client_payloads", atomic.SwapInt64(&w.stats.ClientPayloads, 0), nil, 1)
+	metrics.Count("datadog.trace_agent.stats_writer.payloads", atomic.SwapInt64(&w.stats.Payloads, 0), nil, 1)
+	metrics.Count("datadog.trace_agent.stats_writer.stats_buckets", atomic.SwapInt64(&w.stats.StatsBuckets, 0), nil, 1)
+	metrics.Count("datadog.trace_agent.stats_writer.stats_entries", atomic.SwapInt64(&w.stats.StatsEntries, 0), nil, 1)
+	metrics.Count("datadog.trace_agent.stats_writer.bytes", atomic.SwapInt64(&w.stats.Bytes, 0), nil, 1)
+	metrics.Count("datadog.trace_agent.stats_writer.retries", atomic.SwapInt64(&w.stats.Retries, 0), nil, 1)
+	metrics.Count("datadog.trace_agent.stats_writer.splits", atomic.SwapInt64(&w.stats.Splits, 0), nil, 1)
+	metrics.Count("datadog.trace_agent.stats_writer.errors", atomic.SwapInt64(&w.stats.Errors, 0), nil, 1)
 }
 
 // recordEvent implements eventRecorder.
@@ -336,17 +337,17 @@ func (w *StatsWriter) recordEvent(t eventType, data *eventData) {
 	switch t {
 	case eventTypeRetry:
 		log.Debugf("Retrying to flush stats payload (error: %q)", data.err)
-		w.stats.Retries.Inc()
+		atomic.AddInt64(&w.stats.Retries, 1)
 
 	case eventTypeSent:
 		log.Debugf("Flushed stats to the API; time: %s, bytes: %d", data.duration, data.bytes)
 		timing.Since("datadog.trace_agent.stats_writer.flush_duration", time.Now().Add(-data.duration))
-		w.stats.Bytes.Add(int64(data.bytes))
-		w.stats.Payloads.Inc()
+		atomic.AddInt64(&w.stats.Bytes, int64(data.bytes))
+		atomic.AddInt64(&w.stats.Payloads, 1)
 
 	case eventTypeRejected:
 		log.Warnf("Stats writer payload rejected by edge: %v", data.err)
-		w.stats.Errors.Inc()
+		atomic.AddInt64(&w.stats.Errors, 1)
 
 	case eventTypeDropped:
 		w.easylog.Warn("Stats writer queue full. Payload dropped (%.2fKB).", float64(data.bytes)/1024)

--- a/pkg/trace/writer/trace.go
+++ b/pkg/trace/writer/trace.go
@@ -11,6 +11,7 @@ import (
 	"math"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
@@ -175,9 +176,9 @@ func (w *TraceWriter) FlushSync() error {
 }
 
 func (w *TraceWriter) addSpans(pkg *SampledChunks) {
-	w.stats.Spans.Add(pkg.SpanCount)
-	w.stats.Traces.Add(int64(len(pkg.TracerPayload.Chunks)))
-	w.stats.Events.Add(pkg.EventCount)
+	atomic.AddInt64(&w.stats.Spans, pkg.SpanCount)
+	atomic.AddInt64(&w.stats.Traces, int64(len(pkg.TracerPayload.Chunks)))
+	atomic.AddInt64(&w.stats.Events, pkg.EventCount)
 
 	size := pkg.Size
 	if size+w.bufferedSize > MaxPayloadSize {
@@ -238,8 +239,8 @@ func (w *TraceWriter) flush() {
 		return
 	}
 
-	w.stats.BytesUncompressed.Add(int64(len(b)))
-	w.stats.BytesEstimated.Add(int64(w.bufferedSize))
+	atomic.AddInt64(&w.stats.BytesUncompressed, int64(len(b)))
+	atomic.AddInt64(&w.stats.BytesEstimated, int64(w.bufferedSize))
 
 	w.wg.Add(1)
 	go func() {
@@ -269,15 +270,15 @@ func (w *TraceWriter) flush() {
 }
 
 func (w *TraceWriter) report() {
-	metrics.Count("datadog.trace_agent.trace_writer.payloads", w.stats.Payloads.Swap(0), nil, 1)
-	metrics.Count("datadog.trace_agent.trace_writer.bytes_uncompressed", w.stats.BytesUncompressed.Swap(0), nil, 1)
-	metrics.Count("datadog.trace_agent.trace_writer.retries", w.stats.Retries.Swap(0), nil, 1)
-	metrics.Count("datadog.trace_agent.trace_writer.bytes_estimated", w.stats.BytesEstimated.Swap(0), nil, 1)
-	metrics.Count("datadog.trace_agent.trace_writer.bytes", w.stats.Bytes.Swap(0), nil, 1)
-	metrics.Count("datadog.trace_agent.trace_writer.errors", w.stats.Errors.Swap(0), nil, 1)
-	metrics.Count("datadog.trace_agent.trace_writer.traces", w.stats.Traces.Swap(0), nil, 1)
-	metrics.Count("datadog.trace_agent.trace_writer.events", w.stats.Events.Swap(0), nil, 1)
-	metrics.Count("datadog.trace_agent.trace_writer.spans", w.stats.Spans.Swap(0), nil, 1)
+	metrics.Count("datadog.trace_agent.trace_writer.payloads", atomic.SwapInt64(&w.stats.Payloads, 0), nil, 1)
+	metrics.Count("datadog.trace_agent.trace_writer.bytes_uncompressed", atomic.SwapInt64(&w.stats.BytesUncompressed, 0), nil, 1)
+	metrics.Count("datadog.trace_agent.trace_writer.retries", atomic.SwapInt64(&w.stats.Retries, 0), nil, 1)
+	metrics.Count("datadog.trace_agent.trace_writer.bytes_estimated", atomic.SwapInt64(&w.stats.BytesEstimated, 0), nil, 1)
+	metrics.Count("datadog.trace_agent.trace_writer.bytes", atomic.SwapInt64(&w.stats.Bytes, 0), nil, 1)
+	metrics.Count("datadog.trace_agent.trace_writer.errors", atomic.SwapInt64(&w.stats.Errors, 0), nil, 1)
+	metrics.Count("datadog.trace_agent.trace_writer.traces", atomic.SwapInt64(&w.stats.Traces, 0), nil, 1)
+	metrics.Count("datadog.trace_agent.trace_writer.events", atomic.SwapInt64(&w.stats.Events, 0), nil, 1)
+	metrics.Count("datadog.trace_agent.trace_writer.spans", atomic.SwapInt64(&w.stats.Spans, 0), nil, 1)
 }
 
 var _ eventRecorder = (*TraceWriter)(nil)
@@ -291,17 +292,17 @@ func (w *TraceWriter) recordEvent(t eventType, data *eventData) {
 	switch t {
 	case eventTypeRetry:
 		log.Debugf("Retrying to flush trace payload; error: %s", data.err)
-		w.stats.Retries.Inc()
+		atomic.AddInt64(&w.stats.Retries, 1)
 
 	case eventTypeSent:
 		log.Debugf("Flushed traces to the API; time: %s, bytes: %d", data.duration, data.bytes)
 		timing.Since("datadog.trace_agent.trace_writer.flush_duration", time.Now().Add(-data.duration))
-		w.stats.Bytes.Add(int64(data.bytes))
-		w.stats.Payloads.Inc()
+		atomic.AddInt64(&w.stats.Bytes, int64(data.bytes))
+		atomic.AddInt64(&w.stats.Payloads, 1)
 
 	case eventTypeRejected:
 		log.Warnf("Trace writer payload rejected by edge: %v", data.err)
-		w.stats.Errors.Inc()
+		atomic.AddInt64(&w.stats.Errors, 1)
 
 	case eventTypeDropped:
 		w.easylog.Warn("Trace writer queue full. Payload dropped (%.2fKB).", float64(data.bytes)/1024)


### PR DESCRIPTION
This reverts commit 2469fbac5d39d3cea002dbf119035b3d48142a17.

This is due to serialization issues resulting from PR #12120 which block the agent release.
Error message from `agent status` before revert:
```
template: /trace-agent.tmpl:46:139: executing "/trace-agent.tmpl" at <.trace_writer.Bytes>: wrong type for value; expected float64; got map[string]interface {}
```

Below is the revert steps to call out merge conflicts:
```
~ git revert https://github.com/DataDog/datadog-agent/commit/2469fbac5d39d3cea002dbf119035b3d48142a17
Auto-merging pkg/trace/agent/agent.go
Auto-merging pkg/trace/agent/agent_test.go
Auto-merging pkg/trace/api/responses.go
Auto-merging pkg/trace/go.mod
CONFLICT (content): Merge conflict in pkg/trace/go.mod
Auto-merging pkg/trace/sampler/dynamic_config.go
CONFLICT (content): Merge conflict in pkg/trace/sampler/dynamic_config.go
Auto-merging pkg/trace/sampler/prioritysampler_test.go
CONFLICT (content): Merge conflict in pkg/trace/sampler/prioritysampler_test.go
Auto-merging pkg/trace/sampler/rare_sampler.go
CONFLICT (content): Merge conflict in pkg/trace/sampler/rare_sampler.go
Auto-merging pkg/trace/sampler/remote_rates.go
CONFLICT (content): Merge conflict in pkg/trace/sampler/remote_rates.go
Auto-merging pkg/trace/sampler/remote_rates_test.go
CONFLICT (content): Merge conflict in pkg/trace/sampler/remote_rates_test.go
error: could not revert https://github.com/DataDog/datadog-agent/commit/2469fbac5d39d3cea002dbf119035b3d48142a17... pkg/trace: use go.uber.com/atomic (https://github.com/DataDog/datadog-agent/pull/12120)
```

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
