### PR TITLE
[CWS] improve process checks in functional tests

### DIFF
--- a/pkg/security/tests/cmdwrapper.go
+++ b/pkg/security/tests/cmdwrapper.go
@@ -19,6 +19,7 @@ import (
 type wrapperType string
 
 const (
+	noWrapperType     wrapperType = "" //nolint:deadcode,unused
 	stdWrapperType    wrapperType = "std"
 	dockerWrapperType wrapperType = "docker"
 	multiWrapperType  wrapperType = "multi"

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -285,16 +285,16 @@ func (h *testProbeHandler) HandleCustomEvent(rule *rules.Rule, event *sprobe.Cus
 }
 
 //nolint:deadcode,unused
-func getInode(t *testing.T, path string) uint64 {
+func getInode(tb testing.TB, path string) uint64 {
 	fileInfo, err := os.Lstat(path)
 	if err != nil {
-		t.Error(err)
+		tb.Error(err)
 		return 0
 	}
 
 	stats, ok := fileInfo.Sys().(*syscall.Stat_t)
 	if !ok {
-		t.Error(errors.New("Not a syscall.Stat_t"))
+		tb.Error(errors.New("Not a syscall.Stat_t"))
 		return 0
 	}
 
@@ -302,10 +302,10 @@ func getInode(t *testing.T, path string) uint64 {
 }
 
 //nolint:deadcode,unused
-func which(t *testing.T, name string) string {
+func which(tb testing.TB, name string) string {
 	executable, err := exec.LookPath(name)
 	if err != nil {
-		t.Fatalf("couldn't resolve %s: %v", name, err)
+		tb.Fatalf("couldn't resolve %s: %v", name, err)
 	}
 
 	if dest, err := filepath.EvalSymlinks(executable); err == nil {
@@ -326,79 +326,90 @@ func copyFile(src string, dst string, mode fs.FileMode) error {
 }
 
 //nolint:deadcode,unused
-func assertMode(t *testing.T, actualMode, expectedMode uint32, msgAndArgs ...interface{}) bool {
-	t.Helper()
+func assertMode(tb testing.TB, actualMode, expectedMode uint32, msgAndArgs ...interface{}) bool {
+	tb.Helper()
 	if len(msgAndArgs) == 0 {
 		msgAndArgs = append(msgAndArgs, "wrong mode")
 	}
-	return assert.Equal(t, strconv.FormatUint(uint64(expectedMode), 8), strconv.FormatUint(uint64(actualMode), 8), msgAndArgs...)
+	return assert.Equal(tb, strconv.FormatUint(uint64(expectedMode), 8), strconv.FormatUint(uint64(actualMode), 8), msgAndArgs...)
 }
 
 //nolint:deadcode,unused
-func assertRights(t *testing.T, actualMode, expectedMode uint16, msgAndArgs ...interface{}) bool {
-	t.Helper()
-	return assertMode(t, uint32(actualMode)&01777, uint32(expectedMode), msgAndArgs...)
+func assertRights(tb testing.TB, actualMode, expectedMode uint16, msgAndArgs ...interface{}) bool {
+	tb.Helper()
+	return assertMode(tb, uint32(actualMode)&01777, uint32(expectedMode), msgAndArgs...)
 }
 
 //nolint:deadcode,unused
-func assertNearTime(t *testing.T, ns uint64) bool {
-	t.Helper()
+func assertNearTime(tb testing.TB, ns uint64) bool {
+	tb.Helper()
 	now, event := time.Now(), time.Unix(0, int64(ns))
 	if event.After(now) || event.Before(now.Add(-1*time.Hour)) {
-		t.Errorf("expected time close to %s, got %s", now, event)
+		tb.Errorf("expected time close to %s, got %s", now, event)
 		return false
 	}
 	return true
 }
 
 //nolint:deadcode,unused
-func assertTriggeredRule(t *testing.T, r *rules.Rule, id string) bool {
-	t.Helper()
-	return assert.Equal(t, id, r.ID, "wrong triggered rule")
+func assertTriggeredRule(tb testing.TB, r *rules.Rule, id string) bool {
+	tb.Helper()
+	return assert.Equal(tb, id, r.ID, "wrong triggered rule")
 }
 
 //nolint:deadcode,unused
-func assertReturnValue(t *testing.T, retval, expected int64) bool {
-	t.Helper()
-	return assert.Equal(t, expected, retval, "wrong return value")
+func assertReturnValue(tb testing.TB, retval, expected int64) bool {
+	tb.Helper()
+	return assert.Equal(tb, expected, retval, "wrong return value")
 }
 
 //nolint:deadcode,unused
-func assertFieldEqual(t *testing.T, e *sprobe.Event, field string, value interface{}, msgAndArgs ...interface{}) bool {
-	t.Helper()
+func assertFieldEqual(tb testing.TB, e *sprobe.Event, field string, value interface{}, msgAndArgs ...interface{}) bool {
+	tb.Helper()
 	fieldValue, err := e.GetFieldValue(field)
 	if err != nil {
-		t.Errorf("failed to get field '%s': %s", field, err)
+		tb.Errorf("failed to get field '%s': %s", field, err)
 		return false
 	}
-	return assert.Equal(t, value, fieldValue, msgAndArgs...)
+	return assert.Equal(tb, value, fieldValue, msgAndArgs...)
 }
 
 //nolint:deadcode,unused
-func assertFieldContains(t *testing.T, e *sprobe.Event, field string, value interface{}, msgAndArgs ...interface{}) bool {
-	t.Helper()
+func assertFieldNotEmpty(tb testing.TB, e *sprobe.Event, field string, msgAndArgs ...interface{}) bool {
+	tb.Helper()
 	fieldValue, err := e.GetFieldValue(field)
 	if err != nil {
-		t.Errorf("failed to get field '%s': %s", field, err)
+		tb.Errorf("failed to get field '%s': %s", field, err)
 		return false
 	}
-	return assert.Contains(t, fieldValue, value, msgAndArgs...)
+	return assert.NotEmpty(tb, fieldValue, msgAndArgs...)
 }
 
 //nolint:deadcode,unused
-func assertFieldStringArrayIndexedOneOf(t *testing.T, e *sprobe.Event, field string, index int, values []string, msgAndArgs ...interface{}) bool {
-	t.Helper()
+func assertFieldContains(tb testing.TB, e *sprobe.Event, field string, value interface{}, msgAndArgs ...interface{}) bool {
+	tb.Helper()
 	fieldValue, err := e.GetFieldValue(field)
 	if err != nil {
-		t.Errorf("failed to get field '%s': %s", field, err)
+		tb.Errorf("failed to get field '%s': %s", field, err)
+		return false
+	}
+	return assert.Contains(tb, fieldValue, value, msgAndArgs...)
+}
+
+//nolint:deadcode,unused
+func assertFieldStringArrayIndexedOneOf(tb *testing.T, e *sprobe.Event, field string, index int, values []string, msgAndArgs ...interface{}) bool {
+	tb.Helper()
+	fieldValue, err := e.GetFieldValue(field)
+	if err != nil {
+		tb.Errorf("failed to get field '%s': %s", field, err)
 		return false
 	}
 
 	if fieldValues, ok := fieldValue.([]string); ok {
-		return assert.Contains(t, values, fieldValues[index])
+		return assert.Contains(tb, values, fieldValues[index])
 	}
 
-	t.Errorf("failed to get field '%s' as an array", field)
+	tb.Errorf("failed to get field '%s' as an array", field)
 	return false
 }
 
@@ -494,27 +505,37 @@ func validateProcessContextSECL(tb testing.TB, event *sprobe.Event) bool {
 }
 
 //nolint:deadcode,unused
-func validateEvent(tb testing.TB, validate func(event *sprobe.Event, rule *rules.Rule)) func(event *sprobe.Event, rule *rules.Rule) {
-	return func(event *sprobe.Event, rule *rules.Rule) {
-		validate(event, rule)
+func validateProcessContext(tb testing.TB, event *sprobe.Event) {
+	if !validateProcessContextLineage(tb, event) {
+		tb.Error(event.String())
+	}
 
-		if !validateProcessContextLineage(tb, event) {
-			tb.Error(event.String())
-		}
-
-		if !validateProcessContextSECL(tb, event) {
-			tb.Error(event.String())
-		}
+	if !validateProcessContextSECL(tb, event) {
+		tb.Error(event.String())
 	}
 }
 
 //nolint:deadcode,unused
-func validateExecEvent(t *testing.T, validate func(event *sprobe.Event, rule *rules.Rule)) func(event *sprobe.Event, rule *rules.Rule) {
+func validateEvent(tb testing.TB, validate func(event *sprobe.Event, rule *rules.Rule)) func(event *sprobe.Event, rule *rules.Rule) {
 	return func(event *sprobe.Event, rule *rules.Rule) {
 		validate(event, rule)
 
-		if !validateExecSchema(t, event) {
-			t.Error(event.String())
+		validateProcessContext(tb, event)
+	}
+}
+
+//nolint:deadcode,unused
+func validateExecEvent(tb *testing.T, kind wrapperType, validate func(event *sprobe.Event, rule *rules.Rule)) func(event *sprobe.Event, rule *rules.Rule) {
+	return func(event *sprobe.Event, rule *rules.Rule) {
+		validate(event, rule)
+
+		if kind == dockerWrapperType {
+			assertFieldNotEmpty(tb, event, "exec.container.id", "exec container id not found")
+			assertFieldNotEmpty(tb, event, "process.container.id", "process container id not found")
+		}
+
+		if !validateExecSchema(tb, event) {
+			tb.Error(event.String())
 		}
 	}
 }
@@ -1386,16 +1407,16 @@ func init() {
 }
 
 //nolint:deadcode,unused
-func checkKernelCompatibility(t *testing.T, why string, skipCheck func(kv *kernel.Version) bool) {
-	t.Helper()
+func checkKernelCompatibility(tb testing.TB, why string, skipCheck func(kv *kernel.Version) bool) {
+	tb.Helper()
 	kv, err := kernel.NewKernelVersion()
 	if err != nil {
-		t.Errorf("failed to get kernel version: %s", err)
+		tb.Errorf("failed to get kernel version: %s", err)
 		return
 	}
 
 	if skipCheck(kv) {
-		t.Skipf("kernel version not supported: %s", why)
+		tb.Skipf("kernel version not supported: %s", why)
 	}
 }
 

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -375,6 +375,17 @@ func assertFieldEqual(t *testing.T, e *sprobe.Event, field string, value interfa
 }
 
 //nolint:deadcode,unused
+func assertFieldContains(t *testing.T, e *sprobe.Event, field string, value interface{}, msgAndArgs ...interface{}) bool {
+	t.Helper()
+	fieldValue, err := e.GetFieldValue(field)
+	if err != nil {
+		t.Errorf("failed to get field '%s': %s", field, err)
+		return false
+	}
+	return assert.Contains(t, fieldValue, value, msgAndArgs...)
+}
+
+//nolint:deadcode,unused
 func assertFieldStringArrayIndexedOneOf(t *testing.T, e *sprobe.Event, field string, index int, values []string, msgAndArgs ...interface{}) bool {
 	t.Helper()
 	fieldValue, err := e.GetFieldValue(field)

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -1483,9 +1483,9 @@ func TestProcessBusybox(t *testing.T) {
 				return fmt.Errorf("%s: %w", out, err)
 			}
 			return nil
-		}, validateExecEvent(t, kind, func(event *sprobe.Event, rule *rules.Rule) {
+		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assert.Equal(t, "test_busybox_1", rule.ID, "wrong rule triggered")
-		}))
+		})
 	})
 
 	wrapper.Run(t, "busybox-2", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
@@ -1495,9 +1495,9 @@ func TestProcessBusybox(t *testing.T) {
 				return fmt.Errorf("%s: %w", out, err)
 			}
 			return nil
-		}, validateExecEvent(t, kind, func(event *sprobe.Event, rule *rules.Rule) {
+		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assert.Equal(t, "test_busybox_2", rule.ID, "wrong rule triggered")
-		}))
+		})
 	})
 
 	wrapper.Run(t, "busybox-3", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
@@ -1507,9 +1507,9 @@ func TestProcessBusybox(t *testing.T) {
 				return fmt.Errorf("%s: %w", out, err)
 			}
 			return nil
-		}, validateExecEvent(t, kind, func(event *sprobe.Event, rule *rules.Rule) {
+		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assert.Equal(t, "test_busybox_3", rule.ID, "wrong rule triggered")
-		}))
+		})
 	})
 
 	wrapper.Run(t, "busybox-4", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
@@ -1519,9 +1519,9 @@ func TestProcessBusybox(t *testing.T) {
 				return fmt.Errorf("%s: %w", out, err)
 			}
 			return nil
-		}, validateExecEvent(t, kind, func(event *sprobe.Event, rule *rules.Rule) {
+		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assert.Equal(t, "test_busybox_4", rule.ID, "wrong rule triggered")
-		}))
+		})
 	})
 }
 

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -145,6 +145,10 @@ func TestProcessContext(t *testing.T) {
 			ID:         "test_rule_ctx_4",
 			Expression: `open.file.path == "{{.Root}}/test-process-ctx-4" && process.file.path != ""`,
 		},
