### PR TITLE
[demux] WaitForSamples returns both live and timed metrics.

### DIFF
--- a/pkg/aggregator/demultiplexer_mock.go
+++ b/pkg/aggregator/demultiplexer_mock.go
@@ -52,40 +52,40 @@ func (a *TestAgentDemultiplexer) AddLateMetrics(metrics metrics.MetricSampleBatc
 	a.Unlock()
 }
 
-func (a *TestAgentDemultiplexer) samples() ([]metrics.MetricSample, []metrics.MetricSample) {
+func (a *TestAgentDemultiplexer) samples() (ontime []metrics.MetricSample, timed []metrics.MetricSample) {
 	a.Lock()
-	c := make([]metrics.MetricSample, len(a.receivedSamples))
-	l := make([]metrics.MetricSample, len(a.lateMetrics))
+	ontime = make([]metrics.MetricSample, len(a.receivedSamples))
+	timed = make([]metrics.MetricSample, len(a.lateMetrics))
 	for i, s := range a.receivedSamples {
-		c[i] = s
+		ontime[i] = s
 	}
 	for i, s := range a.lateMetrics {
-		l[i] = s
+		timed[i] = s
 	}
 	a.Unlock()
-	return c, l
+	return ontime, timed
 }
 
 // WaitForSamples returns the samples received by the demultiplexer.
 // Note that it returns as soon as something is avaible in either the live
 // metrics buffer or the late metrics one.
-func (a *TestAgentDemultiplexer) WaitForSamples(timeout time.Duration) ([]metrics.MetricSample, []metrics.MetricSample) {
+func (a *TestAgentDemultiplexer) WaitForSamples(timeout time.Duration) (ontime []metrics.MetricSample, timed []metrics.MetricSample) {
 	ticker := time.NewTicker(10 * time.Millisecond)
 	defer ticker.Stop()
 	timeoutOn := time.Now().Add(timeout)
 	for {
 		select {
 		case <-ticker.C:
-			s, l := a.samples()
+			ontime, timed = a.samples()
 
 			// this case could always take priority on the timeout case, we have to make sure
 			// we've not timeout
 			if time.Now().After(timeoutOn) {
-				return s, l
+				return ontime, timed
 			}
 
-			if len(s) > 0 || len(l) > 0 {
-				return s, l
+			if len(ontime) > 0 || len(timed) > 0 {
+				return ontime, timed
 			}
 		case <-time.After(timeout):
 			return nil, nil

--- a/pkg/dogstatsd/server_bench_test.go
+++ b/pkg/dogstatsd/server_bench_test.go
@@ -56,8 +56,8 @@ func benchParsePackets(b *testing.B, rawPacket []byte) {
 
 	done := make(chan struct{})
 	go func() {
-		s := demux.WaitForSamples(time.Millisecond * 1)
-		if len(s) > 0 {
+		s, l := demux.WaitForSamples(time.Millisecond * 1)
+		if len(s) > 0 || len(l) > 0 {
 			return
 		}
 	}()
@@ -102,8 +102,8 @@ func BenchmarkPbarseMetricMessage(b *testing.B) {
 
 	done := make(chan struct{})
 	go func() {
-		s := demux.WaitForSamples(time.Millisecond * 1)
-		if len(s) > 0 {
+		s, l := demux.WaitForSamples(time.Millisecond * 1)
+		if len(s) > 0 || len(l) > 0 {
 			return
 		}
 	}()
@@ -159,8 +159,8 @@ func BenchmarkMapperControl(b *testing.B) {
 
 	done := make(chan struct{})
 	go func() {
-		s := demux.WaitForSamples(time.Millisecond * 1)
-		if len(s) > 0 {
+		s, l := demux.WaitForSamples(time.Millisecond * 1)
+		if len(s) > 0 || len(l) > 0 {
 			return
 		}
 	}()

--- a/pkg/dogstatsd/server_test.go
+++ b/pkg/dogstatsd/server_test.go
@@ -92,6 +92,10 @@ func TestUDPReceive(t *testing.T) {
 	port, err := getAvailableUDPPort()
 	require.NoError(t, err)
 	config.Datadog.SetDefault("dogstatsd_port", port)
+	config.Datadog.SetDefault("dogstatsd_no_aggregation_pipeline", true)
+	defer func() {
+		config.Datadog.SetDefault("dogstatsd_no_aggregation_pipeline", false)
+	}()
 
 	demux := aggregator.InitTestAgentDemultiplexerWithFlushInterval(10 * time.Millisecond)
 	defer demux.Stop(false)
@@ -106,8 +110,9 @@ func TestUDPReceive(t *testing.T) {
 
 	// Test metric
 	conn.Write([]byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2"))
-	samples := demux.WaitForSamples(time.Second * 2)
-	require.Equal(t, 1, len(samples))
+	samples, timedSamples := demux.WaitForSamples(time.Second * 2)
+	require.Len(t, samples, 1)
+	require.Len(t, timedSamples, 0)
 	sample := samples[0]
 	assert.NotNil(t, sample)
 	assert.Equal(t, sample.Name, "daemon")
@@ -117,8 +122,9 @@ func TestUDPReceive(t *testing.T) {
 	demux.Reset()
 
 	conn.Write([]byte("daemon:666|c|@0.5|#sometag1:somevalue1,sometag2:somevalue2"))
-	samples = demux.WaitForSamples(time.Second * 2)
-	require.Equal(t, 1, len(samples))
+	samples, timedSamples = demux.WaitForSamples(time.Second * 2)
+	require.Len(t, samples, 1)
+	require.Len(t, timedSamples, 0)
 	sample = samples[0]
 	assert.NotNil(t, sample)
 	assert.Equal(t, sample.Name, "daemon")
@@ -128,8 +134,9 @@ func TestUDPReceive(t *testing.T) {
 	demux.Reset()
 
 	conn.Write([]byte("daemon:666|h|@0.5|#sometag1:somevalue1,sometag2:somevalue2"))
-	samples = demux.WaitForSamples(time.Second * 2)
-	require.Equal(t, 1, len(samples))
+	samples, timedSamples = demux.WaitForSamples(time.Second * 2)
+	require.Len(t, samples, 1)
+	require.Len(t, timedSamples, 0)
 	sample = samples[0]
 	assert.NotNil(t, sample)
 	assert.Equal(t, sample.Name, "daemon")
@@ -139,8 +146,9 @@ func TestUDPReceive(t *testing.T) {
 	demux.Reset()
 
 	conn.Write([]byte("daemon:666|ms|@0.5|#sometag1:somevalue1,sometag2:somevalue2"))
-	samples = demux.WaitForSamples(time.Second * 2)
-	require.Equal(t, 1, len(samples))
+	samples, timedSamples = demux.WaitForSamples(time.Second * 2)
+	require.Len(t, samples, 1)
+	require.Len(t, timedSamples, 0)
 	sample = samples[0]
 	assert.NotNil(t, sample)
 	assert.Equal(t, sample.Name, "daemon")
@@ -150,8 +158,9 @@ func TestUDPReceive(t *testing.T) {
 	demux.Reset()
 
 	conn.Write([]byte("daemon_set:abc|s|#sometag1:somevalue1,sometag2:somevalue2"))
-	samples = demux.WaitForSamples(time.Second * 2)
-	require.Equal(t, 1, len(samples))
+	samples, timedSamples = demux.WaitForSamples(time.Second * 2)
+	require.Len(t, samples, 1)
+	require.Len(t, timedSamples, 0)
 	sample = samples[0]
 	assert.NotNil(t, sample)
 	assert.Equal(t, sample.Name, "daemon_set")
@@ -161,8 +170,9 @@ func TestUDPReceive(t *testing.T) {
 
 	// multi-metric packet
 	conn.Write([]byte("daemon1:666|c\ndaemon2:1000|c"))
-	samples = demux.WaitForSamples(time.Second * 2)
-	require.Equal(t, 2, len(samples))
+	samples, timedSamples = demux.WaitForSamples(time.Second * 2)
+	require.Len(t, samples, 2)
+	require.Len(t, timedSamples, 0)
 	sample1 := samples[0]
 	assert.NotNil(t, sample1)
 	assert.Equal(t, sample1.Name, "daemon1")
@@ -177,8 +187,9 @@ func TestUDPReceive(t *testing.T) {
 
 	// multi-value packet
 	conn.Write([]byte("daemon1:666:123|c\ndaemon2:1000|c"))
-	samples = demux.WaitForSamples(time.Second * 2)
-	require.Equal(t, 3, len(samples))
+	samples, timedSamples = demux.WaitForSamples(time.Second * 2)
+	require.Len(t, samples, 3)
+	require.Len(t, timedSamples, 0)
 	sample1 = samples[0]
 	assert.NotNil(t, sample1)
 	assert.Equal(t, sample1.Name, "daemon1")
@@ -198,8 +209,9 @@ func TestUDPReceive(t *testing.T) {
 
 	// multi-value packet with skip empty
 	conn.Write([]byte("daemon1::666::123::::|c\ndaemon2:1000|c"))
-	samples = demux.WaitForSamples(time.Second * 2)
-	require.Equal(t, 3, len(samples))
+	samples, timedSamples = demux.WaitForSamples(time.Second * 2)
+	require.Len(t, samples, 3)
+	require.Len(t, timedSamples, 0)
 	sample1 = samples[0]
 	assert.NotNil(t, sample1)
 	assert.Equal(t, sample1.Name, "daemon1")
@@ -219,8 +231,9 @@ func TestUDPReceive(t *testing.T) {
 
 	//	// slightly malformed multi-metric packet, should still be parsed in whole
 	conn.Write([]byte("daemon1:666|c\n\ndaemon2:1000|c\n"))
-	samples = demux.WaitForSamples(time.Second * 2)
-	require.Equal(t, 2, len(samples))
+	samples, timedSamples = demux.WaitForSamples(time.Second * 2)
+	require.Len(t, samples, 2)
+	require.Len(t, timedSamples, 0)
 	sample1 = samples[0]
 	assert.NotNil(t, sample1)
 	assert.Equal(t, sample1.Name, "daemon1")
@@ -235,8 +248,9 @@ func TestUDPReceive(t *testing.T) {
 
 	// Test erroneous metric
 	conn.Write([]byte("daemon1:666a|g\ndaemon2:666|g|#sometag1:somevalue1,sometag2:somevalue2"))
-	samples = demux.WaitForSamples(time.Second * 2)
-	require.Equal(t, 1, len(samples))
+	samples, timedSamples = demux.WaitForSamples(time.Second * 2)
+	require.Len(t, samples, 1)
+	require.Len(t, timedSamples, 0)
 	sample = samples[0]
 	assert.NotNil(t, sample)
 	assert.Equal(t, sample.Name, "daemon2")
@@ -244,8 +258,9 @@ func TestUDPReceive(t *testing.T) {
 
 	// Test empty metric
 	conn.Write([]byte("daemon1:|g\ndaemon2:666|g|#sometag1:somevalue1,sometag2:somevalue2\ndaemon3: :1:|g"))
-	samples = demux.WaitForSamples(time.Second * 2)
-	require.Equal(t, 1, len(samples))
+	samples, timedSamples = demux.WaitForSamples(time.Second * 2)
+	require.Len(t, samples, 1)
+	require.Len(t, timedSamples, 0)
 	sample = samples[0]
 	assert.NotNil(t, sample)
 	assert.Equal(t, sample.Name, "daemon2")
@@ -253,12 +268,27 @@ func TestUDPReceive(t *testing.T) {
 
 	// Late metric
 	conn.Write([]byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2|T1658328888"))
-	samples = demux.WaitForSamples(time.Second * 2)
-	require.Equal(t, 1, len(samples))
-	sample = samples[0]
+	samples, timedSamples = demux.WaitForSamples(time.Second * 2)
+	require.Len(t, samples, 0)
+	require.Len(t, timedSamples, 1)
+	sample = timedSamples[0]
 	require.NotNil(t, sample)
 	assert.Equal(t, sample.Name, "daemon")
 	assert.Equal(t, sample.Timestamp, float64(1658328888))
+	demux.Reset()
+
+	// Late metric and a normal one
+	conn.Write([]byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2|T1658328888\ndaemon2:666|c"))
+	samples, timedSamples = demux.WaitForSamples(time.Second * 2)
+	require.Len(t, samples, 1)
+	require.Len(t, timedSamples, 1)
+	sample = timedSamples[0]
+	require.NotNil(t, sample)
+	assert.Equal(t, sample.Name, "daemon")
+	assert.Equal(t, sample.Timestamp, float64(1658328888))
+	sample = samples[0]
+	require.NotNil(t, sample)
+	assert.Equal(t, sample.Name, "daemon2")
 	demux.Reset()
 
 	// Test Service Check
@@ -387,8 +417,9 @@ func TestHistToDist(t *testing.T) {
 	// Test metric
 	conn.Write([]byte("daemon:666|h|#sometag1:somevalue1,sometag2:somevalue2"))
 	time.Sleep(time.Millisecond * 200) // give some time to the socket write/read
-	samples := demux.WaitForSamples(time.Second * 2)
+	samples, timedSamples := demux.WaitForSamples(time.Second * 2)
 	require.Equal(t, 2, len(samples))
+	require.Equal(t, 0, len(timedSamples))
 	histMetric := samples[0]
 	distMetric := samples[1]
 	assert.NotNil(t, histMetric)
@@ -475,8 +506,9 @@ func TestE2EParsing(t *testing.T) {
 
 	// Test metric
 	conn.Write([]byte("daemon:666|g|#foo:bar\ndaemon:666|g|#foo:bar"))
-	samples := demux.WaitForSamples(time.Second * 2)
+	samples, timedSamples := demux.WaitForSamples(time.Second * 2)
 	assert.Equal(t, 2, len(samples))
+	assert.Equal(t, 0, len(timedSamples))
 	demux.Reset()
 	demux.Stop(false)
 	s.Stop()
@@ -492,8 +524,9 @@ func TestE2EParsing(t *testing.T) {
 
 	// Test metric expecting an EOL
 	conn.Write([]byte("daemon:666|g|#foo:bar\ndaemon:666|g|#foo:bar"))
-	samples = demux.WaitForSamples(time.Second * 2)
+	samples, timedSamples = demux.WaitForSamples(time.Second * 2)
 	require.Equal(t, 1, len(samples))
+	assert.Equal(t, 0, len(timedSamples))
 	s.Stop()
 	demux.Reset()
 	demux.Stop(false)
@@ -518,8 +551,9 @@ func TestExtraTags(t *testing.T) {
 
 	// Test metric
 	conn.Write([]byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2"))
-	samples := demux.WaitForSamples(time.Second * 2)
+	samples, timedSamples := demux.WaitForSamples(time.Second * 2)
 	require.Equal(t, 1, len(samples))
+	require.Equal(t, 0, len(timedSamples))
 	sample := samples[0]
 	assert.NotNil(t, sample)
 	assert.Equal(t, sample.Name, "daemon")
@@ -551,8 +585,9 @@ func TestStaticTags(t *testing.T) {
 
 	// Test metric
 	conn.Write([]byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2"))
-	samples := demux.WaitForSamples(time.Second * 2)
+	samples, timedSamples := demux.WaitForSamples(time.Second * 2)
 	require.Equal(t, 1, len(samples))
+	require.Equal(t, 0, len(timedSamples))
 	sample := samples[0]
 	assert.NotNil(t, sample)
 	assert.Equal(t, sample.Name, "daemon")

--- a/pkg/serverless/invocationlifecycle/lifecycle_test.go
+++ b/pkg/serverless/invocationlifecycle/lifecycle_test.go
@@ -40,8 +40,9 @@ func TestGenerateEnhancedErrorMetricOnInvocationEnd(t *testing.T) {
 	}
 	go testProcessor.OnInvokeEnd(&endDetails)
 
-	generatedMetrics := demux.WaitForSamples(time.Millisecond * 250)
+	generatedMetrics, timedMetrics := demux.WaitForSamples(time.Millisecond * 250)
 
+	assert.Len(t, timedMetrics, 0)
 	assert.Equal(t, generatedMetrics, []metrics.MetricSample{{
 		Name:       "aws.lambda.enhanced.errors",
 		Value:      1.0,
@@ -378,7 +379,7 @@ func TestTriggerTypesLifecycleEventForAPIGateway5xxResponse(t *testing.T) {
 	}, testProcessor.GetTags())
 
 	// assert error metrics equal
-	generatedMetrics := demux.WaitForSamples(100 * time.Millisecond)
+	generatedMetrics, lateMetrics := demux.WaitForSamples(100 * time.Millisecond)
 	assert.Equal(t, generatedMetrics[:1], []metrics.MetricSample{{
 		Name:       "aws.lambda.enhanced.errors",
 		Value:      1.0,
@@ -387,6 +388,7 @@ func TestTriggerTypesLifecycleEventForAPIGateway5xxResponse(t *testing.T) {
 		SampleRate: 1,
 		Timestamp:  float64(endTime.Unix()),
 	}})
+	assert.Len(t, lateMetrics, 0)
 
 	// assert span error set to 1
 	executionSpan := tracePayload.TracerPayload.Chunks[0].Spans[0]
@@ -465,7 +467,7 @@ func TestTriggerTypesLifecycleEventForAPIGatewayNonProxy5xxResponse(t *testing.T
 	}, testProcessor.GetTags())
 
 	// assert error metrics equal
-	generatedMetrics := demux.WaitForSamples(100 * time.Millisecond)
+	generatedMetrics, lateMetrics := demux.WaitForSamples(100 * time.Millisecond)
 	assert.Equal(t, generatedMetrics[:1], []metrics.MetricSample{{
 		Name:       "aws.lambda.enhanced.errors",
 		Value:      1.0,
@@ -474,6 +476,7 @@ func TestTriggerTypesLifecycleEventForAPIGatewayNonProxy5xxResponse(t *testing.T
 		SampleRate: 1,
 		Timestamp:  float64(endTime.Unix()),
 	}})
+	assert.Len(t, lateMetrics, 0)
 
 	// assert span error set to 1
 	executionSpan := tracePayload.TracerPayload.Chunks[0].Spans[0]
@@ -546,7 +549,7 @@ func TestTriggerTypesLifecycleEventForAPIGatewayWebsocket5xxResponse(t *testing.
 	}, testProcessor.GetTags())
 
 	// assert error metrics equal
-	generatedMetrics := demux.WaitForSamples(100 * time.Millisecond)
+	generatedMetrics, lateMetrics := demux.WaitForSamples(100 * time.Millisecond)
 	assert.Equal(t, generatedMetrics[:1], []metrics.MetricSample{{
 		Name:       "aws.lambda.enhanced.errors",
 		Value:      1.0,
@@ -555,6 +558,7 @@ func TestTriggerTypesLifecycleEventForAPIGatewayWebsocket5xxResponse(t *testing.
 		SampleRate: 1,
 		Timestamp:  float64(endTime.Unix()),
 	}})
+	assert.Len(t, lateMetrics, 0)
 
 	// assert span error set to 1
 	executionSpan := tracePayload.TracerPayload.Chunks[0].Spans[0]
@@ -631,7 +635,7 @@ func TestTriggerTypesLifecycleEventForALB5xxResponse(t *testing.T) {
 	}, testProcessor.GetTags())
 
 	// assert error metrics equal
-	generatedMetrics := demux.WaitForSamples(100 * time.Millisecond)
+	generatedMetrics, lateMetrics := demux.WaitForSamples(100 * time.Millisecond)
 	assert.Equal(t, generatedMetrics[:1], []metrics.MetricSample{{
 		Name:       "aws.lambda.enhanced.errors",
 		Value:      1.0,
@@ -640,6 +644,7 @@ func TestTriggerTypesLifecycleEventForALB5xxResponse(t *testing.T) {
 		SampleRate: 1,
 		Timestamp:  float64(endTime.Unix()),
 	}})
+	assert.Len(t, lateMetrics, 0)
 
 	// assert span error set to 1
 	executionSpan := tracePayload.TracerPayload.Chunks[0].Spans[0]

--- a/pkg/serverless/logs/logs_test.go
+++ b/pkg/serverless/logs/logs_test.go
@@ -220,15 +220,17 @@ func TestProcessMessageValid(t *testing.T) {
 
 	go processMessage(message, mockExecutionContext, computeEnhancedMetrics, metricTags, demux, func() {})
 
-	received := demux.WaitForSamples(100 * time.Millisecond)
-	assert.Equal(t, len(received), 6)
+	received, timed := demux.WaitForSamples(100 * time.Millisecond)
+	assert.Len(t, received, 6)
+	assert.Len(t, timed, 0)
 	demux.Reset()
 
 	computeEnhancedMetrics = false
 	go processMessage(message, mockExecutionContext, computeEnhancedMetrics, metricTags, demux, func() {})
 
-	received = demux.WaitForSamples(100 * time.Millisecond)
-	assert.Equal(t, len(received), 0, "we should NOT have received metrics")
+	received, timed = demux.WaitForSamples(100 * time.Millisecond)
+	assert.Len(t, received, 0, "we should NOT have received metrics")
+	assert.Len(t, timed, 0)
 }
 
 func TestProcessMessageStartValid(t *testing.T) {
@@ -350,8 +352,9 @@ func TestProcessMessageShouldNotProcessArnNotSet(t *testing.T) {
 	computeEnhancedMetrics := true
 	go processMessage(message, mockExecutionContext, computeEnhancedMetrics, metricTags, demux, func() {})
 
-	received := demux.WaitForSamples(100 * time.Millisecond)
-	assert.Equal(t, len(received), 0, "We should NOT have received metrics")
+	received, timed := demux.WaitForSamples(100 * time.Millisecond)
+	assert.Len(t, received, 0, "We should NOT have received metrics")
+	assert.Len(t, timed, 0)
 }
 
 func TestProcessMessageShouldNotProcessLogsDropped(t *testing.T) {
@@ -373,8 +376,9 @@ func TestProcessMessageShouldNotProcessLogsDropped(t *testing.T) {
 
 	go processMessage(message, mockExecutionContext, computeEnhancedMetrics, metricTags, demux, func() {})
 
-	received := demux.WaitForSamples(100 * time.Millisecond)
-	assert.Equal(t, len(received), 0, "We should NOT have received metrics")
+	received, timed := demux.WaitForSamples(100 * time.Millisecond)
+	assert.Len(t, received, 0, "We should NOT have received metrics")
+	assert.Len(t, timed, 0)
 }
 
 func TestProcessMessageShouldProcessLogTypeFunction(t *testing.T) {
@@ -396,8 +400,9 @@ func TestProcessMessageShouldProcessLogTypeFunction(t *testing.T) {
 
 	go processMessage(message, mockExecutionContext, computeEnhancedMetrics, metricTags, demux, func() {})
 
-	received := demux.WaitForSamples(100 * time.Millisecond)
-	assert.Equal(t, len(received), 2)
+	received, timed := demux.WaitForSamples(100 * time.Millisecond)
+	assert.Len(t, received, 2)
+	assert.Len(t, timed, 0)
 	assert.Equal(t, serverlessMetrics.OutOfMemoryMetric, received[0].Name)
 	assert.Equal(t, serverlessMetrics.ErrorsMetric, received[1].Name)
 }

--- a/pkg/serverless/metrics/enhanced_metrics_test.go
+++ b/pkg/serverless/metrics/enhanced_metrics_test.go
@@ -23,8 +23,9 @@ func TestGenerateEnhancedMetricsFromFunctionLogOutOfMemory(t *testing.T) {
 	reportLogTime := time.Now()
 	go GenerateEnhancedMetricsFromFunctionLog("JavaScript heap out of memory", reportLogTime, tags, demux)
 
-	generatedMetrics := demux.WaitForSamples(100 * time.Millisecond)
-	assert.Equal(t, 2, len(generatedMetrics), "two enhanced metrics should have been generated")
+	generatedMetrics, timedMetrics := demux.WaitForSamples(100 * time.Millisecond)
+	assert.Len(t, generatedMetrics, 2, "two enhanced metrics should have been generated")
+	assert.Len(t, timedMetrics, 0)
 	assert.Equal(t, generatedMetrics, []metrics.MetricSample{{
 		Name:       OutOfMemoryMetric,
 		Value:      1.0,
@@ -49,8 +50,9 @@ func TestGenerateEnhancedMetricsFromFunctionLogNoMetric(t *testing.T) {
 
 	go GenerateEnhancedMetricsFromFunctionLog("Task timed out after 30.03 seconds", time.Now(), tags, demux)
 
-	generatedMetrics := demux.WaitForSamples(100 * time.Millisecond)
-	assert.Equal(t, 0, len(generatedMetrics), "no metrics should have been generated")
+	generatedMetrics, timedMetrics := demux.WaitForSamples(100 * time.Millisecond)
+	assert.Len(t, generatedMetrics, 0, "no metrics should have been generated")
+	assert.Len(t, timedMetrics, 0)
 }
 
 func TestGenerateEnhancedMetricsFromReportLogColdStart(t *testing.T) {
@@ -60,7 +62,7 @@ func TestGenerateEnhancedMetricsFromReportLogColdStart(t *testing.T) {
 	reportLogTime := time.Now()
 	go GenerateEnhancedMetricsFromReportLog(100.0, 1000.0, 800.0, 1024.0, 256.0, reportLogTime, tags, demux)
 
-	generatedMetrics := demux.WaitForSamples(100 * time.Millisecond)
+	generatedMetrics, timedMetrics := demux.WaitForSamples(100 * time.Millisecond)
 
 	assert.Equal(t, generatedMetrics[:6], []metrics.MetricSample{{
 		Name:       maxMemoryUsedMetric,
@@ -105,6 +107,7 @@ func TestGenerateEnhancedMetricsFromReportLogColdStart(t *testing.T) {
 		SampleRate: 1,
 		Timestamp:  float64(reportLogTime.UnixNano()) / float64(time.Second),
 	}})
+	assert.Len(t, timedMetrics, 0)
 }
 
 func TestGenerateEnhancedMetricsFromReportLogNoColdStart(t *testing.T) {
@@ -115,7 +118,7 @@ func TestGenerateEnhancedMetricsFromReportLogNoColdStart(t *testing.T) {
 
 	go GenerateEnhancedMetricsFromReportLog(0, 1000.0, 800.0, 1024.0, 256.0, reportLogTime, tags, demux)
 
-	generatedMetrics := demux.WaitForSamples(100 * time.Millisecond)
+	generatedMetrics, timedMetrics := demux.WaitForSamples(100 * time.Millisecond)
 
 	assert.Equal(t, generatedMetrics[:5], []metrics.MetricSample{{
 		Name:       maxMemoryUsedMetric,
@@ -153,6 +156,7 @@ func TestGenerateEnhancedMetricsFromReportLogNoColdStart(t *testing.T) {
 		SampleRate: 1,
 		Timestamp:  float64(reportLogTime.UnixNano()) / float64(time.Second),
 	}})
+	assert.Len(t, timedMetrics, 0)
 }
 
 func TestSendTimeoutEnhancedMetric(t *testing.T) {
@@ -162,7 +166,7 @@ func TestSendTimeoutEnhancedMetric(t *testing.T) {
 
 	go SendTimeoutEnhancedMetric(tags, demux)
 
-	generatedMetrics := demux.WaitForSamples(100 * time.Millisecond)
+	generatedMetrics, timedMetrics := demux.WaitForSamples(100 * time.Millisecond)
 
 	assert.Equal(t, generatedMetrics[:1], []metrics.MetricSample{{
 		Name:       timeoutsMetric,
@@ -173,6 +177,7 @@ func TestSendTimeoutEnhancedMetric(t *testing.T) {
 		// compare the generated timestamp to itself because we can't know its value
 		Timestamp: generatedMetrics[0].Timestamp,
 	}})
+	assert.Len(t, timedMetrics, 0)
 }
 
 func TestSendInvocationEnhancedMetric(t *testing.T) {
@@ -182,7 +187,7 @@ func TestSendInvocationEnhancedMetric(t *testing.T) {
 
 	go SendInvocationEnhancedMetric(tags, demux)
 
-	generatedMetrics := demux.WaitForSamples(100 * time.Millisecond)
+	generatedMetrics, timedMetrics := demux.WaitForSamples(100 * time.Millisecond)
 
 	assert.Equal(t, generatedMetrics[:1], []metrics.MetricSample{{
 		Name:       invocationsMetric,
@@ -193,6 +198,7 @@ func TestSendInvocationEnhancedMetric(t *testing.T) {
 		// compare the generated timestamp to itself because we can't know its value
 		Timestamp: generatedMetrics[0].Timestamp,
 	}})
+	assert.Len(t, timedMetrics, 0)
 }
 
 func TestSendOutOfMemoryEnhancedMetric(t *testing.T) {
@@ -202,7 +208,7 @@ func TestSendOutOfMemoryEnhancedMetric(t *testing.T) {
 	mockTime := time.Now()
 	go SendOutOfMemoryEnhancedMetric(tags, mockTime, demux)
 
-	generatedMetrics := demux.WaitForSamples(100 * time.Millisecond)
+	generatedMetrics, timedMetrics := demux.WaitForSamples(100 * time.Millisecond)
 
 	assert.Equal(t, generatedMetrics[:1], []metrics.MetricSample{{
 		Name:       OutOfMemoryMetric,
@@ -212,6 +218,7 @@ func TestSendOutOfMemoryEnhancedMetric(t *testing.T) {
 		SampleRate: 1,
 		Timestamp:  float64(mockTime.UnixNano()) / float64(time.Second),
 	}})
+	assert.Len(t, timedMetrics, 0)
 }
 
 func TestSendErrorsEnhancedMetric(t *testing.T) {
@@ -221,7 +228,7 @@ func TestSendErrorsEnhancedMetric(t *testing.T) {
 	mockTime := time.Now()
 	go SendErrorsEnhancedMetric(tags, mockTime, demux)
 
-	generatedMetrics := demux.WaitForSamples(100 * time.Millisecond)
+	generatedMetrics, timedMetrics := demux.WaitForSamples(100 * time.Millisecond)
 
 	assert.Equal(t, generatedMetrics[:1], []metrics.MetricSample{{
 		Name:       ErrorsMetric,
@@ -231,6 +238,7 @@ func TestSendErrorsEnhancedMetric(t *testing.T) {
 		SampleRate: 1,
 		Timestamp:  float64(mockTime.UnixNano()) / float64(time.Second),
 	}})
+	assert.Len(t, timedMetrics, 0)
 }
 
 func TestCalculateEstimatedCost(t *testing.T) {
@@ -280,8 +288,9 @@ func TestGenerateRuntimeDurationMetricNoStartDate(t *testing.T) {
 	startTime := time.Time{}
 	endTime := time.Now()
 	go GenerateRuntimeDurationMetric(startTime, endTime, "myStatus", tags, demux)
-	generatedMetrics := demux.WaitForSamples(100 * time.Millisecond)
-	assert.Equal(t, 0, len(generatedMetrics), "no metrics should have been generated")
+	generatedMetrics, timedMetrics := demux.WaitForSamples(100 * time.Millisecond)
+	assert.Len(t, generatedMetrics, 0, "no metrics should have been generated")
+	assert.Len(t, timedMetrics, 0)
 }
 
 func TestGenerateRuntimeDurationMetricNoEndDate(t *testing.T) {
@@ -291,8 +300,9 @@ func TestGenerateRuntimeDurationMetricNoEndDate(t *testing.T) {
 	startTime := time.Now()
 	endTime := time.Time{}
 	go GenerateRuntimeDurationMetric(startTime, endTime, "myStatus", tags, demux)
-	generatedMetrics := demux.WaitForSamples(100 * time.Millisecond)
-	assert.Equal(t, 0, len(generatedMetrics), "no metrics should have been generated")
+	generatedMetrics, timedMetrics := demux.WaitForSamples(100 * time.Millisecond)
+	assert.Len(t, generatedMetrics, 0, "no metrics should have been generated")
+	assert.Len(t, timedMetrics, 0)
 }
 
 func TestGenerateRuntimeDurationMetricOK(t *testing.T) {
@@ -302,7 +312,7 @@ func TestGenerateRuntimeDurationMetricOK(t *testing.T) {
 	startTime := time.Date(2020, 01, 01, 01, 01, 01, 500000000, time.UTC)
 	endTime := time.Date(2020, 01, 01, 01, 01, 01, 653000000, time.UTC) //153 ms later
 	go GenerateRuntimeDurationMetric(startTime, endTime, "myStatus", tags, demux)
-	generatedMetrics := demux.WaitForSamples(100 * time.Millisecond)
+	generatedMetrics, timedMetrics := demux.WaitForSamples(100 * time.Millisecond)
 	assert.Equal(t, generatedMetrics[:1], []metrics.MetricSample{{
 		Name:       runtimeDurationMetric,
 		Value:      153,
@@ -311,5 +321,5 @@ func TestGenerateRuntimeDurationMetricOK(t *testing.T) {
 		SampleRate: 1,
 		Timestamp:  float64(endTime.UnixNano()) / float64(time.Second),
 	}})
-
+	assert.Len(t, timedMetrics, 0)
 }


### PR DESCRIPTION
### What does this PR do?

A unit tests improvement around the `WaitForSamples` method in the mocked `AgentDemultiplexer` which now returns both live metrics and timed metrics.

### Describe how to test/QA your changes

No QA needed: It is only modifying unit tests, if they pass, we're all good for the QA.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
