### PR TITLE
Fix a guard ensuring that the arithmetic expression used in allocation cannot overflow

### DIFF
--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -217,8 +217,8 @@ func (ku *KubeUtil) GetLocalPodList(ctx context.Context) ([]*Pod, error) {
 			// Limits hardcoded here are huge enough to never be hit.
 			if len(pod.Status.Containers) > 10000 ||
 				len(pod.Status.InitContainers) > 10000 {
-				log.Errorf("pod %s has a crazy number of containers: %d or init containers: %d. Skipping it!",
-					pod.Metadata.UID, len(pod.Spec.Containers), len(pod.Spec.InitContainers))
+				log.Errorf("Pod %s has a crazy number of containers: %d or init containers: %d. Skipping it!",
+					pod.Metadata.UID, len(pod.Status.Containers), len(pod.Status.InitContainers))
 				continue
 			}
 			allContainers := make([]ContainerStatus, 0, len(pod.Status.InitContainers)+len(pod.Status.Containers))

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -215,8 +215,8 @@ func (ku *KubeUtil) GetLocalPodList(ctx context.Context) ([]*Pod, error) {
 		if pod != nil {
 			// Validate allocation size.
 			// Limits hardcoded here are huge enough to never be hit.
-			if len(pod.Spec.Containers) > 10000 ||
-				len(pod.Spec.InitContainers) > 10000 {
+			if len(pod.Status.Containers) > 10000 ||
+				len(pod.Status.InitContainers) > 10000 {
 				log.Errorf("pod %s has a crazy number of containers: %d or init containers: %d. Skipping it!",
 					pod.Metadata.UID, len(pod.Spec.Containers), len(pod.Spec.InitContainers))
 				continue


### PR DESCRIPTION
### What does this PR do?

Fix a guard ensuring that the arithmetic expression used in allocation cannot overflow.

The allocation was using `len(pod.Status.Containers)` and the guard was wrongly checking `len(pod.Spec.Containers)` instead.

### Motivation

Make static code analyser happy.

Fix
* https://github.com/DataDog/datadog-agent/security/code-scanning/80
* https://github.com/DataDog/datadog-agent/security/code-scanning/81


In practice, triggering the overflow would require to create a pod with 2⁶⁴ containers. The machine would have blown up before this overflow would become problematic.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
