### PR TITLE
[corechecks/containers/docker] Fix `docker.containers.running` grouping

### DIFF
--- a/pkg/collector/corechecks/containers/docker/check_test.go
+++ b/pkg/collector/corechecks/containers/docker/check_test.go
@@ -213,8 +213,9 @@ func TestDockerCustomPart(t *testing.T) {
 
 	mockSender.AssertMetric(t, "Gauge", "docker.containers.running", 1, "", []string{"image_name:datadog/agent", "short:agent", "tag:latest"})
 	mockSender.AssertMetric(t, "Gauge", "docker.containers.running", 1, "", []string{"image_name:datadog/agent", "short:agent", "tag:7.32.0-rc.1"})
-	mockSender.AssertMetric(t, "Gauge", "docker.containers.running", 2, "", []string{"app:foo"})
-	mockSender.AssertMetric(t, "Gauge", "docker.containers.stopped", 1, "", []string{"image_name:datadog/agent", "short:agent", "tag:latest"})
+	mockSender.AssertMetric(t, "Gauge", "docker.containers.running", 1, "", []string{"app:foo"})
+	mockSender.AssertMetric(t, "Gauge", "docker.containers.stopped", 1, "", []string{"docker_image:datadog/agent:latest", "image_name:datadog/agent", "image_tag:latest", "short_image:agent"})
+
 	mockSender.AssertMetric(t, "Gauge", "docker.containers.running.total", 4, "", nil)
 	mockSender.AssertMetric(t, "Gauge", "docker.containers.stopped.total", 1, "", nil)
 
@@ -229,4 +230,63 @@ func TestDockerCustomPart(t *testing.T) {
 	mockSender.AssertMetric(t, "Gauge", "docker.volume.count", 2, "", []string{"volume_state:dangling"})
 
 	mockSender.AssertServiceCheck(t, DockerServiceUp, coreMetrics.ServiceCheckOK, "", nil, "")
+}
+
+func TestContainersRunning(t *testing.T) {
+	mockSender := mocksender.NewMockSender(check.ID(t.Name()))
+	mockSender.SetupAcceptAll()
+
+	// Define tags for 3 different containers. The first 2 have the same tags.
+	// The third one shares the image-related tags, but has a different
+	// "service" tag.
+	fakeTagger := local.NewFakeTagger()
+	fakeTagger.SetTags("container_id://e2d5394a5321d4a59497f53552a0131b2aafe64faba37f4738e78c531289fc45", "foo", []string{"image_name:datadog/agent", "short:agent", "tag:latest", "service:s1"}, nil, nil, nil)
+	fakeTagger.SetTags("container_id://b781900d227cf8d63a0922705018b66610f789644bf236cb72c8698b31383074", "foo", []string{"image_name:datadog/agent", "short:agent", "tag:latest", "service:s1"}, nil, nil, nil)
+	fakeTagger.SetTags("container_id://be2584a7d1a2a3ae9f9c688e9ce7a88991c028507fec7c70a660b705bd2a5b90", "foo", []string{"image_name:datadog/agent", "short:agent", "tag:latest", "service:s2"}, nil, nil, nil)
+	tagger.SetDefaultTagger(fakeTagger)
+
+	// Image ID is shared by the 3 containers
+	imageID := "sha256:7e813d42985b2e5a0269f868aaf238ffc952a877fba964f55aa1ff35fd0bf5f6"
+
+	// Mock client + fake data
+	dockerClient := dockerUtil.MockClient{}
+	dockerClient.FakeContainerList = []dockerTypes.Container{
+		{
+			ID:      "e2d5394a5321d4a59497f53552a0131b2aafe64faba37f4738e78c531289fc45",
+			Names:   []string{"agent"},
+			Image:   "datadog/agent",
+			ImageID: imageID,
+			State:   containers.ContainerRunningState,
+		},
+		{
+			ID:      "b781900d227cf8d63a0922705018b66610f789644bf236cb72c8698b31383074",
+			Names:   []string{"agent"},
+			Image:   "datadog/agent",
+			ImageID: imageID,
+			State:   containers.ContainerRunningState,
+		},
+		{
+			ID:      "be2584a7d1a2a3ae9f9c688e9ce7a88991c028507fec7c70a660b705bd2a5b90",
+			Names:   []string{"agent"},
+			Image:   "datadog/agent",
+			ImageID: imageID,
+			State:   containers.ContainerRunningState,
+		},
+	}
+
+	// Create Docker check
+	check := DockerCheck{
+		instance:        &DockerConfig{},
+		dockerHostname:  "testhostname",
+		containerFilter: &containers.Filter{},
+	}
+
+	err := check.runDockerCustom(mockSender, &dockerClient, dockerClient.FakeContainerList)
+	assert.NoError(t, err)
+
+	// Containers that share the same set of tags should be reported together,
+	// but containers that only share some tags should not be reported together
+
+	mockSender.AssertMetric(t, "Gauge", "docker.containers.running", 2, "", []string{"image_name:datadog/agent", "short:agent", "tag:latest", "service:s1"})
+	mockSender.AssertMetric(t, "Gauge", "docker.containers.running", 1, "", []string{"image_name:datadog/agent", "short:agent", "tag:latest", "service:s2"})
 }

--- a/releasenotes/notes/fix-docker-containers-running-2d89307e2941a2d1.yaml
+++ b/releasenotes/notes/fix-docker-containers-running-2d89307e2941a2d1.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed a bug in the Docker check that affects the
+    `docker.containers.running` metric. It was reporting wrong values in cases
+    where multiple containers with different `env`, `service`, `version`, etc.
+    tags were using the same image.


### PR DESCRIPTION
### What does this PR do?

Fixes a bug in the Docker check that affects the `docker.containers.running` metric.

We were reporting the metric once on every run per docker image. However, that's not correct because it assumes that if 2 containers use the same image they must also share other tags like `service`, `env`, etc.


### Describe how to test/QA your changes

Deploy the agent on a host with docker. Deploy 2 containers that use the same image, but define for each of them a different label like `service`, `env`, etc. (For example `com.datadoghq.tags.service=service1` in one and `com.datadoghq.tags.service=service2` in the other).

Run `agent check docker` and verify that `docker.containers.running` is returned 2 times, once for each container and with a value of 1. Check that the labels are correct. Notice that in the latest version of the agent, it reports `docker.containers.running` with a value of 2, and the tags are correct only for one of the containers.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
