### PR TITLE
[CWS] fix process context support for busybox command

### DIFF
--- a/pkg/security/secl/model/oo_symlink.go
+++ b/pkg/security/secl/model/oo_symlink.go
@@ -14,7 +14,7 @@ var (
 		{
 			EvalFnc: func(ctx *eval.Context) string {
 				// empty symlink, generate a fake so that it doesn't match
-				if path := (*Event)(ctx.Object).Exec.Process.SymlinkPathnameStr[0]; path != "" {
+				if path := (*Event)(ctx.Object).ProcessContext.SymlinkPathnameStr[0]; path != "" {
 					return path
 				}
 				return "~" // to ensure that it will not match an empty path
@@ -23,7 +23,7 @@ var (
 		{
 			EvalFnc: func(ctx *eval.Context) string {
 				// empty symlink, generate a fake so that it doesn't match
-				if path := (*Event)(ctx.Object).Exec.Process.SymlinkPathnameStr[1]; path != "" {
+				if path := (*Event)(ctx.Object).ProcessContext.SymlinkPathnameStr[1]; path != "" {
 					return path
 				}
 				return "~" // to ensure that it will not match an empty path
@@ -33,7 +33,7 @@ var (
 
 	symlinkBasenameEvaluator = &eval.StringEvaluator{
 		EvalFnc: func(ctx *eval.Context) string {
-			return (*Event)(ctx.Object).Exec.Process.SymlinkBasenameStr
+			return (*Event)(ctx.Object).ProcessContext.SymlinkBasenameStr
 		},
 	}
 
@@ -46,7 +46,7 @@ var (
 			}
 
 			// currently only override exec events
-			if a.Field == "exec.file.path" {
+			if a.Field == "exec.file.path" || a.Field == "process.file.path" {
 				se1, err := eval.GlobCmp.StringEquals(symlinkPathnameEvaluators[0], b, state)
 				if err != nil {
 					return nil, err
@@ -61,7 +61,7 @@ var (
 				}
 
 				return eval.Or(path, or, state)
-			} else if b.Field == "exec.file.path" {
+			} else if b.Field == "exec.file.path" || b.Field == "process.file.path" {
 				se1, err := eval.GlobCmp.StringEquals(symlinkPathnameEvaluators[0], a, state)
 				if err != nil {
 					return nil, err
@@ -87,7 +87,7 @@ var (
 			}
 
 			// currently only override exec events
-			if a.Field == "exec.file.path" {
+			if a.Field == "exec.file.path" || a.Field == "process.file.path" {
 				se1, err := eval.GlobCmp.StringValuesContains(symlinkPathnameEvaluators[0], b, state)
 				if err != nil {
 					return nil, err
@@ -113,7 +113,7 @@ var (
 			}
 
 			// currently only override exec events
-			if a.Field == "exec.file.path" {
+			if a.Field == "exec.file.path" || a.Field == "process.file.path" {
 				se1, err := eval.GlobCmp.StringArrayContains(symlinkPathnameEvaluators[0], b, state)
 				if err != nil {
 					return nil, err
@@ -146,13 +146,13 @@ var (
 			}
 
 			// currently only override exec events
-			if a.Field == "exec.file.name" {
+			if a.Field == "exec.file.name" || a.Field == "process.file.name" {
 				symlink, err := eval.StringEquals(symlinkBasenameEvaluator, b, state)
 				if err != nil {
 					return nil, err
 				}
 				return eval.Or(path, symlink, state)
-			} else if b.Field == "exec.file.name" {
+			} else if b.Field == "exec.file.name" || b.Field == "process.file.name" {
 				symlink, err := eval.StringEquals(a, symlinkBasenameEvaluator, state)
 				if err != nil {
 					return nil, err
@@ -169,7 +169,7 @@ var (
 			}
 
 			// currently only override exec events
-			if a.Field == "exec.file.name" {
+			if a.Field == "exec.file.name" || a.Field == "process.file.name" {
 				symlink, err := eval.StringValuesContains(symlinkBasenameEvaluator, b, state)
 				if err != nil {
 					return nil, err
@@ -186,7 +186,7 @@ var (
 			}
 
 			// currently only override exec events
-			if a.Field == "exec.file.name" {
+			if a.Field == "exec.file.name" || a.Field == "process.file.name" {
 				symlink, err := eval.StringArrayContains(symlinkBasenameEvaluator, b, state)
 				if err != nil {
 					return nil, err


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
