### PR TITLE
[AD][Kubelet] Fix invalid configs making AD skip valid configs

### DIFF
--- a/pkg/autodiscovery/providers/kubecontainer.go
+++ b/pkg/autodiscovery/providers/kubecontainer.go
@@ -252,7 +252,10 @@ func (k *KubeContainerConfigProvider) generateConfigs() ([]integration.Config, e
 					log.Errorf("Can't parse template for pod %s: %s", pod.Name, err)
 					errs = append(errs, err)
 				}
-				continue
+				if len(c) == 0 {
+					// Only got errors, no valid configs so let's move on to the next container.
+					continue
+				}
 			}
 
 			_, trackedByContainer := k.containerCache[podContainer.ID]

--- a/pkg/autodiscovery/providers/kubecontainer_test.go
+++ b/pkg/autodiscovery/providers/kubecontainer_test.go
@@ -286,6 +286,37 @@ func TestGenerateConfigs_KubeContainer_KubeSpecific(t *testing.T) {
 				"annotation ad.datadoghq.com/nonmatching.instances is invalid: nonmatching doesn't match a container identifier [apache nginx]":    {},
 			},
 		},
+		{
+			desc: "One invalid config, one valid config",
+			pod: &workloadmeta.KubernetesPod{
+				EntityMeta: workloadmeta.EntityMeta{
+					Annotations: map[string]string{
+						"ad.datadoghq.com/nginx.check_names":  "[\"http_check\"]",
+						"ad.datadoghq.com/nginx.init_configs": "[{}]",
+						"ad.datadoghq.com/nginx.instances":    "[{\"name\": \"nginx\", \"url\": \"http://%%host%%\", \"timeout\": 1}]",
+						"ad.datadoghq.com/nginx.logs":         "[{\"source\": \"nginx\" \"service\": \"nginx\"}]", // invalid json
+					},
+				},
+				Containers: []workloadmeta.OrchestratorContainer{
+					{
+						Name: "nginx",
+						ID:   "4ac8352d70bf1",
+					},
+				},
+			},
+			expectedCfg: []integration.Config{
+				{
+					Name:          "http_check",
+					ADIdentifiers: []string{"docker://4ac8352d70bf1"},
+					InitConfig:    integration.Data("{}"),
+					Instances:     []integration.Data{integration.Data("{\"name\":\"nginx\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
+					Source:        "kubelet:docker://4ac8352d70bf1",
+				},
+			},
+			expectedErr: ErrorMsgSet{
+				"could not extract logs config: in logs: invalid character '\"' after object key:value pair": {},
+			},
+		},
 	} {
 		t.Run(fmt.Sprintf("case %d: %s", nb, tc.desc), func(t *testing.T) {
 			store := workloadmetatesting.NewStore()

--- a/pkg/autodiscovery/providers/kubelet.go
+++ b/pkg/autodiscovery/providers/kubelet.go
@@ -164,7 +164,10 @@ func (k *KubeletConfigProvider) generateConfigs() ([]integration.Config, error) 
 					log.Errorf("Can't parse template for pod %s: %s", pod.Name, err)
 					errs = append(errs, err)
 				}
-				continue
+				if len(c) == 0 {
+					// Only got errors, no valid configs so let's move on to the next container.
+					continue
+				}
 			}
 
 			if util.CcaInAD() {

--- a/pkg/autodiscovery/providers/kubelet_test.go
+++ b/pkg/autodiscovery/providers/kubelet_test.go
@@ -245,6 +245,37 @@ func TestParseKubeletPodlist(t *testing.T) {
 				"annotation ad.datadoghq.com/nonmatching.instances is invalid: nonmatching doesn't match a container identifier [apache nginx]":    {},
 			},
 		},
+		{
+			desc: "One invalid config, one valid config",
+			pod: &workloadmeta.KubernetesPod{
+				EntityMeta: workloadmeta.EntityMeta{
+					Annotations: map[string]string{
+						"ad.datadoghq.com/nginx.check_names":  "[\"http_check\"]",
+						"ad.datadoghq.com/nginx.init_configs": "[{}]",
+						"ad.datadoghq.com/nginx.instances":    "[{\"name\": \"nginx\", \"url\": \"http://%%host%%\", \"timeout\": 1}]",
+						"ad.datadoghq.com/nginx.logs":         "[{\"source\": \"nginx\" \"service\": \"nginx\"}]", // invalid json
+					},
+				},
+				Containers: []workloadmeta.OrchestratorContainer{
+					{
+						Name: "nginx",
+						ID:   "4ac8352d70bf1",
+					},
+				},
+			},
+			expectedCfg: []integration.Config{
+				{
+					Name:          "http_check",
+					ADIdentifiers: []string{"docker://4ac8352d70bf1"},
+					InitConfig:    integration.Data("{}"),
+					Instances:     []integration.Data{integration.Data("{\"name\":\"nginx\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
+					Source:        "kubelet:docker://4ac8352d70bf1",
+				},
+			},
+			expectedErr: ErrorMsgSet{
+				"could not extract logs config: in logs: invalid character '\"' after object key:value pair": {},
+			},
+		},
 	} {
 		t.Run(fmt.Sprintf("case %d: %s", nb, tc.desc), func(t *testing.T) {
 			store := workloadmetatesting.NewStore()

--- a/releasenotes/notes/fix-ad-annotations-ad9de50036225e50.yaml
+++ b/releasenotes/notes/fix-ad-annotations-ad9de50036225e50.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed a bug in Kubernetes Autodiscovery based on pod annotations: The Agent no longer skips valid configurations if other invalid configurations exist.
+    Note: This regression was introduced in Agents 7.36.0 and 6.36.0


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fixes a bug in Kubernetes Autodiscovery based on pod annotations: The Agent no longer skips valid configurations if other invalid configurations exist.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

- Bug fix
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

- This regression was introduced in Agents 7.36.0 and 6.36.0

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Apply a mix of valid and invalid configs in the same pod annotations and make sure the agent schedule the valid ones.

Example with invalid log config (malformed json):

```
  annotations:
    ad.datadoghq.com/redis.check_names: '["redisdb"]'
    ad.datadoghq.com/redis.init_configs: '[{}]'
    ad.datadoghq.com/redis.instances: |
      [
        {
          "host": "%%host%%",
          "port":"6379",
          "tags": ["extra_tag:extra_tag"]
        }
      ]
    ad.datadoghq.com/redis.logs: |-
      [{
        "source": "redis"
        "service": "redis"
      }]
```

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
