### PR TITLE
[network/ebpf/https] use do_sys_openat2 when available

### DIFF
--- a/pkg/network/http/ebpf_ssl.go
+++ b/pkg/network/http/ebpf_ssl.go
@@ -58,12 +58,18 @@ var gnuTLSProbes = map[string]string{
 const (
 	sslSockByCtxMap        = "ssl_sock_by_ctx"
 	sharedLibrariesPerfMap = "shared_libraries"
+)
 
-	// probe used for streaming shared library events
-	doSysOpen       = "kprobe/do_sys_open"
-	doSysOpenRet    = "kretprobe/do_sys_open"
-	doSysOpenAt2    = "kprobe/do_sys_openat2"
-	doSysOpenAt2Ret = "kretprobe/do_sys_openat2"
+type ebpfSectionFunction struct {
+	section  string
+	function string
+}
+
+// probe used for streaming shared library events
+var (
+	kprobeKretprobePrefix = []string{"kprobe", "kretprobe"}
+	doSysOpen             = ebpfSectionFunction{section: "do_sys_open", function: "do_sys_open"}
+	doSysOpenAt2          = ebpfSectionFunction{section: "do_sys_openat2", function: "do_sys_openat2"}
 )
 
 type sslProgram struct {
@@ -95,7 +101,7 @@ func (o *sslProgram) ConfigureManager(m *manager.Manager) {
 
 	o.manager = m
 
-	if !o.httpsSupported() {
+	if !httpsSupported() {
 		return
 	}
 
@@ -110,29 +116,15 @@ func (o *sslProgram) ConfigureManager(m *manager.Manager) {
 		},
 	})
 
-	m.Probes = append(m.Probes,
-		&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			EBPFSection:  doSysOpen,
-			EBPFFuncName: "kprobe__do_sys_open",
-			UID:          probeUID,
-		}, KProbeMaxActive: maxActive},
-		&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			EBPFSection:  doSysOpenRet,
-			EBPFFuncName: "kretprobe__do_sys_open",
-			UID:          probeUID,
-		}, KProbeMaxActive: maxActive},
-	)
-
-	if runningOnARM() {
+	probeSysOpen := doSysOpen
+	if sysOpenAt2Supported() {
+		probeSysOpen = doSysOpenAt2
+	}
+	for _, kprobe := range kprobeKretprobePrefix {
 		m.Probes = append(m.Probes,
 			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  doSysOpenAt2,
-				EBPFFuncName: "kprobe__do_sys_openat2",
-				UID:          probeUID,
-			}, KProbeMaxActive: maxActive},
-			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  doSysOpenAt2Ret,
-				EBPFFuncName: "kretprobe__do_sys_openat2",
+				EBPFSection:  kprobe + "/" + probeSysOpen.section,
+				EBPFFuncName: kprobe + "__" + probeSysOpen.function,
 				UID:          probeUID,
 			}, KProbeMaxActive: maxActive},
 		)
@@ -144,7 +136,7 @@ func (o *sslProgram) ConfigureOptions(options *manager.Options) {
 		return
 	}
 
-	if !o.httpsSupported() {
+	if !httpsSupported() {
 		return
 	}
 
@@ -154,36 +146,16 @@ func (o *sslProgram) ConfigureOptions(options *manager.Options) {
 		EditorFlag: manager.EditMaxEntries,
 	}
 
-	options.ActivatedProbes = append(options.ActivatedProbes,
-		&manager.ProbeSelector{
-			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  doSysOpen,
-				EBPFFuncName: "kprobe__do_sys_open",
-				UID:          probeUID,
-			},
-		},
-		&manager.ProbeSelector{
-			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  doSysOpenRet,
-				EBPFFuncName: "kretprobe__do_sys_open",
-				UID:          probeUID,
-			},
-		},
-	)
-
-	if runningOnARM() {
+	probeSysOpen := doSysOpen
+	if sysOpenAt2Supported() {
+		probeSysOpen = doSysOpenAt2
+	}
+	for _, kprobe := range kprobeKretprobePrefix {
 		options.ActivatedProbes = append(options.ActivatedProbes,
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  doSysOpenAt2,
-					EBPFFuncName: "kprobe__do_sys_openat2",
-					UID:          probeUID,
-				},
-			},
-			&manager.ProbeSelector{
-				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  doSysOpenAt2Ret,
-					EBPFFuncName: "kretprobe__do_sys_openat2",
+					EBPFSection:  kprobe + "/" + probeSysOpen.section,
+					EBPFFuncName: kprobe + "__" + probeSysOpen.function,
 					UID:          probeUID,
 				},
 			},
@@ -314,7 +286,7 @@ func runningOnARM() bool {
 }
 
 // We only support ARM with kernel >= 5.5.0 and with runtime compilation enabled
-func (o *sslProgram) httpsSupported() bool {
+func httpsSupported() bool {
 	if !runningOnARM() {
 		return true
 	}
@@ -326,4 +298,14 @@ func (o *sslProgram) httpsSupported() bool {
 	}
 
 	return kversion >= kernel.VersionCode(5, 5, 0)
+}
+
+func sysOpenAt2Supported() bool {
+	kversion, err := kernel.HostVersion()
+	if err != nil {
+		log.Error("could not determine the current kernel version. fallback to do_sys_open")
+		return false
+	}
+
+	return kversion >= kernel.VersionCode(5, 6, 0)
 }

--- a/pkg/network/http/ebpf_ssl.go
+++ b/pkg/network/http/ebpf_ssl.go
@@ -303,7 +303,7 @@ func httpsSupported() bool {
 
 func (o *sslProgram) sysOpenAt2Supported() bool {
 	ksymPath := filepath.Join(o.cfg.ProcRoot, "kallsyms")
-	missing, err := ddebpf.VerifyKernelFuncs(ksymPath, []string{doSysOpenAt2.function})
+	missing, err := ddebpf.VerifyKernelFuncs(ksymPath, []string{doSysOpenAt2.section})
 	if err == nil && len(missing) == 0 {
 		return true
 	}


### PR DESCRIPTION
It's safe to only hook on do_sys_openat2 as do_sys_open will call the new api from kernel 5.6.0
Note: recent ld loader (x86) call directly sys_openat from Ubuntu 22.04

### What does this PR do?

Fixing https on recent distribution like x86 Ubuntu 22.04 and Arm64 5.5.x kernel


### Describe how to test/QA your changes

```
system_probe_config:
  log_level: debug
  enable_runtime_compiler: true
network_config:
  enable_http_monitoring: true
  enable_https_monitoring: true
```

 * run system-probe on Ubuntu 22.04 
 * `wget https://httpbin.org/anything/foo/200`
 * `sudo curl -s --unix-socket /opt/datadog-agent/run/sysprobe.sock http://unix/network_tracer/connections | tee cnx | jq '.conns[].tags , .tags'`
You should see openssl tags : `tls.library:openssl`
 * `sudo curl -s --unix-socket /opt/datadog-agent/run/sysprobe.sock http://unix/network_tracer/debug/http_monitoring`
 * 
### Reviewer's Checklist
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
