### PR TITLE
[cmd] status: log at info level always when running the command

### DIFF
--- a/cmd/agent/app/status.go
+++ b/cmd/agent/app/status.go
@@ -77,7 +77,9 @@ var statusCmd = &cobra.Command{
 			return fmt.Errorf("unable to set up global agent configuration: %v", err)
 		}
 
-		err = config.SetupLogger(loggerName, config.GetEnvDefault("DD_LOG_LEVEL", "info"), "", "", false, true, false)
+		// log level should always be info as that's the level at which we log the
+		// status output.
+		err = config.SetupLogger(loggerName, "info", "", "", false, true, false)
 		if err != nil {
 			fmt.Printf("Cannot setup logger, exiting: %v\n", err)
 			return err

--- a/releasenotes/notes/agent-status-log-level-fix-93b84dd50b4a9257.yaml
+++ b/releasenotes/notes/agent-status-log-level-fix-93b84dd50b4a9257.yaml
@@ -8,5 +8,5 @@
 ---
 fixes:
   - |
-    Agent status command should always log at info level to avoid
-    interference from agent-wide log-level setting in printout.
+    Agent status command should always log at info level to allow
+    full status output regardless of Agent log level settings.

--- a/releasenotes/notes/agent-status-log-level-fix-93b84dd50b4a9257.yaml
+++ b/releasenotes/notes/agent-status-log-level-fix-93b84dd50b4a9257.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Agent status command should always log at info level to avoid
+    interference from agent-wide log-level setting in printout.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

This PR sets the log level when running the agent status command always to
`info` as that is the level at which the status is logged to screen.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Currently the log level for the status command is grabbed from the environment
or defaults to `info`. The feature works as expected on hosted environments, but
can break the feature on containerized environments due to the DD_LOG_LEVEL
env var being commonly used. We should _always_ default to log level for this
command as the entire output from the status map is logged using `log.Info(...)`. 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

None

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

None

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

1. Start a containerized agent and set `DD_LOG_LEVEL` to "warn" or higher.
2.  Run the agent status command: `agent status`
3. Make sure there's correct valid status update; as opposed to nothing.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ x At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
