### PR TITLE
Sending agent configuration to inventories

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/DataDog/gopsutil v1.1.0
 	github.com/DataDog/nikos v1.8.0
 	github.com/DataDog/sketches-go v1.4.1
-	github.com/DataDog/viper v1.9.0
+	github.com/DataDog/viper v1.11.0
 	github.com/DataDog/watermarkpodautoscaler v0.5.0-rc.1.0.20220530183114-687bca6395e8
 	github.com/DataDog/zstd v1.5.2
 	github.com/DataDog/zstd_0 v0.0.0-20210310093942-586c1286621f

--- a/go.sum
+++ b/go.sum
@@ -170,8 +170,8 @@ github.com/DataDog/nikos v1.8.0/go.mod h1:s/Eta3daH5lqW4tLNNweLpD+Y/xPT2O2PAVfMf
 github.com/DataDog/sketches-go v1.0.0/go.mod h1:O+XkJHWk9w4hDwY2ZUDU31ZC9sNYlYo8DiFsxjYeo1k=
 github.com/DataDog/sketches-go v1.4.1 h1:j5G6as+9FASM2qC36lvpvQAj9qsv/jUs3FtO8CwZNAY=
 github.com/DataDog/sketches-go v1.4.1/go.mod h1:xJIXldczJyyjnbDop7ZZcLxJdV3+7Kra7H1KMgpgkLk=
