### PR TITLE
[CODEOWNERS] Update agent-shared-components components with correct ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -81,7 +81,7 @@
 
 /chocolatey/                            @DataDog/agent-platform
 
-/cmd/                                   @DataDog/agent-core
+/cmd/                                   @DataDog/agent-shared-components
 /cmd/trace-agent/                       @DataDog/agent-apm
 /cmd/agent/app/integrations*.go         @DataDog/software-integrity-and-trust @DataDog/agent-integrations @DataDog/agent-core
 /cmd/agent/app/remote_config.go         @Datadog/remote-config
@@ -128,7 +128,7 @@
 /Makefile.trace                         @DataDog/agent-apm
 
 /omnibus/                               @DataDog/agent-platform
-/omnibus/config/software/datadog-agent*.rb                @Datadog/agent-core @DataDog/agent-platform
+/omnibus/config/software/datadog-agent*.rb                @Datadog/agent-shared-components @DataDog/agent-platform
 /omnibus/config/software/datadog-agent-integrations-*.rb  @DataDog/agent-integrations
 /omnibus/config/software/datadog-security-agent*.rb       @Datadog/agent-security @DataDog/agent-platform
 /omnibus/config/software/snmp-traps.rb                    @DataDog/infrastructure-integrations
@@ -139,14 +139,14 @@
 /pkg/dogstatsd/                         @DataDog/agent-metrics-logs
 /pkg/forwarder/                         @DataDog/agent-metrics-logs
 /pkg/jmxfetch/                          @DataDog/agent-metrics-logs
-/pkg/metadata/                          @DataDog/agent-core
+/pkg/metadata/                          @DataDog/agent-shared-components
 /pkg/metrics/                           @DataDog/agent-metrics-logs
 /pkg/serializer/                        @DataDog/agent-metrics-logs
 /pkg/serverless/                        @DataDog/serverless
-/pkg/status/                            @DataDog/agent-core
+/pkg/status/                            @DataDog/agent-shared-components
 /pkg/status/templates/process-agent.tmpl    @DataDog/processes
-/pkg/telemetry/                         @DataDog/agent-core
-/pkg/version/                           @DataDog/agent-core
+/pkg/telemetry/                         @DataDog/agent-shared-components
+/pkg/version/                           @DataDog/agent-shared-components
 /pkg/obfuscate/                         @DataDog/agent-apm
 /pkg/trace/                             @DataDog/agent-apm
 /pkg/autodiscovery/                     @DataDog/container-integrations @DataDog/agent-core
@@ -173,7 +173,7 @@
 /pkg/collector/corechecks/system/       @DataDog/agent-platform
 /pkg/collector/corechecks/systemd/      @DataDog/agent-integrations
 /pkg/collector/corechecks/nvidia/       @DataDog/agent-platform
-/pkg/config/config_template.yaml        @DataDog/agent-core @DataDog/documentation
+/pkg/config/config_template.yaml        @DataDog/agent-shared-components @DataDog/documentation
 /pkg/config/apm.go                      @DataDog/agent-apm
 /pkg/config/autodiscovery/              @Datadog/container-integrations
 /pkg/config/environment*.go             @DataDog/container-integrations @DataDog/container-app
@@ -231,10 +231,10 @@
 /releasenotes-installscript/            @DataDog/documentation
 /releasenotes-dca/                      @DataDog/documentation @DataDog/container-integrations @Datadog/container-app
 
-/rtloader/                              @DataDog/agent-core
+/rtloader/                              @DataDog/agent-shared-components
 
 /tasks/                                 @DataDog/agent-platform
