### PR TITLE
CWS: add missing `__NR3264` syscalls

### DIFF
--- a/pkg/security/secl/model/syscall_table_generator/syscall_table_generator.go
+++ b/pkg/security/secl/model/syscall_table_generator/syscall_table_generator.go
@@ -110,14 +110,14 @@ func parseLinuxFile(url string, perLine func(string) (*syscallDefinition, error)
 	return syscalls, nil
 }
 
-var unistdDefinedRe = regexp.MustCompile(`#define __NR_([0-9a-zA-Z_][0-9a-zA-Z_]*)\s+([0-9]+)`)
+var unistdDefinedRe = regexp.MustCompile(`#define __NR(3264)?_([0-9a-zA-Z_][0-9a-zA-Z_]*)\s+([0-9]+)`)
 
 func parseUnistdTable(url string) ([]*syscallDefinition, error) {
 	return parseLinuxFile(url, func(line string) (*syscallDefinition, error) {
 		subs := unistdDefinedRe.FindStringSubmatch(line)
 		if subs != nil {
-			name := subs[1]
-			nr, err := strconv.ParseInt(subs[2], 10, 0)
+			name := subs[2]
+			nr, err := strconv.ParseInt(subs[3], 10, 0)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/security/secl/model/syscalls_linux_arm64.go
+++ b/pkg/security/secl/model/syscalls_linux_arm64.go
@@ -39,6 +39,7 @@ const (
 	SysEpollPwait               Syscall = 22
 	SysDup                      Syscall = 23
 	SysDup3                     Syscall = 24
+	SysFcntl                    Syscall = 25
 	SysInotifyInit1             Syscall = 26
 	SysInotifyAddWatch          Syscall = 27
 	SysInotifyRmWatch           Syscall = 28
@@ -56,6 +57,10 @@ const (
 	SysMount                    Syscall = 40
 	SysPivotRoot                Syscall = 41
 	SysNfsservctl               Syscall = 42
+	SysStatfs                   Syscall = 43
+	SysFstatfs                  Syscall = 44
+	SysTruncate                 Syscall = 45
+	SysFtruncate                Syscall = 46
 	SysFallocate                Syscall = 47
 	SysFaccessat                Syscall = 48
 	SysChdir                    Syscall = 49
@@ -71,6 +76,7 @@ const (
 	SysPipe2                    Syscall = 59
 	SysQuotactl                 Syscall = 60
 	SysGetdents64               Syscall = 61
+	SysLseek                    Syscall = 62
 	SysRead                     Syscall = 63
 	SysWrite                    Syscall = 64
 	SysReadv                    Syscall = 65
@@ -79,6 +85,7 @@ const (
 	SysPwrite64                 Syscall = 68
 	SysPreadv                   Syscall = 69
 	SysPwritev                  Syscall = 70
+	SysSendfile                 Syscall = 71
 	SysPselect6                 Syscall = 72
 	SysPpoll                    Syscall = 73
 	SysSignalfd4                Syscall = 74
@@ -86,6 +93,8 @@ const (
 	SysSplice                   Syscall = 76
 	SysTee                      Syscall = 77
 	SysReadlinkat               Syscall = 78
+	SysFstatat                  Syscall = 79
+	SysFstat                    Syscall = 80
 	SysSync                     Syscall = 81
 	SysFsync                    Syscall = 82
 	SysFdatasync                Syscall = 83
@@ -228,6 +237,8 @@ const (
 	SysKeyctl                   Syscall = 219
 	SysClone                    Syscall = 220
 	SysExecve                   Syscall = 221
+	SysMmap                     Syscall = 222
+	SysFadvise64                Syscall = 223
 	SysSwapon                   Syscall = 224
 	SysSwapoff                  Syscall = 225
 	SysMprotect                 Syscall = 226

--- a/pkg/security/secl/model/syscalls_string_linux_arm64.go
+++ b/pkg/security/secl/model/syscalls_string_linux_arm64.go
@@ -33,6 +33,7 @@ func _() {
 	_ = x[SysEpollPwait-22]
 	_ = x[SysDup-23]
 	_ = x[SysDup3-24]
+	_ = x[SysFcntl-25]
 	_ = x[SysInotifyInit1-26]
 	_ = x[SysInotifyAddWatch-27]
 	_ = x[SysInotifyRmWatch-28]
@@ -50,6 +51,10 @@ func _() {
 	_ = x[SysMount-40]
 	_ = x[SysPivotRoot-41]
 	_ = x[SysNfsservctl-42]
+	_ = x[SysStatfs-43]
+	_ = x[SysFstatfs-44]
+	_ = x[SysTruncate-45]
+	_ = x[SysFtruncate-46]
 	_ = x[SysFallocate-47]
 	_ = x[SysFaccessat-48]
 	_ = x[SysChdir-49]
@@ -65,6 +70,7 @@ func _() {
 	_ = x[SysPipe2-59]
 	_ = x[SysQuotactl-60]
 	_ = x[SysGetdents64-61]
+	_ = x[SysLseek-62]
 	_ = x[SysRead-63]
 	_ = x[SysWrite-64]
 	_ = x[SysReadv-65]
@@ -73,6 +79,7 @@ func _() {
 	_ = x[SysPwrite64-68]
 	_ = x[SysPreadv-69]
 	_ = x[SysPwritev-70]
+	_ = x[SysSendfile-71]
 	_ = x[SysPselect6-72]
 	_ = x[SysPpoll-73]
 	_ = x[SysSignalfd4-74]
@@ -80,6 +87,8 @@ func _() {
 	_ = x[SysSplice-76]
 	_ = x[SysTee-77]
 	_ = x[SysReadlinkat-78]
+	_ = x[SysFstatat-79]
+	_ = x[SysFstat-80]
 	_ = x[SysSync-81]
 	_ = x[SysFsync-82]
 	_ = x[SysFdatasync-83]
@@ -222,6 +231,8 @@ func _() {
 	_ = x[SysKeyctl-219]
 	_ = x[SysClone-220]
 	_ = x[SysExecve-221]
+	_ = x[SysMmap-222]
+	_ = x[SysFadvise64-223]
 	_ = x[SysSwapon-224]
 	_ = x[SysSwapoff-225]
 	_ = x[SysMprotect-226]
@@ -329,62 +340,32 @@ func _() {
 }
 
 const (
-	_Syscall_name_0 = "SysIoSetupSysIoDestroySysIoSubmitSysIoCancelSysIoGeteventsSysSetxattrSysLsetxattrSysFsetxattrSysGetxattrSysLgetxattrSysFgetxattrSysListxattrSysLlistxattrSysFlistxattrSysRemovexattrSysLremovexattrSysFremovexattrSysGetcwdSysLookupDcookieSysEventfd2SysEpollCreate1SysEpollCtlSysEpollPwaitSysDupSysDup3"
-	_Syscall_name_1 = "SysInotifyInit1SysInotifyAddWatchSysInotifyRmWatchSysIoctlSysIoprioSetSysIoprioGetSysFlockSysMknodatSysMkdiratSysUnlinkatSysSymlinkatSysLinkatSysRenameatSysUmount2SysMountSysPivotRootSysNfsservctl"
-	_Syscall_name_2 = "SysFallocateSysFaccessatSysChdirSysFchdirSysChrootSysFchmodSysFchmodatSysFchownatSysFchownSysOpenatSysCloseSysVhangupSysPipe2SysQuotactlSysGetdents64"
-	_Syscall_name_3 = "SysReadSysWriteSysReadvSysWritevSysPread64SysPwrite64SysPreadvSysPwritev"
-	_Syscall_name_4 = "SysPselect6SysPpollSysSignalfd4SysVmspliceSysSpliceSysTeeSysReadlinkat"
-	_Syscall_name_5 = "SysSyncSysFsyncSysFdatasyncSysSyncFileRange2SysTimerfdCreateSysTimerfdSettimeSysTimerfdGettimeSysUtimensatSysAcctSysCapgetSysCapsetSysPersonalitySysExitSysExitGroupSysWaitidSysSetTidAddressSysUnshareSysFutexSysSetRobustListSysGetRobustListSysNanosleepSysGetitimerSysSetitimerSysKexecLoadSysInitModuleSysDeleteModuleSysTimerCreateSysTimerGettimeSysTimerGetoverrunSysTimerSettimeSysTimerDeleteSysClockSettimeSysClockGettimeSysClockGetresSysClockNanosleepSysSyslogSysPtraceSysSchedSetparamSysSchedSetschedulerSysSchedGetschedulerSysSchedGetparamSysSchedSetaffinitySysSchedGetaffinitySysSchedYieldSysSchedGetPriorityMaxSysSchedGetPriorityMinSysSchedRrGetIntervalSysRestartSyscallSysKillSysTkillSysTgkillSysSigaltstackSysRtSigsuspendSysRtSigactionSysRtSigprocmaskSysRtSigpendingSysRtSigtimedwaitSysRtSigqueueinfoSysRtSigreturnSysSetprioritySysGetprioritySysRebootSysSetregidSysSetgidSysSetreuidSysSetuidSysSetresuidSysGetresuidSysSetresgidSysGetresgidSysSetfsuidSysSetfsgidSysTimesSysSetpgidSysGetpgidSysGetsidSysSetsidSysGetgroupsSysSetgroupsSysUnameSysSethostnameSysSetdomainnameSysGetrlimitSysSetrlimitSysGetrusageSysUmaskSysPrctlSysGetcpuSysGettimeofdaySysSettimeofdaySysAdjtimexSysGetpidSysGetppidSysGetuidSysGeteuidSysGetgidSysGetegidSysGettidSysSysinfoSysMqOpenSysMqUnlinkSysMqTimedsendSysMqTimedreceiveSysMqNotifySysMqGetsetattrSysMsggetSysMsgctlSysMsgrcvSysMsgsndSysSemgetSysSemctlSysSemtimedopSysSemopSysShmgetSysShmctlSysShmatSysShmdtSysSocketSysSocketpairSysBindSysListenSysAcceptSysConnectSysGetsocknameSysGetpeernameSysSendtoSysRecvfromSysSetsockoptSysGetsockoptSysShutdownSysSendmsgSysRecvmsgSysReadaheadSysBrkSysMunmapSysMremapSysAddKeySysRequestKeySysKeyctlSysCloneSysExecve"
-	_Syscall_name_6 = "SysSwaponSysSwapoffSysMprotectSysMsyncSysMlockSysMunlockSysMlockallSysMunlockallSysMincoreSysMadviseSysRemapFilePagesSysMbindSysGetMempolicySysSetMempolicySysMigratePagesSysMovePagesSysRtTgsigqueueinfoSysPerfEventOpenSysAccept4SysRecvmmsgSysArchSpecificSyscall"
-	_Syscall_name_7 = "SysWait4SysPrlimit64SysFanotifyInitSysFanotifyMarkSysNameToHandleAtSysOpenByHandleAtSysClockAdjtimeSysSyncfsSysSetnsSysSendmmsgSysProcessVmReadvSysProcessVmWritevSysKcmpSysFinitModuleSysSchedSetattrSysSchedGetattrSysRenameat2SysSeccompSysGetrandomSysMemfdCreateSysBpfSysExecveatSysUserfaultfdSysMembarrierSysMlock2SysCopyFileRangeSysPreadv2SysPwritev2SysPkeyMprotectSysPkeyAllocSysPkeyFreeSysStatxSysIoPgeteventsSysRseqSysKexecFileLoad"
-	_Syscall_name_8 = "SysClockGettime64SysClockSettime64SysClockAdjtime64SysClockGetresTime64SysClockNanosleepTime64SysTimerGettime64SysTimerSettime64SysTimerfdGettime64SysTimerfdSettime64SysUtimensatTime64SysPselect6Time64SysPpollTime64"
-	_Syscall_name_9 = "SysIoPgeteventsTime64SysRecvmmsgTime64SysMqTimedsendTime64SysMqTimedreceiveTime64SysSemtimedopTime64SysRtSigtimedwaitTime64SysFutexTime64SysSchedRrGetIntervalTime64SysPidfdSendSignalSysIoUringSetupSysIoUringEnterSysIoUringRegisterSysOpenTreeSysMoveMountSysFsopenSysFsconfigSysFsmountSysFspickSysPidfdOpenSysClone3SysCloseRangeSysOpenat2SysPidfdGetfdSysFaccessat2SysProcessMadviseSysEpollPwait2SysMountSetattrSysQuotactlFdSysLandlockCreateRulesetSysLandlockAddRuleSysLandlockRestrictSelfSysMemfdSecretSysProcessMreleaseSysFutexWaitvSysSetMempolicyHomeNodeSysSyscalls"
+	_Syscall_name_0 = "SysIoSetupSysIoDestroySysIoSubmitSysIoCancelSysIoGeteventsSysSetxattrSysLsetxattrSysFsetxattrSysGetxattrSysLgetxattrSysFgetxattrSysListxattrSysLlistxattrSysFlistxattrSysRemovexattrSysLremovexattrSysFremovexattrSysGetcwdSysLookupDcookieSysEventfd2SysEpollCreate1SysEpollCtlSysEpollPwaitSysDupSysDup3SysFcntlSysInotifyInit1SysInotifyAddWatchSysInotifyRmWatchSysIoctlSysIoprioSetSysIoprioGetSysFlockSysMknodatSysMkdiratSysUnlinkatSysSymlinkatSysLinkatSysRenameatSysUmount2SysMountSysPivotRootSysNfsservctlSysStatfsSysFstatfsSysTruncateSysFtruncateSysFallocateSysFaccessatSysChdirSysFchdirSysChrootSysFchmodSysFchmodatSysFchownatSysFchownSysOpenatSysCloseSysVhangupSysPipe2SysQuotactlSysGetdents64SysLseekSysReadSysWriteSysReadvSysWritevSysPread64SysPwrite64SysPreadvSysPwritevSysSendfileSysPselect6SysPpollSysSignalfd4SysVmspliceSysSpliceSysTeeSysReadlinkatSysFstatatSysFstatSysSyncSysFsyncSysFdatasyncSysSyncFileRange2SysTimerfdCreateSysTimerfdSettimeSysTimerfdGettimeSysUtimensatSysAcctSysCapgetSysCapsetSysPersonalitySysExitSysExitGroupSysWaitidSysSetTidAddressSysUnshareSysFutexSysSetRobustListSysGetRobustListSysNanosleepSysGetitimerSysSetitimerSysKexecLoadSysInitModuleSysDeleteModuleSysTimerCreateSysTimerGettimeSysTimerGetoverrunSysTimerSettimeSysTimerDeleteSysClockSettimeSysClockGettimeSysClockGetresSysClockNanosleepSysSyslogSysPtraceSysSchedSetparamSysSchedSetschedulerSysSchedGetschedulerSysSchedGetparamSysSchedSetaffinitySysSchedGetaffinitySysSchedYieldSysSchedGetPriorityMaxSysSchedGetPriorityMinSysSchedRrGetIntervalSysRestartSyscallSysKillSysTkillSysTgkillSysSigaltstackSysRtSigsuspendSysRtSigactionSysRtSigprocmaskSysRtSigpendingSysRtSigtimedwaitSysRtSigqueueinfoSysRtSigreturnSysSetprioritySysGetprioritySysRebootSysSetregidSysSetgidSysSetreuidSysSetuidSysSetresuidSysGetresuidSysSetresgidSysGetresgidSysSetfsuidSysSetfsgidSysTimesSysSetpgidSysGetpgidSysGetsidSysSetsidSysGetgroupsSysSetgroupsSysUnameSysSethostnameSysSetdomainnameSysGetrlimitSysSetrlimitSysGetrusageSysUmaskSysPrctlSysGetcpuSysGettimeofdaySysSettimeofdaySysAdjtimexSysGetpidSysGetppidSysGetuidSysGeteuidSysGetgidSysGetegidSysGettidSysSysinfoSysMqOpenSysMqUnlinkSysMqTimedsendSysMqTimedreceiveSysMqNotifySysMqGetsetattrSysMsggetSysMsgctlSysMsgrcvSysMsgsndSysSemgetSysSemctlSysSemtimedopSysSemopSysShmgetSysShmctlSysShmatSysShmdtSysSocketSysSocketpairSysBindSysListenSysAcceptSysConnectSysGetsocknameSysGetpeernameSysSendtoSysRecvfromSysSetsockoptSysGetsockoptSysShutdownSysSendmsgSysRecvmsgSysReadaheadSysBrkSysMunmapSysMremapSysAddKeySysRequestKeySysKeyctlSysCloneSysExecveSysMmapSysFadvise64SysSwaponSysSwapoffSysMprotectSysMsyncSysMlockSysMunlockSysMlockallSysMunlockallSysMincoreSysMadviseSysRemapFilePagesSysMbindSysGetMempolicySysSetMempolicySysMigratePagesSysMovePagesSysRtTgsigqueueinfoSysPerfEventOpenSysAccept4SysRecvmmsgSysArchSpecificSyscall"
+	_Syscall_name_1 = "SysWait4SysPrlimit64SysFanotifyInitSysFanotifyMarkSysNameToHandleAtSysOpenByHandleAtSysClockAdjtimeSysSyncfsSysSetnsSysSendmmsgSysProcessVmReadvSysProcessVmWritevSysKcmpSysFinitModuleSysSchedSetattrSysSchedGetattrSysRenameat2SysSeccompSysGetrandomSysMemfdCreateSysBpfSysExecveatSysUserfaultfdSysMembarrierSysMlock2SysCopyFileRangeSysPreadv2SysPwritev2SysPkeyMprotectSysPkeyAllocSysPkeyFreeSysStatxSysIoPgeteventsSysRseqSysKexecFileLoad"
+	_Syscall_name_2 = "SysClockGettime64SysClockSettime64SysClockAdjtime64SysClockGetresTime64SysClockNanosleepTime64SysTimerGettime64SysTimerSettime64SysTimerfdGettime64SysTimerfdSettime64SysUtimensatTime64SysPselect6Time64SysPpollTime64"
+	_Syscall_name_3 = "SysIoPgeteventsTime64SysRecvmmsgTime64SysMqTimedsendTime64SysMqTimedreceiveTime64SysSemtimedopTime64SysRtSigtimedwaitTime64SysFutexTime64SysSchedRrGetIntervalTime64SysPidfdSendSignalSysIoUringSetupSysIoUringEnterSysIoUringRegisterSysOpenTreeSysMoveMountSysFsopenSysFsconfigSysFsmountSysFspickSysPidfdOpenSysClone3SysCloseRangeSysOpenat2SysPidfdGetfdSysFaccessat2SysProcessMadviseSysEpollPwait2SysMountSetattrSysQuotactlFdSysLandlockCreateRulesetSysLandlockAddRuleSysLandlockRestrictSelfSysMemfdSecretSysProcessMreleaseSysFutexWaitvSysSetMempolicyHomeNodeSysSyscalls"
 )
 
 var (
-	_Syscall_index_0 = [...]uint16{0, 10, 22, 33, 44, 58, 69, 81, 93, 104, 116, 128, 140, 153, 166, 180, 195, 210, 219, 235, 246, 261, 272, 285, 291, 298}
-	_Syscall_index_1 = [...]uint8{0, 15, 33, 50, 58, 70, 82, 90, 100, 110, 121, 133, 142, 153, 163, 171, 183, 196}
-	_Syscall_index_2 = [...]uint8{0, 12, 24, 32, 41, 50, 59, 70, 81, 90, 99, 107, 117, 125, 136, 149}
-	_Syscall_index_3 = [...]uint8{0, 7, 15, 23, 32, 42, 53, 62, 72}
-	_Syscall_index_4 = [...]uint8{0, 11, 19, 31, 42, 51, 57, 70}
-	_Syscall_index_5 = [...]uint16{0, 7, 15, 27, 44, 60, 77, 94, 106, 113, 122, 131, 145, 152, 164, 173, 189, 199, 207, 223, 239, 251, 263, 275, 287, 300, 315, 329, 344, 362, 377, 391, 406, 421, 435, 452, 461, 470, 486, 506, 526, 542, 561, 580, 593, 615, 637, 658, 675, 682, 690, 699, 713, 728, 742, 758, 773, 790, 807, 821, 835, 849, 858, 869, 878, 889, 898, 910, 922, 934, 946, 957, 968, 976, 986, 996, 1005, 1014, 1026, 1038, 1046, 1060, 1076, 1088, 1100, 1112, 1120, 1128, 1137, 1152, 1167, 1178, 1187, 1197, 1206, 1216, 1225, 1235, 1244, 1254, 1263, 1274, 1288, 1305, 1316, 1331, 1340, 1349, 1358, 1367, 1376, 1385, 1398, 1406, 1415, 1424, 1432, 1440, 1449, 1462, 1469, 1478, 1487, 1497, 1511, 1525, 1534, 1545, 1558, 1571, 1582, 1592, 1602, 1614, 1620, 1629, 1638, 1647, 1660, 1669, 1677, 1686}
-	_Syscall_index_6 = [...]uint16{0, 9, 19, 30, 38, 46, 56, 67, 80, 90, 100, 117, 125, 140, 155, 170, 182, 201, 217, 227, 238, 260}
-	_Syscall_index_7 = [...]uint16{0, 8, 20, 35, 50, 67, 84, 99, 108, 116, 127, 144, 162, 169, 183, 198, 213, 225, 235, 247, 261, 267, 278, 292, 305, 314, 330, 340, 351, 366, 378, 389, 397, 412, 419, 435}
-	_Syscall_index_8 = [...]uint8{0, 17, 34, 51, 71, 94, 111, 128, 147, 166, 184, 201, 215}
-	_Syscall_index_9 = [...]uint16{0, 21, 38, 58, 81, 100, 123, 137, 164, 182, 197, 212, 230, 241, 253, 262, 273, 283, 292, 304, 313, 326, 336, 349, 362, 379, 393, 408, 421, 445, 463, 486, 500, 518, 531, 554, 565}
+	_Syscall_index_0 = [...]uint16{0, 10, 22, 33, 44, 58, 69, 81, 93, 104, 116, 128, 140, 153, 166, 180, 195, 210, 219, 235, 246, 261, 272, 285, 291, 298, 306, 321, 339, 356, 364, 376, 388, 396, 406, 416, 427, 439, 448, 459, 469, 477, 489, 502, 511, 521, 532, 544, 556, 568, 576, 585, 594, 603, 614, 625, 634, 643, 651, 661, 669, 680, 693, 701, 708, 716, 724, 733, 743, 754, 763, 773, 784, 795, 803, 815, 826, 835, 841, 854, 864, 872, 879, 887, 899, 916, 932, 949, 966, 978, 985, 994, 1003, 1017, 1024, 1036, 1045, 1061, 1071, 1079, 1095, 1111, 1123, 1135, 1147, 1159, 1172, 1187, 1201, 1216, 1234, 1249, 1263, 1278, 1293, 1307, 1324, 1333, 1342, 1358, 1378, 1398, 1414, 1433, 1452, 1465, 1487, 1509, 1530, 1547, 1554, 1562, 1571, 1585, 1600, 1614, 1630, 1645, 1662, 1679, 1693, 1707, 1721, 1730, 1741, 1750, 1761, 1770, 1782, 1794, 1806, 1818, 1829, 1840, 1848, 1858, 1868, 1877, 1886, 1898, 1910, 1918, 1932, 1948, 1960, 1972, 1984, 1992, 2000, 2009, 2024, 2039, 2050, 2059, 2069, 2078, 2088, 2097, 2107, 2116, 2126, 2135, 2146, 2160, 2177, 2188, 2203, 2212, 2221, 2230, 2239, 2248, 2257, 2270, 2278, 2287, 2296, 2304, 2312, 2321, 2334, 2341, 2350, 2359, 2369, 2383, 2397, 2406, 2417, 2430, 2443, 2454, 2464, 2474, 2486, 2492, 2501, 2510, 2519, 2532, 2541, 2549, 2558, 2565, 2577, 2586, 2596, 2607, 2615, 2623, 2633, 2644, 2657, 2667, 2677, 2694, 2702, 2717, 2732, 2747, 2759, 2778, 2794, 2804, 2815, 2837}
+	_Syscall_index_1 = [...]uint16{0, 8, 20, 35, 50, 67, 84, 99, 108, 116, 127, 144, 162, 169, 183, 198, 213, 225, 235, 247, 261, 267, 278, 292, 305, 314, 330, 340, 351, 366, 378, 389, 397, 412, 419, 435}
+	_Syscall_index_2 = [...]uint8{0, 17, 34, 51, 71, 94, 111, 128, 147, 166, 184, 201, 215}
+	_Syscall_index_3 = [...]uint16{0, 21, 38, 58, 81, 100, 123, 137, 164, 182, 197, 212, 230, 241, 253, 262, 273, 283, 292, 304, 313, 326, 336, 349, 362, 379, 393, 408, 421, 445, 463, 486, 500, 518, 531, 554, 565}
 )
 
 func (i Syscall) String() string {
 	switch {
-	case 0 <= i && i <= 24:
+	case 0 <= i && i <= 244:
 		return _Syscall_name_0[_Syscall_index_0[i]:_Syscall_index_0[i+1]]
-	case 26 <= i && i <= 42:
-		i -= 26
-		return _Syscall_name_1[_Syscall_index_1[i]:_Syscall_index_1[i+1]]
-	case 47 <= i && i <= 61:
-		i -= 47
-		return _Syscall_name_2[_Syscall_index_2[i]:_Syscall_index_2[i+1]]
-	case 63 <= i && i <= 70:
-		i -= 63
-		return _Syscall_name_3[_Syscall_index_3[i]:_Syscall_index_3[i+1]]
-	case 72 <= i && i <= 78:
-		i -= 72
-		return _Syscall_name_4[_Syscall_index_4[i]:_Syscall_index_4[i+1]]
-	case 81 <= i && i <= 221:
-		i -= 81
-		return _Syscall_name_5[_Syscall_index_5[i]:_Syscall_index_5[i+1]]
-	case 224 <= i && i <= 244:
-		i -= 224
-		return _Syscall_name_6[_Syscall_index_6[i]:_Syscall_index_6[i+1]]
 	case 260 <= i && i <= 294:
 		i -= 260
-		return _Syscall_name_7[_Syscall_index_7[i]:_Syscall_index_7[i+1]]
+		return _Syscall_name_1[_Syscall_index_1[i]:_Syscall_index_1[i+1]]
 	case 403 <= i && i <= 414:
 		i -= 403
-		return _Syscall_name_8[_Syscall_index_8[i]:_Syscall_index_8[i+1]]
+		return _Syscall_name_2[_Syscall_index_2[i]:_Syscall_index_2[i+1]]
 	case 416 <= i && i <= 451:
 		i -= 416
-		return _Syscall_name_9[_Syscall_index_9[i]:_Syscall_index_9[i+1]]
+		return _Syscall_name_3[_Syscall_index_3[i]:_Syscall_index_3[i+1]]
 	default:
 		return "Syscall(" + strconv.FormatInt(int64(i), 10) + ")"
 	}


### PR DESCRIPTION
### What does this PR do?

This PR adds missing syscalls on arm64

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
