### PR TITLE
Fix kernel header search

### DIFF
--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -469,9 +469,7 @@ def get_linux_header_dirs(kernel_release=None):
         if os.path.isdir(src_kernels_dir):
             linux_headers = [os.path.join(src_kernels_dir, d) for d in os.listdir(src_kernels_dir)]
         else:
-            linux_headers = [
-                os.path.join(src_dir, d) for d in os.listdir(src_dir) if d.startswith("linux-")
-            ]
+            linux_headers = [os.path.join(src_dir, d) for d in os.listdir(src_dir) if d.startswith("linux-")]
 
     # fallback to /usr as a last report
     if len(linux_headers) == 0:

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -7,6 +7,7 @@ import re
 import shutil
 import sys
 import tempfile
+from pathlib import Path
 from subprocess import check_output
 
 from invoke import task
@@ -449,33 +450,24 @@ def get_linux_header_dirs(kernel_release=None):
         os_info = os.uname()
         kernel_release = os_info.release
 
-    centos_headers_dir = "/usr/src/kernels"
-    debian_headers_dir = "/usr/src"
+    possible_dirs = [
+        f"/lib/modules/{kernel_release}/build",
+        f"/lib/modules/{kernel_release}/source",
+        f"/usr/src/linux-headers-{kernel_release}",
+        f"/usr/src/kernels/{kernel_release}",
+    ]
     linux_headers = []
-    if os.path.isdir(centos_headers_dir):
-        for d in os.listdir(centos_headers_dir):
-            if kernel_release in d:
-                linux_headers.append(os.path.join(centos_headers_dir, d))
-    else:
-        for d in os.listdir(debian_headers_dir):
-            if d.startswith("linux-") and kernel_release in d:
-                linux_headers.append(os.path.join(debian_headers_dir, d))
+    for d in possible_dirs:
+        if os.path.isdir(d):
+            # resolve symlinks
+            linux_headers.append(Path(d).resolve())
 
-    # fallback to non-filtered version for Docker where `uname -r` is not correct
+    # fallback to /usr/src as a last report
     if len(linux_headers) == 0:
-        if os.path.isdir(centos_headers_dir):
-            linux_headers = [os.path.join(centos_headers_dir, d) for d in os.listdir(centos_headers_dir)]
-        else:
-            linux_headers = [
-                os.path.join(debian_headers_dir, d) for d in os.listdir(debian_headers_dir) if d.startswith("linux-")
-            ]
+        linux_headers = ["/usr/src"]
 
-    # fallback to the running kernel/build headers via /lib/modules/$(uname -r)/build/
-    if len(linux_headers) == 0:
-        uname_r = check_output('''uname -r''', shell=True).decode('utf-8').strip()
-        build_dir = f"/lib/modules/{uname_r}/build"
-        if os.path.isdir(build_dir):
-            linux_headers = [build_dir]
+    # deduplicate
+    linux_headers = list(dict.fromkeys(linux_headers))
 
     # Mapping used by the kernel, from https://elixir.bootlin.com/linux/latest/source/scripts/subarch.include
     arch = (


### PR DESCRIPTION


<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fixes the kernel header directory search to be more comprehensive

### Motivation

This allows system-probe to build on debian

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
