### PR TITLE
Set use_v2_api.series to true by default

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -440,7 +440,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("serializer_max_series_payload_size", 512000)
 	config.BindEnvAndSetDefault("serializer_max_series_uncompressed_payload_size", 5242880)
 
-	config.BindEnvAndSetDefault("use_v2_api.series", false)
+	config.BindEnvAndSetDefault("use_v2_api.series", true)
 	// Serializer: allow user to blacklist any kind of payload to be sent
 	config.BindEnvAndSetDefault("enable_payloads.events", true)
 	config.BindEnvAndSetDefault("enable_payloads.series", true)

--- a/pkg/serializer/serializer_test.go
+++ b/pkg/serializer/serializer_test.go
@@ -274,6 +274,8 @@ func TestSendV1Series(t *testing.T) {
 	f.On("SubmitV1Series", matcher, jsonExtraHeadersWithCompression).Return(nil).Times(1)
 	config.Datadog.Set("enable_stream_payload_serialization", false)
 	defer config.Datadog.Set("enable_stream_payload_serialization", nil)
+	config.Datadog.Set("use_v2_api.series", false)
+	defer config.Datadog.Set("use_v2_api.series", true)
 
 	s := NewSerializer(f, nil, nil)
 
@@ -286,8 +288,7 @@ func TestSendSeries(t *testing.T) {
 	f := &forwarder.MockedForwarder{}
 	matcher := createProtoPayloadMatcher([]byte{0xa, 0xa, 0xa, 0x6, 0xa, 0x4, 0x68, 0x6f, 0x73, 0x74, 0x28, 0x3})
 	f.On("SubmitSeries", matcher, protobufExtraHeadersWithCompression).Return(nil).Times(1)
-	config.Datadog.Set("use_v2_api.series", true)
-	defer config.Datadog.Set("use_v2_api.series", false)
+	config.Datadog.Set("use_v2_api.series", true) // default value, but just to be sure
 
 	s := NewSerializer(f, nil, nil)
 

--- a/releasenotes/notes/use_v2_api_for_series-53ac2d6b49b181b9.yaml
+++ b/releasenotes/notes/use_v2_api_for_series-53ac2d6b49b181b9.yaml
@@ -9,5 +9,5 @@
 enhancements:
   - |
     The Agent now uses the V2 API to submit series data to the Datadog intake
-    by default.  This can be reverted by setting ``use_v2_api.series`` to
+    by default. This can be reverted by setting ``use_v2_api.series`` to
     false.

--- a/releasenotes/notes/use_v2_api_for_series-53ac2d6b49b181b9.yaml
+++ b/releasenotes/notes/use_v2_api_for_series-53ac2d6b49b181b9.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The Agent now uses the V2 API to submit series data to the Datadog intake
+    by default.  This can be reverted by setting ``use_v2_api.series`` to
+    false.


### PR DESCRIPTION
This will enable the v2 API for all customers once they upgrade to 7.39.

### Motivation

V2 API is working well internally.

### Describe how to test/QA your changes

No need.  This is already enabled internally.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
