### PR TITLE
Remove metadata when a check is unscheduled

### DIFF
--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/runner"
 	"github.com/DataDog/datadog-agent/pkg/collector/runner/expvars"
 	"github.com/DataDog/datadog-agent/pkg/collector/scheduler"
+	"github.com/DataDog/datadog-agent/pkg/metadata/inventories"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"go.uber.org/atomic"
 )
@@ -156,6 +157,7 @@ func (c *Collector) StopCheck(id check.ID) error {
 
 	// remove the check from the stats map
 	expvars.RemoveCheckStats(id)
+	inventories.RemoveCheckMetadata(string(id))
 
 	// vaporize the check
 	c.delete(id)

--- a/pkg/metadata/inventories/inventories.go
+++ b/pkg/metadata/inventories/inventories.go
@@ -135,6 +135,10 @@ func SetHostMetadata(name AgentMetadataName, value interface{}) {
 
 // SetCheckMetadata updates a metadata value for one check instance in the cache.
 func SetCheckMetadata(checkID, key string, value interface{}) {
+	if checkID == "" {
+		return
+	}
+
 	checkMetadataMutex.Lock()
 	defer checkMetadataMutex.Unlock()
 
@@ -155,6 +159,14 @@ func SetCheckMetadata(checkID, key string, value interface{}) {
 		default: // To make sure this call is not blocking
 		}
 	}
+}
+
+// RemoveCheckMetadata removes metadata for a check. This need to be called when a check is unscheduled.
+func RemoveCheckMetadata(checkID string) {
+	checkMetadataMutex.Lock()
+	defer checkMetadataMutex.Unlock()
+
+	delete(checkMetadata, checkID)
 }
 
 func createCheckInstanceMetadata(checkID, configProvider string) *CheckInstanceMetadata {

--- a/pkg/metadata/inventories/inventories_test.go
+++ b/pkg/metadata/inventories/inventories_test.go
@@ -90,6 +90,20 @@ func waitForCalledSignal(calledSignal chan interface{}) bool {
 	}
 }
 
+func TestRemoveCheckMetadata(t *testing.T) {
+	ctx := context.Background()
+	defer func() { clearMetadata() }()
+
+	SetCheckMetadata("check1", "check_provided_key1", 123)
+	SetCheckMetadata("check2", "check_provided_key1", 123)
+	RemoveCheckMetadata("check1")
+
+	p := GetPayload(ctx, "testHostname", nil, nil)
+	checks := *p.CheckMetadata
+	assert.Len(t, checks, 1)
+	assert.Len(t, checks["check2"], 1)
+}
+
 func TestGetPayload(t *testing.T) {
 	ctx := context.Background()
 	defer func() { clearMetadata() }()
@@ -111,23 +125,23 @@ func TestGetPayload(t *testing.T) {
 	assert.Len(t, agentMetadata, 1)
 	assert.Equal(t, true, agentMetadata["test"])
 
-	checkMetadata := *p.CheckMetadata
-	assert.Len(t, checkMetadata, 3)
-	assert.Len(t, checkMetadata["check1"], 2) // check1 has two instances
-	check1Instance1 := *checkMetadata["check1"][0]
+	checkMeta := *p.CheckMetadata
+	assert.Len(t, checkMeta, 3)
+	assert.Len(t, checkMeta["check1"], 2) // check1 has two instances
+	check1Instance1 := *checkMeta["check1"][0]
 	assert.Len(t, check1Instance1, 5)
 	assert.Equal(t, startNow.UnixNano(), check1Instance1["last_updated"])
 	assert.Equal(t, "check1_instance1", check1Instance1["config.hash"])
 	assert.Equal(t, "provider1", check1Instance1["config.provider"])
 	assert.Equal(t, 123, check1Instance1["check_provided_key1"])
 	assert.Equal(t, "Hi", check1Instance1["check_provided_key2"])
-	check1Instance2 := *checkMetadata["check1"][1]
+	check1Instance2 := *checkMeta["check1"][1]
 	assert.Len(t, check1Instance2, 3)
 	assert.Equal(t, agentStartupTime.UnixNano(), check1Instance2["last_updated"])
 	assert.Equal(t, "check1_instance2", check1Instance2["config.hash"])
 	assert.Equal(t, "provider1", check1Instance2["config.provider"])
-	assert.Len(t, checkMetadata["check2"], 1) // check2 has one instance
-	check2Instance1 := *checkMetadata["check2"][0]
+	assert.Len(t, checkMeta["check2"], 1) // check2 has one instance
+	check2Instance1 := *checkMeta["check2"][0]
 	assert.Len(t, check2Instance1, 3)
 	assert.Equal(t, agentStartupTime.UnixNano(), check2Instance1["last_updated"])
 	assert.Equal(t, "check2_instance1", check2Instance1["config.hash"])
@@ -149,21 +163,21 @@ func TestGetPayload(t *testing.T) {
 	assert.Len(t, agentMetadata, 2)
 	assert.Equal(t, true, agentMetadata["test"])
 
-	checkMetadata = *p.CheckMetadata
-	assert.Len(t, checkMetadata, 3)
-	check1Instance1 = *checkMetadata["check1"][0]
+	checkMeta = *p.CheckMetadata
+	assert.Len(t, checkMeta, 3)
+	check1Instance1 = *checkMeta["check1"][0]
 	assert.Len(t, check1Instance1, 5)
 	assert.Equal(t, startNow.UnixNano(), check1Instance1["last_updated"]) // last_updated has changed
 	assert.Equal(t, "check1_instance1", check1Instance1["config.hash"])
 	assert.Equal(t, "provider1", check1Instance1["config.provider"])
 	assert.Equal(t, 456, check1Instance1["check_provided_key1"]) //Key has been updated
 	assert.Equal(t, "Hi", check1Instance1["check_provided_key2"])
-	check1Instance2 = *checkMetadata["check1"][1]
+	check1Instance2 = *checkMeta["check1"][1]
 	assert.Len(t, check1Instance2, 3)
 	assert.Equal(t, agentStartupTime.UnixNano(), check1Instance2["last_updated"]) // last_updated still the same
 	assert.Equal(t, "check1_instance2", check1Instance2["config.hash"])
 	assert.Equal(t, "provider1", check1Instance2["config.provider"])
-	check2Instance1 = *checkMetadata["check2"][0]
+	check2Instance1 = *checkMeta["check2"][0]
 	assert.Len(t, check2Instance1, 4)
 	assert.Equal(t, originalStartNow.UnixNano(), check2Instance1["last_updated"]) // reflects when check_provided_key1 was changed
 	assert.Equal(t, "check2_instance1", check2Instance1["config.hash"])
@@ -294,7 +308,7 @@ func TestSetup(t *testing.T) {
 	assert.True(t, ms.lastSendNowDelay > time.Duration(0))
 }
 
-func Test_createCheckInstanceMetadata_returnsNewMetadata(t *testing.T) {
+func TestCreateCheckInstanceMetadataReturnsNewMetadata(t *testing.T) {
 	defer clearMetadata()
 
 	const (


### PR DESCRIPTION
### What does this PR do?

When a check with custom metadata was unscheduled we would not remove it
from the inventories payload.

### Describe how to test/QA your changes

Start the agent with the docker socket mounted correctly (`-v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro`) and spawn a redis container. The Agent will automatically start monitoring it.

Check that the `status` page is updated with the redis version. Check that the inventory payload is updated too (using command `troubleshooting metadata_inventory`). Then stop the container and check that the inventory payload no longer contains data about the redis check (you will have to wait `inventories_min_interval` seconds).