### PR TITLE
Revert force usage of CRI v1 API (allows fallback to v1alpha2)

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1653,6 +1653,7 @@ core,k8s.io/component-base/metrics/prometheus/workqueue,Apache-2.0,Copyright 201
 core,k8s.io/component-base/metrics/testutil,Apache-2.0,Copyright 2014 The Kubernetes Authors.
 core,k8s.io/component-base/version,Apache-2.0,Copyright 2014 The Kubernetes Authors.
 core,k8s.io/cri-api/pkg/apis/runtime/v1,Apache-2.0,Copyright 2014 The Kubernetes Authors.
+core,k8s.io/cri-api/pkg/apis/runtime/v1alpha2,Apache-2.0,Copyright 2014 The Kubernetes Authors.
 core,k8s.io/cri-api/pkg/apis/testing,Apache-2.0,Copyright 2014 The Kubernetes Authors.
 core,k8s.io/gengo/args,Apache-2.0,Copyright 2014 The Kubernetes Authors.
 core,k8s.io/gengo/examples/set-gen/sets,Apache-2.0,Copyright 2014 The Kubernetes Authors.

--- a/pkg/util/containers/cri/conversion.go
+++ b/pkg/util/containers/cri/conversion.go
@@ -1,0 +1,39 @@
+//go:build cri
+// +build cri
+
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cri
+
+import (
+	"unsafe"
+
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	"k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+func fromV1alpha2VersionResponse(from *v1alpha2.VersionResponse) *runtimeapi.VersionResponse {
+	return (*runtimeapi.VersionResponse)(unsafe.Pointer(from))
+}
+
+func fromV1alpha2ListContainerStatsResponse(from *v1alpha2.ListContainerStatsResponse) *runtimeapi.ListContainerStatsResponse {
+	return (*runtimeapi.ListContainerStatsResponse)(unsafe.Pointer(from))
+}
+
+func v1alpha2ContainerStatsFilter(from *runtimeapi.ContainerStatsFilter) *v1alpha2.ContainerStatsFilter {
+	return (*v1alpha2.ContainerStatsFilter)(unsafe.Pointer(from))
+}

--- a/pkg/util/containers/cri/crimock/criutil.go
+++ b/pkg/util/containers/cri/crimock/criutil.go
@@ -10,7 +10,7 @@ package crimock
 
 import (
 	"github.com/stretchr/testify/mock"
-	pb "k8s.io/cri-api/pkg/apis/runtime/v1"
+	criv1 "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 // MockCRIClient is used for tests
@@ -19,21 +19,15 @@ type MockCRIClient struct {
 }
 
 // ListContainerStats sends a ListContainerStatsRequest to the server, and parses the returned response
-func (m *MockCRIClient) ListContainerStats() (map[string]*pb.ContainerStats, error) {
+func (m *MockCRIClient) ListContainerStats() (map[string]*criv1.ContainerStats, error) {
 	args := m.Called()
-	return args.Get(0).(map[string]*pb.ContainerStats), args.Error(1)
+	return args.Get(0).(map[string]*criv1.ContainerStats), args.Error(1)
 }
 
 // GetContainerStats returns the stats for the container with the given ID
-func (m *MockCRIClient) GetContainerStats(containerID string) (*pb.ContainerStats, error) {
+func (m *MockCRIClient) GetContainerStats(containerID string) (*criv1.ContainerStats, error) {
 	args := m.Called(containerID)
-	return args.Get(0).(*pb.ContainerStats), args.Error(1)
-}
-
-// GetContainerStatus sends a ContainerStatusRequest to the server, and parses the returned response
-func (m *MockCRIClient) GetContainerStatus(containerID string) (*pb.ContainerStatus, error) {
-	args := m.Called(containerID)
-	return args.Get(0).(*pb.ContainerStatus), args.Error(1)
+	return args.Get(0).(*criv1.ContainerStats), args.Error(1)
 }
 
 // GetRuntime is a mock of GetRuntime


### PR DESCRIPTION
### What does this PR do?

Revert force usage of CRI v1 API (allows fallback to v1alpha2) from #12216 

### Motivation

The CRI v1 API is not widely supported yet (for instance, it requires `containerd` >= 1.6)

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Deploy the Agent on Kubernetes with `containerd` < 1.6 with the `collect_disk` option for the CRI check.
Verify that the `cri.disk.used` metric is emitted, verify this log is not produced:
```
Unable to reach CRI socket, err: temporary failure in criutil, will retry later: rpc error: code = Unimplemented desc = unknown service runtime.v1.RuntimeService
```

Deploy the Agent on Kubernetes with `containerd` >= 1.6 or OpenShift >= 4.10 with the `collect_disk` option for the CRI check.
Verify that the `cri.disk.used` metric is emitted.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
