### PR TITLE
upgrade(remote-config): Add validation checks on client config requests

### DIFF
--- a/pkg/config/remote/service/service_test.go
+++ b/pkg/config/remote/service/service_test.go
@@ -336,6 +336,7 @@ func TestService(t *testing.T) {
 	targets := []byte(`testtargets`)
 	testTargetsCustom := []byte(`{"opaque_backend_state":"dGVzdF9zdGF0ZQ=="}`)
 	client := &pbgo.Client{
+		Id: "testid",
 		State: &pbgo.ClientState{
 			RootVersion: 2,
 		},
@@ -424,7 +425,8 @@ func TestService(t *testing.T) {
 // Test for client predicates
 func TestServiceClientPredicates(t *testing.T) {
 	clientID := "client-id"
-	clientIDFail := clientID + "_fail"
+	runtimeID := "runtime-id"
+	runtimeIDFail := runtimeID + "_fail"
 
 	assert := assert.New(t)
 	clock := clock.NewMock()
@@ -437,6 +439,7 @@ func TestServiceClientPredicates(t *testing.T) {
 	service := newTestService(t, api, uptaneClient, clock)
 
 	client := &pbgo.Client{
+		Id: clientID,
 		State: &pbgo.ClientState{
 			RootVersion: 2,
 		},
@@ -445,7 +448,10 @@ func TestServiceClientPredicates(t *testing.T) {
 		},
 		IsTracer: true,
 		ClientTracer: &pbgo.ClientTracer{
-			RuntimeId: clientID,
+			RuntimeId:  runtimeID,
+			Language:   "php",
+			Env:        "staging",
+			AppVersion: "1",
 		},
 	}
 	uptaneClient.On("TargetsMeta").Return([]byte(`testtargets`), nil)
@@ -457,13 +463,13 @@ func TestServiceClientPredicates(t *testing.T) {
 		"datadog/2/APM_SAMPLING/id/1": {FileMeta: data.FileMeta{Custom: customMeta([]*pbgo.TracerPredicateV1{})}},
 		"datadog/2/APM_SAMPLING/id/2": {FileMeta: data.FileMeta{Custom: customMeta([]*pbgo.TracerPredicateV1{
 			{
-				RuntimeID: clientID,
+				RuntimeID: runtimeID,
 			},
 		})}},
 		// must not be delivered
 		"datadog/2/TESTING1/id/1": {FileMeta: data.FileMeta{Custom: customMeta([]*pbgo.TracerPredicateV1{
 			{
-				RuntimeID: clientIDFail,
+				RuntimeID: runtimeIDFail,
 			},
 		})}},
 		"datadog/2/APPSEC/id/1": {FileMeta: data.FileMeta{Custom: customMeta([]*pbgo.TracerPredicateV1{


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Adds a bunch of validation checks when a client requests configurations from the agent. Mostly, they ensure that every required field is set and that conflicting fields are not set at the same time.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Making sure tracer clients are respecting the integration rules

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
N/A
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
N/A
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Try to request the backend using incomplete or errored payloads, check that if fails properly
Also make sure that the nominal functioning works, ie that you get configurations when using a correct payload.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
