### PR TITLE
[Windows] Fix styling of the Windows Agent installer GUI dialogs

### DIFF
--- a/omnibus/resources/agent/msi/assets/apikeydlg.wxi
+++ b/omnibus/resources/agent/msi/assets/apikeydlg.wxi
@@ -1,36 +1,35 @@
 <Include>
- <Dialog Id="ApiKeyDlg" Width="370" Height="270" Title="!(loc.ApiKeyDialogTitle)">
-   
-   <Control Id="KeyFromDefault" Type="Edit" Height="15" Width="320" X="25" Y="148"
-          Property="APIKEY"
-         />
-        <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17"
-              Text="Back">
+  <Dialog Id="ApiKeyDlg" Width="370" Height="270" Title="!(loc.ApiKeyDialog_Title)">
+    <Control Id="KeyFromDefault" Type="Edit" Height="15" Width="320" X="25" Y="148"
+             Property="APIKEY" />
+      <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17"
+               Text="Back">
           
-          <Publish Event="NewDialog" Value="MaintenanceTypeDlg">WixUI_InstallMode = "Repair"</Publish>
+        <Publish Event="NewDialog" Value="MaintenanceTypeDlg">WixUI_InstallMode = "Repair"</Publish>
           <?if $(var.IncludeSysprobe) = true ?>
             <Publish Event="NewDialog" Value="CustomizeDlg">NOT INSTALLED</Publish>
           <?else ?>
             <Publish Event="NewDialog" Value="LicenseAgreementDlg">NOT INSTALLED</Publish>
           <?endif ?>
-        </Control>
-        <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes"
+      </Control>
+      <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes"
                Text="Next">
-          <Publish Event="NewDialog" Value="SiteDlg" />
-          
-        </Control>
-        <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes"
+        <Publish Event="NewDialog" Value="SiteDlg" />
+      </Control>
+      <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes"
                Text="Cancel">
-          <Publish Event="EndDialog" Value="Exit">1</Publish>
-        </Control>
+        <Publish Event="EndDialog" Value="Exit">1</Publish>
+      </Control>
 
-   <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="!(loc.LicenseAgreementDlgBannerBitmap)" />
-   <Control Id="BannerLine" Type="Line" X="0" Y="44" Width="370" Height="0" />
-   <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" />
-   <Control Id="Description" Type="Text" X="25" Y="23" Width="340" Height="32" 
-            Transparent="yes" NoPrefix="yes" Text="!(loc.ApiKeyDialogDescription)" />
-   
-   <Control Id="EnterKey" Type="Text" Height="32" Width="320" X="25" Y="116"
-               Text="!(loc.ApiKeyDialogKeyLabel)" />
-      </Dialog>
+    <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="!(loc.LicenseAgreementDlgBannerBitmap)" />
+    <Control Id="BannerLine" Type="Line" X="0" Y="44" Width="370" Height="0" />
+    <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" />
+    <Control Id="Title" Type="Text" X="15" Y="6" Width="340" Height="15"
+             Transparent="yes" NoPrefix="yes" Text="!(loc.ApiKeyDialogTitle)" />
+    <Control Id="Description" Type="Text" X="25" Y="23" Width="340" Height="15"
+             Transparent="yes" NoPrefix="yes" Text="!(loc.ApiKeyDialogDescription)" />
+
+    <Control Id="EnterKey" Type="Text" Height="32" Width="320" X="25" Y="116"
+             Text="!(loc.ApiKeyDialogKeyLabel)" />
+  </Dialog>
 </Include>

--- a/omnibus/resources/agent/msi/assets/sitedlg.wxi
+++ b/omnibus/resources/agent/msi/assets/sitedlg.wxi
@@ -6,30 +6,31 @@
     <ListItem Text="us5.datadoghq.com" Value="us5.datadoghq.com"/>
     <ListItem Text="ddog-gov.com" Value="ddog-gov.com"/>
   </ComboBox>
- <Dialog Id="SiteDlg" Width="370" Height="270" Title="!(loc.SiteDialogTitle)">
-  <Control Id="SiteFromDefault" Type="ComboBox" ComboList="no" Height="15" Width="320" X="25" Y="148" Property="SITE"/>
-  <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17"
-        Text="Back">
+  <Dialog Id="SiteDlg" Width="370" Height="270" Title="!(loc.SiteDialog_Title)">
+    <Control Id="SiteFromDefault" Type="ComboBox" ComboList="no" Height="15" Width="320" X="25" Y="148" Property="SITE"/>
+    <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17"
+             Text="Back">
 
-    <Publish Event="NewDialog" Value="ApiKeyDlg">1</Publish>
-  </Control>
-  <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes"
-          Text="Next">
-    <Publish Event="NewDialog" Value="VerifyReadyDlg" />
+      <Publish Event="NewDialog" Value="ApiKeyDlg">1</Publish>
+    </Control>
+    <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes"
+             Text="Next">
+      <Publish Event="NewDialog" Value="VerifyReadyDlg" />
 
