### PR TITLE
Add QA cases for logs-agent cca_in_ad

### DIFF
--- a/tools/agent_QA/README.md
+++ b/tools/agent_QA/README.md
@@ -8,13 +8,15 @@ A collection of scripts that generate release QA tasks for the logs agent in a T
 2. `source venv/bin/activate`
 3. `pip install -r requirements.txt`
 
-create a `.env` file (or supply env vars via CLI) with:
+In order to actually make a new board, create a `.env` file (or supply env vars via CLI) with:
 
 ```
 API_KEY=<TRELLO API KEY>
 API_SECRET=<TRELLO API SECRET>
 ORG_ID=<TRELLO ORG ID>
 ```
+
+If these are omitted, then the board is rendered to the console.
 
 ## Generate the board 
 

--- a/tools/agent_QA/board.py
+++ b/tools/agent_QA/board.py
@@ -1,0 +1,53 @@
+import os
+
+from dotenv import load_dotenv
+from trello import TrelloClient
+
+
+class LocalBoard:
+    """A LocalBoard is like a Trello Board, but just prints cards to the console."""
+
+    def add_list(self, name):
+        return LocalList(name)
+
+
+class LocalList:
+    """A LocalList is like a Trello List, but just prints cards to the console."""
+
+    def __init__(self, name):
+        self.name = name
+
+    def add_card(self, name, content):
+        heading = f"{name} [List: {self.name}]"
+        print("=" * len(heading))
+        print(heading)
+        print("=" * len(heading))
+        print("")
+        print(content)
+        print("")
+
+
+def setup(version):
+    # Setup env
+    load_dotenv()
+    api_key = os.getenv('API_KEY')
+    api_secret = os.getenv('API_SECRET')
+    org_id = os.getenv('ORG_ID')
+
+    if api_key and api_secret and org_id:
+        # Setup trello
+        client = TrelloClient(api_key=api_key, api_secret=api_secret)
+        board = client.add_board("[" + version + "] Logs Agent Release QA", None, org_id)
+
+        for list in board.all_lists():
+            list.close()
+        board.add_list("Done")
+        return board
+
+    return LocalBoard()
+
+
+def finish(board):
+    if not isinstance(board, LocalBoard):
+        print("Your QA board is ready: ")
+        print(board.url)

--- a/tools/agent_QA/release_qa.py
+++ b/tools/agent_QA/release_qa.py
@@ -40,40 +40,74 @@ version = sys.argv[1]
 board = setup(version)
 
 # Test that apply to all host platforms
-xplatHostTests = [TailFile, TailFileWildcard, TailFileStartPosition]
+xplatHostTests = [
+    TailFile(),
+    TailFileWildcard(),
+    TailFileStartPosition(),
+]
 
 misc = board.add_list("Misc (any platform)")
 Suite(
-    LinuxConfig(), [TailFileMultiLine, TailFileUTF16, TailTCPUDP, EndpointTests, DualShipping, Serverless, StreamLogs]
+    LinuxConfig(),
+    [
+        TailFileMultiLine(),
+        TailFileUTF16(),
+        TailTCPUDP(),
+        EndpointTests(),
+        DualShipping(),
+        Serverless(),
+        StreamLogs(),
+    ],
 ).build(misc.add_card)
 
 kube = board.add_list("Kubernetes")
 Suite(
-    LinuxConfig(), [K8CollectAllDocker, K8DockerContainerLabels, K8CollectAll, K8PodAnnotation, K8FileTailingAnnotation]
+    LinuxConfig(),
+    [
+        K8CollectAllDocker(),
+        K8DockerContainerLabels(),
+        K8CollectAll(),
+        K8PodAnnotation(),
+        K8FileTailingAnnotation(),
+    ],
 ).build(kube.add_card)
 
 containers = board.add_list("Container Runtimes")
 Suite(
     LinuxConfig(),
     [
-        ContainerTailJounald,
-        ContainerCollectAll,
-        AgentUsesAdLabels,
-        DockerMaxFile,
-        DockerFileTailingAD,
-        DockerFileTail,
-        PodmanFileTail,
-        PodmanSocketTail,
+        ContainerTailJounald(),
+        ContainerCollectAll(),
+        AgentUsesAdLabels(),
+        DockerMaxFile(),
+        DockerFileTailingAD(),
+        DockerFileTail(),
+        PodmanFileTail(),
+        PodmanSocketTail(),
     ],
 ).build(containers.add_card)
 
 windows = board.add_list("Windows")
