### PR TITLE
CWS: remove recursion in `FileActivityNode.InsertFileEvent`

### DIFF
--- a/pkg/security/probe/activity_dump.go
+++ b/pkg/security/probe/activity_dump.go
@@ -1376,7 +1376,7 @@ func (fan *FileActivityNode) InsertFileEvent(fileEvent *model.FileEvent, event *
 		parent, nextParentIndex := extractFirstParent(currentPath)
 		if nextParentIndex == 0 {
 			currentFan.enrichFromEvent(event)
-			return somethingChanged
+			break
 		}
 
 		if mergeCtx.enabled && len(currentFan.Children) >= 10 {
@@ -1391,9 +1391,10 @@ func (fan *FileActivityNode) InsertFileEvent(fileEvent *model.FileEvent, event *
 		}
 
 		// create new child
+		somethingChanged = true
 		if len(currentPath) <= nextParentIndex+1 {
 			currentFan.Children[parent] = NewFileActivityNode(fileEvent, event, parent, generationType)
-			return true
+			break
 		} else {
 			child := NewFileActivityNode(nil, nil, parent, generationType)
 			currentFan.Children[parent] = child
@@ -1404,6 +1405,8 @@ func (fan *FileActivityNode) InsertFileEvent(fileEvent *model.FileEvent, event *
 			continue
 		}
 	}
+
+	return somethingChanged
 }
 
 func (fan *FileActivityNode) mergeCommonPaths(mergeCtx adPathMergeContext) {

--- a/pkg/security/probe/activity_dump.go
+++ b/pkg/security/probe/activity_dump.go
@@ -1398,7 +1398,6 @@ func (fan *FileActivityNode) InsertFileEvent(fileEvent *model.FileEvent, event *
 			child := NewFileActivityNode(nil, nil, parent, generationType)
 			currentFan.Children[parent] = child
 
-			somethingChanged = true
 			currentFan = child
 			currentPath = currentPath[nextParentIndex:]
 			continue


### PR DESCRIPTION
### What does this PR do?

This PR removes the recursion in `FileActivityNode.InsertFileEvent`, protecting us a bit against stack overflows in case of a very long path

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
