### PR TITLE
CWS: dynamic AD config

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "473f02ec440767dd77c3a6d9fec990bc16b87bd84e8e4e7d018324bc3b0fdb0d")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "6c281164f9ba6d5da030a53976a270524055a34d78c48b0c7f8076049161a491")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "8700c8e9f23a0d48d02ec21a648343f1478f7b34a377faded6b29b879cd63b7a")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "9160e71087faa4543d653d2523e716cbf253fdbe44feb4023e3e3d37c270dbea")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "9160e71087faa4543d653d2523e716cbf253fdbe44feb4023e3e3d37c270dbea")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "473f02ec440767dd77c3a6d9fec990bc16b87bd84e8e4e7d018324bc3b0fdb0d")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "6c281164f9ba6d5da030a53976a270524055a34d78c48b0c7f8076049161a491")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "477407635aedcbb5c51e11c4355c6d630a7a14d127108a8d679f821d37c4f3bf")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "d0f30afe5682740e725d9a30fa248a0570e72933ab96a46f9d755f70a54f4822")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "8700c8e9f23a0d48d02ec21a648343f1478f7b34a377faded6b29b879cd63b7a")

--- a/pkg/security/ebpf/c/activity_dump.h
+++ b/pkg/security/ebpf/c/activity_dump.h
@@ -170,7 +170,7 @@ __attribute__((always_inline)) void freeup_traced_cgroup_spot(char cgroup[CONTAI
         return;
     }
 
-    __sync_fetch_and_add(&counter->counter, -1);
+    counter->counter -= 1;
     unlock_cgroups_counter();
 }
 

--- a/pkg/security/ebpf/c/activity_dump.h
+++ b/pkg/security/ebpf/c/activity_dump.h
@@ -8,6 +8,18 @@ struct bpf_map_def SEC("maps/traced_cgroups") traced_cgroups = {
     .max_entries = 200, // might be overridden at runtime
 };
 
+struct traced_cgroups_counter_t {
+    u64 max;
+    u64 counter;
+};
+
+struct bpf_map_def SEC("maps/traced_cgroups_counter") traced_cgroups_counter = {
+    .type = BPF_MAP_TYPE_ARRAY,
+    .key_size = sizeof(u32),
+    .value_size = sizeof(struct traced_cgroups_counter_t),
+    .max_entries = 1,
+};
+
 struct bpf_map_def SEC("maps/cgroup_wait_list") cgroup_wait_list = {
     .type = BPF_MAP_TYPE_LRU_HASH,
     .key_size = CONTAINER_ID_LEN,
@@ -100,13 +112,65 @@ __attribute__((always_inline)) struct cgroup_tracing_event_t *get_cgroup_tracing
     return evt;
 }
 
