### PR TITLE
Use go.uber.org/atomic in pkg/network

### DIFF
--- a/pkg/network/driver_interface.go
+++ b/pkg/network/driver_interface.go
@@ -74,12 +74,11 @@ func NewDriverInterface(cfg *config.Config) (*DriverInterface, error) {
 		closedFlows:    atomic.NewInt64(0),
 		openFlows:      atomic.NewInt64(0),
 		moreDataErrors: atomic.NewInt64(0),
-		bufferSize:     atomic.NewInt64(0),
+		bufferSize:     atomic.NewInt64(defaultDriverBufferSize),
 
 		cfg:                   cfg,
 		enableMonotonicCounts: cfg.EnableMonotonicCount,
 		readBuffer:            make([]byte, defaultDriverBufferSize),
-		bufferSize:            int64(defaultDriverBufferSize),
 		maxOpenFlows:          uint64(cfg.MaxTrackedConnections),
 		maxClosedFlows:        uint64(cfg.MaxClosedConnectionsBuffered),
 	}

--- a/pkg/network/driver_interface.go
+++ b/pkg/network/driver_interface.go
@@ -12,12 +12,12 @@ import (
 	"fmt"
 	"math"
 	"sync"
-	"sync/atomic"
 	"unsafe"
 
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/driver"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"go.uber.org/atomic"
 	"golang.org/x/sys/windows"
 )
 
