### PR TITLE
[epforwarder] Update NetFlow default configs

### DIFF
--- a/pkg/epforwarder/epforwarder.go
+++ b/pkg/epforwarder/epforwarder.go
@@ -98,9 +98,15 @@ var passthroughPipelineDescs = []passthroughPipelineDesc{
 		hostnameEndpointPrefix:        "ndmflow-intake.",
 		intakeTrackType:               "ndmflow",
 		defaultBatchMaxConcurrentSend: 10,
-		defaultBatchMaxContentSize:    20e6, // max 20Mb uncompressed size per payload
-		defaultBatchMaxSize:           pkgconfig.DefaultBatchMaxSize,
-		defaultInputChanSize:          pkgconfig.DefaultInputChanSize,
+		defaultBatchMaxContentSize:    pkgconfig.DefaultBatchMaxContentSize,
+
+		// Each NetFlow flow is about 500 bytes
+		// 10k BatchMaxSize is about 5Mo of content size
+		defaultBatchMaxSize: 10000,
+
+		// High input chan (100k) is needed to handle high number (100k or more) of flows being flushed by NetFlow Server every 10s
+		// 100k is enough for queueing 10 NetFlow payloads (each payload can have up to 10k flows)
+		defaultInputChanSize: 100000,
 	},
 }
 

--- a/pkg/epforwarder/epforwarder.go
+++ b/pkg/epforwarder/epforwarder.go
@@ -104,9 +104,14 @@ var passthroughPipelineDescs = []passthroughPipelineDesc{
 		// 10k BatchMaxSize is about 5Mo of content size
 		defaultBatchMaxSize: 10000,
 
-		// High input chan (100k) is needed to handle high number (100k or more) of flows being flushed by NetFlow Server every 10s
-		// 100k is enough for queueing 10 NetFlow payloads (each payload can have up to 10k flows)
-		defaultInputChanSize: 100000,
+		// High input chan is needed to handle high number of flows being flushed by NetFlow Server every 10s
+		// Customers might need to set `network_devices.forwarder.input_chan_size` to higher value if flows are dropped
+		// due to input channel being full.
+		// TODO: A possible better solution is to make SendEventPlatformEvent blocking when input chan is full and avoid
+		//   dropping events. This can't be done right now due to SendEventPlatformEvent being called by
+		//   aggregator loop, making SendEventPlatformEvent blocking might slow down other type of data handled
+		//   by aggregator.
+		defaultInputChanSize: 10000,
 	},
 }
 

--- a/pkg/epforwarder/epforwarder.go
+++ b/pkg/epforwarder/epforwarder.go
@@ -226,7 +226,7 @@ func newHTTPPassthroughPipeline(desc passthroughPipelineDesc, destinationsContex
 	if endpoints.BatchMaxSize <= pkgconfig.DefaultBatchMaxSize {
 		endpoints.BatchMaxSize = desc.defaultBatchMaxSize
 	}
-	if endpoints.InputChanSize <= 0 {
+	if endpoints.InputChanSize <= pkgconfig.DefaultInputChanSize {
 		endpoints.InputChanSize = desc.defaultInputChanSize
 	}
 	reliable := []client.Destination{}

--- a/releasenotes/notes/update_netflow_default_configs-fe0c68eb55dcf012.yaml
+++ b/releasenotes/notes/update_netflow_default_configs-fe0c68eb55dcf012.yaml
@@ -8,5 +8,5 @@
 ---
 fixes:
   - |
-    [epforwarder] Update NetFlow default configs (1. Revert defaultBatchMaxContentSize to 5Mo,
-    2. Update defaultBatchMaxSize to 10k, 3. Update defaultInputChanSize to 100k)
+    [epforwarder] Update NetFlow default configs to: 1. Revert `defaultBatchMaxContentSize` to 5Mo,
+    2. Update `defaultBatchMaxSize` to 10k, 3. Update `defaultInputChanSize` to 100k.

--- a/releasenotes/notes/update_netflow_default_configs-fe0c68eb55dcf012.yaml
+++ b/releasenotes/notes/update_netflow_default_configs-fe0c68eb55dcf012.yaml
@@ -8,5 +8,4 @@
 ---
 fixes:
   - |
-    [epforwarder] Update NetFlow default configs to: 1. Revert `defaultBatchMaxContentSize` to 5Mo,
-    2. Update `defaultBatchMaxSize` to 10k, 3. Update `defaultInputChanSize` to 100k.
+    [epforwarder] Update NetFlow EP forwarder default configs

--- a/releasenotes/notes/update_netflow_default_configs-fe0c68eb55dcf012.yaml
+++ b/releasenotes/notes/update_netflow_default_configs-fe0c68eb55dcf012.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    [epforwarder] Update NetFlow default configs (1. Revert defaultBatchMaxContentSize to 5Mo,
+    2. Update defaultBatchMaxSize to 10k, 3. Update defaultInputChanSize to 100k)


### PR DESCRIPTION
Depend on https://github.com/DataDog/datadog-agent/pull/12933

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do? + Motivations

[epforwarder] Update NetFlow default configs

1/ Revert `defaultBatchMaxContentSize` to 5Mo (20Mo requires backend intake changes, currently if payload >5Mo is send, intake will return "content too large" error)

2/ Update defaultBatchMaxSize to 10k, since NetFlow traffic is about high volume of small messages. Higher BatchMaxSize will reduce the number of payloads sent to intake.

3/ Update defaultInputChanSize to 10k
```
// High input chan is needed to handle high number of flows being flushed by NetFlow Server every 10s
// Customers might need to set `network_devices.forwarder.input_chan_size` to higher value if flows are dropped
// due to input channel being full.
// TODO: A possible better solution is to make SendEventPlatformEvent blocking when input chan is full and avoid
//   dropping events. This can't be done right now due to SendEventPlatformEvent being called by
//   aggregator loop, making SendEventPlatformEvent blocking might slow down other type of data handled
//   by aggregator.
```

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
