### PR TITLE
CWS: improve the userspace DNS decoder

### DIFF
--- a/pkg/security/secl/model/dns_helpers.go
+++ b/pkg/security/secl/model/dns_helpers.go
@@ -1,0 +1,68 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package model
+
+import (
+	"bytes"
+	"fmt"
+)
+
+func decodeDNS(raw []byte) string {
+	rawLen := len(raw)
+	var rep bytes.Buffer
+	i := 0
+	atStart := true
+
+	for i < rawLen {
+		// Parse label length
+		labelLen := int(raw[i])
+		i++
+
+		if labelLen == 0 {
+			// end of name
+			break
+		}
+
+		if labelLen&0xC0 != 0 {
+			// pointer compression, we do not support this yet
+			break
+		}
+
+		if rawLen < i+labelLen {
+			// out of bounds
+			break
+		}
+
+		labelRaw := raw[i : i+labelLen]
+
+		if !atStart {
+			rep.WriteRune('.')
+		}
+		for _, c := range labelRaw {
+			if isSimpleSpecialChar(c) {
+				rep.WriteRune('\\')
+				rep.WriteByte(c)
+			} else if c < ' ' || '~' < c {
+				rep.WriteString(fmt.Sprintf("\\%d", c))
+			} else {
+				rep.WriteByte(c)
+			}
+		}
+
+		atStart = false
+		i += labelLen
+	}
+
+	return rep.String()
+}
+
+func isSimpleSpecialChar(b byte) bool {
+	switch b {
+	case '.', ' ', '\'', '@', ';', '(', ')', '"', '\\':
+		return true
+	}
+	return false
+}

--- a/pkg/security/secl/model/dns_helpers.go
+++ b/pkg/security/secl/model/dns_helpers.go
@@ -42,10 +42,7 @@ func decodeDNS(raw []byte) string {
 			rep.WriteRune('.')
 		}
 		for _, c := range labelRaw {
-			if isSimpleSpecialChar(c) {
-				rep.WriteRune('\\')
-				rep.WriteByte(c)
-			} else if c < ' ' || '~' < c {
+			if c < ' ' || '~' < c {
 				rep.WriteString(fmt.Sprintf("\\%d", c))
 			} else {
 				rep.WriteByte(c)
@@ -57,12 +54,4 @@ func decodeDNS(raw []byte) string {
 	}
 
 	return rep.String()
-}
-
-func isSimpleSpecialChar(b byte) bool {
-	switch b {
-	case '.', ' ', '\'', '@', ';', '(', ')', '"', '\\':
-		return true
-	}
-	return false
 }

--- a/pkg/security/secl/model/dns_helpers.go
+++ b/pkg/security/secl/model/dns_helpers.go
@@ -13,7 +13,7 @@ import (
 var (
 	errDNSNamePointerNotSupported = errors.New("dns name pointer compression is not supported")
 	errDNSNameOutOfBounds         = errors.New("dns name out of bound")
-	errDNSNameNonPrintableAscii   = errors.New("dns name non-printable ascii")
+	errDNSNameNonPrintableASCII   = errors.New("dns name non-printable ascii")
 )
 
 func decodeDNSName(raw []byte) (string, error) {
@@ -56,7 +56,7 @@ LOOP:
 		for _, c := range labelRaw {
 			if c < ' ' || '~' < c {
 				// non-printable ascii char
-				err = errDNSNameNonPrintableAscii
+				err = errDNSNameNonPrintableASCII
 				break LOOP
 			}
 		}

--- a/pkg/security/secl/model/unmarshallers.go
+++ b/pkg/security/secl/model/unmarshallers.go
@@ -885,32 +885,6 @@ func (e *DNSEvent) UnmarshalBinary(data []byte) (int, error) {
 	return len(data), nil
 }
 
-func decodeDNS(raw []byte) string {
-	rawLen := len(raw)
-	rep := ""
-	i := 0
-	for {
-		// Parse label length
-		if rawLen < i+1 {
-			break
-		}
-		labelLen := int(raw[i])
-
-		if rawLen-(i+1) < labelLen || labelLen == 0 {
-			break
-		}
-		labelRaw := raw[i+1 : i+1+labelLen]
-
-		if i == 0 {
-			rep = string(labelRaw)
-		} else {
-			rep = rep + "." + string(labelRaw)
-		}
-		i += labelLen + 1
-	}
-	return rep
-}
-
 // UnmarshalBinary unmarshalls a binary representation of itself
 func (d *NetDevice) UnmarshalBinary(data []byte) (int, error) {
 	if len(data[:]) < 32 {

--- a/pkg/security/secl/model/unmarshallers.go
+++ b/pkg/security/secl/model/unmarshallers.go
@@ -881,7 +881,7 @@ func (e *DNSEvent) UnmarshalBinary(data []byte) (int, error) {
 	e.Type = ByteOrder.Uint16(data[4:6])
 	e.Class = ByteOrder.Uint16(data[6:8])
 	e.Size = ByteOrder.Uint16(data[8:10])
-	e.Name = decodeDNS(data[10:])
+	e.Name, _ = decodeDNSName(data[10:])
 	return len(data), nil
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR improves the userspace DNS decoder, now handling:
- ptr compression (we currently do not really support it but at least we detect it and exit early)
- non-ascii char escapes

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
