### PR TITLE
[ksm] Introduce kubernetes_state.job.duration metric

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/customresources/job.go
+++ b/pkg/collector/corechecks/cluster/ksm/customresources/job.go
@@ -1,0 +1,103 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package customresources
+
+import (
+	"context"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/kube-state-metrics/v2/pkg/customresource"
+	"k8s.io/kube-state-metrics/v2/pkg/metric"
+	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
+)
+
+var descJobLabelsDefaultLabels = []string{"namespace", "job_name"}
+
+// NewJobFactory returns a new Job metric family generator factory.
+func NewJobFactory() customresource.RegistryFactory {
+	return &jobFactory{}
+}
+
+type jobFactory struct{}
+
+func (f *jobFactory) Name() string {
+	return "jobs_extended"
+}
+
+// CreateClient is not implemented
+func (f *jobFactory) CreateClient(cfg *rest.Config) (interface{}, error) {
+	panic("not implemented")
+}
+
+func (f *jobFactory) MetricFamilyGenerators(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
+	return []generator.FamilyGenerator{
+		*generator.NewFamilyGenerator(
+			"kube_job_duration",
+			"Duration represents the time elapsed between the StartTime and CompletionTime of a Job",
+			metric.Gauge,
+			"",
+			wrapJobFunc(func(j *batchv1.Job) *metric.Family {
+				ms := []*metric.Metric{}
+
+				if j.Status.StartTime != nil {
+					start := j.Status.StartTime.Unix()
+					end := time.Now().Unix()
+
+					if j.Status.CompletionTime != nil {
+						end = j.Status.CompletionTime.Unix()
+					}
+
+					ms = append(ms, &metric.Metric{
+						Value: float64(end - start),
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		),
+	}
+}
+
+func wrapJobFunc(f func(*batchv1.Job) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
+		cronJob := obj.(*batchv1.Job)
+
+		metricFamily := f(cronJob)
+
+		for _, m := range metricFamily.Metrics {
+			m.LabelKeys, m.LabelValues = mergeKeyValues(descJobLabelsDefaultLabels, []string{cronJob.Namespace, cronJob.Name}, m.LabelKeys, m.LabelValues)
+		}
+
+		return metricFamily
+	}
+}
+
+func (f *jobFactory) ExpectedType() interface{} {
+	return &batchv1.Job{}
+}
+
+func (f *jobFactory) ListWatch(customResourceClient interface{}, ns string, fieldSelector string) cache.ListerWatcher {
+	client := customResourceClient.(kubernetes.Interface)
+	return &cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			opts.FieldSelector = fieldSelector
+			return client.BatchV1().Jobs(ns).List(context.TODO(), opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			opts.FieldSelector = fieldSelector
+			return client.BatchV1().Jobs(ns).Watch(context.TODO(), opts)
+		},
+	}
+}

--- a/pkg/collector/corechecks/cluster/ksm/customresources/job.go
+++ b/pkg/collector/corechecks/cluster/ksm/customresources/job.go
@@ -31,6 +31,7 @@ func NewJobFactory() customresource.RegistryFactory {
 
 type jobFactory struct{}
 
+// Name is the name of the factory
 func (f *jobFactory) Name() string {
 	return "jobs_extended"
 }
@@ -40,11 +41,12 @@ func (f *jobFactory) CreateClient(cfg *rest.Config) (interface{}, error) {
 	panic("not implemented")
 }
 
+// MetricFamilyGenerators returns the extended job metric family generators
 func (f *jobFactory) MetricFamilyGenerators(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
 	return []generator.FamilyGenerator{
 		*generator.NewFamilyGenerator(
 			"kube_job_duration",
-			"Duration represents the time elapsed between the StartTime and CompletionTime of a Job",
+			"Duration represents the time elapsed between the StartTime and CompletionTime of a Job, or the current time if the job is still running",
 			metric.Gauge,
 			"",
 			wrapJobFunc(func(j *batchv1.Job) *metric.Family {
@@ -89,10 +91,12 @@ func wrapJobFunc(f func(*batchv1.Job) *metric.Family) func(interface{}) *metric.
 	}
 }
 
+// ExpectedType returns the type expected by the factory
 func (f *jobFactory) ExpectedType() interface{} {
 	return &batchv1.Job{}
 }
 
+// ListWatch returns a ListerWatcher for batchv1.Job
 func (f *jobFactory) ListWatch(customResourceClient interface{}, ns string, fieldSelector string) cache.ListerWatcher {
 	client := customResourceClient.(kubernetes.Interface)
 	return &cache.ListWatch{

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -52,6 +52,10 @@ const (
 	ownerNameKey = "owner_name"
 )
 
+var extendedCollectors = map[string]string{
+	"jobs": "jobs_extended",
+}
+
 // KSMConfig contains the check config parameters
 type KSMConfig struct {
 	// Collectors defines the resource type collectors.
@@ -284,6 +288,14 @@ func (k *KSMCheck) Configure(config, initConfig integration.Data, source string)
 	builder.WithCustomResourceStoreFactories(factories...)
 	builder.WithCustomResourceClients(clients)
 	builder.WithGenerateCustomResourceStoresFunc(builder.GenerateCustomResourceStoresFunc)
+
+	// automatically add extended collectors if their standard ones are
+	// enabled
+	for _, c := range collectors {
+		if extended, ok := extendedCollectors[c]; ok {
+			collectors = append(collectors, extended)
+		}
+	}
 
 	// must call WithEnabledResources after custom resources have been
 	// registered, otherwise they will fail with "resource does not exist"

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.md
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.md
@@ -316,6 +316,9 @@
 `kubernetes_state.job.completion.failed`
 : The job has failed its execution. Tags:`kube_job` or `kube_cronjob` `kube_namespace` (`env` `service` `version` from standard labels).
 
+`kubernetes_state.job.duration
+: Time elapsed between the start and completion time of the job. Tags:`kube_job` `kube_namespace` (`env` `service` `version` from standard labels).
+
 `kubernetes_state.resourcequota.<resource>.limit`
 : Information about resource quota limits by resource. Tags:`kube_namespace` `resourcequota`.
 

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.md
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.md
@@ -317,7 +317,7 @@
 : The job has failed its execution. Tags:`kube_job` or `kube_cronjob` `kube_namespace` (`env` `service` `version` from standard labels).
 
 `kubernetes_state.job.duration
-: Time elapsed between the start and completion time of the job. Tags:`kube_job` `kube_namespace` (`env` `service` `version` from standard labels).
+: Time elapsed between the start and completion time of the job, or the current time if the job is still running. Tags:`kube_job` `kube_namespace` (`env` `service` `version` from standard labels).
 
 `kubernetes_state.resourcequota.<resource>.limit`
 : Information about resource quota limits by resource. Tags:`kube_namespace` `resourcequota`.

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
@@ -82,6 +82,7 @@ func defaultMetricNamesMapper() map[string]string {
 		"kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_minallowed":             "vpa.spec_container_minallowed",
 		"kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_maxallowed":             "vpa.spec_container_maxallowed",
 		"kube_cronjob_spec_suspend":                                                                "cronjob.spec_suspend",
+		"kube_job_duration":                                                                        "job.duration",
 		"kube_ingress_path":                                                                        "ingress.path",
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Introduce a new KSM metric, `kubernetes_state.job.duration`, with the job's completion time (if present, otherwise current time) minus the job's start time.


### Possible Drawbacks / Trade-offs

This was introduced as a custom KSM resource, named `jobs_extended`. ~It needs to be referred to by name in the configuration to be able to work, otherwise it won't be enabled by default. I added the `need-change` labels for helm and operator so we can make that happen once this PR is merged.~ The resource is now enabled automatically, but will indeed show up in the list of enabled resources as `jobs_extended`.

### Describe how to test/QA your changes

Enable KSM core, create cronjobs in your cluster, and check that the `kubernetes_state.job.duration` metric gets reported correctly.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
