### PR TITLE
Fix extension panic when end invocation logs are delayed

### DIFF
--- a/pkg/serverless/daemon/daemon.go
+++ b/pkg/serverless/daemon/daemon.go
@@ -321,6 +321,14 @@ func (d *Daemon) TellDaemonRuntimeStarted() {
 func (d *Daemon) TellDaemonRuntimeDone() {
 	d.runtimeStateMutex.Lock()
 	defer d.runtimeStateMutex.Unlock()
+	// It's possible that we have a lambda function from a previous invocation sending a finished
+	// log line to the agent, and it's possible that this happens before the current invocation is
+	// received, in which case TellDaemonRuntimeDoneOnce is nil. We add this check in to ensure that
+	// if this is the case, it won't crash the extension. This should be safe, since the code that modifies
+	// the Once is locked by a mutex.
+	if d.TellDaemonRuntimeDoneOnce == nil {
+		return
+	}
 	d.TellDaemonRuntimeDoneOnce.Do(func() {
 		d.RuntimeWg.Done()
 	})

--- a/pkg/serverless/daemon/daemon_test.go
+++ b/pkg/serverless/daemon/daemon_test.go
@@ -178,3 +178,13 @@ func TestSetTraceTagOk(t *testing.T) {
 	}
 	assert.True(t, d.setTraceTags(tagsMap))
 }
+
+func TestOutOfOrderInvocations(t *testing.T) {
+	port := testutil.FreeTCPPort(t)
+	d := StartDaemon(fmt.Sprint("127.0.0.1:", port))
+	time.Sleep(100 * time.Millisecond)
+	defer d.Stop()
+
+	assert.NotPanics(t, d.TellDaemonRuntimeDone)
+	d.TellDaemonRuntimeStarted()
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR fixes an issue in the extension that causes panics due to dereferencing a nil `Once` variable. This happens under the following conditions:

1. A lambda function is invoked, and times out or runs out of memory. The datadog-agent shuts down.
2. The same lambda function is invoked again, and a new datadog-agent starts up.
3. The new datadog-agent receives an endInvocation event for the previous event that timed out. It then runs `TellDaemonRuntimeDone`, which accesses a `Once` value.
4. Because `TellDaemonRuntimeStarted` hasn't run yet, this `Once` value is not initialized yet, as it is a pointer, and we get a segfault.

The fix is to add a nil check inside the logic to access the `Once` value. This fixes the issue.

### Additional Notes

This has been tested by deploying a new layer. I've also added a unit test case for it.

### Possible Drawbacks / Trade-offs

I'm not exactly sure of the behavior of exiting early here, maybe @maxday or @nhinsch could chime in. Particularly, I'm unsure of whether or not exiting early will cause something weird with the wait group counter, as I don't know what should happen in this case.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
