### PR TITLE
Add lambda function URL trigger types

### DIFF
--- a/pkg/serverless/invocationlifecycle/init.go
+++ b/pkg/serverless/invocationlifecycle/init.go
@@ -1,6 +1,8 @@
 package invocationlifecycle
 
 import (
+	"fmt"
+
 	"github.com/DataDog/datadog-agent/pkg/serverless/trigger"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/aws/aws-lambda-go/events"
@@ -85,7 +87,8 @@ func (lp *LifecycleProcessor) initFromSQSEvent(event events.SQSEvent) {
 
 }
 
-func (lp *LifecycleProcessor) initFromLambdaFunctionURLEvent(event events.LambdaFunctionURLRequest) {
+func (lp *LifecycleProcessor) initFromLambdaFunctionURLEvent(event events.LambdaFunctionURLRequest, region string, accountID string, functionName string) {
 	lp.addTag("function_trigger.event_source", "lambda-function-url")
+	lp.addTag("function_trigger.event_source_arn", fmt.Sprintf("arn:aws:lambda:%v:%v:url:%v", region, accountID, functionName))
 	lp.addTags(trigger.GetTagsFromLambdaFunctionURLRequest(event))
 }

--- a/pkg/serverless/invocationlifecycle/init.go
+++ b/pkg/serverless/invocationlifecycle/init.go
@@ -87,4 +87,5 @@ func (lp *LifecycleProcessor) initFromSQSEvent(event events.SQSEvent) {
 
 func (lp *LifecycleProcessor) initFromLambdaFunctionURLEvent(event events.LambdaFunctionURLRequest) {
 	lp.addTag("function_trigger.event_source", "lambda-function-url")
+	lp.addTags(trigger.GetTagsFromLambdaFunctionURLRequest(event))
 }

--- a/pkg/serverless/invocationlifecycle/lifecycle.go
+++ b/pkg/serverless/invocationlifecycle/lifecycle.go
@@ -66,7 +66,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 	lp.newRequest(startDetails.InvokeEventRawPayload, startDetails.StartTime)
 
 	payloadBytes := []byte(lambdaPayloadString)
-	region, account, arnParseErr := trigger.ParseArn(startDetails.InvokedFunctionARN)
+	region, account, resource, arnParseErr := trigger.ParseArn(startDetails.InvokedFunctionARN)
 	if err != nil {
 		log.Debugf("[lifecycle] Error parsing ARN: %v", err)
 	}
@@ -129,8 +129,8 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 		}
 	case trigger.LambdaFunctionURLEvent:
 		var event events.LambdaFunctionURLRequest
-		if err := json.Unmarshal(payloadBytes, &event); err == nil {
-			lp.initFromLambdaFunctionURLEvent(event)
+		if err := json.Unmarshal(payloadBytes, &event); err == nil && arnParseErr == nil {
+			lp.initFromLambdaFunctionURLEvent(event, region, account, resource)
 		}
 	default:
 		log.Debug("Skipping adding trigger types and inferred spans as a non-supported payload was received.")

--- a/pkg/serverless/trigger/events.go
+++ b/pkg/serverless/trigger/events.go
@@ -131,6 +131,10 @@ func GetEventType(payload map[string]interface{}) AWSEventType {
 		return EventBridgeEvent
 	}
 
+	if isLambdaFunctionURLEvent(payload) {
+		return LambdaFunctionURLEvent
+	}
+
 	return Unknown
 }
 
@@ -228,6 +232,14 @@ func isAppSyncResolverEvent(event map[string]interface{}) bool {
 
 func isEventBridgeEvent(event map[string]interface{}) bool {
 	return json.GetNestedValue(event, "detail-type") != nil && json.GetNestedValue(event, "source") != "aws.events"
+}
+
+func isLambdaFunctionURLEvent(event map[string]interface{}) bool {
+	lambdaURL, ok := json.GetNestedValue(event, "requestcontext", "domainname").(string)
+	if !ok {
+		return false
+	}
+	return strings.Contains(lambdaURL, "lambda-url")
 }
 
 func eventRecordsKeyExists(event map[string]interface{}, key string) bool {

--- a/pkg/serverless/trigger/events_test.go
+++ b/pkg/serverless/trigger/events_test.go
@@ -26,6 +26,7 @@ func TestEventPayloadParsing(t *testing.T) {
 		"s3.json":                        isS3Event,
 		"sns.json":                       isSNSEvent,
 		"sqs.json":                       isSQSEvent,
+		"lambdaurl.json":                 isLambdaFunctionURLEvent,
 	}
 	for testFile, testFunc := range testCases {
 		file, err := os.Open(fmt.Sprintf("%v/%v", testDir, testFile))
@@ -56,6 +57,7 @@ func TestEventPayloadParsingWrong(t *testing.T) {
 		"s3.json":                        isS3Event,
 		"sns.json":                       isSNSEvent,
 		"sqs.json":                       isSQSEvent,
+		"lambdaurl.json":                 isLambdaFunctionURLEvent,
 	}
 	for correctTestFile, testFunc := range testCases {
 		wrongTestFiles, err := os.ReadDir(testDir)
@@ -95,6 +97,7 @@ func TestGetEventType(t *testing.T) {
 		"s3.json":                        S3Event,
 		"sns.json":                       SNSEvent,
 		"sqs.json":                       SQSEvent,
+		"lambdaurl.json":                 LambdaFunctionURLEvent,
 	}
 
 	for testFile, expectedEventType := range testCases {

--- a/pkg/serverless/trigger/extractor.go
+++ b/pkg/serverless/trigger/extractor.go
@@ -173,10 +173,13 @@ func GetStatusCodeFromHTTPResponse(rawPayload []byte) (string, error) {
 }
 
 // ParseArn parses an AWS ARN and returns the region and account
-func ParseArn(arn string) (string, string, error) {
+func ParseArn(arn string) (string, string, string, error) {
 	arnTokens := strings.Split(arn, ":")
 	if len(arnTokens) < 5 {
-		return "", "", fmt.Errorf("Malformed arn %v provided", arn)
+		return "", "", "", fmt.Errorf("Malformed arn %v provided", arn)
 	}
-	return arnTokens[3], arnTokens[4], nil
+	if len(arnTokens) >= 7 {
+		return arnTokens[3], arnTokens[4], arnTokens[6], nil
+	}
+	return arnTokens[3], arnTokens[4], "", nil
 }

--- a/pkg/serverless/trigger/extractor_test.go
+++ b/pkg/serverless/trigger/extractor_test.go
@@ -197,6 +197,29 @@ func TestExtractSQSEventARN(t *testing.T) {
 	assert.Equal(t, "test-arn", arn)
 }
 
+func TestExtractFunctionURLEventARN(t *testing.T) {
+	event := events.APIGatewayProxyRequest{
+		Headers: map[string]string{
+			"key":     "val",
+			"Referer": "referer",
+		},
+		RequestContext: events.APIGatewayProxyRequestContext{
+			DomainName: "domain-name",
+			Path:       "path",
+			HTTPMethod: "http-method",
+		},
+	}
+
+	httpTags := GetTagsFromAPIGatewayEvent(event)
+
+	assert.Equal(t, map[string]string{
+		"http.url":              "domain-name",
+		"http.url_details.path": "path",
+		"http.method":           "http-method",
+		"http.referer":          "referer",
+	}, httpTags)
+}
+
 func TestGetTagsFromAPIGatewayEvent(t *testing.T) {
 	event := events.APIGatewayProxyRequest{
 		Headers: map[string]string{

--- a/pkg/serverless/trigger/extractor_test.go
+++ b/pkg/serverless/trigger/extractor_test.go
@@ -262,6 +262,31 @@ func TestGetTagsFromALBTargetGroupRequest(t *testing.T) {
 	}, httpTags)
 }
 
+func TestGetTagsFromFunctionURLRequest(t *testing.T) {
+	event := events.LambdaFunctionURLRequest{
+		Headers: map[string]string{
+			"key":     "val",
+			"Referer": "referer",
+		},
+		RequestContext: events.LambdaFunctionURLRequestContext{
+			DomainName: "test-domain",
+			HTTP: events.LambdaFunctionURLRequestContextHTTPDescription{
+				Path:   "asd",
+				Method: "GET",
+			},
+		},
+	}
+
+	httpTags := GetTagsFromLambdaFunctionURLRequest(event)
+
+	assert.Equal(t, map[string]string{
+		"http.url_details.path": "asd",
+		"http.method":           "GET",
+		"http.referer":          "referer",
+		"http.url":              "test-domain",
+	}, httpTags)
+}
+
 func TestExtractStatusCodeFromHTTPResponse(t *testing.T) {
 	noStatusCodePayload := []byte(`{}`)
 

--- a/pkg/serverless/trigger/testData/lambdaurl.json
+++ b/pkg/serverless/trigger/testData/lambdaurl.json
@@ -1,0 +1,36 @@
+{
+  "version": "2.0",
+  "routeKey": "$default",
+  "rawPath": "/",
+  "rawQueryString": "",
+  "headers": {
+    "x-amzn-tls-cipher-suite": "ECDHE-RSA-AES128-GCM-SHA256",
+    "x-amzn-tls-version": "TLSv1.2",
+    "x-amzn-trace-id": "Root=1-62bc996d-0d0e784546ccbb85590e8d8f",
+    "x-forwarded-proto": "https",
+    "host": "test123.lambda-url.sa-east-1.on.aws",
+    "x-forwarded-port": "443",
+    "x-forwarded-for": "2600:4040:2489:a900:ec48:b628:3b62:28d6",
+    "accept": "*/*",
+    "user-agent": "curl/7.79.1"
+  },
+  "requestContext": {
+    "accountId": "anonymous",
+    "apiId": "test123",
+    "domainName": "test123.lambda-url.sa-east-1.on.aws",
+    "domainPrefix": "test123",
+    "http": {
+      "method": "GET",
+      "path": "/",
+      "protocol": "HTTP/1.1",
+      "sourceIp": "2600:4040:2489:a900:ec48:b628:3b62:28d6",
+      "userAgent": "curl/7.79.1"
+    },
+    "requestId": "d60989c6-2e4f-4672-8838-25d0a6bcb14d",
+    "routeKey": "$default",
+    "stage": "$default",
+    "time": "29/Jun/2022:18:26:53 +0000",
+    "timeEpoch": 1656527213249
+  },
+  "isBase64Encoded": false
+}


### PR DESCRIPTION
### Motivation

We missed this trigger type in the testing.

### Additional Notes

<img width="813" alt="image" src="https://user-images.githubusercontent.com/2540856/177381164-9ab8455c-0985-4913-83ec-72ff7991687c.png">

Working in version 890 of the extension.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
