### PR TITLE
[macOS] Build rtloader with macOS 10.13 as the target OS version

### DIFF
--- a/tasks/rtloader.py
+++ b/tasks/rtloader.py
@@ -4,6 +4,7 @@ RtLoader namespaced tasks
 import errno
 import os
 import shutil
+import sys
 
 from invoke import task
 from invoke.exceptions import Exit
@@ -82,6 +83,9 @@ def make(ctx, install_prefix=None, python_runtimes='3', cmake_options='', arch="
 
     if arch == "x86":
         cmake_args += " -DARCH_I386=ON"
+
+    if sys.platform == 'darwin':
+        cmake_args += " -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12"
 
     # Perform "out of the source build" in `rtloader_build_path` folder.
     try:

--- a/tasks/rtloader.py
+++ b/tasks/rtloader.py
@@ -85,7 +85,7 @@ def make(ctx, install_prefix=None, python_runtimes='3', cmake_options='', arch="
         cmake_args += " -DARCH_I386=ON"
 
     if sys.platform == 'darwin':
-        cmake_args += " -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12"
+        cmake_args += " -DCMAKE_OSX_DEPLOYMENT_TARGET=10.13"
 
     # Perform "out of the source build" in `rtloader_build_path` folder.
     try:


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Forces `cmake` to build `rtloader` using macOS 10.13 as its deployment target.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Since the macOS GitHub Actions runner upgrade to macOS 11, the build and use of `rtloader` in go unit tests generates `ld` warnings:

```
ld: warning: dylib (/Users/runner/go/src/github.com/DataDog/datadog-agent/dev/lib/libdatadog-agent-rtloader.dylib) was built for newer macOS version (11.6) than being linked (11.0)
```

This happens because, by default, `cmake` targets the current OS version (11.6 for up-to-date macOS 11 OSes), while the system libs it links against indicate that they are from 11.0.

This isn't an issue in itself, but `go`, when running unit tests, sees these warnings and decides that failed tests aren't safe to rerun, meaning that flaky tests make the pipeline fail more often than usual.

Why macOS 10.13 as the target?
- this is the earliest version of macOS that we can still support today (due to go 1.17 [dropping support for macOS 10.12](https://go.dev/doc/go1.17)) - we used to support 10.12 and above before.
- it doesn't create any `ld` warnings when using macOS 11 (system libs target 11.0) and Python 3.8 (targets 10.13).

Note: this may break again once we upgrade Python to 3.9 (targets 11.0), or when we switch runners to macOS 12.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

Local builds on some macOS versions (eg. macOS 12) could display warnings after this is merged. This fixes the CI for now, if local builds become an issue, we may want to make setting the `cmake` target option configurable.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Check that building `rtloader` and running `go` unit tests on macOS 11 + Python 3.8 doesn't create any warnings. Ex. https://github.com/DataDog/datadog-agent-macos-build/actions/runs/2780898322.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
