### PR TITLE
[DOCS-3569] Add tagger_warmup_duration param to datadog.yaml

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1003,6 +1003,13 @@ api_key:
   #
   # open_files_limit: 100
 
+  ## @param tagger_warmup_duration - optional - default: 0
+  ## @env DD_LOGS_CONFIG_TAGGER_WARMUP_DURATION - optional - default: 0 
+  ## The number of seconds that the log agent waits for the internal tagger to 
+  ## add the related container/pod tags to the logs before the logs are sent.
+  #
+  # tagger_warmup_duration: 0
+
 {{ end -}}
 {{- if .TraceAgent }}
 


### PR DESCRIPTION
### What does this PR do?

Adds the `tagger_warmup_duration` param to the datadog.yaml.  Info is based on this answer to a Github issue: https://github.com/DataDog/datadog-agent/issues/5667#issuecomment-640690972

### Motivation

Requested by customer.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
