### PR TITLE
Fix warnings about config on system-probe startup

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1256,8 +1256,16 @@ func findUnexpectedUnicode(config Config) []string {
 	allKeys := config.AllKeys()
 	for _, key := range allKeys {
 		checkAndRecordString(key, fmt.Sprintf("Configuration key string '%s'", key))
-		value := config.GetString(key)
-		checkAndRecordString(value, fmt.Sprintf("For key '%s', configuration value string '%s'", key, value))
+		if value := config.Get(key); value != nil {
+			switch v := value.(type) {
+			case string:
+				checkAndRecordString(v, fmt.Sprintf("For key '%s', configuration value string '%s'", key, v))
+			case []string:
+				for _, s := range v {
+					checkAndRecordString(s, fmt.Sprintf("For key '%s', configuration value string '%s'", key, s))
+				}
+			}
+		}
 	}
 
 	return messages


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fix warning logs on startup of system-probe: 
```
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "statsd_metric_namespace_blacklist": unable to cast []string{"datadog.agent", "datadog.dogstatsd", "datadog.process", "datadog.trace_agent", "datadog.tracer", "activemq", "activemq_58", "airflow", "cassandra", "confluent", "hazelcast", "hive", "ignite", "jboss", "jvm", "kafka", "presto", "sidekiq", "solr", "tomcat", "runtime"} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "telemetry.dogstatsd.listeners_channel_latency_buckets": unable to cast []string{} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "runtime_security_config.log_tags": unable to cast []string{} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "kubernetes_node_annotations_as_tags": unable to cast map[string]string{"cluster.k8s.io/machine":"kube_machine"} of type map[string]string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "histogram_percentiles": unable to cast []string{"0.95"} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "network_devices.snmp_traps.community_strings": unable to cast []string{} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "external_metrics_provider.config": unable to cast map[string]string{} of type map[string]string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "system_probe_config.dest_excludes": unable to cast map[string][]string{} of type map[string][]string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "docker_labels_as_tags": unable to cast map[string]string{} of type map[string]string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "extra_tags": unable to cast []string{} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "process_config.drop_check_payloads": unable to cast []string{} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "histogram_aggregates": unable to cast []string{"max", "median", "avg", "count"} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "containerd_exclude_namespaces": unable to cast []string{"moby"} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "ignore_autoconf": unable to cast []string{} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "orchestrator_explorer.extra_tags": unable to cast []string{} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "runtime_security_config.activity_dump.traced_event_types": unable to cast []string{"exec", "open", "dns", "bind"} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "cloud_provider_metadata": unable to cast []string{"aws", "gcp", "azure", "alibaba", "oracle", "ibm"} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "runtime_security_config.custom_sensitive_words": unable to cast []string{} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "dogstatsd_eol_required": unable to cast []string{} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "telemetry.dogstatsd.aggregator_channel_latency_buckets": unable to cast []string{} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "telemetry.dogstatsd.listeners_latency_buckets": unable to cast []string{} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "container_labels_as_tags": unable to cast map[string]string{} of type map[string]string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "autoconfig_include_features": unable to cast []string{} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "orchestrator_explorer.custom_sensitive_words": unable to cast []string{} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "cluster_checks.extra_tags": unable to cast []string{} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "additional_endpoints": unable to cast map[string][]string{} of type map[string][]string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "tag_value_split_separator": unable to cast map[string]string{} of type map[string]string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "otlp_config.traces.span_name_remappings": unable to cast map[string]string{} of type map[string]string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "container_include": unable to cast []string{} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "kubernetes_pod_annotations_as_tags": unable to cast map[string]string{} of type map[string]string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "system_probe_config.memory_controller.thresholds": unable to cast map[string]string{} of type map[string]string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "ac_include": unable to cast []string{} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "statsd_metric_blocklist": unable to cast []string{} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "runtime_security_config.activity_dump.local_storage.formats": unable to cast []string{} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "kubernetes_node_annotations_as_host_aliases": unable to cast []string{"cluster.k8s.io/machine"} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "system_probe_config.excluded_linux_versions": unable to cast []string{} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "container_env_as_tags": unable to cast map[string]string{} of type map[string]string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "secret_backend_arguments": unable to cast []string{} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "system_probe_config.kernel_header_dirs": unable to cast []string{} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "extra_listeners": unable to cast []string{} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "containerd_namespace": unable to cast []string{} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "tags": unable to cast []string{} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "kubernetes_namespace_labels_as_tags": unable to cast map[string]string{} of type map[string]string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "runtime_security_config.network.lazy_interface_prefixes": unable to cast []string{} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "kubernetes_node_labels_as_tags": unable to cast map[string]string{} of type map[string]string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "runtime_security_config.log_patterns": unable to cast []string{} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "ac_exclude": unable to cast []string{} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "network_config.dns_recorded_query_types": unable to cast []string{} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "container_include_logs": unable to cast []string{} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "system_probe_config.memory_controller.pressure_levels": unable to cast map[string]string{} of type map[string]string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "process_config.events_additional_endpoints": unable to cast map[string][]string{} of type map[string][]string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "logs_config.auto_multi_line_extra_patterns": unable to cast []string{} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "system_probe_config.source_excludes": unable to cast map[string]interface {}{"192.168.0.0/24":[]interface {}{"*"}} of type map[string]interface {} to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "autoconfig_exclude_features": unable to cast []string{} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "cloud_foundry_bbs.env_exclude": unable to cast []string{} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "kubernetes_pod_labels_as_tags": unable to cast map[string]string{} of type map[string]string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "host_aliases": unable to cast []string{} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "jmx_custom_jars": unable to cast []string{} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "auto_exit.noprocess.excluded_processes": unable to cast []string{} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "containerd_namespaces": unable to cast []string{} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "container_include_metrics": unable to cast []string{} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "exclude_gce_tags": unable to cast []string{"kube-env", "kubelet-config", "containerd-configure-sh", "startup-script", "shutdown-script", "configure-sh", "sshKeys", "ssh-keys", "user-data", "cli-cert", "ipsec-cert", "ssl-cert", "google-container-manifest", "bosh_settings", "windows-startup-script-ps1", "common-psm1", "k8s-node-setup-psm1", "serial-port-logging-enable", "enable-oslogin", "disable-address-manager", "disable-legacy-endpoints", "windows-keys", "kubeconfig"} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "flare_stripped_keys": unable to cast []string{} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "dogstatsd_tags": unable to cast []string{} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "extra_config_providers": unable to cast []string{} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "docker_env_as_tags": unable to cast map[string]string{} of type map[string]string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "process_config.additional_endpoints": unable to cast map[string][]string{} of type map[string][]string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "cloud_foundry_bbs.env_include": unable to cast []string{} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "container_exclude_logs": unable to cast []string{} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "runtime_security_config.activity_dump.remote_storage.formats": unable to cast []string{"json"} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "container_exclude_metrics": unable to cast []string{} of type []string to string
2022-07-12 22:34:05 UTC | SYS-PROBE | WARN | (pkg/util/log/log.go:591 in func1) | failed to get configuration value for key "container_exclude": unable to cast []string{} of type []string to string
```

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
