### PR TITLE
fix: Adds any slices to config values checked for unexpected unicode

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1253,18 +1253,27 @@ func findUnexpectedUnicode(config Config) []string {
 		}
 	}
 
+	var visitElement func(string, interface{})
+	visitElement = func(key string, element interface{}) {
+		switch elementValue := element.(type) {
+		case string:
+			checkAndRecordString(elementValue, fmt.Sprintf("For key '%s', configuration value string '%s'", key, elementValue))
+		case []string:
+			for _, s := range elementValue {
+				checkAndRecordString(s, fmt.Sprintf("For key '%s', configuration value string '%s'", key, s))
+			}
+		case []interface{}:
+			for _, listItem := range elementValue {
+				visitElement(key, listItem)
+			}
+		}
+	}
+
 	allKeys := config.AllKeys()
 	for _, key := range allKeys {
 		checkAndRecordString(key, fmt.Sprintf("Configuration key string '%s'", key))
-		if value := config.Get(key); value != nil {
-			switch v := value.(type) {
-			case string:
-				checkAndRecordString(v, fmt.Sprintf("For key '%s', configuration value string '%s'", key, v))
-			case []string:
-				for _, s := range v {
-					checkAndRecordString(s, fmt.Sprintf("For key '%s', configuration value string '%s'", key, s))
-				}
-			}
+		if unknownValue := config.Get(key); unknownValue != nil {
+			visitElement(key, unknownValue)
 		}
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -166,6 +166,11 @@ func TestUnexpectedWhitespace(t *testing.T) {
 			expectedWarningText: "U+202F",
 			expectedPosition:    fmt.Sprintf("position %d", 0),
 		},
+		{
+			yaml:                "root_element:\n  nestedKey: [validValue, \u202fhiddenInvalidWhitespaceToLeft]\n",
+			expectedWarningText: "U+202F",
+			expectedPosition:    fmt.Sprintf("position %d", 0),
+		},
 	}
 	for _, tc := range tests {
 		testConfig := setupConfFromYAML(tc.yaml)


### PR DESCRIPTION
### What does this PR do?
This extends the "Unexpected Unicode" check by adding a test and handling the case where a key's value is an unknown slice containing strings.

Followup to #12738 which was a followup to #12682

I believe there is no need to handle a "map" case because this is already iterating over all keys, so there would never be a key with a "map" value that wouldn't be visited already.

### Motivation
Completeness of implementation

### Additional Notes

### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes
none - QA for #12682 will be sufficient

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
