### PR TITLE
Fix empty remote tagger

### DIFF
--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -329,6 +329,9 @@ func StartAgent() error {
 		}
 	}
 
+	// create and setup the Autoconfig instance
+	common.LoadComponents(common.MainCtx, config.Datadog.GetString("confd_path"))
+
 	// start the cmd HTTP server
 	if runtime.GOOS != "android" {
 		if err = api.StartServer(configService); err != nil {
@@ -402,9 +405,6 @@ func StartAgent() error {
 
 	// Append version and timestamp to version history log file if this Agent is different than the last run version
 	util.LogVersionHistory()
-
-	// create and setup the Autoconfig instance
-	common.LoadComponents(common.MainCtx, config.Datadog.GetString("confd_path"))
 
 	// Set up check collector
 	common.AC.AddScheduler("check", collector.InitCheckScheduler(common.Coll), true)

--- a/pkg/tagger/remote/tagger.go
+++ b/pkg/tagger/remote/tagger.go
@@ -268,6 +268,13 @@ func (t *Tagger) run() {
 }
 
 func (t *Tagger) processResponse(response *pb.StreamTagsResponse) error {
+	// returning early when there are no events prevents a keep-alive sent
+	// from the core agent from wiping the store clean in case the remote
+	// tagger was previously in an unready (but filled) state.
+	if len(response.Events) == 0 {
+		return nil
+	}
+
 	events := make([]types.EntityEvent, 0, len(response.Events))
 	for _, ev := range response.Events {
 		eventType, err := convertEventType(ev.Type)


### PR DESCRIPTION
### What does this PR do?

This addresses two issues that were causing the remote tagger to be empty:

* A race condition that allowed a remote tagger stream to be started before the tagger was correctly set up.
* Another race condition that allowed a keep-alive message to wipe the remote tagger's contents if it was previously unready.

### Possible Drawbacks / Trade-offs

This changes the order of things when starting up the core agent. I verified to the best of my knowledge that there were no dependencies that would be affected by this change, but this is old code that relies on global state, so please yell if you think I missed something.

### Describe how to test/QA your changes

I'm not sure why, but the issue was consistently reproducible in an agent running in a GKE cluster, deployed with the helm chart, with host network disabled (deploys with the operator, and with host network enabled). Before this PR, either the process-agent or trace-agent would emit data with no tags (in the trace agent, this can be inspected by setting `DD_LOG_LEVEL=trace`, and looking for [this log](https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/api/api.go#L840)). After this PR, tags should be present as soon as the remote tagger starts.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
