### PR TITLE
Update the inventory metadata when needed

### DIFF
--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -141,6 +141,7 @@ func (c *Collector) RunCheck(ch check.Check) (check.ID, error) {
 	}
 
 	c.checks[ch.ID()] = ch
+	inventories.Refresh()
 	return ch.ID(), nil
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1840,21 +1840,3 @@ func GetVectorURL(datatype DataType) (string, error) {
 	}
 	return "", nil
 }
-
-// GetInventoriesMinInterval gets the inventories_min_interval value, applying the default if it is zero.
-func GetInventoriesMinInterval() time.Duration {
-	minInterval := time.Duration(Datadog.GetInt("inventories_min_interval")) * time.Second
-	if minInterval == 0 {
-		minInterval = DefaultInventoriesMinInterval * time.Second
-	}
-	return minInterval
-}
-
-// GetInventoriesMaxInterval gets the inventories_max_interval value, applying the default if it is zero.
-func GetInventoriesMaxInterval() time.Duration {
-	maxInterval := time.Duration(Datadog.GetInt("inventories_max_interval")) * time.Second
-	if maxInterval == 0 {
-		maxInterval = DefaultInventoriesMaxInterval * time.Second
-	}
-	return maxInterval
-}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1156,25 +1156,3 @@ network_devices:
 	config = setupConfFromYAML(datadogYaml)
 	assert.Equal(t, "dev", config.GetString("network_devices.namespace"))
 }
-
-func TestGetInventoriesMinInterval(t *testing.T) {
-	Mock(t).Set("inventories_min_interval", 6)
-	assert.EqualValues(t, 6*time.Second, GetInventoriesMinInterval())
-}
-
-func TestGetInventoriesMinIntervalInvalid(t *testing.T) {
-	// an invalid integer results in a value of 0 from Viper (with a logged warning)
-	Mock(t).Set("inventories_min_interval", 0)
-	assert.EqualValues(t, DefaultInventoriesMinInterval*time.Second, GetInventoriesMinInterval())
-}
-
-func TestGetInventoriesMaxInterval(t *testing.T) {
-	Mock(t).Set("inventories_max_interval", 6)
-	assert.EqualValues(t, 6*time.Second, GetInventoriesMaxInterval())
-}
-
-func TestGetInventoriesMaxIntervalInvalid(t *testing.T) {
-	// an invalid integer results in a value of 0 from Viper (with a logged warning)
-	Mock(t).Set("inventories_max_interval", 0)
-	assert.EqualValues(t, DefaultInventoriesMaxInterval*time.Second, GetInventoriesMaxInterval())
-}

--- a/pkg/config/settings/runtime_setting_log_level.go
+++ b/pkg/config/settings/runtime_setting_log_level.go
@@ -7,6 +7,7 @@ package settings
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/metadata/inventories"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -51,5 +52,7 @@ func (l LogLevelRuntimeSetting) Set(v interface{}) error {
 		key = l.ConfigKey
 	}
 	config.Datadog.Set(key, logLevel)
+	// we trigger a new inventory metadata payload since the configuration was updated by the user.
+	inventories.Refresh()
 	return nil
 }

--- a/pkg/metadata/inventories/inventories.go
+++ b/pkg/metadata/inventories/inventories.go
@@ -103,7 +103,7 @@ const (
 )
 
 // Refresh signals that some data has been updated and a new payload should be sent (ex: when configuration is changed