+		{
+			ID:         "test_rule_container",
+			Expression: `exec.file.name == "touch" && exec.argv == "{{.Root}}/test-container"`,
+		},
 	}
 
 	test, err := newTestModule(t, nil, ruleDefs, testOpts{})
@@ -194,9 +198,9 @@ func TestProcessContext(t *testing.T) {
 			os.Remove(testFile)
 
 			return nil
-		}, validateExecEvent(t, func(event *sprobe.Event, rule *rules.Rule) {
+		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_exec_time_2")
-		}))
+		})
 	})
 
 	t.Run("inode", func(t *testing.T) {
@@ -232,7 +236,7 @@ func TestProcessContext(t *testing.T) {
 			// we need to ignore the error because "--password" is not a valid option for ls
 			_ = cmd.Run()
 			return nil
-		}, validateExecEvent(t, func(event *sprobe.Event, rule *rules.Rule) {
+		}, validateExecEvent(t, kind, func(event *sprobe.Event, rule *rules.Rule) {
 			argv0, err := event.GetFieldValue("exec.argv0")
 			if err != nil {
 				t.Errorf("not able to get argv0")
@@ -298,7 +302,7 @@ func TestProcessContext(t *testing.T) {
 			cmd := cmdFunc("ls", args, envs)
 			_ = cmd.Run()
 			return nil
-		}, validateExecEvent(t, func(event *sprobe.Event, rule *rules.Rule) {
+		}, validateExecEvent(t, kind, func(event *sprobe.Event, rule *rules.Rule) {
 			assert.Equal(t, "test_rule_envp", rule.ID, "wrong rule triggered")
 		}))
 	})
@@ -309,7 +313,7 @@ func TestProcessContext(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			cmd := exec.Command(lsExecutable, "-ll")
 			return cmd.Run()
-		}, validateExecEvent(t, func(event *sprobe.Event, rule *rules.Rule) {
+		}, validateExecEvent(t, noWrapperType, func(event *sprobe.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_rule_argv")
 		}))
 	})
@@ -320,7 +324,7 @@ func TestProcessContext(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			cmd := exec.Command(lsExecutable, "-ls", "--escape")
 			return cmd.Run()
-		}, validateExecEvent(t, func(event *sprobe.Event, rule *rules.Rule) {
+		}, validateExecEvent(t, noWrapperType, func(event *sprobe.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_rule_args_flags")
 		}))
 	})
