### PR TITLE
[CWS] fix discarder with symlink

### DIFF
--- a/pkg/security/probe/discarders.go
+++ b/pkg/security/probe/discarders.go
@@ -41,7 +41,7 @@ const (
 	maxParentDiscarderDepth = 3
 
 	// allEventTypes is a mask to match all the events
-	allEventTypes = 0xffffffffffffffff
+	allEventTypes = math.MaxUint32
 
 	// inode/mountid that won't be resubmitted
 	maxRecentlyAddedCacheSize = uint64(64)

--- a/pkg/security/probe/discarders_test.go
+++ b/pkg/security/probe/discarders_test.go
@@ -332,6 +332,60 @@ func TestIsGrandParentDiscarder(t *testing.T) {
 	}
 }
 
+type testEventListener struct {
+	fields map[eval.Field]int
+}
+
+func (l *testEventListener) RuleMatch(rule *rules.Rule, event eval.Event) {}
+
+func (l *testEventListener) EventDiscarderFound(rs *rules.RuleSet, event eval.Event, field eval.Field, eventType eval.EventType) {
+	if l.fields == nil {
+		l.fields = make(map[eval.Field]int)
+	}
+	l.fields[field]++
+}
+
+func TestIsDiscarderOverride(t *testing.T) {
+	enabled := map[eval.EventType]bool{"*": true}
+
+	var evalOpts eval.Opts
+	evalOpts.
+		WithConstants(model.SECLConstants).
+		WithLegacyFields(model.SECLLegacyFields)
+
+	var opts rules.Opts
+	opts.
+		WithEventTypeEnabled(enabled).
+		WithLogger(&seclog.PatternLogger{})
+
+	var listener testEventListener
+
+	rs := rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs.AddListener(&listener)
+	addRuleExpr(t, rs, `unlink.file.path == "/var/log/httpd" && process.file.path == "/bin/touch"`)
+
+	var event Event
+	event.Init()
+
+	event.Type = uint32(model.FileUnlinkEventType)
+	event.SetFieldValue("unlink.file.path", "/var/log/httpd")
+	event.SetFieldValue("process.file.path", "/bin/touch")
+
+	rs.Evaluate(&event)
+
+	if listener.fields["process.file.path"] > 0 {
+		t.Error("shouldn't get a discarder")
+	}
+
+	event.SetFieldValue("process.file.path", "/bin/cat")
+
+	rs.Evaluate(&event)
+
+	if listener.fields["process.file.path"] == 0 {
+		t.Error("should get a discarder")
+	}
+}
+
 func BenchmarkParentDiscarder(b *testing.B) {
 	id, _ := newInodeDiscarders(nil, nil, nil, nil)
 

--- a/pkg/security/secl/model/events.go
+++ b/pkg/security/secl/model/events.go
@@ -8,7 +8,7 @@ package model
 import "github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 
 // EventType describes the type of an event sent from the kernel
-type EventType uint64
+type EventType uint32
 
 const (
 	// UnknownEventType unknow event

--- a/pkg/security/secl/model/oo_symlink.go
+++ b/pkg/security/secl/model/oo_symlink.go
@@ -10,31 +10,40 @@ import (
 )
 
 var (
-	symlinkPathnameEvaluators = [MaxSymlinks]*eval.StringEvaluator{
-		{
-			EvalFnc: func(ctx *eval.Context) string {
-				// empty symlink, generate a fake so that it doesn't match
-				if path := (*Event)(ctx.Object).ProcessContext.SymlinkPathnameStr[0]; path != "" {
-					return path
-				}
-				return "~" // to ensure that it will not match an empty path
-			},
+	symlinkPathnameEvaluators = [MaxSymlinks]func(field eval.Field) *eval.StringEvaluator{
+		func(field eval.Field) *eval.StringEvaluator {
+			return &eval.StringEvaluator{
+				Field: field,
+				EvalFnc: func(ctx *eval.Context) string {
+					// empty symlink, generate a fake so that it doesn't match
+					if path := (*Event)(ctx.Object).ProcessContext.SymlinkPathnameStr[0]; path != "" {
+						return path
+					}
+					return "~" // to ensure that it will not match an empty path
+				},
+			}
 		},
-		{
-			EvalFnc: func(ctx *eval.Context) string {
-				// empty symlink, generate a fake so that it doesn't match
-				if path := (*Event)(ctx.Object).ProcessContext.SymlinkPathnameStr[1]; path != "" {
-					return path
-				}
-				return "~" // to ensure that it will not match an empty path
-			},
+		func(field eval.Field) *eval.StringEvaluator {
+			return &eval.StringEvaluator{
+				Field: field,
+				EvalFnc: func(ctx *eval.Context) string {
+					// empty symlink, generate a fake so that it doesn't match
+					if path := (*Event)(ctx.Object).ProcessContext.SymlinkPathnameStr[1]; path != "" {
+						return path
+					}
+					return "~" // to ensure that it will not match an empty path
+				},
+			}
 		},
 	}
 
-	symlinkBasenameEvaluator = &eval.StringEvaluator{
-		EvalFnc: func(ctx *eval.Context) string {
-			return (*Event)(ctx.Object).ProcessContext.SymlinkBasenameStr
-		},
+	symlinkBasenameEvaluator = func(field eval.Field) *eval.StringEvaluator {
+		return &eval.StringEvaluator{
+			Field: field,
+			EvalFnc: func(ctx *eval.Context) string {
+				return (*Event)(ctx.Object).ProcessContext.SymlinkBasenameStr
+			},
+		}
 	}
 
 	// ProcessSymlinkPathname handles symlink for process enrtries
@@ -47,14 +56,16 @@ var (
 
 			// currently only override exec events
 			if a.Field == "exec.file.path" || a.Field == "process.file.path" {
-				se1, err := eval.GlobCmp.StringEquals(symlinkPathnameEvaluators[0], b, state)
+				se1, err := eval.GlobCmp.StringEquals(symlinkPathnameEvaluators[0](a.Field), b, state)
 				if err != nil {
 					return nil, err
 				}
-				se2, err := eval.GlobCmp.StringEquals(symlinkPathnameEvaluators[1], b, state)
+
+				se2, err := eval.GlobCmp.StringEquals(symlinkPathnameEvaluators[1](a.Field), b, state)
 				if err != nil {
 					return nil, err
 				}
+
 				or, err := eval.Or(se1, se2, state)
 				if err != nil {
 					return nil, err
@@ -62,14 +73,16 @@ var (
 
 				return eval.Or(path, or, state)
 			} else if b.Field == "exec.file.path" || b.Field == "process.file.path" {
-				se1, err := eval.GlobCmp.StringEquals(symlinkPathnameEvaluators[0], a, state)
+				se1, err := eval.GlobCmp.StringEquals(symlinkPathnameEvaluators[0](b.Field), a, state)
 				if err != nil {
 					return nil, err
 				}
-				se2, err := eval.GlobCmp.StringEquals(symlinkPathnameEvaluators[1], a, state)
+
+				se2, err := eval.GlobCmp.StringEquals(symlinkPathnameEvaluators[1](b.Field), a, state)
 				if err != nil {
 					return nil, err
 				}
+
 				or, err := eval.Or(se1, se2, state)
 				if err != nil {
 					return nil, err
@@ -88,11 +101,11 @@ var (
 
 			// currently only override exec events
 			if a.Field == "exec.file.path" || a.Field == "process.file.path" {
-				se1, err := eval.GlobCmp.StringValuesContains(symlinkPathnameEvaluators[0], b, state)
+				se1, err := eval.GlobCmp.StringValuesContains(symlinkPathnameEvaluators[0](a.Field), b, state)
 				if err != nil {
 					return nil, err
 				}
-				se2, err := eval.GlobCmp.StringValuesContains(symlinkPathnameEvaluators[1], b, state)
+				se2, err := eval.GlobCmp.StringValuesContains(symlinkPathnameEvaluators[1](a.Field), b, state)
 				if err != nil {
 					return nil, err
 				}
@@ -114,11 +127,11 @@ var (
 
 			// currently only override exec events
 			if a.Field == "exec.file.path" || a.Field == "process.file.path" {
-				se1, err := eval.GlobCmp.StringArrayContains(symlinkPathnameEvaluators[0], b, state)
+				se1, err := eval.GlobCmp.StringArrayContains(symlinkPathnameEvaluators[0](a.Field), b, state)
 				if err != nil {
 					return nil, err
 				}
-				se2, err := eval.GlobCmp.StringArrayContains(symlinkPathnameEvaluators[1], b, state)
+				se2, err := eval.GlobCmp.StringArrayContains(symlinkPathnameEvaluators[1](a.Field), b, state)
 				if err != nil {
 					return nil, err
 				}
@@ -147,13 +160,13 @@ var (
 
 			// currently only override exec events
 			if a.Field == "exec.file.name" || a.Field == "process.file.name" {
-				symlink, err := eval.StringEquals(symlinkBasenameEvaluator, b, state)
+				symlink, err := eval.StringEquals(symlinkBasenameEvaluator(a.Field), b, state)
 				if err != nil {
 					return nil, err
 				}
 				return eval.Or(path, symlink, state)
 			} else if b.Field == "exec.file.name" || b.Field == "process.file.name" {
-				symlink, err := eval.StringEquals(a, symlinkBasenameEvaluator, state)
+				symlink, err := eval.StringEquals(a, symlinkBasenameEvaluator(b.Field), state)
 				if err != nil {
 					return nil, err
 				}
@@ -170,7 +183,7 @@ var (
 
 			// currently only override exec events
 			if a.Field == "exec.file.name" || a.Field == "process.file.name" {
-				symlink, err := eval.StringValuesContains(symlinkBasenameEvaluator, b, state)
+				symlink, err := eval.StringValuesContains(symlinkBasenameEvaluator(a.Field), b, state)
 				if err != nil {
 					return nil, err
 				}
@@ -187,7 +200,7 @@ var (
 
 			// currently only override exec events
 			if a.Field == "exec.file.name" || a.Field == "process.file.name" {
-				symlink, err := eval.StringArrayContains(symlinkBasenameEvaluator, b, state)
+				symlink, err := eval.StringArrayContains(symlinkBasenameEvaluator(a.Field), b, state)
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR fixes the discarder discovery for file with the symlink operator override.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
