### PR TITLE
SNMP Traps: Add custom tags support

### DIFF
--- a/pkg/snmp/traps/formatter.go
+++ b/pkg/snmp/traps/formatter.go
@@ -25,6 +25,7 @@ type Formatter interface {
 type JSONFormatter struct {
 	oidResolver OIDResolver
 	namespace   string
+	userTags    []string
 }
 
 type trapVariable struct {
@@ -39,11 +40,11 @@ const (
 )
 
 // NewJSONFormatter creates a new JSONFormatter instance with an optional OIDResolver variable.
-func NewJSONFormatter(oidResolver OIDResolver, namespace string) (JSONFormatter, error) {
+func NewJSONFormatter(oidResolver OIDResolver, namespace string, tags []string) (JSONFormatter, error) {
 	if oidResolver == nil {
 		return JSONFormatter{}, fmt.Errorf("NewJSONFormatter called with a nil OIDResolver")
 	}
-	return JSONFormatter{oidResolver, namespace}, nil
+	return JSONFormatter{oidResolver, namespace, tags}, nil
 }
 
 // FormatPacket converts a raw SNMP trap packet to a FormattedSnmpPacket containing the JSON data and the tags to attach
@@ -89,11 +90,12 @@ func (f JSONFormatter) FormatPacket(packet *SnmpPacket) ([]byte, error) {
 
 // GetTags returns a list of tags associated to an SNMP trap packet.
 func (f JSONFormatter) getTags(packet *SnmpPacket) []string {
-	return []string{
+	tags := []string{
 		"snmp_version:" + formatVersion(packet.Content),
 		"device_namespace:" + f.namespace,
 		"snmp_device:" + packet.Addr.IP.String(),
 	}
+	return append(tags, f.userTags...)
 }
 
 func (f JSONFormatter) formatV1Trap(packet *gosnmp.SnmpPacket) map[string]interface{} {

--- a/pkg/snmp/traps/formatter_test.go
+++ b/pkg/snmp/traps/formatter_test.go
@@ -34,7 +34,7 @@ func (or NoOpOIDResolver) GetVariableMetadata(trapOID string, varOID string) (Va
 }
 
 var (
-	defaultFormatter, _ = NewJSONFormatter(NoOpOIDResolver{}, "totoro")
+	defaultFormatter, _ = NewJSONFormatter(NoOpOIDResolver{}, "totoro", []string{"data:dog", "dog:data"})
 
 	// LinkUp Example Trap V2+
 	LinkUpExampleV2Trap = gosnmp.SnmpTrap{
@@ -125,7 +125,7 @@ func TestFormatPacketV1Generic(t *testing.T) {
 	trapContent := data["trap"].(map[string]interface{})
 
 	assert.Equal(t, "snmp-traps", trapContent["ddsource"])
-	assert.Equal(t, "snmp_version:1,device_namespace:totoro,snmp_device:127.0.0.1", trapContent["ddtags"])
+	assert.Equal(t, "snmp_version:1,device_namespace:totoro,snmp_device:127.0.0.1,data:dog,dog:data", trapContent["ddtags"])
 
 	assert.Equal(t, "1.3.6.1.6.3.1.1.5.3", trapContent["snmpTrapOID"])
 	assert.NotNil(t, trapContent["uptime"])
@@ -168,7 +168,7 @@ func TestFormatPacketV1Specific(t *testing.T) {
 	trapContent := data["trap"].(map[string]interface{})
 
 	assert.Equal(t, "snmp-traps", trapContent["ddsource"])
-	assert.Equal(t, "snmp_version:1,device_namespace:totoro,snmp_device:127.0.0.1", trapContent["ddtags"])
+	assert.Equal(t, "snmp_version:1,device_namespace:totoro,snmp_device:127.0.0.1,data:dog,dog:data", trapContent["ddtags"])
 
 	assert.Equal(t, "1.3.6.1.2.1.118.0.2", trapContent["snmpTrapOID"])
 	assert.NotNil(t, trapContent["uptime"])
@@ -208,7 +208,7 @@ func TestFormatPacketToJSON(t *testing.T) {
 	trapContent := data["trap"].(map[string]interface{})
 
 	assert.Equal(t, "snmp-traps", trapContent["ddsource"])
-	assert.Equal(t, "snmp_version:2,device_namespace:totoro,snmp_device:127.0.0.1", trapContent["ddtags"])
+	assert.Equal(t, "snmp_version:2,device_namespace:totoro,snmp_device:127.0.0.1,data:dog,dog:data", trapContent["ddtags"])
 
 	assert.Equal(t, "1.3.6.1.4.1.8072.2.3.0.1", trapContent["snmpTrapOID"])
 	assert.NotNil(t, trapContent["uptime"])
@@ -263,6 +263,8 @@ func TestGetTags(t *testing.T) {
 		"snmp_version:2",
 		"device_namespace:totoro",
 		"snmp_device:127.0.0.1",
+		"data:dog",
+		"dog:data",
 	})
 }
 
@@ -273,11 +275,13 @@ func TestGetTagsForUnsupportedVersionShouldStillSucceed(t *testing.T) {
 		"snmp_version:unknown",
 		"device_namespace:totoro",
 		"snmp_device:127.0.0.1",
+		"data:dog",
+		"dog:data",
 	})
 }
 
 func TestNewJSONFormatterWithNilStillWorks(t *testing.T) {
-	var formatter, err = NewJSONFormatter(NoOpOIDResolver{}, "mononoke")
+	var formatter, err = NewJSONFormatter(NoOpOIDResolver{}, "mononoke", []string{})
 	require.NoError(t, err)
 	packet := createTestPacket(NetSNMPExampleHeartbeatNotification)
 	_, err = formatter.FormatPacket(packet)
@@ -456,7 +460,7 @@ func TestFormatterWithResolverAndTrapV2(t *testing.T) {
 
 	for _, d := range data {
 		t.Run(d.description, func(t *testing.T) {
-			formatter, err := NewJSONFormatter(d.resolver, d.namespace)
+			formatter, err := NewJSONFormatter(d.resolver, d.namespace, []string{})
 			require.NoError(t, err)
 			packet := createTestPacket(d.trap)
 			data, err := formatter.FormatPacket(packet)
@@ -483,7 +487,7 @@ func TestFormatterWithResolverAndTrapV2(t *testing.T) {
 }
 
 func TestFormatterWithResolverAndTrapV1Generic(t *testing.T) {
-	formatter, err := NewJSONFormatter(resolverWithData, "porco_rosso")
+	formatter, err := NewJSONFormatter(resolverWithData, "porco_rosso", []string{})
 	require.NoError(t, err)
 	packet := createTestV1GenericPacket()
 	data, err := formatter.FormatPacket(packet)

--- a/pkg/snmp/traps/server.go
+++ b/pkg/snmp/traps/server.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/gosnmp/gosnmp"
 )
@@ -40,7 +41,7 @@ var (
 
 // StartServer starts the global trap server.
 func StartServer(agentHostname string, demux aggregator.Demultiplexer) error {
-	config, err := ReadConfig(agentHostname)
+	cfg, err := ReadConfig(agentHostname)
 	if err != nil {
 		return err
 	}
@@ -52,11 +53,11 @@ func StartServer(agentHostname string, demux aggregator.Demultiplexer) error {
 	if err != nil {
 		return err
 	}
-	formatter, err := NewJSONFormatter(oidResolver, config.Namespace)
+	formatter, err := NewJSONFormatter(oidResolver, cfg.Namespace, config.GetConfiguredTags(false))
 	if err != nil {
 		return err
 	}
-	server, err := NewTrapServer(*config, formatter, sender)
+	server, err := NewTrapServer(*cfg, formatter, sender)
 	serverInstance = server
 	startError = err
 	return err


### PR DESCRIPTION
Use common agent tags and send them in the traps payload:
![image](https://user-images.githubusercontent.com/22912273/179535615-6535bc32-a4a1-4cf2-a8b4-ecc89b0995c3.png)


Questions:
1. Should we use global host tags from the config or should we define a new "tags" field just for traps (knowing that one agent = one trap listener)?
2. Should we have both?