### PR TITLE
[CWS] remove prerelease and metadata before checking agent version

### DIFF
--- a/pkg/security/secl/rules/policy.go
+++ b/pkg/security/secl/rules/policy.go
@@ -118,6 +118,15 @@ func checkAgentVersionConstraint(constraint string, agentVersion *semver.Version
 		return true, nil
 	}
 
+	withoutPreAgentVersion, err := agentVersion.SetPrerelease("")
+	if err != nil {
+		return true, nil
+	}
+	cleanAgentVersion, err := withoutPreAgentVersion.SetMetadata("")
+	if err != nil {
+		return true, nil
+	}
+
 	constraint = strings.TrimSpace(constraint)
 	if constraint == "" {
 		return true, nil
@@ -128,5 +137,5 @@ func checkAgentVersionConstraint(constraint string, agentVersion *semver.Version
 		return false, err
 	}
 
-	return semverConstraint.Check(agentVersion), nil
+	return semverConstraint.Check(&cleanAgentVersion), nil
 }

--- a/pkg/security/secl/rules/policy_test.go
+++ b/pkg/security/secl/rules/policy_test.go
@@ -519,6 +519,12 @@ func TestRuleAgentConstraint(t *testing.T) {
 			ruleConstraint: ">= 7.30, < 7.37, != 7.35",
 			expectLoad:     false,
 		},
+		{
+			name:           "rc_prerelease",
+			agentVersion:   "7.38.0-rc.2",
+			ruleConstraint: ">= 7.38",
+			expectLoad:     true,
+		},
 	}
 
 	for _, entry := range testEntries {


### PR DESCRIPTION
### What does this PR do?

The semver library is a bit confused by RCs and prerelease versions (evaluating `7.38.0-rc.2 >= 7.38` to false) because the semver norm [does not define an ABI guarantee for prereleases](https://pkg.go.dev/github.com/Masterminds/semver@v1.5.0#section-readme:~:text=SemVer%20comparisons%20without%20a%20pre%2Drelease%20comparator%20will%20skip%20pre%2Drelease%20versions.%20For%20example%2C%20%3E%3D1.2.3%20will%20skip%20pre%2Dreleases%20when%20looking%20at%20a%20list%20of%20releases%20while%20%3E%3D1.2.3%2D0%20will%20evaluate%20and%20find%20pre%2Dreleases). This PR cleans up the version by removing all prerelease information (thus mapping `7.38.0-rc.2` to `7.38`) when checking for agent constraints in CWS policy versioning system.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
