### PR TITLE
[Internal Profiling] Fix internal_profiling.period not used

### DIFF
--- a/pkg/config/settings/runtime_setting_profiling.go
+++ b/pkg/config/settings/runtime_setting_profiling.go
@@ -81,7 +81,7 @@ func (l ProfilingRuntimeSetting) Set(v interface{}) error {
 			ProfilingURL:         site,
 			Env:                  config.Datadog.GetString("env"),
 			Service:              service,
-			Period:               profiling.DefaultProfilingPeriod,
+			Period:               config.Datadog.GetDuration("internal_profiling.period"),
 			MutexProfileFraction: profiling.GetMutexProfileFraction(),
 			BlockProfileRate:     profiling.GetBlockProfileRate(),
 			WithGoroutineProfile: config.Datadog.GetBool("internal_profiling.enable_goroutine_stacktraces"),

--- a/pkg/util/profiling/profiling.go
+++ b/pkg/util/profiling/profiling.go
@@ -7,7 +7,6 @@ package profiling
 
 import (
 	"sync"
-	"time"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/profiler"
 
@@ -24,8 +23,6 @@ const (
 	ProfilingURLTemplate = "https://intake.profile.%s/v1/input"
 	// ProfilingLocalURLTemplate is the constant used to compute the URL of the local trace agent
 	ProfilingLocalURLTemplate = "http://%v/profiling/v1/input"
-	// DefaultProfilingPeriod defines the default profiling period
-	DefaultProfilingPeriod = 5 * time.Minute
 )
 
 // Start initiates profiling with the supplied parameters;

--- a/releasenotes/notes/fix-internal-prof-period-conf-af1ef5b6886cd783.yaml
+++ b/releasenotes/notes/fix-internal-prof-period-conf-af1ef5b6886cd783.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    The ``internal_profiling.period`` parameter is now taken into account by the agent.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fixed a bug causing the impossibility of configuring the internal profiling period in the core agent 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Bug fix

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

Looks like the regression was introduced in https://github.com/DataDog/datadog-agent/pull/8025 where `internal_profiling.period` was read by the process and security agents but not by the core agent

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

- Custom: run the agent with these env variables `DD_INTERNAL_PROFILING_ENABLED=true` and `DD_INTERNAL_PROFILING_PERIOD=1m0s` make sure it logs `"profile_period":"1m0s"` when it starts.
- Default: run the agent with this env variable `DD_INTERNAL_PROFILING_ENABLED=true` make sure it logs `"profile_period":"5m0s"` when it starts.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
