### PR TITLE
pkg/trace/stats: consider http.status_code from Metrics

### DIFF
--- a/pkg/trace/stats/aggregation.go
+++ b/pkg/trace/stats/aggregation.go
@@ -44,6 +44,11 @@ type PayloadAggregationKey struct {
 }
 
 func getStatusCode(s *pb.Span) uint32 {
+	code, ok := traceutil.GetMetric(s, tagStatusCode)
+	if ok {
+		// only 7.39.0+, for lesser versions, always use Meta
+		return uint32(code)
+	}
 	strC := traceutil.GetMetaDefault(s, tagStatusCode, "")
 	if strC == "" {
 		return 0

--- a/pkg/trace/stats/aggregation_test.go
+++ b/pkg/trace/stats/aggregation_test.go
@@ -1,0 +1,53 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package stats
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/trace/pb"
+)
+
+func TestGetStatusCode(t *testing.T) {
+	for _, tt := range []struct {
+		in  *pb.Span
+		out uint32
+	}{
+		{
+			&pb.Span{},
+			0,
+		},
+		{
+			&pb.Span{
+				Meta: map[string]string{"http.status_code": "200"},
+			},
+			200,
+		},
+		{
+			&pb.Span{
+				Metrics: map[string]float64{"http.status_code": 302},
+			},
+			302,
+		},
+		{
+			&pb.Span{
+				Meta:    map[string]string{"http.status_code": "200"},
+				Metrics: map[string]float64{"http.status_code": 302},
+			},
+			302,
+		},
+		{
+			&pb.Span{
+				Meta: map[string]string{"http.status_code": "x"},
+			},
+			0,
+		},
+	} {
+		if got := getStatusCode(tt.in); got != tt.out {
+			t.Fatalf("Expected %d, got %d", tt.out, got)
+		}
+	}
+}

--- a/pkg/trace/traceutil/span.go
+++ b/pkg/trace/traceutil/span.go
@@ -81,6 +81,15 @@ func SetMeta(s *pb.Span, key, val string) {
 	s.Meta[key] = val
 }
 
+// GetMetric returns the value of a metric and reports its presence.
+func GetMetric(s *pb.Span, key string) (float64, bool) {
+	if s.Metrics == nil {
+		return 0, false
+	}
+	val, ok := s.Metrics[key]
+	return val, ok
+}
+
 // GetMeta gets the metadata value in the span Meta map.
 func GetMeta(s *pb.Span, key string) (string, bool) {
 	if s.Meta == nil {

--- a/releasenotes/notes/apm-status-code-metrics-95766efbc01100e1.yaml
+++ b/releasenotes/notes/apm-status-code-metrics-95766efbc01100e1.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    APM: The "http.status_code" tag is now supported as a numeric value too when computing APM trace stats.
+    APM: The "http.status_code" tag is now supported as a numeric value too when computing APM trace stats. If set as both a string and a numeric value, the numeric value takes precedence and the string value is ignored.

--- a/releasenotes/notes/apm-status-code-metrics-95766efbc01100e1.yaml
+++ b/releasenotes/notes/apm-status-code-metrics-95766efbc01100e1.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    APM: The "http.status_code" tag is now supported as a numeric value too when computing APM trace stats.


### PR DESCRIPTION
This change makes sure that stats computation consider the
http.status_code aggregation key when present in Metrics too, and even
prioritise it. The reasoning is that the status code is an integer by
nature and tends to get sent as such. This should not cause a defect in
the generation of APM stats aggregation keys and tags.