### PR TITLE
[orchestrator] [check] fix colon at the end

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/pod.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/pod.go
@@ -292,12 +292,18 @@ func getConditionMessage(p *corev1.Pod) string {
 
 // mapToTags converts a map for which both keys and values are strings to a
 // slice of strings containing those key-value pairs under the "key:value" form.
+// if the map contains empty values we only use the key instead
 func mapToTags(m map[string]string) []string {
 	slice := make([]string, len(m))
 
 	i := 0
 	for k, v := range m {
-		slice[i] = k + ":" + v
+		// Labels can contain empty values: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
+		if v == "" {
+			slice[i] = k
+		} else {
+			slice[i] = k + ":" + v
+		}
 		i++
 	}
 

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/pod_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/pod_test.go
@@ -762,3 +762,14 @@ func TestGenerateUniqueStaticPodHashHardCoded(t *testing.T) {
 
 	assert.Equal(t, uniqueHash, expectedHash)
 }
+
+func TestMapToTags(t *testing.T) {
+	labels := map[string]string{}
+	labels["foo"] = "bar"
+	labels["node-role.kubernetes.io/nodeless"] = ""
+
+	tags := mapToTags(labels)
+
+	assert.ElementsMatch(t, []string{"foo:bar", "node-role.kubernetes.io/nodeless"}, tags)
+	assert.Len(t, tags, 2)
+}

--- a/releasenotes/notes/fix-colon-7c0da6b0c5b5732f.yaml
+++ b/releasenotes/notes/fix-colon-7c0da6b0c5b5732f.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Orchestrator check: make sure we don't return labels and annotations with a suffixed `:`


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

- we converted labels to tags, but labels can have empty values leading to something like this `["tag:"]`
- note: Labels can contain empty values: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
