### PR TITLE
[remote tagger] Prevent hanging on shutdown

### DIFF
--- a/pkg/tagger/remote/tagger.go
+++ b/pkg/tagger/remote/tagger.go
@@ -215,8 +215,10 @@ func (t *Tagger) run() {
 	for {
 		select {
 		case <-t.health.C:
+			continue
 		case <-t.telemetryTicker.C:
 			t.store.collectTelemetry()
+			continue
 		case <-t.ctx.Done():
 			return
 		default:

--- a/pkg/tagger/remote/tagger.go
+++ b/pkg/tagger/remote/tagger.go
@@ -225,12 +225,9 @@ func (t *Tagger) run() {
 		}
 
 		if t.stream == nil {
-			// startTaggerStream(noTimeout) will never return
-			// unless a stream can be established, or the tagger
-			// has been stopped, which means the error handling
-			// here is just a sanity check.
 			if err := t.startTaggerStream(noTimeout); err != nil {
 				log.Warnf("error received trying to start stream: %s", err)
+				continue
 			}
 		}
 


### PR DESCRIPTION
### What does this PR do?

In some rare instances where the remote tagger is stopped at the same
time as either the health check or telemetry ticker trigger, the
`select` would not see that `t.Ctx` was already cancelled, and would
carry on trying to re-start the stream. This messes with the shut down
of other agent components, as `Tagger.Stop()` seems to block in that
case.

To make sure that `<-t.ctx.Done()` is always evaluated, we now re-start
the loop on the health check and telemetry ticks.

### Describe how to test/QA your changes

Same as #12592, `error received trying to start stream: tagger stream not started` should not be present 100% of the time (it's been reported that the failure rate was ~30%). Also, this was occasionally breaking kitchen tests. Applying the skip-qa label as this QA is already covered by both of those things.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
