### PR TITLE
Adds logging functions to conditionally execute based on current runtime log level

### DIFF
--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -542,6 +542,14 @@ func Tracec(message string, context ...interface{}) {
 	TracecStackDepth(message, 1, context...)
 }
 
+// TraceFunc calls and logs the result of 'logFunc' if and only if Trace (or more verbose) logs are enabled
+func TraceFunc(logFunc func() string) {
+	currentLevel, _ := GetLogLevel()
+	if currentLevel <= seelog.TraceLvl {
+		Trace(logFunc())
+	}
+}
+
 // Debug logs at the debug level
 func Debug(v ...interface{}) {
 	log(seelog.DebugLvl, func() { Debug(v...) }, logger.debug, v...)
@@ -560,6 +568,14 @@ func DebugcStackDepth(message string, depth int, context ...interface{}) {
 // Debugc logs at the debug level with context
 func Debugc(message string, context ...interface{}) {
 	DebugcStackDepth(message, 1, context...)
+}
+
+// DebugFunc calls and logs the result of 'logFunc' if and only if Debug (or more verbose) logs are enabled
+func DebugFunc(logFunc func() string) {
+	currentLevel, _ := GetLogLevel()
+	if currentLevel <= seelog.DebugLvl {
+		Debug(logFunc())
+	}
 }
 
 // Info logs at the info level
@@ -582,6 +598,14 @@ func Infoc(message string, context ...interface{}) {
 	InfocStackDepth(message, 1, context...)
 }
 
+// InfoFunc calls and logs the result of 'logFunc' if and only if Info (or more verbose) logs are enabled
+func InfoFunc(logFunc func() string) {
+	currentLevel, _ := GetLogLevel()
+	if currentLevel <= seelog.InfoLvl {
+		Info(logFunc())
+	}
+}
+
 // Warn logs at the warn level and returns an error containing the formated log message
 func Warn(v ...interface{}) error {
 	return logWithError(seelog.WarnLvl, func() { Warn(v...) }, logger.warn, false, v...)
@@ -600,6 +624,14 @@ func WarncStackDepth(message string, depth int, context ...interface{}) error {
 // Warnc logs at the warn level with context and returns an error containing the formated log message
 func Warnc(message string, context ...interface{}) error {
 	return WarncStackDepth(message, 1, context...)
+}
+
+// WarnFunc calls and logs the result of 'logFunc' if and only if Warn (or more verbose) logs are enabled
+func WarnFunc(logFunc func() string) {
+	currentLevel, _ := GetLogLevel()
+	if currentLevel <= seelog.WarnLvl {
+		Warn(logFunc())
+	}
 }
 
 // Error logs at the error level and returns an error containing the formated log message
@@ -622,6 +654,14 @@ func Errorc(message string, context ...interface{}) error {
 	return ErrorcStackDepth(message, 1, context...)
 }
 
+// ErrorFunc calls and logs the result of 'logFunc' if and only if Error (or more verbose) logs are enabled
+func ErrorFunc(logFunc func() string) {
+	currentLevel, _ := GetLogLevel()
+	if currentLevel <= seelog.ErrorLvl {
+		Error(logFunc())
+	}
+}
+
 // Critical logs at the critical level and returns an error containing the formated log message
 func Critical(v ...interface{}) error {
 	return logWithError(seelog.CriticalLvl, func() { Critical(v...) }, logger.critical, true, v...)
@@ -640,6 +680,14 @@ func CriticalcStackDepth(message string, depth int, context ...interface{}) erro
 // Criticalc logs at the critical level with context and returns an error containing the formated log message
 func Criticalc(message string, context ...interface{}) error {
 	return CriticalcStackDepth(message, 1, context...)
+}
+
+// CriticalFunc calls and logs the result of 'logFunc' if and only if Critical (or more verbose) logs are enabled
+func CriticalFunc(logFunc func() string) {
+	currentLevel, _ := GetLogLevel()
+	if currentLevel <= seelog.CriticalLvl {
+		Critical(logFunc())
+	}
 }
 
 // InfoStackDepth logs at the info level and the current stack depth plus the additional given one

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -546,7 +546,7 @@ func Tracec(message string, context ...interface{}) {
 func TraceFunc(logFunc func() string) {
 	currentLevel, _ := GetLogLevel()
 	if currentLevel <= seelog.TraceLvl {
-		Trace(logFunc())
+		TraceStackDepth(2, logFunc())
 	}
 }
 
@@ -574,7 +574,7 @@ func Debugc(message string, context ...interface{}) {
 func DebugFunc(logFunc func() string) {
 	currentLevel, _ := GetLogLevel()
 	if currentLevel <= seelog.DebugLvl {
-		Debug(logFunc())
+		DebugStackDepth(2, logFunc())
 	}
 }
 
@@ -602,7 +602,7 @@ func Infoc(message string, context ...interface{}) {
 func InfoFunc(logFunc func() string) {
 	currentLevel, _ := GetLogLevel()
 	if currentLevel <= seelog.InfoLvl {
-		Info(logFunc())
+		InfoStackDepth(2, logFunc())
 	}
 }
 
@@ -630,7 +630,7 @@ func Warnc(message string, context ...interface{}) error {
 func WarnFunc(logFunc func() string) {
 	currentLevel, _ := GetLogLevel()
 	if currentLevel <= seelog.WarnLvl {
-		Warn(logFunc())
+		WarnStackDepth(2, logFunc())
 	}
 }
 
@@ -658,7 +658,7 @@ func Errorc(message string, context ...interface{}) error {
 func ErrorFunc(logFunc func() string) {
 	currentLevel, _ := GetLogLevel()
 	if currentLevel <= seelog.ErrorLvl {
-		Error(logFunc())
+		ErrorStackDepth(2, logFunc())
 	}
 }
 
@@ -686,7 +686,7 @@ func Criticalc(message string, context ...interface{}) error {
 func CriticalFunc(logFunc func() string) {
 	currentLevel, _ := GetLogLevel()
 	if currentLevel <= seelog.CriticalLvl {
-		Critical(logFunc())
+		CriticalStackDepth(2, logFunc())
 	}
 }
 

--- a/pkg/util/log/log_test.go
+++ b/pkg/util/log/log_test.go
@@ -375,3 +375,89 @@ func TestCriticalcNotNil(t *testing.T) {
 
 	assert.NotNil(t, Criticalc("test", "key", "val"))
 }
+
+func TestDebugFuncNoExecute(t *testing.T) {
+	var b bytes.Buffer
+	w := bufio.NewWriter(&b)
+
+	l, _ := seelog.LoggerFromWriterWithMinLevelAndFormat(w, seelog.InfoLvl, "[%LEVEL] %FuncShort: %Msg")
+	SetupLogger(l, "info")
+
+	i := 0
+	DebugFunc(func() string { i = 1; return "hello" })
+
+	w.Flush()
+
+	assert.Equal(t, strings.Count(b.String(), "hello"), 0)
+	assert.Equal(t, i, 0)
+}
+
+func TestDebugFuncExecute(t *testing.T) {
+	var b bytes.Buffer
+	w := bufio.NewWriter(&b)
+
+	l, _ := seelog.LoggerFromWriterWithMinLevelAndFormat(w, seelog.DebugLvl, "[%LEVEL] %FuncShort: %Msg")
+	SetupLogger(l, "debug")
+
+	i := 0
+	DebugFunc(func() string {
+		i = 1
+		return "hello"
+	})
+
+	w.Flush()
+
+	assert.Equal(t, 1, strings.Count(b.String(), "hello"))
+	assert.Equal(t, i, 1)
+}
+
+func TestFuncVersions(t *testing.T) {
+	cases := []struct {
+		seelogLevel        seelog.LogLevel
+		strLogLevel        string
+		logFunc            func(func() string)
+		expectedToBeCalled bool
+	}{
+		{seelog.ErrorLvl, "error", DebugFunc, false},
+		{seelog.WarnLvl, "warn", DebugFunc, false},
+		{seelog.InfoLvl, "info", DebugFunc, false},
+		{seelog.DebugLvl, "debug", DebugFunc, true},
+		{seelog.TraceLvl, "trace", DebugFunc, true},
+
+		{seelog.TraceLvl, "trace", TraceFunc, true},
+		{seelog.InfoLvl, "info", TraceFunc, false},
+
+		{seelog.InfoLvl, "info", InfoFunc, true},
+		{seelog.WarnLvl, "warn", InfoFunc, false},
+
+		{seelog.WarnLvl, "warn", WarnFunc, true},
+		{seelog.ErrorLvl, "error", WarnFunc, false},
+
+		{seelog.ErrorLvl, "error", ErrorFunc, true},
+		{seelog.CriticalLvl, "critical", ErrorFunc, false},
+
+		{seelog.CriticalLvl, "critical", CriticalFunc, true},
+	}
+
+	for _, tc := range cases {
+		var b bytes.Buffer
+		w := bufio.NewWriter(&b)
+
+		l, _ := seelog.LoggerFromWriterWithMinLevelAndFormat(w, tc.seelogLevel, "[%LEVEL] %FuncShort: %Msg")
+		SetupLogger(l, tc.strLogLevel)
+
+		i := 0
+		tc.logFunc(func() string { i = 1; return "hello" })
+
+		w.Flush()
+
+		if tc.expectedToBeCalled {
+			assert.Equal(t, 1, strings.Count(b.String(), "hello"), tc)
+			assert.Equal(t, 1, i, tc)
+		} else {
+			assert.Equal(t, 0, strings.Count(b.String(), "hello"), tc)
+			assert.Equal(t, 0, i, tc)
+		}
+	}
+
+}


### PR DESCRIPTION
### What does this PR do?
Adds logging functions that take a function which will be executed (and printed) only if the current log level matches.
These are useful when a developer wants to log something that could be expensive to calculate/fetch.

### Motivation
```go
func example() {
    log.DebugFunc(func() string {
       return getExpensiveThing().String()
    })
}
```

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