-Suite(WindowsConfig(), xplatHostTests + [TestEventLog]).build(windows.add_card)
+Suite(
+    WindowsConfig(),
+    xplatHostTests
+    + [
+        TestEventLog(),
+    ],
+).build(windows.add_card)
 
 mac = board.add_list("Mac")
 Suite(MacConfig(), xplatHostTests + []).build(mac.add_card)
 
 linux = board.add_list("Linux")
-Suite(LinuxConfig(), xplatHostTests + [TailJounald, TailJournaldStartPosition, SNMPTraps]).build(linux.add_card)
+Suite(
+    LinuxConfig(),
+    xplatHostTests
+    + [
+        TailJounald(),
+        TailJournaldStartPosition(),
+        SNMPTraps(),
+    ],
+).build(linux.add_card)
 
 finish(board)

--- a/tools/agent_QA/release_qa.py
+++ b/tools/agent_QA/release_qa.py
@@ -1,7 +1,6 @@
-import os
 import sys
 
-from dotenv import load_dotenv
+from board import finish, setup
 from test_builder import LinuxConfig, MacConfig, Suite, WindowsConfig
 from test_cases.containers import (
     AgentUsesAdLabels,
@@ -32,26 +31,13 @@ from test_cases.xplat.file_tests import (
     TailFileWildcard,
 )
 from test_cases.xplat.network import TailTCPUDP
-from trello import TrelloClient
 
 if len(sys.argv) < 2:
     print("Usage: python release_qa.py <AGENT_VERSON>")
     exit(1)
 version = sys.argv[1]
 
-# Setup env
-load_dotenv()
-api_key = os.getenv('API_KEY')
-api_secret = os.getenv('API_SECRET')
-org_id = os.getenv('ORG_ID')
-
-# Setup trello
-client = TrelloClient(api_key=api_key, api_secret=api_secret)
-board = client.add_board("[" + version + "] Logs Agent Release QA", None, org_id)
-
-for list in board.all_lists():
-    list.close()
-board.add_list("Done")
+board = setup(version)
 
 # Test that apply to all host platforms
 xplatHostTests = [TailFile, TailFileWildcard, TailFileStartPosition]
@@ -90,5 +76,4 @@ Suite(MacConfig(), xplatHostTests + []).build(mac.add_card)
 linux = board.add_list("Linux")
 Suite(LinuxConfig(), xplatHostTests + [TailJounald, TailJournaldStartPosition, SNMPTraps]).build(linux.add_card)
 
-print("Your QA board is ready: ")
-print(board.url)
+finish(board)

--- a/tools/agent_QA/release_qa.py
+++ b/tools/agent_QA/release_qa.py
@@ -5,13 +5,13 @@ from test_builder import LinuxConfig, MacConfig, Suite, WindowsConfig
 from test_cases.containers import (
     AgentUsesAdLabels,
     ContainerCollectAll,
+    ContainerScenario,
     ContainerTailJounald,
     DockerFileTail,
     DockerFileTailingAD,
     DockerMaxFile,
     PodmanFileTail,
     PodmanSocketTail,
-    ContainerScenario,
 )
 from test_cases.kubernetes import (
     K8CollectAll,
@@ -85,14 +85,15 @@ Suite(
         DockerFileTail(),
         PodmanFileTail(),
         PodmanSocketTail(),
-    ] + [
+    ]
+    + [
         ContainerScenario(k8s, cfgsource, cca, kcuf, dcuf)
         for k8s in ('docker', 'containerd', 'none')
         for cfgsource in ('label' if k8s == 'docker' else 'annotation', 'file', 'none')
         for cca in (True, False)
         for kcuf in (True, False)
         for dcuf in (True, False)
-    ]
+    ],
 ).build(containers.add_card)
 
 windows = board.add_list("Windows")

