### PR TITLE
Use more granular locking in AutoConfig

### DIFF
--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -45,7 +45,10 @@ type AutoConfig struct {
 	delService         chan listeners.Service
 	store              *store
 	cfgMgr             configManager
-	m                  sync.RWMutex
+
+	// m covers the `configPollers`, `listenerCandidates`, `listeners`, and `listenerRetryStop`, but
+	// not the values they point to.
+	m sync.RWMutex
 
 	// ranOnce is set to 1 once the AutoConfig has been executed
 	ranOnce *atomic.Bool
@@ -147,11 +150,8 @@ func (ac *AutoConfig) checkTagFreshness(ctx context.Context) {
 // AutoConfig is not supposed to be restarted, so this is expected
 // to be called only once at program exit.
 func (ac *AutoConfig) Stop() {
-	ac.m.Lock()
-	defer ac.m.Unlock()
-
-	// stop polled config providers
-	for _, pd := range ac.configPollers {
+	// stop polled config providers without holding ac.m
+	for _, pd := range ac.getConfigPollers() {
 		pd.stop()
 	}
 
@@ -160,6 +160,9 @@ func (ac *AutoConfig) Stop() {
 
 	// stop the meta scheduler
 	ac.scheduler.Stop()
+
+	ac.m.RLock()
+	defer ac.m.RUnlock()
 
 	// stop the listener retry logic if running
 	if ac.listenerRetryStop != nil {
@@ -178,9 +181,6 @@ func (ac *AutoConfig) Stop() {
 // Agent lifetime.
 // If the config provider is polled, the routine is scheduled right away
 func (ac *AutoConfig) AddConfigProvider(provider providers.ConfigProvider, shouldPoll bool, pollInterval time.Duration) {
-	ac.m.Lock()
-	defer ac.m.Unlock()
-
 	if shouldPoll {
 		log.Infof("Registering %s config provider polled every %s", provider.String(), pollInterval.String())
 	} else {
@@ -188,6 +188,9 @@ func (ac *AutoConfig) AddConfigProvider(provider providers.ConfigProvider, shoul
 	}
 
 	cp := newConfigPoller(provider, shouldPoll, pollInterval)
+
+	ac.m.Lock()
+	defer ac.m.Unlock()
 	ac.configPollers = append(ac.configPollers, cp)
 }
 
@@ -195,10 +198,7 @@ func (ac *AutoConfig) AddConfigProvider(provider providers.ConfigProvider, shoul
 // and schedules them. Should always be run once so providers
 // that don't need polling will be queried at least once
 func (ac *AutoConfig) LoadAndRun(ctx context.Context) {
-	ac.m.Lock()
-	defer ac.m.Unlock()
-
-	for _, cp := range ac.configPollers {
+	for _, cp := range ac.getConfigPollers() {
 		cp.start(ctx, ac)
 
 		// TODO: this probably belongs somewhere inside the file config
@@ -353,9 +353,6 @@ func (ac *AutoConfig) retryListenerCandidates() {
 // unscheduled can be replayed with the replayConfigs flag.  This replay occurs
 // immediately, before the AddScheduler call returns.
 func (ac *AutoConfig) AddScheduler(name string, s scheduler.Scheduler, replayConfigs bool) {
-	ac.m.Lock()
-	defer ac.m.Unlock()
-
 	ac.scheduler.Register(name, s, replayConfigs)
 }
 
@@ -464,14 +461,11 @@ func (ac *AutoConfig) processDelService(ctx context.Context, svc listeners.Servi
 // unique error messages.  The resource names do not match other identifiers
 // and are only intended for display in diagnostic tools like `agent status`.
 func (ac *AutoConfig) GetAutodiscoveryErrors() map[string]map[string]providers.ErrorMsgSet {
-	ac.m.Lock()
-	defer ac.m.Unlock()
-
 	errors := map[string]map[string]providers.ErrorMsgSet{}
-	for _, pd := range ac.configPollers {
-		configErrors := pd.provider.GetConfigErrors()
+	for _, cp := range ac.getConfigPollers() {
+		configErrors := cp.provider.GetConfigErrors()
 		if len(configErrors) > 0 {
-			errors[pd.provider.String()] = configErrors
+			errors[cp.provider.String()] = configErrors
 		}
 	}
 	return errors
@@ -494,6 +488,17 @@ func (ac *AutoConfig) applyChanges(changes integration.ConfigChanges) {
 
 		ac.scheduler.Schedule(changes.Schedule)
 	}
+}
+
+// getConfigPollers gets a slice of config pollers that can be used without holding
+// ac.m.
+func (ac *AutoConfig) getConfigPollers() []*configPoller {
+	ac.m.RLock()
+	defer ac.m.RUnlock()
+
+	// this value is only ever appended to, so the sliced elements will not change and
+	// no race can occur.
+	return ac.configPollers
 }
 
 func configType(c integration.Config) string {


### PR DESCRIPTION
* Be explicit about fields covered by mutex
* use RLock where fields are only read
* reduce lock durations

In particular, this avoids holding the lock for a long time in
LoadAndRun, which can cause `GetAutodiscoveryErrors` to hang.


### Motivation

Fix an unnecessary dependency where GetAutodiscoveryErrors hangs forever waiting for LoadAndRun to finish.

### Additional Notes

I think this is the right fix, but maybe it makes sense to land this on `main` and something simpler for the release -- feel free to submit such a simpler PR.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

From AML-406:

Running the agent in a single-node k8s cluster (and possibly in simple ‘docker’ as well) with the following values.yaml will cause any calls to `agent status` to hang and never return.

values.yaml:
```
datadog:
  apiKey: ******
  logs:
    enabled: false
    containerCollectAll: false
  env:
    - name: DD_LOGS_CONFIG_CCA_IN_AD
      value: true

agents:
  image:
    pullPolicy: Always
    tag: 7.39.0-rc.1
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
