### PR TITLE
Fix data race in Admission controller test

### DIFF
--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
@@ -28,9 +28,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
-var (
-	v1beta1Cfg = NewConfig(false, false)
-)
+var v1beta1Cfg = NewConfig(false, false)
 
 func TestSecretNotFoundV1beta1(t *testing.T) {
 	f := newFixtureV1beta1(t)
@@ -122,7 +120,7 @@ func TestUpdateOutdatedWebhookV1beta1(t *testing.T) {
 
 func TestAdmissionControllerFailureModeIgnoreV1beta1(t *testing.T) {
 	f := newFixtureV1beta1(t)
-	c := f.run(t)
+	c, _ := f.createController()
 	c.config = NewConfig(true, false)
 
 	holdValue := config.Datadog.Get("admission_controller.failure_policy")
@@ -158,7 +156,7 @@ func TestAdmissionControllerFailureModeFailV1beta1(t *testing.T) {
 	defer config.Datadog.Set("admission_controller.failure_policy", holdValue)
 
 	f := newFixtureV1beta1(t)
-	c := f.run(t)
+	c, _ := f.createController()
 
 	config.Datadog.Set("admission_controller.failure_policy", "Fail")
 	c.config = NewConfig(true, false)
@@ -611,20 +609,24 @@ func newFixtureV1beta1(t *testing.T) *fixtureV1beta1 {
 	return f
 }
 
-func (f *fixtureV1beta1) run(t *testing.T) *ControllerV1beta1 {
-	stopCh := make(chan struct{})
-	defer close(stopCh)
-
+func (f *fixtureV1beta1) createController() (*ControllerV1beta1, informers.SharedInformerFactory) {
 	factory := informers.NewSharedInformerFactory(f.client, time.Duration(0))
-	c := NewControllerV1beta1(
+
+	return NewControllerV1beta1(
 		f.client,
 		factory.Core().V1().Secrets(),
 		factory.Admissionregistration().V1beta1().MutatingWebhookConfigurations(),
 		func() bool { return true },
 		make(chan struct{}),
 		v1beta1Cfg,
-	)
+	), factory
+}
 
+func (f *fixtureV1beta1) run(t *testing.T) *ControllerV1beta1 {
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	c, factory := f.createController()
 	factory.Start(stopCh)
 	go c.Run(stopCh)
 
@@ -653,7 +655,7 @@ func validateV1beta1(w *admiv1beta1.MutatingWebhookConfiguration, s *corev1.Secr
 
 func TestAdmissionControllerReinvocationPolicyV1beta1(t *testing.T) {
 	f := newFixtureV1beta1(t)
-	c := f.run(t)
+	c, _ := f.createController()
 	c.config = NewConfig(true, false)
 
 	defaultValue := config.Datadog.Get("admission_controller.reinvocation_policy")


### PR DESCRIPTION
### What does this PR do?

Fix data race in unit test.

### Motivation

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

No QA needed.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
