### PR TITLE
Add CD to the datadog-agent pipeline by deploying to Kubernetes after e2e on nightly

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,6 +29,7 @@ include:
   - /.gitlab/kitchen_cleanup.yml
   - /.gitlab/functional_test.yml
   - /.gitlab/functional_test_cleanup.yml
+  - /.gitlab/internal_kubernetes_deploy.yml
   - /.gitlab/notify.yml
   # FIXME: our current Gitlab version doesn't support importing a file more than once
   # For now, the workaround is to include "common" files once in the top-level .gitlab-ci.yml file
@@ -79,6 +80,7 @@ stages:
   - kitchen_cleanup
   - functional_test
   - functional_test_cleanup
+  - internal_kubernetes_deploy
   - notify
 
 variables:

--- a/.gitlab/internal_image_deploy.yml
+++ b/.gitlab/internal_image_deploy.yml
@@ -25,6 +25,7 @@ docker_trigger_internal:
   script:
     - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_pipelines_scheduler_token --with-decryption --query "Parameter.Value" --out text)
     - if [ "$BUCKET_BRANCH" = "beta" ] || [ "$BUCKET_BRANCH" = "stable" ]; then TMPL_SRC_REPO="${TMPL_SRC_REPO}-release"; fi
+    - if [ "$BUCKET_BRANCH" = "nightly" ]; then RELEASE_TAG="${RELEASE_TAG}-${CI_COMMIT_SHORT_SHA}"; fi
     - inv pipeline.trigger-child-pipeline --project-name "DataDog/images" --git-ref "master" --variables "IMAGE_VERSION,IMAGE_NAME,RELEASE_TAG,BUILD_TAG,TMPL_SRC_IMAGE,TMPL_SRC_REPO,RELEASE_STAGING,RELEASE_PROD"
 
 
@@ -51,4 +52,5 @@ docker_trigger_cluster_agent_internal:
   script:
     - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_pipelines_scheduler_token --with-decryption --query "Parameter.Value" --out text)
     - if [ "$BUCKET_BRANCH" = "beta" ] || [ "$BUCKET_BRANCH" = "stable" ]; then TMPL_SRC_REPO="${TMPL_SRC_REPO}-release"; fi
+    - if [ "$BUCKET_BRANCH" = "nightly" ]; then RELEASE_TAG="${RELEASE_TAG}-${CI_COMMIT_SHORT_SHA}"; fi
     - inv pipeline.trigger-child-pipeline --project-name "DataDog/images" --git-ref "master" --variables "IMAGE_VERSION,IMAGE_NAME,RELEASE_TAG,BUILD_TAG,TMPL_SRC_IMAGE,TMPL_SRC_REPO,RELEASE_STAGING,RELEASE_PROD"

--- a/.gitlab/internal_kubernetes_deploy.yml
+++ b/.gitlab/internal_kubernetes_deploy.yml
@@ -1,0 +1,31 @@
+---
+# internal_kubernetes_deploy stage
+# Contains jobs to trigger a pipeline in our k8s-datadog-agent-ops repo
+
+internal_kubernetes_deploy_experimental:
+  stage: internal_kubernetes_deploy
+  rules:
+  - if: $FORCE_K8S_DEPLOYMENT == "true"
+    when: always
+  - if: $CI_COMMIT_BRANCH != "main"
+    when: never
+  - !reference [.on_deploy_a7]
+  needs:
+  - job: docker_trigger_internal
+    artifacts: false
+  - job: docker_trigger_cluster_agent_internal
+    artifacts: false
+  - job: k8s-e2e-main # Currently only require container Argo workflow
+    artifacts: false
+    optional: true
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
+  tags: ["runner:main"]
+  variables:
+    OPTION_AUTOMATIC_ROLLOUT: "true"
+    OPTION_PRE_SCRIPT: "patch-cluster-images-operator.sh snowver ${CI_COMMIT_REF_SLUG}-jmx-${CI_COMMIT_SHORT_SHA} clusteragent.image.tag=${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHORT_SHA}"
+    SKIP_PLAN_CHECK: "true"
+    WORKFLOW: "agents"
+    FILTER: "cluster.env == 'experimental' and cluster.shortName == 'snowver'"
+  script:
+    - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_pipelines_scheduler_token --with-decryption --query "Parameter.Value" --out text)
+    - inv pipeline.trigger-child-pipeline --project-name "DataDog/k8s-datadog-agent-ops" --git-ref "vboulineau/auto-staging" --variables "OPTION_AUTOMATIC_ROLLOUT,WORKFLOW,OPTION_PRE_SCRIPT,FILTER,SKIP_PLAN_CHECK"


### PR DESCRIPTION
### What does this PR do?

Add CD to the datadog-agent pipeline by deploying to Kubernetes after e2e on nightly

### Motivation

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
