### PR TITLE
[runtime-security] Populate exit time in exit events

### DIFF
--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -662,6 +662,10 @@ func (p *Probe) handleEvent(CPU int, data []byte) {
 		}
 
 		event.ProcessCacheEntry = event.ResolveProcessCacheEntry()
+		// Use the event timestamp as exit time
+		// The local process cache hasn't been updated yet with the exit time when the exit event is first seen
+		// The pid_cache kernel map has the exit_time but it's only accessed if there's a local miss
+		event.ProcessCacheEntry.Process.ExitTime = event.ResolveEventTimestamp()
 		event.Exit.Process = &event.ProcessCacheEntry.Process
 	case model.SetuidEventType:
 		if _, err = event.SetUID.UnmarshalBinary(data[offset:]); err != nil {

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -888,6 +888,8 @@ func TestProcessExecExit(t *testing.T) {
 				}
 			}
 		case model.ExitEventType:
+			// assert that exit time >= exec time
+			assert.False(t, event.ProcessCacheEntry.ExitTime.Before(event.ProcessCacheEntry.ExecTime), "exit time < exec time")
 			if execPid != 0 && int(event.ProcessContext.Pid) == execPid {
 				return true
 			}
@@ -1234,10 +1236,14 @@ func TestProcessExit(t *testing.T) {
 			cmd.Env = envp
 			return cmd.Run()
 		}, func(event *sprobe.Event, rule *rules.Rule) {
+			if !validateExitSchema(t, event) {
+				t.Error(event.String())
+			}
 			assertTriggeredRule(t, rule, "test_exit_ok")
 			assertFieldEqual(t, event, "exit.file.path", sleepExec)
 			assert.Equal(t, uint32(model.ExitExited), event.Exit.Cause, "wrong exit cause")
 			assert.Equal(t, uint32(0), event.Exit.Code, "wrong exit code")
+			assert.False(t, event.ProcessCacheEntry.ExitTime.Before(event.ProcessCacheEntry.ExecTime), "exit time < exec time")
 		})
 	})
 
@@ -1251,10 +1257,14 @@ func TestProcessExit(t *testing.T) {
 			_ = cmd.Run()
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
+			if !validateExitSchema(t, event) {
+				t.Error(event.String())
+			}
 			assertTriggeredRule(t, rule, "test_exit_error")
 			assertFieldEqual(t, event, "exit.file.path", sleepExec)
 			assert.Equal(t, uint32(model.ExitExited), event.Exit.Cause, "wrong exit cause")
 			assert.Equal(t, uint32(1), event.Exit.Code, "wrong exit code")
+			assert.False(t, event.ProcessCacheEntry.ExitTime.Before(event.ProcessCacheEntry.ExecTime), "exit time < exec time")
 		})
 	})
 
@@ -1268,10 +1278,14 @@ func TestProcessExit(t *testing.T) {
 			_ = cmd.Run()
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
+			if !validateExitSchema(t, event) {
+				t.Error(event.String())
+			}
 			assertTriggeredRule(t, rule, "test_exit_coredump")
 			assertFieldEqual(t, event, "exit.file.path", sleepExec)
 			assert.Equal(t, uint32(model.ExitCoreDumped), event.Exit.Cause, "wrong exit cause")
 			assert.Equal(t, uint32(syscall.SIGQUIT), event.Exit.Code, "wrong exit code")
+			assert.False(t, event.ProcessCacheEntry.ExitTime.Before(event.ProcessCacheEntry.ExecTime), "exit time < exec time")
 		})
 	})
 
@@ -1285,10 +1299,14 @@ func TestProcessExit(t *testing.T) {
 			_ = cmd.Run()
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
+			if !validateExitSchema(t, event) {
+				t.Error(event.String())
+			}
 			assertTriggeredRule(t, rule, "test_exit_signal")
 			assertFieldEqual(t, event, "exit.file.path", sleepExec)
 			assert.Equal(t, uint32(model.ExitSignaled), event.Exit.Cause, "wrong exit cause")
 			assert.Equal(t, uint32(syscall.SIGKILL), event.Exit.Code, "wrong exit code")
+			assert.False(t, event.ProcessCacheEntry.ExitTime.Before(event.ProcessCacheEntry.ExecTime), "exit time < exec time")
 		})
 	})
 
