### PR TITLE
[pkg/otlp] Deep copy values when reading a configuration section

### DIFF
--- a/pkg/otlp/config.go
+++ b/pkg/otlp/config.go
@@ -16,6 +16,7 @@ import (
 	"go.uber.org/multierr"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/mohae/deepcopy"
 )
 
 func portToUint(v int) (port uint, err error) {
@@ -48,7 +49,8 @@ func readConfigSection(cfg config.Config, section string) *confmap.Conf {
 	rawVal := cfg.Get(section)
 	stringMap := map[string]interface{}{}
 	if val, ok := rawVal.(map[string]interface{}); ok {
-		stringMap = val
+		// deep copy since `cfg.Get` returns a reference
+		stringMap = deepcopy.Copy(val).(map[string]interface{})
 	}
 
 	// Step two works around https://github.com/spf13/viper/issues/1012
@@ -58,7 +60,8 @@ func readConfigSection(cfg config.Config, section string) *confmap.Conf {
 	for _, key := range cfg.AllKeys() {
 		if strings.HasPrefix(key, prefix) && cfg.IsSet(key) {
 			mapKey := strings.ReplaceAll(key[len(prefix):], ".", confmap.KeyDelimiter)
-			stringMap[mapKey] = cfg.Get(key)
+			// deep copy since `cfg.Get` returns a reference
+			stringMap[mapKey] = deepcopy.Copy(cfg.Get(key))
 		}
 	}
 	return confmap.NewFromStringMap(stringMap)

--- a/releasenotes/notes/fix-otlp-concurrency-4966bff7ebac155e.yaml
+++ b/releasenotes/notes/fix-otlp-concurrency-4966bff7ebac155e.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Fix concurrent map access issues when using OTLP ingest
+    Fix concurrent map access issues when using OTLP ingest.

--- a/releasenotes/notes/fix-otlp-concurrency-4966bff7ebac155e.yaml
+++ b/releasenotes/notes/fix-otlp-concurrency-4966bff7ebac155e.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix concurrent map access issues when using OTLP ingest


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Deep copy objects gotten via the `Get` method 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Viper returns a reference to maps/slices, which can cause concurrency issues. This avoids concurrent modifications of the returned references.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

We could also deep copy at the `pkg/config` level, but I am not sure what the implications of that would be.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

See https://github.com/DataDog/datadog-agent/pull/12985#issuecomment-1204948693

<To be filled>

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
