### PR TITLE
config: Adds warning when configuration contains unexpected unicode characters

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1235,7 +1235,7 @@ func findUnknownKeys(config Config) []string {
 func findUnexpectedUnicode(config Config) []string {
 	messages := make([]string, 0)
 	checkAndRecordString := func(str string) {
-		if res := FreeFromUnexpectedUnicode([]byte(str)); len(res) != 0 {
+		if res := FindUnexpectedUnicode([]byte(str)); len(res) != 0 {
 			for _, detected := range res {
 				msg := fmt.Sprintf("In configuration string '%s' - Unexpected unicode codepoint '%U' detected at byte position %v. Reason=%v", str, detected.codepoint, detected.position, detected.reason)
 				messages = append(messages, msg)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1235,7 +1235,7 @@ func findUnknownKeys(config Config) []string {
 func findUnexpectedUnicode(config Config) []string {
 	messages := make([]string, 0)
 	checkAndRecordString := func(str string) {
-		if res := FindUnexpectedUnicode([]byte(str)); len(res) != 0 {
+		if res := FindUnexpectedUnicode(str); len(res) != 0 {
 			for _, detected := range res {
 				msg := fmt.Sprintf("In configuration string '%s' - Unexpected unicode codepoint '%U' detected at byte position %v. Reason=%v", str, detected.codepoint, detected.position, detected.reason)
 				messages = append(messages, msg)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1234,10 +1234,10 @@ func findUnknownKeys(config Config) []string {
 
 func findUnexpectedUnicode(config Config) []string {
 	messages := make([]string, 0)
-	checkAndRecordString := func(str string) {
+	checkAndRecordString := func(str string, prefix string) {
 		if res := FindUnexpectedUnicode(str); len(res) != 0 {
 			for _, detected := range res {
-				msg := fmt.Sprintf("In configuration string '%s' - Unexpected unicode codepoint '%U' detected at byte position %v. Reason=%v", str, detected.codepoint, detected.position, detected.reason)
+				msg := fmt.Sprintf("%s - Unexpected unicode %s codepoint '%U' detected at byte position %v", prefix, detected.reason, detected.codepoint, detected.position)
 				messages = append(messages, msg)
 			}
 		}
@@ -1245,9 +1245,9 @@ func findUnexpectedUnicode(config Config) []string {
 
 	allKeys := config.AllKeys()
 	for _, key := range allKeys {
-		checkAndRecordString(key)
+		checkAndRecordString(key, fmt.Sprintf("Configuration key string '%s'", key))
 		value := config.GetString(key)
-		checkAndRecordString(value)
+		checkAndRecordString(value, fmt.Sprintf("For key '%s', configuration value string '%s'", key, value))
 	}
 
 	return messages

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -119,15 +119,24 @@ api_key: fakeapikey
 }
 
 func TestUnexpectedUnicode(t *testing.T) {
-	yaml := "api_\u202akey: fa\u202akeapikey\n"
+	keyYaml := "api_\u202akey: fakeapikey\n"
+	valueYaml := "api_key: fa\u202akeapikey\n"
 
-	testConfig := setupConfFromYAML(yaml)
+	testConfig := setupConfFromYAML(keyYaml)
 
 	warnings := findUnexpectedUnicode(testConfig)
-	require.Len(t, warnings, 2)
+	require.Len(t, warnings, 1)
 
+	assert.Contains(t, warnings[0], "Configuration key string")
 	assert.Contains(t, warnings[0], "U+202A")
-	assert.Contains(t, warnings[1], "U+202A")
+
+	testConfig = setupConfFromYAML(valueYaml)
+
+	warnings = findUnexpectedUnicode(testConfig)
+
+	require.Len(t, warnings, 1)
+	assert.Contains(t, warnings[0], "For key 'api_key'")
+	assert.Contains(t, warnings[0], "U+202A")
 }
 
 func TestUnexpectedNestedUnicode(t *testing.T) {
@@ -138,6 +147,7 @@ func TestUnexpectedNestedUnicode(t *testing.T) {
 	require.Len(t, warnings, 1)
 
 	assert.Contains(t, warnings[0], "U+202A")
+	assert.Contains(t, warnings[0], "For key 'runtime_security_config.activity_dump.remote_storage.endpoints.logs_dd_url'")
 }
 
 func TestUnexpectedWhitespace(t *testing.T) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -119,11 +119,9 @@ api_key: fakeapikey
 }
 
 func TestUnexpectedUnicode(t *testing.T) {
-	datadogYaml := `
-api_‪key: fa‪keapikey
-`
+	yaml := "api_\u202akey: fa\u202akeapikey\n"
 
-	testConfig := setupConfFromYAML(datadogYaml)
+	testConfig := setupConfFromYAML(yaml)
 
 	warnings := findUnexpectedUnicode(testConfig)
 	require.Len(t, warnings, 2)
@@ -133,14 +131,8 @@ api_‪key: fa‪keapikey
 }
 
 func TestUnexpectedNestedUnicode(t *testing.T) {
-	simpleNesting := `
-runtime_security_config:
-  activity_dump:
-    remote_storage:
-      endpoints:
-        logs_dd_url: "http://‪datadawg.com"
-`
-	testConfig := setupConfFromYAML(simpleNesting)
+	yaml := "runtime_security_config:\n  activity_dump:\n    remote_storage:\n      endpoints:\n        logs_dd_url: \"http://\u202adatadawg.com\""
+	testConfig := setupConfFromYAML(yaml)
 
 	warnings := findUnexpectedUnicode(testConfig)
 	require.Len(t, warnings, 1)
@@ -149,23 +141,16 @@ runtime_security_config:
 }
 
 func TestUnexpectedWhitespace(t *testing.T) {
-
 	tests := []struct {
 		yaml                string
 		expectedWarningText string
 	}{
 		{
-			yaml: `
-root_element:
-  nestedKey: "hiddenI​nvalidWhitespaceEmbedded"
-`,
+			yaml:                "root_element:\n  nestedKey: \"hiddenI\u200bnvalidWhitespaceEmbedded\n\"",
 			expectedWarningText: "U+200B",
 		},
 		{
-			yaml: `
-root_element:
-  nestedKey:  hiddenInvalidWhitespaceToLeft
-`,
+			yaml:                "root_element:\n  nestedKey: \u202fhiddenInvalidWhitespaceToLeft\n",
 			expectedWarningText: "U+202F",
 		},
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -144,14 +144,17 @@ func TestUnexpectedWhitespace(t *testing.T) {
 	tests := []struct {
 		yaml                string
 		expectedWarningText string
+		expectedPosition    string
 	}{
 		{
 			yaml:                "root_element:\n  nestedKey: \"hiddenI\u200bnvalidWhitespaceEmbedded\n\"",
 			expectedWarningText: "U+200B",
+			expectedPosition:    fmt.Sprintf("position %d", 7),
 		},
 		{
 			yaml:                "root_element:\n  nestedKey: \u202fhiddenInvalidWhitespaceToLeft\n",
 			expectedWarningText: "U+202F",
+			expectedPosition:    fmt.Sprintf("position %d", 0),
 		},
 	}
 	for _, tc := range tests {
@@ -159,7 +162,8 @@ func TestUnexpectedWhitespace(t *testing.T) {
 		warnings := findUnexpectedUnicode(testConfig)
 		require.Len(t, warnings, 1)
 
-		assert.Contains(t, warnings[0], tc.expectedWarningText)
+		assert.Contains(t, warnings[0], tc.expectedPosition)
+		assert.Contains(t, warnings[0], tc.expectedPosition)
 	}
 }
 

--- a/pkg/config/unexpectedunicodefinder.go
+++ b/pkg/config/unexpectedunicodefinder.go
@@ -5,12 +5,16 @@ import (
 	"unicode/utf8"
 )
 
+// UnexpectedUnicodeCodepoint contains specifics about an occurrence of an unexpected unicode codepoint
 type UnexpectedUnicodeCodepoint struct {
 	codepoint rune
 	reason    string
 	position  int
 }
 
+// FreeFromUnexpectedUnicode checks whether or not a given byte slice contains any
+// unicode codepoints that are 'unexpected'.
+// Unexpected here generally means invisible whitespace and control chars
 func FreeFromUnexpectedUnicode(input []byte) []UnexpectedUnicodeCodepoint {
 	totalSize := len(input)
 	currentIndex := 0

--- a/pkg/config/unexpectedunicodefinder.go
+++ b/pkg/config/unexpectedunicodefinder.go
@@ -25,16 +25,16 @@ func FindUnexpectedUnicode(input string) []UnexpectedUnicodeCodepoint {
 		reason := ""
 		switch {
 		case r == utf8.RuneError:
-			reason = "RuneError, invalid unicode"
+			reason = "RuneError"
 		case r == ' ' || r == '\r' || r == '\n' || r == '\t':
 			// These are allowed whitespace
 			reason = ""
 		case unicode.IsSpace(r):
-			reason = "Unsupported whitespace codepoint"
+			reason = "unsupported whitespace"
 		case unicode.Is(unicode.Bidi_Control, r):
-			reason = "Bidirectional control codepoint"
+			reason = "Bidirectional control"
 		case unicode.Is(unicode.C, r):
-			reason = "Control/surrogate codepoint"
+			reason = "Control/surrogate"
 		}
 
 		if reason != "" {

--- a/pkg/config/unexpectedunicodefinder.go
+++ b/pkg/config/unexpectedunicodefinder.go
@@ -15,12 +15,13 @@ type UnexpectedUnicodeCodepoint struct {
 // FreeFromUnexpectedUnicode checks whether or not a given byte slice contains any
 // unicode codepoints that are 'unexpected'.
 // Unexpected here generally means invisible whitespace and control chars
-func FindUnexpectedUnicode(input []byte) []UnexpectedUnicodeCodepoint {
-	totalSize := len(input)
+func FindUnexpectedUnicode(input string) []UnexpectedUnicodeCodepoint {
 	currentIndex := 0
+	str := input
 	results := make([]UnexpectedUnicodeCodepoint, 0)
-	for currentIndex < totalSize {
-		r, size := utf8.DecodeRune(input[currentIndex:])
+
+	for len(str) > 0 {
+		r, size := utf8.DecodeRuneInString(str)
 		reason := ""
 		switch {
 		case r == utf8.RuneError:
@@ -45,6 +46,7 @@ func FindUnexpectedUnicode(input []byte) []UnexpectedUnicodeCodepoint {
 		}
 
 		currentIndex += size
+		str = str[size:]
 	}
 	return results
 }

--- a/pkg/config/unexpectedunicodefinder.go
+++ b/pkg/config/unexpectedunicodefinder.go
@@ -1,0 +1,46 @@
+package config
+
+import (
+	"unicode"
+	"unicode/utf8"
+)
+
+type UnexpectedUnicodeCodepoint struct {
+	codepoint rune
+	reason    string
+	position  int
+}
+
+func FreeFromUnexpectedUnicode(input []byte) []UnexpectedUnicodeCodepoint {
+	totalSize := len(input)
+	currentIndex := 0
+	results := make([]UnexpectedUnicodeCodepoint, 0)
+	for currentIndex < totalSize {
+		r, size := utf8.DecodeRune(input[currentIndex:])
+		reason := ""
+		switch {
+		case r == utf8.RuneError:
+			reason = "RuneError, invalid unicode"
+		case r == ' ' || r == '\r' || r == '\n' || r == '\t':
+			// These are allowed whitespace
+			reason = ""
+		case unicode.IsSpace(r):
+			reason = "Unsupported whitespace codepoint"
+		case unicode.Is(unicode.Bidi_Control, r):
+			reason = "Bidirectional control codepoint"
+		case unicode.Is(unicode.C, r):
+			reason = "Control/surrogate codepoint"
+		}
+
+		if reason != "" {
+			results = append(results, UnexpectedUnicodeCodepoint{
+				codepoint: r,
+				reason:    reason,
+				position:  currentIndex,
+			})
+		}
+
+		currentIndex += size
+	}
+	return results
+}

--- a/pkg/config/unexpectedunicodefinder.go
+++ b/pkg/config/unexpectedunicodefinder.go
@@ -15,7 +15,7 @@ type UnexpectedUnicodeCodepoint struct {
 // FreeFromUnexpectedUnicode checks whether or not a given byte slice contains any
 // unicode codepoints that are 'unexpected'.
 // Unexpected here generally means invisible whitespace and control chars
-func FreeFromUnexpectedUnicode(input []byte) []UnexpectedUnicodeCodepoint {
+func FindUnexpectedUnicode(input []byte) []UnexpectedUnicodeCodepoint {
 	totalSize := len(input)
 	currentIndex := 0
 	results := make([]UnexpectedUnicodeCodepoint, 0)

--- a/pkg/config/unexpectedunicodefinder.go
+++ b/pkg/config/unexpectedunicodefinder.go
@@ -12,8 +12,8 @@ type UnexpectedUnicodeCodepoint struct {
 	position  int
 }
 
-// FreeFromUnexpectedUnicode checks whether or not a given byte slice contains any
-// unicode codepoints that are 'unexpected'.
+// FindUnexpectedUnicode reports any _unexpected_ unicode codepoints
+// found in the given 'input' string
 // Unexpected here generally means invisible whitespace and control chars
 func FindUnexpectedUnicode(input string) []UnexpectedUnicodeCodepoint {
 	currentIndex := 0

--- a/pkg/config/unexpectedunicodefinder_test.go
+++ b/pkg/config/unexpectedunicodefinder_test.go
@@ -5,7 +5,7 @@ import "testing"
 func TestCleanStrings(t *testing.T) {
 	cleanString := "container_collect_some"
 
-	res := FindUnexpectedUnicode([]byte(cleanString))
+	res := FindUnexpectedUnicode(cleanString)
 	if len(res) != 0 {
 		t.Errorf("Expected no unexpected codepoints, but found some: %v", res)
 	}
@@ -14,7 +14,7 @@ func TestCleanStrings(t *testing.T) {
 func TestDirtyStrings(t *testing.T) {
 	dirtyString := "\u202acontainer_collect_some"
 
-	res := FindUnexpectedUnicode([]byte(dirtyString))
+	res := FindUnexpectedUnicode(dirtyString)
 	if len(res) != 1 {
 		t.Errorf("Expected 1 unexpected codepoint, but found: %v", len(res))
 		return
@@ -29,31 +29,31 @@ func TestDirtyStrings(t *testing.T) {
 
 func TestVariousCodepoints(t *testing.T) {
 	tests := []struct {
-		input              []byte
+		input              string
 		expectedCodepoints []rune
 	}{
 		{
-			input:              []byte("hello world"),
+			input:              "hello world",
 			expectedCodepoints: nil,
 		},
 		{
-			input:              []byte("hello \u202aworld"),
+			input:              "hello \u202aworld",
 			expectedCodepoints: []rune{'\u202a'},
 		},
 		{
-			input:              []byte("hello \nworld"),
+			input:              "hello \nworld",
 			expectedCodepoints: nil,
 		},
 		{
-			input:              []byte("hello·world😿"),
+			input:              "hello\u00b7world\U0001f63f",
 			expectedCodepoints: nil,
 		},
 		{
-			input:              []byte("test\u200bing"),
+			input:              "test\u200bing",
 			expectedCodepoints: []rune{'\u200b'},
 		},
 		{
-			input:              []byte("test\u202fte\u200asti\u2000ng"),
+			input:              "test\u202fte\u200asti\u2000ng",
 			expectedCodepoints: []rune{'\u202f', '\u200a', '\u2000'},
 		},
 	}

--- a/pkg/config/unexpectedunicodefinder_test.go
+++ b/pkg/config/unexpectedunicodefinder_test.go
@@ -12,7 +12,7 @@ func TestCleanStrings(t *testing.T) {
 }
 
 func TestDirtyStrings(t *testing.T) {
-	dirtyString := "‪container_collect_some"
+	dirtyString := "\u202acontainer_collect_some"
 
 	res := FindUnexpectedUnicode([]byte(dirtyString))
 	if len(res) != 1 {
@@ -22,7 +22,7 @@ func TestDirtyStrings(t *testing.T) {
 
 	unexpected := res[0]
 
-	if unexpected.codepoint != '‪' {
+	if unexpected.codepoint != '\u202a' {
 		t.Errorf("Did not detect bidirectional control character")
 	}
 }
@@ -37,8 +37,8 @@ func TestVariousCodepoints(t *testing.T) {
 			expectedCodepoints: nil,
 		},
 		{
-			input:              []byte("hello ‪world"),
-			expectedCodepoints: []rune{'‪'},
+			input:              []byte("hello \u202aworld"),
+			expectedCodepoints: []rune{'\u202a'},
 		},
 		{
 			input:              []byte("hello \nworld"),
@@ -49,12 +49,12 @@ func TestVariousCodepoints(t *testing.T) {
 			expectedCodepoints: nil,
 		},
 		{
-			input:              []byte("test​ing"),
-			expectedCodepoints: []rune{'​'},
+			input:              []byte("test\u200bing"),
+			expectedCodepoints: []rune{'\u200b'},
 		},
 		{
-			input:              []byte("test te sti ng"),
-			expectedCodepoints: []rune{' ', ' ', ' '},
+			input:              []byte("test\u202fte\u200asti\u2000ng"),
+			expectedCodepoints: []rune{'\u202f', '\u200a', '\u2000'},
 		},
 	}
 	for _, tc := range tests {

--- a/pkg/config/unexpectedunicodefinder_test.go
+++ b/pkg/config/unexpectedunicodefinder_test.go
@@ -5,7 +5,7 @@ import "testing"
 func TestCleanStrings(t *testing.T) {
 	cleanString := "container_collect_some"
 
-	res := FreeFromUnexpectedUnicode([]byte(cleanString))
+	res := FindUnexpectedUnicode([]byte(cleanString))
 	if len(res) != 0 {
 		t.Errorf("Expected no unexpected codepoints, but found some: %v", res)
 	}
@@ -14,7 +14,7 @@ func TestCleanStrings(t *testing.T) {
 func TestDirtyStrings(t *testing.T) {
 	dirtyString := "‪container_collect_some"
 
-	res := FreeFromUnexpectedUnicode([]byte(dirtyString))
+	res := FindUnexpectedUnicode([]byte(dirtyString))
 	if len(res) != 1 {
 		t.Errorf("Expected 1 unexpected codepoint, but found: %v", len(res))
 		return
@@ -58,7 +58,7 @@ func TestVariousCodepoints(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		res := FreeFromUnexpectedUnicode(tc.input)
+		res := FindUnexpectedUnicode(tc.input)
 		if len(res) != len(tc.expectedCodepoints) {
 			t.Errorf("Expected %v unexpected codepoints but found %v: %v\n", len(tc.expectedCodepoints), len(res), res)
 			continue

--- a/pkg/config/unexpectedunicodefinder_test.go
+++ b/pkg/config/unexpectedunicodefinder_test.go
@@ -1,0 +1,72 @@
+package config
+
+import "testing"
+
+func TestCleanStrings(t *testing.T) {
+	cleanString := "container_collect_some"
+
+	res := FreeFromUnexpectedUnicode([]byte(cleanString))
+	if len(res) != 0 {
+		t.Errorf("Expected no unexpected codepoints, but found some: %v", res)
+	}
+}
+
+func TestDirtyStrings(t *testing.T) {
+	dirtyString := "‪container_collect_some"
+
+	res := FreeFromUnexpectedUnicode([]byte(dirtyString))
+	if len(res) != 1 {
+		t.Errorf("Expected 1 unexpected codepoint, but found: %v", len(res))
+		return
+	}
+
+	unexpected := res[0]
+
+	if unexpected.codepoint != '‪' {
+		t.Errorf("Did not detect bidirectional control character")
+	}
+}
+
+func TestVariousCodepoints(t *testing.T) {
+	tests := []struct {
+		input              []byte
+		expectedCodepoints []rune
+	}{
+		{
+			input:              []byte("hello world"),
+			expectedCodepoints: nil,
+		},
+		{
+			input:              []byte("hello ‪world"),
+			expectedCodepoints: []rune{'‪'},
+		},
+		{
+			input:              []byte("hello \nworld"),
+			expectedCodepoints: nil,
+		},
+		{
+			input:              []byte("hello·world😿"),
+			expectedCodepoints: nil,
+		},
+		{
+			input:              []byte("test​ing"),
+			expectedCodepoints: []rune{'​'},
+		},
+		{
+			input:              []byte("test te sti ng"),
+			expectedCodepoints: []rune{' ', ' ', ' '},
+		},
+	}
+	for _, tc := range tests {
+		res := FreeFromUnexpectedUnicode(tc.input)
+		if len(res) != len(tc.expectedCodepoints) {
+			t.Errorf("Expected %v unexpected codepoints but found %v: %v\n", len(tc.expectedCodepoints), len(res), res)
+			continue
+		}
+		for i, expectedCodepoint := range tc.expectedCodepoints {
+			if expectedCodepoint != res[i].codepoint {
+				t.Errorf("Expected to find codepoint '%U' but instead found %v", expectedCodepoint, res[i].codepoint)
+			}
+		}
+	}
+}


### PR DESCRIPTION
### What does this PR do?
Adds a warning message printed out when the configuration is loaded if there are any "unexpected" unicode codepoints present.
The intention is to catch any invisible/control characters that may be present which would cause issues later in the agent runtime.

An example warning string would be:
When found in a key:
`Configuration key string 'api_‪key' - Unexpected unicode Bidirectional control codepoint 'U+202A' detected at byte position 4`
When found in a value:
`For key 'api_key', configuration value string 'fa‪keapikey' - Unexpected unicode Bidirectional control codepoint 'U+202A' detected at byte position 2`


### Motivation
Customers have encountered this before. Usually these would occur from a copy-paste. See [oldnewthing](https://devblogs.microsoft.com/oldnewthing/20150506-00/?p=44924) for a specific example


### Additional Notes
Prior art for similar unicode checks
- [gittea](https://github.com/go-gitea/gitea/pull/17562/files)
- [rust lint](https://github.com/rust-lang/rust/blob/3bebee73397b692e84b9cc1b6af439fae78918c9/src/tools/clippy/clippy_lints/src/unicode.rs)

### Possible Drawbacks / Trade-offs
If the set of unicode checks is too lax, then we'll continue to see customers affected by this type of bug.
If the set of unicode checks is too strict, then we'll see false-positive `WARN` logs in the agent output.

### Describe how to test/QA your changes
- Generate a configuration that contains an invalid codepoint.
    - Use `printf "api_key: abc\u202Adef"` and redirect to a file or copy/paste the result
- Run an agent with this configuration (either via config file or env var)
- Ensure you see a `WARN` message containing `Unexpected unicode` similar to above examples

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
