### PR TITLE
Optimize procfs/sysfs relative path creation

### DIFF
--- a/pkg/ebpf/config.go
+++ b/pkg/ebpf/config.go
@@ -75,7 +75,7 @@ func NewConfig() *Config {
 		BPFDir:                   cfg.GetString(key(spNS, "bpf_dir")),
 		ExcludedBPFLinuxVersions: cfg.GetStringSlice(key(spNS, "excluded_linux_versions")),
 		EnableTracepoints:        cfg.GetBool(key(spNS, "enable_tracepoints")),
-		ProcRoot:                 util.GetProcRoot(),
+		ProcRoot:                 util.HostProc,
 
 		EnableRuntimeCompiler:      cfg.GetBool(key(spNS, "enable_runtime_compiler")),
 		RuntimeCompilerOutputDir:   cfg.GetString(key(spNS, "runtime_compiler_output_dir")),

--- a/pkg/network/tracer/utils_linux.go
+++ b/pkg/network/tracer/utils_linux.go
@@ -68,7 +68,7 @@ func verifyOSVersion(kernelCode kernel.Version, platform string, exclusionList [
 		return false, fmt.Sprintf("Known bug for kernel %s on platform %s, see: \n- https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1763454", kernelCode, platform)
 	}
 
-	missing, err := ddebpf.VerifyKernelFuncs(path.Join(util.GetProcRoot(), "kallsyms"), requiredKernelFuncs)
+	missing, err := ddebpf.VerifyKernelFuncs(path.Join(util.HostProc, "kallsyms"), requiredKernelFuncs)
 	if err != nil {
 		log.Warnf("error reading /proc/kallsyms file: %s (check your kernel version, current is: %s)", err, kernelCode)
 		// If we can't read the /proc/kallsyms file let's just return true to avoid blocking the tracer from running

--- a/pkg/process/procutil/process_linux.go
+++ b/pkg/process/procutil/process_linux.go
@@ -108,7 +108,7 @@ type probe struct {
 
 // NewProcessProbe initializes a new Probe object
 func NewProcessProbe(options ...Option) Probe {
-	hostProc := util.HostProc()
+	hostProc := util.HostProc
 	bootTime, err := bootTime(hostProc)
 	if err != nil {
 		log.Errorf("could not parse boot time: %s", err)

--- a/pkg/security/probe/activity_dump.go
+++ b/pkg/security/probe/activity_dump.go
@@ -1105,7 +1105,7 @@ func (pan *ProcessActivityNode) snapshotBoundSockets(p *process.Process, ad *Act
 	}
 
 	// use /proc/[pid]/net/tcp,tcp6,udp,udp6 to extract the ports opened by the current process
-	proc, _ := procfs.NewFS(filepath.Join(util.HostProc(fmt.Sprintf("%d", p.Pid))))
+	proc, _ := procfs.NewFS(filepath.Join(util.HostProc, strconv.Itoa(int(p.Pid))))
 	if err != nil {
 		return err
 	}

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -190,7 +190,7 @@ func (p *Probe) VerifyEnvironment() *multierror.Error {
 			err = multierror.Append(err, errors.New("/etc/group doesn't seem to be a mountpoint"))
 		}
 
-		if mounted, _ := mountinfo.Mounted(util.HostProc()); !mounted {
+		if mounted, _ := mountinfo.Mounted(util.HostProc); !mounted {
 			err = multierror.Append(err, errors.New("/etc/group doesn't seem to be a mountpoint"))
 		}
 
@@ -198,7 +198,7 @@ func (p *Probe) VerifyEnvironment() *multierror.Error {
 			err = multierror.Append(err, fmt.Errorf("%s doesn't seem to be a mountpoint", p.kernelVersion.OsReleasePath))
 		}
 
-		securityFSPath := filepath.Join(util.GetSysRoot(), "kernel/security")
+		securityFSPath := filepath.Join(util.HostSys, "kernel/security")
 		if mounted, _ := mountinfo.Mounted(securityFSPath); !mounted {
 			err = multierror.Append(err, fmt.Errorf("%s doesn't seem to be a mountpoint", securityFSPath))
 		}

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -1142,7 +1142,7 @@ type tracePipeLogger struct {
 func (l *tracePipeLogger) handleEvent(event *TraceEvent) {
 	// for some reason, the event task is resolved to "<...>"
 	// so we check that event.PID is the ID of a task of the running process
-	taskPath := filepath.Join(util.HostProc(), strconv.Itoa(int(utils.Getpid())), "task", event.PID)
+	taskPath := filepath.Join(util.HostProc, strconv.Itoa(int(utils.Getpid())), "task", event.PID)
 	_, err := os.Stat(taskPath)
 
 	if event.Task == l.executable || (event.Task == "<...>" && err == nil) {

--- a/pkg/security/utils/proc_test.go
+++ b/pkg/security/utils/proc_test.go
@@ -6,21 +6,21 @@
 //go:build linux
 // +build linux
 
-package util
+package utils
 
 import (
-	"os"
-	"path/filepath"
-	"strconv"
+	"math/rand"
+	"runtime"
+	"testing"
+	"time"
 )
 
-// GetRootNSPID returns the current PID from the root namespace
-func GetRootNSPID() (int, error) {
-	pidPath := filepath.Join(HostProc, "self")
-	pidStr, err := os.Readlink(pidPath)
-	if err != nil {
-		return 0, err
+func BenchmarkNetNSPathFromPid(b *testing.B) {
+	rand.Seed(time.Now().UnixNano())
+	pid := rand.Uint32()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s := NetNSPathFromPid(pid)
+		runtime.KeepAlive(s)
 	}
-
-	return strconv.Atoi(pidStr)
 }

--- a/pkg/security/utils/sys.go
+++ b/pkg/security/utils/sys.go
@@ -20,7 +20,7 @@ import (
 
 // CgroupSysPath returns the path to the provided file within the provided cgroup
 func CgroupSysPath(controller string, path string, file string) string {
-	return filepath.Join(util.HostSys("fs/cgroup/", controller, path, file))
+	return filepath.Join(util.HostSys, "fs/cgroup", controller, path, file)
 }
 
 // ReadCgroupFile reads the content of a cgroup file

--- a/pkg/util/kernel/fs.go
+++ b/pkg/util/kernel/fs.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/moby/sys/mountinfo"
@@ -21,7 +22,7 @@ import (
 
 // MountInfoPidPath returns the path to the mountinfo file of a pid in /proc
 func MountInfoPidPath(pid int32) string {
-	return filepath.Join(util.HostProc(), fmt.Sprintf("/%d/mountinfo", pid))
+	return filepath.Join(util.HostProc, strconv.Itoa(int(pid)), "mountinfo")
 }
 
 // ParseMountInfoFile collects the mounts for a specific process ID.

--- a/pkg/util/kernel/ip.go
+++ b/pkg/util/kernel/ip.go
@@ -17,6 +17,6 @@ import (
 
 // IsIPv6Enabled returns whether or not IPv6 has been enabled on the host
 func IsIPv6Enabled() bool {
-	_, err := ioutil.ReadFile(filepath.Join(util.GetProcRoot(), "net/if_inet6"))
+	_, err := ioutil.ReadFile(filepath.Join(util.HostProc, "net/if_inet6"))
 	return err == nil
 }

--- a/pkg/util/kernel/lockdown.go
+++ b/pkg/util/kernel/lockdown.go
@@ -48,7 +48,7 @@ func getLockdownMode(data string) LockdownMode {
 
 // GetLockdownMode returns the lockdown
 func GetLockdownMode() LockdownMode {
-	data, err := ioutil.ReadFile(filepath.Join(util.GetSysRoot(), "kernel/security/lockdown"))
+	data, err := ioutil.ReadFile(filepath.Join(util.HostSys, "kernel/security/lockdown"))
 	if err != nil {
 		return Unknown
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Optimizes the creation of procfs and sysfs relative paths

### Motivation

Path creation showing up as ~1-2% of CPU in a profile.

### Additional Notes

Before
```
BenchmarkNetNSPathFromPid-4   	 7409443	       161.3 ns/op	      40 B/op	       3 allocs/op
BenchmarkNetNSPathFromPid-4   	 7428150	       161.3 ns/op	      40 B/op	       3 allocs/op
BenchmarkNetNSPathFromPid-4   	 7425012	       162.4 ns/op	      40 B/op	       3 allocs/op
BenchmarkNetNSPathFromPid-4   	 7419609	       162.6 ns/op	      40 B/op	       3 allocs/op
BenchmarkNetNSPathFromPid-4   	 7422080	       162.4 ns/op	      40 B/op	       3 allocs/op
```

After
```
BenchmarkNetNSPathFromPid-4   	31301336	        37.75 ns/op	      24 B/op	       1 allocs/op
BenchmarkNetNSPathFromPid-4   	30881817	        37.75 ns/op	      24 B/op	       1 allocs/op
BenchmarkNetNSPathFromPid-4   	31662494	        37.93 ns/op	      24 B/op	       1 allocs/op
BenchmarkNetNSPathFromPid-4   	31453562	        37.82 ns/op	      24 B/op	       1 allocs/op
BenchmarkNetNSPathFromPid-4   	31063453	        37.96 ns/op	      24 B/op	       1 allocs/op
```

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
