### PR TITLE
CWS: add missing `t.Helper()` calls

### DIFF
--- a/pkg/security/tests/schemas.go
+++ b/pkg/security/tests/schemas.go
@@ -50,8 +50,9 @@ func (v ValidInodeFormatChecker) IsFormat(input interface{}) bool {
 
 //nolint:deadcode,unused
 func validateSchema(t *testing.T, json string, path string) bool {
-	fs := http.FS(schemaAssetFS)
+	t.Helper()
 
+	fs := http.FS(schemaAssetFS)
 	gojsonschema.FormatCheckers.Add("ValidInode", ValidInodeFormatChecker{})
 
 	documentLoader := gojsonschema.NewStringLoader(json)
@@ -75,115 +76,138 @@ func validateSchema(t *testing.T, json string, path string) bool {
 
 //nolint:deadcode,unused
 func validateEventSchema(t *testing.T, event *sprobe.Event, path string) bool {
+	t.Helper()
 	return validateSchema(t, event.String(), path)
 }
 
 //nolint:deadcode,unused
 func validateStringSchema(t *testing.T, ad string, path string) bool {
+	t.Helper()
 	return validateSchema(t, ad, path)
 }
 
 //nolint:deadcode,unused
 func validateExecSchema(t *testing.T, event *sprobe.Event) bool {
+	t.Helper()
 	return validateEventSchema(t, event, "file:///schemas/exec.schema.json")
 }
 
 //nolint:deadcode,unused
 func validateOpenSchema(t *testing.T, event *sprobe.Event) bool {
+	t.Helper()
 	return validateEventSchema(t, event, "file:///schemas/open.schema.json")
 }
 
 //nolint:deadcode,unused
 func validateRenameSchema(t *testing.T, event *sprobe.Event) bool {
+	t.Helper()
 	return validateEventSchema(t, event, "file:///schemas/rename.schema.json")
 }
 
 //nolint:deadcode,unused
 func validateChmodSchema(t *testing.T, event *sprobe.Event) bool {
+	t.Helper()
 	return validateEventSchema(t, event, "file:///schemas/chmod.schema.json")
 }
 
 //nolint:deadcode,unused
 func validateChownSchema(t *testing.T, event *sprobe.Event) bool {
+	t.Helper()
 	return validateEventSchema(t, event, "file:///schemas/chown.schema.json")
 }
 
 //nolint:deadcode,unused
 func validateSELinuxSchema(t *testing.T, event *sprobe.Event) bool {
+	t.Helper()
 	return validateEventSchema(t, event, "file:///schemas/selinux.schema.json")
 }
 
 //nolint:deadcode,unused
 func validateLinkSchema(t *testing.T, event *sprobe.Event) bool {
+	t.Helper()
 	return validateEventSchema(t, event, "file:///schemas/link.schema.json")
 }
 
 //nolint:deadcode,unused
 func validateSpanSchema(t *testing.T, event *sprobe.Event) bool {
+	t.Helper()
 	return validateEventSchema(t, event, "file:///schemas/span.schema.json")
 }
 
 //nolint:deadcode,unused
 func validateBPFSchema(t *testing.T, event *sprobe.Event) bool {
+	t.Helper()
 	return validateEventSchema(t, event, "file:///schemas/bpf.schema.json")
 }
 
 //nolint:deadcode,unused
 func validateMMapSchema(t *testing.T, event *sprobe.Event) bool {
+	t.Helper()
 	return validateEventSchema(t, event, "file:///schemas/mmap.schema.json")
 }
 
 //nolint:deadcode,unused
 func validateMProtectSchema(t *testing.T, event *sprobe.Event) bool {
+	t.Helper()
 	return validateEventSchema(t, event, "file:///schemas/mprotect.schema.json")
 }
 
 //nolint:deadcode,unused
 func validatePTraceSchema(t *testing.T, event *sprobe.Event) bool {
+	t.Helper()
 	return validateEventSchema(t, event, "file:///schemas/ptrace.schema.json")
 }
 
 //nolint:deadcode,unused
 func validateLoadModuleSchema(t *testing.T, event *sprobe.Event) bool {
+	t.Helper()
 	return validateEventSchema(t, event, "file:///schemas/load_module.schema.json")
 }
 
 //nolint:deadcode,unused
 func validateLoadModuleNoFileSchema(t *testing.T, event *sprobe.Event) bool {
+	t.Helper()
 	return validateEventSchema(t, event, "file:///schemas/load_module_no_file.schema.json")
 }
 
 //nolint:deadcode,unused
 func validateUnloadModuleSchema(t *testing.T, event *sprobe.Event) bool {
+	t.Helper()
 	return validateEventSchema(t, event, "file:///schemas/unload_module.schema.json")
 }
 
 //nolint:deadcode,unused
 func validateSignalSchema(t *testing.T, event *sprobe.Event) bool {
+	t.Helper()
 	return validateEventSchema(t, event, "file:///schemas/signal.schema.json")
 }
 
 //nolint:deadcode,unused
 func validateSpliceSchema(t *testing.T, event *sprobe.Event) bool {
+	t.Helper()
 	return validateEventSchema(t, event, "file:///schemas/splice.schema.json")
 }
 
 //nolint:deadcode,unused
 func validateDNSSchema(t *testing.T, event *sprobe.Event) bool {
+	t.Helper()
 	return validateEventSchema(t, event, "file:///schemas/dns.schema.json")
 }
 
 //nolint:deadcode,unused
 func validateBindSchema(t *testing.T, event *sprobe.Event) bool {
+	t.Helper()
 	return validateEventSchema(t, event, "file:///schemas/bind.schema.json")
 }
 
 //nolint:deadcode,unused
 func validateActivityDumpSchema(t *testing.T, ad string) bool {
+	t.Helper()
 	return validateStringSchema(t, ad, "file:///schemas/activity_dump.schema.json")
 }
 
 //nolint:deadcode,unused
 func validateActivityDumpProtoSchema(t *testing.T, ad string) bool {
+	t.Helper()
 	return validateStringSchema(t, ad, "file:///schemas/activity_dump_proto.schema.json")
 }


### PR DESCRIPTION
### What does this PR do?

Add missing `t.Helper()` calls around JSON schema validation

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
