### PR TITLE
[CWS] fix negative process file/base name rules

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "b768ce691be49719d148299eaa911e027430a4af570050b56fe145d9ff3583a9")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "e5850afb88a20a98b5a79b18f46549b7fa9a0a50dd72791ba1388db5808857b7")

--- a/pkg/security/ebpf/c/dns.h
+++ b/pkg/security/ebpf/c/dns.h
@@ -75,7 +75,6 @@ __attribute__((always_inline)) struct dns_event_t *reset_dns_event(struct __sk_b
     // network context
     fill_network_context(&evt->network, skb, pkt);
 
-
     struct proc_cache_t *entry = get_proc_cache(evt->process.pid);
     if (entry == NULL) {
         evt->container.container_id[0] = 0;

--- a/pkg/security/secl/model/oo_symlink.go
+++ b/pkg/security/secl/model/oo_symlink.go
@@ -15,11 +15,10 @@ var (
 			return &eval.StringEvaluator{
 				Field: field,
 				EvalFnc: func(ctx *eval.Context) string {
-					// empty symlink, generate a fake so that it doesn't match
 					if path := (*Event)(ctx.Object).ProcessContext.SymlinkPathnameStr[0]; path != "" {
 						return path
 					}
-					return "~" // to ensure that it will not match an empty path
+					return (*Event)(ctx.Object).ProcessContext.FileEvent.PathnameStr
 				},
 			}
 		},
@@ -27,11 +26,10 @@ var (
 			return &eval.StringEvaluator{
 				Field: field,
 				EvalFnc: func(ctx *eval.Context) string {
-					// empty symlink, generate a fake so that it doesn't match
 					if path := (*Event)(ctx.Object).ProcessContext.SymlinkPathnameStr[1]; path != "" {
 						return path
 					}
-					return "~" // to ensure that it will not match an empty path
+					return (*Event)(ctx.Object).ProcessContext.FileEvent.PathnameStr
 				},
 			}
 		},
@@ -41,7 +39,10 @@ var (
 		return &eval.StringEvaluator{
 			Field: field,
 			EvalFnc: func(ctx *eval.Context) string {
-				return (*Event)(ctx.Object).ProcessContext.SymlinkBasenameStr
+				if name := (*Event)(ctx.Object).ProcessContext.SymlinkBasenameStr; name != "" {
+					return name
+				}
+				return (*Event)(ctx.Object).ProcessContext.FileEvent.BasenameStr
 			},
 		}
 	}

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -62,6 +62,11 @@ func TestProcess(t *testing.T) {
 }
 
 func TestProcessContext(t *testing.T) {
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	ruleDefs := []*rules.RuleDefinition{
 		{
 			ID:         "test_rule_inode",
@@ -122,6 +127,22 @@ func TestProcessContext(t *testing.T) {
 		{
 			ID:         "test_self_exec",
 			Expression: `exec.file.name == "syscall_tester" && exec.argv0 == "selfexec123" && process.comm == "exe"`,
+		},
+		{
+			ID:         "test_rule_ctx_1",
+			Expression: fmt.Sprintf(`open.file.path == "{{.Root}}/test-process-ctx-1" && process.file.name == "%s"`, path.Base(executable)),
+		},
+		{
+			ID:         "test_rule_ctx_2",
+			Expression: `open.file.path == "{{.Root}}/test-process-ctx-2" && process.file.name != ""`,
+		},
+		{
+			ID:         "test_rule_ctx_3",
+			Expression: fmt.Sprintf(`open.file.path == "{{.Root}}/test-process-ctx-3" && process.file.path == "%s"`, executable),
+		},
+		{
+			ID:         "test_rule_ctx_4",
+			Expression: `open.file.path == "{{.Root}}/test-process-ctx-4" && process.file.path != ""`,
 		},
 	}
 
@@ -603,6 +624,31 @@ func TestProcessContext(t *testing.T) {
 			assertTriggeredRule(t, rule, "test_self_exec")
 		}))
 	})
+
+	testProcessContextRule := func(t *testing.T, ruleID, filename string) {
+		test.Run(t, ruleID, func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+			testFile, _, err := test.Path(filename)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			test.WaitSignal(t, func() error {
+				f, err := os.Create(testFile)
+				if err != nil {
+					return err
+				}
+				f.Close()
+				return os.Remove(testFile)
+			}, validateExecEvent(t, func(event *sprobe.Event, rule *rules.Rule) {
+				assert.Equal(t, ruleID, rule.ID, "wrong rule triggered")
+			}))
+		})
+	}
+
+	testProcessContextRule(t, "test_rule_ctx_1", "test-process-ctx-1")
+	testProcessContextRule(t, "test_rule_ctx_2", "test-process-ctx-2")
+	testProcessContextRule(t, "test_rule_ctx_3", "test-process-ctx-3")
+	testProcessContextRule(t, "test_rule_ctx_4", "test-process-ctx-4")
 }
 
 func TestProcessEnvsWithValue(t *testing.T) {

--- a/releasenotes/notes/fix-negative-process-ctx-rule-3142038e95e1a97a.yaml
+++ b/releasenotes/notes/fix-negative-process-ctx-rule-3142038e95e1a97a.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes CWS rules with 'process.file.name !=""' expression.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

this fix empty negative process context rule.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
