### PR TITLE
Add a new `vscode` top level command to invoke task.

### DIFF
--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -26,6 +26,7 @@ from . import (
     system_probe,
     systray,
     trace_agent,
+    vscode,
 )
 from .build_tags import audit_tag_impact
 from .go import (
@@ -106,7 +107,7 @@ ns.add_collection(rtloader)
 ns.add_collection(system_probe)
 ns.add_collection(process_agent)
 ns.add_collection(security_agent)
-
+ns.add_collection(vscode)
 ns.configure(
     {
         'run': {

--- a/tasks/vscode.py
+++ b/tasks/vscode.py
@@ -18,7 +18,7 @@ VSCODE_FILE = "settings.json"
 
 @task
 def set_buildtags(
-    ctx,
+    _,
     target="agent",
     build_include=None,
     build_exclude=None,
@@ -32,7 +32,7 @@ def set_buildtags(
 
     if target not in build_tags[flavor].keys():
         print("Must choose a valid target.  Valid targets are: \n")
-        print("{}\n".format(",".join(build_tags[flavor].keys())))
+        print(f'{", ".join(build_tags[flavor].keys())} \n')
         return
 
     build_include = (

--- a/tasks/vscode.py
+++ b/tasks/vscode.py
@@ -1,0 +1,58 @@
+"""
+vscode namespaced tags
+
+Helpers for getting vscode set up nicely
+"""
+import json
+import os
+from collections import OrderedDict
+
+from invoke import task
+
+from .build_tags import build_tags, filter_incompatible_tags, get_build_tags, get_default_build_tags
+from .flavor import AgentFlavor
+
+VSCODE_DIR = ".vscode"
+VSCODE_FILE = "settings.json"
+
+
+@task
+def set_buildtags(
+    ctx,
+    target="agent",
+    build_include=None,
+    build_exclude=None,
+    flavor=AgentFlavor.base.name,
+    arch='x64',
+):
+    """
+    Modifies vscode settings file for this project to include correct build tags
+    """
+    flavor = AgentFlavor[flavor]
+
+    if target not in build_tags[flavor].keys():
+        print("Must choose a valid target.  Valid targets are: \n")
+        print("{}\n".format(",".join(build_tags[flavor].keys())))
+        return
+
+    build_include = (
+        get_default_build_tags(build=target, arch=arch, flavor=flavor)
+        if build_include is None
+        else filter_incompatible_tags(build_include.split(","), arch=arch)
+    )
+    build_exclude = [] if build_exclude is None else build_exclude.split(",")
+    use_tags = get_build_tags(build_include, build_exclude)
+
+    if not os.path.exists(VSCODE_DIR):
+        os.makedirs(VSCODE_DIR)
+
+    settings = {}
+    fullpath = os.path.join(VSCODE_DIR, VSCODE_FILE)
+    if os.path.exists(fullpath):
+        with open(fullpath, "r") as sf:
+            settings = json.load(sf, object_pairs_hook=OrderedDict)
+
+    settings["go.buildTags"] = ",".join(use_tags)
+
+    with open(fullpath, "w") as sf:
+        json.dump(settings, sf, indent=4, sort_keys=False, separators=(',', ': '))


### PR DESCRIPTION
Add a `set-buildtags` command for setting the local go build tags in the
vscode settings file.

Many of the included files have specific go build tags; if you don't set
the build tags, then vscode/gopls can't do all the function/type mapping
that makes modern IDEs so fun.

Creates a new invoke task
`inv vscode.set-buildtags` which creates/edit the local project `.vscode/settings.json` file, adding the correct go build tags for the component that you're working on.
### Motivation

When using visual studio code as the editor, for many `go` files the parser (`gopls`) couldn't match up types/functions/etc.
This was because the file was excluded due to go build tags that the environment didn't know about.


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->


### Reviewer's Checklist
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
