### PR TITLE
[DCA] Send RFC-1123 compliant host names for k8s events

### DIFF
--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
@@ -353,7 +353,7 @@ func (k *KubeASCheck) processEvents(sender aggregator.Sender, events []*v1.Event
 
 	ctx := context.TODO()
 	hostnameDetected, _ := hostname.Get(ctx)
-	clusterName := clustername.GetClusterName(ctx, hostnameDetected)
+	clusterName := clustername.GetRFC1123CompliantClusterName(ctx, hostnameDetected)
 
 	for id, bundle := range bundlesByObject {
 		datadogEv, err := bundle.formatEvents(clusterName, k.providerIDCache)

--- a/pkg/util/kubelet/hostname.go
+++ b/pkg/util/kubelet/hostname.go
@@ -11,7 +11,6 @@ package kubelet
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/containers/v2/metrics"
@@ -63,11 +62,7 @@ func getRFC1123CompliantClusterName(ctx context.Context, hostname string) (strin
 
 // makeClusterNameRFC1123Compliant returns the compliant cluster name and as the second return value the initial clusterName
 func makeClusterNameRFC1123Compliant(clusterName string) (string, string) {
-	if strings.Contains(clusterName, "_") {
-		finalName := strings.ReplaceAll(clusterName, "_", "-")
-		return finalName, clusterName
-	}
-	return clusterName, clusterName
+	return clustername.MakeClusterNameRFC1123Compliant(clusterName), clusterName
 }
 
 // IsAgentKubeHostNetwork returns true if the agent is running on a POD with hostNetwork

--- a/pkg/util/kubernetes/clustername/clustername.go
+++ b/pkg/util/kubernetes/clustername/clustername.go
@@ -135,6 +135,12 @@ func GetClusterName(ctx context.Context, hostname string) string {
 	return getClusterName(ctx, defaultClusterNameData, hostname)
 }
 
+// GetRFC1123CompliantClusterName returns an RFC-1123 compliant k8s cluster
+// name if it exists, either directly specified or autodiscovered
+func GetRFC1123CompliantClusterName(ctx context.Context, hostname string) string {
+	return MakeClusterNameRFC1123Compliant(getClusterName(ctx, defaultClusterNameData, hostname))
+}
+
 func resetClusterName(data *clusterNameData) {
 	data.mutex.Lock()
 	defer data.mutex.Unlock()
@@ -178,6 +184,14 @@ func GetClusterID() (string, error) {
 
 	cache.Cache.Set(cacheClusterIDKey, clusterID, cache.NoExpiration)
 	return clusterID, nil
+}
+
+// MakeClusterNameRFC1123Compliant returns the RFC-1123 compliant cluster name.
+func MakeClusterNameRFC1123Compliant(clusterName string) string {
+	if strings.Contains(clusterName, "_") {
+		return strings.ReplaceAll(clusterName, "_", "-")
+	}
+	return clusterName
 }
 
 // setProviderCatalog should only be used for testing.


### PR DESCRIPTION
### What does this PR do?

This matches the rest of the core agent, where the "official" hostname
is normalized, and the raw, non-RFC-1123 compliant hostname is just an
alias. Without this, Kubernetes events will not have host tags attached.

### Motivation

This was brought up as a support case, where the customer has an EC2 cluster name with underscores, and it's not easy for them to fix that due to existing data like dashboards and monitors.

### Describe how to test/QA your changes

This is annoying to test, since it requires a k8s cluster running in EC2, with a `kubernetes.io/cluster/name_with_underscores` applied to the instances. Ideally setting `DD_CLUSTER_NAME` would work, but an invalid one is completely ignored. You can instead build a custom image where `DD_CLUSTER_NAME` is not ignored here: https://github.com/DataDog/datadog-agent/blob/main/pkg/util/kubernetes/clustername/clustername.go#L84

In either case, deploy both the core agent with a custom `DD_TAGS`, and the cluster agent with k8s event collection enabled. Check that the events show up with a host where the underscores have been replaced by hiphens, and that `DD_TAGS` has been applied.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
