### PR TITLE
KSM: use v1beta1 PodDisruptionBudget and CronJob resources

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -668,6 +668,7 @@ core,github.com/richardartoul/molecule,MIT,Copyright (c) 2020 Richard Artoul
 core,github.com/richardartoul/molecule/src/codec,Apache-2.0,Copyright (c) 2020 Richard Artoul
 core,github.com/richardartoul/molecule/src/protowire,BSD-3-Clause,Copyright (c) 2018 The Go Authors. All rights reserved | Copyright (c) 2020 Richard Artoul
 core,github.com/rivo/uniseg,MIT,Copyright (c) 2019 Oliver Kuederle
+core,github.com/robfig/cron,MIT,Copyright (C) 2012 Rob Figueiredo
 core,github.com/robfig/cron/v3,MIT,Copyright (C) 2012 Rob Figueiredo
 core,github.com/rs/cors,MIT,Copyright (c) 2014 Olivier Poitrey <rs@dailymotion.com>
 core,github.com/samuel/go-zookeeper/zk,BSD-3-Clause,"Copyright (c) 2013, Samuel Stauffer <samuel@descolada.com>"

--- a/go.mod
+++ b/go.mod
@@ -407,7 +407,10 @@ require (
 	k8s.io/apiextensions-apiserver v0.23.5 // indirect
 )
 
-require github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.38.0-rc.1
+require (
+	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.38.0-rc.1
+	github.com/robfig/cron v1.2.0
+)
 
 // Fixing a CVE on a transitive dep of k8s/etcd, should be cleaned-up once k8s.io/apiserver dep is removed (but double-check with `go mod why` that no other dep pulls it)
 replace github.com/dgrijalva/jwt-go => github.com/golang-jwt/jwt v3.2.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1523,6 +1523,8 @@ github.com/richardartoul/molecule v0.0.0-20210914193524-25d8911bb85b h1:mbJ/v+xr
 github.com/richardartoul/molecule v0.0.0-20210914193524-25d8911bb85b/go.mod h1:uvX/8buq8uVeiZiFht+0lqSLBHF+uGV8BrTv8W/SIwk=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
+github.com/robfig/cron v1.2.0 h1:ZjScXvvxeQ63Dbyxy76Fj3AT3Ut0aKsyd2/tl3DTMuQ=
+github.com/robfig/cron v1.2.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=

