### PR TITLE
CWS: fix race on activity dump tags

### DIFF
--- a/pkg/security/probe/activity_dump.go
+++ b/pkg/security/probe/activity_dump.go
@@ -508,7 +508,7 @@ func (ad *ActivityDump) GetSelectorStr() string {
 
 // getSelectorStr internal, thread-unsafe version of GetSelectorStr
 func (ad *ActivityDump) getSelectorStr() string {
-	var tags []string
+	tags := make([]string, 0, len(ad.Tags)+2)
 	if len(ad.DumpMetadata.ContainerID) > 0 {
 		tags = append(tags, fmt.Sprintf("container_id:%s", ad.DumpMetadata.ContainerID))
 	}

--- a/pkg/security/probe/activity_dump.go
+++ b/pkg/security/probe/activity_dump.go
@@ -500,6 +500,14 @@ func (ad *ActivityDump) FindFirstMatchingNode(comm string) *ProcessActivityNode 
 
 // GetSelectorStr returns a string representation of the profile selector
 func (ad *ActivityDump) GetSelectorStr() string {
+	ad.Lock()
+	defer ad.Unlock()
+
+	return ad.getSelectorStr()
+}
+
+// getSelectorStr internal, thread-unsafe version of GetSelectorStr
+func (ad *ActivityDump) getSelectorStr() string {
 	var tags []string
 	if len(ad.DumpMetadata.ContainerID) > 0 {
 		tags = append(tags, fmt.Sprintf("container_id:%s", ad.DumpMetadata.ContainerID))

--- a/pkg/security/probe/activity_dump_graph.go
+++ b/pkg/security/probe/activity_dump_graph.go
@@ -97,12 +97,12 @@ func (ad *ActivityDump) EncodeDOT() (*bytes.Buffer, error) {
 	ad.Lock()
 	defer ad.Unlock()
 
-	title := fmt.Sprintf("%s: %s", ad.DumpMetadata.Name, ad.GetSelectorStr())
+	title := fmt.Sprintf("%s: %s", ad.DumpMetadata.Name, ad.getSelectorStr())
 	data := ad.prepareGraphData(title)
 	t := template.Must(template.New("tmpl").Parse(GraphTemplate))
 	raw := bytes.NewBuffer(nil)
 	if err := t.Execute(raw, data); err != nil {
-		return nil, fmt.Errorf("couldn't encode %s in %s: %w", ad.GetSelectorStr(), dump.DOT, err)
+		return nil, fmt.Errorf("couldn't encode %s in %s: %w", ad.getSelectorStr(), dump.DOT, err)
 	}
 	return raw, nil
 }


### PR DESCRIPTION
### What does this PR do?

This fixes:
```
       ==================
       WARNING: DATA RACE
       Write at 0x00c000798060 by goroutine 31:
         github.com/DataDog/datadog-agent/pkg/security/probe.(*ActivityDump).resolveTags()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/activity_dump.go:587 +0x1b0
         github.com/DataDog/datadog-agent/pkg/security/probe.(*ActivityDump).Snapshot()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/activity_dump.go:569 +0x15c
         github.com/DataDog/datadog-agent/pkg/security/probe.(*ActivityDumpManager).Start()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/activity_dump_manager.go:80 +0x394
       
       Previous read at 0x00c000798060 by goroutine 96:
         github.com/DataDog/datadog-agent/pkg/security/probe.(*ActivityDump).GetSelectorStr()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/activity_dump.go:510 +0x304
         github.com/DataDog/datadog-agent/pkg/security/probe.(*ActivityDumpManager).HandleCgroupTracingEvent()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/activity_dump_manager.go:321 +0x334
         github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).handleEvent()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe.go:485 +0xeb4
         github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).handleEvent-fm()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe.go:424 +0x60
         github.com/DataDog/datadog-agent/pkg/security/probe.NewOrderedPerfMap.func1()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/perfmap.go:93 +0xc4
         github.com/DataDog/datadog-agent/pkg/security/probe.(*reOrdererHeap).dequeue()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/reorderer.go:144 +0x5c0
         github.com/DataDog/datadog-agent/pkg/security/probe.(*ReOrderer).Start()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/reorderer.go:233 +0x580
       
       Goroutine 31 (running) created at:
         github.com/DataDog/datadog-agent/pkg/security/probe.(*Monitor).Start()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe_monitor.go:105 +0x110
         github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).Setup()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe.go:317 +0xcc
         github.com/DataDog/datadog-agent/pkg/security/module.(*Module).Start()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/module/module.go:136 +0x54
         github.com/DataDog/datadog-agent/pkg/security/tests.newTestModule()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/module_tester.go:692 +0x1598
         github.com/DataDog/datadog-agent/pkg/security/tests.TestActivityDumps()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/activity_dumps_test.go:26 +0xa4
         testing.tRunner()
             /root/.gimme/versions/go1.17.11.linux.arm64/src/testing/testing.go:1259 +0x198
       
       Goroutine 96 (running) created at:
         github.com/DataDog/datadog-agent/pkg/security/probe.(*OrderedPerfMap).Start()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/perfmap.go:73 +0xb4
         github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).Start()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe.go:322 +0x198
         github.com/DataDog/datadog-agent/pkg/security/module.(*Module).Start()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/module/module.go:146 +0x154
         github.com/DataDog/datadog-agent/pkg/security/tests.newTestModule()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/module_tester.go:692 +0x1598
         github.com/DataDog/datadog-agent/pkg/security/tests.TestActivityDumps()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/activity_dumps_test.go:26 +0xa4
         testing.tRunner()
             /root/.gimme/versions/go1.17.11.linux.arm64/src/testing/testing.go:1259 +0x198
       ==================

```

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
