### PR TITLE
[RCM] fix(tracer_predicates): Match new tracer predicates constraints

### DIFF
--- a/pkg/config/remote/service/client_predicates.go
+++ b/pkg/config/remote/service/client_predicates.go
@@ -7,7 +7,6 @@ package service
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/Masterminds/semver"
 	"github.com/theupdateframework/go-tuf/data"
@@ -82,23 +81,23 @@ func executePredicate(client *pbgo.Client, predicates []*pbgo.TracerPredicateV1)
 		if client.IsTracer {
 			tracer := client.ClientTracer
 			if predicate.RuntimeID != "" && tracer.RuntimeId != predicate.RuntimeID {
-				return false, nil
+				continue
 			}
 
 			if predicate.Service != "" && tracer.Service != predicate.Service {
-				return false, nil
+				continue
 			}
 
 			if predicate.Environment != "" && tracer.Env != predicate.Environment {
-				return false, nil
+				continue
 			}
 
 			if predicate.Language != "" && tracer.Language != predicate.Language {
-				return false, nil
+				continue
 			}
 
 			if predicate.AppVersion != "" && tracer.AppVersion != predicate.AppVersion {
-				return false, nil
+				continue
 			}
 
 			if predicate.TracerVersion != "" {
@@ -112,15 +111,14 @@ func executePredicate(client *pbgo.Client, predicates []*pbgo.TracerPredicateV1)
 				}
 
 				matched, errs := versionConstraint.Validate(version)
-				if len(errs) != 0 {
-					return false, fmt.Errorf("errors: %s", errs)
-				}
+				// We don't return on error here, it's simply the version not matching
 				if !matched || len(errs) > 0 {
-					return false, nil
+					continue
 				}
 			}
 		}
+		return true, nil
 	}
 
-	return true, nil
+	return false, nil
 }

--- a/pkg/config/remote/service/client_predicates_test.go
+++ b/pkg/config/remote/service/client_predicates_test.go
@@ -85,8 +85,8 @@ func TestClientPredicates(t *testing.T) {
 	// empty string match
 	tester(true, []*pbgo.TracerPredicateV1{{Language: empty}})
 
-	// test match all
-	tester(true, []*pbgo.TracerPredicateV1{})
+	// test match nothing
+	tester(false, []*pbgo.TracerPredicateV1{})
 
 	// multiple fields
 	tester(
@@ -113,6 +113,40 @@ func TestClientPredicates(t *testing.T) {
 			{
 				TracerVersion: tracerVersion,
 				Service:       empty,
+			},
+		},
+	)
+
+	// multiple predicates, none matching
+	tester(
+		false,
+		[]*pbgo.TracerPredicateV1{
+			{
+				TracerVersion: tracerVersion,
+				Service:       serviceFail,
+			},
+			{
+				TracerVersion: tracerVersionFail,
+				Service:       serviceMatch,
+			},
+		},
+	)
+
+	// multple predicates, at least one matching
+	tester(
+		false,
+		[]*pbgo.TracerPredicateV1{
+			{
+				TracerVersion: tracerVersion,
+				Service:       serviceFail,
+			},
+			{
+				TracerVersion: tracerVersionFail,
+				Service:       serviceMatch,
+			},
+			{
+				TracerVersion: tracerVersionFail,
+				Service:       serviceMatch,
 			},
 		},
 	)

--- a/pkg/config/remote/service/client_predicates_test.go
+++ b/pkg/config/remote/service/client_predicates_test.go
@@ -85,6 +85,9 @@ func TestClientPredicates(t *testing.T) {
 	// empty string match
 	tester(true, []*pbgo.TracerPredicateV1{{Language: empty}})
 
+	// test match everything
+	tester(true, []*pbgo.TracerPredicateV1{{}})
+
 	// test match nothing
 	tester(false, []*pbgo.TracerPredicateV1{})
 


### PR DESCRIPTION
### What does this PR do?
To match the backend predicates logic, we want the tracer predicates to
follow the following rules:
- An empty list matches nothing
- At least one predicate matching is enough to pass

### Motivation
Preparing new product launches

### Additional Notes
There is a route in our internal API that will let you test this

### Possible Drawbacks / Trade-offs
Configurations currently using tracer predicates may see their behavior change. Still, as far as we know, this field is not used yet so the change shouldn't have much impact

### Describe how to test/QA your changes
- Create a configuration with a tracer predicate (or better: multiple tracer predicates) and make sure it lands where it should
- Create a configuration with an empty list of tracer predicates and make sure no one can access it
- Create a configuration with a list of an empty tracer predicate (`[{}]`) and make sure everyone can access it

### Reviewer's Checklist
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x]  At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
