### PR TITLE
[CWS] Set default ring buffer size to a power of 2 and multiple of page size

### DIFF
--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -315,6 +315,10 @@ func NewConfig(cfg *config.Config) (*Config, error) {
 		}
 	}
 
+	if c.EventStreamBufferSize%os.Getpagesize() != 0 || c.EventStreamBufferSize&(c.EventStreamBufferSize-1) != 0 {
+		return nil, fmt.Errorf("runtime_security_config.event_stream.buffer_size must be a power of 2 and a multiple of %d", os.Getpagesize())
+	}
+
 	setEnv()
 	return c, nil
 }

--- a/pkg/security/ebpf/manager.go
+++ b/pkg/security/ebpf/manager.go
@@ -25,7 +25,6 @@ func NewDefaultOptions() manager.Options {
 		DefaultKProbeMaxActive: 512,
 
 		DefaultPerfRingBufferSize: probes.EventsPerfRingBufferSize,
-		DefaultRingBufferSize:     probes.EventsRingBufferSize,
 
 		VerifierOptions: ebpf.CollectionOptions{
 			Programs: ebpf.ProgramOptions{

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -11,8 +11,8 @@ package probes
 import (
 	"math"
 	"os"
-	"runtime"
 
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	manager "github.com/DataDog/ebpf-manager"
 	"github.com/cilium/ebpf"
 	"golang.org/x/sys/unix"
@@ -22,9 +22,8 @@ const (
 	minPathnamesEntries = 64000 // ~27 MB
 	maxPathnamesEntries = 96000
 
-	minProcEntries          = 16394
-	maxProcEntries          = 131072
-	maxEventsRingBufferSize = 16 * 1024 // 16384 pages
+	minProcEntries = 16394
+	maxProcEntries = 131072
 )
 
 var (
@@ -34,13 +33,25 @@ var (
 	// PLEASE NOTE: for the perf ring buffer usage metrics to be accurate, the provided value must have the
 	// following form: (1 + 2^n) * pages. Checkout https://github.com/DataDog/ebpf for more.
 	EventsPerfRingBufferSize = 257 * os.Getpagesize()
-	// EventsRingBufferSize is the default buffer size of the ring buffers for events.
-	EventsRingBufferSize int
+	// defaultEventsRingBufferSize is the default buffer size of the ring buffers for events.
+	// Must be a power of 2 and a multiple of the page size
+	defaultEventsRingBufferSize uint32
+	maxEventsRingBufferSize     = uint32(64 * 256 * os.Getpagesize()) // 67108864
 )
 
 func init() {
-	if EventsRingBufferSize = runtime.NumCPU() * 1024; EventsRingBufferSize > maxEventsRingBufferSize {
-		EventsPerfRingBufferSize = maxEventsRingBufferSize
+	numCPU, err := utils.NumCPU()
+	if err != nil {
+		numCPU = 1
+	}
+
+	defaultEventsRingBufferSize = uint32(1)
+	for defaultEventsRingBufferSize < uint32(numCPU*os.Getpagesize()) {
+		defaultEventsRingBufferSize *= 2
+	}
+
+	if defaultEventsRingBufferSize > maxEventsRingBufferSize {
+		defaultEventsRingBufferSize = maxEventsRingBufferSize
 	}
 }
 
@@ -160,7 +171,7 @@ func getMaxEntries(numCPU int, min int, max int) uint32 {
 }
 
 // AllMapSpecEditors returns the list of map editors
-func AllMapSpecEditors(numCPU int, tracedCgroupsCount int, cgroupWaitListSize int, supportMmapableMaps, useRingBuffers bool) map[string]manager.MapSpecEditor {
+func AllMapSpecEditors(numCPU int, tracedCgroupsCount int, cgroupWaitListSize int, supportMmapableMaps, useRingBuffers bool, ringBufferSize uint32) map[string]manager.MapSpecEditor {
 	if tracedCgroupsCount <= 0 || tracedCgroupsCount > MaxTracedCgroupsCount {
 		tracedCgroupsCount = MaxTracedCgroupsCount
 	}
@@ -196,8 +207,11 @@ func AllMapSpecEditors(numCPU int, tracedCgroupsCount int, cgroupWaitListSize in
 		}
 	}
 	if useRingBuffers {
+		if ringBufferSize == 0 {
+			ringBufferSize = defaultEventsRingBufferSize
+		}
 		editors["events"] = manager.MapSpecEditor{
-			MaxEntries: uint32(EventsRingBufferSize),
+			MaxEntries: ringBufferSize,
 			Type:       ebpf.RingBuf,
 			EditorFlag: manager.EditType | manager.EditMaxEntries,
 		}

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -36,7 +36,6 @@ var (
 	// defaultEventsRingBufferSize is the default buffer size of the ring buffers for events.
 	// Must be a power of 2 and a multiple of the page size
 	defaultEventsRingBufferSize uint32
-	maxEventsRingBufferSize     = uint32(64 * 256 * os.Getpagesize()) // 67108864
 )
 
 func init() {
@@ -45,13 +44,10 @@ func init() {
 		numCPU = 1
 	}
 
-	defaultEventsRingBufferSize = uint32(1)
-	for defaultEventsRingBufferSize < uint32(numCPU*os.Getpagesize()) {
-		defaultEventsRingBufferSize *= 2
-	}
-
-	if defaultEventsRingBufferSize > maxEventsRingBufferSize {
-		defaultEventsRingBufferSize = maxEventsRingBufferSize
+	if numCPU < 64 {
+		defaultEventsRingBufferSize = uint32(64 * 256 * os.Getpagesize())
+	} else {
+		defaultEventsRingBufferSize = uint32(128 * 256 * os.Getpagesize())
 	}
 }
 

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -1286,6 +1286,7 @@ func NewProbe(config *config.Config, statsdClient statsd.ClientInterface) (*Prob
 		p.config.ActivityDumpCgroupWaitListSize,
 		useMmapableMaps,
 		useRingBuffers,
+		uint32(p.config.EventStreamBufferSize),
 	)
 
 	if !p.config.EnableKernelFilters {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
