### PR TITLE
[gitlab] Upload built packages to the newly created release bucket

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -125,6 +125,7 @@ variables:
   S3_ARTIFACTS_URI: s3://dd-ci-artefacts-build-stable/$CI_PROJECT_NAME/$CI_PIPELINE_ID
   S3_PERMANENT_ARTIFACTS_URI: s3://dd-ci-persistent-artefacts-build-stable/$CI_PROJECT_NAME
   S3_SBOM_STORAGE_URI: s3://sbom-root-us1-ddbuild-io/$CI_PROJECT_NAME/$CI_PIPELINE_ID
+  S3_RELEASE_ARTIFACTS_URI: s3://dd-release-artifacts/$CI_PROJECT_NAME/$CI_PIPELINE_ID
   ## comment out both lines below (S3_OMNIBUS_CACHE_BUCKET and USE_S3_CACHING) to allow
   ## build to succeed with S3 caching disabled.
   S3_OMNIBUS_CACHE_BUCKET: dd-ci-datadog-agent-omnibus-cache-build-stable

--- a/.gitlab/deploy_6/nix.yml
+++ b/.gitlab/deploy_6/nix.yml
@@ -36,6 +36,9 @@ deploy_staging_deb-6:
     - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c $BUCKET_BRANCH -m 6 -b $DEB_S3_BUCKET -a x86_64 --sign=$DEB_GPG_KEY_ID --gpg_options="--passphrase-fd 0 --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/*_6.*amd64.deb
     - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c $BUCKET_BRANCH -m 6 -b $DEB_S3_BUCKET -a arm64 --sign=$DEB_GPG_KEY_ID --gpg_options="--passphrase-fd 0 --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/*_6.*arm64.deb
 
+    - $S3_CP_CMD --recursive --exclude "*" --include "*_6.*amd64.deb" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/deb/amd64/ ||:
+    - $S3_CP_CMD --recursive --exclude "*" --include "*_6.*arm64.deb" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/deb/arm64/ ||:
+
 deploy_staging_rpm-6:
   rules:
     !reference [.on_deploy_a6]