-github.com/DataDog/viper v1.9.0 h1:9Ha1yJebecIKtboH/GXUM3brfoMofvdd8BlMck8Cs8Q=
-github.com/DataDog/viper v1.9.0/go.mod h1:Gx7+/WONkbQIh3ac52KqcFTzipQ1OYHhCQGWAgHlzpc=
+github.com/DataDog/viper v1.11.0 h1:mwpluIgZL4fGd2p76prLES6SAMjeowxh+Z3nOkb5UyQ=
+github.com/DataDog/viper v1.11.0/go.mod h1:Gx7+/WONkbQIh3ac52KqcFTzipQ1OYHhCQGWAgHlzpc=
 github.com/DataDog/watermarkpodautoscaler v0.5.0-rc.1.0.20220530183114-687bca6395e8 h1:2+uhTsVJvKbLIIGJxRoI3NTSPB9rNWqmLqFAqgPWkPM=
 github.com/DataDog/watermarkpodautoscaler v0.5.0-rc.1.0.20220530183114-687bca6395e8/go.mod h1:AvpNq6Yp+0VfeNNCmpH2pU4htkxfbSlhuDS2JaSfU1M=
 github.com/DataDog/zstd v1.3.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1016,6 +1016,8 @@ func InitConfig(config Config) {
 
 	// inventories
 	config.BindEnvAndSetDefault("inventories_enabled", true)
+	config.BindEnvAndSetDefault("inventories_configuration_enabled", true)
+	// when updating the default here also update pkg/metadata/inventories/README.md
 	config.BindEnvAndSetDefault("inventories_max_interval", DefaultInventoriesMaxInterval) // integer seconds
 	config.BindEnvAndSetDefault("inventories_min_interval", DefaultInventoriesMinInterval) // integer seconds
 

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -61,6 +61,7 @@ type Config interface {
 	MergeConfigOverride(in io.Reader) error
 
 	AllSettings() map[string]interface{}
+	AllSettingsWithoutDefault() map[string]interface{}
 	AllKeys() []string
 
 	AddConfigPath(in string)

--- a/pkg/config/viper.go
+++ b/pkg/config/viper.go
@@ -395,6 +395,16 @@ func (c *safeConfig) AllSettings() map[string]interface{} {
 	return c.Viper.AllSettings()
 }
 
+// AllSettingsWithoutDefault wraps Viper for concurrent access
+func (c *safeConfig) AllSettingsWithoutDefault() map[string]interface{} {
+	c.Lock()
+	defer c.Unlock()
+
+	// AllSettingsWithoutDefault returns a fresh map, so the caller may do with it
+	// as they please without holding the lock.
+	return c.Viper.AllSettingsWithoutDefault()
+}
+
 // AddConfigPath wraps Viper for concurrent access
 func (c *safeConfig) AddConfigPath(in string) {
 	c.Lock()

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -93,13 +93,16 @@ func init() {
 	// We add a replacer to scrub even those credentials.
 	//
 	// It is a best effort to match the api key field without matching our
-	// own already scrubbed (we don't want to match: **************************abcde)
-	// Basically we allow many special chars while forbidding *
-	otherAPIKeysRx := regexp.MustCompile(`api_key\s*:\s*[a-zA-Z0-9\\\/\^\]\[\(\){}!|%:;"~><=#@$_\-\+]+`)
+	// own already scrubbed (we don't want to match: "**************************abcde")
+	// Basically we allow many special chars while forbidding *.
+	//
+	// We want the value to be at least 2 characters which will avoid matching the first '"' from the regular
+	// replacer for api_key.
+	otherAPIKeysRx := regexp.MustCompile(`api_key\s*:\s*[a-zA-Z0-9\\\/\^\]\[\(\){}!|%:;"~><=#@$_\-\+]{2,}`)
 	flareScrubber.AddReplacer(scrubber.SingleLine, scrubber.Replacer{
 		Regex: otherAPIKeysRx,
 		ReplFunc: func(b []byte) []byte {
-			return []byte("api_key: ********")
+			return []byte("api_key: \"********\"")
 		},
 	})
 }

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -471,9 +471,9 @@ instances:
 	redacted := `init_config:
 instances:
 - host: 127.0.0.1
-  api_key: ***************************aaaaa
+  api_key: "***************************aaaaa"
   port: 8082
-  api_key: ********
+  api_key: "********"
   version: 4 # omit this line if you're running pdns_recursor version 3.x`
 
 	err := writeScrubbedFile(filename, []byte(clear))
@@ -531,7 +531,7 @@ func TestZipProcessAgentFullConfig(t *testing.T) {
 		},
 	}
 
-	exp := `api_key: ***************************aaaaa
+	exp := `api_key: "***************************aaaaa"
 dd_url: https://my-url.com
 process_config:
   enabled: "true"`

--- a/pkg/metadata/inventories/agent_configuration.go
+++ b/pkg/metadata/inventories/agent_configuration.go
@@ -1,0 +1,47 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package inventories
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
+	"gopkg.in/yaml.v2"
+)
+
+func marshalAndScrub(conf map[string]interface{}) (string, error) {
+	flareScrubber := scrubber.NewWithDefaults()
+
+	provided, err := yaml.Marshal(conf)
+	if err != nil {
+		return "", log.Errorf("could not marshal agent configuration: %s", err)
+	}
+
+	scrubbed, err := flareScrubber.ScrubBytes(provided)
+	if err != nil {
+		return "", log.Errorf("could not scrubb agent configuration: %s", err)
+	}
+
+	return string(scrubbed), nil
+}
+
+func getProvidedAgentConfiguration() (string, error) {
+	if !config.Datadog.GetBool("inventories_configuration_enabled") {
+		return "", fmt.Errorf("inventories_configuration_enabled is disabled")
+	}
+
+	return marshalAndScrub(config.Datadog.AllSettingsWithoutDefault())
+}
+
+func getFullAgentConfiguration() (string, error) {
+	if !config.Datadog.GetBool("inventories_configuration_enabled") {
+		return "", fmt.Errorf("inventories_configuration_enabled is disabled")
+	}
+
+	return marshalAndScrub(config.Datadog.AllSettings())
+}

--- a/pkg/metadata/inventories/inventories.go
+++ b/pkg/metadata/inventories/inventories.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
@@ -98,6 +99,10 @@ const (
 	AgentLogsEnabled                   AgentMetadataName = "feature_logs_enabled"
 	AgentCSPMEnabled                   AgentMetadataName = "feature_cspm_enabled"
 	AgentAPMEnabled                    AgentMetadataName = "feature_apm_enabled"
+
+	// Those are reserved fields for the agentMetadata payload.
+	agentProvidedConf AgentMetadataName = "provided_configuration"
+	agentFullConf     AgentMetadataName = "full_configuration"
 
 	// key for the host metadata cache. See host_metadata.go
 	HostOSVersion AgentMetadataName = "os_version"
@@ -232,6 +237,16 @@ func createPayload(ctx context.Context, hostname string, ac AutoConfigInterface,
 	payloadAgentMeta := make(AgentMetadata)
 	for k, v := range agentMetadata {
 		payloadAgentMeta[k] = v
+	}
+	if fullConf, err := getFullAgentConfiguration(); err == nil {
+		payloadAgentMeta[string(agentFullConf)] = fullConf
+	} else {
+		log.Errorf("inv error: %s", err)
+	}
+	if providedConf, err := getProvidedAgentConfiguration(); err == nil {
+		payloadAgentMeta[string(agentProvidedConf)] = providedConf
+	} else {
+		log.Errorf("inv error: %s", err)
 	}
 
 	agentMetadataMutex.Unlock()

--- a/pkg/metadata/inventories/inventories_test.go
+++ b/pkg/metadata/inventories/inventories_test.go
@@ -122,7 +122,7 @@ func TestGetPayload(t *testing.T) {
 	assert.Equal(t, startNow.UnixNano(), p.Timestamp)
 
 	agentMetadata := *p.AgentMetadata
-	assert.Len(t, agentMetadata, 1)
+	assert.Len(t, agentMetadata, 3) // keys are: "test", "full_configuration", "provided_configuration"
 	assert.Equal(t, true, agentMetadata["test"])
 
 	checkMeta := *p.CheckMetadata
@@ -155,12 +155,15 @@ func TestGetPayload(t *testing.T) {
 	resetFunc := setupHostMetadataMock()
 	defer resetFunc()
 
+	mockConfig := config.Mock(t)
+	mockConfig.Set("inventories_configuration_enabled", false)
+
 	p = GetPayload(ctx, "testHostname", &mockAutoConfig{}, &mockCollector{})
 
 	assert.Equal(t, startNow.UnixNano(), p.Timestamp) //updated startNow is returned
 
 	agentMetadata = *p.AgentMetadata
-	assert.Len(t, agentMetadata, 2)
+	assert.Len(t, agentMetadata, 2) // keys are: "test", "cloud_provider"
 	assert.Equal(t, true, agentMetadata["test"])
 
 	checkMeta = *p.CheckMetadata

--- a/pkg/metadata/inventories/payload.go
+++ b/pkg/metadata/inventories/payload.go
@@ -38,7 +38,49 @@ func (p *Payload) MarshalJSON() ([]byte, error) {
 	return json.Marshal((*PayloadAlias)(p))
 }
 
-// SplitPayload breaks the payload into times number of pieces
+// SplitPayload implements marshaler.AbstractMarshaler#SplitPayload.
+//
+// In this case, the payload can only be split at the top level, so `times` is ignored
+// and each top-level component is returned as a distinct payload.
 func (p *Payload) SplitPayload(times int) ([]marshaler.AbstractMarshaler, error) {
-	return nil, fmt.Errorf("Inventories Payload splitting is not implemented")
+	newPayloads := []marshaler.AbstractMarshaler{}
+	fieldName := ""
+
+	// Each field can be sent individually but we can't split any more than this as the backend expects each payload
+	// to be received complete.
+
+	if p.CheckMetadata != nil {
+		fieldName = "check_metadata"
+		newPayloads = append(newPayloads,
+			&Payload{
+				Hostname:      p.Hostname,
+				Timestamp:     p.Timestamp,
+				CheckMetadata: p.CheckMetadata,
+			})
+	}
+	if p.AgentMetadata != nil {
+		fieldName = "agent_metadata"
+		newPayloads = append(newPayloads,
+			&Payload{
+				Hostname:      p.Hostname,
+				Timestamp:     p.Timestamp,
+				AgentMetadata: p.AgentMetadata,
+			})
+	}
+	if p.HostMetadata != nil {
+		fieldName = "host_metadata"
+		newPayloads = append(newPayloads,
+			&Payload{
+				Hostname:     p.Hostname,
+				Timestamp:    p.Timestamp,
+				HostMetadata: p.HostMetadata,
+			})
+	}
+
+	// if only one field is set we can't split any more
+	if len(newPayloads) <= 1 {
+		return nil, fmt.Errorf("could not split inventories payload any more, %s metadata is too big for intake", fieldName)
+	}
+
+	return newPayloads, nil
 }

--- a/pkg/util/scrubber/default.go
+++ b/pkg/util/scrubber/default.go
@@ -47,9 +47,17 @@ func AddDefaultReplacers(scrubber *Scrubber) {
 		Hints: []string{"Bearer"},
 		Repl:  []byte(`Bearer ***********************************************************$1`),
 	}
+	apiKeyReplacerYAML := Replacer{
+		Regex: regexp.MustCompile(`(\-|\:|,|\[|\{)(\s+)?\b[a-fA-F0-9]{27}([a-fA-F0-9]{5})\b`),
+		Repl:  []byte(`$1$2"***************************$3"`),
+	}
 	apiKeyReplacer := Replacer{
 		Regex: regexp.MustCompile(`\b[a-fA-F0-9]{27}([a-fA-F0-9]{5})\b`),
 		Repl:  []byte(`***************************$1`),
+	}
+	appKeyReplacerYAML := Replacer{
+		Regex: regexp.MustCompile(`(\-|\:|,|\[|\{)(\s+)?\b[a-fA-F0-9]{35}([a-fA-F0-9]{5})\b`),
+		Repl:  []byte(`$1$2"***********************************$3"`),
 	}
 	appKeyReplacer := Replacer{
 		Regex: regexp.MustCompile(`\b[a-fA-F0-9]{35}([a-fA-F0-9]{5})\b`),
@@ -64,22 +72,22 @@ func AddDefaultReplacers(scrubber *Scrubber) {
 	passwordReplacer := Replacer{
 		Regex: matchYAMLKeyPart(`(pass(word)?|pwd)`),
 		Hints: []string{"pass", "pwd"},
-		Repl:  []byte(`$1 ********`),
+		Repl:  []byte(`$1 "********"`),
 	}
 	tokenReplacer := Replacer{
 		Regex: matchYAMLKeyEnding(`token`),
 		Hints: []string{"token"},
-		Repl:  []byte(`$1 ********`),
+		Repl:  []byte(`$1 "********"`),
 	}
 	snmpReplacer := Replacer{
 		Regex: matchYAMLKey(`(community_string|authKey|privKey|community|authentication_key|privacy_key)`),
 		Hints: []string{"community_string", "authKey", "privKey", "community", "authentication_key", "privacy_key"},
-		Repl:  []byte(`$1 ********`),
+		Repl:  []byte(`$1 "********"`),
 	}
 	snmpMultilineReplacer := Replacer{
 		Regex: matchYAMLKeyWithListValue("(community_strings)"),
 		Hints: []string{"community_strings"},
-		Repl:  []byte(`$1 ********`),
+		Repl:  []byte(`$1 "********"`),
 	}
 	certReplacer := Replacer{
 		Regex: matchCert(),
@@ -89,7 +97,9 @@ func AddDefaultReplacers(scrubber *Scrubber) {
 	scrubber.AddReplacer(SingleLine, hintedAPIKeyReplacer)
 	scrubber.AddReplacer(SingleLine, hintedAPPKeyReplacer)
 	scrubber.AddReplacer(SingleLine, hintedBearerReplacer)
+	scrubber.AddReplacer(SingleLine, apiKeyReplacerYAML)
 	scrubber.AddReplacer(SingleLine, apiKeyReplacer)
+	scrubber.AddReplacer(SingleLine, appKeyReplacerYAML)
 	scrubber.AddReplacer(SingleLine, appKeyReplacer)
 	scrubber.AddReplacer(SingleLine, uriPasswordReplacer)
 	scrubber.AddReplacer(SingleLine, passwordReplacer)
@@ -186,7 +196,7 @@ func AddStrippedKeys(strippedKeys []string) {
 		configReplacer := Replacer{
 			Regex: matchYAMLKey(fmt.Sprintf("(%s)", strings.Join(strippedKeys, "|"))),
 			Hints: strippedKeys,
-			Repl:  []byte(`$1 ********`),
+			Repl:  []byte(`$1 "********"`),
 		}
 		DefaultScrubber.AddReplacer(SingleLine, configReplacer)
 	}

--- a/pkg/util/scrubber/scrubber.go
+++ b/pkg/util/scrubber/scrubber.go
@@ -74,6 +74,13 @@ func New() *Scrubber {
 	}
 }
 
+// NewWithDefaults creates a new scrubber with the default replacers installed.
+func NewWithDefaults() *Scrubber {
+	s := New()
+	AddDefaultReplacers(s)
+	return s
+}
+
 // AddReplacer adds a replacer of the given kind to the scrubber.
 func (c *Scrubber) AddReplacer(kind ReplacerKind, replacer Replacer) {
 	switch kind {

--- a/pkg/util/scrubber/scrubber_test.go
+++ b/pkg/util/scrubber/scrubber_test.go
@@ -12,8 +12,20 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestNewWithDefaults(t *testing.T) {
+	scrubber := NewWithDefaults()
+	scrubberEmpty := New()
+	AddDefaultReplacers(scrubberEmpty)
+
+	assert.NotZero(t, len(scrubber.singleLineReplacers))
+	assert.NotZero(t, len(scrubber.multiLineReplacers))
+	assert.Equal(t, len(scrubberEmpty.singleLineReplacers), len(scrubber.singleLineReplacers))
+	assert.Equal(t, len(scrubberEmpty.multiLineReplacers), len(scrubber.multiLineReplacers))
+}
 
 func TestRepl(t *testing.T) {
 	scrubber := New()

--- a/pkg/util/scrubber/test/conf.yaml
+++ b/pkg/util/scrubber/test/conf.yaml
@@ -1,0 +1,57 @@
+api_key: aaaaaaaaaaaaaaaaaaaaaaaaaaaabbbb
+api_key2: |
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaabbbb
+api_key3: >
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaabbbb
+
+app_key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbb
+app_key2: |
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbb
+app_key3: >
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbb
+
+list_api_key: [aaaaaaaaaaaaaaaaaaaaaaaaaaaabbbb, aaaaaaaaaaaaaaaaaaaaaaaaaaaabbbb]
+list_app_key: [aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbb, aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbb]
+
+dict_api_key: {one: aaaaaaaaaaaaaaaaaaaaaaaaaaaabbbb, two: aaaaaaaaaaaaaaaaaaaaaaaaaaaabbbb}
+dict_app_key: {two: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbb, two: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbb}
+
+additional_endpoints:
+  "https://app.datadoghq.com":
+    - aaaaaaaaaaaaaaaaaaaaaaaaaaaabbbb
+    - bbbbbbbbbbbbbbbbbbbbbbbbbbbbaaaa
+  "https://dog.datadoghq.com":
+    - aaaaaaaaaaaaaaaaaaaaaaaaaaaabbbb
+    - bbbbbbbbbbbbbbbbbbbbbbbbbbbbaaaa
+
+container_id: b32bd6f9b73ba7ccb64953a04b82b48e29dfafab65fd57ca01d3b94a0e024885
+random_url_key1: http://user:p@ssw0r)@host:port
+random_url_key2: protocol://user:p@ssw0r)@host:port
+random_url_key3: "http://user:password@host:port"
+random_domain_key: 'user:password@host:port'
+random_url_key1: |
+  http://user:password@host:port
+random_url_key2: >
+  http://user:password@host:port
+random_url_key3:   'http://user:password@host:port'
+random_url_key4:   'mongodb+s.r-v://user:password@host:port'
+random_url_key5:   'mongodb+srv://user:pass-with-hyphen@abc.example.com/database'
+random_url_key6:   'http://user-with-hyphen:pass-with-hyphen@abc.example.com/database'
+random_url_key7:   'http://user-with-hyphen:pass@abc.example.com/database'
+
+mysql_password1: password
+mysql_password3: "password"
+pwd: 'password'
+pass: p@ssw0r
+password: p@ssw0r
+token: 123465749798
+
+network_devices:
+  snmp_traps:
+    community_strings:
+      - 'password1'
+      - 'password2'
+
+community: password
+authentication_key: password
+privacy_key: password

--- a/pkg/util/scrubber/test/conf_scrubbed.yaml
+++ b/pkg/util/scrubber/test/conf_scrubbed.yaml
@@ -1,0 +1,55 @@
+api_key: "***************************abbbb"
+api_key2: |
+  ***************************abbbb
+api_key3: >
+  ***************************abbbb
+
+app_key: "***********************************abbbb"
+app_key2: |
+  ***********************************abbbb
+app_key3: >
+  ***********************************abbbb
+
+list_api_key: ["***************************abbbb", "***************************abbbb"]
+list_app_key: ["***********************************abbbb", "***********************************abbbb"]
+
+dict_api_key: {one: "***************************abbbb", two: "***************************abbbb"}
+dict_app_key: {two: "***********************************abbbb", two: "***********************************abbbb"}
+
+additional_endpoints:
+  "https://app.datadoghq.com":
+    - "***************************abbbb"
+    - "***************************baaaa"
+  "https://dog.datadoghq.com":
+    - "***************************abbbb"
+    - "***************************baaaa"
+
+container_id: b32bd6f9b73ba7ccb64953a04b82b48e29dfafab65fd57ca01d3b94a0e024885
+random_url_key1: http://user:********@host:port
+random_url_key2: protocol://user:********@host:port
+random_url_key3: "http://user:********@host:port"
+random_domain_key: 'user:********@host:port'
+random_url_key1: |
+  http://user:********@host:port
+random_url_key2: >
+  http://user:********@host:port
+random_url_key3:   'http://user:********@host:port'
+random_url_key4:   'mongodb+s.r-v://user:********@host:port'
+random_url_key5:   'mongodb+srv://user:********@abc.example.com/database'
+random_url_key6:   'http://user-with-hyphen:********@abc.example.com/database'
+random_url_key7:   'http://user-with-hyphen:********@abc.example.com/database'
+
+mysql_password1: "********"
+mysql_password3: "********"
+pwd: "********"
+pass: "********"
+password: "********"
+token: "********"
+
+network_devices:
+  snmp_traps:
+    community_strings: "********"
+
+community: "********"
+authentication_key: "********"
+privacy_key: "********"


### PR DESCRIPTION
### What does this PR do?

This PR is waiting on https://github.com/DataDog/viper/pull/24 to be merged before updating go.mod

### Describe how to test/QA your changes

use the `datadog-agent troubleshooting metadata_inventory` command to see that the runtime configuration and provided configuration are sent as valid YAML.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