-  </Control>
-  <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes"
-          Text="Cancel">
-    <Publish Event="EndDialog" Value="Exit">1</Publish>
-  </Control>
+    </Control>
+    <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes"
+             Text="Cancel">
+      <Publish Event="EndDialog" Value="Exit">1</Publish>
+    </Control>
 
-   <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="!(loc.LicenseAgreementDlgBannerBitmap)" />
-   <Control Id="BannerLine" Type="Line" X="0" Y="44" Width="370" Height="0" />
-   <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" />
-   <Control Id="Description" Type="Text" X="25" Y="23" Width="340" Height="32" 
-            Transparent="yes" NoPrefix="yes" Text="!(loc.SiteDialogDescription)" />
-
-   <Control Id="EnterKey" Type="Text" Height="32" Width="320" X="25" Y="116"
-               Text="!(loc.SiteDialogKeyLabel)" />
-      </Dialog>
+    <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="!(loc.LicenseAgreementDlgBannerBitmap)" />
+    <Control Id="BannerLine" Type="Line" X="0" Y="44" Width="370" Height="0" />
+    <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" />
+    <Control Id="Title" Type="Text" X="15" Y="6" Width="340" Height="15"
+             Transparent="yes" NoPrefix="yes" Text="!(loc.SiteDialogTitle)" />
+    <Control Id="Description" Type="Text" X="25" Y="23" Width="340" Height="15"
+             Transparent="yes" NoPrefix="yes" Text="!(loc.SiteDialogDescription)" />
+    <Control Id="EnterKey" Type="Text" Height="32" Width="320" X="25" Y="116"
+             Text="!(loc.SiteDialogKeyLabel)" />
+  </Dialog>
 </Include>

--- a/omnibus/resources/agent/msi/localization-en-us.wxl.erb
+++ b/omnibus/resources/agent/msi/localization-en-us.wxl.erb
@@ -17,35 +17,45 @@
   <!-- these strings are for the process agent service install -->
   <String Id="ServiceProcessDisplayName">[ShortCompanyName] Process Agent</String>
   <String Id="ServiceProcessDescription">Send process metrics to [ShortCompanyName]</String>
-  
 
   <String Id="WelcomeDlgTitle">{\WixUI_Font_Bigger}Welcome to the [ProductName] Setup Wizard</String>
-  <String Id="WelcomeDlgDescription">{\WixUI_Font_Normal}The Setup Wizard will install [ProductName] on your computer.  Click Next to continue or Cancel to exit the Setup Wizard</String>
+  <String Id="WelcomeDlgDescription">{\WixUI_Font_Normal}The Setup Wizard will install [ProductName] on your computer. Click Next to continue or Cancel to exit the Setup Wizard</String>
 
-  <String Id="LicenseAgreementDlgTitle">{\WixUI_Font_Title_White}End-User License Agreement</String>
-  <String Id="LicenseAgreementDlgDescription">{\WixUI_Font_Normal_White}Please read the following license agreement carefully</String>
-
+  <!-- Override to make font white -->
+  <String Id="BrowseDlgTitle">{\WixUI_Font_Title_White}Change destination folder</String>
+  <String Id="BrowseDlgDescription">{\WixUI_Font_Normal_White}Browse to the destination folder</String>
+  <String Id="CustomizeDlgTitle" Overridable="yes">{\WixUI_Font_Title_White}Custom Setup</String>
+  <String Id="CustomizeDlgDescription" Overridable="yes">{\WixUI_Font_Normal_White}Select the way you want features to be installed.</String>
+  <String Id="DiskCostDlgTitle">{\WixUI_Font_Title_White}Disk Space Requirements</String>
+  <String Id="DiskCostDlgDescription">{\WixUI_Font_Normal_White}The disk space required for the installation of the selected features.</String>
   <String Id="InstallDirDlgTitle">{\WixUI_Font_Title_White}Destination Folder</String>
   <String Id="InstallDirDlgDescription">{\WixUI_Font_Normal_White}Click Next to install to the default folder or click Change to choose another.</String>
-
+  <String Id="LicenseAgreementDlgTitle">{\WixUI_Font_Title_White}End-User License Agreement</String>
+  <String Id="LicenseAgreementDlgDescription">{\WixUI_Font_Normal_White}Please read the following license agreement carefully</String>
+  <String Id="MaintenanceTypeDlgTitle">{\WixUI_Font_Title_White}Change, repair, or remove installation</String>
+  <String Id="MaintenanceTypeDlgDescription">{\WixUI_Font_Normal_White}Select the operation you wish to perform.</String>
   <String Id="ProgressDlgTitleInstalling">{\WixUI_Font_Title_White}Installing [ProductName]</String>
