### PR TITLE
[CWS] Add datadog.security_agent.activity_dump.entity_too_large metric

### DIFF
--- a/pkg/security/agent/agent.go
+++ b/pkg/security/agent/agent.go
@@ -88,7 +88,7 @@ func (rsa *RuntimeSecurityAgent) Start(reporter event.Reporter, endpoints *confi
 	// Start activity dumps listener
 	go rsa.StartActivityDumpListener()
 	// Send Runtime Security Agent telemetry
-	go rsa.telemetry.run(ctx)
+	go rsa.telemetry.run(ctx, rsa)
 }
 
 // Stop the runtime recurity agent

--- a/pkg/security/agent/telemetry.go
+++ b/pkg/security/agent/telemetry.go
@@ -39,7 +39,7 @@ func newTelemetry() (*telemetry, error) {
 	}, nil
 }
 
-func (t *telemetry) run(ctx context.Context) {
+func (t *telemetry) run(ctx context.Context, rsa *RuntimeSecurityAgent) {
 	log.Info("started collecting Runtime Security Agent telemetry")
 	defer log.Info("stopping Runtime Security Agent telemetry")
 
@@ -53,6 +53,9 @@ func (t *telemetry) run(ctx context.Context) {
 		case <-metricsTicker.C:
 			if err := t.reportContainers(); err != nil {
 				log.Debugf("couldn't report containers: %v", err)
+			}
+			if rsa.storage != nil {
+				rsa.storage.SendTelemetry()
 			}
 		}
 	}

--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -151,6 +151,10 @@ var (
 	// MetricActivityDumpActiveDumps is the name of the metric used to report the number of active dumps
 	// Tags: -
 	MetricActivityDumpActiveDumps = newRuntimeMetric(".activity_dump.active_dumps")
+	// MetricActivityDumpEntityTooLarge is the name of the metric used to report the number of active dumps that couldn't
+	// be sent because they are too big
+	// Tags: format, compression
+	MetricActivityDumpEntityTooLarge = newAgentMetric(".activity_dump.entity_too_large")
 
 	// Namespace resolver metrics
 

--- a/pkg/security/probe/activity_dump_local_storage.go
+++ b/pkg/security/probe/activity_dump_local_storage.go
@@ -19,9 +19,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/golang-lru/simplelru"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	seclog "github.com/DataDog/datadog-agent/pkg/security/log"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/dump"
-	"github.com/hashicorp/golang-lru/simplelru"
 )
 
 type dumpFiles struct {
@@ -202,3 +204,6 @@ func (storage *ActivityDumpLocalStorage) Persist(request dump.StorageRequest, ad
 	seclog.Infof("[%s] file for [%s] written at: [%s]", request.Format, ad.GetSelectorStr(), outputPath)
 	return nil
 }
+
+// SendTelemetry sends telemetry for the current storage
+func (storage *ActivityDumpLocalStorage) SendTelemetry(sender aggregator.Sender) {}

--- a/pkg/security/probe/activity_dump_remote_storage_forwarder.go
+++ b/pkg/security/probe/activity_dump_remote_storage_forwarder.go
@@ -16,6 +16,7 @@ import (
 	strings "strings"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/security/api"
 	seclog "github.com/DataDog/datadog-agent/pkg/security/log"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/dump"
@@ -76,3 +77,6 @@ func (storage *ActivityDumpRemoteStorageForwarder) Persist(request dump.StorageR
 	seclog.Infof("[%s] file for activity dump [%s] was forwarded to the security-agent", request.Format, ad.GetSelectorStr())
 	return nil
 }
+
+// SendTelemetry sends telemetry for the current storage
+func (storage *ActivityDumpRemoteStorageForwarder) SendTelemetry(sender aggregator.Sender) {}

--- a/pkg/security/probe/activity_dump_storage_manager_unsupported.go
+++ b/pkg/security/probe/activity_dump_storage_manager_unsupported.go
@@ -24,6 +24,9 @@ func (manager *ActivityDumpStorageManager) PersistRaw(requests []dump.StorageReq
 	return nil
 }
 
+// SendTelemetry send telemetry of all storages
+func (manager *ActivityDumpStorageManager) SendTelemetry() {}
+
 // NewSecurityAgentStorageManager returns a new instance of ActivityDumpStorageManager
 func NewSecurityAgentStorageManager() (*ActivityDumpStorageManager, error) {
 	return nil, fmt.Errorf("the activity dump manager is unsupported on this platform")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

This PR adds a new metric to track if dumps are dropped because they are above the intake limit.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
