### PR TITLE
[status] fix status + preserve empty lines in scrubber

### DIFF
--- a/pkg/status/templates/aggregator.tmpl
+++ b/pkg/status/templates/aggregator.tmpl
@@ -1,9 +1,10 @@
 {{/*
 NOTE: Changes made to this template should be reflected on the following templates, if applicable:
 * cmd/agent/gui/views/templates/generalStatus.tmpl
-*/}}=========
+*/}}
+==========
 Aggregator
-=========
+==========
 {{- if .ChecksMetricSample }}
   Checks Metric Sample: {{humanize .ChecksMetricSample}}
 {{- end }}

--- a/pkg/status/templates/dogstatsd.tmpl
+++ b/pkg/status/templates/dogstatsd.tmpl
@@ -1,7 +1,8 @@
 {{/*
 NOTE: Changes made to this template should be reflected on the following templates, if applicable:
 * cmd/agent/gui/views/templates/generalStatus.tmpl
-*/}}=========
+*/}}
+=========
 DogStatsD
 =========
 {{- range $key, $value := .}}

--- a/pkg/status/templates/header.tmpl
+++ b/pkg/status/templates/header.tmpl
@@ -1,7 +1,8 @@
 {{/*
 NOTE: Changes made to this template should be reflected on the following templates, if applicable:
 * cmd/agent/gui/views/templates/generalStatus.tmpl
-*/}}{{printDashes .title "="}}
+*/}}
+{{printDashes .title "="}}
 {{.title}}
 {{printDashes .title "="}}
 

--- a/pkg/status/templates/logsagent.tmpl
+++ b/pkg/status/templates/logsagent.tmpl
@@ -5,7 +5,8 @@ NOTE: Changes made to this template should be reflected on the following templat
 ==========
 Logs Agent
 ==========
-{{if eq .is_running false }}
+
+{{- if eq .is_running false }}
 
   Logs Agent is not running
 {{- end }}

--- a/pkg/status/templates/process-agent.tmpl
+++ b/pkg/status/templates/process-agent.tmpl
@@ -1,3 +1,7 @@
+{{/*
+NOTE: Changes made to this template should be reflected on the following templates, if applicable:
+* cmd/agent/gui/views/templates/generalStatus.tmpl
+*/}}
 =============
 Process Agent
 =============

--- a/pkg/status/templates/trace-agent.tmpl
+++ b/pkg/status/templates/trace-agent.tmpl
@@ -1,11 +1,16 @@
+{{/*
+NOTE: Changes made to this template should be reflected on the following templates, if applicable:
+* cmd/agent/gui/views/templates/generalStatus.tmpl
+*/}}
 =========
 APM Agent
 =========
- 
+
 {{- if .error }}
+
   Status: Not running or unreachable on localhost:{{.port}}.
   Error: {{.error}}
-{{else}}
+{{- else}}
   Status: Running
   Pid: {{.pid}}
   Uptime: {{.uptime}} seconds
@@ -47,4 +52,4 @@ APM Agent
     {{- if gt .trace_writer.Errors 0.0}}WARNING: Traces API errors (1 min): {{.trace_writer.Errors}}{{end}}
     Stats: {{.stats_writer.Payloads}} payloads, {{.stats_writer.StatsBuckets}} stats buckets, {{humanize .stats_writer.Bytes}} bytes
     {{- if gt .stats_writer.Errors 0.0}}WARNING: Stats API errors (1 min): {{.stats_writer.Errors}}{{end}}
-{{end}}
+{{- end}}

--- a/pkg/util/scrubber/default_test.go
+++ b/pkg/util/scrubber/default_test.go
@@ -460,10 +460,21 @@ log_level: info`)
 
 func TestConfigFile(t *testing.T) {
 	cleanedConfigFile := `dd_url: https://app.datadoghq.com
+
 api_key: ***************************aaaaa
+
 proxy: http://user:********@host:port
+
+
+
+
+
+
 dogstatsd_port : 8125
-log_level: info`
+
+
+log_level: info
+`
 
 	wd, _ := os.Getwd()
 	filePath := filepath.Join(wd, "test", "datadog.yaml")