@@ -47,12 +47,11 @@ var DriverExpvarNames = []DriverExpvar{totalFlowStats, flowHandleStats, flowStat
 
 // DriverInterface holds all necessary information for interacting with the windows driver
 type DriverInterface struct {
-	// declare totalFlows first so it remains on a 64 bit boundary since it is used by atomic functions
-	totalFlows     int64
-	closedFlows    int64
-	openFlows      int64
-	moreDataErrors int64
-	bufferSize     int64
+	totalFlows     *atomic.Int64
+	closedFlows    *atomic.Int64
+	openFlows      *atomic.Int64
+	moreDataErrors *atomic.Int64
+	bufferSize     *atomic.Int64
 
 	maxOpenFlows   uint64
 	maxClosedFlows uint64
@@ -71,6 +70,12 @@ type DriverInterface struct {
 // NewDriverInterface returns a DriverInterface struct for interacting with the driver
 func NewDriverInterface(cfg *config.Config) (*DriverInterface, error) {
 	dc := &DriverInterface{
+		totalFlows:     atomic.NewInt64(0),
+		closedFlows:    atomic.NewInt64(0),
+		openFlows:      atomic.NewInt64(0),
+		moreDataErrors: atomic.NewInt64(0),
+		bufferSize:     atomic.NewInt64(0),
+
 		cfg:                   cfg,
 		enableMonotonicCounts: cfg.EnableMonotonicCount,
 		readBuffer:            make([]byte, defaultDriverBufferSize),
@@ -153,11 +158,11 @@ func (di *DriverInterface) GetStats() (map[DriverExpvar]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	totalFlows := atomic.LoadInt64(&di.totalFlows)
-	openFlows := atomic.SwapInt64(&di.openFlows, 0)
-	closedFlows := atomic.SwapInt64(&di.closedFlows, 0)
-	moreDataErrors := atomic.SwapInt64(&di.moreDataErrors, 0)
-	bufferSize := atomic.LoadInt64(&di.bufferSize)
+	totalFlows := di.totalFlows.Load()
+	openFlows := di.openFlows.Swap(0)
+	closedFlows := di.closedFlows.Swap(0)
+	moreDataErrors := di.moreDataErrors.Swap(0)
+	bufferSize := di.bufferSize.Load()
 
 	return map[DriverExpvar]interface{}{
 		totalFlowStats:  totalDriverStats,
@@ -194,7 +199,7 @@ func (di *DriverInterface) GetConnectionStats(activeBuf *ConnectionBuffer, close
 			if err != windows.ERROR_MORE_DATA {
 				return 0, 0, fmt.Errorf("ReadFile: %w", err)
 			}
-			atomic.AddInt64(&di.moreDataErrors, 1)
+			di.moreDataErrors.Inc()
 		}
 		totalBytesRead += bytesRead
 
@@ -221,14 +226,14 @@ func (di *DriverInterface) GetConnectionStats(activeBuf *ConnectionBuffer, close
 		}
 
 		di.readBuffer = resizeDriverBuffer(int(totalBytesRead), di.readBuffer)
-		atomic.StoreInt64(&di.bufferSize, int64(len(di.readBuffer)))
+		di.bufferSize.Store(int64(len(di.readBuffer)))
 	}
 
 	activeCount := activeBuf.Len() - startActive
 	closedCount := closedBuf.Len() - startClosed
-	atomic.AddInt64(&di.openFlows, int64(activeCount))
-	atomic.AddInt64(&di.closedFlows, int64(closedCount))
-	atomic.AddInt64(&di.totalFlows, int64(activeCount+closedCount))
+	di.openFlows.Add(int64(activeCount))
+	di.closedFlows.Add(int64(closedCount))
+	di.totalFlows.Add(int64(activeCount + closedCount))
 
 	return activeCount, closedCount, nil
 }

--- a/pkg/network/http/http_statkeeper_test.go
+++ b/pkg/network/http/http_statkeeper_test.go
@@ -227,7 +227,7 @@ func TestHTTPCorrectness(t *testing.T) {
 		transactions := []httpTX{tx}
 
 		sk.Process(transactions)
-		require.Equal(t, int64(1), tel.malformed)
+		require.Equal(t, int64(1), tel.malformed.Load())
 
 		stats := sk.GetAndResetAllStats()
 		require.Len(t, stats, 0)
@@ -251,7 +251,7 @@ func TestHTTPCorrectness(t *testing.T) {
 		transactions := []httpTX{tx}
 
 		sk.Process(transactions)
-		require.Equal(t, int64(1), tel.malformed)
+		require.Equal(t, int64(1), tel.malformed.Load())
 
 		stats := sk.GetAndResetAllStats()
 		require.Len(t, stats, 0)
@@ -274,7 +274,7 @@ func TestHTTPCorrectness(t *testing.T) {
 		transactions := []httpTX{tx}
 
 		sk.Process(transactions)
-		require.Equal(t, int64(1), tel.malformed)
+		require.Equal(t, int64(1), tel.malformed.Load())
 
 		stats := sk.GetAndResetAllStats()
 		require.Len(t, stats, 0)

--- a/pkg/network/http/incomplete_stats.go
+++ b/pkg/network/http/incomplete_stats.go
@@ -5,7 +5,6 @@ package http
 
 import (
 	"sort"
-	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/network/config"
@@ -75,7 +74,7 @@ func (b *incompleteBuffer) Add(tx *httpTX) {
 	parts, ok := b.data[key]
 	if !ok {
 		if len(b.data) >= b.maxEntries {
-			atomic.AddInt64(&b.telemetry.dropped, 1)
+			b.telemetry.dropped.Inc()
 			return
 		}
 

--- a/pkg/network/http/telemetry.go
+++ b/pkg/network/http/telemetry.go
@@ -1,4 +1,4 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
+// Unless expliciAdd(1)tly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
@@ -10,30 +10,41 @@ package http
 
 import (
 	"fmt"
-	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/network/stats"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"go.uber.org/atomic"
 )
 
 type telemetry struct {
-	then    int64
-	elapsed int64
+	then    *atomic.Int64
+	elapsed *atomic.Int64
 
-	hits1XX, hits2XX, hits3XX, hits4XX, hits5XX int64 `stats:"atomic"`
-	misses                                      int64 `stats:"atomic"` // this happens when we can't cope with the rate of events
-	dropped                                     int64 `stats:"atomic"` // this happens when httpStatKeeper reaches capacity
-	rejected                                    int64 `stats:"atomic"` // this happens when an user-defined reject-filter matches a request
-	malformed                                   int64 `stats:"atomic"` // this happens when the request doesn't have the expected format
-	aggregations                                int64 `stats:"atomic"`
+	hits1XX, hits2XX, hits3XX, hits4XX, hits5XX *atomic.Int64 `stats:""`
+	misses                                      *atomic.Int64 `stats:""` // this happens when we can't cope with the rate of events
+	dropped                                     *atomic.Int64 `stats:""` // this happens when httpStatKeeper reaches capacity
+	rejected                                    *atomic.Int64 `stats:""` // this happens when an user-defined reject-filter matches a request
+	malformed                                   *atomic.Int64 `stats:""` // this happens when the request doesn't have the expected format
+	aggregations                                *atomic.Int64 `stats:""`
 
 	reporter stats.Reporter
 }
 
 func newTelemetry() (*telemetry, error) {
 	t := &telemetry{
-		then: time.Now().Unix(),
+		then:         atomic.NewInt64(time.Now().Unix()),
+		elapsed:      atomic.NewInt64(0),
+		hits1XX:      atomic.NewInt64(0),
+		hits2XX:      atomic.NewInt64(0),
+		hits3XX:      atomic.NewInt64(0),
+		hits4XX:      atomic.NewInt64(0),
+		hits5XX:      atomic.NewInt64(0),
+		misses:       atomic.NewInt64(0),
+		dropped:      atomic.NewInt64(0),
+		rejected:     atomic.NewInt64(0),
+		malformed:    atomic.NewInt64(0),
+		aggregations: atomic.NewInt64(0),
 	}
 
 	var err error
@@ -49,54 +60,54 @@ func (t *telemetry) aggregate(txs []httpTX, err error) {
 	for _, tx := range txs {
 		switch tx.StatusClass() {
 		case 100:
-			atomic.AddInt64(&t.hits1XX, 1)
+			t.hits1XX.Inc()
 		case 200:
-			atomic.AddInt64(&t.hits2XX, 1)
+			t.hits2XX.Inc()
 		case 300:
-			atomic.AddInt64(&t.hits3XX, 1)
+			t.hits3XX.Inc()
 		case 400:
-			atomic.AddInt64(&t.hits4XX, 1)
+			t.hits4XX.Inc()
 		case 500:
-			atomic.AddInt64(&t.hits5XX, 1)
+			t.hits5XX.Inc()
 		}
 	}
 
 	if err == errLostBatch {
-		atomic.AddInt64(&t.misses, int64(HTTPBatchSize))
+		t.misses.Add(int64(HTTPBatchSize))
 	}
 }
 
 func (t *telemetry) reset() telemetry {
 	now := time.Now().Unix()
-	then := atomic.SwapInt64(&t.then, now)
+	then := t.then.Swap(now)
 
 	delta, _ := newTelemetry()
-	delta.hits1XX = atomic.SwapInt64(&t.hits1XX, 0)
-	delta.hits2XX = atomic.SwapInt64(&t.hits2XX, 0)
-	delta.hits3XX = atomic.SwapInt64(&t.hits3XX, 0)
-	delta.hits4XX = atomic.SwapInt64(&t.hits4XX, 0)
-	delta.hits5XX = atomic.SwapInt64(&t.hits5XX, 0)
-	delta.misses = atomic.SwapInt64(&t.misses, 0)
-	delta.dropped = atomic.SwapInt64(&t.dropped, 0)
-	delta.rejected = atomic.SwapInt64(&t.rejected, 0)
-	delta.malformed = atomic.SwapInt64(&t.malformed, 0)
-	delta.aggregations = atomic.SwapInt64(&t.aggregations, 0)
-	delta.elapsed = now - then
+	delta.hits1XX.Store(t.hits1XX.Swap(0))
+	delta.hits2XX.Store(t.hits2XX.Swap(0))
+	delta.hits3XX.Store(t.hits3XX.Swap(0))
+	delta.hits4XX.Store(t.hits4XX.Swap(0))
+	delta.hits5XX.Store(t.hits5XX.Swap(0))
+	delta.misses.Store(t.misses.Swap(0))
+	delta.dropped.Store(t.dropped.Swap(0))
+	delta.rejected.Store(t.rejected.Swap(0))
+	delta.malformed.Store(t.malformed.Swap(0))
+	delta.aggregations.Store(t.aggregations.Swap(0))
+	delta.elapsed.Store(now - then)
 
-	totalRequests := delta.hits1XX + delta.hits2XX + delta.hits3XX + delta.hits4XX + delta.hits5XX
+	totalRequests := delta.hits1XX.Load() + delta.hits2XX.Load() + delta.hits3XX.Load() + delta.hits4XX.Load() + delta.hits5XX.Load()
 	log.Debugf(
 		"http stats summary: requests_processed=%d(%.2f/s) requests_missed=%d(%.2f/s) requests_dropped=%d(%.2f/s) requests_rejected=%d(%.2f/s) requests_malformed=%d(%.2f/s) aggregations=%d",
 		totalRequests,
-		float64(totalRequests)/float64(delta.elapsed),
-		delta.misses,
-		float64(delta.misses)/float64(delta.elapsed),
-		delta.dropped,
-		float64(delta.dropped)/float64(delta.elapsed),
-		delta.rejected,
-		float64(delta.rejected)/float64(delta.elapsed),
-		delta.malformed,
-		float64(delta.malformed)/float64(delta.elapsed),
-		delta.aggregations,
+		float64(totalRequests)/float64(delta.elapsed.Load()),
+		delta.misses.Load(),
+		float64(delta.misses.Load())/float64(delta.elapsed.Load()),
+		delta.dropped.Load(),
+		float64(delta.dropped.Load())/float64(delta.elapsed.Load()),
+		delta.rejected.Load(),
+		float64(delta.rejected.Load())/float64(delta.elapsed.Load()),
+		delta.malformed.Load(),
+		float64(delta.malformed.Load())/float64(delta.elapsed.Load()),
+		delta.aggregations.Load(),
 	)
 
 	return *delta

--- a/pkg/network/netlink/circuit_breaker.go
+++ b/pkg/network/netlink/circuit_breaker.go
@@ -7,16 +7,14 @@ package netlink
 
 import (
 	"math"
-	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"go.uber.org/atomic"
 )
 
 const (
-	tickInterval  = 3 * time.Second
-	breakerOpen   = int64(1)
-	breakerClosed = int64(0)
+	tickInterval = 3 * time.Second
 
 	// The lower this number is the more amortized the average is
 	// For example, if ewmaWeight is 1, a single burst of events might
@@ -32,18 +30,17 @@ type CircuitBreaker struct {
 	maxEventsPerSec int64
 
 	// The number of events elapsed since the last tick
-	eventCount int64
+	eventCount *atomic.Int64
 
 	// An exponentially weighted average of the event rate (per second)
 	// This is what actually compare against maxEventsPersec
-	eventRate int64
+	eventRate *atomic.Int64
 
 	// Represents the status of the cicuit breaker.
-	// 1 means open, 0 means closed
-	status int64
+	isOpen *atomic.Bool
 
 	// The timestamp in nanoseconds of when we last updated eventRate
-	lastUpdate int64
+	lastUpdate *atomic.Int64
 
 	done chan struct{}
 }
@@ -57,6 +54,10 @@ func NewCircuitBreaker(maxEventsPerSec int64) *CircuitBreaker {
 	}
 
 	c := &CircuitBreaker{
+		eventCount:      atomic.NewInt64(0),
+		eventRate:       atomic.NewInt64(0),
+		isOpen:          atomic.NewBool(false),
+		lastUpdate:      atomic.NewInt64(0),
 		maxEventsPerSec: maxEventsPerSec,
 		done:            make(chan struct{}),
 	}
@@ -80,25 +81,25 @@ func NewCircuitBreaker(maxEventsPerSec int64) *CircuitBreaker {
 // IsOpen returns true when the circuit breaker trips and remain
 // unchanched until Reset() is called.
 func (c *CircuitBreaker) IsOpen() bool {
-	return atomic.LoadInt64(&c.status) == breakerOpen
+	return c.isOpen.Load()
 }
 
 // Tick represents one or more events passing through the circuit breaker.
 func (c *CircuitBreaker) Tick(n int) {
-	atomic.AddInt64(&c.eventCount, int64(n))
+	c.eventCount.Add(int64(n))
 }
 
 // Rate returns the current rate of events
 func (c *CircuitBreaker) Rate() int64 {
-	return atomic.LoadInt64(&c.eventRate)
+	return c.eventRate.Load()
 }
 
 // Reset closes the circuit breaker and its state.
 func (c *CircuitBreaker) Reset() {
-	atomic.StoreInt64(&c.eventCount, 0)
-	atomic.StoreInt64(&c.eventRate, 0)
-	atomic.StoreInt64(&c.lastUpdate, time.Now().UnixNano())
-	atomic.StoreInt64(&c.status, breakerClosed)
+	c.eventCount.Store(0)
+	c.eventRate.Store(0)
+	c.lastUpdate.Store(time.Now().UnixNano())
+	c.isOpen.Store(false)
 }
 
 // Stop stops the circuit breaker.
@@ -111,7 +112,7 @@ func (c *CircuitBreaker) update(now time.Time) {
 		return
 	}
 
-	lastUpdate := atomic.LoadInt64(&c.lastUpdate)
+	lastUpdate := c.lastUpdate.Load()
 	deltaInSec := float64(now.UnixNano()-lastUpdate) / float64(time.Second.Nanoseconds())
 
 	// This is to avoid a divide by 0 panic or a spurious spike due
@@ -121,8 +122,8 @@ func (c *CircuitBreaker) update(now time.Time) {
 	}
 
 	// Calculate the event rate (EWMA)
-	eventCount := atomic.SwapInt64(&c.eventCount, 0)
-	prevEventRate := atomic.LoadInt64(&c.eventRate)
+	eventCount := c.eventCount.Swap(0)
+	prevEventRate := c.eventRate.Load()
 	newEventRate := ewmaWeight*float64(eventCount)/deltaInSec + (1-ewmaWeight)*float64(prevEventRate)
 
 	// If we just started we don't amortize the value.
@@ -131,8 +132,8 @@ func (c *CircuitBreaker) update(now time.Time) {
 		newEventRate = float64(eventCount) / deltaInSec
 	}
 
-	atomic.StoreInt64(&c.lastUpdate, now.UnixNano())
-	atomic.StoreInt64(&c.eventRate, int64(newEventRate))
+	c.lastUpdate.Store(now.UnixNano())
+	c.eventRate.Store(int64(newEventRate))
 
 	// Update circuit breaker status accordingly
 	if int64(newEventRate) > c.maxEventsPerSec {
@@ -141,6 +142,6 @@ func (c *CircuitBreaker) update(now time.Time) {
 			c.maxEventsPerSec,
 			int(newEventRate),
 		)
-		atomic.StoreInt64(&c.status, breakerOpen)
+		c.isOpen.Store(true)
 	}
 }

--- a/pkg/network/netlink/circuit_breaker_test.go
+++ b/pkg/network/netlink/circuit_breaker_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/atomic"
 )
 
 func TestCircuitBreakerDefaultState(t *testing.T) {
@@ -135,7 +136,13 @@ func TestCircuitBreakerRateCalculation(t *testing.T) {
 }
 
 func newTestBreaker(maxEventRate int) *CircuitBreaker {
-	c := &CircuitBreaker{maxEventsPerSec: int64(maxEventRate)}
+	c := &CircuitBreaker{
+		eventCount:      atomic.NewInt64(0),
+		eventRate:       atomic.NewInt64(0),
+		isOpen:          atomic.NewBool(false),
+		lastUpdate:      atomic.NewInt64(0),
+		maxEventsPerSec: int64(maxEventRate),
+	}
 	c.Reset()
 	return c
 }

--- a/pkg/network/netlink/conntracker.go
+++ b/pkg/network/netlink/conntracker.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"net"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/network"
@@ -22,6 +21,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/hashicorp/golang-lru/simplelru"
+	"go.uber.org/atomic"
 	"golang.org/x/sys/unix"
 	"inet.af/netaddr"
 )
@@ -59,6 +59,17 @@ type orphanEntry struct {
 	expires time.Time
 }
 
+type stats struct {
+	gets                 *atomic.Int64
+	getTimeTotal         *atomic.Int64
+	registers            *atomic.Int64
+	registersDropped     *atomic.Int64
+	registersTotalTime   *atomic.Int64
+	unregisters          *atomic.Int64
+	unregistersTotalTime *atomic.Int64
+	evicts               *atomic.Int64
+}
+
 type realConntracker struct {
 	sync.RWMutex
 	consumer *Consumer
@@ -69,16 +80,7 @@ type realConntracker struct {
 	maxStateSize int
 
 	compactTicker *time.Ticker
-	stats         struct {
-		gets                 int64
-		getTimeTotal         int64
-		registers            int64
-		registersDropped     int64
-		registersTotalTime   int64
-		unregisters          int64
-		unregistersTotalTime int64
-		evicts               int64
-	}
+	stats         stats
 }
 
 // NewConntracker creates a new conntracker with a short term buffer capped at the given size
@@ -103,6 +105,19 @@ func NewConntracker(config *config.Config) (Conntracker, error) {
 	}
 }
 
+func newStats() stats {
+	return stats{
+		gets:                 atomic.NewInt64(0),
+		getTimeTotal:         atomic.NewInt64(0),
+		registers:            atomic.NewInt64(0),
+		registersDropped:     atomic.NewInt64(0),
+		registersTotalTime:   atomic.NewInt64(0),
+		unregisters:          atomic.NewInt64(0),
+		unregistersTotalTime: atomic.NewInt64(0),
+		evicts:               atomic.NewInt64(0),
+	}
+}
+
 func newConntrackerOnce(procRoot string, maxStateSize, targetRateLimit int, listenAllNamespaces bool) (Conntracker, error) {
 	consumer := NewConsumer(procRoot, targetRateLimit, listenAllNamespaces)
 	ctr := &realConntracker{
@@ -111,6 +126,7 @@ func newConntrackerOnce(procRoot string, maxStateSize, targetRateLimit int, list
 		maxStateSize:  maxStateSize,
 		compactTicker: time.NewTicker(compactInterval),
 		decoder:       NewDecoder(),
+		stats:         newStats(),
 	}
 
 	for _, family := range []uint8{unix.AF_INET, unix.AF_INET6} {
@@ -132,8 +148,8 @@ func newConntrackerOnce(procRoot string, maxStateSize, targetRateLimit int, list
 func (ctr *realConntracker) GetTranslationForConn(c network.ConnectionStats) *network.IPTranslation {
 	then := time.Now().UnixNano()
 	defer func() {
-		atomic.AddInt64(&ctr.stats.gets, 1)
-		atomic.AddInt64(&ctr.stats.getTimeTotal, time.Now().UnixNano()-then)
+		ctr.stats.gets.Inc()
+		ctr.stats.getTimeTotal.Add(time.Now().UnixNano() - then)
 	}()
 
 	ctr.Lock()
@@ -165,28 +181,28 @@ func (ctr *realConntracker) GetStats() map[string]int64 {
 		"orphan_size": int64(orphanSize),
 	}
 
-	gets := atomic.LoadInt64(&ctr.stats.gets)
-	getTimeTotal := atomic.LoadInt64(&ctr.stats.getTimeTotal)
+	gets := ctr.stats.gets.Load()
+	getTimeTotal := ctr.stats.getTimeTotal.Load()
 	m["gets_total"] = gets
 	if gets != 0 {
 		m["nanoseconds_per_get"] = getTimeTotal / gets
 	}
 
-	registers := atomic.LoadInt64(&ctr.stats.registers)
+	registers := ctr.stats.registers.Load()
 	m["registers_total"] = registers
-	registersTotalTime := atomic.LoadInt64(&ctr.stats.registersTotalTime)
+	registersTotalTime := ctr.stats.registersTotalTime.Load()
 	if registers != 0 {
 		m["nanoseconds_per_register"] = registersTotalTime / registers
 	}
-	m["registers_dropped"] = atomic.LoadInt64(&ctr.stats.registersDropped)
+	m["registers_dropped"] = ctr.stats.registersDropped.Load()
 
-	unregisters := atomic.LoadInt64(&ctr.stats.unregisters)
-	unregisterTotalTime := atomic.LoadInt64(&ctr.stats.unregistersTotalTime)
+	unregisters := ctr.stats.unregisters.Load()
+	unregisterTotalTime := ctr.stats.unregistersTotalTime.Load()
 	m["unregisters_total"] = unregisters
 	if unregisters != 0 {
 		m["nanoseconds_per_unregister"] = unregisterTotalTime / unregisters
 	}
-	m["evicts_total"] = atomic.LoadInt64(&ctr.stats.evicts)
+	m["evicts_total"] = ctr.stats.evicts.Load()
 
 	// Merge telemetry from the consumer
 	for k, v := range ctr.consumer.GetStats() {
@@ -199,7 +215,7 @@ func (ctr *realConntracker) GetStats() map[string]int64 {
 func (ctr *realConntracker) DeleteTranslation(c network.ConnectionStats) {
 	then := time.Now().UnixNano()
 	defer func() {
-		atomic.AddInt64(&ctr.stats.unregistersTotalTime, time.Now().UnixNano()-then)
+		ctr.stats.unregistersTotalTime.Add(time.Now().UnixNano() - then)
 	}()
 
 	ctr.Lock()
@@ -212,7 +228,7 @@ func (ctr *realConntracker) DeleteTranslation(c network.ConnectionStats) {
 	}
 
 	if ctr.cache.Remove(k) {
-		atomic.AddInt64(&ctr.stats.unregisters, 1)
+		ctr.stats.unregisters.Inc()
 	}
 }
 
@@ -234,8 +250,8 @@ func (ctr *realConntracker) loadInitialState(events <-chan Event) {
 			}
 
 			evicts := ctr.cache.Add(c, false)
-			atomic.AddInt64(&ctr.stats.registers, 1)
-			atomic.AddInt64(&ctr.stats.evicts, int64(evicts))
+			ctr.stats.registers.Inc()
+			ctr.stats.evicts.Add(int64(evicts))
 		}
 	}
 }
@@ -245,7 +261,7 @@ func (ctr *realConntracker) loadInitialState(events <-chan Event) {
 func (ctr *realConntracker) register(c Con) int {
 	// don't bother storing if the connection is not NAT
 	if !IsNAT(c) {
-		atomic.AddInt64(&ctr.stats.registersDropped, 1)
+		ctr.stats.registersDropped.Inc()
 		return 0
 	}
 
@@ -256,9 +272,9 @@ func (ctr *realConntracker) register(c Con) int {
 
 	evicts := ctr.cache.Add(c, true)
 
-	atomic.AddInt64(&ctr.stats.registers, 1)
-	atomic.AddInt64(&ctr.stats.evicts, int64(evicts))
-	atomic.AddInt64(&ctr.stats.registersTotalTime, time.Now().UnixNano()-then)
+	ctr.stats.registers.Inc()
+	ctr.stats.evicts.Add(int64(evicts))
+	ctr.stats.registersTotalTime.Add(time.Now().UnixNano() - then)
 
 	return 0
 }
@@ -296,7 +312,7 @@ func (ctr *realConntracker) run() error {
 func (ctr *realConntracker) compact() {
 	var removed int64
 	defer func() {
-		atomic.AddInt64(&ctr.stats.unregisters, removed)
+		ctr.stats.unregisters.Add(removed)
 		log.Debugf("removed %d orphans", removed)
 	}()
 

--- a/pkg/network/netlink/conntracker_test.go
+++ b/pkg/network/netlink/conntracker_test.go
@@ -430,6 +430,7 @@ func newConntracker(maxSize int) *realConntracker {
 	rt := &realConntracker{
 		maxStateSize: maxSize,
 		cache:        newConntrackCache(maxSize, defaultOrphanTimeout),
+		stats:        newStats(),
 	}
 
 	return rt

--- a/pkg/network/netlink/consumer_test.go
+++ b/pkg/network/netlink/consumer_test.go
@@ -10,7 +10,6 @@ package netlink
 
 import (
 	"net"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -39,7 +38,7 @@ func TestConsumerKeepsRunningAfterCircuitBreakerTrip(t *testing.T) {
 	}()
 
 	isRecvLoopRunning := func() bool {
-		return atomic.LoadInt32(&c.recvLoopRunning) == 1
+		return c.recvLoopRunning.Load()
 	}
 
 	require.Eventually(t, func() bool {

--- a/pkg/network/route_cache.go
+++ b/pkg/network/route_cache.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"net"
 	"sync"
-	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -21,6 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/golang/groupcache/lru"
 	"github.com/vishvananda/netlink"
+	"go.uber.org/atomic"
 	"golang.org/x/sys/unix"
 )
 
@@ -47,10 +47,10 @@ type routeCache struct {
 	router Router
 	ttl    time.Duration
 
-	size    uint64 `stats:"atomic"`
-	misses  uint64 `stats:"atomic"`
-	lookups uint64 `stats:"atomic"`
-	expires uint64 `stats:"atomic"`
+	size    *atomic.Uint64 `stats:""`
+	misses  *atomic.Uint64 `stats:""`
+	lookups *atomic.Uint64 `stats:""`
+	expires *atomic.Uint64 `stats:""`
 
 	reporter netstats.Reporter
 }
@@ -86,6 +86,11 @@ func newRouteCache(size int, router Router, ttl time.Duration) *routeCache {
 		cache:  lru.New(size),
 		router: router,
 		ttl:    ttl,
+
+		size:    atomic.NewUint64(0),
+		misses:  atomic.NewUint64(0),
+		lookups: atomic.NewUint64(0),
+		expires: atomic.NewUint64(0),
 	}
 
 	var err error
@@ -105,18 +110,18 @@ func (c *routeCache) Get(source, dest util.Address, netns uint32) (Route, bool) 
 	c.Lock()
 	defer c.Unlock()
 
-	atomic.AddUint64(&c.lookups, 1)
+	c.lookups.Inc()
 	k := newRouteKey(source, dest, netns)
 	if entry, ok := c.cache.Get(k); ok {
 		if time.Now().Unix() < entry.(*routeTTL).eta {
 			return entry.(*routeTTL).entry, ok
 		}
 
-		atomic.AddUint64(&c.expires, 1)
+		c.expires.Inc()
 		c.cache.Remove(k)
-		atomic.AddUint64(&c.size, ^uint64(0))
+		c.size.Dec()
 	} else {
-		atomic.AddUint64(&c.misses, 1)
+		c.misses.Inc()
 	}
 
 	if r, ok := c.router.Route(source, dest, netns); ok {
@@ -126,7 +131,7 @@ func (c *routeCache) Get(source, dest util.Address, netns uint32) (Route, bool) 
 		}
 
 		c.cache.Add(k, entry)
-		atomic.AddUint64(&c.size, 1)
+		c.size.Inc()
 		return r, true
 	}
 
@@ -167,14 +172,14 @@ type netlinkRouter struct {
 	ifcache  *lru.Cache
 	nlHandle *netlink.Handle
 
-	netlinkLookups uint64 `stats:"atomic"`
-	netlinkErrors  uint64 `stats:"atomic"`
-	netlinkMisses  uint64 `stats:"atomic"`
+	netlinkLookups *atomic.Uint64 `stats:""`
+	netlinkErrors  *atomic.Uint64 `stats:""`
+	netlinkMisses  *atomic.Uint64 `stats:""`
 
-	ifCacheLookups uint64 `stats:"atomic"`
-	ifCacheMisses  uint64 `stats:"atomic"`
-	ifCacheSize    uint64 `stats:"atomic"`
-	ifCacheErrors  uint64 `stats:"atomic"`
+	ifCacheLookups *atomic.Uint64 `stats:""`
+	ifCacheMisses  *atomic.Uint64 `stats:""`
+	ifCacheSize    *atomic.Uint64 `stats:""`
+	ifCacheErrors  *atomic.Uint64 `stats:""`
 
 	reporter netstats.Reporter
 }
@@ -211,6 +216,15 @@ func newNetlinkRouter(procRoot string) (*netlinkRouter, error) {
 		// ifcache should ideally fit all interfaces on a given node
 		ifcache:  lru.New(128),
 		nlHandle: nlHandle,
+
+		netlinkLookups: atomic.NewUint64(0),
+		netlinkErrors:  atomic.NewUint64(0),
+		netlinkMisses:  atomic.NewUint64(0),
+
+		ifCacheLookups: atomic.NewUint64(0),
+		ifCacheMisses:  atomic.NewUint64(0),
+		ifCacheSize:    atomic.NewUint64(0),
+		ifCacheErrors:  atomic.NewUint64(0),
 	}
 
 	nr.reporter, err = netstats.NewReporter(nr)
@@ -257,7 +271,7 @@ func (n *netlinkRouter) Route(source, dest util.Address, netns uint32) (Route, b
 		}
 	}
 
-	atomic.AddUint64(&n.netlinkLookups, 1)
+	n.netlinkLookups.Inc()
 	dstIP := util.NetIPFromAddress(dest, *dstBuf)
 	routes, err := n.nlHandle.RouteGetWithOptions(
 		dstIP,
@@ -267,7 +281,7 @@ func (n *netlinkRouter) Route(source, dest util.Address, netns uint32) (Route, b
 		})
 
 	if err != nil {
-		atomic.AddUint64(&n.netlinkErrors, 1)
+		n.netlinkErrors.Inc()
 		if iifIndex > 0 {
 			if errno, ok := err.(syscall.Errno); ok && (errno == syscall.EINVAL || errno == syscall.ENODEV) {
 				// invalidate interface cache entry as this may have been the cause of the netlink error
@@ -275,7 +289,7 @@ func (n *netlinkRouter) Route(source, dest util.Address, netns uint32) (Route, b
 			}
 		}
 	} else if len(routes) != 1 {
-		atomic.AddUint64(&n.netlinkMisses, 1)
+		n.netlinkMisses.Inc()
 	}
 	if err != nil || len(routes) != 1 {
 		log.Tracef("could not get route for src=%s dest=%s err=%s routes=%+v", source, dest, err, routes)
@@ -296,27 +310,27 @@ func (n *netlinkRouter) removeInterface(srcAddress util.Address, netns uint32) {
 }
 
 func (n *netlinkRouter) getInterface(srcAddress util.Address, srcIP net.IP, netns uint32) *ifEntry {
-	atomic.AddUint64(&n.ifCacheLookups, 1)
+	n.ifCacheLookups.Inc()
 
 	key := ifkey{ip: srcAddress, netns: netns}
 	if entry, ok := n.ifcache.Get(key); ok {
 		return entry.(*ifEntry)
 	}
-	atomic.AddUint64(&n.ifCacheMisses, 1)
+	n.ifCacheMisses.Inc()
 
-	atomic.AddUint64(&n.netlinkLookups, 1)
+	n.netlinkLookups.Inc()
 	routes, err := n.nlHandle.RouteGet(srcIP)
 	if err != nil {
-		atomic.AddUint64(&n.netlinkErrors, 1)
+		n.netlinkErrors.Inc()
 		return nil
 	} else if len(routes) != 1 {
-		atomic.AddUint64(&n.netlinkMisses, 1)
+		n.netlinkMisses.Inc()
 		return nil
 	}
 
 	ifr, err := unix.NewIfreq("")
 	if err != nil {
-		atomic.AddUint64(&n.ifCacheErrors, 1)
+		n.ifCacheErrors.Inc()
 		return nil
 	}
 
@@ -325,12 +339,12 @@ func (n *netlinkRouter) getInterface(srcAddress util.Address, srcIP net.IP, netn
 	// necessary to make the subsequent request to
 	// get the link flags
 	if err = unix.IoctlIfreq(n.ioctlFD, unix.SIOCGIFNAME, ifr); err != nil {
-		atomic.AddUint64(&n.ifCacheErrors, 1)
+		n.ifCacheErrors.Inc()
 		log.Tracef("error getting interface name for link index %d, src ip %s: %s", routes[0].LinkIndex, srcIP, err)
 		return nil
 	}
 	if err = unix.IoctlIfreq(n.ioctlFD, unix.SIOCGIFFLAGS, ifr); err != nil {
-		atomic.AddUint64(&n.ifCacheErrors, 1)
+		n.ifCacheErrors.Inc()
 		log.Tracef("error getting interface flags for link index %d, src ip %s: %s", routes[0].LinkIndex, srcIP, err)
 		return nil
 	}
@@ -338,6 +352,6 @@ func (n *netlinkRouter) getInterface(srcAddress util.Address, srcIP net.IP, netn
 	iff := &ifEntry{index: routes[0].LinkIndex, loopback: (ifr.Uint16() & unix.IFF_LOOPBACK) != 0}
 	log.Tracef("adding interface entry, key=%+v, entry=%v", key, *iff)
 	n.ifcache.Add(key, iff)
-	atomic.AddUint64(&n.ifCacheSize, 1)
+	n.ifCacheSize.Inc()
 	return iff
 }

--- a/pkg/network/state_test.go
+++ b/pkg/network/state_test.go
@@ -10,7 +10,6 @@ import (
 	"math"
 	"math/rand"
 	"sync"
-	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -20,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 )
 
 func BenchmarkConnectionsGet(b *testing.B) {
@@ -83,7 +83,7 @@ func BenchmarkConnectionsGet(b *testing.B) {
 			ns := newDefaultState()
 
 			// Initial fetch to set up client
-			ns.GetDelta(DEBUGCLIENT, latestTime, nil, nil, nil)
+			ns.GetDelta(DEBUGCLIENT, latestTime.Load(), nil, nil, nil)
 
 			for _, c := range closed[:bench.closedCount] {
 				ns.StoreClosedConnections([]ConnectionStats{c})
@@ -93,7 +93,7 @@ func BenchmarkConnectionsGet(b *testing.B) {
 			b.ReportAllocs()
 
 			for n := 0; n < b.N; n++ {
-				ns.GetDelta(DEBUGCLIENT, latestTime, conns[:bench.connCount], nil, nil)
+				ns.GetDelta(DEBUGCLIENT, latestTime.Load(), conns[:bench.connCount], nil, nil)
 			}
 		})
 	}
@@ -1714,10 +1714,10 @@ func generateRandConnections(n int) []ConnectionStats {
 	return cs
 }
 
-var latestTime uint64
+var latestTime atomic.Uint64
 
 func latestEpochTime() uint64 {
-	return atomic.AddUint64(&latestTime, 1)
+	return latestTime.Inc()
 }
 
 func newDefaultState() State {

--- a/pkg/network/stats/reporter_test.go
+++ b/pkg/network/stats/reporter_test.go
@@ -26,13 +26,15 @@ func TestStatsAllowedTypes(t *testing.T) {
 		u16 uint16 `stats:""`
 		u8  uint8  `stats:""`
 		u   uint   `stats:""`
+
+		uptr uintptr `stats:""`
 	}
 
 	v := &test{}
 	s, err := NewReporter(v)
 	require.NoError(t, err)
 	stats := s.Report()
-	require.Len(t, stats, 10)
+	require.Len(t, stats, 11)
 	require.Equal(t, int64(0), stats["i64"])
 	require.Equal(t, int32(0), stats["i32"])
 	require.Equal(t, int16(0), stats["i16"])
@@ -44,6 +46,8 @@ func TestStatsAllowedTypes(t *testing.T) {
 	require.Equal(t, uint16(0), stats["u16"])
 	require.Equal(t, uint8(0), stats["u8"])
 	require.Equal(t, uint(0), stats["u"])
+
+	require.Equal(t, uintptr(0), stats["uptr"])
 }
 
 func TestStatsSnakeCase(t *testing.T) {
@@ -86,26 +90,12 @@ func TestStatsSkipNoTag(t *testing.T) {
 func TestStatsAllowedTypesAtomic(t *testing.T) {
 	//nolint:structcheck,unused
 	type test struct {
-		i64 int64 `stats:"atomic"`
-		i32 int32 `stats:"atomic"`
-
-		u64  uint64  `stats:"atomic"`
-		u32  uint32  `stats:"atomic"`
-		u    uint    `stats:"atomic"`
-		uptr uintptr `stats:"atomic"`
-
 		boolp *atomic.Bool   `stats:""`
 		i64p  *atomic.Int64  `stats:""`
 		u64p  *atomic.Uint64 `stats:""`
 	}
 
 	v := &test{
-		i64:   1,
-		i32:   2,
-		u64:   3,
-		u32:   4,
-		u:     5,
-		uptr:  uintptr(0),
 		boolp: atomic.NewBool(true),
 		i64p:  atomic.NewInt64(6),
 		u64p:  atomic.NewUint64(7),
@@ -113,15 +103,8 @@ func TestStatsAllowedTypesAtomic(t *testing.T) {
 	s, err := NewReporter(v)
 	require.NoError(t, err)
 	stats := s.Report()
-	require.Len(t, stats, 9)
-	require.Equal(t, int64(1), stats["i64"])
-	require.Equal(t, int32(2), stats["i32"])
-
-	require.Equal(t, uint64(3), stats["u64"])
-	require.Equal(t, uint32(4), stats["u32"])
-	require.Equal(t, uint(5), stats["u"])
-	require.Equal(t, uintptr(0), stats["uptr"])
-
+	require.Len(t, stats, 3)
+	require.Equal(t, true, stats["boolp"])
 	require.Equal(t, int64(6), stats["i64p"])
 	require.Equal(t, uint64(7), stats["u64p"])
 }

--- a/pkg/network/stats/reporter_test.go
+++ b/pkg/network/stats/reporter_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 )
 
 func TestStatsAllowedTypes(t *testing.T) {
@@ -92,18 +93,35 @@ func TestStatsAllowedTypesAtomic(t *testing.T) {
 		u32  uint32  `stats:"atomic"`
 		u    uint    `stats:"atomic"`
 		uptr uintptr `stats:"atomic"`
+
+		boolp *atomic.Bool   `stats:""`
+		i64p  *atomic.Int64  `stats:""`
+		u64p  *atomic.Uint64 `stats:""`
 	}
 
-	v := &test{}
+	v := &test{
+		i64:   1,
+		i32:   2,
+		u64:   3,
+		u32:   4,
+		u:     5,
+		uptr:  uintptr(0),
+		boolp: atomic.NewBool(true),
+		i64p:  atomic.NewInt64(6),
+		u64p:  atomic.NewUint64(7),
+	}
 	s, err := NewReporter(v)
 	require.NoError(t, err)
 	stats := s.Report()
-	require.Len(t, stats, 6)
-	require.Equal(t, int64(0), stats["i64"])
-	require.Equal(t, int32(0), stats["i32"])
+	require.Len(t, stats, 9)
+	require.Equal(t, int64(1), stats["i64"])
+	require.Equal(t, int32(2), stats["i32"])
 
-	require.Equal(t, uint64(0), stats["u64"])
-	require.Equal(t, uint32(0), stats["u32"])
-	require.Equal(t, uint(0), stats["u"])
+	require.Equal(t, uint64(3), stats["u64"])
+	require.Equal(t, uint32(4), stats["u32"])
+	require.Equal(t, uint(5), stats["u"])
 	require.Equal(t, uintptr(0), stats["uptr"])
+
+	require.Equal(t, int64(6), stats["i64p"])
+	require.Equal(t, uint64(7), stats["u64p"])
 }

--- a/pkg/network/tracer/ebpf_conntracker.go
+++ b/pkg/network/tracer/ebpf_conntracker.go
@@ -15,7 +15,6 @@ import (
 	"io"
 	"math"
 	"sync"
-	"sync/atomic"
 	"time"
 	"unsafe"
 
@@ -30,6 +29,7 @@ import (
 	"github.com/cihub/seelog"
 	"github.com/cilium/ebpf"
 	libnetlink "github.com/mdlayher/netlink"
+	"go.uber.org/atomic"
 	"golang.org/x/sys/unix"
 )
 
@@ -37,6 +37,22 @@ var tuplePool = sync.Pool{
 	New: func() interface{} {
 		return new(netebpf.ConntrackTuple)
 	},
+}
+
+type ebpfConntrackerStats struct {
+	gets                 *atomic.Int64
+	getTotalTime         *atomic.Int64
+	unregisters          *atomic.Int64
+	unregistersTotalTime *atomic.Int64
+}
+
+func newEbpfConntrackerStats() ebpfConntrackerStats {
+	return ebpfConntrackerStats{
+		gets:                 atomic.NewInt64(0),
+		getTotalTime:         atomic.NewInt64(0),
+		unregisters:          atomic.NewInt64(0),
+		unregistersTotalTime: atomic.NewInt64(0),
+	}
 }
 
 type ebpfConntracker struct {
@@ -48,12 +64,7 @@ type ebpfConntracker struct {
 	consumer *netlink.Consumer
 	decoder  *netlink.Decoder
 
-	stats struct {
-		gets                 int64
-		getTotalTime         int64
-		unregisters          int64
-		unregistersTotalTime int64
-	}
+	stats ebpfConntrackerStats
 }
 
 // NewEBPFConntracker creates a netlink.Conntracker that monitor conntrack NAT entries via eBPF
@@ -103,6 +114,7 @@ func NewEBPFConntracker(cfg *config.Config) (netlink.Conntracker, error) {
 		ctMap:        ctMap,
 		telemetryMap: telemetryMap,
 		rootNS:       rootNS,
+		stats:        newEbpfConntrackerStats(),
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.ConntrackInitTimeout)
@@ -254,8 +266,8 @@ func (e *ebpfConntracker) GetTranslationForConn(stats network.ConnectionStats) *
 	}
 	defer tuplePool.Put(dst)
 
-	atomic.AddInt64(&e.stats.gets, 1)
-	atomic.AddInt64(&e.stats.getTotalTime, time.Now().Sub(start).Nanoseconds())
+	e.stats.gets.Inc()
+	e.stats.getTotalTime.Add(time.Now().Sub(start).Nanoseconds())
 	return &network.IPTranslation{
 		ReplSrcIP:   dst.SourceAddress(),
 		ReplDstIP:   dst.DestAddress(),
@@ -303,8 +315,8 @@ func (e *ebpfConntracker) DeleteTranslation(stats network.ConnectionStats) {
 		e.delete(dst)
 		tuplePool.Put(dst)
 	}
-	atomic.AddInt64(&e.stats.unregisters, 1)
-	atomic.AddInt64(&e.stats.unregistersTotalTime, time.Now().Sub(start).Nanoseconds())
+	e.stats.unregisters.Inc()
+	e.stats.unregistersTotalTime.Add(time.Now().Sub(start).Nanoseconds())
 }
 
 func (e *ebpfConntracker) GetStats() map[string]int64 {
@@ -319,15 +331,15 @@ func (e *ebpfConntracker) GetStats() map[string]int64 {
 		m["registers_dropped"] = int64(telemetry.Dropped)
 	}
 
-	gets := atomic.LoadInt64(&e.stats.gets)
-	getTimeTotal := atomic.LoadInt64(&e.stats.getTotalTime)
+	gets := e.stats.gets.Load()
+	getTimeTotal := e.stats.getTotalTime.Load()
 	m["gets_total"] = gets
 	if gets > 0 {
 		m["nanoseconds_per_get"] = getTimeTotal / gets
 	}
 
-	unregisters := atomic.LoadInt64(&e.stats.unregisters)
-	unregistersTimeTotal := atomic.LoadInt64(&e.stats.unregistersTotalTime)
+	unregisters := e.stats.unregisters.Load()
+	unregistersTimeTotal := e.stats.unregistersTotalTime.Load()
 	m["unregisters_total"] = unregisters
 	if unregisters > 0 {
 		m["nanoseconds_per_unregister"] = unregistersTimeTotal / unregisters

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"math"
 	"sync"
-	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -38,6 +37,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	manager "github.com/DataDog/ebpf-manager"
 	"github.com/cilium/ebpf"
+	"go.uber.org/atomic"
 	"golang.org/x/sys/unix"
 )
 
@@ -52,7 +52,7 @@ type Tracer struct {
 	ebpfTracer  connection.Tracer
 
 	// Telemetry
-	skippedConns int64 `stats:"atomic"`
+	skippedConns *atomic.Int64 `stats:""`
 	// Will track the count of expired TCP connections
 	// We are manually expiring TCP connections because it seems that we are losing some TCP close events
 	// For now we are only tracking the `tcp_close` probe, but we should also track the `tcp_set_state` probe when
@@ -65,10 +65,10 @@ type Tracer struct {
 	//
 	// If we want to have a way to track the # of active TCP connections in the future we could use the procfs like here: https://github.com/DataDog/datadog-agent/pull/3728
 	// to determine whether a connection is truly closed or not
-	expiredTCPConns  int64 `stats:"atomic"`
-	closedConns      int64 `stats:"atomic"`
-	connStatsMapSize int64 `stats:"atomic"`
-	lastCheck        int64 `stats:"atomic"`
+	expiredTCPConns  *atomic.Int64 `stats:""`
+	closedConns      *atomic.Int64 `stats:""`
+	connStatsMapSize *atomic.Int64 `stats:""`
+	lastCheck        *atomic.Int64 `stats:""`
 
 	activeBuffer *network.ConnectionBuffer
 	bufferLock   sync.Mutex
@@ -170,6 +170,12 @@ func NewTracer(config *config.Config) (*Tracer, error) {
 		sysctlUDPConnStreamTimeout: sysctl.NewInt(config.ProcRoot, "net/netfilter/nf_conntrack_udp_timeout_stream", time.Minute),
 		gwLookup:                   gwLookup,
 		ebpfTracer:                 ebpfTracer,
+
+		skippedConns:     atomic.NewInt64(0),
+		expiredTCPConns:  atomic.NewInt64(0),
+		closedConns:      atomic.NewInt64(0),
+		connStatsMapSize: atomic.NewInt64(0),
+		lastCheck:        atomic.NewInt64(0),
 	}
 
 	if tr.statsReporter, err = stats.NewReporter(tr); err != nil {
@@ -309,8 +315,8 @@ func (t *Tracer) storeClosedConnections(connections []network.ConnectionStats) {
 	}
 
 	connections = connections[rejected:]
-	atomic.AddInt64(&t.closedConns, int64(len(connections)))
-	atomic.AddInt64(&t.skippedConns, int64(rejected))
+	t.closedConns.Add(int64(len(connections)))
+	t.skippedConns.Add(int64(rejected))
 	t.state.StoreClosedConnections(connections)
 }
 
@@ -345,7 +351,7 @@ func (t *Tracer) GetActiveConnections(clientID string) (*network.Connections, er
 	names := t.reverseDNS.Resolve(ips)
 	ctm := t.state.GetTelemetryDelta(clientID, t.getConnTelemetry(len(active)))
 	rctm := t.getRuntimeCompilationTelemetry()
-	atomic.StoreInt64(&t.lastCheck, time.Now().Unix())
+	t.lastCheck.Store(time.Now().Unix())
 
 	return &network.Connections{
 		BufferedData:                delta.BufferedData,
@@ -368,7 +374,7 @@ func (t *Tracer) getConnTelemetry(mapSize int) map[network.ConnTelemetryType]int
 		network.MonotonicKprobesTriggered: kprobeStats.Hits,
 		network.MonotonicKprobesMissed:    kprobeStats.Misses,
 		network.ConnsBpfMapSize:           int64(mapSize),
-		network.MonotonicConnsClosed:      atomic.LoadInt64(&t.closedConns),
+		network.MonotonicConnsClosed:      t.closedConns.Load(),
 	}
 
 	stats, err := t.getStats(conntrackStats, dnsStats, epbfStats, httpStats)
@@ -463,14 +469,14 @@ func (t *Tracer) getConnections(activeBuffer *network.ConnectionBuffer) (latestU
 		if t.connectionExpired(c, uint64(latestTime), cachedConntrack) {
 			expired = append(expired, *c)
 			if c.Type == network.TCP {
-				atomic.AddInt64(&t.expiredTCPConns, 1)
+				t.expiredTCPConns.Inc()
 			}
-			atomic.AddInt64(&t.closedConns, 1)
+			t.closedConns.Inc()
 			return false
 		}
 
 		if t.shouldSkipConnection(c) {
-			atomic.AddInt64(&t.skippedConns, 1)
+			t.skippedConns.Inc()
 			return false
 		}
 		return true
@@ -496,7 +502,7 @@ func (t *Tracer) getConnections(activeBuffer *network.ConnectionBuffer) (latestU
 	} else if (float64(entryCount) / float64(t.config.MaxTrackedConnections)) >= 0.9 {
 		log.Warnf("connection tracking map size of %d is approaching the limit of %d. The config value `system_probe_config.max_tracked_connections` may be increased to avoid any accuracy problems.", entryCount, t.config.MaxTrackedConnections)
 	}
-	atomic.SwapInt64(&t.connStatsMapSize, int64(entryCount))
+	t.connStatsMapSize.Store(int64(entryCount))
 
 	// Remove expired entries
 	t.removeEntries(expired)


### PR DESCRIPTION
 ### What does this PR do?

Uses go.uber.com/atomic to ensure alignment of atomic access in pkg/network.

### Motivation

Alignment issues with atomic access, and enforcing atomic access to atomic variables.  See #11716.

There were a few potential alignment errors fixed here, but all non-atomic accesses were limited to tests, where it's an easy mistake to make.  So, this is unlikely to fix any production bugs, but makes it much less likely that new bugs will be introduced.

### Additional Notes

* I don't know if any of the structs to which I've added more `*atomic.Foo` are allocated frequently.  If so, then those additional allocations might cause additional GC load.
* Reporter is pretty cool!  I modified it to read directly from `*atomic.Foo` types, and tested it, but please have an extra-close look at this to make sure I got it right.

### Describe how to test/QA your changes

Basic network testing should uncover any issues here.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
