### PR TITLE
use go.uber.org/atomic in cmd/trace-agent/test/backend.go

### DIFF
--- a/cmd/trace-agent/test/backend.go
+++ b/cmd/trace-agent/test/backend.go
@@ -14,10 +14,10 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
-	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
+	"go.uber.org/atomic"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/tinylib/msgp/msgp"
@@ -32,7 +32,7 @@ const defaultBackendAddress = "localhost:8888"
 const defaultChannelSize = 100
 
 type fakeBackend struct {
-	started uint64           // 0 if server is stopped
+	started *atomic.Bool
 	out     chan interface{} // payload output
 	srv     http.Server
 }
@@ -43,7 +43,8 @@ func newFakeBackend(channelSize int) *fakeBackend {
 		size = channelSize
 	}
 	fb := fakeBackend{
-		out: make(chan interface{}, size),
+		started: atomic.NewBool(false),
+		out:     make(chan interface{}, size),
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v0.2/traces", fb.handleTraces)
@@ -58,13 +59,13 @@ func newFakeBackend(channelSize int) *fakeBackend {
 }
 
 func (s *fakeBackend) Start() error {
-	if atomic.LoadUint64(&s.started) > 0 {
+	if s.started.Load() {
 		// already running
 		return nil
 	}
 	go func() {
-		atomic.StoreUint64(&s.started, 1)
-		defer atomic.StoreUint64(&s.started, 0)
+		s.started.Store(true)
+		defer s.started.Store(false)
 		if err := s.srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			log.Fatalf("server: %v", err)
 		}


### PR DESCRIPTION
### What does this PR do?

As part of the ongoing [project to remove uses of sync/atomic](https://github.com/DataDog/datadog-agent/pull/11716), this addresses such a use in cmd/trace-agent/test/backend.go.  This probably could have been included in #12581 but that's already partly reviewed so I've made a second PR.

### Motivation

See https://github.com/DataDog/datadog-agent/pull/11716.

### Describe how to test/QA your changes

This appears to be testing code only, so no need.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
