### PR TITLE
Add Checks configuration to inventory payloads

### DIFF
--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -464,7 +464,7 @@ func StartAgent() error {
 	}
 
 	if config.Datadog.GetBool("inventories_enabled") {
-		if err := metadata.SetupInventories(common.MetadataScheduler, common.AC, common.Coll); err != nil {
+		if err := metadata.SetupInventories(common.MetadataScheduler, common.Coll); err != nil {
 			return err
 		}
 	}

--- a/cmd/agent/common/commands/check.go
+++ b/cmd/agent/common/commands/check.go
@@ -155,7 +155,7 @@ func Check(loggerName config.LoggerName, confFilePath *string, flagNoColor *bool
 			common.AC.LoadAndRun()
 
 			if config.Datadog.GetBool("inventories_enabled") {
-				metadata.SetupInventoriesExpvar(common.AC, common.Coll)
+				metadata.SetupInventoriesExpvar(common.Coll)
 			}
 
 			// Create the CheckScheduler, but do not attach it to

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -220,7 +220,7 @@ func runAgent(ctx context.Context) (err error) {
 	}
 
 	if config.Datadog.GetBool("inventories_enabled") {
-		if err = metadata.SetupInventories(metaScheduler, nil, nil); err != nil {
+		if err = metadata.SetupInventories(metaScheduler, nil); err != nil {
 			return
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -224,7 +224,7 @@ require (
 	code.cloudfoundry.org/tlsconfig v0.0.0-20200131000646-bbe0f8da39b3 // indirect
 	contrib.go.opencensus.io/exporter/prometheus v0.4.1 // indirect
 	github.com/AlekSi/pointer v1.1.0 // indirect
-	github.com/BurntSushi/toml v0.4.1 // indirect
+	github.com/BurntSushi/toml v1.1.0 // indirect
 	github.com/DataDog/aptly v1.5.0 // indirect
 	github.com/DataDog/extendeddaemonset v0.7.1-0.20220530183123-9c60ea5abbc6 // indirect
 	github.com/DataDog/gostackparse v0.5.0 // indirect
@@ -331,7 +331,7 @@ require (
 	github.com/opencontainers/selinux v1.10.1 // indirect
 	github.com/outcaste-io/ristretto v0.2.0 // indirect
 	github.com/pborman/uuid v1.2.1 // indirect
-	github.com/pelletier/go-toml v1.9.4 // indirect
+	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/philhofer/fwd v1.1.1 // indirect
 	github.com/pierrec/lz4/v4 v4.1.14 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -132,8 +132,8 @@ github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZ
 github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbtp2fGCgRFtBroKn4Dk=
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/BurntSushi/toml v0.4.1 h1:GaI7EiDXDRfa8VshkTj7Fym7ha+y8/XxIgD2okUIjLw=
-github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
+github.com/BurntSushi/toml v1.1.0 h1:ksErzDEI1khOiGPgpwuI7x2ebx/uXQNw7xJpn9Eq1+I=
+github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/agent-payload/v5 v5.0.23 h1:T+xalP3F9XOMZRSokcG4pK1hqyDBbEDPxp68tSBmfhc=
 github.com/DataDog/agent-payload/v5 v5.0.23/go.mod h1:2gapp8p4Vd548JI+axD8kCExklNvVI6AMF5/+IfN/4g=
@@ -1484,8 +1484,8 @@ github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
 github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
-github.com/pelletier/go-toml v1.9.4 h1:tjENF6MfZAg8e4ZmZTeWaWiT2vXtsoO6+iuOjFhECwM=
-github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
+github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
+github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/peterh/liner v0.0.0-20170211195444-bf27d3ba8e1d/go.mod h1:xIteQHvHuaLYG9IFj6mSxM0fCKrs34IrEQUhOYuGPHc=
 github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5/go.mod h1:iIss55rKnNBTvrwdmkUpLnDpZoAHvWaiq5+iMmen4AE=

--- a/pkg/collector/check/check.go
+++ b/pkg/collector/check/check.go
@@ -39,4 +39,27 @@ type Check interface {
 	ConfigSource() string
 	// IsTelemetryEnabled returns if telemetry is enabled for this check
 	IsTelemetryEnabled() bool
+	// InitConfig returns the init_config configuration of the check
+	InitConfig() string
+	// InstanceConfig returns the instance configuration of the check
+	InstanceConfig() string
+}
+
+// Info is an interface to pull information from types capable to run checks. This is a subsection from the Check
+// interface with only read only method.
+type Info interface {
+	// String provides a printable version of the check name
+	String() string
+	// Interval returns the interval time for the check
+	Interval() time.Duration
+	// ID provides a unique identifier for every check instance
+	ID() ID
+	// Version returns the version of the check if available
+	Version() string
+	// ConfigSource returns the configuration source of the check
+	ConfigSource() string
+	// InitConfig returns the init_config configuration of the check
+	InitConfig() string
+	// InstanceConfig returns the instance configuration of the check
+	InstanceConfig() string
 }

--- a/pkg/collector/check/check_mock.go
+++ b/pkg/collector/check/check_mock.go
@@ -1,0 +1,40 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package check
+
+import (
+	"time"
+)
+
+// MockInfo is a mock for test using check.Info interface
+type MockInfo struct {
+	Name         string
+	CheckID      ID
+	Source       string
+	InitConf     string
+	InstanceConf string
+}
+
+// String returns the name of the check
+func (m MockInfo) String() string { return m.Name }
+
+// Interval returns 0 always
+func (m MockInfo) Interval() time.Duration { return 0 }
+
+// ID returns the ID of the check
+func (m MockInfo) ID() ID { return m.CheckID }
+
+// Version returns an empty string
+func (m MockInfo) Version() string { return "" }
+
+// ConfigSource returns the source of the check
+func (m MockInfo) ConfigSource() string { return m.Source }
+
+// InitConfig returns the init_config of the check
+func (m MockInfo) InitConfig() string { return m.InitConf }
+
+// InstanceConfig returns the instance config of the check
+func (m MockInfo) InstanceConfig() string { return m.InstanceConf }

--- a/pkg/collector/check/stub.go
+++ b/pkg/collector/check/stub.go
@@ -49,3 +49,9 @@ func (c *StubCheck) GetSenderStats() (SenderStats, error) { return NewSenderStat
 
 // IsTelemetryEnabled returns false
 func (c *StubCheck) IsTelemetryEnabled() bool { return false }
+
+// InitConfig returns the init_config configuration of the check
+func (c *StubCheck) InitConfig() string { return "" }
+
+// InstanceConfig returns the instance configuration of the check
+func (c *StubCheck) InstanceConfig() string { return "" }

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -221,6 +221,18 @@ func (c *Collector) started() bool {
 	return c.state.Load() == started
 }
 
+// MapOverChecks call the callback with the list of checks locked.
+func (c *Collector) MapOverChecks(cb func([]check.Info)) {
+	c.m.RLock()
+	defer c.m.RUnlock()
+
+	cInfo := []check.Info{}
+	for _, c := range c.checks {
+		cInfo = append(cInfo, c)
+	}
+	cb(cInfo)
+}
+
 // GetAllInstanceIDs returns the ID's of all instances of a check
 func (c *Collector) GetAllInstanceIDs(checkName string) []check.ID {
 	c.m.RLock()

--- a/pkg/collector/corechecks/checkbase.go
+++ b/pkg/collector/corechecks/checkbase.go
@@ -44,6 +44,8 @@ type CheckBase struct {
 	checkInterval  time.Duration
 	source         string
 	telemetry      bool
+	initConfig     string
+	instanceConfig string
 }
 
 // NewCheckBase returns a check base struct with a given check name
@@ -70,24 +72,7 @@ func (c *CheckBase) BuildID(instance, initConfig integration.Data) {
 // Configure is provided for checks that require no config. If overridden,
 // the call to CommonConfigure must be preserved.
 func (c *CheckBase) Configure(data integration.Data, initConfig integration.Data, source string) error {
-	commonGlobalOptions := integration.CommonGlobalConfig{}
-	err := yaml.Unmarshal(initConfig, &commonGlobalOptions)
-	if err != nil {
-		log.Errorf("invalid init_config section for check %s: %s", string(c.ID()), err)
-		return err
-	}
-
-	// Set service for this check
-	if len(commonGlobalOptions.Service) > 0 {
-		s, err := c.GetSender()
-		if err != nil {
-			log.Errorf("failed to retrieve a sender for check %s: %s", string(c.ID()), err)
-			return err
-		}
-		s.SetCheckService(commonGlobalOptions.Service)
-	}
-
-	err = c.CommonConfigure(data, source)
+	err := c.CommonConfigure(initConfig, data, source)
 	if err != nil {
 		return err
 	}
@@ -105,50 +90,62 @@ func (c *CheckBase) Configure(data integration.Data, initConfig integration.Data
 
 // CommonConfigure is called when checks implement their own Configure method,
 // in order to setup common options (run interval, empty hostname)
-func (c *CheckBase) CommonConfigure(instance integration.Data, source string) error {
-	commonOptions := integration.CommonInstanceConfig{}
-	err := yaml.Unmarshal(instance, &commonOptions)
-	if err != nil {
-		log.Errorf("invalid instance section for check %s: %s", string(c.ID()), err)
+func (c *CheckBase) CommonConfigure(initConfig, instanceConfig integration.Data, source string) error {
+	handleConf := func(conf integration.Data, c *CheckBase) error {
+		commonOptions := integration.CommonInstanceConfig{}
+		err := yaml.Unmarshal(conf, &commonOptions)
+		if err != nil {
+			log.Errorf("invalid configuration section for check %s: %s", string(c.ID()), err)
+			return err
+		}
+
+		// See if a collection interval was specified
+		if commonOptions.MinCollectionInterval > 0 {
+			c.checkInterval = time.Duration(commonOptions.MinCollectionInterval) * time.Second
+		}
+
+		// Disable default hostname if specified
+		if commonOptions.EmptyDefaultHostname {
+			s, err := c.GetSender()
+			if err != nil {
+				log.Errorf("failed to retrieve a sender for check %s: %s", string(c.ID()), err)
+				return err
+			}
+			s.DisableDefaultHostname(true)
+		}
+
+		// Set custom tags configured for this check
+		if len(commonOptions.Tags) > 0 {
+			s, err := c.GetSender()
+			if err != nil {
+				log.Errorf("failed to retrieve a sender for check %s: %s", string(c.ID()), err)
+				return err
+			}
+			s.SetCheckCustomTags(commonOptions.Tags)
+		}
+
+		// Set configured service for this check, overriding the one possibly defined globally
+		if len(commonOptions.Service) > 0 {
+			s, err := c.GetSender()
+			if err != nil {
+				log.Errorf("failed to retrieve a sender for check %s: %s", string(c.ID()), err)
+				return err
+			}
+			s.SetCheckService(commonOptions.Service)
+		}
+
+		c.source = source
+		return nil
+	}
+	if err := handleConf(initConfig, c); err != nil {
+		return err
+	}
+	if err := handleConf(instanceConfig, c); err != nil {
 		return err
 	}
 
-	// See if a collection interval was specified
-	if commonOptions.MinCollectionInterval > 0 {
-		c.checkInterval = time.Duration(commonOptions.MinCollectionInterval) * time.Second
-	}
-
-	// Disable default hostname if specified
-	if commonOptions.EmptyDefaultHostname {
-		s, err := c.GetSender()
-		if err != nil {
-			log.Errorf("failed to retrieve a sender for check %s: %s", string(c.ID()), err)
-			return err
-		}
-		s.DisableDefaultHostname(true)
-	}
-
-	// Set custom tags configured for this check
-	if len(commonOptions.Tags) > 0 {
-		s, err := c.GetSender()
-		if err != nil {
-			log.Errorf("failed to retrieve a sender for check %s: %s", string(c.ID()), err)
-			return err
-		}
-		s.SetCheckCustomTags(commonOptions.Tags)
-	}
-
-	// Set configured service for this check, overriding the one possibly defined globally
-	if len(commonOptions.Service) > 0 {
-		s, err := c.GetSender()
-		if err != nil {
-			log.Errorf("failed to retrieve a sender for check %s: %s", string(c.ID()), err)
-			return err
-		}
-		s.SetCheckService(commonOptions.Service)
-	}
-
-	c.source = source
+	c.initConfig = string(initConfig)
+	c.instanceConfig = string(instanceConfig)
 	return nil
 }
 
@@ -207,6 +204,16 @@ func (c *CheckBase) Version() string {
 // from the agent
 func (c *CheckBase) ConfigSource() string {
 	return c.source
+}
+
+// InitConfig returns the init_config configuration for the check.
+func (c *CheckBase) InitConfig() string {
+	return c.initConfig
+}
+
+// InstanceConfig returns the instance configuration for the check.
+func (c *CheckBase) InstanceConfig() string {
+	return c.instanceConfig
 }
 
 // ID returns a unique ID for that check instance

--- a/pkg/collector/corechecks/checkbase_test.go
+++ b/pkg/collector/corechecks/checkbase_test.go
@@ -37,13 +37,13 @@ func TestCommonConfigure(t *testing.T) {
 	}
 	mockSender := mocksender.NewMockSender(mycheck.ID())
 
-	err := mycheck.CommonConfigure([]byte(defaultsInstance), "test")
+	err := mycheck.CommonConfigure(nil, []byte(defaultsInstance), "test")
 	assert.NoError(t, err)
 	assert.Equal(t, defaults.DefaultCheckInterval, mycheck.Interval())
 	mockSender.AssertNumberOfCalls(t, "DisableDefaultHostname", 0)
 
 	mockSender.On("DisableDefaultHostname", true).Return().Once()
-	err = mycheck.CommonConfigure([]byte(customInstance), "test")
+	err = mycheck.CommonConfigure(nil, []byte(customInstance), "test")
 	assert.NoError(t, err)
 	assert.Equal(t, 60*time.Second, mycheck.Interval())
 	mycheck.BuildID([]byte(customInstance), []byte(initConfig))
@@ -61,7 +61,7 @@ func TestCommonConfigureCustomID(t *testing.T) {
 	mockSender := mocksender.NewMockSender(mycheck.ID())
 
 	mockSender.On("DisableDefaultHostname", true).Return().Once()
-	err := mycheck.CommonConfigure([]byte(customInstance), "test")
+	err := mycheck.CommonConfigure(nil, []byte(customInstance), "test")
 	assert.NoError(t, err)
 	assert.Equal(t, 60*time.Second, mycheck.Interval())
 	mycheck.BuildID([]byte(customInstance), []byte(initConfig))

--- a/pkg/collector/corechecks/cluster/helm/helm.go
+++ b/pkg/collector/corechecks/cluster/helm/helm.go
@@ -96,17 +96,12 @@ func factory() check.Check {
 func (hc *HelmCheck) Configure(config, initConfig integration.Data, source string) error {
 	hc.BuildID(config, initConfig)
 
-	err := hc.CommonConfigure(config, source)
+	err := hc.CommonConfigure(initConfig, config, source)
 	if err != nil {
 		return err
 	}
 
 	if err = hc.instance.Parse(config); err != nil {
-		return err
-	}
-
-	err = hc.CommonConfigure(initConfig, source)
-	if err != nil {
 		return err
 	}
 

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -172,12 +172,7 @@ func init() {
 func (k *KSMCheck) Configure(config, initConfig integration.Data, source string) error {
 	k.BuildID(config, initConfig)
 
-	err := k.CommonConfigure(config, source)
-	if err != nil {
-		return err
-	}
-
-	err = k.CommonConfigure(initConfig, source)
+	err := k.CommonConfigure(initConfig, config, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
@@ -119,7 +119,7 @@ func KubernetesASFactory() check.Check {
 
 // Configure parses the check configuration and init the check.
 func (k *KubeASCheck) Configure(config, initConfig integration.Data, source string) error {
-	err := k.CommonConfigure(config, source)
+	err := k.CommonConfigure(initConfig, config, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
@@ -96,7 +96,7 @@ func (o *OrchestratorCheck) Interval() time.Duration {
 func (o *OrchestratorCheck) Configure(config, initConfig integration.Data, source string) error {
 	o.BuildID(config, initConfig)
 
-	err := o.CommonConfigure(config, source)
+	err := o.CommonConfigure(initConfig, config, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/containerlifecycle/check.go
+++ b/pkg/collector/corechecks/containerlifecycle/check.go
@@ -58,7 +58,7 @@ func (c *Check) Configure(config, initConfig integration.Data, source string) er
 
 	var err error
 
-	err = c.CommonConfigure(config, source)
+	err = c.CommonConfigure(initConfig, config, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/containers/containerd/check.go
+++ b/pkg/collector/corechecks/containers/containerd/check.go
@@ -68,7 +68,7 @@ func (co *ContainerdConfig) Parse(data []byte) error {
 // Configure parses the check configuration and init the check
 func (c *ContainerdCheck) Configure(config, initConfig integration.Data, source string) error {
 	var err error
-	if err = c.CommonConfigure(config, source); err != nil {
+	if err = c.CommonConfigure(initConfig, config, source); err != nil {
 		return err
 	}
 

--- a/pkg/collector/corechecks/containers/cri/check.go
+++ b/pkg/collector/corechecks/containers/cri/check.go
@@ -66,7 +66,7 @@ func (c *CRIConfig) Parse(data []byte) error {
 // Configure parses the check configuration and init the check
 func (c *CRICheck) Configure(config, initConfig integration.Data, source string) error {
 	var err error
-	if err = c.CommonConfigure(config, source); err != nil {
+	if err = c.CommonConfigure(initConfig, config, source); err != nil {
 		return err
 	}
 

--- a/pkg/collector/corechecks/containers/docker/check.go
+++ b/pkg/collector/corechecks/containers/docker/check.go
@@ -64,7 +64,7 @@ func DockerFactory() check.Check {
 
 // Configure parses the check configuration and init the check
 func (d *DockerCheck) Configure(config, initConfig integration.Data, source string) error {
-	err := d.CommonConfigure(config, source)
+	err := d.CommonConfigure(initConfig, config, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/containers/generic/check.go
+++ b/pkg/collector/corechecks/containers/generic/check.go
@@ -51,7 +51,7 @@ func ContainerCheckFactory() check.Check {
 
 // Configure parses the check configuration and init the check
 func (c *ContainerCheck) Configure(config, initConfig integration.Data, source string) error {
-	err := c.CommonConfigure(config, source)
+	err := c.CommonConfigure(initConfig, config, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/ebpf/oom_kill.go
+++ b/pkg/collector/corechecks/ebpf/oom_kill.go
@@ -72,7 +72,7 @@ func (m *OOMKillCheck) Configure(config, initConfig integration.Data, source str
 	// TODO: Remove that hard-code and put it somewhere else
 	process_net.SetSystemProbePath(dd_config.Datadog.GetString("system_probe_config.sysprobe_socket"))
 
-	err := m.CommonConfigure(config, source)
+	err := m.CommonConfigure(initConfig, config, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/ebpf/tcp_queue_length.go
+++ b/pkg/collector/corechecks/ebpf/tcp_queue_length.go
@@ -69,7 +69,7 @@ func (t *TCPQueueLengthCheck) Configure(config, initConfig integration.Data, sou
 	// TODO: Remove that hard-code and put it somewhere else
 	process_net.SetSystemProbePath(dd_config.Datadog.GetString("system_probe_config.sysprobe_socket"))
 
-	err := t.CommonConfigure(config, source)
+	err := t.CommonConfigure(initConfig, config, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/embed/apm.go
+++ b/pkg/collector/corechecks/embed/apm.go
@@ -34,13 +34,15 @@ type apmCheckConf struct {
 
 // APMCheck keeps track of the running command
 type APMCheck struct {
-	binPath     string
-	commandOpts []string
-	running     *atomic.Bool
-	stop        chan struct{}
-	stopDone    chan struct{}
-	source      string
-	telemetry   bool
+	binPath        string
+	commandOpts    []string
+	running        *atomic.Bool
+	stop           chan struct{}
+	stopDone       chan struct{}
+	source         string
+	telemetry      bool
+	initConfig     string
+	instanceConfig string
 }
 
 // String displays the Agent name
@@ -175,6 +177,8 @@ func (c *APMCheck) Configure(data integration.Data, initConfig integration.Data,
 
 	c.source = source
 	c.telemetry = telemetry_utils.IsCheckEnabled("apm")
+	c.initConfig = string(initConfig)
+	c.instanceConfig = string(data)
 	return nil
 }
 
@@ -216,6 +220,16 @@ func (c *APMCheck) GetWarnings() []error {
 // GetSenderStats returns the stats from the last run of the check, but there aren't any
 func (c *APMCheck) GetSenderStats() (check.SenderStats, error) {
 	return check.NewSenderStats(), nil
+}
+
+// InitConfig returns the initConfig for the APM check
+func (c *APMCheck) InitConfig() string {
+	return c.initConfig
+}
+
+// InstanceConfig returns the instance config for the APM check
+func (c *APMCheck) InstanceConfig() string {
+	return c.instanceConfig
 }
 
 func init() {

--- a/pkg/collector/corechecks/embed/jmx/check.go
+++ b/pkg/collector/corechecks/embed/jmx/check.go
@@ -20,12 +20,14 @@ import (
 
 // JMXCheck TODO <agent-core> : IML-199
 type JMXCheck struct {
-	id        check.ID
-	name      string
-	config    integration.Config
-	stop      chan struct{}
-	source    string
-	telemetry bool
+	id             check.ID
+	name           string
+	config         integration.Config
+	stop           chan struct{}
+	source         string
+	telemetry      bool
+	initConfig     string
+	instanceConfig string
 }
 
 func newJMXCheck(config integration.Config, source string) *JMXCheck {
@@ -83,8 +85,20 @@ func (c *JMXCheck) ConfigSource() string {
 	return c.source
 }
 
+// InitConfig TODO <agent-core> : IML-199
+func (c *JMXCheck) InitConfig() string {
+	return c.initConfig
+}
+
+// InstanceConfig TODO <agent-core> : IML-199
+func (c *JMXCheck) InstanceConfig() string {
+	return c.instanceConfig
+}
+
 // Configure TODO <agent-core> : IML-199
 func (c *JMXCheck) Configure(config integration.Data, initConfig integration.Data, source string) error {
+	c.initConfig = string(config)
+	c.instanceConfig = string(initConfig)
 	return nil
 }
 

--- a/pkg/collector/corechecks/embed/process_agent.go
+++ b/pkg/collector/corechecks/embed/process_agent.go
@@ -35,13 +35,15 @@ type processAgentCheckConf struct {
 
 // ProcessAgentCheck keeps track of the running command
 type ProcessAgentCheck struct {
-	binPath     string
-	commandOpts []string
-	running     *atomic.Bool
-	stop        chan struct{}
-	stopDone    chan struct{}
-	source      string
-	telemetry   bool
+	binPath        string
+	commandOpts    []string
+	running        *atomic.Bool
+	stop           chan struct{}
+	stopDone       chan struct{}
+	source         string
+	telemetry      bool
+	initConfig     string
+	instanceConfig string
 }
 
 // String displays the Agent name
@@ -57,6 +59,16 @@ func (c *ProcessAgentCheck) Version() string {
 // ConfigSource displays the command's source
 func (c *ProcessAgentCheck) ConfigSource() string {
 	return c.source
+}
+
+// InitConfig returns the init configuration
+func (c *ProcessAgentCheck) InitConfig() string {
+	return c.initConfig
+}
+
+// InstanceConfig returns the instance configuration
+func (c *ProcessAgentCheck) InstanceConfig() string {
+	return c.instanceConfig
 }
 
 // Run executes the check with retries
@@ -170,6 +182,8 @@ func (c *ProcessAgentCheck) Configure(data integration.Data, initConfig integrat
 
 	c.source = source
 	c.telemetry = telemetry_utils.IsCheckEnabled("process_agent")
+	c.initConfig = string(initConfig)
+	c.instanceConfig = string(data)
 	return nil
 }
 

--- a/pkg/collector/corechecks/net/network.go
+++ b/pkg/collector/corechecks/net/network.go
@@ -281,7 +281,7 @@ func netstatTCPExtCounters() (map[string]int64, error) {
 
 // Configure configures the network checks
 func (c *NetworkCheck) Configure(rawInstance integration.Data, rawInitConfig integration.Data, source string) error {
-	err := c.CommonConfigure(rawInstance, source)
+	err := c.CommonConfigure(rawInitConfig, rawInstance, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/net/ntp.go
+++ b/pkg/collector/corechecks/net/ntp.go
@@ -150,7 +150,7 @@ func (c *NTPCheck) Configure(data integration.Data, initConfig integration.Data,
 	c.BuildID(data, initConfig)
 	c.cfg = cfg
 
-	err = c.CommonConfigure(data, source)
+	err = c.CommonConfigure(initConfig, data, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/nvidia/jetson/jetson.go
+++ b/pkg/collector/corechecks/nvidia/jetson/jetson.go
@@ -154,7 +154,7 @@ func (c *JetsonCheck) Run() error {
 
 // Configure the GPU check
 func (c *JetsonCheck) Configure(data integration.Data, initConfig integration.Data, source string) error {
-	err := c.CommonConfigure(data, source)
+	err := c.CommonConfigure(initConfig, data, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/snmp/snmp.go
+++ b/pkg/collector/corechecks/snmp/snmp.go
@@ -135,7 +135,7 @@ func (c *Check) Configure(rawInstance integration.Data, rawInitConfig integratio
 	// Must be called before c.CommonConfigure
 	c.BuildID(rawInstance, rawInitConfig)
 
-	err = c.CommonConfigure(rawInstance, source)
+	err = c.CommonConfigure(rawInitConfig, rawInstance, source)
 	if err != nil {
 		return fmt.Errorf("common configure failed: %s", err)
 	}

--- a/pkg/collector/corechecks/system/cpu/cpu.go
+++ b/pkg/collector/corechecks/system/cpu/cpu.go
@@ -90,7 +90,7 @@ func (c *Check) Run() error {
 
 // Configure the CPU check
 func (c *Check) Configure(data integration.Data, initConfig integration.Data, source string) error {
-	err := c.CommonConfigure(data, source)
+	err := c.CommonConfigure(initConfig, data, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/system/cpu/cpu_windows.go
+++ b/pkg/collector/corechecks/system/cpu/cpu_windows.go
@@ -105,7 +105,7 @@ func getProcessorPDHCounter(counterName, instance string) (pdhutil.PdhSingleInst
 
 // Configure the CPU check doesn't need configuration
 func (c *Check) Configure(data integration.Data, initConfig integration.Data, source string) error {
-	if err := c.CommonConfigure(data, source); err != nil {
+	if err := c.CommonConfigure(initConfig, data, source); err != nil {
 		return err
 	}
 

--- a/pkg/collector/corechecks/system/cpu/load.go
+++ b/pkg/collector/corechecks/system/cpu/load.go
@@ -56,7 +56,7 @@ func (c *LoadCheck) Run() error {
 
 // Configure the CPU check
 func (c *LoadCheck) Configure(data integration.Data, initConfig integration.Data, source string) error {
-	err := c.CommonConfigure(data, source)
+	err := c.CommonConfigure(initConfig, data, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/system/disk/disk_nix.go
+++ b/pkg/collector/corechecks/system/disk/disk_nix.go
@@ -144,7 +144,7 @@ func (c *Check) sendDiskMetrics(sender aggregator.Sender, ioCounter disk.IOCount
 
 // Configure the disk check
 func (c *Check) Configure(data integration.Data, initConfig integration.Data, source string) error {
-	err := c.CommonConfigure(data, source)
+	err := c.CommonConfigure(initConfig, data, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/system/disk/iostats.go
+++ b/pkg/collector/corechecks/system/disk/iostats.go
@@ -25,7 +25,7 @@ const (
 
 // Configure the IOstats check
 func (c *IOCheck) commonConfigure(data integration.Data, initConfig integration.Data, source string) error {
-	if err := c.CommonConfigure(data, source); err != nil {
+	if err := c.CommonConfigure(initConfig, data, source); err != nil {
 		return err
 	}
 

--- a/pkg/collector/corechecks/system/filehandles/file_handles_freebsd.go
+++ b/pkg/collector/corechecks/system/filehandles/file_handles_freebsd.go
@@ -53,7 +53,7 @@ func (c *fhCheck) Run() error {
 
 // The check doesn't need configuration
 func (c *fhCheck) Configure(data integration.Data, initConfig integration.Data, source string) (err error) {
-	if err := c.CommonConfigure(data, source); err != nil {
+	if err := c.CommonConfigure(initConfig, data, source); err != nil {
 		return err
 	}
 

--- a/pkg/collector/corechecks/system/filehandles/file_handles_windows.go
+++ b/pkg/collector/corechecks/system/filehandles/file_handles_windows.go
@@ -44,7 +44,7 @@ func (c *fhCheck) Run() error {
 
 // The check doesn't need configuration
 func (c *fhCheck) Configure(data integration.Data, initConfig integration.Data, source string) (err error) {
-	if err := c.CommonConfigure(data, source); err != nil {
+	if err := c.CommonConfigure(initConfig, data, source); err != nil {
 		return err
 	}
 

--- a/pkg/collector/corechecks/system/memory/memory_windows.go
+++ b/pkg/collector/corechecks/system/memory/memory_windows.go
@@ -38,7 +38,7 @@ const mbSize float64 = 1024 * 1024
 
 // Configure handles initial configuration/initialization of the check
 func (c *Check) Configure(data integration.Data, initConfig integration.Data, source string) (err error) {
-	if err := c.CommonConfigure(data, source); err != nil {
+	if err := c.CommonConfigure(initConfig, data, source); err != nil {
 		return err
 	}
 

--- a/pkg/collector/corechecks/system/winkmem/winkmem.go
+++ b/pkg/collector/corechecks/system/winkmem/winkmem.go
@@ -90,7 +90,7 @@ func (w *KMemCheck) Configure(data integration.Data, initConfig integration.Data
 		return err
 	}
 
-	if err := w.CommonConfigure(data, source); err != nil {
+	if err := w.CommonConfigure(initConfig, data, source); err != nil {
 		return err
 	}
 	cf := Config{

--- a/pkg/collector/corechecks/system/winproc/winproc_windows.go
+++ b/pkg/collector/corechecks/system/winproc/winproc_windows.go
@@ -40,7 +40,7 @@ func (c *processChk) Run() error {
 }
 
 func (c *processChk) Configure(data integration.Data, initConfig integration.Data, source string) error {
-	err := c.CommonConfigure(data, source)
+	err := c.CommonConfigure(initConfig, data, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/systemd/systemd.go
+++ b/pkg/collector/corechecks/systemd/systemd.go
@@ -525,7 +525,7 @@ func (c *SystemdCheck) Configure(rawInstance integration.Data, rawInitConfig int
 	// Must be called before CommonConfigure that uses checkID
 	c.BuildID(rawInstance, rawInitConfig)
 
-	err := c.CommonConfigure(rawInstance, source)
+	err := c.CommonConfigure(rawInitConfig, rawInstance, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/systemd/systemd_test.go
+++ b/pkg/collector/corechecks/systemd/systemd_test.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 
-	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/metadata/inventories"
@@ -969,19 +968,12 @@ func TestGetPropertyBool(t *testing.T) {
 	}
 }
 
-type mockAutoConfig struct{}
-
-func (*mockAutoConfig) MapOverLoadedConfigs(f func(map[string]integration.Config)) {
-	f(map[string]integration.Config{})
+type mockCollector struct {
+	Checks []check.Info
 }
 
-type mockCollector struct{}
-
-func (*mockCollector) GetAllInstanceIDs(checkName string) []check.ID {
-	if checkName == "systemd" {
-		return []check.ID{"systemd"}
-	}
-	return nil
+func (m mockCollector) MapOverChecks(fn func([]check.Info)) {
+	fn(m.Checks)
 }
 
 func TestGetVersion(t *testing.T) {
@@ -995,20 +987,31 @@ unit_names:
 	stats.On("ListUnits", mock.Anything).Return([]dbus.UnitStatus{}, nil)
 	stats.On("GetVersion", mock.Anything).Return(systemdVersion)
 
-	check := SystemdCheck{
+	systemdCheck := SystemdCheck{
 		stats:     stats,
 		CheckBase: core.NewCheckBase(systemdCheckName),
 	}
-	mockSender := mocksender.NewMockSender(check.ID())
+	mockSender := mocksender.NewMockSender(systemdCheck.ID())
 	mockSender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	mockSender.On("ServiceCheck", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	mockSender.On("Commit").Return()
 
-	check.Configure(rawInstanceConfig, nil, "test")
+	systemdCheck.Configure(rawInstanceConfig, nil, "test")
 	// run
-	check.Run()
+	systemdCheck.Run()
 
-	p := inventories.GetPayload(context.Background(), "testHostname", &mockAutoConfig{}, &mockCollector{})
+	coll := mockCollector{
+		[]check.Info{
+			check.MockInfo{
+				Name:         "systemd",
+				CheckID:      systemdCheck.ID(),
+				Source:       "provider1",
+				InitConf:     "",
+				InstanceConf: "{}",
+			},
+		}}
+
+	p := inventories.GetPayload(context.Background(), "testHostname", coll)
 	checkMetadata := *p.CheckMetadata
 	systemdMetadata := *checkMetadata["systemd"][0]
 	assert.Equal(t, systemdVersion, systemdMetadata["version.raw"])

--- a/pkg/collector/python/check.go
+++ b/pkg/collector/python/check.go
@@ -38,15 +38,17 @@ import "C"
 
 // PythonCheck represents a Python check, implements `Check` interface
 type PythonCheck struct {
-	id           check.ID
-	version      string
-	instance     *C.rtloader_pyobject_t
-	class        *C.rtloader_pyobject_t
-	ModuleName   string
-	interval     time.Duration
-	lastWarnings []error
-	source       string
-	telemetry    bool // whether or not the telemetry is enabled for this check
+	id             check.ID
+	version        string
+	instance       *C.rtloader_pyobject_t
+	class          *C.rtloader_pyobject_t
+	ModuleName     string
+	interval       time.Duration
+	lastWarnings   []error
+	source         string
+	telemetry      bool // whether or not the telemetry is enabled for this check
+	initConfig     string
+	instanceConfig string
 }
 
 // NewPythonCheck conveniently creates a PythonCheck instance
@@ -156,6 +158,16 @@ func (c *PythonCheck) IsTelemetryEnabled() bool {
 // ConfigSource returns the source of the configuration for this check
 func (c *PythonCheck) ConfigSource() string {
 	return c.source
+}
+
+// InitConfig returns the init_config configuration for the check.
+func (c *PythonCheck) InitConfig() string {
+	return c.initConfig
+}
+
+// InstanceConfig returns the instance configuration for the check.
+func (c *PythonCheck) InstanceConfig() string {
+	return c.instanceConfig
 }
 
 // GetWarnings grabs the last warnings from the struct
@@ -292,6 +304,9 @@ func (c *PythonCheck) Configure(data integration.Data, initConfig integration.Da
 	} else {
 		s.FinalizeCheckServiceTag()
 	}
+
+	c.initConfig = string(initConfig)
+	c.instanceConfig = string(data)
 
 	log.Debugf("python check configure done %s", c.ModuleName)
 	return nil

--- a/pkg/compliance/checks/check.go
+++ b/pkg/compliance/checks/check.go
@@ -62,6 +62,14 @@ func (c *complianceCheck) ID() check.ID {
 	return check.ID(c.ruleID)
 }
 
+func (c *complianceCheck) InitConfig() string {
+	return ""
+}
+
+func (c *complianceCheck) InstanceConfig() string {
+	return ""
+}
+
 func (c *complianceCheck) GetWarnings() []error {
 	return nil
 }

--- a/pkg/metadata/inventories/README.md
+++ b/pkg/metadata/inventories/README.md
@@ -53,6 +53,8 @@ The payload is a JSON dict with the following fields
     - `last_updated` - **int**: timestamp of the last metadata update for this instance
     - `config.hash` - **string**: the instance ID for this instance (as shown in the status page).
     - `config.provider` - **string**: where the configuration came from for this instance (disk, docker labels, ...).
+    - `init_config` - **string**: the `init_config` part of the configuration for this check instance.
+    - `instance_config` - **string**: the YAML configuration for this check instance
     - Any other metadata registered by the instance (instance version, version of the software monitored, ...).
 <!-- NOTE: when modifying this list, please also update the constants in `inventories.go` -->
 - `agent_metadata` - **dict of string to JSON type**:
@@ -166,66 +168,74 @@ Here an example of an inventory payload:
     }
     "check_metadata": {
         "cpu": [
-           {
-               "config.hash": "cpu",
-               "config.provider": "file",
-               "last_updated": 1631281744506400319
-           }
+            {
+                "config.hash": "cpu",
+                "config.provider": "file",
+                "last_updated": 1631281744506400319,
+                "init_config": "",
+                "instance_config: {}
+            }
         ],
         "disk": [
             {
                 "config.hash": "disk:e5dffb8bef24336f",
                 "config.provider": "file",
-                "last_updated": 1631281744506400319
+                "last_updated": 1631281744506400319,
+                "init_config": "",
+                "instance_config: {}
             }
         ],
         "file_handle": [
             {
                 "config.hash": "file_handle",
                 "config.provider": "file",
-                "last_updated": 1631281744506400319
+                "last_updated": 1631281744506400319,
+                "init_config": "",
+                "instance_config: {}
             }
         ],
         "io": [
             {
                 "config.hash": "io",
                 "config.provider": "file",
-                "last_updated": 1631281744506400319
+                "last_updated": 1631281744506400319,
+                "init_config": "",
+                "instance_config: {}
             }
         ],
         "load": [
             {
                 "config.hash": "load",
                 "config.provider": "file",
-                "last_updated": 1631281744506400319
+                "last_updated": 1631281744506400319,
+                "init_config": "",
+                "instance_config: {}
             }
         ],
-        "memory": [
+        "redisdb": [
             {
-                "config.hash": "memory",
-                "config.provider": "file",
-                "last_updated": 1631281744506400319
-            }
-        ],
-        "network": [
+                "config.hash": "redisdb:6e5e79e5b724c83a",
+                "config.provider": "container",
+                "init_config": "test: 21",
+                "instance_config": "host: localhost\nport: 6379\ntags:\n- docker_image:redis\n- image_name:redis\n- short_image:redis",
+                "last_updated": 1658327911867365638,
+                "version.major": "7",
+                "version.minor": "0",
+                "version.patch": "2",
+                "version.raw": "7.0.2",
+                "version.scheme": "semver"
+            },
             {
-                "config.hash": "network:d884b5186b651429",
-                "config.provider": "file",
-                "last_updated": 1631281744506400319
-            }
-        ],
-        "ntp": [
-            {
-                "config.hash": "ntp:d884b5186b651429",
-                "config.provider": "file",
-                "last_updated": 1631281744506400319
-            }
-        ],
-        "uptime": [
-            {
-                "config.hash": "uptime",
-                "config.provider": "file",
-                "last_updated": 1631281744506400319
+                "config.hash": "redisdb:c776ecdbdded09b8",
+                "config.provider": "container",
+                "init_config": "test: 21",
+                "instance_config": "host: localhost\nport: 7379\ntags:\n- docker_image:redis\n- image_name:redis\n- short_image:redis",
+                "last_updated": 1658327940850060982,
+                "version.major": "7",
+                "version.minor": "0",
+                "version.patch": "2",
+                "version.raw": "7.0.2",
+                "version.scheme": "semver"
             }
         ]
     },

--- a/pkg/metadata/inventories/inventories_test.go
+++ b/pkg/metadata/inventories/inventories_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/version"
@@ -40,32 +39,6 @@ L:
 			break L
 		}
 	}
-}
-
-type mockAutoConfig struct{}
-
-func (*mockAutoConfig) MapOverLoadedConfigs(f func(map[string]integration.Config)) {
-	configs := make(map[string]integration.Config)
-	configs["check1_digest"] = integration.Config{
-		Name:     "check1",
-		Provider: "provider1",
-	}
-	configs["check2_digest"] = integration.Config{
-		Name:     "check2",
-		Provider: "provider2",
-	}
-	f(configs)
-}
-
-type mockCollector struct{}
-
-func (*mockCollector) GetAllInstanceIDs(checkName string) []check.ID {
-	if checkName == "check1" {
-		return []check.ID{"check1_instance1", "check1_instance2"}
-	} else if checkName == "check2" {
-		return []check.ID{"check2_instance1"}
-	}
-	return nil
 }
 
 type mockScheduler struct {
@@ -99,10 +72,18 @@ func TestRemoveCheckMetadata(t *testing.T) {
 	SetCheckMetadata("check2", "check_provided_key1", 123)
 	RemoveCheckMetadata("check1")
 
-	p := GetPayload(ctx, "testHostname", nil, nil)
+	p := GetPayload(ctx, "testHostname", nil)
 	checks := *p.CheckMetadata
 	assert.Len(t, checks, 1)
 	assert.Len(t, checks["check2"], 1)
+}
+
+type mockCollector struct {
+	Checks []check.Info
+}
+
+func (m mockCollector) MapOverChecks(fn func([]check.Info)) {
+	fn(m.Checks)
 }
 
 func TestGetPayload(t *testing.T) {
@@ -113,12 +94,36 @@ func TestGetPayload(t *testing.T) {
 	timeNow = func() time.Time { return startNow } // time of the first run
 	defer func() { timeNow = time.Now }()
 
+	coll := mockCollector{[]check.Info{
+		check.MockInfo{
+			Name:         "check1",
+			CheckID:      check.ID("check1_instance1"),
+			Source:       "provider1",
+			InitConf:     "",
+			InstanceConf: "{}",
+		},
+		check.MockInfo{
+			Name:         "check1",
+			CheckID:      check.ID("check1_instance2"),
+			Source:       "provider1",
+			InitConf:     "",
+			InstanceConf: "{\"test\":21}",
+		},
+		check.MockInfo{
+			Name:         "check2",
+			CheckID:      check.ID("check2_instance1"),
+			Source:       "provider2",
+			InitConf:     "",
+			InstanceConf: "{}",
+		},
+	}}
+
 	SetAgentMetadata("test", true)
 	SetCheckMetadata("check1_instance1", "check_provided_key1", 123)
 	SetCheckMetadata("check1_instance1", "check_provided_key2", "Hi")
 	SetCheckMetadata("non_running_checkid", "check_provided_key1", "this_should_be_kept")
 
-	p := GetPayload(ctx, "testHostname", &mockAutoConfig{}, &mockCollector{})
+	p := GetPayload(ctx, "testHostname", coll)
 
 	assert.Equal(t, startNow.UnixNano(), p.Timestamp)
 
@@ -129,24 +134,30 @@ func TestGetPayload(t *testing.T) {
 	checkMeta := *p.CheckMetadata
 	assert.Len(t, checkMeta, 3)
 	assert.Len(t, checkMeta["check1"], 2) // check1 has two instances
+
 	check1Instance1 := *checkMeta["check1"][0]
-	assert.Len(t, check1Instance1, 5)
 	assert.Equal(t, startNow.UnixNano(), check1Instance1["last_updated"])
 	assert.Equal(t, "check1_instance1", check1Instance1["config.hash"])
 	assert.Equal(t, "provider1", check1Instance1["config.provider"])
 	assert.Equal(t, 123, check1Instance1["check_provided_key1"])
 	assert.Equal(t, "Hi", check1Instance1["check_provided_key2"])
+	assert.Equal(t, "", check1Instance1["init_config"])
+	assert.Equal(t, "{}", check1Instance1["instance_config"])
+
 	check1Instance2 := *checkMeta["check1"][1]
-	assert.Len(t, check1Instance2, 3)
 	assert.Equal(t, agentStartupTime.UnixNano(), check1Instance2["last_updated"])
 	assert.Equal(t, "check1_instance2", check1Instance2["config.hash"])
 	assert.Equal(t, "provider1", check1Instance2["config.provider"])
+	assert.Equal(t, "", check1Instance2["init_config"])
+	assert.Equal(t, "{\"test\":21}", check1Instance2["instance_config"])
+
 	assert.Len(t, checkMeta["check2"], 1) // check2 has one instance
 	check2Instance1 := *checkMeta["check2"][0]
-	assert.Len(t, check2Instance1, 3)
 	assert.Equal(t, agentStartupTime.UnixNano(), check2Instance1["last_updated"])
 	assert.Equal(t, "check2_instance1", check2Instance1["config.hash"])
 	assert.Equal(t, "provider2", check2Instance1["config.provider"])
+	assert.Equal(t, "", check2Instance1["init_config"])
+	assert.Equal(t, "{}", check2Instance1["instance_config"])
 
 	SetCheckMetadata("check2_instance1", "check_provided_key1", "hi")
 	originalStartNow := startNow
@@ -156,33 +167,34 @@ func TestGetPayload(t *testing.T) {
 	resetFunc := setupHostMetadataMock()
 	defer resetFunc()
 
-	mockConfig := config.Mock(t)
-	mockConfig.Set("inventories_configuration_enabled", false)
-
-	p = GetPayload(ctx, "testHostname", &mockAutoConfig{}, &mockCollector{})
+	p = GetPayload(ctx, "testHostname", coll)
 
 	assert.Equal(t, startNow.UnixNano(), p.Timestamp) //updated startNow is returned
 
 	agentMetadata = *p.AgentMetadata
-	assert.Len(t, agentMetadata, 2) // keys are: "test", "cloud_provider"
+	assert.Len(t, agentMetadata, 4) // keys are: "test", "cloud_provider", "full_configuration" and "provided_configuration"
 	assert.Equal(t, true, agentMetadata["test"])
+
+	// no point in asserting every field from the agent configuration. We just check they are present and then set
+	// then delete them to assert the rest.
+	assert.NotNil(t, agentMetadata["provided_configuration"])
+	assert.NotNil(t, agentMetadata["full_configuration"])
+	delete(agentMetadata, "provided_configuration")
+	delete(agentMetadata, "full_configuration")
 
 	checkMeta = *p.CheckMetadata
 	assert.Len(t, checkMeta, 3)
 	check1Instance1 = *checkMeta["check1"][0]
-	assert.Len(t, check1Instance1, 5)
 	assert.Equal(t, startNow.UnixNano(), check1Instance1["last_updated"]) // last_updated has changed
 	assert.Equal(t, "check1_instance1", check1Instance1["config.hash"])
 	assert.Equal(t, "provider1", check1Instance1["config.provider"])
 	assert.Equal(t, 456, check1Instance1["check_provided_key1"]) //Key has been updated
 	assert.Equal(t, "Hi", check1Instance1["check_provided_key2"])
 	check1Instance2 = *checkMeta["check1"][1]
-	assert.Len(t, check1Instance2, 3)
 	assert.Equal(t, agentStartupTime.UnixNano(), check1Instance2["last_updated"]) // last_updated still the same
 	assert.Equal(t, "check1_instance2", check1Instance2["config.hash"])
 	assert.Equal(t, "provider1", check1Instance2["config.provider"])
 	check2Instance1 = *checkMeta["check2"][0]
-	assert.Len(t, check2Instance1, 4)
 	assert.Equal(t, originalStartNow.UnixNano(), check2Instance1["last_updated"]) // reflects when check_provided_key1 was changed
 	assert.Equal(t, "check2_instance1", check2Instance1["config.hash"])
 	assert.Equal(t, "provider2", check2Instance1["config.provider"])
@@ -203,11 +215,15 @@ func TestGetPayload(t *testing.T) {
 					"check_provided_key2": "Hi",
 					"config.hash": "check1_instance1",
 					"config.provider": "provider1",
+					"init_config": "",
+					"instance_config": "{}",
 					"last_updated": %v
 				},
 				{
 					"config.hash": "check1_instance2",
 					"config.provider": "provider1",
+					"init_config": "",
+					"instance_config": "{\"test\":21}",
 					"last_updated": %v
 				}
 			],
@@ -217,6 +233,8 @@ func TestGetPayload(t *testing.T) {
 					"check_provided_key1": "hi",
 					"config.hash": "check2_instance1",
 					"config.provider": "provider2",
+					"init_config": "",
+					"instance_config": "{}",
 					"last_updated": %v
 				}
 			],
@@ -226,6 +244,8 @@ func TestGetPayload(t *testing.T) {
 					"check_provided_key1": "this_should_be_kept",
 					"config.hash": "non_running_checkid",
 					"config.provider": "",
+					"init_config": "",
+					"instance_config": "",
 					"last_updated": %v
 				}
 			]
@@ -327,7 +347,7 @@ func TestCreateCheckInstanceMetadataReturnsNewMetadata(t *testing.T) {
 		},
 	}
 
-	md := createCheckInstanceMetadata(checkID, configProvider)
+	md := createCheckInstanceMetadata(checkID, configProvider, "", "")
 	(*md)[metadataKey] = "a-different-metadata-value"
 
 	assert.NotEqual(t, checkMetadata[checkID].CheckInstanceMetadata[metadataKey], (*md)[metadataKey])

--- a/pkg/trace/go.mod
+++ b/pkg/trace/go.mod
@@ -98,7 +98,7 @@ require (
 	github.com/opencontainers/selinux v1.10.1 // indirect
 	github.com/outcaste-io/ristretto v0.2.0 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
-	github.com/pelletier/go-toml v1.9.4 // indirect
+	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/philhofer/fwd v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20220216144756-c35f1ee13d7c // indirect

--- a/pkg/trace/go.sum
+++ b/pkg/trace/go.sum
@@ -793,8 +793,8 @@ github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTK
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
-github.com/pelletier/go-toml v1.9.4 h1:tjENF6MfZAg8e4ZmZTeWaWiT2vXtsoO6+iuOjFhECwM=
-github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
+github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
+github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/philhofer/fwd v1.1.1 h1:GdGcTjf5RNAxwS4QLsiMzJYj5KEvPJD3Abr261yRQXQ=
 github.com/philhofer/fwd v1.1.1/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG3ZVNU=

--- a/pkg/util/scrubber/default.go
+++ b/pkg/util/scrubber/default.go
@@ -181,6 +181,15 @@ func ScrubBytes(file []byte) ([]byte, error) {
 	return DefaultScrubber.ScrubBytes(file)
 }
 
+// ScrubString scrubs credentials from the given string, using the default scrubber.
+func ScrubString(data string) (string, error) {
+	res, err := DefaultScrubber.ScrubBytes([]byte(data))
+	if err != nil {
+		return "", err
+	}
+	return string(res), nil
+}
+
 // ScrubLine scrubs credentials from a single line of text, using the default
 // scrubber.  It can be safely applied to URLs or to strings containing URLs.
 // It does not run multi-line replacers, and should not be used on multi-line


### PR DESCRIPTION
### What does this PR do?
This commit extend the `check` interface with 2 new methods:
`InitConfig` and `InstanceConfig`.

This also create a new interface `check.Info` which is a read-only
subset of method from `check.Check`. This allows other packages to
 pull information from currently running checks. We no longer
need to use both `AutoDiscovery` and the `Collector` to explore the
running checks.

### Describe how to test/QA your changes

Run checks with configuration from file and docker labels and check that those configurations (both init_config and instance config) show up in the inventory payload (command `troubleshooting metadata_inventory` to see the last payload send).

Then check that checks are removed from the list when the related container is stopped.