### PR TITLE
Agent (system probe) changes corresponding to driver updates for HTTP.

### DIFF
--- a/pkg/network/driver/types.go
+++ b/pkg/network/driver/types.go
@@ -25,12 +25,12 @@ const (
 	GetStatsIOCTL             = C.DDNPMDRIVER_IOCTL_GETSTATS
 	SetFlowFilterIOCTL        = C.DDNPMDRIVER_IOCTL_SET_FLOW_FILTER
 	SetDataFilterIOCTL        = C.DDNPMDRIVER_IOCTL_SET_DATA_FILTER
-	GetFlowsIOCTL			  = C.DDNPMDRIVER_IOCTL_GET_FLOWS
+	GetFlowsIOCTL             = C.DDNPMDRIVER_IOCTL_GET_FLOWS
 	SetMaxOpenFlowsIOCTL      = C.DDNPMDRIVER_IOCTL_SET_MAX_OPEN_FLOWS
 	SetMaxClosedFlowsIOCTL    = C.DDNPMDRIVER_IOCTL_SET_MAX_CLOSED_FLOWS
 	FlushPendingHttpTxnsIOCTL = C.DDNPMDRIVER_IOCTL_FLUSH_PENDING_HTTP_TRANSACTIONS
-	GetHttpTransactionsIOCTL  = C.DDNPMDRIVER_IOCTL_GET_HTTP_TRANSACTIONS
-	EnableHttpIOCTL           = C.DDNPMDRIVER_IOCTL_ENABLE_HTTP
+	//	GetHttpTransactionsIOCTL  = C.DDNPMDRIVER_IOCTL_GET_HTTP_TRANSACTIONS
+	EnableHttpIOCTL = C.DDNPMDRIVER_IOCTL_ENABLE_HTTP
 )
 
 type FilterAddress C.struct__filterAddress
@@ -78,6 +78,7 @@ const (
 )
 
 type HttpTransactionType C.struct__HttpTransactionType
+type HttpConfigurationSettings C.struct__HttpConfigurationSettings
 type ConnTupleType C.struct__ConnTupleType
 type HttpMethodType C.enum__HttpMethodType
 
@@ -85,4 +86,5 @@ const (
 	HttpBatchSize           = C.HTTP_BATCH_SIZE
 	HttpBufferSize          = C.HTTP_BUFFER_SIZE
 	HttpTransactionTypeSize = C.sizeof_struct__HttpTransactionType
+	HttpSettingsTypeSize    = C.sizeof_struct__HttpConfigurationSettings
 )

