### PR TITLE
AML-4: Fixing enqueuing of messages when DogStatsD capture has stopped

### DIFF
--- a/pkg/dogstatsd/listeners/uds_common.go
+++ b/pkg/dogstatsd/listeners/uds_common.go
@@ -110,7 +110,7 @@ func NewUDSListener(packetOut chan packets.Packets, sharedPacketPoolManager *pac
 	}
 
 	if listener.trafficCapture != nil {
-		err = listener.trafficCapture.Writer.RegisterSharedPoolManager(listener.sharedPacketPoolManager)
+		err = listener.trafficCapture.RegisterSharedPoolManager(listener.sharedPacketPoolManager)
 		if err != nil {
 			return nil, err
 		}
@@ -128,7 +128,7 @@ func NewUDSListener(packetOut chan packets.Packets, sharedPacketPoolManager *pac
 
 		listener.oobPoolManager = packets.NewPoolManager(pool)
 		if listener.trafficCapture != nil {
-			err = listener.trafficCapture.Writer.RegisterOOBPoolManager(listener.oobPoolManager)
+			err = listener.trafficCapture.RegisterOOBPoolManager(listener.oobPoolManager)
 			if err != nil {
 				return nil, err
 			}
@@ -245,7 +245,7 @@ func (l *UDSListener) Listen() {
 		}
 
 		if capBuff != nil {
-			l.trafficCapture.Writer.Enqueue(capBuff)
+			l.trafficCapture.Enqueue(capBuff)
 		}
 
 		if err != nil {

--- a/pkg/dogstatsd/replay/capture.go
+++ b/pkg/dogstatsd/replay/capture.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/dogstatsd/packets"
 )
 
 const (
@@ -23,7 +24,7 @@ const (
 
 // TrafficCapture allows capturing traffic from our listeners and writing it to file
 type TrafficCapture struct {
-	Writer *TrafficCaptureWriter
+	writer *TrafficCaptureWriter
 
 	sync.RWMutex
 }
@@ -36,7 +37,7 @@ func NewTrafficCapture() (*TrafficCapture, error) {
 	}
 
 	tc := &TrafficCapture{
-		Writer: writer,
+		writer: writer,
 	}
 
 	return tc, nil
@@ -47,11 +48,11 @@ func (tc *TrafficCapture) IsOngoing() bool {
 	tc.RLock()
 	defer tc.RUnlock()
 
-	if tc.Writer == nil {
+	if tc.writer == nil {
 		return false
 	}
 
-	return tc.Writer.IsOngoing()
+	return tc.writer.IsOngoing()
 }
 
 // Start starts a TrafficCapture and returns an error in the event of an issue.
@@ -60,12 +61,12 @@ func (tc *TrafficCapture) Start(p string, d time.Duration, compressed bool) erro
 		return fmt.Errorf("Ongoing capture in progress")
 	}
 
-	_, err := tc.Writer.ValidateLocation(p)
+	_, err := ValidateLocation(p)
 	if err != nil {
 		return err
 	}
 
-	go tc.Writer.Capture(p, d, compressed)
+	go tc.writer.Capture(p, d, compressed)
 
 	return nil
 
@@ -76,7 +77,7 @@ func (tc *TrafficCapture) Stop() {
 	tc.Lock()
 	defer tc.Unlock()
 
-	tc.Writer.StopCapture()
+	tc.writer.StopCapture()
 }
 
 // Path returns the path to the underlying TrafficCapture file, and an error if any.
@@ -84,5 +85,26 @@ func (tc *TrafficCapture) Path() (string, error) {
 	tc.RLock()
 	defer tc.RUnlock()
 
-	return tc.Writer.Path()
+	return tc.writer.Path()
+}
+
+// RegisterSharedPoolManager registers the shared pool manager with the TrafficCapture.
+func (tc *TrafficCapture) RegisterSharedPoolManager(p *packets.PoolManager) error {
+	tc.Lock()
+	defer tc.Unlock()
+	return tc.writer.RegisterSharedPoolManager(p)
+}
+
+// RegisterOOBPoolManager registers the OOB shared pool manager with the TrafficCapture.
+func (tc *TrafficCapture) RegisterOOBPoolManager(p *packets.PoolManager) error {
+	tc.Lock()
+	defer tc.Unlock()
+	return tc.writer.RegisterOOBPoolManager(p)
+}
+
+// Enqueue enqueues a capture buffer so it's written to file.
+func (tc *TrafficCapture) Enqueue(msg *CaptureBuffer) bool {
+	tc.RLock()
+	defer tc.RUnlock()
+	return tc.writer.Enqueue(msg)
 }

--- a/pkg/dogstatsd/replay/writer.go
+++ b/pkg/dogstatsd/replay/writer.go
@@ -19,6 +19,7 @@ import (
 	// Refactor relevant bits
 	"github.com/DataDog/zstd"
 	"github.com/spf13/afero"
+	"go.uber.org/atomic"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/dogstatsd/packets"
@@ -65,13 +66,14 @@ var CapPool = sync.Pool{
 
 // TrafficCaptureWriter allows writing dogstatsd traffic to a file.
 type TrafficCaptureWriter struct {
-	File     afero.File
-	zWriter  *zstd.Writer
-	writer   *bufio.Writer
-	Traffic  chan *CaptureBuffer
-	Location string
-	shutdown chan struct{}
-	ongoing  bool
+	File      afero.File
+	zWriter   *zstd.Writer
+	writer    *bufio.Writer
+	Traffic   chan *CaptureBuffer
+	Location  string
+	shutdown  chan struct{}
+	ongoing   bool
+	accepting *atomic.Bool
 
 	sharedPacketPoolManager *packets.PoolManager
 	oobPacketPoolManager    *packets.PoolManager
@@ -87,6 +89,7 @@ func NewTrafficCaptureWriter(depth int) *TrafficCaptureWriter {
 	return &TrafficCaptureWriter{
 		Traffic:     make(chan *CaptureBuffer, depth),
 		taggerState: make(map[int32]string),
+		accepting:   atomic.NewBool(false),
 	}
 }
 
@@ -226,6 +229,7 @@ func (tc *TrafficCaptureWriter) Capture(l string, d time.Duration, compressed bo
 	tc.shutdown = shutdown
 
 	tc.ongoing = true
+	tc.accepting.Store(true)
 
 	err = tc.WriteHeader()
 	if err != nil {
@@ -262,6 +266,7 @@ process:
 			}
 		case <-shutdown:
 			log.Debug("Capture shutting down")
+			tc.accepting.Store(false)
 			break process
 		}
 	}
@@ -333,14 +338,13 @@ func (tc *TrafficCaptureWriter) StopCapture() {
 
 // Enqueue enqueues a capture buffer so it's written to file.
 func (tc *TrafficCaptureWriter) Enqueue(msg *CaptureBuffer) bool {
-	qd := false
 
-	if tc.IsOngoing() {
+	if tc.accepting.Load() {
 		tc.Traffic <- msg
-		qd = true
+		return true
 	}
 
-	return qd
+	return false
 }
 
 // RegisterSharedPoolManager registers the shared pool manager with the TrafficCaptureWriter.

--- a/pkg/dogstatsd/replay/writer.go
+++ b/pkg/dogstatsd/replay/writer.go
@@ -132,7 +132,7 @@ func (tc *TrafficCaptureWriter) ProcessMessage(msg *CaptureBuffer) error {
 
 // ValidateLocation validates the location passed as an argument is writable.
 // The location and/or and error if any are returned.
-func (tc *TrafficCaptureWriter) ValidateLocation(l string) (string, error) {
+func ValidateLocation(l string) (string, error) {
 	captureFs.RLock()
 	defer captureFs.RUnlock()
 
@@ -140,7 +140,7 @@ func (tc *TrafficCaptureWriter) ValidateLocation(l string) (string, error) {
 		return "", fmt.Errorf("no filesystem backend available, impossible to start capture")
 	}
 
-	defaultLocation := (l == "")
+	defaultLocation := l == ""
 
 	var location string
 	if defaultLocation {
@@ -193,7 +193,7 @@ func (tc *TrafficCaptureWriter) Capture(l string, d time.Duration, compressed bo
 		return
 	}
 
-	location, err = tc.ValidateLocation(l)
+	location, err = ValidateLocation(l)
 	if err != nil {
 		return
 	}

--- a/pkg/dogstatsd/replay/writer_test.go
+++ b/pkg/dogstatsd/replay/writer_test.go
@@ -7,7 +7,9 @@ package replay
 
 import (
 	"io"
+	"math/rand"
 	"path"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -15,6 +17,7 @@ import (
 	"github.com/DataDog/zstd"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/atomic"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/dogstatsd/packets"
@@ -48,51 +51,69 @@ func writerTest(t *testing.T, z bool) {
 
 	var wg sync.WaitGroup
 	const (
-		iterations    = 50
-		sleepInterval = 100 * time.Millisecond
+		iterations   = 100
+		testDuration = 5 * time.Second
 	)
-
+	sleepDuration := testDuration / iterations
+	// For test to fail consistently we need to run with more threads than available CPU
+	threads := runtime.NumCPU()
 	start := make(chan struct{})
+	enqueued := atomic.NewInt32(0)
+
+	for i := 0; i < threads; i++ {
+		wg.Add(1)
+		go func(wg *sync.WaitGroup, threadNo int) {
+			defer wg.Done()
+			r := rand.New(rand.NewSource(int64(9223372036854 / (threadNo + 1))))
+			<-start
+			// Add a little bit of controlled jitter so tests fail if enqueuing not correct
+			duration := time.Duration(r.Int63n(int64(sleepDuration)))
+			time.Sleep(duration)
+
+			for i := 0; i < iterations; i++ {
+				buff := CapPool.Get().(*CaptureBuffer)
+				pkt := manager.Get().(*packets.Packet)
+				pkt.Buffer = []byte("foo.bar|5|#some:tag")
+				pkt.Source = packets.UDS
+				pkt.Contents = pkt.Buffer
+
+				buff.Pb.Timestamp = time.Now().Unix()
+				buff.Buff = pkt
+				buff.Pb.Pid = 0
+				buff.Pb.AncillarySize = int32(0)
+				buff.Pb.PayloadSize = int32(len(pkt.Buffer))
+				buff.Pb.Payload = pkt.Buffer // or packet.Buffer[:n] ?
+
+				if writer.Enqueue(buff) {
+					enqueued.Inc()
+				}
+			}
+
+			writer.StopCapture()
+		}(&wg, i)
+	}
 
 	wg.Add(1)
 	go func(wg *sync.WaitGroup) {
 		defer wg.Done()
 
 		close(start)
-		writer.Capture("foo/bar", iterations*sleepInterval, z)
+		writer.Capture("foo/bar", testDuration, z)
 	}(&wg)
 
-	enqueued := 0
-	wg.Add(1)
+	wgc := make(chan struct{})
 	go func(wg *sync.WaitGroup) {
-		defer wg.Done()
-
-		<-start
-
-		for i := 0; i < iterations; i++ {
-			time.Sleep(sleepInterval)
-			buff := CapPool.Get().(*CaptureBuffer)
-			pkt := manager.Get().(*packets.Packet)
-			pkt.Buffer = []byte("foo.bar|5|#some:tag")
-			pkt.Source = packets.UDS
-			pkt.Contents = pkt.Buffer
-
-			buff.Pb.Timestamp = time.Now().Unix()
-			buff.Buff = pkt
-			buff.Pb.Pid = 0
-			buff.Pb.AncillarySize = int32(0)
-			buff.Pb.PayloadSize = int32(len(pkt.Buffer))
-			buff.Pb.Payload = pkt.Buffer // or packet.Buffer[:n] ?
-
-			if writer.Enqueue(buff) {
-				enqueued++
-			}
-		}
-
-		writer.StopCapture()
+		defer close(wgc)
+		wg.Wait()
 	}(&wg)
 
-	wg.Wait()
+	<-start
+	select {
+	case <-wgc:
+		break
+	case <-time.After(testDuration * 2):
+		assert.FailNow(t, "Timed out waiting for capture to finish", "Timeout was: %v", testDuration*2)
+	}
 
 	// assert file
 	writer.RLock()
@@ -137,11 +158,13 @@ func writerTest(t *testing.T, z bool) {
 	reader.offset = uint32(len(datadogHeader))
 	reader.Unlock()
 
-	cnt := 0
+	var cnt int32
 	for _, err = reader.ReadNext(); err != io.EOF; _, err = reader.ReadNext() {
 		cnt++
 	}
-	assert.Equal(t, cnt, enqueued)
+	assert.Equal(t, cnt, enqueued.Load())
+	// Expect at least every thread to have enqueued a message
+	assert.Greater(t, enqueued.Load(), int32(threads))
 }
 
 func TestWriterUncompressed(t *testing.T) {
@@ -177,5 +200,4 @@ func TestValidateLocation(t *testing.T) {
 	l, err := ValidateLocation(locationGood)
 	assert.Nil(t, err)
 	assert.Equal(t, locationGood, l)
-
 }

--- a/pkg/dogstatsd/replay/writer_test.go
+++ b/pkg/dogstatsd/replay/writer_test.go
@@ -172,10 +172,9 @@ func TestValidateLocation(t *testing.T) {
 		captureFs.fs = originalFs
 	}()
 
-	writer := NewTrafficCaptureWriter(1)
-	_, err := writer.ValidateLocation(locationBad)
+	_, err := ValidateLocation(locationBad)
 	assert.NotNil(t, err)
-	l, err := writer.ValidateLocation(locationGood)
+	l, err := ValidateLocation(locationGood)
 	assert.Nil(t, err)
 	assert.Equal(t, locationGood, l)
 

--- a/pkg/dogstatsd/server_test.go
+++ b/pkg/dogstatsd/server_test.go
@@ -524,6 +524,7 @@ func TestStaticTags(t *testing.T) {
 	config.Datadog.SetDefault("dogstatsd_tags", []string{"sometag3:somevalue3"})
 	config.Datadog.SetDefault("eks_fargate", true) // triggers DD_TAGS in static_tags
 	config.Datadog.SetDefault("tags", []string{"from:dd_tags"})
+	config.SetDetectedFeatures(config.FeatureMap{})
 	defer config.Datadog.SetDefault("dogstatsd_tags", []string{})
 	defer config.Datadog.SetDefault("eks_fargate", false)
 

--- a/releasenotes/notes/fix-dogstatsd-capture-deadlock-enqueuing-msgs-c16dbd78fe8f115d.yaml
+++ b/releasenotes/notes/fix-dogstatsd-capture-deadlock-enqueuing-msgs-c16dbd78fe8f115d.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed a deadlock in the DogStatsD when running the capture (`agent dogstatsd-capture`). The Agent now flushes the
+    captured messages properly when the capture stops.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This fixes an issue where running `agent dogstatsd-capture` would sometimes cause clients connected to the Agent (via [UDS socket](https://docs.datadoghq.com/developers/dogstatsd/unix_socket/?tabs=host)) to block. When the client is blocked, no metrics will be sent via the Agent and no new connections can be made. Also, the capture would never correctly drain so would sometimes the capture would have missing metrics.

### Motivation


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

The PR adds a couple of more locks, so there is potential for another deadlock to appear when making a dogstatsd capture.

### Describe how to test/QA your changes

- Setup a VM with at least two cores and 4Gb of memory
- Install [Docker](https://docs.docker.com/engine/install/)
- Run the Agent in Docker, enabling UDS on shared volume
- Run a second container that is sending metrics to the UDS socket on the shared container (simple script can be found [here](https://gist.github.com/carlosroman/6369af24847422953664f33d717db90b)). I'd recommend running more than one of these to increase the chance of a deadlock happening. If you can, run something that uses the DogStatsD client and enable telemetry so you can check how many metrics are being sent through the Agent using the telemetry metrics (`datadog.dogstatsd.client.metrics`)
- Once your containers are running, run in the Agent container `agent dogstatsd-capture` to start a capture.
- Check to see if metrics are still being sent through the Agent. Run some more captures to make sure that none of them cause the Agent UDS socket to block
 
### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
