### PR TITLE
[WA-31] PDH Checks - Retrying Failed Instance Initializations

### DIFF
--- a/pkg/collector/corechecks/system/cpu/cpu_windows.go
+++ b/pkg/collector/corechecks/system/cpu/cpu_windows.go
@@ -22,7 +22,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil/pdhutil"
 )
 
@@ -66,7 +65,7 @@ func (c *Check) Run() error {
 		val, err = c.interruptsCounter.GetValue()
 	}
 	if err != nil {
-		log.Errorf("cpu.Check: could not establish interrupt time counter %v", err)
+		c.Warnf("cpu.Check: could not establish interrupt time counter: %v", err)
 	} else {
 		sender.Gauge("system.cpu.interrupt", float64(val), "", nil)
 	}
@@ -79,7 +78,7 @@ func (c *Check) Run() error {
 		val, err = c.idleCounter.GetValue()
 	}
 	if err != nil {
-		log.Errorf("cpu.Check: could not establish idle time counter %v", err)
+		c.Warnf("cpu.Check: could not establish idle time counter: %v", err)
 	} else {
 		sender.Gauge("system.cpu.idle", float64(val), "", nil)
 	}
@@ -92,7 +91,7 @@ func (c *Check) Run() error {
 		val, err = c.userCounter.GetValue()
 	}
 	if err != nil {
-		log.Errorf("cpu.Check: could not establish user time counter %v", err)
+		c.Warnf("cpu.Check: could not establish user time counter: %v", err)
 	} else {
 		sender.Gauge("system.cpu.user", float64(val), "", nil)
 	}
@@ -105,7 +104,7 @@ func (c *Check) Run() error {
 		val, err = c.privilegedCounter.GetValue()
 	}
 	if err != nil {
-		log.Errorf("cpu.Check: could not establish system time counter %v", err)
+		c.Warnf("cpu.Check: could not establish system time counter: %v", err)
 	} else {
 		sender.Gauge("system.cpu.system", float64(val), "", nil)
 	}

--- a/pkg/collector/corechecks/system/cpu/cpu_windows.go
+++ b/pkg/collector/corechecks/system/cpu/cpu_windows.go
@@ -41,10 +41,10 @@ var cpuInfo = cpu.GetCpuInfo
 type Check struct {
 	core.CheckBase
 	nbCPU             float64
-	interruptsCounter pdhutil.PdhSingleInstanceCounterSet
-	idleCounter       pdhutil.PdhSingleInstanceCounterSet
-	userCounter       pdhutil.PdhSingleInstanceCounterSet
-	privilegedCounter pdhutil.PdhSingleInstanceCounterSet
+	interruptsCounter *pdhutil.PdhSingleInstanceCounterSet
+	idleCounter       *pdhutil.PdhSingleInstanceCounterSet
+	userCounter       *pdhutil.PdhSingleInstanceCounterSet
+	privilegedCounter *pdhutil.PdhSingleInstanceCounterSet
 }
 
 // Run executes the check
