### PR TITLE
Fix truncated logs in the Cloud Run Agent

### DIFF
--- a/cmd/serverless-init/initcontainer/initcontainer.go
+++ b/cmd/serverless-init/initcontainer/initcontainer.go
@@ -9,6 +9,7 @@
 package initcontainer
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -44,10 +45,12 @@ func execute(config *serverlessLog.Config, metricAgent *metrics.ServerlessMetric
 	commandName, commandArgs := buildCommandParam(args)
 	cmd := exec.Command(commandName, commandArgs...)
 	cmd.Stdout = &serverlessLog.CustomWriter{
-		LogConfig: config,
+		LogConfig:  config,
+		LineBuffer: bytes.Buffer{},
 	}
 	cmd.Stderr = &serverlessLog.CustomWriter{
-		LogConfig: config,
+		LogConfig:  config,
+		LineBuffer: bytes.Buffer{},
 	}
 	handleSignals(cmd.Process, config, metricAgent, traceAgent)
 	err := cmd.Start()

--- a/cmd/serverless-init/log/log.go
+++ b/cmd/serverless-init/log/log.go
@@ -6,6 +6,8 @@
 package log
 
 import (
+	"bufio"
+	"bytes"
 	"fmt"
 	"os"
 	"strings"
@@ -40,7 +42,8 @@ type Config struct {
 
 // CustomWriter wraps the log config to allow stdout/stderr redirection
 type CustomWriter struct {
-	LogConfig *Config
+	LogConfig  *Config
+	LineBuffer bytes.Buffer
 }
 
 // CreateConfig builds and returns a log config
@@ -90,7 +93,11 @@ func SetupLog(conf *Config) {
 
 func (cw *CustomWriter) Write(p []byte) (n int, err error) {
 	fmt.Print(string(p))
-	Write(cw.LogConfig, p)
+	cw.LineBuffer.Write(p)
+	scanner := bufio.NewScanner(&cw.LineBuffer)
+	for scanner.Scan() {
+		Write(cw.LogConfig, scanner.Bytes())
+	}
 	return len(p), nil
 }
 

--- a/cmd/serverless-init/log/log_test.go
+++ b/cmd/serverless-init/log/log_test.go
@@ -46,6 +46,23 @@ func TestCustomWriterBuffered(t *testing.T) {
 	assert.Equal(t, 2, numMessages)
 }
 
+func TestWriteEnabled(t *testing.T) {
+	testContent := []byte("hello this is a log")
+	logChannel := make(chan *config.ChannelMessage)
+	config := &Config{
+		channel:   logChannel,
+		isEnabled: true,
+	}
+	go Write(config, testContent)
+	select {
+	case received := <-logChannel:
+		assert.NotNil(t, received)
+		assert.Equal(t, testContent, received.Content)
+	case <-time.After(100 * time.Millisecond):
+		assert.Fail(t, "We should have received logs")
+	}
+}
+
 func TestWriteDisabled(t *testing.T) {
 	testContent := []byte("hello this is a log")
 	logChannel := make(chan *config.ChannelMessage)


### PR DESCRIPTION
Fix truncated logs for GCP cloud run agent by adding buffering. 

<img width="966" alt="image" src="https://user-images.githubusercontent.com/2540856/182742114-9fb10d70-26c5-4a90-8d3f-d119562f97ac.png">
