### PR TITLE
[Helm check] Avoid re-processing known objects

### DIFF
--- a/pkg/collector/corechecks/cluster/helm/helm_test.go
+++ b/pkg/collector/corechecks/cluster/helm/helm_test.go
@@ -541,3 +541,21 @@ func encodeRelease(rls *release) (string, error) {
 
 	return b64.EncodeToString(buf.Bytes()), nil
 }
+
+func TestKnownObjects(t *testing.T) {
+	check := factory().(*HelmCheck)
+
+	assert.True(t, check.shouldProcessObject("uid-1", "1"))
+	check.addKnownObject("uid-1", "1")
+	assert.Equal(t, check.knownObjects["uid-1"], "1")
+	assert.False(t, check.shouldProcessObject("uid-1", "1"))
+
+	assert.True(t, check.shouldProcessObject("uid-1", "2"))
+	check.addKnownObject("uid-1", "2")
+	assert.Equal(t, check.knownObjects["uid-1"], "2")
+	assert.False(t, check.shouldProcessObject("uid-1", "2"))
+
+	check.deleteKnownObject("uid-1")
+	assert.NotContains(t, check.knownObjects, "uid-1")
+	assert.True(t, check.shouldProcessObject("uid-1", "2"))
+}

--- a/pkg/collector/corechecks/cluster/helm/helm_test.go
+++ b/pkg/collector/corechecks/cluster/helm/helm_test.go
@@ -203,13 +203,11 @@ func TestRun(t *testing.T) {
 				fake.NewSimpleClientset(kubeObjects...),
 				time.Minute,
 			)
-			err := check.setupInformers()
-			assert.NoError(t, err)
 
 			mockedSender := mocksender.NewMockSender(checkName)
 			mockedSender.SetupAcceptAll()
 
-			err = check.Run()
+			err := check.Run()
 			assert.NoError(t, err)
 
 			for _, tags := range test.expectedTags {
@@ -246,8 +244,6 @@ func TestRun_withCollectEvents(t *testing.T) {
 
 	k8sClient := fake.NewSimpleClientset()
 	check.informerFactory = informers.NewSharedInformerFactory(k8sClient, time.Minute)
-	err = check.setupInformers()
-	assert.NoError(t, err)
 
 	mockedSender := mocksender.NewMockSender(checkName)
 	mockedSender.SetupAcceptAll()
@@ -425,6 +421,9 @@ func TestRun_ServiceCheck(t *testing.T) {
 			mockedSender := mocksender.NewMockSender(checkName)
 			mockedSender.SetupAcceptAll()
 
+			k8sClient := fake.NewSimpleClientset()
+			check.informerFactory = informers.NewSharedInformerFactory(k8sClient, time.Minute)
+
 			err := check.Run()
 			assert.NoError(t, err)
 
@@ -540,22 +539,4 @@ func encodeRelease(rls *release) (string, error) {
 	w.Close()
 
 	return b64.EncodeToString(buf.Bytes()), nil
-}
-
-func TestKnownObjects(t *testing.T) {
-	check := factory().(*HelmCheck)
-
-	assert.True(t, check.shouldProcessObject("uid-1", "1"))
-	check.addKnownObject("uid-1", "1")
-	assert.Equal(t, check.knownObjects["uid-1"], "1")
-	assert.False(t, check.shouldProcessObject("uid-1", "1"))
-
-	assert.True(t, check.shouldProcessObject("uid-1", "2"))
-	check.addKnownObject("uid-1", "2")
-	assert.Equal(t, check.knownObjects["uid-1"], "2")
-	assert.False(t, check.shouldProcessObject("uid-1", "2"))
-
-	check.deleteKnownObject("uid-1")
-	assert.NotContains(t, check.knownObjects, "uid-1")
-	assert.True(t, check.shouldProcessObject("uid-1", "2"))
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

- Fast return in the update event handlers if the resource version is unchanged (typically on informer resync)
- Remove `addExistingReleases` - initial fill is not needed to be done explicitly. The informers will handle it.
- Move sync'ing the informers to `Run` to avoid blocking `Configure` - Note that `Configure` is invoked in a _very_ hot path.
- Rework how we handle existing releases 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

- Avoid unnecessary and costly processing when informer resyncs happen
- Improve the reliability of the check and the agent in general
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

In the 2 first commits I explored an approach that turned out to be unnecessary to achieve what we wanted. 
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

- The memory and cpu profiles show significant perf improvements 
- The helm check reports metrics/events/service checks reliably
- The check doesn't send events for existing releases (prior to check instantiation)

![image](https://user-images.githubusercontent.com/38987709/182924613-c8c47eae-c622-4b39-a6c3-89146ae5680c.png)

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
