### PR TITLE
[process-agent] Correct counter for process check duration log

### DIFF
--- a/cmd/process-agent/collector.go
+++ b/cmd/process-agent/collector.go
@@ -185,7 +185,6 @@ func (l *Collector) runCheck(c checks.Check, results *api.WeightedQueue) {
 }
 
 func (l *Collector) runCheckWithRealTime(c checks.CheckWithRealTime, results, rtResults *api.WeightedQueue, options checks.RunOptions) {
-	runCounter := l.nextRunCounter(c.Name())
 	start := time.Now()
 	// update the last collected timestamp for info
 	updateLastCollectTime(start)
@@ -197,6 +196,7 @@ func (l *Collector) runCheckWithRealTime(c checks.CheckWithRealTime, results, rt
 	}
 	l.messagesToResults(start, c.Name(), run.Standard, results)
 	if options.RunStandard {
+		runCounter := l.nextRunCounter(c.Name())
 		checks.StoreCheckOutput(c.Name(), run.Standard)
 		logCheckDuration(c.Name(), start, runCounter)
 	}

--- a/cmd/process-agent/collector.go
+++ b/cmd/process-agent/collector.go
@@ -196,6 +196,9 @@ func (l *Collector) runCheckWithRealTime(c checks.CheckWithRealTime, results, rt
 	}
 	l.messagesToResults(start, c.Name(), run.Standard, results)
 	if options.RunStandard {
+		// We are only updating the run counter for the standard check
+		// since RT checks are too frequent and we only log standard check
+		// durations
 		runCounter := l.nextRunCounter(c.Name())
 		checks.StoreCheckOutput(c.Name(), run.Standard)
 		logCheckDuration(c.Name(), start, runCounter)


### PR DESCRIPTION


<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Process check is the shared implementation home for both RT and regular process payload collection.
This change ensures we only increment run counter for the standard check since we only log that case.

### Motivation

Ensure we are logging process check duration correctly.

### Describe how to test/QA your changes

Enable process collection and run process-agent while viewing Live Processes page. Observe in the logs that checks runs are correctly reported at 1, 5, and every 20th check afterwards:

```
PROCESS | INFO | (collector.go:218 in logCheckDuration) | Finished process check #1 in 20.0724ms
PROCESS | INFO | (collector.go:218 in logCheckDuration) | Finished process check #2 in 30.6708ms
PROCESS | INFO | (collector.go:218 in logCheckDuration) | Finished process check #5 in 20.4508ms
PROCESS | INFO | (collector.go:222 in logCheckDuration) | Finish process check #20 in 27.7847ms
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
