### PR TITLE
Traps: Resolve table variables that have a suffix

### DIFF
--- a/pkg/snmp/traps/formatter.go
+++ b/pkg/snmp/traps/formatter.go
@@ -200,6 +200,7 @@ func IsValidOID(value string) bool {
 		if char == '.' && previousChar == '.' {
 			return false
 		}
+		previousChar = char
 	}
 	return previousChar != '.'
 }

--- a/pkg/snmp/traps/formatter.go
+++ b/pkg/snmp/traps/formatter.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"unicode"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/gosnmp/gosnmp"
@@ -185,6 +186,22 @@ func NormalizeOID(value string) string {
 	// OIDs can be formatted as ".1.2.3..." ("absolute form") or "1.2.3..." ("relative form").
 	// Convert everything to relative form, like we do in the Python check.
 	return strings.TrimLeft(value, ".")
+}
+
+// IsValidOID returns true if a looks like a valid OID.
+// An OID is made of digits and dots, but OIDs do not end with a dot and there are always
+// digits between dots.
+func IsValidOID(value string) bool {
+	var previousChar rune
+	for _, char := range value {
+		if char != '.' && !unicode.IsDigit(char) {
+			return false
+		}
+		if char == '.' && previousChar == '.' {
+			return false
+		}
+	}
+	return previousChar != '.'
 }
 
 // parseValue checks to see if the variable has a mapping in an enum and

--- a/pkg/snmp/traps/formatter_test.go
+++ b/pkg/snmp/traps/formatter_test.go
@@ -8,9 +8,12 @@ package traps
 import (
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"net"
 	"sort"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/gosnmp/gosnmp"
@@ -508,4 +511,66 @@ func TestFormatterWithResolverAndTrapV1Generic(t *testing.T) {
 		"device_namespace:porco_rosso",
 		"snmp_device:127.0.0.1",
 	})
+}
+
+func TestIsValidOID_PropertyBasedTesting(t *testing.T) {
+	rand.Seed(time.Now().Unix())
+	testSize := 100
+	validOIDs := make([]string, testSize)
+	for i := 0; i < testSize; i++ {
+		// Valid cases
+		oidLen := rand.Intn(100) + 2
+		oidParts := make([]string, oidLen)
+		for j := 0; j < oidLen; j++ {
+			oidParts[j] = fmt.Sprint(rand.Intn(100000))
+		}
+		recreatedOID := strings.Join(oidParts, ".")
+		if rand.Intn(2) == 0 {
+			recreatedOID = "." + recreatedOID
+		}
+		validOIDs[i] = recreatedOID
+		require.True(t, IsValidOID(validOIDs[i]), "OID: %s", validOIDs[i])
+
+	}
+
+	var invalidRunes = []rune(",?><|\\}{[]()*&^%$#@!abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	for i := 0; i < testSize; i++ {
+		// Valid cases
+		oid := validOIDs[i]
+		x := 0
+		switch x = rand.Intn(3); x {
+		case 0:
+			// Append a dot at the end, this is not possible
+			oid = oid + "."
+		case 1:
+			// Append a random invalid character anywhere
+			randomRune := invalidRunes[rand.Intn(len(invalidRunes))]
+			randomIdx := rand.Intn(len(oid))
+			oid = oid[:randomIdx] + string(randomRune) + oid[randomIdx:]
+		case 2:
+			// Put two dots next to each other
+			oidParts := strings.Split(oid, ".")
+			randomIdx := rand.Intn(len(oidParts))
+			oidParts[randomIdx] = "." + oidParts[randomIdx]
+			oid = strings.Join(oidParts, ".")
+		}
+		require.False(t, IsValidOID(oid), "OID: %s", oid)
+	}
+}
+
+func TestIsValidOID_Unit(t *testing.T) {
+	cases := map[string]bool{
+		"1.3.6.1.4.1.4962.2.1.6.3":       true,
+		".1.3.6.1.4.1.4962.2.1.6.999999": true,
+		"1":                              true,
+		"1.3.6.1.4.1.4962.2.1.-6.3":      false,
+		"1.3.6.1.4.1..4962.2.1.6.3":      false,
+		"1.3.6.1foo.4.1.4962.2.1.6.3":    false,
+		"1.3.6.1foo.4.1.4962_2.1.6.3":    false,
+		"1.3.6.1.4.1.4962.2.1.6.999999.": false,
+	}
+
+	for oid, expected := range cases {
+		require.Equal(t, expected, IsValidOID(oid))
+	}
 }

