### PR TITLE
[system-probe] Fix client-side TCP connections not being counted until data is sent

### DIFF
--- a/pkg/network/ebpf/c/prebuilt/tracer.c
+++ b/pkg/network/ebpf/c/prebuilt/tracer.c
@@ -420,6 +420,11 @@ int kprobe__tcp_set_state(struct pt_regs* ctx) {
     tcp_stats_t stats = { .state_transitions = (1 << state) };
     update_tcp_stats(&t, stats);
 
+    __u8 old_state = 0;
+    bpf_probe_read(&old_state, sizeof(old_state), (void *)&sk->sk_state);
+    if (old_state == TCP_SYN_SENT)
+        update_conn_stats(&t, 0, 0, bpf_ktime_get_ns(), CONN_DIRECTION_OUTGOING, 0, 0, PACKET_COUNT_NONE);
+
     return 0;
 }
 

--- a/pkg/network/ebpf/c/runtime/tracer.c
+++ b/pkg/network/ebpf/c/runtime/tracer.c
@@ -398,6 +398,11 @@ int kprobe__tcp_set_state(struct pt_regs* ctx) {
     tcp_stats_t stats = { .state_transitions = (1 << state) };
     update_tcp_stats(&t, stats);
 
+    __u8 old_state = 0;
+    bpf_probe_read(&old_state, sizeof(old_state), (void *)&sk->sk_state);
+    if (old_state == TCP_SYN_SENT)
+        update_conn_stats(&t, 0, 0, bpf_ktime_get_ns(), CONN_DIRECTION_OUTGOING, 0, 0, PACKET_COUNT_NONE);
+
     return 0;
 }
 

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -523,6 +523,7 @@ func TestTCPConnsReported(t *testing.T) {
 	// Connect to server
 	c, err := net.DialTimeout("tcp", server.address, 50*time.Millisecond)
 	require.NoError(t, err)
+	defer c.Close()
 
 	// Test
 	initTracerState(t, tr)

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -505,6 +505,36 @@ func TestTCPCollectionDisabled(t *testing.T) {
 	require.False(t, ok)
 }
 
+func TestTCPConnsReported(t *testing.T) {
+	// Setup
+	config := testConfig()
+	config.CollectTCPConns = true
+
+	tr, err := NewTracer(config)
+	require.NoError(t, err)
+	defer tr.Stop()
+
+	server := NewTCPServer(func(c net.Conn) {})
+	doneChan := make(chan struct{})
+	err = server.Run(doneChan)
+	require.NoError(t, err)
+	defer close(doneChan)
+
+	// Connect to server
+	c, err := net.DialTimeout("tcp", server.address, 50*time.Millisecond)
+	require.NoError(t, err)
+
+	// Test
+	initTracerState(t, tr)
+	connections := getConnections(t, tr)
+	// Server-side
+	_, ok := findConnection(c.RemoteAddr(), c.LocalAddr(), connections)
+	require.True(t, ok)
+	// Client-side
+	_, ok = findConnection(c.LocalAddr(), c.RemoteAddr(), connections)
+	require.True(t, ok)
+}
+
 func TestUDPSendAndReceive(t *testing.T) {
 	t.Run("v4", func(t *testing.T) {
 		testUDPSendAndReceive(t, "127.0.0.1:8001")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR fixes reporting of client-side TCP connections not being reported until data is sent. Currently, opened TCP connections are only reported server side (thanks to our probe on the `accept(2)` syscall).
This PR make it so connections are also reported on the client-side, by looking if, when the connection state switches to `TCP_ESTABLISHED`, the previous state was `SYN_SENT` (which means this is a client initiating a TCP handshake). If so, we add a new connection.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
A unit test is included with the PR. This can also be manually tested by setting up a client/server connection with two instances of netcat. Here is an exemple, with the client and server running on different network namespaces with a network on `10.0.0.0/24` between them:

```shell
# Server
nc -l 8080
# client
nc 10.0.0.1 8080
```

...and fetching the `/connections` route to see if the connection is present:
```shell
sudo curl -s --unix-socket /opt/datadog-agent/run/sysprobe.sock http://unix/network_tracer/connections|jq '.conns[]| select(.laddr.ip | contains("10.0.0."))|{laddr: .laddr.ip, raddr: .raddr.ip}'
```
With this command, one should see two connections, one for each side.


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [X] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [X] Changed code has automated tests for its functionality.
- [X] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [X] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
