### PR TITLE
Minor agent_QA fixups

### DIFF
--- a/tools/agent_QA/test_cases/xplat/file_tests.py
+++ b/tools/agent_QA/test_cases/xplat/file_tests.py
@@ -10,7 +10,19 @@ class TailFile(TestCase):
         self.append("# Setup")
         self.append(confDir(config))
 
-        path = "/var/log/hello-world.log" if config.platform != Platform.windows else "C:\\tmp\\hello-world.log"
+        if config.platform == Platform.windows:
+            path = "C:\\tmp\\hello-world.log"
+            genlogs = "`echo foo >> hello-world.log`"
+            blockPermissions = "right-click on the file; properties; security; advanced; disable inheritance; convert; remove all but yourself; ok; ok"
+            restorePermissions = "right-click on the file; properties; security; advanced; enable inheritance; ok; ok"
+            rotate = f"`move hello-world.log hello-world.old` {genlogs}"
+        else:
+            path = "/var/log/hello-world.log"
+            genlogs = "`docker run -it bfloerschddog/flog -l > hello-world.log`"
+            blockPermissions = "`chmod 000 hello-world.log`"
+            restorePermissions = "`chmod 755 hello-world.log`"
+            rotate = "`mv hello-world.log hello-world.log.old && touch hello-world.log`"
+
         self.append(
             f"""
 ```
@@ -20,20 +32,15 @@ logs:
     service: test-file-tailing
     source: hello-world
 ``` 
-"""
-        )
-
-        self.append(
-            """
-- Start the agent")
-- generate some logs `docker run -it bfloerschddog/flog -l > hello-world.log`
+- Start the agent
+- generate some logs ({genlogs})
 
 # Test
 - Validate the logs show up in app with the correct `source` and `service` tags
-- Block permission to the file (`chmod 000 hello-world.log`) and check that the Agent status shows that it is inaccessible. 
-- Chang the permissions back so it is accessible again. 
+- Block permission to the file ({blockPermissions}) and check that the Agent status shows that it is inaccessible. 
+- Change the permissions back ({restorePermissions}) so it is accessible again. 
 - Stop the agent, generate new logs, start the agent and make sure those are sent.
-- Rotate the log file (`mv hello-world.log hello-world.log.old && touch hello-world.log`), ensure that logs continue to send after rotation. 
+- Rotate the log file ({rotate}), ensure that logs continue to send after rotation. 
 """
         )
 

--- a/tools/agent_QA/test_cases/xplat/file_tests.py
+++ b/tools/agent_QA/test_cases/xplat/file_tests.py
@@ -146,8 +146,8 @@ logs:
 - `docker run -it bfloerschddog/flog -l > 3.log`
 
 # Test
-- the tag `filename` tag is set on the log metadata
-- the tag directory name tag is set on the log metadata
+- the tag `filename` is set on the log metadata
+- the tag `dirname` is set on the log metadata
 - Change the `logs_config.open_files_limit` to 1 in `datadog.yaml`, restart the agent and make sure the agent is only tailing 1 file
 """
         )


### PR DESCRIPTION
### What does this PR do?

Minor fixups that should help the cards to be platform-specific.


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
