### PR TITLE
Fix parsing of init_config in AD annotations v2

### DIFF
--- a/pkg/autodiscovery/common/utils/pod_annotations.go
+++ b/pkg/autodiscovery/common/utils/pod_annotations.go
@@ -54,9 +54,9 @@ func ExtractTemplatesFromPodAnnotations(entityName string, annotations map[strin
 // (ad.datadoghq.com/redis.checks) JSON string into []integration.Config.
 func parseChecksJSON(adIdentifier string, checksJSON string) ([]integration.Config, error) {
 	var namedChecks map[string]struct {
-		Name       string            `json:"name"`
-		InitConfig *integration.Data `json:"init_config"`
-		Instances  []interface{}     `json:"instances"`
+		Name       string          `json:"name"`
+		InitConfig json.RawMessage `json:"init_config"`
+		Instances  []interface{}   `json:"instances"`
 	}
 
 	err := json.Unmarshal([]byte(checksJSON), &namedChecks)
@@ -70,16 +70,13 @@ func parseChecksJSON(adIdentifier string, checksJSON string) ([]integration.Conf
 			name = config.Name
 		}
 
-		var initConfig integration.Data
-		if config.InitConfig != nil {
-			initConfig = *config.InitConfig
-		} else {
-			initConfig = integration.Data("{}")
+		if len(config.InitConfig) == 0 {
+			config.InitConfig = json.RawMessage("{}")
 		}
 
 		c := integration.Config{
 			Name:          name,
-			InitConfig:    initConfig,
+			InitConfig:    integration.Data(config.InitConfig),
 			ADIdentifiers: []string{adIdentifier},
 		}
 

--- a/pkg/autodiscovery/common/utils/pod_annotations_test.go
+++ b/pkg/autodiscovery/common/utils/pod_annotations_test.go
@@ -74,7 +74,6 @@ func TestExtractCheckNamesFromPodAnnotations(t *testing.T) {
 			assert.Nil(t, err)
 			assert.ElementsMatch(t, tt.checkNames, checkNames, "check names do not match")
 		})
-
 	}
 }
 
@@ -300,6 +299,26 @@ func TestExtractTemplatesFromPodAnnotations(t *testing.T) {
 					Name:          "apache",
 					Instances:     []integration.Data{integration.Data(`{"apache_status_url":"http://%%host%%/server-status?auto2"}`)},
 					InitConfig:    integration.Data("{}"),
+					ADIdentifiers: []string{adID},
+				},
+			},
+		},
+		{
+			name: "v2 annotations with init_config",
+			annotations: map[string]string{
+				"ad.datadoghq.com/foobar.checks": `{
+					"jmx": {
+						"init_config": {"is_jmx": true, "collect_default_metrics": false},
+						"instances": [{"host":"%%host%%","port":"9012"}]
+					}
+				}`,
+			},
+			adIdentifier: "foobar",
+			output: []integration.Config{
+				{
+					Name:          "jmx",
+					Instances:     []integration.Data{integration.Data(`{"host":"%%host%%","port":"9012"}`)},
+					InitConfig:    integration.Data(`{"is_jmx": true, "collect_default_metrics": false}`),
 					ADIdentifiers: []string{adID},
 				},
 			},

--- a/releasenotes/notes/fix-init-config-ad-v2-605a929b338aad30.yaml
+++ b/releasenotes/notes/fix-init-config-ad-v2-605a929b338aad30.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix parsing of init_config in AD annotations v2.


### PR DESCRIPTION
### What does this PR do?

Fix a parsing issue that prevents the parsing of AD annotations V2 if `init_config` is used.

### Motivation

Bugfix.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Deploy the Agent and add a check using AD annotations V2, specifying an `init_config`, for instance for Tomcat:
```
annotations:
                ad.datadoghq.com/tomcat.checks: |
                  {
                  	"jmx": {
                  		"init_config": {
                  			"is_jmx": true,
                  			"collect_default_metrics": false
                  		},
                  		"instances": [{
                  			"host": "%%host%%",
                  			"port": "9012"
                  		}]
                  	}
                  }
```

Verify that the check runs properly in `agent status`.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