@@ -51,6 +54,9 @@ deploy_staging_rpm-6:
     - set +x
     - echo "$RPM_SIGNING_PASSPHRASE" | rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_S3_BUCKET -p "$BUCKET_BRANCH/6/x86_64/" -a "x86_64" --sign --metadata-signing-key $RPM_GPG_KEY_ID $OMNIBUS_PACKAGE_DIR/*-6.*x86_64.rpm
     - echo "$RPM_SIGNING_PASSPHRASE" | rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_S3_BUCKET -p "$BUCKET_BRANCH/6/aarch64/" -a "aarch64" --sign --metadata-signing-key $RPM_GPG_KEY_ID $OMNIBUS_PACKAGE_DIR/*-6.*aarch64.rpm
+
+    - $S3_CP_CMD --recursive --exclude "*" --include "*-6.*x86_64.rpm" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/rpm/x86_64/ ||:
+    - $S3_CP_CMD --recursive --exclude "*" --include "*-6.*aarch64.rpm" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/rpm/aarch64/ ||:
 
 # NOTE: no SuSE ARM builds currently.
 deploy_staging_suse_rpm-6:
@@ -68,6 +74,8 @@ deploy_staging_suse_rpm-6:
     - set +x
     - echo "$RPM_SIGNING_PASSPHRASE" | rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_S3_BUCKET -p "suse/$BUCKET_BRANCH/6/x86_64/" -a "x86_64" --sign --metadata-signing-key $RPM_GPG_KEY_ID --repodata-store-public-key $OMNIBUS_PACKAGE_DIR_SUSE/*-6.*x86_64.rpm
 
+    - $S3_CP_CMD --recursive --exclude "*" --include "*-6.*x86_64.rpm" $OMNIBUS_PACKAGE_DIR_SUSE $S3_RELEASE_ARTIFACTS_URI/suse_rpm/x86_64/ ||:
+
 # Deploy MacOS dmg builds
 deploy_staging_dmg-a6:
   allow_failure: true
@@ -81,3 +89,5 @@ deploy_staging_dmg-a6:
     - ls $OMNIBUS_PACKAGE_DIR
   script:
     - $S3_CP_CMD --recursive --exclude "*" --include "datadog-agent-6*.dmg" $OMNIBUS_PACKAGE_DIR s3://$MACOS_S3_BUCKET/$BUCKET_BRANCH/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
+
+    - $S3_CP_CMD --recursive --exclude "*" --include "datadog-agent-6*.dmg" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/dmg/x86_64/ ||:

--- a/.gitlab/deploy_6/nix.yml
+++ b/.gitlab/deploy_6/nix.yml
@@ -36,8 +36,8 @@ deploy_staging_deb-6:
     - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c $BUCKET_BRANCH -m 6 -b $DEB_S3_BUCKET -a x86_64 --sign=$DEB_GPG_KEY_ID --gpg_options="--passphrase-fd 0 --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/*_6.*amd64.deb
     - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c $BUCKET_BRANCH -m 6 -b $DEB_S3_BUCKET -a arm64 --sign=$DEB_GPG_KEY_ID --gpg_options="--passphrase-fd 0 --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/*_6.*arm64.deb
 
-    - $S3_CP_CMD --recursive --exclude "*" --include "*_6.*amd64.deb" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/deb/amd64/ ||:
-    - $S3_CP_CMD --recursive --exclude "*" --include "*_6.*arm64.deb" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/deb/arm64/ ||:
+    - $S3_CP_CMD --recursive --exclude "*" --include "*_6.*amd64.deb" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/deb/amd64/ || true
+    - $S3_CP_CMD --recursive --exclude "*" --include "*_6.*arm64.deb" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/deb/arm64/ || true
 
 deploy_staging_rpm-6:
   rules:
@@ -55,8 +55,8 @@ deploy_staging_rpm-6:
     - echo "$RPM_SIGNING_PASSPHRASE" | rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_S3_BUCKET -p "$BUCKET_BRANCH/6/x86_64/" -a "x86_64" --sign --metadata-signing-key $RPM_GPG_KEY_ID $OMNIBUS_PACKAGE_DIR/*-6.*x86_64.rpm
     - echo "$RPM_SIGNING_PASSPHRASE" | rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_S3_BUCKET -p "$BUCKET_BRANCH/6/aarch64/" -a "aarch64" --sign --metadata-signing-key $RPM_GPG_KEY_ID $OMNIBUS_PACKAGE_DIR/*-6.*aarch64.rpm
 
-    - $S3_CP_CMD --recursive --exclude "*" --include "*-6.*x86_64.rpm" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/rpm/x86_64/ ||:
-    - $S3_CP_CMD --recursive --exclude "*" --include "*-6.*aarch64.rpm" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/rpm/aarch64/ ||:
+    - $S3_CP_CMD --recursive --exclude "*" --include "*-6.*x86_64.rpm" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/rpm/x86_64/ || true
+    - $S3_CP_CMD --recursive --exclude "*" --include "*-6.*aarch64.rpm" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/rpm/aarch64/ || true
 
 # NOTE: no SuSE ARM builds currently.
 deploy_staging_suse_rpm-6:
@@ -74,7 +74,7 @@ deploy_staging_suse_rpm-6:
     - set +x
     - echo "$RPM_SIGNING_PASSPHRASE" | rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_S3_BUCKET -p "suse/$BUCKET_BRANCH/6/x86_64/" -a "x86_64" --sign --metadata-signing-key $RPM_GPG_KEY_ID --repodata-store-public-key $OMNIBUS_PACKAGE_DIR_SUSE/*-6.*x86_64.rpm
 
-    - $S3_CP_CMD --recursive --exclude "*" --include "*-6.*x86_64.rpm" $OMNIBUS_PACKAGE_DIR_SUSE $S3_RELEASE_ARTIFACTS_URI/suse_rpm/x86_64/ ||:
+    - $S3_CP_CMD --recursive --exclude "*" --include "*-6.*x86_64.rpm" $OMNIBUS_PACKAGE_DIR_SUSE $S3_RELEASE_ARTIFACTS_URI/suse_rpm/x86_64/ || true
 
 # Deploy MacOS dmg builds
 deploy_staging_dmg-a6:
@@ -90,4 +90,4 @@ deploy_staging_dmg-a6:
   script:
     - $S3_CP_CMD --recursive --exclude "*" --include "datadog-agent-6*.dmg" $OMNIBUS_PACKAGE_DIR s3://$MACOS_S3_BUCKET/$BUCKET_BRANCH/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
-    - $S3_CP_CMD --recursive --exclude "*" --include "datadog-agent-6*.dmg" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/dmg/x86_64/ ||:
+    - $S3_CP_CMD --recursive --exclude "*" --include "datadog-agent-6*.dmg" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/dmg/x86_64/ || true

--- a/.gitlab/deploy_6/windows.yml
+++ b/.gitlab/deploy_6/windows.yml
@@ -19,6 +19,14 @@ deploy_staging_windows-6:
       $OMNIBUS_PACKAGE_DIR s3://$WINDOWS_BUILDS_S3_BUCKET/$BUCKET_BRANCH/
       --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
       full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
+    - $S3_CP_CMD
+      --recursive
+      --exclude "*"
+      --include "datadog-agent-6*.msi"
+      --include "datadog-agent-6*.debug.zip"
+      --include "datadog-agent-6.*.wixpdb"
+      --include "customaction-6*.pdb"
+      $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/msi/x86_64/ ||:
 
 deploy_staging_windows_master-latest-6:
   rules:

--- a/.gitlab/deploy_6/windows.yml
+++ b/.gitlab/deploy_6/windows.yml
@@ -26,7 +26,7 @@ deploy_staging_windows-6:
       --include "datadog-agent-6*.debug.zip"
       --include "datadog-agent-6.*.wixpdb"
       --include "customaction-6*.pdb"
-      $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/msi/x86_64/ ||:
+      $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/msi/x86_64/ || true
 
 deploy_staging_windows_master-latest-6:
   rules:

--- a/.gitlab/deploy_7/nix.yml
+++ b/.gitlab/deploy_7/nix.yml
@@ -44,9 +44,9 @@ deploy_staging_deb-7:
     - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c $BUCKET_BRANCH -m 7 -b $DEB_S3_BUCKET -a arm64 --sign=$DEB_GPG_KEY_ID --gpg_options="--passphrase-fd 0 --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/*_7.*arm64.deb
     - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c $BUCKET_BRANCH -m 7 -b $DEB_S3_BUCKET -a armhf --sign=$DEB_GPG_KEY_ID --gpg_options="--passphrase-fd 0 --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/*_7.*armhf.deb
 
-   - $S3_CP_CMD --recursive --exclude "*" --include "*_7.*amd64.deb" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/deb/amd64/ ||:
-   - $S3_CP_CMD --recursive --exclude "*" --include "*_7.*arm64.deb" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/deb/arm64/ ||:
-   - $S3_CP_CMD --recursive --exclude "*" --include "*_7.*armhf.deb" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/deb/armhf/ ||:
+   - $S3_CP_CMD --recursive --exclude "*" --include "*_7.*amd64.deb" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/deb/amd64/ || true
+   - $S3_CP_CMD --recursive --exclude "*" --include "*_7.*arm64.deb" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/deb/arm64/ || true
+   - $S3_CP_CMD --recursive --exclude "*" --include "*_7.*armhf.deb" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/deb/armhf/ || true
 
 deploy_staging_rpm-7:
   rules:
@@ -71,9 +71,9 @@ deploy_staging_rpm-7:
     - echo "$RPM_SIGNING_PASSPHRASE" | rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_S3_BUCKET -p "$BUCKET_BRANCH/7/aarch64/" -a "aarch64" --sign --metadata-signing-key $RPM_GPG_KEY_ID $OMNIBUS_PACKAGE_DIR/*-7.*aarch64.rpm
     - echo "$RPM_SIGNING_PASSPHRASE" | rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_S3_BUCKET -p "$BUCKET_BRANCH/7/armv7hl/" -a "armv7hl" --sign --metadata-signing-key $RPM_GPG_KEY_ID $OMNIBUS_PACKAGE_DIR/*-7.*armv7hl.rpm
 
-   - $S3_CP_CMD --recursive --exclude "*" --include "*-7.*x86_64.rpm" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/rpm/x86_64/ ||:
-   - $S3_CP_CMD --recursive --exclude "*" --include "*-7.*aarch64.rpm" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/rpm/aarch64/ ||:
-   - $S3_CP_CMD --recursive --exclude "*" --include "*-7.*armv7hl.rpm" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/rpm/armv7hl/ ||:
+   - $S3_CP_CMD --recursive --exclude "*" --include "*-7.*x86_64.rpm" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/rpm/x86_64/ || true
+   - $S3_CP_CMD --recursive --exclude "*" --include "*-7.*aarch64.rpm" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/rpm/aarch64/ || true
+   - $S3_CP_CMD --recursive --exclude "*" --include "*-7.*armv7hl.rpm" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/rpm/armv7hl/ || true
 
 deploy_staging_suse_rpm-7:
   rules:
@@ -93,7 +93,7 @@ deploy_staging_suse_rpm-7:
     - set +x
     - echo "$RPM_SIGNING_PASSPHRASE" | rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_S3_BUCKET -p "suse/$BUCKET_BRANCH/7/x86_64/" -a "x86_64" --sign --metadata-signing-key $RPM_GPG_KEY_ID --repodata-store-public-key $OMNIBUS_PACKAGE_DIR_SUSE/*-7.*x86_64.rpm
 
-   - $S3_CP_CMD --recursive --exclude "*" --include "*-7.*x86_64.rpm" $OMNIBUS_PACKAGE_DIR_SUSE $S3_RELEASE_ARTIFACTS_URI/suse_rpm/x86_64/ ||:
+   - $S3_CP_CMD --recursive --exclude "*" --include "*-7.*x86_64.rpm" $OMNIBUS_PACKAGE_DIR_SUSE $S3_RELEASE_ARTIFACTS_URI/suse_rpm/x86_64/ || true
 
 deploy_staging_dmg-a7:
   allow_failure: true
@@ -108,7 +108,7 @@ deploy_staging_dmg-a7:
   script:
     - $S3_CP_CMD --recursive --exclude "*" --include "datadog-agent-7*.dmg" $OMNIBUS_PACKAGE_DIR s3://$MACOS_S3_BUCKET/$BUCKET_BRANCH/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
-    - $S3_CP_CMD --recursive --exclude "*" --include "datadog-agent-7*.dmg" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/dmg/x86_64/ ||:
+    - $S3_CP_CMD --recursive --exclude "*" --include "datadog-agent-7*.dmg" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/dmg/x86_64/ || true
 
 
 # deploy dogstatsd x64, non-static binary to staging bucket

--- a/.gitlab/deploy_7/nix.yml
+++ b/.gitlab/deploy_7/nix.yml
@@ -44,9 +44,9 @@ deploy_staging_deb-7:
     - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c $BUCKET_BRANCH -m 7 -b $DEB_S3_BUCKET -a arm64 --sign=$DEB_GPG_KEY_ID --gpg_options="--passphrase-fd 0 --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/*_7.*arm64.deb
     - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c $BUCKET_BRANCH -m 7 -b $DEB_S3_BUCKET -a armhf --sign=$DEB_GPG_KEY_ID --gpg_options="--passphrase-fd 0 --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/*_7.*armhf.deb
 
-   - $S3_CP_CMD --recursive --exclude "*" --include "*_7.*amd64.deb" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/deb/amd64/ || :
-   - $S3_CP_CMD --recursive --exclude "*" --include "*_7.*arm64.deb" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/deb/arm64/ || :
-   - $S3_CP_CMD --recursive --exclude "*" --include "*_7.*armhf.deb" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/deb/armhf/ || :
+   - $S3_CP_CMD --recursive --exclude "*" --include "*_7.*amd64.deb" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/deb/amd64/ ||:
+   - $S3_CP_CMD --recursive --exclude "*" --include "*_7.*arm64.deb" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/deb/arm64/ ||:
+   - $S3_CP_CMD --recursive --exclude "*" --include "*_7.*armhf.deb" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/deb/armhf/ ||:
 
 deploy_staging_rpm-7:
   rules:
@@ -71,9 +71,9 @@ deploy_staging_rpm-7:
     - echo "$RPM_SIGNING_PASSPHRASE" | rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_S3_BUCKET -p "$BUCKET_BRANCH/7/aarch64/" -a "aarch64" --sign --metadata-signing-key $RPM_GPG_KEY_ID $OMNIBUS_PACKAGE_DIR/*-7.*aarch64.rpm
     - echo "$RPM_SIGNING_PASSPHRASE" | rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_S3_BUCKET -p "$BUCKET_BRANCH/7/armv7hl/" -a "armv7hl" --sign --metadata-signing-key $RPM_GPG_KEY_ID $OMNIBUS_PACKAGE_DIR/*-7.*armv7hl.rpm
 
-   - $S3_CP_CMD --recursive --exclude "*" --include "*-7.*x86_64.rpm" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/rpm/x86_64/ || :
-   - $S3_CP_CMD --recursive --exclude "*" --include "*-7.*aarch64.rpm" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/rpm/aarch64/ || :
-   - $S3_CP_CMD --recursive --exclude "*" --include "*-7.*armv7hl.rpm" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/rpm/armv7hl/ || :
+   - $S3_CP_CMD --recursive --exclude "*" --include "*-7.*x86_64.rpm" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/rpm/x86_64/ ||:
+   - $S3_CP_CMD --recursive --exclude "*" --include "*-7.*aarch64.rpm" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/rpm/aarch64/ ||:
+   - $S3_CP_CMD --recursive --exclude "*" --include "*-7.*armv7hl.rpm" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/rpm/armv7hl/ ||:
 
 deploy_staging_suse_rpm-7:
   rules:
@@ -93,7 +93,7 @@ deploy_staging_suse_rpm-7:
     - set +x
     - echo "$RPM_SIGNING_PASSPHRASE" | rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_S3_BUCKET -p "suse/$BUCKET_BRANCH/7/x86_64/" -a "x86_64" --sign --metadata-signing-key $RPM_GPG_KEY_ID --repodata-store-public-key $OMNIBUS_PACKAGE_DIR_SUSE/*-7.*x86_64.rpm
 
-   - $S3_CP_CMD --recursive --exclude "*" --include "*-7.*x86_64.rpm" $OMNIBUS_PACKAGE_DIR_SUSE $S3_RELEASE_ARTIFACTS_URI/suse_rpm/x86_64/ || :
+   - $S3_CP_CMD --recursive --exclude "*" --include "*-7.*x86_64.rpm" $OMNIBUS_PACKAGE_DIR_SUSE $S3_RELEASE_ARTIFACTS_URI/suse_rpm/x86_64/ ||:
 
 deploy_staging_dmg-a7:
   allow_failure: true

--- a/.gitlab/deploy_7/nix.yml
+++ b/.gitlab/deploy_7/nix.yml
@@ -44,9 +44,9 @@ deploy_staging_deb-7:
     - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c $BUCKET_BRANCH -m 7 -b $DEB_S3_BUCKET -a arm64 --sign=$DEB_GPG_KEY_ID --gpg_options="--passphrase-fd 0 --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/*_7.*arm64.deb
     - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c $BUCKET_BRANCH -m 7 -b $DEB_S3_BUCKET -a armhf --sign=$DEB_GPG_KEY_ID --gpg_options="--passphrase-fd 0 --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/*_7.*armhf.deb
 
-   - $S3_CP_CMD --recursive --exclude "*" --include "*_7.*amd64.deb" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/deb/amd64/ || true
-   - $S3_CP_CMD --recursive --exclude "*" --include "*_7.*arm64.deb" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/deb/arm64/ || true
-   - $S3_CP_CMD --recursive --exclude "*" --include "*_7.*armhf.deb" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/deb/armhf/ || true
+    - $S3_CP_CMD --recursive --exclude "*" --include "*_7.*amd64.deb" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/deb/amd64/ || true
+    - $S3_CP_CMD --recursive --exclude "*" --include "*_7.*arm64.deb" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/deb/arm64/ || true
+    - $S3_CP_CMD --recursive --exclude "*" --include "*_7.*armhf.deb" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/deb/armhf/ || true
 
 deploy_staging_rpm-7:
   rules:
@@ -71,9 +71,9 @@ deploy_staging_rpm-7:
     - echo "$RPM_SIGNING_PASSPHRASE" | rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_S3_BUCKET -p "$BUCKET_BRANCH/7/aarch64/" -a "aarch64" --sign --metadata-signing-key $RPM_GPG_KEY_ID $OMNIBUS_PACKAGE_DIR/*-7.*aarch64.rpm
     - echo "$RPM_SIGNING_PASSPHRASE" | rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_S3_BUCKET -p "$BUCKET_BRANCH/7/armv7hl/" -a "armv7hl" --sign --metadata-signing-key $RPM_GPG_KEY_ID $OMNIBUS_PACKAGE_DIR/*-7.*armv7hl.rpm
 
-   - $S3_CP_CMD --recursive --exclude "*" --include "*-7.*x86_64.rpm" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/rpm/x86_64/ || true
-   - $S3_CP_CMD --recursive --exclude "*" --include "*-7.*aarch64.rpm" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/rpm/aarch64/ || true
-   - $S3_CP_CMD --recursive --exclude "*" --include "*-7.*armv7hl.rpm" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/rpm/armv7hl/ || true
+    - $S3_CP_CMD --recursive --exclude "*" --include "*-7.*x86_64.rpm" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/rpm/x86_64/ || true
+    - $S3_CP_CMD --recursive --exclude "*" --include "*-7.*aarch64.rpm" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/rpm/aarch64/ || true
+    - $S3_CP_CMD --recursive --exclude "*" --include "*-7.*armv7hl.rpm" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/rpm/armv7hl/ || true
 
 deploy_staging_suse_rpm-7:
   rules:
@@ -93,7 +93,7 @@ deploy_staging_suse_rpm-7:
     - set +x
     - echo "$RPM_SIGNING_PASSPHRASE" | rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_S3_BUCKET -p "suse/$BUCKET_BRANCH/7/x86_64/" -a "x86_64" --sign --metadata-signing-key $RPM_GPG_KEY_ID --repodata-store-public-key $OMNIBUS_PACKAGE_DIR_SUSE/*-7.*x86_64.rpm
 
-   - $S3_CP_CMD --recursive --exclude "*" --include "*-7.*x86_64.rpm" $OMNIBUS_PACKAGE_DIR_SUSE $S3_RELEASE_ARTIFACTS_URI/suse_rpm/x86_64/ || true
+    - $S3_CP_CMD --recursive --exclude "*" --include "*-7.*x86_64.rpm" $OMNIBUS_PACKAGE_DIR_SUSE $S3_RELEASE_ARTIFACTS_URI/suse_rpm/x86_64/ || true
 
 deploy_staging_dmg-a7:
   allow_failure: true

--- a/.gitlab/deploy_7/nix.yml
+++ b/.gitlab/deploy_7/nix.yml
@@ -44,6 +44,10 @@ deploy_staging_deb-7:
     - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c $BUCKET_BRANCH -m 7 -b $DEB_S3_BUCKET -a arm64 --sign=$DEB_GPG_KEY_ID --gpg_options="--passphrase-fd 0 --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/*_7.*arm64.deb
     - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c $BUCKET_BRANCH -m 7 -b $DEB_S3_BUCKET -a armhf --sign=$DEB_GPG_KEY_ID --gpg_options="--passphrase-fd 0 --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/*_7.*armhf.deb
 
+   - $S3_CP_CMD --recursive --exclude "*" --include "*_7.*amd64.deb" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/deb/amd64/ || :
+   - $S3_CP_CMD --recursive --exclude "*" --include "*_7.*arm64.deb" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/deb/arm64/ || :
+   - $S3_CP_CMD --recursive --exclude "*" --include "*_7.*armhf.deb" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/deb/armhf/ || :
+
 deploy_staging_rpm-7:
   rules:
     !reference [.on_deploy_a7]
@@ -67,6 +71,10 @@ deploy_staging_rpm-7:
     - echo "$RPM_SIGNING_PASSPHRASE" | rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_S3_BUCKET -p "$BUCKET_BRANCH/7/aarch64/" -a "aarch64" --sign --metadata-signing-key $RPM_GPG_KEY_ID $OMNIBUS_PACKAGE_DIR/*-7.*aarch64.rpm
     - echo "$RPM_SIGNING_PASSPHRASE" | rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_S3_BUCKET -p "$BUCKET_BRANCH/7/armv7hl/" -a "armv7hl" --sign --metadata-signing-key $RPM_GPG_KEY_ID $OMNIBUS_PACKAGE_DIR/*-7.*armv7hl.rpm
 
+   - $S3_CP_CMD --recursive --exclude "*" --include "*-7.*x86_64.rpm" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/rpm/x86_64/ || :
+   - $S3_CP_CMD --recursive --exclude "*" --include "*-7.*aarch64.rpm" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/rpm/aarch64/ || :
+   - $S3_CP_CMD --recursive --exclude "*" --include "*-7.*armv7hl.rpm" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/rpm/armv7hl/ || :
+
 deploy_staging_suse_rpm-7:
   rules:
     !reference [.on_deploy_a7]
@@ -85,6 +93,8 @@ deploy_staging_suse_rpm-7:
     - set +x
     - echo "$RPM_SIGNING_PASSPHRASE" | rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_S3_BUCKET -p "suse/$BUCKET_BRANCH/7/x86_64/" -a "x86_64" --sign --metadata-signing-key $RPM_GPG_KEY_ID --repodata-store-public-key $OMNIBUS_PACKAGE_DIR_SUSE/*-7.*x86_64.rpm
 
+   - $S3_CP_CMD --recursive --exclude "*" --include "*-7.*x86_64.rpm" $OMNIBUS_PACKAGE_DIR_SUSE $S3_RELEASE_ARTIFACTS_URI/suse_rpm/x86_64/ || :
+
 deploy_staging_dmg-a7:
   allow_failure: true
   rules:
@@ -97,6 +107,9 @@ deploy_staging_dmg-a7:
     - ls $OMNIBUS_PACKAGE_DIR
   script:
     - $S3_CP_CMD --recursive --exclude "*" --include "datadog-agent-7*.dmg" $OMNIBUS_PACKAGE_DIR s3://$MACOS_S3_BUCKET/$BUCKET_BRANCH/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
+
+    - $S3_CP_CMD --recursive --exclude "*" --include "datadog-agent-7*.dmg" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/dmg/x86_64/ ||:
+
 
 # deploy dogstatsd x64, non-static binary to staging bucket
 deploy_staging_dsd:

--- a/.gitlab/deploy_7/windows.yml
+++ b/.gitlab/deploy_7/windows.yml
@@ -20,6 +20,14 @@ deploy_staging_windows-7:
       s3://$WINDOWS_BUILDS_S3_BUCKET/$BUCKET_BRANCH/
       --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
       full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
+    - $S3_CP_CMD
+      --recursive
+      --exclude "*"
+      --include "datadog-agent-7*.msi"
+      --include "datadog-agent-7*.debug.zip"
+      --include "datadog-agent-7*.wixpdb"
+      --include "customaction-7*.pdb"
+      $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/msi/x86_64/ ||:
 
 deploy_staging_windows_master-latest-7:
   rules:

--- a/.gitlab/deploy_7/windows.yml
+++ b/.gitlab/deploy_7/windows.yml
@@ -27,7 +27,7 @@ deploy_staging_windows-7:
       --include "datadog-agent-7*.debug.zip"
       --include "datadog-agent-7*.wixpdb"
       --include "customaction-7*.pdb"
-      $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/msi/x86_64/ ||:
+      $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/msi/x86_64/ || true
 
 deploy_staging_windows_master-latest-7:
   rules:


### PR DESCRIPTION
### What does this PR do?

Uploads all built packages to the newly created dd-release-artifacts bucket. For now, we do this in addition to uploading to staging repos. Additionally, all the new lines contain `||:` to ensure we don't cause any problems during releases.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
