### PR TITLE
Add a new `min_tls_version` config parameter

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -366,8 +366,9 @@ func InitConfig(config Config) {
 	// IPC API server timeout
 	config.BindEnvAndSetDefault("server_timeout", 30)
 
-	// Use to force client side TLS version to 1.2
-	config.BindEnvAndSetDefault("force_tls_12", false)
+	// Configuration for TLS for outgoing connections
+	config.BindEnvAndSetDefault("force_tls_12", false) // deprecated
+	config.BindEnvAndSetDefault("min_tls_version", "") // default depends on force_tls_12
 
 	// Defaults to safe YAML methods in base and custom checks.
 	config.BindEnvAndSetDefault("disable_unsafe_yaml", true)

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -63,8 +63,8 @@ api_key:
 # sslkeylogfile: ""
 
 
-## @param min_tls_version - string - optional - default: "tlsv1.0" or "tlsv1.2"
-## @env DD_MIN_TLS_VERSION - string - optional - default: "tlsv1.0" or "tlsv1.2"
+## @param min_tls_version - string - optional - default: "tlsv1.0"
+## @env DD_MIN_TLS_VERSION - string - optional - default: "tlsv1.0"
 ## This option defines the minimum TLS version that will be used when
 ## submitting data to the Datadog intake specified in "site" or "dd_url".
 ## This parameter defaults to "tlsv1.0" (but see `force_tls_12`, below).
@@ -75,8 +75,9 @@ api_key:
 
 ## @param force_tls_12 - boolean - optional - default: false
 ## @env DD_FORCE_TLS_12 - boolean - optional - default: false
-## Setting this option to "true" is equivalent to setting `min_tls_version`
-## to "tlsv1.2".
+## Setting this option to "true" is equivalent to setting the default for
+## `min_tls_version` to `tlsv1.2`.  This parameter is deprecated in favor of
+## `min_tls_version`.
 #
 # force_tls_12: false
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -63,12 +63,15 @@ api_key:
 # sslkeylogfile: ""
 
 
-## @param force_tls_12 - boolean - optional - default: false
-## @env DD_FORCE_TLS_12 - boolean - optional - default: false
-## Setting this option to "true" forces the Agent to only use TLS 1.2 when
+## @param min_tls_version - string - optional - default: "1.0" or "1.2"
+## @env DD_MIN_TLS_VERSION - string - optional - default: "1.0" or "1.2"
+## This option defines the minimum TLS version that will be used when
 ## pushing data to the Datadog intake specified in "site" or "dd_url".
+## This parameter defaults to "1.0", but if the deprecated configuration
+## parameter `force_tls_12` is set then it defaults to "1.2".  Always use
+## double quotes with this value.
 #
-# force_tls_12: false
+# min_tls_version: "1.0"
 
 ## @param hostname - string - optional - default: auto-detected
 ## @env DD_HOSTNAME - string - optional - default: auto-detected

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -66,7 +66,7 @@ api_key:
 ## @param min_tls_version - string - optional - default: "tlsv1.0" or "tlsv1.2"
 ## @env DD_MIN_TLS_VERSION - string - optional - default: "tlsv1.0" or "tlsv1.2"
 ## This option defines the minimum TLS version that will be used when
-## pushing data to the Datadog intake specified in "site" or "dd_url".
+## submitting data to the Datadog intake specified in "site" or "dd_url".
 ## This parameter defaults to "tlsv1.0" (but see `force_tls_12`, below).
 ## Possible values are: tlsv1.0, tlsv1.1, tlsv1.2, tlsv1.3.
 #

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -63,15 +63,21 @@ api_key:
 # sslkeylogfile: ""
 
 
-## @param min_tls_version - string - optional - default: "1.0" or "1.2"
-## @env DD_MIN_TLS_VERSION - string - optional - default: "1.0" or "1.2"
+## @param min_tls_version - string - optional - default: "tlsv1.0" or "tlsv1.2"
+## @env DD_MIN_TLS_VERSION - string - optional - default: "tlsv1.0" or "tlsv1.2"
 ## This option defines the minimum TLS version that will be used when
 ## pushing data to the Datadog intake specified in "site" or "dd_url".
-## This parameter defaults to "1.0", but if the deprecated configuration
-## parameter `force_tls_12` is set then it defaults to "1.2".  Always use
-## double quotes with this value.
+## This parameter defaults to "tlsv1.0" (but see `force_tls_12`, below).
+## Possible values are: tlsv1.0, tlsv1.1, tlsv1.2, tlsv1.3.
 #
-# min_tls_version: "1.0"
+# min_tls_version: "tlsv1.0"
+
+## @param force_tls_12 - boolean - optional - default: false
+## @env DD_FORCE_TLS_12 - boolean - optional - default: false
+## Setting this option to "true" is equivalent to setting `min_tls_version`
+## to "tlsv1.2".
+#
+# force_tls_12: false
 
 ## @param hostname - string - optional - default: auto-detected
 ## @env DD_HOSTNAME - string - optional - default: auto-detected

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -68,7 +68,8 @@ api_key:
 ## This option defines the minimum TLS version that will be used when
 ## submitting data to the Datadog intake specified in "site" or "dd_url".
 ## This parameter defaults to "tlsv1.0" (but see `force_tls_12`, below).
-## Possible values are: tlsv1.0, tlsv1.1, tlsv1.2, tlsv1.3.
+## Possible values are: tlsv1.0, tlsv1.1, tlsv1.2, tlsv1.3; values are case-
+## insensitive.
 #
 # min_tls_version: "tlsv1.0"
 

--- a/pkg/util/http/transport.go
+++ b/pkg/util/http/transport.go
@@ -61,23 +61,25 @@ func warnOnce(warnMap map[string]bool, key string, format string, params ...inte
 // The returned result is one of the `tls.VersionTLSxxx` constants.
 func minTLSVersionFromConfig(cfg config.Config) uint16 {
 	var min uint16
-	switch cfg.GetString("min_tls_version") {
-	case "1.0":
+	minTLSVersion := cfg.GetString("min_tls_version")
+	switch minTLSVersion {
+	case "tlsv1.0":
 		min = tls.VersionTLS10
-	case "1.1":
+	case "tlsv1.1":
 		min = tls.VersionTLS11
-	case "1.2":
+	case "tlsv1.2":
 		min = tls.VersionTLS12
-	case "1.3":
+	case "tlsv1.3":
 		min = tls.VersionTLS13
-	case "": // default
+	default:
 		if cfg.GetBool("force_tls_12") {
 			min = tls.VersionTLS12
 		} else {
 			min = tls.VersionTLS10
 		}
-	default:
-		log.Warnf("Invalid `min_tls_version` %#v", cfg.GetString("min_tls_version"))
+		if minTLSVersion != "" {
+			log.Warnf("Invalid `min_tls_version` %#v; using %#v", minTLSVersion, min)
+		}
 	}
 	return min
 }

--- a/pkg/util/http/transport.go
+++ b/pkg/util/http/transport.go
@@ -62,7 +62,7 @@ func warnOnce(warnMap map[string]bool, key string, format string, params ...inte
 func minTLSVersionFromConfig(cfg config.Config) uint16 {
 	var min uint16
 	minTLSVersion := cfg.GetString("min_tls_version")
-	switch minTLSVersion {
+	switch strings.ToLower(minTLSVersion) {
 	case "tlsv1.0":
 		min = tls.VersionTLS10
 	case "tlsv1.1":

--- a/pkg/util/http/transport.go
+++ b/pkg/util/http/transport.go
@@ -78,7 +78,7 @@ func minTLSVersionFromConfig(cfg config.Config) uint16 {
 			min = tls.VersionTLS10
 		}
 		if minTLSVersion != "" {
-			log.Warnf("Invalid `min_tls_version` %#v; using %#v", minTLSVersion, min)
+			log.Warnf("Invalid `min_tls_version` %#v; using default", minTLSVersion)
 		}
 	}
 	return min

--- a/pkg/util/http/transport_test.go
+++ b/pkg/util/http/transport_test.go
@@ -205,6 +205,10 @@ func TestMinTLSVersionFromConfig(t *testing.T) {
 		{"tlsv1.2", true, tls.VersionTLS12},
 		{"tlsv1.3", false, tls.VersionTLS13},
 		{"tlsv1.3", true, tls.VersionTLS13},
+		// case-insensitive
+		{"TlSv1.0", false, tls.VersionTLS10},
+		{"TlSv1.3", true, tls.VersionTLS13},
+		// defaults
 		{"", false, tls.VersionTLS10},
 		{"", true, tls.VersionTLS12},
 		// invalid values

--- a/pkg/util/http/transport_test.go
+++ b/pkg/util/http/transport_test.go
@@ -7,6 +7,7 @@ package http
 
 import (
 	"crypto/tls"
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -160,12 +161,12 @@ func TestCreateHTTPTransport(t *testing.T) {
 	mockConfig.Set("force_tls_12", false)
 	transport := CreateHTTPTransport()
 	assert.False(t, transport.TLSClientConfig.InsecureSkipVerify)
-	assert.Equal(t, transport.TLSClientConfig.MinVersion, uint16(0))
+	assert.Equal(t, transport.TLSClientConfig.MinVersion, uint16(tls.VersionTLS10))
 
 	mockConfig.Set("skip_ssl_validation", true)
 	transport = CreateHTTPTransport()
 	assert.True(t, transport.TLSClientConfig.InsecureSkipVerify)
-	assert.Equal(t, transport.TLSClientConfig.MinVersion, uint16(0))
+	assert.Equal(t, transport.TLSClientConfig.MinVersion, uint16(tls.VersionTLS10))
 
 	mockConfig.Set("force_tls_12", true)
 	transport = CreateHTTPTransport()
@@ -188,4 +189,37 @@ func TestNoProxyWarningMap(t *testing.T) {
 	assert.Equal(t, "https://user:pass@proxy.com:3128", proxyURL.String())
 
 	assert.Equal(t, NoProxyIgnoredWarningMap["http://api.test_http.com"], true)
+}
+
+func TestMinTLSVersionFromConfig(t *testing.T) {
+	tests := []struct {
+		minTLSVersion string
+		forceTLS12    bool
+		expect        uint16
+	}{
+		{"1.0", false, tls.VersionTLS10},
+		{"1.0", true, tls.VersionTLS10},
+		{"1.1", false, tls.VersionTLS11},
+		{"1.1", true, tls.VersionTLS11},
+		{"1.2", false, tls.VersionTLS12},
+		{"1.2", true, tls.VersionTLS12},
+		{"1.3", false, tls.VersionTLS13},
+		{"1.3", true, tls.VersionTLS13},
+		{"", false, tls.VersionTLS10},
+		{"", true, tls.VersionTLS12},
+	}
+
+	for _, test := range tests {
+		t.Run(
+			fmt.Sprintf("min_tls_version=%s/force_tls_12=%t", test.minTLSVersion, test.forceTLS12),
+			func(t *testing.T) {
+				cfg := config.Mock(t)
+				if test.minTLSVersion != "" {
+					cfg.Set("min_tls_version", test.minTLSVersion)
+				}
+				cfg.Set("force_tls_12", test.forceTLS12)
+				got := minTLSVersionFromConfig(cfg)
+				require.Equal(t, test.expect, got)
+			})
+	}
 }

--- a/pkg/util/http/transport_test.go
+++ b/pkg/util/http/transport_test.go
@@ -197,16 +197,21 @@ func TestMinTLSVersionFromConfig(t *testing.T) {
 		forceTLS12    bool
 		expect        uint16
 	}{
-		{"1.0", false, tls.VersionTLS10},
-		{"1.0", true, tls.VersionTLS10},
-		{"1.1", false, tls.VersionTLS11},
-		{"1.1", true, tls.VersionTLS11},
-		{"1.2", false, tls.VersionTLS12},
-		{"1.2", true, tls.VersionTLS12},
-		{"1.3", false, tls.VersionTLS13},
-		{"1.3", true, tls.VersionTLS13},
+		{"tlsv1.0", false, tls.VersionTLS10},
+		{"tlsv1.0", true, tls.VersionTLS10},
+		{"tlsv1.1", false, tls.VersionTLS11},
+		{"tlsv1.1", true, tls.VersionTLS11},
+		{"tlsv1.2", false, tls.VersionTLS12},
+		{"tlsv1.2", true, tls.VersionTLS12},
+		{"tlsv1.3", false, tls.VersionTLS13},
+		{"tlsv1.3", true, tls.VersionTLS13},
 		{"", false, tls.VersionTLS10},
 		{"", true, tls.VersionTLS12},
+		// invalid values
+		{"tlsv1.9", false, tls.VersionTLS10},
+		{"tlsv1.9", true, tls.VersionTLS12},
+		{"blergh", false, tls.VersionTLS10},
+		{"blergh", true, tls.VersionTLS12},
 	}
 
 	for _, test := range tests {

--- a/releasenotes/notes/min_tls_version-43fd3ea989571192.yaml
+++ b/releasenotes/notes/min_tls_version-43fd3ea989571192.yaml
@@ -1,0 +1,12 @@
+---
+enhancements:
+  - |
+    The new ``min_tls_version`` configuration parameter allows configuration of
+    the minimum TLS version used for connections to the Datadog intake.  This
+    replaces the ``force_tls_12`` configuration parameter which only allowed
+    the minimum to be set to 1.2.
+deprecations:
+  - |
+    The ``force_tls_12`` configuration parameter is deprecated, replaced by
+    ``min_tls_version``.  If ``min_tls_version`` is not given, but ``force_tls_12``
+    is true, then ``min_tls_version`` defaults to 1.2.

--- a/releasenotes/notes/min_tls_version-43fd3ea989571192.yaml
+++ b/releasenotes/notes/min_tls_version-43fd3ea989571192.yaml
@@ -5,8 +5,3 @@ enhancements:
     the minimum TLS version used for connections to the Datadog intake.  This
     replaces the ``force_tls_12`` configuration parameter which only allowed
     the minimum to be set to 1.2.
-deprecations:
-  - |
-    The ``force_tls_12`` configuration parameter is deprecated, replaced by
-    ``min_tls_version``.  If ``min_tls_version`` is not given, but ``force_tls_12``
-    is true, then ``min_tls_version`` defaults to 1.2.

--- a/releasenotes/notes/min_tls_version-43fd3ea989571192.yaml
+++ b/releasenotes/notes/min_tls_version-43fd3ea989571192.yaml
@@ -4,4 +4,9 @@ enhancements:
     The new ``min_tls_version`` configuration parameter allows configuration of
     the minimum TLS version used for connections to the Datadog intake.  This
     replaces the ``force_tls_12`` configuration parameter which only allowed
-    the minimum to be set to 1.2.
+    the minimum to be set to tlsv1.2.
+deprecations:
+  - |
+    The ``force_tls_12`` configuration parameter is deprecated, replaced by
+    ``min_tls_version``.  If ``min_tls_version`` is not given, but ``force_tls_12``
+    is true, then ``min_tls_version`` defaults to tlsv1.2.


### PR DESCRIPTION
### What does this PR do?

Adds a new `min_tls_version` config parameter to allow users to flexibly select a minimum TLS version allowed by the agent.

### Motivation

The previous config parameter, `force_tls_12`, only supported enforcing a minimum of 1.2, but customers need more flexibility.

### Additional Notes

This maintains backward compatibility.  It also unconditionally sets `tlsConfig.MinVersion`, so Go's own defaults do not apply.  Those defaults will change when we adopt go1.18, so this avoids a potential unexpected behavior change.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Set up nginx to serve TLS with various settings.  First create a key and cert:

```
⸩ openssl req -x509 -nodes -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 365
Generating a RSA private key
.........................................................................++++
.......++++
writing new private key to 'key.pem'
-----
You are about to be asked to enter information that will be incorporated
into your certificate request.
What you are about to enter is what is called a Distinguished Name or a DN.
There are quite a few fields but you can leave some blank
For some fields there will be a default value,
If you enter '.', the field will be left blank.
-----
Country Name (2 letter code) [AU]:
State or Province Name (full name) [Some-State]:
Locality Name (eg, city) []:
Organization Name (eg, company) [Internet Widgits Pty Ltd]:
Organizational Unit Name (eg, section) []:
Common Name (e.g. server FQDN or YOUR name) []:127.0.0.1
Email Address []:
```

Then create a config file:
```
user  nginx;
worker_processes  auto;

error_log  /var/log/nginx/error.log notice;
pid        /var/run/nginx.pid;


events {
    worker_connections  1024;
}


http {
    include       /etc/nginx/mime.types;
    default_type  application/octet-stream;

    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                      '$status $body_bytes_sent "$http_referer" '
                      '"$http_user_agent" "$http_x_forwarded_for"';

    access_log  /var/log/nginx/access.log  main;

    sendfile        on;
    #tcp_nopush     on;

    keepalive_timeout  65;

    #gzip  on;

    include /etc/nginx/conf.d/*.conf;
    server {
        listen              443 ssl;
        server_name         www.example.com;
        ssl_certificate     /cert.pem;
        ssl_certificate_key /key.pem;
        ssl_protocols       TLSv1.2;
        ssl_ciphers         HIGH:!aNULL:!MD5;
    }
}
```

you'll adjust the `ssl_protocols` field later.  Note that 1.0 is spelled "TLSv1" and not "TLSv1.0".  Run the docker image:
```
docker run --rm --name nginx -p 4433:443  -v $PWD/nginx.conf:/etc/nginx/nginx.conf:ro -v $PWD/cert.pem:/cert.pem:ro -v $PWD/key.pem:/key.pem:ro nginx
```
confirm with `s_client`:
```
openssl s_client -connect 127.0.0.1:4433 -tls1_2
```
the output differs for each TLS version, but you should not see an error about no protocols available.

Run the agent, with `DD_PROXY_HTTPS=https://127.0.0.1:4433`:

Look for `pkg/forwarder` in the logs to see errors.  You should see things like "server selected unsupported protocol version 303" when the versions aren't allowed.  "certificate relies on legacy Common Name field, use SANs instead" is fine since nginx is using a bogus cert.  Try:

* `min_tls_version: "1.0"` with nginx configured to use 1 (should be OK)
* `min_tls_version: "1.0"` with nginx configured to use 1.3 (should be OK)
* `min_tls_version: "1.3"` with nginx configured to use 1 (should fail)
* `min_tls_version: "1.3"` with nginx configured to use 1.3 (should be OK)
* `force_tls_12: true` with nginx configured to use 1.1 (should fail)
* `force_tls_12: true` with nginx configured to use 1.3 (should be OK)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
