### PR TITLE
[DCA] Fix a race condition that could lead to wrong `is_leader` metric tag

### DIFF
--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go
@@ -76,7 +76,7 @@ func (le *LeaderEngine) newElection() (*ld.LeaderElector, error) {
 	callbacks := ld.LeaderCallbacks{
 		OnNewLeader: func(identity string) {
 			le.updateLeaderIdentity(identity)
-			le.reportLeaderMetric(false)
+			le.reportLeaderMetric(identity == le.HolderIdentity)
 			log.Infof("New leader %q", identity)
 		},
 		OnStartedLeading: func(ctx context.Context) {

--- a/releasenotes-dca/notes/Fix-leader-metric-6371ddf439eb190c.yaml
+++ b/releasenotes-dca/notes/Fix-leader-metric-6371ddf439eb190c.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG-DCA.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix the DCA `leader_election_is_leader` metric that could sometimes report ``is_leader="false"`` on the leader instance


### PR DESCRIPTION
### What does this PR do?

Fix a race condition that could lead the `is_leader` tag of the `leader_election_is_leader` metric to set to `false` on the leader instance.

### Motivation

Under some circumstances, `OnNewLeader` can be executed after `OnStartedLeading` on the instance which is becoming the leader, as it can been seen in those captured logs:

```
$ kubectl --kubeconfig ~/.kube/config-prod --context logs10.eu1.prod.dog --namespace datadog-agent logs pod/datadog-cluster-agent-6774d7ddbd-6d9t5 | grep -i leader

Defaulted container "datadog-cluster-agent" out of: datadog-cluster-agent, config-seed (init)
I0704 07:41:32.248814       1 leaderelection.go:248] attempting to acquire leader lease datadog-agent/datadog-leader-election...
2022-07-04 07:41:32 UTC | CLUSTER | INFO | (pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go:202 in runLeaderElection) | Starting leader election process for "datadog-cluster-agent-6774d7ddbd-6d9t5"...
2022-07-04 07:41:32 UTC | CLUSTER | INFO | (pkg/clusteragent/clusterchecks/handler.go:119 in Run) | Becoming leader, waiting 30s for node-agents to report
2022-07-04 07:41:32 UTC | CLUSTER | INFO | (pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go:80 in func1) | New leader "datadog-cluster-agent-7cbdb64b56-2b7zg"
2022-07-04 07:41:34 UTC | CLUSTER | INFO | (pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go:190 in EnsureLeaderElectionRuns) | Leader election running, current leader is "datadog-cluster-agent-7cbdb64b56-2b7zg"
2022-07-04 07:42:42 UTC | CLUSTER | WARN | (pkg/clusteragent/clusterchecks/handler.go:192 in leaderWatch) | Could not refresh leadership status: "target named datadog-cluster-agent-7cbdb64b56-2b7zg" not found, will only log every 100 errors
2022-07-04 07:43:00 UTC | CLUSTER | INFO | (pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go:86 in func2) | Started leading as "datadog-cluster-agent-6774d7ddbd-6d9t5"...
2022-07-04 07:43:00 UTC | CLUSTER | INFO | (pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go:80 in func1) | New leader "datadog-cluster-agent-6774d7ddbd-6d9t5"
I0704 07:43:00.904855       1 leaderelection.go:258] successfully acquired lease datadog-agent/datadog-leader-election
2022-07-04 07:43:00 UTC | CLUSTER | INFO | (pkg/clusteragent/admission/controllers/secret/controller.go:98 in enqueueOnLeaderNotif) | Got a leader notification, enqueuing a reconciliation for datadog-agent/webhook-certificate
2022-07-04 07:43:00 UTC | CLUSTER | INFO | (pkg/clusteragent/admission/controllers/webhook/controller_base.go:65 in enqueueOnLeaderNotif) | Got a leader notification, enqueuing a reconciliation for "datadog-webhook"
2022-07-04 07:43:04 UTC | CLUSTER | INFO | (pkg/clusteragent/clusterchecks/handler.go:119 in Run) | Becoming leader, waiting 30s for node-agents to report
2022-07-04 07:43:04 UTC | CLUSTER | INFO | (pkg/clusteragent/clusterchecks/handler.go:198 in leaderWatch) | Found leadership status after 4 tries
```

We can see that the `Started leading as %q...` log appeared before the `New leader %q` one.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Start several instances of the DCA.
Check which one is the leader.

```
kubectl get cm/datadog-agent-linux-leader-election -o json | jq -r '.metadata.annotations."control-plane.alpha.kubernetes.io/leader"'
```

Check the `leader_election_is_leader` metric on all instances.

```
$ kubectl get pods -l app=datadog-agent-linux-cluster-agent -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}}' | while read -r pod; do echo "===> $pod <==="; kubectl datadog-agent-helm exec "$pod" -- curl -s http://localhost:5000/metrics | grep -E '^leader_election_is_leader'; done

===> datadog-agent-linux-cluster-agent-5df6b78b4b-bhdxd <===
leader_election_is_leader{is_leader="true",join_leader="true"} 1
===> datadog-agent-linux-cluster-agent-5df6b78b4b-lvbdn <===
leader_election_is_leader{is_leader="false",join_leader="true"} 1
```

Delete the leader pod. Wait for a new leader to be elected.
Check the metrics again.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
