### PR TITLE
Add CRLSign bit to API Cert as it serves as CA

### DIFF
--- a/pkg/api/security/security.go
+++ b/pkg/api/security/security.go
@@ -79,7 +79,7 @@ func GenerateRootCert(hosts []string, bits int) (cert *x509.Certificate, certPEM
 
 	// describe what the certificate will be used for
 	rootCertTmpl.IsCA = true
-	rootCertTmpl.KeyUsage = x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature
+	rootCertTmpl.KeyUsage = x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature | x509.KeyUsageCRLSign
 	rootCertTmpl.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth}
 
 	for _, h := range hosts {


### PR DESCRIPTION
### What does this PR do?

Add CRLSign bit to API Cert (Agent/DCA) as it's used as a CA (even though we don't pus a CRL)

### Motivation

FR (Qualys scanner, see CONS-4628)

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Exec into an Agent pod, run:
```
echo | openssl s_client -showcerts -connect localhost:5001 2>/dev/null | openssl x509 -inform pem -noout -text
```

You should see a new field in:
```
        X509v3 extensions:
            X509v3 Key Usage: critical
                Digital Signature, Certificate Sign, <CRL Sign>
```

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
