### PR TITLE
workloadmeta: one last pull before shutting down

### DIFF
--- a/pkg/collector/corechecks/containerlifecycle/check.go
+++ b/pkg/collector/corechecks/containerlifecycle/check.go
@@ -118,10 +118,20 @@ func (c *Check) Run() error {
 
 	for {
 		select {
-		case eventBundle := <-contEventsCh:
+		case eventBundle, ok := <-contEventsCh:
+			if !ok {
+				continue
+			}
+
 			c.processor.processEvents(eventBundle)
-		case eventBundle := <-podEventsCh:
+
+		case eventBundle, ok := <-podEventsCh:
+			if !ok {
+				continue
+			}
+
 			c.processor.processEvents(eventBundle)
+
 		case <-c.stopCh:
 			stopProcessor()
 			return nil

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -279,6 +279,8 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("allow_arbitrary_tags", false)
 	config.BindEnvAndSetDefault("use_proxy_for_cloud_metadata", false)
 	config.BindEnvAndSetDefault("remote_tagger_timeout_seconds", 30)
+	config.BindEnvAndSetDefault("collect_container_events_during_shutdown", false)
+	config.BindEnvAndSetDefault("collect_container_events_during_shutdown_timeout", 5)
 
 	// Remote config
 	config.BindEnvAndSetDefault("remote_configuration.enabled", false)

--- a/pkg/workloadmeta/testing/store.go
+++ b/pkg/workloadmeta/testing/store.go
@@ -136,6 +136,11 @@ func (s *Store) Start(ctx context.Context) {
 	panic("not implemented")
 }
 
+// StopAndWait is not implemented in the testing store.
+func (s *Store) StopAndWait() {
+	panic("not implemented")
+}
+
 // Subscribe is not implemented in the testing store.
 func (s *Store) Subscribe(name string, _ workloadmeta.SubscriberPriority, filter *workloadmeta.Filter) chan workloadmeta.EventBundle {
 	panic("not implemented")

--- a/pkg/workloadmeta/types.go
+++ b/pkg/workloadmeta/types.go
@@ -27,6 +27,11 @@ type Store interface {
 	// agent startup.
 	Start(ctx context.Context)
 
+	// StopAndWait stops workloadmeta and blocks until one last pull is attempted
+	// on collectors. This is useful to pick up events from containers in the same
+	// pod/task as the agent itself when it is shutting down.
+	StopAndWait()
+
 	// Subscribe subscribes the caller to events representing changes to the
 	// store, limited to events matching the filter.  The name is used for
 	// telemetry and debugging.


### PR DESCRIPTION
### What does this PR do?

This is a failed attempt at collecting stopped container events when stopping an ECS Fargate task, before the agent itself exits. It turned out that the ECS API does not reflect the stopped containers early enough, so the agent has no way to detect that they stopped. The workloadmeta bits may still be useful in the future though, so I'm leaving this PR around as a historical record of the attempt :)