### PR TITLE
[Serverless] add isError flag to channelMessage

### DIFF
--- a/pkg/logs/config/channel_message.go
+++ b/pkg/logs/config/channel_message.go
@@ -15,7 +15,8 @@ type ChannelMessage struct {
 	Timestamp time.Time
 	// Optional.
 	// Used in the Serverless Agent
-	Lambda *Lambda
+	Lambda  *Lambda
+	IsError bool
 }
 
 // Lambda is a struct storing information about the Lambda function and function execution.

--- a/pkg/logs/internal/tailers/channel/tailer_test.go
+++ b/pkg/logs/internal/tailers/channel/tailer_test.go
@@ -8,10 +8,12 @@ package channel
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
 )
 
 func TestComputeServiceName(t *testing.T) {
@@ -53,4 +55,47 @@ func TestServerlessModeCloudRun(t *testing.T) {
 func TestServerlessModeLambda(t *testing.T) {
 	lambdaConfig := &config.Lambda{}
 	assert.True(t, isServerlessOrigin(lambdaConfig))
+}
+
+func TestBuildMessageNoLambda(t *testing.T) {
+	logline := &config.ChannelMessage{
+		Content:   []byte("bababang"),
+		Timestamp: time.Date(2010, 01, 01, 01, 01, 01, 00, time.UTC),
+		IsError:   false,
+	}
+	origin := &message.Origin{}
+	builtMessage := buildMessage(logline, origin)
+	assert.Equal(t, "bababang", string(builtMessage.Content))
+	assert.Nil(t, builtMessage.Lambda)
+	assert.Equal(t, message.StatusInfo, builtMessage.GetStatus())
+}
+
+func TestBuildMessageLambda(t *testing.T) {
+	logline := &config.ChannelMessage{
+		Content:   []byte("bababang"),
+		Timestamp: time.Date(2010, 01, 01, 01, 01, 01, 00, time.UTC),
+		IsError:   false,
+		Lambda: &config.Lambda{
+			ARN:       "myTestARN",
+			RequestID: "myTestRequestId",
+		},
+	}
+	origin := &message.Origin{}
+	builtMessage := buildMessage(logline, origin)
+	assert.Equal(t, "bababang", string(builtMessage.Content))
+	assert.Equal(t, "myTestARN", builtMessage.Lambda.ARN)
+	assert.Equal(t, "myTestRequestId", builtMessage.Lambda.RequestID)
+	assert.Equal(t, message.StatusInfo, builtMessage.GetStatus())
+}
+
+func TestBuildErrorMessage(t *testing.T) {
+	logline := &config.ChannelMessage{
+		Content:   []byte("bababang"),
+		Timestamp: time.Date(2010, 01, 01, 01, 01, 01, 00, time.UTC),
+		IsError:   true,
+	}
+	origin := &message.Origin{}
+	builtMessage := buildMessage(logline, origin)
+	assert.Equal(t, "bababang", string(builtMessage.Content))
+	assert.Equal(t, message.StatusError, builtMessage.GetStatus())
 }


### PR DESCRIPTION
### What does this PR do?

This PR adds `IsError` field to the `ChannelMessage` structure.
Before all message were set with status `info` but in some case, we want to tag message as error right away, for instance if we know that these are coming from stderr

<img width="722" alt="Screen Shot 2022-08-09 at 2 45 49 PM" src="https://user-images.githubusercontent.com/864493/183737370-90d74458-4955-40ef-b481-5a896f995cf7.png">

### Motivation

Set the correct level in message

### Describe how to test/QA your changes

Unit test

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
