### PR TITLE
Prohibit use of sync/atomic using golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -66,8 +66,13 @@ linters:
     - errcheck    # errcheck is a program for checking for unchecked errors in go programs.
     - staticcheck # staticcheck is a go vet on steroids, applying a ton of static analysis checks
     - govet       # Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
+    - depguard    # Depguard is useful for preventing specific packages from being used
 
 linters-settings:
+  depguard:
+    include-go-root: true
+    packages-with-error-message:
+      - sync/atomic: "Use go.uber.org/atomic instead; see docs/dev/atomics.md"
   errcheck:
     # Disable warnings for `fmt` and `log` packages. Also ignore `Write` functions from `net/http` package.
     ignore: fmt:.*,github.com/DataDog/datadog-agent/pkg/util/log:.*,net/http:Write,github.com/DataDog/datadog-agent/pkg/trace/metrics:.*


### PR DESCRIPTION
### What does this PR do?

Now that we've replaced sync/atomic with go.uber.org/atomic everywhere (well, not yet, but by the time this is ready for review..), let's prohibit re-introduction of use of sync/atomic.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

This doesn't work for me locally, despite uses of this package remaining in the codebase.  If I comment out all of the entries in `linters.enabled` except `depguard`, it finds 8 issues with `inv golangci-lint -t ./cmd`.  If I comment out everything except `depguard` and `govet` it finds 3 issues (a subset of that 8).  If I leave all linters enabled, it finds nothing.  I can't quite see the pattern here.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
