### PR TITLE
[AD] Fix a minor memory leak in adIDToServices

### DIFF
--- a/pkg/autodiscovery/configmgr.go
+++ b/pkg/autodiscovery/configmgr.go
@@ -6,6 +6,7 @@
 package autodiscovery
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -60,7 +61,7 @@ type configManager interface {
 
 	// processDelService handles removal of a service, unscheduling any configs
 	// that had been resolved for it.
-	processDelService(svc listeners.Service) configChanges
+	processDelService(ctx context.Context, svc listeners.Service) configChanges
 
 	// processNewConfig handles a new config
 	processNewConfig(config integration.Config) configChanges
@@ -175,7 +176,7 @@ func (cm *reconcilingConfigManager) processNewService(adIdentifiers []string, sv
 }
 
 // processDelService implements configManager#processDelService.
-func (cm *reconcilingConfigManager) processDelService(svc listeners.Service) configChanges {
+func (cm *reconcilingConfigManager) processDelService(_ context.Context, svc listeners.Service) configChanges {
 	cm.m.Lock()
 	defer cm.m.Unlock()
 

--- a/pkg/autodiscovery/configmgr_test.go
+++ b/pkg/autodiscovery/configmgr_test.go
@@ -146,7 +146,7 @@ func (suite *ConfigManagerSuite) TestNewTemplateBeforeService_ConfigRemovedFirst
 	assertConfigsMatch(suite.T(), changes.schedule)
 	assertConfigsMatch(suite.T(), changes.unschedule, matchAll(matchName("template"), matchLogsConfig("source: myhost\n")))
 
-	changes = suite.cm.processDelService(myService)
+	changes = suite.cm.processDelService(context.TODO(), myService)
 	assertConfigsMatch(suite.T(), changes.schedule)
 	assertConfigsMatch(suite.T(), changes.unschedule)
 }
@@ -163,7 +163,7 @@ func (suite *ConfigManagerSuite) TestNewTemplateBeforeService_ServiceRemovedFirs
 	assertConfigsMatch(suite.T(), changes.schedule, matchAll(matchName("template"), matchLogsConfig("source: myhost\n")))
 	assertConfigsMatch(suite.T(), changes.unschedule)
 
-	changes = suite.cm.processDelService(myService)
+	changes = suite.cm.processDelService(context.TODO(), myService)
 	assertConfigsMatch(suite.T(), changes.schedule)
 	assertConfigsMatch(suite.T(), changes.unschedule, matchAll(matchName("template"), matchLogsConfig("source: myhost\n")))
 
@@ -188,7 +188,7 @@ func (suite *ConfigManagerSuite) TestNewServiceBeforeTemplate_ConfigRemovedFirst
 	assertConfigsMatch(suite.T(), changes.schedule)
 	assertConfigsMatch(suite.T(), changes.unschedule, matchAll(matchName("template"), matchLogsConfig("source: myhost\n")))
 
-	changes = suite.cm.processDelService(myService)
+	changes = suite.cm.processDelService(context.TODO(), myService)
 	assertConfigsMatch(suite.T(), changes.schedule)
 	assertConfigsMatch(suite.T(), changes.unschedule)
 }
@@ -205,7 +205,7 @@ func (suite *ConfigManagerSuite) TestNewServiceBeforeTemplate_ServiceRemovedFirs
 	assertConfigsMatch(suite.T(), changes.schedule, matchAll(matchName("template"), matchLogsConfig("source: myhost\n")))
 	assertConfigsMatch(suite.T(), changes.unschedule)
 
-	changes = suite.cm.processDelService(myService)
+	changes = suite.cm.processDelService(context.TODO(), myService)
 	assertConfigsMatch(suite.T(), changes.schedule)
 	assertConfigsMatch(suite.T(), changes.unschedule, matchAll(matchName("template"), matchLogsConfig("source: myhost\n")))
 
@@ -315,7 +315,7 @@ func (suite *ConfigManagerSuite) TestFuzz() {
 						delete(services, id)
 						adIDs, _ := svc.GetADIdentifiers(context.Background())
 						fmt.Printf("remove service %s with AD idents %s\n", id, strings.Join(adIDs, ", "))
-						applyChanges(cm.processDelService(svc))
+						applyChanges(cm.processDelService(context.TODO(), svc))
 						break
 					}
 					i--
@@ -423,7 +423,7 @@ func (suite *ReconcilingConfigManagerSuite) TestServiceTemplateFiltering() {
 	)
 
 	// removing a service removes only the scheduled configs
-	changes = suite.cm.processDelService(filterSvc)
+	changes = suite.cm.processDelService(context.TODO(), filterSvc)
 	assertConfigsMatch(suite.T(), changes.schedule)
 	assertConfigsMatch(suite.T(), changes.unschedule, matchAll(matchName("cfg2-keep"), matchSvc("filter")))
 	assertLoadedConfigsMatch(suite.T(), suite.cm,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Remove entries from `adIDToServices` on service deletion events.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Fixes a slow/minor memory leak

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

- AD works as usual
- Using profiling, make sure `setADIDForServices` is not leaking anymore in high container-churn environments 

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
