### PR TITLE
container-launcher: get image info from WLM

### DIFF
--- a/pkg/logs/internal/launchers/container/tailerfactory/factory.go
+++ b/pkg/logs/internal/launchers/container/tailerfactory/factory.go
@@ -48,8 +48,7 @@ type factory struct {
 	// containers or pods.
 	cop containersorpods.Chooser
 
-	// dockerutil memoizes a DockerUtil instance; fetch this with
-	// getDockerUtil().
+	// dockerutil memoizes a DockerUtil instance; fetch this with getDockerUtil().
 	dockerutil *dockerutilPkg.DockerUtil
 }
 


### PR DESCRIPTION
### What does this PR do?

NOTE: this is a PR against the branch for #12440.

Using dockerutil to get container information assumes that it is a
docker container, which is not always the case.  WLM can provide the
information directly and more simply.

### Motivation

Fix errors like

```
2022-07-01 20:17:50 UTC | CORE | WARN | (pkg/logs/internal/launchers/container/tailerfactory/defaults.go:86 in defaultSourceAndServiceInner) | Could not inspect container b229ed1b1167bb47da9d8bc9143b87b712fb99fae70e3b8a28f3eea646387505: "docker container b229ed1b1167bb47da9d8bc9143b87b712fb99fae70e3b8a28f3eea646387505" not found
```

and resulting lack of default source/service set for the log source.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Run the agent in a containerd-based k8s environment, with container_collect_all enabled, and start a pod.  Check that the logs for that pod have the appropriate source and service (either with `agent stream-logs` or `agent status`).

Repeat in a docker-based k8s environment.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
