### PR TITLE
[install_mac_os] Check for existence of user and group selected for systemwide installation

### DIFF
--- a/cmd/agent/install_mac_os.sh
+++ b/cmd/agent/install_mac_os.sh
@@ -61,8 +61,8 @@ if [ -n "$DD_SYSTEMDAEMON_INSTALL" ]; then
         exit 1;
     fi
     # groups output is in form `username : group1 group2 ...`, so we use `cut` to strip the `username :` part
-    if ! groups "$systemdaemon_user" | cut -d' ' -f3- | grep -w "$systemdaemon_group" >/dev/null 2>&1; then
-        printf "\033[31mUser $systemdaemon_user is not a member of group $systemdaemon_group, can't proceed with installation\033[0m\n"
+    if ! dscacheutil -q group | grep "name:" | awk '{print $2}' | grep -w "$systemdaemon_group" >/dev/null 2>&1; then
+        printf "\033[31mGroup $systemdaemon_group not found, can't proceed with installation\033[0m\n"
         exit 1;
     fi
 fi

--- a/cmd/agent/install_mac_os.sh
+++ b/cmd/agent/install_mac_os.sh
@@ -60,7 +60,12 @@ if [ -n "$DD_SYSTEMDAEMON_INSTALL" ]; then
         printf "\033[31mUser $systemdaemon_user not found, can't proceed with installation\033[0m\n"
         exit 1;
     fi
-    # groups output is in form `username : group1 group2 ...`, so we use `cut` to strip the `username :` part
+    # dscacheutil -q group output is in form:
+    #   name: groupname
+    #   password: *
+    #   gid: 1001
+    #   users: user1 user2
+    # so we use `grep` and `awk` to get the group name
     if ! dscacheutil -q group | grep "name:" | awk '{print $2}' | grep -w "$systemdaemon_group" >/dev/null 2>&1; then
         printf "\033[31mGroup $systemdaemon_group not found, can't proceed with installation\033[0m\n"
         exit 1;


### PR DESCRIPTION
### What does this PR do?

Implements a check for existence of user/group selected for systemwide installation.

### Motivation

Failing fast and explicitly if user/group don't exist.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

* Provide an existing user with its group, ensure the systemwide installation still passes fine.
* Provide a non-existing user, the script should fail immediately with a meaningful message.
* Provide an existing user with either non-existing group or group that they're not member of. The script should fail immediately with a meaningful message.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
