### PR TITLE
CWS: fix race regarding `totalResidents`

### DIFF
--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -115,6 +115,7 @@ type ProcessResolver struct {
 
 // ArgsEnvsPool defines a pool for args/envs allocations
 type ArgsEnvsPool struct {
+	lock sync.RWMutex
 	pool *sync.Pool
 
 	// entries that wont be release to the pool
@@ -125,6 +126,9 @@ type ArgsEnvsPool struct {
 
 // Get returns a cache entry
 func (a *ArgsEnvsPool) Get() *model.ArgsEnvsCacheEntry {
+	a.lock.RLock()
+	defer a.lock.RUnlock()
+
 	// first try from resident pool
 	if el := a.freeResidents.Front(); el != nil {
 		entry := el.Value.(*model.ArgsEnvsCacheEntry)
@@ -137,6 +141,9 @@ func (a *ArgsEnvsPool) Get() *model.ArgsEnvsCacheEntry {
 
 // GetFrom returns a new entry with value from the given entry
 func (a *ArgsEnvsPool) GetFrom(event *model.ArgsEnvsEvent) *model.ArgsEnvsCacheEntry {
+	a.lock.RLock()
+	defer a.lock.RUnlock()
+
 	entry := a.Get()
 
 	entry.Size = event.ArgsEnvs.Size
@@ -148,6 +155,9 @@ func (a *ArgsEnvsPool) GetFrom(event *model.ArgsEnvsEvent) *model.ArgsEnvsCacheE
 
 // Put returns a cache entry to the pool
 func (a *ArgsEnvsPool) Put(entry *model.ArgsEnvsCacheEntry) {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+
 	if entry.Container != nil {
 		// from the residents list
 		a.freeResidents.MoveToBack(entry.Container)


### PR DESCRIPTION
### What does this PR do?

This PR fixes the following race:
```
       === RUN   TestActivityDumps/activity-dump-comm-dns-std
       ==================
       WARNING: DATA RACE
       Read at 0x00c0017a2470 by goroutine 39:
         github.com/DataDog/datadog-agent/pkg/security/probe.(*ArgsEnvsPool).Put()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/process_resolver.go:154 +0x364
         github.com/DataDog/datadog-agent/pkg/security/probe.(*ArgsEnvsPool).Put-fm()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/process_resolver.go:150 +0x44
         github.com/DataDog/datadog-agent/pkg/security/secl/model.(*ArgsEnvsCacheEntry).release()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/secl/model/process_cache_entry.go:177 +0x16a
         github.com/DataDog/datadog-agent/pkg/security/secl/model.(*ArgsEntry).ToArray()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/secl/model/process_cache_entry.go:274 +0x184
         github.com/DataDog/datadog-agent/pkg/security/probe.(*ProcessResolver).GetProcessArgv()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/process_resolver.go:776 +0x6c
         github.com/DataDog/datadog-agent/pkg/security/probe.(*ProcessResolver).GetProcessScrubbedArgv()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/process_resolver.go:804 +0x72
         github.com/DataDog/datadog-agent/pkg/security/probe.(*ProcessActivityNode).scrubAndReleaseArgsEnvs()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/activity_dump.go:819 +0x67
         github.com/DataDog/datadog-agent/pkg/security/probe.(*ActivityDump).scrubAndRetainProcessArgsEnvs()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/activity_dump.go:295 +0xd7
         github.com/DataDog/datadog-agent/pkg/security/probe.(*ActivityDump).scrubAndRetainProcessArgsEnvs()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/activity_dump.go:298 +0x111
         github.com/DataDog/datadog-agent/pkg/security/probe.(*ActivityDump).Stop()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/activity_dump.go:341 +0x7b5
         github.com/DataDog/datadog-agent/pkg/security/probe.(*ActivityDumpManager).StopActivityDump()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/activity_dump_manager.go:376 +0x21d
         github.com/DataDog/datadog-agent/pkg/security/probe.(*Monitor).StopActivityDump()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe_monitor.go:272 +0x19e
         github.com/DataDog/datadog-agent/pkg/security/tests.(*testModule).StopActivityDumpComm()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/module_tester.go:1423 +0xd6
         github.com/DataDog/datadog-agent/pkg/security/tests.TestActivityDumps.func2()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/activity_dumps_test.go:123 +0x205
         github.com/DataDog/datadog-agent/pkg/security/tests.(*stdCmdWrapper).Run.func1()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/cmdwrapper.go:44 +0xb3
         testing.tRunner()
             /root/.gimme/versions/go1.17.11.linux.amd64/src/testing/testing.go:1259 +0x22f
         testing.(*T).Run·dwrap·21()
             /root/.gimme/versions/go1.17.11.linux.amd64/src/testing/testing.go:1306 +0x47
       
       Previous write at 0x00c0017a2470 by goroutine 90:
         github.com/DataDog/datadog-agent/pkg/security/probe.(*ArgsEnvsPool).Put()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/process_resolver.go:157 +0x4aa
         github.com/DataDog/datadog-agent/pkg/security/probe.(*ArgsEnvsPool).Put-fm()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/process_resolver.go:150 +0x44
         github.com/DataDog/datadog-agent/pkg/security/secl/model.(*ArgsEnvsCacheEntry).release()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/secl/model/process_cache_entry.go:177 +0x16a
         github.com/DataDog/datadog-agent/pkg/security/secl/model.(*ArgsEnvsCacheEntry).Release()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/secl/model/process_cache_entry.go:206 +0x195
         github.com/DataDog/datadog-agent/pkg/security/probe.NewProcessCacheEntryPool.func1.1()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/process_resolver.go:207 +0x108
         github.com/DataDog/datadog-agent/pkg/security/secl/model.(*ProcessCacheEntry).Release()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/secl/model/model.go:570 +0xc5
         github.com/DataDog/datadog-agent/pkg/security/probe.(*ProcessResolver).deleteEntry()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/process_resolver.go:510 +0x144
         github.com/DataDog/datadog-agent/pkg/security/probe.(*ProcessResolver).DeleteEntry()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/process_resolver.go:518 +0xd5
         github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).handleEvent·dwrap·77()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe.go:786 +0x6e
         github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).handleEvent()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe.go:793 +0x73a5
         github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).handleEvent-fm()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe.go:424 +0x6d
         github.com/DataDog/datadog-agent/pkg/security/probe.NewOrderedPerfMap.func1()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/perfmap.go:93 +0x113
         github.com/DataDog/datadog-agent/pkg/security/probe.(*reOrdererHeap).dequeue()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/reorderer.go:144 +0x701
         github.com/DataDog/datadog-agent/pkg/security/probe.(*ReOrderer).Start()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/reorderer.go:233 +0x6b2
         github.com/DataDog/datadog-agent/pkg/security/probe.(*OrderedPerfMap).Start·dwrap·65()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/perfmap.go:73 +0x47
       
       Goroutine 39 (running) created at:
         testing.(*T).Run()
             /root/.gimme/versions/go1.17.11.linux.amd64/src/testing/testing.go:1306 +0x726
         github.com/DataDog/datadog-agent/pkg/security/tests.(*stdCmdWrapper).Run()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/cmdwrapper.go:43 +0xe9
         github.com/DataDog/datadog-agent/pkg/security/tests.(*multiCmdWrapper).Run()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/cmdwrapper.go:139 +0x183
         github.com/DataDog/datadog-agent/pkg/security/tests.(*testModule).Run()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/module_tester.go:709 +0x628
         github.com/DataDog/datadog-agent/pkg/security/tests.TestActivityDumps()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/activity_dumps_test.go:111 +0x51e
         testing.tRunner()
             /root/.gimme/versions/go1.17.11.linux.amd64/src/testing/testing.go:1259 +0x22f
         testing.(*T).Run·dwrap·21()
             /root/.gimme/versions/go1.17.11.linux.amd64/src/testing/testing.go:1306 +0x47
       
       Goroutine 90 (running) created at:
         github.com/DataDog/datadog-agent/pkg/security/probe.(*OrderedPerfMap).Start()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/perfmap.go:73 +0x1bc
         github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).Start()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe.go:322 +0x1c9
         github.com/DataDog/datadog-agent/pkg/security/module.(*Module).Start()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/module/module.go:146 +0x177
         github.com/DataDog/datadog-agent/pkg/security/tests.newTestModule()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/module_tester.go:692 +0x1744
         github.com/DataDog/datadog-agent/pkg/security/tests.TestActivityDumps()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/activity_dumps_test.go:24 +0xa9
         testing.tRunner()
             /root/.gimme/versions/go1.17.11.linux.amd64/src/testing/testing.go:1259 +0x22f
         testing.(*T).Run·dwrap·21()
             /root/.gimme/versions/go1.17.11.linux.amd64/src/testing/testing.go:1306 +0x47
       ==================
           testing.go:1152: race detected during execution of test

```

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
