### PR TITLE
[CWS] Use runtime compilation in functional tests

### DIFF
--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -71,7 +71,7 @@ tests_ebpf_x64:
     - invoke -e security-agent.build-embed-syscall-tester
     - invoke -e security-agent.build-embed-latency-tools
     # Compile runtime security functional tests to be executed in kitchen tests
-    - inv -e security-agent.build-functional-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/testsuite --race --nikos-embedded-path=$NIKOS_EMBEDDED_PATH
+    - inv -e security-agent.build-functional-tests --no-bundle-ebpf --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/testsuite --race --nikos-embedded-path=$NIKOS_EMBEDDED_PATH
     # Compile runtime security stress tests to be executed in kitchen tests
     - inv -e security-agent.build-stress-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/stresssuite
     # Copy nikos archive to be extracted in kitchen tests
@@ -105,7 +105,7 @@ tests_ebpf_arm64:
     - invoke -e security-agent.build-embed-syscall-tester --arch arm64
     - invoke -e security-agent.build-embed-latency-tools
     # Compile runtime security functional tests to be executed in kitchen tests
-    - inv -e security-agent.build-functional-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/testsuite --race --nikos-embedded-path=$NIKOS_EMBEDDED_PATH
+    - inv -e security-agent.build-functional-tests --no-bundle-ebpf --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/testsuite --race --nikos-embedded-path=$NIKOS_EMBEDDED_PATH
     # Compile runtime security stress tests to be executed in kitchen tests
     - inv -e security-agent.build-stress-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/stresssuite
     # Copy nikos archive to be extracted in kitchen tests

--- a/pkg/collector/corechecks/ebpf/probe/oom_kill.go
+++ b/pkg/collector/corechecks/ebpf/probe/oom_kill.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode/runtime"
+	"github.com/DataDog/datadog-agent/pkg/process/statsd"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -40,7 +41,7 @@ type OOMKillProbe struct {
 }
 
 func NewOOMKillProbe(cfg *ebpf.Config) (*OOMKillProbe, error) {
-	compiledOutput, err := runtime.OomKill.Compile(cfg, nil)
+	compiledOutput, err := runtime.OomKill.Compile(cfg, nil, statsd.Client)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/collector/corechecks/ebpf/probe/oom_kill_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/oom_kill_test.go
@@ -61,7 +61,7 @@ func TestOOMKillCompile(t *testing.T) {
 
 	cfg := ebpf.NewConfig()
 	cfg.BPFDebug = true
-	_, err = runtime.OomKill.Compile(cfg, nil)
+	_, err = runtime.OomKill.Compile(cfg, nil, nil)
 	require.NoError(t, err)
 }
 

--- a/pkg/collector/corechecks/ebpf/probe/oom_kill_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/oom_kill_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode/runtime"
+	"github.com/DataDog/datadog-agent/pkg/process/statsd"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
 
@@ -61,7 +62,7 @@ func TestOOMKillCompile(t *testing.T) {
 
 	cfg := ebpf.NewConfig()
 	cfg.BPFDebug = true
-	_, err = runtime.OomKill.Compile(cfg, nil, nil)
+	_, err = runtime.OomKill.Compile(cfg, nil, statsd.Client)
 	require.NoError(t, err)
 }
 

--- a/pkg/collector/corechecks/ebpf/probe/tcp_queue_length.go
+++ b/pkg/collector/corechecks/ebpf/probe/tcp_queue_length.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode/runtime"
+	"github.com/DataDog/datadog-agent/pkg/process/statsd"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -43,7 +44,7 @@ type TCPQueueLengthTracer struct {
 }
 
 func NewTCPQueueLengthTracer(cfg *ebpf.Config) (*TCPQueueLengthTracer, error) {
-	compiledOutput, err := runtime.TcpQueueLength.Compile(cfg, nil)
+	compiledOutput, err := runtime.TcpQueueLength.Compile(cfg, nil, statsd.Client)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/collector/corechecks/ebpf/probe/tcp_queue_length_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/tcp_queue_length_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode/runtime"
+	"github.com/DataDog/datadog-agent/pkg/process/statsd"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
 
@@ -32,7 +33,7 @@ func TestTCPQueueLengthCompile(t *testing.T) {
 
 	cfg := ebpf.NewConfig()
 	cfg.BPFDebug = true
-	_, err = runtime.TcpQueueLength.Compile(cfg, nil, nil)
+	_, err = runtime.TcpQueueLength.Compile(cfg, nil, statsd.Client)
 	require.NoError(t, err)
 }
 

--- a/pkg/collector/corechecks/ebpf/probe/tcp_queue_length_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/tcp_queue_length_test.go
@@ -32,7 +32,7 @@ func TestTCPQueueLengthCompile(t *testing.T) {
 
 	cfg := ebpf.NewConfig()
 	cfg.BPFDebug = true
-	_, err = runtime.TcpQueueLength.Compile(cfg, nil)
+	_, err = runtime.TcpQueueLength.Compile(cfg, nil, nil)
 	require.NoError(t, err)
 }
 

--- a/pkg/ebpf/bytecode/permissions.go
+++ b/pkg/ebpf/bytecode/permissions.go
@@ -26,7 +26,7 @@ func VerifyAssetPermissions(assetPath string) error {
 	if !ok {
 		return fmt.Errorf("error getting permissions for output file %s: %w", assetPath, err)
 	}
-	if stat.Uid != 0 || stat.Gid != 0 || info.Mode().Perm() != 0644 {
+	if stat.Uid != 0 || stat.Gid != 0 || info.Mode().Perm()&os.FileMode(0022) != 0 {
 		return fmt.Errorf("%s has incorrect permissions: user=%v, group=%v, permissions=%v", assetPath, stat.Uid, stat.Gid, info.Mode().Perm())
 	}
 	return nil

--- a/pkg/ebpf/bytecode/runtime/conntrack.go
+++ b/pkg/ebpf/bytecode/runtime/conntrack.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Conntrack = NewRuntimeAsset("conntrack.c", "b26b80270d71684f79afd57412662e3a0f9321e6cea5174a3d3fb1f2f099a37d")
+var Conntrack = NewRuntimeAsset("conntrack.c", "4bc72979b91d7318fda20d73defacaaaec778cb1470f3122bf7c2b6a2899f2ff")

--- a/pkg/ebpf/bytecode/runtime/http.go
+++ b/pkg/ebpf/bytecode/runtime/http.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Http = NewRuntimeAsset("http.c", "5b3d452e675b07c8ab4a87bc0581ec78ebaad491f0e399655c8e90eedc38c3f8")
+var Http = NewRuntimeAsset("http.c", "20d74770e7c633deb35545195aa8207d8b15d52ade10f0a603af3eb9505cb08b")

--- a/pkg/ebpf/bytecode/runtime/oom-kill.go
+++ b/pkg/ebpf/bytecode/runtime/oom-kill.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var OomKill = NewRuntimeAsset("oom-kill.c", "1946f3793d38d2adc4af6fafbfdc90b7a63b31511de629fd8b62c1aa605a418a")
+var OomKill = NewRuntimeAsset("oom-kill.c", "08385fe12ddc9dc767fbeb4bc3b1ccb23be5466a5cba04ac8abcc6dd74eb745c")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "483752a67208045aa3c5dfce58deebb1daa05b379a4b1d603e946649c7770193")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "32059cd0ff44fe789b9efbe87d0b8b55f930201cdc7751de2cac17aae672e537")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "32059cd0ff44fe789b9efbe87d0b8b55f930201cdc7751de2cac17aae672e537")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "ccd67d94ab237951cd7853f7d97239b67144aca91f57cc944518ce786a75ae35")

