### PR TITLE
[kubernetes/autoscalers/datadogclient] Add missing nil check

### DIFF
--- a/pkg/util/kubernetes/autoscalers/datadogclient.go
+++ b/pkg/util/kubernetes/autoscalers/datadogclient.go
@@ -218,10 +218,19 @@ func GetStatus(datadogClient DatadogClient) map[string]interface{} {
 
 	switch ddCl := datadogClient.(type) {
 	case *datadog.Client:
+		// Can be nil if there's an error in NewDatadogClient()
+		if ddCl == nil {
+			return status
+		}
+
 		clientStatus := make(map[string]interface{})
 		clientStatus["url"] = ddCl.GetBaseUrl()
 		status["client"] = clientStatus
 	case *datadogFallbackClient:
+		if ddCl == nil {
+			return status
+		}
+
 		status["lastUsedClient"] = ddCl.lastUsedClient
 		clientsStatus := make([]map[string]interface{}, len(ddCl.clients))
 		for i, individualClient := range ddCl.clients {

--- a/releasenotes-dca/notes/fix-nil-check-autoscalers-ddclient-943e99f47dbc6e95.yaml
+++ b/releasenotes-dca/notes/fix-nil-check-autoscalers-ddclient-943e99f47dbc6e95.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed an error when running `datadog-cluster-agent status` with
+    `DD_EXTERNAL_METRICS_PROVIDER_ENABLED=true` and no app key set.
+


### PR DESCRIPTION

### What does this PR do?

Fixes an error that happens when running `datadog-cluster-agent status` with `DD_EXTERNAL_METRICS_PROVIDER_ENABLED` set to true and no app key set.

In that scenario, the DCA shows this error:
```
CLUSTER | ERROR | (/goroot/src/net/http/server.go:3158 in logf) | Error from the agent http API server: http: panic serving 127.0.0.1:44398: runtime error: invalid memory address or nil pointer dereference
goroutine 43764 [running]:
net/http.(*conn).serve.func1()
/goroot/src/net/http/server.go:1802 +0xb9
panic({0x2e81320, 0x56c1700})
/goroot/src/runtime/panic.go:1047 +0x266
gopkg.in/zorkian/go-datadog-api%2ev2.(*Client).GetBaseUrl(...)
/go/pkg/mod/gopkg.in/zorkian/go-datadog-api.v2@v2.30.0/client.go:84
github.com/DataDog/datadog-agent/pkg/util/kubernetes/autoscalers.GetStatus({0x39bfdf0, 0x0})
/go/src/github.com/DataDog/datadog-agent/pkg/util/kubernetes/autoscalers/datadogclient.go:220 +0x15b
github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver.GetStatus(...)
/go/src/github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/status.go:18
github.com/DataDog/datadog-agent/pkg/status.GetDCAStatus()
/go/src/github.com/DataDog/datadog-agent/pkg/status/status.go:185 +0x69a
github.com/DataDog/datadog-agent/cmd/cluster-agent/api/agent.getStatus({0x39dcd60, 0xc001332380}, 0x8)
/go/src/github.com/DataDog/datadog-agent/cmd/cluster-agent/api/agent/agent.go:50 +0x5b
net/http.HandlerFunc.ServeHTTP(0x39dcd60, {0x39dcd60, 0xc001332380}, 0x34b7428)
/goroot/src/net/http/server.go:2047 +0x2f
github.com/DataDog/datadog-agent/cmd/cluster-agent/api.validateToken.func1({0x39dcd60, 0xc001332380}, 0xc000b44700)
/go/src/github.com/DataDog/datadog-agent/cmd/cluster-agent/api/server.go:141 +0xa9
net/http.HandlerFunc.ServeHTTP(0xc000b44600, {0x39dcd60, 0xc001332380}, 0x7ff033dddf00)
/goroot/src/net/http/server.go:2047 +0x2f
github.com/gorilla/mux.(*Router).ServeHTTP(0xc000598f00, {0x39dcd60, 0xc001332380}, 0xc000b44300)
/go/pkg/mod/github.com/gorilla/mux@v1.8.0/mux.go:210 +0x1cf
net/http.serverHandler.ServeHTTP({0xc000f035f0}, {0x39dcd60, 0xc001332380}, 0xc000b44300)
/goroot/src/net/http/server.go:2879 +0x43b
net/http.(*conn).serve(0xc000d15400, {0x3a014c8, 0xc000bc70b0})
/goroot/src/net/http/server.go:1930 +0xb08
created by net/http.(*Server).Serve
/goroot/src/net/http/server.go:3034 +0x4e8
```

### Describe how to test/QA your changes

Run the DCA with `DD_EXTERNAL_METRICS_PROVIDER_ENABLED` set to true and no app key set.
Check that `datadog-cluster-agent status` works.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
