### PR TITLE
Remove 'last_udpated' from the inventory payload

### DIFF
--- a/pkg/metadata/inventories/README.md
+++ b/pkg/metadata/inventories/README.md
@@ -50,7 +50,6 @@ The payload is a JSON dict with the following fields
 - `check_metadata` - **dict of string to list**: dictionary with check names as keys; values are a list of the metadata for each
   instance of that check.
   Each instance is composed of:
-    - `last_updated` - **int**: timestamp of the last metadata update for this instance
     - `config.hash` - **string**: the instance ID for this instance (as shown in the status page).
     - `config.provider` - **string**: where the configuration came from for this instance (disk, docker labels, ...).
     - `init_config` - **string**: the `init_config` part of the configuration for this check instance.
@@ -171,7 +170,6 @@ Here an example of an inventory payload:
             {
                 "config.hash": "cpu",
                 "config.provider": "file",
-                "last_updated": 1631281744506400319,
                 "init_config": "",
                 "instance_config: {}
             }
@@ -180,7 +178,6 @@ Here an example of an inventory payload:
             {
                 "config.hash": "disk:e5dffb8bef24336f",
                 "config.provider": "file",
-                "last_updated": 1631281744506400319,
                 "init_config": "",
                 "instance_config: {}
             }
@@ -189,7 +186,6 @@ Here an example of an inventory payload:
             {
                 "config.hash": "file_handle",
                 "config.provider": "file",
-                "last_updated": 1631281744506400319,
                 "init_config": "",
                 "instance_config: {}
             }
@@ -198,7 +194,6 @@ Here an example of an inventory payload:
             {
                 "config.hash": "io",
                 "config.provider": "file",
-                "last_updated": 1631281744506400319,
                 "init_config": "",
                 "instance_config: {}
             }
@@ -207,7 +202,6 @@ Here an example of an inventory payload:
             {
                 "config.hash": "load",
                 "config.provider": "file",
-                "last_updated": 1631281744506400319,
                 "init_config": "",
                 "instance_config: {}
             }
@@ -218,7 +212,6 @@ Here an example of an inventory payload:
                 "config.provider": "container",
                 "init_config": "test: 21",
                 "instance_config": "host: localhost\nport: 6379\ntags:\n- docker_image:redis\n- image_name:redis\n- short_image:redis",
-                "last_updated": 1658327911867365638,
                 "version.major": "7",
                 "version.minor": "0",
                 "version.patch": "2",
@@ -230,7 +223,6 @@ Here an example of an inventory payload:
                 "config.provider": "container",
                 "init_config": "test: 21",
                 "instance_config": "host: localhost\nport: 7379\ntags:\n- docker_image:redis\n- image_name:redis\n- short_image:redis",
-                "last_updated": 1658327940850060982,
                 "version.major": "7",
                 "version.minor": "0",
                 "version.patch": "2",

