### PR TITLE
[networks] Expire stale entries from `http_in_flight` eBPF map

### DIFF
--- a/pkg/ebpf/map_cleaner.go
+++ b/pkg/ebpf/map_cleaner.go
@@ -1,0 +1,135 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+// +build linux_bpf
+
+package ebpf
+
+import (
+	"fmt"
+	"reflect"
+	"sync"
+	"time"
+	"unsafe"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	cebpf "github.com/cilium/ebpf"
+)
+
+// MapCleaner is responsible for periodically sweeping an eBPF map
+// and deleting entries that satisfy a certain predicate function supplied by the user
+type MapCleaner struct {
+	emap *cebpf.Map
+	key  interface{}
+	val  interface{}
+	once sync.Once
+
+	// we resort to unsafe.Pointers because by doing so the underlying eBPF
+	// library avoids marshaling the key/value variables while traversing the
+	// map, which not only has an overhead but also requires all fields from the
+	// datatype to be exported
+	keyPtr unsafe.Pointer
+	valPtr unsafe.Pointer
+
+	// termination
+	stopOnce sync.Once
+	done     chan struct{}
+}
+
+// NewMapCleaner instantiates a new MapCleaner
+func NewMapCleaner(emap *cebpf.Map, key, val interface{}) (*MapCleaner, error) {
+	// we force types to be of pointer kind because of the reasons mentioned above
+	if reflect.ValueOf(key).Kind() != reflect.Ptr {
+		return nil, fmt.Errorf("%T is not a pointer kind", key)
+	}
+	if reflect.ValueOf(val).Kind() != reflect.Ptr {
+		return nil, fmt.Errorf("%T is not a pointer kind", val)
+	}
+
+	return &MapCleaner{
+		emap:   emap,
+		key:    key,
+		val:    val,
+		keyPtr: unsafe.Pointer(reflect.ValueOf(key).Elem().Addr().Pointer()),
+		valPtr: unsafe.Pointer(reflect.ValueOf(val).Elem().Addr().Pointer()),
+		done:   make(chan struct{}),
+	}, nil
+}
+
+// Clean eBPF map
+// `interval` determines how often the eBPF map is scanned;
+// `shouldClean` is a predicate method that determines whether or not a certain
+// map entry should be deleted. the callback argument `nowTS` can be directly
+// compared to timestamps generated using the `bpf_ktime_get_ns()` helper;
+func (mc *MapCleaner) Clean(interval time.Duration, shouldClean func(nowTS int64, k, v interface{}) bool) {
+	if mc == nil {
+		return
+	}
+
+	mc.once.Do(func() {
+		ticker := time.NewTicker(interval)
+		go func() {
+			defer ticker.Stop()
+
+			for {
+				select {
+				case <-ticker.C:
+					// TODO: use pkg/security/probe/time_resolver.go to account for
+					// clock drifts when system was suspended
+					now, err := NowNanoseconds()
+					if err != nil {
+						break
+					}
+					mc.clean(now, shouldClean)
+				case <-mc.done:
+					return
+				}
+			}
+
+		}()
+	})
+}
+
+func (mc *MapCleaner) Stop() {
+	if mc == nil {
+		return
+	}
+
+	mc.stopOnce.Do(func() {
+		mc.done <- struct{}{}
+		close(mc.done)
+	})
+}
+
+func (mc *MapCleaner) clean(nowTS int64, shouldClean func(nowTS int64, k, v interface{}) bool) error {
+	totalCount, deletedCount := 0, 0
+	entries := mc.emap.Iterate()
+	now := time.Now()
+
+	for entries.Next(mc.keyPtr, mc.valPtr) {
+		totalCount++
+		if shouldClean(nowTS, mc.key, mc.val) {
+			err := mc.emap.Delete(mc.keyPtr)
+			if err == nil {
+				deletedCount++
+			}
+		}
+	}
+
+	if err := entries.Err(); err != nil {
+		return err
+	}
+
+	elapsed := time.Now().Sub(now)
+	log.Debugf(
+		"finished cleaning map=%s entries_checked=%d entries_deleted=%d, elasped=%s",
+		mc.emap,
+		totalCount,
+		deletedCount,
+		elapsed,
+	)
+	return nil
+}

--- a/pkg/ebpf/map_cleaner.go
+++ b/pkg/ebpf/map_cleaner.go
@@ -9,12 +9,17 @@
 package ebpf
 
 import (
+	"bytes"
+	"encoding"
+	"encoding/binary"
+	"errors"
 	"fmt"
 	"reflect"
 	"sync"
 	"time"
 	"unsafe"
 
+	internal "github.com/DataDog/btf-internals"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	cebpf "github.com/cilium/ebpf"
 )
