### PR TITLE
[AD] When adding a kubelet provider, prevent adding a container provider

### DIFF
--- a/cmd/agent/common/autodiscovery_test.go
+++ b/cmd/agent/common/autodiscovery_test.go
@@ -1,0 +1,66 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+func TestIncompatibleListenerWarning(t *testing.T) {
+	cases := []struct {
+		listeners        []config.Listeners
+		expectedWarnings int
+	}{
+		{
+			listeners: []config.Listeners{
+				{Name: "kubelet"},
+				{Name: "foo"},
+				{Name: "bar"},
+			},
+			expectedWarnings: 0,
+		},
+		{
+			listeners: []config.Listeners{
+				{Name: "kubelet"},
+				{Name: "container"},
+				{Name: "bar"},
+			},
+			expectedWarnings: 2,
+		},
+	}
+
+	for _, tc := range cases {
+		if warnings := warnOnIncompatibleListeners(tc.listeners); warnings != tc.expectedWarnings {
+			t.Errorf("Expected %d incompatible warnings, but got %d warnings for input %v\n", tc.expectedWarnings, warnings, tc.listeners)
+		}
+	}
+}
+
+func TestIncompatibleProvidersWarning(t *testing.T) {
+	cases := []struct {
+		providers        map[string]config.ConfigurationProviders
+		expectedWarnings int
+	}{
+		{
+			providers: map[string]config.ConfigurationProviders{
+				"kubelet": {Name: "kubelet"},
+				"foo":     {Name: "foo"},
+			},
+			expectedWarnings: 0,
+		},
+		{
+			providers: map[string]config.ConfigurationProviders{
+				"kubelet":   {Name: "kubelet"},
+				"container": {Name: "container"},
+				"foo":       {Name: "foo"},
+			},
+			expectedWarnings: 2,
+		},
+	}
+
+	for _, tc := range cases {
+		if warnings := warnOnIncompatibleProviders(tc.providers); warnings != tc.expectedWarnings {
+			t.Errorf("Expected %d incompatible warnings, but got %d warnings for input %v\n", tc.expectedWarnings, warnings, tc.providers)
+		}
+	}
+}

--- a/pkg/config/autodiscovery/autodiscovery.go
+++ b/pkg/config/autodiscovery/autodiscovery.go
@@ -81,19 +81,15 @@ func DiscoverComponentsFromEnv() ([]config.ConfigurationProviders, []config.List
 		return detectedProviders, detectedListeners
 	}
 
-	if config.IsFeaturePresent(config.Docker) || config.IsFeaturePresent(config.Containerd) || config.IsFeaturePresent(config.Podman) || config.IsFeaturePresent(config.ECSFargate) {
-		detectedProviders = append(detectedProviders, config.ConfigurationProviders{Name: names.Container, Polling: true, PollInterval: "1s"})
-		if !config.IsFeaturePresent(config.Kubernetes) {
-			detectedListeners = append(detectedListeners, config.Listeners{Name: names.Container})
-			log.Info("Adding Container listener from environment")
-		}
-		log.Info("Adding Container provider from environment")
-	}
-
+	// Either add kubelet listener/provider or container listener/provider, not both
 	if config.IsFeaturePresent(config.Kubernetes) {
 		detectedProviders = append(detectedProviders, config.ConfigurationProviders{Name: "kubelet", Polling: true})
 		detectedListeners = append(detectedListeners, config.Listeners{Name: "kubelet"})
 		log.Info("Adding Kubelet autodiscovery provider and listener from environment")
+	} else if config.IsFeaturePresent(config.Docker) || config.IsFeaturePresent(config.Containerd) || config.IsFeaturePresent(config.Podman) || config.IsFeaturePresent(config.ECSFargate) {
+		detectedProviders = append(detectedProviders, config.ConfigurationProviders{Name: names.Container, Polling: true, PollInterval: "1s"})
+		detectedListeners = append(detectedListeners, config.Listeners{Name: names.Container})
+		log.Info("Adding Container listener and provider from environment")
 	}
 
 	return detectedProviders, detectedListeners


### PR DESCRIPTION
### What does this PR do?
When detecting the environment in auto-discovery, it is possible to find both kubernetes and a container runtime.
These two can be conflicting in terms of autodiscovery because there will be overlap in the data provided by each.

This switches the behavior to prefer kubernetes if it is present and brings `Provider`s inline with `Listener`s which already had this behavior.

Additionally, since users can provide configuration for `listeners` and `providers`, there is a new `warn` log when an incompatible combination is detected. Eg:
```
2022-07-19 22:55:25 UTC | CORE | WARN | (cmd/agent/common/autodiscovery.go:63 in warnOnIncompatibleProviders) | Provider kubelet is incompatible with provider container, but both are present.
2022-07-19 22:55:25 UTC | CORE | WARN | (cmd/agent/common/autodiscovery.go:63 in warnOnIncompatibleProviders) | Provider container is incompatible with provider kubelet, but both are present.
```

### Motivation
The logs refactor into autodiscovery uncovered this issue when `container_collect_all` is turned on, there will be multiple `Config`s produced for a single container.

### Additional Notes


### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes
- Bring up a `containerd` based kubernetes cluster. (GKE standard works)
- Deploy the agent using the standard helm chart
- Ensure that containers are still reported correctly in the datadog app
- Ensure that a given agent container's logs detect both kubernetes and containerd
    - a log similar to `Features detected from environment: docker,cri,containerd,kubernetes` should be in the first few lines

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
