### PR TITLE
Check for copyright headers in `git commit`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,13 @@ repos:
       language: system
       require_serial: true
       files: \.go$
+    - id: copyright
+      name: copyright
+      description: copyright headers
+      entry: 'python3 tasks/git-hooks/copyright.py'
+      language: system
+      require_serial: true
+      files: \.go$
     - id: win-clang-format
       name: win-clang-format
       description: clang-format

--- a/tasks/git-hooks/copyright.py
+++ b/tasks/git-hooks/copyright.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+
+import sys
+
+sys.path.insert(0, "tasks")
+from libs.copyright import CopyrightLinter, LintFailure  # noqa: E402
+
+# Exclude non go files
+files = [path for path in sys.argv[1:] if path.endswith(".go")]
+try:
+    CopyrightLinter().assert_compliance(files=files)
+except LintFailure:
+    # the linter prints useful messages on its own, so no need to print the exception
+    sys.exit(1)

--- a/tasks/libs/copyright.py
+++ b/tasks/libs/copyright.py
@@ -62,6 +62,10 @@ COMPILED_PATH_EXCLUSION_REGEX = [re.compile(regex, re.UNICODE) for regex in PATH
 COMPILED_HEADER_EXCLUSION_REGEX = [re.compile(regex, re.UNICODE) for regex in HEADER_EXCLUSION_REGEX]
 
 
+class LintFailure(Exception):
+    pass
+
+
 class CopyrightLinter:
     """
     This class is used to enforce copyright headers on specified file patterns
@@ -227,40 +231,43 @@ class CopyrightLinter:
             if not self._fix_file_header(filepath, dry_run=dry_run):
                 error_message = f"'{filepath}' could not be fixed!"
                 print(f"[WARN] ({idx+1:3d}/{failing_files_cnt:3}) {error_message}")
-                errors.append(Exception(error_message))
+                errors.append(LintFailure(error_message))
 
         return errors
 
-    def assert_compliance(self, fix=False, dry_run=True):
+    def assert_compliance(self, fix=False, dry_run=True, files=None):
         """
-        This method applies the GLOB_PATTERN to the root of the repository and
-        verifies that all files have the expected copyright header.
+        This method verifies that all named files have the expected copyright header.
+
+        If files is not given, this method applies the GLOB_PATTERN to the root
+        of the repository to determine the files to check.
         """
-        git_repo_dir = CopyrightLinter._get_repo_dir()
+        if files is None:
+            git_repo_dir = CopyrightLinter._get_repo_dir()
 
-        if self._debug:
-            print(f"[DEBG] Repo root: {git_repo_dir}")
-            print(f"[DEBG] Finding all files in {git_repo_dir} matching '{GLOB_PATTERN}'...")
+            if self._debug:
+                print(f"[DEBG] Repo root: {git_repo_dir}")
+                print(f"[DEBG] Finding all files in {git_repo_dir} matching '{GLOB_PATTERN}'...")
 
-        matching_files = CopyrightLinter._get_matching_files(
-            git_repo_dir,
-            GLOB_PATTERN,
-            exclude=COMPILED_PATH_EXCLUSION_REGEX,
-        )
-        print(f"[INFO] Found {len(matching_files)} files matching '{GLOB_PATTERN}'")
+            files = CopyrightLinter._get_matching_files(
+                git_repo_dir,
+                GLOB_PATTERN,
+                exclude=COMPILED_PATH_EXCLUSION_REGEX,
+            )
+            print(f"[INFO] Found {len(files)} files matching '{GLOB_PATTERN}'")
 
-        failing_files = self._assert_copyrights(matching_files)
+        failing_files = self._assert_copyrights(files)
         if len(failing_files) > 0:
             if not fix:
                 print("CHECK: FAIL")
-                raise Exception(
+                raise LintFailure(
                     f"Copyright linting found {len(failing_files)} files that did not have the expected header!"
                 )
 
             # If "fix=True", we will attempt to fix the failing files
             errors = self._fix(failing_files, dry_run=dry_run)
             if errors:
-                raise Exception(f"Copyright linter was unable to fix {len(errors)}/{len(failing_files)} files!")
+                raise LintFailure(f"Copyright linter was unable to fix {len(errors)}/{len(failing_files)} files!")
 
             return
 

--- a/tasks/libs/copyright.py
+++ b/tasks/libs/copyright.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+import datetime
 import re
 import subprocess
 import sys
@@ -8,11 +9,11 @@ from pathlib import Path, PurePosixPath
 
 GLOB_PATTERN = "**/*.go"
 
-COPYRIGHT_HEADER = """
+COPYRIGHT_HEADER = f"""
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-present Datadog, Inc.
+// Copyright {datetime.datetime.now().year}-present Datadog, Inc.
 """.strip()
 
 COPYRIGHT_REGEX = [


### PR DESCRIPTION
### What does this PR do?

We already check for copyright headers in CI; this just performs the check in a pre-commit hook too.

This also sets the correct year in the copyright header when adding a new one.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
