### PR TITLE
Skip duplicated events in workloadmeta and tagger

### DIFF
--- a/pkg/workloadmeta/store.go
+++ b/pkg/workloadmeta/store.go
@@ -392,11 +392,17 @@ func (s *store) handleEvents(evs []CollectorEvent) {
 				cachedEntity = entitiesOfKind[entityID.ID]
 			}
 
-			if found := cachedEntity.set(ev.Source, ev.Entity); !found {
+			found, changed := cachedEntity.set(ev.Source, ev.Entity)
+
+			if !found {
 				telemetry.StoredEntities.Inc(
 					string(entityID.Kind),
 					string(ev.Source),
 				)
+			}
+
+			if !changed {
+				continue
 			}
 		case EventTypeUnset:
 			// if the entity we're trying to remove was not

--- a/pkg/workloadmeta/store_test.go
+++ b/pkg/workloadmeta/store_test.go
@@ -516,6 +516,39 @@ func TestSubscribe(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:      "sets unchanged entity twice",
+			preEvents: []CollectorEvent{},
+			postEvents: [][]CollectorEvent{
+				{
+					{
+						Type:   EventTypeSet,
+						Source: fooSource,
+						Entity: fooContainer,
+					},
+					{
+						Type:   EventTypeSet,
+						Source: fooSource,
+						// DeepCopy to ensure we're not
+						// just comparing pointers, as
+						// collectors return a freshly
+						// built object every time
+						Entity: fooContainer.DeepCopy(),
+					},
+				},
+			},
+			filter: nil,
+			expected: []EventBundle{
+				{
+					Events: []Event{
+						{
+							Type:   EventTypeSet,
+							Entity: fooContainer,
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### What does this PR do?

This is a minor performance improvement. Collectors generate identical
entities very often, when the changes to them are not relevant to
workloadmeta (or, in the case of pulling collectors, on every pull).
This has some minor overhead internally, generating deep-copies of
unchanged objects for bookkeeping, but has a somewhat bigger impact
externally, as every subscriber gets notified of basically no-op events.
This has an *even bigger* impact on the remote tagger, as those no-op
events get serialized, go over the "network" (locally, but still), and
get de-serialized on the other end. So this patch operates under the
assumption that a deep-equal check is much cheaper than all that.

### Describe how to test/QA your changes

This has already been tested in staging and no effect has been noticed (except for the massive decrease in events). To QA this in any environment, check that AD and the tagger still work correctly, particularly after changing an existing container post-agent start.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
