### PR TITLE
Submit runtime compilation telemetry to statsd

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	code.cloudfoundry.org/bbs v0.0.0-20200403215808-d7bc971db0db
 	code.cloudfoundry.org/garden v0.0.0-20210208153517-580cadd489d2
 	code.cloudfoundry.org/lager v2.0.0+incompatible
-	github.com/DataDog/agent-payload/v5 v5.0.23
+	github.com/DataDog/agent-payload/v5 v5.0.25
 	github.com/DataDog/btf-internals v0.0.0-20220424171854-ebe6bce9afb0
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.38.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/otlp/model v0.38.0-rc.3

--- a/go.sum
+++ b/go.sum
@@ -135,8 +135,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.1.0 h1:ksErzDEI1khOiGPgpwuI7x2ebx/uXQNw7xJpn9Eq1+I=
 github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/DataDog/agent-payload/v5 v5.0.23 h1:T+xalP3F9XOMZRSokcG4pK1hqyDBbEDPxp68tSBmfhc=
-github.com/DataDog/agent-payload/v5 v5.0.23/go.mod h1:2gapp8p4Vd548JI+axD8kCExklNvVI6AMF5/+IfN/4g=
+github.com/DataDog/agent-payload/v5 v5.0.25 h1:wINvEkjisaNz9fgOF6/qJJOSc5MtEYcAtaOs3dOnFbc=
+github.com/DataDog/agent-payload/v5 v5.0.25/go.mod h1:2gapp8p4Vd548JI+axD8kCExklNvVI6AMF5/+IfN/4g=
 github.com/DataDog/aptly v1.5.0 h1:Oy6JVRC9iDgnmpeVYa4diXwP/exU7wJ/U1kuI4Zacxg=
 github.com/DataDog/aptly v1.5.0/go.mod h1:KVyvkYXGcFugxadGFZ+u5Fc3M6q/EfzFZyeTD9HVbkY=
 github.com/DataDog/btf-internals v0.0.0-20220424171854-ebe6bce9afb0 h1:01FWXvRqmUWsh9dWSWA0PkRK3XSBftQVj/tQ0yq9Z50=

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -455,7 +455,7 @@ func (t *Tracer) getRuntimeCompilationTelemetry() map[string]network.RuntimeComp
 		result[assetName] = tm
 
 		statsdMetricPrefix := "datadog.system_probe." + assetName
-		tags := []string{fmt.Sprintf("version:%s", version.AgentVersion)}
+		tags := []string{fmt.Sprintf("agent_version:%s", version.AgentVersion)}
 
 		if tm.RuntimeCompilationEnabled {
 			if err := statsd.Client.Gauge(statsdMetricPrefix + ".runtime_compilation_result", float64(tm.RuntimeCompilationResult), tags, 1); err != nil {

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -454,14 +454,13 @@ func (t *Tracer) getRuntimeCompilationTelemetry() map[string]network.RuntimeComp
 		}
 		result[assetName] = tm
 
-		statsdMetricPrefix := "datadog.system_probe." + assetName
-		tags := []string{fmt.Sprintf("agent_version:%s", version.AgentVersion)}
-
 		if tm.RuntimeCompilationEnabled {
-			if err := statsd.Client.Gauge(statsdMetricPrefix + ".runtime_compilation_result", float64(tm.RuntimeCompilationResult), tags, 1); err != nil {
+			tags := []string{fmt.Sprintf("agent_version:%s", version.AgentVersion), fmt.Sprintf("asset_name:%s", assetName)}
+
+			if err := statsd.Client.Gauge("datadog.system_probe.runtime_compilation_result", float64(tm.RuntimeCompilationResult), tags, 1); err != nil {
 				log.Warnf("error submitting runtime compilation metric to statsd: %s", err)
 			}
-			if err := statsd.Client.Gauge(statsdMetricPrefix + ".kernel_header_fetch_result", float64(tm.KernelHeaderFetchResult), tags, 1); err != nil {
+			if err := statsd.Client.Gauge("datadog.system_probe.kernel_header_fetch_result", float64(tm.KernelHeaderFetchResult), tags, 1); err != nil {
 				log.Warnf("error submitting kernel header downloading metric to statsd: %s", err)
 			}
 		}

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -36,12 +36,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/tracer/connection"
 	"github.com/DataDog/datadog-agent/pkg/network/tracer/connection/kprobe"
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
-	"github.com/DataDog/datadog-agent/pkg/process/statsd"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/atomicstats"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
 const defaultUDPConnTimeoutNanoSeconds = uint64(time.Duration(120) * time.Second)
@@ -453,17 +451,6 @@ func (t *Tracer) getRuntimeCompilationTelemetry() map[string]network.RuntimeComp
 			tm.RuntimeCompilationDuration = duration
 		}
 		result[assetName] = tm
-
-		if tm.RuntimeCompilationEnabled {
-			tags := []string{fmt.Sprintf("agent_version:%s", version.AgentVersion), fmt.Sprintf("asset_name:%s", assetName)}
-
-			if err := statsd.Client.Gauge("datadog.system_probe.runtime_compilation_result", float64(tm.RuntimeCompilationResult), tags, 1); err != nil {
-				log.Warnf("error submitting runtime compilation metric to statsd: %s", err)
-			}
-			if err := statsd.Client.Gauge("datadog.system_probe.kernel_header_fetch_result", float64(tm.KernelHeaderFetchResult), tags, 1); err != nil {
-				log.Warnf("error submitting kernel header downloading metric to statsd: %s", err)
-			}
-		}
 	}
 
 	return result

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -36,10 +36,12 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/tracer/connection"
 	"github.com/DataDog/datadog-agent/pkg/network/tracer/connection/kprobe"
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
+	"github.com/DataDog/datadog-agent/pkg/process/statsd"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/atomicstats"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
 const defaultUDPConnTimeoutNanoSeconds = uint64(time.Duration(120) * time.Second)
@@ -451,6 +453,18 @@ func (t *Tracer) getRuntimeCompilationTelemetry() map[string]network.RuntimeComp
 			tm.RuntimeCompilationDuration = duration
 		}
 		result[assetName] = tm