--- a/tools/agent_QA/release_qa.py
+++ b/tools/agent_QA/release_qa.py
@@ -11,6 +11,7 @@ from test_cases.containers import (
     DockerMaxFile,
     PodmanFileTail,
     PodmanSocketTail,
+    ContainerScenario,
 )
 from test_cases.kubernetes import (
     K8CollectAll,
@@ -84,7 +85,14 @@ Suite(
         DockerFileTail(),
         PodmanFileTail(),
         PodmanSocketTail(),
-    ],
+    ] + [
+        ContainerScenario(k8s, cfgsource, cca, kcuf, dcuf)
+        for k8s in ('docker', 'containerd', 'none')
+        for cfgsource in ('label' if k8s == 'docker' else 'annotation', 'file', 'none')
+        for cca in (True, False)
+        for kcuf in (True, False)
+        for dcuf in (True, False)
+    ]
 ).build(containers.add_card)
 
 windows = board.add_list("Windows")

--- a/tools/agent_QA/test_builder.py
+++ b/tools/agent_QA/test_builder.py
@@ -36,8 +36,7 @@ class Suite:
         self.tests = tests
 
     def build(self, renderDelegate):
-        for test in self.tests:
-            t = test()
+        for t in self.tests:
             renderDelegate(t.name, t.render(self.config))
 
 

--- a/tools/agent_QA/test_cases/containers.py
+++ b/tools/agent_QA/test_cases/containers.py
@@ -1,3 +1,5 @@
+import textwrap
+
 from test_builder import TestCase
 
 
