### PR TITLE
fix(remote-config): Throw TUF errors when getting configs from Director

### DIFF
--- a/pkg/config/remote/uptane/client.go
+++ b/pkg/config/remote/uptane/client.go
@@ -234,7 +234,11 @@ func (c *Client) verifyUptane() error {
 	for targetPath, targetMeta := range directorTargets {
 		configTargetMeta, err := c.configTUFClient.Target(targetPath)
 		if err != nil {
-			return fmt.Errorf("failed to find target '%s' in config repository", targetPath)
+			if client.IsNotFound(err) {
+				return fmt.Errorf("failed to find target '%s' in config repository", targetPath)
+			}
+			// Other errors such as expired metadata
+			return err
 		}
 		if configTargetMeta.Length != targetMeta.Length {
 			return fmt.Errorf("target '%s' has size %d in directory repository and %d in config repository", targetPath, configTargetMeta.Length, targetMeta.Length)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Currently any TUF error happening when getting a config from the
Director results in a Not Found error. If our snapshot is expired or
simply does not exist, we want to be able to get a meaningful error.
If that change is not made, we may fall into a case where we don't know
what is happening when we have a TUF issue in the agent or the backend.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Better error management in the remote-config Uptane client
Follow-up of #12391 changes
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
N/A
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
N/A
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
One way of testing is to create an org, run the datadog-agent and set it up for remote-config. Then, wait until the snapshot / timestamp is expired (1 day), and, if it is not re-sign, try to run the agent again. While querying configurations, the trace-agent should throw a TUF error instead of an Not Found.
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
