### PR TITLE
[omnibus] Patch psutil to fix automount logs in Docker container with disk check

### DIFF
--- a/omnibus/config/patches/datadog-agent-integrations-py2/remove-maxfile-maxpath-psutil.patch
+++ b/omnibus/config/patches/datadog-agent-integrations-py2/remove-maxfile-maxpath-psutil.patch
@@ -1,3 +1,4 @@
+Partially reverts https://github.com/giampaolo/psutil/pull/1863 to remove the maxpath / maxfile fetch
 diff --git a/psutil/__init__.py b/psutil/__init__.py
 index 1a113bc3..ce962a61 100644
 --- a/psutil/__init__.py

--- a/omnibus/config/patches/datadog-agent-integrations-py2/remove-maxfile-maxpath-psutil.patch
+++ b/omnibus/config/patches/datadog-agent-integrations-py2/remove-maxfile-maxpath-psutil.patch
@@ -1,0 +1,29 @@
+diff --git a/psutil/__init__.py b/psutil/__init__.py
+index 1a113bc3..ce962a61 100644
+--- a/psutil/__init__.py
++++ b/psutil/__init__.py
+@@ -2012,23 +2012,7 @@ def disk_partitions(all=False):
+     If *all* parameter is False return physical devices only and ignore
+     all others.
+     """
+-    def pathconf(path, name):
+-        try:
+-            return os.pathconf(path, name)
+-        except (OSError, AttributeError):
+-            pass
+-
+-    ret = _psplatform.disk_partitions(all)
+-    if POSIX:
+-        new = []
+-        for item in ret:
+-            nt = item._replace(
+-                maxfile=pathconf(item.mountpoint, 'PC_NAME_MAX'),
+-                maxpath=pathconf(item.mountpoint, 'PC_PATH_MAX'))
+-            new.append(nt)
+-        return new
+-    else:
+-        return ret
++    return _psplatform.disk_partitions(all)
+ 
+ 
+ def disk_io_counters(perdisk=False, nowrap=True):

--- a/omnibus/config/patches/datadog-agent-integrations-py3/remove-maxfile-maxpath-psutil.patch
+++ b/omnibus/config/patches/datadog-agent-integrations-py3/remove-maxfile-maxpath-psutil.patch
@@ -1,3 +1,4 @@
+Partially reverts https://github.com/giampaolo/psutil/pull/1863 to remove the maxpath / maxfile fetch
 diff --git a/psutil/__init__.py b/psutil/__init__.py
 index 1a113bc3..ce962a61 100644
 --- a/psutil/__init__.py

--- a/omnibus/config/patches/datadog-agent-integrations-py3/remove-maxfile-maxpath-psutil.patch
+++ b/omnibus/config/patches/datadog-agent-integrations-py3/remove-maxfile-maxpath-psutil.patch
@@ -1,0 +1,29 @@
+diff --git a/psutil/__init__.py b/psutil/__init__.py
+index 1a113bc3..ce962a61 100644
+--- a/psutil/__init__.py
++++ b/psutil/__init__.py
+@@ -2012,23 +2012,7 @@ def disk_partitions(all=False):
+     If *all* parameter is False return physical devices only and ignore
+     all others.
+     """
+-    def pathconf(path, name):
+-        try:
+-            return os.pathconf(path, name)
+-        except (OSError, AttributeError):
+-            pass
+-
+-    ret = _psplatform.disk_partitions(all)
+-    if POSIX:
+-        new = []
+-        for item in ret:
+-            nt = item._replace(
+-                maxfile=pathconf(item.mountpoint, 'PC_NAME_MAX'),
+-                maxpath=pathconf(item.mountpoint, 'PC_PATH_MAX'))
+-            new.append(nt)
+-        return new
+-    else:
+-        return ret
++    return _psplatform.disk_partitions(all)
+ 
+ 
+ def disk_io_counters(perdisk=False, nowrap=True):

--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -423,9 +423,11 @@ build do
       if windows?
         patch :source => "create-regex-at-runtime.patch", :target => "#{python_2_embedded}/Lib/site-packages/yaml/reader.py"
         patch :source => "tuf-0.17.0-cve-2021-41131.patch", :target => "#{python_2_embedded}/Lib/site-packages/tuf/client/updater.py"
+        patch :source => "remove-maxfile-maxpath-psutil.patch", :target => "#{python_2_embedded}/Lib/site-packages/psutil/__init__.py"
       else
         patch :source => "create-regex-at-runtime.patch", :target => "#{install_dir}/embedded/lib/python2.7/site-packages/yaml/reader.py"
         patch :source => "tuf-0.17.0-cve-2021-41131.patch", :target => "#{install_dir}/embedded/lib/python2.7/site-packages/tuf/client/updater.py"
+        patch :source => "remove-maxfile-maxpath-psutil.patch", :target => "#{install_dir}/embedded/lib/python2.7/site-packages/psutil/__init__.py"
       end
 
       # Run pip check to make sure the agent's python environment is clean, all the dependencies are compatible

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -424,6 +424,13 @@ build do
       # We have to run these operations in block, so they get applied after operations
       # from the last block
 
