### PR TITLE
[process-agent] Refactor uses of WithPermission in Process check

### DIFF
--- a/pkg/process/checks/process_probe.go
+++ b/pkg/process/checks/process_probe.go
@@ -29,8 +29,9 @@ func getProcessProbe() procutil.Probe {
 				return
 			}
 			log.Info("Using perf counters probe for process data collection")
+
 		}
-		processProbe = procutil.NewProcessProbe()
+		processProbe = procutil.NewProcessProbe(procutil.WithPermission(Process.SysprobeProcessModuleEnabled))
 	})
 	return processProbe
 }

--- a/pkg/process/procutil/option_unsupported.go
+++ b/pkg/process/procutil/option_unsupported.go
@@ -18,7 +18,7 @@ func WithReturnZeroPermStats(enabled bool) Option {
 
 // WithPermission configures if process collection should fetch fields
 // that require elevated permission or not
-func WithPermission(enabled bool) Option {
+func WithPermission(elevatedPermissions bool) Option {
 	return func(p Probe) {}
 }
 

--- a/pkg/process/procutil/process_linux.go
+++ b/pkg/process/procutil/process_linux.go
@@ -73,10 +73,10 @@ func WithReturnZeroPermStats(enabled bool) Option {
 
 // WithPermission configures if process collection should fetch fields
 // that require elevated permission or not
-func WithPermission(enabled bool) Option {
+func WithPermission(elevatedPermissions bool) Option {
 	return func(p Probe) {
 		if linuxProbe, ok := p.(*probe); ok {
-			linuxProbe.elevatedPermissions = enabled
+			linuxProbe.elevatedPermissions = elevatedPermissions
 		}
 	}
 }

--- a/pkg/process/procutil/process_linux.go
+++ b/pkg/process/procutil/process_linux.go
@@ -76,7 +76,7 @@ func WithReturnZeroPermStats(enabled bool) Option {
 func WithPermission(enabled bool) Option {
 	return func(p Probe) {
 		if linuxProbe, ok := p.(*probe); ok {
-			linuxProbe.withPermission = enabled
+			linuxProbe.elevatedPermissions = enabled
 		}
 	}
 }
@@ -101,7 +101,7 @@ type probe struct {
 	exit         chan struct{}
 
 	// configurations
-	withPermission          bool
+	elevatedPermissions     bool
 	returnZeroPermStats     bool
 	bootTimeRefreshInterval time.Duration
 }
@@ -186,7 +186,7 @@ func (p *probe) StatsForPIDs(pids []int32, now time.Time) (map[int32]*Stats, err
 			CtxSwitches: statusInfo.ctxSwitches, // /proc/[pid]/status
 			NumThreads:  statusInfo.numThreads,  // /proc/[pid]/status
 		}
-		if p.withPermission {
+		if p.elevatedPermissions {
 			stats.OpenFdCount = p.getFDCountImproved(pathForPID) // /proc/[pid]/fd, requires permission checks
 			stats.IOStat = p.parseIO(pathForPID)                 // /proc/[pid]/io, requires permission checks
 		} else {
@@ -258,7 +258,7 @@ func (p *probe) ProcessesByPID(now time.Time, collectStats bool) (map[int32]*Pro
 				NumThreads:  statusInfo.numThreads,  // /proc/[pid]/status
 			},
 		}
-		if p.withPermission {
+		if p.elevatedPermissions {
 			proc.Stats.OpenFdCount = p.getFDCountImproved(pathForPID) // /proc/[pid]/fd, requires permission checks
 			proc.Stats.IOStat = p.parseIO(pathForPID)                 // /proc/[pid]/io, requires permission checks
 		} else {


### PR DESCRIPTION
### What does this PR do?

- Move use of `WithPermission` to happen at probe initialization time.
- Deduplicate logic relying on system probe features in RT and regular payload collection.

### Motivation

Make use of `WithOption`-style options in procutil more idiomatic, improve code clarity.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Functionality relying on the process module in system probe (FD and IO stats collection) should still work.

Note indirectly retrieval of stats in the system probe can be confirmed by observing these logs:
```
SYS-PROBE | DEBUG | (cmd/system-probe/modules/process.go:107 in logProcTracerRequests) | Got request on /process/stats (count: 13): retrieved 78 stats in 6.223213ms
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
