### PR TITLE
Defer auto multi-line timeout until first log is processed

### DIFF
--- a/pkg/logs/internal/decoder/line_handler_test.go
+++ b/pkg/logs/internal/decoder/line_handler_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
+	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -228,9 +229,7 @@ func TestSingleLineHandlerSendsRawInvalidMessages(t *testing.T) {
 
 	h.process(getDummyMessage("one message"))
 
-	var output *Message
-
-	output = <-outputChan
+	output := <-outputChan
 	assert.Equal(t, "one message", string(output.Content))
 }
 
@@ -347,4 +346,34 @@ func TestAutoMultiLineHandlerHandelsMessageConflictingPatternsNoWinner(t *testin
 	assert.Nil(t, h.multiLineHandler)
 
 	assert.Equal(t, "Jul 12, 2021 12:55:15 PM test message 2", string(output.Content))
+}
+
+func TestAutoMultiLineHandlerSwitchesToMultiLineModeWithDelay(t *testing.T) {
+	outputFn, _ := lineHandlerChans()
+	source := sources.NewReplaceableSource(sources.NewLogSource("config", &config.LogsConfig{}))
+	detectedPattern := &DetectedPattern{}
+
+	h := NewAutoMultilineHandler(outputFn, 100, 5, 1.0, 10*time.Millisecond, 10*time.Millisecond, source, []*regexp.Regexp{}, detectedPattern)
+	clock := clock.NewMock()
+	h.clk = clock
+
+	// Advanced the clock past the (10ms) detection timeout. (timer should not have started yet)
+	clock.Add(time.Second)
+
+	// Process a log that will match - the timer should start now
+	h.process(getDummyMessageWithLF("Jul 12, 2021 12:55:15 PM test message"))
+
+	// Have not finished detection yet
+	assert.NotNil(t, h.singleLineHandler)
+	assert.Nil(t, h.multiLineHandler)
+
+	// Advanced the clock past the (10ms) detection timeout.
+	clock.Add(time.Second)
+
+	// Process a log that will match. The timer has already timed out
+	h.process(getDummyMessageWithLF("Jul 12, 2021 12:55:15 PM test message"))
+
+	// Have not finished detection yet
+	assert.Nil(t, h.singleLineHandler)
+	assert.NotNil(t, h.multiLineHandler)
 }

--- a/pkg/logs/internal/decoder/line_handler_test.go
+++ b/pkg/logs/internal/decoder/line_handler_test.go
@@ -357,7 +357,7 @@ func TestAutoMultiLineHandlerSwitchesToMultiLineModeWithDelay(t *testing.T) {
 	clock := clock.NewMock()
 	h.clk = clock
 
-	// Advanced the clock past the (10ms) detection timeout. (timer should not have started yet)
+	// Advance the clock past the (10ms) detection timeout. (timer should not have started yet)
 	clock.Add(time.Second)
 
 	// Process a log that will match - the timer should start now
@@ -367,7 +367,7 @@ func TestAutoMultiLineHandlerSwitchesToMultiLineModeWithDelay(t *testing.T) {
 	assert.NotNil(t, h.singleLineHandler)
 	assert.Nil(t, h.multiLineHandler)
 
-	// Advanced the clock past the (10ms) detection timeout.
+	// Advance the clock past the (10ms) detection timeout.
 	clock.Add(time.Second)
 
 	// Process a log that will match. The timer has already timed out

--- a/releasenotes/notes/defer-auto-multi-line-timeout-263f216bc15d2fc6.yaml
+++ b/releasenotes/notes/defer-auto-multi-line-timeout-263f216bc15d2fc6.yaml
@@ -8,5 +8,5 @@
 ---
 enhancements:
   - |
-    Delay starting the auto multi line detection timeout until at 
+    Delay starting the auto multi-line detection timeout until at 
     least one log has been processed. 

--- a/releasenotes/notes/defer-auto-multi-line-timeout-263f216bc15d2fc6.yaml
+++ b/releasenotes/notes/defer-auto-multi-line-timeout-263f216bc15d2fc6.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Delay starting the auto multi line detection timeout until at 
+    least one log has been processed. 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Wait until the first log line is processed before starting the auto-multi-line timeout timer. 

### Motivation

In cases where a log file is created but not written to for some time, auto multi line detection could time out before logs were written. This improves auto multi line detection behavior in low log volume scenarios. 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

1. set `auto_multi_line_detection` to `true` (either globally or for a specific log config) 
2. Create an empty log file
3. wait 31 seconds 
4. run `docker run -it bfloerschddog/java-excepton-logger > /path/to/file.log`
5. wait for 10 seconds - then kill `bfloerschddog/java-excepton-logger`
6. watch the agent logs and wait another ~20 seconds. You should see a log line like:

```
2022-07-11 11:11:35 EDT | CORE | DEBUG | (pkg/logs/internal/decoder/auto_multiline_handler.go:170 in processAndTry) | Pattern ^\d+-\d+-\d+ \d+:\d+:\d+(,\d+)? matched 486 lines with a ratio of 0.972000
``` 



### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
