### PR TITLE
Add arbitrary journald filtering

### DIFF
--- a/pkg/logs/config/integration_config.go
+++ b/pkg/logs/config/integration_config.go
@@ -49,6 +49,8 @@ type LogsConfig struct {
 	ExcludeSystemUnits []string `mapstructure:"exclude_units" json:"exclude_units"`           // Journald
 	IncludeUserUnits   []string `mapstructure:"include_user_units" json:"include_user_units"` // Journald
 	ExcludeUserUnits   []string `mapstructure:"exclude_user_units" json:"exclude_user_units"` // Journald
+	IncludeMatches     []string `mapstructure:"include_matches" json:"include_matches"`       // Journald
+	ExcludeMatches     []string `mapstructure:"exclude_matches" json:"exclude_matches"`       // Journald
 	ContainerMode      bool     `mapstructure:"container_mode" json:"container_mode"`         // Journald
 
 	Image string // Docker

--- a/pkg/logs/internal/tailers/journald/tailer.go
+++ b/pkg/logs/internal/tailers/journald/tailer.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"regexp"
 	"time"
 
 	"github.com/coreos/go-systemd/sdjournal"
@@ -45,12 +46,13 @@ const (
 
 // Tailer collects logs from a journal.
 type Tailer struct {
-	source       *sources.LogSource
-	outputChan   chan *message.Message
-	journal      Journal
-	excludeUnits struct {
-		system map[string]bool
-		user   map[string]bool
+	source     *sources.LogSource
+	outputChan chan *message.Message
+	journal    Journal
+	exclude    struct {
+		systemUnits map[string]bool
+		userUnits   map[string]bool
+		matches     map[string]map[string]bool
 	}
 	stop chan struct{}
 	done chan struct{}
@@ -96,10 +98,13 @@ func (t *Tailer) Stop() {
 func (t *Tailer) setup() error {
 	config := t.source.Config
 
+	matchRe := regexp.MustCompile("^([^=]+)=(.+)$")
+
 	t.initializeTagger()
 
 	// add filters to collect only the logs of the units defined in the configuration,
-	// if no units are defined for both System and User, collect all the logs of the journal by default.
+	// if no units for both System and User, and no matches are defined,
+	// collect all the logs of the journal by default.
 	for _, unit := range config.IncludeSystemUnits {
 		// add filters to collect only the logs of the system-level units defined in the configuration.
 		match := sdjournal.SD_JOURNAL_FIELD_SYSTEMD_UNIT + "=" + unit
@@ -126,16 +131,44 @@ func (t *Tailer) setup() error {
 		}
 	}
 
-	t.excludeUnits.system = make(map[string]bool)
-	for _, unit := range config.ExcludeSystemUnits {
-		// add filters to drop all the logs related to system units to exclude.
-		t.excludeUnits.system[unit] = true
+	for _, match := range config.IncludeMatches {
+		// add filters to collect only the logs of the matches defined in the configuration.
+		submatches := matchRe.FindStringSubmatch(match)
+		if len(submatches) < 1 {
+			return fmt.Errorf("incorrectly formatted IncludeMatch (must be `[field]=[value]`: %s", match)
+		}
+		err := t.journal.AddMatch(match)
+		if err != nil {
+			return fmt.Errorf("could not add filter %s: %s", match, err)
+		}
 	}
 
-	t.excludeUnits.user = make(map[string]bool)
+	t.exclude.systemUnits = make(map[string]bool)
+	for _, unit := range config.ExcludeSystemUnits {
+		// add filters to drop all the logs related to system units to exclude.
+		t.exclude.systemUnits[unit] = true
+	}
+
+	t.exclude.userUnits = make(map[string]bool)
 	for _, unit := range config.ExcludeUserUnits {
 		// add filters to drop all the logs related to user units to exclude.
-		t.excludeUnits.user[unit] = true
+		t.exclude.userUnits[unit] = true
+	}
+
+	t.exclude.matches = make(map[string]map[string]bool)
+	for _, match := range config.ExcludeMatches {
+		// add filters to drop all the logs related to the matches to exclude.
+		submatches := matchRe.FindStringSubmatch(match)
+		if len(submatches) < 1 {
+			return fmt.Errorf("incorrectly formatted ExcludeMatch (must be `[field]=[value]`: %s", match)
+		}
+
+		key := submatches[1]
+		if t.exclude.matches[key] == nil {
+			t.exclude.matches[key] = map[string]bool{}
+		}
+		value := submatches[2]
+		t.exclude.matches[key][value] = true
 	}
 
 	return nil
@@ -215,6 +248,14 @@ func (t *Tailer) tail() {
 // shouldDrop returns true if the entry should be dropped,
 // returns false otherwise.
 func (t *Tailer) shouldDrop(entry *sdjournal.JournalEntry) bool {
+	for key, values := range t.exclude.matches {
+		if value, ok := entry.Fields[key]; ok {
+			if _, contains := values[value]; contains {
+				return true
+			}
+		}
+	}
+
 	sysUnit, exists := entry.Fields[sdjournal.SD_JOURNAL_FIELD_SYSTEMD_UNIT]
 	if !exists {
 		return false
@@ -222,15 +263,15 @@ func (t *Tailer) shouldDrop(entry *sdjournal.JournalEntry) bool {
 	usrUnit, exists := entry.Fields[sdjournal.SD_JOURNAL_FIELD_SYSTEMD_USER_UNIT]
 	if !exists {
 		// JournalEntry is a System-level unit
-		excludeAllSys := t.excludeUnits.system["*"]
-		if _, excluded := t.excludeUnits.system[sysUnit]; excludeAllSys || excluded {
+		excludeAllSys := t.exclude.systemUnits["*"]
+		if _, excluded := t.exclude.systemUnits[sysUnit]; excludeAllSys || excluded {
 			// drop the entry
 			return true
 		}
 	} else {
 		// JournalEntry is a User-level unit
-		excludeAllUsr := t.excludeUnits.user["*"]
-		if _, excluded := t.excludeUnits.user[usrUnit]; excludeAllUsr || excluded {
+		excludeAllUsr := t.exclude.userUnits["*"]
+		if _, excluded := t.exclude.userUnits[usrUnit]; excludeAllUsr || excluded {
 			// drop the entry
 			return true
 		}

--- a/pkg/logs/status/builder.go
+++ b/pkg/logs/status/builder.go
@@ -157,6 +157,8 @@ func (b *Builder) toDictionary(c *config.LogsConfig) map[string]interface{} {
 		dictionary["ExcludeSystemUnits"] = strings.Join(c.ExcludeSystemUnits, ", ")
 		dictionary["IncludeUserUnits"] = strings.Join(c.IncludeUserUnits, ", ")
 		dictionary["ExcludeUserUnits"] = strings.Join(c.ExcludeUserUnits, ", ")
+		dictionary["IncludeMatches"] = strings.Join(c.IncludeMatches, ", ")
+		dictionary["ExcludeMatches"] = strings.Join(c.ExcludeMatches, ", ")
 	case config.WindowsEventType:
 		dictionary["ChannelPath"] = c.ChannelPath
 		dictionary["Query"] = c.Query

--- a/releasenotes/notes/arbitrary-journald-filtering-adce8c2b292c9586.yaml
+++ b/releasenotes/notes/arbitrary-journald-filtering-adce8c2b292c9586.yaml
@@ -1,0 +1,3 @@
+enhancements:
+  - |
+    Logs: Support filtering on arbitrary journal log fields


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

In addition to the existing inclusion and exclusion filters based on
system-level and user-level units, this change allows users to define
abitrary `KEY=VALUE` journald filters for log inclusion or exclusion.

Without arbitrary filters it's not possible to filter journald logs
that do not belong to a systemd system-level or user-level unit.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Fixes #5579 and duplicates the abandoned #7096.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

- Set up journald integration as per https://docs.datadoghq.com/integrations/journald/?tab=host#configuration
- Add arbitrary filter, for example to include only kernel messages:
```
IncludeMatches: _TRANSPORT=kernel
```

- Verify in datadog log dashboard the appropriate messages are visible

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
