### PR TITLE
Backport #13019 to `7.38.x`: Fix zombie processes created by the agent (#13019)

### DIFF
--- a/releasenotes/notes/Fix-zombie-64b75433b548b963.yaml
+++ b/releasenotes/notes/Fix-zombie-64b75433b548b963.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes a bug making the agent creating a lot of zombie (defunct) processes.
+    This bug happened only with the docker images ``7.38.x`` when the containerized agent was launched without ``hostPID: true``.


### PR DESCRIPTION
### What does this PR do?

* Backport #13019
* Fix #12997 on `7.38.x` branch

### Motivation

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Start the agent in a container without `hostPID`.
It shouldn’t create zombie processes like that: (You can try `7.38.1` to double-check that it does create zombies)
```
$ kubectl --context gke_datadog-sandbox_europe-west3-c_gke-lenaic --namespace datadog-agent-helm exec -ti pod/datadog-agent-linux-jtjf7 -c agent -- /bin/bash
root@gke-gke-lenaic-ubuntu-24eb8318-7nxj:/# ps -ef
UID          PID    PPID  C STIME TTY          TIME CMD
root           1       0 15 11:37 ?        00:00:07 agent run
root           6       1  0 11:37 ?        00:00:00 [agent] <defunct>
root          13       1  0 11:37 ?        00:00:00 [getconf] <defunct>
root          19       1  0 11:37 ?        00:00:00 [uname] <defunct>
root          21       1  0 11:37 ?        00:00:00 [df] <defunct>
root          23       1  0 11:37 ?        00:00:00 [uname] <defunct>
root          25       1  0 11:37 ?        00:00:00 [uname] <defunct>
root          27       1  0 11:37 ?        00:00:00 [python] <defunct>
root          29       1  0 11:38 ?        00:00:00 [blkid] <defunct>
root         184       1  0 11:38 ?        00:00:00 [uname] <defunct>
root         186       1  0 11:38 ?        00:00:00 [uname] <defunct>
root         188       1  0 11:38 ?        00:00:00 [python] <defunct>
root         190       1  0 11:38 ?        00:00:00 [blkid] <defunct>
root         345       1  0 11:38 ?        00:00:00 [uname] <defunct>
root         347       1  0 11:38 ?        00:00:00 [uname] <defunct>
root         349       1  0 11:38 ?        00:00:00 [python] <defunct>
root         350       0  1 11:38 pts/0    00:00:00 /bin/bash
root         355     350  0 11:38 pts/0    00:00:00 [bash] <defunct>
root         357       1  0 11:38 pts/0    00:00:00 [groups] <defunct>
root         359       1  0 11:38 pts/0    00:00:00 [dircolors] <defunct>
root         360     350  0 11:38 pts/0    00:00:00 ps -ef
root         361     360  0 11:38 pts/0    00:00:00 ps -ef
```

It worth also testing that the support of old hosts isn’t broken:

```
$ vagrant init ubuntu/xenial64

$ vagrant up

$ vagrant ssh

$ sudo apt update && sudo apt install -y docker.io
```

Validate that, on such an old host, without the hack (by clearing LD_PRELOAD explicitly), the agent wouldn’t start:

```
$ sudo docker run -ti --rm -e LD_PRELOAD= datadog/agent:7.38.2-rc.X agent version
runtime/cgo: pthread_create failed: Operation not permitted
SIGABRT: abort
PC=0x7fae1bc6ea7c m=0 sigcode=18446744073709551610

goroutine 0 [idle]:
runtime: unknown pc 0x7fae1bc6ea7c
stack: frame={sp:0x7fff65eceee0, fp:0x0} stack=[0x7fff656d0480,0x7fff65ecf4a0)
[…]
```

With the hack (let LD_PRELOAD to its value defined in the image), the agent works:

```
$ sudo docker run -ti --rm datadog/agent:7.38.2-rc.X agent version
faccessat2 seems blocked by the seccomp profile of an old version of docker.
clone3 seems blocked by the seccomp profile of an old version of docker.
load a seccomp profile to force ENOSYS.
Agent 7.38.0-devel - Meta: git.234.92b1b4d - Commit: 92b1b4d - Serialization version: v5.0.22 - Go version: go1.1
```

### Reviewer's Checklist


- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
