### PR TITLE
[pkg/config] Put OTLP config section behind `OTLP` flag

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -3139,7 +3139,7 @@ api_key:
     # stop_timeout: 5.0
 
 {{end -}}
-
+{{- if .OTLP }}
 ###################################
 ## OpenTelemetry Configuration   ##
 ###################################
@@ -3340,3 +3340,4 @@ api_key:
     ## Options are disabled, debug, info, error, warn.
     #
     # loglevel: info
+{{end -}}

--- a/pkg/config/render_config.go
+++ b/pkg/config/render_config.go
@@ -53,6 +53,7 @@ type context struct {
 	SecurityAgent       bool
 	NetworkModule       bool // Sub-module of System Probe
 	PrometheusScrape    bool
+	OTLP                bool
 }
 
 func mkContext(buildType string) context {
@@ -83,6 +84,7 @@ func mkContext(buildType string) context {
 		Compliance:        true,
 		SNMP:              true,
 		PrometheusScrape:  true,
+		OTLP:              true,
 	}
 
 	switch buildType {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Render `otlp_config` section in configuration template only if `context.OTLP` is true. Set `context.OTLP` to true on general builds.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

`otlp_config` section was being rendered in system probe config template

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Install the Agent on Linux, open the `/etc/datadog-agent/system-probe.yaml` file and check that the `otlp_config` section is not present.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
