### PR TITLE
Fix crash in dogstatsd

### DIFF
--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -162,6 +162,7 @@ type Server struct {
 
 	// cachedTlmOriginIds is caching origin -> tlmProcessedOkTags/tlmProcessedErrorTags
 	// to avoid escaping these in the heap in this hot path.
+	cachedTlmLock      sync.Mutex
 	cachedTlmOriginIds map[string]cachedTagsOriginMap
 	cachedOrder        []cachedTagsOriginMap // for cache eviction
 
@@ -618,8 +619,17 @@ func (s *Server) errLog(format string, params ...interface{}) {
 }
 
 // createOriginTagMaps  keeps these in a cache to avoid a lot of heap escape
-// that we can't avoid in this hot path
-func (s *Server) createOriginTagMaps(origin string) cachedTagsOriginMap {
+// that we can't avoid in this hot path.
+//
+// Returned values are thread safe.
+func (s *Server) createOriginTagMaps(origin string) (okCnt telemetry.SimpleCounter, errorCnt telemetry.SimpleCounter) {
+	s.cachedTlmLock.Lock()
+	defer s.cachedTlmLock.Unlock()
+
+	if maps, ok := s.cachedTlmOriginIds[origin]; ok {
+		return maps.okCnt, maps.errCnt
+	}
+
 	okMap := map[string]string{"message_type": "metrics", "state": "ok"}
 	errorMap := map[string]string{"message_type": "metrics", "state": "error"}
 	okMap["origin"] = origin
@@ -645,7 +655,7 @@ func (s *Server) createOriginTagMaps(origin string) cachedTagsOriginMap {
 		tlmProcessed.DeleteWithTags(pop.err)
 	}
 
-	return maps
+	return maps.okCnt, maps.errCnt
 }
 
 // NOTE(remy): for performance purpose, we may need to revisit this method to deal with both a metricSamples slice and a lateMetricSamples
@@ -657,13 +667,7 @@ func (s *Server) parseMetricMessage(metricSamples []metrics.MetricSample, parser
 	okCnt := tlmProcessedOk
 	errorCnt := tlmProcessedError
 	if origin != "" && telemetry {
-		var maps cachedTagsOriginMap // errorMap and okMap for this origin
-		var exists bool
-		if maps, exists = s.cachedTlmOriginIds[origin]; !exists {
-			maps = s.createOriginTagMaps(origin)
-		}
-		okCnt = maps.okCnt
-		errorCnt = maps.errCnt
+		okCnt, errorCnt = s.createOriginTagMaps(origin)
 	}
 
 	sample, err := parser.parseMetricSample(message)

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -161,7 +161,7 @@ type Server struct {
 	disableVerboseLogs bool
 
 	// cachedTlmLock must be held when accessing cachedTlmOriginIds and cachedOrder
-	cachedTlmLock      sync.Mutex
+	cachedTlmLock sync.Mutex
 	// cachedTlmOriginIds stores per-origin metric parse stats
 	// (when dogstatsd debugging is enabled)
 	cachedTlmOriginIds map[string]cachedTagsOriginMap

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -160,9 +160,10 @@ type Server struct {
 	// package (pkg/trace/logutils) for a possible throttler implemetation.
 	disableVerboseLogs bool
 
-	// cachedTlmOriginIds is caching origin -> tlmProcessedOkTags/tlmProcessedErrorTags
-	// to avoid escaping these in the heap in this hot path.
+	// cachedTlmLock must be held when accessing cachedTlmOriginIds and cachedOrder
 	cachedTlmLock      sync.Mutex
+	// cachedTlmOriginIds stores per-origin metric parse stats
+	// (when dogstatsd debugging is enabled)
 	cachedTlmOriginIds map[string]cachedTagsOriginMap
 	cachedOrder        []cachedTagsOriginMap // for cache eviction
 

--- a/pkg/dogstatsd/server_test.go
+++ b/pkg/dogstatsd/server_test.go
@@ -88,6 +88,19 @@ func TestStopServer(t *testing.T) {
 	require.NoError(t, err, "port is not available, it should be")
 }
 
+// This test is proving that no data race occurred on the `cachedTlmOriginIds` map.
+// It should not fail since `cachedTlmOriginIds` and `cachedOrder` should be
+// properly protected from multiple accesses by `cachedTlmLock`.
+// The main purpose of this test is to detect early if a future code change is
+// introducing a data race.
+// Has to be run with the -race option.
+func TestNoRaceOriginTagMaps(t *testing.T) {
+	s := &Server{cachedTlmOriginIds: make(map[string]cachedTagsOriginMap)}
+	for i := 0; i < 100; i++ {
+		go func() { s.createOriginTagMaps("an origin") }()
+	}
+}
+
 func TestUDPReceive(t *testing.T) {
 	port, err := getAvailableUDPPort()
 	require.NoError(t, err)

--- a/releasenotes/notes/dogstatsd-stats-fixed-d44788d9717151b8.yaml
+++ b/releasenotes/notes/dogstatsd-stats-fixed-d44788d9717151b8.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Fixed a crash when ``dogstatsd_metrics_stats_enable`` is true


### PR DESCRIPTION
### What does this PR do?

Fix a crash caused by unsynchronized concurrent map and slice accesses in the dogstatsd origin statistics.

### Motivation

Bugfix.

### Additional Notes

With dogstatsd metric stats enabled, when the dogstatsd server receives traffic for the first time, a structure is created to hold telemetry counters for each origin, which is stored in `cachedTlmOriginIds`. If this happens on multiple goroutines at the same time, the agent crashes with the `concurrent map read and map write` error. This condition is made worse when over 200 containers were observed, and old origins are being removed from the map as well.

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Run the agent with `dogstatsd_metrics_stats_enable: true`.

On docker, start a 5-10 number of containers that start sending metrics at the same time (by timer or another trigger). Agent should not crash.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
