### PR TITLE
[Windows] Track usermode buffer size increases and decreases

### DIFF
--- a/pkg/network/driver_interface.go
+++ b/pkg/network/driver_interface.go
@@ -72,11 +72,13 @@ type DriverInterface struct {
 // NewDriverInterface returns a DriverInterface struct for interacting with the driver
 func NewDriverInterface(cfg *config.Config) (*DriverInterface, error) {
 	dc := &DriverInterface{
-		totalFlows:     atomic.NewInt64(0),
-		closedFlows:    atomic.NewInt64(0),
-		openFlows:      atomic.NewInt64(0),
-		moreDataErrors: atomic.NewInt64(0),
-		bufferSize:     atomic.NewInt64(defaultDriverBufferSize),
+		totalFlows:       atomic.NewInt64(0),
+		closedFlows:      atomic.NewInt64(0),
+		openFlows:        atomic.NewInt64(0),
+		moreDataErrors:   atomic.NewInt64(0),
+		bufferSize:       atomic.NewInt64(defaultDriverBufferSize),
+		nBufferIncreases: atomic.NewInt64(0),
+		nBufferDecreases: atomic.NewInt64(0),
 
 		cfg:                   cfg,
 		enableMonotonicCounts: cfg.EnableMonotonicCount,
@@ -166,7 +168,7 @@ func (di *DriverInterface) GetStats() (map[DriverExpvar]interface{}, error) {
 	moreDataErrors := di.moreDataErrors.Swap(0)
 	bufferSize := di.bufferSize.Load()
 	nBufferIncreases := di.nBufferIncreases.Load()
-	nBufferDecreases := di.nBufferIncreases.Load()
+	nBufferDecreases := di.nBufferDecreases.Load()
 
 	return map[DriverExpvar]interface{}{
 		totalFlowStats:  totalDriverStats,

--- a/pkg/network/driver_interface.go
+++ b/pkg/network/driver_interface.go
@@ -246,13 +246,13 @@ func (di *DriverInterface) resizeDriverBuffer(compareSize int) {
 	// Explicitly setting len to 0 causes the ReadFile syscall to break, so allocate buffer with cap = len
 	if compareSize >= cap(di.readBuffer)*2 {
 		di.readBuffer = make([]uint8, cap(di.readBuffer)*2)
-		atomic.AddInt64(&di.nBufferIncreases, 1)
-		atomic.StoreInt64(&di.bufferSize, int64(len(di.readBuffer)))
+		di.nBufferIncreases.Inc()
+		di.bufferSize.Store(int64(len(di.readBuffer)))
 	} else if compareSize <= cap(di.readBuffer)/2 {
 		// Take the max of di.readBuffer/2 and compareSize to limit future array resizes
 		di.readBuffer = make([]uint8, int(math.Max(float64(cap(di.readBuffer)/2), float64(compareSize))))
-		atomic.AddInt64(&di.nBufferDecreases, 1)
-		atomic.StoreInt64(&di.bufferSize, int64(len(di.readBuffer)))
+		di.nBufferDecreases.Inc()
+		di.bufferSize.Store(int64(len(di.readBuffer)))
 	}
 }
 


### PR DESCRIPTION
* Add 2 expvars (nBufferIncreases and nBufferDecreases) to track
  buffer size changes over time via monotonically increasing counter

*  Convert resizeDriverBuffer to receiver on DriverInterface struct

### What does this PR do?
Adds 2 expvars (`buffer_increases` and `buffer_decreases`), which are tracked internally via `nBufferIncreases` and `nBufferDecreases`

Converts `resizeDriverBuffer` function to receiver method on `DriverInterface` struct.

### Motivation
The motivation for this PR is to gain introspection into the number of Windows user mode buffer resizes over time.

Additionally, since the user mode buffer and variables that track the number of resizes are members of the `DriverInterface` struct it made sense to convert the `resizeDriverBuffer` function to a receiver method on that struct.

### Additional Notes
The expvars are mainly intended to be used internally; however, if needed, customers can enable the expvar check and observe the buffer resize frequency. This is might be useful to debug unexpected behavior under certain network conditions.

### Possible Drawbacks / Trade-offs
None at this time.

### Describe how to test/QA your changes
To test/QA this changeset we will want to verify that the `buffer_increases` and `buffer_decreases` expvars are accesible when the expvar check is enabled.

The following configuration files should be used:
`C:\ProgramData\Datadog\system-probe.yaml`
```yaml
system_probe_config:
  log_level: debug
network_config:
  enabled: true
  enable_http_monitoring: true
```
`C:\ProgramData\Datadog\conf.d\go_expvar.d\conf.yaml`
```yaml
init_config:
instances:
  - expvar_url: http://localhost:3333/debug/vars  # if you've defined `expvar_port` in datadog.yaml, change the port here to that value
    namespace: datadog.npm
    metrics:
      # datadog-agent forwarder monitoring
      - path: modules/network_tracer/driver/buffer_increases
        type: count
      - path: modules/network_tracer/driver/buffer_decreases
        type: count
      - path: modules/network_tracer/driver/buffer_size
        type: gauge
      - path: modules/network_tracer/driver_flow_handle_stats/read_calls
        type: count
      - path: modules/network_tracer/flows/total
        type: gauge
```

1. Provision a Windows VM (i.e. Windows 10).
2. Ensure you can setup a basic listening webserver (Python Simple HTTP server is sufficient)
    a. `py -3 -m http.server`
3. Install the latest RC, ensure `system-probe` is enabled, and use the above configuration files.
4. Ensure you can query the expvars endpoint and see the `buffer_increases` and `buffer_decreases` values
```
PS C:\> (iwr -UseBasicParsing -DisableKeepAlive http://localhost:3333/debug/vars | convertfrom-json).modules.network_tracer.driver

buffer_decreases buffer_increases buffer_size more_data_errors
---------------- ---------------- ----------- ----------------
               1                0        3700                0

```
5. Ensure you can view the `buffer_increases` and `buffer_decreases` through the Metrics Explorer in the UI.
  a. From the UI, on the right side, hover over "Metrics" and then click on "Explorer"
  b. Add the following formulas (fill in HOSTNAME with the name of your test host)
    - `sum:datadog.npm.modules.network_tracer.driver.buffer_decreases{host:HOSTNAME}.as_count()`
    - `sum:datadog.npm.modules.network_tracer.driver.buffer_increases{host:HOSTNAME}.as_count()`
    - `avg:datadog.npm.modules.network_tracer.driver.buffer_size{host:HOSTNAME}`
6. Enable the HTTP server from (2.) if it isn't enabled.
7. Start issuing about 1000 queries to the webserver every 75 seconds
`while($true){for(($i=0); $i -lt 1000; $i++){iwr -UseBasicParsing -DisableKeepAlive http://localhost:8000}; Start-Sleep -Seconds 75}`
8. As the number of connection increases over time, observe through the UI that the number of increases go up (this is indicative that the buffer is being increased commiserate with the new connections).
9. After 2-3 minutes, stop the queries from (7.)
10. Observe in the UI that the number of decreases go up (this is indicative that the buffer is being decreased commiserate with the decrease in connections).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
