### PR TITLE
Fix DCA Changelog generation

### DIFF
--- a/releasenotes-dca/config.yaml
+++ b/releasenotes-dca/config.yaml
@@ -1,10 +1,11 @@
 ---
+default_branch: main
 collapse_pre_releases: true
 no_show_source: true
-release_tag_re: '^dca-([\d.-]|rc)+$'
-pre_release_tag_re: '(?P<pre_release>-rc\d+)$'
+release_tag_re: '^dca-([\d.-]|rc|devel)+$'
+pre_release_tag_re: '(?P<pre_release>-rc\.\d+)$'
 template: |
-          # Each section from every releasenote are combined when the
+          # Each section from every release note are combined when the
           # CHANGELOG-DCA.rst is rendered. So the text needs to be worded so that
           # it does not depend on any information only available in another
           # section. This may mean repeating some details, but each section
@@ -12,6 +13,13 @@ template: |
           #
           # Each section note must be formatted as reStructuredText.
           ---
+          upgrade:
+            - |
+              List upgrade notes here, or remove this section.
+              Upgrade notes should be rare: only list known/potential breaking changes,
+              or major behaviorial changes that require user action before the upgrade.
+              Notes here must include steps that users can follow to 1. know if they're
+              affected and 2. handle the change gracefully on their end.
           features:
             - |
               List new features here, or remove this section.
@@ -22,11 +30,6 @@ template: |
           issues:
             - |
               List known issues here, or remove this section.
-          upgrade:
-            - |
-              List upgrade notes here, or remove this section.
-              Only list known/potential breaking changes, or behavior changes
-              that users should absolutely know about before upgrading.
           deprecations:
             - |
               List deprecations notes here, or remove this section.
@@ -43,11 +46,11 @@ template: |
               used.
 sections:
   # The prelude section is implicitly included.
+  - [upgrade, Upgrade Notes]
   - [features, New Features]
   - [enhancements, Enhancement Notes]
   - [issues, Known Issues]
-  - [upgrade, Upgrade Notes]
   - [deprecations, Deprecation Notes]
-  - [security, Security Issues]
+  - [security, Security Notes]
   - [fixes, Bug Fixes]
   - [other, Other Notes]

--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -1,4 +1,5 @@
 ---
+default_branch: main
 collapse_pre_releases: true
 no_show_source: true
 release_tag_re: '^7\.([\d.-]|rc|devel)+$'


### PR DESCRIPTION
### What does this PR do?

Fix DCA Changelog generation

### Motivation

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
