### PR TITLE
[RCM-357] Send canonical JSON to tracers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -334,7 +334,7 @@ require (
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rs/cors v1.8.2 // indirect
 	github.com/sassoftware/go-rpmutils v0.2.0 // indirect
-	github.com/secure-systems-lab/go-securesystemslib v0.3.1 // indirect
+	github.com/secure-systems-lab/go-securesystemslib v0.3.1
 	github.com/sirupsen/logrus v1.9.0
 	github.com/smira/go-ftp-protocol v0.0.0-20140829150050-066b75c2b70d // indirect
 	github.com/smira/go-xz v0.0.0-20150414201226-0c531f070014

--- a/pkg/config/remote/service/service.go
+++ b/pkg/config/remote/service/service.go
@@ -411,6 +411,9 @@ func (s *Service) getNewDirectorRoots(currentVersion uint64, newVersion uint64) 
 			return nil, err
 		}
 		convertedRoot, err := enforceCanonicalJSON(root)
+		if err != nil {
+			return nil, err
+		}
 		roots = append(roots, convertedRoot)
 	}
 	return roots, nil

--- a/pkg/config/remote/service/service.go
+++ b/pkg/config/remote/service/service.go
@@ -559,12 +559,7 @@ func validateRequest(request *pbgo.ClientGetConfigsRequest) error {
 }
 
 func enforceCanonicalJSON(raw []byte) ([]byte, error) {
-	signedData := map[string]interface{}{}
-	err := json.Unmarshal(raw, &signedData)
-	if err != nil {
-		return nil, err
-	}
-	canonical, err := cjson.EncodeCanonical(signedData)
+	canonical, err := cjson.EncodeCanonical(json.RawMessage(raw))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/config/remote/service/service.go
+++ b/pkg/config/remote/service/service.go
@@ -362,14 +362,14 @@ func (s *Service) ClientGetConfigs(request *pbgo.ClientGetConfigsRequest) (*pbgo
 		}
 	}
 
-	targets, err := enforceCanonicalJSON(targetsRaw)
+	canonicalTargets, err := enforceCanonicalJSON(targetsRaw)
 	if err != nil {
 		return nil, err
 	}
 
 	return &pbgo.ClientGetConfigsResponse{
 		Roots:         roots,
-		Targets:       targets,
+		Targets:       canonicalTargets,
 		TargetFiles:   filteredFiles,
 		ClientConfigs: matchedClientConfigs,
 	}, nil
@@ -410,11 +410,11 @@ func (s *Service) getNewDirectorRoots(currentVersion uint64, newVersion uint64) 
 		if err != nil {
 			return nil, err
 		}
-		convertedRoot, err := enforceCanonicalJSON(root)
+		canonicalRoot, err := enforceCanonicalJSON(root)
 		if err != nil {
 			return nil, err
 		}
-		roots = append(roots, convertedRoot)
+		roots = append(roots, canonicalRoot)
 	}
 	return roots, nil
 }

--- a/pkg/config/remote/service/service_test.go
+++ b/pkg/config/remote/service/service_test.go
@@ -332,9 +332,12 @@ func TestService(t *testing.T) {
 	*uptaneClient = mockUptane{}
 	*api = mockAPI{}
 
-	root3 := []byte(`testroot3`)
-	root4 := []byte(`testroot4`)
-	targets := []byte(`testtargets`)
+	root3 := []byte(`{"signatures": "testroot3", "signed": "signed"}`)
+	canonicalRoot3 := []byte(`{"signatures":"testroot3","signed":"signed"}`)
+	root4 := []byte(`{"signed": "signed", "signatures": "testroot4"}`)
+	canonicalRoot4 := []byte(`{"signatures":"testroot4","signed":"signed"}`)
+	targets := []byte(`{"signatures": "testtargets", "signed": "stuff"}`)
+	canonicalTargets := []byte(`{"signatures":"testtargets","signed":"stuff"}`)
 	testTargetsCustom := []byte(`{"opaque_backend_state":"dGVzdF9zdGF0ZQ=="}`)
 	client := &pbgo.Client{
 		Id: "testid",
@@ -402,9 +405,9 @@ func TestService(t *testing.T) {
 	service.clients.seen(client) // Avoid blocking on channel sending when nothing is at the other end
 	configResponse, err := service.ClientGetConfigs(&pbgo.ClientGetConfigsRequest{Client: client})
 	assert.NoError(t, err)
-	assert.ElementsMatch(t, [][]byte{root3, root4}, configResponse.Roots)
+	assert.ElementsMatch(t, [][]byte{canonicalRoot3, canonicalRoot4}, configResponse.Roots)
 	assert.ElementsMatch(t, []*pbgo.File{{Path: "datadog/2/APM_SAMPLING/id/1", Raw: fileAPM1}, {Path: "datadog/2/APM_SAMPLING/id/2", Raw: fileAPM2}}, configResponse.TargetFiles)
-	assert.Equal(t, targets, configResponse.Targets)
+	assert.Equal(t, canonicalTargets, configResponse.Targets)
 	assert.ElementsMatch(t,
 		configResponse.ClientConfigs,
 		[]string{

--- a/pkg/config/remote/service/service_test.go
+++ b/pkg/config/remote/service/service_test.go
@@ -459,7 +459,7 @@ func TestServiceClientPredicates(t *testing.T) {
 			AppVersion: "1",
 		},
 	}
-	uptaneClient.On("TargetsMeta").Return([]byte(`testtargets`), nil)
+	uptaneClient.On("TargetsMeta").Return([]byte(`{"signed": "testtargets"}`), nil)
 	uptaneClient.On("TargetsCustom").Return([]byte(`{"opaque_backend_state":"dGVzdF9zdGF0ZQ=="}`), nil)
 
 	wrongServiceName := "wrong-service"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Send the canonical JSON (with OLPC spec) of the TUF files to the tracers

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Tracers can verify the TUF files sent without considering the OLPC spec

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

This is safe for the tracers because the snapshot.json is the only TUF file verifying the on-disk version of other TUF files, and not the canonical version. Tracers don't get the snapshots.
This is done at request-time and not at storage-time because we may re-verify with snapshot in the agent

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

Increase CPU usage when tracer requests the configs

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Make sure tracers get canonical JSON

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
