### PR TITLE
Do not drop OOM kill events when not coming from a container

### DIFF
--- a/pkg/collector/corechecks/ebpf/oom_kill.go
+++ b/pkg/collector/corechecks/ebpf/oom_kill.go
@@ -112,7 +112,6 @@ func (m *OOMKillCheck) Run() error {
 		containerID, err := cgroups.ContainerFilter("", line.CgroupName)
 		if err != nil || containerID == "" {
 			log.Warnf("Unable to extract containerID from cgroup name: %s, err: %v", line.CgroupName, err)
-			continue
 		}
 
 		entityID := containers.BuildTaggerEntityName(containerID)


### PR DESCRIPTION
### What does this PR do?

Ensure that the `oom_kill` check reports not only OOM kill events happening inside containers but also the ones happening on host.

### Motivation

### Additional Notes

OOM kill events and metrics are tagged with containers tag.
For kills affecting processes running outside of containers, those tags will obviously be missing.

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Do a host install of the agent on a VM.
Trigger an OOM kill **on the host**, i.e. not inside a container, for ex. with `tail /dev/zero`

An event should be generated and the counter `oom_kill.oom_process.count` should increase.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
