### PR TITLE
CWS: `security_go_generate` improvements

### DIFF
--- a/.gitlab/source_test/go_generate_check.yml
+++ b/.gitlab/source_test/go_generate_check.yml
@@ -12,9 +12,4 @@ security_go_generate_check:
     - inv -e install-tools
     - export PATH=$PATH:$GOPATH/bin
   script:
-    - inv -e security-agent.cws-go-generate
-    - inv -e security-agent.generate-cws-documentation
-    - inv -e security-agent.gen-mocks
-    - inv -e system-probe.generate-runtime-files
-    - git status --porcelain
-    - test -z "$(git status --porcelain)"
+    - inv -e security-agent.go-generate-check

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -12,7 +12,7 @@ from invoke.exceptions import Exit
 from .build_tags import get_default_build_tags
 from .go import golangci_lint
 from .system_probe import CLANG_CMD as CLANG_BPF_CMD
-from .system_probe import CURRENT_ARCH, get_ebpf_build_flags, generate_runtime_files
+from .system_probe import CURRENT_ARCH, generate_runtime_files, get_ebpf_build_flags
 from .test import environ
 from .utils import (
     REPO_PATH,
@@ -630,12 +630,7 @@ def get_git_dirty_files():
 
 @task
 def go_generate_check(ctx):
-    tasks = [
-        [cws_go_generate],
-        [generate_cws_documentation],
-        [gen_mocks],
-        [generate_runtime_files]
-    ]
+    tasks = [[cws_go_generate], [generate_cws_documentation], [gen_mocks], [generate_runtime_files]]
 
     for task_entry in tasks:
         task, args = task_entry[0], task_entry[1:]

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -635,7 +635,8 @@ def go_generate_check(ctx):
     for task_entry in tasks:
         task, args = task_entry[0], task_entry[1:]
         task(ctx, *args)
-        if dirty_files := get_git_dirty_files():
+        dirty_files = get_git_dirty_files()
+        if dirty_files:
             print(f"Task `{task.name}` resulted in dirty files, please re-run it:")
             for file in dirty_files:
                 print(f"* {file}")

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -642,6 +642,11 @@ def go_generate_check(ctx):
     for task_entry in tasks:
         task, args = task_entry[0], task_entry[1:]
         task(ctx, *args)
+        # when running a non-interactive session, python may buffer too much data and thus mix stderr and stdout
+        # this is especially visible in the Gitlab job logs
+        # we flush to ensure correct separation between steps
+        sys.stdout.flush()
+        sys.stderr.flush()
         dirty_files = get_git_dirty_files()
         if dirty_files:
             failing_tasks.append(FailingTask(task.name, dirty_files))

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -7,6 +7,7 @@ import tempfile
 from subprocess import check_output
 
 from invoke import task
+from invoke.exceptions import Exit
 
 from .build_tags import get_default_build_tags
 from .go import golangci_lint
@@ -643,3 +644,4 @@ def go_generate_check(ctx):
             print(f"Task `{task.name}` resulted in dirty files, please re-run it:")
             for file in dirty_files:
                 print(f"* {file}")
+            raise Exit(code=1)


### PR DESCRIPTION
### What does this PR do?

It was reported that in case of failure the output of the `security_go_generate` job was not very clear. This PR improves the situation by checking for git dirty files after each step, and by outputting the name of the failing task with the specific files that were touched.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
