### PR TITLE
Enable copyrights linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -288,6 +288,9 @@ workflows:
       - licenses_linting:
           requires:
             - dependencies
+      - copyrights_linting:
+          requires:
+            - dependencies
       - filename_linting:
           requires:
             - dependencies

--- a/cmd/serverless/env.go
+++ b/cmd/serverless/env.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package main
 
 import (

--- a/cmd/serverless/env_test.go
+++ b/cmd/serverless/env_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package main
 
 import (

--- a/cmd/trace-agent/test/testsuite/proxy_test.go
+++ b/cmd/trace-agent/test/testsuite/proxy_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package testsuite
 
 import (

--- a/pkg/autodiscovery/common/utils/container_collect_all.go
+++ b/pkg/autodiscovery/common/utils/container_collect_all.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package utils
 
 import (

--- a/pkg/autodiscovery/listeners/service_test.go
+++ b/pkg/autodiscovery/listeners/service_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package listeners
 
 import (

--- a/pkg/autodiscovery/multimap_test.go
+++ b/pkg/autodiscovery/multimap_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package autodiscovery
 
 import (

--- a/pkg/autodiscovery/scheduler/meta_test.go
+++ b/pkg/autodiscovery/scheduler/meta_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package scheduler
 
 import (

--- a/pkg/autodiscovery/simple_configmgr.go
+++ b/pkg/autodiscovery/simple_configmgr.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package autodiscovery
 
 import (

--- a/pkg/config/remote/service/client_predicates.go
+++ b/pkg/config/remote/service/client_predicates.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package service
 
 import (

--- a/pkg/config/remote/service/client_predicates_test.go
+++ b/pkg/config/remote/service/client_predicates_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package service
 
 import (

--- a/pkg/config/unexpectedunicodefinder.go
+++ b/pkg/config/unexpectedunicodefinder.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package config
 
 import (

--- a/pkg/config/unexpectedunicodefinder_test.go
+++ b/pkg/config/unexpectedunicodefinder_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package config
 
 import "testing"

--- a/pkg/logs/sources/replaceable_source.go
+++ b/pkg/logs/sources/replaceable_source.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package sources
 
 import (

--- a/pkg/metadata/inventories/host_metadata_test.go
+++ b/pkg/metadata/inventories/host_metadata_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package inventories
 
 import (

--- a/pkg/netflow/common/flow.go
+++ b/pkg/netflow/common/flow.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package common
 
 import (

--- a/pkg/netflow/common/flow_test.go
+++ b/pkg/netflow/common/flow_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package common
 
 import (

--- a/pkg/netflow/common/flowtype.go
+++ b/pkg/netflow/common/flowtype.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package common
 
 import (

--- a/pkg/netflow/common/flowtype_test.go
+++ b/pkg/netflow/common/flowtype_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package common
 
 import (

--- a/pkg/netflow/common/utils.go
+++ b/pkg/netflow/common/utils.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package common
 
 import "net"

--- a/pkg/netflow/common/utils_test.go
+++ b/pkg/netflow/common/utils_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package common
 
 import (

--- a/pkg/netflow/config/config_test.go
+++ b/pkg/netflow/config/config_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package config
 
 import (

--- a/pkg/netflow/enrichment/direction.go
+++ b/pkg/netflow/enrichment/direction.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package enrichment
 
 // RemapDirection remaps direction from 0 or 1 to respectively ingress or egress

--- a/pkg/netflow/enrichment/direction_test.go
+++ b/pkg/netflow/enrichment/direction_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package enrichment
 
 import (

--- a/pkg/netflow/enrichment/ether_type.go
+++ b/pkg/netflow/enrichment/ether_type.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package enrichment
 
 // Currently mapping only IPv4 and IPv6 since those are the main case defined in goflow2

--- a/pkg/netflow/enrichment/ether_type_test.go
+++ b/pkg/netflow/enrichment/ether_type_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package enrichment
 
 import (

--- a/pkg/netflow/enrichment/ip_protocol.go
+++ b/pkg/netflow/enrichment/ip_protocol.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package enrichment
 
 var protocolMap = map[uint32]string{

--- a/pkg/netflow/enrichment/ip_protocol_test.go
+++ b/pkg/netflow/enrichment/ip_protocol_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package enrichment
 
 import (

--- a/pkg/netflow/enrichment/mac.go
+++ b/pkg/netflow/enrichment/mac.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package enrichment
 
 import (

--- a/pkg/netflow/enrichment/mac_test.go
+++ b/pkg/netflow/enrichment/mac_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package enrichment
 
 import (

--- a/pkg/netflow/enrichment/mask.go
+++ b/pkg/netflow/enrichment/mask.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package enrichment
 
 import (

--- a/pkg/netflow/enrichment/mask_test.go
+++ b/pkg/netflow/enrichment/mask_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package enrichment
 
 import (

--- a/pkg/netflow/enrichment/tcp_flags.go
+++ b/pkg/netflow/enrichment/tcp_flags.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package enrichment
 
 var tcpFlagsMapping = map[uint32]string{

--- a/pkg/netflow/enrichment/tcp_flags_test.go
+++ b/pkg/netflow/enrichment/tcp_flags_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package enrichment
 
 import (

--- a/pkg/netflow/flowaggregator/aggregator.go
+++ b/pkg/netflow/flowaggregator/aggregator.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package flowaggregator
 
 import (

--- a/pkg/netflow/flowaggregator/aggregator_test.go
+++ b/pkg/netflow/flowaggregator/aggregator_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package flowaggregator
 
 import (

--- a/pkg/netflow/flowaggregator/buildpayload.go
+++ b/pkg/netflow/flowaggregator/buildpayload.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package flowaggregator
 
 import (

--- a/pkg/netflow/flowaggregator/buildpayload_test.go
+++ b/pkg/netflow/flowaggregator/buildpayload_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package flowaggregator
 
 import (

--- a/pkg/netflow/flowaggregator/flowaccumulator.go
+++ b/pkg/netflow/flowaggregator/flowaccumulator.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package flowaggregator
 
 import (

--- a/pkg/netflow/flowaggregator/flowaccumulator_test.go
+++ b/pkg/netflow/flowaggregator/flowaccumulator_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package flowaggregator
 
 import (

--- a/pkg/netflow/goflowlib/convert.go
+++ b/pkg/netflow/goflowlib/convert.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package goflowlib
 
 import (

--- a/pkg/netflow/goflowlib/convert_test.go
+++ b/pkg/netflow/goflowlib/convert_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package goflowlib
 
 import (

--- a/pkg/netflow/goflowlib/flowstate.go
+++ b/pkg/netflow/goflowlib/flowstate.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package goflowlib
 
 import (

--- a/pkg/netflow/goflowlib/flowstate_test.go
+++ b/pkg/netflow/goflowlib/flowstate_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package goflowlib
 
 import (

--- a/pkg/netflow/goflowlib/formatdriver.go
+++ b/pkg/netflow/goflowlib/formatdriver.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package goflowlib
 
 import (

--- a/pkg/netflow/goflowlib/logger.go
+++ b/pkg/netflow/goflowlib/logger.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package goflowlib
 
 import (

--- a/pkg/netflow/listener.go
+++ b/pkg/netflow/listener.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package netflow
 
 import (

--- a/pkg/netflow/server_test.go
+++ b/pkg/netflow/server_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package netflow
 
 import (

--- a/pkg/netflow/testing_test.go
+++ b/pkg/netflow/testing_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package netflow
 
 import (

--- a/pkg/network/dns/ebpf.go
+++ b/pkg/network/dns/ebpf.go
@@ -39,7 +39,7 @@ func newEBPFProgram(c *config.Config) (*ebpfProgram, error) {
 			{ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				EBPFSection:  string(probes.SocketDnsFilter),
 				EBPFFuncName: funcName,
-				UID: probeUID,
+				UID:          probeUID,
 			}},
 		},
 	}
@@ -72,7 +72,7 @@ func (e *ebpfProgram) Init() error {
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
 					EBPFSection:  string(probes.SocketDnsFilter),
 					EBPFFuncName: funcName,
-					UID: probeUID,
+					UID:          probeUID,
 				},
 			},
 		},

--- a/pkg/network/dns/types_test.go
+++ b/pkg/network/dns/types_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package dns
 
 import (

--- a/pkg/network/http/incomplete_stats.go
+++ b/pkg/network/http/incomplete_stats.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 //go:build linux_bpf
 // +build linux_bpf
 

--- a/pkg/network/http/incomplete_stats_test.go
+++ b/pkg/network/http/incomplete_stats_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 //go:build linux_bpf
 // +build linux_bpf
 

--- a/pkg/network/http/telemetry.go
+++ b/pkg/network/http/telemetry.go
@@ -1,4 +1,4 @@
-// Unless expliciAdd(1)tly stated otherwise all files in this repository are licensed
+// Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.

--- a/pkg/otlp/internal/serializerexporter/exporter_test.go
+++ b/pkg/otlp/internal/serializerexporter/exporter_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package serializerexporter
 
 import (

--- a/pkg/process/events/listener_linux.go
+++ b/pkg/process/events/listener_linux.go
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
-// Copyright 2016-present Datadog, Inc.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
 
 //go:build linux
 // +build linux

--- a/pkg/process/events/listener_linux_test.go
+++ b/pkg/process/events/listener_linux_test.go
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
-// Copyright 2016-present Datadog, Inc.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
 
 //go:build linux
 // +build linux

--- a/pkg/remoteconfig/state/repository_test.go
+++ b/pkg/remoteconfig/state/repository_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package state
 
 import (

--- a/pkg/remoteconfig/state/testingutils_test.go
+++ b/pkg/remoteconfig/state/testingutils_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package state
 
 import (

--- a/pkg/remoteconfig/state/tuf.go
+++ b/pkg/remoteconfig/state/tuf.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package state
 
 import (

--- a/pkg/serverless/invocationlifecycle/init.go
+++ b/pkg/serverless/invocationlifecycle/init.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package invocationlifecycle
 
 import (

--- a/pkg/serverless/trigger/events.go
+++ b/pkg/serverless/trigger/events.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package trigger
 
 import (

--- a/pkg/serverless/trigger/events_test.go
+++ b/pkg/serverless/trigger/events_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package trigger
 
 import (

--- a/pkg/serverless/trigger/extractor.go
+++ b/pkg/serverless/trigger/extractor.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package trigger
 
 import (

--- a/pkg/serverless/trigger/extractor_test.go
+++ b/pkg/serverless/trigger/extractor_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package trigger
 
 import (

--- a/pkg/snmp/traps/forwarder.go
+++ b/pkg/snmp/traps/forwarder.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package traps
 
 import (

--- a/pkg/snmp/traps/forwarder_test.go
+++ b/pkg/snmp/traps/forwarder_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package traps
 
 import (

--- a/pkg/snmp/traps/listener.go
+++ b/pkg/snmp/traps/listener.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package traps
 
 import (

--- a/pkg/snmp/traps/listener_test.go
+++ b/pkg/snmp/traps/listener_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package traps
 
 import (

--- a/pkg/util/containers/cri/conversion.go
+++ b/pkg/util/containers/cri/conversion.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 //go:build cri
 // +build cri
 

--- a/pkg/util/json/nested_json.go
+++ b/pkg/util/json/nested_json.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package json
 
 // GetNestedValue returns the value in the map specified by the array keys,

--- a/pkg/util/json/nested_json_test.go
+++ b/pkg/util/json/nested_json_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
 package json
 
 import (

--- a/tasks/libs/copyright.py
+++ b/tasks/libs/copyright.py
@@ -26,13 +26,18 @@ COPYRIGHT_REGEX = [
 # These path patterns are excluded from checks
 PATH_EXCLUSION_REGEX = [
     # These are auto-generated files but without headers to indicate it
-    '/pkg/remoteconfig/state/products/apmsampling/.*_gen(_test){,1}.go',
+    '/pkg/clusteragent/custommetrics/api/generated/',
     '/pkg/proto/msgpgo/.*_gen(_test){,1}.go',
+    '/pkg/process/events/model/.*_gen.go',
+    '/pkg/remoteconfig/state/products/apmsampling/.*_gen(_test){,1}.go',
     '/pkg/security/probe/accessors.go',
+    '/pkg/security/probe/activity_dump_easyjson.go',
     '/pkg/security/probe/activity_dump_gen_linux.go',
+    '/pkg/security/probe/activity_dump_graph_gen_linux.go',
     '/pkg/security/probe/custom_events_easyjson.go',
     '/pkg/security/probe/fields_resolver.go',
     '/pkg/security/probe/serializers_easyjson.go',
+    '/pkg/security/probe/dump/.*_gen(_test){,1}.go',
     '/pkg/security/secl/model/.*_gen(_test){,1}.go',
     '/pkg/security/secl/model/accessors.go',
     '/pkg/trace/pb/.*_gen(_test){,1}.go',
@@ -42,6 +47,7 @@ PATH_EXCLUSION_REGEX = [
     '/internal/patch/logr/funcr/internal/logr/',
     '/internal/third_party/golang/',
     '/internal/third_party/kubernetes/',
+    '/pkg/collector/corechecks/cluster/ksm/customresources/utils.go',
 ]
 
 # These header matchers skip enforcement of the rules if found in the first

--- a/tasks/libs/copyright.py
+++ b/tasks/libs/copyright.py
@@ -125,7 +125,7 @@ class CopyrightLinter:
     @staticmethod
     def _get_header(filepath):
         header = []
-        with open(filepath, "r") as file_obj:
+        with open(filepath, "r", encoding="utf-8") as file_obj:
             # We expect a specific header format which should be 4 lines
             for _ in range(4):
                 header.append(file_obj.readline().strip())


### PR DESCRIPTION

### What does this PR do?

This enables the copyright header linting on CircleCI. I previously added it incorrectly in PR #11329.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