@@ -28,9 +33,7 @@ type MapCleaner struct {
 	once sync.Once
 
 	// we resort to unsafe.Pointers because by doing so the underlying eBPF
-	// library avoids marshaling the key/value variables while traversing the
-	// map, which not only has an overhead but also requires all fields from the
-	// datatype to be exported
+	// library avoids marshaling the key/value variables while traversing the map
 	keyPtr unsafe.Pointer
 	valPtr unsafe.Pointer
 
@@ -99,37 +102,92 @@ func (mc *MapCleaner) Stop() {
 	}
 
 	mc.stopOnce.Do(func() {
+		// send to channel to synchronize with goroutine doing the map cleaning
 		mc.done <- struct{}{}
 		close(mc.done)
 	})
 }
 
 func (mc *MapCleaner) clean(nowTS int64, shouldClean func(nowTS int64, k, v interface{}) bool) error {
+	keySize := int(mc.emap.KeySize())
+	keysToDelete := make([][]byte, 0, 128)
 	totalCount, deletedCount := 0, 0
-	entries := mc.emap.Iterate()
 	now := time.Now()
 
+	entries := mc.emap.Iterate()
 	for entries.Next(mc.keyPtr, mc.valPtr) {
 		totalCount++
-		if shouldClean(nowTS, mc.key, mc.val) {
-			err := mc.emap.Delete(mc.keyPtr)
-			if err == nil {
-				deletedCount++
-			}
+
+		if !shouldClean(nowTS, mc.key, mc.val) {
+			continue
+		}
+
+		marshalledKey, err := marshalBytes(mc.key, keySize)
+		if err != nil {
+			continue
+		}
+
+		// we accumulate alll keys to delete because it isn't safe to delete map
+		// entries during the traversal. the main downside of doing so is that all
+		// fields from the key type must be exported in order to be marshaled (unless
+		// the key type implements the `encoding.BinaryMarshaler` interface)
+		keysToDelete = append(keysToDelete, marshalledKey)
+	}
+
+	for _, key := range keysToDelete {
+		err := mc.emap.Delete(key)
+		if err == nil {
+			deletedCount++
 		}
 	}
 
-	if err := entries.Err(); err != nil {
-		return err
-	}
-
+	iterationErr := entries.Err()
 	elapsed := time.Now().Sub(now)
 	log.Debugf(
-		"finished cleaning map=%s entries_checked=%d entries_deleted=%d, elapsed=%s",
+		"finished cleaning map=%s entries_checked=%d entries_deleted=%d iteration_error=%v elapsed=%s",
 		mc.emap,
 		totalCount,
 		deletedCount,
+		iterationErr,
 		elapsed,
 	)
 	return nil
+}
+
+// marshalBytes converts an arbitrary value into a byte buffer.
+//
+// Returns an error if the given value isn't representable in exactly
+// length bytes.
+//
+// copied from: https://github.com/cilium/ebpf/blob/master/marshalers.go
+func marshalBytes(data interface{}, length int) (buf []byte, err error) {
+	if data == nil {
+		return nil, errors.New("can't marshal a nil value")
+	}
+
+	switch value := data.(type) {
+	case encoding.BinaryMarshaler:
+		buf, err = value.MarshalBinary()
+	case string:
+		buf = []byte(value)
+	case []byte:
+		buf = value
+	case unsafe.Pointer:
+		err = errors.New("can't marshal from unsafe.Pointer")
+	default:
+		var wr bytes.Buffer
+		err = binary.Write(&wr, internal.NativeEndian, value)
+		if err != nil {
+			err = fmt.Errorf("encoding %T: %v", value, err)
+		}
+		buf = wr.Bytes()
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if len(buf) != length {
+		return nil, fmt.Errorf("%T doesn't marshal to %d bytes", data, length)
+	}
+	return buf, nil
 }

--- a/pkg/ebpf/map_cleaner.go
+++ b/pkg/ebpf/map_cleaner.go
@@ -125,7 +125,7 @@ func (mc *MapCleaner) clean(nowTS int64, shouldClean func(nowTS int64, k, v inte
 
 	elapsed := time.Now().Sub(now)
 	log.Debugf(
-		"finished cleaning map=%s entries_checked=%d entries_deleted=%d, elasped=%s",
+		"finished cleaning map=%s entries_checked=%d entries_deleted=%d, elapsed=%s",
 		mc.emap,
 		totalCount,
 		deletedCount,

--- a/pkg/ebpf/map_cleaner.go
+++ b/pkg/ebpf/map_cleaner.go
@@ -80,8 +80,6 @@ func (mc *MapCleaner) Clean(interval time.Duration, shouldClean func(nowTS int64
 			for {
 				select {
 				case <-ticker.C:
-					// TODO: use pkg/security/probe/time_resolver.go to account for
-					// clock drifts when system was suspended
 					now, err := NowNanoseconds()
 					if err != nil {
 						break

--- a/pkg/ebpf/map_cleaner_test.go
+++ b/pkg/ebpf/map_cleaner_test.go
@@ -1,0 +1,63 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+// +build linux_bpf
+
+package ebpf
+
+import (
+	"testing"
+	"time"
+
+	cebpf "github.com/cilium/ebpf"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMapCleaner(t *testing.T) {
+	var (
+		key = new(int64)
+		val = new(int64)
+	)
+
+	m, err := cebpf.NewMap(&cebpf.MapSpec{
+		Type:       cebpf.Hash,
+		KeySize:    8,
+		ValueSize:  8,
+		MaxEntries: 100,
+	})
+	require.NoError(t, err)
+
+	cleaner, err := NewMapCleaner(m, key, val)
+	require.NoError(t, err)
+	for i := 0; i < 100; i++ {
+		*key = int64(i)
+		err := m.Put(key, val)
+		assert.Nilf(t, err, "can't put key=%d: %s", i, err)
+	}
+	defer cleaner.Stop()
+
+	// Clean all the even entries
+	cleaner.Clean(100*time.Millisecond, func(now int64, k, v interface{}) bool {
+		key := k.(*int64)
+		shouldDelete := *key%2 == 0
+		return shouldDelete
+	})
+
+	time.Sleep(1 * time.Second)
+	for i := 0; i < 100; i++ {
+		*key = int64(i)
+		err := m.Lookup(key, val)
+
+		// If the entry is even, it should have been deleted
+		// otherwise it should be present
+		if i%2 == 0 {
+			assert.NotNilf(t, err, "entry key=%d should not be present", i)
+		} else {
+			assert.Nil(t, err)
+		}
+	}
+}

--- a/pkg/ebpf/map_cleaner_test.go
+++ b/pkg/ebpf/map_cleaner_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	cebpf "github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/rlimit"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -24,6 +25,9 @@ func TestMapCleaner(t *testing.T) {
 		key = new(int64)
 		val = new(int64)
 	)
+
+	err := rlimit.RemoveMemlock()
+	require.NoError(t, err)
 
 	m, err := cebpf.NewMap(&cebpf.MapSpec{
 		Type:       cebpf.Hash,

--- a/pkg/network/http/ebpf_main.go
+++ b/pkg/network/http/ebpf_main.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"time"
 
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"
@@ -45,6 +46,8 @@ const (
 	batchNotificationsChanSize = 100
 
 	probeUID = "http"
+
+	maxRequestLinger = 30 * time.Second
 )
 
 type ebpfProgram struct {
@@ -53,6 +56,7 @@ type ebpfProgram struct {
 	bytecode    bytecode.AssetReader
 	offsets     []manager.ConstantEditor
 	subprograms []subprogram
+	mapCleaner  *ddebpf.MapCleaner
 
 	batchCompletionHandler *ddebpf.PerfHandler
 }
@@ -196,6 +200,8 @@ func (e *ebpfProgram) Start() error {
 		s.Start()
 	}
 
+	e.setupMapCleaner()
+
 	return nil
 }
 
@@ -206,6 +212,32 @@ func (e *ebpfProgram) Close() error {
 		s.Stop()
 	}
 	return err
+}
+
+func (e *ebpfProgram) setupMapCleaner() {
+	httpMap, _, _ := e.GetMap(httpInFlightMap)
+	httpMapCleaner, err := ddebpf.NewMapCleaner(httpMap, new(netebpf.ConnTuple), new(httpTX))
+	if err != nil {
+		log.Errorf("error creating map cleaner: %s", err)
+		return
+	}
+
+	ttl := maxRequestLinger.Nanoseconds()
+	httpMapCleaner.Clean(5*time.Minute, func(now int64, key, val interface{}) bool {
+		httpTX, ok := val.(*httpTX)
+		if !ok {
+			return false
+		}
+
+		if updated := int64(httpTX.response_last_seen); updated > 0 {
+			return (now - updated) > ttl
+		}
+
+		started := int64(httpTX.request_started)
+		return started > 0 && (now-started) > ttl
+	})
+
+	e.mapCleaner = httpMapCleaner
 }
 
 func enableRuntimeCompilation(c *config.Config) bool {

--- a/pkg/network/http/ebpf_main.go
+++ b/pkg/network/http/ebpf_main.go
@@ -206,6 +206,7 @@ func (e *ebpfProgram) Start() error {
 }
 
 func (e *ebpfProgram) Close() error {
+	e.mapCleaner.Stop()
 	err := e.Manager.Stop(manager.CleanAll)
 	e.batchCompletionHandler.Stop()
 	for _, s := range e.subprograms {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

* Add `ebpf.MapCleaner`;
* Expire stale entries from `http_in_flight` eBPF map

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Start system-probe with the following configuration:
```
system_probe_config:
  log_level: debug
network_config:
  enabled: true
  enable_http_monitoring: true
```

Now in one of window of your terminal, run the following command to spin up a TCP server bound to port 8080:
```
nc -l 8080
```

In another window connect to this server:
```
telnet localhost 8080
```

Once the TCP connection is established type in the following and then hit `<enter>`:
```
GET /foobar HTTP/1.1
```

This will essentially simulate the scenario where a HTTP client issues a request that never gets a response, which would cause an eBPF map entry to "leak".

Now wait 5 minutes and make sure that you see a log message similar to the following

```
2022-06-30 16:27:38 UTC | SYS-PROBE | DEBUG | (pkg/ebpf/map_cleaner.go:126 in clean) | finished cleaning map=Hash(http_in_flight)#61 entries_checked=10 entries_deleted=1 elapsed=209.796µs
```

The important bit of information to validate here is `entries_deleted=1`

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
