### PR TITLE
Richl/windows driver test interface

### DIFF
--- a/pkg/network/driver/handle.go
+++ b/pkg/network/driver/handle.go
@@ -58,17 +58,41 @@ var handleTypeToPathName = map[HandleType]string{
 	StatsHandle: "driverstatshandle", // for now just use that; any path will do
 }
 
+type Handle interface {
+	ReadFile(p []byte, bytesRead *uint32, ol *windows.Overlapped) error
+	DeviceIoControl(ioControlCode uint32, inBuffer *byte, inBufferSize uint32, outBuffer *byte, outBufferSize uint32, bytesReturned *uint32, overlapped *windows.Overlapped) (err error)
+	CancelIoEx(ol *windows.Overlapped) error
+	Close() error
+	GetWindowsHandle() windows.Handle
+	GetStatsForHandle() (map[string]map[string]int64, error)
+}
+
 // Handle struct stores the windows handle for the driver as well as information about what type of filter is set
-type Handle struct {
-	windows.Handle
+type RealDriverHandle struct {
+	Handle     windows.Handle
 	handleType HandleType
 
 	// record the last value of number of flows missed due to max exceeded
 	lastNumFlowsMissed uint64
 }
 
+func (rdh *RealDriverHandle) GetWindowsHandle() windows.Handle {
+	return rdh.Handle
+}
+func (rdh *RealDriverHandle) ReadFile(p []byte, bytesRead *uint32, ol *windows.Overlapped) error {
+	return windows.ReadFile(rdh.Handle, p, bytesRead, ol)
+}
+
+func (rdh *RealDriverHandle) DeviceIoControl(ioControlCode uint32, inBuffer *byte, inBufferSize uint32, outBuffer *byte, outBufferSize uint32, bytesReturned *uint32, overlapped *windows.Overlapped) (err error) {
+	return windows.DeviceIoControl(rdh.Handle, ioControlCode, inBuffer, inBufferSize, outBuffer, outBufferSize, bytesReturned, overlapped)
+}
+
+func (rdh *RealDriverHandle) CancelIoEx(ol *windows.Overlapped) error {
+	return windows.CancelIoEx(rdh.Handle, ol)
+}
+
 // NewHandle creates a new windows handle attached to the driver
-func NewHandle(flags uint32, handleType HandleType) (*Handle, error) {
+func NewHandle(flags uint32, handleType HandleType) (Handle, error) {
 	pathext, ok := handleTypeToPathName[handleType]
 	if !ok {
 		return nil, fmt.Errorf("Unknown Handle type %v", handleType)
@@ -89,57 +113,23 @@ func NewHandle(flags uint32, handleType HandleType) (*Handle, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Handle{Handle: h, handleType: handleType}, nil
+	return &RealDriverHandle{Handle: h, handleType: handleType}, nil
 }
 
 // Close closes the underlying windows handle
-func (dh *Handle) Close() error {
+func (dh *RealDriverHandle) Close() error {
 	return windows.CloseHandle(dh.Handle)
 }
 
-// SetFlowFilters installs the provided filters for flows
-func (dh *Handle) SetFlowFilters(filters []FilterDefinition) error {
-	var id int64
-	for _, filter := range filters {
-		err := windows.DeviceIoControl(dh.Handle,
-			SetFlowFilterIOCTL,
-			(*byte)(unsafe.Pointer(&filter)),
-			uint32(unsafe.Sizeof(filter)),
-			(*byte)(unsafe.Pointer(&id)),
-			uint32(unsafe.Sizeof(id)), nil, nil)
-		if err != nil {
-			return fmt.Errorf("failed to set filter: %v", err)
-		}
-	}
-	return nil
-}
-
-// SetDataFilters installs the provided filters for data
-func (dh *Handle) SetDataFilters(filters []FilterDefinition) error {
-	var id int64
-	for _, filter := range filters {
-		err := windows.DeviceIoControl(dh.Handle,
-			SetDataFilterIOCTL,
-			(*byte)(unsafe.Pointer(&filter)),
-			uint32(unsafe.Sizeof(filter)),
-			(*byte)(unsafe.Pointer(&id)),
-			uint32(unsafe.Sizeof(id)), nil, nil)
-		if err != nil {
-			return fmt.Errorf("failed to set filter: %v", err)
-		}
-	}
-	return nil
-}
-
 // GetStatsForHandle gets the relevant stats depending on the handle type
-func (dh *Handle) GetStatsForHandle() (map[string]map[string]int64, error) {
+func (dh *RealDriverHandle) GetStatsForHandle() (map[string]map[string]int64, error) {
 	var (
 		bytesReturned uint32
 		statbuf       = make([]byte, DriverStatsSize)
 		returnmap     = make(map[string]map[string]int64)
 	)
 
-	err := windows.DeviceIoControl(dh.Handle, GetStatsIOCTL, &ddAPIVersionBuf[0], uint32(len(ddAPIVersionBuf)), &statbuf[0], uint32(len(statbuf)), &bytesReturned, nil)
+	err := dh.DeviceIoControl(GetStatsIOCTL, &ddAPIVersionBuf[0], uint32(len(ddAPIVersionBuf)), &statbuf[0], uint32(len(statbuf)), &bytesReturned, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read driver stats for filter type %v - returned error %v", dh.handleType, err)
 	}

--- a/pkg/network/driver_interface_fail_test.go
+++ b/pkg/network/driver_interface_fail_test.go
@@ -1,0 +1,70 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build windows && npm
+// +build windows,npm
+
+package network
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/network/driver"
+	"golang.org/x/sys/windows"
+)
+
+type TestDriverHandleFail struct {
+	// store some state variables
+	hasBeenCalled   bool
+	lastReturnBytes uint32
+	lastBufferSize  int
+	lastError       error
+}
+
+func (tdh *TestDriverHandleFail) ReadFile(p []byte, bytesRead *uint32, ol *windows.Overlapped) error {
+	fmt.Printf("Got ReadFile call")
+	// check state in struct to see if we've been called before
+	if tdh.hasBeenCalled {
+		if tdh.lastReturnBytes == 0 && tdh.lastError == windows.ERROR_MORE_DATA {
+			// last time we returned empty but more...if caller does that twice in a row it's bad
+			if len(p) <= tdh.lastBufferSize {
+				panic(fmt.Errorf("Consecutive calls"))
+			}
+		}
+	}
+	return nil
+}
+
+func (tdh *TestDriverHandleFail) GetWindowsHandle() windows.Handle {
+	return windows.Handle(0)
+}
+
+func (tdh *TestDriverHandleFail) DeviceIoControl(ioControlCode uint32, inBuffer *byte, inBufferSize uint32, outBuffer *byte, outBufferSize uint32, bytesReturned *uint32, overlapped *windows.Overlapped) (err error) {
+	fmt.Printf("Got test ioctl call")
+	if ioControlCode != 0 {
+		return fmt.Errorf("wrong ioctl code")
+	}
+	return nil
+}
+
+func (tdh *TestDriverHandleFail) CancelIoEx(ol *windows.Overlapped) error {
+	return nil
+}
+
+func (tdh *TestDriverHandleFail) GetStatsForHandle() (map[string]map[string]int64, error) {
+	return nil, nil
+}
+func (tdh *TestDriverHandleFail) Close() error {
+	return nil
+}
+
+func NewFailHandle(flags uint32, handleType driver.HandleType) (driver.Handle, error) {
+	return &TestDriverHandleFail{}, nil
+}
+
+func TestSetFlowFiltersFail(t *testing.T) {
+	return
+}

--- a/pkg/network/driver_interface_test.go
+++ b/pkg/network/driver_interface_test.go
@@ -1,0 +1,94 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build windows && npm
+// +build windows,npm
+
+package network
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/network/config"
+	"github.com/DataDog/datadog-agent/pkg/network/driver"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
+)
+
+type TestDriverHandleInfiniteLoop struct {
+	t *testing.T
+	// state variables
+	hasBeenCalled   bool
+	lastReturnBytes uint32
+	lastBufferSize  int
+	lastError       error
+}
+
+func (tdh *TestDriverHandleInfiniteLoop) ReadFile(p []byte, bytesRead *uint32, ol *windows.Overlapped) error {
+	// check state in struct to see if we've been called before
+	if tdh.hasBeenCalled {
+		// TODO: verify <= is correct as opposed to ==
+		if len(p) <= tdh.lastBufferSize {
+			tdh.t.Fatal("Consecutive calls without a larger buffer")
+		}
+		return nil
+	}
+	tdh.hasBeenCalled = true
+	*bytesRead = 0
+	tdh.lastBufferSize = len(p)
+	return windows.ERROR_MORE_DATA
+}
+
+func (tdh *TestDriverHandleInfiniteLoop) GetWindowsHandle() windows.Handle {
+	return windows.Handle(0)
+}
+
+func (tdh *TestDriverHandleInfiniteLoop) DeviceIoControl(ioControlCode uint32, inBuffer *byte, inBufferSize uint32, outBuffer *byte, outBufferSize uint32, bytesReturned *uint32, overlapped *windows.Overlapped) (err error) {
+	return nil
+}
+
+func (tdh *TestDriverHandleInfiniteLoop) CancelIoEx(ol *windows.Overlapped) error {
+	return nil
+}
+
+func (tdh *TestDriverHandleInfiniteLoop) GetStatsForHandle() (map[string]map[string]int64, error) {
+	return nil, nil
+}
+
+func (tdh *TestDriverHandleInfiniteLoop) Close() error {
+	return nil
+}
+
+func TestConnectionStatsInfiniteLoop(t *testing.T) {
+
+	startSize := 10
+	minSize := 10
+
+	activeBuf := NewConnectionBuffer(startSize, minSize)
+	closedBuf := NewConnectionBuffer(startSize, minSize)
+
+	di, err := NewDriverInterface(config.New(), func(flags uint32, handleType driver.HandleType) (driver.Handle, error) {
+		return &TestDriverHandleInfiniteLoop{t: t}, nil
+	})
+	require.NoError(t, err, "Failed to create new driver interface")
+
+	_, _, err = di.GetConnectionStats(activeBuf, closedBuf, func(c *ConnectionStats) bool {
+		return true
+	})
+	require.NoError(t, err, "Failed to get connection stats")
+}
+
+type TestDriverHandleFiltersSuccess struct {
+	t *testing.T
+	// state variables
+	hasBeenCalled   bool
+	lastReturnBytes uint32
+	lastBufferSize  int
+	lastError       error
+}
+
+func (tdh *TestDriverHandleFiltersSuccess) ReadFile(p []byte, bytesRead *uint32, ol *windows.Overlapped) error {
+	return nil
+}

--- a/pkg/network/tracer/tracer_windows.go
+++ b/pkg/network/tracer/tracer_windows.go
@@ -20,6 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/dns"
+	"github.com/DataDog/datadog-agent/pkg/network/driver"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -55,7 +56,7 @@ type Tracer struct {
 
 // NewTracer returns an initialized tracer struct
 func NewTracer(config *config.Config) (*Tracer, error) {
-	di, err := network.NewDriverInterface(config)
+	di, err := network.NewDriverInterface(config, driver.NewHandle)
 
 	if err != nil && errors.Is(err, syscall.ERROR_FILE_NOT_FOUND) {
 		log.Debugf("could not create driver interface: %v", err)


### PR DESCRIPTION
### What does this PR do?

- Creates `Handle` interface for use with DriverInterface struct
  - Enables `system-probe <--> Windows driver` interaction to be emulated w/o needing to install Windows driver
- Adds methods to unit test `system-probe <--> Windows driver` interactions
- Mitigates risk of `system-probe` infinite loop if Windows driver were to return specific `bytesRead` and `ERROR` values
- Adds test to verify infinite loop is no longer possible

### Motivation
Emulating Windows driver return values will allow us to evaluate system probe's behavior under a variety of contrived and unlikely (but possible) scenarios without needing to install the Windows driver.

### Additional Notes
The `TestConnectionStatsInfiniteLoop` demonstrates one of a multitude of conditions that we can now unit test more easily. We will want to expand these tests over time to get better overall test coverage.

### Possible Drawbacks / Trade-offs
None I am currently aware of.

### Describe how to test/QA your changes
This PR is most easily tested and verified by the included unit test (`TestConnectionStatsInfiniteLoop`). At this time, it would be non-trivial to coerce the Windows driver to return what the unit test emulates; therefore, the unit test is sufficient at this time, for this specific changeset.

### Reviewer's Checklist
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
