### PR TITLE
[process-agent] Remove duplicated fmtProcessEvents function

### DIFF
--- a/cmd/process-agent/app/events.go
+++ b/cmd/process-agent/app/events.go
@@ -105,7 +105,7 @@ func printEvents(events ...*model.ProcessEvent) error {
 		return printEventsJSON(events)
 	}
 
-	fmtEvents := fmtProcessEvents(events)
+	fmtEvents := checks.FmtProcessEvents(events)
 	procCollector := &payload.CollectorProcEvent{Events: fmtEvents}
 	msgs := []payload.MessageBody{procCollector}
 	return checks.HumanFormatProcessEvents(msgs, os.Stdout, false)
@@ -206,54 +206,4 @@ func runEventStore(cmd *cobra.Command, args []string) error {
 	log.Flush()
 
 	return nil
-}
-
-// fmtProcessEvents formats process lifecyle events as an agent payload
-// The function in the checks package can't be exported without breaking the android build for the core-agent
-// TODO: fix it
-func fmtProcessEvents(events []*model.ProcessEvent) []*payload.ProcessEvent {
-	payloadEvents := make([]*payload.ProcessEvent, 0, len(events))
-
-	for _, e := range events {
-		pE := &payload.ProcessEvent{
-			CollectionTime: e.CollectionTime.UnixNano(),
-			Pid:            e.Pid,
-			ContainerId:    e.ContainerID,
-			Command: &payload.Command{
-				Exe:  e.Exe,
-				Args: e.Cmdline,
-				Ppid: int32(e.Ppid),
-			},
-			User: &payload.ProcessUser{
-				Name: e.Username,
-				Uid:  int32(e.UID),
-				Gid:  int32(e.GID),
-			},
-		}
-
-		switch e.EventType {
-		case model.Exec:
-			pE.Type = payload.ProcEventType_exec
-			exec := &payload.ProcessExec{
-				ForkTime: e.ForkTime.UnixNano(),
-				ExecTime: e.ExecTime.UnixNano(),
-			}
-			pE.TypedEvent = &payload.ProcessEvent_Exec{Exec: exec}
-		case model.Exit:
-			pE.Type = payload.ProcEventType_exit
-			exit := &payload.ProcessExit{
-				ExecTime: e.ExecTime.UnixNano(),
-				ExitTime: e.ExitTime.UnixNano(),
-				ExitCode: int32(e.ExitCode),
-			}
-			pE.TypedEvent = &payload.ProcessEvent_Exit{Exit: exit}
-		default:
-			log.Error("Unexpected event type, dropping it")
-			continue
-		}
-
-		payloadEvents = append(payloadEvents, pE)
-	}
-
-	return payloadEvents
 }

--- a/pkg/process/checks/process_events_common.go
+++ b/pkg/process/checks/process_events_common.go
@@ -9,7 +9,11 @@ import (
 	"testing"
 	"time"
 
+	payload "github.com/DataDog/agent-payload/v5/process"
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/process/events/model"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 func parseRFC3339Time(t *testing.T, s string) time.Time {
@@ -17,4 +21,52 @@ func parseRFC3339Time(t *testing.T, s string) time.Time {
 	parsed, err := time.Parse(time.RFC3339Nano, s)
 	require.NoError(t, err)
 	return parsed
+}
+
+// FmtProcessEvents formats process lifecyle events to be sent in an agent payload
+func FmtProcessEvents(events []*model.ProcessEvent) []*payload.ProcessEvent {
+	payloadEvents := make([]*payload.ProcessEvent, 0, len(events))
+
+	for _, e := range events {
+		pE := &payload.ProcessEvent{
+			CollectionTime: e.CollectionTime.UnixNano(),
+			Pid:            e.Pid,
+			ContainerId:    e.ContainerID,
+			Command: &payload.Command{
+				Exe:  e.Exe,
+				Args: e.Cmdline,
+				Ppid: int32(e.Ppid),
+			},
+			User: &payload.ProcessUser{
+				Name: e.Username,
+				Uid:  int32(e.UID),
+				Gid:  int32(e.GID),
+			},
+		}
+
+		switch e.EventType {
+		case model.Exec:
+			pE.Type = payload.ProcEventType_exec
+			exec := &payload.ProcessExec{
+				ForkTime: e.ForkTime.UnixNano(),
+				ExecTime: e.ExecTime.UnixNano(),
+			}
+			pE.TypedEvent = &payload.ProcessEvent_Exec{Exec: exec}
+		case model.Exit:
+			pE.Type = payload.ProcEventType_exit
+			exit := &payload.ProcessExit{
+				ExecTime: e.ExecTime.UnixNano(),
+				ExitTime: e.ExitTime.UnixNano(),
+				ExitCode: int32(e.ExitCode),
+			}
+			pE.TypedEvent = &payload.ProcessEvent_Exit{Exit: exit}
+		default:
+			log.Error("Unexpected event type, dropping it")
+			continue
+		}
+
+		payloadEvents = append(payloadEvents, pE)
+	}
+
+	return payloadEvents
 }

--- a/pkg/process/checks/process_events_linux.go
+++ b/pkg/process/checks/process_events_linux.go
@@ -100,7 +100,7 @@ func (e *ProcessEventsCheck) Run(cfg *config.AgentConfig, groupID int32) ([]payl
 		return nil, fmt.Errorf("can't pull events from the Event Store: %v", err)
 	}
 
-	payloadEvents := fmtProcessEvents(events)
+	payloadEvents := FmtProcessEvents(events)
 	chunks := chunkProcessEvents(payloadEvents, e.maxBatchSize)
 
 	messages := make([]payload.MessageBody, len(chunks))
@@ -152,52 +152,4 @@ func chunkProcessEvents(events []*payload.ProcessEvent, size int) [][]*payload.P
 	}
 
 	return chunks
