### PR TITLE
Update agent for new 2.0 driver

### DIFF
--- a/pkg/network/driver/handle.go
+++ b/pkg/network/driver/handle.go
@@ -73,7 +73,8 @@ type RealDriverHandle struct {
 	handleType HandleType
 
 	// record the last value of number of flows missed due to max exceeded
-	lastNumFlowsMissed uint64
+	lastNumFlowsMissed       uint64
+	lastNumClosedFlowsMissed uint64
 }
 
 func (rdh *RealDriverHandle) GetWindowsHandle() windows.Handle {
@@ -111,6 +112,7 @@ func NewHandle(flags uint32, handleType HandleType) (Handle, error) {
 		flags,
 		windows.Handle(0))
 	if err != nil {
+		log.Errorf("Error creating file handle %v", err)
 		return nil, err
 	}
 	return &RealDriverHandle{Handle: h, handleType: handleType}, nil
@@ -125,7 +127,7 @@ func (dh *RealDriverHandle) Close() error {
 func (dh *RealDriverHandle) GetStatsForHandle() (map[string]map[string]int64, error) {
 	var (
 		bytesReturned uint32
-		statbuf       = make([]byte, DriverStatsSize)
+		statbuf       = make([]byte, StatsSize)
 		returnmap     = make(map[string]map[string]int64)
 	)
 
@@ -133,70 +135,51 @@ func (dh *RealDriverHandle) GetStatsForHandle() (map[string]map[string]int64, er
 	if err != nil {
 		return nil, fmt.Errorf("failed to read driver stats for filter type %v - returned error %v", dh.handleType, err)
 	}
-	stats := *(*DriverStats)(unsafe.Pointer(&statbuf[0]))
-
-	// the global stats are returned regardless.  So parse them into the
-	// total map
-	returnmap["driver"] = map[string]int64{
-		"read_calls":                  stats.Total.Handle_stats.Read_calls,
-		"read_calls_outstanding":      stats.Total.Handle_stats.Read_calls_outstanding,
-		"read_calls_completed":        stats.Total.Handle_stats.Read_calls_completed,
-		"read_calls_cancelled":        stats.Total.Handle_stats.Read_calls_cancelled,
-		"write_calls":                 stats.Total.Handle_stats.Write_calls,
-		"write_bytes":                 stats.Total.Handle_stats.Write_bytes,
-		"ioctl_calls":                 stats.Total.Handle_stats.Ioctl_calls,
-		"packets_observed":            stats.Total.Flow_stats.Packets_observed,
-		"packets_processed_flow":      stats.Total.Flow_stats.Packets_processed,
-		"open_flows":                  stats.Total.Flow_stats.Open_flows,
-		"total_flows":                 stats.Total.Flow_stats.Total_flows,
-		"num_flow_searches":           stats.Total.Flow_stats.Num_flow_searches,
-		"num_flow_search_misses":      stats.Total.Flow_stats.Num_flow_search_misses,
-		"num_flow_collisions":         stats.Total.Flow_stats.Num_flow_collisions,
-		"packets_processed_transport": stats.Total.Transport_stats.Packets_processed,
-		"read_packets_skipped":        stats.Total.Transport_stats.Read_packets_skipped,
-		"packets_reported":            stats.Total.Transport_stats.Packets_reported,
-	}
+	stats := *(*Stats)(unsafe.Pointer(&statbuf[0]))
 
 	switch dh.handleType {
 
 	// A FlowHandle handle returns the flow stats specific to this handle
 	case FlowHandle:
-		if dh.lastNumFlowsMissed < uint64(stats.Handle.Flow_stats.Num_flows_missed_max_exceeded) {
-			log.Warnf("Flows missed due to maximum flow limit. %v", stats.Handle.Flow_stats.Num_flows_missed_max_exceeded)
+		if dh.lastNumFlowsMissed < uint64(stats.Flow_stats.Num_flow_alloc_skipped_max_open_exceeded) {
+			log.Warnf("Open Flows missed due to maximum flow limit. %v", stats.Flow_stats.Num_flow_alloc_skipped_max_open_exceeded)
 		}
-		dh.lastNumFlowsMissed = uint64(stats.Handle.Flow_stats.Num_flows_missed_max_exceeded)
+		if dh.lastNumClosedFlowsMissed < uint64(stats.Flow_stats.Num_flow_closed_dropped_max_exceeded) {
+			log.Warnf("Closed Flows dropped due to maximum flow limit. %v", stats.Flow_stats.Num_flow_closed_dropped_max_exceeded)
+		}
+		dh.lastNumFlowsMissed = uint64(stats.Flow_stats.Num_flow_alloc_skipped_max_open_exceeded)
+		dh.lastNumClosedFlowsMissed = uint64(stats.Flow_stats.Num_flow_closed_dropped_max_exceeded)
 		returnmap["handle"] = map[string]int64{
-			"read_calls":                    stats.Handle.Handle_stats.Read_calls,
-			"read_calls_outstanding":        stats.Handle.Handle_stats.Read_calls_outstanding,
-			"read_calls_completed":          stats.Handle.Handle_stats.Read_calls_completed,
-			"read_calls_cancelled":          stats.Handle.Handle_stats.Read_calls_cancelled,
-			"write_calls":                   stats.Handle.Handle_stats.Write_calls,
-			"write_bytes":                   stats.Handle.Handle_stats.Write_bytes,
-			"ioctl_calls":                   stats.Handle.Handle_stats.Ioctl_calls,
-			"packets_observed":              stats.Handle.Flow_stats.Packets_observed,
-			"packets_processed_flow":        stats.Handle.Flow_stats.Packets_processed,
-			"open_flows":                    stats.Handle.Flow_stats.Open_flows,
-			"total_flows":                   stats.Handle.Flow_stats.Total_flows,
-			"num_flow_searches":             stats.Handle.Flow_stats.Num_flow_searches,
-			"num_flow_search_misses":        stats.Handle.Flow_stats.Num_flow_search_misses,
-			"num_flow_collisions":           stats.Handle.Flow_stats.Num_flow_collisions,
-			"num_flow_structures":           stats.Handle.Flow_stats.Num_flow_structures,
-			"peak_num_flow_structures":      stats.Handle.Flow_stats.Peak_num_flow_structures,
-			"num_flows_missed_max_exceeded": stats.Handle.Flow_stats.Num_flows_missed_max_exceeded,
+			"num_flow_collisions":      stats.Flow_stats.Num_flow_collisions,
+			"new_flows_skipped_max":    stats.Flow_stats.Num_flow_alloc_skipped_max_open_exceeded,
+			"closed_flows_skipped_max": stats.Flow_stats.Num_flow_closed_dropped_max_exceeded,
+
+			"num_flow_structs":             stats.Flow_stats.Num_flow_structures,
+			"peak_num_flow_structs":        stats.Flow_stats.Peak_num_flow_structures,
+			"num_flow_closed_structs":      stats.Flow_stats.Num_flow_closed_structures,
+			"peak_num_flow_closed_structs": stats.Flow_stats.Peak_num_flow_closed_structures,
+
+			"open_table_adds":      stats.Flow_stats.Open_table_adds,
+			"open_table_removes":   stats.Flow_stats.Open_table_removes,
+			"closed_table_adds":    stats.Flow_stats.Closed_table_adds,
+			"closed_table_removes": stats.Flow_stats.Closed_table_removes,
+
+			"no_handle_flows":                stats.Flow_stats.Num_flows_no_handle,
+			"no_handle_flows_peak":           stats.Flow_stats.Peak_num_flows_no_handle,
+			"num_flows_missed_max_no_handle": stats.Flow_stats.Num_flows_missed_max_no_handle_exceeded,
+			"num_packets_after_closed":       stats.Flow_stats.Num_packets_after_flow_closed,
+
+			"http_txns_captured":       stats.Http_stats.Txns_captured,
+			"http_txns_skipped_max":    stats.Http_stats.Txns_skipped_max_exceeded,
+			"http_ndis_non_contiguous": stats.Http_stats.Ndis_buffer_non_contiguous,
 		}
 	// A DataHandle handle returns transfer stats specific to this handle
 	case DataHandle:
 		returnmap["handle"] = map[string]int64{
-			"read_calls":                  stats.Handle.Handle_stats.Read_calls,
-			"read_calls_outstanding":      stats.Handle.Handle_stats.Read_calls_outstanding,
-			"read_calls_completed":        stats.Handle.Handle_stats.Read_calls_completed,
-			"read_calls_cancelled":        stats.Handle.Handle_stats.Read_calls_cancelled,
-			"write_calls":                 stats.Handle.Handle_stats.Write_calls,
-			"write_bytes":                 stats.Handle.Handle_stats.Write_bytes,
-			"ioctl_calls":                 stats.Handle.Handle_stats.Ioctl_calls,
-			"packets_processed_transport": stats.Handle.Transport_stats.Packets_processed,
-			"read_packets_skipped":        stats.Handle.Transport_stats.Read_packets_skipped,
-			"packets_reported":            stats.Handle.Transport_stats.Packets_reported,
+			"read_packets_skipped": stats.Transport_stats.Packets_skipped,
+			"reads_requested":      stats.Transport_stats.Calls_requested,
+			"reads_completed":      stats.Transport_stats.Calls_completed,
+			"reads_cancelled":      stats.Transport_stats.Calls_cancelled,
 		}
 	default:
 		return nil, fmt.Errorf("no matching handle type for pulling handle stats")

--- a/pkg/network/driver/types.go
+++ b/pkg/network/driver/types.go
@@ -25,8 +25,11 @@ const (
 	GetStatsIOCTL             = C.DDNPMDRIVER_IOCTL_GETSTATS
 	SetFlowFilterIOCTL        = C.DDNPMDRIVER_IOCTL_SET_FLOW_FILTER
 	SetDataFilterIOCTL        = C.DDNPMDRIVER_IOCTL_SET_DATA_FILTER
-	SetMaxFlowsIOCTL          = C.DDNPMDRIVER_IOCTL_SET_MAX_FLOWS
+	GetFlowsIOCTL             = C.DDNPMDRIVER_IOCTL_GET_FLOWS
+	SetMaxOpenFlowsIOCTL      = C.DDNPMDRIVER_IOCTL_SET_MAX_OPEN_FLOWS
+	SetMaxClosedFlowsIOCTL    = C.DDNPMDRIVER_IOCTL_SET_MAX_CLOSED_FLOWS
 	FlushPendingHttpTxnsIOCTL = C.DDNPMDRIVER_IOCTL_FLUSH_PENDING_HTTP_TRANSACTIONS
+	EnableHttpIOCTL           = C.DDNPMDRIVER_IOCTL_ENABLE_HTTP
 )
 
 type FilterAddress C.struct__filterAddress
@@ -39,14 +42,12 @@ type FilterPacketHeader C.struct_filterPacketHeader
 
 const FilterPacketHeaderSize = C.sizeof_struct_filterPacketHeader
 
-type HandleStats C.struct__handle_stats
 type FlowStats C.struct__flow_handle_stats
 type TransportStats C.struct__transport_handle_stats
 type HttpStats C.struct__http_handle_stats
 type Stats C.struct__stats
-type DriverStats C.struct_driver_stats
 
-const DriverStatsSize = C.sizeof_struct_driver_stats
+const StatsSize = C.sizeof_struct__stats
 
 type PerFlowData C.struct__perFlowData
 type TCPFlowData C.struct__tcpFlowData

--- a/release.json
+++ b/release.json
@@ -11,9 +11,9 @@
         "JMXFETCH_VERSION": "0.46.0",
         "JMXFETCH_HASH": "3c41c0660e9c53451dfb51e8dad33bc87b03be1abc1fcd3c856ea81e6b0894ee",
         "MACOS_BUILD_VERSION": "master",
-        "WINDOWS_DDNPM_DRIVER": "release-signed",
-        "WINDOWS_DDNPM_VERSION": "1.4.3",
-        "WINDOWS_DDNPM_SHASUM": "939960a65f6352b18f21d07b00e543728e93bea123add1f7e8ef283a87197533",
+        "WINDOWS_DDNPM_DRIVER": "testsigned",
+        "WINDOWS_DDNPM_VERSION": "1.4.3.git.28.b4f339c",
+        "WINDOWS_DDNPM_SHASUM": "54142a137e80d0cf80393cdee046e6713b9313fc6057c4ef5dfa4435dc713b60",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "nightly-a7": {
@@ -23,9 +23,9 @@
         "JMXFETCH_VERSION": "0.46.0",
         "JMXFETCH_HASH": "3c41c0660e9c53451dfb51e8dad33bc87b03be1abc1fcd3c856ea81e6b0894ee",
         "MACOS_BUILD_VERSION": "master",
-        "WINDOWS_DDNPM_DRIVER": "release-signed",
-        "WINDOWS_DDNPM_VERSION": "1.4.3",
-        "WINDOWS_DDNPM_SHASUM": "939960a65f6352b18f21d07b00e543728e93bea123add1f7e8ef283a87197533",
+        "WINDOWS_DDNPM_DRIVER": "testsigned",
+        "WINDOWS_DDNPM_VERSION": "1.4.3.git.28.b4f339c",
+        "WINDOWS_DDNPM_SHASUM": "54142a137e80d0cf80393cdee046e6713b9313fc6057c4ef5dfa4435dc713b60",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "release-a6": {

--- a/release.json
+++ b/release.json
@@ -12,8 +12,8 @@
         "JMXFETCH_HASH": "3c41c0660e9c53451dfb51e8dad33bc87b03be1abc1fcd3c856ea81e6b0894ee",
         "MACOS_BUILD_VERSION": "master",
         "WINDOWS_DDNPM_DRIVER": "testsigned",
-        "WINDOWS_DDNPM_VERSION": "2.0.0.git.4.2b8928e",
-        "WINDOWS_DDNPM_SHASUM": "da43a153010666d69e1c2f2b8f0e8b115b701ea4f5ffbe90842557d78a563661",
+        "WINDOWS_DDNPM_VERSION": "2.0.1",
+        "WINDOWS_DDNPM_SHASUM": "e33423f4ed302a722a717fc077ece3beead83e823263b1f4465abc5eb898f5ae",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "nightly-a7": {
@@ -24,8 +24,8 @@
         "JMXFETCH_HASH": "3c41c0660e9c53451dfb51e8dad33bc87b03be1abc1fcd3c856ea81e6b0894ee",
         "MACOS_BUILD_VERSION": "master",
         "WINDOWS_DDNPM_DRIVER": "testsigned",
-        "WINDOWS_DDNPM_VERSION": "2.0.0.git.4.2b8928e",
-        "WINDOWS_DDNPM_SHASUM": "da43a153010666d69e1c2f2b8f0e8b115b701ea4f5ffbe90842557d78a563661",
+        "WINDOWS_DDNPM_VERSION": "2.0.1",
+        "WINDOWS_DDNPM_SHASUM": "e33423f4ed302a722a717fc077ece3beead83e823263b1f4465abc5eb898f5ae",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "release-a6": {

--- a/release.json
+++ b/release.json
@@ -11,9 +11,9 @@
         "JMXFETCH_VERSION": "0.46.0",
         "JMXFETCH_HASH": "3c41c0660e9c53451dfb51e8dad33bc87b03be1abc1fcd3c856ea81e6b0894ee",
         "MACOS_BUILD_VERSION": "master",
-        "WINDOWS_DDNPM_DRIVER": "testsigned",
+        "WINDOWS_DDNPM_DRIVER": "release-signed",
         "WINDOWS_DDNPM_VERSION": "2.0.0",
-        "WINDOWS_DDNPM_SHASUM": "1ff4954aadbcd35d81741255a7b3a7e4869f6a59e08e5f548de98fdca85afa17",
+        "WINDOWS_DDNPM_SHASUM": "0522f82e2ae165bf06267b167b2bcb1763dfd8fc100ffd38d166c9f39cbc0621",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "nightly-a7": {
@@ -23,9 +23,9 @@
         "JMXFETCH_VERSION": "0.46.0",
         "JMXFETCH_HASH": "3c41c0660e9c53451dfb51e8dad33bc87b03be1abc1fcd3c856ea81e6b0894ee",
         "MACOS_BUILD_VERSION": "master",
-        "WINDOWS_DDNPM_DRIVER": "testsigned",
+        "WINDOWS_DDNPM_DRIVER": "release-signed",
         "WINDOWS_DDNPM_VERSION": "2.0.0",
-        "WINDOWS_DDNPM_SHASUM": "1ff4954aadbcd35d81741255a7b3a7e4869f6a59e08e5f548de98fdca85afa17",
+        "WINDOWS_DDNPM_SHASUM": "0522f82e2ae165bf06267b167b2bcb1763dfd8fc100ffd38d166c9f39cbc0621",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "release-a6": {

--- a/release.json
+++ b/release.json
@@ -12,8 +12,8 @@
         "JMXFETCH_HASH": "3c41c0660e9c53451dfb51e8dad33bc87b03be1abc1fcd3c856ea81e6b0894ee",
         "MACOS_BUILD_VERSION": "master",
         "WINDOWS_DDNPM_DRIVER": "testsigned",
-        "WINDOWS_DDNPM_VERSION": "1.4.3.git.28.b4f339c",
-        "WINDOWS_DDNPM_SHASUM": "54142a137e80d0cf80393cdee046e6713b9313fc6057c4ef5dfa4435dc713b60",
+        "WINDOWS_DDNPM_VERSION": "2.0.0",
+        "WINDOWS_DDNPM_SHASUM": "1ff4954aadbcd35d81741255a7b3a7e4869f6a59e08e5f548de98fdca85afa17",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "nightly-a7": {
@@ -24,8 +24,8 @@
         "JMXFETCH_HASH": "3c41c0660e9c53451dfb51e8dad33bc87b03be1abc1fcd3c856ea81e6b0894ee",
         "MACOS_BUILD_VERSION": "master",
         "WINDOWS_DDNPM_DRIVER": "testsigned",
-        "WINDOWS_DDNPM_VERSION": "1.4.3.git.28.b4f339c",
-        "WINDOWS_DDNPM_SHASUM": "54142a137e80d0cf80393cdee046e6713b9313fc6057c4ef5dfa4435dc713b60",
+        "WINDOWS_DDNPM_VERSION": "2.0.0",
+        "WINDOWS_DDNPM_SHASUM": "1ff4954aadbcd35d81741255a7b3a7e4869f6a59e08e5f548de98fdca85afa17",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "release-a6": {

--- a/release.json
+++ b/release.json
@@ -11,9 +11,9 @@
         "JMXFETCH_VERSION": "0.46.0",
         "JMXFETCH_HASH": "3c41c0660e9c53451dfb51e8dad33bc87b03be1abc1fcd3c856ea81e6b0894ee",
         "MACOS_BUILD_VERSION": "master",
-        "WINDOWS_DDNPM_DRIVER": "testsigned",
+        "WINDOWS_DDNPM_DRIVER": "release-signed",
         "WINDOWS_DDNPM_VERSION": "2.0.1",
-        "WINDOWS_DDNPM_SHASUM": "e33423f4ed302a722a717fc077ece3beead83e823263b1f4465abc5eb898f5ae",
+        "WINDOWS_DDNPM_SHASUM": "11e142f0879e2514f1ed03ffca351db2ac2e94e30e8f421ecbe0a8f598ad51de",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "nightly-a7": {
@@ -23,9 +23,9 @@
         "JMXFETCH_VERSION": "0.46.0",
         "JMXFETCH_HASH": "3c41c0660e9c53451dfb51e8dad33bc87b03be1abc1fcd3c856ea81e6b0894ee",
         "MACOS_BUILD_VERSION": "master",
-        "WINDOWS_DDNPM_DRIVER": "testsigned",
+        "WINDOWS_DDNPM_DRIVER": "release-signed",
         "WINDOWS_DDNPM_VERSION": "2.0.1",
-        "WINDOWS_DDNPM_SHASUM": "e33423f4ed302a722a717fc077ece3beead83e823263b1f4465abc5eb898f5ae",
+        "WINDOWS_DDNPM_SHASUM": "11e142f0879e2514f1ed03ffca351db2ac2e94e30e8f421ecbe0a8f598ad51de",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "release-a6": {

--- a/release.json
+++ b/release.json
@@ -11,9 +11,9 @@
         "JMXFETCH_VERSION": "0.46.0",
         "JMXFETCH_HASH": "3c41c0660e9c53451dfb51e8dad33bc87b03be1abc1fcd3c856ea81e6b0894ee",
         "MACOS_BUILD_VERSION": "master",
-        "WINDOWS_DDNPM_DRIVER": "release-signed",
-        "WINDOWS_DDNPM_VERSION": "2.0.0",
-        "WINDOWS_DDNPM_SHASUM": "0522f82e2ae165bf06267b167b2bcb1763dfd8fc100ffd38d166c9f39cbc0621",
+        "WINDOWS_DDNPM_DRIVER": "testsigned",
+        "WINDOWS_DDNPM_VERSION": "2.0.0.git.4.2b8928e",
+        "WINDOWS_DDNPM_SHASUM": "da43a153010666d69e1c2f2b8f0e8b115b701ea4f5ffbe90842557d78a563661",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "nightly-a7": {
@@ -23,9 +23,9 @@
         "JMXFETCH_VERSION": "0.46.0",
         "JMXFETCH_HASH": "3c41c0660e9c53451dfb51e8dad33bc87b03be1abc1fcd3c856ea81e6b0894ee",
         "MACOS_BUILD_VERSION": "master",
-        "WINDOWS_DDNPM_DRIVER": "release-signed",
-        "WINDOWS_DDNPM_VERSION": "2.0.0",
-        "WINDOWS_DDNPM_SHASUM": "0522f82e2ae165bf06267b167b2bcb1763dfd8fc100ffd38d166c9f39cbc0621",
+        "WINDOWS_DDNPM_DRIVER": "testsigned",
+        "WINDOWS_DDNPM_VERSION": "2.0.0.git.4.2b8928e",
+        "WINDOWS_DDNPM_SHASUM": "da43a153010666d69e1c2f2b8f0e8b115b701ea4f5ffbe90842557d78a563661",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "release-a6": {

--- a/releasenotes/notes/windowsdriver20-11f39d5a55f319c0.yaml
+++ b/releasenotes/notes/windowsdriver20-11f39d5a55f319c0.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    On Windows, NPM driver adds support for Receive Segment Coalescing support.
+    This works around Windows bug in which, in some situations, system probe 
+    would hang on start up.

--- a/releasenotes/notes/windowsdriver20-11f39d5a55f319c0.yaml
+++ b/releasenotes/notes/windowsdriver20-11f39d5a55f319c0.yaml
@@ -9,5 +9,5 @@
 fixes:
   - |
     On Windows, NPM driver adds support for Receive Segment Coalescing.
-    This works around Windows bug in which, in some situations, system probe 
-    would hang on start up.
+    This works around a Windows bug which in some situations causes
+    system probe to hang on startup

--- a/releasenotes/notes/windowsdriver20-11f39d5a55f319c0.yaml
+++ b/releasenotes/notes/windowsdriver20-11f39d5a55f319c0.yaml
@@ -8,6 +8,6 @@
 ---
 fixes:
   - |
-    On Windows, NPM driver adds support for Receive Segment Coalescing support.
+    On Windows, NPM driver adds support for Receive Segment Coalescing.
     This works around Windows bug in which, in some situations, system probe 
     would hang on start up.

--- a/test/kitchen/site-cookbooks/dd-agent-install/recipes/_install_windows.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-install/recipes/_install_windows.rb
@@ -20,16 +20,6 @@ if node['dd-agent-install']['enable_testsigning']
   end
 end
 
-##
-## temporarily disable recv segment coalescing.  This appears to be
-## the root cause of the azure bug causing things to hang.
-## remove this once bug is fixed
-execute 'disable RSC' do
-  command "netsh.exe int tcp set global rsc=disable"
-  # ignore failure b/c this will fail on win2008r2 (setting doesn't exist)
-  # however, we don't need it on 2008r2 b/c NPM isn't supported on 2008r2
-  ignore_failure true
-end
 
 include_recipe 'dd-agent-install::_install_windows_base'
 

--- a/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/windows.rb
+++ b/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/windows.rb
@@ -18,13 +18,6 @@ remote_file "#{tmp_dir}\\wix311-binaries.zip" do
   source "https://github.com/wixtoolset/wix3/releases/download/wix3112rtm/wix311-binaries.zip"
 end
 
-##
-## temporarily disable recv segment coalescing.  This appears to be
-## the root cause of the azure bug causing things to hang.
-## remove this once bug is fixed
-execute 'disable RSC' do
-  command "netsh.exe int tcp set global rsc=disable"
-end
 
 execute 'wix-extract' do
   cwd tmp_dir


### PR DESCRIPTION
Handles new ioctls for separately setting open/closed list size
imports new header file

revamp stats collection to match driver changes; fewer (but more useful) stats

Undo RSC workaround for kitchen tests as should be no longer needed.

### Motivation

Include latest NPM driver

### Describe how to test/QA your changes


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
