### PR TITLE
[tools] Reduce resource usage of `dep_tree_resolver`

### DIFF
--- a/tools/dep_tree_resolver/go_deps.go
+++ b/tools/dep_tree_resolver/go_deps.go
@@ -49,7 +49,7 @@ type ModuleDep struct {
 // DependencyTree is a structure that identifies a module and all of its
 // children in a recursive tree
 type DependencyTree struct {
-	Mod          Module
+	Mod          *Module
 	Dependencies []DependencyTree
 }
 
@@ -330,7 +330,7 @@ func resolveRecursive(
 	}
 
 	return &DependencyTree{
-		Mod:          actualModule,
+		Mod:          &actualModule,
 		Dependencies: dependencies,
 	}, nil
 }
@@ -342,7 +342,7 @@ func recomputeDependencyTree(
 ) (*DependencyTree, error) {
 	// Main root node
 	depTree := DependencyTree{
-		Mod: *rootModule,
+		Mod: rootModule,
 	}
 
 	// Some deps have circular dependencies so we need to break out when
@@ -370,7 +370,7 @@ func recomputeDependencyTree(
 // TODO: Actually use `skipDuplicates` value
 func printDepTree(buf *bufio.Writer, depTree *DependencyTree, level int, skipDuplicates bool) {
 	for idx := 0; idx < level; idx++ {
-		io.WriteString(buf, "    ")
+		io.WriteString(buf, "\t")
 	}
 
 	io.WriteString(buf, fmt.Sprintf("- %s@%s\n", depTree.Mod.Path, depTree.Mod.Version))


### PR DESCRIPTION


### What does this PR do?

This change reduces the CPU usage (~20%), memory usage (~9%), and
filesystem usage (~45%) of the `dep_tree_resolver` tool when using a
commit before `6cb039bf4bb0a54ffb7b38fba36927b036f82f7a`. While this
does not solve the breakage of the tool caused by the mentioned
commit, it should improve the situation once the underlying problematic
issue is identified/fixed.

### Motivation

This tool broke on the main branch post [this](https://github.com/DataDog/datadog-agent/commit/6cb039bf4bb0a54ffb7b38fba36927b036f82f7a) commit. Since `dep_tree_resolver`
was initially written about a year ago, our dependencies have ballooned and a failure
was likely.



### Additional Notes

This change does not fix `dep_tree_resolver` for runs against code at-or-after `6cb039bf4bb0a54ffb7b38fba36927b036f82f7a` commit (task owned by @DataDog/software-integrity-and-trust) but it should reduce resources significantly when it is fixed. 

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

- `git checkout df4acc4cd631122ec75cacb158fb9d2c15dafb09` (one commit before `6cb039bf4bb0a54ffb7b38fba36927b036f82f7a`
- Run `inv agent.build-dep-tree`

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
