### PR TITLE
Print status output directly to stdout without 'logger' prefixes

### DIFF
--- a/cmd/agent/app/status.go
+++ b/cmd/agent/app/status.go
@@ -19,7 +19,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/status"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
 
 	"github.com/fatih/color"
@@ -31,6 +30,14 @@ var (
 	prettyPrintJSON bool
 	statusFilePath  string
 )
+
+func scrubMessage(message string) string {
+	msgScrubbed, err := scrubber.ScrubBytes([]byte(message))
+	if err == nil {
+		return string(msgScrubbed)
+	}
+	return "[REDACTED] - failure to clean the message"
+}
 
 func redactError(unscrubbedError error) error {
 	if unscrubbedError == nil {
@@ -77,14 +84,11 @@ var statusCmd = &cobra.Command{
 			return fmt.Errorf("unable to set up global agent configuration: %v", err)
 		}
 
-		// log level should always be info as that's the level at which we log the
-		// status output.
-		err = config.SetupLogger(loggerName, "info", "", "", false, true, false)
+		err = config.SetupLogger(loggerName, config.GetEnvDefault("DD_LOG_LEVEL", "off"), "", "", false, true, false)
 		if err != nil {
 			fmt.Printf("Cannot setup logger, exiting: %v\n", err)
 			return err
 		}
-		defer log.Flush()
 
 		_ = common.SetupSystemProbeConfig(sysProbeConfFilePath)
 
@@ -109,13 +113,6 @@ var componentCmd = &cobra.Command{
 			return fmt.Errorf("a component name must be specified")
 		}
 
-		err = config.SetupLogger(loggerName, config.GetEnvDefault("DD_LOG_LEVEL", "info"), "", "", false, true, false)
-		if err != nil {
-			fmt.Printf("Cannot setup logger, exiting: %v\n", err)
-			return err
-		}
-		defer log.Flush()
-
 		return redactError(componentStatus(args[0]))
 	},
 }
