### PR TITLE
Use go.uber.org/atomic in cmd/process-agent

### DIFF
--- a/cmd/process-agent/collector.go
+++ b/cmd/process-agent/collector.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"strconv"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	model "github.com/DataDog/agent-payload/v5/process"
@@ -29,6 +28,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
+	"go.uber.org/atomic"
 )
 
 type checkResult struct {
@@ -54,11 +54,11 @@ type checkPayload struct {
 
 // Collector will collect metrics from the local system and ship to the backend.
 type Collector struct {
-	// Set to 1 if enabled 0 is not. We're using an integer
-	// so we can use the sync/atomic for thread-safe access.
-	realTimeEnabled int32
+	// true if real-time is enabled
+	realTimeEnabled *atomic.Bool
 
-	groupID int32
+	// the next groupID to be issued
+	groupID *atomic.Int32
 
 	rtIntervalCh chan time.Duration
 	cfg          *config.AgentConfig
@@ -140,12 +140,12 @@ func NewCollectorWithChecks(cfg *config.AgentConfig, checks []checks.Check, runR
 	return Collector{
 		rtIntervalCh:  make(chan time.Duration),
 		cfg:           cfg,
-		groupID:       rand.Int31(),
+		groupID:       atomic.NewInt32(rand.Int31()),
 		enabledChecks: checks,
 
 		// Defaults for real-time on start
 		realTimeInterval: 2 * time.Second,
-		realTimeEnabled:  0,
+		realTimeEnabled:  atomic.NewBool(false),
 
 		processResults:   processResults,
 		rtProcessResults: rtProcessResults,
@@ -224,7 +224,7 @@ func logCheckDuration(name string, start time.Time, runCounter int32) {
 }
 
 func (l *Collector) nextGroupID() int32 {
-	return atomic.AddInt32(&l.groupID, 1)
+	return l.groupID.Inc()
 }
 
 func (l *Collector) messagesToResults(start time.Time, name string, messages []model.MessageBody, results *api.WeightedQueue) {
@@ -487,7 +487,7 @@ func (l *Collector) runnerForCheck(c checks.Check, exit chan struct{}) (func(), 
 			ExitChan:       exit,
 			RtIntervalChan: l.rtIntervalCh,
 			RtEnabled: func() bool {
-				return atomic.LoadInt32(&l.realTimeEnabled) == 1
+				return l.realTimeEnabled.Load()
 			},
 			RunCheck: func(options checks.RunOptions) {
 				l.runCheckWithRealTime(withRealTime, results, rtResults, options)
@@ -507,7 +507,7 @@ func (l *Collector) basicRunner(c checks.Check, results *api.WeightedQueue, exit
 		for {
 			select {
 			case <-ticker.C:
-				realTimeEnabled := l.runRealTime && atomic.LoadInt32(&l.realTimeEnabled) == 1
+				realTimeEnabled := l.runRealTime && l.realTimeEnabled.Load()
 				if !c.RealTime() || realTimeEnabled {
 					l.runCheck(c, results)
 				}
@@ -598,7 +598,7 @@ func (l *Collector) consumePayloads(results *api.WeightedQueue, fwd forwarder.Fo
 }
 
 func (l *Collector) updateRTStatus(statuses []*model.CollectorStatus) {
-	curEnabled := atomic.LoadInt32(&l.realTimeEnabled) == 1
+	curEnabled := l.realTimeEnabled.Load()
 
 	// If any of the endpoints wants real-time we'll do that.
 	// We will pick the maximum interval given since generally this is
@@ -619,10 +619,10 @@ func (l *Collector) updateRTStatus(statuses []*model.CollectorStatus) {
 
 	if curEnabled && !shouldEnableRT {
 		log.Info("Detected 0 clients, disabling real-time mode")
-		atomic.StoreInt32(&l.realTimeEnabled, 0)
+		l.realTimeEnabled.Store(false)
 	} else if !curEnabled && shouldEnableRT {
 		log.Infof("Detected %d active clients, enabling real-time mode", activeClients)
-		atomic.StoreInt32(&l.realTimeEnabled, 1)
+		l.realTimeEnabled.Store(true)
 	}
 
 	if maxInterval != l.realTimeInterval {

--- a/cmd/process-agent/collector_test.go
+++ b/cmd/process-agent/collector_test.go
@@ -6,7 +6,6 @@
 package main
 
 import (
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -34,7 +33,7 @@ func TestUpdateRTStatus(t *testing.T) {
 		{ActiveClients: 0, Interval: 2},
 	}
 	c.updateRTStatus(statuses)
-	assert.Equal(int32(1), atomic.LoadInt32(&c.realTimeEnabled))
+	assert.True(c.realTimeEnabled.Load())
 
 	// Validate that we stay that way
 	statuses = []*model.CollectorStatus{
@@ -43,7 +42,7 @@ func TestUpdateRTStatus(t *testing.T) {
 		{ActiveClients: 0, Interval: 2},
 	}
 	c.updateRTStatus(statuses)
-	assert.Equal(int32(1), atomic.LoadInt32(&c.realTimeEnabled))
+	assert.True(c.realTimeEnabled.Load())
 
 	// And that it can turn back off
 	statuses = []*model.CollectorStatus{
@@ -52,7 +51,7 @@ func TestUpdateRTStatus(t *testing.T) {
 		{ActiveClients: 0, Interval: 2},
 	}
 	c.updateRTStatus(statuses)
-	assert.Equal(int32(0), atomic.LoadInt32(&c.realTimeEnabled))
+	assert.False(c.realTimeEnabled.Load())
 }
 
 func TestUpdateRTInterval(t *testing.T) {
@@ -70,7 +69,7 @@ func TestUpdateRTInterval(t *testing.T) {
 		{ActiveClients: 0, Interval: 10},
 	}
 	c.updateRTStatus(statuses)
-	assert.Equal(int32(1), atomic.LoadInt32(&c.realTimeEnabled))
+	assert.True(c.realTimeEnabled.Load())
 	assert.Equal(10*time.Second, c.realTimeInterval)
 }
 


### PR DESCRIPTION
 ### What does this PR do?

Uses go.uber.com/atomic to ensure alignment of atomic access in cmd/process-agent.

### Motivation

Alignment issues with atomic access, and enforcing atomic access to atomic variables.  See #11716.

In this case, the two atomically-accessed values were, indeed, at the beginning of the struct, but there were no comments to indicate what would happen if they were moved.  AtomicBool/AtomicInt32 remove this risk.

### Additional Notes



### Possible Drawbacks / Trade-offs



### Describe how to test/QA your changes

Any basic process-agent QA that enables and disables realtime should detect issues here.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
