### PR TITLE
Fix diagnose command to print logs in the right order

### DIFF
--- a/cmd/agent/app/diagnose.go
+++ b/cmd/agent/app/diagnose.go
@@ -80,15 +80,7 @@ func configAndLogSetup() error {
 	}
 
 	// log level is always off since this might be use by other agent to get the hostname
-	err = config.SetupLogger(
-		loggerName,
-		config.Datadog.GetString("log_level"),
-		common.DefaultLogFile,
-		config.GetSyslogURI(),
-		config.Datadog.GetBool("syslog_rfc"),
-		config.Datadog.GetBool("log_to_console"),
-		config.Datadog.GetBool("log_format_json"),
-	)
+	err = config.SetupLogger(loggerName, config.GetEnvDefault("DD_LOG_LEVEL", "info"), "", "", false, true, false)
 
 	if err != nil {
 		return fmt.Errorf("error while setting up logging, exiting: %v", err)

--- a/pkg/diagnose/runner.go
+++ b/pkg/diagnose/runner.go
@@ -45,6 +45,7 @@ func RunAll(w io.Writer) error {
 			statusString = color.RedString("FAIL")
 			log.Infof("diagnosis error for %s: %v", name, err)
 		}
+		log.Flush()
 		fmt.Fprintln(w, fmt.Sprintf("===> %s\n", statusString))
 	}
 


### PR DESCRIPTION
### What does this PR do?

This also fix the hardcoded log file path and align the command behavior
with others (where we don't log to the log agent file CLI calls).

This will avoid spamming `seelog internal error: mkdir /var/log/datadog/: permission denied`, in the command output when `log_file` is configured to something else. This also avoids injecting the `diagnose` command log to the agent logs.

The `Flush` part prevent out of order log lines between `fmt.Printf` and `log.Info`.

before:
```
=== Running EC2 Metadata availability diagnosis ===
2022-08-02 14:58:16 CEST | CORE | INFO | (pkg/util/docker/diagnosis.go:35 in diagnose) | successfully got hostname "debdev" from docker
seelog internal error: mkdir /var/log/datadog/: permission denied
[INFO] infof: diagnosis error for EC2 Metadata availability: Get "http://169.254.169.254/latest/meta-data/hostname": dial tcp 169.254.169.254:80: connect: connection refused - 1659445096168750931
===> FAIL

```

now:
```
=== Running EC2 Metadata availability diagnosis ===
[INFO] infof: diagnosis error for EC2 Metadata availability: Get "http://169.254.169.254/latest/meta-data/hostname": dial tcp 169.254.169.254:80: connect: connection refused - 1659444983736983949
2022-08-02 14:56:23 CEST | CORE | INFO | (pkg/diagnose/runner.go:46 in RunAll) | diagnosis error for EC2 Metadata availability: Get "http://169.254.169.254/latest/meta-data/hostname": dial tcp 169.254.169.254:80: connect: connection refused
===> FAIL
```

### Describe how to test/QA your changes

Run the `diagnose metadata-availability` command and check that the info make sens (ex: no docket log in the EC2 section).
Then check that the log lines from the command are not in the agent log file.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
