### PR TITLE
Fix crash when updating checks telemetry

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -811,6 +811,9 @@ func (agg *BufferedAggregator) tags(withVersion bool) []string {
 }
 
 func (agg *BufferedAggregator) updateChecksTelemetry() {
+	agg.mu.Lock()
+	defer agg.mu.Unlock()
+
 	t := metrics.CheckMetricsTelemetryAccumulator{}
 	for _, sampler := range agg.checkSamplers {
 		t.VisitCheckMetrics(&sampler.metrics)


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fix crash when updating checks telemetry

updateChecksTelemetry reads agg.checkSamplers, which needs to be
protected by a mutex to avoid concurrent modification by
`registerSampler`.

### Motivation

Bugfix

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Run agent in k8s with a large number of new pods scheduled to the same box (e.g. several cronjobs); with telemetry enabled.

Agent should not crash (repro can take several hours, as the time window for a race is fairly small).
Check that check_metrics (`curl -s http://localhost:5000/telemetry | grep check_metrics`) are populated.
Check that metrics from the checks (e.g. system metrics) reach the intake.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