-
+  <String Id="ProgressDlgTitleRepairing">{\WixUI_Font_Title_White}Repairing [ProductName]</String>
+  <String Id="ProgressDlgTitleRemoving">{\WixUI_Font_Title_White}Removing [ProductName]</String>
+  <String Id="VerifyReadyDlgChangeTitle">{\WixUI_Font_Title_White}Ready to change [ProductName]</String>
   <String Id="VerifyReadyDlgInstallTitle">{\WixUI_Font_Title_White}Ready to install [ProductName]</String>
+  <String Id="VerifyReadyDlgRepairTitle">{\WixUI_Font_Title_White}Ready to repair [ProductName]</String>
+  <String Id="VerifyReadyDlgRemoveTitle">{\WixUI_Font_Title_White}Ready to remove [ProductName]</String>
 
   <String Id="FeatureMainName"><%= friendly_name %></String>
   <String Id="LaunchAgentManager"> Launch Datadog Agent Manager</String>
 
   <!-- these strings for the api key dialog -->
-  <String Id ="ApiKeyDialogTitle" Overridable="yes" Localizable="yes">[ProductName] Setup</String>
+  <String Id ="ApiKeyDialog_Title" Overridable="yes" Localizable="yes">[ProductName] Setup</String>
   <String Id ="ApiKeyDialogDescription" Overridable="yes" Localizable="yes">{\WixUI_Font_Normal_White}Enter the API Key</String>
-  <String Id ="ApiKeyDialogBannerTitle"  Overridable="yes" Localizable="yes">{\WixUI_Font_Normal_White}[ShortCompanyName] API Key </String>
-  <String Id ="ApiKeyDialogKeyLabel" Overridable="yes" Localizable="yes">Please enter the [ShortCompanyName] API Key</String>
+  <String Id ="ApiKeyDialogTitle"  Overridable="yes" Localizable="yes">{\WixUI_Font_Title_White}[ShortCompanyName] API Key</String>
+  <String Id ="ApiKeyDialogKeyLabel" Overridable="yes" Localizable="yes">Please enter the [ShortCompanyName] API Key:</String>
   <String Id ="ApiKeySampleKey" Overridable="yes" Localizable="yes"></String>
 
-  <!-- these strings for the site dialog -->
-  <String Id ="SiteDialogTitle" Overridable="yes" Localizable="yes">[ProductName] Setup</String>
+  <!-- these strings for the  site dialog -->
+  <String Id ="SiteDialog_Title" Overridable="yes" Localizable="yes">[ProductName] Setup</String>
   <String Id ="SiteDialogDescription" Overridable="yes" Localizable="yes">{\WixUI_Font_Normal_White}Select the [ShortCompanyName] Region</String>
-  <String Id ="SiteDialogBannerTitle"  Overridable="yes" Localizable="yes">{\WixUI_Font_Normal_White}[ShortCompanyName] Region </String>
+  <String Id ="SiteDialogTitle"  Overridable="yes" Localizable="yes">{\WixUI_Font_Title_White}[ShortCompanyName] Region </String>
   <String Id ="SiteDialogKeyLabel" Overridable="yes" Localizable="yes">Which [ShortCompanyName] region do you want the Agent to send data to?</String>
   <String Id ="SiteSampleKey" Overridable="yes" Localizable="yes"></String>
 
@@ -96,7 +106,6 @@
   <String Id="NoMoveInstallDir">The installation directory cannot be changed on an upgrade.</String>
   <String Id="NoMoveConfDir">The configuration file directory cannot be changed on an upgrade.</String>
 
-  
   <!-- Bitmap filenames -->
   <String Id ="LicenseAgreementDlgBannerBitmap" Overridable="yes" Localizable="no">BannerBmp</String>
   <String Id ="WelcomeDlgBitmap" Overridable="yes" Localizable="no">BackgroundBmp</String>


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR makes styling fixes to the Windows Agent Installer GUI Dialogs to make the dialogs consistent. Here is the list of fixes:
* The Windows installer dialogs have inconsistent fonts and colors. The text displayed over the top Datadog banner in each dialog needs to be styled as WixUI_Font_Title_White (Tahoma/White/9/Bold) or WixUI_Font_Normal_White(Tahoma/White/8) for title and description respectively.
* Fix the issue where the top banner title does not show up in the API Key and the Site dialogs.
* Fix the indentation of the .wxi code of the API Key and Site dialogs.

### Motivation

See above

### Additional Notes

N/A

### Possible Drawbacks / Trade-offs

N/A

### Describe how to test/QA your changes

* Run the Windows Installer step by step and verify that the dialog text that appears over the top Datadog banner is consistent across the various dialogs with white color.
* Ensure that the API Key dialog has both the title (Datadog API Key) and description (Enter the API Key) appear over the top banner.
* Ensure that the Site dialog has both the title (Datadog Region) and description (Select the Datadog Region) appear over the top banner.
* After installation, goto "Programs and Features" in Control Panel. Right click on the "Datadog Agent" program and select "Change". Similar to Step 1, verify consistency starting from the (Change/Repair/Remove) dialogs up to the Verify Ready dialogs for all three workflows.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
