### PR TITLE
[process-agent] Remove pkg/process/checks dependency from core packages

### DIFF
--- a/cmd/process-agent/api/server.go
+++ b/cmd/process-agent/api/server.go
@@ -6,9 +6,7 @@
 package api
 
 import (
-	"net"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -34,7 +32,7 @@ func StartServer() error {
 	r := mux.NewRouter()
 	setupHandlers(r)
 
-	addr, err := GetAPIAddressPort()
+	addr, err := ddconfig.GetProcessAPIAddressPort()
 	if err != nil {
 		return err
 	}
@@ -55,21 +53,4 @@ func StartServer() error {
 		}
 	}()
 	return nil
-}
-
-// GetAPIAddressPort returns a listening connection
-func GetAPIAddressPort() (string, error) {
-	address, err := ddconfig.GetIPCAddress()
-	if err != nil {
-		return "", err
-	}
-
-	port := ddconfig.Datadog.GetInt("process_config.cmd_port")
-	if port <= 0 {
-		log.Warnf("Invalid process_config.cmd_port -- %d, using default port %d", port, ddconfig.DefaultProcessCmdPort)
-		port = ddconfig.DefaultProcessCmdPort
-	}
-
-	addrPort := net.JoinHostPort(address, strconv.Itoa(port))
-	return addrPort, nil
 }

--- a/cmd/process-agent/app/status.go
+++ b/cmd/process-agent/app/status.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/DataDog/datadog-agent/cmd/process-agent/api"
 	"github.com/DataDog/datadog-agent/cmd/process-agent/flags"
 	apiutil "github.com/DataDog/datadog-agent/pkg/api/util"
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
@@ -120,7 +119,7 @@ func getAndWriteStatus(statusURL string, w io.Writer, options ...util.StatusOpti
 }
 
 func getStatusURL() (string, error) {
-	addressPort, err := api.GetAPIAddressPort()
+	addressPort, err := ddconfig.GetProcessAPIAddressPort()
 	if err != nil {
 		return "", fmt.Errorf("config error: %s", err.Error())
 	}

--- a/cmd/process-agent/app/status_test.go
+++ b/cmd/process-agent/app/status_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/DataDog/datadog-agent/cmd/process-agent/api"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metadata/host"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
@@ -71,7 +70,7 @@ func TestNotRunning(t *testing.T) {
 	cfg := config.Mock(t)
 	cfg.Set("process_config.cmd_port", 8082)
 
-	addressPort, err := api.GetAPIAddressPort()
+	addressPort, err := config.GetProcessAPIAddressPort()
 	require.NoError(t, err)
 	statusURL := fmt.Sprintf("http://%s/agent/status", addressPort)
 

--- a/pkg/config/process.go
+++ b/pkg/config/process.go
@@ -6,6 +6,7 @@
 package config
 
 import (
+	"net"
 	"strconv"
 	"strings"
 	"sync"
@@ -207,4 +208,21 @@ func loadProcessTransforms(config Config) {
 			config.Set("process_config.container_collection.enabled", true)
 		}
 	}
+}
+
+// GetProcessAPIAddressPort returns the API endpoint of the process agent
+func GetProcessAPIAddressPort() (string, error) {
+	address, err := GetIPCAddress()
+	if err != nil {
+		return "", err
+	}
+
+	port := Datadog.GetInt("process_config.cmd_port")
+	if port <= 0 {
+		log.Warnf("Invalid process_config.cmd_port -- %d, using default port %d", port, DefaultProcessCmdPort)
+		port = DefaultProcessCmdPort
+	}
+
+	addrPort := net.JoinHostPort(address, strconv.Itoa(port))
+	return addrPort, nil
 }

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DataDog/datadog-agent/cmd/process-agent/api"
 	"github.com/DataDog/datadog-agent/pkg/api/security"
 	apiutil "github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -242,7 +241,7 @@ func createArchive(confSearchPaths SearchPaths, local bool, zipFilePath string, 
 			log.Errorf("Could not zip workload list: %s", err)
 		}
 
-		err = zipProcessChecks(tempDir, hostname, api.GetAPIAddressPort)
+		err = zipProcessChecks(tempDir, hostname, config.GetProcessAPIAddressPort)
 		if err != nil {
 			log.Errorf("Could not zip process agent checks: %s", err)
 		}
@@ -548,7 +547,7 @@ func zipSystemProbeStats(tempDir, hostname string) error {
 func zipProcessAgentFullConfig(tempDir, hostname string) error {
 	// procStatusURL can be manually set for test purposes
 	if procStatusURL == "" {
-		addressPort, err := api.GetAPIAddressPort()
+		addressPort, err := config.GetProcessAPIAddressPort()
 		if err != nil {
 			return fmt.Errorf("wrong configuration to connect to process-agent")
 		}

--- a/pkg/status/status_process_agent.go
+++ b/pkg/status/status_process_agent.go
@@ -13,8 +13,8 @@ import (
 
 	"gopkg.in/yaml.v2"
 
-	"github.com/DataDog/datadog-agent/cmd/process-agent/api"
 	apiutil "github.com/DataDog/datadog-agent/pkg/api/util"
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -36,7 +36,7 @@ func getHTTPClient() *http.Client {
 // GetProcessAgentStatus fetches the process-agent status from the process-agent API server
 func GetProcessAgentStatus() map[string]interface{} {
 	s := make(map[string]interface{})
-	addressPort, err := api.GetAPIAddressPort()
+	addressPort, err := config.GetProcessAPIAddressPort()
 	if err != nil {
 		s["error"] = fmt.Sprintf("%v", err.Error())
 		return s


### PR DESCRIPTION
### What does this PR do?

Moves `GetAPIAddressPort` to the `pkg/config` package.
Removes process agent specific package dependencies from common core packages like `pkg/flare` and `pkg/status`

### Motivation

Clean up dependencies

### Describe how to test/QA your changes

Functionality of the process-agent dependent on API port should function correctly.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