+      # Patch applies to only one file: set it explicitly as a target, no need for -p
+      if windows?
+        patch :source => "remove-maxfile-maxpath-psutil.patch", :target => "#{python_3_embedded}/Lib/site-packages/psutil/__init__.py"
+      else
+        patch :source => "remove-maxfile-maxpath-psutil.patch", :target => "#{install_dir}/embedded/lib/python3.8/site-packages/psutil/__init__.py"
+      end
+
       # Run pip check to make sure the agent's python environment is clean, all the dependencies are compatible
       if windows?
         command "#{python} -m pip check"

--- a/releasenotes/notes/psutil-automount-c9a91eccc6c40af2.yaml
+++ b/releasenotes/notes/psutil-automount-c9a91eccc6c40af2.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes a disk check issue in the Docker Agent where a disproportionate amount of automount
+    request system logs would be produced by the host after each disk check run.


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Adds an omnibus patch to `psutil` to fix an issue with that started with the `5.7.4` release of `psutil`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

In Agent 7.35.0, we upgraded the embedded `psutil` version from `5.7.2` to `5.9.0`. One of the changes this brought is https://github.com/giampaolo/psutil/pull/1863, which modified `psutil.disk_partitions` to also collect the `maxpath` and `maxfile` fields.

This new feature has two negative effects:
- it negatively impacts the performance of the `psutil.disk_partitions` (mentioned in https://github.com/giampaolo/psutil/pull/2110)
- on systems where `automount` is enabled, if you run the Docker Agent with the disk check enabled and `/proc` mounted in the container (which is what we document in our install docs), the `automount` of `binfmt_misc` is repeatedly called, causing a huge amount of noise in `/var/log/syslog` (during each check run):
```
Jul  1 11:47:17 ubuntu-bionic systemd[1]: proc-sys-fs-binfmt_misc.automount: Got automount request for /proc/sys/fs/binfmt_misc, triggered by 5809 (agent)
Jul  1 11:47:17 ubuntu-bionic systemd[1]: proc-sys-fs-binfmt_misc.automount: Automount point already active?
Jul  1 11:47:17 ubuntu-bionic systemd[1]: proc-sys-fs-binfmt_misc.automount: Got automount request for /proc/sys/fs/binfmt_misc, triggered by 5809 (agent)
Jul  1 11:47:17 ubuntu-bionic systemd[1]: proc-sys-fs-binfmt_misc.automount: Automount point already active?
Jul  1 11:47:17 ubuntu-bionic systemd[1]: proc-sys-fs-binfmt_misc.automount: Got automount request for /proc/sys/fs/binfmt_misc, triggered by 5809 (agent)
Jul  1 11:47:17 ubuntu-bionic systemd[1]: proc-sys-fs-binfmt_misc.automount: Automount point already active?
Jul  1 11:47:17 ubuntu-bionic systemd[1]: proc-sys-fs-binfmt_misc.automount: Got automount request for /proc/sys/fs/binfmt_misc, triggered by 5809 (agent)
Jul  1 11:47:17 ubuntu-bionic systemd[1]: proc-sys-fs-binfmt_misc.automount: Automount point already active?
Jul  1 11:47:17 ubuntu-bionic systemd[1]: proc-sys-fs-binfmt_misc.automount: Got automount request for /proc/sys/fs/binfmt_misc, triggered by 5809 (agent)
Jul  1 11:47:17 ubuntu-bionic systemd[1]: proc-sys-fs-binfmt_misc.automount: Automount point already active?
Jul  1 11:47:17 ubuntu-bionic systemd[1]: proc-sys-fs-binfmt_misc.automount: Got automount request for /proc/sys/fs/binfmt_misc, triggered by 5809 (agent)
Jul  1 11:47:17 ubuntu-bionic systemd[1]: proc-sys-fs-binfmt_misc.automount: Automount point already active?
```

This PR patches `psutil` to remove the `maxpath` and `maxfile` fetch feature, which we don't use in the check.

Once https://github.com/giampaolo/psutil/pull/2110 is merged and released, we can remove this patch, update `psutil` and add the `get_maxfile_maxpath=False` option to the disk check's `psutil.disk_partitions` calls.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

The issue can be reproduced by rebooting the host, then running:
```
sudo docker run --rm -d --name dd-agent -e DD_API_KEY="<api key>" -e DD_LOG_LEVEL=DEBUG -e DD_SITE="datadoghq.com" -e HOST_PROC=/host/proc -e DOCKER_HOST=unix:///var/run/docker.sock -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro gcr.io/datadoghq/agent:7.35.0
```
on an Ubuntu system (I tried with 18.04).

The fix can be tested by rebooting the host again, then running:
```
sudo docker run --rm -d --name dd-agent -e DD_API_KEY="<api key>" -e DD_LOG_LEVEL=DEBUG -e DD_SITE="datadoghq.com" -e HOST_PROC=/host/proc -e DOCKER_HOST=unix:///var/run/docker.sock -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro docker.io/datadog/agent-dev:nightly-a04d0739-py3
```

### Possible Drawbacks / Trade-offs

n/a

### Describe how to test/QA your changes

Run the setup described in the additional notes, check that the issue happens with `7.35.0` ~ `7.37.1` but not with this PR, and that the disk check works as expected.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