@@ -331,7 +335,7 @@ func TestProcessContext(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			cmd := exec.Command(lsExecutable, "--block-size", "123")
 			return cmd.Run()
-		}, validateExecEvent(t, func(event *sprobe.Event, rule *rules.Rule) {
+		}, validateExecEvent(t, noWrapperType, func(event *sprobe.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_rule_args_options")
 		}))
 	})
@@ -352,7 +356,7 @@ func TestProcessContext(t *testing.T) {
 			// we need to ignore the error because the string of "a" generates a "File name too long" error
 			_ = cmd.Run()
 			return nil
-		}, validateExecEvent(t, func(event *sprobe.Event, rule *rules.Rule) {
+		}, validateExecEvent(t, kind, func(event *sprobe.Event, rule *rules.Rule) {
 			args, err := event.GetFieldValue("exec.args")
 			if err != nil {
 				t.Errorf("not able to get args")
@@ -386,7 +390,7 @@ func TestProcessContext(t *testing.T) {
 			// we need to ignore the error because the string of "a" generates a "File name too long" error
 			_ = cmd.Run()
 			return nil
-		}, validateExecEvent(t, func(event *sprobe.Event, rule *rules.Rule) {
+		}, validateExecEvent(t, kind, func(event *sprobe.Event, rule *rules.Rule) {
 			args, err := event.GetFieldValue("exec.args")
 			if err != nil {
 				t.Errorf("not able to get args")
@@ -453,7 +457,7 @@ func TestProcessContext(t *testing.T) {
 			}
 			return nil
 
-		}, validateExecEvent(t, func(event *sprobe.Event, rule *rules.Rule) {
+		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assertFieldEqual(t, event, "process.file.path", executable)
 
 			if name, _ := event.GetFieldValue("process.tty_name"); !strings.HasPrefix(name.(string), "pts") {
@@ -469,7 +473,7 @@ func TestProcessContext(t *testing.T) {
 			if !strings.Contains(str, "pts") {
 				t.Error("tty not serialized")
 			}
-		}))
+		})
 	})
 
 	test.Run(t, "ancestors", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
@@ -490,10 +494,10 @@ func TestProcessContext(t *testing.T) {
 				return fmt.Errorf("%s: %w", out, err)
 			}
 			return nil
-		}, validateExecEvent(t, func(event *sprobe.Event, rule *rules.Rule) {
+		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_rule_ancestors")
 			assert.Equal(t, "sh", event.ProcessContext.Ancestor.Comm)
-		}))
+		})
 	})
 
 	test.Run(t, "pid1", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
@@ -514,9 +518,9 @@ func TestProcessContext(t *testing.T) {
 				return fmt.Errorf("%s: %w", out, err)
 			}
 			return nil
-		}, validateExecEvent(t, func(event *sprobe.Event, rule *rules.Rule) {
+		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assert.Equal(t, "test_rule_pid1", rule.ID, "wrong rule triggered")
-		}))
+		})
 	})
 
 	test.Run(t, "service-tag", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
@@ -538,12 +542,12 @@ func TestProcessContext(t *testing.T) {
 				return fmt.Errorf("%s: %w", out, err)
 			}
 			return nil
-		}, validateExecEvent(t, func(event *sprobe.Event, rule *rules.Rule) {
+		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assert.Equal(t, "test_rule_inode", rule.ID, "wrong rule triggered")
 
 			service := event.GetProcessServiceTag()
 			assert.Equal(t, service, "myservice")
-		}))
+		})
 	})
 
 	test.Run(t, "ancestors-args", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
@@ -561,9 +565,9 @@ func TestProcessContext(t *testing.T) {
 				return fmt.Errorf("%s: %w", out, err)
 			}
 			return nil
-		}, validateExecEvent(t, func(event *sprobe.Event, rule *rules.Rule) {
+		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assert.Equal(t, "test_rule_ancestors_args", rule.ID, "wrong rule triggered")
-		}))
+		})
 	})
 
 	test.Run(t, "args-envs-dedup", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
@@ -573,7 +577,7 @@ func TestProcessContext(t *testing.T) {
 			cmd := cmdFunc(shell, args, envs)
 			_ = cmd.Run()
 			return nil
-		}, validateExecEvent(t, func(event *sprobe.Event, rule *rules.Rule) {
+		}, validateExecEvent(t, kind, func(event *sprobe.Event, rule *rules.Rule) {
 			assert.Equal(t, "test_rule_args_envs_dedup", rule.ID, "wrong rule triggered")
 
 			var data interface{}
@@ -607,7 +611,7 @@ func TestProcessContext(t *testing.T) {
 			cmd := exec.Command(lsExecutable, "glob")
 			_ = cmd.Run()
 			return nil
-		}, validateExecEvent(t, func(event *sprobe.Event, rule *rules.Rule) {
+		}, validateExecEvent(t, noWrapperType, func(event *sprobe.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_rule_ancestors_glob")
 		}))
 	})
@@ -621,8 +625,34 @@ func TestProcessContext(t *testing.T) {
 			_, _ = cmd.CombinedOutput()
 
 			return nil
-		}, validateExecEvent(t, func(event *sprobe.Event, rule *rules.Rule) {
+		}, validateExecEvent(t, kind, func(event *sprobe.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_self_exec")
+		}))
+	})
+
+	test.Run(t, "container-id", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+		testFile, _, err := test.Path("test-container")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Bash attempts to optimize away forks in the last command in a function body
+		// under appropriate circumstances (source: bash changelog)
+		args := []string{"-c", "$(touch " + testFile + ")"}
+
+		test.WaitSignal(t, func() error {
+			cmd := cmdFunc("sh", args, nil)
+			if out, err := cmd.CombinedOutput(); err != nil {
+				return fmt.Errorf("%s: %w", out, err)
+			}
+			return nil
+		}, validateExecEvent(t, kind, func(event *sprobe.Event, rule *rules.Rule) {
+			assert.Equal(t, "test_rule_container", rule.ID, "wrong rule triggered")
+
+			if kind == dockerWrapperType {
+				assert.Equal(t, event.Exec.Process.ContainerID, event.ProcessCacheEntry.ContainerID)
+				assert.Equal(t, event.Exec.Process.ContainerID, event.ProcessCacheEntry.Ancestor.ContainerID)
+			}
 		}))
 	})
 