--- a/pkg/ebpf/bytecode/runtime/tcp-queue-length.go
+++ b/pkg/ebpf/bytecode/runtime/tcp-queue-length.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var TcpQueueLength = NewRuntimeAsset("tcp-queue-length.c", "5dbe7ff306dfdc40feb45fc485c3931b4701d3c0ca3a45816f332ecdaf703eef")
+var TcpQueueLength = NewRuntimeAsset("tcp-queue-length.c", "fc16a8c7c1906a09b7f3e133225250f9f90d1a9a1c1ccae4b6f84815e8028924")

--- a/pkg/ebpf/bytecode/runtime/tracer.go
+++ b/pkg/ebpf/bytecode/runtime/tracer.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Tracer = NewRuntimeAsset("tracer.c", "6c49784e1b7d8c3f0970dcbfad775e7695e3c019f0e831a8e9bbfa7d9f00d3f2")
+var Tracer = NewRuntimeAsset("tracer.c", "7605d57a64ea1b0062fab8ed31e1beff8687a78d30877e5bdb9f3176fba03a4c")

--- a/pkg/ebpf/c/bpf_helpers.h
+++ b/pkg/ebpf/c/bpf_helpers.h
@@ -68,12 +68,12 @@ static int (*bpf_tail_call_compat)(void* ctx, void* map, int key) = (void*)BPF_F
 static long (*bpf_skb_load_bytes)(const void *skb, u32 offset, void *to, u32 len) = (void*)BPF_FUNC_skb_load_bytes;
 #endif
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 8, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 8, 0) || RHEL_MAJOR == 7
 static u64 (*bpf_get_current_task)(void) = (void*)BPF_FUNC_get_current_task;
 static int (*bpf_probe_write_user)(void *dst, const void *src, int size) = (void *) BPF_FUNC_probe_write_user;
 #endif
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0) || RHEL_MAJOR == 7
 static int (*bpf_probe_read_str)(void* dst, int size, void* unsafe_ptr) = (void*)BPF_FUNC_probe_read_str;
 #endif
 

--- a/pkg/ebpf/compiler/compiler.go
+++ b/pkg/ebpf/compiler/compiler.go
@@ -34,7 +34,7 @@ var (
 	stdargHData []byte
 )
 
