### PR TITLE
pkg/trace/info: Remove BytesEstimated

### DIFF
--- a/pkg/trace/info/writer.go
+++ b/pkg/trace/info/writer.go
@@ -25,7 +25,6 @@ type TraceWriterInfo struct {
 	Retries           atomic.Int64
 	Bytes             atomic.Int64
 	BytesUncompressed atomic.Int64
-	BytesEstimated    atomic.Int64
 	SingleMaxSize     atomic.Int64
 }
 
@@ -69,7 +68,6 @@ func (twi TraceWriterInfo) MarshalJSON() ([]byte, error) {
 		"Retries":           float64(twi.Retries.Load()),
 		"Bytes":             float64(twi.Bytes.Load()),
 		"BytesUncompressed": float64(twi.BytesUncompressed.Load()),
-		"BytesEstimated":    float64(twi.BytesEstimated.Load()),
 		"SingleMaxSize":     float64(twi.SingleMaxSize.Load()),
 	}
 	return json.Marshal(asMap)

--- a/pkg/trace/info/writer_test.go
+++ b/pkg/trace/info/writer_test.go
@@ -21,7 +21,6 @@ func TestPublishTraceWriterInfo(t *testing.T) {
 		atom(7),
 		atom(8),
 		atom(9),
-		atom(10),
 	}
 
 	testExpvarPublish(t, publishTraceWriterInfo,
@@ -35,8 +34,7 @@ func TestPublishTraceWriterInfo(t *testing.T) {
 			"Retries":           6.0,
 			"Bytes":             7.0,
 			"BytesUncompressed": 8.0,
-			"BytesEstimated":    9.0,
-			"SingleMaxSize":     10.0,
+			"SingleMaxSize":     9.0,
 		})
 }
 

--- a/pkg/trace/writer/trace.go
+++ b/pkg/trace/writer/trace.go
@@ -239,7 +239,6 @@ func (w *TraceWriter) flush() {
 	}
 
 	w.stats.BytesUncompressed.Add(int64(len(b)))
-	w.stats.BytesEstimated.Add(int64(w.bufferedSize))
 
 	w.wg.Add(1)
 	go func() {
@@ -272,7 +271,6 @@ func (w *TraceWriter) report() {
 	metrics.Count("datadog.trace_agent.trace_writer.payloads", w.stats.Payloads.Swap(0), nil, 1)
 	metrics.Count("datadog.trace_agent.trace_writer.bytes_uncompressed", w.stats.BytesUncompressed.Swap(0), nil, 1)
 	metrics.Count("datadog.trace_agent.trace_writer.retries", w.stats.Retries.Swap(0), nil, 1)
-	metrics.Count("datadog.trace_agent.trace_writer.bytes_estimated", w.stats.BytesEstimated.Swap(0), nil, 1)
 	metrics.Count("datadog.trace_agent.trace_writer.bytes", w.stats.Bytes.Swap(0), nil, 1)
 	metrics.Count("datadog.trace_agent.trace_writer.errors", w.stats.Errors.Swap(0), nil, 1)
 	metrics.Count("datadog.trace_agent.trace_writer.traces", w.stats.Traces.Swap(0), nil, 1)

--- a/releasenotes/notes/apm-remove-bytes-estimated-ac5ee760bf468464.yaml
+++ b/releasenotes/notes/apm-remove-bytes-estimated-ac5ee760bf468464.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+deprecations:
+  - |
+    APM: The `datadog.trace_agent.trace_writer.bytes_estimated` metric has been removed. It was meant to be a metric used for debugging, without any user added value.


### PR DESCRIPTION
### What does this PR do?

Remove Trace Writer BytesEstimated and its reported timeseries.
BytesEstimated was never meant to be relevant for customers nor our support and was never used. It was only helpful for our development.
As such, I consider this doesn't require a CHANGELOG entry.

### Motivation

Less confusion about what our Trace Agent self-monitoring report (one less timeseries, less code to explain).

