### PR TITLE
internal/tools: add a new tools to ensure submodules don't import datadog-agent

### DIFF
--- a/internal/tools/independent-lint/go.mod
+++ b/internal/tools/independent-lint/go.mod
@@ -1,0 +1,7 @@
+module github.com/DataDog/datadog-agent/cmd/independent-lint
+
+go 1.17
+
+require golang.org/x/mod v0.5.1
+
+require golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 // indirect

--- a/internal/tools/independent-lint/go.sum
+++ b/internal/tools/independent-lint/go.sum
@@ -1,0 +1,4 @@
+golang.org/x/mod v0.5.1 h1:OJxoQ/rynoF0dcCdI7cLPktw/hR2cueqYfjm43oqK38=
+golang.org/x/mod v0.5.1/go.mod h1:5OXOZSfqPIIbmVBIIKWRFfZjPR0E5r58TLhUjH0a2Ro=
+golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 h1:/atklqdjdhuosWIl6AIbOeHJjicWYPqR9bpxqxYG2pA=
+golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/tools/independent-lint/independent.go
+++ b/internal/tools/independent-lint/independent.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/mod/modfile"
+	"golang.org/x/mod/module"
+)
+
+var (
+	path = flag.String("path", ".", "Path to go.mod file to check")
+	deny = flag.String("deny", "github.com/DataDog/datadog-agent", "Comma-separated list of imports to deny")
+)
+
+func main() {
+	flag.Parse()
+	if *path == "" || *deny == "" {
+		flag.PrintDefaults()
+		os.Exit(1)
+	}
+	denylist := map[string]struct{}{}
+	for _, p := range strings.Split(*deny, ",") {
+		denylist[strings.TrimSpace(p)] = struct{}{}
+	}
+	b, err := os.ReadFile(filepath.Join(*path, "go.mod"))
+	if err != nil {
+		fmt.Println("Error opening file %q:", err)
+		return
+	}
+	f, err := modfile.Parse("go.mod", b, func(_, v string) (string, error) {
+		return module.CanonicalVersion(v), nil
+	})
+	for _, req := range f.Require {
+		if len(req.Syntax.Token) < 1 {
+			continue
+		}
+		// From https://go.dev/ref/mod#go-mod-file-require
+		// RequireSpec = ModulePath Version newline .
+		modname := req.Syntax.Token[0]
+		if _, ok := denylist[modname]; ok {
+			fmt.Printf("Error: %q is not an allowed import for %q.\n", modname, *path)
+			os.Exit(1)
+		}
+	}
+}

