### PR TITLE
[Helm check] Introduce sync timeout and resync interval params and increase the defaults

### DIFF
--- a/pkg/collector/corechecks/cluster/helm/helm.go
+++ b/pkg/collector/corechecks/cluster/helm/helm.go
@@ -36,7 +36,8 @@ const (
 	checkName               = "helm"
 	serviceCheckName        = "helm.release_state"
 	maximumWaitForAPIServer = 10 * time.Second
-	informerSyncTimeout     = 60 * time.Second
+	defaultExtraSyncTimeout = 120 * time.Second
+	defaultResyncInterval   = 10 * time.Minute
 	labelSelector           = "owner=helm"
 )
 
@@ -71,7 +72,9 @@ type HelmCheck struct {
 }
 
 type checkConfig struct {
-	CollectEvents bool `yaml:"collect_events"`
+	CollectEvents                  bool `yaml:"collect_events"`
+	ExtraSyncTimeoutSeconds        int  `yaml:"extra_sync_timeout_seconds"`
+	InformersResyncIntervalMinutes int  `yaml:"informers_resync_interval_minutes"`
 }
 
 // Parse parses the config and sets default values
@@ -120,7 +123,7 @@ func (hc *HelmCheck) Configure(config, initConfig integration.Data, source strin
 		return err
 	}
 
-	hc.informerFactory = sharedInformerFactory(apiClient)
+	hc.setSharedInformerFactory(apiClient)
 
 	return hc.setupInformers()
 }
@@ -184,14 +187,14 @@ func (hc *HelmCheck) setupInformers() error {
 			"helm-secrets":    secretInformer.Informer(),
 			"helm-configmaps": configmapInformer.Informer(),
 		},
-		informerSyncTimeout,
+		hc.getExtraSyncTimeout(),
 	)
 }
 
-func sharedInformerFactory(apiClient *apiserver.APIClient) informers.SharedInformerFactory {
-	return informers.NewSharedInformerFactoryWithOptions(
+func (hc *HelmCheck) setSharedInformerFactory(apiClient *apiserver.APIClient) {
+	hc.informerFactory = informers.NewSharedInformerFactoryWithOptions(
 		apiClient.Cl,
-		time.Duration(config.Datadog.GetInt64("kubernetes_informers_resync_period"))*time.Second,
+		hc.getInformersResyncPeriod(),
 		informers.WithTweakListOptions(func(opts *metav1.ListOptions) {
 			opts.LabelSelector = labelSelector
 		}),
@@ -408,4 +411,18 @@ func (hc *HelmCheck) sendServiceCheck(sender aggregator.Sender) {
 			}
 		}
 	}
+}
+
+func (hc *HelmCheck) getExtraSyncTimeout() time.Duration {
+	if hc.instance != nil && hc.instance.ExtraSyncTimeoutSeconds > 0 {
+		return time.Duration(hc.instance.ExtraSyncTimeoutSeconds) * time.Second
+	}
+	return defaultExtraSyncTimeout
+}
+
+func (hc *HelmCheck) getInformersResyncPeriod() time.Duration {
+	if hc.instance != nil && hc.instance.InformersResyncIntervalMinutes > 0 {
+		return time.Duration(hc.instance.InformersResyncIntervalMinutes) * time.Minute
+	}
+	return defaultResyncInterval
 }

--- a/releasenotes-dca/notes/helm-timeout-c88570bd12b6dc1d.yaml
+++ b/releasenotes-dca/notes/helm-timeout-c88570bd12b6dc1d.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The ``helm`` check has new configuration parameters:
+    - ``extra_sync_timeout_seconds`` (default 120)
+    - ``informers_resync_interval_minutes`` (default 10)

--- a/releasenotes/notes/helm-timeout-c88570bd12b6dc1d.yaml
+++ b/releasenotes/notes/helm-timeout-c88570bd12b6dc1d.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The ``helm`` check has new configuration parameters:
+    - ``extra_sync_timeout_seconds`` (default 120)
+    - ``informers_resync_interval_minutes`` (default 10)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

- The `helm` check has new configuration parameters:
  - `extra_sync_timeout_seconds` (default 120)
  - `informers_resync_interval_minutes` (default 10)
- Doubled the default values for the sync timeout and the resync interval
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

- Decouple the check configs from the central agent config
- The configmap informer requires longer timeouts on larger clusters that's why we bumped the default timeout
- An informer resync is a costly operation especially for the configmap informer, that's why we bumped the default resync interval
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

- Make sure the default config works on larger clusters
- Edit the config, make sure it's respected by the check

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