--- a/pkg/util/scrubber/scrubber.go
+++ b/pkg/util/scrubber/scrubber.go
@@ -118,9 +118,9 @@ func (c *Scrubber) scrubReader(file io.Reader) ([]byte, error) {
 	first := true
 	for scanner.Scan() {
 		b := scanner.Bytes()
-		if len(b) == 0 {
+		if blankRegex.Match(b) || string(b) == "" {
 			cleanedFile = append(cleanedFile, byte('\n'))
-		} else if !commentRegex.Match(b) && !blankRegex.Match(b) && string(b) != "" {
+		} else if !commentRegex.Match(b) {
 			b = c.scrub(b, c.singleLineReplacers)
 			if !first {
 				cleanedFile = append(cleanedFile, byte('\n'))

--- a/pkg/util/scrubber/scrubber.go
+++ b/pkg/util/scrubber/scrubber.go
@@ -118,7 +118,7 @@ func (c *Scrubber) scrubReader(file io.Reader) ([]byte, error) {
 	first := true
 	for scanner.Scan() {
 		b := scanner.Bytes()
-		if blankRegex.Match(b) || string(b) == "" {
+		if blankRegex.Match(b) {
 			cleanedFile = append(cleanedFile, byte('\n'))
 		} else if !commentRegex.Match(b) {
 			b = c.scrub(b, c.singleLineReplacers)

--- a/pkg/util/scrubber/scrubber.go
+++ b/pkg/util/scrubber/scrubber.go
@@ -118,7 +118,9 @@ func (c *Scrubber) scrubReader(file io.Reader) ([]byte, error) {
 	first := true
 	for scanner.Scan() {
 		b := scanner.Bytes()
-		if !commentRegex.Match(b) && !blankRegex.Match(b) && string(b) != "" {
+		if len(b) == 0 {
+			cleanedFile = append(cleanedFile, byte('\n'))
+		} else if !commentRegex.Match(b) && !blankRegex.Match(b) && string(b) != "" {
 			b = c.scrub(b, c.singleLineReplacers)
 			if !first {
 				cleanedFile = append(cleanedFile, byte('\n'))

--- a/pkg/util/scrubber/scrubber_test.go
+++ b/pkg/util/scrubber/scrubber_test.go
@@ -66,7 +66,7 @@ func TestCleanFile(t *testing.T) {
 	})
 	res, err := scrubber.ScrubFile(filename)
 	require.NoError(t, err)
-	require.Equal(t, "a line with bar\na line with bar", string(res))
+	require.Equal(t, "a line with bar\n\na line with bar", string(res))
 }
 
 func TestScrubLine(t *testing.T) {

--- a/pkg/util/scrubber/scrubber_test.go
+++ b/pkg/util/scrubber/scrubber_test.go
@@ -51,7 +51,6 @@ func TestSkipComments(t *testing.T) {
 	})
 	res, err := scrubber.ScrubBytes([]byte("a line with foo\n\n  \n  # a comment with foo\nanother line"))
 	require.NoError(t, err)
-	// require.Equal(t, "a line ... line", string(res))
 	require.Equal(t, "a line ... line", string(res))
 }
 

--- a/pkg/util/scrubber/scrubber_test.go
+++ b/pkg/util/scrubber/scrubber_test.go
@@ -39,18 +39,19 @@ func TestReplFunc(t *testing.T) {
 	require.Equal(t, "dog FOOd", string(res))
 }
 
-func TestSkipCommentsAndBlanks(t *testing.T) {
+func TestSkipComments(t *testing.T) {
 	scrubber := New()
 	scrubber.AddReplacer(SingleLine, Replacer{
 		Regex: regexp.MustCompile("foo"),
 		Repl:  []byte("bar"),
 	})
 	scrubber.AddReplacer(MultiLine, Replacer{
-		Regex: regexp.MustCompile("with bar\nanother"),
+		Regex: regexp.MustCompile("with bar\n\n\nanother"),
 		Repl:  []byte("..."),
 	})
 	res, err := scrubber.ScrubBytes([]byte("a line with foo\n\n  \n  # a comment with foo\nanother line"))
 	require.NoError(t, err)
+	// require.Equal(t, "a line ... line", string(res))
 	require.Equal(t, "a line ... line", string(res))
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR fixes multiple issue with the status command output. Now that we're using the logger to print out to stdout, the content therein is getting scrubbed. The scrubber removes empty lines. This PR thus, does two things:
- Scrubber should preserve empty lines
- Status template concatenation should be consistent across different sections, it was a mess currently.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Ugly status in recent RCs.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->
Not really, mostly cosmetic, there shouldn't be much additional computational complexity in the scrubber. 

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Check the `datadog-agent status` for pretty, consistent status reporting.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
