### PR TITLE
Add a dedicated setting to control sending checks config to inventory

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1019,7 +1019,8 @@ func InitConfig(config Config) {
 
 	// inventories
 	config.BindEnvAndSetDefault("inventories_enabled", true)
-	config.BindEnvAndSetDefault("inventories_configuration_enabled", true)
+	config.BindEnvAndSetDefault("inventories_configuration_enabled", true)        // controls the agent configurations
+	config.BindEnvAndSetDefault("inventories_checks_configuration_enabled", true) // controls the checks configurations
 	// when updating the default here also update pkg/metadata/inventories/README.md
 	config.BindEnvAndSetDefault("inventories_max_interval", DefaultInventoriesMaxInterval) // integer seconds
 	config.BindEnvAndSetDefault("inventories_min_interval", DefaultInventoriesMinInterval) // integer seconds

--- a/pkg/metadata/inventories/README.md
+++ b/pkg/metadata/inventories/README.md
@@ -32,6 +32,9 @@ Sending Agent configuration can be disabled using `inventories_configuration_ena
 `SetCheckMetadata` registers data per check instance. Metadata can include the check version, the version of the
 monitored software, ... It depends on each check.
 
+We send for every running checks, no matter if they registered extra metadata or not: name, ID, configuration,
+configuration provider. Sending checks configuration can be disabled using `inventories_checks_configuration_enabled`.
+
 ## Agent metadata
 
 `SetAgentMetadata` registers data about the agent itself.

--- a/pkg/metadata/inventories/README.md
+++ b/pkg/metadata/inventories/README.md
@@ -32,7 +32,7 @@ Sending Agent configuration can be disabled using `inventories_configuration_ena
 `SetCheckMetadata` registers data per check instance. Metadata can include the check version, the version of the
 monitored software, ... It depends on each check.
 
-We send for every running checks, no matter if they registered extra metadata or not: name, ID, configuration,
+For every running check, no matter if it registered extra metadata or not, we send: name, ID, configuration,
 configuration provider. Sending checks configuration can be disabled using `inventories_checks_configuration_enabled`.
 
 ## Agent metadata

--- a/pkg/metadata/inventories/inventories.go
+++ b/pkg/metadata/inventories/inventories.go
@@ -187,7 +187,7 @@ func createCheckInstanceMetadata(checkID, configProvider, initConfig, instanceCo
 	checkInstanceMetadata["config.hash"] = checkID
 	checkInstanceMetadata["config.provider"] = configProvider
 
-	if config.Datadog.GetBool("inventories_configuration_enabled") {
+	if config.Datadog.GetBool("inventories_checks_configuration_enabled") {
 		if instanceScrubbed, err := scrubber.ScrubString(instanceConfig); err != nil {
 			log.Errorf("Could not scrub instance configuration for check id %s: %s", checkID, err)
 		} else {


### PR DESCRIPTION
### What does this PR do?

Add a dedicated setting to control sending checks config to inventory.

### Describe how to test/QA your changes

Set `inventories_checks_configuration_enabled` and check that no check config are sent but the agent config is. They do the same with `inventories_configuration_enabled`.