### PR TITLE
Updating SecretsManager secret fetching logic to always query the SecretsManager region defined in the ARN.

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -140,6 +140,7 @@ core,github.com/awalterschulze/gographviz/internal/parser,Apache-2.0,Copyright (
 core,github.com/awalterschulze/gographviz/internal/token,Apache-2.0,Copyright (c) 2009 The Go Authors. All rights reserved | Copyright 2013 GoGraphviz Authors | Nathan Kitchen <nathan.kitchen@gmail.com> | Robin Eklind <r.eklind.87@gmail.com> | Ruud Kamphuis <https://github.com/ruudk> | Vastech SA (PTY) LTD | Walter Schulze <awalterschulze@gmail.com> | Xavier Chassin <xavier.chassin@live.fr> | Xuanyi Chew <chewxy@gmail.com>
 core,github.com/aws/aws-lambda-go/events,Apache-2.0,"Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved."
 core,github.com/aws/aws-sdk-go/aws,Apache-2.0,"Copyright 2014-2015 Stripe, Inc. | Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved."
+core,github.com/aws/aws-sdk-go/aws/arn,Apache-2.0,"Copyright 2014-2015 Stripe, Inc. | Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved."
 core,github.com/aws/aws-sdk-go/aws/awserr,Apache-2.0,"Copyright 2014-2015 Stripe, Inc. | Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved."
 core,github.com/aws/aws-sdk-go/aws/awsutil,Apache-2.0,"Copyright 2014-2015 Stripe, Inc. | Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved."
 core,github.com/aws/aws-sdk-go/aws/client,Apache-2.0,"Copyright 2014-2015 Stripe, Inc. | Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved."

--- a/cmd/serverless/api_key.go
+++ b/cmd/serverless/api_key.go
@@ -140,7 +140,7 @@ func extractRegionFromSecretsManagerArn(secretsManagerArn string) (string, error
 	re := regexp.MustCompile(regionRegex)
 	matches := re.FindStringSubmatch(arnObject.Region)
 	if len(matches) == 0 {
-		return "", fmt.Errorf("region %s found in arn %s is not a valid region format.", arnObject.Region, secretsManagerArn)
+		return "", fmt.Errorf("region %s found in arn %s is not a valid region format", arnObject.Region, secretsManagerArn)
 	}
 
 	return arnObject.Region, nil

--- a/cmd/serverless/api_key_test.go
+++ b/cmd/serverless/api_key_test.go
@@ -26,10 +26,13 @@ const mockDecodedEncryptedAPIKey = "2222222222222222"
 const expectedDecryptedAPIKey = "1111111111111111"
 
 // mockSecretsManagerAPIKeyArn represents a SecretsManager Arn passed in via DD_API_KEY_SECRET_ARN environment variable
-const mockSecretsManagerAPIKeyArn string = "arn:aws:secretsmanager:us-west-2:123456789012:secret:DatadogAppKeySecret"
+const mockSecretsManagerAPIKeyArn string = "arn:aws:secretsmanager:us-west-2:123456789012:secret:DatadogAPIKeySecret"
 
-// mockMalformedSecretsManagerAPIKeyArn represents a SecretsManager Arn formatted incorrectly that doesn't match regex.
-const mockMalformedSecretsManagerAPIKeyArn string = "arn:aws:secretsmanager:uswest2:123456789012:secret:DatadogAppKeySecret"
+// mockMalformedRegionSecretsManagerAPIKeyArn represents an AWS region in the ARN formatted incorrectly that doesn't match regex.
+const mockMalformedRegionSecretsManagerAPIKeyArn string = "arn:aws:secretsmanager:uswest2:123456789012:secret:DatadogAPIKeySecret"
+
+// mockMalformedPrefixSecretsManagerAPIKeyArn represents an ARN formatted incorrectly that doesn't match regex.
+const mockMalformedPrefixSecretsManagerAPIKeyArn string = "aws:secretsmanager:us-west-2:123456789012:secret:DatadogAPIKeySecret"
 
 // mockFunctionName represents the name of the current function
 var mockFunctionName = "my-Function"
@@ -90,8 +93,14 @@ func TestExtractRegionFromSecretsManagerArn(t *testing.T) {
 	assert.Equal(t, result, "us-west-2")
 }
 
-func TestExtractRegionFromMalformedSecretsManagerArn(t *testing.T) {
-	result, err := extractRegionFromSecretsManagerArn(mockMalformedSecretsManagerAPIKeyArn)
+func TestExtractRegionFromMalformedRegionSecretsManagerArn(t *testing.T) {
+	result, err := extractRegionFromSecretsManagerArn(mockMalformedRegionSecretsManagerAPIKeyArn)
 	assert.Equal(t, result, "")
-	assert.Error(t, err, "Couldn't extract region from arn: arn:aws:secretsmanager:uswest2:123456789012:secret:DatadogAppKeySecret")
+	assert.Error(t, err, "region uswest2 found in arn arn:aws:secretsmanager:uswest2:123456789012:secret:DatadogAPIKeySecret is not a valid region format")
+}
+
+func TestExtractRegionFromMalformedPrefixSecretsManagerArnPrefix(t *testing.T) {
+	result, err := extractRegionFromSecretsManagerArn(mockMalformedPrefixSecretsManagerAPIKeyArn)
+	assert.Equal(t, result, "")
+	assert.Error(t, err, "could not extract region from arn: aws:secretsmanager:us-west-2:123456789012:secret:DatadogAPIKeySecret. arn: invalid prefix")
 }

--- a/cmd/serverless/api_key_test.go
+++ b/cmd/serverless/api_key_test.go
@@ -25,6 +25,12 @@ const mockDecodedEncryptedAPIKey = "2222222222222222"
 // expectedDecryptedAPIKey represents the true value of the API key after decryption by KMS
 const expectedDecryptedAPIKey = "1111111111111111"
 
+// mockSecretsManagerAPIKeyArn represents a SecretsManager Arn passed in via DD_API_KEY_SECRET_ARN environment variable
+const mockSecretsManagerAPIKeyArn string = "arn:aws:secretsmanager:us-west-2:123456789012:secret:DatadogAppKeySecret"
+
+// mockMalformedSecretsManagerAPIKeyArn represents a SecretsManager Arn formatted incorrectly that doesn't match regex.
+const mockMalformedSecretsManagerAPIKeyArn string = "arn:aws:secretsmanager:uswest2:123456789012:secret:DatadogAppKeySecret"
+
 // mockFunctionName represents the name of the current function
 var mockFunctionName = "my-Function"
 
@@ -77,4 +83,15 @@ func TestDecryptKMSNoEncryptionContext(t *testing.T) {
 	client := mockKMSClientNoEncryptionContext{}
 	result, _ := decryptKMS(client, mockEncryptedAPIKeyBase64)
 	assert.Equal(t, expectedDecryptedAPIKey, result)
+}
+
+func TestExtractRegionFromSecretsManagerArn(t *testing.T) {
+	result, _ := extractRegionFromSecretsManagerArn(mockSecretsManagerAPIKeyArn)
+	assert.Equal(t, result, "us-west-2")
+}
+
+func TestExtractRegionFromMalformedSecretsManagerArn(t *testing.T) {
+	result, err := extractRegionFromSecretsManagerArn(mockMalformedSecretsManagerAPIKeyArn)
+	assert.Equal(t, result, "")
+	assert.Error(t, err, "Couldn't extract region from arn: arn:aws:secretsmanager:uswest2:123456789012:secret:DatadogAppKeySecret")
 }


### PR DESCRIPTION
….

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

If the SecretsManager resource lives in a region other than the one your Lambda is running in the SecretsManager client will not be able to access it unless the region at client creation time. 

This change fetches the region out of the arn supplied by the DD_API_KEY_SECRET_ARN environment variable and uses that to explicitly set the SecretsManager region when creating the client.  

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

We'd rather not replicate Secrets to every region where we want to instrument our Lambdas with Datadog.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
--> 

Thought about adding a second environment variable to override the SecretsManager client region but I can't think of a scenario when that would ever differ from the region defined in the arn itself.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

- Unit tests added to validate the regex to pull the region out of the arn.

- Created a local integration test to validate that the region is correctly overridden and was able to pull a secret out of us-west-2 running from us-east-1. 

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
