### PR TITLE
Add tagger-list cmd to process-agent cli

### DIFF
--- a/cmd/agent/api/response/types.go
+++ b/cmd/agent/api/response/types.go
@@ -16,13 +16,3 @@ type ConfigCheckResponse struct {
 	ConfigErrors    map[string]string               `json:"config_errors"`
 	Unresolved      map[string][]integration.Config `json:"unresolved"`
 }
-
-// TaggerListResponse holds the tagger list response
-type TaggerListResponse struct {
-	Entities map[string]TaggerListEntity `json:"entities"`
-}
-
-// TaggerListEntity holds the tagging info about an entity
-type TaggerListEntity struct {
-	Tags map[string][]string `json:"tags"`
-}

--- a/cmd/agent/app/tagger_list.go
+++ b/cmd/agent/app/tagger_list.go
@@ -6,16 +6,12 @@
 package app
 
 import (
-	"encoding/json"
 	"fmt"
-	"sort"
-	"strings"
-
-	"github.com/DataDog/datadog-agent/cmd/agent/api/response"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	tagger_api "github.com/DataDog/datadog-agent/pkg/tagger/api"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -30,7 +26,6 @@ var taggerListCommand = &cobra.Command{
 	Short: "Print the tagger content of a running agent",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
-
 		if flagNoColor {
 			color.NoColor = true
 		}
@@ -46,70 +41,25 @@ var taggerListCommand = &cobra.Command{
 			return err
 		}
 
-		c := util.GetClient(false) // FIX: get certificates right then make this true
-
 		// Set session token
-		err = util.SetAuthToken()
-		if err != nil {
+		if err := util.SetAuthToken(); err != nil {
 			return err
-		}
-		ipcAddress, err := config.GetIPCAddress()
-		if err != nil {
-			return err
-		}
-		r, err := util.DoGet(c, fmt.Sprintf("https://%v:%v/agent/tagger-list", ipcAddress, config.Datadog.GetInt("cmd_port")), util.LeaveConnectionOpen)
-		if err != nil {
-			if r != nil && string(r) != "" {
-				fmt.Fprintln(color.Output, fmt.Sprintf("The agent ran into an error while getting tags list: %s", string(r)))
-			} else {
-				fmt.Fprintln(color.Output, fmt.Sprintf("Failed to query the agent (running?): %s", err))
-			}
 		}
 
-		tr := response.TaggerListResponse{}
-		err = json.Unmarshal(r, &tr)
+		url, err := getTaggerURL()
 		if err != nil {
 			return err
 		}
 
-		for entity, tagItem := range tr.Entities {
-			fmt.Fprintln(color.Output, fmt.Sprintf("\n=== Entity %s ===", color.GreenString(entity)))
-
-			sources := make([]string, 0, len(tagItem.Tags))
-			for source := range tagItem.Tags {
-				sources = append(sources, source)
-			}
-
-			// sort sources for deterministic output
-			sort.Slice(sources, func(i, j int) bool {
-				return sources[i] < sources[j]
-			})
-
-			for _, source := range sources {
-				fmt.Fprintln(color.Output, fmt.Sprintf("== Source %s ==", source))
-
-				fmt.Fprint(color.Output, "Tags: [")
-
-				// sort tags for easy comparison
-				tags := tagItem.Tags[source]
-				sort.Slice(tags, func(i, j int) bool {
-					return tags[i] < tags[j]
-				})
-
-				for i, tag := range tags {
-					tagInfo := strings.Split(tag, ":")
-					fmt.Fprintf(color.Output, "%s:%s", color.BlueString(tagInfo[0]), color.CyanString(strings.Join(tagInfo[1:], ":")))
-					if i != len(tags)-1 {
-						fmt.Fprintf(color.Output, " ")
-					}
-				}
-
-				fmt.Fprintln(color.Output, "]")
-			}
-
-			fmt.Fprintln(color.Output, "===")
-		}
-
-		return nil
+		return tagger_api.GetTaggerList(color.Output, url)
 	},
+}
+
+func getTaggerURL() (string, error) {
+	ipcAddress, err := config.GetIPCAddress()
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("https://%v:%v/agent/tagger-list", ipcAddress, config.Datadog.GetInt("cmd_port")), nil
 }

--- a/cmd/process-agent/api/server.go
+++ b/cmd/process-agent/api/server.go
@@ -23,6 +23,7 @@ func setupHandlers(r *mux.Router) {
 	r.HandleFunc("/config/{setting}", settingshttp.Server.GetValue).Methods("GET")
 	r.HandleFunc("/config/{setting}", settingshttp.Server.SetValue).Methods("POST")
 	r.HandleFunc("/agent/status", statusHandler).Methods("GET")
+	r.HandleFunc("/agent/tagger-list", getTaggerList).Methods("GET")
 	r.HandleFunc("/check/{check}", checkHandler).Methods("GET")
 }
 

--- a/cmd/process-agent/api/status.go
+++ b/cmd/process-agent/api/status.go
@@ -15,11 +15,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-func writeError(err error, code int, w http.ResponseWriter) {
-	body, _ := json.Marshal(map[string]string{"error": err.Error()})
-	http.Error(w, string(body), code)
-}
-
 func statusHandler(w http.ResponseWriter, _ *http.Request) {
 	log.Info("Got a request for the status. Making status.")
 

--- a/cmd/process-agent/api/tagger_list.go
+++ b/cmd/process-agent/api/tagger_list.go
@@ -1,0 +1,27 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/DataDog/datadog-agent/pkg/tagger"
+	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+func getTaggerList(w http.ResponseWriter, r *http.Request) {
+	cardinality := collectors.TagCardinality(tagger.ChecksCardinality)
+	response := tagger.List(cardinality)
+
+	jsonTags, err := json.Marshal(response)
+	if err != nil {
+		setJSONError(w, log.Errorf("Unable to marshal tagger list response: %s", err), 500)
+		return
+	}
+	w.Write(jsonTags)
+}

--- a/cmd/process-agent/api/util.go
+++ b/cmd/process-agent/api/util.go
@@ -4,3 +4,19 @@
 // Copyright 2016-present Datadog, Inc.
 
 package api
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+func writeError(err error, code int, w http.ResponseWriter) {
+	body, _ := json.Marshal(map[string]string{"error": err.Error()})
+	http.Error(w, string(body), code)
+}
+
+func setJSONError(w http.ResponseWriter, err error, errorCode int) {
+	w.Header().Set("Content-Type", "application/json")
+	body, _ := json.Marshal(map[string]string{"error": err.Error()})
+	http.Error(w, string(body), errorCode)
+}

--- a/cmd/process-agent/app/common.go
+++ b/cmd/process-agent/app/common.go
@@ -1,0 +1,38 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
+package app
+
+import (
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/DataDog/datadog-agent/cmd/process-agent/flags"
+	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/process/config"
+)
+
+func initConfig(w io.Writer, cmd *cobra.Command) error {
+	err := config.LoadConfigIfExists(cmd.Flag(flags.CfgPath).Value.String())
+	if err != nil {
+		writeError(w, err)
+		return err
+	}
+
+	err = ddconfig.SetupLogger(
+		"process",
+		ddconfig.Datadog.GetString("log_level"),
+		"",
+		"",
+		false,
+		true,
+		false,
+	)
+	if err != nil {
+		writeError(w, err)
+	}
+	return err
+}

--- a/cmd/process-agent/app/status.go
+++ b/cmd/process-agent/app/status.go
@@ -14,10 +14,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/DataDog/datadog-agent/cmd/process-agent/flags"
 	apiutil "github.com/DataDog/datadog-agent/pkg/api/util"
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/process/config"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	ddstatus "github.com/DataDog/datadog-agent/pkg/status"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -135,23 +133,7 @@ var StatusCmd = &cobra.Command{
 }
 
 func runStatus(cmd *cobra.Command, _ []string) error {
-	err := config.LoadConfigIfExists(cmd.Flag(flags.CfgPath).Value.String())
-	if err != nil {
-		writeError(os.Stdout, err)
-		return err
-	}
-
-	err = ddconfig.SetupLogger(
-		"process",
-		ddconfig.Datadog.GetString("log_level"),
-		"",
-		"",
-		false,
-		true,
-		false,
-	)
-	if err != nil {
-		writeError(os.Stdout, err)
+	if err := initConfig(os.Stdout, cmd); err != nil {
 		return err
 	}
 

--- a/cmd/process-agent/app/tagger_list.go
+++ b/cmd/process-agent/app/tagger_list.go
@@ -1,0 +1,54 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
+package app
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+
+	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
+	tagger_api "github.com/DataDog/datadog-agent/pkg/tagger/api"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const taggerListURLTpl = "http://%s/agent/tagger-list"
+
+// TaggerCmd is a command that prints the process-agent version data
+var TaggerCmd = &cobra.Command{
+	Use:   "tagger-list",
+	Short: "Print the tagger content of a running agent",
+	Long:  "",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return getTaggerList(cmd)
+	},
+	SilenceUsage: true,
+}
+
+func getTaggerList(cmd *cobra.Command) error {
+	log.Info("Got a request for the tagger-list. Calling tagger.")
+
+	if err := initConfig(os.Stdout, cmd); err != nil {
+		return err
+	}
+
+	taggerURL, err := getTaggerURL()
+	if err != nil {
+		return err
+	}
+
+	return tagger_api.GetTaggerList(color.Output, taggerURL)
+}
+
+func getTaggerURL() (string, error) {
+	addressPort, err := ddconfig.GetProcessAPIAddressPort()
+	if err != nil {
+		return "", fmt.Errorf("config error: %s", err.Error())
+	}
+	return fmt.Sprintf(taggerListURLTpl, addressPort), nil
+}

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -93,7 +93,7 @@ func getSettingsClient(_ *cobra.Command, _ []string) (settings.Client, error) {
 }
 
 func init() {
-	rootCmd.AddCommand(configCommand, app.StatusCmd, app.VersionCmd, app.CheckCmd, app.EventsCmd)
+	rootCmd.AddCommand(configCommand, app.StatusCmd, app.VersionCmd, app.CheckCmd, app.EventsCmd, app.TaggerCmd)
 }
 
 const (

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -371,7 +371,7 @@ func TestZipTaggerList(t *testing.T) {
 	dir := t.TempDir()
 
 	taggerListURL = s.URL
-	zipTaggerList(dir, "")
+	zipAgentTaggerList(dir, "")
 	content, err := ioutil.ReadFile(filepath.Join(dir, "tagger-list.json"))
 	if err != nil {
 		log.Fatal(err)

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/settings"
+	tagger_api "github.com/DataDog/datadog-agent/pkg/tagger/api"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
 
@@ -37,7 +38,6 @@ func createTestDirStructure(
 	t *testing.T,
 	filename string,
 ) (string, string, error) {
-
 	srcDir := t.TempDir()
 	dstDir := t.TempDir()
 
@@ -61,8 +61,7 @@ func createTestDirStructure(
 }
 
 func TestArchiveName(t *testing.T) {
-
-	//test with No log level set
+	// test with No log level set
 	zipFilePath := getArchivePath()
 	assert.Contains(t, zipFilePath, "Z.zip")
 	assert.NotContains(t, zipFilePath, "info")
@@ -105,7 +104,6 @@ func TestCreateArchive(t *testing.T) {
 }
 
 func TestCreateArchiveAndGoRoutines(t *testing.T) {
-
 	contents := "No Goroutines for you, my friend!"
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -133,7 +131,6 @@ func TestCreateArchiveAndGoRoutines(t *testing.T) {
 	// printing some of their contents.
 	found := false
 	for _, f := range z.File {
-
 		// find go-routine dump.
 		if path.Base(f.Name) == routineDumpFilename {
 			found = true
@@ -316,7 +313,7 @@ func TestZipLogFiles(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	err = os.Mkdir(filepath.Join(srcDir, "archive"), 0700)
+	err = os.Mkdir(filepath.Join(srcDir, "archive"), 0o700)
 	require.NoError(t, err)
 
 	f, err = os.Create(filepath.Join(srcDir, "archive", "agent.log"))
@@ -355,13 +352,13 @@ func TestZipRegistryJSON(t *testing.T) {
 }
 
 func TestZipTaggerList(t *testing.T) {
-	tagMap := make(map[string]response.TaggerListEntity)
-	tagMap["random_entity_name"] = response.TaggerListEntity{
+	tagMap := make(map[string]tagger_api.TaggerListEntity)
+	tagMap["random_entity_name"] = tagger_api.TaggerListEntity{
 		Tags: map[string][]string{
 			"docker_source_name": {"docker_image:custom-agent:latest", "image_name:custom-agent"},
 		},
 	}
-	resp := response.TaggerListResponse{
+	resp := tagger_api.TaggerListResponse{
 		Entities: tagMap,
 	}
 

--- a/pkg/tagger/api/getlist.go
+++ b/pkg/tagger/api/getlist.go
@@ -1,0 +1,83 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/fatih/color"
+
+	"github.com/DataDog/datadog-agent/pkg/api/util"
+)
+
+// GetTaggerList display in a human readable format the Tagger entities into the io.Write w.
+func GetTaggerList(w io.Writer, url string) error {
+	c := util.GetClient(false) // FIX: get certificates right then make this true
+
+	// get the tagger-list from server
+	r, err := util.DoGet(c, url, util.LeaveConnectionOpen)
+	if err != nil {
+		if r != nil && string(r) != "" {
+			fmt.Fprintf(w, "The agent ran into an error while getting tags list: %s\n", string(r))
+		} else {
+			fmt.Fprintf(w, "Failed to query the agent (running?): %s\n", err)
+		}
+	}
+
+	tr := TaggerListResponse{}
+	err = json.Unmarshal(r, &tr)
+	if err != nil {
+		return err
+	}
+
+	printTaggerEntities(color.Output, &tr)
+	return nil
+}
+
+// printTaggerEntities use to print Tagger entities into an io.Writer
+func printTaggerEntities(w io.Writer, tr *TaggerListResponse) {
+	for entity, tagItem := range tr.Entities {
+		fmt.Fprintf(w, "\n=== Entity %s ===\n", color.GreenString(entity))
+
+		sources := make([]string, 0, len(tagItem.Tags))
+		for source := range tagItem.Tags {
+			sources = append(sources, source)
+		}
+
+		// sort sources for deterministic output
+		sort.Slice(sources, func(i, j int) bool {
+			return sources[i] < sources[j]
+		})
+
+		for _, source := range sources {
+			fmt.Fprintf(w, "== Source %s =\n=", source)
+
+			fmt.Fprint(w, "Tags: [")
+
+			// sort tags for easy comparison
+			tags := tagItem.Tags[source]
+			sort.Slice(tags, func(i, j int) bool {
+				return tags[i] < tags[j]
+			})
+
+			for i, tag := range tags {
+				tagInfo := strings.Split(tag, ":")
+				fmt.Fprintf(w, "%s:%s", color.BlueString(tagInfo[0]), color.CyanString(strings.Join(tagInfo[1:], ":")))
+				if i != len(tags)-1 {
+					fmt.Fprintf(w, " ")
+				}
+			}
+
+			fmt.Fprintln(w, "]")
+		}
+
+		fmt.Fprintln(w, "===")
+	}
+}

--- a/pkg/tagger/api/response.go
+++ b/pkg/tagger/api/response.go
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package api
+
+// TaggerListResponse holds the tagger list response
+type TaggerListResponse struct {
+	Entities map[string]TaggerListEntity `json:"entities"`
+}
+
+// TaggerListEntity holds the tagging info about an entity
+type TaggerListEntity struct {
+	Tags map[string][]string `json:"tags"`
+}

--- a/pkg/tagger/global.go
+++ b/pkg/tagger/global.go
@@ -9,9 +9,9 @@ import (
 	"context"
 	"sync"
 
-	"github.com/DataDog/datadog-agent/cmd/agent/api/response"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/dogstatsd/packets"
+	tagger_api "github.com/DataDog/datadog-agent/pkg/tagger/api"
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
 	"github.com/DataDog/datadog-agent/pkg/tagger/local"
 	"github.com/DataDog/datadog-agent/pkg/tagger/types"
@@ -220,7 +220,7 @@ func Stop() error {
 }
 
 // List the content of the defaulTagger
-func List(cardinality collectors.TagCardinality) response.TaggerListResponse {
+func List(cardinality collectors.TagCardinality) tagger_api.TaggerListResponse {
 	return defaultTagger.List(cardinality)
 }
 

--- a/pkg/tagger/interface.go
+++ b/pkg/tagger/interface.go
@@ -8,7 +8,7 @@ package tagger
 import (
 	"context"
 
-	"github.com/DataDog/datadog-agent/cmd/agent/api/response"
+	tagger_api "github.com/DataDog/datadog-agent/pkg/tagger/api"
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
 	"github.com/DataDog/datadog-agent/pkg/tagger/types"
 	"github.com/DataDog/datadog-agent/pkg/tagset"
@@ -23,7 +23,7 @@ type Tagger interface {
 	Tag(entity string, cardinality collectors.TagCardinality) ([]string, error)
 	AccumulateTagsFor(entity string, cardinality collectors.TagCardinality, tb tagset.TagsAccumulator) error
 	Standard(entity string) ([]string, error)
-	List(cardinality collectors.TagCardinality) response.TaggerListResponse
+	List(cardinality collectors.TagCardinality) tagger_api.TaggerListResponse
 	GetEntity(entityID string) (*types.Entity, error)
 
 	Subscribe(cardinality collectors.TagCardinality) chan []types.EntityEvent

--- a/pkg/tagger/local/fake_tagger.go
+++ b/pkg/tagger/local/fake_tagger.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/DataDog/datadog-agent/cmd/agent/api/response"
+	tagger_api "github.com/DataDog/datadog-agent/pkg/tagger/api"
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
 	"github.com/DataDog/datadog-agent/pkg/tagger/tagstore"
 	"github.com/DataDog/datadog-agent/pkg/tagger/types"
@@ -108,7 +108,7 @@ func (f *FakeTagger) GetEntity(entityID string) (*types.Entity, error) {
 }
 
 // List fake implementation
-func (f *FakeTagger) List(cardinality collectors.TagCardinality) response.TaggerListResponse {
+func (f *FakeTagger) List(cardinality collectors.TagCardinality) tagger_api.TaggerListResponse {
 	return f.store.List()
 }
 

--- a/pkg/tagger/local/tagger.go
+++ b/pkg/tagger/local/tagger.go
@@ -13,7 +13,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/tagset"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 
-	"github.com/DataDog/datadog-agent/cmd/agent/api/response"
+	tagger_api "github.com/DataDog/datadog-agent/pkg/tagger/api"
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
 	"github.com/DataDog/datadog-agent/pkg/tagger/tagstore"
 	"github.com/DataDog/datadog-agent/pkg/tagger/telemetry"
@@ -114,7 +114,7 @@ func (t *Tagger) GetEntity(entityID string) (*types.Entity, error) {
 }
 
 // List the content of the tagger
-func (t *Tagger) List(cardinality collectors.TagCardinality) response.TaggerListResponse {
+func (t *Tagger) List(cardinality collectors.TagCardinality) tagger_api.TaggerListResponse {
 	return t.tagStore.List()
 }
 

--- a/pkg/tagger/remote/tagger.go
+++ b/pkg/tagger/remote/tagger.go
@@ -19,11 +19,11 @@ import (
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/metadata"
 
-	"github.com/DataDog/datadog-agent/cmd/agent/api/response"
 	"github.com/DataDog/datadog-agent/pkg/api/security"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
+	tagger_api "github.com/DataDog/datadog-agent/pkg/tagger/api"
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
 	"github.com/DataDog/datadog-agent/pkg/tagger/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/tagger/types"
@@ -37,9 +37,7 @@ const (
 	streamRecvTimeout = 10 * time.Minute
 )
 
-var (
-	errTaggerStreamNotStarted = errors.New("tagger stream not started")
-)
+var errTaggerStreamNotStarted = errors.New("tagger stream not started")
 
 // Tagger holds a connection to a remote tagger, processes incoming events from
 // it, and manages the storage of entities to allow querying.
@@ -182,14 +180,14 @@ func (t *Tagger) GetEntity(entityID string) (*types.Entity, error) {
 }
 
 // List returns all the entities currently stored by the tagger.
-func (t *Tagger) List(cardinality collectors.TagCardinality) response.TaggerListResponse {
+func (t *Tagger) List(cardinality collectors.TagCardinality) tagger_api.TaggerListResponse {
 	entities := t.store.listEntities()
-	resp := response.TaggerListResponse{
-		Entities: make(map[string]response.TaggerListEntity),
+	resp := tagger_api.TaggerListResponse{
+		Entities: make(map[string]tagger_api.TaggerListEntity),
 	}
 
 	for _, e := range entities {
-		resp.Entities[e.ID] = response.TaggerListEntity{
+		resp.Entities[e.ID] = tagger_api.TaggerListEntity{
 			Tags: map[string][]string{
 				remoteSource: e.GetTags(collectors.HighCardinality),
 			},
@@ -237,7 +235,6 @@ func (t *Tagger) run() {
 			response, err = t.stream.Recv()
 			return err
 		}, streamRecvTimeout)
-
 		if err != nil {
 			t.streamCancel()
 

--- a/pkg/tagger/replay/tagger.go
+++ b/pkg/tagger/replay/tagger.go
@@ -9,10 +9,10 @@ import (
 	"context"
 	"time"
 
-	"github.com/DataDog/datadog-agent/cmd/agent/api/response"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo"
 	pbutils "github.com/DataDog/datadog-agent/pkg/proto/utils"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
+	tagger_api "github.com/DataDog/datadog-agent/pkg/tagger/api"
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
 	"github.com/DataDog/datadog-agent/pkg/tagger/tagstore"
 	"github.com/DataDog/datadog-agent/pkg/tagger/telemetry"
@@ -98,7 +98,7 @@ func (t *Tagger) Standard(entityID string) ([]string, error) {
 }
 
 // List returns all the entities currently stored by the tagger.
-func (t *Tagger) List(cardinality collectors.TagCardinality) response.TaggerListResponse {
+func (t *Tagger) List(cardinality collectors.TagCardinality) tagger_api.TaggerListResponse {
 	return t.store.List()
 }
 
@@ -115,7 +115,6 @@ func (t *Tagger) Unsubscribe(ch chan []types.EntityEvent) {
 
 // LoadState loads the state for the tagger from the supplied map.
 func (t *Tagger) LoadState(state map[string]*pb.Entity) {
-
 	if state == nil {
 		return
 	}

--- a/pkg/tagger/tagstore/tagstore.go
+++ b/pkg/tagger/tagstore/tagstore.go
@@ -12,8 +12,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/DataDog/datadog-agent/cmd/agent/api/response"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
+	tagger_api "github.com/DataDog/datadog-agent/pkg/tagger/api"
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
 	"github.com/DataDog/datadog-agent/pkg/tagger/subscriber"
 	"github.com/DataDog/datadog-agent/pkg/tagger/telemetry"
@@ -284,7 +284,6 @@ func (s *TagStore) Lookup(entity string, cardinality collectors.TagCardinality) 
 
 // LookupStandard returns the standard tags recorded for a given entity
 func (s *TagStore) LookupStandard(entityID string) ([]string, error) {
-
 	storedTags, err := s.GetEntityTags(entityID)
 	if err != nil {
 		return nil, err
@@ -307,16 +306,16 @@ func (s *TagStore) GetEntityTags(entityID string) (*EntityTags, error) {
 }
 
 // List returns full list of entities and their tags per source in an API format.
-func (s *TagStore) List() response.TaggerListResponse {
-	r := response.TaggerListResponse{
-		Entities: make(map[string]response.TaggerListEntity),
+func (s *TagStore) List() tagger_api.TaggerListResponse {
+	r := tagger_api.TaggerListResponse{
+		Entities: make(map[string]tagger_api.TaggerListEntity),
 	}
 
 	s.RLock()
 	defer s.RUnlock()
 
 	for entityID, et := range s.store {
-		entity := response.TaggerListEntity{
+		entity := tagger_api.TaggerListEntity{
 			Tags: make(map[string][]string),
 		}
 

--- a/releasenotes/notes/Add-tagger-list-to-process-agent-6f7773beb28dc2fd.yaml
+++ b/releasenotes/notes/Add-tagger-list-to-process-agent-6f7773beb28dc2fd.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add the `tagger-list` command to the `process-agent` to ease
+    tagging issue investigation.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

* Add `tagger-list` command to the `process-agent`. It allows to display the tags for each entities present in the "tagger" component.
* Add the output of `process-agent tagger-list` to the flare

### Motivation

Ease missing tags investigation in the `process-agent`

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

1. Deploy the `agent` and `process-agent` and run the command `process-agent tagger-list`. 
   The output should be equal to what you get with the `agent tagger-list` command

2. Run the `agent flare` command, the flare should contains a new file call `process-agent_tagger-list.json`

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