--- a/pkg/collector/corechecks/cluster/ksm/customresources/cronjob.go
+++ b/pkg/collector/corechecks/cluster/ksm/customresources/cronjob.go
@@ -1,0 +1,337 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package customresources
+
+// This file has most of its logic copied from the KSM cronjob metric family
+// generators available at
+// https://github.com/kubernetes/kube-state-metrics/blob/release-2.4/internal/store/cronjob.go
+// It exists here to provide backwards compatibility with k8s <1.19, as KSM 2.4
+// uses API v1 instead of v1beta1: https://github.com/kubernetes/kube-state-metrics/pull/1491
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/robfig/cron"
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/kube-state-metrics/v2/pkg/customresource"
+	"k8s.io/kube-state-metrics/v2/pkg/metric"
+	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
+)
+
+var (
+	descCronJobAnnotationsName     = "kube_cronjob_annotations"
+	descCronJobAnnotationsHelp     = "Kubernetes annotations converted to Prometheus labels."
+	descCronJobLabelsName          = "kube_cronjob_labels"
+	descCronJobLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
+	descCronJobLabelsDefaultLabels = []string{"namespace", "cronjob"}
+)
+
+// NewCronJobFactory returns a new CronJob metric family generator factory.
+func NewCronJobFactory() customresource.RegistryFactory {
+	return &cronjobFactory{}
+}
+
+type cronjobFactory struct{}
+
+func (f *cronjobFactory) Name() string {
+	return "cronjobs"
+}
+
+// CreateClient is not implemented
+func (f *cronjobFactory) CreateClient(cfg *rest.Config) (interface{}, error) {
+	panic("not implemented")
+}
+
+func (f *cronjobFactory) MetricFamilyGenerators(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
+	return []generator.FamilyGenerator{
+		*generator.NewFamilyGenerator(
+			descCronJobAnnotationsName,
+			descCronJobAnnotationsHelp,
+			metric.Gauge,
+			"",
+			wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
+				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", j.Annotations, allowAnnotationsList)
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   annotationKeys,
+							LabelValues: annotationValues,
+							Value:       1,
+						},
+					},
+				}
+			}),
+		),
+		*generator.NewFamilyGenerator(
+			descCronJobLabelsName,
+			descCronJobLabelsHelp,
+			metric.Gauge,
+			"",
+			wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
+				labelKeys, labelValues := createPrometheusLabelKeysValues("label", j.Labels, allowLabelsList)
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   labelKeys,
+							LabelValues: labelValues,
+							Value:       1,
+						},
+					},
+				}
+			}),
+		),
+		*generator.NewFamilyGenerator(
+			"kube_cronjob_info",
+			"Info about cronjob.",
+			metric.Gauge,
+			"",
+			wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   []string{"schedule", "concurrency_policy"},
+							LabelValues: []string{j.Spec.Schedule, string(j.Spec.ConcurrencyPolicy)},
+							Value:       1,
+						},
+					},
+				}
+			}),
+		),
+		*generator.NewFamilyGenerator(
+			"kube_cronjob_created",
+			"Unix creation timestamp",
+			metric.Gauge,
+			"",
+			wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
+				ms := []*metric.Metric{}
+				if !j.CreationTimestamp.IsZero() {
+					ms = append(ms, &metric.Metric{
+						LabelKeys:   []string{},
+						LabelValues: []string{},
+						Value:       float64(j.CreationTimestamp.Unix()),
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		),
+		*generator.NewFamilyGenerator(
+			"kube_cronjob_status_active",
+			"Active holds pointers to currently running jobs.",
+			metric.Gauge,
+			"",
+			wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   []string{},
+							LabelValues: []string{},
+							Value:       float64(len(j.Status.Active)),
+						},
+					},
+				}
+			}),
+		),
+		*generator.NewFamilyGenerator(
+			"kube_cronjob_status_last_schedule_time",
+			"LastScheduleTime keeps information of when was the last time the job was successfully scheduled.",
+			metric.Gauge,
+			"",
+			wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
+				ms := []*metric.Metric{}
+
+				if j.Status.LastScheduleTime != nil {
+					ms = append(ms, &metric.Metric{
+						LabelKeys:   []string{},
+						LabelValues: []string{},
+						Value:       float64(j.Status.LastScheduleTime.Unix()),
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		),
+		*generator.NewFamilyGenerator(
+			"kube_cronjob_spec_suspend",
+			"Suspend flag tells the controller to suspend subsequent executions.",
+			metric.Gauge,
+			"",
+			wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
+				ms := []*metric.Metric{}
+
+				if j.Spec.Suspend != nil {
+					ms = append(ms, &metric.Metric{
+						LabelKeys:   []string{},
+						LabelValues: []string{},
+						Value:       boolFloat64(*j.Spec.Suspend),
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		),
+		*generator.NewFamilyGenerator(
+			"kube_cronjob_spec_starting_deadline_seconds",
+			"Deadline in seconds for starting the job if it misses scheduled time for any reason.",
+			metric.Gauge,
+			"",
+			wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
+				ms := []*metric.Metric{}
+
+				if j.Spec.StartingDeadlineSeconds != nil {
+					ms = append(ms, &metric.Metric{
+						LabelKeys:   []string{},
+						LabelValues: []string{},
+						Value:       float64(*j.Spec.StartingDeadlineSeconds),
+					})
+
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		),
+		*generator.NewFamilyGenerator(
+			"kube_cronjob_next_schedule_time",
+			"Next time the cronjob should be scheduled. The time after lastScheduleTime, or after the cron job's creation time if it's never been scheduled. Use this to determine if the job is delayed.",
+			metric.Gauge,
+			"",
+			wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
+				ms := []*metric.Metric{}
+
+				// If the cron job is suspended, don't track the next scheduled time
+				nextScheduledTime, err := getNextScheduledTime(j.Spec.Schedule, j.Status.LastScheduleTime, j.CreationTimestamp)
+				if err != nil {
+					panic(err)
+				} else if !*j.Spec.Suspend {
+					ms = append(ms, &metric.Metric{
+						LabelKeys:   []string{},
+						LabelValues: []string{},
+						Value:       float64(nextScheduledTime.Unix()),
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		),
+		*generator.NewFamilyGenerator(
+			"kube_cronjob_metadata_resource_version",
+			"Resource version representing a specific version of the cronjob.",
+			metric.Gauge,
+			"",
+			wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
+				return &metric.Family{
+					Metrics: resourceVersionMetric(j.ObjectMeta.ResourceVersion),
+				}
+			}),
+		),
+		*generator.NewFamilyGenerator(
+			"kube_cronjob_spec_successful_job_history_limit",
+			"Successful job history limit tells the controller how many completed jobs should be preserved.",
+			metric.Gauge,
+			"",
+			wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
+				ms := []*metric.Metric{}
+
+				if j.Spec.SuccessfulJobsHistoryLimit != nil {
+					ms = append(ms, &metric.Metric{
+						LabelKeys:   []string{},
+						LabelValues: []string{},
+						Value:       float64(*j.Spec.SuccessfulJobsHistoryLimit),
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		),
+		*generator.NewFamilyGenerator(
+			"kube_cronjob_spec_failed_job_history_limit",
+			"Failed job history limit tells the controller how many failed jobs should be preserved.",
+			metric.Gauge,
+			"",
+			wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
+				ms := []*metric.Metric{}
+
+				if j.Spec.FailedJobsHistoryLimit != nil {
+					ms = append(ms, &metric.Metric{
+						LabelKeys:   []string{},
+						LabelValues: []string{},
+						Value:       float64(*j.Spec.FailedJobsHistoryLimit),
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		),
+	}
+}
+
+func wrapCronJobFunc(f func(*batchv1beta1.CronJob) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
+		cronJob := obj.(*batchv1beta1.CronJob)
+
+		metricFamily := f(cronJob)
+
+		for _, m := range metricFamily.Metrics {
+			m.LabelKeys, m.LabelValues = mergeKeyValues(descCronJobLabelsDefaultLabels, []string{cronJob.Namespace, cronJob.Name}, m.LabelKeys, m.LabelValues)
+		}
+
+		return metricFamily
+	}
+}
+
+func (f *cronjobFactory) ExpectedType() interface{} {
+	return &batchv1beta1.CronJob{}
+}
+
+func (f *cronjobFactory) ListWatch(customResourceClient interface{}, ns string, fieldSelector string) cache.ListerWatcher {
+	client := customResourceClient.(kubernetes.Interface)
+	return &cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			opts.FieldSelector = fieldSelector
+			return client.BatchV1beta1().CronJobs(ns).List(context.TODO(), opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			opts.FieldSelector = fieldSelector
+			return client.BatchV1beta1().CronJobs(ns).Watch(context.TODO(), opts)
+		},
+	}
+}
+
+func getNextScheduledTime(schedule string, lastScheduleTime *metav1.Time, createdTime metav1.Time) (time.Time, error) {
+	sched, err := cron.ParseStandard(schedule)
+	if err != nil {
+		return time.Time{}, errors.Wrapf(err, "Failed to parse cron job schedule '%s'", schedule)
+	}
+	if !lastScheduleTime.IsZero() {
+		return sched.Next(lastScheduleTime.Time), nil
+	}
+	if !createdTime.IsZero() {
+		return sched.Next(createdTime.Time), nil
+	}
+	return time.Time{}, errors.New("createdTime and lastScheduleTime are both zero")
+}

--- a/pkg/collector/corechecks/cluster/ksm/customresources/pdb.go
+++ b/pkg/collector/corechecks/cluster/ksm/customresources/pdb.go
@@ -1,0 +1,219 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package customresources
+
+// This file has most of its logic copied from the KSM pdb metric family
+// generators available at
+// https://github.com/kubernetes/kube-state-metrics/blob/release-2.4/internal/store/poddisruptionbudget.go
+// It exists here to provide backwards compatibility with k8s <1.19, as KSM 2.4
+// uses API v1 instead of v1beta1: https://github.com/kubernetes/kube-state-metrics/pull/1491
+
+import (
+	"context"
+
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+
+	"k8s.io/kube-state-metrics/v2/pkg/customresource"
+	"k8s.io/kube-state-metrics/v2/pkg/metric"
+	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
+)
+
+var (
+	descPodDisruptionBudgetLabelsDefaultLabels = []string{"namespace", "poddisruptionbudget"}
+	descPodDisruptionBudgetAnnotationsName     = "kube_poddisruptionbudget_annotations"
+	descPodDisruptionBudgetAnnotationsHelp     = "Kubernetes annotations converted to Prometheus labels."
+	descPodDisruptionBudgetLabelsName          = "kube_poddisruptionbudget_labels"
+	descPodDisruptionBudgetLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
+)
+
+// NewPodDisruptionBudgetFactory returns a new PodDisruptionBudgets metric family generator factory.
+func NewPodDisruptionBudgetFactory() customresource.RegistryFactory {
+	return &pdbFactory{}
+}
+
+type pdbFactory struct{}
+
+func (f *pdbFactory) Name() string {
+	return "poddisruptionbudgets"
+}
+
+// CreateClient is not implemented
+func (f *pdbFactory) CreateClient(cfg *rest.Config) (interface{}, error) {
+	panic("not implemented")
+}
+
+func (f *pdbFactory) MetricFamilyGenerators(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
+	return []generator.FamilyGenerator{
+		*generator.NewFamilyGenerator(
+			descPodDisruptionBudgetAnnotationsName,
+			descPodDisruptionBudgetAnnotationsHelp,
+			metric.Gauge,
+			"",
+			wrapPodDisruptionBudgetFunc(func(p *policyv1beta1.PodDisruptionBudget) *metric.Family {
+				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", p.Annotations, allowAnnotationsList)
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   annotationKeys,
+							LabelValues: annotationValues,
+							Value:       1,
+						},
+					},
+				}
+			}),
+		),
+		*generator.NewFamilyGenerator(
+			descPodDisruptionBudgetLabelsName,
+			descPodDisruptionBudgetLabelsHelp,
+			metric.Gauge,
+			"",
+			wrapPodDisruptionBudgetFunc(func(p *policyv1beta1.PodDisruptionBudget) *metric.Family {
+				labelKeys, labelValues := createPrometheusLabelKeysValues("label", p.Labels, allowLabelsList)
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   labelKeys,
+							LabelValues: labelValues,
+							Value:       1,
+						},
+					},
+				}
+			}),
+		),
+		*generator.NewFamilyGenerator(
+			"kube_poddisruptionbudget_created",
+			"Unix creation timestamp",
+			metric.Gauge,
+			"",
+			wrapPodDisruptionBudgetFunc(func(p *policyv1beta1.PodDisruptionBudget) *metric.Family {
+				ms := []*metric.Metric{}
+
+				if !p.CreationTimestamp.IsZero() {
+					ms = append(ms, &metric.Metric{
+						Value: float64(p.CreationTimestamp.Unix()),
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		),
+		*generator.NewFamilyGenerator(
+			"kube_poddisruptionbudget_status_current_healthy",
+			"Current number of healthy pods",
+			metric.Gauge,
+			"",
+			wrapPodDisruptionBudgetFunc(func(p *policyv1beta1.PodDisruptionBudget) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(p.Status.CurrentHealthy),
+						},
+					},
+				}
+			}),
+		),
+		*generator.NewFamilyGenerator(
+			"kube_poddisruptionbudget_status_desired_healthy",
+			"Minimum desired number of healthy pods",
+			metric.Gauge,
+			"",
+			wrapPodDisruptionBudgetFunc(func(p *policyv1beta1.PodDisruptionBudget) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(p.Status.DesiredHealthy),
+						},
+					},
+				}
+			}),
+		),
+		*generator.NewFamilyGenerator(
+			"kube_poddisruptionbudget_status_pod_disruptions_allowed",
+			"Number of pod disruptions that are currently allowed",
+			metric.Gauge,
+			"",
+			wrapPodDisruptionBudgetFunc(func(p *policyv1beta1.PodDisruptionBudget) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(p.Status.DisruptionsAllowed),
+						},
+					},
+				}
+			}),
+		),
+		*generator.NewFamilyGenerator(
+			"kube_poddisruptionbudget_status_expected_pods",
+			"Total number of pods counted by this disruption budget",
+			metric.Gauge,
+			"",
+			wrapPodDisruptionBudgetFunc(func(p *policyv1beta1.PodDisruptionBudget) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(p.Status.ExpectedPods),
+						},
+					},
+				}
+			}),
+		),
+		*generator.NewFamilyGenerator(
+			"kube_poddisruptionbudget_status_observed_generation",
+			"Most recent generation observed when updating this PDB status",
+			metric.Gauge,
+			"",
+			wrapPodDisruptionBudgetFunc(func(p *policyv1beta1.PodDisruptionBudget) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(p.Status.ObservedGeneration),
+						},
+					},
+				}
+			}),
+		),
+	}
+}
+
+func (f *pdbFactory) ExpectedType() interface{} {
+	return &policyv1beta1.PodDisruptionBudget{}
+}
+
+func (f *pdbFactory) ListWatch(customResourceClient interface{}, ns string, fieldSelector string) cache.ListerWatcher {
+	client := customResourceClient.(kubernetes.Interface)
+	return &cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			opts.FieldSelector = fieldSelector
+			return client.PolicyV1beta1().PodDisruptionBudgets(ns).List(context.TODO(), opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			opts.FieldSelector = fieldSelector
+			return client.PolicyV1beta1().PodDisruptionBudgets(ns).Watch(context.TODO(), opts)
+		},
+	}
+}
+
+func wrapPodDisruptionBudgetFunc(f func(*policyv1beta1.PodDisruptionBudget) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
+		podDisruptionBudget := obj.(*policyv1beta1.PodDisruptionBudget)
+
+		metricFamily := f(podDisruptionBudget)
+
+		for _, m := range metricFamily.Metrics {
+			m.LabelKeys, m.LabelValues = mergeKeyValues(descPodDisruptionBudgetLabelsDefaultLabels, []string{podDisruptionBudget.Namespace, podDisruptionBudget.Name}, m.LabelKeys, m.LabelValues)
+		}
+
+		return metricFamily
+	}
+}

