### PR TITLE
Fix `inv system-probe.build --kernel-release`

### DIFF
--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -316,11 +316,11 @@ def kitchen_genconfig(
 
 
 @task
-def nettop(ctx, incremental_build=False, go_mod="mod", parallel_build=True):
+def nettop(ctx, incremental_build=False, go_mod="mod", parallel_build=True, kernel_release=None):
     """
     Build and run the `nettop` utility for testing
     """
-    build_object_files(ctx, parallel_build=parallel_build)
+    build_object_files(ctx, parallel_build=parallel_build, kernel_release=kernel_release)
 
     cmd = 'go build -mod={go_mod} {build_type} -tags {tags} -o {bin_path} {path}'
     bin_path = os.path.join(BIN_DIR, "nettop")
@@ -435,9 +435,9 @@ def run_tidy(ctx, files, build_flags, fix=False, fail_on_issue=False, checks=Non
 
 
 @task
-def object_files(ctx, parallel_build=True):
+def object_files(ctx, parallel_build=True, kernel_release=None):
     """object_files builds the eBPF object files"""
-    build_object_files(ctx, parallel_build=parallel_build)
+    build_object_files(ctx, parallel_build=parallel_build, kernel_release=kernel_release)
 
 
 def get_ebpf_targets():

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -588,21 +588,21 @@ def build_network_ebpf_link_file(ctx, parallel_build, build_dir, p, debug, netwo
         )
 
 
-def get_http_prebuilt_build_flags(network_c_dir):
+def get_http_prebuilt_build_flags(network_c_dir, kernel_release=None):
     uname_m = check_output("uname -m", shell=True).decode('utf-8').strip()
-    flags = get_ebpf_build_flags(target=["-target", "bpf"])
+    flags = get_ebpf_build_flags(target=["-target", "bpf"], kernel_release=kernel_release)
     flags.append(f"-I{network_c_dir}")
     flags.append(f"-D__{uname_m}__")
     flags.append(f"-isystem /usr/include/{uname_m}-linux-gnu")
     return flags
 
 
-def build_http_ebpf_files(ctx, build_dir):
+def build_http_ebpf_files(ctx, build_dir, kernel_release=None):
     network_bpf_dir = os.path.join(".", "pkg", "network", "ebpf")
     network_c_dir = os.path.join(network_bpf_dir, "c")
     network_prebuilt_dir = os.path.join(network_c_dir, "prebuilt")
 
-    network_flags = get_http_prebuilt_build_flags(network_c_dir)
+    network_flags = get_http_prebuilt_build_flags(network_c_dir, kernel_release=kernel_release)
 
     build_network_ebpf_compile_file(
         ctx, False, build_dir, "http", True, network_prebuilt_dir, network_flags, extension=".o"
@@ -612,20 +612,20 @@ def build_http_ebpf_files(ctx, build_dir):
     )
 
 
-def get_network_build_flags(network_c_dir):
-    flags = get_ebpf_build_flags()
+def get_network_build_flags(network_c_dir, kernel_release=None):
+    flags = get_ebpf_build_flags(kernel_release=kernel_release)
     flags.append(f"-I{network_c_dir}")
     return flags
 
 
-def build_network_ebpf_files(ctx, build_dir, parallel_build=True):
+def build_network_ebpf_files(ctx, build_dir, parallel_build=True, kernel_release=None):
     network_bpf_dir = os.path.join(".", "pkg", "network", "ebpf")
     network_c_dir = os.path.join(network_bpf_dir, "c")
     network_prebuilt_dir = os.path.join(network_c_dir, "prebuilt")
 
     compiled_programs = ["dns", "offset-guess", "tracer"]
 
-    network_flags = get_network_build_flags(network_c_dir)
+    network_flags = get_network_build_flags(network_c_dir, kernel_release=kernel_release)
 
     flavor = []
     for prog in compiled_programs:
@@ -759,8 +759,8 @@ def build_object_files(ctx, parallel_build, kernel_release=None):
     ctx.run(f"mkdir -p {build_dir}")
     ctx.run(f"mkdir -p {build_runtime_dir}")
 
-    build_network_ebpf_files(ctx, build_dir=build_dir, parallel_build=parallel_build)
-    build_http_ebpf_files(ctx, build_dir=build_dir)
+    build_network_ebpf_files(ctx, build_dir=build_dir, parallel_build=parallel_build, kernel_release=kernel_release)
+    build_http_ebpf_files(ctx, build_dir=build_dir, kernel_release=kernel_release)
     build_security_ebpf_files(ctx, build_dir=build_dir, parallel_build=parallel_build, kernel_release=kernel_release)
 
     generate_runtime_files(ctx)


### PR DESCRIPTION
### What does this PR do?

Fix the `--kernel-release` parameter of `inv system-probe.build`.

### Motivation

It wasn’t honoured by all the targets requiring access to the kernel headers.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Try to invoke `inv system-probe.build` on a Debian machine.

It fails with the following error:

```
$ inv system-probe.build
checking for clang executable...
/usr/bin/clang
Encountered a bad command exit code!

Command: 'clang -D__KERNEL__ -DCONFIG_64BIT -D__BPF_TRACING__ -DKBUILD_MODNAME=\\"ddsysprobe\\" -Wno-unused-value -Wno-pointer-sign -Wno-compare-distinct-pointer-types -Wunused -Wall -Werror -emit-llvm -include ./pkg/ebpf/c/asm_goto_workaround.h -O2 -fno-stack-protector -fno-color-diagnostics -fno-unwind-tables -fno-asynchronous-unwind-tables -fno-jump-tables -I./pkg/ebpf/c -isystem /usr/src/linux-headers-5.18.0-2-cloud-amd64/include -isystem /usr/src/linux-headers-5.18.0-2-cloud-amd64/include/uapi -isystem /usr/src/linux-headers-5.18.0-2-cloud-amd64/include/generated/uapi -isystem /usr/src/linux-headers-5.18.0-2-cloud-amd64/arch/x86/include -isystem /usr/src/linux-headers-5.18.0-2-cloud-amd64/arch/x86/include/uapi -isystem /usr/src/linux-headers-5.18.0-2-cloud-amd64/arch/x86/include/generated -I./pkg/network/ebpf/c -c \'./pkg/network/ebpf/c/prebuilt/dns.c\' -o \'./pkg/ebpf/bytecode/build/dns.bc\''

Exit code: 1

Stdout:



Stderr:

In file included from ./pkg/network/ebpf/c/prebuilt/dns.c:2:
./pkg/ebpf/c/bpf_helpers.h:5:10: fatal error: 'uapi/linux/bpf.h' file not found
#include <uapi/linux/bpf.h>
         ^~~~~~~~~~~~~~~~~~
1 error generated.
```

That’s because `uname -r` returns `5.18.0-2-cloud-amd64`, so that kernel headers are looked for only inside `/usr/src/linux-headers-5.18.0-2-cloud-amd64/` and not inside `/usr/src/linux-headers-5.18.0-2-common/` which the directory which contains `uapi/linux/bpf.h`.

Explicitly passing `--kernel-release 5.18.0-2` should now fix the above error.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
