### PR TITLE
raise logs open file limit

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1008,11 +1008,13 @@ api_key:
   #
   # batch_wait: 5
 
-  ## @param open_files_limit - integer - optional - default: 100
-  ## @env DD_LOGS_CONFIG_OPEN_FILES_LIMIT - integer - optional - default: 100
+  ## @param open_files_limit - integer - optional - default: 500
+  ## @env DD_LOGS_CONFIG_OPEN_FILES_LIMIT - integer - optional - default: 500
   ## The maximum number of files that can be tailed in parallel.
+  # Note: the default for windows and Mac OS is 200. The default for
+  # all other systems is 500. 
   #
-  # open_files_limit: 100
+  # open_files_limit: 500
 
 {{ end -}}
 {{- if .TraceAgent }}

--- a/pkg/logs/config/config_test.go
+++ b/pkg/logs/config/config_test.go
@@ -7,6 +7,7 @@ package config
 
 import (
 	"os"
+	"runtime"
 	"testing"
 	"time"
 
@@ -32,7 +33,11 @@ func (suite *ConfigTestSuite) TestDefaultDatadogConfig() {
 	suite.Equal("agent-443-intake.logs.datadoghq.com", suite.config.GetString("logs_config.dd_url_443"))
 	suite.Equal(false, suite.config.GetBool("logs_config.use_port_443"))
 	suite.Equal(true, suite.config.GetBool("logs_config.dev_mode_use_proto"))
-	suite.Equal(100, suite.config.GetInt("logs_config.open_files_limit"))
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+		suite.Equal(200, suite.config.GetInt("logs_config.open_files_limit"))
+	} else {
+		suite.Equal(500, suite.config.GetInt("logs_config.open_files_limit"))
+	}
 	suite.Equal(9000, suite.config.GetInt("logs_config.frame_size"))
 	suite.Equal("", suite.config.GetString("logs_config.socks5_proxy_address"))
 	suite.Equal("", suite.config.GetString("logs_config.logs_dd_url"))

--- a/releasenotes/notes/raise-logs-open-file-limit-938e2a744c68944c.yaml
+++ b/releasenotes/notes/raise-logs-open-file-limit-938e2a744c68944c.yaml
@@ -9,4 +9,4 @@
 enhancements:
   - |
     Raise the default ``logs_config.open_files_limit`` to ``200`` on 
-    Windows and Mac OS. Raised to ``500`` for all other operating systems. 
+    Windows and macOS. Raised to ``500`` for all other operating systems. 

--- a/releasenotes/notes/raise-logs-open-file-limit-938e2a744c68944c.yaml
+++ b/releasenotes/notes/raise-logs-open-file-limit-938e2a744c68944c.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Raise the default ``logs_config.open_files_limit`` to ``200`` on 
+    Windows and Mac OS. Raised to ``500`` for all other operating systems. 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Raise the default `logs_config.open_files_limit` since the previous default was rather small. 

### Motivation

It is common for users to need to raise this setting to accommodate larger logs workloads. This should save some users the effort of needing to change this setting out of the box. 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

Could have higher resource usage in some scenarios. But in reality this simply raises an artificial ceiling. Resource usage typically scales with load anyway so this should not be and unexpected consequence. 

### Describe how to test/QA your changes

Create a logs config that tails files with a wildcard: `/tmp/qa/*.log`

Write a script to generate 201 files on windows and Mac OS:
- verify the agent opens 200 files. 

On linux write a script that generates 501 files
- verify the agent opens 500

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
