### PR TITLE
feat(remote-config): Bypass cache on new client request

### DIFF
--- a/pkg/config/remote/service/clients.go
+++ b/pkg/config/remote/service/clients.go
@@ -20,7 +20,7 @@ type client struct {
 
 type newActiveClients struct {
 	clock    clock.Clock
-	requests chan sync.WaitGroup
+	requests chan *sync.WaitGroup
 	until    time.Time
 }
 

--- a/pkg/config/remote/service/clients.go
+++ b/pkg/config/remote/service/clients.go
@@ -20,7 +20,7 @@ type client struct {
 
 type newActiveClients struct {
 	clock    clock.Clock
-	requests chan *sync.WaitGroup
+	requests chan chan struct{}
 	until    time.Time
 }
 

--- a/pkg/config/remote/service/clients.go
+++ b/pkg/config/remote/service/clients.go
@@ -18,6 +18,21 @@ type client struct {
 	pbClient *pbgo.Client
 }
 
+type newActiveClients struct {
+	clock    clock.Clock
+	requests chan sync.WaitGroup
+	until    time.Time
+}
+
+// setRateLimit updates the next date when a new tracer is allow to bypass cache
+func (c *newActiveClients) setRateLimit(refreshInterval time.Duration) {
+	ttl := defaultClientsTTL
+	if refreshInterval < ttl && refreshInterval >= minimalRefreshInterval {
+		ttl = refreshInterval
+	}
+	c.until = c.clock.Now().UTC().Add(ttl)
+}
+
 func (c *client) expired(clock clock.Clock, ttl time.Duration) bool {
 	return clock.Now().UTC().After(c.lastSeen.Add(ttl))
 }
@@ -30,6 +45,7 @@ type clients struct {
 	clients    map[string]*client
 }
 
+// newClients creates a new clients object
 func newClients(clock clock.Clock, clientsTTL time.Duration) *clients {
 	return &clients{
 		clock:      clock,
@@ -48,6 +64,15 @@ func (c *clients) seen(pbClient *pbgo.Client) {
 		lastSeen: now,
 		pbClient: pbClient,
 	}
+}
+
+// active checks whether a certain client is active
+func (c *clients) active(pbClient *pbgo.Client) bool {
+	client, ok := c.clients[pbClient.Id]
+	if !ok {
+		return false
+	}
+	return !client.expired(c.clock, c.clientsTTL)
 }
 
 // activeClients returns the list of active clients

--- a/pkg/config/remote/service/clients_test.go
+++ b/pkg/config/remote/service/clients_test.go
@@ -41,7 +41,7 @@ func TestNewActiveClientsRateLimit(t *testing.T) {
 	clock := clock.NewMock()
 	newActiveClients := newActiveClients{
 		clock:    clock,
-		requests: make(chan sync.WaitGroup),
+		requests: make(chan *sync.WaitGroup),
 		until:    clock.Now(),
 	}
 

--- a/pkg/config/remote/service/clients_test.go
+++ b/pkg/config/remote/service/clients_test.go
@@ -6,7 +6,6 @@
 package service
 
 import (
-	"sync"
 	"testing"
 	"time"
 
@@ -41,7 +40,7 @@ func TestNewActiveClientsRateLimit(t *testing.T) {
 	clock := clock.NewMock()
 	newActiveClients := newActiveClients{
 		clock:    clock,
-		requests: make(chan *sync.WaitGroup),
+		requests: make(chan chan struct{}),
 		until:    clock.Now(),
 	}
 

--- a/pkg/config/remote/service/service.go
+++ b/pkg/config/remote/service/service.go
@@ -166,7 +166,7 @@ func NewService() (*Service, error) {
 		clients:                newClients(clock, clientsTTL),
 		newActiveClients: newActiveClients{
 			clock:    clock,
-			requests: make(chan sync.WaitGroup),
+			requests: make(chan *sync.WaitGroup),
 			until:    time.Now().UTC(),
 		},
 	}, nil
@@ -305,9 +305,9 @@ func (s *Service) ClientGetConfigs(request *pbgo.ClientGetConfigsRequest) (*pbgo
 		s.Unlock()
 		wg := sync.WaitGroup{}
 		wg.Add(1)
-		s.newActiveClients.requests <- wg
+		s.newActiveClients.requests <- &wg
 		select {
-		case <-waitChan(wg):
+		case <-waitChan(&wg):
 		case <-time.After(newClientBlockTTL):
 			log.Warn("Timed out waiting for upstream new configurations")
 		}

--- a/pkg/config/remote/service/service_test.go
+++ b/pkg/config/remote/service/service_test.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
-	"sync"
 	"testing"
 	"time"
 
@@ -105,11 +104,6 @@ func newTestService(t *testing.T, api *mockAPI, uptane *mockUptane, clock clock.
 	service.api = api
 	service.clock = clock
 	service.uptane = uptane
-	service.newActiveClients = newActiveClients{
-		clock:    clock,
-		until:    clock.Now(),
-		requests: make(chan sync.WaitGroup),
-	}
 	assert.NoError(t, err)
 	return service
 }

--- a/pkg/config/remote/service/util.go
+++ b/pkg/config/remote/service/util.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/config/remote/data"
 	"github.com/DataDog/datadog-agent/pkg/config/remote/uptane"
@@ -20,15 +19,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/version"
 	"go.etcd.io/bbolt"
 )
-
-func waitChan(wg *sync.WaitGroup) chan struct{} {
-	c := make(chan struct{})
-	go func() {
-		defer close(c)
-		wg.Wait()
-	}()
-	return c
-}
 
 func openCacheDB(path string) (*bbolt.DB, error) {
 	db, err := bbolt.Open(path, 0600, &bbolt.Options{})

--- a/pkg/config/remote/service/util.go
+++ b/pkg/config/remote/service/util.go
@@ -21,7 +21,7 @@ import (
 	"go.etcd.io/bbolt"
 )
 
-func waitChan(wg sync.WaitGroup) chan struct{} {
+func waitChan(wg *sync.WaitGroup) chan struct{} {
 	c := make(chan struct{})
 	go func() {
 		defer close(c)

--- a/pkg/config/remote/service/util.go
+++ b/pkg/config/remote/service/util.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/config/remote/data"
 	"github.com/DataDog/datadog-agent/pkg/config/remote/uptane"
@@ -19,6 +20,15 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/version"
 	"go.etcd.io/bbolt"
 )
+
+func waitChan(wg sync.WaitGroup) chan struct{} {
+	c := make(chan struct{})
+	go func() {
+		defer close(c)
+		wg.Wait()
+	}()
+	return c
+}
 
 func openCacheDB(path string) (*bbolt.DB, error) {
 	db, err := bbolt.Open(path, 0600, &bbolt.Options{})

--- a/pkg/config/remote/telemetry/README.md
+++ b/pkg/config/remote/telemetry/README.md
@@ -1,0 +1,3 @@
+## package `telemetry`
+
+This package defines Remote Configuration's telemetry metrics.

--- a/pkg/config/remote/telemetry/telemetry.go
+++ b/pkg/config/remote/telemetry/telemetry.go
@@ -1,0 +1,38 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package telemetry
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/telemetry"
+)
+
+const (
+	subsystem = "remoteconfig"
+)
+
+var (
+	commonOpts = telemetry.Options{NoDoubleUnderscoreSep: true}
+)
+
+var (
+	// CacheBypassRateLimit counts how many cache bypass requests trigger rate limiting.
+	CacheBypassRateLimit = telemetry.NewCounterWithOpts(
+		subsystem,
+		"cache_bypass_ratelimiter_skip",
+		[]string{},
+		"Number of Remote Configuration cache bypass requests skipped by rate limiting.",
+		commonOpts,
+	)
+
+	// CacheBypassTimeout counts how many cache bypass requests timeout
+	CacheBypassTimeout = telemetry.NewCounterWithOpts(
+		subsystem,
+		"cache_bypass_timeout",
+		[]string{},
+		"Number of Remote Configuration cache bypass requests that timeout.",
+		commonOpts,
+	)
+)


### PR DESCRIPTION
### What does this PR do?
Make sure that every client that connects for the first time to the
agent triggers a cache bypass, ie a request to the backend. This is
to avoid cold starts where the client has to wait one minute to get
its configuration.
To avoid handling too many requests in the backend, we introduce a
rate limiter for this specific feature.

### Motivation
[[RFC] Guarantee up to date configs to tracers on connection](https://docs.google.com/document/d/1ei7-BwQ7CieXP0egMdPFAYUfaGTV4Ul59QB_cPjQ1Tc/edit#)

### Additional Notes

### Possible Drawbacks / Trade-offs

- Tracers will wait on their first RC request for `newClientBlockTTL` seconds
- Set up a rate limiter to avoid backend request flooding if many clients connect at once

### Describe how to test/QA your changes

1. Set your agent to have a long poll time
2. Launch it
3. Wait for it to get configurations
4. Create a config in the backend (e.g. with DEBUG product)
5. Launch a request impersonating a tracer
6. See if you get the new configuration you created

Also, it'd nice but not mandatory to check whether the telemetry data is well sent: try to add a sleep or to remove the ack from the main poll loop to make new clients timeout, and see if the corresponding metric triggers something

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