-}
-
-// fmtProcessEvents formats process lifecyle events to be sent in an agent payload
-func fmtProcessEvents(events []*model.ProcessEvent) []*payload.ProcessEvent {
-	payloadEvents := make([]*payload.ProcessEvent, 0, len(events))
-
-	for _, e := range events {
-		pE := &payload.ProcessEvent{
-			CollectionTime: e.CollectionTime.UnixNano(),
-			Pid:            e.Pid,
-			ContainerId:    e.ContainerID,
-			Command: &payload.Command{
-				Exe:  e.Exe,
-				Args: e.Cmdline,
-				Ppid: int32(e.Ppid),
-			},
-			User: &payload.ProcessUser{
-				Name: e.Username,
-				Uid:  int32(e.UID),
-				Gid:  int32(e.GID),
-			},
-		}
-
-		switch e.EventType {
-		case model.Exec:
-			pE.Type = payload.ProcEventType_exec
-			exec := &payload.ProcessExec{
-				ForkTime: e.ForkTime.UnixNano(),
-				ExecTime: e.ExecTime.UnixNano(),
-			}
-			pE.TypedEvent = &payload.ProcessEvent_Exec{Exec: exec}
-		case model.Exit:
-			pE.Type = payload.ProcEventType_exit
-			exit := &payload.ProcessExit{
-				ExecTime: e.ExecTime.UnixNano(),
-				ExitTime: e.ExitTime.UnixNano(),
-				ExitCode: int32(e.ExitCode),
-			}
-			pE.TypedEvent = &payload.ProcessEvent_Exit{Exit: exit}
-		default:
-			log.Error("Unexpected event type, dropping it")
-			continue
-		}
-
-		payloadEvents = append(payloadEvents, pE)
-	}
-
-	return payloadEvents
 }


### PR DESCRIPTION
### What does this PR do?

The `fmtProcessEvents` function from the `checks` package was duplicated in the `app` package due to  a transitive dependency from the core-agent on the former.

This dependency was removed in https://github.com/DataDog/datadog-agent/pull/12957 so the function can now be exported in the `checks` package.

### Motivation

Remove code duplication.

### Additional Notes


### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes

Make sure that the `events listen`, `events pull` and `check process_events` commands are working as expected and outputting data in the right format with and without the `--json` flag. 

Update the `system-probe.yaml` file with
```
runtime_security_config:
  event_monitoring:
    enabled: true
```

Start the `datadog-agent` and make sure that `system-probe` is running. 

Start listening for process events with `process-agent`:
```
sudo ./process-agent events listen <--json>
```

and 
```
sudo ./process-agent events pull <--json>
```

Manually execute a `process_events` check with
```
sudo ./process-agent check process_events -w 10s <--json>
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