@@ -56,30 +56,56 @@ func (c *Check) Run() error {
 
 	sender.Gauge("system.cpu.num_cores", c.nbCPU, "", nil)
 
-	val, err := c.interruptsCounter.GetValue()
+	var val float64
+
+	// counter ("Processor Information", "% Interrupt Time")
+	if c.interruptsCounter == nil {
+		c.interruptsCounter, err = getProcessorPDHCounter("% Interrupt Time", "_Total")
+	}
+	if c.interruptsCounter != nil {
+		val, err = c.interruptsCounter.GetValue()
+	}
 	if err != nil {
-		log.Warnf("Error getting handle value %v", err)
+		log.Errorf("cpu.Check: could not establish interrupt time counter %v", err)
 	} else {
 		sender.Gauge("system.cpu.interrupt", float64(val), "", nil)
 	}
 
-	val, err = c.idleCounter.GetValue()
+	// counter ("Processor Information", "% Idle Time")
+	if c.idleCounter == nil {
+		c.idleCounter, err = getProcessorPDHCounter("% Idle Time", "_Total")
+	}
+	if c.idleCounter != nil {
+		val, err = c.idleCounter.GetValue()
+	}
 	if err != nil {
-		log.Warnf("Error getting handle value %v", err)
+		log.Errorf("cpu.Check: could not establish idle time counter %v", err)
 	} else {
 		sender.Gauge("system.cpu.idle", float64(val), "", nil)
 	}
 
-	val, err = c.userCounter.GetValue()
+	// counter ("Processor Information", "% User Time")
+	if c.userCounter == nil {
+		c.userCounter, err = getProcessorPDHCounter("% User Time", "_Total")
+	}
+	if c.userCounter != nil{
+		val, err = c.userCounter.GetValue()
+	}
 	if err != nil {
-		log.Warnf("Error getting handle value %v", err)
+		log.Errorf("cpu.Check: could not establish user time counter %v", err)
 	} else {
 		sender.Gauge("system.cpu.user", float64(val), "", nil)
 	}
 
-	val, err = c.privilegedCounter.GetValue()
+	// counter ("Processor Information", "% Privileged Time")
+	if c.privilegedCounter == nil {
+		c.privilegedCounter, err = getProcessorPDHCounter("% Privileged Time", "_Total")
+	}
+	if c.privilegedCounter != nil {
+		val, err = c.privilegedCounter.GetValue()
+	}
 	if err != nil {
-		log.Warnf("Error getting handle value %v", err)
+		log.Errorf("cpu.Check: could not establish system time counter %v", err)
 	} else {
 		sender.Gauge("system.cpu.system", float64(val), "", nil)
 	}
@@ -93,14 +119,16 @@ func (c *Check) Run() error {
 }
 
 // Configure the PDH counter according to the running environment.
-// On machines with more than 1 NUMA node, it uses "Process Information",
+// On machines with more than 1 NUMA node, it uses "Processor Information",
 // otherwise it uses "Processor" (e.g. in containers).
-func getProcessorPDHCounter(counterName, instance string) (pdhutil.PdhSingleInstanceCounterSet, error) {
+// Note we use "processor information" instead of "processor" because on multi-processor machines the later only gives
+// you visibility about other applications running on the same processor as you
+func getProcessorPDHCounter(counterName, instance string) (*pdhutil.PdhSingleInstanceCounterSet, error) {
 	counter, err := pdhutil.GetUnlocalizedCounter("Processor Information", counterName, instance)
 	if err != nil {
 		counter, err = pdhutil.GetUnlocalizedCounter("Processor", counterName, instance)
 	}
-	return counter, err
+	return &counter, err
 }
 
 // Configure the CPU check doesn't need configuration
@@ -117,24 +145,6 @@ func (c *Check) Configure(data integration.Data, initConfig integration.Data, so
 	cpucount, _ := strconv.ParseFloat(info["cpu_logical_processors"], 64)
 	c.nbCPU = cpucount
 
-	// Note we use "processor information" instead of "processor" because on multi-processor machines the later only gives
-	// you visibility about other applications running on the same processor as you
-	c.interruptsCounter, err = getProcessorPDHCounter("% Interrupt Time", "_Total")
-	if err != nil {
-		return fmt.Errorf("cpu.Check could not establish interrupt time counter %v", err)
-	}
-	c.idleCounter, err = getProcessorPDHCounter("% Idle Time", "_Total")
-	if err != nil {
-		return fmt.Errorf("cpu.Check could not establish idle time counter %v", err)
-	}
-	c.userCounter, err = getProcessorPDHCounter("% User Time", "_Total")
-	if err != nil {
-		return fmt.Errorf("cpu.Check could not establish user time counter %v", err)
-	}
-	c.privilegedCounter, err = getProcessorPDHCounter("% Privileged Time", "_Total")
-	if err != nil {
-		return fmt.Errorf("cpu.Check could not establish system time counter %v", err)
-	}
 	return nil
 }
 

--- a/pkg/collector/corechecks/system/disk/iostats_pdh_windows.go
+++ b/pkg/collector/corechecks/system/disk/iostats_pdh_windows.go
@@ -106,7 +106,7 @@ func (c *IOCheck) Run() error {
 		if c.counters[name] == nil {
 			c.counters[name], err = pdhutil.GetMultiInstanceCounter("LogicalDisk", name, nil, isDrive)
 			if err != nil {
-				log.Errorf("io.Check: could not establish LogicalDisk '%v' counter %v", name, err)
+				c.Warnf("io.Check: could not establish LogicalDisk '%v' counter: %v", name, err)
 			}
 		}
 	}
@@ -119,7 +119,7 @@ func (c *IOCheck) Run() error {
 		// get counter values
 		vals, err := cset.GetAllValues()
 		if err != nil {
-			log.Errorf("Error getting values %v\n", err)
+			c.Warnf("io.Check: Error getting values for %v: %v", cname, err)
 			continue
 		}
 		for inst, val := range vals {

--- a/pkg/collector/corechecks/system/disk/iostats_pdh_windows.go
+++ b/pkg/collector/corechecks/system/disk/iostats_pdh_windows.go
@@ -9,7 +9,6 @@ package disk
 
 import (
 	"bytes"
-	"fmt"
 	"regexp"
 	"strings"
 	"unsafe"
@@ -89,13 +88,10 @@ func (c *IOCheck) Configure(data integration.Data, initConfig integration.Data, 
 	}
 
 	c.counters = make(map[string]*pdhutil.PdhMultiInstanceCounterSet)
-
 	for name := range c.counternames {
-		c.counters[name], err = pdhutil.GetMultiInstanceCounter("LogicalDisk", name, nil, isDrive)
-		if err != nil {
-			return err
-		}
+		c.counters[name] = nil
 	}
+
 	return nil
 }
 
@@ -105,12 +101,26 @@ func (c *IOCheck) Run() error {
 	if err != nil {
 		return err
 	}
+	// Try to initialize any nil counters
+	for name := range c.counternames {
+		if c.counters[name] == nil {
+			c.counters[name], err = pdhutil.GetMultiInstanceCounter("LogicalDisk", name, nil, isDrive)
+			if err != nil {
+				log.Errorf("io.Check: could not establish LogicalDisk '%v' counter %v", name, err)
+			}
+		}
+	}
 	var tagbuff bytes.Buffer
 	for cname, cset := range c.counters {
+		if cset == nil {
+			// counter is not yet initialized
+			continue
+		}
+		// get counter values
 		vals, err := cset.GetAllValues()
 		if err != nil {
-			fmt.Printf("Error getting values %v\n", err)
-			return err
+			log.Errorf("Error getting values %v\n", err)
+			continue
 		}
 		for inst, val := range vals {
 			if c.blacklist != nil && c.blacklist.MatchString(inst) {

--- a/pkg/collector/corechecks/system/filehandles/file_handles_windows.go
+++ b/pkg/collector/corechecks/system/filehandles/file_handles_windows.go
@@ -40,7 +40,7 @@ func (c *fhCheck) Run() error {
 		vals, err = c.counter.GetAllValues()
 	}
 	if err != nil {
-		log.Errorf("file_handle.Check: Error getting process handle count %v", err)
+		c.Warnf("file_handle.Check: Error getting process handle count: %v", err)
 	} else {
 		val := vals["_Total"]
 		log.Debugf("Submitting system.fs.file_handles_in_use %v", val)

--- a/pkg/collector/corechecks/system/filehandles/file_handles_windows.go
+++ b/pkg/collector/corechecks/system/filehandles/file_handles_windows.go
@@ -29,16 +29,25 @@ func (c *fhCheck) Run() error {
 	if err != nil {
 		return err
 	}
-	vals, err := c.counter.GetAllValues()
-	if err != nil {
-		log.Warnf("Error getting handle value %v", err)
-		return err
-	}
-	val := vals["_Total"]
-	log.Debugf("Submitting system.fs.file_handles_in_use %v", val)
-	sender.Gauge("system.fs.file_handles.in_use", float64(val), "", nil)
-	sender.Commit()
 
+	var vals map[string]float64
+
+	// counter ("Process", "Handle count")
+	if c.counter == nil {
+		c.counter, err = pdhutil.GetMultiInstanceCounter("Process", "Handle Count", &[]string{"_Total"}, nil)
+	}
+	if c.counter != nil {
+		vals, err = c.counter.GetAllValues()
+	}
+	if err != nil {
+		log.Errorf("file_handle.Check: Error getting process handle count %v", err)
+	} else {
+		val := vals["_Total"]
+		log.Debugf("Submitting system.fs.file_handles_in_use %v", val)
+		sender.Gauge("system.fs.file_handles.in_use", float64(val), "", nil)
+	}
+
+	sender.Commit()
 	return nil
 }
 
@@ -48,7 +57,6 @@ func (c *fhCheck) Configure(data integration.Data, initConfig integration.Data, 
 		return err
 	}
 
-	c.counter, err = pdhutil.GetMultiInstanceCounter("Process", "Handle Count", &[]string{"_Total"}, nil)
 	return err
 }
 

--- a/pkg/collector/corechecks/system/memory/memory_windows.go
+++ b/pkg/collector/corechecks/system/memory/memory_windows.go
@@ -13,7 +13,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil/pdhutil"
 )
@@ -64,7 +63,7 @@ func (c *Check) Run() error {
 	if err == nil {
 		sender.Gauge("system.mem.cached", float64(val)/mbSize, "", nil)
 	} else {
-		log.Errorf("memory.Check: Could not retrieve value for system.mem.cached %v", err)
+		c.Warnf("memory.Check: Could not retrieve value for system.mem.cached: %v", err)
 	}
 
 	// counter ("Memory", "Committed Bytes")
@@ -77,7 +76,7 @@ func (c *Check) Run() error {
 	if err == nil {
 		sender.Gauge("system.mem.committed", float64(val)/mbSize, "", nil)
 	} else {
-		log.Errorf("memory.Check: Could not retrieve value for system.mem.committed %v", err)
+		c.Warnf("memory.Check: Could not retrieve value for system.mem.committed: %v", err)
 	}
 
 	// counter ("Memory", "Pool Paged Bytes")
@@ -90,7 +89,7 @@ func (c *Check) Run() error {
 	if err == nil {
 		sender.Gauge("system.mem.paged", float64(val)/mbSize, "", nil)
 	} else {
-		log.Errorf("memory.Check: Could not retrieve value for system.mem.paged %v", err)
+		c.Warnf("memory.Check: Could not retrieve value for system.mem.paged: %v", err)
 	}
 
 	// counter ("Memory", "Pool Nonpaged Bytes")
@@ -103,7 +102,7 @@ func (c *Check) Run() error {
 	if err == nil {
 		sender.Gauge("system.mem.nonpaged", float64(val)/mbSize, "", nil)
 	} else {
-		log.Errorf("memory.Check: Could not retrieve value for system.mem.nonpaged %v", err)
+		c.Warnf("memory.Check: Could not retrieve value for system.mem.nonpaged: %v", err)
 	}
 
 	v, errVirt := virtualMemory()
@@ -114,7 +113,7 @@ func (c *Check) Run() error {
 		sender.Gauge("system.mem.used", float64(v.Total-v.Available)/mbSize, "", nil)
 		sender.Gauge("system.mem.pct_usable", float64(100-v.UsedPercent)/100, "", nil)
 	} else {
-		log.Errorf("memory.Check: could not retrieve virtual memory stats: %s", errVirt)
+		c.Warnf("memory.Check: could not retrieve virtual memory stats: %s", errVirt)
 	}
 
 	s, errSwap := swapMemory()
@@ -124,7 +123,7 @@ func (c *Check) Run() error {
 		sender.Gauge("system.swap.used", float64(s.Used)/mbSize, "", nil)
 		sender.Gauge("system.swap.pct_free", float64(100-s.UsedPercent)/100, "", nil)
 	} else {
-		log.Errorf("memory.Check: could not retrieve swap memory stats: %s", errSwap)
+		c.Warnf("memory.Check: could not retrieve swap memory stats: %s", errSwap)
 	}
 
 	p, errPage := pageMemory()
@@ -134,7 +133,7 @@ func (c *Check) Run() error {
 		sender.Gauge("system.mem.pagefile.free", float64(p.Available)/mbSize, "", nil)
 		sender.Gauge("system.mem.pagefile.used", float64(p.Used)/mbSize, "", nil)
 	} else {
-		log.Errorf("memory.Check: could not retrieve swap memory stats: %s", errSwap)
+		c.Warnf("memory.Check: could not retrieve swap memory stats: %s", errSwap)
 	}
 
 	sender.Commit()

--- a/pkg/collector/corechecks/system/memory/memory_windows.go
+++ b/pkg/collector/corechecks/system/memory/memory_windows.go
@@ -8,7 +8,6 @@
 package memory
 
 import (
-	"fmt"
 	"runtime"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
@@ -42,18 +41,9 @@ func (c *Check) Configure(data integration.Data, initConfig integration.Data, so
 		return err
 	}
 
-	c.cacheBytes, err = pdhutil.GetSingleInstanceCounter("Memory", "Cache Bytes")
-	if err == nil {
-		c.committedBytes, err = pdhutil.GetSingleInstanceCounter("Memory", "Committed Bytes")
-		if err == nil {
-			c.pagedBytes, err = pdhutil.GetSingleInstanceCounter("Memory", "Pool Paged Bytes")
-			if err == nil {
-				c.nonpagedBytes, err = pdhutil.GetSingleInstanceCounter("Memory", "Pool Nonpaged Bytes")
-			}
-		}
-	}
 	return err
 }
+
 
 // Run executes the check
 func (c *Check) Run() error {
@@ -63,41 +53,59 @@ func (c *Check) Run() error {
 	}
 
 	var val float64
+
+	// counter ("Memory", "Cache Bytes")
+	if c.cacheBytes == nil {
+		c.cacheBytes, err = pdhutil.GetSingleInstanceCounter("Memory", "Cache Bytes")
+	}
 	if c.cacheBytes != nil {
 		val, err = c.cacheBytes.GetValue()
-		if err == nil {
-			sender.Gauge("system.mem.cached", float64(val)/mbSize, "", nil)
-		} else {
-			log.Warnf("Could not retrieve value for system.mem.cached %v", err)
-		}
+	}
+	if err == nil {
+		sender.Gauge("system.mem.cached", float64(val)/mbSize, "", nil)
+	} else {
+		log.Errorf("memory.Check: Could not retrieve value for system.mem.cached %v", err)
 	}
 
+	// counter ("Memory", "Committed Bytes")
+	if c.committedBytes == nil {
+		c.committedBytes, err = pdhutil.GetSingleInstanceCounter("Memory", "Committed Bytes")
+	}
 	if c.committedBytes != nil {
 		val, err = c.committedBytes.GetValue()
-		if err == nil {
-			sender.Gauge("system.mem.committed", float64(val)/mbSize, "", nil)
-		} else {
-			log.Warnf("Could not retrieve value for system.mem.committed %v", err)
-		}
+	}
+	if err == nil {
+		sender.Gauge("system.mem.committed", float64(val)/mbSize, "", nil)
+	} else {
+		log.Errorf("memory.Check: Could not retrieve value for system.mem.committed %v", err)
 	}
 
+	// counter ("Memory", "Pool Paged Bytes")
+	if c.pagedBytes == nil {
+		c.pagedBytes, err = pdhutil.GetSingleInstanceCounter("Memory", "Pool Paged Bytes")
+	}
 	if c.pagedBytes != nil {
 		val, err = c.pagedBytes.GetValue()
-		if err == nil {
-			sender.Gauge("system.mem.paged", float64(val)/mbSize, "", nil)
-		} else {
-			log.Warnf("Could not retrieve value for system.mem.paged %v", err)
-		}
+	}
+	if err == nil {
+		sender.Gauge("system.mem.paged", float64(val)/mbSize, "", nil)
+	} else {
+		log.Errorf("memory.Check: Could not retrieve value for system.mem.paged %v", err)
 	}
 
+	// counter ("Memory", "Pool Nonpaged Bytes")
+	if c.nonpagedBytes == nil {
+		c.nonpagedBytes, err = pdhutil.GetSingleInstanceCounter("Memory", "Pool Nonpaged Bytes")
+	}
 	if c.nonpagedBytes != nil {
 		val, err = c.nonpagedBytes.GetValue()
-		if err == nil {
-			sender.Gauge("system.mem.nonpaged", float64(val)/mbSize, "", nil)
-		} else {
-			log.Warnf("Could not retrieve value for system.mem.nonpaged %v", err)
-		}
 	}
+	if err == nil {
+		sender.Gauge("system.mem.nonpaged", float64(val)/mbSize, "", nil)
+	} else {
+		log.Errorf("memory.Check: Could not retrieve value for system.mem.nonpaged %v", err)
+	}
+
 	v, errVirt := virtualMemory()
 	if errVirt == nil {
 		sender.Gauge("system.mem.total", float64(v.Total)/mbSize, "", nil)
@@ -127,10 +135,6 @@ func (c *Check) Run() error {
 		sender.Gauge("system.mem.pagefile.used", float64(p.Used)/mbSize, "", nil)
 	} else {
 		log.Errorf("memory.Check: could not retrieve swap memory stats: %s", errSwap)
-	}
-
-	if errVirt != nil && errSwap != nil {
-		return fmt.Errorf("failed to gather any memory information")
 	}
 
 	sender.Commit()

--- a/pkg/collector/corechecks/system/memory/memory_windows_test.go
+++ b/pkg/collector/corechecks/system/memory/memory_windows_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil"
+	pdhtest "github.com/DataDog/datadog-agent/pkg/util/winutil/pdhutil"
 )
 
 func VirtualMemory() (*winutil.VirtualMemoryStat, error) {
@@ -44,14 +45,30 @@ func PagefileMemory() (*winutil.PagefileStat, error) {
 	}, nil
 }
 
+func addDefaultQueryReturnValues() {
+	pdhtest.SetQueryReturnValue("\\\\.\\Memory\\Cache Bytes", 3456789000.0)
+	pdhtest.SetQueryReturnValue("\\\\.\\Memory\\Committed Bytes", 2345678000.0)
+	pdhtest.SetQueryReturnValue("\\\\.\\Memory\\Pool Paged Bytes", 323456000.0)
+	pdhtest.SetQueryReturnValue("\\\\.\\Memory\\Pool Nonpaged Bytes", 168900000.0)
+}
+
 func TestMemoryCheckWindows(t *testing.T) {
 	virtualMemory = VirtualMemory
 	swapMemory = SwapMemory
 	pageMemory = PagefileMemory
+
+	pdhtest.SetupTesting("..\\testfiles\\counter_indexes_en-us.txt", "..\\testfiles\\allcounters_en-us.txt")
+	addDefaultQueryReturnValues()
+
 	memCheck := new(Check)
+	memCheck.Configure(nil, nil, "test")
 
 	mock := mocksender.NewMockSender(memCheck.ID())
 
+	mock.On("Gauge", "system.mem.cached", 3456789000.0/mbSize, "", []string(nil)).Return().Times(1)
+	mock.On("Gauge", "system.mem.committed", 2345678000.0/mbSize, "", []string(nil)).Return().Times(1)
+	mock.On("Gauge", "system.mem.paged", 323456000.0/mbSize, "", []string(nil)).Return().Times(1)
+	mock.On("Gauge", "system.mem.nonpaged", 168900000.0/mbSize, "", []string(nil)).Return().Times(1)
 	mock.On("Gauge", "system.mem.free", 234567890.0/mbSize, "", []string(nil)).Return().Times(1)
 	mock.On("Gauge", "system.mem.usable", 234567890.0/mbSize, "", []string(nil)).Return().Times(1)
 	mock.On("Gauge", "system.mem.used", 12111100000.0/mbSize, "", []string(nil)).Return().Times(1)
@@ -73,6 +90,6 @@ func TestMemoryCheckWindows(t *testing.T) {
 	require.Nil(t, err)
 
 	mock.AssertExpectations(t)
-	mock.AssertNumberOfCalls(t, "Gauge", 13)
+	mock.AssertNumberOfCalls(t, "Gauge", 17)
 	mock.AssertNumberOfCalls(t, "Commit", 1)
 }

--- a/pkg/collector/corechecks/system/winproc/winproc_windows.go
+++ b/pkg/collector/corechecks/system/winproc/winproc_windows.go
@@ -11,7 +11,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil/pdhutil"
 )
 
@@ -42,7 +41,7 @@ func (c *processChk) Run() error {
 	if err == nil {
 		sender.Gauge("system.proc.count", val, "", nil)
 	} else {
-		log.Errorf("winproc.Check: Error getting number of processes %v", err)
+		c.Warnf("winproc.Check: Error getting number of processes: %v", err)
 	}
 
 	// counter ("System", "Processor Queue Length")
@@ -55,7 +54,7 @@ func (c *processChk) Run() error {
 	if err == nil {
 		sender.Gauge("system.proc.queue_length", val, "", nil)
 	} else {
-		log.Errorf("winproc.Check: Error getting processor queue length %v", err)
+		c.Warnf("winproc.Check: Error getting processor queue length: %v", err)
 	}
 
 	sender.Commit()

--- a/pkg/util/winutil/pdhutil/pdhcounter.go
+++ b/pkg/util/winutil/pdhutil/pdhcounter.go
@@ -59,6 +59,9 @@ type PdhMultiInstanceCounterSet struct {
 // Initialize initializes a counter set object
 func (p *PdhCounterSet) Initialize(className string) error {
 
+	// refresh PDH object cache (refresh will only occur periodically)
+	CachedRefreshPdhObjectCache()
+
 	// the counter index list may be > 1, but for class name, only take the first
 	// one.  If not present at all, try the english counter name
 	ndxlist, err := getCounterIndexList(className)
@@ -90,6 +93,9 @@ func (p *PdhCounterSet) Initialize(className string) error {
 
 // GetUnlocalizedCounter wraps the PdhAddEnglishCounter call that takes unlocalized counter names (as opposed to the other functions which use PdhAddCounter)
 func GetUnlocalizedCounter(className, counterName, instance string) (PdhSingleInstanceCounterSet, error) {
+	// refresh PDH object cache (refresh will only occur periodically)
+	CachedRefreshPdhObjectCache()
+
 	var p PdhSingleInstanceCounterSet
 	winerror := pfnPdhOpenQuery(uintptr(0), uintptr(0), &p.query)
 	if ERROR_SUCCESS != winerror {
@@ -97,7 +103,7 @@ func GetUnlocalizedCounter(className, counterName, instance string) (PdhSingleIn
 	}
 	path, err := pfnPdhMakeCounterPath("", className, instance, counterName)
 	if err != nil {
-		return p, fmt.Errorf("Failed tomake counter path %s: %v", counterName, err)
+		return p, fmt.Errorf("Failed to make counter path %s: %v", counterName, err)
 	}
 	winerror = pfnPdhAddEnglishCounter(p.query, path, uintptr(0), &p.singleCounter)
 	if ERROR_SUCCESS != winerror {
@@ -118,13 +124,16 @@ func GetSingleInstanceCounter(className, counterName string) (*PdhSingleInstance
 		return nil, err
 	}
 	// check to make sure this is really a single instance counter
-	allcounters, instances, _ := pfnPdhEnumObjectItems(p.className)
+	allcounters, instances, err := pfnPdhEnumObjectItems(p.className)
+	if err != nil {
+		return nil, err
+	}
 	if len(instances) > 0 {
 		return nil, fmt.Errorf("Requested counter is not single-instance: %s", p.className)
 	}
 	path, err := p.MakeCounterPath("", counterName, "", allcounters)
 	if err != nil {
-		log.Warnf("Failed pdhEnumObjectItems %v", err)
+		log.Warnf("Failed to make counter path %v", err)
 		return nil, err
 	}
 	winerror := pfnPdhAddCounter(p.query, path, uintptr(0), &p.singleCounter)
@@ -148,8 +157,11 @@ func GetMultiInstanceCounter(className, counterName string, requestedInstances *
 	p.verifyfn = verifyfn
 	p.requestedCounterName = counterName
 
-	// check to make sure this is really a single instance counter
-	_, instances, _ := pfnPdhEnumObjectItems(p.className)
+	// check to make sure this is really a multi instance counter
+	_, instances, err := pfnPdhEnumObjectItems(p.className)
+	if err != nil {
+		return nil, err
+	}
 	if len(instances) <= 0 {
 		return nil, fmt.Errorf("Requested counter is a single-instance: %s", p.className)
 	}
@@ -207,7 +219,7 @@ func (p *PdhMultiInstanceCounterSet) MakeInstanceList() error {
 		}
 		path, err := p.MakeCounterPath("", p.requestedCounterName, inst, allcounters)
 		if err != nil {
-			log.Debugf("Failed tomake counter path %s %s", p.counterName, inst)
+			log.Debugf("Failed to make counter path %s %s", p.counterName, inst)
 			continue
 		}
 		var hc PDH_HCOUNTER

--- a/pkg/util/winutil/pdhutil/pdhcounter.go
+++ b/pkg/util/winutil/pdhutil/pdhcounter.go
@@ -93,6 +93,9 @@ func (p *PdhCounterSet) Initialize(className string) error {
 
 // GetUnlocalizedCounter wraps the PdhAddEnglishCounter call that takes unlocalized counter names (as opposed to the other functions which use PdhAddCounter)
 func GetUnlocalizedCounter(className, counterName, instance string) (PdhSingleInstanceCounterSet, error) {
+	// TODO (WA-52): Restructure GetUnlocalizedCounter / GetSingleInstanceCounter / GetMultiInstanceCounter
+	//               to make code more clear and deduplicate here and Initialize()
+
 	// refresh PDH object cache (refresh will only occur periodically)
 	CachedRefreshPdhObjectCache()
 

--- a/pkg/util/winutil/pdhutil/pdhcounter.go
+++ b/pkg/util/winutil/pdhutil/pdhcounter.go
@@ -60,7 +60,7 @@ type PdhMultiInstanceCounterSet struct {
 func (p *PdhCounterSet) Initialize(className string) error {
 
 	// refresh PDH object cache (refresh will only occur periodically)
-	CachedRefreshPdhObjectCache()
+	tryRefreshPdhObjectCache()
 
 	// the counter index list may be > 1, but for class name, only take the first
 	// one.  If not present at all, try the english counter name
@@ -97,7 +97,7 @@ func GetUnlocalizedCounter(className, counterName, instance string) (PdhSingleIn
 	//               to make code more clear and deduplicate here and Initialize()
 
 	// refresh PDH object cache (refresh will only occur periodically)
-	CachedRefreshPdhObjectCache()
+	tryRefreshPdhObjectCache()
 
 	var p PdhSingleInstanceCounterSet
 	winerror := pfnPdhOpenQuery(uintptr(0), uintptr(0), &p.query)

--- a/pkg/util/winutil/pdhutil/pdhhelper.go
+++ b/pkg/util/winutil/pdhutil/pdhhelper.go
@@ -140,12 +140,12 @@ func refreshPdhObjectCache(forceRefresh bool) (didrefresh bool, err error) {
 	lastPdhRefreshTime.Store(time.Now())
 	return true, nil
 }
-func ForceRefreshPdhObjectCache() (didrefresh bool, err error) {
+func forceRefreshPdhObjectCache() (didrefresh bool, err error) {
 	// Refresh the Windows internal PDH Object cache
 	// see refreshPdhObjectCache() for details
 	return refreshPdhObjectCache(true)
 }
-func CachedRefreshPdhObjectCache() (didrefresh bool, err error) {
+func tryRefreshPdhObjectCache() (didrefresh bool, err error) {
 	// Attempt to refresh the Windows internal PDH Object cache
 	// may be skipped if cache was refreshed recently.
 	// see refreshPdhObjectCache() for details

--- a/releasenotes/notes/retry-failed-performance-counter-init-ed7a676e7a98eee9.yaml
+++ b/releasenotes/notes/retry-failed-performance-counter-init-ed7a676e7a98eee9.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fix golang performance counter initialization errors when counters
+    are not available during agent/check init time.
+    Checks now retry the counter initilization on each interval.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->
On each check interval try to initialize PDH counters if they are not already initialized.

For the agent to find new counters the PDH object cache needs to be refreshed. The refresh is cached as Windows PDH internally has a mutex on PDH calls, and the refresh is sometimes expensive (order of seconds).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Support issues where core checks failed to load because the counters were not available when the agent started.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

[AGENT 7716](https://datadoghq.atlassian.net/browse/AGENT-7716) We are currently investigating an issue relating to refreshing the PDH object cache in our python checks.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

1. Install the agent on a Windows OS
2. Use the following powershell to create the registry values that disable the performance counters needed by the `winproc`, `memory`, `file_handle`, and `io` checks.
   ```powershell
   New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\PerfDisk\Performance" -Name "Disable Performance Counters" -PropertyType "DWORD" -Force -Value 1
   New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\PerfOS\Performance" -Name "Disable Performance Counters" -PropertyType "DWORD" -Force -Value 1
   New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\PerfProc\Performance" -Name "Disable Performance Counters" -PropertyType "DWORD" -Force -Value 1
   ```
3. Restart the agent
4. Check the agent log and/or agent status for warnings about failing to collect counters for the `winproc`, `memory`, `file_handle`, and `io` checks
5. Run the following powershell to re-enable the performance counters
   ```powershell
   New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\PerfDisk\Performance" -Name "Disable Performance Counters" -PropertyType "DWORD" -Force -Value 0
   New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\PerfOS\Performance" -Name "Disable Performance Counters" -PropertyType "DWORD" -Force -Value 0
   New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\PerfProc\Performance" -Name "Disable Performance Counters" -PropertyType "DWORD" -Force -Value 0
   ```
6. Watch the log for a new `Successfully refreshed performance counters!` log line
7. Check the agent log and/or agent status to verify that the `winproc`, `memory`, `file_handle`, and `io` checks are now completing successfully without errors/warnings.


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