@@ -124,7 +121,7 @@ func requestStatus() error {
 	var s string
 
 	if !prettyPrintJSON && !jsonStatus {
-		log.Info("Getting the status from the agent.\n\n")
+		fmt.Printf("Getting the status from the agent.\n\n")
 	}
 	ipcAddress, err := config.GetIPCAddress()
 	if err != nil {
@@ -159,10 +156,12 @@ func requestStatus() error {
 		s = formattedStatus
 	}
 
+	s = scrubMessage(s)
+
 	if statusFilePath != "" {
 		ioutil.WriteFile(statusFilePath, []byte(s), 0644) //nolint:errcheck
 	} else {
-		log.Info(s)
+		fmt.Println(s)
 	}
 
 	return nil
@@ -214,10 +213,12 @@ func componentStatus(component string) error {
 		s = string(r)
 	}
 
+	s = scrubMessage(s)
+
 	if statusFilePath != "" {
 		ioutil.WriteFile(statusFilePath, []byte(s), 0644) //nolint:errcheck
 	} else {
-		log.Info(s)
+		fmt.Println(s)
 	}
 
 	return nil
@@ -242,7 +243,7 @@ func makeRequest(url string) ([]byte, error) {
 			e = fmt.Errorf(err)
 		}
 
-		log.Warnf("Could not reach agent: %v \nMake sure the agent is running before requesting the status and contact support if you continue having issues. \n", e)
+		fmt.Printf("Could not reach agent: %v \nMake sure the agent is running before requesting the status and contact support if you continue having issues. \n", e)
 		return nil, e
 	}
 

--- a/releasenotes/notes/plain-json-agent-status-5d0a427ae6cc2338.yaml
+++ b/releasenotes/notes/plain-json-agent-status-5d0a427ae6cc2338.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    'agent status' command output is now parseable as json
+    directly from stdout. Before this change there was some
+    logger front-matter making it hard to parse 'status'
+    output directly as JSON.

--- a/releasenotes/notes/plain-json-agent-status-5d0a427ae6cc2338.yaml
+++ b/releasenotes/notes/plain-json-agent-status-5d0a427ae6cc2338.yaml
@@ -10,5 +10,5 @@ enhancements:
   - |
     'agent status' command output is now parseable as JSON
     directly from stdout. Before this change, the
-    logger front-matter making it hard to parse 'status'
+    logger front-matter made it hard to parse 'status'
     output directly as JSON.

--- a/releasenotes/notes/plain-json-agent-status-5d0a427ae6cc2338.yaml
+++ b/releasenotes/notes/plain-json-agent-status-5d0a427ae6cc2338.yaml
@@ -8,7 +8,7 @@
 ---
 enhancements:
   - |
-    'agent status' command output is now parseable as json
+    'agent status' command output is now parseable as JSON
     directly from stdout. Before this change there was some
     logger front-matter making it hard to parse 'status'
     output directly as JSON.

--- a/releasenotes/notes/plain-json-agent-status-5d0a427ae6cc2338.yaml
+++ b/releasenotes/notes/plain-json-agent-status-5d0a427ae6cc2338.yaml
@@ -9,6 +9,6 @@
 enhancements:
   - |
     'agent status' command output is now parseable as JSON
-    directly from stdout. Before this change there was some
+    directly from stdout. Before this change, the
     logger front-matter making it hard to parse 'status'
     output directly as JSON.


### PR DESCRIPTION
### What does this PR do?
This changes the behavior of the `agent status` command to no longer use the `logger` component to do the printing.

Before:
```
./bin/agent/agent -c ~/dev/datadog-config-scenarios/tcp-log-listener/ status -j --pretty-json | head
2022-08-15 13:36:56 EDT | CORE | WARN | (pkg/util/log/log.go:616 in func1) | Deactivating Autoconfig will disable most components. It's recommended to use autoconfig_exclude_features and autoconfig_include_features to activate/deactivate features selectively
2022-08-15 13:36:56 EDT | CORE | INFO | (cmd/system-probe/config/config.go:119 in Merge) | no config exists at /etc/datadog-agent/system-probe.yaml, ignoring...
2022-08-15 13:36:56 EDT | CORE | INFO | (cmd/agent/app/status.go:165 in requestStatus) | {
  "JMXStartupError": {
    "LastError": "",
    "Timestamp": 0
  },
  "JMXStatus": {
    "checks": {
      "failed_checks": null,
```


After:
```
./bin/agent/agent -c ~/dev/datadog-config-scenarios/tcp-log-listener/ status -j | jq '. |{hostnameStats}'
{
  "hostnameStats": {
    "errors": {
      "'hostname' configuration/environment": "hostname is empty",
      "'hostname_file' configuration/environment": "'hostname_file' configuration is not enabled",
      "aws": "not retrieving hostname from AWS:START - datadog.apiKey=***************************13add - END the host is not an ECS instance and other providers already retrieve non-default hostnames",
      "azure": "azure_hostname_style is set to 'os'",
      "container": "the agent is not containerized",
      "fargate": "Agent is not running on Fargate START - datadog.apiKey=***************************13add - END",
      "fqdn": "'hostname_fqdn' configuration is not enabled",
      "gce": "unable to retrieve hostname from GCE: GCE metadata API error: Get \"http://169.254.169.254/computeMetadata/v1/instance/hostname\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)"
    },
    "provider": "os"
  }
}
```

### Motivation
We want to be able to specify `-j` to get json output and pipe directly into something that can process json.

In 7.38 and 7.39-rc, this would fail as the `status` output is printed by the `logger` so it has timestamp and other front-matter.


### Additional Notes
The `status` output was previously printed in this same way, directly to stdout using `fmt.Print`, however in https://github.com/DataDog/datadog-agent/pull/12338 I changed this to use the `logger` component in order to take advantage of the "automatic scrubbing" that the logger has.

This had the side effect of changing the default output, and led to other followup issues such as https://github.com/DataDog/datadog-agent/pull/12338 where now log levels are taken into account.

This approach is simpler and closer to the historical behavior of `agent status` ([before any 'scrubber' changes](https://github.com/DataDog/datadog-agent/blob/c0768f4d17511c372be1d4167689a5a3f50ad631/cmd/agent/app/status.go))

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes
N/A

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