-const compilationStepTimeout = 15 * time.Second
+const compilationStepTimeout = 60 * time.Second
 
 func CompileToObjectFile(in io.Reader, outputFile string, cflags []string, headerDirs []string) error {
 	if len(headerDirs) == 0 {

--- a/pkg/network/http/compile.go
+++ b/pkg/network/http/compile.go
@@ -11,13 +11,14 @@ package http
 import (
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode/runtime"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
+	"github.com/DataDog/datadog-agent/pkg/process/statsd"
 )
 
 //go:generate go run ../../../pkg/ebpf/include_headers.go ../../../pkg/network/ebpf/c/runtime/http.c ../../../pkg/ebpf/bytecode/build/runtime/http.c ../../../pkg/ebpf/c ../../../pkg/network/ebpf/c/runtime ../../../pkg/network/ebpf/c
 //go:generate go run ../../../pkg/ebpf/bytecode/runtime/integrity.go ../../../pkg/ebpf/bytecode/build/runtime/http.c ../../../pkg/ebpf/bytecode/runtime/http.go runtime
 
 func getRuntimeCompiledHTTP(config *config.Config) (runtime.CompiledOutput, error) {
-	return runtime.Http.Compile(&config.Config, getCFlags(config))
+	return runtime.Http.Compile(&config.Config, getCFlags(config), statsd.Client)
 }
 
 func getCFlags(config *config.Config) []string {

--- a/pkg/network/tracer/compile.go
+++ b/pkg/network/tracer/compile.go
@@ -11,13 +11,14 @@ package tracer
 import (
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode/runtime"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
+	"github.com/DataDog/datadog-agent/pkg/process/statsd"
 )
 
 //go:generate go run ../../../pkg/ebpf/include_headers.go ../../../pkg/network/ebpf/c/runtime/conntrack.c ../../../pkg/ebpf/bytecode/build/runtime/conntrack.c ../../../pkg/ebpf/c ../../../pkg/network/ebpf/c/runtime ../../../pkg/network/ebpf/c
 //go:generate go run ../../../pkg/ebpf/bytecode/runtime/integrity.go ../../../pkg/ebpf/bytecode/build/runtime/conntrack.c ../../../pkg/ebpf/bytecode/runtime/conntrack.go runtime
 
 func getRuntimeCompiledConntracker(config *config.Config) (runtime.CompiledOutput, error) {
-	return runtime.Conntrack.Compile(&config.Config, getCFlags(config))
+	return runtime.Conntrack.Compile(&config.Config, getCFlags(config), statsd.Client)
 }
 
 func getCFlags(config *config.Config) []string {

--- a/pkg/network/tracer/connection/kprobe/compile.go
+++ b/pkg/network/tracer/connection/kprobe/compile.go
@@ -11,13 +11,14 @@ package kprobe
 import (
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode/runtime"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
+	"github.com/DataDog/datadog-agent/pkg/process/statsd"
 )
 
 //go:generate go run ../../../../../pkg/ebpf/include_headers.go ../../../../../pkg/network/ebpf/c/runtime/tracer.c ../../../../../pkg/ebpf/bytecode/build/runtime/tracer.c ../../../../../pkg/ebpf/c ../../../../../pkg/network/ebpf/c/runtime ../../../../../pkg/network/ebpf/c
 //go:generate go run ../../../../../pkg/ebpf/bytecode/runtime/integrity.go ../../../../../pkg/ebpf/bytecode/build/runtime/tracer.c ../../../../../pkg/ebpf/bytecode/runtime/tracer.go runtime
 
 func getRuntimeCompiledTracer(config *config.Config) (runtime.CompiledOutput, error) {
-	return runtime.Tracer.Compile(&config.Config, getCFlags(config))
+	return runtime.Tracer.Compile(&config.Config, getCFlags(config), statsd.Client)
 }
 
 func getCFlags(config *config.Config) []string {

--- a/pkg/security/ebpf/c/bind.h
+++ b/pkg/security/ebpf/c/bind.h
@@ -67,4 +67,61 @@ int tracepoint_syscalls_sys_exit_bind(struct tracepoint_syscalls_sys_exit_t *arg
     return sys_bind_ret(args, args->ret);
 }
 
+SEC("kprobe/security_socket_bind")
+int kprobe_security_socket_bind(struct pt_regs *ctx) {
+    struct socket *sk = (struct socket *)PT_REGS_PARM1(ctx);
+    struct sockaddr *address = (struct sockaddr *)PT_REGS_PARM2(ctx);
+    struct pid_route_t key = {};
+    u16 family = 0;
+
+    // Extract IP and port from the sockaddr structure
+    bpf_probe_read(&family, sizeof(family), &address->sa_family);
+    if (family == AF_INET) {
+        struct sockaddr_in *addr_in = (struct sockaddr_in *)address;
+        bpf_probe_read(&key.port, sizeof(addr_in->sin_port), &addr_in->sin_port);
+        bpf_probe_read(&key.addr, sizeof(addr_in->sin_addr.s_addr), &addr_in->sin_addr.s_addr);
+    } else if (family == AF_INET6) {
+        struct sockaddr_in6 *addr_in6 = (struct sockaddr_in6 *)address;
+        bpf_probe_read(&key.port, sizeof(addr_in6->sin6_port), &addr_in6->sin6_port);
+        bpf_probe_read(&key.addr, sizeof(u64) * 2, (char *)addr_in6 + offsetof(struct sockaddr_in6, sin6_addr));
+    }
+
+    // fill syscall_cache if necessary
+    struct syscall_cache_t *syscall = peek_syscall(EVENT_BIND);
+    if (syscall) {
+        syscall->bind.addr[0] = key.addr[0];
+        syscall->bind.addr[1] = key.addr[1];
+        syscall->bind.port = key.port;
+        syscall->bind.family = family;
+    }
+
+    // past this point we care only about AF_INET and AF_INET6
+    if (family != AF_INET && family != AF_INET6) {
+        return 0;
+    }
+
+    // Register service PID
+    if (key.port != 0) {
+        u64 id = bpf_get_current_pid_tgid();
+        u32 tid = (u32) id;
+
+        // add netns information
+        key.netns = get_netns_from_socket(sk);
+        if (key.netns != 0) {
+            bpf_map_update_elem(&netns_cache, &tid, &key.netns, BPF_ANY);
+        }
+
+#ifndef DO_NOT_USE_TC
+        u32 pid = id >> 32;
+        bpf_map_update_elem(&flow_pid, &key, &pid, BPF_ANY);
+#endif
+
+#ifdef DEBUG
+        bpf_printk("# registered (bind) pid:%d\n", pid);
+        bpf_printk("# p:%d a:%d a:%d\n", key.port, key.addr[0], key.addr[1]);
+#endif
+    }
+    return 0;
+}
+
 #endif /* _BIND_H_ */

--- a/pkg/security/ebpf/c/bpf.h
+++ b/pkg/security/ebpf/c/bpf.h
@@ -1,6 +1,8 @@
 #ifndef _BPF_MONITORING_H_
 #define _BPF_MONITORING_H_
 
+#include "syscalls.h"
+
 #define CHECK_HELPER_CALL_FUNC_ID 1
 #define CHECK_HELPER_CALL_INSN 2
 

--- a/pkg/security/ebpf/c/bpf_const.h
+++ b/pkg/security/ebpf/c/bpf_const.h
@@ -1,6 +1,10 @@
 #ifndef _BPF_CONST_H_
 #define _BPF_CONST_H_
 
+#ifndef BPF_OBJ_NAME_LEN
+#define BPF_OBJ_NAME_LEN 16U
+#endif
+
 enum bpf_cmd_def {
     BPF_MAP_CREATE_CMD,
     BPF_MAP_LOOKUP_ELEM_CMD,

--- a/pkg/security/ebpf/c/container.h
+++ b/pkg/security/ebpf/c/container.h
@@ -5,8 +5,6 @@ static __attribute__((always_inline)) void copy_container_id(const char src[CONT
     bpf_probe_read(dst, CONTAINER_ID_LEN, (void*)src);
 }
 
-static __attribute__((always_inline)) void copy_container_id_no_tracing(const char src[CONTAINER_ID_LEN], char dst[CONTAINER_ID_LEN]) {
-    __builtin_memmove(dst, src, CONTAINER_ID_LEN);
-}
+#define copy_container_id_no_tracing(src, dst) __builtin_memmove(dst, src, CONTAINER_ID_LEN)
 
 #endif

--- a/pkg/security/ebpf/c/defs.h
+++ b/pkg/security/ebpf/c/defs.h
@@ -459,7 +459,7 @@ struct bpf_map_def SEC("maps/events_stats") events_stats = {
         }                                                                                                              \
     }                                                                                                                  \
 
-#if USE_RING_BUFFER == 1 || LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)
 #define send_event(ctx, event_type, kernel_event)                                                                      \
     u64 size = sizeof(kernel_event);                                                                                   \
     u64 use_ring_buffer;                                                                                               \
@@ -482,10 +482,15 @@ struct bpf_map_def SEC("maps/events_stats") events_stats = {
     }
 #else
 #define send_event(ctx, event_type, kernel_event)                                                                      \
+    int perf_ret;                                                                                                      \
     send_event_with_size_perf(ctx, event_type, kernel_event, sizeof(kernel_event))
+
+#define send_event_with_size(ctx, event_type, kernel_event, size)                                                      \
+    int perf_ret;                                                                                                      \
+    send_event_with_size_perf(ctx, event_type, kernel_event, size)
 #endif
 
-#if USE_RING_BUFFER == 1 || LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)
 #define send_event_ptr(ctx, event_type, kernel_event)                                                                  \
     u64 size = sizeof(*kernel_event);                                                                                  \
     u64 use_ring_buffer;                                                                                               \
@@ -498,10 +503,11 @@ struct bpf_map_def SEC("maps/events_stats") events_stats = {
     }
 #else
 #define send_event_ptr(ctx, event_type, kernel_event)                                                                  \
+    int perf_ret;                                                                                                      \
     send_event_with_size_ptr_perf(ctx, event_type, kernel_event, sizeof(*kernel_event))
 #endif
 
-#if USE_RING_BUFFER == 1 || LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)
 #define send_event_with_size_ptr(ctx, event_type, kernel_event, size)                                                  \
     u64 use_ring_buffer;                                                                                               \
     int perf_ret;                                                                                                      \
@@ -513,6 +519,7 @@ struct bpf_map_def SEC("maps/events_stats") events_stats = {
     }
 #else
 #define send_event_with_size_ptr(ctx, event_type, kernel_event, size)                                                  \
+    int perf_ret;                                                                                                      \
     send_event_with_size_ptr_perf(ctx, event_type, kernel_event, size)
 #endif
 

--- a/pkg/security/ebpf/c/defs.h
+++ b/pkg/security/ebpf/c/defs.h
@@ -459,6 +459,7 @@ struct bpf_map_def SEC("maps/events_stats") events_stats = {
         }                                                                                                              \
     }                                                                                                                  \
 
+#if USE_RING_BUFFER == 1 || LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)
 #define send_event(ctx, event_type, kernel_event)                                                                      \
     u64 size = sizeof(kernel_event);                                                                                   \
     u64 use_ring_buffer;                                                                                               \
@@ -478,8 +479,13 @@ struct bpf_map_def SEC("maps/events_stats") events_stats = {
         send_event_with_size_ringbuf(ctx, event_type, kernel_event, size)                                              \
     } else {                                                                                                           \
         send_event_with_size_perf(ctx, event_type, kernel_event, size)                                                 \
-    }                                                                                                                  \
+    }
+#else
+#define send_event(ctx, event_type, kernel_event)                                                                      \
+    send_event_with_size_perf(ctx, event_type, kernel_event, sizeof(kernel_event))
+#endif
 
+#if USE_RING_BUFFER == 1 || LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)
 #define send_event_ptr(ctx, event_type, kernel_event)                                                                  \
     u64 size = sizeof(*kernel_event);                                                                                  \
     u64 use_ring_buffer;                                                                                               \
@@ -489,8 +495,13 @@ struct bpf_map_def SEC("maps/events_stats") events_stats = {
         send_event_with_size_ptr_ringbuf(ctx, event_type, kernel_event, size)                                          \
     } else {                                                                                                           \
         send_event_with_size_ptr_perf(ctx, event_type, kernel_event, size)                                             \
-    }                                                                                                                  \
+    }
+#else
+#define send_event_ptr(ctx, event_type, kernel_event)                                                                  \
+    send_event_with_size_ptr_perf(ctx, event_type, kernel_event, sizeof(*kernel_event))
+#endif
 
+#if USE_RING_BUFFER == 1 || LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)
 #define send_event_with_size_ptr(ctx, event_type, kernel_event, size)                                                  \
     u64 use_ring_buffer;                                                                                               \
     int perf_ret;                                                                                                      \
@@ -499,7 +510,11 @@ struct bpf_map_def SEC("maps/events_stats") events_stats = {
         send_event_with_size_ptr_ringbuf(ctx, event_type, kernel_event, size)                                          \
     } else {                                                                                                           \
         send_event_with_size_ptr_perf(ctx, event_type, kernel_event, size)                                             \
-    }                                                                                                                  \
+    }
+#else
+#define send_event_with_size_ptr(ctx, event_type, kernel_event, size)                                                  \
+    send_event_with_size_ptr_perf(ctx, event_type, kernel_event, size)
+#endif
 
 // implemented in the discarder.h file
 int __attribute__((always_inline)) bump_discarder_revision(u32 mount_id);

--- a/pkg/security/ebpf/c/defs.h
+++ b/pkg/security/ebpf/c/defs.h
@@ -735,4 +735,23 @@ struct is_discarded_by_inode_t {
     u32 activity_dump_state;
 };
 
+struct pid_route_t {
+    u64 addr[2];
+    u32 netns;
+    u16 port;
+};
+
+struct flow_t {
+    u64 saddr[2];
+    u64 daddr[2];
+    u16 sport;
+    u16 dport;
+    u32 padding;
+};
+
+struct namespaced_flow_t {
+    struct flow_t flow;
+    u32 netns;
+};
+
 #endif

--- a/pkg/security/ebpf/c/dentry.h
+++ b/pkg/security/ebpf/c/dentry.h
@@ -160,9 +160,9 @@ void __attribute__((always_inline)) write_dentry_inode(struct dentry *dentry, st
 }
 
 struct dentry* __attribute__((always_inline)) get_file_dentry(struct file *file) {
-    struct dentry *f_dentry;
-    bpf_probe_read(&f_dentry, sizeof(f_dentry), &file->f_path.dentry);
-    return f_dentry;
+    struct dentry *file_dentry;
+    bpf_probe_read(&file_dentry, sizeof(file_dentry), &file->f_path.dentry);
+    return file_dentry;
 }
 
 struct dentry* __attribute__((always_inline)) get_path_dentry(struct path *path) {

--- a/pkg/security/ebpf/c/dns.h
+++ b/pkg/security/ebpf/c/dns.h
@@ -79,7 +79,7 @@ __attribute__((always_inline)) struct dns_event_t *reset_dns_event(struct __sk_b
     if (entry == NULL) {
         evt->container.container_id[0] = 0;
     } else {
-        fill_container_context_no_tracing(entry, &evt->container);
+        copy_container_id_no_tracing(entry->container.container_id, &evt->container.container_id);
     }
 
     return evt;

--- a/pkg/security/ebpf/c/open.h
+++ b/pkg/security/ebpf/c/open.h
@@ -212,6 +212,14 @@ int kprobe___io_openat_prep(struct pt_regs *ctx) {
     return 0;
 }
 
+#ifndef VALID_OPEN_FLAGS
+#define VALID_OPEN_FLAGS \
+        (O_RDONLY | O_WRONLY | O_RDWR | O_CREAT | O_EXCL | O_NOCTTY | O_TRUNC | \
+         O_APPEND | O_NDELAY | O_NONBLOCK | __O_SYNC | O_DSYNC | \
+         FASYNC | O_DIRECT | O_LARGEFILE | O_DIRECTORY | O_NOFOLLOW | \
+         O_NOATIME | O_CLOEXEC | O_PATH | __O_TMPFILE)
+#endif
+
 SEC("kprobe/io_openat2")
 int kprobe_io_openat2(struct pt_regs *ctx) {
     struct io_open req;

--- a/pkg/security/ebpf/c/prebuilt/probe.c
+++ b/pkg/security/ebpf/c/prebuilt/probe.c
@@ -9,6 +9,7 @@
 #include <uapi/asm-generic/mman-common.h>
 #include <linux/pipe_fs_i.h>
 #include <linux/nsproxy.h>
+#include <linux/module.h>
 
 #include <net/sock.h>
 #include <net/netfilter/nf_conntrack.h>

--- a/pkg/security/ebpf/c/prebuilt/probe.c
+++ b/pkg/security/ebpf/c/prebuilt/probe.c
@@ -59,14 +59,18 @@
 #include "mmap.h"
 #include "mprotect.h"
 #include "raw_syscalls.h"
+
+#ifndef DO_NOT_USE_TC
 #include "flow.h"
 #include "network_parser.h"
 #include "dns.h"
 #include "tc.h"
+#include "net_device.h"
+#endif
+
 #include "module.h"
 #include "signal.h"
 #include "bind.h"
-#include "net_device.h"
 #include "procfs.h"
 #include "offset.h"
 

--- a/pkg/security/ebpf/c/process.h
+++ b/pkg/security/ebpf/c/process.h
@@ -281,9 +281,13 @@ __attribute__((always_inline)) u32 get_netns_from_net(struct net *net) {
         return inum;
     }
 
+#ifndef DO_NOT_USE_TC
     struct ns_common ns;
     bpf_probe_read(&ns, sizeof(ns), (void*)net + net_ns_offset);
     return ns.inum;
+#else
+    return 0;
+#endif
 }
 
 __attribute__((always_inline)) u32 get_netns_from_sock(struct sock *sk) {

--- a/pkg/security/ebpf/c/process.h
+++ b/pkg/security/ebpf/c/process.h
@@ -60,12 +60,6 @@ static void __attribute__((always_inline)) fill_container_context(struct proc_ca
     }
 }
 
-static void __attribute__((always_inline)) fill_container_context_no_tracing(struct proc_cache_t *entry, struct container_context_t *context) {
-    if (entry) {
-        copy_container_id_no_tracing(entry->container.container_id, context->container_id);
-    }
-}
-
 struct credentials_t {
     u32 uid;
     u32 gid;

--- a/pkg/security/ebpf/c/procfs.h
+++ b/pkg/security/ebpf/c/procfs.h
@@ -69,6 +69,8 @@ int kprobe_security_inode_getattr(struct pt_regs *ctx) {
     return 0;
 }
 
+#ifndef DO_NOT_USE_TC
+
 struct bpf_map_def SEC("maps/fd_link_pid") fd_link_pid = {
     .type = BPF_MAP_TYPE_HASH,
     .key_size = sizeof(u8),
@@ -90,7 +92,6 @@ int kprobe_path_get(struct pt_regs *ctx) {
     if (procfs_pid == NULL) {
         return 0;
     }
-    u32 pid = *procfs_pid;
 
     struct path *p = (struct path *)PT_REGS_PARM1(ctx);
     struct file *sock_file = (void *)p - offsetof(struct file, f_path);
@@ -125,6 +126,7 @@ int kprobe_path_get(struct pt_regs *ctx) {
     bpf_probe_read(&route.port, sizeof(route.port), &sk->__sk_common.skc_num);
 
     // save pid route
+    u32 pid = *procfs_pid;
     bpf_map_update_elem(&flow_pid, &route, &pid, BPF_ANY);
 
 #ifdef DEBUG
@@ -168,5 +170,7 @@ int kprobe_proc_fd_link(struct pt_regs *ctx) {
 #endif
     return 0;
 }
+
+#endif // DO_NOT_USE_TC
 
 #endif

--- a/pkg/security/ebpf/compile.go
+++ b/pkg/security/ebpf/compile.go
@@ -27,5 +27,9 @@ func getRuntimeCompiledPrograms(config *config.Config, useSyscallWrapper bool) (
 		cflags = append(cflags, "-DUSE_SYSCALL_WRAPPER=0")
 	}
 
+	if !config.NetworkEnabled {
+		cflags = append(cflags, "-DDO_NOT_USE_TC")
+	}
+
 	return runtime.RuntimeSecurity.Compile(&config.Config, cflags)
 }

--- a/pkg/security/ebpf/compile.go
+++ b/pkg/security/ebpf/compile.go
@@ -12,13 +12,14 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode/runtime"
 	"github.com/DataDog/datadog-agent/pkg/security/config"
+	"github.com/DataDog/datadog-go/v5/statsd"
 )
 
 // TODO change probe.c path to runtime-compilation specific version
 //go:generate go run ../../ebpf/include_headers.go ./c/prebuilt/probe.c ../../ebpf/bytecode/build/runtime/runtime-security.c ./c ../../ebpf/c
 //go:generate go run ../../ebpf/bytecode/runtime/integrity.go ../../ebpf/bytecode/build/runtime/runtime-security.c ../../ebpf/bytecode/runtime/runtime-security.go runtime
 
-func getRuntimeCompiledPrograms(config *config.Config, useSyscallWrapper bool) (bytecode.AssetReader, error) {
+func getRuntimeCompiledPrograms(config *config.Config, useSyscallWrapper bool, client statsd.ClientInterface) (bytecode.AssetReader, error) {
 	var cflags []string
 
 	if useSyscallWrapper {
@@ -31,5 +32,5 @@ func getRuntimeCompiledPrograms(config *config.Config, useSyscallWrapper bool) (
 		cflags = append(cflags, "-DDO_NOT_USE_TC")
 	}
 
-	return runtime.RuntimeSecurity.Compile(&config.Config, cflags)
+	return runtime.RuntimeSecurity.Compile(&config.Config, cflags, client)
 }

--- a/pkg/security/ebpf/compile_test.go
+++ b/pkg/security/ebpf/compile_test.go
@@ -18,6 +18,6 @@ import (
 
 func TestLoaderCompile(t *testing.T) {
 	cfg := ebpf.NewConfig()
-	_, err := getRuntimeCompiledProbe(cfg, false)
+	_, err := getRuntimeCompiledProbe(cfg, false, nil)
 	require.NoError(t, err)
 }

--- a/pkg/security/ebpf/compile_unsupported.go
+++ b/pkg/security/ebpf/compile_unsupported.go
@@ -13,8 +13,9 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"
 	"github.com/DataDog/datadog-agent/pkg/security/config"
+	"github.com/DataDog/datadog-go/v5/statsd"
 )
 
-func getRuntimeCompiledPrograms(config *config.Config, useSyscallWrapper bool) (bytecode.AssetReader, error) {
+func getRuntimeCompiledPrograms(config *config.Config, useSyscallWrapper bool, client statsd.ClientInterface) (bytecode.AssetReader, error) {
 	return nil, fmt.Errorf("runtime compilation unsupported")
 }

--- a/pkg/security/ebpf/loader.go
+++ b/pkg/security/ebpf/loader.go
@@ -38,12 +38,15 @@ func (l *ProbeLoader) Close() error {
 }
 
 // Load eBPF programs
-func (l *ProbeLoader) Load() (bytecode.AssetReader, error) {
+func (l *ProbeLoader) Load() (bytecode.AssetReader, bool, error) {
 	var err error
+	var runtimeCompiled bool
 	if l.config.RuntimeCompilationEnabled {
 		l.bytecodeReader, err = getRuntimeCompiledPrograms(l.config, l.useSyscallWrapper)
 		if err != nil {
 			log.Warnf("error compiling runtime-security probe, falling back to pre-compiled: %s", err)
+		} else {
+			runtimeCompiled = true
 		}
 	}
 
@@ -56,11 +59,11 @@ func (l *ProbeLoader) Load() (bytecode.AssetReader, error) {
 
 		l.bytecodeReader, err = bytecode.GetReader(l.config.BPFDir, asset+".o")
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 	}
 
-	return l.bytecodeReader, nil
+	return l.bytecodeReader, runtimeCompiled, nil
 }
 
 // OffsetGuesserLoader defines an eBPF Loader

--- a/pkg/security/ebpf/probes/bind.go
+++ b/pkg/security/ebpf/probes/bind.go
@@ -20,5 +20,14 @@ func getBindProbes() []*manager.Probe {
 		},
 		SyscallFuncName: "bind",
 	}, EntryAndExit)...)
+
+	bindProbes = append(bindProbes, &manager.Probe{
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/security_socket_bind",
+			EBPFFuncName: "kprobe_security_socket_bind",
+		},
+	})
+
 	return bindProbes
 }

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -568,6 +568,13 @@ func GetSelectorsPerEventType() map[eval.EventType][]manager.ProbesSelector {
 					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "bind"}, EntryAndExit),
 				},
 			},
+
+			// List of probes required to capture DNS events
+			"dns": {
+				&manager.AllOf{Selectors: []manager.ProbesSelector{
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/security_socket_bind", EBPFFuncName: "kprobe_security_socket_bind"}},
+				}},
+			},
 		}
 	}
 	return selectorsPerEventTypeStore

