### PR TITLE
Fix configuration being shown in expvar

### DIFF
--- a/pkg/collector/corechecks/systemd/systemd_test.go
+++ b/pkg/collector/corechecks/systemd/systemd_test.go
@@ -1011,7 +1011,7 @@ unit_names:
 			},
 		}}
 
-	p := inventories.GetPayload(context.Background(), "testHostname", coll)
+	p := inventories.GetPayload(context.Background(), "testHostname", coll, false)
 	checkMetadata := *p.CheckMetadata
 	systemdMetadata := *checkMetadata["systemd"][0]
 	assert.Equal(t, systemdVersion, systemdMetadata["version.raw"])

--- a/pkg/metadata/inventories_collector.go
+++ b/pkg/metadata/inventories_collector.go
@@ -24,13 +24,13 @@ type inventoriesCollector struct {
 	sc   *Scheduler
 }
 
-func getPayload(ctx context.Context, coll inventories.CollectorInterface) (*inventories.Payload, error) {
+func getPayload(ctx context.Context, coll inventories.CollectorInterface, withConfigs bool) (*inventories.Payload, error) {
 	hostnameDetected, err := hostname.Get(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to submit inventories metadata payload, no hostname: %s", err)
 	}
 
-	return inventories.GetPayload(ctx, hostnameDetected, coll), nil
+	return inventories.GetPayload(ctx, hostnameDetected, coll, withConfigs), nil
 }
 
 // Send collects the data needed and submits the payload
@@ -39,7 +39,7 @@ func (c inventoriesCollector) Send(ctx context.Context, s serializer.MetricSeria
 		return nil
 	}
 
-	payload, err := getPayload(ctx, c.coll)
+	payload, err := getPayload(ctx, c.coll, true)
 	if err != nil {
 		return err
 	}
@@ -84,7 +84,7 @@ func SetupInventoriesExpvar(coll inventories.CollectorInterface) {
 
 	expvar.Publish("inventories", expvar.Func(func() interface{} {
 		log.Debugf("Creating inventory payload for expvar")
-		p, err := getPayload(context.TODO(), coll)
+		p, err := getPayload(context.TODO(), coll, false)
 		if err != nil {
 			log.Errorf("Could not create inventory payload for expvar: %s", err)
 			return &inventories.Payload{}

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -420,7 +420,7 @@ func expvarStats(stats map[string]interface{}) (map[string]interface{}, error) {
 					if vStr, ok := v.(string); ok {
 						if k == "config.hash" {
 							checkHash = vStr
-						} else if k != "config.provider" && k != "instance_config" && k != "init_config" {
+						} else if k != "config.provider" {
 							metadata[k] = vStr
 						}
 					}


### PR DESCRIPTION

### What does this PR do?

Fix configuration being shown in expvar

### Describe how to test/QA your changes

Start the agent with `inventories_configuration_enabled` and `inventories_checks_configuration_enabled` enabled. Then curl expvar endpoint and make sure no check configuration nor agent configuration is present.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
