### PR TITLE
Adds 'print-default-build-tags' invoke task

### DIFF
--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -27,10 +27,7 @@ from . import (
     systray,
     trace_agent,
 )
-from .build_tags import (
-    audit_tag_impact,
-    print_default_build_tags,
-)
+from .build_tags import audit_tag_impact, print_default_build_tags
 from .go import (
     check_mod_tidy,
     deps,

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -27,7 +27,10 @@ from . import (
     systray,
     trace_agent,
 )
-from .build_tags import audit_tag_impact
+from .build_tags import (
+    audit_tag_impact,
+    print_default_build_tags,
+)
 from .go import (
     check_mod_tidy,
     deps,
@@ -76,6 +79,7 @@ ns.add_task(lint_milestone)
 ns.add_task(lint_filenames)
 ns.add_task(lint_python)
 ns.add_task(audit_tag_impact)
+ns.add_task(print_default_build_tags)
 ns.add_task(e2e_tests)
 ns.add_task(install_shellcheck)
 ns.add_task(download_tools)

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -197,6 +197,18 @@ def compute_build_tags_for_flavor(
     return get_build_tags(build_include, build_exclude)
 
 
+@task
+def print_default_build_tags(ctx, build="agent", arch="x64", flavor=AgentFlavor.base):
+    """
+    Build the default list of tags based on the build type and current platform.
+    Prints as comma separated list suitable for go tooling (eg, gopls, govulncheck)
+
+    The container integrations are currently only supported on Linux, disabling on
+    the Windows and Darwin builds.
+    """
+
+    print(",".join(sorted(get_default_build_tags(build, arch, flavor))))
+
 def get_default_build_tags(build="agent", arch="x64", flavor=AgentFlavor.base):
     """
     Build the default list of tags based on the build type and current platform.

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -216,6 +216,7 @@ def print_default_build_tags(_, build="agent", arch="x64", flavor=AgentFlavor.ba
 
     print(",".join(sorted(get_default_build_tags(build, arch, flavor))))
 
+
 def get_default_build_tags(build="agent", arch="x64", flavor=AgentFlavor.base):
     """
     Build the default list of tags based on the build type and current platform.

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -198,7 +198,7 @@ def compute_build_tags_for_flavor(
 
 
 @task
-def print_default_build_tags(ctx, build="agent", arch="x64", flavor=AgentFlavor.base.name): # noqa: U100
+def print_default_build_tags(_, build="agent", arch="x64", flavor=AgentFlavor.base.name):
     """
     Build the default list of tags based on the build type and current platform.
     Prints as comma separated list suitable for go tooling (eg, gopls, govulncheck)

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -198,7 +198,7 @@ def compute_build_tags_for_flavor(
 
 
 @task
-def print_default_build_tags(ctx, build="agent", arch="x64", flavor=AgentFlavor.base):
+def print_default_build_tags(ctx, build="agent", arch="x64", flavor=AgentFlavor.base.name): # noqa: U100
     """
     Build the default list of tags based on the build type and current platform.
     Prints as comma separated list suitable for go tooling (eg, gopls, govulncheck)
@@ -206,6 +206,13 @@ def print_default_build_tags(ctx, build="agent", arch="x64", flavor=AgentFlavor.
     The container integrations are currently only supported on Linux, disabling on
     the Windows and Darwin builds.
     """
+
+    try:
+        flavor = AgentFlavor[flavor]
+    except KeyError:
+        flavorOptions = [flavor.name for flavor in AgentFlavor]
+        print(f"'{flavor}' does not correspond to an agent flavor. Options: {flavorOptions}")
+        exit(1)
 
     print(",".join(sorted(get_default_build_tags(build, arch, flavor))))
 


### PR DESCRIPTION
### What does this PR do?
Adds an extra `invoke` task to print out go build tags for a given build configuration.
eg:

```
$ inv print-default-build-tags
apm,consul,containerd,cri,docker,ec2,etcd,gce,jetson,jmx,kubeapiserver,kubelet,netcgo,orchestrator,otlp,podman,process,python,secrets,systemd,zk,zlib

$ inv print-default-build-tags -a arm64 -b agent -f iotoo
'iotoo' does not correspond to an agent flavor. Options: ['base', 'iot', 'heroku', 'dogstatsd']

$ inv print-default-build-tags --help
Usage: inv[oke] [--core-opts] print-default-build-tags [--options] [other tasks here ...]

Docstring:
  Build the default list of tags based on the build type and current platform.
  Prints as comma separated list suitable for go tooling (eg, gopls, govulncheck)

  The container integrations are currently only supported on Linux, disabling on
  the Windows and Darwin builds.

Options:
  -a STRING, --arch=STRING
  -b STRING, --build=STRING
  -f STRING, --flavor=STRING
```

### Motivation
Various go tooling takes in a `build-tags` parameter to run checks/analysis against a codebase.
I implemented this as a convenience for developers to configure their tooling correctly when working on the `agent` codebase.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
N/A

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