--- a/pkg/security/ebpf/probes/flow.go
+++ b/pkg/security/ebpf/probes/flow.go
@@ -15,13 +15,6 @@ var flowProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/security_socket_bind",
-			EBPFFuncName: "kprobe_security_socket_bind",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
 			EBPFSection:  "kprobe/security_sk_classify_flow",
 			EBPFFuncName: "kprobe_security_sk_classify_flow",
 		},

--- a/pkg/security/ebpf/probes/tc.go
+++ b/pkg/security/ebpf/probes/tc.go
@@ -54,6 +54,15 @@ func GetAllTCProgramFunctions() []string {
 	for _, tcProbe := range GetTCProbes() {
 		output = append(output, tcProbe.EBPFFuncName)
 	}
+
+	for _, flowProbe := range getFlowProbes() {
+		output = append(output, flowProbe.EBPFFuncName)
+	}
+
+	for _, netDeviceProbe := range getNetDeviceProbes() {
+		output = append(output, netDeviceProbe.EBPFFuncName)
+	}
+
 	return output
 }
 

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -248,7 +248,7 @@ func (p *Probe) Init() error {
 		return err
 	}
 
-	loader := ebpf.NewProbeLoader(p.config, useSyscallWrapper)
+	loader := ebpf.NewProbeLoader(p.config, useSyscallWrapper, p.statsdClient)
 	defer loader.Close()
 
 	bytecodeReader, runtimeCompiled, err := loader.Load()

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -102,6 +102,7 @@ type Probe struct {
 	discarderRateLimiter *rate.Limiter
 
 	constantOffsets map[string]uint64
+	runtimeCompiled bool
 
 	// network section
 	tcProgramsLock sync.RWMutex
@@ -250,11 +251,13 @@ func (p *Probe) Init() error {
 	loader := ebpf.NewProbeLoader(p.config, useSyscallWrapper)
 	defer loader.Close()
 
-	bytecodeReader, err := loader.Load()
+	bytecodeReader, runtimeCompiled, err := loader.Load()
 	if err != nil {
 		return err
 	}
 	defer bytecodeReader.Close()
+
+	p.runtimeCompiled = runtimeCompiled
 
 	if err := p.eventStream.Init(p.manager, p.config); err != nil {
 		return err
@@ -303,6 +306,11 @@ func (p *Probe) Init() error {
 	p.eventStream.SetMonitor(p.monitor.perfBufferMonitor)
 
 	return nil
+}
+
+// IsRuntimeCompiled returns true if the eBPF programs where successfully runtime compiled
+func (p *Probe) IsRuntimeCompiled() bool {
+	return p.runtimeCompiled
 }
 
 // Setup the runtime security probe

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -71,6 +71,7 @@ system_probe_config:
   enabled: true
   sysprobe_socket: /tmp/test-sysprobe.sock
   enable_kernel_header_download: true
+  enable_runtime_compiler: true
 
 runtime_security_config:
   enabled: true

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -733,6 +733,10 @@ func newTestModule(t testing.TB, macroDefs []*rules.MacroDefinition, ruleDefs []
 		return nil, fmt.Errorf("failed to init module: %w", err)
 	}
 
+	if os.Getenv("DD_TESTS_RUNTIME_COMPILED") == "1" && !testMod.module.GetProbe().IsRuntimeCompiled() {
+		return nil, errors.New("failed to runtime compile module")
+	}
+
 	testMod.probe.AddEventHandler(model.UnknownEventType, testMod.probeHandler)
 
 	if err := testMod.module.Start(); err != nil {

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -734,7 +734,9 @@ func newTestModule(t testing.TB, macroDefs []*rules.MacroDefinition, ruleDefs []
 		return nil, fmt.Errorf("failed to init module: %w", err)
 	}
 
-	if os.Getenv("DD_TESTS_RUNTIME_COMPILED") == "1" && !testMod.module.GetProbe().IsRuntimeCompiled() {
+	kv, _ := kernel.NewKernelVersion()
+
+	if os.Getenv("DD_TESTS_RUNTIME_COMPILED") == "1" && !testMod.module.GetProbe().IsRuntimeCompiled() && !kv.IsSuseKernel() {
 		return nil, errors.New("failed to runtime compile module")
 	}
 

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -669,7 +669,6 @@ def get_security_agent_build_flags(security_agent_c_dir, kernel_release=None, mi
     security_flags.append(f"-I{security_agent_c_dir}")
     if debug:
         security_flags.append("-DDEBUG=1")
-    security_flags.append("-DUSE_RING_BUFFER=1")
     return security_flags
 
 

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -669,6 +669,7 @@ def get_security_agent_build_flags(security_agent_c_dir, kernel_release=None, mi
     security_flags.append(f"-I{security_agent_c_dir}")
     if debug:
         security_flags.append("-DDEBUG=1")
+    security_flags.append("-DUSE_RING_BUFFER=1")
     return security_flags
 
 

--- a/test/kitchen/site-cookbooks/dd-security-agent-check/metadata.rb
+++ b/test/kitchen/site-cookbooks/dd-security-agent-check/metadata.rb
@@ -7,3 +7,4 @@ version          "0.1.0"
 depends 'datadog'
 depends 'docker'
 depends 'selinux'
+depends 'dd-system-probe-check'

--- a/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
@@ -8,8 +8,16 @@
 if node['platform_family'] != 'windows'
   wrk_dir = '/tmp/security-agent'
 
-  directory wrk_dir do
-    recursive true
+  remote_directory wrk_dir do
+    cookbook 'dd-system-probe-check'
+    source 'tests'
+    mode '755'
+    files_mode '755'
+    sensitive true
+    case
+    when !platform?('windows')
+      files_owner 'root'
+    end
   end
 
   cookbook_file "#{wrk_dir}/testsuite" do

--- a/test/kitchen/test/integration/security-agent-test/rspec/security-agent-test_spec.rb
+++ b/test/kitchen/test/integration/security-agent-test/rspec/security-agent-test_spec.rb
@@ -5,7 +5,7 @@ print `uname -a`
 
 describe 'successfully run functional test' do
   it 'displays PASS and returns 0' do
-    output = `sudo /tmp/security-agent/testsuite -test.v -status-metrics 1>&2`
+    output = `DD_TESTS_RUNTIME_COMPILED=1 DD_SYSTEM_PROBE_BPF_DIR=/tmp/security-agent sudo -E /tmp/security-agent/testsuite -test.v -status-metrics 1>&2`
     retval = $?
     expect(retval).to eq(0)
   end

--- a/test/kitchen/test/integration/security-agent-test/rspec/security-agent-test_spec.rb
+++ b/test/kitchen/test/integration/security-agent-test/rspec/security-agent-test_spec.rb
@@ -3,9 +3,13 @@ require 'spec_helper'
 print `cat /etc/os-release`
 print `uname -a`
 
+Dir.glob('/tmp/security-agent/pkg/ebpf/bytecode/build/*.o').each do |f|
+  FileUtils.chmod 0644, f, :verbose => true
+end
+
 describe 'successfully run functional test' do
   it 'displays PASS and returns 0' do
-    output = `DD_TESTS_RUNTIME_COMPILED=1 DD_SYSTEM_PROBE_BPF_DIR=/tmp/security-agent sudo -E /tmp/security-agent/testsuite -test.v -status-metrics 1>&2`
+    output = `DD_TESTS_RUNTIME_COMPILED=1 DD_SYSTEM_PROBE_BPF_DIR=/tmp/security-agent/pkg/ebpf/bytecode/build sudo -E /tmp/security-agent/testsuite -test.v -status-metrics 1>&2`
     retval = $?
     expect(retval).to eq(0)
   end

--- a/test/kitchen/test/integration/security-agent-test/rspec/security-agent-test_spec.rb
+++ b/test/kitchen/test/integration/security-agent-test/rspec/security-agent-test_spec.rb
@@ -18,7 +18,7 @@ end
 if File.readlines("/etc/os-release").grep(/SUSE/).size == 0 and ! File.exists?('/etc/rhsm')
   describe 'successfully run functional test inside a container' do
     it 'displays PASS and returns 0' do
-      output = `sudo docker exec -ti docker-testsuite /tmp/security-agent/testsuite -test.v -status-metrics --env docker 1>&2`
+      output = `sudo docker exec -e DD_SYSTEM_PROBE_BPF_DIR=/tmp/security-agent/pkg/ebpf/bytecode/build -ti docker-testsuite /tmp/security-agent/testsuite -test.v -status-metrics -env docker 1>&2`
       retval = $?
       expect(retval).to eq(0)
     end


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

- Make the CWS eBPF programs compile on all supported kernels
- Enabled runtime compilation in functional tests on all supported platforms

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Currently, CWS eBPF programs fail to compile on older kernels causing runtime compilation to fail.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