+
+		statsdMetricPrefix := "datadog.system_probe." + assetName
+		tags := []string{fmt.Sprintf("version:%s", version.AgentVersion)}
+
+		if tm.RuntimeCompilationEnabled {
+			if err := statsd.Client.Gauge(statsdMetricPrefix + ".runtime_compilation_result", float64(tm.RuntimeCompilationResult), tags, 1); err != nil {
+				log.Warnf("error submitting runtime compilation metric to statsd: %s", err)
+			}
+			if err := statsd.Client.Gauge(statsdMetricPrefix + ".kernel_header_fetch_result", float64(tm.KernelHeaderFetchResult), tags, 1); err != nil {
+				log.Warnf("error submitting kernel header downloading metric to statsd: %s", err)
+			}
+		}
 	}
 
 	return result

--- a/pkg/util/kernel/find_headers.go
+++ b/pkg/util/kernel/find_headers.go
@@ -48,7 +48,7 @@ const (
 	defaultHeadersFound
 	sysfsHeadersFound
 	downloadedHeadersFound
-	downloadSuccess
+	DownloadSuccess
 	hostVersionErr
 	downloadFailure
 	validationFailure
@@ -117,7 +117,7 @@ func GetKernelHeaders(downloadEnabled bool, headerDirs []string, headerDownloadD
 
 	log.Infof("successfully downloaded kernel headers to %s", headerDownloadDir)
 	if dirs := validateHeaderDirs(hv, getDownloadedHeaderDirs(headerDownloadDir), true); len(dirs) > 0 {
-		return dirs, downloadSuccess, nil
+		return dirs, DownloadSuccess, nil
 	}
 	return nil, validationFailure, fmt.Errorf("downloaded headers are not valid")
 }

--- a/pkg/util/kernel/find_headers.go
+++ b/pkg/util/kernel/find_headers.go
@@ -48,12 +48,13 @@ const (
 	defaultHeadersFound
 	sysfsHeadersFound
 	downloadedHeadersFound
+	// DownloadSuccess represents the case where kernel headers were successfully downloaded via nikos
 	DownloadSuccess
 	hostVersionErr
 	downloadFailure
 	validationFailure
 	reposDirAccessFailure
-	headersNotFound
+	headersNotFoundDownloadDisabled
 )
 
 var errReposDirInaccessible = errors.New("unable to access repos directory")
@@ -104,7 +105,7 @@ func GetKernelHeaders(downloadEnabled bool, headerDirs []string, headerDownloadD
 	log.Debugf("unable to find downloaded kernel headers: no valid headers found")
 
 	if !downloadEnabled {
-		return nil, headersNotFound, fmt.Errorf("no valid matching kernel header directories found. To download kernel headers, set system_probe_config.enable_kernel_header_download to true")
+		return nil, headersNotFoundDownloadDisabled, fmt.Errorf("no valid matching kernel header directories found. To download kernel headers, set system_probe_config.enable_kernel_header_download to true")
 	}
 
 	d := headerDownloader{aptConfigDir, yumReposDir, zypperReposDir}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Submits runtime compilation & kernel header downloading telemetry to `statsd`, using the `datadog.system_probe` prefix so customers don't get billed.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Allows customers (or us, for support tickets) to debug any runtime compilation or kernel header downloading errors. Our current telemetry tells us if there's failures and which org they're coming from, but not which specific host failed.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