@@ -297,4 +299,206 @@ To check:
 - All logs from podman containers are collected from the docker socket (see `agent status` that will now show whether a container is tailed from the docker socket or it's log file) 
 - All logs are properly tagged with container metadata
 """
+        )
+
+
+class ContainerScenario(TestCase):
+    def __init__(self, k8s, cfgsource, cca, kcuf, dcuf):
+        super(ContainerScenario, self).__init__()
+        self.k8s = k8s
+        self.cfgsource = cfgsource
+        self.cca = cca
+        self.kcuf = kcuf
+        self.dcuf = dcuf
+
+        self.name = "Container Scenario: "
+        self.name += ('docker' if k8s == 'none' else 'k8s/' + k8s) + ', '
+        self.name += f"config source={cfgsource}, "
+        self.name += f"cca={cca}, "
+        self.name += f"kcuf={kcuf}, "
+        self.name += f"dcuf={dcuf}"
+
+    def build(self, config):  # noqa: U100
+        if self.k8s == 'docker':
+            self.append(
+                textwrap.dedent(
+                    '''\
+                # Set up Kubernetes
+
+                Set up a Kubernetes environment that uses docker as its container runtime, such as
+                `minikube --container-runtime=docker`.'''
+                )
+            )
+        elif self.k8s == 'containerd':
+            self.append(
+                textwrap.dedent(
+                    '''\
+                # Set up Kubernetes
+
+                Set up a Kubernetes environment that uses containerd as its container runtime, such as
+                a newly-minted GKE environment.'''
+                )
+            )
+        elif self.k8s == 'none':
+            self.append(
+                textwrap.dedent(
+                    '''\
+                # Set up Docker
+
+                Set up a simple Docker environment, prepared to run the agent in a container with the
+                necessary access to the host.'''
+                )
+            )
+
+        if self.k8s != 'none':
+            steps = textwrap.dedent(
+                f'''\
+                # Run the Agent
+
+                If you choose to use Helm, include the following in your values:
+
+                * `datadog.apiKey` = your API key
+                * `datadog.logs.enabled` = `true`
+                * `agents.image` = `7-rc`
+                * `datadog.logs.containerCollectAll` = `{'true' if self.cca else 'false'}`
+                * `datadog.logs.containerCollectUsingFiles` = `{'true' if self.kcuf else 'false'}`
+                * `agents.containers.agent.env`:
+
+                    ```
+                    - name: "DD_LOGS_CONFIG_CCA_IN_AD"
+                      value: "true"
+                    - name: "DD_LOGS_CONFIG_DOCKER_CONTAINER_USE_FILE"
+                      value: "{'true' if self.dcuf else 'false'}"
+                    ```
+                '''
+            )
+            if self.k8s == 'docker':
+                steps += textwrap.dedent(
+                    '''\
+                * `datadog.kubelet.tlsVerify` = `false` (for Minikube)
+                * `datadog.criSocketPath` `/var/run/docker.sock` (for Minikube)'''
+                )
+            if self.cfgsource == 'file':
+                steps += textwrap.dedent(
+                    '''\
+                * `datadog.confd`:
+
+                    ```
+                    "bash.yaml": |-
+                      ad_identifiers:
+                        - bash
+                      logs:
+                        service: TESTSVC
+                        source: TESTSRC
+                    ```
+                '''
+                )
+
+            self.append(steps)
+        else:
+            self.append(
+                textwrap.dedent(
+                    f'''\
+                # Run the Agent
+
+                ```
+                docker run -ti --rm --name dd-agent \\
+                        --net=host \\
+                        -e DOCKER_DD_AGENT= \\
+                        -e DD_API_KEY=$DD_API_KEY \\
+                        -e DD_LOGS_ENABLED=true \\
+                        -e DD_LOGS_CONFIG_CCA_IN_AD=true \\
+                        -e LOGS_CONFIG_CONTAINER_COLLECT_ALL={'true' if self.cca else 'false'} \\
+                        -e LOGS_CONFIG_DOCKER_CONTAINER_USE_FILE={'true' if self.dcuf else 'false'} \\
+                        -e LOGS_CONFIG_K8S_CONTAINER_USE_FILE={'true' if self.dcuf else 'false'} \\
+                        -v /var/run/docker.sock:/var/run/docker.sock:ro \\
+                        -v /proc/:/host/proc/:ro \\
+                        -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \\
+                        -v /var/lib/docker/containers:/var/lib/docker/containers:ro \\
+                        datadog/agent:7-rc
+                ```
+                '''
+                )
+            )
+
+        self.append(
+            textwrap.dedent(
+                '''\
+            # Start `agent stream-logs`
+
+            Begin `agent stream-logs` before starting the tested container, so that you can see the totality
+            of the logged data.'''
+            )
+        )
+
+        if self.k8s == "none":
+            labelargs = "\\"
+            if self.cfgsource == "label":
+                labelargs = '''--label com.datadoghq.ad.logs='[{"source": "TESTSRC", "service": "TESTSVC"}]' \\'''
+            self.append(
+                textwrap.dedent(
+                    f'''\
+                # Start the Container
+
+                ```
+                docker run -ti --rm \\
+                    {labelargs}
+                    bash -c 'i=0; while true; do echo "HELLO $i at" $(date); i=$((i+1)); sleep 1; done'
+                ```
+                '''
+                )
+            )
+        else:
+            annotargs = "\\"
+            if self.cfgsource == "label":
+                annotargs = (
+                    '''--annotations ad.datadoghq.com/bash.logs='[{"source":"TESTSRC", "service":"TESTSVC"}]' \\'''
+                )
+            self.append(
+                textwrap.dedent(
+                    f'''\
+                # Start the Container
+
+                ```
+                k run bash --image=bash \
+                    {annotargs}
+                    --command -- bash -c 'i=0; while true; do echo "HELLO $i at" $(date); i=$((i+1)); sleep 1; done'
+                ```
+                '''
+                )
+            )
+
+        if self.cfgsource == "none" and not self.cca:
+            self.append(
+                textwrap.dedent(
+                    f'''\
+                # Observe Nothing Logged
+
+                Check `agent stream-logs`.  This {'container' if self.k8s ==
+                'none' else 'pod'} has no configuration and container_collect_all
+                is disabled, so none of the "HELLO" output should be logged.'''
+                )
+            )
+        else:
+            self.append(
+                textwrap.dedent(
+                    '''\
+                # Observe Logging
+
+                Check `agent stream-logs`:
+                 * "HELLO" output logged
+                 * First message included ("HELLO 0")
+                 * First message has appropriate source and service (TESTSRC / TESTSVC)'''
+                )
+            )
+
+        self.append(
+            textwrap.dedent(
+                '''\
+            # Unexpected Results
+
+            If things aren't working as expected, compare to a run with
+            `cca_in_ad` false.  If the behavior is *better* with `cca_in_ad` set
+            to false, then the check has failed.'''
+            )
         )


### PR DESCRIPTION
### What does this PR do?

Adds a bunch of new QA cases for the logs-agent, generated based on the matrix of scenarios I've been working with for a while now.  It suggests running them all with cca_in_ad: true, and if that does something "weird" then comparing to a run with that value set to false.  

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
