### PR TITLE
[ad] Make KubeContainerConfigProvider into a streaming provider

### DIFF
--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -452,7 +452,7 @@ func StartAgent() error {
 	}
 
 	// load and run all configs in AD
-	common.AC.LoadAndRun()
+	common.AC.LoadAndRun(common.MainCtx)
 
 	// check for common misconfigurations and report them to log
 	misconfig.ToLog()

--- a/cmd/agent/common/autodiscovery.go
+++ b/cmd/agent/common/autodiscovery.go
@@ -100,11 +100,6 @@ func setupAutoDiscovery(confSearchPaths []string, metaScheduler *scheduler.MetaS
 			}
 
 			pollInterval := providers.GetPollInterval(cp)
-			if cp.Polling {
-				log.Infof("Registering %s config provider polled every %s", cp.Name, pollInterval.String())
-			} else {
-				log.Infof("Registering %s config provider", cp.Name)
-			}
 			ad.AddConfigProvider(configProvider, cp.Polling, pollInterval)
 		} else {
 			log.Errorf("Unable to find this provider in the catalog: %v", cp.Name)

--- a/cmd/agent/common/commands/check.go
+++ b/cmd/agent/common/commands/check.go
@@ -152,7 +152,7 @@ func Check(loggerName config.LoggerName, confFilePath *string, flagNoColor *bool
 			demux := aggregator.InitAndStartAgentDemultiplexer(opts, hostnameDetected)
 
 			common.LoadComponents(context.Background(), config.Datadog.GetString("confd_path"))
-			common.AC.LoadAndRun()
+			common.AC.LoadAndRun(context.Background())
 
 			if config.Datadog.GetBool("inventories_enabled") {
 				metadata.SetupInventoriesExpvar(common.Coll)

--- a/cmd/cluster-agent-cloudfoundry/app/app.go
+++ b/cmd/cluster-agent-cloudfoundry/app/app.go
@@ -199,7 +199,7 @@ func run(cmd *cobra.Command, args []string) error {
 	common.Coll.Start()
 
 	// start the autoconfig, this will immediately run any configured check
-	common.AC.LoadAndRun()
+	common.AC.LoadAndRun(mainCtx)
 
 	if err = api.StartServer(); err != nil {
 		return log.Errorf("Error while starting agent API, exiting: %v", err)

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -291,7 +291,7 @@ func start(cmd *cobra.Command, args []string) error {
 	common.Coll.Start()
 
 	// start the autoconfig, this will immediately run any configured check
-	common.AC.LoadAndRun()
+	common.AC.LoadAndRun(mainCtx)
 
 	if config.Datadog.GetBool("cluster_checks.enabled") {
 		// Start the cluster check Autodiscovery

--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -201,8 +201,7 @@ func (ac *AutoConfig) LoadAndRun(ctx context.Context) {
 	defer ac.m.Unlock()
 
 	for _, cp := range ac.configPollers {
-		cp.start(ac)
-		cp.pollOnce(ctx, ac)
+		cp.start(ctx, ac)
 
 		// TODO: this probably belongs somewhere inside the file config
 		// provider itself, but since it already lived in AD it's been

--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -464,6 +464,9 @@ func (ac *AutoConfig) processDelService(ctx context.Context, svc listeners.Servi
 // unique error messages.  The resource names do not match other identifiers
 // and are only intended for display in diagnostic tools like `agent status`.
 func (ac *AutoConfig) GetAutodiscoveryErrors() map[string]map[string]providers.ErrorMsgSet {
+	ac.m.Lock()
+	defer ac.m.Unlock()
+
 	errors := map[string]map[string]providers.ErrorMsgSet{}
 	for _, pd := range ac.configPollers {
 		configErrors := pd.provider.GetConfigErrors()

--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -181,12 +181,10 @@ func (ac *AutoConfig) AddConfigProvider(provider providers.ConfigProvider, shoul
 	ac.m.Lock()
 	defer ac.m.Unlock()
 
-	for _, cp := range ac.configPollers {
-		if cp.provider == provider {
-			// we already know this configuration provider, don't do anything
-			log.Warnf("Provider %s was already added, skipping...", provider)
-			return
-		}
+	if shouldPoll {
+		log.Infof("Registering %s config provider polled every %s", provider.String(), pollInterval.String())
+	} else {
+		log.Infof("Registering %s config provider", provider.String())
 	}
 
 	cp := newConfigPoller(provider, shouldPoll, pollInterval)

--- a/pkg/autodiscovery/autoconfig_test.go
+++ b/pkg/autodiscovery/autoconfig_test.go
@@ -149,17 +149,15 @@ func (suite *AutoConfigTestSuite) TestAddConfigProvider() {
 	assert.Len(suite.T(), ac.configPollers, 0)
 	mp := &MockProvider{}
 	ac.AddConfigProvider(mp, false, 0)
-	ac.AddConfigProvider(mp, false, 0) // this should be a noop
 	ac.AddConfigProvider(&MockProvider2{}, true, 1*time.Second)
-	ac.LoadAndRun(context.Background())
-
-	ac.m.Lock()
-	defer ac.m.Unlock()
 
 	require.Len(suite.T(), ac.configPollers, 2)
-	assert.Equal(suite.T(), 1, mp.collectCounter)
 	assert.False(suite.T(), ac.configPollers[0].canPoll)
 	assert.True(suite.T(), ac.configPollers[1].canPoll)
+
+	ac.LoadAndRun(context.Background())
+
+	assert.Equal(suite.T(), 1, mp.collectCounter)
 }
 
 func (suite *AutoConfigTestSuite) TestAddListener() {

--- a/pkg/autodiscovery/autoconfig_test.go
+++ b/pkg/autodiscovery/autoconfig_test.go
@@ -152,6 +152,10 @@ func (suite *AutoConfigTestSuite) TestAddConfigProvider() {
 	ac.AddConfigProvider(mp, false, 0) // this should be a noop
 	ac.AddConfigProvider(&MockProvider2{}, true, 1*time.Second)
 	ac.LoadAndRun(context.Background())
+
+	ac.m.Lock()
+	defer ac.m.Unlock()
+
 	require.Len(suite.T(), ac.configPollers, 2)
 	assert.Equal(suite.T(), 1, mp.collectCounter)
 	assert.False(suite.T(), ac.configPollers[0].canPoll)

--- a/pkg/autodiscovery/autoconfig_test.go
+++ b/pkg/autodiscovery/autoconfig_test.go
@@ -327,7 +327,7 @@ func TestResolveTemplate(t *testing.T) {
 
 	// no services
 	changes := ac.processNewConfig(tpl)
-	assert.Len(t, changes.schedule, 0)
+	assert.Len(t, changes.Schedule, 0)
 
 	service := dummyService{
 		ID:            "a5901276aed16ae9ea11660a41fecd674da47e8f5d8d5bce0080a611feed2be9",
@@ -337,7 +337,7 @@ func TestResolveTemplate(t *testing.T) {
 
 	// there are no template vars but it's ok
 	changes = ac.processNewConfig(tpl)
-	assert.Len(t, changes.schedule, 1)
+	assert.Len(t, changes.Schedule, 1)
 }
 
 func countLoadedConfigs(ac *AutoConfig) int {
@@ -373,7 +373,7 @@ func TestRemoveTemplate(t *testing.T) {
 		ADIdentifiers: []string{"redis"},
 	}
 	changes := ac.processNewConfig(tpl)
-	assert.Len(t, changes.schedule, 1)
+	assert.Len(t, changes.Schedule, 1)
 	assert.Equal(t, countLoadedConfigs(ac), 2)
 
 	// Remove the template, config should be removed too
@@ -402,7 +402,7 @@ func TestCheckOverride(t *testing.T) {
 		ADIdentifiers: []string{"redis"},
 		CheckNames:    []string{"redis"},
 	})
-	assert.Len(t, ac.processNewConfig(tpl).schedule, 0)
+	assert.Len(t, ac.processNewConfig(tpl).Schedule, 0)
 
 	// check must be overridden (empty config)
 	ac = NewAutoConfig(scheduler.NewMetaScheduler())
@@ -411,7 +411,7 @@ func TestCheckOverride(t *testing.T) {
 		ADIdentifiers: []string{"redis"},
 		CheckNames:    []string{""},
 	})
-	assert.Len(t, ac.processNewConfig(tpl).schedule, 0)
+	assert.Len(t, ac.processNewConfig(tpl).Schedule, 0)
 
 	// check must be scheduled (different checks)
 	ac = NewAutoConfig(scheduler.NewMetaScheduler())
@@ -420,7 +420,7 @@ func TestCheckOverride(t *testing.T) {
 		ADIdentifiers: []string{"redis"},
 		CheckNames:    []string{"tcp_check"},
 	})
-	assert.Len(t, ac.processNewConfig(tpl).schedule, 1)
+	assert.Len(t, ac.processNewConfig(tpl).Schedule, 1)
 }
 
 func TestDecryptConfig(t *testing.T) {
@@ -452,7 +452,7 @@ func TestDecryptConfig(t *testing.T) {
 	}
 	changes := ac.processNewConfig(tpl)
 
-	require.Len(t, changes.schedule, 1)
+	require.Len(t, changes.Schedule, 1)
 
 	resolved := integration.Config{
 		Name:          "cpu",
@@ -463,7 +463,7 @@ func TestDecryptConfig(t *testing.T) {
 		LogsConfig:    integration.Data{},
 		ServiceID:     "abcd",
 	}
-	assert.Equal(t, resolved, changes.schedule[0])
+	assert.Equal(t, resolved, changes.Schedule[0])
 
 	assert.True(t, mockDecrypt.haveAllScenariosBeenCalled())
 }

--- a/pkg/autodiscovery/config_poller.go
+++ b/pkg/autodiscovery/config_poller.go
@@ -236,16 +236,3 @@ func (cp *configPoller) storeAndDiffConfigs(configs []integration.Config) ([]int
 
 	return newConf, removedConf
 }
-
-func (cp *configPoller) getConfigs() []integration.Config {
-	cp.configsMu.Lock()
-	defer cp.configsMu.Unlock()
-
-	configs := make([]integration.Config, 0, len(cp.configs))
-
-	for _, cfg := range cp.configs {
-		configs = append(configs, cfg)
-	}
-
-	return configs
-}

--- a/pkg/autodiscovery/config_poller.go
+++ b/pkg/autodiscovery/config_poller.go
@@ -104,7 +104,13 @@ func (cp *configPoller) stream(ch chan struct{}, provider providers.StreamingCon
 			if !changes.IsEmpty() {
 				log.Infof("%v provider: collected %d new configurations, removed %d", provider, len(changes.Schedule), len(changes.Unschedule))
 
-				ac.applyChanges(changes)
+				ac.processRemovedConfigs(changes.Unschedule)
+
+				for _, added := range changes.Schedule {
+					added.Provider = cp.provider.String()
+					resolvedChanges := ac.processNewConfig(added)
+					ac.applyChanges(resolvedChanges)
+				}
 			}
 
 			if !ranOnce {

--- a/pkg/autodiscovery/config_poller.go
+++ b/pkg/autodiscovery/config_poller.go
@@ -41,51 +41,51 @@ func newConfigPoller(provider providers.ConfigProvider, canPoll bool, interval t
 }
 
 // stop stops the provider descriptor if it's polling
-func (pd *configPoller) stop() {
-	if !pd.canPoll || pd.isPolling {
+func (cp *configPoller) stop() {
+	if !cp.canPoll || cp.isPolling {
 		return
 	}
-	pd.stopChan <- struct{}{}
-	pd.isPolling = false
+	cp.stopChan <- struct{}{}
+	cp.isPolling = false
 }
 
 // start starts polling the provider descriptor
-func (pd *configPoller) start(ctx context.Context, ac *AutoConfig) {
-	_, isStreaming := pd.provider.(providers.StreamingConfigProvider)
+func (cp *configPoller) start(ctx context.Context, ac *AutoConfig) {
+	_, isStreaming := cp.provider.(providers.StreamingConfigProvider)
 
 	if !isStreaming {
-		pd.pollOnce(ctx, ac)
+		cp.collectOnce(ctx, ac)
 	}
 
-	if !pd.canPoll {
+	if !cp.canPoll {
 		return
 	}
 
-	pd.stopChan = make(chan struct{})
-	pd.healthHandle = health.RegisterLiveness(fmt.Sprintf("ad-config-provider-%s", pd.provider.String()))
-	pd.isPolling = true
+	cp.stopChan = make(chan struct{})
+	cp.healthHandle = health.RegisterLiveness(fmt.Sprintf("ad-config-provider-%s", cp.provider.String()))
+	cp.isPolling = true
 
 	if isStreaming {
 		ch := make(chan struct{})
-		go pd.stream(ch, ac)
+		go cp.stream(ch, ac)
 		<-ch
 	} else {
-		go pd.poll(ac)
+		go cp.poll(ac)
 	}
 }
 
 // stream streams config from the corresponding config provider
-func (pd *configPoller) stream(ch chan struct{}, ac *AutoConfig) {
+func (cp *configPoller) stream(ch chan struct{}, ac *AutoConfig) {
 	var ranOnce bool
 	ctx, cancel := context.WithCancel(context.Background())
-	changesCh := pd.provider.(providers.StreamingConfigProvider).Stream(ctx)
+	changesCh := cp.provider.(providers.StreamingConfigProvider).Stream(ctx)
 
 	for {
 		select {
-		case <-pd.healthHandle.C:
+		case <-cp.healthHandle.C:
 
-		case <-pd.stopChan:
-			err := pd.healthHandle.Deregister()
+		case <-cp.stopChan:
+			err := cp.healthHandle.Deregister()
 			if err != nil {
 				log.Errorf("error de-registering health check: %s", err)
 			}
@@ -95,10 +95,7 @@ func (pd *configPoller) stream(ch chan struct{}, ac *AutoConfig) {
 			return
 
 		case changes := <-changesCh:
-			ac.applyChanges(configChanges{
-				schedule:   changes.Schedule,
-				unschedule: changes.Unschedule,
-			})
+			ac.applyChanges(changes)
 
 			if !ranOnce {
 				close(ch)
@@ -109,16 +106,16 @@ func (pd *configPoller) stream(ch chan struct{}, ac *AutoConfig) {
 }
 
 // poll polls config of the corresponding config provider
-func (pd *configPoller) poll(ac *AutoConfig) {
+func (cp *configPoller) poll(ac *AutoConfig) {
 	ctx, cancel := context.WithCancel(context.Background())
-	ticker := time.NewTicker(pd.pollInterval)
+	ticker := time.NewTicker(cp.pollInterval)
 	for {
 		select {
-		case healthDeadline := <-pd.healthHandle.C:
+		case healthDeadline := <-cp.healthHandle.C:
 			cancel()
 			ctx, cancel = context.WithDeadline(context.Background(), healthDeadline)
-		case <-pd.stopChan:
-			err := pd.healthHandle.Deregister()
+		case <-cp.stopChan:
+			err := cp.healthHandle.Deregister()
 			if err != nil {
 				log.Errorf("error de-registering health check: %s", err)
 			}
@@ -127,30 +124,30 @@ func (pd *configPoller) poll(ac *AutoConfig) {
 			ticker.Stop()
 			return
 		case <-ticker.C:
-			upToDate, err := pd.provider.IsUpToDate(ctx)
+			upToDate, err := cp.provider.IsUpToDate(ctx)
 			if err != nil {
-				log.Errorf("Cache processing of %v configuration provider failed: %v", pd.provider, err)
+				log.Errorf("Cache processing of %v configuration provider failed: %v", cp.provider, err)
 				continue
 			}
 
 			if upToDate {
-				log.Debugf("No modifications in the templates stored in %v configuration provider", pd.provider)
+				log.Debugf("No modifications in the templates stored in %v configuration provider", cp.provider)
 				continue
 			}
 
-			pd.pollOnce(ctx, ac)
+			cp.collectOnce(ctx, ac)
 		}
 	}
 }
 
-func (pd *configPoller) pollOnce(ctx context.Context, ac *AutoConfig) {
+func (cp *configPoller) collectOnce(ctx context.Context, ac *AutoConfig) {
 	// retrieve the list of newly added configurations as well
 	// as removed configurations
-	newConfigs, removedConfigs := pd.collect(ctx)
+	newConfigs, removedConfigs := cp.collect(ctx)
 	if len(newConfigs) > 0 || len(removedConfigs) > 0 {
-		log.Infof("%v provider: collected %d new configurations, removed %d", pd.provider, len(newConfigs), len(removedConfigs))
+		log.Infof("%v provider: collected %d new configurations, removed %d", cp.provider, len(newConfigs), len(removedConfigs))
 	} else {
-		log.Debugf("%v provider: no configuration change", pd.provider)
+		log.Debugf("%v provider: no configuration change", cp.provider)
 	}
 
 	// Process removed configs first to handle the case where a
@@ -158,7 +155,7 @@ func (pd *configPoller) pollOnce(ctx context.Context, ac *AutoConfig) {
 	ac.processRemovedConfigs(removedConfigs)
 
 	for _, config := range newConfigs {
-		if _, ok := pd.provider.(*providers.FileConfigProvider); ok {
+		if _, ok := cp.provider.(*providers.FileConfigProvider); ok {
 			// JMX checks can have 2 YAML files: one containing the
 			// metrics to collect, one containing the instance
 			// configuration. If the file provider finds any of
@@ -174,7 +171,7 @@ func (pd *configPoller) pollOnce(ctx context.Context, ac *AutoConfig) {
 			errorStats.removeConfigError(config.Name)
 		}
 
-		config.Provider = pd.provider.String()
+		config.Provider = cp.provider.String()
 		changes := ac.processNewConfig(config)
 		ac.applyChanges(changes)
 	}
@@ -183,24 +180,24 @@ func (pd *configPoller) pollOnce(ctx context.Context, ac *AutoConfig) {
 
 // collect is just a convenient wrapper to fetch configurations from a provider and
 // see what changed from the last time we called Collect().
-func (pd *configPoller) collect(ctx context.Context) ([]integration.Config, []integration.Config) {
+func (cp *configPoller) collect(ctx context.Context) ([]integration.Config, []integration.Config) {
 	start := time.Now()
 	defer func() {
-		telemetry.PollDuration.Observe(time.Since(start).Seconds(), pd.provider.String())
+		telemetry.PollDuration.Observe(time.Since(start).Seconds(), cp.provider.String())
 	}()
 
-	fetched, err := pd.provider.Collect(ctx)
+	fetched, err := cp.provider.Collect(ctx)
 	if err != nil {
-		log.Errorf("Unable to collect configurations from provider %s: %s", pd.provider, err)
+		log.Errorf("Unable to collect configurations from provider %s: %s", cp.provider, err)
 		return nil, nil
 	}
 
-	return pd.storeAndDiffConfigs(fetched)
+	return cp.storeAndDiffConfigs(fetched)
 }
 
-func (pd *configPoller) storeAndDiffConfigs(configs []integration.Config) ([]integration.Config, []integration.Config) {
-	pd.configsMu.Lock()
-	defer pd.configsMu.Unlock()
+func (cp *configPoller) storeAndDiffConfigs(configs []integration.Config) ([]integration.Config, []integration.Config) {
+	cp.configsMu.Lock()
+	defer cp.configsMu.Unlock()
 
 	var newConf []integration.Config
 	var removedConf []integration.Config
@@ -211,28 +208,28 @@ func (pd *configPoller) storeAndDiffConfigs(configs []integration.Config) ([]int
 	for _, c := range configs {
 		cHash := c.FastDigest()
 		fetchedMap[cHash] = c
-		if _, found := pd.configs[cHash]; found {
-			delete(pd.configs, cHash)
+		if _, found := cp.configs[cHash]; found {
+			delete(cp.configs, cHash)
 		} else {
 			newConf = append(newConf, c)
 		}
 	}
 
-	for _, c := range pd.configs {
+	for _, c := range cp.configs {
 		removedConf = append(removedConf, c)
 	}
-	pd.configs = fetchedMap
+	cp.configs = fetchedMap
 
 	return newConf, removedConf
 }
 
-func (pd *configPoller) getConfigs() []integration.Config {
-	pd.configsMu.Lock()
-	defer pd.configsMu.Unlock()
+func (cp *configPoller) getConfigs() []integration.Config {
+	cp.configsMu.Lock()
+	defer cp.configsMu.Unlock()
 
-	configs := make([]integration.Config, 0, len(pd.configs))
+	configs := make([]integration.Config, 0, len(cp.configs))
 
-	for _, cfg := range pd.configs {
+	for _, cfg := range cp.configs {
 		configs = append(configs, cfg)
 	}
 

--- a/pkg/autodiscovery/configmgr.go
+++ b/pkg/autodiscovery/configmgr.go
@@ -16,39 +16,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// configChanges contains the changes that occurred due to an event in a
-// configManager.
-type configChanges struct {
-	// schedule contains configs that should be scheduled as a result of this
-	// event.
-	schedule []integration.Config
-
-	// unschedule contains configs that should be unscheduled as a result of
-	// this event.
-	unschedule []integration.Config
-}
-
-// scheduleConfig adds a config to `schedule`
-func (c *configChanges) scheduleConfig(config integration.Config) {
-	c.schedule = append(c.schedule, config)
-}
-
-// unscheduleConfig adds a config to `unschedule`
-func (c *configChanges) unscheduleConfig(config integration.Config) {
-	c.unschedule = append(c.unschedule, config)
-}
-
-// isEmpty determines whether this set of changes is empty
-func (c *configChanges) isEmpty() bool {
-	return len(c.schedule) == 0 && len(c.unschedule) == 0
-}
-
-// merge merges the given configChanges into this one.
-func (c *configChanges) merge(other configChanges) {
-	c.schedule = append(c.schedule, other.schedule...)
-	c.unschedule = append(c.unschedule, other.unschedule...)
-}
-
 // configManager implememnts the logic of handling additions and removals of
 // configs (which may or may not be templates) and services, and reconciling
 // those together to resolve templates.
@@ -56,20 +23,20 @@ func (c *configChanges) merge(other configChanges) {
 // This type is threadsafe, internally using a mutex to serialize operations.
 type configManager interface {
 	// processNewService handles a new service, with the given AD identifiers
-	processNewService(adIdentifiers []string, svc listeners.Service) configChanges
+	processNewService(adIdentifiers []string, svc listeners.Service) integration.ConfigChanges
 
 	// processDelService handles removal of a service, unscheduling any configs
 	// that had been resolved for it.
-	processDelService(ctx context.Context, svc listeners.Service) configChanges
+	processDelService(ctx context.Context, svc listeners.Service) integration.ConfigChanges
 
 	// processNewConfig handles a new config
-	processNewConfig(config integration.Config) configChanges
+	processNewConfig(config integration.Config) integration.ConfigChanges
 
 	// processDelConfigs handles removal of a config, unscheduling the config
 	// itself or, if it is a template, any configs resolved from it.  Note that
 	// this applies to a slice of configs, where the other methods in this
 	// interface apply to only one config.
-	processDelConfigs(configs []integration.Config) configChanges
+	processDelConfigs(configs []integration.Config) integration.ConfigChanges
 
 	// mapOverLoadedConfigs calls the given function with a map of all
 	// loaded configs (those which have been scheduled but not unscheduled).
@@ -122,10 +89,10 @@ type reconcilingConfigManager struct {
 	// that service: serviceID -> template digest -> resolved config digest.
 	serviceResolutions map[string]map[string]string
 
-	// scheduledConfigs contains an entry for each scheduled config, keyed by
-	// its digest.  This is a mix of resolved templates and non-template
-	// configs.  The returned configChanges from interface methods correspond
-	// exactly to changes in this map.
+	// scheduledConfigs contains an entry for each scheduled config, keyed
+	// by its digest.  This is a mix of resolved templates and non-template
+	// configs.  The returned integration.ConfigChanges from interface
+	// methods correspond exactly to changes in this map.
 	scheduledConfigs map[string]integration.Config
 }
 
@@ -144,14 +111,14 @@ func newReconcilingConfigManager() configManager {
 }
 
 // processNewService implements configManager#processNewService.
-func (cm *reconcilingConfigManager) processNewService(adIdentifiers []string, svc listeners.Service) configChanges {
+func (cm *reconcilingConfigManager) processNewService(adIdentifiers []string, svc listeners.Service) integration.ConfigChanges {
 	cm.m.Lock()
 	defer cm.m.Unlock()
 
 	svcID := svc.GetServiceID()
 	if _, found := cm.activeServices[svcID]; found {
 		log.Debugf("Service %s is already tracked by autodiscovery", svcID)
-		return configChanges{}
+		return integration.ConfigChanges{}
 	}
 
 	// Execute the steps outlined in the comment on reconcilingConfigManager:
@@ -175,7 +142,7 @@ func (cm *reconcilingConfigManager) processNewService(adIdentifiers []string, sv
 }
 
 // processDelService implements configManager#processDelService.
-func (cm *reconcilingConfigManager) processDelService(_ context.Context, svc listeners.Service) configChanges {
+func (cm *reconcilingConfigManager) processDelService(_ context.Context, svc listeners.Service) integration.ConfigChanges {
 	cm.m.Lock()
 	defer cm.m.Unlock()
 
@@ -183,7 +150,7 @@ func (cm *reconcilingConfigManager) processDelService(_ context.Context, svc lis
 	svcAndADIDs, found := cm.activeServices[svcID]
 	if !found {
 		log.Debugf("Service %s is not tracked by autodiscovery", svcID)
-		return configChanges{}
+		return integration.ConfigChanges{}
 	}
 
 	// Execute the steps outlined in the comment on reconcilingConfigManager:
@@ -204,14 +171,14 @@ func (cm *reconcilingConfigManager) processDelService(_ context.Context, svc lis
 }
 
 // processNewConfig implements configManager#processNewConfig.
-func (cm *reconcilingConfigManager) processNewConfig(config integration.Config) configChanges {
+func (cm *reconcilingConfigManager) processNewConfig(config integration.Config) integration.ConfigChanges {
 	cm.m.Lock()
 	defer cm.m.Unlock()
 
 	digest := config.Digest()
 	if _, found := cm.activeConfigs[digest]; found {
 		log.Debugf("Config %s (digest %s) is already tracked by autodiscovery", config.Name, config.Digest())
-		return configChanges{}
+		return integration.ConfigChanges{}
 	}
 
 	// Execute the steps outlined in the comment on reconcilingConfigManager:
@@ -219,7 +186,7 @@ func (cm *reconcilingConfigManager) processNewConfig(config integration.Config) 
 	//  1. update orctiveConfigs / activeServices
 	cm.activeConfigs[digest] = config
 
-	var changes configChanges
+	var changes integration.ConfigChanges
 	if config.IsTemplate() {
 		//  2. update templatesByADID or servicesByADID to match
 		matchingServices := map[string]struct{}{}
@@ -232,7 +199,7 @@ func (cm *reconcilingConfigManager) processNewConfig(config integration.Config) 
 
 		//  3. update serviceResolutions, generating changes
 		for svcID := range matchingServices {
-			changes.merge(cm.reconcileService(svcID))
+			changes.Merge(cm.reconcileService(svcID))
 		}
 	} else {
 		// Secrets always need to be resolved (done in reconcileService if template)
@@ -241,7 +208,7 @@ func (cm *reconcilingConfigManager) processNewConfig(config integration.Config) 
 			log.Errorf("Unable to resolve secrets for config '%s', dropping check configuration, err: %s", config.Name, err.Error())
 		}
 
-		changes.scheduleConfig(config)
+		changes.ScheduleConfig(config)
 	}
 
 	//  4. update scheduledConfigs
@@ -249,11 +216,11 @@ func (cm *reconcilingConfigManager) processNewConfig(config integration.Config) 
 }
 
 // processDelConfigs implements configManager#processDelConfigs.
-func (cm *reconcilingConfigManager) processDelConfigs(configs []integration.Config) configChanges {
+func (cm *reconcilingConfigManager) processDelConfigs(configs []integration.Config) integration.ConfigChanges {
 	cm.m.Lock()
 	defer cm.m.Unlock()
 
-	var allChanges configChanges
+	var allChanges integration.ConfigChanges
 	for _, config := range configs {
 		digest := config.Digest()
 		if _, found := cm.activeConfigs[digest]; !found {
@@ -266,7 +233,7 @@ func (cm *reconcilingConfigManager) processDelConfigs(configs []integration.Conf
 		//  1. update activeConfigs / activeServices
 		delete(cm.activeConfigs, digest)
 
-		var changes configChanges
+		var changes integration.ConfigChanges
 		if config.IsTemplate() {
 			//  2. update templatesByADID or servicesByADID to match
 			matchingServices := map[string]struct{}{}
@@ -279,7 +246,7 @@ func (cm *reconcilingConfigManager) processDelConfigs(configs []integration.Conf
 
 			//  3. update serviceResolutions, generating changes
 			for svcID := range matchingServices {
-				changes.merge(cm.reconcileService(svcID))
+				changes.Merge(cm.reconcileService(svcID))
 			}
 		} else {
 			// Secrets need to be resolved before being unscheduled as otherwise
@@ -289,11 +256,11 @@ func (cm *reconcilingConfigManager) processDelConfigs(configs []integration.Conf
 				log.Errorf("Unable to resolve secrets for config '%s', check may not be unscheduled properly, err: %s", config.Name, err.Error())
 			}
 
-			changes.unscheduleConfig(config)
+			changes.UnscheduleConfig(config)
 		}
 
 		//  4. update scheduledConfigs
-		allChanges.merge(cm.applyChanges(changes))
+		allChanges.Merge(cm.applyChanges(changes))
 	}
 
 	return allChanges
@@ -312,8 +279,8 @@ func (cm *reconcilingConfigManager) mapOverLoadedConfigs(f func(map[string]integ
 // changes.
 //
 // This method must be called with cm.m locked.
-func (cm *reconcilingConfigManager) reconcileService(svcID string) configChanges {
-	var changes configChanges
+func (cm *reconcilingConfigManager) reconcileService(svcID string) integration.ConfigChanges {
+	var changes integration.ConfigChanges
 
 	// note that this method can be called in a case where svcID is not in the
 	// activeServices: this occurs when the service is removed.
@@ -348,7 +315,7 @@ func (cm *reconcilingConfigManager) reconcileService(svcID string) configChanges
 	// existingResolutions in-place
 	for templateDigest, resolvedDigest := range existingResolutions {
 		if _, found = expectedResolutions[templateDigest]; !found {
-			changes.unscheduleConfig(cm.scheduledConfigs[resolvedDigest])
+			changes.UnscheduleConfig(cm.scheduledConfigs[resolvedDigest])
 			delete(existingResolutions, templateDigest)
 		}
 	}
@@ -361,7 +328,7 @@ func (cm *reconcilingConfigManager) reconcileService(svcID string) configChanges
 			if !ok {
 				continue
 			}
-			changes.scheduleConfig(resolved)
+			changes.ScheduleConfig(resolved)
 			existingResolutions[digest] = resolved.Digest()
 		}
 	}
@@ -398,12 +365,12 @@ func (cm *reconcilingConfigManager) resolveTemplateForService(tpl integration.Co
 // applyChanges applies the given changes to cm.scheduledConfigs
 //
 // This method must be called with cm.m locked.
-func (cm *reconcilingConfigManager) applyChanges(changes configChanges) configChanges {
-	for _, cfg := range changes.unschedule {
+func (cm *reconcilingConfigManager) applyChanges(changes integration.ConfigChanges) integration.ConfigChanges {
+	for _, cfg := range changes.Unschedule {
 		digest := cfg.Digest()
 		delete(cm.scheduledConfigs, digest)
 	}
-	for _, cfg := range changes.schedule {
+	for _, cfg := range changes.Schedule {
 		digest := cfg.Digest()
 		cm.scheduledConfigs[digest] = cfg
 	}

--- a/pkg/autodiscovery/configmgr_test.go
+++ b/pkg/autodiscovery/configmgr_test.go
@@ -119,12 +119,12 @@ func (suite *ConfigManagerSuite) SetupTest() {
 // deleted
 func (suite *ConfigManagerSuite) TestNewNonTemplateScheduled() {
 	changes := suite.cm.processNewConfig(nonTemplateConfig)
-	assertConfigsMatch(suite.T(), changes.schedule, matchName("non-template"))
-	assertConfigsMatch(suite.T(), changes.unschedule)
+	assertConfigsMatch(suite.T(), changes.Schedule, matchName("non-template"))
+	assertConfigsMatch(suite.T(), changes.Unschedule)
 
 	changes = suite.cm.processDelConfigs([]integration.Config{nonTemplateConfig})
-	assertConfigsMatch(suite.T(), changes.schedule)
-	assertConfigsMatch(suite.T(), changes.unschedule, matchName("non-template"))
+	assertConfigsMatch(suite.T(), changes.Schedule)
+	assertConfigsMatch(suite.T(), changes.Unschedule, matchName("non-template"))
 }
 
 // A new, non-template config with secrets is scheduled immediately and unscheduled when
@@ -148,30 +148,30 @@ func (suite *ConfigManagerSuite) TestNewNonTemplateWithSecretsScheduled() {
 
 	inputNewConfig := deepcopy.Copy(nonTemplateConfigWithSecrets).(integration.Config)
 	changes := suite.cm.processNewConfig(inputNewConfig)
-	assertConfigsMatch(suite.T(), changes.schedule, matchName(nonTemplateConfigWithSecrets.Name))
-	assertConfigsMatch(suite.T(), changes.unschedule)
+	assertConfigsMatch(suite.T(), changes.Schedule, matchName(nonTemplateConfigWithSecrets.Name))
+	assertConfigsMatch(suite.T(), changes.Unschedule)
 	// Verify content is actually decoded
-	require.True(suite.T(), strings.Contains(string(changes.schedule[0].Instances[0]), "barDecoded"))
-	newConfigDigest := changes.schedule[0].Digest()
+	require.True(suite.T(), strings.Contains(string(changes.Schedule[0].Instances[0]), "barDecoded"))
+	newConfigDigest := changes.Schedule[0].Digest()
 
 	inputDelConfig := deepcopy.Copy(nonTemplateConfigWithSecrets).(integration.Config)
 	changes = suite.cm.processDelConfigs([]integration.Config{inputDelConfig})
-	assertConfigsMatch(suite.T(), changes.schedule)
-	assertConfigsMatch(suite.T(), changes.unschedule, matchName(nonTemplateConfigWithSecrets.Name))
-	assertConfigsMatch(suite.T(), changes.unschedule, matchDigest(newConfigDigest))
-	require.True(suite.T(), strings.Contains(string(changes.unschedule[0].Instances[0]), "barDecoded"))
+	assertConfigsMatch(suite.T(), changes.Schedule)
+	assertConfigsMatch(suite.T(), changes.Unschedule, matchName(nonTemplateConfigWithSecrets.Name))
+	assertConfigsMatch(suite.T(), changes.Unschedule, matchDigest(newConfigDigest))
+	require.True(suite.T(), strings.Contains(string(changes.Unschedule[0].Instances[0]), "barDecoded"))
 }
 
 // A new template config is not scheduled when there is no matching service, and
 // not unscheduled when removed
 func (suite *ConfigManagerSuite) TestNewTemplateNotScheduled() {
 	changes := suite.cm.processNewConfig(templateConfig)
-	assertConfigsMatch(suite.T(), changes.schedule)
-	assertConfigsMatch(suite.T(), changes.unschedule)
+	assertConfigsMatch(suite.T(), changes.Schedule)
+	assertConfigsMatch(suite.T(), changes.Unschedule)
 
 	changes = suite.cm.processDelConfigs([]integration.Config{templateConfig})
-	assertConfigsMatch(suite.T(), changes.schedule)
-	assertConfigsMatch(suite.T(), changes.unschedule)
+	assertConfigsMatch(suite.T(), changes.Schedule)
+	assertConfigsMatch(suite.T(), changes.Unschedule)
 }
 
 // A new template config is not scheduled when there is no matching service, but
@@ -179,20 +179,20 @@ func (suite *ConfigManagerSuite) TestNewTemplateNotScheduled() {
 // unschedules the resolved configs.
 func (suite *ConfigManagerSuite) TestNewTemplateBeforeService_ConfigRemovedFirst() {
 	changes := suite.cm.processNewConfig(templateConfig)
-	assertConfigsMatch(suite.T(), changes.schedule)
-	assertConfigsMatch(suite.T(), changes.unschedule)
+	assertConfigsMatch(suite.T(), changes.Schedule)
+	assertConfigsMatch(suite.T(), changes.Unschedule)
 
 	changes = suite.cm.processNewService(myService.ADIdentifiers, myService)
-	assertConfigsMatch(suite.T(), changes.schedule, matchAll(matchName("template"), matchLogsConfig("source: myhost\n")))
-	assertConfigsMatch(suite.T(), changes.unschedule)
+	assertConfigsMatch(suite.T(), changes.Schedule, matchAll(matchName("template"), matchLogsConfig("source: myhost\n")))
+	assertConfigsMatch(suite.T(), changes.Unschedule)
 
 	changes = suite.cm.processDelConfigs([]integration.Config{templateConfig})
-	assertConfigsMatch(suite.T(), changes.schedule)
-	assertConfigsMatch(suite.T(), changes.unschedule, matchAll(matchName("template"), matchLogsConfig("source: myhost\n")))
+	assertConfigsMatch(suite.T(), changes.Schedule)
+	assertConfigsMatch(suite.T(), changes.Unschedule, matchAll(matchName("template"), matchLogsConfig("source: myhost\n")))
 
 	changes = suite.cm.processDelService(context.TODO(), myService)
-	assertConfigsMatch(suite.T(), changes.schedule)
-	assertConfigsMatch(suite.T(), changes.unschedule)
+	assertConfigsMatch(suite.T(), changes.Schedule)
+	assertConfigsMatch(suite.T(), changes.Unschedule)
 }
 
 // A new template config is not scheduled when there is no matching service, but
@@ -200,20 +200,20 @@ func (suite *ConfigManagerSuite) TestNewTemplateBeforeService_ConfigRemovedFirst
 // unschedules the resolved configs.
 func (suite *ConfigManagerSuite) TestNewTemplateBeforeService_ServiceRemovedFirst() {
 	changes := suite.cm.processNewConfig(templateConfig)
-	assertConfigsMatch(suite.T(), changes.schedule)
-	assertConfigsMatch(suite.T(), changes.unschedule)
+	assertConfigsMatch(suite.T(), changes.Schedule)
+	assertConfigsMatch(suite.T(), changes.Unschedule)
 
 	changes = suite.cm.processNewService(myService.ADIdentifiers, myService)
-	assertConfigsMatch(suite.T(), changes.schedule, matchAll(matchName("template"), matchLogsConfig("source: myhost\n")))
-	assertConfigsMatch(suite.T(), changes.unschedule)
+	assertConfigsMatch(suite.T(), changes.Schedule, matchAll(matchName("template"), matchLogsConfig("source: myhost\n")))
+	assertConfigsMatch(suite.T(), changes.Unschedule)
 
 	changes = suite.cm.processDelService(context.TODO(), myService)
-	assertConfigsMatch(suite.T(), changes.schedule)
-	assertConfigsMatch(suite.T(), changes.unschedule, matchAll(matchName("template"), matchLogsConfig("source: myhost\n")))
+	assertConfigsMatch(suite.T(), changes.Schedule)
+	assertConfigsMatch(suite.T(), changes.Unschedule, matchAll(matchName("template"), matchLogsConfig("source: myhost\n")))
 
 	changes = suite.cm.processDelConfigs([]integration.Config{templateConfig})
-	assertConfigsMatch(suite.T(), changes.schedule)
-	assertConfigsMatch(suite.T(), changes.unschedule)
+	assertConfigsMatch(suite.T(), changes.Schedule)
+	assertConfigsMatch(suite.T(), changes.Unschedule)
 }
 
 // A new service is not scheduled when there is no matching template, but
@@ -221,20 +221,20 @@ func (suite *ConfigManagerSuite) TestNewTemplateBeforeService_ServiceRemovedFirs
 // unschedules the resolved configs.
 func (suite *ConfigManagerSuite) TestNewServiceBeforeTemplate_ConfigRemovedFirst() {
 	changes := suite.cm.processNewService(myService.ADIdentifiers, myService)
-	assertConfigsMatch(suite.T(), changes.schedule)
-	assertConfigsMatch(suite.T(), changes.unschedule)
+	assertConfigsMatch(suite.T(), changes.Schedule)
+	assertConfigsMatch(suite.T(), changes.Unschedule)
 
 	changes = suite.cm.processNewConfig(templateConfig)
-	assertConfigsMatch(suite.T(), changes.schedule, matchAll(matchName("template"), matchLogsConfig("source: myhost\n")))
-	assertConfigsMatch(suite.T(), changes.unschedule)
+	assertConfigsMatch(suite.T(), changes.Schedule, matchAll(matchName("template"), matchLogsConfig("source: myhost\n")))
+	assertConfigsMatch(suite.T(), changes.Unschedule)
 
 	changes = suite.cm.processDelConfigs([]integration.Config{templateConfig})
-	assertConfigsMatch(suite.T(), changes.schedule)
-	assertConfigsMatch(suite.T(), changes.unschedule, matchAll(matchName("template"), matchLogsConfig("source: myhost\n")))
+	assertConfigsMatch(suite.T(), changes.Schedule)
+	assertConfigsMatch(suite.T(), changes.Unschedule, matchAll(matchName("template"), matchLogsConfig("source: myhost\n")))
 
 	changes = suite.cm.processDelService(context.TODO(), myService)
-	assertConfigsMatch(suite.T(), changes.schedule)
-	assertConfigsMatch(suite.T(), changes.unschedule)
+	assertConfigsMatch(suite.T(), changes.Schedule)
+	assertConfigsMatch(suite.T(), changes.Unschedule)
 }
 
 // A new service is not scheduled when there is no matching template, but
@@ -242,20 +242,20 @@ func (suite *ConfigManagerSuite) TestNewServiceBeforeTemplate_ConfigRemovedFirst
 // unschedules the resolved configs.
 func (suite *ConfigManagerSuite) TestNewServiceBeforeTemplate_ServiceRemovedFirst() {
 	changes := suite.cm.processNewService(myService.ADIdentifiers, myService)
-	assertConfigsMatch(suite.T(), changes.schedule)
-	assertConfigsMatch(suite.T(), changes.unschedule)
+	assertConfigsMatch(suite.T(), changes.Schedule)
+	assertConfigsMatch(suite.T(), changes.Unschedule)
 
 	changes = suite.cm.processNewConfig(templateConfig)
-	assertConfigsMatch(suite.T(), changes.schedule, matchAll(matchName("template"), matchLogsConfig("source: myhost\n")))
-	assertConfigsMatch(suite.T(), changes.unschedule)
+	assertConfigsMatch(suite.T(), changes.Schedule, matchAll(matchName("template"), matchLogsConfig("source: myhost\n")))
+	assertConfigsMatch(suite.T(), changes.Unschedule)
 
 	changes = suite.cm.processDelService(context.TODO(), myService)
-	assertConfigsMatch(suite.T(), changes.schedule)
-	assertConfigsMatch(suite.T(), changes.unschedule, matchAll(matchName("template"), matchLogsConfig("source: myhost\n")))
+	assertConfigsMatch(suite.T(), changes.Schedule)
+	assertConfigsMatch(suite.T(), changes.Unschedule, matchAll(matchName("template"), matchLogsConfig("source: myhost\n")))
 
 	changes = suite.cm.processDelConfigs([]integration.Config{templateConfig})
-	assertConfigsMatch(suite.T(), changes.schedule)
-	assertConfigsMatch(suite.T(), changes.unschedule)
+	assertConfigsMatch(suite.T(), changes.Schedule)
+	assertConfigsMatch(suite.T(), changes.Unschedule)
 }
 
 // Fuzz the config manager to ensure it doesn't "leak" configs -- that schedule
@@ -269,8 +269,8 @@ func (suite *ConfigManagerSuite) TestFuzz() {
 		scheduled := map[string]struct{}{} // currently-scheduled config digests
 
 		// apply the given changes, checking for double-schedules and double-unschedules
-		applyChanges := func(changes configChanges) {
-			for _, cfg := range changes.unschedule {
+		applyChanges := func(changes integration.ConfigChanges) {
+			for _, cfg := range changes.Unschedule {
 				digest := cfg.Digest()
 				fmt.Printf("unschedule config %s -- Name: %#v, ADIdentifiers: [%s], ServiceID: %#v\n",
 					digest, cfg.Name, strings.Join(cfg.ADIdentifiers, ", "), cfg.ServiceID)
@@ -279,7 +279,7 @@ func (suite *ConfigManagerSuite) TestFuzz() {
 				}
 				delete(scheduled, digest)
 			}
-			for _, cfg := range changes.schedule {
+			for _, cfg := range changes.Schedule {
 				digest := cfg.Digest()
 				fmt.Printf("schedule config %s -- Name: %#v, ADIdentifiers: [%s], ServiceID: %#v\n",
 					digest, cfg.Name, strings.Join(cfg.ADIdentifiers, ", "), cfg.ServiceID)
@@ -435,31 +435,31 @@ func (suite *ReconcilingConfigManagerSuite) TestServiceTemplateFiltering() {
 
 	// adding service with no templates has no effect
 	changes := suite.cm.processNewService(myService.ADIdentifiers, myService)
-	assertConfigsMatch(suite.T(), changes.schedule)
-	assertConfigsMatch(suite.T(), changes.unschedule)
+	assertConfigsMatch(suite.T(), changes.Schedule)
+	assertConfigsMatch(suite.T(), changes.Unschedule)
 	assertLoadedConfigsMatch(suite.T(), suite.cm)
 
 	// adding service with no templates has no effect
 	changes = suite.cm.processNewService(filterSvc.ADIdentifiers, filterSvc)
-	assertConfigsMatch(suite.T(), changes.schedule)
-	assertConfigsMatch(suite.T(), changes.unschedule)
+	assertConfigsMatch(suite.T(), changes.Schedule)
+	assertConfigsMatch(suite.T(), changes.Unschedule)
 	assertLoadedConfigsMatch(suite.T(), suite.cm)
 
 	// adding a template that does not end in -keep only matches my-service
 	cfg1 := integration.Config{Name: "cfg1", ADIdentifiers: []string{"my-service", "filter"}}
 	changes = suite.cm.processNewConfig(cfg1)
-	assertConfigsMatch(suite.T(), changes.schedule, matchAll(matchName("cfg1"), matchSvc("my-service")))
-	assertConfigsMatch(suite.T(), changes.unschedule)
+	assertConfigsMatch(suite.T(), changes.Schedule, matchAll(matchName("cfg1"), matchSvc("my-service")))
+	assertConfigsMatch(suite.T(), changes.Unschedule)
 	assertLoadedConfigsMatch(suite.T(), suite.cm, matchAll(matchName("cfg1"), matchSvc("my-service")))
 
 	// adding a template that ends in -keep matches both services
 	cfg2 := integration.Config{Name: "cfg2-keep", ADIdentifiers: []string{"my-service", "filter"}}
 	changes = suite.cm.processNewConfig(cfg2)
-	assertConfigsMatch(suite.T(), changes.schedule,
+	assertConfigsMatch(suite.T(), changes.Schedule,
 		matchAll(matchName("cfg2-keep"), matchSvc("my-service")),
 		matchAll(matchName("cfg2-keep"), matchSvc("filter")),
 	)
-	assertConfigsMatch(suite.T(), changes.unschedule)
+	assertConfigsMatch(suite.T(), changes.Unschedule)
 	assertLoadedConfigsMatch(suite.T(), suite.cm,
 		matchAll(matchName("cfg1"), matchSvc("my-service")),
 		matchAll(matchName("cfg2-keep"), matchSvc("my-service")),
@@ -468,8 +468,8 @@ func (suite *ReconcilingConfigManagerSuite) TestServiceTemplateFiltering() {
 
 	// removing a service removes only the scheduled configs
 	changes = suite.cm.processDelService(context.TODO(), filterSvc)
-	assertConfigsMatch(suite.T(), changes.schedule)
-	assertConfigsMatch(suite.T(), changes.unschedule, matchAll(matchName("cfg2-keep"), matchSvc("filter")))
+	assertConfigsMatch(suite.T(), changes.Schedule)
+	assertConfigsMatch(suite.T(), changes.Unschedule, matchAll(matchName("cfg2-keep"), matchSvc("filter")))
 	assertLoadedConfigsMatch(suite.T(), suite.cm,
 		matchAll(matchName("cfg1"), matchSvc("my-service")),
 		matchAll(matchName("cfg2-keep"), matchSvc("my-service")),

--- a/pkg/autodiscovery/integration/config.go
+++ b/pkg/autodiscovery/integration/config.go
@@ -464,3 +464,15 @@ func (c *Config) Dump(multiline bool) string {
 	fmt.Fprintf(&b, ws("LogsExcluded: %t} (digest %s)"), c.LogsExcluded, c.Digest())
 	return b.String()
 }
+
+// ConfigChanges contains the changes that occurred due to an event in
+// AutoDiscovery.
+type ConfigChanges struct {
+	// Schedule contains configs that should be scheduled as a result of
+	// this event.
+	Schedule []Config
+
+	// Unschedule contains configs that should be unscheduled as a result of
+	// this event.
+	Unschedule []Config
+}

--- a/pkg/autodiscovery/integration/config.go
+++ b/pkg/autodiscovery/integration/config.go
@@ -476,3 +476,24 @@ type ConfigChanges struct {
 	// this event.
 	Unschedule []Config
 }
+
+// ScheduleConfig adds a config to `Schedule`
+func (c *ConfigChanges) ScheduleConfig(config Config) {
+	c.Schedule = append(c.Schedule, config)
+}
+
+// UnscheduleConfig adds a config to `Unschedule`
+func (c *ConfigChanges) UnscheduleConfig(config Config) {
+	c.Unschedule = append(c.Unschedule, config)
+}
+
+// IsEmpty determines whether this set of changes is empty
+func (c *ConfigChanges) IsEmpty() bool {
+	return len(c.Schedule) == 0 && len(c.Unschedule) == 0
+}
+
+// Merge merges the given ConfigChanges into this one.
+func (c *ConfigChanges) Merge(other ConfigChanges) {
+	c.Schedule = append(c.Schedule, other.Schedule...)
+	c.Unschedule = append(c.Unschedule, other.Unschedule...)
+}

--- a/pkg/autodiscovery/providers/kubecontainer.go
+++ b/pkg/autodiscovery/providers/kubecontainer.go
@@ -168,6 +168,11 @@ func (k *KubeContainerConfigProvider) generateConfig(e workloadmeta.Entity) ([]i
 		containerEntityName := containers.BuildEntityName(string(entity.Runtime), containerID)
 		configs, errs = utils.ExtractTemplatesFromContainerLabels(containerEntityName, entity.Labels)
 
+		// AddContainerCollectAllConfigs is only needed when handling
+		// the container event, even when the container belongs to a
+		// pod. Calling it when handling the KubernetesPod will always
+		// result in a duplicated config, as each KubernetesPod will
+		// also generate events for each of its containers.
 		configs = utils.AddContainerCollectAllConfigs(configs, containerEntityName)
 
 		for idx := range configs {
@@ -204,8 +209,6 @@ func (k *KubeContainerConfigProvider) generateConfig(e workloadmeta.Entity) ([]i
 					continue
 				}
 			}
-
-			c = utils.AddContainerCollectAllConfigs(c, containerEntity)
 
 			containerIdentifiers[adIdentifier] = struct{}{}
 			containerNames[podContainer.Name] = struct{}{}

--- a/pkg/autodiscovery/providers/kubecontainer.go
+++ b/pkg/autodiscovery/providers/kubecontainer.go
@@ -11,16 +11,12 @@ package providers
 import (
 	"context"
 	"fmt"
-	"strings"
 	"sync"
-	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/common/utils"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers/names"
-	"github.com/DataDog/datadog-agent/pkg/autodiscovery/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
@@ -33,13 +29,9 @@ import (
 // `ContainerConfigProvider`
 type KubeContainerConfigProvider struct {
 	workloadmetaStore workloadmeta.Store
-	podCache          map[string]*workloadmeta.KubernetesPod
-	containerCache    map[string]*workloadmeta.Container
 	configErrors      map[string]ErrorMsgSet
-	upToDate          bool
-	streaming         bool
-	once              sync.Once
-	sync.RWMutex
+	configCache       map[string]map[string]integration.Config
+	mu                sync.RWMutex
 }
 
 // NewKubeContainerConfigProvider returns a new ConfigProvider subscribed to both container
@@ -47,9 +39,8 @@ type KubeContainerConfigProvider struct {
 func NewKubeContainerConfigProvider(*config.ConfigurationProviders) (ConfigProvider, error) {
 	return &KubeContainerConfigProvider{
 		workloadmetaStore: workloadmeta.GetGlobalStore(),
+		configCache:       make(map[string]map[string]integration.Config),
 		configErrors:      make(map[string]ErrorMsgSet),
-		podCache:          make(map[string]*workloadmeta.KubernetesPod),
-		containerCache:    make(map[string]*workloadmeta.Container),
 	}, nil
 }
 
@@ -58,212 +49,157 @@ func (k *KubeContainerConfigProvider) String() string {
 	return names.KubeContainer
 }
 
-// Collect retrieves all running pods and extract AD templates from their annotations.
+// Collect is not implemented
 func (k *KubeContainerConfigProvider) Collect(ctx context.Context) ([]integration.Config, error) {
-	k.once.Do(func() {
-		go k.listen()
-	})
-
-	k.Lock()
-	k.upToDate = true
-	k.Unlock()
-
-	return k.generateConfigs()
+	return nil, nil
 }
 
-func (k *KubeContainerConfigProvider) listen() {
+// Stream starts listening to workloadmeta to generate configs as they come
+// instead of relying on a periodic call to Collect.
+func (k *KubeContainerConfigProvider) Stream(ctx context.Context) <-chan integration.ConfigChanges {
 	const name = "ad-kubecontainerprovider"
 
-	k.Lock()
-	k.streaming = true
-	health := health.RegisterLiveness(name)
-	defer func() {
-		err := health.Deregister()
-		if err != nil {
-			log.Warnf("error de-registering health check: %s", err)
-		}
-	}()
-	k.Unlock()
+	outCh := make(chan integration.ConfigChanges)
 
-	ch := k.workloadmetaStore.Subscribe(name, workloadmeta.NormalPriority, workloadmeta.NewFilter(
+	inCh := k.workloadmetaStore.Subscribe(name, workloadmeta.ConfigProviderPriority, workloadmeta.NewFilter(
 		[]workloadmeta.Kind{workloadmeta.KindKubernetesPod, workloadmeta.KindContainer},
 		workloadmeta.SourceAll,
 		workloadmeta.EventTypeAll,
 	))
 
-	for {
-		select {
-		case evBundle, ok := <-ch:
-			if !ok {
-				return
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				k.workloadmetaStore.Unsubscribe(inCh)
+
+			case evBundle, ok := <-inCh:
+				if !ok {
+					return
+				}
+
+				outCh <- k.processEvents(evBundle)
+
+				close(evBundle.Ch)
 			}
-
-			k.processEvents(evBundle)
-
-		case <-health.C:
-
 		}
-	}
+	}()
+
+	return outCh
 }
 
-func (k *KubeContainerConfigProvider) processEvents(evBundle workloadmeta.EventBundle) {
-	close(evBundle.Ch)
+func (k *KubeContainerConfigProvider) processEvents(evBundle workloadmeta.EventBundle) integration.ConfigChanges {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+
+	changes := integration.ConfigChanges{}
 
 	for _, event := range evBundle.Events {
+		configID := buildConfigID(event.Entity.GetID())
+
 		switch event.Type {
 		case workloadmeta.EventTypeSet:
-			k.addEntity(event.Entity)
+			configs, err := k.generateConfig(event.Entity)
+
+			k.configErrors[configID] = err
+
+			configsToAdd := make(map[string]integration.Config)
+			for _, config := range configs {
+				configsToAdd[config.Digest()] = config
+			}
+
+			oldConfigs, found := k.configCache[configID]
+			if found {
+				for digest, config := range oldConfigs {
+					_, ok := configsToAdd[digest]
+					if ok {
+						delete(configsToAdd, digest)
+					} else {
+						delete(k.configCache[configID], digest)
+						changes.Unschedule = append(changes.Unschedule, config)
+					}
+				}
+			} else {
+				k.configCache[configID] = configsToAdd
+			}
+
+			for _, config := range configsToAdd {
+				changes.Schedule = append(changes.Schedule, config)
+			}
+
 		case workloadmeta.EventTypeUnset:
-			k.deleteEntity(event.Entity)
+			oldConfigs, found := k.configCache[configID]
+			if !found {
+				log.Debugf("entity %q removed from workloadmeta store but not found in cache. skipping", configID)
+				continue
+			}
+
+			for _, oldConfig := range oldConfigs {
+				changes.Unschedule = append(changes.Unschedule, oldConfig)
+			}
+
+			delete(k.configCache, configID)
+			delete(k.configErrors, configID)
 
 		default:
 			log.Errorf("cannot handle event of type %d", event.Type)
 		}
 	}
+
+	return changes
 }
 
-func (k *KubeContainerConfigProvider) addEntity(entity workloadmeta.Entity) {
-	switch e := entity.(type) {
-	case *workloadmeta.KubernetesPod:
-		k.addPod(e)
+func (k *KubeContainerConfigProvider) generateConfig(e workloadmeta.Entity) ([]integration.Config, ErrorMsgSet) {
+	var (
+		errMsgSet ErrorMsgSet
+		errs      []error
+		configs   []integration.Config
+	)
+
+	switch entity := e.(type) {
 	case *workloadmeta.Container:
-		k.RLock()
-		_, containerSeen := k.containerCache[e.ID]
-		k.RUnlock()
-		if containerSeen {
-			// This is for short-lived detection, see `deleteEntity`.
-			//
-			// If we get a 'start' event for a container we've seen before,
-			// then it is likely (guaranteed?) that we saw a 'delete' event before this.
-			//
-			// The containerCache entry is still present which means that the
-			// deletion is currently "pending" and the actual deletion will occur in the
-			// the future, specifically in [0, delayDuration) amount of time.
-			// To guarantee our 'add' operation is processed _after_ the deletion occurs,
-			// set delay for 'delayDuration'
-			time.AfterFunc(delayDuration, func() {
-				k.addContainer(e)
-			})
-		} else {
-			k.addContainer(e)
+		containerID := entity.GetID().ID
+		containerEntityName := containers.BuildEntityName(string(entity.Runtime), containerID)
+		configs, errs = utils.ExtractTemplatesFromContainerLabels(containerEntityName, entity.Labels)
+
+		configs = utils.AddContainerCollectAllConfigs(configs, containerEntityName)
+
+		for idx := range configs {
+			configs[idx].Source = names.Container + ":" + containerEntityName
 		}
 
-	}
-}
-
-func (k *KubeContainerConfigProvider) addPod(p *workloadmeta.KubernetesPod) {
-	k.Lock()
-	defer k.Unlock()
-	id := p.GetID().ID
-	k.podCache[id] = p
-	log.Debugf("Adding entity pod with ID %s\n", id)
-	k.upToDate = false
-}
-
-func (k *KubeContainerConfigProvider) addContainer(c *workloadmeta.Container) {
-	k.Lock()
-	defer k.Unlock()
-	k.containerCache[c.ID] = c
-	log.Debugf("Adding entity container with ID %s\n", c.ID)
-	k.upToDate = false
-}
-
-func (k *KubeContainerConfigProvider) deleteEntity(entity workloadmeta.Entity) {
-	switch e := entity.(type) {
 	case *workloadmeta.KubernetesPod:
-		k.deletePod(e)
-	case *workloadmeta.Container:
-		// Delay for short-lived detection
-		time.AfterFunc(delayDuration, func() {
-			k.deleteContainer(e)
-		})
-	}
-}
-
-func (k *KubeContainerConfigProvider) deletePod(p *workloadmeta.KubernetesPod) {
-	k.Lock()
-	defer k.Unlock()
-	delete(k.podCache, p.GetID().ID)
-	log.Debugf("Deleting entity pod with ID %s\n", p.GetID().ID)
-	k.upToDate = false
-}
-
-func (k *KubeContainerConfigProvider) deleteContainer(c *workloadmeta.Container) {
-	k.Lock()
-	defer k.Unlock()
-	log.Debugf("Deleting entity container with ID %s\n", c.ID)
-	delete(k.containerCache, c.ID)
-	k.upToDate = false
-}
-
-func (k *KubeContainerConfigProvider) generateConfigs() ([]integration.Config, error) {
-	k.Lock()
-	defer k.Unlock()
-
-	adErrors := make(map[string]ErrorMsgSet)
-
-	configs := make([]integration.Config, 0, len(k.containerCache))
-
-	log.Debugf("Generating Configs for %d containers\n", len(k.containerCache))
-	for containerID, container := range k.containerCache {
-		containerEntityName := containers.BuildEntityName(string(container.Runtime), containerID)
-		c, errors := utils.ExtractTemplatesFromContainerLabels(containerEntityName, container.Labels)
-
-		for _, err := range errors {
-			adErrors[containerEntityName] = map[string]struct{}{err.Error(): {}}
-			log.Errorf("Can't parse template for container %s: %s", containerID, err)
-		}
-
-		c = utils.AddContainerCollectAllConfigs(c, containerEntityName)
-
-		for idx := range c {
-			c[idx].Source = names.Container + ":" + containerEntityName
-		}
-
-		configs = append(configs, c...)
-	}
-
-	log.Debugf("Generating Configs for %d pods\n", len(k.podCache))
-	for _, pod := range k.podCache {
-		var errs []error
 		containerIdentifiers := map[string]struct{}{}
 		containerNames := map[string]struct{}{}
-		for _, podContainer := range pod.Containers {
+		for _, podContainer := range entity.Containers {
 			container, err := k.workloadmetaStore.GetContainer(podContainer.ID)
 			if err != nil {
-				log.Debugf("Pod %q has reference to non-existing container %q", pod.Name, podContainer.ID)
+				log.Debugf("Pod %q has reference to non-existing container %q", entity.Name, podContainer.ID)
 				continue
 			}
 
 			adIdentifier := podContainer.Name
-			if customADID, found := utils.ExtractCheckIDFromPodAnnotations(pod.Annotations, podContainer.Name); found {
+			if customADID, found := utils.ExtractCheckIDFromPodAnnotations(entity.Annotations, podContainer.Name); found {
 				adIdentifier = customADID
 			}
 
 			containerEntity := containers.BuildEntityName(string(container.Runtime), container.ID)
 			c, errors := utils.ExtractTemplatesFromPodAnnotations(
 				containerEntity,
-				pod.Annotations,
+				entity.Annotations,
 				adIdentifier,
 			)
 
 			if len(errors) > 0 {
-				for _, err := range errors {
-					log.Errorf("Can't parse template for pod %s: %s", pod.Name, err)
-					errs = append(errs, err)
-				}
+				errs = append(errs, errors...)
 				if len(c) == 0 {
-					// Only got errors, no valid configs so let's move on to the next container.
+					// Only got errors, no valid configs so
+					// let's move on to the next container.
 					continue
 				}
 			}
 
-			_, trackedByContainer := k.containerCache[podContainer.ID]
-			if !trackedByContainer {
-				c = utils.AddContainerCollectAllConfigs(c, containerEntity)
-			} else {
-				log.Debugf("Pod %q has container %q, however container is tracked by containerCache, skipping log config creation...", pod.Name, podContainer.ID)
-			}
+			c = utils.AddContainerCollectAllConfigs(c, containerEntity)
 
 			containerIdentifiers[adIdentifier] = struct{}{}
 			containerNames[podContainer.Name] = struct{}{}
@@ -276,36 +212,28 @@ func (k *KubeContainerConfigProvider) generateConfigs() ([]integration.Config, e
 		}
 
 		errs = append(errs, utils.ValidateAnnotationsMatching(
-			pod.Annotations,
+			entity.Annotations,
 			containerIdentifiers,
 			containerNames)...)
 
-		namespacedName := pod.Namespace + "/" + pod.Name
+	default:
+		log.Errorf("cannot handle entity of kind %s", e.GetID().Kind)
+	}
+
+	if len(errs) > 0 {
+		errMsgSet = make(ErrorMsgSet)
 		for _, err := range errs {
-			if _, found := adErrors[namespacedName]; !found {
-				adErrors[namespacedName] = map[string]struct{}{err.Error(): {}}
-			} else {
-				adErrors[namespacedName][err.Error()] = struct{}{}
-			}
+			errMsgSet[err.Error()] = struct{}{}
 		}
 	}
 
-	bldr := strings.Builder{}
-	for _, c := range configs {
-		fmt.Fprintf(&bldr, "  %s %s %s\n", c.Name, c.Source, c.Digest())
-	}
-	log.Debugf("KubeContainerConfigProvider#generateConfigs generated:\n%s", bldr.String())
-
-	k.configErrors = adErrors
-	telemetry.Errors.Set(float64(len(adErrors)), names.KubeContainer)
-
-	return configs, nil
+	return configs, errMsgSet
 }
 
 // GetConfigErrors returns a map of configuration errors for each namespace/pod
 func (k *KubeContainerConfigProvider) GetConfigErrors() map[string]ErrorMsgSet {
-	k.RLock()
-	defer k.RUnlock()
+	k.mu.RLock()
+	defer k.mu.RUnlock()
 	return k.configErrors
 }
 
@@ -313,9 +241,11 @@ func (k *KubeContainerConfigProvider) GetConfigErrors() map[string]ErrorMsgSet {
 // received by the listen goroutine. If listening fails, we fallback to
 // collecting everytime.
 func (k *KubeContainerConfigProvider) IsUpToDate(ctx context.Context) (bool, error) {
-	k.RLock()
-	defer k.RUnlock()
-	return k.streaming && k.upToDate, nil
+	return true, nil
+}
+
+func buildConfigID(entityID workloadmeta.EntityID) string {
+	return fmt.Sprintf("%s://%s", entityID.Kind, entityID.ID)
 }
 
 func init() {

--- a/pkg/autodiscovery/providers/kubecontainer_test.go
+++ b/pkg/autodiscovery/providers/kubecontainer_test.go
@@ -9,67 +9,100 @@
 package providers
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 	workloadmetatesting "github.com/DataDog/datadog-agent/pkg/workloadmeta/testing"
 )
 
-// Only testing generateConfigs, lifecycle should be tested in end-to-end test
+func TestProcessEvents(t *testing.T) {
+	store := workloadmetatesting.NewStore()
 
-func TestGenerateConfigs_KubeContainer_ContainerSpecific(t *testing.T) {
-	configProvider := KubeContainerConfigProvider{
-		containerCache: map[string]*workloadmeta.Container{
-			"nolabels": {
-				Runtime: workloadmeta.ContainerRuntimeContainerd,
-			},
-			"3b8efe0c50e8": {
-				EntityMeta: workloadmeta.EntityMeta{
-					Labels: map[string]string{
-						"com.datadoghq.ad.check_names":  "[\"apache\",\"http_check\"]",
-						"com.datadoghq.ad.init_configs": "[{}, {}]",
-						"com.datadoghq.ad.instances":    "[{\"apache_status_url\": \"http://%%host%%/server-status?auto\"},{\"name\": \"My service\", \"url\": \"http://%%host%%\", \"timeout\": 1}]",
-					},
+	cp := &KubeContainerConfigProvider{
+		workloadmetaStore: store,
+		configCache:       make(map[string]map[string]integration.Config),
+		configErrors:      make(map[string]ErrorMsgSet),
+	}
+
+	tests := []struct {
+		name    string
+		events  []workloadmeta.Event
+		changes integration.ConfigChanges
+	}{
+		{
+			name: "create config",
+			events: []workloadmeta.Event{
+				{
+					Type:   workloadmeta.EventTypeSet,
+					Entity: basicDockerContainer(),
 				},
-				Runtime: workloadmeta.ContainerRuntimeDocker,
+			},
+			changes: integration.ConfigChanges{
+				Schedule: basicDockerConfigs(),
+			},
+		},
+		{
+			name: "replace config",
+			events: []workloadmeta.Event{
+				{
+					Type:   workloadmeta.EventTypeSet,
+					Entity: basicDockerContainerSingleCheck(),
+				},
+			},
+			changes: integration.ConfigChanges{
+				Unschedule: []integration.Config{
+					basicDockerConfigs()[1],
+				},
+			},
+		},
+		{
+			name: "delete config",
+			events: []workloadmeta.Event{
+				{
+					Type:   workloadmeta.EventTypeUnset,
+					Entity: basicDockerContainer(),
+				},
+			},
+			changes: integration.ConfigChanges{
+				Unschedule: []integration.Config{
+					basicDockerConfigs()[0],
+				},
 			},
 		},
 	}
 
-	checks, err := configProvider.generateConfigs()
-	assert.Nil(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			changes := cp.processEvents(workloadmeta.EventBundle{
+				Events: tt.events,
+			})
 
-	assert.Len(t, checks, 2)
-
-	assert.Equal(t, []string{"docker://3b8efe0c50e8"}, checks[0].ADIdentifiers)
-	assert.Equal(t, "{}", string(checks[0].InitConfig))
-	assert.Equal(t, "container:docker://3b8efe0c50e8", checks[0].Source)
-	assert.Len(t, checks[0].Instances, 1)
-	assert.Equal(t, "{\"apache_status_url\":\"http://%%host%%/server-status?auto\"}", string(checks[0].Instances[0]))
-	assert.Equal(t, "apache", checks[0].Name)
-
-	assert.Equal(t, []string{"docker://3b8efe0c50e8"}, checks[1].ADIdentifiers)
-	assert.Equal(t, "{}", string(checks[1].InitConfig))
-	assert.Equal(t, "container:docker://3b8efe0c50e8", checks[1].Source)
-	assert.Len(t, checks[1].Instances, 1)
-	assert.Equal(t, "{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}", string(checks[1].Instances[0]))
-	assert.Equal(t, "http_check", checks[1].Name)
+			assert.ElementsMatch(t, tt.changes.Schedule, changes.Schedule)
+			assert.ElementsMatch(t, tt.changes.Unschedule, changes.Unschedule)
+		})
+	}
 }
 
-func TestGenerateConfigs_KubeContainer_KubeSpecific(t *testing.T) {
-	for nb, tc := range []struct {
-		desc        string
-		pod         *workloadmeta.KubernetesPod
-		expectedCfg []integration.Config
-		expectedErr ErrorMsgSet
+func TestGenerateConfig(t *testing.T) {
+	tests := []struct {
+		name                string
+		entity              workloadmeta.Entity
+		expectedConfigs     []integration.Config
+		expectedErr         ErrorMsgSet
+		containerCollectAll bool
 	}{
 		{
-			desc: "No annotations",
-			pod: &workloadmeta.KubernetesPod{
+			name:            "container check",
+			entity:          basicDockerContainer(),
+			expectedConfigs: basicDockerConfigs(),
+		},
+		{
+			name: "No annotations",
+			entity: &workloadmeta.KubernetesPod{
 				Containers: []workloadmeta.OrchestratorContainer{
 					{
 						Name: "testName",
@@ -77,12 +110,10 @@ func TestGenerateConfigs_KubeContainer_KubeSpecific(t *testing.T) {
 					},
 				},
 			},
-			expectedCfg: []integration.Config{},
-			expectedErr: nil,
 		},
 		{
-			desc: "v2 annotations",
-			pod: &workloadmeta.KubernetesPod{
+			name: "v2 annotations",
+			entity: &workloadmeta.KubernetesPod{
 				EntityMeta: workloadmeta.EntityMeta{
 					Annotations: map[string]string{
 						"ad.datadoghq.com/apache.checks": `{
@@ -108,7 +139,7 @@ func TestGenerateConfigs_KubeContainer_KubeSpecific(t *testing.T) {
 					},
 				},
 			},
-			expectedCfg: []integration.Config{
+			expectedConfigs: []integration.Config{
 				{
 					Name:          "http_check",
 					ADIdentifiers: []string{"docker://3b8efe0c50e8"},
@@ -120,8 +151,8 @@ func TestGenerateConfigs_KubeContainer_KubeSpecific(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
-			desc: "New + old, new takes over",
-			pod: &workloadmeta.KubernetesPod{
+			name: "New + old, new takes over",
+			entity: &workloadmeta.KubernetesPod{
 				EntityMeta: workloadmeta.EntityMeta{
 					Annotations: map[string]string{
 						"ad.datadoghq.com/apache.check_names":                 "[\"http_check\"]",
@@ -139,7 +170,7 @@ func TestGenerateConfigs_KubeContainer_KubeSpecific(t *testing.T) {
 					},
 				},
 			},
-			expectedCfg: []integration.Config{
+			expectedConfigs: []integration.Config{
 				{
 					Name:          "http_check",
 					ADIdentifiers: []string{"docker://3b8efe0c50e8"},
@@ -151,8 +182,8 @@ func TestGenerateConfigs_KubeContainer_KubeSpecific(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
-			desc: "New annotation prefix, two templates",
-			pod: &workloadmeta.KubernetesPod{
+			name: "New annotation prefix, two templates",
+			entity: &workloadmeta.KubernetesPod{
 				EntityMeta: workloadmeta.EntityMeta{
 					Annotations: map[string]string{
 						"ad.datadoghq.com/apache.check_names":  "[\"http_check\"]",
@@ -174,7 +205,7 @@ func TestGenerateConfigs_KubeContainer_KubeSpecific(t *testing.T) {
 					},
 				},
 			},
-			expectedCfg: []integration.Config{
+			expectedConfigs: []integration.Config{
 				{
 					Name:          "http_check",
 					ADIdentifiers: []string{"docker://3b8efe0c50e8"},
@@ -193,8 +224,8 @@ func TestGenerateConfigs_KubeContainer_KubeSpecific(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
-			desc: "Legacy annotation prefix, two checks in one template",
-			pod: &workloadmeta.KubernetesPod{
+			name: "Legacy annotation prefix, two checks in one template",
+			entity: &workloadmeta.KubernetesPod{
 				EntityMeta: workloadmeta.EntityMeta{
 					Annotations: map[string]string{
 						"service-discovery.datadoghq.com/apache.check_names":  "[\"apache\",\"http_check\"]",
@@ -209,7 +240,7 @@ func TestGenerateConfigs_KubeContainer_KubeSpecific(t *testing.T) {
 					},
 				},
 			},
-			expectedCfg: []integration.Config{
+			expectedConfigs: []integration.Config{
 				{
 					Name:          "apache",
 					ADIdentifiers: []string{"docker://3b8efe0c50e8"},
@@ -228,8 +259,8 @@ func TestGenerateConfigs_KubeContainer_KubeSpecific(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
-			desc: "Custom check ID",
-			pod: &workloadmeta.KubernetesPod{
+			name: "Custom check ID",
+			entity: &workloadmeta.KubernetesPod{
 				EntityMeta: workloadmeta.EntityMeta{
 					Annotations: map[string]string{
 						"ad.datadoghq.com/nginx.check.id":            "nginx-custom",
@@ -245,7 +276,7 @@ func TestGenerateConfigs_KubeContainer_KubeSpecific(t *testing.T) {
 					},
 				},
 			},
-			expectedCfg: []integration.Config{
+			expectedConfigs: []integration.Config{
 				{
 					Name:          "http_check",
 					ADIdentifiers: []string{"docker://4ac8352d70bf1"},
@@ -257,8 +288,8 @@ func TestGenerateConfigs_KubeContainer_KubeSpecific(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
-			desc: "Non-duplicate errors",
-			pod: &workloadmeta.KubernetesPod{
+			name: "Non-duplicate errors",
+			entity: &workloadmeta.KubernetesPod{
 				EntityMeta: workloadmeta.EntityMeta{
 					Name:      "nginx-1752f8c774-wtjql",
 					Namespace: "testNamespace",
@@ -279,7 +310,6 @@ func TestGenerateConfigs_KubeContainer_KubeSpecific(t *testing.T) {
 					},
 				},
 			},
-			expectedCfg: []integration.Config{},
 			expectedErr: ErrorMsgSet{
 				"annotation ad.datadoghq.com/nonmatching.check_names is invalid: nonmatching doesn't match a container identifier [apache nginx]":  {},
 				"annotation ad.datadoghq.com/nonmatching.init_configs is invalid: nonmatching doesn't match a container identifier [apache nginx]": {},
@@ -287,8 +317,8 @@ func TestGenerateConfigs_KubeContainer_KubeSpecific(t *testing.T) {
 			},
 		},
 		{
-			desc: "One invalid config, one valid config",
-			pod: &workloadmeta.KubernetesPod{
+			name: "One invalid config, one valid config",
+			entity: &workloadmeta.KubernetesPod{
 				EntityMeta: workloadmeta.EntityMeta{
 					Annotations: map[string]string{
 						"ad.datadoghq.com/nginx.check_names":  "[\"http_check\"]",
@@ -304,7 +334,7 @@ func TestGenerateConfigs_KubeContainer_KubeSpecific(t *testing.T) {
 					},
 				},
 			},
-			expectedCfg: []integration.Config{
+			expectedConfigs: []integration.Config{
 				{
 					Name:          "http_check",
 					ADIdentifiers: []string{"docker://4ac8352d70bf1"},
@@ -317,37 +347,132 @@ func TestGenerateConfigs_KubeContainer_KubeSpecific(t *testing.T) {
 				"could not extract logs config: in logs: invalid character '\"' after object key:value pair": {},
 			},
 		},
-	} {
-		t.Run(fmt.Sprintf("case %d: %s", nb, tc.desc), func(t *testing.T) {
+		{
+			name: "bare container, container collect all",
+			entity: &workloadmeta.Container{
+				EntityID: workloadmeta.EntityID{
+					ID: "3b8efe0c50e8",
+				},
+				Runtime: workloadmeta.ContainerRuntimeDocker,
+			},
+			expectedConfigs: []integration.Config{
+				{
+					Name:          "container_collect_all",
+					Source:        "container:docker://3b8efe0c50e8",
+					LogsConfig:    integration.Data("[{}]"),
+					ADIdentifiers: []string{"docker://3b8efe0c50e8"},
+				},
+			},
+			containerCollectAll: true,
+		},
+		{
+			name: "bare pod, container collect all",
+			entity: &workloadmeta.KubernetesPod{
+				Containers: []workloadmeta.OrchestratorContainer{
+					{
+						Name: "testName",
+						ID:   "testID",
+					},
+				},
+			},
+			expectedConfigs: []integration.Config{
+				{
+					Name:          "container_collect_all",
+					Source:        "kubelet:docker://testID",
+					LogsConfig:    integration.Data("[{}]"),
+					ADIdentifiers: []string{"docker://testID"},
+				},
+			},
+			containerCollectAll: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config.Datadog.Set("logs_config.container_collect_all", tt.containerCollectAll)
+			defer config.Datadog.Set("logs_config.container_collect_all", false)
+
 			store := workloadmetatesting.NewStore()
 
-			for _, c := range tc.pod.Containers {
-				store.Set(&workloadmeta.Container{
-					EntityID: workloadmeta.EntityID{
-						Kind: workloadmeta.KindContainer,
-						ID:   c.ID,
-					},
-					Runtime: workloadmeta.ContainerRuntimeDocker,
-				})
+			if pod, ok := tt.entity.(*workloadmeta.KubernetesPod); ok {
+				for _, c := range pod.Containers {
+					store.Set(&workloadmeta.Container{
+						EntityID: workloadmeta.EntityID{
+							Kind: workloadmeta.KindContainer,
+							ID:   c.ID,
+						},
+						Runtime: workloadmeta.ContainerRuntimeDocker,
+					})
+				}
 			}
 
-			m := &KubeContainerConfigProvider{
+			cp := &KubeContainerConfigProvider{
 				workloadmetaStore: store,
+				configCache:       make(map[string]map[string]integration.Config),
 				configErrors:      make(map[string]ErrorMsgSet),
-				podCache: map[string]*workloadmeta.KubernetesPod{
-					tc.pod.GetID().ID: tc.pod,
-				},
 			}
 
-			checks, err := m.generateConfigs()
-			assert.NoError(t, err)
+			configs, err := cp.generateConfig(tt.entity)
 
-			assert.Equal(t, len(tc.expectedCfg), len(checks))
-			assert.EqualValues(t, tc.expectedCfg, checks)
-
-			namespacedName := tc.pod.Namespace + "/" + tc.pod.Name
-			assert.Equal(t, len(tc.expectedErr), len(m.configErrors[namespacedName]))
-			assert.EqualValues(t, tc.expectedErr, m.configErrors[namespacedName])
+			assert.Equal(t, tt.expectedConfigs, configs)
+			assert.Equal(t, tt.expectedErr, err)
 		})
+	}
+}
+
+func basicDockerContainer() *workloadmeta.Container {
+	return &workloadmeta.Container{
+		EntityID: workloadmeta.EntityID{
+			ID:   "3b8efe0c50e8",
+			Kind: workloadmeta.KindContainer,
+		},
+		EntityMeta: workloadmeta.EntityMeta{
+			Labels: map[string]string{
+				"com.datadoghq.ad.check_names":  "[\"apache\",\"http_check\"]",
+				"com.datadoghq.ad.init_configs": "[{}, {}]",
+				"com.datadoghq.ad.instances":    "[{\"apache_status_url\": \"http://%%host%%/server-status?auto\"},{\"name\": \"My service\", \"url\": \"http://%%host%%\", \"timeout\": 1}]",
+			},
+		},
+		Runtime: workloadmeta.ContainerRuntimeDocker,
+	}
+}
+
+func basicDockerContainerSingleCheck() *workloadmeta.Container {
+	return &workloadmeta.Container{
+		EntityID: workloadmeta.EntityID{
+			ID:   "3b8efe0c50e8",
+			Kind: workloadmeta.KindContainer,
+		},
+		EntityMeta: workloadmeta.EntityMeta{
+			Labels: map[string]string{
+				"com.datadoghq.ad.check_names":  "[\"apache\"]",
+				"com.datadoghq.ad.init_configs": "[{}]",
+				"com.datadoghq.ad.instances":    "[{\"apache_status_url\": \"http://%%host%%/server-status?auto\"}]",
+			},
+		},
+		Runtime: workloadmeta.ContainerRuntimeDocker,
+	}
+}
+
+func basicDockerConfigs() []integration.Config {
+	return []integration.Config{
+		{
+			Name:          "apache",
+			ADIdentifiers: []string{"docker://3b8efe0c50e8"},
+			InitConfig:    integration.Data("{}"),
+			Source:        "container:docker://3b8efe0c50e8",
+			Instances: []integration.Data{
+				integration.Data("{\"apache_status_url\":\"http://%%host%%/server-status?auto\"}"),
+			},
+		},
+		{
+			Name:          "http_check",
+			ADIdentifiers: []string{"docker://3b8efe0c50e8"},
+			InitConfig:    integration.Data("{}"),
+			Source:        "container:docker://3b8efe0c50e8",
+			Instances: []integration.Data{
+				integration.Data("{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}"),
+			},
+		},
 	}
 }

--- a/pkg/autodiscovery/providers/kubecontainer_test.go
+++ b/pkg/autodiscovery/providers/kubecontainer_test.go
@@ -365,26 +365,6 @@ func TestGenerateConfig(t *testing.T) {
 			},
 			containerCollectAll: true,
 		},
-		{
-			name: "bare pod, container collect all",
-			entity: &workloadmeta.KubernetesPod{
-				Containers: []workloadmeta.OrchestratorContainer{
-					{
-						Name: "testName",
-						ID:   "testID",
-					},
-				},
-			},
-			expectedConfigs: []integration.Config{
-				{
-					Name:          "container_collect_all",
-					Source:        "kubelet:docker://testID",
-					LogsConfig:    integration.Data("[{}]"),
-					ADIdentifiers: []string{"docker://testID"},
-				},
-			},
-			containerCollectAll: true,
-		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/autodiscovery/providers/providers.go
+++ b/pkg/autodiscovery/providers/providers.go
@@ -33,22 +33,26 @@ type ConfigProviderFactory func(providerConfig *config.ConfigurationProviders) (
 // Any type implementing the interface will take care of any dependency
 // or data needed to access the resource providing the configuration.
 type ConfigProvider interface {
-	// Collect is responsible of populating a list of Config instances by
-	// retrieving configuration patterns from external resources.
-	Collect(context.Context) ([]integration.Config, error)
-
 	// String returns the name of the provider.  All Config instances produced
 	// by this provider will have this value in their Provider field.
 	String() string
-
-	// IsUpToDate determines whether the information returned from the last
-	// call to Collect is still correct.  If not, Collect will be called again.
-	IsUpToDate(context.Context) (bool, error)
 
 	// GetConfigErrors returns a map of errors that occurred on the last Collect
 	// call, indexed by a description of the resource that generated the error.
 	// The result is displayed in diagnostic tools such as `agent status`.
 	GetConfigErrors() map[string]ErrorMsgSet
+}
+
+// CollectingConfigProvider is an interface used together with ConfigProvider.
+// ConfigProviders that are NOT able to use streaming, and therefore need external reconciliation, should implement it.
+type CollectingConfigProvider interface {
+	// Collect is responsible of populating a list of Config instances by
+	// retrieving configuration patterns from external resources.
+	Collect(context.Context) ([]integration.Config, error)
+
+	// IsUpToDate determines whether the information returned from the last
+	// call to Collect is still correct.  If not, Collect will be called again.
+	IsUpToDate(context.Context) (bool, error)
 }
 
 // StreamingConfigProvider is an interface used together with ConfigProvider.

--- a/pkg/autodiscovery/providers/providers.go
+++ b/pkg/autodiscovery/providers/providers.go
@@ -50,3 +50,12 @@ type ConfigProvider interface {
 	// The result is displayed in diagnostic tools such as `agent status`.
 	GetConfigErrors() map[string]ErrorMsgSet
 }
+
+// StreamingConfigProvider is an interface used together with ConfigProvider.
+// ConfigProviders that are able to use streaming should implement it, and the
+// config poller will use Stream instead of Collect to collect config changes.
+type StreamingConfigProvider interface {
+	// Stream starts the streaming config provider until the provided
+	// context is cancelled. Config changes are sent on the return channel.
+	Stream(context.Context) <-chan integration.ConfigChanges
+}

--- a/pkg/autodiscovery/simple_configmgr.go
+++ b/pkg/autodiscovery/simple_configmgr.go
@@ -37,7 +37,7 @@ func newSimpleConfigManager() configManager {
 }
 
 // processNewService implements configManager#processNewService.
-func (cm *simpleConfigManager) processNewService(adIdentifiers []string, svc listeners.Service) configChanges {
+func (cm *simpleConfigManager) processNewService(adIdentifiers []string, svc listeners.Service) integration.ConfigChanges {
 	cm.m.Lock()
 	defer cm.m.Unlock()
 
@@ -66,16 +66,16 @@ func (cm *simpleConfigManager) processNewService(adIdentifiers []string, svc lis
 	}
 
 	// build the config changes to return
-	changes := configChanges{}
+	changes := integration.ConfigChanges{}
 	for _, v := range resolvedSet {
-		changes.scheduleConfig(v)
+		changes.ScheduleConfig(v)
 	}
 
 	return changes
 }
 
 // processDelService implements configManager#processDelService.
-func (cm *simpleConfigManager) processDelService(ctx context.Context, svc listeners.Service) configChanges {
+func (cm *simpleConfigManager) processDelService(ctx context.Context, svc listeners.Service) integration.ConfigChanges {
 	cm.m.Lock()
 	defer cm.m.Unlock()
 
@@ -88,10 +88,10 @@ func (cm *simpleConfigManager) processDelService(ctx context.Context, svc listen
 	}
 
 	removedConfigs := cm.store.removeConfigsForService(svc.GetServiceID())
-	changes := configChanges{}
+	changes := integration.ConfigChanges{}
 	for _, c := range removedConfigs {
 		if cm.store.removeLoadedConfig(c) {
-			changes.unscheduleConfig(c)
+			changes.UnscheduleConfig(c)
 		}
 	}
 
@@ -99,10 +99,10 @@ func (cm *simpleConfigManager) processDelService(ctx context.Context, svc listen
 }
 
 // processNewConfig implements configManager#processNewConfig.
-func (cm *simpleConfigManager) processNewConfig(config integration.Config) configChanges {
+func (cm *simpleConfigManager) processNewConfig(config integration.Config) integration.ConfigChanges {
 	cm.m.Lock()
 	defer cm.m.Unlock()
-	changes := configChanges{}
+	changes := integration.ConfigChanges{}
 
 	if config.IsTemplate() {
 		// store the template in the cache in any case
@@ -112,7 +112,7 @@ func (cm *simpleConfigManager) processNewConfig(config integration.Config) confi
 
 		// try to resolve the template
 		resolvedConfigs := cm.resolveTemplate(config)
-		if resolvedConfigs.isEmpty() {
+		if resolvedConfigs.IsEmpty() {
 			e := fmt.Sprintf("Can't resolve the template for %s at this moment.", config.Name)
 			errorStats.setResolveWarning(config.Name, e)
 			log.Debug(e)
@@ -128,17 +128,17 @@ func (cm *simpleConfigManager) processNewConfig(config integration.Config) confi
 		log.Errorf("Dropping conf for '%s': %s", config.Name, err.Error())
 		return changes // empty result
 	}
-	changes.scheduleConfig(config)
+	changes.ScheduleConfig(config)
 	cm.store.setLoadedConfig(config)
 
 	return changes
 }
 
 // processDelConfigs implements configManager#processDelConfigs.
-func (cm *simpleConfigManager) processDelConfigs(configs []integration.Config) configChanges {
+func (cm *simpleConfigManager) processDelConfigs(configs []integration.Config) integration.ConfigChanges {
 	cm.m.Lock()
 	defer cm.m.Unlock()
-	changes := configChanges{}
+	changes := integration.ConfigChanges{}
 
 	for _, c := range configs {
 		if c.IsTemplate() {
@@ -147,7 +147,7 @@ func (cm *simpleConfigManager) processDelConfigs(configs []integration.Config) c
 			removedConfigs := cm.store.removeConfigsForTemplate(tplDigest)
 			for _, rc := range removedConfigs {
 				if cm.store.removeLoadedConfig(rc) {
-					changes.unscheduleConfig(rc)
+					changes.UnscheduleConfig(rc)
 				}
 			}
 
@@ -165,7 +165,7 @@ func (cm *simpleConfigManager) processDelConfigs(configs []integration.Config) c
 			}
 
 			cm.store.removeLoadedConfig(c)
-			changes.unscheduleConfig(c)
+			changes.UnscheduleConfig(c)
 		}
 	}
 
@@ -210,7 +210,7 @@ func (cm *simpleConfigManager) resolveTemplateForService(tpl integration.Config,
 // The function might return an empty list in the case the configuration has a
 // list of Autodiscovery identifiers for services that are unknown to the
 // resolver at this moment.
-func (cm *simpleConfigManager) resolveTemplate(tpl integration.Config) configChanges {
+func (cm *simpleConfigManager) resolveTemplate(tpl integration.Config) integration.ConfigChanges {
 	// use a map to dedupe configurations
 	resolvedSet := map[string]integration.Config{}
 
@@ -240,9 +240,9 @@ func (cm *simpleConfigManager) resolveTemplate(tpl integration.Config) configCha
 	}
 
 	// build the config changes to return
-	changes := configChanges{}
+	changes := integration.ConfigChanges{}
 	for _, v := range resolvedSet {
-		changes.scheduleConfig(v)
+		changes.ScheduleConfig(v)
 	}
 
 	return changes

--- a/pkg/workloadmeta/types.go
+++ b/pkg/workloadmeta/types.go
@@ -636,6 +636,11 @@ const (
 	// come first.
 	TaggerPriority SubscriberPriority = iota
 
+	// ConfigProviderPriority is the priority for the AD Config Provider.
+	// This should come before other subscribers so that config provided by
+	// entities is available to those other subscribers.
+	ConfigProviderPriority SubscriberPriority = iota
+
 	// NormalPriority should be used by subscribers on which other components
 	// do not depend.
 	NormalPriority SubscriberPriority = iota

--- a/test/integration/config_providers/etcd/etcd_provider_test.go
+++ b/test/integration/config_providers/etcd/etcd_provider_test.go
@@ -150,7 +150,7 @@ func (suite *EtcdTestSuite) TestWorkingConnectionAnon() {
 		panic(err)
 	}
 
-	checks, err := p.Collect(ctx)
+	checks, err := p.(providers.CollectingConfigProvider).Collect(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -169,7 +169,7 @@ func (suite *EtcdTestSuite) TestBadConnection() {
 	p, err := providers.NewEtcdConfigProvider(&config)
 	assert.Nil(suite.T(), err)
 
-	checks, err := p.Collect(ctx)
+	checks, err := p.(providers.CollectingConfigProvider).Collect(ctx)
 	assert.Nil(suite.T(), err)
 	assert.Empty(suite.T(), checks)
 }
@@ -186,7 +186,7 @@ func (suite *EtcdTestSuite) TestWorkingAuth() {
 	p, err := providers.NewEtcdConfigProvider(&config)
 	assert.Nil(suite.T(), err)
 
-	checks, err := p.Collect(ctx)
+	checks, err := p.(providers.CollectingConfigProvider).Collect(ctx)
 	assert.Nil(suite.T(), err)
 	assert.Equal(suite.T(), 2, len(checks))
 }
@@ -203,7 +203,7 @@ func (suite *EtcdTestSuite) TestBadAuth() {
 	p, err := providers.NewEtcdConfigProvider(&config)
 	assert.Nil(suite.T(), err)
 
-	checks, err := p.Collect(ctx)
+	checks, err := p.(providers.CollectingConfigProvider).Collect(ctx)
 	assert.Nil(suite.T(), err)
 	assert.Empty(suite.T(), checks)
 }

--- a/test/integration/config_providers/zookeeper/zookeeper_provider_test.go
+++ b/test/integration/config_providers/zookeeper/zookeeper_provider_test.go
@@ -137,7 +137,7 @@ func (suite *ZkTestSuite) TestCollect() {
 	zk, err := providers.NewZookeeperConfigProvider(&suite.providerConfig)
 	require.Nil(suite.T(), err)
 
-	templates, err := zk.Collect(ctx)
+	templates, err := zk.(providers.CollectingConfigProvider).Collect(ctx)
 
 	require.Nil(suite.T(), err)
 	require.Len(suite.T(), templates, 3)


### PR DESCRIPTION
### What does this PR do?

Introduces a streaming interface for config providers, as well as implementing it for KubeContainerConfigProvider. This will allow us to more finely control the order in which configs and services are emitted in AutoDiscovery

### Describe how to test/QA your changes

Same as #12851. Additionally, check that `agent check` still works as expected, especially in regards to file and AD configs.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
