### PR TITLE
[networks] Change probe responsible for sending HTTP notifications

### DIFF
--- a/pkg/ebpf/bytecode/runtime/http.go
+++ b/pkg/ebpf/bytecode/runtime/http.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Http = NewRuntimeAsset("http.c", "27fbf1ba36913af6152881cd47acaddb2f085445ae3c4ed569ce054c37212346")
+var Http = NewRuntimeAsset("http.c", "f3731a76597e367750a01ebe6bcd32b9531b5ed07298baba47dd2e768896afa6")

--- a/pkg/ebpf/bytecode/runtime/http.go
+++ b/pkg/ebpf/bytecode/runtime/http.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Http = NewRuntimeAsset("http.c", "bfe189eb79030212a38778118b688675f59a4ee9380665a20a392acf05295d88")
+var Http = NewRuntimeAsset("http.c", "27fbf1ba36913af6152881cd47acaddb2f085445ae3c4ed569ce054c37212346")

--- a/pkg/network/ebpf/c/prebuilt/http.c
+++ b/pkg/network/ebpf/c/prebuilt/http.c
@@ -115,8 +115,8 @@ int kprobe__tcp_sendmsg(struct pt_regs* ctx) {
     return 0;
 }
 
-SEC("kretprobe/sk_filter_trim_cap")
-int kretprobe__sk_filter_trim_cap(struct pt_regs* ctx) {
+SEC("kretprobe/security_sock_rcv_skb")
+int kretprobe__security_sock_rcv_skb(struct pt_regs* ctx) {
     // send batch completion notification to userspace
     // because perf events can't be sent from socket filter programs
     http_notify_batch(ctx);

--- a/pkg/network/ebpf/c/prebuilt/http.c
+++ b/pkg/network/ebpf/c/prebuilt/http.c
@@ -115,8 +115,8 @@ int kprobe__tcp_sendmsg(struct pt_regs* ctx) {
     return 0;
 }
 
-SEC("kretprobe/tcp_sendmsg")
-int kretprobe__tcp_sendmsg(struct pt_regs* ctx) {
+SEC("kretprobe/sk_filter_trim_cap")
+int kretprobe__sk_filter_trim_cap(struct pt_regs* ctx) {
     // send batch completion notification to userspace
     // because perf events can't be sent from socket filter programs
     http_notify_batch(ctx);

--- a/pkg/network/ebpf/c/runtime/http.c
+++ b/pkg/network/ebpf/c/runtime/http.c
@@ -122,8 +122,8 @@ int kprobe__tcp_sendmsg(struct pt_regs *ctx) {
     return 0;
 }
 
-SEC("kretprobe/tcp_sendmsg")
-int kretprobe__tcp_sendmsg(struct pt_regs *ctx) {
+SEC("kretprobe/sk_filter_trim_cap")
+int kretprobe__sk_filter_trim_cap(struct pt_regs* ctx) {
     // send batch completion notification to userspace
     // because perf events can't be sent from socket filter programs
     http_notify_batch(ctx);

--- a/pkg/network/ebpf/c/runtime/http.c
+++ b/pkg/network/ebpf/c/runtime/http.c
@@ -122,8 +122,8 @@ int kprobe__tcp_sendmsg(struct pt_regs *ctx) {
     return 0;
 }
 
-SEC("kretprobe/sk_filter_trim_cap")
-int kretprobe__sk_filter_trim_cap(struct pt_regs* ctx) {
+SEC("kretprobe/security_sock_rcv_skb")
+int kretprobe__security_sock_rcv_skb(struct pt_regs* ctx) {
     // send batch completion notification to userspace
     // because perf events can't be sent from socket filter programs
     http_notify_batch(ctx);

--- a/pkg/network/http/ebpf_main.go
+++ b/pkg/network/http/ebpf_main.go
@@ -128,8 +128,8 @@ func newEBPFProgram(c *config.Config, offsets []manager.ConstantEditor, sockFD *
 			},
 			{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  "kretprobe/sk_filter_trim_cap",
-					EBPFFuncName: "kretprobe__sk_filter_trim_cap",
+					EBPFSection:  "kretprobe/security_sock_rcv_skb",
+					EBPFFuncName: "kretprobe__security_sock_rcv_skb",
 					UID:          probeUID,
 				},
 				KProbeMaxActive: maxActive,
@@ -204,8 +204,8 @@ func (e *ebpfProgram) Init() error {
 			},
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  "kretprobe/sk_filter_trim_cap",
-					EBPFFuncName: "kretprobe__sk_filter_trim_cap",
+					EBPFSection:  "kretprobe/security_sock_rcv_skb",
+					EBPFFuncName: "kretprobe__security_sock_rcv_skb",
 					UID:          probeUID,
 				},
 			},

--- a/pkg/network/http/ebpf_main.go
+++ b/pkg/network/http/ebpf_main.go
@@ -118,9 +118,29 @@ func newEBPFProgram(c *config.Config, offsets []manager.ConstantEditor, sockFD *
 			},
 		},
 		Probes: []*manager.Probe{
-			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: string(probes.TCPSendMsg), EBPFFuncName: "kprobe__tcp_sendmsg", UID: probeUID}, KProbeMaxActive: maxActive},
-			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: string(probes.TCPSendMsgReturn), EBPFFuncName: "kretprobe__tcp_sendmsg", UID: probeUID}, KProbeMaxActive: maxActive},
-			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: httpSocketFilterStub, EBPFFuncName: "socket__http_filter_entry", UID: probeUID}},
+			{
+				ProbeIdentificationPair: manager.ProbeIdentificationPair{
+					EBPFSection:  string(probes.TCPSendMsg),
+					EBPFFuncName: "kprobe__tcp_sendmsg",
+					UID:          probeUID,
+				},
+				KProbeMaxActive: maxActive,
+			},
+			{
+				ProbeIdentificationPair: manager.ProbeIdentificationPair{
+					EBPFSection:  "kretprobe/sk_filter_trim_cap",
+					EBPFFuncName: "kretprobe__sk_filter_trim_cap",
+					UID:          probeUID,
+				},
+				KProbeMaxActive: maxActive,
+			},
+			{
+				ProbeIdentificationPair: manager.ProbeIdentificationPair{
+					EBPFSection:  httpSocketFilterStub,
+					EBPFFuncName: "socket__http_filter_entry",
+					UID:          probeUID,
+				},
+			},
 		},
 	}
 