-/tasks/agent.py                         @DataDog/agent-core
+/tasks/agent.py                         @DataDog/agent-shared-components
 /tasks/cluster_agent_cloudfoundry.py    @DataDog/integrations-tools-and-libraries
 /tasks/process_agent.py                 @DataDog/processes
 /tasks/system_probe.py                  @DataDog/agent-network

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -153,8 +153,8 @@
 /pkg/autodiscovery/listeners/cloudfoundry*.go  @DataDog/integrations-tools-and-libraries
 /pkg/autodiscovery/listeners/snmp*.go   @DataDog/infrastructure-integrations
 /pkg/autodiscovery/providers/           @DataDog/container-integrations
-/pkg/autodiscovery/providers/file*.go   @DataDog/agent-shared-components
-/pkg/autodiscovery/providers/config_reader*.go @DataDog/container-integrations @DataDog/agent-shared-components
+/pkg/autodiscovery/providers/file*.go   @DataDog/agent-metrics-logs
+/pkg/autodiscovery/providers/config_reader*.go @DataDog/container-integrations @DataDog/agent-metrics-logs
 /pkg/autodiscovery/providers/cloudfoundry*.go  @DataDog/integrations-tools-and-libraries
 /pkg/clusteragent/                      @DataDog/container-integrations
 /pkg/clusteragent/orchestrator/         @DataDog/container-app

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -243,7 +243,7 @@
 /releasenotes-installscript/            @DataDog/documentation
 /releasenotes-dca/                      @DataDog/documentation @DataDog/container-integrations @Datadog/container-app
 
-/rtloader/                              @DataDog/agent-shared-components
+/rtloader/                              @DataDog/agent-metrics-logs
 
 /tasks/                                 @DataDog/agent-platform
 /tasks/agent.py                         @DataDog/agent-shared-components

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -194,7 +194,7 @@
 /pkg/remoteconfig/                      @DataDog/remote-config
 /pkg/runtime/                           @DataDog/agent-shared-components
 /pkg/secrets/                           @DataDog/agent-shared-components
-/pkg/serializer/                        @DataDog/agent-shared-components
+/pkg/serializer/                        @DataDog/agent-metrics-logs
 /pkg/tagger/                            @DataDog/container-integrations
 /pkg/tagset/                            @DataDog/agent-shared-components
 /pkg/util/cloudproviders/cloudfoundry/  @DataDog/integrations-tools-and-libraries

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,7 +23,7 @@
 # Todo: is this file still needed?
 /Makefile.trace                         @DataDog/agent-platform
 
-/release.json                           @DataDog/agent-platform @DataDog/agent-core
+/release.json                           @DataDog/agent-platform @DataDog/agent-shared-components
 /requirements.txt                       @DataDog/agent-platform
 /pyproject.toml                         @DataDog/agent-platform
 /setup.cfg                              @DataDog/agent-platform
@@ -83,9 +83,9 @@
 
 /cmd/                                   @DataDog/agent-shared-components
 /cmd/trace-agent/                       @DataDog/agent-apm
-/cmd/agent/app/integrations*.go         @DataDog/software-integrity-and-trust @DataDog/agent-integrations @DataDog/agent-core
+/cmd/agent/app/integrations*.go         @DataDog/software-integrity-and-trust @DataDog/agent-integrations @DataDog/agent-shared-components
 /cmd/agent/app/remote_config.go         @Datadog/remote-config
