### PR TITLE
[process-agent] Collect exit code for exit events

### DIFF
--- a/cmd/process-agent/app/events.go
+++ b/cmd/process-agent/app/events.go
@@ -244,7 +244,7 @@ func fmtProcessEvents(events []*model.ProcessEvent) []*payload.ProcessEvent {
 			exit := &payload.ProcessExit{
 				ExecTime: e.ExecTime.UnixNano(),
 				ExitTime: e.ExitTime.UnixNano(),
-				ExitCode: 0,
+				ExitCode: int32(e.ExitCode),
 			}
 			pE.TypedEvent = &payload.ProcessEvent_Exit{Exit: exit}
 		default:

--- a/pkg/process/checks/process_events_linux.go
+++ b/pkg/process/checks/process_events_linux.go
@@ -188,7 +188,7 @@ func fmtProcessEvents(events []*model.ProcessEvent) []*payload.ProcessEvent {
 			exit := &payload.ProcessExit{
 				ExecTime: e.ExecTime.UnixNano(),
 				ExitTime: e.ExitTime.UnixNano(),
-				ExitCode: 0,
+				ExitCode: int32(e.ExitCode),
 			}
 			pE.TypedEvent = &payload.ProcessEvent_Exit{Exit: exit}
 		default:

--- a/pkg/process/checks/process_events_linux_test.go
+++ b/pkg/process/checks/process_events_linux_test.go
@@ -125,6 +125,7 @@ func mockedData(t *testing.T) []*eventTestData {
 						},
 					},
 				},
