### PR TITLE
[networks] Fix HTTP overcount in the event of PID collisions

### DIFF
--- a/pkg/network/encoding/http.go
+++ b/pkg/network/encoding/http.go
@@ -14,7 +14,7 @@ import (
 )
 
 type httpEncoder struct {
-	aggregations map[http.KeyTuple]*model.HTTPAggregations
+	aggregations map[http.KeyTuple]*aggregationWrapper
 	tags         map[http.KeyTuple]uint64
 
 	// pre-allocated objects
@@ -25,13 +25,60 @@ type httpEncoder struct {
 	orphanEntries int
 }
 
+// aggregationWrapper is meant to handle collision scenarios where multiple
+// `ConnectionStats` objects may claim the same `HTTPAggregations` object because
+// they generate the same http.KeyTuple
+// TODO: we should probably revist/get rid of this if we ever replace socket
+// filters by kprobes, since in that case we would have access to PIDs, and
+// could incorporate that information in the `http.KeyTuple` struct.
+type aggregationWrapper struct {
+	*model.HTTPAggregations
+
+	// we keep track of the source and destination ports of the first
+	// `ConnectionStats` to claim this `HTTPAggregations` object
+	sport, dport uint16
+}
+
+func (a *aggregationWrapper) ValueFor(c network.ConnectionStats) *model.HTTPAggregations {
+	if a == nil {
+		return nil
+	}
+
+	if a.sport == 0 && a.dport == 0 {
+		// This is the first time a ConnectionStats claim this aggregation. In
+		// this case we return the value and save the source and destination
+		// ports
+		a.sport = c.SPort
+		a.dport = c.DPort
+		return a.HTTPAggregations
+	}
+
+	if c.SPort == a.dport && c.DPort == a.sport {
+		// We have have a collision with another `ConnectionStats`, but this is a
+		// legit scenario where we're dealing with the opposite ends of the
+		// same connection, which means both server and client are in the same host.
+		// In this particular case it is correct to have both connections
+		// (client:server and server:client) referencing the same HTTP data.
+		return a.HTTPAggregations
+	}
+
+	// Return nil otherwise. This is to prevent multiple `ConnectionStats` with
+	// exactly the same source and destination addresses but different PIDs to
+	// "bind" to the same HTTPAggregations object, which would result in a
+	// overcount problem. (Note that this is due to the fact that
+	// `http.KeyTuple` doesn't have a PID field.) This happens mostly in the
+	// context of pre-fork web servers, where multiple worker proceses share the
+	// same socket
+	return nil
+}
+
 func newHTTPEncoder(payload *network.Connections) *httpEncoder {
 	if len(payload.HTTP) == 0 {
 		return nil
 	}
 
 	encoder := &httpEncoder{
-		aggregations: make(map[http.KeyTuple]*model.HTTPAggregations, len(payload.Conns)),
+		aggregations: make(map[http.KeyTuple]*aggregationWrapper, len(payload.Conns)),
 		tags:         make(map[http.KeyTuple]uint64, len(payload.Conns)),
 
 		// pre-allocate all data objects at once
@@ -56,7 +103,7 @@ func (e *httpEncoder) GetHTTPAggregationsAndTags(c network.ConnectionStats) (*mo
 	}
 
 	keyTuple := network.HTTPKeyTupleFromConn(c)
-	return e.aggregations[keyTuple], e.tags[keyTuple]
+	return e.aggregations[keyTuple].ValueFor(c), e.tags[keyTuple]
 }
 
 func (e *httpEncoder) buildAggregations(payload *network.Connections) {
@@ -74,8 +121,10 @@ func (e *httpEncoder) buildAggregations(payload *network.Connections) {
 		}
 
 		if aggregation == nil {
-			aggregation = &model.HTTPAggregations{
-				EndpointAggregations: make([]*model.HTTPStats, 0, aggrSize[key.KeyTuple]),
+			aggregation = &aggregationWrapper{
+				HTTPAggregations: &model.HTTPAggregations{
+					EndpointAggregations: make([]*model.HTTPStats, 0, aggrSize[key.KeyTuple]),
+				},
 			}
 			e.aggregations[key.KeyTuple] = aggregation
 		}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fix HTTP overcount bug in the event of multiple connections sharing the same source and destination address, but with different PIDs.

### Motivation

Ensure that we're emitting correct data in the context of pre-fork web servers (where multiple worker processes share the same socket).

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

The approach will randomly assign the HTTP stats to one of the connections sharing the same `http.KeyTuple`, which means that at if we look at PID granularity the stats won't be necessarily correct. However in practical terms the aggregated view of things (the sum of all stats belonging to the same (src, dst) address tuple) will be accurate.

### Describe how to test/QA your changes

Change covered by unit tests

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
