### PR TITLE
[epforwarder] Pass correct BatchMaxSize to NewBatchStrategy

### DIFF
--- a/pkg/epforwarder/epforwarder.go
+++ b/pkg/epforwarder/epforwarder.go
@@ -231,7 +231,7 @@ func newHTTPPassthroughPipeline(desc passthroughPipelineDesc, destinationsContex
 		senderInput,
 		sender.ArraySerializer,
 		endpoints.BatchWait,
-		pkgconfig.DefaultBatchMaxSize,
+		endpoints.BatchMaxSize,
 		endpoints.BatchMaxContentSize,
 		desc.eventType,
 		encoder)

--- a/pkg/logs/sender/batch_strategy.go
+++ b/pkg/logs/sender/batch_strategy.go
@@ -134,6 +134,8 @@ func (s *batchStrategy) flushBuffer(outputChan chan *message.Payload) {
 
 func (s *batchStrategy) sendMessages(messages []*message.Message, outputChan chan *message.Payload) {
 	serializedMessage := s.serializer.Serialize(messages)
+	log.Debugf("Send messages (msg_count:%d, content_size=%d, avg_msg_size=%.2f)", len(messages), len(serializedMessage), float64(len(serializedMessage))/float64(len(messages)))
+
 	encodedPayload, err := s.contentEncoding.encode(serializedMessage)
 	if err != nil {
 		log.Warn("Encoding failed - dropping payload", err)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

[epforwarder] Pass correct BatchMaxSize to NewBatchStrategy

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

We likely want to pass the BatchMaxSize configured in `passthroughPipelineDescs`: https://github.com/DataDog/datadog-agent/blob/2b5f4619b72f4c717077818a21fb189cfaa5208a/pkg/epforwarder/epforwarder.go#L41-L99

For ndmflow track, we would like to set a higher default BatchMaxSize that is not possible right now due to the bug: https://github.com/DataDog/datadog-agent/blob/2b5f4619b72f4c717077818a21fb189cfaa5208a/pkg/epforwarder/epforwarder.go#L97

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

When changing `network_devices.netflow.forwarder.batch_max_size`, verify that the max batch size is correct by looking at this log 


0/ Install Agent locally (e.g. on your Mac)

1/ change `network_devices.netflow.forwarder.batch_max_size` so something low like `50`

Example:

```
network_devices:
  netflow:
    enabled: true
    listeners:
      - flow_type: netflow9   # netflow, sflow, ipfix
        bind_host: 0.0.0.0
        port: 9999 # default 2055 for netflow
      - flow_type: netflow5   # netflow, sflow, ipfix
        bind_host: 0.0.0.0
        port: 9995 # default 2055 for netflow
        workers: 2
    forwarder:
      batch_max_size: 50
```

2/ Send this some netflow data using

```
git clone git@github.com:AlexandreYang/nflow-generator.git
cd nflow-generator
git checkout alex/mod_netflow_generator
go build
 ./nflow-generator -t 127.0.0.1 -p 9995 --duration 5000 --flow-count 10 --batch-size 100 --interval 1000
```

3/ verify in agent logs this log:
https://github.com/DataDog/datadog-agent/pull/12930/files#diff-ba94f7aaec863db5b437320428d8778b3381e2e728aae094e8d2dc33973f9b5dR137

and check that the `msg_count` correspond to the batch size.



<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
