### PR TITLE
pkg/jmxfetch: avoid panic when agent stops

### DIFF
--- a/pkg/jmxfetch/jmxfetch_nix.go
+++ b/pkg/jmxfetch/jmxfetch_nix.go
@@ -20,9 +20,11 @@ import (
 func (j *JMXFetch) Stop() error {
 	var stopChan chan struct{}
 
-	err := j.cmd.Process.Signal(syscall.SIGTERM)
-	if err != nil {
-		return err
+	if j.cmd.Process != nil {
+		err := j.cmd.Process.Signal(syscall.SIGTERM)
+		if err != nil {
+			return err
+		}
 	}
 
 	if j.managed {
@@ -39,13 +41,15 @@ func (j *JMXFetch) Stop() error {
 
 	select {
 	case <-time.After(time.Millisecond * 500):
+		if j.cmd.Process == nil {
+			return nil
+		}
 		log.Warnf("Jmxfetch did not exit during it's grace period, killing it")
-		err = j.cmd.Process.Signal(os.Kill)
+		err := j.cmd.Process.Signal(os.Kill)
 		if err != nil {
 			log.Warnf("Could not kill jmxfetch: %v", err)
 		}
 	case <-stopChan:
 	}
 	return nil
-
 }

--- a/pkg/jmxfetch/jmxfetch_windows.go
+++ b/pkg/jmxfetch/jmxfetch_windows.go
@@ -18,9 +18,11 @@ import (
 func (j *JMXFetch) Stop() error {
 	var stopChan chan struct{}
 
-	err := j.cmd.Process.Kill()
-	if err != nil {
-		return err
+	if j.cmd.Process != nil {
+		err := j.cmd.Process.Kill()
+		if err != nil {
+			return err
+		}
 	}
 
 	if j.managed {

--- a/releasenotes/notes/avoid-jmxfetch-panic-when-stopping-agent-3b4c24040581d772.yaml
+++ b/releasenotes/notes/avoid-jmxfetch-panic-when-stopping-agent-3b4c24040581d772.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix panic when Agent stops jmxfetch.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Avoid panic when agent stops.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x15fc3fb]
goroutine 1 [running]:
os.(*Process).signal(0x0, 0x4e15868, 0x4d6d800, 0x0, 0x0)
/root/.gimme/versions/go1.16.7.linux.amd64/src/os/exec_unix.go:63 +0x3b
os.(*Process).Signal(...)
/root/.gimme/versions/go1.16.7.linux.amd64/src/os/exec.go:135
github.com/DataDog/datadog-agent/pkg/jmxfetch.(*JMXFetch).Stop(0xc00055f790, 0x0, 0xc000f0dc00)
```

### Motivation

AGENT-8314

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
