### PR TITLE
[process-agent] Escape check name on writing error response

### DIFF
--- a/cmd/process-agent/api/check.go
+++ b/cmd/process-agent/api/check.go
@@ -8,6 +8,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
+	"html"
 	"io"
 	"net/http"
 
@@ -22,7 +23,7 @@ func checkHandler(w http.ResponseWriter, req *http.Request) {
 	checkOutput, ok := checks.GetCheckOutput(requestedCheck)
 	if !ok {
 		w.WriteHeader(http.StatusNotFound)
-		_, err := io.WriteString(w, fmt.Sprintf("%s check is not running or has not been scheduled yet\n", requestedCheck))
+		_, err := io.WriteString(w, fmt.Sprintf("%s check is not running or has not been scheduled yet\n", html.EscapeString(requestedCheck)))
 		if err != nil {
 			_ = log.Error()
 		}


### PR DESCRIPTION
### What does this PR do?

Run `html.EscapeString` on `requestedCheck` (user input).

### Describe how to test/QA your changes

Basic testing of `process-agent check` command with invalid input.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
