### PR TITLE
Minor bugfixes to config handling

### DIFF
--- a/pkg/aggregator/demultiplexer_test.go
+++ b/pkg/aggregator/demultiplexer_test.go
@@ -201,7 +201,7 @@ func TestDemuxFlushAggregatorToSerializer(t *testing.T) {
 
 func TestGetDogStatsDWorkerAndPipelineCount(t *testing.T) {
 	pc := config.Datadog.GetInt("dogstatsd_pipeline_count")
-	aa := config.Datadog.GetInt("dogstatsd_pipeline_autoadjust")
+	aa := config.Datadog.GetBool("dogstatsd_pipeline_autoadjust")
 	defer func() {
 		config.Datadog.Set("dogstatsd_pipeline_count", pc)
 		config.Datadog.Set("dogstatsd_pipeline_autoadjust", aa)

--- a/pkg/clusteragent/admission/controllers/webhook/config.go
+++ b/pkg/clusteragent/admission/controllers/webhook/config.go
@@ -41,7 +41,7 @@ func NewConfig(admissionV1Enabled, namespaceSelectorEnabled bool) Config {
 		namespaceSelectorEnabled: namespaceSelectorEnabled,
 		svcName:                  config.Datadog.GetString("admission_controller.service_name"),
 		svcPort:                  int32(443),
-		timeout:                  config.Datadog.GetInt32("admission_controller.timeout_seconds"),
+		timeout:                  config.Datadog.GetInt("admission_controller.timeout_seconds"),
 		failurePolicy:            config.Datadog.GetString("admission_controller.failure_policy"),
 		reinvocationPolicy:       config.Datadog.GetString("admission_controller.reinvocation_policy"),
 	}

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
@@ -179,7 +179,7 @@ func TestGenerateTemplatesV1(t *testing.T) {
 	matchPolicy := admiv1.Exact
 	sideEffects := admiv1.SideEffectClassNone
 	port := int32(443)
-	timeout := config.Datadog.GetInt32("admission_controller.timeout_seconds")
+	timeout := config.Datadog.GetInt("admission_controller.timeout_seconds")
 	webhook := func(name, path string, objSelector, nsSelector *metav1.LabelSelector) admiv1.MutatingWebhook {
 		return admiv1.MutatingWebhook{
 			Name: name,
@@ -458,7 +458,7 @@ func TestGetWebhookSkeletonV1(t *testing.T) {
 	sideEffects := admiv1.SideEffectClassNone
 	port := int32(443)
 	path := "/bar"
-	defaultTimeout := config.Datadog.GetInt32("admission_controller.timeout_seconds")
+	defaultTimeout := config.Datadog.GetInt("admission_controller.timeout_seconds")
 	customTimeout := int32(2)
 	namespaceSelector, _ := buildLabelSelectors(true)
 	_, objectSelector := buildLabelSelectors(false)

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
@@ -179,7 +179,7 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 	matchPolicy := admiv1beta1.Exact
 	sideEffects := admiv1beta1.SideEffectClassNone
 	port := int32(443)
-	timeout := config.Datadog.GetInt32("admission_controller.timeout_seconds")
+	timeout := config.Datadog.GetInt("admission_controller.timeout_seconds")
 	webhook := func(name, path string, objSelector, nsSelector *metav1.LabelSelector) admiv1beta1.MutatingWebhook {
 		return admiv1beta1.MutatingWebhook{
 			Name: name,
@@ -458,7 +458,7 @@ func TestGetWebhookSkeletonV1beta1(t *testing.T) {
 	defaultReinvocationPolicy := admiv1beta1.IfNeededReinvocationPolicy
 	port := int32(443)
 	path := "/bar"
-	defaultTimeout := config.Datadog.GetInt32("admission_controller.timeout_seconds")
+	defaultTimeout := config.Datadog.GetInt("admission_controller.timeout_seconds")
 	customTimeout := int32(2)
 	namespaceSelector, _ := buildLabelSelectors(true)
 	_, objectSelector := buildLabelSelectors(false)

--- a/pkg/clusteragent/clusterchecks/dispatcher_main.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_main.go
@@ -39,7 +39,7 @@ func newDispatcher() *dispatcher {
 	d := &dispatcher{
 		store: newClusterStore(),
 	}
-	d.nodeExpirationSeconds = config.Datadog.GetInt64("cluster_checks.node_expiration_timeout")
+	d.nodeExpirationSeconds = config.Datadog.GetInt("cluster_checks.node_expiration_timeout")
 	d.extraTags = config.Datadog.GetStringSlice("cluster_checks.extra_tags")
 
 	hname, _ := hostname.Get(context.TODO())

--- a/pkg/clusteragent/custommetrics/provider.go
+++ b/pkg/clusteragent/custommetrics/provider.go
@@ -45,17 +45,17 @@ type datadogProvider struct {
 	store           Store
 	isServing       bool
 	timestamp       int64
-	maxAge          int64
+	maxAge          int64 // in seconds
 }
 
 // NewDatadogProvider creates a Custom Metrics and External Metrics Provider.
 func NewDatadogProvider(ctx context.Context, client dynamic.Interface, mapper apimeta.RESTMapper, store Store) provider.MetricsProvider {
-	maxAge := config.Datadog.GetInt64("external_metrics_provider.local_copy_refresh_rate")
+	maxAge := config.Datadog.GetInt("external_metrics_provider.local_copy_refresh_rate")
 	d := &datadogProvider{
 		client: client,
 		mapper: mapper,
 		store:  store,
-		maxAge: maxAge,
+		maxAge: int64(maxAge),
 	}
 	go d.externalMetricsSetter(ctx)
 	return d

--- a/pkg/clusteragent/externalmetrics/provider.go
+++ b/pkg/clusteragent/externalmetrics/provider.go
@@ -52,7 +52,7 @@ func NewDatadogMetricProvider(ctx context.Context, apiCl *apiserver.APIClient) (
 	rollup := config.Datadog.GetInt("external_metrics_provider.rollup")
 	setQueryConfigValues(aggregator, rollup)
 
-	refreshPeriod := config.Datadog.GetInt64("external_metrics_provider.refresh_period")
+	refreshPeriod := int64(config.Datadog.GetInt("external_metrics_provider.refresh_period"))
 	retrieverMetricsMaxAge := int64(math.Max(config.Datadog.GetFloat64("external_metrics_provider.max_age"), float64(3*rollup)))
 	autogenNamespace := common.GetResourcesNamespace()
 

--- a/pkg/collector/corechecks/cluster/helm/helm.go
+++ b/pkg/collector/corechecks/cluster/helm/helm.go
@@ -196,7 +196,7 @@ func (hc *HelmCheck) setupInformers() error {
 func sharedInformerFactory(apiClient *apiserver.APIClient) informers.SharedInformerFactory {
 	return informers.NewSharedInformerFactoryWithOptions(
 		apiClient.Cl,
-		time.Duration(config.Datadog.GetInt64("kubernetes_informers_resync_period"))*time.Second,
+		time.Duration(config.Datadog.GetInt("kubernetes_informers_resync_period"))*time.Second,
 		informers.WithTweakListOptions(func(opts *metav1.ListOptions) {
 			opts.LabelSelector = labelSelector
 		}),

--- a/pkg/config/appsec.go
+++ b/pkg/config/appsec.go
@@ -9,5 +9,5 @@ package config
 func setupAppSec(cfg Config) {
 	cfg.BindEnvAndSetDefault("appsec_config.enabled", true, "DD_APPSEC_ENABLED")
 	cfg.BindEnvAndSetDefault("appsec_config.appsec_dd_url", "", "DD_APPSEC_DD_URL")
-	cfg.BindEnvAndSetDefault("appsec_config.max_payload_size", 5*1024*1024, "DD_APPSEC_MAX_PAYLOAD_SIZE")
+	cfg.BindEnvAndSetDefault("appsec_config.max_payload_size", int64(5*1024*1024), "DD_APPSEC_MAX_PAYLOAD_SIZE")
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -768,7 +768,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("jmx_use_cgroup_memory_limit", false)
 	config.BindEnvAndSetDefault("jmx_use_container_support", false)
 	config.BindEnvAndSetDefault("jmx_max_restarts", 3)
-	config.BindEnvAndSetDefault("jmx_restart_interval", int64(5))
+	config.BindEnvAndSetDefault("jmx_restart_interval", 5)
 	config.BindEnvAndSetDefault("jmx_thread_pool_size", 3)
 	config.BindEnvAndSetDefault("jmx_reconnection_thread_pool_size", 3)
 	config.BindEnvAndSetDefault("jmx_collection_timeout", 60)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -767,7 +767,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("jmx_custom_jars", []string{})
 	config.BindEnvAndSetDefault("jmx_use_cgroup_memory_limit", false)
 	config.BindEnvAndSetDefault("jmx_use_container_support", false)
-	config.BindEnvAndSetDefault("jmx_max_restarts", int64(3))
+	config.BindEnvAndSetDefault("jmx_max_restarts", 3)
 	config.BindEnvAndSetDefault("jmx_restart_interval", int64(5))
 	config.BindEnvAndSetDefault("jmx_thread_pool_size", 3)
 	config.BindEnvAndSetDefault("jmx_reconnection_thread_pool_size", 3)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -914,7 +914,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("external_metrics_provider.batch_window", 10)             // value in seconds. Batch the events from the Autoscalers informer to push updates to the ConfigMap (GlobalStore)
 	config.BindEnvAndSetDefault("external_metrics_provider.max_age", 120)                 // value in seconds. 4 cycles from the Autoscaler controller (up to Kubernetes 1.11) is enough to consider a metric stale
 	config.BindEnvAndSetDefault("external_metrics.aggregator", "avg")                     // aggregator used for the external metrics. Choose from [avg,sum,max,min]
-	config.BindEnvAndSetDefault("external_metrics_provider.bucket_size", 60*5)            // Window to query to get the metric from Datadog.
+	config.BindEnvAndSetDefault("external_metrics_provider.bucket_size", 60*5)            // Window (in seconds) to query to get the metric from Datadog.
 	config.BindEnvAndSetDefault("external_metrics_provider.rollup", 30)                   // Bucket size to circumvent time aggregation side effects.
 	config.BindEnvAndSetDefault("external_metrics_provider.wpa_controller", false)        // Activates the controller for Watermark Pod Autoscalers.
 	config.BindEnvAndSetDefault("external_metrics_provider.use_datadogmetric_crd", false) // Use DatadogMetric CRD with custom Datadog Queries instead of ConfigMap

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -274,7 +274,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("auth_token_file_path", "")
 	config.BindEnv("bind_host")
 	config.BindEnvAndSetDefault("ipc_address", "localhost")
-	config.BindEnvAndSetDefault("health_port", int64(0))
+	config.BindEnvAndSetDefault("health_port", 0)
 	config.BindEnvAndSetDefault("disable_py3_validation", false)
 	config.BindEnvAndSetDefault("python_version", DefaultPython)
 	config.BindEnvAndSetDefault("allow_arbitrary_tags", false)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -470,7 +470,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("forwarder_storage_path", "")
 	config.BindEnvAndSetDefault("forwarder_outdated_file_in_days", 10)
 	config.BindEnvAndSetDefault("forwarder_flush_to_disk_mem_ratio", 0.5)
-	config.BindEnvAndSetDefault("forwarder_storage_max_size_in_bytes", 0)                // 0 means disabled. This is a BETA feature.
+	config.BindEnvAndSetDefault("forwarder_storage_max_size_in_bytes", int64(0))         // 0 means disabled. This is a BETA feature.
 	config.BindEnvAndSetDefault("forwarder_storage_max_disk_ratio", 0.80)                // Do not store transactions on disk when the disk usage exceeds 80% of the disk capacity. Use 80% as some applications do not behave well when the disk space is very small.
 	config.BindEnvAndSetDefault("forwarder_retry_queue_capacity_time_interval_sec", 900) // 15 mins
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -270,7 +270,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("integration_tracing", false)
 	config.BindEnvAndSetDefault("enable_metadata_collection", true)
 	config.BindEnvAndSetDefault("enable_gohai", true)
-	config.BindEnvAndSetDefault("check_runners", int64(4))
+	config.BindEnvAndSetDefault("check_runners", DefaultNumWorkers)
 	config.BindEnvAndSetDefault("auth_token_file_path", "")
 	config.BindEnv("bind_host")
 	config.BindEnvAndSetDefault("ipc_address", "localhost")

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -265,9 +265,9 @@ func getPartialConfig() map[string]string {
 	conf["log_level"] = config.Datadog.GetString("log_level")
 	conf["confd_path"] = config.Datadog.GetString("confd_path")
 	conf["additional_checksd"] = config.Datadog.GetString("additional_checksd")
-	forwarderStorageMaxSizeInBytes := config.Datadog.GetInt("forwarder_storage_max_size_in_bytes")
+	forwarderStorageMaxSizeInBytes := config.Datadog.GetInt64("forwarder_storage_max_size_in_bytes")
 	if forwarderStorageMaxSizeInBytes > 0 {
-		conf["forwarder_storage_max_size_in_bytes"] = strconv.Itoa(forwarderStorageMaxSizeInBytes)
+		conf["forwarder_storage_max_size_in_bytes"] = strconv.FormatInt(forwarderStorageMaxSizeInBytes, 10)
 	}
 	return conf
 }

--- a/pkg/util/clusteragent/clusteragent.go
+++ b/pkg/util/clusteragent/clusteragent.go
@@ -125,7 +125,7 @@ func (c *DCAClient) init() error {
 	}
 
 	// Run DCA connection refresh
-	c.startReconnectHandler(time.Duration(config.Datadog.GetInt64("cluster_agent.client_reconnect_period_seconds")) * time.Second)
+	c.startReconnectHandler(time.Duration(config.Datadog.GetInt("cluster_agent.client_reconnect_period_seconds")) * time.Second)
 
 	log.Infof("Successfully connected to the Datadog Cluster Agent %s", c.clusterAgentVersion.String())
 	return nil

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -227,7 +227,7 @@ func getKubeVPAClient(timeout time.Duration) (vpa.Interface, error) {
 
 func getWPAInformerFactory() (dynamicinformer.DynamicSharedInformerFactory, error) {
 	// default to 300s
-	resyncPeriodSeconds := time.Duration(config.Datadog.GetInt64("kubernetes_informers_resync_period"))
+	resyncPeriodSeconds := time.Duration(config.Datadog.GetInt("kubernetes_informers_resync_period"))
 	client, err := getKubeDynamicClient(0) // No timeout for the Informers, to allow long watch.
 	if err != nil {
 		log.Infof("Could not get apiserver client: %v", err)
@@ -247,7 +247,7 @@ func getDDClient(timeout time.Duration) (dynamic.Interface, error) {
 
 func getDDInformerFactory() (dynamicinformer.DynamicSharedInformerFactory, error) {
 	// default to 300s
-	resyncPeriodSeconds := time.Duration(config.Datadog.GetInt64("kubernetes_informers_resync_period"))
+	resyncPeriodSeconds := time.Duration(config.Datadog.GetInt("kubernetes_informers_resync_period"))
 	client, err := getKubeDynamicClient(0) // No timeout for the Informers, to allow long watch.
 	if err != nil {
 		log.Infof("Could not get apiserver client: %v", err)
@@ -257,7 +257,7 @@ func getDDInformerFactory() (dynamicinformer.DynamicSharedInformerFactory, error
 }
 
 func getInformerFactory() (informers.SharedInformerFactory, error) {
-	resyncPeriodSeconds := time.Duration(config.Datadog.GetInt64("kubernetes_informers_resync_period"))
+	resyncPeriodSeconds := time.Duration(config.Datadog.GetInt("kubernetes_informers_resync_period"))
 	client, err := GetKubeClient(0) // No timeout for the Informers, to allow long watch.
 	if err != nil {
 		log.Errorf("Could not get apiserver client: %v", err)
@@ -267,7 +267,7 @@ func getInformerFactory() (informers.SharedInformerFactory, error) {
 }
 
 func getInformerFactoryWithOption(options ...informers.SharedInformerOption) (informers.SharedInformerFactory, error) {
-	resyncPeriodSeconds := time.Duration(config.Datadog.GetInt64("kubernetes_informers_resync_period"))
+	resyncPeriodSeconds := time.Duration(config.Datadog.GetInt("kubernetes_informers_resync_period"))
 	client, err := GetKubeClient(0) // No timeout for the Informers, to allow long watch.
 	if err != nil {
 		log.Errorf("Could not get apiserver client: %v", err)

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -101,7 +101,7 @@ type APIClient struct {
 
 func initAPIClient() {
 	globalAPIClient = &APIClient{
-		timeoutSeconds: config.Datadog.GetInt64("kubernetes_apiserver_client_timeout"),
+		timeoutSeconds: int64(config.Datadog.GetInt("kubernetes_apiserver_client_timeout")),
 	}
 	globalAPIClient.initRetry.SetupRetrier(&retry.Config{ //nolint:errcheck
 		Name:              "apiserver",

--- a/pkg/util/kubernetes/autoscalers/datadogexternal.go
+++ b/pkg/util/kubernetes/autoscalers/datadogexternal.go
@@ -60,7 +60,7 @@ const (
 
 // queryDatadogExternal converts the metric name and labels from the Ref format into a Datadog metric.
 // It returns the last value for a bucket of 5 minutes,
-func (p *Processor) queryDatadogExternal(ddQueries []string, bucketSize int64) (map[string]Point, error) {
+func (p *Processor) queryDatadogExternal(ddQueries []string, bucketSize int) (map[string]Point, error) {
 	ddQueriesLen := len(ddQueries)
 	if ddQueriesLen == 0 {
 		log.Tracef("No query in input - nothing to do")
@@ -68,7 +68,7 @@ func (p *Processor) queryDatadogExternal(ddQueries []string, bucketSize int64) (
 	}
 
 	query := strings.Join(ddQueries, ",")
-	seriesSlice, err := p.datadogClient.QueryMetrics(time.Now().Unix()-bucketSize, time.Now().Unix(), query)
+	seriesSlice, err := p.datadogClient.QueryMetrics(time.Now().Unix()-int64(bucketSize), time.Now().Unix(), query)
 	if err != nil {
 		ddRequests.Inc("error", le.JoinLeaderValue)
 		return nil, log.Errorf("Error while executing metric query %s: %s", query, err)

--- a/pkg/util/kubernetes/autoscalers/datadogexternal_test.go
+++ b/pkg/util/kubernetes/autoscalers/datadogexternal_test.go
@@ -258,7 +258,7 @@ func TestDatadogExternalQuery(t *testing.T) {
 				queryMetricsFunc: test.queryfunc,
 			}
 			p := Processor{datadogClient: cl}
-			points, err := p.queryDatadogExternal(test.metricName, config.Datadog.GetInt64("external_metrics_provider.bucket_size"))
+			points, err := p.queryDatadogExternal(test.metricName, config.Datadog.GetInt("external_metrics_provider.bucket_size"))
 			if test.err != nil {
 				require.EqualError(t, test.err, err.Error())
 			}

--- a/pkg/util/kubernetes/autoscalers/processor.go
+++ b/pkg/util/kubernetes/autoscalers/processor.go
@@ -170,7 +170,7 @@ func (p *Processor) QueryExternalMetric(queries []string) (processed map[string]
 		return processed, nil
 	}
 
-	bucketSize := config.Datadog.GetInt64("external_metrics_provider.bucket_size")
+	bucketSize := config.Datadog.GetInt("external_metrics_provider.bucket_size")
 	chunks := makeChunks(queries)
 	log.Tracef("List of batches %v", chunks)
 


### PR DESCRIPTION
### What does this PR do?

This fixes the types of accesses made to config values, mostly to align bit sizes.  It should have no effect, but rationalizes at least a few uses of Viper.

### Motivation

Looking into bugs related to Viper's default values and the various GetXxx methods used to get them.  These were the "easy fixes".

### Additional Notes

Each commit changes one config parameter, so review commit-by-commit, for the config parameters you're responsible for.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

For each affected team, verify that the team's changed config parameters still work.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