@@ -640,9 +670,9 @@ func TestProcessContext(t *testing.T) {
 				}
 				f.Close()
 				return os.Remove(testFile)
-			}, validateExecEvent(t, func(event *sprobe.Event, rule *rules.Rule) {
+			}, func(event *sprobe.Event, rule *rules.Rule) {
 				assert.Equal(t, ruleID, rule.ID, "wrong rule triggered")
-			}))
+			})
 		})
 	}
 
@@ -680,11 +710,11 @@ func TestProcessEnvsWithValue(t *testing.T) {
 			cmd.Env = envp
 			_ = cmd.Run()
 			return nil
-		}, func(event *sprobe.Event, rule *rules.Rule) {
+		}, validateExecEvent(t, noWrapperType, func(event *sprobe.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_ldpreload_from_tmp_with_envs")
 			assertFieldEqual(t, event, "exec.file.path", lsExec)
 			assertFieldStringArrayIndexedOneOf(t, event, "exec.envs", 0, []string{"LD_PRELOAD=/tmp/dyn.so"})
-		})
+		}))
 	})
 }
 
@@ -711,7 +741,7 @@ func TestProcessExecCTime(t *testing.T) {
 
 		cmd := exec.Command(testFile, "/tmp/test")
 		return cmd.Run()
-	}, validateExecEvent(t, func(event *sprobe.Event, rule *rules.Rule) {
+	}, validateExecEvent(t, noWrapperType, func(event *sprobe.Event, rule *rules.Rule) {
 		assert.Equal(t, "test_exec_ctime", rule.ID, "wrong rule triggered")
 	}))
 }
