### PR TITLE
http debug malformed in debug log, dump tags and connection tuple

### DIFF
--- a/pkg/network/http/http_statkeeper.go
+++ b/pkg/network/http/http_statkeeper.go
@@ -163,7 +163,7 @@ func (h *httpStatKeeper) processHTTPPath(tx *httpTX, path []byte) (pathStr strin
 	// Otherwise, we don't want the custom path to be rejected by our path formatting check.
 	if !match && pathIsMalformed(path) {
 		if h.oversizedLogLimit.ShouldLog() {
-			log.Warnf("http path malformed: %s", tx.String())
+			log.Debugf("http path malformed: %+v %s", h.newKey(tx, "", false).KeyTuple, tx.String())
 		}
 		h.telemetry.malformed.Inc()
 		return "", true

--- a/pkg/network/http/model.go
+++ b/pkg/network/http/model.go
@@ -10,6 +10,7 @@ package http
 
 import (
 	"encoding/hex"
+	"strconv"
 	"strings"
 	"unsafe"
 )
@@ -100,6 +101,7 @@ func (tx *httpTX) String() string {
 	fragment := *(*[HTTPBufferSize]byte)(unsafe.Pointer(&tx.request_fragment))
 	output.WriteString("httpTX{")
 	output.WriteString("Method: '" + Method(tx.request_method).String() + "', ")
+	output.WriteString("Tags: '0x" + strconv.FormatUint(tx.Tags(), 16) + "', ")
 	output.WriteString("Fragment: '" + hex.EncodeToString(fragment[:]) + "', ")
 	output.WriteString("}")
 	return output.String()


### PR DESCRIPTION
### What does this PR do?

Dumping malformed http request in Debug() as we counting already the malformed request on telemetry
We don't want customer reporting us Warn() malformed requests due to dd-trace-py or kafka containing  HTTP like request but it's a protobuf or other serialized format.
Adding more fields to understand the source of the malformed request, like connection tuple and tags.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
