### PR TITLE
[Serverless] Add runtime duration and post runtime duration to report log statement.

### DIFF
--- a/pkg/serverless/logs/logs.go
+++ b/pkg/serverless/logs/logs.go
@@ -176,7 +176,6 @@ func (l *logMessage) UnmarshalJSON(data []byte) error {
 				} else {
 					log.Error("LogMessage.UnmarshalJSON: can't read the metrics object")
 				}
-				l.stringRecord = createStringRecordForReportLog(l)
 			case logTypePlatformRuntimeDone:
 				if status, ok := objectRecord["status"].(string); ok {
 					l.objectRecord.runtimeDoneItem.status = status
@@ -195,7 +194,7 @@ func (l *logMessage) UnmarshalJSON(data []byte) error {
 }
 
 // shouldProcessLog returns whether or not the log should be further processed.
-func shouldProcessLog(ecs *executioncontext.State, message logMessage) bool {
+func shouldProcessLog(ecs *executioncontext.State, message *logMessage) bool {
 	// If the global request ID or ARN variable isn't set at this point, do not process further
 	if len(ecs.ARN) == 0 || len(ecs.LastRequestID) == 0 {
 		return false
@@ -212,10 +211,14 @@ func shouldProcessLog(ecs *executioncontext.State, message logMessage) bool {
 	return true
 }
 
-func createStringRecordForReportLog(l *logMessage) string {
-	stringRecord := fmt.Sprintf("REPORT RequestId: %s\tDuration: %.2f ms\tBilled Duration: %d ms\tMemory Size: %d MB\tMax Memory Used: %d MB",
+func createStringRecordForReportLog(l *logMessage, ecs executioncontext.State) string {
+	runtimeDurationMs := float64(ecs.EndTime.Sub(ecs.StartTime).Milliseconds())
+	postRuntimeDurationMs := l.objectRecord.reportLogItem.durationMs - runtimeDurationMs
+	stringRecord := fmt.Sprintf("REPORT RequestId: %s\tDuration: %.2f ms\tRuntime Duration: %.2f ms\tPost Runtime Duration: %.2f ms\tBilled Duration: %d ms\tMemory Size: %d MB\tMax Memory Used: %d MB",
 		l.objectRecord.requestID,
 		l.objectRecord.reportLogItem.durationMs,
+		runtimeDurationMs,
+		postRuntimeDurationMs,
 		l.objectRecord.reportLogItem.billedDurationMs,
 		l.objectRecord.reportLogItem.memorySizeMB,
 		l.objectRecord.reportLogItem.maxMemoryUsedMB,
@@ -263,7 +266,7 @@ func (c *LambdaLogsCollector) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 
 func processLogMessages(c *LambdaLogsCollector, messages []logMessage) {
 	for _, message := range messages {
-		processMessage(message, c.ExecutionContext, c.EnhancedMetricsEnabled, c.ExtraTags.Tags, c.Demux, c.HandleRuntimeDone)
+		processMessage(&message, c.ExecutionContext, c.EnhancedMetricsEnabled, c.ExtraTags.Tags, c.Demux, c.HandleRuntimeDone)
 		// We always collect and process logs for the purpose of extracting enhanced metrics.
 		// However, if logs are not enabled, we do not send them to the intake.
 		if c.LogsEnabled {
@@ -280,7 +283,7 @@ func processLogMessages(c *LambdaLogsCollector, messages []logMessage) {
 
 // processMessage performs logic about metrics and tags on the message
 func processMessage(
-	message logMessage,
+	message *logMessage,
 	ec *executioncontext.ExecutionContext,
 	enhancedMetricsEnabled bool,
 	metricTags []string,
@@ -319,6 +322,7 @@ func processMessage(
 				Demux:            demux,
 			}
 			serverlessMetrics.GenerateEnhancedMetricsFromReportLog(args)
+			message.stringRecord = createStringRecordForReportLog(message, ecs)
 		}
 		if message.logType == logTypePlatformRuntimeDone {
 			serverlessMetrics.GenerateRuntimeDurationMetric(ecs.StartTime, message.time, message.objectRecord.runtimeDoneItem.status, tags, demux)

--- a/pkg/serverless/logs/logs_test.go
+++ b/pkg/serverless/logs/logs_test.go
@@ -8,6 +8,7 @@ package logs
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -19,6 +20,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
+	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/serverless/executioncontext"
 	serverlessMetrics "github.com/DataDog/datadog-agent/pkg/serverless/metrics"
 )
@@ -41,18 +43,18 @@ func TestUnmarshalExtensionLog(t *testing.T) {
 
 func TestShouldProcessLog(t *testing.T) {
 
-	validLog := logMessage{
+	validLog := &logMessage{
 		logType: logTypePlatformReport,
 		objectRecord: platformObjectRecord{
 			requestID: "8286a188-ba32-4475-8077-530cd35c09a9",
 		},
 	}
 
-	invalidLog0 := logMessage{
+	invalidLog0 := &logMessage{
 		logType: logTypePlatformLogsSubscription,
 	}
 
-	invalidLog1 := logMessage{
+	invalidLog1 := &logMessage{
 		logType: logTypePlatformExtension,
 	}
 
@@ -84,7 +86,7 @@ func TestShouldNotProcessEmptyLog(t *testing.T) {
 			ARN:           "arn:aws:lambda:us-east-1:123456789012:function:my-function",
 			LastRequestID: "8286a188-ba32-4475-8077-530cd35c09a9",
 		},
-		logMessage{
+		&logMessage{
 			stringRecord: "aaa",
 			objectRecord: platformObjectRecord{
 				requestID: "",
@@ -96,7 +98,7 @@ func TestShouldNotProcessEmptyLog(t *testing.T) {
 			ARN:           "arn:aws:lambda:us-east-1:123456789012:function:my-function",
 			LastRequestID: "8286a188-ba32-4475-8077-530cd35c09a9",
 		},
-		logMessage{
+		&logMessage{
 			stringRecord: "",
 			objectRecord: platformObjectRecord{
 				requestID: "aaa",
@@ -108,7 +110,7 @@ func TestShouldNotProcessEmptyLog(t *testing.T) {
 			ARN:           "arn:aws:lambda:us-east-1:123456789012:function:my-function",
 			LastRequestID: "8286a188-ba32-4475-8077-530cd35c09a9",
 		},
-		logMessage{
+		&logMessage{
 			stringRecord: "",
 			objectRecord: platformObjectRecord{
 				requestID: "",
@@ -117,7 +119,7 @@ func TestShouldNotProcessEmptyLog(t *testing.T) {
 	)
 }
 func TestCreateStringRecordForReportLogWithInitDuration(t *testing.T) {
-	var sampleLogMessage = logMessage{
+	var sampleLogMessage = &logMessage{
 		objectRecord: platformObjectRecord{
 			requestID: "cf84ebaf-606a-4b0f-b99b-3685bfe973d7",
 			reportLogItem: reportLogMetrics{
@@ -129,13 +131,20 @@ func TestCreateStringRecordForReportLogWithInitDuration(t *testing.T) {
 			},
 		},
 	}
-	output := createStringRecordForReportLog(&sampleLogMessage)
-	expectedOutput := "REPORT RequestId: cf84ebaf-606a-4b0f-b99b-3685bfe973d7\tDuration: 100.00 ms\tBilled Duration: 100 ms\tMemory Size: 128 MB\tMax Memory Used: 128 MB\tInit Duration: 50.00 ms"
+
+	now := time.Now()
+	ecs := executioncontext.State{
+		StartTime: now,
+		EndTime:   now.Add(10 * time.Millisecond),
+	}
+
+	output := createStringRecordForReportLog(sampleLogMessage, ecs)
+	expectedOutput := "REPORT RequestId: cf84ebaf-606a-4b0f-b99b-3685bfe973d7\tDuration: 100.00 ms\tRuntime Duration: 10.00 ms\tPost Runtime Duration: 90.00 ms\tBilled Duration: 100 ms\tMemory Size: 128 MB\tMax Memory Used: 128 MB\tInit Duration: 50.00 ms"
 	assert.Equal(t, expectedOutput, output)
 }
 
 func TestCreateStringRecordForReportLogWithoutInitDuration(t *testing.T) {
-	var sampleLogMessage = logMessage{
+	var sampleLogMessage = &logMessage{
 		objectRecord: platformObjectRecord{
 			requestID: "cf84ebaf-606a-4b0f-b99b-3685bfe973d7",
 			reportLogItem: reportLogMetrics{
@@ -147,8 +156,15 @@ func TestCreateStringRecordForReportLogWithoutInitDuration(t *testing.T) {
 			},
 		},
 	}
-	output := createStringRecordForReportLog(&sampleLogMessage)
-	expectedOutput := "REPORT RequestId: cf84ebaf-606a-4b0f-b99b-3685bfe973d7\tDuration: 100.00 ms\tBilled Duration: 100 ms\tMemory Size: 128 MB\tMax Memory Used: 128 MB"
+
+	now := time.Now()
+	ecs := executioncontext.State{
+		StartTime: now,
+		EndTime:   now.Add(10 * time.Millisecond),
+	}
+
+	output := createStringRecordForReportLog(sampleLogMessage, ecs)
+	expectedOutput := "REPORT RequestId: cf84ebaf-606a-4b0f-b99b-3685bfe973d7\tDuration: 100.00 ms\tRuntime Duration: 10.00 ms\tPost Runtime Duration: 90.00 ms\tBilled Duration: 100 ms\tMemory Size: 128 MB\tMax Memory Used: 128 MB"
 	assert.Equal(t, expectedOutput, output)
 }
 
@@ -218,7 +234,7 @@ func TestProcessMessageValid(t *testing.T) {
 	mockExecutionContext := &executioncontext.ExecutionContext{}
 	mockExecutionContext.SetFromInvocation(arn, lastRequestID)
 
-	go processMessage(message, mockExecutionContext, computeEnhancedMetrics, metricTags, demux, func() {})
+	processMessage(&message, mockExecutionContext, computeEnhancedMetrics, metricTags, demux, func() {})
 
 	received, timed := demux.WaitForSamples(100 * time.Millisecond)
 	assert.Len(t, received, 7)
@@ -226,7 +242,7 @@ func TestProcessMessageValid(t *testing.T) {
 	demux.Reset()
 
 	computeEnhancedMetrics = false
-	go processMessage(message, mockExecutionContext, computeEnhancedMetrics, metricTags, demux, func() {})
+	processMessage(&message, mockExecutionContext, computeEnhancedMetrics, metricTags, demux, func() {})
 
 	received, timed = demux.WaitForSamples(100 * time.Millisecond)
 	assert.Len(t, received, 0, "we should NOT have received metrics")
@@ -237,7 +253,7 @@ func TestProcessMessageStartValid(t *testing.T) {
 	demux := aggregator.InitTestAgentDemultiplexerWithFlushInterval(time.Hour)
 	defer demux.Stop(false)
 
-	message := logMessage{
+	message := &logMessage{
 		logType: logTypePlatformStart,
 		time:    time.Now(),
 		objectRecord: platformObjectRecord{
@@ -291,7 +307,7 @@ func TestProcessMessagePlatformRuntimeDoneValid(t *testing.T) {
 		runtimeDoneCallbackWasCalled = true
 	}
 
-	processMessage(message, mockExecutionContext, computeEnhancedMetrics, metricTags, demux, mockRuntimeDone)
+	processMessage(&message, mockExecutionContext, computeEnhancedMetrics, metricTags, demux, mockRuntimeDone)
 	ecs := mockExecutionContext.GetCurrentState()
 	assert.Equal(t, runtimeDoneCallbackWasCalled, true)
 	assert.WithinDuration(t, messageTime, ecs.EndTime, time.Millisecond)
@@ -303,7 +319,7 @@ func TestProcessMessagePlatformRuntimeDonePreviousInvocation(t *testing.T) {
 
 	previousRequestID := "9397b299-cb43-5586-9188-641de46d10b0"
 	currentRequestID := "8286a188-ba32-4475-8077-530cd35c09a9"
-	message := logMessage{
+	message := &logMessage{
 		logType: logTypePlatformRuntimeDone,
 		time:    time.Now(),
 		objectRecord: platformObjectRecord{
@@ -334,7 +350,7 @@ func TestProcessMessagePlatformRuntimeDonePreviousInvocation(t *testing.T) {
 func TestProcessMessageShouldNotProcessArnNotSet(t *testing.T) {
 	demux := aggregator.InitTestAgentDemultiplexerWithFlushInterval(time.Hour)
 	defer demux.Stop(false)
-	message := logMessage{
+	message := &logMessage{
 		logType: logTypePlatformReport,
 		time:    time.Now(),
 		objectRecord: platformObjectRecord{
@@ -363,7 +379,7 @@ func TestProcessMessageShouldNotProcessArnNotSet(t *testing.T) {
 func TestProcessMessageShouldNotProcessLogsDropped(t *testing.T) {
 	demux := aggregator.InitTestAgentDemultiplexerWithFlushInterval(time.Hour)
 	defer demux.Stop(false)
-	message := logMessage{
+	message := &logMessage{
 		logType:      logTypePlatformLogsDropped,
 		time:         time.Now(),
 		stringRecord: "bla bla bla",
@@ -387,7 +403,7 @@ func TestProcessMessageShouldNotProcessLogsDropped(t *testing.T) {
 func TestProcessMessageShouldProcessLogTypeFunction(t *testing.T) {
 	demux := aggregator.InitTestAgentDemultiplexerWithFlushInterval(time.Hour)
 	defer demux.Stop(false)
-	message := logMessage{
+	message := &logMessage{
 		logType:      logTypeFunction,
 		time:         time.Now(),
 		stringRecord: "fatal error: runtime: out of memory",
@@ -701,4 +717,78 @@ func TestUnmarshalPlatformRuntimeDoneLogNotFatal(t *testing.T) {
 	}
 	err := logMessage.UnmarshalJSON(raw)
 	assert.Nil(t, err)
+}
+
+func TestRuntimeMetricsMatchLogs(t *testing.T) {
+	// The test ensures that the values listed in the report log statement
+	// matches the values of the metrics being reported.
+	demux := aggregator.InitTestAgentDemultiplexerWithFlushInterval(time.Hour)
+	defer demux.Stop(false)
+
+	runtimeDurationMs := 10.0
+	postRuntimeDurationMs := 90.0
+	durationMs := runtimeDurationMs + postRuntimeDurationMs
+
+	startTime := time.Now()
+	endTime := startTime.Add(time.Duration(runtimeDurationMs) * time.Millisecond)
+	reportLogTime := endTime.Add(time.Duration(postRuntimeDurationMs) * time.Millisecond)
+
+	requestID := "13dee504-0d50-4c86-8d82-efd20693afc9"
+	mockExecutionContext := &executioncontext.ExecutionContext{}
+	mockExecutionContext.SetFromInvocation("arn not used", requestID)
+	mockExecutionContext.UpdateFromStartLog(requestID, startTime)
+	computeEnhancedMetrics := true
+
+	doneMessage := &logMessage{
+		time:    endTime,
+		logType: logTypePlatformRuntimeDone,
+		objectRecord: platformObjectRecord{
+			requestID:       requestID,
+			runtimeDoneItem: runtimeDoneItem{},
+		},
+	}
+	reportMessage := &logMessage{
+		time:    reportLogTime,
+		logType: logTypePlatformReport,
+		objectRecord: platformObjectRecord{
+			requestID: requestID,
+			reportLogItem: reportLogMetrics{
+				durationMs: durationMs,
+			},
+		},
+	}
+
+	processMessage(doneMessage, mockExecutionContext, computeEnhancedMetrics, []string{}, demux, func() {})
+	processMessage(reportMessage, mockExecutionContext, computeEnhancedMetrics, []string{}, demux, func() {})
+
+	generatedMetrics, timedMetrics := demux.WaitForSamples(100 * time.Millisecond)
+	postRuntimeMetricTimestamp := float64(reportLogTime.UnixNano()) / float64(time.Second)
+	runtimeMetricTimestamp := float64(endTime.UnixNano()) / float64(time.Second)
+	assert.Equal(t, generatedMetrics[0], metrics.MetricSample{
+		Name:       "aws.lambda.enhanced.runtime_duration",
+		Value:      runtimeDurationMs, // in milliseconds
+		Mtype:      metrics.DistributionType,
+		Tags:       []string{"cold_start:true"},
+		SampleRate: 1,
+		Timestamp:  runtimeMetricTimestamp,
+	})
+	assert.Equal(t, generatedMetrics[4], metrics.MetricSample{
+		Name:       "aws.lambda.enhanced.duration",
+		Value:      durationMs / 1000, // in seconds
+		Mtype:      metrics.DistributionType,
+		Tags:       []string{"cold_start:true"},
+		SampleRate: 1,
+		Timestamp:  postRuntimeMetricTimestamp,
+	})
+	assert.Equal(t, generatedMetrics[6], metrics.MetricSample{
+		Name:       "aws.lambda.enhanced.post_runtime_duration",
+		Value:      postRuntimeDurationMs, // in milliseconds
+		Mtype:      metrics.DistributionType,
+		Tags:       []string{"cold_start:true"},
+		SampleRate: 1,
+		Timestamp:  postRuntimeMetricTimestamp,
+	})
+	expectedStringRecord := fmt.Sprintf("REPORT RequestId: 13dee504-0d50-4c86-8d82-efd20693afc9\tDuration: %.2f ms\tRuntime Duration: %.2f ms\tPost Runtime Duration: %.2f ms\tBilled Duration: 0 ms\tMemory Size: 0 MB\tMax Memory Used: 0 MB", durationMs, runtimeDurationMs, postRuntimeDurationMs)
+	assert.Equal(t, reportMessage.stringRecord, expectedStringRecord)
+	assert.Len(t, timedMetrics, 0)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->
This pull request adds the `aws.lambda.enhanced.runtime_duration` and `aws.lambda.enhanced.post_runtime_duration` metric values to the report log. This report log is a log line that the extension creates when receiving the Report Log event.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

The report log is a helpful way for users to see their lambda usage. Without the values of `aws.lambda.enhanced.runtime_duration` and `aws.lambda.enhanced.post_runtime_duration`, customers are not getting the full story. These two new additions to the log statement help customers better understand the overhead added by our instrumentation.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Currently, the data reported in this report log statement comes entirely from the Report Log event itself. However, the `aws.lambda.enhanced.runtime_duration` and `aws.lambda.enhanced.post_runtime_duration` metric values rely on us having previously received Runtime Done event. Therefore, this pull request includes two main changes related to this requirement.

First, the location where the report log statement is created has changed. It used to occur during json unmarshalling. Since we do not have access to all the information needed at this point, I have pushed the creation of the log string to later, when we have access to the context from previous lambda runtime events.

Second, I had to change the `logMessage` argument to `processMessage` from a struct to a pointer. This is necessary because the method now needs to update the string value of the report log statement.


### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->
The report log statement now relies on the receipt of the Runtime Done event. If this event is not received for some reason, the log statement might look a bit weird. For instance, instead of

> REPORT RequestId: 13dee504-0d50-4c86-8d82-efd20693afc9 Duration: 100.00 ms        Runtime Duration: 10.00 ms      Post Runtime Duration: 90.00 ms Billed Duration: 0 ms      Memory Size: 0 MB       Max Memory Used: 0 MB

the log statement would look something like

> REPORT RequestId: 13dee504-0d50-4c86-8d82-efd20693afc9 Duration: 100.00 ms        Runtime Duration: -9223372036854.00 ms  Post Runtime Duration: 9223372036954.00 ms Billed Duration: 0 ms   Memory Size: 0 MB       Max Memory Used: 0 MB

Notice the really weird values for Runtime Duration and Post Runtime Duration.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
The contents of this PR can be tested by deploying a lambda function, running the lambda function, then looking in the UI for the log output.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
