### PR TITLE
Adds instructions for attaching delve to stripped running binary

### DIFF
--- a/docs/dev/tools.md
+++ b/docs/dev/tools.md
@@ -55,6 +55,31 @@ $ sudo dlv attach `pgrep -f '/opt/datadog-agent/bin/agent/agent run'`
 (dlv) goroutine <number> # switch to goroutine
 ```
 
+### Using external/split debug symbols
+If you're running a stripped binary of the agent, you can `attach` and point
+delve at the debug symbols.
+
+> As of writing this, no release has been made with [PR
+> 3073](https://github.com/go-delve/delve/pull/3073) which is needed.
+> Any version > 1.9 should have this PR, but build from `master` until then.
+
+Configure delve to search for debug symbols in the path you installed debug
+symbols to.
+
+Eg, on ubuntu/debian, `apt install datadog-agent-dbg` installs to
+`/opt/datadog-agent/.debug`, so modify your [delve config
+file](https://github.com/go-delve/delve/blob/master/Documentation/cli/README.md#configuration-and-command-history)
+to search this directory:
+
+```
+# delve config file is at $HOME/.config/dlv/config.yaml
+debug-info-directories: ["/usr/lib/debug/.build-id", "/opt/datadog-agent/.debug/" ]
+```
+
+One last note is if you use `sudo` to run `dlv attach`, `$HOME` will be set to `/root`.
+You may want to symlink `/root/.config/dlv/config.yaml` to point to your user
+delve config file.
+
 ## gdb
 
 GDB can in some rare cases be useful to troubleshoot the embedded python interpreter.
@@ -127,8 +152,7 @@ Where core dumps end up depends on the pattern set in `/proc/sys/kernel/core_pat
 For previous versions of the Agent and for crashes that happen before initialization (e.g. during Go runtime initialization or during configuration initialization), you need to set the crashing setting manually. To do this follow these steps:
 
 1. Set the user limit for core dump maximum size limit to a high-enough value. For example, you can set it to be arbitrarily big by running `ulimit -c unlimited`.
-2. 
-3. Run any of the Datadog Agents debug packages manually, setting the `GOTRACEBACK` environment variable to `crash`. This will send a `SIGABRT` signal to the Agent process and trigger the creation of a core dump.
+2. Run any of the Datadog Agents debug packages manually, setting the `GOTRACEBACK` environment variable to `crash`. This will send a `SIGABRT` signal to the Agent process and trigger the creation of a core dump.
 
 
 ### Inspecting a core dump


### PR DESCRIPTION
### What does this PR do?
Adds some dev instructions on how to debug the agent with a stripped binary.

### Motivation

### Additional Notes

### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
