### PR TITLE
On a Windows docker host with many containers running, run pre-fetch in parallel

### DIFF
--- a/pkg/util/containers/providers/windows/provider.go
+++ b/pkg/util/containers/providers/windows/provider.go
@@ -72,6 +72,8 @@ func (mp *provider) Prefetch() error {
 		return err
 	}
 
+	log.Debugf("Retrieved %d containers from docker", len(rawContainers))
+
 	// Used to find if Agent is running in a container.
 	// With K8S entrypoint, `agentPID` should match
 	// With Docker entrypoint, `parentPID` should match
@@ -79,31 +81,57 @@ func (mp *provider) Prefetch() error {
 	parentPID := os.Getppid()
 
 	containers := make(map[string]containerBundle, len(rawContainers))
-	for _, container := range rawContainers {
-		containerBundle := containerBundle{}
-
-		cjson, err := dockerUtil.Inspect(context.TODO(), container.ID, false)
-		if err == nil {
-			mp.fillContainerDetails(cjson, &containerBundle)
-
-			// Luckily for us, on Windows PIDs are the same inside/outside containers
-			if cjson.State.Pid == agentPID || cjson.State.Pid == parentPID {
-				mp.agentCID = &container.ID
-			}
-		} else {
-			log.Debugf("Impossible to inspect container %s: %v", container.ID, err)
-		}
-
-		stats, err := dockerUtil.GetContainerStats(context.TODO(), container.ID)
-		if err == nil && stats != nil {
-			mp.fillContainerMetrics(stats, &containerBundle)
-			mp.fillContainerNetworkMetrics(stats, &containerBundle)
-		} else {
-			log.Debugf("Impossible to get stats for container %s: %v", container.ID, err)
-		}
-
-		containers[container.ID] = containerBundle
+	var containersLock = sync.RWMutex{}
+	var wg sync.WaitGroup
+	// On Windows fetching the info on docker containers can be slow.
+	// On a host with ~100 hosts running, this can easily take up more than 30s,
+	// causing the Agent to appear 'stuck' and the entrypoint/SCM to consider the Agent dead.
+	// Divide the fetch into batches to accelerate this process; here 8 is chosen arbitrarily.
+	chunkSize := len(rawContainers) / 8
+	if chunkSize <= 1 {
+		chunkSize = len(rawContainers)
 	}
+	log.Infof("Fetching container info by batch of %d\n", chunkSize)
+	for i := 0; i < len(rawContainers); i += chunkSize {
+		wg.Add(1)
+		go func(wg *sync.WaitGroup, start int) {
+			defer wg.Done()
+			end := start + chunkSize
+			if end > len(rawContainers) {
+				end = len(rawContainers)
+			}
+			log.Debugf("Retrieving info on containers %d -> %d\n", start, end)
+
+			for _, container := range rawContainers[start:end] {
+				containerBundle := containerBundle{}
+				log.Debugf("Inspecting container %s", container.ID)
+				cjson, err := dockerUtil.Inspect(context.TODO(), container.ID, false)
+				if err == nil {
+					mp.fillContainerDetails(cjson, &containerBundle)
+
+					// Luckily for us, on Windows PIDs are the same inside/outside containers
+					if cjson.State.Pid == agentPID || cjson.State.Pid == parentPID {
+						mp.agentCID = &container.ID
+					}
+				} else {
+					log.Infof("Impossible to inspect container %s: %v", container.ID, err)
+				}
+				stats, err := dockerUtil.GetContainerStats(context.TODO(), container.ID)
+				if err == nil && stats != nil {
+					mp.fillContainerMetrics(stats, &containerBundle)
+					mp.fillContainerNetworkMetrics(stats, &containerBundle)
+				} else {
+					log.Infof("Impossible to get stats for container %s: %v", container.ID, err)
+				}
+				containersLock.Lock()
+				containers[container.ID] = containerBundle
+				containersLock.Unlock()
+				log.Debugf("Done inspecting %s", container.ID)
+			}
+
+		}(&wg, i)
+	}
+	wg.Wait()
 
 	mp.containersLock.Lock()
 	defer mp.containersLock.Unlock()

--- a/pkg/util/containers/providers/windows/provider.go
+++ b/pkg/util/containers/providers/windows/provider.go
@@ -81,7 +81,7 @@ func (mp *provider) Prefetch() error {
 	parentPID := os.Getppid()
 
 	containers := make(map[string]containerBundle, len(rawContainers))
-	var containersLock = sync.RWMutex{}
+	var containersLock = sync.Mutex{}
 	var wg sync.WaitGroup
 	// On Windows fetching the info on docker containers can be slow.
 	// On a host with ~100 hosts running, this can easily take up more than 30s,

--- a/pkg/util/containers/providers/windows/provider.go
+++ b/pkg/util/containers/providers/windows/provider.go
@@ -84,7 +84,7 @@ func (mp *provider) Prefetch() error {
 	var containersLock = sync.Mutex{}
 	var wg sync.WaitGroup
 	// On Windows fetching the info on docker containers can be slow.
-	// On a host with ~100 hosts running, this can easily take up more than 30s,
+	// On a host with ~100 containers running, this can easily take up more than 30s,
 	// causing the Agent to appear 'stuck' and the entrypoint/SCM to consider the Agent dead.
 	// Divide the fetch into batches to accelerate this process; here 8 is chosen arbitrarily.
 	chunkSize := len(rawContainers) / 8

--- a/pkg/util/hostname/common.go
+++ b/pkg/util/hostname/common.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"runtime"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -100,6 +101,11 @@ func isOSHostnameUsable(ctx context.Context) (osHostnameUsable bool) {
 	// If the agent is not containerized, just skip all this detection logic
 	if !isContainerized() {
 		return true
+	}
+
+	// TODO: Revisit when we introduce support for Windows privileged containers
+	if runtime.GOOS == "windows" {
+		return false
 	}
 
 	// Check UTS namespace from docker

--- a/pkg/util/hostname/common.go
+++ b/pkg/util/hostname/common.go
@@ -104,11 +104,11 @@ func isOSHostnameUsable(ctx context.Context) (osHostnameUsable bool) {
 	}
 
 	// Check UTS namespace from docker
-    // TODO: Revisit when we introduce support for Windows privileged containers
-    if runtime.GOOS == "windows" {
-        return false
-    }
-	
+	// TODO: Revisit when we introduce support for Windows privileged containers
+	if runtime.GOOS == "windows" {
+		return false
+	}
+
 	utsMode, err := docker.GetAgentUTSMode(ctx)
 	if err == nil && (utsMode != containers.HostUTSMode && utsMode != containers.UnknownUTSMode) {
 		log.Debug("Agent is running in a docker container without host UTS mode: OS-provided hostnames cannot be used for hostname resolution.")

--- a/pkg/util/hostname/common.go
+++ b/pkg/util/hostname/common.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"runtime"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -103,10 +104,13 @@ func isOSHostnameUsable(ctx context.Context) (osHostnameUsable bool) {
 	}
 
 	// Check UTS namespace from docker
-	utsMode, err := docker.GetAgentUTSMode(ctx)
-	if err == nil && (utsMode != containers.HostUTSMode && utsMode != containers.UnknownUTSMode) {
-		log.Debug("Agent is running in a docker container without host UTS mode: OS-provided hostnames cannot be used for hostname resolution.")
-		return false
+	// Don't run it on Windows as it doesn't exists
+	if runtime.GOOS != "windows" {
+		utsMode, err := docker.GetAgentUTSMode(ctx)
+		if err == nil && (utsMode != containers.HostUTSMode && utsMode != containers.UnknownUTSMode) {
+			log.Debug("Agent is running in a docker container without host UTS mode: OS-provided hostnames cannot be used for hostname resolution.")
+			return false
+		}
 	}
 
 	// Check hostNetwork from kubernetes

--- a/pkg/util/hostname/common.go
+++ b/pkg/util/hostname/common.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"runtime"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -104,11 +103,6 @@ func isOSHostnameUsable(ctx context.Context) (osHostnameUsable bool) {
 	}
 
 	// Check UTS namespace from docker
-	// TODO: Revisit when we introduce support for Windows privileged containers
-	if runtime.GOOS == "windows" {
-		return false
-	}
-
 	utsMode, err := docker.GetAgentUTSMode(ctx)
 	if err == nil && (utsMode != containers.HostUTSMode && utsMode != containers.UnknownUTSMode) {
 		log.Debug("Agent is running in a docker container without host UTS mode: OS-provided hostnames cannot be used for hostname resolution.")

--- a/pkg/util/hostname/common.go
+++ b/pkg/util/hostname/common.go
@@ -104,13 +104,15 @@ func isOSHostnameUsable(ctx context.Context) (osHostnameUsable bool) {
 	}
 
 	// Check UTS namespace from docker
-	// Don't run it on Windows as it doesn't exists
-	if runtime.GOOS != "windows" {
-		utsMode, err := docker.GetAgentUTSMode(ctx)
-		if err == nil && (utsMode != containers.HostUTSMode && utsMode != containers.UnknownUTSMode) {
-			log.Debug("Agent is running in a docker container without host UTS mode: OS-provided hostnames cannot be used for hostname resolution.")
-			return false
-		}
+    // TODO: Revisit when we introduce support for Windows privileged containers
+    if runtime.GOOS == "windows" {
+        return false
+    }
+	
+	utsMode, err := docker.GetAgentUTSMode(ctx)
+	if err == nil && (utsMode != containers.HostUTSMode && utsMode != containers.UnknownUTSMode) {
+		log.Debug("Agent is running in a docker container without host UTS mode: OS-provided hostnames cannot be used for hostname resolution.")
+		return false
 	}
 
 	// Check hostNetwork from kubernetes

--- a/releasenotes/notes/win_docker_prefetch_parallel-2fafa2bfe3fc4dda.yaml
+++ b/releasenotes/notes/win_docker_prefetch_parallel-2fafa2bfe3fc4dda.yaml
@@ -1,5 +1,4 @@
 ---
 fixes:
   - |
-    On a Windows Docker host with many containers running, the Agent now starts faster by fetching the
-    running containers in parallel.
+    The Agent starts faster on a Windows Docker host with many containers running by fetching the containers in parallel.

--- a/releasenotes/notes/win_docker_prefetch_parallel-2fafa2bfe3fc4dda.yaml
+++ b/releasenotes/notes/win_docker_prefetch_parallel-2fafa2bfe3fc4dda.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    On a Windows Docker host with many containers running, the Agent now starts faster by fetching the
+    running containers in parallel.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR runs the pre-fetch for the Docker container on Windows in parallel.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
In a host with many running containers (tested with 100) the pre-fetch code easily takes more than 30s to run, causing the entrypoint to consider the Agent dead.
By running the container pre-fetch in batches, we can speed this up considerably.
On a test server (AMD EPYC 7452 32-core CPU (8 vCPUs), 32GB RAM) without the parallel pre-fetch the code takes 1m44s to fetch 100 containers:
```
2022-07-18 21:42:35 GMT | CORE | INFO | (C:/mnt/cmd/agent/app/run.go:255 in StartAgent) | Starting Datadog Agent v7.38.0-rc.3+git.139.d3f8fb1
2022-07-18 21:42:36 GMT | CORE | INFO | (C:/mnt/pkg/util/containers/providers/windows/provider.go:256 in GetAgentCID) | AgentCID is empty, forcing a prefetch
2022-07-18 21:44:20 GMT | CORE | INFO | (C:/mnt/pkg/util/containers/providers/windows/provider.go:259 in GetAgentCID) | Pretech finished
2022-07-18 21:44:24 GMT | CORE | INFO | (C:/mnt/cmd/agent/app/run.go:313 in StartAgent) | Hostname is: jl
```

With the prefetch it takes 14s to fetch the same 100 containers:
```
2022-07-18 23:05:27 GMT | CORE | INFO | (C:/mnt/cmd/agent/app/run.go:255 in StartAgent) | Starting Datadog Agent v7.38.0-rc.3+git.139.d3f8fb1
2022-07-18 23:05:28 GMT | CORE | INFO | (C:/mnt/pkg/util/containers/providers/windows/provider.go:280 in GetAgentCID) | AgentCID is empty, forcing a prefetch
2022-07-18 23:05:28 GMT | CORE | INFO | (C:/mnt/pkg/util/containers/providers/windows/provider.go:90 in Prefetch) | Fetching container info by batch of 12
2022-07-18 23:05:42 GMT | CORE | INFO | (C:/mnt/pkg/util/containers/providers/windows/provider.go:283 in GetAgentCID) | Pretech finished
2022-07-18 23:05:46 GMT | CORE | INFO | (C:/mnt/cmd/agent/app/run.go:313 in StartAgent) | Hostname is: jl
```

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
When the number of container is small, the parallel pre-fetch could be slower. Currently if the host has less than 8 containers running, we prefetch in a single batch.
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
On a *powerful* Windows server (20GB+ RAM recommended), get 100 containers running.
You can use the following sample code to generate a `docker-compose.yml`:
```
from string import Template

if __name__ == '__main__':
    web_service = Template('''$svc_name:
    build: .\\samples\\aspnetapp
    ports:
      - "$svc_port:80"''')

    print('''version: "3.9"
services:''')
    for i in range(0, 100):
        print(web_service.substitute(svc_name=f'web{i}', svc_port=f'{8000+i}'))
```
The `docker-compose.yml` file uses the `ASP .Net` sample app from https://github.com/dotnet/dotnet-docker.
You can use the following `dockerfile` sample to build the `ASP .Net` app. It's taken from https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/docker/building-net-docker-images?view=aspnetcore-6.0:
```
# https://hub.docker.com/_/microsoft-dotnet
FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
WORKDIR /source

# copy csproj and restore as distinct layers
COPY *.sln .
COPY aspnetapp/*.csproj ./aspnetapp/
RUN dotnet restore

# copy everything else and build app
COPY aspnetapp/. ./aspnetapp/
WORKDIR /source/aspnetapp
RUN dotnet publish -c release -o /app --no-restore

# final stage/image
FROM mcr.microsoft.com/dotnet/aspnet:6.0
WORKDIR /app
COPY --from=build /app ./
ENTRYPOINT ["dotnet", "aspnetapp.dll"]
```
Once the 100 containers are running (check with your browser that the containers are returning the sample page), run the Agent. The following command was used as an example:
```
docker run -d --name dd-agent --restart unless-stopped -p 8126:8126 -e DD_EXPVAR_PORT=6000 -e DD_CMD_PORT=6001 -e DD_GUI_PORT=6002 -e DD_SITE="us5.datadoghq.com" -e DD_API_KEY=AAAAAA -e DD_APM_ENABLED=true -e DD_APM_NON_LOCAL_TRAFFIC=true -e DD_LOGS_ENABLED=true -e DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true -e DD_DOGSTATSD_NON_LOCAL_TRAFFIC=true -e DD_PROCESS_AGENT_ENABLED=true -e DD_CONTAINER_LABELS_AS_TAGS='{"application":"application","team":"team"}' -v \\.\pipe\docker_engine:\\.\pipe\docker_engine gcr.io/datadoghq/agent
```

Then check the Agent logs to make sure it started correctly.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
