### PR TITLE
CWS: AD load controller feedback loop

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1091,6 +1091,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.cleanup_period", 30)
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.tags_resolution_period", 60)
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.load_controller_period", 2)
+	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.load_controller_max_total_size", 100)
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.path_merge.enabled", true)
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.traced_cgroups_count", 3)
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.traced_event_types", []string{"exec", "open", "dns", "bind"})

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1090,6 +1090,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.enabled", false)
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.cleanup_period", 30)
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.tags_resolution_period", 60)
+	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.load_controller_period", 2)
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.path_merge.enabled", true)
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.traced_cgroups_count", 3)
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.traced_event_types", []string{"exec", "open", "dns", "bind"})

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -106,6 +106,8 @@ type Config struct {
 	// ActivityDumpTagsResolutionPeriod defines the period at which the activity dump manager should try to resolve
 	// missing container tags.
 	ActivityDumpTagsResolutionPeriod time.Duration
+	// ActivityDumpLoadControlPeriod defines the period at which the activity dump manager should trigger the load controller
+	ActivityDumpLoadControlPeriod time.Duration
 	// ActivityDumpPathMergeEnabled defines if path merge should be enabled
 	ActivityDumpPathMergeEnabled bool
 	// ActivityDumpTracedCgroupsCount defines the maximum count of cgroups that should be monitored concurrently. Set
@@ -235,6 +237,7 @@ func NewConfig(cfg *config.Config) (*Config, error) {
 		ActivityDumpEnabled:                   coreconfig.Datadog.GetBool("runtime_security_config.activity_dump.enabled"),
 		ActivityDumpCleanupPeriod:             time.Duration(coreconfig.Datadog.GetInt("runtime_security_config.activity_dump.cleanup_period")) * time.Second,
 		ActivityDumpTagsResolutionPeriod:      time.Duration(coreconfig.Datadog.GetInt("runtime_security_config.activity_dump.tags_resolution_period")) * time.Second,
+		ActivityDumpLoadControlPeriod:         time.Duration(coreconfig.Datadog.GetInt("runtime_security_config.activity_dump.load_controller_period")) * time.Minute,
 		ActivityDumpPathMergeEnabled:          coreconfig.Datadog.GetBool("runtime_security_config.activity_dump.path_merge.enabled"),
 		ActivityDumpTracedCgroupsCount:        coreconfig.Datadog.GetInt("runtime_security_config.activity_dump.traced_cgroups_count"),
 		ActivityDumpTracedEventTypes:          model.ParseEventTypeStringSlice(coreconfig.Datadog.GetStringSlice("runtime_security_config.activity_dump.traced_event_types")),

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -108,6 +108,8 @@ type Config struct {
 	ActivityDumpTagsResolutionPeriod time.Duration
 	// ActivityDumpLoadControlPeriod defines the period at which the activity dump manager should trigger the load controller
 	ActivityDumpLoadControlPeriod time.Duration
+	// ActivityDumpLoadControlMaxTotalSize defines the maximum total size after which the load controller will try to reduce the dynamic config
+	ActivityDumpLoadControlMaxTotalSize int
 	// ActivityDumpPathMergeEnabled defines if path merge should be enabled
 	ActivityDumpPathMergeEnabled bool
 	// ActivityDumpTracedCgroupsCount defines the maximum count of cgroups that should be monitored concurrently. Set
@@ -238,6 +240,7 @@ func NewConfig(cfg *config.Config) (*Config, error) {
 		ActivityDumpCleanupPeriod:             time.Duration(coreconfig.Datadog.GetInt("runtime_security_config.activity_dump.cleanup_period")) * time.Second,
 		ActivityDumpTagsResolutionPeriod:      time.Duration(coreconfig.Datadog.GetInt("runtime_security_config.activity_dump.tags_resolution_period")) * time.Second,
 		ActivityDumpLoadControlPeriod:         time.Duration(coreconfig.Datadog.GetInt("runtime_security_config.activity_dump.load_controller_period")) * time.Minute,
+		ActivityDumpLoadControlMaxTotalSize:   coreconfig.Datadog.GetInt(" runtime_security_config.activity_dump.load_controller_max_total_size"),
 		ActivityDumpPathMergeEnabled:          coreconfig.Datadog.GetBool("runtime_security_config.activity_dump.path_merge.enabled"),
 		ActivityDumpTracedCgroupsCount:        coreconfig.Datadog.GetInt("runtime_security_config.activity_dump.traced_cgroups_count"),
 		ActivityDumpTracedEventTypes:          model.ParseEventTypeStringSlice(coreconfig.Datadog.GetStringSlice("runtime_security_config.activity_dump.traced_event_types")),

--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -157,6 +157,9 @@ var (
 	// MetricActivityDumpPathMergeCount is the name of the metric used to report the number of path merged
 	// Tags: -
 	MetricActivityDumpPathMergeCount = newRuntimeMetric(".activity_dump.path_merged")
+	// MetricActivityDumpLoadControllerTriggered is the name of the metric used to report that the ADM load controller reduced the config envelope
+	// Tags: -
+	MetricActivityDumpLoadControllerTriggered = newRuntimeMetric(".activity_dump.load_controller_triggered")
 	// MetricActivityDumpEntityTooLarge is the name of the metric used to report the number of active dumps that couldn't
 	// be sent because they are too big
 	// Tags: format, compression

--- a/pkg/security/probe/activity_dump.go
+++ b/pkg/security/probe/activity_dump.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/DataDog/gopsutil/process"
+	"github.com/DmitriyVTitov/size"
 	"github.com/prometheus/procfs"
 	"github.com/tinylib/msgp/msgp"
 	"go.uber.org/atomic"
@@ -98,6 +99,7 @@ type ActivityDump struct {
 	addedRuntimeCount  map[model.EventType]*atomic.Uint64
 	addedSnapshotCount map[model.EventType]*atomic.Uint64
 	pathMergedCount    *atomic.Uint64
+	lastComputedSize   uint64
 
 	// standard attributes used by the intake
 	Host    string   `msg:"host" json:"host,omitempty"`
@@ -246,6 +248,20 @@ func (ad *ActivityDump) AddStorageRequest(request dump.StorageRequest) {
 		ad.StorageRequests = make(map[dump.StorageFormat][]dump.StorageRequest)
 	}
 	ad.StorageRequests[request.Format] = append(ad.StorageRequests[request.Format], request)
+}
+
+func (ad *ActivityDump) computeMemorySize() uint64 {
+	ad.Lock()
+	defer ad.Unlock()
+
+	if ad.lastComputedSize == 0 {
+		adSize := size.Of(ad)
+		if adSize < 0 {
+			adSize = 0
+		}
+		ad.lastComputedSize = uint64(adSize)
+	}
+	return ad.lastComputedSize
 }
 
 // getTimeoutRawTimestamp returns the timeout timestamp of the current activity dump as a monolitic kernel timestamp
@@ -416,6 +432,9 @@ func (ad *ActivityDump) Insert(event *Event) (newEntry bool) {
 	// the count of processed events is the count of events that matched the activity dump selector = the events for
 	// which we successfully found a process activity node
 	ad.processedCount[event.GetEventType()].Inc()
+
+	// we invalidate the precomputed memory size
+	ad.lastComputedSize = 0
 
 	// insert the event based on its type
 	switch event.GetEventType() {

--- a/pkg/security/probe/activity_dump.go
+++ b/pkg/security/probe/activity_dump.go
@@ -29,7 +29,6 @@ import (
 	"time"
 
 	"github.com/DataDog/gopsutil/process"
-	"github.com/DmitriyVTitov/size"
 	"github.com/prometheus/procfs"
 	"github.com/tinylib/msgp/msgp"
 	"go.uber.org/atomic"
@@ -255,11 +254,8 @@ func (ad *ActivityDump) computeMemorySize() uint64 {
 	defer ad.Unlock()
 
 	if ad.lastComputedSize == 0 {
-		adSize := size.Of(ad)
-		if adSize < 0 {
-			adSize = 0
-		}
-		ad.lastComputedSize = uint64(adSize)
+		stats := ad.computeSizeStats()
+		ad.lastComputedSize = stats.approximateSize()
 	}
 	return ad.lastComputedSize
 }

--- a/pkg/security/probe/activity_dump_load_controller.go
+++ b/pkg/security/probe/activity_dump_load_controller.go
@@ -22,11 +22,70 @@ import (
 	"github.com/cilium/ebpf"
 )
 
-// ActivityDumpLoadController is a load controller allowing dynamic change of Activity Dump configuration
-type ActivityDumpLoadController struct {
+// ActivityDumpLCConfig represents the dynamic configuration managed by the load controller
+type ActivityDumpLCConfig struct {
 	tracedEventTypes   []model.EventType
 	tracedCgroupsCount uint64
 	dumpTimeout        time.Duration
+}
+
+// NewActivityDumpLCConfig returns a new dynamic config from user config
+func NewActivityDumpLCConfig(cfg *config.Config) *ActivityDumpLCConfig {
+	tracedCgroupsCount := uint64(cfg.ActivityDumpTracedCgroupsCount)
+	if tracedCgroupsCount > probes.MaxTracedCgroupsCount {
+		tracedCgroupsCount = probes.MaxTracedCgroupsCount
+	}
+
+	return &ActivityDumpLCConfig{
+		tracedEventTypes:   cfg.ActivityDumpTracedEventTypes,
+		tracedCgroupsCount: tracedCgroupsCount,
+		dumpTimeout:        cfg.ActivityDumpCgroupDumpTimeout,
+	}
+}
+
+const minDumpTimeout = 10 * time.Minute
+
+func (lcCfg *ActivityDumpLCConfig) reduced() *ActivityDumpLCConfig {
+	// first we try reducing the amount of concurrently traced cgroups
+	if lcCfg.tracedCgroupsCount > 1 {
+		return &ActivityDumpLCConfig{
+			tracedEventTypes:   lcCfg.tracedEventTypes,
+			tracedCgroupsCount: lcCfg.tracedCgroupsCount - 1,
+			dumpTimeout:        lcCfg.dumpTimeout,
+		}
+	}
+
+	// then we try to reduce the timeout
+	if lcCfg.dumpTimeout > minDumpTimeout {
+		newTimeout := lcCfg.dumpTimeout * 3 / 4 // reduce by 25%
+		if newTimeout < minDumpTimeout {
+			newTimeout = minDumpTimeout
+		}
+		return &ActivityDumpLCConfig{
+			tracedEventTypes:   lcCfg.tracedEventTypes,
+			tracedCgroupsCount: lcCfg.tracedCgroupsCount,
+			dumpTimeout:        newTimeout,
+		}
+	}
+
+	// finally, as a last resort, we try removing file events
+	newEventTypes := make([]model.EventType, 0, len(lcCfg.tracedEventTypes))
+	for _, et := range lcCfg.tracedEventTypes {
+		if et != model.FileOpenEventType {
+			newEventTypes = append(newEventTypes, et)
+		}
+	}
+	return &ActivityDumpLCConfig{
+		tracedEventTypes:   newEventTypes,
+		tracedCgroupsCount: lcCfg.tracedCgroupsCount,
+		dumpTimeout:        lcCfg.dumpTimeout,
+	}
+}
+
+// ActivityDumpLoadController is a load controller allowing dynamic change of Activity Dump configuration
+type ActivityDumpLoadController struct {
+	originalConfig *ActivityDumpLCConfig
+	currentConfig  *ActivityDumpLCConfig
 
 	tracedEventTypesMap     *ebpf.Map
 	tracedCgroupsCounterMap *ebpf.Map
@@ -60,11 +119,6 @@ func NewActivityDumpLoadController(cfg *config.Config, man *manager.Manager) (*A
 		return nil, fmt.Errorf("couldn't find traced_cgroups_lock map")
 	}
 
-	tracedCgroupsCount := uint64(cfg.ActivityDumpTracedCgroupsCount)
-	if tracedCgroupsCount > probes.MaxTracedCgroupsCount {
-		tracedCgroupsCount = probes.MaxTracedCgroupsCount
-	}
-
 	dumpTimeoutMap, found, err := man.GetMap("ad_dump_timeout")
 	if err != nil {
 		return nil, err
@@ -74,9 +128,7 @@ func NewActivityDumpLoadController(cfg *config.Config, man *manager.Manager) (*A
 	}
 
 	return &ActivityDumpLoadController{
-		tracedEventTypes:   cfg.ActivityDumpTracedEventTypes,
-		tracedCgroupsCount: tracedCgroupsCount,
-		dumpTimeout:        cfg.ActivityDumpCgroupDumpTimeout,
+		originalConfig: NewActivityDumpLCConfig(cfg),
 
 		tracedEventTypesMap:     tracedEventTypesMap,
 		tracedCgroupsCounterMap: tracedCgroupsCounterMap,
@@ -85,21 +137,36 @@ func NewActivityDumpLoadController(cfg *config.Config, man *manager.Manager) (*A
 	}, nil
 }
 
+func (lc *ActivityDumpLoadController) getCurrentConfig() *ActivityDumpLCConfig {
+	if lc.currentConfig != nil {
+		return lc.currentConfig
+	}
+	return lc.originalConfig
+}
+
+func (lc *ActivityDumpLoadController) reduceConfig() {
+	lcCfg := lc.getCurrentConfig()
+	newCfg := lcCfg.reduced()
+	lc.currentConfig = newCfg
+}
+
 func (lc *ActivityDumpLoadController) propagateLoadSettings() error {
 	return retry.Do(lc.propagateLoadSettingsRaw)
 }
 
 func (lc *ActivityDumpLoadController) propagateLoadSettingsRaw() error {
+	lcConfig := lc.getCurrentConfig()
+
 	// traced event types
 	isTraced := uint64(1)
-	for _, evtType := range lc.tracedEventTypes {
+	for _, evtType := range lcConfig.tracedEventTypes {
 		if err := lc.tracedEventTypesMap.Put(evtType, isTraced); err != nil {
 			return fmt.Errorf("failed to insert traced event type: %w", err)
 		}
 	}
 
 	// dump timeout
-	if err := lc.dumpTimeoutMap.Put(ebpfutils.ZeroUint32MapItem, uint64(lc.dumpTimeout.Nanoseconds())); err != nil {
+	if err := lc.dumpTimeoutMap.Put(ebpfutils.ZeroUint32MapItem, uint64(lcConfig.dumpTimeout.Nanoseconds())); err != nil {
 		return fmt.Errorf("failed to update dump timeout: %w", err)
 	}
 
@@ -120,7 +187,7 @@ func (lc *ActivityDumpLoadController) propagateLoadSettingsRaw() error {
 	}
 	log.Debugf("AD: got counter = %v, when propagating config", counter)
 
-	counter.Max = lc.tracedCgroupsCount
+	counter.Max = lcConfig.tracedCgroupsCount
 	if err := lc.tracedCgroupsCounterMap.Put(ebpfutils.ZeroUint32MapItem, counter); err != nil {
 		return fmt.Errorf("failed to change counter max: %w", err)
 	}

--- a/pkg/security/probe/activity_dump_manager.go
+++ b/pkg/security/probe/activity_dump_manager.go
@@ -536,5 +536,9 @@ func (adm *ActivityDumpManager) triggerLoadController() {
 	maxTotalADSize := adm.probe.config.ActivityDumpLoadControlMaxTotalSize * (1 << 20)
 	if totalSize > maxTotalADSize {
 		adm.loadController.reduceConfig()
+
+		if err := adm.probe.statsdClient.Count(metrics.MetricActivityDumpLoadControllerTriggered, 1, nil, 1.0); err != nil {
+			seclog.Errorf("couldn't send %s metric: %v", metrics.MetricActivityDumpLoadControllerTriggered, err)
+		}
 	}
 }

--- a/pkg/security/probe/activity_dump_manager.go
+++ b/pkg/security/probe/activity_dump_manager.go
@@ -518,8 +518,6 @@ func (adm *ActivityDumpManager) AddContextTags(ad *ActivityDump) {
 	}
 }
 
-const maxTotalADSize = 100 * (2 << 20) // 100 MiB
-
 func (adm *ActivityDumpManager) triggerLoadController() {
 	adm.Lock()
 	defer adm.Unlock()
@@ -535,6 +533,7 @@ func (adm *ActivityDumpManager) triggerLoadController() {
 		ad.Unlock()
 	}
 
+	maxTotalADSize := adm.probe.config.ActivityDumpLoadControlMaxTotalSize * (1 << 20)
 	if totalSize > maxTotalADSize {
 		adm.loadController.reduceConfig()
 	}

--- a/pkg/security/probe/activity_dump_memlimits.go
+++ b/pkg/security/probe/activity_dump_memlimits.go
@@ -1,0 +1,78 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+// +build linux
+
+package probe
+
+import "unsafe"
+
+type ActivityDumpSizeStats struct {
+	processNodes uint64
+	fileNodes    uint64
+	dnsNodes     uint64
+	socketNodes  uint64
+}
+
+func (stats *ActivityDumpSizeStats) approximateSize() uint64 {
+	var total uint64
+	total += stats.processNodes * uint64(unsafe.Sizeof(ProcessActivityNode{}))
+	total += stats.fileNodes * uint64(unsafe.Sizeof(FileActivityNode{}))
+	total += stats.dnsNodes * uint64(unsafe.Sizeof(DNSNode{}))
+	total += stats.socketNodes * uint64(unsafe.Sizeof(SocketNode{}))
+	return total
+}
+
+// Caution: you must hold a lock on the AD before calling this
+func (ad *ActivityDump) computeSizeStats() ActivityDumpSizeStats {
+	stats := ActivityDumpSizeStats{}
+
+	openList := make([]*ProcessActivityNode, len(ad.ProcessActivityTree))
+	copy(openList, ad.ProcessActivityTree)
+
+	for len(openList) != 0 {
+		current := openList[len(openList)-1]
+		openList = openList[:len(openList)-1]
+
+		stats.processNodes += 1
+
+		// files
+		stats.fileNodes += countFileNodes(current.Files)
+
+		// DNS
+		for _, dnsNode := range current.DNSNames {
+			stats.dnsNodes += uint64(len(dnsNode.Requests))
+		}
+
+		// sockets
+		for _, socketNode := range current.Sockets {
+			// each bind node + 1 for the global socket node
+			stats.socketNodes += uint64(len(socketNode.Bind)) + 1
+		}
+
+		openList = append(openList, current.Children...)
+	}
+
+	return stats
+}
+
+func countFileNodes(files map[string]*FileActivityNode) uint64 {
+	var counter uint64
+
+	openList := []map[string]*FileActivityNode{files}
+
+	for len(openList) != 0 {
+		current := openList[len(openList)-1]
+		openList = openList[:len(openList)-1]
+
+		for _, f := range current {
+			counter += 1
+			openList = append(openList, f.Children)
+		}
+	}
+
+	return counter
+}

--- a/pkg/security/probe/activity_dump_memlimits.go
+++ b/pkg/security/probe/activity_dump_memlimits.go
@@ -10,6 +10,7 @@ package probe
 
 import "unsafe"
 
+// ActivityDumpSizeStats represents the node counts in an activity dump
 type ActivityDumpSizeStats struct {
 	processNodes uint64
 	fileNodes    uint64
@@ -37,7 +38,7 @@ func (ad *ActivityDump) computeSizeStats() ActivityDumpSizeStats {
 		current := openList[len(openList)-1]
 		openList = openList[:len(openList)-1]
 
-		stats.processNodes += 1
+		stats.processNodes++
 
 		// files
 		stats.fileNodes += countFileNodes(current.Files)
@@ -69,7 +70,7 @@ func countFileNodes(files map[string]*FileActivityNode) uint64 {
 		openList = openList[:len(openList)-1]
 
 		for _, f := range current {
-			counter += 1
+			counter++
 			openList = append(openList, f.Children)
 		}
 	}


### PR DESCRIPTION
### What does this PR do?

This PR implements a very simple feedback loop for the load controller. It periodically compute the total size occupied by currently in-flight dumps, and reduce the config scope if it goes over a provided limit.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
