### PR TITLE
Updated CODEOWNERS to include folders owned by @DataDog/agent-metrics-logs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -98,6 +98,7 @@
 /cmd/cluster-agent/commands/            @DataDog/container-integrations @DataDog/integrations-tools-and-libraries
 /cmd/cluster-agent-cloudfoundry/        @DataDog/integrations-tools-and-libraries
 /cmd/cluster-agent/api/v1/cloudfoundry_metadata.go        @DataDog/integrations-tools-and-libraries
+/cmd/dogstatsd/                         @DataDog/agent-metrics-logs
 /cmd/process-agent/                     @DataDog/processes
 /cmd/serverless/                        @DataDog/serverless
 /cmd/system-probe/                      @DataDog/agent-network
@@ -110,7 +111,7 @@
 
 /docs/                                  @DataDog/documentation @DataDog/agent-platform
 /docs/agent/                            @DataDog/documentation @DataDog/agent-core
-/docs/dogstatsd/                        @DataDog/documentation @DataDog/agent-core
+/docs/dogstatsd/                        @DataDog/documentation @DataDog/agent-metrics-logs
 /docs/trace-agent/                      @DataDog/documentation @DataDog/agent-apm
 /docs/cluster-agent/                    @DataDog/documentation @DataDog/container-integrations
 /docs/dev/checks/                       @DataDog/documentation @DataDog/agent-core
@@ -133,12 +134,14 @@
 /omnibus/config/software/snmp-traps.rb                    @DataDog/infrastructure-integrations
 
 /pkg/                                   @DataDog/agent-core
-/pkg/aggregator/                        @DataDog/agent-core
-/pkg/collector/                         @DataDog/agent-core
-/pkg/forwarder/                         @DataDog/agent-core
+/pkg/aggregator/                        @DataDog/agent-metrics-logs
+/pkg/collector/                         @DataDog/agent-metrics-logs
+/pkg/dogstatsd/                         @DataDog/agent-metrics-logs
+/pkg/forwarder/                         @DataDog/agent-metrics-logs
+/pkg/jmxfetch/                          @DataDog/agent-metrics-logs
 /pkg/metadata/                          @DataDog/agent-core
-/pkg/metrics/                           @DataDog/agent-core
-/pkg/serializer/                        @DataDog/agent-core
+/pkg/metrics/                           @DataDog/agent-metrics-logs
+/pkg/serializer/                        @DataDog/agent-metrics-logs
 /pkg/serverless/                        @DataDog/serverless
 /pkg/status/                            @DataDog/agent-core
 /pkg/status/templates/process-agent.tmpl    @DataDog/processes
@@ -162,7 +165,7 @@
 /pkg/collector/corechecks/containerlifecycle/   @DataDog/container-integrations
 /pkg/collector/corechecks/ebpf/         @DataDog/container-integrations
 /pkg/collector/corechecks/embed/        @Datadog/agent-platform
-/pkg/collector/corechecks/embed/jmx/    @Datadog/agent-core
+/pkg/collector/corechecks/embed/jmx/    @Datadog/agent-metrics-logs
 /pkg/collector/corechecks/embed/apm*.go            @Datadog/agent-platform @DataDog/agent-apm
 /pkg/collector/corechecks/embed/process_agent*.go  @Datadog/agent-platform @DataDog/processes
 /pkg/collector/corechecks/net/          @DataDog/agent-platform
@@ -174,6 +177,7 @@
 /pkg/config/apm.go                      @DataDog/agent-apm
 /pkg/config/autodiscovery/              @Datadog/container-integrations
 /pkg/config/environment*.go             @DataDog/container-integrations @DataDog/container-app
+/pkg/config/log*.go                     @Datadog/agent-platform
 /pkg/config/process*.go                 @DataDog/processes
 /pkg/config/system_probe.go             @DataDog/agent-network
 /pkg/config/remote/                     @DataDog/remote-config
@@ -195,9 +199,9 @@
 /pkg/util/cgroups/                      @DataDog/container-integrations
 /pkg/util/retry/                        @DataDog/container-integrations
 /pkg/util/intern/                       @DataDog/agent-network
-/pkg/logs/                              @DataDog/agent-core
-/pkg/logs/internal/launchers/traps/     @DataDog/infrastructure-integrations @DataDog/agent-core
-/pkg/logs/internal/tailers/traps/       @DataDog/infrastructure-integrations @DataDog/agent-core
+/pkg/logs/                              @DataDog/agent-metrics-logs
+/pkg/logs/internal/launchers/traps/     @DataDog/infrastructure-integrations @DataDog/agent-metrics-logs
+/pkg/logs/internal/tailers/traps/       @DataDog/infrastructure-integrations @DataDog/agent-metrics-logs
 /pkg/process/                           @DataDog/processes
 /pkg/process/util/address*.go           @DataDog/agent-network
 /pkg/process/util/netns*.go             @DataDog/agent-network
@@ -261,7 +265,7 @@
 /tools/                                 @DataDog/agent-platform
 /tools/ebpf/                            @DataDog/agent-network
 /tools/gdb/                             @DataDog/agent-core
-/tools/retry_file_dump/                 @DataDog/agent-core
+/tools/retry_file_dump/                 @DataDog/agent-metrics-logs
 /tools/windows/                         @DataDog/agent-platform
 /tools/agent_QA/                        @DataDog/agent-metrics-logs
 

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -332,6 +332,7 @@ GITHUB_SLACK_MAP = {
     "@DataDog/infrastructure-integrations": "#infrastructure-integrations",
     "@DataDog/processes": "#processes",
     "@DataDog/agent-core": "#agent-core",
+    "@DataDog/agent-metrics-logs": "#agent-metrics-logs",
     "@DataDog/container-app": "#container-app",
     "@DataDog/metrics-aggregation": "#metrics-aggregation",
     "@DataDog/serverless": "#serverless-agent",


### PR DESCRIPTION


### What does this PR do?

This updates some of the packages so that they are owned by @DataDog/agent-metrics-logs.

### Motivation

This should mean that changes to those packages will get the correct reviewer tag.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
