### PR TITLE
include log Source and Service in 'agent status'

### DIFF
--- a/pkg/logs/status/builder.go
+++ b/pkg/logs/status/builder.go
@@ -138,6 +138,8 @@ func (b *Builder) toString(status *status.LogStatus) string {
 // toDictionary returns a representation of the configuration.
 func (b *Builder) toDictionary(c *config.LogsConfig) map[string]interface{} {
 	dictionary := make(map[string]interface{})
+	dictionary["Service"] = c.Service
+	dictionary["Source"] = c.Source
 	switch c.Type {
 	case config.TCPType, config.UDPType:
 		dictionary["Port"] = c.Port


### PR DESCRIPTION
### What does this PR do?

adds "Service" and "Source" to each log source in `agent status`:
```
    - Type: docker
      Service: nginx
      Source: nginx
```

### Motivation

Helpful for debugging the agent and probably also helpful to customers.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

In any other logs-agent QA, check that these fields are present (and useful?!)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
