### PR TITLE
 [orchestrator check] Fixes race condition during check startup.

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
@@ -132,6 +132,10 @@ func (cb *CollectorBundle) Initialize() error {
 			// we run each enabled informer individually, because starting them through the factory
 			// would prevent us from restarting them again if the check is unscheduled/rescheduled
 			// see https://github.com/kubernetes/client-go/blob/3511ef41b1fbe1152ef5cab2c0b950dfd607eea7/informers/factory.go#L64-L66
+
+			// TODO: right now we use a stop channel which we don't close, that can lead to resource leaks
+			// A recent go-client update https://github.com/kubernetes/kubernetes/pull/104853 changed the behaviour so that
+			// we are not able to start informers anymore once they have been stopped. We will need to work around this. Once this is fixed we can properly release the resources during a check.Close().
 			go informer.Run(cb.stopCh)
 		}
 	}

--- a/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
@@ -111,8 +111,10 @@ func (cb *CollectorBundle) prepareExtraSyncTimeout() {
 // synced.
 func (cb *CollectorBundle) Initialize() error {
 	informersToSync := make(map[apiserver.InformerName]cache.SharedInformer)
-	availableCollectors := []collectors.Collector{}
-
+	var availableCollectors []collectors.Collector
+	// informerSynced is a helper map which makes sure that we don't initialize the same informer twice.
+	// i.e. the cluster and nodes resources share the same informer and using both can lead to a race condition activating both concurrently.
+	informerSynced := map[cache.SharedInformer]struct{}{}
 	for _, collector := range cb.collectors {
 		collector.Init(cb.runCfg)
 		if !collector.IsAvailable() {
@@ -123,12 +125,15 @@ func (cb *CollectorBundle) Initialize() error {
 		availableCollectors = append(availableCollectors, collector)
 
 		informer := collector.Informer()
-		informersToSync[apiserver.InformerName(collector.Metadata().Name)] = informer
 
-		// we run each enabled informer individually as starting them through the factory
-		// would prevent us to restarting them again if the check is unscheduled/rescheduled
-		// see https://github.com/kubernetes/client-go/blob/3511ef41b1fbe1152ef5cab2c0b950dfd607eea7/informers/factory.go#L64-L66
-		go informer.Run(cb.stopCh)
+		if _, found := informerSynced[informer]; !found {
+			informersToSync[apiserver.InformerName(collector.Metadata().Name)] = informer
+			informerSynced[informer] = struct{}{}
+			// we run each enabled informer individually, because starting them through the factory
+			// would prevent us from restarting them again if the check is unscheduled/rescheduled
+			// see https://github.com/kubernetes/client-go/blob/3511ef41b1fbe1152ef5cab2c0b950dfd607eea7/informers/factory.go#L64-L66
+			go informer.Run(cb.stopCh)
+		}
 	}
 
 	cb.collectors = availableCollectors

--- a/pkg/collector/corechecks/cluster/orchestrator/orchestrator_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/orchestrator_test.go
@@ -1,0 +1,82 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed
+ * under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-2022 Datadog, Inc.
+ */
+
+package orchestrator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// TestOrchestratorCheckStartupAndCleanup close simulates the check being closed and then restarted with .Start again
+func TestOrchestratorCheckStartupAndCleanup(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+	cl := &apiserver.APIClient{Cl: client, InformerFactory: informerFactory, UnassignedPodInformerFactory: informerFactory}
+	orchCheck := OrchestratorFactory().(*OrchestratorCheck)
+	orchCheck.apiClient = cl
+
+	bundle := NewCollectorBundle(orchCheck)
+	err := bundle.Initialize()
+	assert.NoError(t, err)
+
+	// We will create an informer that writes added pods to a channel.
+	nodes := make(chan *corev1.Node, 1)
+
+	nodeInformer := informerFactory.Core().V1().Nodes().Informer()
+	nodeInformer.AddEventHandler(&cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			node := obj.(*corev1.Node)
+			t.Logf("node added: %s/%s", node.Namespace, node.Name)
+			nodes <- node
+		},
+	})
+
+	writeNode(t, client, "1")
+	select {
+	case node := <-nodes:
+		t.Logf("Got node from channel: %s/%s", node.Namespace, node.Name)
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Error("Informer did not get the added node")
+	}
+
+	// getting unscheduled
+	orchCheck.Cancel()
+	writeNode(t, client, "2")
+	writeNode(t, client, "3")
+	writeNode(t, client, "4")
+
+	<-orchCheck.stopCh
+
+	// we closed the channel, now we don't expect to receive a node
+	assert.Empty(t, nodes)
+}
+
+func writeNode(t *testing.T, client *fake.Clientset, version string) {
+	kubeN := corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			ResourceVersion: version,
+			UID:             types.UID("126430c6-5e57-11ea-91d5-42010a8400c6-" + version),
+			Name:            "another-system-" + version,
+		},
+	}
+	_, err := client.CoreV1().Nodes().Create(context.TODO(), &kubeN, metav1.CreateOptions{})
+	assert.NoError(t, err)
+}

--- a/pkg/collector/corechecks/cluster/orchestrator/orchestrator_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/orchestrator_test.go
@@ -3,6 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build kubeapiserver && orchestrator
+// +build kubeapiserver,orchestrator
+
 package orchestrator
 
 import (

--- a/pkg/collector/corechecks/cluster/orchestrator/orchestrator_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/orchestrator_test.go
@@ -1,9 +1,7 @@
-/*
- * Unless explicitly stated otherwise all files in this repository are licensed
- * under the Apache License Version 2.0.
- * This product includes software developed at Datadog (https://www.datadoghq.com/).
- * Copyright 2016-2022 Datadog, Inc.
- */
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
 
 package orchestrator
 
@@ -56,17 +54,6 @@ func TestOrchestratorCheckStartupAndCleanup(t *testing.T) {
 	case <-time.After(wait.ForeverTestTimeout):
 		t.Error("Informer did not get the added node")
 	}
-
-	// getting unscheduled
-	orchCheck.Cancel()
-	writeNode(t, client, "2")
-	writeNode(t, client, "3")
-	writeNode(t, client, "4")
-
-	<-orchCheck.stopCh
-
-	// we closed the channel, now we don't expect to receive a node
-	assert.Empty(t, nodes)
 }
 
 func writeNode(t *testing.T, client *fake.Clientset, version string) {

--- a/pkg/process/util/chunking.go
+++ b/pkg/process/util/chunking.go
@@ -33,7 +33,7 @@ type ChunkAllocator interface {
 // - keep track of size and weight available for allocation (`TakenSize` and `TakenWeight`)
 // - create a new chunk once we exceed these limits
 // - consider case when the current item exceeds the max allowed weight and create a new chunk at the end (`Append`)
-// this implementation allows for multiple pases through the chunks, which can be useful in cases with different payload types
+// this implementation allows for multiple passes through the chunks, which can be useful in cases with different payload types
 // being allocated within chunks
 func ChunkPayloadsBySizeAndWeight(l PayloadList, a ChunkAllocator, maxChunkSize int, maxChunkWeight int) {
 	start := 0

--- a/releasenotes/notes/fix-panic-1311d497ce5dd63d.yaml
+++ b/releasenotes/notes/fix-panic-1311d497ce5dd63d.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    [orchestrator check] Fixes race condition during check startup.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

- split up from: https://github.com/DataDog/datadog-agent/pull/12633 to not include the resource leak fix. Due to an go-client update this might have unforeseen behaviours which we still need to verify

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
