### PR TITLE
[process-agent] Separate endpoint for connections payloads

### DIFF
--- a/cmd/process-agent/collector_api_test.go
+++ b/cmd/process-agent/collector_api_test.go
@@ -71,7 +71,7 @@ func TestSendConnectionsMessage(t *testing.T) {
 	runCollectorTest(t, check, config.NewDefaultAgentConfig(), &endpointConfig{}, ddconfig.Mock(t), func(cfg *config.AgentConfig, ep *mockEndpoint) {
 		req := <-ep.Requests
 
-		assert.Equal(t, "/api/v1/collector", req.uri)
+		assert.Equal(t, "/api/v1/connections", req.uri)
 
 		assert.Equal(t, cfg.HostName, req.headers.Get(headers.HostHeader))
 		apiEps, err := getAPIEndpoints()
@@ -582,6 +582,7 @@ func newMockEndpoint(t *testing.T, config *endpointConfig) *mockEndpoint {
 	collectorMux := http.NewServeMux()
 	collectorMux.HandleFunc("/api/v1/validate", m.handleValidate)
 	collectorMux.HandleFunc("/api/v1/collector", m.handle)
+	collectorMux.HandleFunc("/api/v1/connections", m.handle)
 	collectorMux.HandleFunc("/api/v1/container", m.handle)
 	collectorMux.HandleFunc("/api/v1/discovery", m.handle)
 

--- a/pkg/forwarder/endpoints/endpoints.go
+++ b/pkg/forwarder/endpoints/endpoints.go
@@ -47,7 +47,7 @@ var (
 	// RtContainerEndpoint is a v1 endpoint used to send real time container checks
 	RtContainerEndpoint = transaction.Endpoint{Route: "/api/v1/container", Name: "rtcontainer"}
 	// ConnectionsEndpoint is a v1 endpoint used to send connection checks
-	ConnectionsEndpoint = transaction.Endpoint{Route: "/api/v1/collector", Name: "connections"}
+	ConnectionsEndpoint = transaction.Endpoint{Route: "/api/v1/connections", Name: "connections"}
 	// LegacyOrchestratorEndpoint is a v1 endpoint used to send orchestrator checks
 	LegacyOrchestratorEndpoint = transaction.Endpoint{Route: "/api/v1/orchestrator", Name: "orchestrator"}
 	// OrchestratorEndpoint is a v2 endpoint used to send orchestrator checks


### PR DESCRIPTION

### What does this PR do?

- Use separate endpoint route for connections payload

### Motivation

Being able to route payloads differently by their type.

### Describe how to test/QA your changes

Validate that connections payload submission still works.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
