### PR TITLE
pkg/config: update DD_APM_MAX_TPS to reflect new 0 value

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1061,9 +1061,9 @@ api_key:
   ## @env DD_APM_MAX_TPS - integer - optional - default: 10
   ## The target traces per second to sample. Sampling rates to apply are adjusted given
   ## the received traffic and communicated to tracers. This configures head base sampling.
-  ## As of 7.35.0 setting max_traces_per_second to 0 no longer disables sampling and instead
-  ## sends no traces to the intake. Sampling can not be disabled, to avoid rate limiting set this value
-  ## sufficiently high for your traffic pattern.
+  ## As of 7.35.0 sampling cannot be disabled and setting 'max_traces_per_second' to 0 no longer 
+  ## disables sampling, but instead sends no traces to the intake. To avoid rate limiting, set this
+  ## value sufficiently high for your traffic pattern.
   #
   # max_traces_per_second: 10
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1061,8 +1061,8 @@ api_key:
   ## @env DD_APM_MAX_TPS - integer - optional - default: 10
   ## The target traces per second to sample. Sampling rates to apply are adjusted given
   ## the received traffic and communicated to tracers. This configures head base sampling.
-  ## As of 7.35.0 setting max_traces_per_second to 0 no longer disables sampling and will instead
-  ## send no traces to the intake. Sampling can not be disabled, to avoid rate limiting set this value
+  ## As of 7.35.0 setting max_traces_per_second to 0 no longer disables sampling and instead
+  ## sends no traces to the intake. Sampling can not be disabled, to avoid rate limiting set this value
   ## sufficiently high for your traffic pattern.
   #
   # max_traces_per_second: 10

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1061,7 +1061,9 @@ api_key:
   ## @env DD_APM_MAX_TPS - integer - optional - default: 10
   ## The target traces per second to sample. Sampling rates to apply are adjusted given
   ## the received traffic and communicated to tracers. This configures head base sampling.
-  ## Set to 0 to disable sampling.
+  ## As of 7.35.0 setting max_traces_per_second to 0 no longer disables sampling and will instead
+  ## send no traces to the intake. Sampling can not be disabled, to avoid rate limiting set this value
+  ## sufficiently high for your traffic pattern.
   #
   # max_traces_per_second: 10
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This fixes the config documentation to align with a change made in 7.35.0
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Describe how to test/QA your changes
No QA needed, just a docs change
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
