### PR TITLE
CWS: add debug cli arg to build security code with DEBUG=1

### DIFF
--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -655,6 +655,7 @@ def build_network_ebpf_files(ctx, build_dir, parallel_build=True, kernel_release
     for promise in promises_link:
         promise.join()
 
+
 def get_security_agent_build_flags(security_agent_c_dir, kernel_release=None, debug=False):
     security_flags = get_ebpf_build_flags(kernel_release=kernel_release)
     security_flags.append(f"-I{security_agent_c_dir}")
@@ -767,7 +768,9 @@ def build_object_files(ctx, parallel_build, kernel_release=None, debug=False):
 
     build_network_ebpf_files(ctx, build_dir=build_dir, parallel_build=parallel_build, kernel_release=kernel_release)
     build_http_ebpf_files(ctx, build_dir=build_dir, kernel_release=kernel_release)
-    build_security_ebpf_files(ctx, build_dir=build_dir, parallel_build=parallel_build, kernel_release=kernel_release, debug=debug)
+    build_security_ebpf_files(
+        ctx, build_dir=build_dir, parallel_build=parallel_build, kernel_release=kernel_release, debug=debug
+    )
 
     generate_runtime_files(ctx)
 

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -62,6 +62,7 @@ def build(
     bundle_ebpf=False,
     parallel_build=True,
     kernel_release=None,
+    debug=False,
 ):
     """
     Build the system_probe
@@ -84,7 +85,7 @@ def build(
         )
     elif compile_ebpf:
         # Only build ebpf files on unix
-        build_object_files(ctx, parallel_build=parallel_build, kernel_release=kernel_release)
+        build_object_files(ctx, parallel_build=parallel_build, kernel_release=kernel_release, debug=debug)
 
     generate_cgo_types(ctx, windows=windows)
     ldflags, gcflags, env = get_build_flags(
@@ -654,16 +655,22 @@ def build_network_ebpf_files(ctx, build_dir, parallel_build=True, kernel_release
     for promise in promises_link:
         promise.join()
 
+def get_security_agent_build_flags(security_agent_c_dir, kernel_release=None, debug=False):
+    security_flags = get_ebpf_build_flags(kernel_release=kernel_release)
+    security_flags.append(f"-I{security_agent_c_dir}")
+    if debug:
+        security_flags.append("-DDEBUG=1")
+    return security_flags
 
-def build_security_offset_guesser_ebpf_files(ctx, build_dir, kernel_release=None):
+
+def build_security_offset_guesser_ebpf_files(ctx, build_dir, kernel_release=None, debug=False):
     security_agent_c_dir = os.path.join(".", "pkg", "security", "ebpf", "c")
     security_agent_prebuilt_dir = os.path.join(security_agent_c_dir, "prebuilt")
     security_c_file = os.path.join(security_agent_prebuilt_dir, "offset-guesser.c")
     security_bc_file = os.path.join(build_dir, "runtime-security-offset-guesser.bc")
     security_agent_obj_file = os.path.join(build_dir, "runtime-security-offset-guesser.o")
 
-    security_flags = get_ebpf_build_flags(kernel_release=kernel_release)
-    security_flags.append(f"-I{security_agent_c_dir}")
+    security_flags = get_security_agent_build_flags(security_agent_c_dir, kernel_release=kernel_release, debug=debug)
 
     ctx.run(
         CLANG_CMD.format(
@@ -677,15 +684,14 @@ def build_security_offset_guesser_ebpf_files(ctx, build_dir, kernel_release=None
     )
 
 
-def build_security_probe_ebpf_files(ctx, build_dir, parallel_build=True, kernel_release=None):
+def build_security_probe_ebpf_files(ctx, build_dir, parallel_build=True, kernel_release=None, debug=False):
     security_agent_c_dir = os.path.join(".", "pkg", "security", "ebpf", "c")
     security_agent_prebuilt_dir = os.path.join(security_agent_c_dir, "prebuilt")
     security_c_file = os.path.join(security_agent_prebuilt_dir, "probe.c")
     security_bc_file = os.path.join(build_dir, "runtime-security.bc")
     security_agent_obj_file = os.path.join(build_dir, "runtime-security.o")
 
-    security_flags = get_ebpf_build_flags(kernel_release=kernel_release)
-    security_flags.append(f"-I{security_agent_c_dir}")
+    security_flags = get_security_agent_build_flags(security_agent_c_dir, kernel_release=kernel_release, debug=debug)
 
     # compile
     promises = []
@@ -741,12 +747,12 @@ def build_security_probe_ebpf_files(ctx, build_dir, parallel_build=True, kernel_
             p.join()
 
 
-def build_security_ebpf_files(ctx, build_dir, parallel_build=True, kernel_release=None):
-    build_security_probe_ebpf_files(ctx, build_dir, parallel_build, kernel_release=kernel_release)
-    build_security_offset_guesser_ebpf_files(ctx, build_dir, kernel_release=kernel_release)
+def build_security_ebpf_files(ctx, build_dir, parallel_build=True, kernel_release=None, debug=False):
+    build_security_probe_ebpf_files(ctx, build_dir, parallel_build, kernel_release=kernel_release, debug=debug)
+    build_security_offset_guesser_ebpf_files(ctx, build_dir, kernel_release=kernel_release, debug=debug)
 
 
-def build_object_files(ctx, parallel_build, kernel_release=None):
+def build_object_files(ctx, parallel_build, kernel_release=None, debug=False):
     """build_object_files builds only the eBPF object"""
 
     # if clang is missing, subsequent calls to ctx.run("clang ...") will fail silently
@@ -761,7 +767,7 @@ def build_object_files(ctx, parallel_build, kernel_release=None):
 
     build_network_ebpf_files(ctx, build_dir=build_dir, parallel_build=parallel_build, kernel_release=kernel_release)
     build_http_ebpf_files(ctx, build_dir=build_dir, kernel_release=kernel_release)
-    build_security_ebpf_files(ctx, build_dir=build_dir, parallel_build=parallel_build, kernel_release=kernel_release)
+    build_security_ebpf_files(ctx, build_dir=build_dir, parallel_build=parallel_build, kernel_release=kernel_release, debug=debug)
 
     generate_runtime_files(ctx)
 


### PR DESCRIPTION
### What does this PR do?

This PR adds an option to `inv -e system-probe.build --debug` to enable `DEBUG=1`. This only works for CWS code for now.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
