### PR TITLE
Load proxy settings in the serverless agent

### DIFF
--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -201,6 +201,7 @@ func runAgent(stopCh chan struct{}) (serverlessDaemon *daemon.Daemon, err error)
 		log.Error("No API key configured, exiting")
 	}
 	config.Datadog.SetConfigFile(datadogConfigPath)
+	config.Load()
 
 	logChannel := make(chan *logConfig.ChannelMessage)
 

--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -201,7 +201,10 @@ func runAgent(stopCh chan struct{}) (serverlessDaemon *daemon.Daemon, err error)
 		log.Error("No API key configured, exiting")
 	}
 	config.Datadog.SetConfigFile(datadogConfigPath)
-	config.Load()
+	_, err = config.Load()
+	if err != nil {
+		log.Debug("Error loading config: %v", err)
+	}
 
 	logChannel := make(chan *logConfig.ChannelMessage)
 

--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -201,10 +201,7 @@ func runAgent(stopCh chan struct{}) (serverlessDaemon *daemon.Daemon, err error)
 		log.Error("No API key configured, exiting")
 	}
 	config.Datadog.SetConfigFile(datadogConfigPath)
-	_, err = config.Load()
-	if err != nil {
-		log.Debug("Error loading config: %v", err)
-	}
+	config.LoadProxyFromEnv(config.Datadog)
 
 	logChannel := make(chan *logConfig.ChannelMessage)
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1134,6 +1134,13 @@ func GetProxies() *Proxy {
 	return proxies
 }
 
+// LoadProxyFromEnv allows the privately-scoped function to be called outside
+// of NewConfig. This is needed because we must call this function independently
+// in a serverless environment.
+func LoadProxyFromEnv(config Config) {
+	loadProxyFromEnv(config)
+}
+
 // loadProxyFromEnv overrides the proxy settings with environment variables
 func loadProxyFromEnv(config Config) {
 	// Viper doesn't handle mixing nested variables from files and set

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1134,15 +1134,8 @@ func GetProxies() *Proxy {
 	return proxies
 }
 
-// LoadProxyFromEnv allows the privately-scoped function to be called outside
-// of NewConfig. This is needed because we must call this function independently
-// in a serverless environment.
+// LoadProxyFromEnv overrides the proxy settings with environment variables
 func LoadProxyFromEnv(config Config) {
-	loadProxyFromEnv(config)
-}
-
-// loadProxyFromEnv overrides the proxy settings with environment variables
-func loadProxyFromEnv(config Config) {
 	// Viper doesn't handle mixing nested variables from files and set
 	// manually.  If we manually set one of the sub value for "proxy" all
 	// other values from the conf file will be shadowed when using
@@ -1399,7 +1392,7 @@ func load(config Config, origin string, loadSecret bool) (*Warnings, error) {
 	}
 
 	useHostEtc(config)
-	loadProxyFromEnv(config)
+	LoadProxyFromEnv(config)
 	SanitizeAPIKeyConfig(config, "api_key")
 	// setTracemallocEnabled *must* be called before setNumWorkers
 	warnings.TraceMallocEnabledWithPy2 = setTracemallocEnabled(config)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -711,7 +711,7 @@ func TestLoadProxyFromStdEnvNoValue(t *testing.T) {
 	resetEnv := unsetEnvForTest("NO_PROXY") // CircleCI sets NO_PROXY, so unset it for this test
 	defer resetEnv()
 
-	loadProxyFromEnv(config)
+	LoadProxyFromEnv(config)
 	assert.Nil(t, config.Get("proxy"))
 
 	proxies := GetProxies()
@@ -730,7 +730,7 @@ func TestLoadProxyConfOnly(t *testing.T) {
 	resetEnv := unsetEnvForTest("NO_PROXY") // CircleCI sets NO_PROXY, so unset it for this test
 	defer resetEnv()
 
-	loadProxyFromEnv(config)
+	LoadProxyFromEnv(config)
 	proxies := GetProxies()
 	assert.Equal(t, p, proxies)
 }
@@ -749,7 +749,7 @@ func TestLoadProxyStdEnvOnly(t *testing.T) {
 	defer resetHTTPSProxyUpper()
 	defer resetNoProxyUpper()
 
-	loadProxyFromEnv(config)
+	LoadProxyFromEnv(config)
 
 	proxies := GetProxies()
 	assert.Equal(t,
@@ -772,7 +772,7 @@ func TestLoadProxyStdEnvOnly(t *testing.T) {
 	defer resetHTTPSProxyLower()
 	defer resetNoProxyLower()
 
-	loadProxyFromEnv(config)
+	LoadProxyFromEnv(config)
 	proxies = GetProxies()
 	assert.Equal(t,
 		&Proxy{
@@ -794,7 +794,7 @@ func TestLoadProxyDDSpecificEnvOnly(t *testing.T) {
 	defer resetHTTPSProxy()
 	defer resetNoProxy()
 
-	loadProxyFromEnv(config)
+	LoadProxyFromEnv(config)
 
 	proxies := GetProxies()
 	assert.Equal(t,
@@ -823,7 +823,7 @@ func TestLoadProxyDDSpecificEnvPrecedenceOverStdEnv(t *testing.T) {
 	defer resetHTTPSProxy()
 	defer resetNoProxy()
 
-	loadProxyFromEnv(config)
+	LoadProxyFromEnv(config)
 
 	proxies := GetProxies()
 	assert.Equal(t,
@@ -846,7 +846,7 @@ func TestLoadProxyStdEnvAndConf(t *testing.T) {
 	defer resetHTTPProxy()
 	defer resetNoProxy()
 
-	loadProxyFromEnv(config)
+	LoadProxyFromEnv(config)
 	proxies := GetProxies()
 	assert.Equal(t,
 		&Proxy{
@@ -868,7 +868,7 @@ func TestLoadProxyDDSpecificEnvAndConf(t *testing.T) {
 	defer resetHTTPProxy()
 	defer resetNoProxy()
 
-	loadProxyFromEnv(config)
+	LoadProxyFromEnv(config)
 	proxies := GetProxies()
 	assert.Equal(t,
 		&Proxy{
@@ -895,7 +895,7 @@ func TestLoadProxyEmptyValuePrecedence(t *testing.T) {
 	defer resetHTTPSProxy()
 	defer resetNoProxy()
 
-	loadProxyFromEnv(config)
+	LoadProxyFromEnv(config)
 
 	proxies := GetProxies()
 	assert.Equal(t,
@@ -919,7 +919,7 @@ func TestLoadProxyWithoutNoProxy(t *testing.T) {
 	defer resetHTTPSProxy()
 	defer resetNoProxy()
 
-	loadProxyFromEnv(config)
+	LoadProxyFromEnv(config)
 
 	proxies := GetProxies()
 	assert.Equal(t,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR fixes a bug where we the dogstatsd server wasn't respecting the DD_PROXY_HTTPS environment variable. The problem was because `config.Load()` was called downstream somewhere in the trace/logs agent, and isn't picked up by the metrics agent. Thus, the metrics agent didn't get the DD_PROXY_HTTPS setting.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
