### PR TITLE
Optimize null-terminated string extraction

### DIFF
--- a/pkg/security/secl/model/utils.go
+++ b/pkg/security/secl/model/utils.go
@@ -46,11 +46,11 @@ func UnmarshalStringArray(data []byte) ([]string, error) {
 
 		if i+n > len {
 			// truncated
-			arg := string(bytes.SplitN(data[i:len-1], []byte{0}, 2)[0])
+			arg := nullTerminatedString(data[i : len-1])
 			return append(result, arg), ErrStringArrayOverflow
 		}
 
-		arg := string(bytes.SplitN(data[i:i+n], []byte{0}, 2)[0])
+		arg := nullTerminatedString(data[i : i+n])
 		i += n
 
 		result = append(result, arg)
@@ -65,7 +65,15 @@ func UnmarshalString(data []byte, size int) (string, error) {
 		return "", ErrNotEnoughData
 	}
 
-	return string(bytes.SplitN(data[:size], []byte{0}, 2)[0]), nil
+	return nullTerminatedString(data[:size]), nil
+}
+
+func nullTerminatedString(d []byte) string {
+	idx := bytes.IndexByte(d, 0)
+	if idx == -1 {
+		return string(d)
+	}
+	return string(d[:idx])
 }
 
 // UnmarshalPrintableString unmarshal printable string

--- a/pkg/security/secl/model/utils_test.go
+++ b/pkg/security/secl/model/utils_test.go
@@ -6,6 +6,7 @@
 package model
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -19,4 +20,13 @@ func TestUnmarshalString(t *testing.T) {
 	}
 
 	assert.Equal(t, "ABC", str)
+}
+
+func BenchmarkNullTerminatedString(b *testing.B) {
+	array := []byte{65, 66, 67, 0, 0, 0, 65, 66}
+	var s string
+	for i := 0; i < b.N; i++ {
+		s = nullTerminatedString(array)
+	}
+	runtime.KeepAlive(s)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Optimizes the extraction of a null-terminated string from a byte array.

### Motivation

This showed up prominently in some CPU profiles in our load-testing environment.

### Additional Notes

Before:
```
BenchmarkNullTerminatedString-10    	25523991	        46.94 ns/op	      51 B/op	       2 allocs/op
```

After:
```
BenchmarkNullTerminatedString-10    	74333887	        15.81 ns/op	       3 B/op	       1 allocs/op
```

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
