### PR TITLE
CWS: delay id generation to graph generation. remove from tree

### DIFF
--- a/pkg/security/probe/activity_dump.go
+++ b/pkg/security/probe/activity_dump.go
@@ -862,7 +862,6 @@ func (ad *ActivityDump) DecodeProtobuf(reader io.Reader) error {
 
 // ProcessActivityNode holds the activity of a process
 type ProcessActivityNode struct {
-	id             NodeID
 	Process        model.Process      `msg:"process"`
 	GenerationType NodeGenerationType `msg:"generation_type"`
 
@@ -871,14 +870,6 @@ type ProcessActivityNode struct {
 	Sockets  []*SocketNode                `msg:"sockets,omitempty"`
 	Syscalls []int                        `msg:"syscalls,omitempty"`
 	Children []*ProcessActivityNode       `msg:"children,omitempty"`
-}
-
-// GetID returns a unique ID to identify the current node
-func (pan *ProcessActivityNode) GetID() NodeID {
-	if pan.id == 0 {
-		pan.id = NewNodeID()
-	}
-	return pan.id
 }
 
 // NewProcessActivityNode returns a new ProcessActivityNode instance
@@ -1318,14 +1309,6 @@ type FileActivityNode struct {
 	Children map[string]*FileActivityNode `msg:"children,omitempty"`
 }
 
-// GetID returns a unique ID to identify the current node
-func (fan *FileActivityNode) GetID() NodeID {
-	if fan.id == 0 {
-		fan.id = NewNodeID()
-	}
-	return fan.id
-}
-
 // OpenNode contains the relevant fields of an Open event on which we might want to write a profiling rule
 type OpenNode struct {
 	model.SyscallEvent
@@ -1510,7 +1493,6 @@ func (fan *FileActivityNode) debug(prefix string) {
 
 // DNSNode is used to store a DNS node
 type DNSNode struct {
-	id       NodeID
 	Requests []model.DNSEvent `msg:"requests"`
 }
 
@@ -1521,14 +1503,6 @@ func NewDNSNode(event *model.DNSEvent) *DNSNode {
 	}
 }
 
-// GetID returns the ID of the current DNS node
-func (n *DNSNode) GetID() NodeID {
-	if n.id == 0 {
-		n.id = NewNodeID()
-	}
-	return n.id
-}
-
 // BindNode is used to store a bind node
 type BindNode struct {
 	Port uint16 `msg:"port"`
@@ -1537,7 +1511,6 @@ type BindNode struct {
 
 // SocketNode is used to store a Socket node and associated events
 type SocketNode struct {
-	id     NodeID
 	Family string      `msg:"family"`
 	Bind   []*BindNode `msg:"bind,omitempty"`
 }
@@ -1569,30 +1542,4 @@ func NewSocketNode(family string) *SocketNode {
 	return &SocketNode{
 		Family: family,
 	}
-}
-
-// GetID returns the ID of the current Socket node
-func (n *SocketNode) GetID() NodeID {
-	if n.id == 0 {
-		n.id = NewNodeID()
-	}
-	return n.id
-}
-
-// NodeID represents the ID of a Node
-//msgp:ignore NodeID
-type NodeID uint64
-
-// NewNodeID returns a new random NodeID
-func NewNodeID() NodeID {
-	return NodeID(eval.RandNonZeroUint64())
-}
-
-// IsUnset checks if the NodeID is unset
-func (id NodeID) IsUnset() bool {
-	return id == 0
-}
-
-func (id NodeID) String() string {
-	return fmt.Sprintf("node%d", uint64(id))
 }

--- a/pkg/security/probe/activity_dump.go
+++ b/pkg/security/probe/activity_dump.go
@@ -889,7 +889,6 @@ func NewProcessActivityNode(entry *model.ProcessCacheEntry, generationType NodeG
 		Files:          make(map[string]*FileActivityNode),
 		DNSNames:       make(map[string]*DNSNode),
 	}
-	_ = pan.GetID()
 	pan.retain()
 	return &pan
 }
@@ -1341,7 +1340,6 @@ func NewFileActivityNode(fileEvent *model.FileEvent, event *Event, name string, 
 		GenerationType: generationType,
 		Children:       make(map[string]*FileActivityNode),
 	}
-	_ = fan.GetID()
 	if fileEvent != nil {
 		fileEventTmp := *fileEvent
 		fan.File = &fileEventTmp

--- a/pkg/security/probe/activity_dump_graph.go
+++ b/pkg/security/probe/activity_dump_graph.go
@@ -315,6 +315,10 @@ func NewGraphIDWithDescription(description string, ids ...NodeID) GraphID {
 	}
 }
 
+func (id GraphID) String() string {
+	return id.raw
+}
+
 // NodeID represents the ID of a Node
 //msgp:ignore NodeID
 type NodeID uint64

--- a/pkg/security/probe/activity_dump_graph.go
+++ b/pkg/security/probe/activity_dump_graph.go
@@ -319,11 +319,12 @@ func NewGraphIDWithDescription(description string, ids ...NodeID) GraphID {
 //msgp:ignore NodeID
 type NodeID uint64
 
-// NewNodeID returns a new random NodeID
+// NewRandomNodeID returns a new random NodeID
 func NewRandomNodeID() NodeID {
 	return NodeID(eval.RandNonZeroUint64())
 }
 
+// NewNodeIDFromPtr returns a new NodeID based on a pointer value
 func NewNodeIDFromPtr(v interface{}) NodeID {
 	rv := reflect.ValueOf(v)
 	if rv.Kind() != reflect.Ptr || rv.IsNil() {

--- a/pkg/security/probe/activity_dump_graph.go
+++ b/pkg/security/probe/activity_dump_graph.go
@@ -85,7 +85,8 @@ var GraphTemplate = `digraph {
 		edge [penwidth=2]
 
 		{{ range .Nodes }}
-		{{ .ID }} [label={{ if not .IsTable }}"{{ end }}{{ .Label }}{{ if not .IsTable }}"{{ end }}, fontsize={{ .Size }}, shape={{ .Shape }}, fontname = "arial", color="{{ .Color }}", fillcolor="{{ .FillColor }}", style="filled"]{{ end }}
+		{{ .ID }} [label={{ if not .IsTable }}"{{ end }}{{ .Label }}{{ if not .IsTable }}"{{ end }}, fontsize={{ .Size }}, shape={{ .Shape }}, fontname = "arial", color="{{ .Color }}", fillcolor="{{ .FillColor }}", style="filled"]
+		{{ end }}
 
 		{{ range .Edges }}
 		{{ .Link }} [arrowhead=none, color="{{ .Color }}"]
@@ -130,8 +131,9 @@ func (ad *ActivityDump) prepareProcessActivityNode(p *ProcessActivityNode, data 
 			args = strings.ReplaceAll(args, "|", "\\|")
 		}
 	}
+	panGraphID := NewGraphID(NewNodeIDFromPtr(p))
 	pan := node{
-		ID:    NewGraphID(NewNodeIDFromPtr(p)),
+		ID:    panGraphID,
 		Label: fmt.Sprintf("%s %s", p.Process.FileEvent.PathnameStr, args),
 		Size:  60,
 		Color: processColor,
@@ -143,38 +145,38 @@ func (ad *ActivityDump) prepareProcessActivityNode(p *ProcessActivityNode, data 
 	case Snapshot:
 		pan.FillColor = processSnapshotColor
 	}
-	data.Nodes[NewGraphID(NewNodeIDFromPtr(p))] = pan
+	data.Nodes[panGraphID] = pan
 
 	for _, n := range p.Sockets {
-		ad.prepareSocketNode(n, data, NewNodeIDFromPtr(p))
+		ad.prepareSocketNode(n, data, panGraphID)
 	}
 	for _, n := range p.DNSNames {
 		data.Edges = append(data.Edges, edge{
-			Link:  fmt.Sprintf("%s -> %s", NewNodeIDFromPtr(p), NewGraphID(NewNodeIDFromPtr(p), NewNodeIDFromPtr(n))),
+			Link:  fmt.Sprintf("%s -> %s", panGraphID, panGraphID.derive(NewNodeIDFromPtr(n))),
 			Color: networkColor,
 		})
-		ad.prepareDNSNode(n, data, NewNodeIDFromPtr(p))
+		ad.prepareDNSNode(n, data, panGraphID)
 	}
 	for _, f := range p.Files {
 		data.Edges = append(data.Edges, edge{
-			Link:  fmt.Sprintf("%s -> %s", NewNodeIDFromPtr(p), NewGraphID(NewNodeIDFromPtr(p), NewNodeIDFromPtr(f))),
+			Link:  fmt.Sprintf("%s -> %s", panGraphID, panGraphID.derive(NewNodeIDFromPtr(f))),
 			Color: fileColor,
 		})
-		ad.prepareFileNode(f, data, "", NewNodeIDFromPtr(p))
+		ad.prepareFileNode(f, data, "", panGraphID)
 	}
 	if len(p.Syscalls) > 0 {
 		ad.prepareSyscallsNode(p, data)
 	}
 	for _, child := range p.Children {
 		data.Edges = append(data.Edges, edge{
-			Link:  fmt.Sprintf("%s -> %s", NewNodeIDFromPtr(p), NewNodeIDFromPtr(child)),
+			Link:  fmt.Sprintf("%s -> %s", panGraphID, NewGraphID(NewNodeIDFromPtr(child))),
 			Color: processColor,
 		})
 		ad.prepareProcessActivityNode(child, data)
 	}
 }
 
-func (ad *ActivityDump) prepareDNSNode(n *DNSNode, data *graph, processID NodeID) {
+func (ad *ActivityDump) prepareDNSNode(n *DNSNode, data *graph, processID GraphID) {
 	if len(n.Requests) == 0 {
 		// save guard, this should never happen
 		return
@@ -186,7 +188,7 @@ func (ad *ActivityDump) prepareDNSNode(n *DNSNode, data *graph, processID NodeID
 	name += ")"
 
 	dnsNode := node{
-		ID:        NewGraphID(processID, NewNodeIDFromPtr(n)),
+		ID:        processID.derive(NewNodeIDFromPtr(n)),
 		Label:     name,
 		Size:      30,
 		Color:     networkColor,
@@ -196,8 +198,8 @@ func (ad *ActivityDump) prepareDNSNode(n *DNSNode, data *graph, processID NodeID
 	data.Nodes[dnsNode.ID] = dnsNode
 }
 
-func (ad *ActivityDump) prepareSocketNode(n *SocketNode, data *graph, processID NodeID) {
-	targetID := NewGraphID(processID, NewNodeIDFromPtr(n))
+func (ad *ActivityDump) prepareSocketNode(n *SocketNode, data *graph, processID GraphID) {
+	targetID := processID.derive(NewNodeIDFromPtr(n))
 
 	// prepare main socket node
 	data.Edges = append(data.Edges, edge{
@@ -221,7 +223,7 @@ func (ad *ActivityDump) prepareSocketNode(n *SocketNode, data *graph, processID 
 
 	for i, name := range names {
 		socketNode := node{
-			ID:        NewGraphID(processID, NewNodeIDFromPtr(n), NodeID(i+1)),
+			ID:        processID.derive(NewNodeIDFromPtr(n), NodeID{inner: uint64(i + 1)}),
 			Label:     name,
 			Size:      30,
 			Color:     networkColor,
@@ -229,15 +231,15 @@ func (ad *ActivityDump) prepareSocketNode(n *SocketNode, data *graph, processID 
 			Shape:     networkShape,
 		}
 		data.Edges = append(data.Edges, edge{
-			Link:  fmt.Sprintf("%s -> %s", NewGraphID(processID, NewNodeIDFromPtr(n)), socketNode.ID),
+			Link:  fmt.Sprintf("%s -> %s", processID.derive(NewNodeIDFromPtr(n)), socketNode.ID),
 			Color: networkColor,
 		})
 		data.Nodes[socketNode.ID] = socketNode
 	}
 }
 
-func (ad *ActivityDump) prepareFileNode(f *FileActivityNode, data *graph, prefix string, processID NodeID) {
-	mergedID := NewGraphID(processID, NewNodeIDFromPtr(f))
+func (ad *ActivityDump) prepareFileNode(f *FileActivityNode, data *graph, prefix string, processID GraphID) {
+	mergedID := processID.derive(NewNodeIDFromPtr(f))
 	fn := node{
 		ID:    mergedID,
 		Label: f.getNodeLabel(),
@@ -255,7 +257,7 @@ func (ad *ActivityDump) prepareFileNode(f *FileActivityNode, data *graph, prefix
 
 	for _, child := range f.Children {
 		data.Edges = append(data.Edges, edge{
-			Link:  fmt.Sprintf("%s -> %s", mergedID, NewGraphID(processID, NewNodeIDFromPtr(child))),
+			Link:  fmt.Sprintf("%s -> %s", mergedID, processID.derive(NewNodeIDFromPtr(child))),
 			Color: fileColor,
 		})
 		ad.prepareFileNode(child, data, prefix+f.Name, processID)
@@ -270,7 +272,7 @@ func (ad *ActivityDump) prepareSyscallsNode(p *ProcessActivityNode, data *graph)
 	label += "</TABLE>>"
 
 	syscallsNode := node{
-		ID:        NewGraphID(NewNodeIDFromPtr(p)),
+		ID:        NewGraphIDWithDescription("syscalls", NewNodeIDFromPtr(p)),
 		Label:     label,
 		Size:      30,
 		Color:     processColor,
@@ -280,7 +282,7 @@ func (ad *ActivityDump) prepareSyscallsNode(p *ProcessActivityNode, data *graph)
 	}
 	data.Nodes[syscallsNode.ID] = syscallsNode
 	data.Edges = append(data.Edges, edge{
-		Link:  fmt.Sprintf("%s -> %s", NewNodeIDFromPtr(p), syscallsNode.ID),
+		Link:  fmt.Sprintf("%s -> %s", NewGraphID(NewNodeIDFromPtr(p)), syscallsNode.ID),
 		Color: processColor,
 	})
 }
@@ -292,26 +294,28 @@ type GraphID struct {
 }
 
 // NewGraphID returns a new GraphID based on the provided NodeIDs
-func NewGraphID(ids ...NodeID) GraphID {
-	return NewGraphIDWithDescription("", ids...)
+func NewGraphID(id NodeID) GraphID {
+	return NewGraphIDWithDescription("", id)
 }
 
 // NewGraphIDWithDescription returns a new GraphID based on a description and on the provided NodeIDs
-func NewGraphIDWithDescription(description string, ids ...NodeID) GraphID {
-	var b strings.Builder
-	if description != "" {
-		b.WriteString(description)
-	} else {
-		b.WriteString("node")
+func NewGraphIDWithDescription(description string, id NodeID) GraphID {
+	if description == "" {
+		description = "node"
 	}
-
-	for _, id := range ids {
-		b.WriteString("_")
-		b.WriteString(id.String())
-	}
-
 	return GraphID{
-		raw: b.String(),
+		raw: fmt.Sprintf("%s_%d", description, id.inner),
+	}
+}
+
+func (id *GraphID) derive(ids ...NodeID) GraphID {
+	var builder strings.Builder
+	builder.WriteString(id.raw)
+	for _, sub := range ids {
+		builder.WriteString(fmt.Sprintf("_%d", sub.inner))
+	}
+	return GraphID{
+		raw: builder.String(),
 	}
 }
 
@@ -321,11 +325,15 @@ func (id GraphID) String() string {
 
 // NodeID represents the ID of a Node
 //msgp:ignore NodeID
-type NodeID uint64
+type NodeID struct {
+	inner uint64
+}
 
 // NewRandomNodeID returns a new random NodeID
 func NewRandomNodeID() NodeID {
-	return NodeID(eval.RandNonZeroUint64())
+	return NodeID{
+		inner: eval.RandNonZeroUint64(),
+	}
 }
 
 // NewNodeIDFromPtr returns a new NodeID based on a pointer value
@@ -337,14 +345,12 @@ func NewNodeIDFromPtr(v interface{}) NodeID {
 	}
 
 	ptr := rv.Pointer()
-	return NodeID(uint64(ptr))
+	return NodeID{
+		inner: uint64(ptr),
+	}
 }
 
 // IsUnset checks if the NodeID is unset
 func (id NodeID) IsUnset() bool {
-	return id == 0
-}
-
-func (id NodeID) String() string {
-	return fmt.Sprintf("node%d", uint64(id))
+	return id.inner == 0
 }

--- a/pkg/security/probe/namespace_resolver_graph.go
+++ b/pkg/security/probe/namespace_resolver_graph.go
@@ -64,7 +64,7 @@ func (nr *NamespaceResolver) generateGraphDataFromDump(dump []NetworkNamespaceDu
 	for _, netns := range dump {
 		// create namespace node
 		netnsNode := node{
-			ID:    NewGraphID(NewNodeID()),
+			ID:    NewGraphID(NewRandomNodeID()),
 			Label: fmt.Sprintf("%v [fd:%d][handle:%v]", netns.NsID, netns.HandleFD, netns.HandlePath),
 			Color: namespaceColor,
 			Shape: namespaceShape,
@@ -80,7 +80,7 @@ func (nr *NamespaceResolver) generateGraphDataFromDump(dump []NetworkNamespaceDu
 		// create active and queued devices nodes
 		for _, dev := range netns.Devices {
 			devNode := node{
-				ID:        NewGraphID(NewNodeID()),
+				ID:        NewGraphID(NewRandomNodeID()),
 				Label:     fmt.Sprintf("%s [%d]", dev.IfName, dev.IfIndex),
 				FillColor: activeDeviceColor,
 				Color:     deviceColor,
@@ -97,7 +97,7 @@ func (nr *NamespaceResolver) generateGraphDataFromDump(dump []NetworkNamespaceDu
 		}
 		for _, dev := range netns.DevicesInQueue {
 			devNode := node{
-				ID:        NewGraphID(NewNodeID()),
+				ID:        NewGraphID(NewRandomNodeID()),
 				Label:     fmt.Sprintf("%s [%d]", dev.IfName, dev.IfIndex),
 				FillColor: queuedDeviceColor,
 				Color:     deviceColor,


### PR DESCRIPTION
### What does this PR do?

- Before: `sizeof ProcessActivityNode = 864`
- After: `sizeof ProcessActivityNode = 856`

Also: no random in insertion path
This also fixes the graph

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