--- a/pkg/snmp/traps/formatter_test.go
+++ b/pkg/snmp/traps/formatter_test.go
@@ -530,7 +530,6 @@ func TestIsValidOID_PropertyBasedTesting(t *testing.T) {
 		}
 		validOIDs[i] = recreatedOID
 		require.True(t, IsValidOID(validOIDs[i]), "OID: %s", validOIDs[i])
-
 	}
 
 	var invalidRunes = []rune(",?><|\\}{[]()*&^%$#@!abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
@@ -550,10 +549,11 @@ func TestIsValidOID_PropertyBasedTesting(t *testing.T) {
 		case 2:
 			// Put two dots next to each other
 			oidParts := strings.Split(oid, ".")
-			randomIdx := rand.Intn(len(oidParts))
+			randomIdx := rand.Intn(len(oidParts)-1) + 1
 			oidParts[randomIdx] = "." + oidParts[randomIdx]
 			oid = strings.Join(oidParts, ".")
 		}
+
 		require.False(t, IsValidOID(oid), "OID: %s", oid)
 	}
 }

--- a/pkg/snmp/traps/oid_resolver.go
+++ b/pkg/snmp/traps/oid_resolver.go
@@ -186,6 +186,10 @@ func (or *MultiFilesOIDResolver) updateResolverWithData(trapDB trapDBFileContent
 
 	allOIDs := make([]string, 0, len(trapDB.Variables))
 	for variableOID := range trapDB.Variables {
+		if !IsValidOID(variableOID) {
+			log.Errorf("trap variable OID %s does not look like a valid OID", variableOID)
+			continue
+		}
 		allOIDs = append(allOIDs, NormalizeOID(variableOID))
 	}
 
@@ -201,7 +205,7 @@ func (or *MultiFilesOIDResolver) updateResolverWithData(trapDB trapDBFileContent
 		isNode := false
 		if idx+1 < len(allOIDs) {
 			nextOID := allOIDs[idx+1]
-			isNode = strings.HasPrefix(nextOID, variableOID)
+			isNode = strings.HasPrefix(nextOID, variableOID+".")
 		}
 
 		variableData := trapDB.Variables[variableOID]
@@ -214,6 +218,10 @@ func (or *MultiFilesOIDResolver) updateResolverWithData(trapDB trapDBFileContent
 	}
 
 	for trapOID, trapData := range trapDB.Traps {
+		if !IsValidOID(trapOID) {
+			log.Errorf("trap OID %s does not look like a valid OID", trapOID)
+			continue
+		}
 		trapOID := NormalizeOID(trapOID)
 		if _, trapConflict := or.traps[trapOID]; trapConflict {
 			log.Debugf("a trap with OID %s is defined in multiple traps db files", trapOID)

--- a/pkg/snmp/traps/oid_resolver.go
+++ b/pkg/snmp/traps/oid_resolver.go
@@ -197,7 +197,7 @@ func (or *MultiFilesOIDResolver) updateResolverWithData(trapDB trapDBFileContent
 	// with 'isNode: true'. i.e if an OID <FOO>.<BAR> exists in the trapsDB but <FOO> also exists in the trapsDB
 	// then <FOO> acts as a 'Node' of the OID tree and should not be considered a match for resolving variables.
 	// In this fast algorithm the list is sorted then each OID is compared with its successor. It the successor starts
-	// with the current OID, then the current OID is a Node.
+	// with the current OID + a dot, then the current OID is a Node. 'Dots' are before digits in the lexicographic order.
 	// Note that in practice, OIDs that act both as Node and Leaf of the OID tree is extremely rare and is not expected
 	// in normal circumstamces. Thing is they sometimes exist.
 	sort.Strings(allOIDs)

--- a/pkg/snmp/traps/oid_resolver_test.go
+++ b/pkg/snmp/traps/oid_resolver_test.go
@@ -10,10 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/fs"
-	"math/rand"
-	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
@@ -298,51 +295,6 @@ func TestResolverWithNoMatchVariableShouldStopBeforeRoot(t *testing.T) {
 	_, err = resolver.GetVariableMetadata("1.3.6.1.6.3.1.1.5.4", "1.8")
 	require.Error(t, err)
 
-}
-
-func TestIsValidOID(t *testing.T) {
-	rand.Seed(time.Now().Unix())
-	testSize := 100
-	validOIDs := make([]string, testSize)
-	for i := 0; i < testSize; i++ {
-		// Valid cases
-		oidLen := rand.Intn(100) + 2
-		oidParts := make([]string, oidLen)
-		for j := 0; j < oidLen; j++ {
-			oidParts[j] = fmt.Sprint(rand.Intn(100000))
-		}
-		recreatedOID := strings.Join(oidParts, ".")
-		if rand.Intn(2) == 0 {
-			recreatedOID = "." + recreatedOID
-		}
-		validOIDs[i] = recreatedOID
-		require.True(t, IsValidOID(validOIDs[i]), "OID: %s", validOIDs[i])
-
-	}
-
-	var invalidRunes = []rune(",?><|\\}{[]()*&^%$#@!abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
-	for i := 0; i < testSize; i++ {
-		// Valid cases
-		oid := validOIDs[i]
-		x := 0
-		switch x = rand.Intn(3); x {
-		case 0:
-			// Append a dot at the end, this is not possible
-			oid = oid + "."
-		case 1:
-			// Append a random invalid character anywhere
-			randomRune := invalidRunes[rand.Intn(len(invalidRunes))]
-			randomIdx := rand.Intn(len(oid))
-			oid = oid[:randomIdx] + string(randomRune) + oid[randomIdx:]
-		case 2:
-			// Put two dots next to each other
-			oidParts := strings.Split(oid, ".")
-			randomIdx := rand.Intn(len(oidParts))
-			oidParts[randomIdx] = "." + oidParts[randomIdx]
-			oid = strings.Join(oidParts, ".")
-		}
-		require.False(t, IsValidOID(oid), "OID: %s", oid)
-	}
 }
 
 func updateResolverWithIntermediateJSONReader(t *testing.T, oidResolver *MultiFilesOIDResolver, trapData trapDBFileContent) {

--- a/pkg/snmp/traps/oid_resolver_test.go
+++ b/pkg/snmp/traps/oid_resolver_test.go
@@ -10,7 +10,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/fs"
+	"math/rand"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
@@ -295,6 +298,51 @@ func TestResolverWithNoMatchVariableShouldStopBeforeRoot(t *testing.T) {
 	_, err = resolver.GetVariableMetadata("1.3.6.1.6.3.1.1.5.4", "1.8")
 	require.Error(t, err)
 
+}
+
+func TestIsValidOID(t *testing.T) {
+	rand.Seed(time.Now().Unix())
+	testSize := 100
+	validOIDs := make([]string, testSize)
+	for i := 0; i < testSize; i++ {
+		// Valid cases
+		oidLen := rand.Intn(100) + 2
+		oidParts := make([]string, oidLen)
+		for j := 0; j < oidLen; j++ {
+			oidParts[j] = fmt.Sprint(rand.Intn(100000))
+		}
+		recreatedOID := strings.Join(oidParts, ".")
+		if rand.Intn(2) == 0 {
+			recreatedOID = "." + recreatedOID
+		}
+		validOIDs[i] = recreatedOID
+		require.True(t, IsValidOID(validOIDs[i]), "OID: %s", validOIDs[i])
+
+	}
+
+	var invalidRunes = []rune(",.?><|\\}{[]()*&^%$#@!abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	for i := 0; i < testSize; i++ {
+		// Valid cases
+		oid := validOIDs[i]
+		switch rand.Intn(3) {
+		case 0:
+			// Append a dot at the end, this is not possible
+			oid = oid + "."
+		case 1:
+			// Append a random invalid character anywhere
+			randomRune := invalidRunes[rand.Intn(len(invalidRunes))]
+			randomIdx := rand.Intn(len(oid))
+			oid = oid[:randomIdx] + string(randomRune) + oid[randomIdx:]
+		case 2:
+			// Put two dots next to each other
+			oidParts := strings.Split(oid, ".")
+			randomIdx := rand.Intn(len(oidParts))
+			oidParts[randomIdx] = "." + oidParts[randomIdx]
+			oid = strings.Join(oidParts, ".")
+		}
+
+		require.False(t, IsValidOID(oid), "OID: %s", oid)
+	}
 }
 
 func updateResolverWithIntermediateJSONReader(t *testing.T, oidResolver *MultiFilesOIDResolver, trapData trapDBFileContent) {

--- a/pkg/snmp/traps/oid_resolver_test.go
+++ b/pkg/snmp/traps/oid_resolver_test.go
@@ -320,11 +320,12 @@ func TestIsValidOID(t *testing.T) {
 
 	}
 
-	var invalidRunes = []rune(",.?><|\\}{[]()*&^%$#@!abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	var invalidRunes = []rune(",?><|\\}{[]()*&^%$#@!abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 	for i := 0; i < testSize; i++ {
 		// Valid cases
 		oid := validOIDs[i]
-		switch rand.Intn(3) {
+		x := 0
+		switch x = rand.Intn(3); x {
 		case 0:
 			// Append a dot at the end, this is not possible
 			oid = oid + "."
@@ -340,7 +341,6 @@ func TestIsValidOID(t *testing.T) {
 			oidParts[randomIdx] = "." + oidParts[randomIdx]
 			oid = strings.Join(oidParts, ".")
 		}
-
 		require.False(t, IsValidOID(oid), "OID: %s", oid)
 	}
 }

--- a/pkg/snmp/traps/traps_db.go
+++ b/pkg/snmp/traps/traps_db.go
@@ -7,10 +7,10 @@ package traps
 
 // VariableMetadata is the MIB-extracted information of a given trap variable
 type VariableMetadata struct {
-	Name        string         `yaml:"name" json:"name"`
-	Description string         `yaml:"descr" json:"descr"`
-	Enumeration map[int]string `yaml:"enum" json:"enum"`
-	isNode      bool
+	Name               string         `yaml:"name" json:"name"`
+	Description        string         `yaml:"descr" json:"descr"`
+	Enumeration        map[int]string `yaml:"enum" json:"enum"`
+	isIntermediateNode bool
 	// In theory, variables should always be leaves of the OID tree as intermediate nodes do not contain data.
 	// This isn't true in practice (see 1.3.6.1.4.1.4962.2.1.6.3).
 	// Variables are resolved by 'climbing' up the OID tree until finding a match, but variables that are known to be nodes

--- a/pkg/snmp/traps/traps_db.go
+++ b/pkg/snmp/traps/traps_db.go
@@ -10,6 +10,11 @@ type VariableMetadata struct {
 	Name        string         `yaml:"name" json:"name"`
 	Description string         `yaml:"descr" json:"descr"`
 	Enumeration map[int]string `yaml:"enum" json:"enum"`
+	isNode      bool
+	// In theory, variables should always be leaves of the OID tree as intermediate nodes do not contain data.
+	// This isn't true in practice (see 1.3.6.1.4.1.4962.2.1.6.3).
+	// Variables are resolved by 'climbing' up the OID tree until finding a match, but variables that are known to be nodes
+	// should never be used for resolving.
 }
 
 // variableSpec contains the variableMetadata for each known variable of a given trap db file

--- a/releasenotes/notes/Traps---Resolve-table-variables-that-have-a-suffix-fec0f41479599210.yaml
+++ b/releasenotes/notes/Traps---Resolve-table-variables-that-have-a-suffix-fec0f41479599210.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Traps variable OIDs that had the index as a suffix are now correctly resolved.


### PR DESCRIPTION
Trap variable OIDs coming from tables may have an "index" suffix at the end which represents the index (or row) of the data in the table.
To correctly resolve these OIDs we need to strip the suffix.

Unfortunately there is no way to detect which part of the OID is the suffix and which one is the actual variable name. Our only option is to "climb the OID tree" until we find a match.
Such a strategy should work in most case but we should be extra careful that climbing up the tree does not make the Agent resolve the wrong OID. In theory it should work fine because all OIDs in the trapsDB are "leaves" of the OID tree. 
In practice this doesn't work because:
- Some MIBs don't care and have OIDs nodes that act both as a parent and as a leaf.
- TrapsDB is user configurable, so we have to expect bad configuration were a user inputs a "parent" OID


To solve these issues, on top of adding this "climbing up the tree strategy", this PR also:
- Validate OIDs from the trapsDB to make sure they are OIDs and not something else.
- When loading trapsDB file, OIDs are compared to try to find "OIDs" that are both defined in the trapsDB file and that are a parent of other OIDs. These nodes are marked as "isNode: true", and will stop the "climbing up the tree strategy" when ecountered.
- To compare OIDs in a smart and efficient way, all OIDs are sorted as string in the lexicographic order (dots are before digits). This has the effect of putting "children" right after "parents" so we just have to compare OIDs with their successor