### PR TITLE
[install_mac_os] Fix systemwide installation process executed under the root user

### DIFF
--- a/cmd/agent/install_mac_os.sh
+++ b/cmd/agent/install_mac_os.sh
@@ -129,18 +129,21 @@ fi`
 # set real_user to the target user of the systemwide installation.
 if [ "$systemdaemon_install" = true ] && [ "$real_user" = root ]; then
     real_user="$(echo "$systemdaemon_user_group" | awk -F: '{ print $1 }')"
+    # The install will copy plist file to real_user home dir => we add `-H`
+    # as a sudo argument to properly get its home for access to the plist file.
+    cmd_real_user="sudo -EHu $real_user"
+else
+    cmd_real_user="sudo -Eu $real_user"
 fi
 
 TMPDIR=`sudo -u "$real_user" getconf DARWIN_USER_TEMP_DIR`
 export TMPDIR
 
-cmd_real_user="sudo -EHu $real_user"
-
 # shellcheck disable=SC2016
-user_home=$($cmd_real_user bash -c 'echo "$HOME"')
+install_user_home=$($cmd_real_user bash -c 'echo "$HOME"')
 # shellcheck disable=SC2016
 user_uid=$($cmd_real_user bash -c 'echo "$UID"')
-user_plist_file=${user_home}/Library/LaunchAgents/${service_name}.plist
+user_plist_file=${install_user_home}/Library/LaunchAgents/${service_name}.plist
 
 # In order to install with the right user
 rm -f /tmp/datadog-install-user

--- a/cmd/agent/install_mac_os.sh
+++ b/cmd/agent/install_mac_os.sh
@@ -124,14 +124,22 @@ real_user=`if [ "$SUDO_USER" ]; then
 else
   echo "$USER"
 fi`
+# If this is a systemwide install done over SSH or a similar method, the real_user is now root
+# which will eventually make the installation fail in the postinstall script. In this case, we
+# set real_user to the target user of the systemwide installation.
+if [ "$systemdaemon_install" = true ] && [ "$real_user" = root ]; then
+    real_user="$(echo "$systemdaemon_user_group" | awk -F: '{ print $1 }')"
+fi
 
 TMPDIR=`sudo -u "$real_user" getconf DARWIN_USER_TEMP_DIR`
 export TMPDIR
 
-cmd_real_user="sudo -Eu $real_user"
+cmd_real_user="sudo -EHu $real_user"
 
 # shellcheck disable=SC2016
 user_home=$($cmd_real_user bash -c 'echo "$HOME"')
+# shellcheck disable=SC2016
+user_uid=$($cmd_real_user bash -c 'echo "$UID"')
 user_plist_file=${user_home}/Library/LaunchAgents/${service_name}.plist
 
 # In order to install with the right user
@@ -269,7 +277,7 @@ else
     # if it is running - it's not running if the script was launched when
     # the GUI was not running for the user (e.g. a run of this script via
     # ssh for user not logged in via GUI).
-    if $cmd_launchctl print gui/$UID/$service_name 1>/dev/null 2>/dev/null; then
+    if $cmd_launchctl print "gui/$user_uid/$service_name" 1>/dev/null 2>/dev/null; then
         $cmd_real_user osascript -e 'tell application "System Events" to if login item "Datadog Agent" exists then delete login item "Datadog Agent"'
         $cmd_launchctl stop "$service_name"
         $cmd_launchctl unload "$user_plist_file"


### PR DESCRIPTION
### What does this PR do?

This PR ensures we can use the provided systemwide user as the `real_user` throughout the script as well as `INSTALL_USER` throughout pre/post package scripts. Previously, root was used in this case and make the installation fail (in the postinstall script), even though we actually had a non-root user to use instead.

NOTE: the process will still (intentionally) fail when the root is the target user of the systemwide install.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

* Test the systemwide installation in case where `real_user` would previously evaluate to `root`. This can usually be achieved either via ssh or via `sudo su` and then unsetting `SUDO_USER` and `SUDO_UID`.
* Also ensure no regressions were made by running the systemwide installation using `sudo` under a regular user.

Basically, executing a command similar to this in both of the above environments should give you a systemwide agent installation running under `tester:staff` user/group: `DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=<YOURAPIKEY> DD_SYSTEMDAEMON_USER_GROUP=tester:staff DD_SYSTEMDAEMON_INSTALL=true ./cmd/agent/install_mac_os.sh`

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