-/cmd/agent/internal/clcrunnerapi/       @DataDog/container-integrations @DataDog/agent-core
+/cmd/agent/internal/clcrunnerapi/       @DataDog/container-integrations @DataDog/agent-shared-components
 /cmd/agent/dist/conf.d/jetson.d         @DataDog/agent-platform
 /cmd/agent/dist/conf.d/snmp.d/          @DataDog/infrastructure-integrations
 /cmd/agent/*.manifest                   @DataDog/agent-platform
@@ -110,11 +110,11 @@
 /Dockerfiles/                           @DataDog/container-integrations
 
 /docs/                                  @DataDog/documentation @DataDog/agent-platform
-/docs/agent/                            @DataDog/documentation @DataDog/agent-core
+/docs/agent/                            @DataDog/documentation @DataDog/agent-shared-components
 /docs/dogstatsd/                        @DataDog/documentation @DataDog/agent-metrics-logs
 /docs/trace-agent/                      @DataDog/documentation @DataDog/agent-apm
 /docs/cluster-agent/                    @DataDog/documentation @DataDog/container-integrations
-/docs/dev/checks/                       @DataDog/documentation @DataDog/agent-core
+/docs/dev/checks/                       @DataDog/documentation @DataDog/agent-shared-components
 /docs/cloud-workload-security/          @DataDog/documentation @DataDog/agent-security
 
 /google-marketplace/                    @DataDog/container-integrations
@@ -128,12 +128,11 @@
 /Makefile.trace                         @DataDog/agent-apm
 
 /omnibus/                               @DataDog/agent-platform
-/omnibus/config/software/datadog-agent*.rb                @Datadog/agent-shared-components @DataDog/agent-platform
 /omnibus/config/software/datadog-agent-integrations-*.rb  @DataDog/agent-integrations
 /omnibus/config/software/datadog-security-agent*.rb       @Datadog/agent-security @DataDog/agent-platform
 /omnibus/config/software/snmp-traps.rb                    @DataDog/infrastructure-integrations
 
-/pkg/                                   @DataDog/agent-core
+/pkg/                                   @DataDog/agent-shared-components
 /pkg/aggregator/                        @DataDog/agent-metrics-logs
 /pkg/collector/                         @DataDog/agent-metrics-logs
 /pkg/dogstatsd/                         @DataDog/agent-metrics-logs
@@ -149,16 +148,17 @@
 /pkg/version/                           @DataDog/agent-shared-components
 /pkg/obfuscate/                         @DataDog/agent-apm
 /pkg/trace/                             @DataDog/agent-apm
-/pkg/autodiscovery/                     @DataDog/container-integrations @DataDog/agent-core
+/pkg/autodiscovery/                     @DataDog/container-integrations @DataDog/agent-metrics-logs
 /pkg/autodiscovery/listeners/           @DataDog/container-integrations
 /pkg/autodiscovery/listeners/cloudfoundry*.go  @DataDog/integrations-tools-and-libraries
 /pkg/autodiscovery/listeners/snmp*.go   @DataDog/infrastructure-integrations
 /pkg/autodiscovery/providers/           @DataDog/container-integrations
-/pkg/autodiscovery/providers/file*.go   @DataDog/agent-core
-/pkg/autodiscovery/providers/config_reader*.go @DataDog/container-integrations @DataDog/agent-core
+/pkg/autodiscovery/providers/file*.go   @DataDog/agent-shared-components
+/pkg/autodiscovery/providers/config_reader*.go @DataDog/container-integrations @DataDog/agent-shared-components
 /pkg/autodiscovery/providers/cloudfoundry*.go  @DataDog/integrations-tools-and-libraries
 /pkg/clusteragent/                      @DataDog/container-integrations
 /pkg/clusteragent/orchestrator/         @DataDog/container-app
+/pkg/collector/                         @DataDog/agent-metrics-logs
 /pkg/collector/corechecks/cluster/      @DataDog/container-integrations
 /pkg/collector/corechecks/cluster/orchestrator  @DataDog/container-app
 /pkg/collector/corechecks/containers/   @DataDog/container-integrations
@@ -173,6 +173,7 @@
 /pkg/collector/corechecks/system/       @DataDog/agent-platform
 /pkg/collector/corechecks/systemd/      @DataDog/agent-integrations
 /pkg/collector/corechecks/nvidia/       @DataDog/agent-platform
+/pkg/config/                            @DataDog/agent-shared-components
 /pkg/config/config_template.yaml        @DataDog/agent-shared-components @DataDog/documentation
 /pkg/config/apm.go                      @DataDog/agent-apm
 /pkg/config/autodiscovery/              @Datadog/container-integrations
@@ -182,9 +183,20 @@
 /pkg/config/system_probe.go             @DataDog/agent-network
 /pkg/config/remote/                     @DataDog/remote-config
 /pkg/config/remote/service/meta/        @DataDog/remote-config @DataDog/software-integrity-and-trust
+/pkg/diagnose/                          @Datadog/container-integrations
+/pkg/diagnose/connectivity/             @DataDog/agent-shared-components
+/pkg/epforwarder/                       @DataDog/agent-shared-components
+/pkg/flare/                             @DataDog/agent-shared-components
 /pkg/otlp/                              @DataDog/agent-platform
+/pkg/pidfile/                           @DataDog/agent-shared-components
+/pkg/persistentcache/                   @DataDog/agent-metrics-logs
+/pkg/proto/                             @DataDog/agent-shared-components
 /pkg/remoteconfig/                      @DataDog/remote-config
+/pkg/runtime/                           @DataDog/agent-shared-components
+/pkg/secrets/                           @DataDog/agent-shared-components
+/pkg/serializer/                        @DataDog/agent-shared-components
 /pkg/tagger/                            @DataDog/container-integrations
+/pkg/tagset/                            @DataDog/agent-shared-components
 /pkg/util/cloudproviders/cloudfoundry/  @DataDog/integrations-tools-and-libraries
 /pkg/util/clusteragent/                 @DataDog/container-integrations
 /pkg/util/containerd/                   @DataDog/container-integrations
@@ -242,7 +254,7 @@
 /tasks/security_agent.py                @DataDog/agent-security
 
 /test/                                  @DataDog/agent-platform
-/test/benchmarks/                       @DataDog/agent-core
+/test/benchmarks/                       @DataDog/agent-metrics-logs
 /test/benchmarks/kubernetes_state/      @DataDog/container-integrations
 /test/e2e/                              @DataDog/container-integrations @DataDog/agent-security
 /test/e2e/cws-tests/                    @DataDog/agent-security
@@ -260,11 +272,12 @@
 /test/kitchen/kitchen-vagrant-system-probe.yml @DataDog/agent-network
 /test/kitchen/site-cookbooks/dd-system-probe-check/ @DataDog/agent-network
 /test/kitchen/test/integration/dd-system-probe-test/ @DataDog/agent-network
-/test/system/                           @DataDog/agent-core
+/test/system/                           @DataDog/agent-shared-components
+/test/system/dogstatsd/                 @DataDog/agent-metrics-logs
 
 /tools/                                 @DataDog/agent-platform
 /tools/ebpf/                            @DataDog/agent-network
-/tools/gdb/                             @DataDog/agent-core
+/tools/gdb/                             @DataDog/agent-shared-components
 /tools/retry_file_dump/                 @DataDog/agent-metrics-logs
 /tools/windows/                         @DataDog/agent-platform
 /tools/agent_QA/                        @DataDog/agent-metrics-logs

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -333,6 +333,7 @@ GITHUB_SLACK_MAP = {
     "@DataDog/processes": "#processes",
     "@DataDog/agent-core": "#agent-core",
     "@DataDog/agent-metrics-logs": "#agent-metrics-logs",
+    "@DataDog/agent-shared-components": "#agent-shared-components",
     "@DataDog/container-app": "#container-app",
     "@DataDog/metrics-aggregation": "#metrics-aggregation",
     "@DataDog/serverless": "#serverless-agent",


### PR DESCRIPTION
### What does this PR do?

Changes ownership of some files and directories from @DataDog/agent-core
to @DataDog/agent-shared-components.

### Motivation

Since @DataDog/agent-core is split now, we have some clarity on the
components that will be owned by @DataDog/agent-shared-components. 

### Additional Notes

We still have a few items that will need sorting but this should be enough
to get us started.

### Possible Drawbacks / Trade-offs

N/A

### Describe how to test/QA your changes

N/A

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