@@ -1301,10 +1319,14 @@ func TestProcessExit(t *testing.T) {
 			cmd.Env = envp
 			return cmd.Run()
 		}, func(event *sprobe.Event, rule *rules.Rule) {
+			if !validateExitSchema(t, event) {
+				t.Error(event.String())
+			}
 			assertTriggeredRule(t, rule, "test_exit_time_1")
 			assertFieldEqual(t, event, "exit.file.path", sleepExec)
 			assert.Equal(t, uint32(model.ExitExited), event.Exit.Cause, "wrong exit cause")
 			assert.Equal(t, uint32(0), event.Exit.Code, "wrong exit code")
+			assert.False(t, event.ProcessCacheEntry.ExitTime.Before(event.ProcessCacheEntry.ExecTime), "exit time < exec time")
 		})
 	})
 
@@ -1317,10 +1339,14 @@ func TestProcessExit(t *testing.T) {
 			cmd.Env = envp
 			return cmd.Run()
 		}, func(event *sprobe.Event, rule *rules.Rule) {
+			if !validateExitSchema(t, event) {
+				t.Error(event.String())
+			}
 			assertTriggeredRule(t, rule, "test_exit_time_2")
 			assertFieldEqual(t, event, "exit.file.path", sleepExec)
 			assert.Equal(t, uint32(model.ExitExited), event.Exit.Cause, "wrong exit cause")
 			assert.Equal(t, uint32(0), event.Exit.Code, "wrong exit code")
+			assert.False(t, event.ProcessCacheEntry.ExitTime.Before(event.ProcessCacheEntry.ExecTime), "exit time < exec time")
 		})
 	})
 }

--- a/pkg/security/tests/schemas.go
+++ b/pkg/security/tests/schemas.go
@@ -89,6 +89,11 @@ func validateExecSchema(t *testing.T, event *sprobe.Event) bool {
 }
 
 //nolint:deadcode,unused
+func validateExitSchema(t *testing.T, event *sprobe.Event) bool {
+	return validateEventSchema(t, event, "file:///schemas/exit.schema.json")
+}
+
+//nolint:deadcode,unused
 func validateOpenSchema(t *testing.T, event *sprobe.Event) bool {
 	return validateEventSchema(t, event, "file:///schemas/open.schema.json")
 }

--- a/pkg/security/tests/schemas/exit.schema.json
+++ b/pkg/security/tests/schemas/exit.schema.json
@@ -1,0 +1,39 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "exic.json",
+    "type": "object",
+    "allOf": [
+        {
+            "properties": {
+                "exit": {
+                    "type": "object",
+                    "required" : [
+                        "cause",
+                        "code"
+                    ]
+                },
+                "process": {
+                    "type": "object",
+                    "required": [
+                        "pid",
+                        "ppid",
+                        "tid",
+                        "uid",
+                        "gid",
+                        "user",
+                        "group",
+                        "comm",
+                        "tty",
+                        "fork_time",
+                        "exec_time",
+                        "exit_time"
+                    ]
+                }
+            },
+            "required": [
+                "exit",
+                "process"
+            ]
+        }
+    ]
+}

--- a/pkg/security/tests/schemas/exit.schema.json
+++ b/pkg/security/tests/schemas/exit.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "exic.json",
+    "$id": "exit.json",
     "type": "object",
     "allOf": [
         {


### PR DESCRIPTION
### What does this PR do?

This PR updates the runtime-security probe to populate the ExitTime field of Exit events. It also extends functional tests and add a JSON validation for exit events.

### Motivation

Exit events exposed by system-probe currently don't have the exit time set. This is happening because a local entry from ProcessResolver is used to enrich the event and this entry doesn't have the exit time set.

This is an example of an exit event output:

#### Before the fix

```
> Type: exit
  Collection Time: 2022-07-27T10:52:59Z
  PID: 343820 PPID: 313407
  ContainerID:
  Exe: /usr/bin/ls
  Args: 'ls' '--color=auto' 'invalid-path'
  User: vagrant Uid: 1000 Gid: 1000
  ExecTime: 2022-07-27T10:52:59Z
  ExitTime: 1754-08-30T22:43:41Z
  ExitCode: 2
```
#### After the fix

```
> Type: exit
  Collection Time: 2022-07-27T10:50:58Z
  PID: 342525 PPID: 313407
  ContainerID:
  Exe: /usr/bin/ls
  Args: 'ls' '--color=auto' 'invalid-path'
  User: vagrant Uid: 1000 Gid: 1000
  ExecTime: 2022-07-27T10:50:58Z
  ExitTime: 2022-07-27T10:50:58Z
  ExitCode: 2
```

### Additional Notes


### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes

On Linux, update the `system-probe.yaml` file with
```
runtime_security_config:
  event_monitoring:
    enabled: true
```

Start the `datadog-agent` and make sure that `system-probe` is running. 

Start listening for process events with `process-agent`:
```
sudo ./process-agent events listen
```

Execute some short-lived processes (e.g. `ls`, `curl`) and make sure that the ExitTime is correctly populated for the associated exit event.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