@@ -184,8 +204,8 @@ func (e *ebpfProgram) Init() error {
 			},
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  string(probes.TCPSendMsgReturn),
-					EBPFFuncName: "kretprobe__tcp_sendmsg",
+					EBPFSection:  "kretprobe/sk_filter_trim_cap",
+					EBPFFuncName: "kretprobe__sk_filter_trim_cap",
 					UID:          probeUID,
 				},
 			},


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Changes the kprobe responsible for checking the status of HTTP batches and notifying userspace when they're complete and ready to be consumed. This greatly reduces the latency between the time a HTTP batch fills up on Kernel side and the time userspace is notified of it which in turn reduces the chance of data loss, because delayed notifications could arrive in userspace after a batch was no longer available.

The problem stems from the fact that we were previously using the probe `tcp_sendmsg` to send such notifications, but those don't correlate with the execution of a socket filter program (in other words, a socket filter program can be executed in one CPU and `tcp_sendmsg` would be executed in another CPU). Since we have essentially one HTTP buffer per CPU, it could take too long for the "right" `tcp_sendmsg` probe be executed.

We're now hooking into the ~`sk_filter_trim_cap`~ `security_sock_rcv_skb` function instead, which is in the same "call stack" of a socket filter program execution.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Changes are cover by our unit tests in `http/monitor_test.go` and the impact can only be measured through a performance test which was already done.

For purposes of documentation, though, this is how a simple load test can be done:
* Start system-probe;
* Install vegeta on your agent-dev VM;
* Start a nginx server via `docker run --rm -p 8080:80 nginx:latest`
* Issue 1000 requests/s for 30s using the following command:
```
echo "GET http://127.0.0.1:8080/" | vegeta attack -rate=1000 -duration="30s" | vegeta report && curl -s --unix /opt/datadog-agent/run/sysprobe.sock http://unix/network_tracer/debug/http_monitoring > /dev/null
```

You should see the following output from vegeta:
```
Requests      [total, rate, throughput]  30000, 1000.08, 1000.04
Duration      [total, attack, wait]      29.998933334s, 29.997564863s, 1.368471ms
Latencies     [mean, 50, 95, 99, max]    830.5µs, 721.974µs, 1.575169ms, 2.520016ms, 13.15698ms
Bytes In      [total, mean]              18450000, 615.00
Bytes Out     [total, mean]              0, 0.00
Success       [ratio]                    100.00%
Status Codes  [code:count]               200:30000
```
And the following output from system-probe:
```
022-08-02 18:57:33 UTC | SYS-PROBE | DEBUG | (pkg/network/http/telemetry.go:87 in reset) | http stats summary: requests_processed=60000(1132.08/s) requests_missed=0(0.00/s) requests_dropped=0(0.00/s) requests_rejected=0(0.00/s) requests_malformed=0(0.00/s) aggregations=80
```

(Note that the total amount of requests captured by system-probe (60000) will be 2x the number reported by vegeta because of the traffic forwarding of this setup (127.0.0.1:client_port -> 127.0.0.1:8080 and veth-pair:8080 -> 80)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
