### PR TITLE
[SOCE-256] [datadog-agent]: Fix kubernetes event messages

### DIFF
--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_eventbundle.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_eventbundle.go
@@ -133,16 +133,25 @@ func (b *kubernetesEventBundle) formatEvents(clusterName string, providerIDCache
 		Tags:           tags,
 		AggregationKey: fmt.Sprintf("kubernetes_apiserver:%s", b.objUID),
 		AlertType:      b.alertType,
-		Text: fmt.Sprintf(
-			"%%%%%% \n%s \n _Events emitted by the %s seen at %s since %s_ \n\n %%%%%%",
-			formatStringIntMap(b.countByAction),
-			b.component,
-			time.Unix(int64(b.lastTimestamp), 0),
-			time.Unix(int64(b.timeStamp), 0),
-		),
+		Text:           b.formatEventText(),
 	}
 
 	return output, nil
+}
+
+func (b *kubernetesEventBundle) formatEventText() string {
+	eventText := fmt.Sprintf(
+		"%%%%%% \n%s \n _Events emitted by the %s seen at %s since %s_ \n\n %%%%%%",
+		formatStringIntMap(b.countByAction),
+		b.component,
+		time.Unix(int64(b.lastTimestamp), 0),
+		time.Unix(int64(b.timeStamp), 0),
+	)
+
+	// Escape the ~ character to not strike out the text
+	eventText = strings.ReplaceAll(eventText, "~", "\\~")
+
+	return eventText
 }
 
 // getKindTag returns the kube_<kind>:<name> tag.

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_eventbundle_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_eventbundle_test.go
@@ -24,12 +24,12 @@ import (
 func TestFormatEvent(t *testing.T) {
 	ev1 := createEvent(2, "default", "dca-789976f5d7-2ljx6", "Pod", "e6417a7f-f566-11e7-9749-0e4863e1cbf4", "default-scheduler", "machine-blue", "Scheduled", "Successfully assigned dca-789976f5d7-2ljx6 to ip-10-0-0-54", "Normal", 709662600)
 	ev2 := createEvent(3, "default", "dca-789976f5d7-2ljx6", "Pod", "e6417a7f-f566-11e7-9749-0e4863e1cbf4", "default-scheduler", "machine-blue", "Started", "Started container", "Normal", 709662600)
-	ev3 := createEvent(3, "default", "dca-789976f5d7-2ljx6", "Pod", "e6417a7f-f566-11e7-9749-0e4863e1cbf4", "default-scheduler", "machine-blue", "Failed", "Error: error response: filepath: ~file~", "Normal", 709662600)
+	// ev3 := createEvent(3, "default", "dca-789976f5d7-2ljx6", "Pod", "e6417a7f-f566-11e7-9749-0e4863e1cbf4", "default-scheduler", "machine-blue", "Failed", "Error: error response: filepath: ~file~", "Normal", 709662600)
 
 	eventList := []*v1.Event{
 		ev1,
 		ev2,
-		ev3,
+		// ev3,
 	}
 	b := &kubernetesEventBundle{
 		name:          "dca-789976f5d7-2ljx6",
@@ -58,6 +58,10 @@ func TestFormatEvent(t *testing.T) {
 	assert.Nil(t, err, "not nil")
 	assert.Equal(t, expectedOutput.Text, output.Text)
 	assert.ElementsMatch(t, expectedOutput.Tags, output.Tags)
+}
+
+func TestFormatEventEscapeCharacter(t *testing.T) {
+	assert.Equal(1, 2)
 }
 
 func TestFormatEventWithNodename(t *testing.T) {

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_eventbundle_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_eventbundle_test.go
@@ -10,6 +10,7 @@ package kubernetesapiserver
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -226,3 +227,28 @@ func TestEventsTagging(t *testing.T) {
 		})
 	}
 }
+
+func benchmarkEscapeEventMessage(nbEvents int, b *testing.B) {
+	eventMessage := "~" + strings.Repeat("event message ", 10) + "~"
+
+	var bundle *kubernetesEventBundle
+
+	for i := 0; i < nbEvents; i++ {
+		eventReason := fmt.Sprintf("Reason %d", i)
+		event := createEvent(2, "default", "dca-789976f5d7-2ljx6", "Pod", "e6417a7f-f566-11e7-9749-0e4863e1cbf4", "default-scheduler", "machine-blue", eventReason, eventMessage, "Normal", 709662600)
+
+		if i == 0 {
+			bundle = newKubernetesEventBundler(event)
+		}
+		bundle.addEvent(event)
+	}
+
+	for n := 0; n < b.N; n++ {
+		bundle.formatEventText()
+	}
+}
+
+func BenchmarkEscapeEventMessage1(b *testing.B)  { benchmarkEscapeEventMessage(1, b) }
+func BenchmarkEscapeEventMessage2(b *testing.B)  { benchmarkEscapeEventMessage(2, b) }
+func BenchmarkEscapeEventMessage5(b *testing.B)  { benchmarkEscapeEventMessage(5, b) }
+func BenchmarkEscapeEventMessage10(b *testing.B) { benchmarkEscapeEventMessage(10, b) }

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_eventbundle_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_eventbundle_test.go
@@ -24,10 +24,12 @@ import (
 func TestFormatEvent(t *testing.T) {
 	ev1 := createEvent(2, "default", "dca-789976f5d7-2ljx6", "Pod", "e6417a7f-f566-11e7-9749-0e4863e1cbf4", "default-scheduler", "machine-blue", "Scheduled", "Successfully assigned dca-789976f5d7-2ljx6 to ip-10-0-0-54", "Normal", 709662600)
 	ev2 := createEvent(3, "default", "dca-789976f5d7-2ljx6", "Pod", "e6417a7f-f566-11e7-9749-0e4863e1cbf4", "default-scheduler", "machine-blue", "Started", "Started container", "Normal", 709662600)
+	ev3 := createEvent(3, "default", "dca-789976f5d7-2ljx6", "Pod", "e6417a7f-f566-11e7-9749-0e4863e1cbf4", "default-scheduler", "machine-blue", "Failed", "Error: error response: filepath: ~file~", "Normal", 709662600)
 
 	eventList := []*v1.Event{
 		ev1,
 		ev2,
+		ev3,
 	}
 	b := &kubernetesEventBundle{
 		name:          "dca-789976f5d7-2ljx6",

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_eventbundle_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_eventbundle_test.go
@@ -10,7 +10,6 @@ package kubernetesapiserver
 import (
 	"fmt"
 	"reflect"
-	"strings"
 	"testing"
 	"time"
 
@@ -82,9 +81,10 @@ func TestFormatEventEscapeCharacter(t *testing.T) {
 		Tags:           []string{fmt.Sprintf("source_component:%s", b.component), fmt.Sprintf("kubernetes_kind:%s", b.kind), fmt.Sprintf("name:%s", b.name), fmt.Sprintf("pod_name:%s", b.name), fmt.Sprintf("namespace:%s", "default"), fmt.Sprintf("kube_namespace:%s", "default")},
 		AggregationKey: fmt.Sprintf("kubernetes_apiserver:%s", b.objUID),
 	}
-
-	expectedOutput.Text = "%%% \n" + fmt.Sprintf("%s \n _Events emitted by the %s seen at %s since %s_ \n", formatStringIntMap(b.countByAction), b.component, time.Unix(int64(b.lastTimestamp), 0), time.Unix(int64(b.timeStamp), 0)) + "\n %%%"
-	expectedOutput.Text = strings.ReplaceAll(expectedOutput.Text, "~", "\\~")
+	expectedOutput.Text = "%%% \n" +
+		"3 **Failed**: Error: error response: filepath: \\~file\\~\n" +
+		fmt.Sprintf(" \n _Events emitted by the %s seen at %s since %s_ \n", b.component, time.Unix(int64(b.lastTimestamp), 0), time.Unix(int64(b.timeStamp), 0)) + "\n" +
+		" %%%"
 
 	providerIDCache := cache.New(defaultCacheExpire, defaultCachePurge)
 	output, err := b.formatEvents("", providerIDCache)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Escape the `~` character in kubernetes event messages to not strike out the text when it is rendered as markdown.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
[Support JIRA Ticket](https://datadoghq.atlassian.net/browse/SOCE-256)

<img width="721" alt="image" src="https://user-images.githubusercontent.com/80697114/177116068-c9d207b6-9c0f-46fa-b81a-78c259231298.png">


<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
Running a benchmark with event messages of 142 characters and varying the number of events, the benchmark result of the new modification show that this overhead is relatively important.

Benchmark without escaping the ~
![image](https://user-images.githubusercontent.com/80697114/177771675-a6299686-a65a-44db-b88e-66ae4b489234.png)

Benchmark escaping the ~
![image](https://user-images.githubusercontent.com/80697114/177771704-d67aa8a8-7532-44ad-b500-d8a4f2df0642.png)


<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