-// byt the user, new checks starts, etc). This will trigger a new payload to be sent while still respecting
+// by the user, new checks starts, etc). This will trigger a new payload to be sent while still respecting
 // 'inventories_min_interval'.
 func Refresh() {
 	select {

--- a/pkg/metadata/inventories_collector.go
+++ b/pkg/metadata/inventories_collector.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"expvar"
 	"fmt"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metadata/inventories"
@@ -49,11 +50,29 @@ func (c inventoriesCollector) Send(ctx context.Context, s serializer.MetricSeria
 	return nil
 }
 
+// getMinInterval gets the inventories_min_interval value, applying the default if it is zero.
+func getMinInterval() time.Duration {
+	minInterval := time.Duration(config.Datadog.GetInt("inventories_min_interval")) * time.Second
+	if minInterval <= 0 {
+		minInterval = config.DefaultInventoriesMinInterval * time.Second
+	}
+	return minInterval
+}
+
+// getMaxInterval gets the inventories_max_interval value, applying the default if it is zero.
+func getMaxInterval() time.Duration {
+	maxInterval := time.Duration(config.Datadog.GetInt("inventories_max_interval")) * time.Second
+	if maxInterval <= 0 {
+		maxInterval = config.DefaultInventoriesMaxInterval * time.Second
+	}
+	return maxInterval
+}
+
 // Init initializes the inventory metadata collection. This should be called in
 // all agents that wish to track inventory, after configuration is initialized.
 func (c inventoriesCollector) Init() error {
 	inventories.InitializeData()
-	return inventories.StartMetadataUpdatedGoroutine(c.sc, config.GetInventoriesMinInterval())
+	return inventories.StartMetadataUpdatedGoroutine(c.sc, getMinInterval())
 }
 
 // SetupInventoriesExpvar init the expvar function for inventories
@@ -87,7 +106,7 @@ func SetupInventories(sc *Scheduler, coll inventories.CollectorInterface) error 
 	}
 	RegisterCollector("inventories", ic)
 
-	if err := sc.AddCollector("inventories", config.GetInventoriesMaxInterval()); err != nil {
+	if err := sc.AddCollector("inventories", getMaxInterval()); err != nil {
 		return err
 	}
 

--- a/pkg/metadata/inventories_collector_test.go
+++ b/pkg/metadata/inventories_collector_test.go
@@ -1,0 +1,46 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
+package metadata
+
+import (
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetMinInterval(t *testing.T) {
+	config.Mock(t).Set("inventories_min_interval", 6)
+	assert.EqualValues(t, 6*time.Second, getMinInterval())
+}
+
+func TestGetMinIntervalInvalid(t *testing.T) {
+	mockConf := config.Mock(t)
+
+	// an invalid integer results in a value of 0 from Viper (with a logged warning)
+	mockConf.Set("inventories_min_interval", 0)
+	assert.EqualValues(t, config.DefaultInventoriesMinInterval*time.Second, getMinInterval())
+
+	// an invalid integer results in a value of 0 from Viper (with a logged warning)
+	mockConf.Set("inventories_min_interval", -1)
+	assert.EqualValues(t, config.DefaultInventoriesMinInterval*time.Second, getMinInterval())
+}
+
+func TestGetMaxInterval(t *testing.T) {
+	config.Mock(t).Set("inventories_max_interval", 6)
+	assert.EqualValues(t, 6*time.Second, getMaxInterval())
+}
+
+func TestGetMaxIntervalInvalid(t *testing.T) {
+	mockConf := config.Mock(t)
+
+	// an invalid integer results in a value of 0 from Viper (with a logged warning)
+	mockConf.Set("inventories_max_interval", 0)
+	assert.EqualValues(t, config.DefaultInventoriesMaxInterval*time.Second, getMaxInterval())
+	mockConf.Set("inventories_max_interval", -1)
+	assert.EqualValues(t, config.DefaultInventoriesMaxInterval*time.Second, getMaxInterval())
+}


### PR DESCRIPTION
### What does this PR do?

Update the inventory metadata when needed

We need to resend a new payload when the configuration is updated by the user or when a check is started/stopped.

### Describe how to test/QA your changes

Start the Agent and wait for 2 min (ie: longer than `inventories_min_interval`, check the inventory metadata payload (`datadog-agent troubleshooting metadata_inventory`). Then update the log level at runtime (without restarting the agent).
The inventory payload should be updated with the new value.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
