### PR TITLE
Compile http prebuilt files using clang+llc method.

### DIFF
--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -591,7 +591,7 @@ def build_network_ebpf_link_file(ctx, parallel_build, build_dir, p, debug, netwo
 
 def get_http_prebuilt_build_flags(network_c_dir, kernel_release=None):
     uname_m = check_output("uname -m", shell=True).decode('utf-8').strip()
-    flags = get_ebpf_build_flags(target=["-target", "bpf"], kernel_release=kernel_release)
+    flags = get_ebpf_build_flags(kernel_release=kernel_release)
     flags.append(f"-I{network_c_dir}")
     flags.append(f"-D__{uname_m}__")
     flags.append(f"-isystem /usr/include/{uname_m}-linux-gnu")
@@ -605,12 +605,11 @@ def build_http_ebpf_files(ctx, build_dir, kernel_release=None):
 
     network_flags = get_http_prebuilt_build_flags(network_c_dir, kernel_release=kernel_release)
 
-    build_network_ebpf_compile_file(
-        ctx, False, build_dir, "http", True, network_prebuilt_dir, network_flags, extension=".o"
-    )
-    build_network_ebpf_compile_file(
-        ctx, False, build_dir, "http", False, network_prebuilt_dir, network_flags, extension=".o"
-    )
+    build_network_ebpf_compile_file(ctx, False, build_dir, "http", True, network_prebuilt_dir, network_flags)
+    build_network_ebpf_link_file(ctx, False, build_dir, "http", True, network_flags)
+
+    build_network_ebpf_compile_file(ctx, False, build_dir, "http", False, network_prebuilt_dir, network_flags)
+    build_network_ebpf_link_file(ctx, False, build_dir, "http", False, network_flags)
 
 
 def get_network_build_flags(network_c_dir, kernel_release=None):


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Instead of of using `-target bpf` when compiling the prebuilt http ebpf files, this PR compiles to llvm bytecode with clang, and assembles using llc.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
This issue discussed [here](https://github.com/DataDog/datadog-agent/pull/10418#discussion_r779144902) has begun to resurface. It has been noted when compiling on kernel 4.4 and kernel 5.15.0.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
