### PR TITLE
CWS: fix entry nil pointer when checking for IsKworker

### DIFF
--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -769,10 +769,11 @@ func (p *ProcessResolver) resolveFromProcfs(pid uint32, maxDepth int) *model.Pro
 			return nil
 		}
 
+		entry, inserted = p.syncCache(proc, filledProc)
+
 		// consider kworker processes with 0 as ppid
 		entry.IsKworker = filledProc.Ppid == 0
 
-		entry, inserted = p.syncCache(proc, filledProc)
 		ppid = uint32(filledProc.Ppid)
 	} else {
 		ppid = entry.PPid


### PR DESCRIPTION
### What does this PR do?

This PR fixes:
```
[37margo-datadog-agent-5gwjw-1953364531: 2022-08-05 09:45:55 UTC | SYS-PROBE | INFO | (pkg/security/module/module.go:304 in LoadPolicies) | load policies[0m
[37margo-datadog-agent-5gwjw-1953364531: panic: runtime error: invalid memory address or nil pointer dereference[0m
[37margo-datadog-agent-5gwjw-1953364531: [signal SIGSEGV: segmentation violation code=0x1 addr=0xc pc=0x446511d][0m
[37margo-datadog-agent-5gwjw-1953364531: [0m
[37margo-datadog-agent-5gwjw-1953364531: goroutine 277 [running]:[0m
[37margo-datadog-agent-5gwjw-1953364531: github.com/DataDog/datadog-agent/pkg/security/probe.(*ProcessResolver).resolveFromProcfs(0xc00002cb40, 0x976, 0x10)[0m
[37margo-datadog-agent-5gwjw-1953364531: 	/go/src/github.com/DataDog/datadog-agent/pkg/security/probe/process_resolver.go:773 +0xbd[0m
[37margo-datadog-agent-5gwjw-1953364531: github.com/DataDog/datadog-agent/pkg/security/probe.(*ProcessResolver).resolve(0xc00002cb40, 0x27396a0, 0x31eb)[0m
[37margo-datadog-agent-5gwjw-1953364531: 	/go/src/github.com/DataDog/datadog-agent/pkg/security/probe/process_resolver.go:565 +0x98[0m
[37margo-datadog-agent-5gwjw-1953364531: github.com/DataDog/datadog-agent/pkg/security/probe.(*ProcessResolver).Resolve(0xc00002cb40, 0x6279b40, 0x0)[0m
[37margo-datadog-agent-5gwjw-1953364531: 	/go/src/github.com/DataDog/datadog-agent/pkg/security/probe/process_resolver.go:545 +0x7e[0m
[37margo-datadog-agent-5gwjw-1953364531: github.com/DataDog/datadog-agent/pkg/security/probe.(*Event).ResolveProcessCacheEntry(0xc0004a8a00)[0m
[37margo-datadog-agent-5gwjw-1953364531: 	/go/src/github.com/DataDog/datadog-agent/pkg/security/probe/model.go:473 +0x46[0m
[37margo-datadog-agent-5gwjw-1953364531: github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).handleEvent(0xc0000bca00, 0xc002739dc8, {0xc00029e9a0, 0xd4, 0x30})[0m
[37margo-datadog-agent-5gwjw-1953364531: 	/go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe.go:787 +0x4c05[0m
[37margo-datadog-agent-5gwjw-1953364531: github.com/DataDog/datadog-agent/pkg/security/probe.NewOrderedPerfMap.func1(0xc00130d408)[0m
[37margo-datadog-agent-5gwjw-1953364531: 	/go/src/github.com/DataDog/datadog-agent/pkg/security/probe/perfmap.go:94 +0x83[0m
[37margo-datadog-agent-5gwjw-1953364531: github.com/DataDog/datadog-agent/pkg/security/probe.(*reOrdererHeap).dequeue(0xc0038db4a0, 0xc00024ebb8, 0xa, 0xc00073c258, 0xc00073c230)[0m
[37margo-datadog-agent-5gwjw-1953364531: 	/go/src/github.com/DataDog/datadog-agent/pkg/security/probe/reorderer.go:144 +0x164[0m
[37margo-datadog-agent-5gwjw-1953364531: github.com/DataDog/datadog-agent/pkg/security/probe.(*ReOrderer).Start(0xc00073c200, 0x0)[0m
[37margo-datadog-agent-5gwjw-1953364531: 	/go/src/github.com/DataDog/datadog-agent/pkg/security/probe/reorderer.go:233 +0x34b[0m
[37margo-datadog-agent-5gwjw-1953364531: created by github.com/DataDog/datadog-agent/pkg/security/probe.(*OrderedPerfMap).Start[0m
[37margo-datadog-agent-5gwjw-1953364531: 	/go/src/github.com/DataDog/datadog-agent/pkg/security/probe/perfmap.go:74 +0xfd[0m
```

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
