### PR TITLE
clarify doc for collect_kubernetes_events

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2862,7 +2862,7 @@ api_key:
 ## @env DD_COLLECT_KUBERNETES_EVENTS - boolean - optional - default: false
 ## Set `collect_kubernetes_events` to true to enable collection of kubernetes
 ## events to be sent to Datadog.
-## Note: leader election must be enabled must be enabled below to to collect events.
+## Note: leader election must be enabled below to to collect events.
 ##       Only the leader Agent collects events.
 ## See https://github.com/DataDog/datadog-agent/blob/main/Dockerfiles/agent/README.md#event-collection
 #

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2862,7 +2862,7 @@ api_key:
 ## @env DD_COLLECT_KUBERNETES_EVENTS - boolean - optional - default: false
 ## Set `collect_kubernetes_events` to true to enable collection of kubernetes
 ## events to be sent to Datadog.
-## Note: leader election must be enabled below to to collect events.
+## Note: leader election must be enabled below to collect events.
 ##       Only the leader Agent collects events.
 ## See https://github.com/DataDog/datadog-agent/blob/main/Dockerfiles/agent/README.md#event-collection
 #

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2860,8 +2860,9 @@ api_key:
 
 ## @param collect_kubernetes_events - boolean - optional - default: false
 ## @env DD_COLLECT_KUBERNETES_EVENTS - boolean - optional - default: false
-## Set `collect_kubernetes_events` to true to enable log collection.
-## Note: leader election must be enabled must be enabled  bellow to to collect events.
+## Set `collect_kubernetes_events` to true to enable collection of kubernetes
+## events to be sent to Datadog.
+## Note: leader election must be enabled must be enabled below to to collect events.
 ##       Only the leader Agent collects events.
 ## See https://github.com/DataDog/datadog-agent/blob/main/Dockerfiles/agent/README.md#event-collection
 #


### PR DESCRIPTION
### What does this PR do?

Updates the doc for this config parameter

### Motivation

The old doc suggested that this parameter had to be enabled to use the logs agent.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