--- a/internal/tools/independent-lint/independent.go
+++ b/internal/tools/independent-lint/independent.go
@@ -1,3 +1,11 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
+// Package independent-lint checks a go.mod file at a given path specified by the -path argument
+// to ensure that it does not import the list of modules specified by the -deny argument. If
+// the module is found, it exits with status code 1 and logs an error.
 package main
 
 import (

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -14,7 +14,7 @@ from invoke.exceptions import Exit
 
 from .build_tags import get_default_build_tags
 from .licenses import get_licenses_list
-from .modules import INDEPENDENT_MODULES, DEFAULT_MODULES, generate_dummy_package
+from .modules import DEFAULT_MODULES, INDEPENDENT_MODULES, generate_dummy_package
 from .utils import get_build_flags
 
 

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -14,7 +14,7 @@ from invoke.exceptions import Exit
 
 from .build_tags import get_default_build_tags
 from .licenses import get_licenses_list
-from .modules import DEFAULT_MODULES, generate_dummy_package
+from .modules import INDEPENDENT_MODULES, DEFAULT_MODULES, generate_dummy_package
 from .utils import get_build_flags
 
 
@@ -235,6 +235,10 @@ def check_mod_tidy(ctx, test_folder="testmodule"):
                 res = ctx.run("git diff-files --exit-code go.mod go.sum", warn=True)
                 if res.exited is None or res.exited > 0:
                     errors_found.append(f"go.mod or go.sum for {mod.import_path} module is out of sync")
+
+        for mod in INDEPENDENT_MODULES.values():
+            # Ensure that none of these modules import the datadog-agent main module.
+            ctx.run(f"go run ./internal/tools/independent-lint/independent.go --path={mod.full_path()}")
 
         with ctx.cd(dummy_folder):
             ctx.run("go mod tidy -compat=1.17")

--- a/tasks/modules.py
+++ b/tasks/modules.py
@@ -122,6 +122,7 @@ INDEPENDENT_MODULES = {
     "pkg/quantile": GoModule("pkg/quantile"),
     "pkg/obfuscate": GoModule("pkg/obfuscate"),
     "pkg/trace": GoModule("pkg/trace"),
+    "pkg/security/secl": GoModule("pkg/security/secl"),
     "pkg/otlp/model": GoModule("pkg/otlp/model"),
 }
 

--- a/tasks/modules.py
+++ b/tasks/modules.py
@@ -114,6 +114,17 @@ DEFAULT_MODULES = {
     "pkg/remoteconfig/state": GoModule("pkg/remoteconfig/state"),
 }
 
+"""
+These sub-modules are not allowed to import the datadog-agent repository, in order to retain their independence
+and facilitate their external usage.
+"""
+INDEPENDENT_MODULES = {
+    "pkg/quantile": GoModule("pkg/quantile"),
+    "pkg/obfuscate": GoModule("pkg/obfuscate"),
+    "pkg/trace": GoModule("pkg/trace"),
+    "pkg/otlp/model": GoModule("pkg/otlp/model"),
+}
+
 MAIN_TEMPLATE = """package main
 
 import (

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -138,6 +138,7 @@ def lint_flavor(
                     ctx, targets=module.targets, rtloader_root=rtloader_root, build_tags=build_tags, arch=arch
                 )
 
+
 def test_flavor(
     ctx,
     flavor: AgentFlavor,

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -23,7 +23,7 @@ from .flavor import AgentFlavor
 from .go import golangci_lint
 from .libs.copyright import CopyrightLinter
 from .libs.junit_upload import add_flavor_to_junitxml, junit_upload_from_tgz, produce_junit_tar
-from .modules import INDEPENDENT_MODULES, DEFAULT_MODULES, GoModule
+from .modules import DEFAULT_MODULES, GoModule
 from .trace_agent import integration_tests as trace_integration_tests
 from .utils import DEFAULT_BRANCH, get_build_flags
 
@@ -137,19 +137,6 @@ def lint_flavor(
                 golangci_lint(
                     ctx, targets=module.targets, rtloader_root=rtloader_root, build_tags=build_tags, arch=arch
                 )
-
-def independent_submodule_check(ctx, modules: List[GoModule]):
-    """
-    Checks all modules to ensure that they do not import the github.com/DataDog/datadog-agent module.
-    """
-    for module in modules:
-        print(f"----- Module '{module.full_path()}'")
-        if not module.condition():
-            print("----- Skipped")
-            continue
-
-        ctx.run(f"go run ./internal/tools/independent-lint/independent.go --path={module.full_path()}")
-
 
 def test_flavor(
     ctx,
@@ -267,16 +254,6 @@ def test(
     else:
         print("Using default modules and targets")
         modules = DEFAULT_MODULES.values()
-
-    # All of the modules in INDEPENDENT_MODULES must be checked, but we should refrain
-    # from checking any ones missing from specified module/targets combination.
-    independent_modules = []
-    for m in modules:
-        for im in INDEPENDENT_MODULES.values():
-            if im.path == m.path:
-                independent_modules.append(im)
-
-    independent_submodule_check(ctx, modules=independent_modules)
 
     if not flavors:
         flavors = [AgentFlavor.base]


### PR DESCRIPTION
This change adds a new tool inside internal/tools which checks that a
given list of submodules (defined in tasks/) does not import a given
list of modules (in this case "github.com/DataDog/datadog-agent").

See incident in #13001