+				ExitCode: 0,
 			},
 			payloadEvent: &payload.ProcessEvent{
 				Type:           payload.ProcEventType_exit,
@@ -145,6 +146,123 @@ func mockedData(t *testing.T) []*eventTestData {
 					Exit: &payload.ProcessExit{
 						ExecTime: parseRFC3339Time(t, "2022-06-12T12:00:02Z").UnixNano(),
 						ExitTime: parseRFC3339Time(t, "2022-06-12T12:00:12Z").UnixNano(),
+						ExitCode: 0,
+					},
+				},
+			},
+		},
+		{
+			rawEvent: &model.ProcessMonitoringEvent{
+				EventType:      "exec",
+				CollectionTime: parseRFC3339Time(t, "2022-06-12T12:00:14Z"),
+				ProcessCacheEntry: &secmodel.ProcessCacheEntry{
+					ProcessContext: secmodel.ProcessContext{
+						Process: secmodel.Process{
+							PIDContext: secmodel.PIDContext{
+								Pid: 1010,
+							},
+							ContainerID: "0123456789abcdef",
+							PPid:        1,
+							Credentials: secmodel.Credentials{
+								UID:   100,
+								GID:   100,
+								User:  "user",
+								Group: "mygroup",
+							},
+							FileEvent: secmodel.FileEvent{
+								PathnameStr: "/usr/bin/ls",
+							},
+							ArgsEntry: &secmodel.ArgsEntry{
+								Values: []string{
+									"ls",
+									"invalid-path",
+								},
+							},
+							ForkTime: parseRFC3339Time(t, "2022-06-12T12:00:11Z"),
+							ExecTime: parseRFC3339Time(t, "2022-06-12T12:00:12Z"),
+							ExitTime: time.Time{},
+						},
+					},
+				},
+			},
+			payloadEvent: &payload.ProcessEvent{
+				Type:           payload.ProcEventType_exec,
+				CollectionTime: parseRFC3339Time(t, "2022-06-12T12:00:14Z").UnixNano(),
+				Pid:            1010,
+				ContainerId:    "0123456789abcdef",
+				Command: &payload.Command{
+					Exe:  "/usr/bin/ls",
+					Args: []string{"ls", "invalid-path"},
+					Ppid: 1,
+				},
+				User: &payload.ProcessUser{
+					Name: "user",
+					Uid:  100,
+					Gid:  100,
+				},
+				TypedEvent: &payload.ProcessEvent_Exec{
+					Exec: &payload.ProcessExec{
+						ForkTime: parseRFC3339Time(t, "2022-06-12T12:00:11Z").UnixNano(),
+						ExecTime: parseRFC3339Time(t, "2022-06-12T12:00:12Z").UnixNano(),
+					},
+				},
+			},
+		},
+		{
+			rawEvent: &model.ProcessMonitoringEvent{
+				EventType:      "exit",
+				CollectionTime: parseRFC3339Time(t, "2022-06-12T12:00:14Z"),
+				ProcessCacheEntry: &secmodel.ProcessCacheEntry{
+					ProcessContext: secmodel.ProcessContext{
+						Process: secmodel.Process{
+							PIDContext: secmodel.PIDContext{
+								Pid: 1010,
+							},
+							ContainerID: "0123456789abcdef",
+							PPid:        1,
+							Credentials: secmodel.Credentials{
+								UID:   100,
+								GID:   100,
+								User:  "user",
+								Group: "mygroup",
+							},
+							FileEvent: secmodel.FileEvent{
+								PathnameStr: "/usr/bin/ls",
+							},
+							ArgsEntry: &secmodel.ArgsEntry{
+								Values: []string{
+									"ls",
+									"invalid-path",
+								},
+							},
+							ForkTime: parseRFC3339Time(t, "2022-06-12T12:00:11Z"),
+							ExecTime: parseRFC3339Time(t, "2022-06-12T12:00:12Z"),
+							ExitTime: parseRFC3339Time(t, "2022-06-12T12:00:13Z"),
+						},
+					},
+				},
+				ExitCode: 2,
+			},
+			payloadEvent: &payload.ProcessEvent{
+				Type:           payload.ProcEventType_exit,
+				CollectionTime: parseRFC3339Time(t, "2022-06-12T12:00:14Z").UnixNano(),
+				Pid:            1010,
+				ContainerId:    "0123456789abcdef",
+				Command: &payload.Command{
+					Exe:  "/usr/bin/ls",
+					Args: []string{"ls", "invalid-path"},
+					Ppid: 1,
+				},
+				User: &payload.ProcessUser{
+					Name: "user",
+					Uid:  100,
+					Gid:  100,
+				},
+				TypedEvent: &payload.ProcessEvent_Exit{
+					Exit: &payload.ProcessExit{
+						ExecTime: parseRFC3339Time(t, "2022-06-12T12:00:12Z").UnixNano(),
+						ExitTime: parseRFC3339Time(t, "2022-06-12T12:00:13Z").UnixNano(),
+						ExitCode: 2,
 					},
 				},
 			},

--- a/pkg/process/events/listener_linux_test.go
+++ b/pkg/process/events/listener_linux_test.go
@@ -29,16 +29,16 @@ func TestProcessEventFiltering(t *testing.T) {
 	handlers := make([]EventHandler, 0)
 
 	// The listener should drop unexpected events and not call the EventHandler for it
-	rawEvents = append(rawEvents, model.NewMockedProcessMonitoringEvent(model.Fork, time.Now(), 23, "/usr/bin/ls", []string{"ls", "-lah"}))
+	rawEvents = append(rawEvents, model.ProcessEventToProcessMonitoringEvent(model.NewMockedForkEvent(time.Now(), 23, "/usr/bin/ls", []string{"ls", "-lah"})))
 
 	// Verify that expected events are correctly consumed
-	rawEvents = append(rawEvents, model.NewMockedProcessMonitoringEvent(model.Exec, time.Now(), 23, "/usr/bin/ls", []string{"ls", "-lah"}))
+	rawEvents = append(rawEvents, model.ProcessEventToProcessMonitoringEvent(model.NewMockedExecEvent(time.Now(), 23, "/usr/bin/ls", []string{"ls", "-lah"})))
 	handlers = append(handlers, func(e *model.ProcessEvent) {
 		require.Equal(t, model.Exec, e.EventType)
 		require.Equal(t, uint32(23), e.Pid)
 	})
 
-	rawEvents = append(rawEvents, model.NewMockedProcessMonitoringEvent(model.Exit, time.Now(), 23, "/usr/bin/ls", []string{"ls", "-lah"}))
+	rawEvents = append(rawEvents, model.ProcessEventToProcessMonitoringEvent(model.NewMockedExitEvent(time.Now(), 23, "/usr/bin/ls", []string{"ls", "-lah"}, 0)))
 	handlers = append(handlers, func(e *model.ProcessEvent) {
 		require.Equal(t, model.Exit, e.EventType)
 		require.Equal(t, uint32(23), e.Pid)
@@ -70,28 +70,11 @@ func TestProcessEventHandling(t *testing.T) {
 	stream := mocks.NewSecurityModule_GetProcessEventsClient(t)
 	client.On("GetProcessEvents", ctx, &api.GetProcessEventParams{}).Return(stream, nil)
 
-	now := time.Now()
 	events := make([]*model.ProcessEvent, 0)
-	e1 := model.ProcessEvent{
-		EventType:      model.Exec,
-		CollectionTime: now,
-		Pid:            32,
-		ContainerID:    "01234567890abcdef",
-		Ppid:           1,
-		UID:            124,
-		GID:            2,
-		Username:       "agent",
-		Group:          "dd-agent",
-		Exe:            "/usr/bin/ls",
-		Cmdline:        []string{"ls", "-lah"},
-		ExecTime:       time.Now().Add(-10 * time.Second),
-	}
-	events = append(events, &e1)
-
-	e2 := e1
-	e2.EventType = model.Exit
-	e2.ExitTime = time.Now().Add(-2 * time.Second)
-	events = append(events, &e2)
+	events = append(events, model.NewMockedExecEvent(time.Now().Add(-10*time.Second), 32, "/usr/bin/ls", []string{"ls", "-lah"}))
+	events = append(events, model.NewMockedExitEvent(time.Now().Add(-9*time.Second), 32, "/usr/bin/ls", []string{"ls", "-lah"}, 0))
+	events = append(events, model.NewMockedExecEvent(time.Now().Add(-5*time.Second), 32, "/usr/bin/ls", []string{"ls", "invalid-path"}))
+	events = append(events, model.NewMockedExitEvent(time.Now().Add(-5*time.Second), 32, "/usr/bin/ls", []string{"ls", "invalid-path"}, 2))
 
 	for _, e := range events {
 		sysEvent := model.ProcessEventToProcessMonitoringEvent(e)

--- a/pkg/process/events/model/model_common.go
+++ b/pkg/process/events/model/model_common.go
@@ -12,18 +12,47 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// EventType represents the type of the process lifecycle event
+type EventType int32
+
 const (
-	// Exec TODO <processes>
-	Exec = "exec"
-	// Fork TODO <processes>
-	Fork = "fork"
-	// Exit TODO <processes>
-	Exit = "exit"
+	// Fork represents a process fork event
+	Fork EventType = iota
+	// Exec represents a process exec event
+	Exec
+	// Exit represents a process exit event
+	Exit
 )
+
+// String returns the string representation of an EventType
+func (e EventType) String() string {
+	switch e {
+	case Fork:
+		return "fork"
+	case Exec:
+		return "exec"
+	case Exit:
+		return "exit"
+	}
+	return "unknown"
+}
+
+// NewEventType returns the EventType associated with a string
+func NewEventType(eventType string) EventType {
+	switch eventType {
+	case Fork.String():
+		return Fork
+	case Exec.String():
+		return Exec
+	case Exit.String():
+		return Exit
+	}
+	return -1
+}
 
 // ProcessEvent is a common interface for collected process events shared across multiple event listener implementations
 type ProcessEvent struct {
-	EventType      string    `json:"event_type"`
+	EventType      EventType `json:"event_type"`
 	CollectionTime time.Time `json:"collection_time"`
 	Pid            uint32    `json:"pid"`
 	ContainerID    string    `json:"container_id"`
@@ -37,22 +66,13 @@ type ProcessEvent struct {
 	ForkTime       time.Time `json:"fork_time,omitempty"`
 	ExecTime       time.Time `json:"exec_time,omitempty"`
 	ExitTime       time.Time `json:"exit_time,omitempty"`
+	ExitCode       uint32    `json:"exit_code,omitempty"`
 }
 
-// NewMockedProcessEvent creates a mocked ProcessEvent for tests
-func NewMockedProcessEvent(evtType string, ts time.Time, pid uint32, exe string, args []string) *ProcessEvent {
-	var forkTime, execTime, exitTime time.Time
-	switch evtType {
-	case Fork:
-		forkTime = ts
-	case Exec:
-		execTime = ts
-	case Exit:
-		exitTime = ts
-	}
-
+// NewMockedForkEvent creates a mocked Fork event for tests
+func NewMockedForkEvent(ts time.Time, pid uint32, exe string, args []string) *ProcessEvent {
 	return &ProcessEvent{
-		EventType:      evtType,
+		EventType:      Fork,
 		CollectionTime: time.Now(),
 		Pid:            pid,
 		ContainerID:    "01234567890abcedf",
@@ -63,9 +83,47 @@ func NewMockedProcessEvent(evtType string, ts time.Time, pid uint32, exe string,
 		Group:          "dd-agent",
 		Exe:            exe,
 		Cmdline:        args,
-		ForkTime:       forkTime,
-		ExecTime:       execTime,
-		ExitTime:       exitTime,
+		ForkTime:       ts,
+	}
+}
+
+// NewMockedExecEvent creates a mocked Exec event for tests
+func NewMockedExecEvent(ts time.Time, pid uint32, exe string, args []string) *ProcessEvent {
+	return &ProcessEvent{
+		EventType:      Exec,
+		CollectionTime: time.Now(),
+		Pid:            pid,
+		ContainerID:    "01234567890abcedf",
+		Ppid:           1,
+		UID:            100,
+		GID:            100,
+		Username:       "dog",
+		Group:          "dd-agent",
+		Exe:            exe,
+		Cmdline:        args,
+		ForkTime:       ts,
+		ExecTime:       ts,
+	}
+}
+
+// NewMockedExitEvent creates a mocked Exit event for tests
+func NewMockedExitEvent(ts time.Time, pid uint32, exe string, args []string, code uint32) *ProcessEvent {
+	return &ProcessEvent{
+		EventType:      Exit,
+		CollectionTime: time.Now(),
+		Pid:            pid,
+		ContainerID:    "01234567890abcedf",
+		Ppid:           1,
+		UID:            100,
+		GID:            100,
+		Username:       "dog",
+		Group:          "dd-agent",
+		Exe:            exe,
+		Cmdline:        args,
+		ForkTime:       ts.Add(-10 * time.Second),
+		ExecTime:       ts.Add(-10 * time.Second),
+		ExitTime:       ts,
+		ExitCode:       code,
 	}
 }
 
@@ -88,4 +146,5 @@ func AssertProcessEvents(t *testing.T, expected, actual *ProcessEvent) {
 	assert.WithinDuration(t, expected.ForkTime, actual.ForkTime, 0)
 	assert.WithinDuration(t, expected.ExecTime, actual.ExecTime, 0)
 	assert.WithinDuration(t, expected.ExitTime, actual.ExitTime, 0)
+	assert.Equal(t, expected.ExitCode, actual.ExitCode)
 }

--- a/pkg/process/events/model/model_sysprobe.go
+++ b/pkg/process/events/model/model_sysprobe.go
@@ -18,6 +18,7 @@ type ProcessMonitoringEvent struct {
 	*model.ProcessCacheEntry
 	EventType      string    `json:"EventType" msg:"evt_type"`
 	CollectionTime time.Time `json:"CollectionTime" msg:"collection_time"`
+	ExitCode       uint32    `json:"ExitCode" msg:"exit_code"`
 }
 
 // ProcessMonitoringToProcessEvent converts a ProcessMonitoringEvent to a generic ProcessEvent
@@ -28,7 +29,7 @@ func ProcessMonitoringToProcessEvent(e *ProcessMonitoringEvent) *ProcessEvent {
 	}
 
 	return &ProcessEvent{
-		EventType:      e.EventType,
+		EventType:      NewEventType(e.EventType),
 		CollectionTime: e.CollectionTime,
 		Pid:            e.Pid,
 		ContainerID:    e.ContainerID,
@@ -42,6 +43,7 @@ func ProcessMonitoringToProcessEvent(e *ProcessMonitoringEvent) *ProcessEvent {
 		ForkTime:       e.ForkTime,
 		ExecTime:       e.ExecTime,
 		ExitTime:       e.ExitTime,
+		ExitCode:       e.ExitCode,
 	}
 }
 
@@ -49,7 +51,7 @@ func ProcessMonitoringToProcessEvent(e *ProcessMonitoringEvent) *ProcessEvent {
 // It's used during tests to mock a ProcessMonitoringEvent message
 func ProcessEventToProcessMonitoringEvent(e *ProcessEvent) *ProcessMonitoringEvent {
 	return &ProcessMonitoringEvent{
-		EventType:      e.EventType,
+		EventType:      e.EventType.String(),
 		CollectionTime: e.CollectionTime,
 		ProcessCacheEntry: &model.ProcessCacheEntry{
 			ProcessContext: model.ProcessContext{
@@ -77,48 +79,6 @@ func ProcessEventToProcessMonitoringEvent(e *ProcessEvent) *ProcessMonitoringEve
 				},
 			},
 		},
-	}
-}
-
-// NewMockedProcessMonitoringEvent returns a new mocked ProcessMonitoringEvent
-func NewMockedProcessMonitoringEvent(evtType string, ts time.Time, pid uint32, exe string, args []string) *ProcessMonitoringEvent {
-	var forkTime, execTime, exitTime time.Time
-	switch evtType {
-	case Fork:
-		forkTime = ts
-	case Exec:
-		execTime = ts
-	case Exit:
-		exitTime = ts
-	}
-
-	return &ProcessMonitoringEvent{
-		EventType:      evtType,
-		CollectionTime: time.Now(),
-		ProcessCacheEntry: &model.ProcessCacheEntry{
-			ProcessContext: model.ProcessContext{
-				Process: model.Process{
-					PIDContext: model.PIDContext{
-						Pid: pid,
-					},
-					PPid: 1,
-					Credentials: model.Credentials{
-						UID:   100,
-						GID:   100,
-						User:  "dog",
-						Group: "dd-agent",
-					},
-					FileEvent: model.FileEvent{
-						PathnameStr: exe,
-					},
-					ArgsEntry: &model.ArgsEntry{
-						Values: args,
-					},
-					ForkTime: forkTime,
-					ExecTime: execTime,
-					ExitTime: exitTime,
-				},
-			},
-		},
+		ExitCode: e.ExitCode,
 	}
 }

--- a/pkg/process/events/model/model_sysprobe_gen.go
+++ b/pkg/process/events/model/model_sysprobe_gen.go
@@ -55,6 +55,12 @@ func (z *ProcessMonitoringEvent) DecodeMsg(dc *msgp.Reader) (err error) {
 				err = msgp.WrapError(err, "CollectionTime")
 				return
 			}
+		case "exit_code":
+			z.ExitCode, err = dc.ReadUint32()
+			if err != nil {
+				err = msgp.WrapError(err, "ExitCode")
+				return
+			}
 		default:
 			err = dc.Skip()
 			if err != nil {
@@ -68,9 +74,9 @@ func (z *ProcessMonitoringEvent) DecodeMsg(dc *msgp.Reader) (err error) {
 
 // EncodeMsg implements msgp.Encodable
 func (z *ProcessMonitoringEvent) EncodeMsg(en *msgp.Writer) (err error) {
-	// map header, size 3
+	// map header, size 4
 	// write "ProcessCacheEntry"
-	err = en.Append(0x83, 0xb1, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x43, 0x61, 0x63, 0x68, 0x65, 0x45, 0x6e, 0x74, 0x72, 0x79)
+	err = en.Append(0x84, 0xb1, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x43, 0x61, 0x63, 0x68, 0x65, 0x45, 0x6e, 0x74, 0x72, 0x79)
 	if err != nil {
 		return
 	}
@@ -106,15 +112,25 @@ func (z *ProcessMonitoringEvent) EncodeMsg(en *msgp.Writer) (err error) {
 		err = msgp.WrapError(err, "CollectionTime")
 		return
 	}
+	// write "exit_code"
+	err = en.Append(0xa9, 0x65, 0x78, 0x69, 0x74, 0x5f, 0x63, 0x6f, 0x64, 0x65)
+	if err != nil {
+		return
+	}
+	err = en.WriteUint32(z.ExitCode)
+	if err != nil {
+		err = msgp.WrapError(err, "ExitCode")
+		return
+	}
 	return
 }
 
 // MarshalMsg implements msgp.Marshaler
 func (z *ProcessMonitoringEvent) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
-	// map header, size 3
+	// map header, size 4
 	// string "ProcessCacheEntry"
-	o = append(o, 0x83, 0xb1, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x43, 0x61, 0x63, 0x68, 0x65, 0x45, 0x6e, 0x74, 0x72, 0x79)
+	o = append(o, 0x84, 0xb1, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x43, 0x61, 0x63, 0x68, 0x65, 0x45, 0x6e, 0x74, 0x72, 0x79)
 	if z.ProcessCacheEntry == nil {
 		o = msgp.AppendNil(o)
 	} else {
@@ -130,6 +146,9 @@ func (z *ProcessMonitoringEvent) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "collection_time"
 	o = append(o, 0xaf, 0x63, 0x6f, 0x6c, 0x6c, 0x65, 0x63, 0x74, 0x69, 0x6f, 0x6e, 0x5f, 0x74, 0x69, 0x6d, 0x65)
 	o = msgp.AppendTime(o, z.CollectionTime)
+	// string "exit_code"
+	o = append(o, 0xa9, 0x65, 0x78, 0x69, 0x74, 0x5f, 0x63, 0x6f, 0x64, 0x65)
+	o = msgp.AppendUint32(o, z.ExitCode)
 	return
 }
 
@@ -180,6 +199,12 @@ func (z *ProcessMonitoringEvent) UnmarshalMsg(bts []byte) (o []byte, err error) 
 				err = msgp.WrapError(err, "CollectionTime")
 				return
 			}
+		case "exit_code":
+			z.ExitCode, bts, err = msgp.ReadUint32Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "ExitCode")
+				return
+			}
 		default:
 			bts, err = msgp.Skip(bts)
 			if err != nil {
@@ -200,6 +225,6 @@ func (z *ProcessMonitoringEvent) Msgsize() (s int) {
 	} else {
 		s += z.ProcessCacheEntry.Msgsize()
 	}
-	s += 9 + msgp.StringPrefixSize + len(z.EventType) + 16 + msgp.TimeSize
+	s += 9 + msgp.StringPrefixSize + len(z.EventType) + 16 + msgp.TimeSize + 10 + msgp.Uint32Size
 	return
 }

--- a/pkg/process/events/model/serialization_test.go
+++ b/pkg/process/events/model/serialization_test.go
@@ -20,7 +20,7 @@ func newBenchmarkProcessEvent(argCount int) *ProcessMonitoringEvent {
 		args = append(args, fmt.Sprintf("arg_%d", i))
 	}
 
-	return NewMockedProcessMonitoringEvent(Exit, time.Now(), 42, "/usr/bin/exe", args)
+	return ProcessEventToProcessMonitoringEvent(NewMockedExitEvent(time.Now(), 42, "/usr/bin/exe", args, 0))
 }
 
 // Benchmark between JSON and messagePack serialization changing the command-line length of the collected event

--- a/pkg/process/events/store_test.go
+++ b/pkg/process/events/store_test.go
@@ -43,9 +43,9 @@ func TestRingStoreWithoutLoop(t *testing.T) {
 	s.Run()
 	defer s.Stop()
 
-	e1 := model.NewMockedProcessEvent(model.Exec, now, 23, "/usr/bin/curl", []string{"curl", "localhost:6062"})
-	e2 := model.NewMockedProcessEvent(model.Exit, now, 23, "/usr/bin/curl", []string{"curl", "localhost:6062"})
-	e3 := model.NewMockedProcessEvent(model.Exit, now, 23, "/usr/bin/ls", []string{"ls", "-lah"})
+	e1 := model.NewMockedExecEvent(now, 23, "/usr/bin/curl", []string{"curl", "localhost:6062"})
+	e2 := model.NewMockedExitEvent(now, 23, "/usr/bin/curl", []string{"curl", "localhost:6062"}, 0)
+	e3 := model.NewMockedExecEvent(now, 23, "/usr/bin/ls", []string{"ls", "-lah"})
 
 	// Push and pull 1 event
 	pushSync(t, s, e1)
@@ -92,9 +92,9 @@ func TestRingStoreWithLoop(t *testing.T) {
 	s, ok := store.(*RingStore)
 	require.True(t, ok)
 
-	e1 := model.NewMockedProcessEvent(model.Exec, now, 23, "/usr/bin/curl", []string{"curl", "localhost:6062"})
-	e2 := model.NewMockedProcessEvent(model.Exit, now, 23, "/usr/bin/curl", []string{"curl", "localhost:6062"})
-	e3 := model.NewMockedProcessEvent(model.Exit, now, 23, "/usr/bin/ls", []string{"ls", "-lah"})
+	e1 := model.NewMockedExecEvent(now, 23, "/usr/bin/curl", []string{"curl", "localhost:6062"})
+	e2 := model.NewMockedExitEvent(now, 23, "/usr/bin/curl", []string{"curl", "localhost:6062"}, 0)
+	e3 := model.NewMockedExecEvent(now, 23, "/usr/bin/ls", []string{"ls", "-lah"})
 
 	// Initialize store with len(buffer)-1 events that have already been consumed
 	s.head = 2
@@ -151,10 +151,10 @@ func TestRingStoreWithDroppedData(t *testing.T) {
 	s.Run()
 	defer s.Stop()
 
-	e1 := model.NewMockedProcessEvent(model.Exec, now, 23, "/usr/bin/curl", []string{"curl", "localhost:6062"})
-	e2 := model.NewMockedProcessEvent(model.Exit, now, 23, "/usr/bin/curl", []string{"curl", "localhost:6062"})
-	e3 := model.NewMockedProcessEvent(model.Exit, now, 23, "/usr/bin/ls", []string{"ls", "-lah"})
-	e4 := model.NewMockedProcessEvent(model.Exit, now, 23, "/usr/bin/ls", []string{"ls", "-lah"})
+	e1 := model.NewMockedExecEvent(now, 23, "/usr/bin/curl", []string{"curl", "localhost:6062"})
+	e2 := model.NewMockedExitEvent(now, 23, "/usr/bin/curl", []string{"curl", "localhost:6062"}, 0)
+	e3 := model.NewMockedExecEvent(now, 23, "/usr/bin/ls", []string{"ls", "-lah"})
+	e4 := model.NewMockedExitEvent(now, 23, "/usr/bin/ls", []string{"ls", "-lah"}, 0)
 
 	// Fill up buffer
 	pushSync(t, s, e1)
@@ -207,8 +207,8 @@ func TestRingStoreAsynchronousPush(t *testing.T) {
 	s.Run()
 	defer s.Stop()
 
-	e1 := model.NewMockedProcessEvent(model.Exec, now, 23, "/usr/bin/curl", []string{"curl", "localhost:6062"})
-	e2 := model.NewMockedProcessEvent(model.Exit, now, 23, "/usr/bin/curl", []string{"curl", "localhost:6062"})
+	e1 := model.NewMockedExecEvent(now, 23, "/usr/bin/curl", []string{"curl", "localhost:6062"})
+	e2 := model.NewMockedExitEvent(now, 23, "/usr/bin/curl", []string{"curl", "localhost:6062"}, 0)
 	err = s.Push(e1, nil)
 	require.NoError(t, err)
 
@@ -272,7 +272,7 @@ func TestRingStorePushErrors(t *testing.T) {
 	s, ok := store.(*RingStore)
 	require.True(t, ok)
 
-	e := model.NewMockedProcessEvent(model.Exec, time.Now(), 23, "/usr/bin/curl", []string{"curl", "localhost:6062"})
+	e := model.NewMockedExecEvent(time.Now(), 23, "/usr/bin/curl", []string{"curl", "localhost:6062"})
 
 	// Do not start the store in order to queue push requests
 	for i := 0; i < maxPushes; i++ {

--- a/pkg/security/module/process_monitor.go
+++ b/pkg/security/module/process_monitor.go
@@ -35,6 +35,7 @@ func (p *ProcessMonitoring) HandleEvent(event *sprobe.Event) {
 		ProcessCacheEntry: entry,
 		EventType:         event.GetEventType().String(),
 		CollectionTime:    event.Timestamp,
+		ExitCode:          event.Exit.Code,
 	}
 
 	data, err := e.MarshalMsg(nil)


### PR DESCRIPTION
### What does this PR do?

This PR extends the `ProcessMonitoring` handler in the `runtime-security` module to export the exit code collected with exit events. The exit code collection has been added on the eBPF side by https://github.com/DataDog/datadog-agent/pull/12116.

The following changes have been introduced:
* Add the `ExitCode` to the `ProcessMonitoringEvent` and regenerate the msgpack marshaling/unmarshaling functions
* Create the `EventType` type to avoid handling it as plain string
* Split `NewMockedProcessEvent` into functions to generate fork/exec/exit events
* Remove `NewMockedProcessMonitoringEvent` and rely on the new mocked functions instead

### Motivation

Collect exit code with exit events.

### Additional Notes

Since the `process_events` check is in alpha phase, we're not advertising it on the CHANGELOG.

### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes

On Linux, update the `system-probe.yaml` file with
```
runtime_security_config:
  event_monitoring:
    enabled: true
```

Start the `datadog-agent` and make sure that `system-probe` is running. 

Start listening for process events with `process-agent`:
```
sudo ./process-agent events listen
```

Execute a `ls` command and make sure that the listen command outputs it with `ExitCode: 0`. Execute `ls invalid-path` and make sure that this time the listen command outputs `ExitCode: 2` for the associated process.

Run a `process_events` check manually for 10s with:
```
sudo ./process-agent check process_events -w 10s
```

While `process-agent` is listening for events, execute `ls` and `ls invalid-path`. Make sure that the check output shows the correct exit code for each one of them.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