+struct bpf_map_def SEC("maps/traced_cgroups_lock") traced_cgroups_lock = {
+    .type = BPF_MAP_TYPE_HASH,
+    .key_size = sizeof(u32),
+    .value_size = sizeof(u32),
+    .max_entries = 1,
+};
+
+__attribute__((always_inline)) bool reserve_traced_cgroup_spot(char cgroup[CONTAINER_ID_LEN]) {
+    void *already_in = bpf_map_lookup_elem(&traced_cgroups, &cgroup[0]);
+    if (already_in) {
+        return false;
+    }
+
+    u32 key = 0;
+    if(!bpf_map_update_elem(&traced_cgroups_lock, &key, &key, BPF_NOEXIST)) {
+        // we don't have the lock
+        return false;
+    }
+
+    struct traced_cgroups_counter_t *counter = bpf_map_lookup_elem(&traced_cgroups_counter, &key);
+    if (!counter) {
+        return false;
+    }
+
+    bool res = false;
+    if (counter->counter < counter->max) {
+        counter->counter++;
+        res = true;
+    }
+
+    bpf_map_delete_elem(&traced_cgroups_lock, &key);
+    return res;
+}
+
+__attribute__((always_inline)) void freeup_traced_cgroup_spot(char cgroup[CONTAINER_ID_LEN]) {
+    bpf_map_delete_elem(&traced_cgroups, &cgroup[0]);
+
+    u32 key = 0;
+    struct traced_cgroups_counter_t *counter = bpf_map_lookup_elem(&traced_cgroups_counter, &key);
+    if (!counter) {
+        return;
+    }
+
+    __sync_fetch_and_add(&counter->counter, -1);
+}
+
 __attribute__((always_inline)) u64 trace_new_cgroup(void *ctx, char cgroup[CONTAINER_ID_LEN]) {
     u64 timeout = bpf_ktime_get_ns() + get_dump_timeout();
+
+    if (!reserve_traced_cgroup_spot(cgroup)) {
+        // we're already tracing too many cgroups concurrently, ignore this one for now
+        return 0;
+    }
+
 
     // try to lock an entry in traced_cgroups
     int ret = bpf_map_update_elem(&traced_cgroups, &cgroup[0], &timeout, BPF_NOEXIST);
     if (ret < 0) {
-        // we're already tracing too many cgroups concurrently, ignore this one for now
+        // this should be caught earlier but we're already tracing too many cgroups concurrently, ignore this one for now
         return 0;
     }
     // lock acquired ! send cgroup tracing event
@@ -145,7 +209,7 @@ __attribute__((always_inline)) void should_trace_new_process_cgroup(void *ctx, u
         if (dump_timeout) {
             if (now > *dump_timeout) {
                 // delete expired cgroup entry
-                bpf_map_delete_elem(&traced_cgroups, &cgroup[0]);
+                freeup_traced_cgroup_spot(cgroup);
             } else {
                 // We're still tracing this cgroup, update the pid timeout
                 update_traced_pid_timeout(pid, *dump_timeout);

--- a/pkg/security/ebpf/c/activity_dump.h
+++ b/pkg/security/ebpf/c/activity_dump.h
@@ -121,7 +121,7 @@ struct bpf_map_def SEC("maps/traced_cgroups_lock") traced_cgroups_lock = {
 
 __attribute__((always_inline)) bool lock_cgroups_counter() {
     u32 key = 0;
-    return bpf_map_update_elem(&traced_cgroups_lock, &key, &key, BPF_NOEXIST);
+    return bpf_map_update_elem(&traced_cgroups_lock, &key, &key, BPF_NOEXIST) == 0;
 }
 
 __attribute__((always_inline)) void unlock_cgroups_counter() {

--- a/pkg/security/ebpf/c/activity_dump.h
+++ b/pkg/security/ebpf/c/activity_dump.h
@@ -36,12 +36,6 @@ struct bpf_map_def SEC("maps/traced_event_types") traced_event_types = {
     .max_entries = EVENT_MAX + 1,
 };
 
-__attribute__((always_inline)) u64 get_traced_cgroups_count() {
-    u64 traced_cgroups_count;
-    LOAD_CONSTANT("traced_cgroups_count", traced_cgroups_count);
-    return traced_cgroups_count;
-}
-
 __attribute__((always_inline)) u64 get_dump_timeout() {
     u64 dump_timeout;
     LOAD_CONSTANT("dump_timeout", dump_timeout);
@@ -49,8 +43,9 @@ __attribute__((always_inline)) u64 get_dump_timeout() {
 }
 
 __attribute__((always_inline)) u64 is_cgroup_activity_dumps_enabled() {
-    u64 count = get_traced_cgroups_count();
-    return count == -1 || count > 0;
+    u64 cgroup_activity_dumps_enabled;
+    LOAD_CONSTANT("cgroup_activity_dumps_enabled", cgroup_activity_dumps_enabled);
+    return cgroup_activity_dumps_enabled != 0;
 }
 
 __attribute__((always_inline)) u64 lookup_or_delete_traced_pid_timeout(u32 pid, u64 now) {

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -140,7 +140,7 @@ func AllMaps() []*manager.Map {
 
 const (
 	// MaxTracedCgroupsCount hard limit for the count of traced cgroups
-	MaxTracedCgroupsCount = 1000
+	MaxTracedCgroupsCount = 128
 )
 
 func getMaxEntries(numCPU int, min int, max int) uint32 {
@@ -153,10 +153,7 @@ func getMaxEntries(numCPU int, min int, max int) uint32 {
 }
 
 // AllMapSpecEditors returns the list of map editors
-func AllMapSpecEditors(numCPU int, tracedCgroupsCount int, cgroupWaitListSize int, supportMmapableMaps, useRingBuffers bool, ringBufferSize uint32) map[string]manager.MapSpecEditor {
-	if tracedCgroupsCount <= 0 || tracedCgroupsCount > MaxTracedCgroupsCount {
-		tracedCgroupsCount = MaxTracedCgroupsCount
-	}
+func AllMapSpecEditors(numCPU int, cgroupWaitListSize int, supportMmapableMaps, useRingBuffers bool, ringBufferSize uint32) map[string]manager.MapSpecEditor {
 	if cgroupWaitListSize <= 0 || cgroupWaitListSize > MaxTracedCgroupsCount {
 		cgroupWaitListSize = MaxTracedCgroupsCount
 	}
@@ -174,7 +171,7 @@ func AllMapSpecEditors(numCPU int, tracedCgroupsCount int, cgroupWaitListSize in
 			EditorFlag: manager.EditMaxEntries,
 		},
 		"traced_cgroups": {
-			MaxEntries: uint32(tracedCgroupsCount),
+			MaxEntries: MaxTracedCgroupsCount,
 			EditorFlag: manager.EditMaxEntries,
 		},
 		"cgroup_wait_list": {

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -585,14 +585,10 @@ func (a *APIServer) SendProcessEvent(data []byte) {
 
 // NewAPIServer returns a new gRPC event server
 func NewAPIServer(cfg *config.Config, probe *sprobe.Probe, client statsd.ClientInterface) *APIServer {
-	cgroupsCount := cfg.ActivityDumpTracedCgroupsCount
-	if cgroupsCount < 0 {
-		cgroupsCount = 1
-	}
 	es := &APIServer{
 		msgs:                 make(chan *api.SecurityEventMessage, cfg.EventServerBurst*3),
 		processMsgs:          make(chan *api.SecurityProcessEventMessage, cfg.EventServerBurst*3),
-		activityDumps:        make(chan *api.ActivityDumpStreamMessage, cgroupsCount*2),
+		activityDumps:        make(chan *api.ActivityDumpStreamMessage),
 		expiredEvents:        make(map[rules.RuleID]*atomic.Int64),
 		expiredProcessEvents: atomic.NewInt64(0),
 		expiredDumps:         atomic.NewInt64(0),

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/security/api"
 	"github.com/DataDog/datadog-agent/pkg/security/config"
+	"github.com/DataDog/datadog-agent/pkg/security/ebpf/probes"
 	seclog "github.com/DataDog/datadog-agent/pkg/security/log"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
 	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
@@ -588,7 +589,7 @@ func NewAPIServer(cfg *config.Config, probe *sprobe.Probe, client statsd.ClientI
 	es := &APIServer{
 		msgs:                 make(chan *api.SecurityEventMessage, cfg.EventServerBurst*3),
 		processMsgs:          make(chan *api.SecurityProcessEventMessage, cfg.EventServerBurst*3),
-		activityDumps:        make(chan *api.ActivityDumpStreamMessage),
+		activityDumps:        make(chan *api.ActivityDumpStreamMessage, probes.MaxTracedCgroupsCount*2),
 		expiredEvents:        make(map[rules.RuleID]*atomic.Int64),
 		expiredProcessEvents: atomic.NewInt64(0),
 		expiredDumps:         atomic.NewInt64(0),

--- a/pkg/security/probe/activity_dump_load_controller.go
+++ b/pkg/security/probe/activity_dump_load_controller.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/ebpf"
 )
 
+// ActivityDumpLoadController is a load controller allowing dynamic change of Activity Dump configuration
 type ActivityDumpLoadController struct {
 	tracedEventTypes   []model.EventType
 	tracedCgroupsCount uint64
@@ -28,6 +29,7 @@ type ActivityDumpLoadController struct {
 	tracedCgroupsLockMap    *ebpf.Map
 }
 
+// NewActivityDumpLoadController returns a new activity dump load controller
 func NewActivityDumpLoadController(cfg *config.Config, man *manager.Manager) (*ActivityDumpLoadController, error) {
 	tracedEventTypesMap, found, err := man.GetMap("traced_event_types")
 	if err != nil {

--- a/pkg/security/probe/activity_dump_load_controller.go
+++ b/pkg/security/probe/activity_dump_load_controller.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	ebpfutils "github.com/DataDog/datadog-agent/pkg/security/ebpf"
+	"github.com/DataDog/datadog-agent/pkg/security/ebpf/probes"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	manager "github.com/DataDog/ebpf-manager"
@@ -55,9 +56,14 @@ func NewActivityDumpLoadController(cfg *config.Config, man *manager.Manager) (*A
 		return nil, fmt.Errorf("couldn't find traced_cgroups_lock map")
 	}
 
+	tracedCgroupsCount := uint64(cfg.ActivityDumpTracedCgroupsCount)
+	if tracedCgroupsCount > probes.MaxTracedCgroupsCount {
+		tracedCgroupsCount = probes.MaxTracedCgroupsCount
+	}
+
 	return &ActivityDumpLoadController{
 		tracedEventTypes:   cfg.ActivityDumpTracedEventTypes,
-		tracedCgroupsCount: uint64(cfg.ActivityDumpTracedCgroupsCount),
+		tracedCgroupsCount: tracedCgroupsCount,
 
 		tracedEventTypesMap:     tracedEventTypesMap,
 		tracedCgroupsCounterMap: tracedCgroupsCounterMap,

--- a/pkg/security/probe/activity_dump_load_controller.go
+++ b/pkg/security/probe/activity_dump_load_controller.go
@@ -1,0 +1,97 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+// +build linux
+
+package probe
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/security/config"
+	ebpfutils "github.com/DataDog/datadog-agent/pkg/security/ebpf"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	manager "github.com/DataDog/ebpf-manager"
+	"github.com/cilium/ebpf"
+)
+
+type ActivityDumpLoadController struct {
+	tracedEventTypes   []model.EventType
+	tracedCgroupsCount uint64
+
+	tracedEventTypesMap     *ebpf.Map
+	tracedCgroupsCounterMap *ebpf.Map
+	tracedCgroupsLockMap    *ebpf.Map
+}
+
+func NewActivityDumpLoadController(cfg *config.Config, man *manager.Manager) (*ActivityDumpLoadController, error) {
+	tracedEventTypesMap, found, err := man.GetMap("traced_event_types")
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, fmt.Errorf("couldn't find traced_event_types map")
+	}
+
+	tracedCgroupsCounterMap, found, err := man.GetMap("traced_cgroups_counter")
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, fmt.Errorf("couldn't find traced_cgroups_counter map")
+	}
+
+	tracedCgroupsLockMap, found, err := man.GetMap("traced_cgroups_lock")
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, fmt.Errorf("couldn't find traced_cgroups_lock map")
+	}
+
+	return &ActivityDumpLoadController{
+		tracedEventTypes:   cfg.ActivityDumpTracedEventTypes,
+		tracedCgroupsCount: uint64(cfg.ActivityDumpTracedCgroupsCount),
+
+		tracedEventTypesMap:     tracedEventTypesMap,
+		tracedCgroupsCounterMap: tracedCgroupsCounterMap,
+		tracedCgroupsLockMap:    tracedCgroupsLockMap,
+	}, nil
+}
+
+func (lc *ActivityDumpLoadController) propagateLoadSettings() error {
+	// init traced event types
+	isTraced := uint64(1)
+	for _, evtType := range lc.tracedEventTypes {
+		if err := lc.tracedEventTypesMap.Put(evtType, isTraced); err != nil {
+			return fmt.Errorf("failed to insert traced event type: %w", err)
+		}
+	}
+
+	if err := lc.tracedCgroupsLockMap.Put(ebpfutils.ZeroUint32MapItem, uint32(1)); err != nil {
+		return fmt.Errorf("failed to lock traced cgroup counter: %w", err)
+	}
+
+	defer func() {
+		if err := lc.tracedCgroupsLockMap.Put(ebpfutils.ZeroUint32MapItem, uint32(0)); err != nil {
+			log.Errorf("failed to unlock traced cgroup counter: %v", err)
+		}
+	}()
+
+	var counter tracedCgroupsCounter
+	if err := lc.tracedCgroupsCounterMap.Lookup(ebpfutils.ZeroUint32MapItem, &counter); err != nil {
+		return fmt.Errorf("failed to get traced cgroup counter: %w", err)
+	}
+	log.Debugf("AD: got counter = %v, when propagating config", counter)
+
+	counter.Max = lc.tracedCgroupsCount
+	if err := lc.tracedCgroupsCounterMap.Put(ebpfutils.ZeroUint32MapItem, counter); err != nil {
+		return fmt.Errorf("failed to change counter max: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/security/probe/activity_dump_manager.go
+++ b/pkg/security/probe/activity_dump_manager.go
@@ -30,8 +30,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 )
 
-func getTracedCgroupsCount(p *Probe) uint64 {
-	return uint64(p.config.ActivityDumpTracedCgroupsCount)
+func areCGroupADsEnabled(p *Probe) bool {
+	return p.config.ActivityDumpTracedCgroupsCount > 0
 }
 
 func getCgroupDumpTimeout(p *Probe) uint64 {

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -1473,7 +1473,7 @@ func NewProbe(config *config.Config, statsdClient statsd.ClientInterface) (*Prob
 		},
 		manager.ConstantEditor{
 			Name:  "cgroup_activity_dumps_enabled",
-			Value: boolTouint64(areCGroupADsEnabled(p)),
+			Value: utils.BoolTouint64(areCGroupADsEnabled(p)),
 		},
 		manager.ConstantEditor{
 			Name:  "dump_timeout",
@@ -1499,7 +1499,7 @@ func NewProbe(config *config.Config, statsdClient statsd.ClientInterface) (*Prob
 		p.managerOptions.ConstantEditors = append(p.managerOptions.ConstantEditors,
 			manager.ConstantEditor{
 				Name:  "tracepoint_raw_syscall_fallback",
-				Value: boolTouint64(true),
+				Value: utils.BoolTouint64(true),
 			},
 		)
 	}
@@ -1508,7 +1508,7 @@ func NewProbe(config *config.Config, statsdClient statsd.ClientInterface) (*Prob
 		p.managerOptions.ConstantEditors = append(p.managerOptions.ConstantEditors,
 			manager.ConstantEditor{
 				Name:  "use_ring_buffer",
-				Value: boolTouint64(true),
+				Value: utils.BoolTouint64(true),
 			},
 		)
 	}
@@ -1550,13 +1550,6 @@ func NewProbe(config *config.Config, statsdClient statsd.ClientInterface) (*Prob
 	}
 
 	return p, nil
-}
-
-func boolTouint64(value bool) uint64 {
-	if value {
-		return 1
-	}
-	return 0
 }
 
 func (p *Probe) ensureConfigDefaults() {

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -1555,9 +1555,8 @@ func NewProbe(config *config.Config, statsdClient statsd.ClientInterface) (*Prob
 func boolTouint64(value bool) uint64 {
 	if value {
 		return 1
-	} else {
-		return 0
 	}
+	return 0
 }
 
 func (p *Probe) ensureConfigDefaults() {

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -1398,7 +1398,6 @@ func NewProbe(config *config.Config, statsdClient statsd.ClientInterface) (*Prob
 	}
 	p.managerOptions.MapSpecEditors = probes.AllMapSpecEditors(
 		numCPU,
-		p.config.ActivityDumpTracedCgroupsCount,
 		p.config.ActivityDumpCgroupWaitListSize,
 		useMmapableMaps,
 		useRingBuffers,
@@ -1473,8 +1472,8 @@ func NewProbe(config *config.Config, statsdClient statsd.ClientInterface) (*Prob
 			Value: getCheckHelperCallInputType(p),
 		},
 		manager.ConstantEditor{
-			Name:  "traced_cgroups_count",
-			Value: getTracedCgroupsCount(p),
+			Name:  "cgroup_activity_dumps_enabled",
+			Value: boolTouint64(areCGroupADsEnabled(p)),
 		},
 		manager.ConstantEditor{
 			Name:  "dump_timeout",
@@ -1500,7 +1499,7 @@ func NewProbe(config *config.Config, statsdClient statsd.ClientInterface) (*Prob
 		p.managerOptions.ConstantEditors = append(p.managerOptions.ConstantEditors,
 			manager.ConstantEditor{
 				Name:  "tracepoint_raw_syscall_fallback",
-				Value: uint64(1),
+				Value: boolTouint64(true),
 			},
 		)
 	}
@@ -1509,7 +1508,7 @@ func NewProbe(config *config.Config, statsdClient statsd.ClientInterface) (*Prob
 		p.managerOptions.ConstantEditors = append(p.managerOptions.ConstantEditors,
 			manager.ConstantEditor{
 				Name:  "use_ring_buffer",
-				Value: uint64(1),
+				Value: boolTouint64(true),
 			},
 		)
 	}
@@ -1551,6 +1550,14 @@ func NewProbe(config *config.Config, statsdClient statsd.ClientInterface) (*Prob
 	}
 
 	return p, nil
+}
+
+func boolTouint64(value bool) uint64 {
+	if value {
+		return 1
+	} else {
+		return 0
+	}
 }
 
 func (p *Probe) ensureConfigDefaults() {

--- a/pkg/security/utils/utils.go
+++ b/pkg/security/utils/utils.go
@@ -21,6 +21,7 @@ func GetAgentSemverVersion() (*semver.Version, error) {
 	return semver.NewVersion(av.GetNumberAndPre())
 }
 
+// BoolTouint64 converts a boolean value to an uint64
 func BoolTouint64(value bool) uint64 {
 	if value {
 		return 1

--- a/pkg/security/utils/utils.go
+++ b/pkg/security/utils/utils.go
@@ -20,3 +20,10 @@ func GetAgentSemverVersion() (*semver.Version, error) {
 
 	return semver.NewVersion(av.GetNumberAndPre())
 }
+
+func BoolTouint64(value bool) uint64 {
+	if value {
+		return 1
+	}
+	return 0
+}


### PR DESCRIPTION
### What does this PR do?

This PR allows the configuration of traced event types and traced cgroup configs to be changed dynamically, while the system probe is running. This is the receiving end of the load controlling mechanism that we want to introduce to activity dumps collection.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
