### PR TITLE
CWS: cleanup last usages of mkdirtemp in tests

### DIFF
--- a/pkg/security/tests/filters_test.go
+++ b/pkg/security/tests/filters_test.go
@@ -431,7 +431,7 @@ func TestDiscarderRetentionFilter(t *testing.T) {
 		Expression: `open.file.path =~ "{{.Root}}/no-approver-*" && open.flags & (O_CREAT | O_SYNC) > 0`,
 	}
 
-	testDrive, err := newTestDrive("xfs", nil)
+	testDrive, err := newTestDrive(t, "xfs", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/latency_test.go
+++ b/pkg/security/tests/latency_test.go
@@ -31,7 +31,7 @@ var (
 var benchLatencyhFS embed.FS
 
 // modified version of testModule.CreateWithOption, to be able to call it without testing module
-func CreateWithOptions(filename string, user, group, mode int) (string, unsafe.Pointer, error) {
+func CreateWithOptions(tb testing.TB, filename string, user, group, mode int) (string, unsafe.Pointer, error) {
 	var macros []*rules.MacroDefinition
 	var rules []*rules.RuleDefinition
 
@@ -39,7 +39,7 @@ func CreateWithOptions(filename string, user, group, mode int) (string, unsafe.P
 		return "", nil, err
 	}
 
-	st, err := newSimpleTest(macros, rules, "")
+	st, err := newSimpleTest(tb, macros, rules, "")
 	if err != nil {
 		return "", nil, err
 	}
@@ -62,14 +62,14 @@ func CreateWithOptions(filename string, user, group, mode int) (string, unsafe.P
 }
 
 // load embedded binary
-func loadBenchLatencyBin(binary string) (string, error) {
+func loadBenchLatencyBin(tb testing.TB, binary string) (string, error) {
 	testerBin, err := benchLatencyhFS.ReadFile(fmt.Sprintf("latency/bin/%s", binary))
 	if err != nil {
 		return "", err
 	}
 
 	perm := 0o700
-	binPath, _, _ := CreateWithOptions(binary, -1, -1, perm)
+	binPath, _, _ := CreateWithOptions(tb, binary, -1, -1, perm)
 
 	f, err := os.OpenFile(binPath, os.O_WRONLY|os.O_CREATE, os.FileMode(perm))
 	if err != nil {
@@ -100,7 +100,7 @@ func benchLatencyDNS(t *testing.T, rule *rules.RuleDefinition, executable string
 	}
 
 	// load bench binary
-	executable, err := loadBenchLatencyBin(executable)
+	executable, err := loadBenchLatencyBin(t, executable)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -600,7 +600,7 @@ func newTestModule(t testing.TB, macroDefs []*rules.MacroDefinition, ruleDefs []
 		return nil, err
 	}
 
-	st, err := newSimpleTest(macroDefs, ruleDefs, opts.testDir)
+	st, err := newSimpleTest(t, macroDefs, ruleDefs, opts.testDir)
 	if err != nil {
 		return nil, err
 	}
@@ -1162,7 +1162,6 @@ func (tm *testModule) startTracing() (*tracePipeLogger, error) {
 }
 
 func (tm *testModule) cleanup() {
-	tm.st.Close()
 	tm.module.Close()
 }
 
@@ -1217,14 +1216,7 @@ func swapLogLevel(logLevel seelog.LogLevel) (seelog.LogLevel, error) {
 }
 
 type simpleTest struct {
-	root     string
-	toRemove bool
-}
-
-func (t *simpleTest) Close() {
-	if t.toRemove {
-		os.RemoveAll(t.root)
-	}
+	root string
 }
 
 func (t *simpleTest) Root() string {
@@ -1277,19 +1269,13 @@ func (t *simpleTest) load(macros []*rules.MacroDefinition, rules []*rules.RuleDe
 	return nil
 }
 
-func newSimpleTest(macros []*rules.MacroDefinition, rules []*rules.RuleDefinition, testDir string) (*simpleTest, error) {
-	var err error
-
+func newSimpleTest(tb testing.TB, macros []*rules.MacroDefinition, rules []*rules.RuleDefinition, testDir string) (*simpleTest, error) {
 	t := &simpleTest{
 		root: testDir,
 	}
 
 	if testDir == "" {
-		t.root, err = os.MkdirTemp("", "test-secagent-root")
-		if err != nil {
-			return nil, err
-		}
-		t.toRemove = true
+		t.root = tb.TempDir()
 		if err := os.Chmod(t.root, 0o711); err != nil {
 			return nil, err
 		}

--- a/pkg/security/tests/mount_test.go
+++ b/pkg/security/tests/mount_test.go
@@ -35,7 +35,7 @@ func TestMount(t *testing.T) {
 		Expression: fmt.Sprintf(`chown.file.path == "{{.Root}}/%s/test-release"`, dstMntBasename),
 	}}
 
-	testDrive, err := newTestDrive("xfs", []string{})
+	testDrive, err := newTestDrive(t, "xfs", []string{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/overlayfs_test.go
+++ b/pkg/security/tests/overlayfs_test.go
@@ -90,7 +90,7 @@ func TestOverlayFS(t *testing.T) {
 		},
 	}
 
-	testDrive, err := newTestDrive("xfs", nil)
+	testDrive, err := newTestDrive(t, "xfs", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/rename_test.go
+++ b/pkg/security/tests/rename_test.go
@@ -268,7 +268,7 @@ func TestRenameReuseInode(t *testing.T) {
 		Expression: `open.file.path == "{{.Root}}/test-rename-new"`,
 	}}
 
-	testDrive, err := newTestDrive("xfs", nil)
+	testDrive, err := newTestDrive(t, "xfs", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/testdrive.go
+++ b/pkg/security/tests/testdrive.go
@@ -15,6 +15,7 @@ import (
 	"path"
 	"strings"
 	"syscall"
+	"testing"
 	"unsafe"
 
 	"github.com/avast/retry-go"
@@ -43,11 +44,11 @@ func (td *testDrive) Path(filename ...string) (string, unsafe.Pointer, error) {
 	return path, unsafe.Pointer(filenamePtr), nil
 }
 
-func newTestDrive(fsType string, mountOpts []string) (*testDrive, error) {
-	return newTestDriveWithMountPoint(fsType, mountOpts, "")
+func newTestDrive(tb testing.TB, fsType string, mountOpts []string) (*testDrive, error) {
+	return newTestDriveWithMountPoint(tb, fsType, mountOpts, "")
 }
 
-func newTestDriveWithMountPoint(fsType string, mountOpts []string, mountPoint string) (*testDrive, error) {
+func newTestDriveWithMountPoint(tb testing.TB, fsType string, mountOpts []string, mountPoint string) (*testDrive, error) {
 	backingFile, err := os.CreateTemp("", "secagent-testdrive-")
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create testdrive backing file")
@@ -57,12 +58,8 @@ func newTestDriveWithMountPoint(fsType string, mountOpts []string, mountPoint st
 		return nil, errors.Wrap(err, "failed to close testdrive backing file")
 	}
 
-	if len(mountPoint) == 0 {
-		mountPoint, err = os.MkdirTemp("", "secagent-testdrive-")
-		if err != nil {
-			os.Remove(backingFile.Name())
-			return nil, errors.Wrap(err, "failed to create testdrive mount point")
-		}
+	if mountPoint == "" {
+		mountPoint = tb.TempDir()
 	}
 
 	var loopback *losetup.Device

--- a/pkg/security/tests/xattr_test.go
+++ b/pkg/security/tests/xattr_test.go
@@ -27,7 +27,7 @@ func TestSetXAttr(t *testing.T) {
 		Expression: `((setxattr.file.path == "{{.Root}}/test-setxattr" && setxattr.file.uid == 98 && setxattr.file.gid == 99) || setxattr.file.path == "{{.Root}}/test-setxattr-link") && setxattr.file.destination.namespace == "user" && setxattr.file.destination.name == "user.test_xattr"`,
 	}
 
-	testDrive, err := newTestDrive("ext4", []string{"user_xattr"})
+	testDrive, err := newTestDrive(t, "ext4", []string{"user_xattr"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -152,7 +152,7 @@ func TestRemoveXAttr(t *testing.T) {
 		},
 	}
 
-	testDrive, err := newTestDrive("ext4", []string{"user_xattr"})
+	testDrive, err := newTestDrive(t, "ext4", []string{"user_xattr"})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

followup on https://github.com/DataDog/datadog-agent/pull/12121
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
