### PR TITLE
SLS-2383: Add origin:cloudrun tag to metadata sent by the cloud run agent

### DIFF
--- a/cmd/serverless-init/tag/tag.go
+++ b/cmd/serverless-init/tag/tag.go
@@ -59,6 +59,8 @@ func GetBaseTagsMapWithMetadata(metadata map[string]string) map[string]string {
 		tags[key] = value
 	}
 
+	tags["origin"] = "cloudrun"
+
 	return tags
 }
 

--- a/cmd/serverless-init/tag/tag_test.go
+++ b/cmd/serverless-init/tag/tag_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestGetBaseTagsArrayNoEnvNoMetadata(t *testing.T) {
-	assert.Equal(t, 0, len(GetBaseTagsArrayWithMetadataTags(make(map[string]string, 0))))
+	assert.Equal(t, 1, len(GetBaseTagsArrayWithMetadataTags(make(map[string]string, 0))))
 }
 
 func TestGetBaseTagsArrayWithMetadataTagsNoMetadata(t *testing.T) {
@@ -30,12 +30,13 @@ func TestGetBaseTagsArrayWithMetadataTagsNoMetadata(t *testing.T) {
 	defer os.Unsetenv("DD_VERSION")
 	tags := GetBaseTagsArrayWithMetadataTags(make(map[string]string, 0))
 	sort.Strings(tags)
-	assert.Equal(t, 5, len(tags))
+	assert.Equal(t, 6, len(tags))
 	assert.Equal(t, "env:myenv", tags[0])
-	assert.Equal(t, "revision_name:fdgf34", tags[1])
-	assert.Equal(t, "service:superservice", tags[2])
-	assert.Equal(t, "service_name:myservice", tags[3])
-	assert.Equal(t, "version:123.4", tags[4])
+	assert.Equal(t, "origin:cloudrun", tags[1])
+	assert.Equal(t, "revision_name:fdgf34", tags[2])
+	assert.Equal(t, "service:superservice", tags[3])
+	assert.Equal(t, "service_name:myservice", tags[4])
+	assert.Equal(t, "version:123.4", tags[5])
 }
 
 func TestGetTagFound(t *testing.T) {
@@ -53,7 +54,7 @@ func TestGetTagNotFound(t *testing.T) {
 }
 
 func TestGetBaseTagsMapNoEnvNoMetadata(t *testing.T) {
-	assert.Equal(t, 0, len(GetBaseTagsMapWithMetadata(make(map[string]string, 0))))
+	assert.Equal(t, 1, len(GetBaseTagsMapWithMetadata(make(map[string]string, 0))))
 }
 
 func TestGetBaseTagsMapNoMetadata(t *testing.T) {
@@ -68,12 +69,13 @@ func TestGetBaseTagsMapNoMetadata(t *testing.T) {
 	os.Setenv("DD_VERSION", "123.4")
 	defer os.Unsetenv("DD_VERSION")
 	tags := GetBaseTagsMapWithMetadata(make(map[string]string, 0))
-	assert.Equal(t, 5, len(tags))
+	assert.Equal(t, 6, len(tags))
 	assert.Equal(t, "myenv", tags["env"])
 	assert.Equal(t, "fdgf34", tags["revision_name"])
 	assert.Equal(t, "superservice", tags["service"])
 	assert.Equal(t, "myservice", tags["service_name"])
 	assert.Equal(t, "123.4", tags["version"])
+	assert.Equal(t, "cloudrun", tags["origin"])
 }
 
 func TestGetBaseTagsMapWithMetadata(t *testing.T) {
@@ -83,10 +85,11 @@ func TestGetBaseTagsMapWithMetadata(t *testing.T) {
 		"location":      "mysuperlocation",
 		"othermetadata": "mysuperothermetadatavalue",
 	})
-	assert.Equal(t, 3, len(tags))
+	assert.Equal(t, 4, len(tags))
 	assert.Equal(t, "mysuperlocation", tags["location"])
 	assert.Equal(t, "mysuperothermetadatavalue", tags["othermetadata"])
 	assert.Equal(t, "myservice", tags["service_name"])
+	assert.Equal(t, "cloudrun", tags["origin"])
 }
 
 func TestGetBaseTagsArrayWithMetadataTags(t *testing.T) {
@@ -97,9 +100,10 @@ func TestGetBaseTagsArrayWithMetadataTags(t *testing.T) {
 		"othermetadata": "mysuperothermetadatavalue",
 	})
 	sort.Strings(tags)
-	assert.Equal(t, 3, len(tags))
+	assert.Equal(t, 4, len(tags))
 	assert.Equal(t, "location:mysuperlocation", tags[0])
-	assert.Equal(t, "othermetadata:mysuperothermetadatavalue", tags[1])
-	assert.Equal(t, "revision_name:fdgf34", tags[2])
+	assert.Equal(t, "origin:cloudrun", tags[1])
+	assert.Equal(t, "othermetadata:mysuperothermetadatavalue", tags[2])
+	assert.Equal(t, "revision_name:fdgf34", tags[3])
 
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Small PR to add an `origin:cloudrun` tag to all metadata sent by the trace/metrics/logs agent.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
