### PR TITLE
CWS: dynamic AD dump timeout

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "477407635aedcbb5c51e11c4355c6d630a7a14d127108a8d679f821d37c4f3bf")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "421248de4a459fc78ee713749f5f196c5fb6d2c1b79683a3c030696f42b6915e")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "421248de4a459fc78ee713749f5f196c5fb6d2c1b79683a3c030696f42b6915e")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "97ff2bb427751a1bb00a0cd50676e46a82f9f07533cd1abb70201b1865f35b0b")

--- a/pkg/security/ebpf/c/activity_dump.h
+++ b/pkg/security/ebpf/c/activity_dump.h
@@ -60,7 +60,7 @@ struct bpf_map_def SEC("maps/ad_dump_timeout") ad_dump_timeout = {
 __attribute__((always_inline)) u64 get_dump_timeout() {
     u32 key = 0;
     u64 *value = bpf_map_lookup_elem(&ad_dump_timeout, &key);
-    if (!value) {
+    if (!value || *value == 0) {
         return DURATION_30_MINUTES;
     }
     return *value;

--- a/pkg/security/ebpf/c/activity_dump.h
+++ b/pkg/security/ebpf/c/activity_dump.h
@@ -48,10 +48,22 @@ struct bpf_map_def SEC("maps/traced_event_types") traced_event_types = {
     .max_entries = EVENT_MAX + 1,
 };
 
+struct bpf_map_def SEC("maps/ad_dump_timeout") ad_dump_timeout = {
+    .type = BPF_MAP_TYPE_ARRAY,
+    .key_size = sizeof(u32),
+    .value_size = sizeof(u64),
+    .max_entries = 1,
+};
+
+#define DURATION_30_MINUTES (30 * 60 * 1000000000ull)
+
 __attribute__((always_inline)) u64 get_dump_timeout() {
-    u64 dump_timeout;
-    LOAD_CONSTANT("dump_timeout", dump_timeout);
-    return dump_timeout;
+    u32 key = 0;
+    u64 *value = bpf_map_lookup_elem(&ad_dump_timeout, &key);
+    if (!value) {
+        return DURATION_30_MINUTES;
+    }
+    return *value;
 }
 
 __attribute__((always_inline)) u64 is_cgroup_activity_dumps_enabled() {

--- a/pkg/security/probe/activity_dump_manager.go
+++ b/pkg/security/probe/activity_dump_manager.go
@@ -34,10 +34,6 @@ func areCGroupADsEnabled(p *Probe) bool {
 	return p.config.ActivityDumpTracedCgroupsCount > 0
 }
 
-func getCgroupDumpTimeout(p *Probe) uint64 {
-	return uint64(p.config.ActivityDumpCgroupDumpTimeout.Nanoseconds())
-}
-
 // ActivityDumpManager is used to manage ActivityDumps
 type ActivityDumpManager struct {
 	sync.RWMutex

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -1476,10 +1476,6 @@ func NewProbe(config *config.Config, statsdClient statsd.ClientInterface) (*Prob
 			Value: utils.BoolTouint64(areCGroupADsEnabled(p)),
 		},
 		manager.ConstantEditor{
-			Name:  "dump_timeout",
-			Value: getCgroupDumpTimeout(p),
-		},
-		manager.ConstantEditor{
 			Name:  "net_struct_type",
 			Value: getNetStructType(p.kernelVersion),
 		},


### PR DESCRIPTION
### What does this PR do?

This PR adds support for dynamic configuration of the timeout value of a dump.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
