### PR TITLE
CWS: compute activity dump node stats inline with insertion

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1096,7 +1096,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.traced_cgroups_count", 3)
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.traced_event_types", []string{"exec", "open", "dns", "bind"})
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.cgroup_dump_timeout", 20)
-	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.cgroup_wait_list_size", 1)
+	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.cgroup_wait_list_size", 0)
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.cgroup_differentiate_args", true)
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.local_storage.max_dumps_count", 100)
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.local_storage.output_directory", "/tmp/activity_dumps/")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1096,7 +1096,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.traced_cgroups_count", 3)
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.traced_event_types", []string{"exec", "open", "dns", "bind"})
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.cgroup_dump_timeout", 20)
-	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.cgroup_wait_list_size", 10)
+	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.cgroup_wait_list_size", 1)
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.cgroup_differentiate_args", true)
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.local_storage.max_dumps_count", 100)
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.local_storage.output_directory", "/tmp/activity_dumps/")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "45029003e6c322d508b662e1d8e71f337c4d0c25d462c3718583793e907cc1af")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "483752a67208045aa3c5dfce58deebb1daa05b379a4b1d603e946649c7770193")

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -240,7 +240,7 @@ func NewConfig(cfg *config.Config) (*Config, error) {
 		ActivityDumpCleanupPeriod:             time.Duration(coreconfig.Datadog.GetInt("runtime_security_config.activity_dump.cleanup_period")) * time.Second,
 		ActivityDumpTagsResolutionPeriod:      time.Duration(coreconfig.Datadog.GetInt("runtime_security_config.activity_dump.tags_resolution_period")) * time.Second,
 		ActivityDumpLoadControlPeriod:         time.Duration(coreconfig.Datadog.GetInt("runtime_security_config.activity_dump.load_controller_period")) * time.Minute,
-		ActivityDumpLoadControlMaxTotalSize:   coreconfig.Datadog.GetInt(" runtime_security_config.activity_dump.load_controller_max_total_size"),
+		ActivityDumpLoadControlMaxTotalSize:   coreconfig.Datadog.GetInt("runtime_security_config.activity_dump.load_controller_max_total_size"),
 		ActivityDumpPathMergeEnabled:          coreconfig.Datadog.GetBool("runtime_security_config.activity_dump.path_merge.enabled"),
 		ActivityDumpTracedCgroupsCount:        coreconfig.Datadog.GetInt("runtime_security_config.activity_dump.traced_cgroups_count"),
 		ActivityDumpTracedEventTypes:          model.ParseEventTypeStringSlice(coreconfig.Datadog.GetStringSlice("runtime_security_config.activity_dump.traced_event_types")),

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -112,8 +112,7 @@ type Config struct {
 	ActivityDumpLoadControlMaxTotalSize int
 	// ActivityDumpPathMergeEnabled defines if path merge should be enabled
 	ActivityDumpPathMergeEnabled bool
-	// ActivityDumpTracedCgroupsCount defines the maximum count of cgroups that should be monitored concurrently. Set
-	// this parameter to -1 to monitor all cgroups at the same time. Leave this parameter to 0 to prevent the generation
+	// ActivityDumpTracedCgroupsCount defines the maximum count of cgroups that should be monitored concurrently. Leave this parameter to 0 to prevent the generation
 	// of activity dumps based on cgroups.
 	ActivityDumpTracedCgroupsCount int
 	// ActivityDumpTracedEventTypes defines the list of events that should be captured in an activity dump. Leave this
@@ -317,6 +316,10 @@ func NewConfig(cfg *config.Config) (*Config, error) {
 		if err != nil {
 			return nil, fmt.Errorf("invalid value for runtime_security_config.activity_dump.remote_storage.formats: %w", err)
 		}
+	}
+
+	if c.ActivityDumpCgroupWaitListSize <= 0 {
+		c.ActivityDumpCgroupWaitListSize = c.ActivityDumpTracedCgroupsCount
 	}
 
 	lazyInterfaces := make(map[string]bool)

--- a/pkg/security/ebpf/c/activity_dump.h
+++ b/pkg/security/ebpf/c/activity_dump.h
@@ -177,12 +177,10 @@ __attribute__((always_inline)) void freeup_traced_cgroup_spot(char cgroup[CONTAI
 
     u32 key = 0;
     struct traced_cgroups_counter_t *counter = bpf_map_lookup_elem(&traced_cgroups_counter, &key);
-    if (!counter) {
-        unlock_cgroups_counter();
-        return;
+    if (counter && counter->counter > 0) {
+        counter->counter -= 1;
     }
 
-    counter->counter -= 1;
     unlock_cgroups_counter();
 }
 

--- a/pkg/security/probe/activity_dump_load_controller.go
+++ b/pkg/security/probe/activity_dump_load_controller.go
@@ -26,9 +26,13 @@ import (
 
 // ActivityDumpLCConfig represents the dynamic configuration managed by the load controller
 type ActivityDumpLCConfig struct {
+	// dynamic
 	tracedEventTypes   []model.EventType
 	tracedCgroupsCount uint64
 	dumpTimeout        time.Duration
+
+	// static
+	cgroupWaitListSize int
 }
 
 // NewActivityDumpLCConfig returns a new dynamic config from user config
@@ -42,6 +46,8 @@ func NewActivityDumpLCConfig(cfg *config.Config) *ActivityDumpLCConfig {
 		tracedEventTypes:   cfg.ActivityDumpTracedEventTypes,
 		tracedCgroupsCount: tracedCgroupsCount,
 		dumpTimeout:        cfg.ActivityDumpCgroupDumpTimeout,
+
+		cgroupWaitListSize: cfg.ActivityDumpCgroupWaitListSize,
 	}
 }
 
@@ -219,4 +225,9 @@ func (lc *ActivityDumpLoadController) propagateLoadSettingsRaw() error {
 	}
 
 	return nil
+}
+
+func (lc *ActivityDumpLoadController) getCgroupWaitTimeout() time.Duration {
+	lcCfg := lc.getCurrentConfig()
+	return lcCfg.dumpTimeout * time.Duration(lcCfg.cgroupWaitListSize)
 }

--- a/pkg/security/probe/activity_dump_load_controller.go
+++ b/pkg/security/probe/activity_dump_load_controller.go
@@ -174,6 +174,13 @@ func (lc *ActivityDumpLoadController) propagateLoadSettingsRaw() error {
 	lcConfig := lc.getCurrentConfig()
 
 	// traced event types
+	for i := uint64(0); i != uint64(model.MaxKernelEventType); i++ {
+		evtType := model.EventType(i)
+		if err := lc.tracedEventTypesMap.Delete(evtType); err != nil && err != ebpf.ErrKeyNotExist {
+			return fmt.Errorf("failed to delete old traced event type: %w", err)
+		}
+	}
+
 	isTraced := uint64(1)
 	for _, evtType := range lcConfig.tracedEventTypes {
 		if err := lc.tracedEventTypesMap.Put(evtType, isTraced); err != nil {

--- a/pkg/security/probe/activity_dump_load_controller.go
+++ b/pkg/security/probe/activity_dump_load_controller.go
@@ -9,6 +9,7 @@
 package probe
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -176,7 +177,7 @@ func (lc *ActivityDumpLoadController) propagateLoadSettingsRaw() error {
 	// traced event types
 	for i := uint64(0); i != uint64(model.MaxKernelEventType); i++ {
 		evtType := model.EventType(i)
-		if err := lc.tracedEventTypesMap.Delete(evtType); err != nil && err != ebpf.ErrKeyNotExist {
+		if err := lc.tracedEventTypesMap.Delete(evtType); err != nil && !errors.Is(err, ebpf.ErrKeyNotExist) {
 			return fmt.Errorf("failed to delete old traced event type: %w", err)
 		}
 	}

--- a/pkg/security/probe/activity_dump_load_controller.go
+++ b/pkg/security/probe/activity_dump_load_controller.go
@@ -153,7 +153,7 @@ func (lc *ActivityDumpLoadController) getCurrentConfig() *ActivityDumpLCConfig {
 	return lc.originalConfig
 }
 
-func (lc *ActivityDumpLoadController) reduceConfig() {
+func (lc *ActivityDumpLoadController) reduceConfig() bool {
 	if lc.rateLimiter.Allow() {
 		lcCfg := lc.getCurrentConfig()
 		newCfg := lcCfg.reduced()
@@ -164,7 +164,9 @@ func (lc *ActivityDumpLoadController) reduceConfig() {
 		}
 
 		lc.rateLimiter.SetLimit(rate.Every(newCfg.dumpTimeout))
+		return true
 	}
+	return false
 }
 
 func (lc *ActivityDumpLoadController) propagateLoadSettings() error {

--- a/pkg/security/probe/activity_dump_manager.go
+++ b/pkg/security/probe/activity_dump_manager.go
@@ -530,10 +530,13 @@ func (adm *ActivityDumpManager) triggerLoadController() {
 
 	maxTotalADSize := adm.probe.config.ActivityDumpLoadControlMaxTotalSize * (1 << 20)
 	if totalSize > uint64(maxTotalADSize) {
-		adm.loadController.reduceConfig()
+		// we may be rate limited
+		success := adm.loadController.reduceConfig()
 
-		if err := adm.probe.statsdClient.Count(metrics.MetricActivityDumpLoadControllerTriggered, 1, nil, 1.0); err != nil {
-			seclog.Errorf("couldn't send %s metric: %v", metrics.MetricActivityDumpLoadControllerTriggered, err)
+		if success {
+			if err := adm.probe.statsdClient.Count(metrics.MetricActivityDumpLoadControllerTriggered, 1, nil, 1.0); err != nil {
+				seclog.Errorf("couldn't send %s metric: %v", metrics.MetricActivityDumpLoadControllerTriggered, err)
+			}
 		}
 	}
 }

--- a/pkg/security/probe/activity_dump_manager.go
+++ b/pkg/security/probe/activity_dump_manager.go
@@ -245,7 +245,7 @@ func (adm *ActivityDumpManager) insertActivityDump(newDump *ActivityDump) error 
 		// put this container ID on the wait list so that we don't snapshot it again before a while
 		containerIDB := make([]byte, model.ContainerIDLen)
 		copy(containerIDB, newDump.DumpMetadata.ContainerID)
-		waitListTimeout := time.Now().Add(time.Duration(adm.probe.config.ActivityDumpCgroupWaitListSize) * adm.probe.config.ActivityDumpCgroupDumpTimeout)
+		waitListTimeout := time.Now().Add(adm.loadController.getCgroupWaitTimeout())
 		waitListTimeoutRaw := adm.probe.resolvers.TimeResolver.ComputeMonotonicTimestamp(waitListTimeout)
 		err := adm.cgroupWaitListMap.Put(containerIDB, waitListTimeoutRaw)
 		if err != nil {

--- a/pkg/security/probe/activity_dump_memlimits.go
+++ b/pkg/security/probe/activity_dump_memlimits.go
@@ -10,70 +10,19 @@ package probe
 
 import "unsafe"
 
-// ActivityDumpSizeStats represents the node counts in an activity dump
-type ActivityDumpSizeStats struct {
+// ActivityDumpNodeStats represents the node counts in an activity dump
+type ActivityDumpNodeStats struct {
 	processNodes uint64
 	fileNodes    uint64
 	dnsNodes     uint64
 	socketNodes  uint64
 }
 
-func (stats *ActivityDumpSizeStats) approximateSize() uint64 {
+func (stats *ActivityDumpNodeStats) approximateSize() uint64 {
 	var total uint64
 	total += stats.processNodes * uint64(unsafe.Sizeof(ProcessActivityNode{}))
 	total += stats.fileNodes * uint64(unsafe.Sizeof(FileActivityNode{}))
 	total += stats.dnsNodes * uint64(unsafe.Sizeof(DNSNode{}))
 	total += stats.socketNodes * uint64(unsafe.Sizeof(SocketNode{}))
 	return total
-}
-
-// Caution: you must hold a lock on the AD before calling this
-func (ad *ActivityDump) computeSizeStats() ActivityDumpSizeStats {
-	stats := ActivityDumpSizeStats{}
-
-	openList := make([]*ProcessActivityNode, len(ad.ProcessActivityTree))
-	copy(openList, ad.ProcessActivityTree)
-
-	for len(openList) != 0 {
-		current := openList[len(openList)-1]
-		openList = openList[:len(openList)-1]
-
-		stats.processNodes++
-
-		// files
-		stats.fileNodes += countFileNodes(current.Files)
-
-		// DNS
-		for _, dnsNode := range current.DNSNames {
-			stats.dnsNodes += uint64(len(dnsNode.Requests))
-		}
-
-		// sockets
-		for _, socketNode := range current.Sockets {
-			// each bind node + 1 for the global socket node
-			stats.socketNodes += uint64(len(socketNode.Bind)) + 1
-		}
-
-		openList = append(openList, current.Children...)
-	}
-
-	return stats
-}
-
-func countFileNodes(files map[string]*FileActivityNode) uint64 {
-	var counter uint64
-
-	openList := []map[string]*FileActivityNode{files}
-
-	for len(openList) != 0 {
-		current := openList[len(openList)-1]
-		openList = openList[:len(openList)-1]
-
-		for _, f := range current {
-			counter++
-			openList = append(openList, f.Children)
-		}
-	}
-
-	return counter
 }

--- a/pkg/security/probe/activity_dump_proto_dec_v1.go
+++ b/pkg/security/probe/activity_dump_proto_dec_v1.go
@@ -257,7 +257,9 @@ func protoDecodeProtoSocket(sn *adproto.SocketNode) *SocketNode {
 		return nil
 	}
 
-	socketNode := NewSocketNode(sn.Family)
+	socketNode := &SocketNode{
+		Family: sn.Family,
+	}
 
 	for _, bindNode := range sn.GetBind() {
 		socketNode.Bind = append(socketNode.Bind, &BindNode{

--- a/pkg/security/probe/activity_dump_test.go
+++ b/pkg/security/probe/activity_dump_test.go
@@ -116,13 +116,14 @@ func TestInsertFileEvent(t *testing.T) {
 	mergeCtx := adPathMergeContext{
 		enabled: false,
 	}
+	nodeStats := ActivityDumpNodeStats{}
 
 	for _, path := range pathToInserts {
 		fileEvent := &model.FileEvent{
 			IsPathnameStrResolved: true,
 			PathnameStr:           path,
 		}
-		pan.InsertFileEvent(fileEvent, nil, Unknown, mergeCtx)
+		pan.InsertFileEvent(fileEvent, nil, Unknown, mergeCtx, &nodeStats)
 	}
 
 	var builder strings.Builder

--- a/pkg/security/probe/activity_dump_test.go
+++ b/pkg/security/probe/activity_dump_test.go
@@ -113,17 +113,14 @@ func TestInsertFileEvent(t *testing.T) {
         - foo
 `)
 
-	mergeCtx := adPathMergeContext{
-		enabled: false,
-	}
-	nodeStats := ActivityDumpNodeStats{}
+	ad := NewEmptyActivityDump()
 
 	for _, path := range pathToInserts {
 		fileEvent := &model.FileEvent{
 			IsPathnameStrResolved: true,
 			PathnameStr:           path,
 		}
-		pan.InsertFileEvent(fileEvent, nil, Unknown, mergeCtx, &nodeStats)
+		ad.InsertFileEventInProcess(&pan, fileEvent, nil, Unknown)
 	}
 
 	var builder strings.Builder

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -474,7 +474,7 @@ func (p *Probe) handleEvent(CPU int, data []byte) {
 
 		return
 	case model.CgroupTracingEventType:
-		if p.config.ActivityDumpEnabled {
+		if !p.config.ActivityDumpEnabled {
 			log.Error("shouldn't receive Cgroup event if activity dumps are disabled")
 			return
 		}


### PR DESCRIPTION
### What does this PR do?

This PR improves performances of activity dump memory size computation by measuring at insertion time, instead of requiring a whole tree walk.

This PR also fixes some bugs in the activity dump paths:
- wrong config for `ActivityDumpLoadControlMaxTotalSize`
- no reset before updating traced event types
- no rate limit on config reduction
- no link between cgroup wait list timeout and dump timeout
- wrong check for activity dumps enabled stats -> log printed when it shouldn't be

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

The performance impact should be minimal when the activity dump feature is enabled. the fixed bug should be fixed

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
