### PR TITLE
Prevent inventory from flooding the log with gohai warnings

### DIFF
--- a/pkg/metadata/inventories/host_metadata.go
+++ b/pkg/metadata/inventories/host_metadata.go
@@ -11,7 +11,6 @@ import (
 	"github.com/DataDog/gohai/network"
 	"github.com/DataDog/gohai/platform"
 
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
@@ -62,7 +61,7 @@ type HostMetadata struct {
 // For now we simply logs warnings from gohai.
 func logWarnings(warnings []string) {
 	for _, w := range warnings {
-		log.Infof("gohai: %s", w)
+		logInfof("gohai: %s", w)
 	}
 }
 
@@ -72,7 +71,7 @@ func getHostMetadata() *HostMetadata {
 
 	cpuInfo, warnings, err := cpuGet()
 	if err != nil {
-		log.Errorf("Failed to retrieve cpu metadata from gohai: %s", err)
+		logErrorf("Failed to retrieve cpu metadata from gohai: %s", err) //nolint:errcheck
 	} else {
 		logWarnings(warnings)
 
@@ -89,7 +88,7 @@ func getHostMetadata() *HostMetadata {
 
 	platformInfo, warnings, err := platformGet()
 	if err != nil {
-		log.Errorf("failed to retrieve host platform metadata from gohai: %s", err)
+		logErrorf("failed to retrieve host platform metadata from gohai: %s", err) //nolint:errcheck
 	} else {
 		logWarnings(warnings)
 
@@ -103,7 +102,7 @@ func getHostMetadata() *HostMetadata {
 
 	memoryInfo, warnings, err := memoryGet()
 	if err != nil {
-		log.Errorf("failed to retrieve host memory metadata from gohai: %s", err)
+		logErrorf("failed to retrieve host memory metadata from gohai: %s", err) //nolint:errcheck
 	} else {
 		logWarnings(warnings)
 
@@ -113,7 +112,7 @@ func getHostMetadata() *HostMetadata {
 
 	networkInfo, warnings, err := networkGet()
 	if err != nil {
-		log.Errorf("failed to retrieve host network metadata from gohai: %s", err)
+		logErrorf("failed to retrieve host network metadata from gohai: %s", err) //nolint:errcheck
 	} else {
 		logWarnings(warnings)
 
@@ -131,10 +130,10 @@ func getHostMetadata() *HostMetadata {
 		if stringValue, ok := value.(string); ok {
 			metadata.CloudProvider = stringValue
 		} else {
-			log.Errorf("cloud provider is not a string in agent metadata cache")
+			logErrorf("cloud provider is not a string in agent metadata cache") //nolint:errcheck
 		}
 	} else {
-		log.Infof("cloud provider not found in agent metadata cache")
+		logInfof("cloud provider not found in agent metadata cache")
 	}
 
 	hostMetadataMutex.Lock()
@@ -144,10 +143,10 @@ func getHostMetadata() *HostMetadata {
 		if stringValue, ok := value.(string); ok {
 			metadata.OsVersion = stringValue
 		} else {
-			log.Errorf("OS version is not a string in host metadata cache")
+			logErrorf("OS version is not a string in host metadata cache") //nolint:errcheck
 		}
 	} else {
-		log.Errorf("OS version not found in agent metadata cache")
+		logErrorf("OS version not found in agent metadata cache") //nolint:errcheck
 	}
 	return metadata
 }

--- a/pkg/metadata/inventories/host_metadata.go
+++ b/pkg/metadata/inventories/host_metadata.go
@@ -123,9 +123,6 @@ func getHostMetadata() *HostMetadata {
 
 	metadata.AgentVersion = version.AgentVersion
 
-	agentMetadataMutex.Lock()
-	defer agentMetadataMutex.Unlock()
-
 	if value, ok := agentMetadata[string(AgentCloudProvider)]; ok {
 		if stringValue, ok := value.(string); ok {
 			metadata.CloudProvider = stringValue
@@ -135,9 +132,6 @@ func getHostMetadata() *HostMetadata {
 	} else {
 		logInfof("cloud provider not found in agent metadata cache")
 	}
-
-	hostMetadataMutex.Lock()
-	defer hostMetadataMutex.Unlock()
 
 	if value, ok := hostMetadata[string(HostOSVersion)]; ok {
 		if stringValue, ok := value.(string); ok {

--- a/pkg/metadata/inventories/host_metadata_test.go
+++ b/pkg/metadata/inventories/host_metadata_test.go
@@ -105,12 +105,10 @@ func setupHostMetadataMock() func() {
 		networkGet = network.Get
 		platformGet = platform.Get
 
-		agentMetadataMutex.Lock()
-		hostMetadataMutex.Lock()
+		inventoryMutex.Lock()
 		delete(agentMetadata, string(AgentCloudProvider))
 		delete(hostMetadata, string(HostOSVersion))
-		agentMetadataMutex.Unlock()
-		hostMetadataMutex.Unlock()
+		inventoryMutex.Unlock()
 	}
 
 	cpuGet = cpuMock

--- a/pkg/metadata/inventories/inventories_test.go
+++ b/pkg/metadata/inventories/inventories_test.go
@@ -23,11 +23,10 @@ import (
 )
 
 func clearMetadata() {
-	checkMetadataMutex.Lock()
-	defer checkMetadataMutex.Unlock()
+	inventoryMutex.Lock()
+	defer inventoryMutex.Unlock()
+
 	checkMetadata = make(map[string]*checkMetadataCacheEntry)
-	agentMetadataMutex.Lock()
-	defer agentMetadataMutex.Unlock()
 	agentMetadata = make(AgentMetadata)
 
 	// purge metadataUpdatedC


### PR DESCRIPTION
### What does this PR do?

Prevent inventory from flooding the log with gohai warnings.

The PR also cleanup the many mutexes we have in the `inventories`.

We don't need control on data access in inventory. This commit replaces all the different mutexes we have in inventory by a single one. This should not impact performances as metadata is rarely added or updated. We now have a single mutex we lock when entering the module.

### Describe how to test/QA your changes

Start the agent on a host where gohai produce warnings. For example a linux host without `python` in PATH. The warning should only be log once at the start (and the every ~2h) instead of every 10min.