### PR TITLE
[network/ebpf] don't access derefering map value after delete

### DIFF
--- a/pkg/ebpf/bytecode/runtime/tracer.go
+++ b/pkg/ebpf/bytecode/runtime/tracer.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Tracer = NewRuntimeAsset("tracer.c", "2561097ecef29498ab28aedef16388e44c81a6262720b7f4d381a6a665f54d5b")
+var Tracer = NewRuntimeAsset("tracer.c", "14b54f98c4f170960495003e6ab3a17390ca7ec0c12611d7c2763f4f3a3125ca")

--- a/pkg/network/ebpf/c/prebuilt/offset-guess.c
+++ b/pkg/network/ebpf/c/prebuilt/offset-guess.c
@@ -257,9 +257,8 @@ int kretprobe__tcp_v6_connect(struct pt_regs* __attribute__((unused)) ctx) {
         return 0; // missed entry
     }
 
-    bpf_map_delete_elem(&connectsock_ipv6, &pid);
-
     struct sock* skp = *skpp;
+    bpf_map_delete_elem(&connectsock_ipv6, &pid);
 
     status = bpf_map_lookup_elem(&tracer_status, &zero);
     if (status == NULL) {

--- a/pkg/network/ebpf/c/prebuilt/tracer.c
+++ b/pkg/network/ebpf/c/prebuilt/tracer.c
@@ -54,6 +54,7 @@ int kretprobe__tcp_sendmsg(struct pt_regs* ctx) {
         return 0;
     }
 
+    struct sock *skp = *skpp;
     bpf_map_delete_elem(&tcp_sendmsg_args, &pid_tgid);
 
     int sent = PT_REGS_RC(ctx);
@@ -62,7 +63,6 @@ int kretprobe__tcp_sendmsg(struct pt_regs* ctx) {
         return 0;
     }
 
-    struct sock *skp = *skpp;
     if (!skp) {
         return 0;
     }
@@ -302,10 +302,10 @@ static __always_inline int handle_ret_udp_recvmsg(int copied, struct bpf_map_def
         return 0;
     }
 
-    // Make sure we clean up the key
-    bpf_map_delete_elem(udp_sock_map, &pid_tgid);
     if (copied < 0) { // Non-zero values are errors (or a peek) (e.g -EINVAL)
         log_debug("kretprobe/udp_recvmsg: ret=%d < 0, pid_tgid=%d\n", copied, pid_tgid);
+        // Make sure we clean up the key
+        bpf_map_delete_elem(udp_sock_map, &pid_tgid);
         return 0;
     }
 
@@ -321,8 +321,10 @@ static __always_inline int handle_ret_udp_recvmsg(int copied, struct bpf_map_def
 
     if (!read_conn_tuple_partial(&t, st->sk, pid_tgid, CONN_TYPE_UDP)) {
         log_debug("ERR(kretprobe/udp_recvmsg): error reading conn tuple, pid_tgid=%d\n", pid_tgid);
+        bpf_map_delete_elem(udp_sock_map, &pid_tgid);
         return 0;
     }
+    bpf_map_delete_elem(udp_sock_map, &pid_tgid);
 
     log_debug("kretprobe/udp_recvmsg: pid_tgid: %d, return: %d\n", pid_tgid, copied);
     // segment count is not currently enabled on prebuilt.
@@ -540,13 +542,13 @@ static __always_inline int sys_exit_bind(__s64 ret) {
         return 0;
     }
 
+    __u16 sin_port = args->port;
     bpf_map_delete_elem(&pending_bind, &tid);
 
     if (ret != 0) {
         return 0;
     }
 
-    __u16 sin_port = args->port;
     port_binding_t pb = {};
     pb.netns = 0; // don't have net ns info in this context
     pb.port = sin_port;

--- a/pkg/network/ebpf/c/runtime/tracer.c
+++ b/pkg/network/ebpf/c/runtime/tracer.c
@@ -59,6 +59,7 @@ int kretprobe__tcp_sendmsg(struct pt_regs* ctx) {
         return 0;
     }
 
+    struct sock *skp = *skpp;
     bpf_map_delete_elem(&tcp_sendmsg_args, &pid_tgid);
 
     int sent = PT_REGS_RC(ctx);
@@ -66,7 +67,6 @@ int kretprobe__tcp_sendmsg(struct pt_regs* ctx) {
         return 0;
     }
 
-    struct sock *skp = *skpp;
     if (!skp) {
         return 0;
     }
@@ -541,14 +541,13 @@ static __always_inline int sys_exit_bind(__s64 ret) {
         log_debug("sys_exit_bind: was not a UDP bind, will not process\n");
         return 0;
     }
-
+    __u16 sin_port = args->port;
     bpf_map_delete_elem(&pending_bind, &tid);
 
     if (ret != 0) {
         return 0;
     }
 
-    __u16 sin_port = args->port;
     port_binding_t pb = {};
     pb.netns = 0; // don't have net ns info in this context
     pb.port = sin_port;

--- a/pkg/network/ebpf/c/tracer-events.h
+++ b/pkg/network/ebpf/c/tracer-events.h
@@ -18,7 +18,6 @@ static __always_inline void cleanup_conn(conn_tuple_t *tup) {
 
     // Will hold the full connection data to send through the perf buffer
     conn_t conn = { .tup = *tup };
-    tcp_stats_t *tst = NULL;
     conn_stats_ts_t *cst = NULL;
     bool is_tcp = get_proto(&conn.tup) == CONN_TYPE_TCP;
     bool is_udp = get_proto(&conn.tup) == CONN_TYPE_UDP;
@@ -26,23 +25,20 @@ static __always_inline void cleanup_conn(conn_tuple_t *tup) {
     // TCP stats don't have the PID
     if (is_tcp) {
         conn.tup.pid = 0;
-        tst = bpf_map_lookup_elem(&tcp_stats, &(conn.tup));
-        bpf_map_delete_elem(&tcp_stats, &(conn.tup));
-        conn.tup.pid = tup->pid;
-
+        tcp_stats_t *tst = bpf_map_lookup_elem(&tcp_stats, &(conn.tup));
         if (tst) {
             conn.tcp_stats = *tst;
+            bpf_map_delete_elem(&tcp_stats, &(conn.tup));
         }
+        conn.tup.pid = tup->pid;
 
         conn.tcp_stats.state_transitions |= (1 << TCP_CLOSE);
     }
 
     cst = bpf_map_lookup_elem(&conn_stats, &(conn.tup));
-    // Delete this connection from our stats map
-    bpf_map_delete_elem(&conn_stats, &(conn.tup));
-
     if (cst) {
         conn.conn_stats = *cst;
+        bpf_map_delete_elem(&conn_stats, &(conn.tup));
     }
     conn.conn_stats.timestamp = bpf_ktime_get_ns();
 


### PR DESCRIPTION
### What does this PR do?

Noop
Fixing map value access during his lifespan.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
