### PR TITLE
[CWS] Add the ability to expose the value of some environment variables

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1097,6 +1097,7 @@ func InitConfig(config Config) {
 	bindEnvAndSetLogsConfigKeys(config, "runtime_security_config.activity_dump.remote_storage.endpoints.")
 	config.BindEnvAndSetDefault("runtime_security_config.event_stream.use_ring_buffer", false)
 	config.BindEnv("runtime_security_config.event_stream.buffer_size")
+	config.BindEnvAndSetDefault("runtime_security_config.envs_whitelist", []string{})
 
 	// Serverless Agent
 	config.BindEnvAndSetDefault("serverless.logs_enabled", true)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1097,7 +1097,7 @@ func InitConfig(config Config) {
 	bindEnvAndSetLogsConfigKeys(config, "runtime_security_config.activity_dump.remote_storage.endpoints.")
 	config.BindEnvAndSetDefault("runtime_security_config.event_stream.use_ring_buffer", false)
 	config.BindEnv("runtime_security_config.event_stream.buffer_size")
-	config.BindEnvAndSetDefault("runtime_security_config.envs_whitelist", []string{})
+	config.BindEnvAndSetDefault("runtime_security_config.envs_with_value", []string{})
 
 	// Serverless Agent
 	config.BindEnvAndSetDefault("serverless.logs_enabled", true)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1097,7 +1097,7 @@ func InitConfig(config Config) {
 	bindEnvAndSetLogsConfigKeys(config, "runtime_security_config.activity_dump.remote_storage.endpoints.")
 	config.BindEnvAndSetDefault("runtime_security_config.event_stream.use_ring_buffer", false)
 	config.BindEnv("runtime_security_config.event_stream.buffer_size")
-	config.BindEnvAndSetDefault("runtime_security_config.envs_with_value", []string{})
+	config.BindEnvAndSetDefault("runtime_security_config.envs_with_value", []string{"LD_PRELOAD", "LD_LIBRARY_PATH", "PATH", "HISTSIZE", "HISTFILESIZE"})
 
 	// Serverless Agent
 	config.BindEnvAndSetDefault("serverless.logs_enabled", true)

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1574,6 +1574,19 @@ api_key:
   #   - 'sql*'
   #   - '*pass*d*'
 
+  ## @param envs_with_value - list of strings - optional
+  ## @env DD_RUNTIME_SECURITY_CONFIG_ENVS_WITH_VALUE - space separated list of strings - optional
+  ## Define your own list of non-sensitive environment variable names whose value will not be
+  ## concealed by the runtime security module.
+  ## Default: LD_PRELOAD, LD_LIBRARY_PATH, PATH, HISTSIZE, HISTFILESIZE
+  #
+  # envs_with_value:
+  #   - LD_PRELOAD
+  #   - LD_LIBRARY_PATH
+  #   - PATH
+  #   - HISTSIZE
+  #   - HISTFILESIZE
+
 {{ end -}}
 {{ end -}}
 

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -93,8 +93,8 @@ type Config struct {
 	LogTags []string
 	// SelfTestEnabled defines if the self tests should be executed at startup or not
 	SelfTestEnabled bool
-	// EnvsWhitelist lists environnement variables that will be fully exported
-	EnvsWhitelist []string
+	// EnvsWithValue lists environnement variables that will be fully exported
+	EnvsWithValue []string
 
 	// ActivityDumpEnabled defines if the activity dump manager should be enabled
 	ActivityDumpEnabled bool
@@ -221,7 +221,7 @@ func NewConfig(cfg *config.Config) (*Config, error) {
 		RemoteConfigurationEnabled:         coreconfig.Datadog.GetBool("runtime_security_config.remote_configuration.enabled"),
 		EventStreamUseRingBuffer:           coreconfig.Datadog.GetBool("runtime_security_config.event_stream.use_ring_buffer"),
 		EventStreamBufferSize:              coreconfig.Datadog.GetInt("runtime_security_config.event_stream.buffer_size"),
-		EnvsWhitelist:                      coreconfig.Datadog.GetStringSlice("runtime_security_config.envs_whitelist"),
+		EnvsWithValue:                      coreconfig.Datadog.GetStringSlice("runtime_security_config.envs_with_value"),
 
 		// runtime compilation
 		RuntimeCompilationEnabled:       coreconfig.Datadog.GetBool("runtime_security_config.runtime_compilation.enabled"),

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -95,6 +95,8 @@ type Config struct {
 	LogTags []string
 	// SelfTestEnabled defines if the self tests should be executed at startup or not
 	SelfTestEnabled bool
+	// EnvsWhitelist lists environnement variables that will be fully exported
+	EnvsWhitelist []string
 
 	// ActivityDumpEnabled defines if the activity dump manager should be enabled
 	ActivityDumpEnabled bool
@@ -222,6 +224,7 @@ func NewConfig(cfg *config.Config) (*Config, error) {
 		RemoteConfigurationEnabled:         coreconfig.Datadog.GetBool("runtime_security_config.remote_configuration.enabled"),
 		EventStreamUseRingBuffer:           coreconfig.Datadog.GetBool("runtime_security_config.event_stream.use_ring_buffer"),
 		EventStreamBufferSize:              coreconfig.Datadog.GetInt("runtime_security_config.event_stream.buffer_size"),
+		EnvsWhitelist:                      coreconfig.Datadog.GetStringSlice("runtime_security_config.envs_whitelist"),
 
 		// runtime compilation
 		RuntimeCompilationEnabled:       coreconfig.Datadog.GetBool("runtime_security_config.runtime_compilation.enabled"),

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -58,8 +58,6 @@ type Config struct {
 	EventServerRetention int
 	// PIDCacheSize is the size of the user space PID caches
 	PIDCacheSize int
-	// CookieCacheSize is the size of the cookie cache used to cache process context
-	CookieCacheSize int
 	// LoadControllerEventsCountThreshold defines the amount of events past which we will trigger the in-kernel circuit breaker
 	LoadControllerEventsCountThreshold int64
 	// LoadControllerDiscarderTimeout defines the amount of time discarders set by the load controller should last
@@ -202,7 +200,6 @@ func NewConfig(cfg *config.Config) (*Config, error) {
 		EventServerRate:                    coreconfig.Datadog.GetInt("runtime_security_config.event_server.rate"),
 		EventServerRetention:               coreconfig.Datadog.GetInt("runtime_security_config.event_server.retention"),
 		PIDCacheSize:                       coreconfig.Datadog.GetInt("runtime_security_config.pid_cache_size"),
-		CookieCacheSize:                    coreconfig.Datadog.GetInt("runtime_security_config.cookie_cache_size"),
 		LoadControllerEventsCountThreshold: int64(coreconfig.Datadog.GetInt("runtime_security_config.load_controller.events_count_threshold")),
 		LoadControllerDiscarderTimeout:     time.Duration(coreconfig.Datadog.GetInt("runtime_security_config.load_controller.discarder_timeout")) * time.Second,
 		LoadControllerControlPeriod:        time.Duration(coreconfig.Datadog.GetInt("runtime_security_config.load_controller.control_period")) * time.Second,

--- a/pkg/security/probe/model_test.go
+++ b/pkg/security/probe/model_test.go
@@ -74,7 +74,7 @@ func TestProcessArgsFlags(t *testing.T) {
 		},
 	}
 
-	resolver, _ := NewProcessResolver(&Probe{}, nil, NewProcessResolverOpts(10000, nil))
+	resolver, _ := NewProcessResolver(&Probe{}, nil, NewProcessResolverOpts(nil))
 	e.resolvers = &Resolvers{
 		ProcessResolver: resolver,
 	}
@@ -133,7 +133,7 @@ func TestProcessArgsOptions(t *testing.T) {
 		},
 	}
 
-	resolver, _ := NewProcessResolver(&Probe{}, nil, NewProcessResolverOpts(10000, nil))
+	resolver, _ := NewProcessResolver(&Probe{}, nil, NewProcessResolverOpts(nil))
 	e.resolvers = &Resolvers{
 		ProcessResolver: resolver,
 	}

--- a/pkg/security/probe/model_test.go
+++ b/pkg/security/probe/model_test.go
@@ -74,7 +74,7 @@ func TestProcessArgsFlags(t *testing.T) {
 		},
 	}
 
-	resolver, _ := NewProcessResolver(&Probe{}, nil, NewProcessResolverOpts(10000))
+	resolver, _ := NewProcessResolver(&Probe{}, nil, NewProcessResolverOpts(10000, nil))
 	e.resolvers = &Resolvers{
 		ProcessResolver: resolver,
 	}
@@ -133,7 +133,7 @@ func TestProcessArgsOptions(t *testing.T) {
 		},
 	}
 
-	resolver, _ := NewProcessResolver(&Probe{}, nil, NewProcessResolverOpts(10000))
+	resolver, _ := NewProcessResolver(&Probe{}, nil, NewProcessResolverOpts(10000, nil))
 	e.resolvers = &Resolvers{
 		ProcessResolver: resolver,
 	}

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -86,7 +86,9 @@ func getCGroupWriteConstants() manager.ConstantEditor {
 }
 
 // ProcessResolverOpts options of resolver
-type ProcessResolverOpts struct{}
+type ProcessResolverOpts struct {
+	envsWhitelist map[string]bool
+}
 
 // ProcessResolver resolved process context
 type ProcessResolver struct {
@@ -859,7 +861,7 @@ func (p *ProcessResolver) GetProcessEnvs(pr *model.Process) ([]string, bool) {
 		return nil, false
 	}
 
-	keys, truncated := pr.EnvsEntry.Keys()
+	keys, truncated := pr.EnvsEntry.FilterEnvs(p.opts.envsWhitelist)
 
 	return keys, pr.ArgsTruncated || truncated
 }
@@ -1213,6 +1215,14 @@ func NewProcessResolver(probe *Probe, resolvers *Resolvers, opts ProcessResolver
 }
 
 // NewProcessResolverOpts returns a new set of process resolver options
-func NewProcessResolverOpts(cookieCacheSize int) ProcessResolverOpts {
-	return ProcessResolverOpts{}
+func NewProcessResolverOpts(cookieCacheSize int, envsWhitelist []string) ProcessResolverOpts {
+	opts := ProcessResolverOpts{
+		envsWhitelist: make(map[string]bool),
+	}
+
+	for _, envVar := range envsWhitelist {
+		opts.envsWhitelist[envVar] = true
+	}
+
+	return opts
 }

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -1217,7 +1217,7 @@ func NewProcessResolver(probe *Probe, resolvers *Resolvers, opts ProcessResolver
 // NewProcessResolverOpts returns a new set of process resolver options
 func NewProcessResolverOpts(envsWhitelist []string) ProcessResolverOpts {
 	opts := ProcessResolverOpts{
-		envsWhitelist: make(map[string]bool),
+		envsWhitelist: make(map[string]bool, len(envsWhitelist)),
 	}
 
 	for _, envVar := range envsWhitelist {

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -1215,7 +1215,7 @@ func NewProcessResolver(probe *Probe, resolvers *Resolvers, opts ProcessResolver
 }
 
 // NewProcessResolverOpts returns a new set of process resolver options
-func NewProcessResolverOpts(cookieCacheSize int, envsWhitelist []string) ProcessResolverOpts {
+func NewProcessResolverOpts(envsWhitelist []string) ProcessResolverOpts {
 	opts := ProcessResolverOpts{
 		envsWhitelist: make(map[string]bool),
 	}

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -87,7 +87,7 @@ func getCGroupWriteConstants() manager.ConstantEditor {
 
 // ProcessResolverOpts options of resolver
 type ProcessResolverOpts struct {
-	envsWhitelist map[string]bool
+	envsWithValue map[string]bool
 }
 
 // ProcessResolver resolved process context
@@ -861,7 +861,7 @@ func (p *ProcessResolver) GetProcessEnvs(pr *model.Process) ([]string, bool) {
 		return nil, false
 	}
 
-	keys, truncated := pr.EnvsEntry.FilterEnvs(p.opts.envsWhitelist)
+	keys, truncated := pr.EnvsEntry.FilterEnvs(p.opts.envsWithValue)
 
 	return keys, pr.ArgsTruncated || truncated
 }
@@ -1215,13 +1215,13 @@ func NewProcessResolver(probe *Probe, resolvers *Resolvers, opts ProcessResolver
 }
 
 // NewProcessResolverOpts returns a new set of process resolver options
-func NewProcessResolverOpts(envsWhitelist []string) ProcessResolverOpts {
+func NewProcessResolverOpts(envsWithValue []string) ProcessResolverOpts {
 	opts := ProcessResolverOpts{
-		envsWhitelist: make(map[string]bool, len(envsWhitelist)),
+		envsWithValue: make(map[string]bool, len(envsWithValue)),
 	}
 
-	for _, envVar := range envsWhitelist {
-		opts.envsWhitelist[envVar] = true
+	for _, envVar := range envsWithValue {
+		opts.envsWithValue[envVar] = true
 	}
 
 	return opts

--- a/pkg/security/probe/process_resolver_test.go
+++ b/pkg/security/probe/process_resolver_test.go
@@ -33,7 +33,7 @@ func testCacheSize(t *testing.T, resolver *ProcessResolver) {
 }
 
 func TestFork1st(t *testing.T) {
-	resolver, err := NewProcessResolver(nil, nil, NewProcessResolverOpts(10000))
+	resolver, err := NewProcessResolver(nil, nil, NewProcessResolverOpts(10000, nil))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -72,7 +72,7 @@ func TestFork1st(t *testing.T) {
 }
 
 func TestFork2nd(t *testing.T) {
-	resolver, err := NewProcessResolver(nil, nil, NewProcessResolverOpts(10000))
+	resolver, err := NewProcessResolver(nil, nil, NewProcessResolverOpts(10000, nil))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -113,7 +113,7 @@ func TestFork2nd(t *testing.T) {
 }
 
 func TestForkExec(t *testing.T) {
-	resolver, err := NewProcessResolver(nil, nil, NewProcessResolverOpts(10000))
+	resolver, err := NewProcessResolver(nil, nil, NewProcessResolverOpts(10000, nil))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -168,7 +168,7 @@ func TestForkExec(t *testing.T) {
 }
 
 func TestOrphanExec(t *testing.T) {
-	resolver, err := NewProcessResolver(nil, nil, NewProcessResolverOpts(10000))
+	resolver, err := NewProcessResolver(nil, nil, NewProcessResolverOpts(10000, nil))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -223,7 +223,7 @@ func TestOrphanExec(t *testing.T) {
 }
 
 func TestForkExecExec(t *testing.T) {
-	resolver, err := NewProcessResolver(nil, nil, NewProcessResolverOpts(10000))
+	resolver, err := NewProcessResolver(nil, nil, NewProcessResolverOpts(10000, nil))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -292,7 +292,7 @@ func TestForkExecExec(t *testing.T) {
 }
 
 func TestForkReuse(t *testing.T) {
-	resolver, err := NewProcessResolver(nil, nil, NewProcessResolverOpts(10000))
+	resolver, err := NewProcessResolver(nil, nil, NewProcessResolverOpts(10000, nil))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -386,7 +386,7 @@ func TestForkReuse(t *testing.T) {
 }
 
 func TestForkForkExec(t *testing.T) {
-	resolver, err := NewProcessResolver(nil, nil, NewProcessResolverOpts(10000))
+	resolver, err := NewProcessResolver(nil, nil, NewProcessResolverOpts(10000, nil))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/probe/process_resolver_test.go
+++ b/pkg/security/probe/process_resolver_test.go
@@ -33,7 +33,7 @@ func testCacheSize(t *testing.T, resolver *ProcessResolver) {
 }
 
 func TestFork1st(t *testing.T) {
-	resolver, err := NewProcessResolver(nil, nil, NewProcessResolverOpts(10000, nil))
+	resolver, err := NewProcessResolver(nil, nil, NewProcessResolverOpts(nil))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -72,7 +72,7 @@ func TestFork1st(t *testing.T) {
 }
 
 func TestFork2nd(t *testing.T) {
-	resolver, err := NewProcessResolver(nil, nil, NewProcessResolverOpts(10000, nil))
+	resolver, err := NewProcessResolver(nil, nil, NewProcessResolverOpts(nil))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -113,7 +113,7 @@ func TestFork2nd(t *testing.T) {
 }
 
 func TestForkExec(t *testing.T) {
-	resolver, err := NewProcessResolver(nil, nil, NewProcessResolverOpts(10000, nil))
+	resolver, err := NewProcessResolver(nil, nil, NewProcessResolverOpts(nil))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -168,7 +168,7 @@ func TestForkExec(t *testing.T) {
 }
 
 func TestOrphanExec(t *testing.T) {
-	resolver, err := NewProcessResolver(nil, nil, NewProcessResolverOpts(10000, nil))
+	resolver, err := NewProcessResolver(nil, nil, NewProcessResolverOpts(nil))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -223,7 +223,7 @@ func TestOrphanExec(t *testing.T) {
 }
 
 func TestForkExecExec(t *testing.T) {
-	resolver, err := NewProcessResolver(nil, nil, NewProcessResolverOpts(10000, nil))
+	resolver, err := NewProcessResolver(nil, nil, NewProcessResolverOpts(nil))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -292,7 +292,7 @@ func TestForkExecExec(t *testing.T) {
 }
 
 func TestForkReuse(t *testing.T) {
-	resolver, err := NewProcessResolver(nil, nil, NewProcessResolverOpts(10000, nil))
+	resolver, err := NewProcessResolver(nil, nil, NewProcessResolverOpts(nil))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -386,7 +386,7 @@ func TestForkReuse(t *testing.T) {
 }
 
 func TestForkForkExec(t *testing.T) {
-	resolver, err := NewProcessResolver(nil, nil, NewProcessResolverOpts(10000, nil))
+	resolver, err := NewProcessResolver(nil, nil, NewProcessResolverOpts(nil))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/probe/resolvers.go
+++ b/pkg/security/probe/resolvers.go
@@ -73,7 +73,7 @@ func NewResolvers(config *config.Config, probe *Probe) (*Resolvers, error) {
 		NamespaceResolver: namespaceResolver,
 	}
 
-	processResolver, err := NewProcessResolver(probe, resolvers, NewProcessResolverOpts(probe.config.CookieCacheSize, probe.config.EnvsWhitelist))
+	processResolver, err := NewProcessResolver(probe, resolvers, NewProcessResolverOpts(probe.config.EnvsWhitelist))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/probe/resolvers.go
+++ b/pkg/security/probe/resolvers.go
@@ -73,7 +73,7 @@ func NewResolvers(config *config.Config, probe *Probe) (*Resolvers, error) {
 		NamespaceResolver: namespaceResolver,
 	}
 
-	processResolver, err := NewProcessResolver(probe, resolvers, NewProcessResolverOpts(probe.config.EnvsWhitelist))
+	processResolver, err := NewProcessResolver(probe, resolvers, NewProcessResolverOpts(probe.config.EnvsWithValue))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/probe/resolvers.go
+++ b/pkg/security/probe/resolvers.go
@@ -73,7 +73,7 @@ func NewResolvers(config *config.Config, probe *Probe) (*Resolvers, error) {
 		NamespaceResolver: namespaceResolver,
 	}
 
-	processResolver, err := NewProcessResolver(probe, resolvers, NewProcessResolverOpts(probe.config.CookieCacheSize))
+	processResolver, err := NewProcessResolver(probe, resolvers, NewProcessResolverOpts(probe.config.CookieCacheSize, probe.config.EnvsWhitelist))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/secl/model/process_cache_entry.go
+++ b/pkg/security/secl/model/process_cache_entry.go
@@ -322,8 +322,8 @@ func (p *EnvsEntry) ToArray() ([]string, bool) {
 	return p.Values, p.Truncated
 }
 
-// FilterEnvs returns an array of envs, only the name of each variable is returned if the variable isn't part of the whitelist
-func (p *EnvsEntry) FilterEnvs(whitelist map[string]bool) ([]string, bool) {
+// FilterEnvs returns an array of envs, only the name of each variable is returned unless the variable name is part of the provided filter
+func (p *EnvsEntry) FilterEnvs(envsWithValue map[string]bool) ([]string, bool) {
 	if p.filteredEnvs != nil {
 		return p.filteredEnvs, p.Truncated
 	}
@@ -342,7 +342,7 @@ func (p *EnvsEntry) FilterEnvs(whitelist map[string]bool) ([]string, bool) {
 			continue
 		}
 
-		if whitelist[kv[0]] {
+		if envsWithValue[kv[0]] {
 			p.filteredEnvs[i] = value
 		} else {
 			p.filteredEnvs[i] = kv[0]

--- a/pkg/security/secl/model/process_cache_entry.go
+++ b/pkg/security/secl/model/process_cache_entry.go
@@ -299,9 +299,9 @@ type EnvsEntry struct {
 	Values    []string `msg:"values"`
 	Truncated bool     `msg:"-"`
 
-	parsed bool
-	keys   []string
-	kv     map[string]string
+	parsed       bool
+	filteredEnvs []string
+	kv           map[string]string
 }
 
 // ToArray returns envs as an array
@@ -322,10 +322,10 @@ func (p *EnvsEntry) ToArray() ([]string, bool) {
 	return p.Values, p.Truncated
 }
 
-// Keys returns only keys
-func (p *EnvsEntry) Keys() ([]string, bool) {
-	if p.keys != nil {
-		return p.keys, p.Truncated
+// FilterEnvs returns an array of envs, only the name of each variable is returned if the variable isn't part of the whitelist
+func (p *EnvsEntry) FilterEnvs(whitelist map[string]bool) ([]string, bool) {
+	if p.filteredEnvs != nil {
+		return p.filteredEnvs, p.Truncated
 	}
 
 	values, _ := p.ToArray()
@@ -333,7 +333,7 @@ func (p *EnvsEntry) Keys() ([]string, bool) {
 		return nil, p.Truncated
 	}
 
-	p.keys = make([]string, len(values))
+	p.filteredEnvs = make([]string, len(values))
 
 	var i int
 	for _, value := range values {
@@ -342,11 +342,15 @@ func (p *EnvsEntry) Keys() ([]string, bool) {
 			continue
 		}
 
-		p.keys[i] = kv[0]
+		if whitelist[kv[0]] {
+			p.filteredEnvs[i] = value
+		} else {
+			p.filteredEnvs[i] = kv[0]
+		}
 		i++
 	}
 
-	return p.keys, p.Truncated
+	return p.filteredEnvs, p.Truncated
 }
 
 func (p *EnvsEntry) toMap() {

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -112,6 +113,10 @@ runtime_security_config:
   {{range .LogTags}}
     - {{.}}
   {{end}}
+  envs_whitelist:
+  {{range .EnvsWhitelist}}
+    - {{.}}
+  {{end}}
 `
 
 const testPolicy = `---
@@ -170,6 +175,7 @@ type testOpts struct {
 	reuseProbeHandler           bool
 	disableERPCDentryResolution bool
 	disableMapDentryResolution  bool
+	envsWhitelist               []string
 }
 
 func (s *stringSlice) String() string {
@@ -190,7 +196,8 @@ func (to testOpts) Equal(opts testOpts) bool {
 		to.eventsCountThreshold == opts.eventsCountThreshold &&
 		to.reuseProbeHandler == opts.reuseProbeHandler &&
 		to.disableERPCDentryResolution == opts.disableERPCDentryResolution &&
-		to.disableMapDentryResolution == opts.disableMapDentryResolution
+		to.disableMapDentryResolution == opts.disableMapDentryResolution &&
+		reflect.DeepEqual(to.envsWhitelist, opts.envsWhitelist)
 }
 
 type testModule struct {
@@ -567,6 +574,7 @@ func genTestConfig(dir string, opts testOpts) (*config.Config, error) {
 		"MapDentryResolutionEnabled":  mapDentryResolutionEnabled,
 		"LogPatterns":                 logPatterns,
 		"LogTags":                     logTags,
+		"EnvsWhitelist":               opts.envsWhitelist,
 	}); err != nil {
 		return nil, err
 	}

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -113,8 +113,8 @@ runtime_security_config:
   {{range .LogTags}}
     - {{.}}
   {{end}}
-  envs_whitelist:
-  {{range .EnvsWhitelist}}
+  envs_with_value:
+  {{range .EnvsWithValue}}
     - {{.}}
   {{end}}
 `
@@ -175,7 +175,7 @@ type testOpts struct {
 	reuseProbeHandler           bool
 	disableERPCDentryResolution bool
 	disableMapDentryResolution  bool
-	envsWhitelist               []string
+	envsWithValue               []string
 }
 
 func (s *stringSlice) String() string {
@@ -197,7 +197,7 @@ func (to testOpts) Equal(opts testOpts) bool {
 		to.reuseProbeHandler == opts.reuseProbeHandler &&
 		to.disableERPCDentryResolution == opts.disableERPCDentryResolution &&
 		to.disableMapDentryResolution == opts.disableMapDentryResolution &&
-		reflect.DeepEqual(to.envsWhitelist, opts.envsWhitelist)
+		reflect.DeepEqual(to.envsWithValue, opts.envsWithValue)
 }
 
 type testModule struct {
@@ -574,7 +574,7 @@ func genTestConfig(dir string, opts testOpts) (*config.Config, error) {
 		"MapDentryResolutionEnabled":  mapDentryResolutionEnabled,
 		"LogPatterns":                 logPatterns,
 		"LogTags":                     logTags,
-		"EnvsWhitelist":               opts.envsWhitelist,
+		"EnvsWithValue":               opts.envsWithValue,
 	}); err != nil {
 		return nil, err
 	}

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -605,7 +605,7 @@ func TestProcessContext(t *testing.T) {
 	})
 }
 
-func TestProcessEnvsWhitelist(t *testing.T) {
+func TestProcessEnvsWithValue(t *testing.T) {
 	lsExec := which(t, "ls")
 	ruleDefs := []*rules.RuleDefinition{
 		{
@@ -615,7 +615,7 @@ func TestProcessEnvsWhitelist(t *testing.T) {
 	}
 
 	opts := testOpts{
-		envsWhitelist: []string{"LD_PRELOAD"},
+		envsWithValue: []string{"LD_PRELOAD"},
 	}
 
 	test, err := newTestModule(t, nil, ruleDefs, opts)

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -605,6 +605,42 @@ func TestProcessContext(t *testing.T) {
 	})
 }
 
+func TestProcessEnvsWhitelist(t *testing.T) {
+	lsExec := which(t, "ls")
+	ruleDefs := []*rules.RuleDefinition{
+		{
+			ID:         "test_ldpreload_from_tmp_with_envs",
+			Expression: fmt.Sprintf(`exec.file.path == "%s" && exec.envs in [~"LD_PRELOAD=*/tmp/*"]`, lsExec),
+		},
+	}
+
+	opts := testOpts{
+		envsWhitelist: []string{"LD_PRELOAD"},
+	}
+
+	test, err := newTestModule(t, nil, ruleDefs, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+
+	t.Run("ldpreload", func(t *testing.T) {
+		test.WaitSignal(t, func() error {
+			args := []string{}
+			envp := []string{"LD_PRELOAD=/tmp/dyn.so"}
+
+			cmd := exec.Command(lsExec, args...)
+			cmd.Env = envp
+			_ = cmd.Run()
+			return nil
+		}, func(event *sprobe.Event, rule *rules.Rule) {
+			assertTriggeredRule(t, rule, "test_ldpreload_from_tmp_with_envs")
+			assertFieldEqual(t, event, "exec.file.path", lsExec)
+			assertFieldStringArrayIndexedOneOf(t, event, "exec.envs", 0, []string{"LD_PRELOAD=/tmp/dyn.so"})
+		})
+	})
+}
+
 func TestProcessExecCTime(t *testing.T) {
 	executable := which(t, "touch")
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR adds a new config option `runtime_security_config.envs_with_value` to pass a list of environment variable names that won't be concealed by the runtime security module.

Associated functional test:
`inv -e security-agent.functional-tests --testflags "-test.v -test.run TestProcessEnvsWithValue"`

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