--- a/pkg/collector/corechecks/cluster/ksm/customresources/utils.go
+++ b/pkg/collector/corechecks/cluster/ksm/customresources/utils.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package customresources
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"k8s.io/kube-state-metrics/v2/pkg/metric"
+	"k8s.io/kube-state-metrics/v2/pkg/options"
+)
+
+var (
+	invalidLabelCharRE = regexp.MustCompile(`[^a-zA-Z0-9_]`)
+	matchAllCap        = regexp.MustCompile("([a-z0-9])([A-Z])")
+)
+
+func resourceVersionMetric(rv string) []*metric.Metric {
+	v, err := strconv.ParseFloat(rv, 64)
+	if err != nil {
+		return []*metric.Metric{}
+	}
+
+	return []*metric.Metric{
+		{
+			Value: v,
+		},
+	}
+
+}
+
+func boolFloat64(b bool) float64 {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+func kubeMapToPrometheusLabels(prefix string, input map[string]string) ([]string, []string) {
+	return mapToPrometheusLabels(input, prefix)
+}
+
+func mapToPrometheusLabels(labels map[string]string, prefix string) ([]string, []string) {
+	labelKeys := make([]string, 0, len(labels))
+	labelValues := make([]string, 0, len(labels))
+
+	sortedKeys := make([]string, 0)
+	for key := range labels {
+		sortedKeys = append(sortedKeys, key)
+	}
+	sort.Strings(sortedKeys)
+
+	// conflictDesc holds some metadata for resolving potential label conflicts
+	type conflictDesc struct {
+		// the number of conflicting label keys we saw so far
+		count int
+
+		// the offset of the initial conflicting label key, so we could
+		// later go back and rename "label_foo" to "label_foo_conflict1"
+		initial int
+	}
+
+	conflicts := make(map[string]*conflictDesc)
+	for _, k := range sortedKeys {
+		labelKey := labelName(prefix, k)
+		if conflict, ok := conflicts[labelKey]; ok {
+			if conflict.count == 1 {
+				// this is the first conflict for the label,
+				// so we have to go back and rename the initial label that we've already added
+				labelKeys[conflict.initial] = labelConflictSuffix(labelKeys[conflict.initial], conflict.count)
+			}
+
+			conflict.count++
+			labelKey = labelConflictSuffix(labelKey, conflict.count)
+		} else {
+			// we'll need this info later in case there are conflicts
+			conflicts[labelKey] = &conflictDesc{
+				count:   1,
+				initial: len(labelKeys),
+			}
+		}
+		labelKeys = append(labelKeys, labelKey)
+		labelValues = append(labelValues, labels[k])
+	}
+	return labelKeys, labelValues
+}
+
+func labelName(prefix, labelName string) string {
+	return prefix + "_" + lintLabelName(sanitizeLabelName(labelName))
+}
+
+func sanitizeLabelName(s string) string {
+	return invalidLabelCharRE.ReplaceAllString(s, "_")
+}
+
+func lintLabelName(s string) string {
+	return toSnakeCase(s)
+}
+
+func toSnakeCase(s string) string {
+	snake := matchAllCap.ReplaceAllString(s, "${1}_${2}")
+	return strings.ToLower(snake)
+}
+
+func labelConflictSuffix(label string, count int) string {
+	return fmt.Sprintf("%s_conflict%d", label, count)
+}
+
+// createPrometheusLabelKeysValues takes in passed kubernetes annotations/labels
+// and associated allowed list in kubernetes label format.
+// It returns only those allowed annotations/labels that exist in the list and converts them to Prometheus labels.
+func createPrometheusLabelKeysValues(prefix string, allKubeData map[string]string, allowList []string) ([]string, []string) {
+	allowedKubeData := make(map[string]string)
+
+	if len(allowList) > 0 {
+		if allowList[0] == options.LabelWildcard {
+			return kubeMapToPrometheusLabels(prefix, allKubeData)
+		}
+
+		for _, l := range allowList {
+			v, found := allKubeData[l]
+			if found {
+				allowedKubeData[l] = v
+			}
+		}
+	}
+	return kubeMapToPrometheusLabels(prefix, allowedKubeData)
+}
+
+// mergeKeyValues merges label keys and values slice pairs into a single slice pair.
+// Arguments are passed as equal-length pairs of slices, where the first slice contains keys and second contains values.
+// Example: mergeKeyValues(keys1, values1, keys2, values2) => (keys1+keys2, values1+values2)
+func mergeKeyValues(keyValues ...[]string) (keys, values []string) {
+	capacity := 0
+	for i := 0; i < len(keyValues); i += 2 {
+		capacity += len(keyValues[i])
+	}
+
+	// Allocate one contiguous block, then split it up to keys and values zero'd slices.
+	keysValues := make([]string, 0, capacity*2)
+	keys = (keysValues[0:capacity:capacity])[:0]
+	values = (keysValues[capacity : capacity*2])[:0]
+
+	for i := 0; i < len(keyValues); i += 2 {
+		keys = append(keys, keyValues[i]...)
+		values = append(values, keyValues[i+1]...)
+	}
+
+	return keys, values
+}


### PR DESCRIPTION
### What does this PR do?

This fixes a regression introduced when we upgraded to KSM 2.4:
https://github.com/kubernetes/kube-state-metrics/pull/1491. This
restores metrics for CronJob and PodDisruptionBudget resources for
Kubernetes 1.19 and older.

### Describe how to test/QA your changes

Verify that the DCA collects cronjob and pdb KSM metrics.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
