### PR TITLE
use the correct format verb when a config has already been tracked

### DIFF
--- a/pkg/autodiscovery/configmgr.go
+++ b/pkg/autodiscovery/configmgr.go
@@ -210,7 +210,7 @@ func (cm *reconcilingConfigManager) processNewConfig(config integration.Config) 
 
 	digest := config.Digest()
 	if _, found := cm.activeConfigs[digest]; found {
-		log.Debug("Config %s (digest %s) is already tracked by autodiscovery", config.Name, config.Digest())
+		log.Debugf("Config %s (digest %s) is already tracked by autodiscovery", config.Name, config.Digest())
 		return configChanges{}
 	}
 

--- a/pkg/autodiscovery/configmgr.go
+++ b/pkg/autodiscovery/configmgr.go
@@ -210,7 +210,7 @@ func (cm *reconcilingConfigManager) processNewConfig(config integration.Config) 
 
 	digest := config.Digest()
 	if _, found := cm.activeConfigs[digest]; found {
-		log.Debug("Config %v is already tracked by autodiscovery", config.Name)
+		log.Debug("Config %s is already tracked by autodiscovery", config.Name)
 		return configChanges{}
 	}
 

--- a/pkg/autodiscovery/configmgr.go
+++ b/pkg/autodiscovery/configmgr.go
@@ -210,7 +210,7 @@ func (cm *reconcilingConfigManager) processNewConfig(config integration.Config) 
 
 	digest := config.Digest()
 	if _, found := cm.activeConfigs[digest]; found {
-		log.Debug("Config %s is already tracked by autodiscovery", config.Name)
+		log.Debug("Config %s (digest %s) is already tracked by autodiscovery", config.Name, config.Digest())
 		return configChanges{}
 	}
 


### PR DESCRIPTION
### What does this PR do?

Fixes the fmt verb used in a debug log message.

### Motivation

It's wrong :)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
