### PR TITLE
[process-agent] Abstract exchange of create times for connections check

### DIFF
--- a/pkg/process/checks/net.go
+++ b/pkg/process/checks/net.go
@@ -134,7 +134,7 @@ func (c *ConnectionsCheck) getConnections() (*model.Connections, error) {
 
 func (c *ConnectionsCheck) enrichConnections(conns []*model.Connection) []*model.Connection {
 	// Process create-times required to construct unique process hash keys on the backend
-	createTimeForPID := Process.createTimesforPIDs(connectionPIDs(conns))
+	createTimeForPID := ProcessNotify.GetCreateTimes(connectionPIDs(conns))
 	for _, conn := range conns {
 		if _, ok := createTimeForPID[conn.Pid]; !ok {
 			createTimeForPID[conn.Pid] = 0

--- a/pkg/process/checks/process_common_test.go
+++ b/pkg/process/checks/process_common_test.go
@@ -50,6 +50,12 @@ func makeProcess(pid int32, cmdline string) *procutil.Process {
 	}
 }
 
+func makeProcessWithCreateTime(pid int32, cmdline string, createTime int64) *procutil.Process {
+	p := makeProcess(pid, cmdline)
+	p.Stats.CreateTime = createTime
+	return p
+}
+
 func makeProcessModel(t *testing.T, process *procutil.Process) *model.Process {
 	t.Helper()
 
@@ -67,8 +73,9 @@ func makeProcessModel(t *testing.T, process *procutil.Process) *model.Process {
 			SystemPct: float32(cpu.SystemPct),
 			TotalPct:  float32(cpu.UserPct + cpu.SystemPct),
 		},
-		IoStat:   &model.IOStat{},
-		Networks: &model.ProcessNetworks{},
+		CreateTime: process.Stats.CreateTime,
+		IoStat:     &model.IOStat{},
+		Networks:   &model.ProcessNetworks{},
 	}
 }
 

--- a/pkg/process/checks/process_notify.go
+++ b/pkg/process/checks/process_notify.go
@@ -9,9 +9,7 @@ import "go.uber.org/atomic"
 
 // ProcessNotify implements an exchange mechanism for other checks to receive updates on changes
 // from process collection
-var ProcessNotify = &processNotify{
-	createTimes: &atomic.Value{},
-}
+var ProcessNotify = newProcessNotify()
 
 // processNotify implements an exchange mechanism for other checks to receive updates on changes
 // from process collection, in the future it can be replaced with a gRPC streaming interface
@@ -19,6 +17,12 @@ var ProcessNotify = &processNotify{
 type processNotify struct {
 	// Create times by PID used in the network check
 	createTimes *atomic.Value
+}
+
+func newProcessNotify() *processNotify {
+	return &processNotify{
+		createTimes: &atomic.Value{},
+	}
 }
 
 // UpdateCreateTimes updates create times for collected processes

--- a/pkg/process/checks/process_notify.go
+++ b/pkg/process/checks/process_notify.go
@@ -36,7 +36,6 @@ func (p *processNotify) GetCreateTimes(pids []int32) map[int32]int64 {
 				createTimeForPID[pid] = ctime
 			}
 		}
-		return createTimeForPID
 	}
 	return createTimeForPID
 }

--- a/pkg/process/checks/process_notify.go
+++ b/pkg/process/checks/process_notify.go
@@ -1,0 +1,42 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package checks
+
+import "go.uber.org/atomic"
+
+// ProcessNotify implements an exchange mechanism for other checks to receive updates on changes
+// from process collection
+var ProcessNotify = &processNotify{
+	createTimes: &atomic.Value{},
+}
+
+// processNotify implements an exchange mechanism for other checks to receive updates on changes
+// from process collection, in the future it can be replaced with a gRPC streaming interface
+// to allow notifying checks running in other processes
+type processNotify struct {
+	// Create times by PID used in the network check
+	createTimes *atomic.Value
+}
+
+// UpdateCreateTimes updates create times for collected processes
+func (p *processNotify) UpdateCreateTimes(createTimes map[int32]int64) {
+	p.createTimes.Store(createTimes)
+}
+
+// GetCreateTimes retrieves create times for given PIDs
+func (p *processNotify) GetCreateTimes(pids []int32) map[int32]int64 {
+	createTimeForPID := make(map[int32]int64)
+	if result := p.createTimes.Load(); result != nil {
+		createTimesAllPIDs := result.(map[int32]int64)
+		for _, pid := range pids {
+			if ctime, ok := createTimesAllPIDs[pid]; ok {
+				createTimeForPID[pid] = ctime
+			}
+		}
+		return createTimeForPID
+	}
+	return createTimeForPID
+}

--- a/pkg/process/checks/process_notify_test.go
+++ b/pkg/process/checks/process_notify_test.go
@@ -1,0 +1,39 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package checks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProcessNotify(t *testing.T) {
+	pn := newProcessNotify()
+
+	// Empty map on initialization
+	assert.Equal(t, map[int32]int64{}, pn.GetCreateTimes([]int32{1, 2, 3}))
+
+	createTimes := map[int32]int64{
+		1: 1,
+		2: 2,
+		3: 3,
+		4: 4,
+	}
+
+	// Test all existing PIDs
+	pn.UpdateCreateTimes(createTimes)
+
+	assert.Equal(t, createTimes, pn.GetCreateTimes([]int32{1, 2, 3, 4}))
+
+	// Test non-existent PIDs
+	expectedCreateTimes := map[int32]int64{
+		1: 1,
+		3: 3,
+	}
+
+	assert.Equal(t, expectedCreateTimes, pn.GetCreateTimes([]int32{1, 3, 5}))
+}


### PR DESCRIPTION
### What does this PR do?

- Add `ProcessNotify` as a placeholder of a future interface to allow process check to exchange data with other checks.

### Motivation

Eventually allowing streaming these updates across process and connections checks running in different process spaces.

### Describe how to test/QA your changes

Verify that functionality in the connections check relying on create time enrichment works correctly.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