--- a/pkg/metadata/inventories/inventories.go
+++ b/pkg/metadata/inventories/inventories.go
@@ -43,8 +43,6 @@ var (
 	hostMetadata       = make(AgentMetadata)
 	hostMetadataMutex  = &sync.Mutex{}
 
-	agentStartupTime = timeNow()
-
 	lastPayload         *Payload
 	lastGetPayload      = timeNow()
 	lastGetPayloadMutex = &sync.Mutex{}
@@ -174,16 +172,13 @@ func RemoveCheckMetadata(checkID string) {
 
 func createCheckInstanceMetadata(checkID, configProvider, initConfig, instanceConfig string) *CheckInstanceMetadata {
 	checkInstanceMetadata := CheckInstanceMetadata{}
-	lastUpdated := agentStartupTime
 
 	if entry, found := checkMetadata[checkID]; found {
 		for k, v := range entry.CheckInstanceMetadata {
 			checkInstanceMetadata[k] = v
 		}
-		lastUpdated = entry.LastUpdated
 	}
 
-	checkInstanceMetadata["last_updated"] = lastUpdated.UnixNano()
 	checkInstanceMetadata["config.hash"] = checkID
 	checkInstanceMetadata["config.provider"] = configProvider
 

--- a/pkg/metadata/inventories/inventories_test.go
+++ b/pkg/metadata/inventories/inventories_test.go
@@ -136,7 +136,6 @@ func TestGetPayload(t *testing.T) {
 	assert.Len(t, checkMeta["check1"], 2) // check1 has two instances
 
 	check1Instance1 := *checkMeta["check1"][0]
-	assert.Equal(t, startNow.UnixNano(), check1Instance1["last_updated"])
 	assert.Equal(t, "check1_instance1", check1Instance1["config.hash"])
 	assert.Equal(t, "provider1", check1Instance1["config.provider"])
 	assert.Equal(t, 123, check1Instance1["check_provided_key1"])
@@ -145,7 +144,6 @@ func TestGetPayload(t *testing.T) {
 	assert.Equal(t, "{}", check1Instance1["instance_config"])
 
 	check1Instance2 := *checkMeta["check1"][1]
-	assert.Equal(t, agentStartupTime.UnixNano(), check1Instance2["last_updated"])
 	assert.Equal(t, "check1_instance2", check1Instance2["config.hash"])
 	assert.Equal(t, "provider1", check1Instance2["config.provider"])
 	assert.Equal(t, "", check1Instance2["init_config"])
@@ -153,14 +151,12 @@ func TestGetPayload(t *testing.T) {
 
 	assert.Len(t, checkMeta["check2"], 1) // check2 has one instance
 	check2Instance1 := *checkMeta["check2"][0]
-	assert.Equal(t, agentStartupTime.UnixNano(), check2Instance1["last_updated"])
 	assert.Equal(t, "check2_instance1", check2Instance1["config.hash"])
 	assert.Equal(t, "provider2", check2Instance1["config.provider"])
 	assert.Equal(t, "", check2Instance1["init_config"])
 	assert.Equal(t, "{}", check2Instance1["instance_config"])
 
 	SetCheckMetadata("check2_instance1", "check_provided_key1", "hi")
-	originalStartNow := startNow
 	startNow = startNow.Add(1000 * time.Second)
 	SetCheckMetadata("check1_instance1", "check_provided_key1", 456)
 
@@ -185,17 +181,14 @@ func TestGetPayload(t *testing.T) {
 	checkMeta = *p.CheckMetadata
 	assert.Len(t, checkMeta, 3)
 	check1Instance1 = *checkMeta["check1"][0]
-	assert.Equal(t, startNow.UnixNano(), check1Instance1["last_updated"]) // last_updated has changed
 	assert.Equal(t, "check1_instance1", check1Instance1["config.hash"])
 	assert.Equal(t, "provider1", check1Instance1["config.provider"])
 	assert.Equal(t, 456, check1Instance1["check_provided_key1"]) //Key has been updated
 	assert.Equal(t, "Hi", check1Instance1["check_provided_key2"])
 	check1Instance2 = *checkMeta["check1"][1]
-	assert.Equal(t, agentStartupTime.UnixNano(), check1Instance2["last_updated"]) // last_updated still the same
 	assert.Equal(t, "check1_instance2", check1Instance2["config.hash"])
 	assert.Equal(t, "provider1", check1Instance2["config.provider"])
 	check2Instance1 = *checkMeta["check2"][0]
-	assert.Equal(t, originalStartNow.UnixNano(), check2Instance1["last_updated"]) // reflects when check_provided_key1 was changed
 	assert.Equal(t, "check2_instance1", check2Instance1["config.hash"])
 	assert.Equal(t, "provider2", check2Instance1["config.provider"])
 	assert.Equal(t, "hi", check2Instance1["check_provided_key1"]) // New key added
@@ -216,15 +209,13 @@ func TestGetPayload(t *testing.T) {
 					"config.hash": "check1_instance1",
 					"config.provider": "provider1",
 					"init_config": "",
-					"instance_config": "{}",
-					"last_updated": %v
+					"instance_config": "{}"
 				},
 				{
 					"config.hash": "check1_instance2",
 					"config.provider": "provider1",
 					"init_config": "",
-					"instance_config": "{\"test\":21}",
-					"last_updated": %v
+					"instance_config": "{\"test\":21}"
 				}
 			],
 			"check2":
@@ -234,8 +225,7 @@ func TestGetPayload(t *testing.T) {
 					"config.hash": "check2_instance1",
 					"config.provider": "provider2",
 					"init_config": "",
-					"instance_config": "{}",
-					"last_updated": %v
+					"instance_config": "{}"
 				}
 			],
 			"non_running_checkid":
@@ -245,8 +235,7 @@ func TestGetPayload(t *testing.T) {
 					"config.hash": "non_running_checkid",
 					"config.provider": "",
 					"init_config": "",
-					"instance_config": "",
-					"last_updated": %v
+					"instance_config": ""
 				}
 			]
 		},
@@ -282,7 +271,7 @@ func TestGetPayload(t *testing.T) {
 			"os_version": "testOS"
 		}
 	}`
-	jsonString = fmt.Sprintf(jsonString, startNow.UnixNano(), startNow.UnixNano(), agentStartupTime.UnixNano(), originalStartNow.UnixNano(), originalStartNow.UnixNano(), version.AgentVersion)
+	jsonString = fmt.Sprintf(jsonString, startNow.UnixNano(), version.AgentVersion)
 	jsonString = strings.Join(strings.Fields(jsonString), "") // Removes whitespaces and new lines
 	assert.Equal(t, jsonString, string(marshaled))
 

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -420,7 +420,7 @@ func expvarStats(stats map[string]interface{}) (map[string]interface{}, error) {
 					if vStr, ok := v.(string); ok {
 						if k == "config.hash" {
 							checkHash = vStr
-						} else if k != "config.provider" && k != "last_updated" {
+						} else if k != "config.provider" && k != "instance_config" && k != "init_config" {
 							metadata[k] = vStr
 						}
 					}


### PR DESCRIPTION
### What does this PR do?

Remove `last_udpated` from the inventory payload
This info has very low value for customer but produce an update on the backend

### Describe how to test/QA your changes

Use the `troubleshooting metadata_inventory` command to check that `last_updated` is not send.
