### PR TITLE
cmd/trace-agent: Add vector override for traces

### DIFF
--- a/cmd/trace-agent/config/config.go
+++ b/cmd/trace-agent/config/config.go
@@ -138,7 +138,11 @@ func applyDatadogConfig(c *config.AgentConfig) error {
 		c.StatsdPort = coreconfig.Datadog.GetInt("dogstatsd_port")
 	}
 
-	c.Endpoints[0].Host = coreconfig.GetMainEndpoint(apiEndpointPrefix, "apm_config.apm_dd_url")
+	if coreconfig.Datadog.GetBool("vector.traces.enabled") && coreconfig.Datadog.IsSet("vector.traces.url") && len(coreconfig.Datadog.GetString("vector.traces.url")) > 0 {
+		c.Endpoints[0].Host = coreconfig.Datadog.GetString("vector.traces.url")
+	} else {
+		c.Endpoints[0].Host = coreconfig.GetMainEndpoint(apiEndpointPrefix, "apm_config.apm_dd_url")
+	}
 	c.Endpoints = appendEndpoints(c.Endpoints, "apm_config.additional_endpoints")
 
 	if coreconfig.Datadog.IsSet("proxy.no_proxy") {

--- a/cmd/trace-agent/config/config.go
+++ b/cmd/trace-agent/config/config.go
@@ -138,7 +138,12 @@ func applyDatadogConfig(c *config.AgentConfig) error {
 		c.StatsdPort = coreconfig.Datadog.GetInt("dogstatsd_port")
 	}
 
-	if coreconfig.Datadog.GetBool("vector.traces.enabled") && coreconfig.Datadog.IsSet("vector.traces.url") && len(coreconfig.Datadog.GetString("vector.traces.url")) > 0 {
+	if coreconfig.Datadog.GetBool("vector.traces.enabled") {
+	    if host := coreconfig.Datadog.GetString("vector.traces.url"); host == "" {
+	        log.Error("vector.traces.enabled but vector.traces.url is empty.")
+	    } else {
+	        c.Endpoints[0].Host = host
+	    }
 		c.Endpoints[0].Host = coreconfig.Datadog.GetString("vector.traces.url")
 	} else {
 		c.Endpoints[0].Host = coreconfig.GetMainEndpoint(apiEndpointPrefix, "apm_config.apm_dd_url")

--- a/cmd/trace-agent/config/config.go
+++ b/cmd/trace-agent/config/config.go
@@ -139,12 +139,11 @@ func applyDatadogConfig(c *config.AgentConfig) error {
 	}
 
 	if coreconfig.Datadog.GetBool("vector.traces.enabled") {
-	    if host := coreconfig.Datadog.GetString("vector.traces.url"); host == "" {
-	        log.Error("vector.traces.enabled but vector.traces.url is empty.")
-	    } else {
-	        c.Endpoints[0].Host = host
-	    }
-		c.Endpoints[0].Host = coreconfig.Datadog.GetString("vector.traces.url")
+		if host := coreconfig.Datadog.GetString("vector.traces.url"); host == "" {
+			log.Error("vector.traces.enabled but vector.traces.url is empty.")
+		} else {
+			c.Endpoints[0].Host = host
+		}
 	} else {
 		c.Endpoints[0].Host = coreconfig.GetMainEndpoint(apiEndpointPrefix, "apm_config.apm_dd_url")
 	}

--- a/cmd/trace-agent/config/config_test.go
+++ b/cmd/trace-agent/config/config_test.go
@@ -354,7 +354,7 @@ func TestSite(t *testing.T) {
 		"eu":       {"./testdata/site_eu.yaml", "https://trace.agent.datadoghq.eu"},
 		"url":      {"./testdata/site_url.yaml", "some.other.datadoghq.eu"},
 		"override": {"./testdata/site_override.yaml", "some.other.datadoghq.eu"},
-		"vector": {"./testdata/vector_override.yaml", "https://vector.domain.tld:8443"},
+		"vector":   {"./testdata/vector_override.yaml", "https://vector.domain.tld:8443"},
 	} {
 		t.Run(name, func(t *testing.T) {
 			defer cleanConfig()()

--- a/cmd/trace-agent/config/config_test.go
+++ b/cmd/trace-agent/config/config_test.go
@@ -354,6 +354,7 @@ func TestSite(t *testing.T) {
 		"eu":       {"./testdata/site_eu.yaml", "https://trace.agent.datadoghq.eu"},
 		"url":      {"./testdata/site_url.yaml", "some.other.datadoghq.eu"},
 		"override": {"./testdata/site_override.yaml", "some.other.datadoghq.eu"},
+		"vector": {"./testdata/vector_override.yaml", "https://vector.domain.tld:8443"},
 	} {
 		t.Run(name, func(t *testing.T) {
 			defer cleanConfig()()

--- a/cmd/trace-agent/config/testdata/vector_override.yaml
+++ b/cmd/trace-agent/config/testdata/vector_override.yaml
@@ -1,7 +1,7 @@
 api_key: api_key_test
 dd_url: https://app.datadoghq.com
 site: datadoghq.eu
-vector
+vector:
   traces:
-  enabled: true
-  url: https://vector.domain.tld:8443
+    enabled: true
+    url: https://vector.domain.tld:8443

--- a/cmd/trace-agent/config/testdata/vector_override.yaml
+++ b/cmd/trace-agent/config/testdata/vector_override.yaml
@@ -1,6 +1,7 @@
 api_key: api_key_test
 dd_url: https://app.datadoghq.com
 site: datadoghq.eu
-vector.traces:
+vector
+  traces:
   enabled: true
   url: https://vector.domain.tld:8443

--- a/cmd/trace-agent/config/testdata/vector_override.yaml
+++ b/cmd/trace-agent/config/testdata/vector_override.yaml
@@ -1,0 +1,6 @@
+api_key: api_key_test
+dd_url: https://app.datadoghq.com
+site: datadoghq.eu
+vector.traces:
+  enabled: true
+  url: https://vector.domain.tld:8443

--- a/pkg/config/apm.go
+++ b/pkg/config/apm.go
@@ -16,7 +16,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
- 
 // Used for Vector override
 const Traces DataType = "traces"
 
@@ -53,7 +52,7 @@ func setupAPM(config Config) {
 	config.SetKnown("apm_config.bucket_size_seconds")
 	config.SetKnown("apm_config.watchdog_check_delay")
 	config.SetKnown("apm_config.sync_flushing")
-    
+
 	bindVectorOptions(config, Traces)
 
 	if runtime.GOARCH == "386" && runtime.GOOS == "windows" {

--- a/pkg/config/apm.go
+++ b/pkg/config/apm.go
@@ -16,6 +16,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+ 
+// Used for Vector override
+const Traces DataType = "traces"
+
 func setupAPM(config Config) {
 	config.SetKnown("apm_config.obfuscation.elasticsearch.enabled")
 	config.SetKnown("apm_config.obfuscation.elasticsearch.keep_values")
@@ -49,6 +53,8 @@ func setupAPM(config Config) {
 	config.SetKnown("apm_config.bucket_size_seconds")
 	config.SetKnown("apm_config.watchdog_check_delay")
 	config.SetKnown("apm_config.sync_flushing")
+    
+	bindVectorOptions(config, Traces)
 
 	if runtime.GOARCH == "386" && runtime.GOOS == "windows" {
 		// on Windows-32 bit, the trace agent isn't installed.  Set the default to disabled

--- a/pkg/config/apm.go
+++ b/pkg/config/apm.go
@@ -16,7 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// Used for Vector override
+// Traces type used for Vector override
 const Traces DataType = "traces"
 
 func setupAPM(config Config) {

--- a/pkg/config/apm.go
+++ b/pkg/config/apm.go
@@ -16,7 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// Traces specifies the data type used for Vector override.
+// Traces specifies the data type used for Vector override. See https://vector.dev/docs/reference/configuration/sources/datadog_agent/ for additional details.
 const Traces DataType = "traces"
 
 func setupAPM(config Config) {

--- a/pkg/config/apm.go
+++ b/pkg/config/apm.go
@@ -16,7 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// Traces type used for Vector override
+// Traces specifies the data type used for Vector override.
 const Traces DataType = "traces"
 
 func setupAPM(config Config) {

--- a/releasenotes/notes/vector-traces-override-bebe167f286f7a3d.yaml
+++ b/releasenotes/notes/vector-traces-override-bebe167f286f7a3d.yaml
@@ -1,0 +1,15 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Add two options under the `vector` config prefix to send traces
+    to Vector instead of Datadog. `vector.traces.enabled` must be
+    set to true, along with `vector.traces.url` that should be set to
+    point to a Vector configured accordingly. This overrides the main
+    endpoint, additional endpoints remains fully functional.

--- a/releasenotes/notes/vector-traces-override-bebe167f286f7a3d.yaml
+++ b/releasenotes/notes/vector-traces-override-bebe167f286f7a3d.yaml
@@ -9,7 +9,6 @@
 features:
   - |
     Add two options under the `vector` config prefix to send traces
-    to Vector instead of Datadog. `vector.traces.enabled` must be
-    set to true, along with `vector.traces.url` that should be set to
-    point to a Vector configured accordingly. This overrides the main
-    endpoint, additional endpoints remains fully functional.
+    to Vector instead of Datadog. Set `vector.traces.enabled` to true.
+    Set `vector.traces.url` to point to a Vector endpoint. This overrides 
+    the main endpoint. Additional endpoints remains fully functional.

--- a/releasenotes/notes/vector-traces-override-bebe167f286f7a3d.yaml
+++ b/releasenotes/notes/vector-traces-override-bebe167f286f7a3d.yaml
@@ -8,7 +8,7 @@
 ---
 features:
   - |
-    Add two options under the `vector` config prefix to send traces
+    APM: Add two options under the `vector` config prefix to send traces
     to Vector instead of Datadog. Set `vector.traces.enabled` to true.
     Set `vector.traces.url` to point to a Vector endpoint. This overrides 
     the main endpoint. Additional endpoints remains fully functional.


### PR DESCRIPTION
### What does this PR do?

Simple PR to add `vector.traces.url` and `vector.traces.enabled` (like metrics & logs).

### Motivation

Consistency with other `vector.(logs|metrics).(enabled|url)` config keys.

### Additional Notes

N/A

### Possible Drawbacks / Trade-offs

N/A

### Describe how to test/QA your changes

With `vector.traces.*` disabled ensure that there is no unforeseen behaviour changes.
And with the newer option set traces should be sent to the url set in `vector.traces.url` (it is really just an alias of `apm_config.apm_dd_url`).

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
