### PR TITLE
AML-302 fix for race condtion in `pkg/log` test

### DIFF
--- a/pkg/config/mock.go
+++ b/pkg/config/mock.go
@@ -28,12 +28,14 @@ func (c *MockConfig) Set(key string, value interface{}) {
 
 // Mock is creating and returning a mock config
 func Mock(t *testing.T) *MockConfig {
+	// Attempt to make sure we don't have two mocks trying to update Datadog at the same time in a test
+	m.Lock()
+	defer m.Unlock()
+
 	// We only check isConfigMocked when registering a cleanup function. 'isConfigMocked' avoids nested calls to
 	// Mock to reset the config to a blank state. This way we have only one mock per test and test helpers can call
 	// Mock.
 	if t != nil {
-		m.Lock()
-		defer m.Unlock()
 		if isConfigMocked {
 			// The configuration is already mocked.
 			return &MockConfig{Datadog}

--- a/pkg/logs/internal/tag/local_provider_test.go
+++ b/pkg/logs/internal/tag/local_provider_test.go
@@ -37,6 +37,7 @@ func TestLocalProviderExpectedTags(t *testing.T) {
 
 	oldStartTime := coreConfig.StartTime
 	coreConfig.StartTime = clock.Now()
+	coreConfig.SetDetectedFeatures(coreConfig.FeatureMap{})
 	defer func() {
 		coreConfig.StartTime = oldStartTime
 	}()

--- a/pkg/logs/internal/tailers/file/tailer_test.go
+++ b/pkg/logs/internal/tailers/file/tailer_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -45,7 +46,7 @@ func (suite *TailerTestSuite) SetupTest() {
 	var err error
 	suite.testDir = suite.T().TempDir()
 
-	suite.testPath = fmt.Sprintf("%s/tailer.log", suite.testDir)
+	suite.testPath = path.Join(suite.testDir, "tailer.log")
 	f, err := os.Create(suite.testPath)
 	suite.Nil(err)
 	suite.testFile = f

--- a/pkg/logs/internal/util/containersorpods/containers_or_pods.go
+++ b/pkg/logs/internal/util/containersorpods/containers_or_pods.go
@@ -121,6 +121,11 @@ func NewDecidedChooser(decision LogWhat) Chooser {
 
 // Wait implements Chooser#Wait.
 func (ch *chooser) Wait(ctx context.Context) LogWhat {
+	// Assume if ctx has an error the context is cancelled or something gone wrong so can't tell which should be used
+	if ctx.Err() != nil {
+		return LogUnknown
+	}
+
 	ch.start()
 	select {
 	case c := <-ch.choice:


### PR DESCRIPTION

### What does this PR do?

This fixes a race condition in a test in `pkg/logs/logs_test.go` picked up by the race detector when run on macOS.

### Motivation

This helps to keep the CI builds green.

### Additional Notes

The fix isn't the perfect solution. Not 100% convinced this truly fixes the issue but has stopped CI from breaking. The main source of the problem is `pkg/config/mock.go` and how it replaces the global reference to the Datadog global configuration. A more permanent fix would be change how the global configuration works, which would be bigger and tougher change.

### Describe how to test/QA your changes

Run the following command from the root of the project on macOS:

```
go clean -testcache && gotestsum   --format pkgname --rerun-fails=2 --packages="./pkg/logs/..." --  -mod=mod -vet=off -timeout 180s -tags "jmx orchestrator zk clusterchecks otlp kubeapiserver ec2 process secrets apm python etcd fargateprocess zlib gce consul kubelet test" -gcflags="" -ldflags="-X github.com/DataDog/datadog-agent/pkg/version.Commit=c57fc3287 -X github.com/DataDog/datadog-agent/pkg/version.AgentVersion=7.39.0-devel+git.238.c57fc32 -X github.com/DataDog/datadog-agent/pkg/serializer.AgentPayloadVersion=v5.0.23 -X github.com/DataDog/datadog-agent/pkg/config.ForceDefaultPython=true -X github.com/DataDog/datadog-agent/pkg/config.DefaultPython=3 -r /Users/runner/go/src/github.com/DataDog/datadog-agent/dev/lib '-extldflags=-Wl,-bind_at_load ' " -p 3 -race -short -v -count=1 -covermode=atomic -coverprofile=profile.cov
```

You might need to install `gotestsum` (easy as `go install gotest.tools/gotestsum@latest`)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