@@ -867,7 +897,7 @@ func TestProcessExec(t *testing.T) {
 	test.WaitSignal(t, func() error {
 		cmd := exec.Command("sh", "-c", executable+" /dev/null")
 		return cmd.Run()
-	}, validateExecEvent(t, func(event *sprobe.Event, rule *rules.Rule) {
+	}, validateExecEvent(t, noWrapperType, func(event *sprobe.Event, rule *rules.Rule) {
 		assertFieldEqual(t, event, "exec.file.path", executable)
 		// TODO: use `process.ancestors[0].file.name` directly when this feature is reintroduced
 		assertFieldStringArrayIndexedOneOf(t, event, "process.ancestors.file.name", 0, []string{"sh", "bash", "dash"})
@@ -910,12 +940,12 @@ func TestProcessMetadata(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			cmd := exec.Command(testFile)
 			return cmd.Run()
-		}, func(event *sprobe.Event, rule *rules.Rule) {
+		}, validateExecEvent(t, noWrapperType, func(event *sprobe.Event, rule *rules.Rule) {
 			assert.Equal(t, "exec", event.GetType(), "wrong event type")
 			assertRights(t, event.Exec.FileEvent.Mode, uint16(expectedMode))
 			assertNearTime(t, event.Exec.FileEvent.MTime)
 			assertNearTime(t, event.Exec.FileEvent.CTime)
-		})
+		}))
 	})
 
 	t.Run("credentials", func(t *testing.T) {
@@ -930,7 +960,7 @@ func TestProcessMetadata(t *testing.T) {
 			}
 			_, err := syscall.ForkExec(testFile, []string{}, attr)
 			return err
-		}, validateExecEvent(t, func(event *sprobe.Event, rule *rules.Rule) {
+		}, validateExecEvent(t, noWrapperType, func(event *sprobe.Event, rule *rules.Rule) {
 			assert.Equal(t, "exec", event.GetType(), "wrong event type")
 			assert.Equal(t, 1001, int(event.Exec.Credentials.UID), "wrong uid")
 			assert.Equal(t, 1001, int(event.Exec.Credentials.EUID), "wrong euid")
@@ -964,16 +994,27 @@ func TestProcessExecExit(t *testing.T) {
 	}, func(event *sprobe.Event) bool {
 		switch event.GetEventType() {
 		case model.ExecEventType:
-			if !validateProcessContextLineage(t, event) {
-				t.Error(event.String())
+			if basename, err := event.GetFieldValue("exec.file.name"); err != nil || basename.(string) != "touch" {
+				return false
 			}
 
-			if !validateProcessContextSECL(t, event) {
-				t.Error(event.String())
+			if args, err := event.GetFieldValue("exec.args"); err != nil || !strings.Contains(args.(string), "01010101") {
+				return false
 			}
 
-			assertFieldEqual(t, event, "exec.file.name", "touch")
-			assertFieldContains(t, event, "exec.args", "01010101")
+			validate := validateExecEvent(t, noWrapperType, func(event *sprobe.Event, rule *rules.Rule) {
+				if !validateProcessContextLineage(t, event) {
+					t.Error(event.String())
+				}
+
+				if !validateProcessContextSECL(t, event) {
+					t.Error(event.String())
+				}
+
+				assertFieldEqual(t, event, "exec.file.name", "touch")
+				assertFieldContains(t, event, "exec.args", "01010101")
+			})
+			validate(event, nil)
 
 			execPid = event.ProcessContext.Pid
 
@@ -989,6 +1030,8 @@ func TestProcessExecExit(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+
+	assert.NotEmpty(t, execPid, "exec pid not found")
 
 	// make sure that the process cache entry of the process was properly deleted from the cache
 	err = retry.Do(func() error {
@@ -1440,7 +1483,7 @@ func TestProcessBusybox(t *testing.T) {
 				return fmt.Errorf("%s: %w", out, err)
 			}
 			return nil
-		}, validateExecEvent(t, func(event *sprobe.Event, rule *rules.Rule) {
+		}, validateExecEvent(t, kind, func(event *sprobe.Event, rule *rules.Rule) {
 			assert.Equal(t, "test_busybox_1", rule.ID, "wrong rule triggered")
 		}))
 	})
@@ -1452,7 +1495,7 @@ func TestProcessBusybox(t *testing.T) {
 				return fmt.Errorf("%s: %w", out, err)
 			}
 			return nil
-		}, validateExecEvent(t, func(event *sprobe.Event, rule *rules.Rule) {
+		}, validateExecEvent(t, kind, func(event *sprobe.Event, rule *rules.Rule) {
 			assert.Equal(t, "test_busybox_2", rule.ID, "wrong rule triggered")
 		}))
 	})
@@ -1464,7 +1507,7 @@ func TestProcessBusybox(t *testing.T) {
 				return fmt.Errorf("%s: %w", out, err)
 			}
 			return nil
-		}, validateExecEvent(t, func(event *sprobe.Event, rule *rules.Rule) {
+		}, validateExecEvent(t, kind, func(event *sprobe.Event, rule *rules.Rule) {
 			assert.Equal(t, "test_busybox_3", rule.ID, "wrong rule triggered")
 		}))
 	})
@@ -1476,7 +1519,7 @@ func TestProcessBusybox(t *testing.T) {
 				return fmt.Errorf("%s: %w", out, err)
 			}
 			return nil
-		}, validateExecEvent(t, func(event *sprobe.Event, rule *rules.Rule) {
+		}, validateExecEvent(t, kind, func(event *sprobe.Event, rule *rules.Rule) {
 			assert.Equal(t, "test_busybox_4", rule.ID, "wrong rule triggered")
 		}))
 	})


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