--- a/pkg/network/driver/types_windows.go
+++ b/pkg/network/driver/types_windows.go
@@ -13,8 +13,8 @@ const (
 	SetMaxOpenFlowsIOCTL      = 0x122024
 	SetMaxClosedFlowsIOCTL    = 0x122028
 	FlushPendingHttpTxnsIOCTL = 0x122020
-	GetHttpTransactionsIOCTL  = 0x122030
-	EnableHttpIOCTL           = 0x122034
+
+	EnableHttpIOCTL = 0x122034
 )
 
 type FilterAddress struct {
@@ -166,8 +166,15 @@ type HttpTransactionType struct {
 	Tup                ConnTupleType
 	RequestMethod      uint32
 	ResponseStatusCode uint16
-	RequestFragment    [25]uint8
-	Pad_cgo_0          [1]byte
+	MaxRequestFragment uint16
+	SzRequestFragment  uint16
+	Pad                [6]uint8
+	RequestFragment    *uint8
+}
+type HttpConfigurationSettings struct {
+	MaxTransactions        uint64
+	NotificationThreshhold uint64
+	MaxRequestFragment     uint16
 }
 type ConnTupleType struct {
 	CliAddr [16]uint8
@@ -175,11 +182,13 @@ type ConnTupleType struct {
 	CliPort uint16
 	SrvPort uint16
 	Family  uint16
+	Pad     uint16
 }
 type HttpMethodType uint32
 
 const (
 	HttpBatchSize           = 0xf
 	HttpBufferSize          = 0x19
-	HttpTransactionTypeSize = 0x58
+	HttpTransactionTypeSize = 0x50
+	HttpSettingsTypeSize    = 0x12
 )

--- a/pkg/network/driver_interface.go
+++ b/pkg/network/driver_interface.go
@@ -107,7 +107,7 @@ func (di *DriverInterface) Close() error {
 // setupFlowHandle generates a windows Driver Handle, and creates a DriverHandle struct to pull flows from the driver
 // by setting the necessary filters
 func (di *DriverInterface) setupFlowHandle() error {
-	dh, err := driver.NewHandle(windows.FILE_FLAG_OVERLAPPED, driver.FlowHandle)
+	dh, err := driver.NewHandle(0, driver.FlowHandle)
 	if err != nil {
 		return err
 	}
@@ -185,17 +185,18 @@ func (di *DriverInterface) GetConnectionStats(activeBuf *ConnectionBuffer, close
 
 	var bytesRead uint32
 	var totalBytesRead uint32
-	sig := driver.Signature
+	//sig := driver.Signature
 	// keep reading while driver says there is more data available
 	for err := error(windows.ERROR_MORE_DATA); err == windows.ERROR_MORE_DATA; {
-		//err = windows.ReadFile(di.driverFlowHandle.Handle, di.readBuffer, &bytesRead, nil)
-		err = windows.DeviceIoControl(di.driverFlowHandle.Handle,
-			driver.GetFlowsIOCTL,
-			(*byte)(unsafe.Pointer(&sig)), uint32(unsafe.Sizeof(sig)),
-			&di.readBuffer[0], uint32(len(di.readBuffer)),
-			&bytesRead,
-			nil)
-
+		err = windows.ReadFile(di.driverFlowHandle.Handle, di.readBuffer, &bytesRead, nil)
+		/*
+			err = windows.DeviceIoControl(di.driverFlowHandle.Handle,
+				driver.GetFlowsIOCTL,
+				(*byte)(unsafe.Pointer(&sig)), uint32(unsafe.Sizeof(sig)),
+				&di.readBuffer[0], uint32(len(di.readBuffer)),
+				&bytesRead,
+				nil)
+		*/
 		if err != nil {
 			if err == windows.ERROR_NO_MORE_ITEMS {
 				break

--- a/pkg/network/http/model_windows.go
+++ b/pkg/network/http/model_windows.go
@@ -22,7 +22,7 @@ import (
 const HTTPBufferSize = driver.HttpBufferSize
 const HTTPBatchSize = driver.HttpBatchSize
 
-type httpTX driver.HttpTransactionType
+type httpTX FullHttpTransaction
 
 // errLostBatch isn't a valid error in windows
 var errLostBatch = errors.New("invalid error")
@@ -35,62 +35,62 @@ func (tx *httpTX) ReqFragment() []byte {
 // StatusClass returns an integer representing the status code class
 // Example: a 404 would return 400
 func (tx *httpTX) StatusClass() int {
-	return (int(tx.ResponseStatusCode) / 100) * 100
+	return (int(tx.Txn.ResponseStatusCode) / 100) * 100
 }
 
 // RequestLatency returns the latency of the request in nanoseconds
 func (tx *httpTX) RequestLatency() float64 {
-	return nsTimestampToFloat(uint64(tx.ResponseLastSeen - tx.RequestStarted))
+	return nsTimestampToFloat(uint64(tx.Txn.ResponseLastSeen - tx.Txn.RequestStarted))
 }
 
 func (tx *httpTX) isIPV4() bool {
-	return tx.Tup.Family == windows.AF_INET
+	return tx.Txn.Tup.Family == windows.AF_INET
 }
 
 func (tx *httpTX) SrcIPLow() uint64 {
 	// Source & dest IP are given to us as a 16-byte slices in network byte order (BE). To convert to
 	// low/high representation, we must convert to host byte order (LE).
 	if tx.isIPV4() {
-		return uint64(binary.LittleEndian.Uint32(tx.Tup.CliAddr[:4]))
+		return uint64(binary.LittleEndian.Uint32(tx.Txn.Tup.CliAddr[:4]))
 	}
-	return binary.LittleEndian.Uint64(tx.Tup.CliAddr[8:])
+	return binary.LittleEndian.Uint64(tx.Txn.Tup.CliAddr[8:])
 }
 
 func (tx *httpTX) SrcIPHigh() uint64 {
 	if tx.isIPV4() {
 		return uint64(0)
 	}
-	return binary.LittleEndian.Uint64(tx.Tup.CliAddr[:8])
+	return binary.LittleEndian.Uint64(tx.Txn.Tup.CliAddr[:8])
 }
 
 func (tx *httpTX) SrcPort() uint16 {
-	return tx.Tup.CliPort
+	return tx.Txn.Tup.CliPort
 }
 
 func (tx *httpTX) DstIPLow() uint64 {
 	if tx.isIPV4() {
-		return uint64(binary.LittleEndian.Uint32(tx.Tup.SrvAddr[:4]))
+		return uint64(binary.LittleEndian.Uint32(tx.Txn.Tup.SrvAddr[:4]))
 	}
-	return binary.LittleEndian.Uint64(tx.Tup.SrvAddr[8:])
+	return binary.LittleEndian.Uint64(tx.Txn.Tup.SrvAddr[8:])
 }
 
 func (tx *httpTX) DstIPHigh() uint64 {
 	if tx.isIPV4() {
 		return uint64(0)
 	}
-	return binary.LittleEndian.Uint64(tx.Tup.SrvAddr[:8])
+	return binary.LittleEndian.Uint64(tx.Txn.Tup.SrvAddr[:8])
 }
 
 func (tx *httpTX) DstPort() uint16 {
-	return tx.Tup.SrvPort
+	return tx.Txn.Tup.SrvPort
 }
 
 func (tx *httpTX) Method() Method {
-	return Method(tx.RequestMethod)
+	return Method(tx.Txn.RequestMethod)
 }
 
 func (tx *httpTX) StatusCode() uint16 {
-	return tx.ResponseStatusCode
+	return tx.Txn.ResponseStatusCode
 }
 
 // Tags are not part of windows http transactions
@@ -126,20 +126,20 @@ func generateIPv4HTTPTransaction(client util.Address, server util.Address, cliPo
 	cli := client.Bytes()
 	srv := server.Bytes()
 
-	tx.RequestStarted = 1
-	tx.ResponseLastSeen = tx.RequestStarted + latencyNS
-	tx.ResponseStatusCode = uint16(code)
+	tx.Txn.RequestStarted = 1
+	tx.Txn.ResponseLastSeen = tx.Txn.RequestStarted + latencyNS
+	tx.Txn.ResponseStatusCode = uint16(code)
 	for i := 0; i < len(tx.RequestFragment) && i < len(reqFragment); i++ {
 		tx.RequestFragment[i] = uint8(reqFragment[i])
 	}
-	for i := 0; i < len(tx.Tup.CliAddr) && i < len(cli); i++ {
-		tx.Tup.CliAddr[i] = cli[i]
+	for i := 0; i < len(tx.Txn.Tup.CliAddr) && i < len(cli); i++ {
+		tx.Txn.Tup.CliAddr[i] = cli[i]
 	}
-	for i := 0; i < len(tx.Tup.SrvAddr) && i < len(srv); i++ {
-		tx.Tup.SrvAddr[i] = srv[i]
+	for i := 0; i < len(tx.Txn.Tup.SrvAddr) && i < len(srv); i++ {
+		tx.Txn.Tup.SrvAddr[i] = srv[i]
 	}
-	tx.Tup.CliPort = uint16(cliPort)
-	tx.Tup.SrvPort = uint16(srvPort)
+	tx.Txn.Tup.CliPort = uint16(cliPort)
+	tx.Txn.Tup.SrvPort = uint16(srvPort)
 
 	return tx
 }


### PR DESCRIPTION
Remove all of the overlapped processing for HTTP transactions.
Configure at probe startup max number of outstanding transactions,
number of transactions the driver should buffer before notifying the
probe, and the HTTP buffer length.

Have a single read loop (implemented with Ioctl()) for reading
transactions from the driver.
