### PR TITLE
[CWS] fix negative process name backport

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "23ccae58056e4739b8934f49943f15c16a5c0a995fd94c0329aba1215b64dca1")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "f6176e4cd99090d47e26a102fc03f07031240921ae42488ac6d2f88b48698068")

--- a/pkg/security/ebpf/c/dns.h
+++ b/pkg/security/ebpf/c/dns.h
@@ -75,7 +75,6 @@ __attribute__((always_inline)) struct dns_event_t *reset_dns_event(struct __sk_b
     // network context
     fill_network_context(&evt->network, skb, pkt);
 
-
     struct proc_cache_t *entry = get_proc_cache(evt->process.pid);
     if (entry == NULL) {
         evt->container.container_id[0] = 0;

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -33,50 +33,61 @@ func (m *Model) NewEvent() eval.Event {
 	return &Event{}
 }
 
-// ValidateField validates the value of a field
-func (m *Model) ValidateField(field eval.Field, fieldValue eval.FieldValue) error {
-	// check that all path are absolute
-	if strings.HasSuffix(field, "path") {
+// check that all path are absolute
+func validatePath(field eval.Field, fieldValue eval.FieldValue) error {
+	// do not support regular expression on path, currently unable to support discarder for regex value
+	if fieldValue.Type == eval.RegexpValueType {
+		return fmt.Errorf("regexp not supported on path `%s`", field)
+	}
 
-		// do not support regular expression on path, currently unable to support discarder for regex value
-		if fieldValue.Type == eval.RegexpValueType {
-			return fmt.Errorf("regexp not supported on path `%s`", field)
+	if value, ok := fieldValue.Value.(string); ok {
+		errAbs := fmt.Errorf("invalid path `%s`, all the path have to be absolute", value)
+		errDepth := fmt.Errorf("invalid path `%s`, path depths have to be shorter than %d", value, MaxPathDepth)
+		errSegment := fmt.Errorf("invalid path `%s`, each segment of a path must be shorter than %d", value, MaxSegmentLength)
+
+		if value == "" {
+			return nil
 		}
 
-		if value, ok := fieldValue.Value.(string); ok {
-			errAbs := fmt.Errorf("invalid path `%s`, all the path have to be absolute", value)
-			errDepth := fmt.Errorf("invalid path `%s`, path depths have to be shorter than %d", value, MaxPathDepth)
-			errSegment := fmt.Errorf("invalid path `%s`, each segment of a path must be shorter than %d", value, MaxSegmentLength)
+		if value != path.Clean(value) {
+			return errAbs
+		}
 
-			if value != path.Clean(value) {
+		if value == "*" {
+			return errAbs
+		}
+
+		if !filepath.IsAbs(value) && len(value) > 0 && value[0] != '*' {
+			return errAbs
+		}
+
+		if strings.HasPrefix(value, "~") {
+			return errAbs
+		}
+
+		// check resolution limitations
+		segments := strings.Split(value, "/")
+		if len(segments) > MaxPathDepth {
+			return errDepth
+		}
+		for _, segment := range segments {
+			if segment == ".." {
 				return errAbs
 			}
+			if len(segment) > MaxSegmentLength {
+				return errSegment
+			}
+		}
+	}
 
-			if value == "*" {
-				return errAbs
-			}
+	return nil
+}
 
-			if !filepath.IsAbs(value) && len(value) > 0 && value[0] != '*' {
-				return errAbs
-			}
-
-			if strings.HasPrefix(value, "~") {
-				return errAbs
-			}
-
-			// check resolution limitations
-			segments := strings.Split(value, "/")
-			if len(segments) > MaxPathDepth {
-				return errDepth
-			}
-			for _, segment := range segments {
-				if segment == ".." {
-					return errAbs
-				}
-				if len(segment) > MaxSegmentLength {
-					return errSegment
-				}
-			}
+// ValidateField validates the value of a field
+func (m *Model) ValidateField(field eval.Field, fieldValue eval.FieldValue) error {
+	if strings.HasSuffix(field, "path") {
+		if err := validatePath(field, fieldValue); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/security/secl/model/oo_symlink.go
+++ b/pkg/security/secl/model/oo_symlink.go
@@ -13,27 +13,28 @@ var (
 	symlinkPathnameEvaluators = [MaxSymlinks]*eval.StringEvaluator{
 		{
 			EvalFnc: func(ctx *eval.Context) string {
-				// empty symlink, generate a fake so that it doesn't match
 				if path := (*Event)(ctx.Object).ProcessContext.SymlinkPathnameStr[0]; path != "" {
 					return path
 				}
-				return "~" // to ensure that it will not match an empty path
+				return (*Event)(ctx.Object).ProcessContext.FileEvent.PathnameStr
 			},
 		},
 		{
 			EvalFnc: func(ctx *eval.Context) string {
-				// empty symlink, generate a fake so that it doesn't match
 				if path := (*Event)(ctx.Object).ProcessContext.SymlinkPathnameStr[1]; path != "" {
 					return path
 				}
-				return "~" // to ensure that it will not match an empty path
+				return (*Event)(ctx.Object).ProcessContext.FileEvent.PathnameStr
 			},
 		},
 	}
 
 	symlinkBasenameEvaluator = &eval.StringEvaluator{
 		EvalFnc: func(ctx *eval.Context) string {
-			return (*Event)(ctx.Object).ProcessContext.SymlinkBasenameStr
+			if name := (*Event)(ctx.Object).ProcessContext.SymlinkBasenameStr; name != "" {
+				return name
+			}
+			return (*Event)(ctx.Object).ProcessContext.FileEvent.BasenameStr
 		},
 	}
 

--- a/releasenotes/notes/fix-negative-process-ctx-rule-3142038e95e1a97a.yaml
+++ b/releasenotes/notes/fix-negative-process-ctx-rule-3142038e95e1a97a.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes CWS rules with 'process.file.name !=""' expression.


### PR DESCRIPTION
(cherry picked from commit 2cb7dccfdedf267d792d8dd8efbfa7a9c9ced1d0)

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
