### PR TITLE
CWS: cleanup usage of `seclog`

### DIFF
--- a/pkg/security/module/module.go
+++ b/pkg/security/module/module.go
@@ -38,7 +38,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
@@ -105,7 +104,7 @@ func (m *Module) Init() error {
 		defer m.wg.Done()
 
 		if err := m.grpcServer.Serve(ln); err != nil {
-			log.Error(err)
+			seclog.Errorf("error launching the grpc server: %v", err)
 		}
 	}()
 
@@ -165,7 +164,7 @@ func (m *Module) Start() error {
 
 	agentVersion, err := utils.GetAgentSemverVersion()
 	if err != nil {
-		log.Errorf("failed to parse agent version: %v", err)
+		seclog.Errorf("failed to parse agent version: %v", err)
 	}
 
 	m.policyOpts = rules.PolicyLoaderOpts{
@@ -178,7 +177,7 @@ func (m *Module) Start() error {
 
 	// directory policy provider
 	if provider, err := rules.NewPoliciesDirProvider(m.config.PoliciesDir, m.config.WatchPoliciesDir); err != nil {
-		log.Errorf("failed to load policies: %s", err)
+		seclog.Errorf("failed to load policies: %s", err)
 	} else {
 		policyProviders = append(policyProviders, provider)
 	}
@@ -187,14 +186,14 @@ func (m *Module) Start() error {
 	if m.config.RemoteConfigurationEnabled {
 		rcPolicyProvider, err := rconfig.NewRCPolicyProvider("security-agent", agentVersion)
 		if err != nil {
-			log.Errorf("will be unable to load remote policy: %s", err)
+			seclog.Errorf("will be unable to load remote policy: %s", err)
 		} else {
 			policyProviders = append(policyProviders, rcPolicyProvider)
 		}
 	}
 
 	if err := m.LoadPolicies(policyProviders, true); err != nil {
-		log.Errorf("failed to load policies: %s", err)
+		seclog.Errorf("failed to load policies: %s", err)
 	}
 
 	m.wg.Add(1)
@@ -208,7 +207,7 @@ func (m *Module) Start() error {
 
 		for range m.sigupChan {
 			if err := m.ReloadPolicies(); err != nil {
-				log.Errorf("failed to reload policies: %s", err)
+				seclog.Errorf("failed to reload policies: %s", err)
 			}
 		}
 	}()
@@ -219,7 +218,7 @@ func (m *Module) Start() error {
 
 		for range m.policyLoader.NewPolicyReady() {
 			if err := m.ReloadPolicies(); err != nil {
-				log.Errorf("failed to reload policies: %s", err)
+				seclog.Errorf("failed to reload policies: %s", err)
 			}
 		}
 	}()
@@ -233,7 +232,7 @@ func (m *Module) Start() error {
 
 func (m *Module) displayReport(report *sprobe.Report) {
 	content, _ := json.Marshal(report)
-	log.Debugf("Policy report: %s", content)
+	seclog.Debugf("Policy report: %s", content)
 }
 
 func (m *Module) getEventTypeEnabled() map[eval.EventType]bool {
@@ -294,14 +293,14 @@ func getPoliciesVersions(rs *rules.RuleSet) []string {
 
 // ReloadPolicies reloads the policies
 func (m *Module) ReloadPolicies() error {
-	log.Info("reload policies")
+	seclog.Infof("reload policies")
 
 	return m.LoadPolicies(m.policyProviders, true)
 }
 
 // LoadPolicies loads the policies
 func (m *Module) LoadPolicies(policyProviders []rules.PolicyProvider, sendLoadedReport bool) error {
-	log.Info("load policies")
+	seclog.Infof("load policies")
 
 	m.Lock()
 	defer m.Unlock()
@@ -527,13 +526,13 @@ func (m *Module) metricsSender() {
 			}
 
 			if err := m.probe.SendStats(); err != nil {
-				log.Debug(err)
+				seclog.Debugf("failed to send probe stats: %s", err)
 			}
 			if err := m.rateLimiter.SendStats(); err != nil {
-				log.Debug(err)
+				seclog.Debugf("failed to send rate limiter stats: %s", err)
 			}
 			if err := m.apiServer.SendStats(); err != nil {
-				log.Debug(err)
+				seclog.Debugf("failed to send api server stats: %s", err)
 			}
 		case <-heartbeatTicker.C:
 			tags := []string{fmt.Sprintf("version:%s", version.AgentVersion)}
@@ -623,7 +622,7 @@ func NewModule(cfg *sconfig.Config, opts ...Opts) (module.Module, error) {
 
 	selfTester, err := selftests.NewSelfTester()
 	if err != nil {
-		log.Errorf("unable to instantiate self tests: %s", err)
+		seclog.Errorf("unable to instantiate self tests: %s", err)
 	}
 
 	m := &Module{
@@ -657,7 +656,7 @@ func (m *Module) RunSelfTest(sendLoadedReport bool) error {
 	if len(prevProviders) > 0 {
 		defer func() {
 			if err := m.LoadPolicies(prevProviders, false); err != nil {
-				log.Errorf("failed to load policies: %s", err)
+				seclog.Errorf("failed to load policies: %s", err)
 			}
 		}()
 	}
@@ -674,7 +673,7 @@ func (m *Module) RunSelfTest(sendLoadedReport bool) error {
 		return err
 	}
 
-	log.Debugf("self-test results : success : %v, failed : %v", success, fails)
+	seclog.Debugf("self-test results : success : %v, failed : %v", success, fails)
 
 	// send the report
 	if m.config.SelfTestSendReport {
@@ -696,8 +695,8 @@ func logLoadingErrors(msg string, m *multierror.Error) {
 	}
 
 	if errorLevel {
-		log.Errorf(msg, m.Error())
+		seclog.Errorf(msg, m.Error())
 	} else {
-		log.Warnf(msg, m.Error())
+		seclog.Warnf(msg, m.Error())
 	}
 }

--- a/pkg/security/module/module.go
+++ b/pkg/security/module/module.go
@@ -334,7 +334,7 @@ func (m *Module) LoadPolicies(policyProviders []rules.PolicyProvider, sendLoaded
 				}, nil)
 			},
 		}).
-		WithLogger(&seclog.PatternLogger{})
+		WithLogger(seclog.DefaultLogger)
 
 	// approver ruleset
 	model := &model.Model{}

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -30,7 +30,6 @@ import (
 	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
@@ -176,7 +175,7 @@ func (a *APIServer) DumpDiscarders(ctx context.Context, params *api.DumpDiscarde
 	if err != nil {
 		return nil, err
 	}
-	log.Infof("Discarder dump file path: %s", filePath)
+	seclog.Infof("Discarder dump file path: %s", filePath)
 
 	return &api.DumpDiscardersMessage{DumpFilename: filePath}, nil
 }
@@ -447,13 +446,13 @@ func (a *APIServer) SendEvent(rule *rules.Rule, event Event, extTagsCb func() []
 
 	probeJSON, err := json.Marshal(event)
 	if err != nil {
-		log.Errorf("failed to marshal event: %v", err)
+		seclog.Errorf("failed to marshal event: %v", err)
 		return
 	}
 
 	ruleEventJSON, err := easyjson.Marshal(ruleEvent)
 	if err != nil {
-		log.Errorf("failed to marshal event context: %v", err)
+		seclog.Errorf("failed to marshal event context: %v", err)
 		return
 	}
 

--- a/pkg/security/probe/approvers_test.go
+++ b/pkg/security/probe/approvers_test.go
@@ -28,7 +28,7 @@ func TestApproverAncestors1(t *testing.T) {
 	var opts rules.Opts
 	opts.
 		WithEventTypeEnabled(enabled).
-		WithLogger(&seclog.PatternLogger{})
+		WithLogger(seclog.DefaultLogger)
 
 	m := &model.Model{}
 	rs := rules.NewRuleSet(m, m.NewEvent, &opts, &evalOpts, &eval.MacroStore{})
@@ -60,7 +60,7 @@ func TestApproverAncestors2(t *testing.T) {
 	var opts rules.Opts
 	opts.
 		WithEventTypeEnabled(enabled).
-		WithLogger(&seclog.PatternLogger{})
+		WithLogger(seclog.DefaultLogger)
 
 	m := &model.Model{}
 	rs := rules.NewRuleSet(m, m.NewEvent, &opts, &evalOpts, &eval.MacroStore{})
@@ -89,7 +89,7 @@ func TestApproverAncestors3(t *testing.T) {
 	var opts rules.Opts
 	opts.
 		WithEventTypeEnabled(enabled).
-		WithLogger(&seclog.PatternLogger{})
+		WithLogger(seclog.DefaultLogger)
 
 	m := &model.Model{}
 	rs := rules.NewRuleSet(m, m.NewEvent, &opts, &evalOpts, &eval.MacroStore{})

--- a/pkg/security/probe/discarders.go
+++ b/pkg/security/probe/discarders.go
@@ -25,7 +25,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (
@@ -279,7 +278,7 @@ func (id *inodeDiscarders) initRevision(mountEvent *model.MountEvent) {
 	id.revisionCache[key] = revision
 
 	if err := id.revisions.Put(ebpf.Uint32MapItem(key), ebpf.Uint32MapItem(revision)); err != nil {
-		log.Errorf("unable to initialize discarder revisions: %s", err)
+		seclog.Errorf("unable to initialize discarder revisions: %s", err)
 	}
 }
 

--- a/pkg/security/probe/discarders_test.go
+++ b/pkg/security/probe/discarders_test.go
@@ -49,7 +49,7 @@ func TestIsParentDiscarder(t *testing.T) {
 	var opts rules.Opts
 	opts.
 		WithEventTypeEnabled(enabled).
-		WithLogger(&seclog.PatternLogger{})
+		WithLogger(seclog.DefaultLogger)
 
 	rs := rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
 	addRuleExpr(t, rs, `unlink.file.path =~ "/var/log/*" && unlink.file.path != "/var/log/datadog/system-probe.log"`)
@@ -224,7 +224,7 @@ func TestIsGrandParentDiscarder(t *testing.T) {
 	var opts rules.Opts
 	opts.
 		WithEventTypeEnabled(enabled).
-		WithLogger(&seclog.PatternLogger{})
+		WithLogger(seclog.DefaultLogger)
 
 	rs := rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
 	addRuleExpr(t, rs, `unlink.file.path == "/var/lib/datadog/system-probe.cache"`)
@@ -356,7 +356,7 @@ func TestIsDiscarderOverride(t *testing.T) {
 	var opts rules.Opts
 	opts.
 		WithEventTypeEnabled(enabled).
-		WithLogger(&seclog.PatternLogger{})
+		WithLogger(seclog.DefaultLogger)
 
 	var listener testEventListener
 
@@ -399,7 +399,7 @@ func BenchmarkParentDiscarder(b *testing.B) {
 	var opts rules.Opts
 	opts.
 		WithEventTypeEnabled(enabled).
-		WithLogger(&seclog.PatternLogger{})
+		WithLogger(seclog.DefaultLogger)
 
 	rs := rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
 	addRuleExpr(b, rs, `unlink.file.path =~ "/var/log/*" && unlink.file.path != "/var/log/datadog/system-probe.log"`)

--- a/pkg/security/probe/load_controller.go
+++ b/pkg/security/probe/load_controller.go
@@ -21,7 +21,6 @@ import (
 	seclog "github.com/DataDog/datadog-agent/pkg/security/log"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (
@@ -142,7 +141,7 @@ func (lc *LoadController) discardNoisiestProcess() {
 	// push a temporary discarder on the noisiest process & event type tuple
 	seclog.Tracef("discarding events from pid %d for %s seconds", maxKey.Pid, lc.DiscarderTimeout)
 	if err := lc.probe.pidDiscarders.discardWithTimeout(&erpcRequest, allEventTypes, maxKey.Pid, lc.DiscarderTimeout.Nanoseconds()); err != nil {
-		log.Warnf("couldn't insert temporary discarder: %v", err)
+		seclog.Warnf("couldn't insert temporary discarder: %v", err)
 		return
 	}
 
@@ -157,7 +156,7 @@ func (lc *LoadController) discardNoisiestProcess() {
 	if lc.NoisyProcessCustomEventRate.Allow() {
 		process := lc.probe.resolvers.ProcessResolver.Resolve(maxKey.Pid, maxKey.Pid)
 		if process == nil {
-			log.Warnf("Unable to resolve process with pid: %d", maxKey.Pid)
+			seclog.Warnf("Unable to resolve process with pid: %d", maxKey.Pid)
 			return
 		}
 

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -45,7 +45,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	utilkernel "github.com/DataDog/datadog-agent/pkg/util/kernel"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // ActivityDumpHandler represents an handler for the activity dumps sent by the probe
@@ -163,7 +162,7 @@ func (p *Probe) sanityChecks() error {
 	}
 
 	if p.config.NetworkEnabled && p.kernelVersion.IsRH7Kernel() {
-		log.Warn("The network feature of CWS isn't supported on Centos7, setting runtime_security_config.network.enabled to false")
+		seclog.Warnf("The network feature of CWS isn't supported on Centos7, setting runtime_security_config.network.enabled to false")
 		p.config.NetworkEnabled = false
 	}
 
@@ -427,7 +426,7 @@ func (p *Probe) handleEvent(CPU int, data []byte) {
 
 	read, err := event.UnmarshalBinary(data)
 	if err != nil {
-		log.Errorf("failed to decode event: %s", err)
+		seclog.Errorf("failed to decode event: %s", err)
 		return
 	}
 	offset += read
@@ -439,7 +438,7 @@ func (p *Probe) handleEvent(CPU int, data []byte) {
 	switch eventType {
 	case model.MountReleasedEventType:
 		if _, err = event.MountReleased.UnmarshalBinary(data[offset:]); err != nil {
-			log.Errorf("failed to decode mount released event: %s (offset %d, len %d)", err, offset, dataLen)
+			seclog.Errorf("failed to decode mount released event: %s (offset %d, len %d)", err, offset, dataLen)
 			return
 		}
 
@@ -452,12 +451,12 @@ func (p *Probe) handleEvent(CPU int, data []byte) {
 
 		// Delete new mount point from cache
 		if err = p.resolvers.MountResolver.Delete(event.MountReleased.MountID); err != nil {
-			log.Debugf("failed to delete mount point %d from cache: %s", event.MountReleased.MountID, err)
+			seclog.Debugf("failed to delete mount point %d from cache: %s", event.MountReleased.MountID, err)
 		}
 		return
 	case model.InvalidateDentryEventType:
 		if _, err = event.InvalidateDentry.UnmarshalBinary(data[offset:]); err != nil {
-			log.Errorf("failed to decode invalidate dentry event: %s (offset %d, len %d)", err, offset, dataLen)
+			seclog.Errorf("failed to decode invalidate dentry event: %s (offset %d, len %d)", err, offset, dataLen)
 			return
 		}
 
@@ -466,7 +465,7 @@ func (p *Probe) handleEvent(CPU int, data []byte) {
 		return
 	case model.ArgsEnvsEventType:
 		if _, err = event.ArgsEnvs.UnmarshalBinary(data[offset:]); err != nil {
-			log.Errorf("failed to decode args envs event: %s (offset %d, len %d)", err, offset, dataLen)
+			seclog.Errorf("failed to decode args envs event: %s (offset %d, len %d)", err, offset, dataLen)
 			return
 		}
 
@@ -475,12 +474,12 @@ func (p *Probe) handleEvent(CPU int, data []byte) {
 		return
 	case model.CgroupTracingEventType:
 		if !p.config.ActivityDumpEnabled {
-			log.Error("shouldn't receive Cgroup event if activity dumps are disabled")
+			seclog.Errorf("shouldn't receive Cgroup event if activity dumps are disabled")
 			return
 		}
 
 		if _, err = event.CgroupTracing.UnmarshalBinary(data[offset:]); err != nil {
-			log.Errorf("failed to decode cgroup tracing event: %s (offset %d, len %d)", err, offset, dataLen)
+			seclog.Errorf("failed to decode cgroup tracing event: %s (offset %d, len %d)", err, offset, dataLen)
 			return
 		}
 
@@ -490,7 +489,7 @@ func (p *Probe) handleEvent(CPU int, data []byte) {
 
 	read, err = p.unmarshalContexts(data[offset:], event)
 	if err != nil {
-		log.Errorf("failed to decode event `%s`: %s", eventType, err)
+		seclog.Errorf("failed to decode event `%s`: %s", eventType, err)
 		return
 	}
 	offset += read
@@ -501,7 +500,7 @@ func (p *Probe) handleEvent(CPU int, data []byte) {
 
 	if model.GetEventTypeCategory(eventType.String()) == model.NetworkCategory {
 		if read, err = event.NetworkContext.UnmarshalBinary(data[offset:]); err != nil {
-			log.Errorf("failed to decode Network Context")
+			seclog.Errorf("failed to decode Network Context")
 		}
 		offset += read
 	}
@@ -509,7 +508,7 @@ func (p *Probe) handleEvent(CPU int, data []byte) {
 	switch eventType {
 	case model.FileMountEventType:
 		if _, err = event.Mount.UnmarshalBinary(data[offset:]); err != nil {
-			log.Errorf("failed to decode mount event: %s (offset %d, len %d)", err, offset, dataLen)
+			seclog.Errorf("failed to decode mount event: %s (offset %d, len %d)", err, offset, dataLen)
 			return
 		}
 
@@ -520,7 +519,7 @@ func (p *Probe) handleEvent(CPU int, data []byte) {
 		// Insert new mount point in cache
 		err = p.resolvers.MountResolver.Insert(event.Mount)
 		if err != nil {
-			log.Errorf("failed to insert mount event: %v", err)
+			seclog.Errorf("failed to insert mount event: %v", err)
 		}
 
 		if event.Mount.GetFSType() == "nsfs" {
@@ -538,7 +537,7 @@ func (p *Probe) handleEvent(CPU int, data []byte) {
 		p.resolvers.DentryResolver.DelCacheEntries(event.Mount.MountID)
 	case model.FileUmountEventType:
 		if _, err = event.Umount.UnmarshalBinary(data[offset:]); err != nil {
-			log.Errorf("failed to decode umount event: %s (offset %d, len %d)", err, offset, dataLen)
+			seclog.Errorf("failed to decode umount event: %s (offset %d, len %d)", err, offset, dataLen)
 			return
 		}
 
@@ -552,17 +551,17 @@ func (p *Probe) handleEvent(CPU int, data []byte) {
 
 	case model.FileOpenEventType:
 		if _, err = event.Open.UnmarshalBinary(data[offset:]); err != nil {
-			log.Errorf("failed to decode open event: %s (offset %d, len %d)", err, offset, dataLen)
+			seclog.Errorf("failed to decode open event: %s (offset %d, len %d)", err, offset, dataLen)
 			return
 		}
 	case model.FileMkdirEventType:
 		if _, err = event.Mkdir.UnmarshalBinary(data[offset:]); err != nil {
-			log.Errorf("failed to decode mkdir event: %s (offset %d, len %d)", err, offset, dataLen)
+			seclog.Errorf("failed to decode mkdir event: %s (offset %d, len %d)", err, offset, dataLen)
 			return
 		}
 	case model.FileRmdirEventType:
 		if _, err = event.Rmdir.UnmarshalBinary(data[offset:]); err != nil {
-			log.Errorf("failed to decode rmdir event: %s (offset %d, len %d)", err, offset, dataLen)
+			seclog.Errorf("failed to decode rmdir event: %s (offset %d, len %d)", err, offset, dataLen)
 			return
 		}
 
@@ -572,7 +571,7 @@ func (p *Probe) handleEvent(CPU int, data []byte) {
 		}
 	case model.FileUnlinkEventType:
 		if _, err = event.Unlink.UnmarshalBinary(data[offset:]); err != nil {
-			log.Errorf("failed to decode unlink event: %s (offset %d, len %d)", err, offset, dataLen)
+			seclog.Errorf("failed to decode unlink event: %s (offset %d, len %d)", err, offset, dataLen)
 			return
 		}
 
@@ -582,7 +581,7 @@ func (p *Probe) handleEvent(CPU int, data []byte) {
 		}
 	case model.FileRenameEventType:
 		if _, err = event.Rename.UnmarshalBinary(data[offset:]); err != nil {
-			log.Errorf("failed to decode rename event: %s (offset %d, len %d)", err, offset, dataLen)
+			seclog.Errorf("failed to decode rename event: %s (offset %d, len %d)", err, offset, dataLen)
 			return
 		}
 
@@ -592,22 +591,22 @@ func (p *Probe) handleEvent(CPU int, data []byte) {
 		}
 	case model.FileChmodEventType:
 		if _, err = event.Chmod.UnmarshalBinary(data[offset:]); err != nil {
-			log.Errorf("failed to decode chmod event: %s (offset %d, len %d)", err, offset, dataLen)
+			seclog.Errorf("failed to decode chmod event: %s (offset %d, len %d)", err, offset, dataLen)
 			return
 		}
 	case model.FileChownEventType:
 		if _, err = event.Chown.UnmarshalBinary(data[offset:]); err != nil {
-			log.Errorf("failed to decode chown event: %s (offset %d, len %d)", err, offset, dataLen)
+			seclog.Errorf("failed to decode chown event: %s (offset %d, len %d)", err, offset, dataLen)
 			return
 		}
 	case model.FileUtimesEventType:
 		if _, err = event.Utimes.UnmarshalBinary(data[offset:]); err != nil {
-			log.Errorf("failed to decode utime event: %s (offset %d, len %d)", err, offset, dataLen)
+			seclog.Errorf("failed to decode utime event: %s (offset %d, len %d)", err, offset, dataLen)
 			return
 		}
 	case model.FileLinkEventType:
 		if _, err = event.Link.UnmarshalBinary(data[offset:]); err != nil {
-			log.Errorf("failed to decode link event: %s (offset %d, len %d)", err, offset, dataLen)
+			seclog.Errorf("failed to decode link event: %s (offset %d, len %d)", err, offset, dataLen)
 			return
 		}
 
@@ -618,17 +617,17 @@ func (p *Probe) handleEvent(CPU int, data []byte) {
 		}
 	case model.FileSetXAttrEventType:
 		if _, err = event.SetXAttr.UnmarshalBinary(data[offset:]); err != nil {
-			log.Errorf("failed to decode setxattr event: %s (offset %d, len %d)", err, offset, dataLen)
+			seclog.Errorf("failed to decode setxattr event: %s (offset %d, len %d)", err, offset, dataLen)
 			return
 		}
 	case model.FileRemoveXAttrEventType:
 		if _, err = event.RemoveXAttr.UnmarshalBinary(data[offset:]); err != nil {
-			log.Errorf("failed to decode removexattr event: %s (offset %d, len %d)", err, offset, dataLen)
+			seclog.Errorf("failed to decode removexattr event: %s (offset %d, len %d)", err, offset, dataLen)
 			return
 		}
 	case model.ForkEventType:
 		if _, err = event.UnmarshalProcessCacheEntry(data[offset:]); err != nil {
-			log.Errorf("failed to decode fork event: %s (offset %d, len %d)", err, offset, dataLen)
+			seclog.Errorf("failed to decode fork event: %s (offset %d, len %d)", err, offset, dataLen)
 			return
 		}
 
@@ -643,12 +642,12 @@ func (p *Probe) handleEvent(CPU int, data []byte) {
 	case model.ExecEventType:
 		// unmarshal and fill event.processCacheEntry
 		if _, err = event.UnmarshalProcessCacheEntry(data[offset:]); err != nil {
-			log.Errorf("failed to decode exec event: %s (offset %d, len %d)", err, offset, len(data))
+			seclog.Errorf("failed to decode exec event: %s (offset %d, len %d)", err, offset, len(data))
 			return
 		}
 
 		if err = p.resolvers.ProcessResolver.ResolveNewProcessCacheEntry(event.ProcessCacheEntry); err != nil {
-			log.Debugf("failed to resolve new process cache entry context: %s", err)
+			seclog.Debugf("failed to resolve new process cache entry context: %s", err)
 		}
 
 		p.resolvers.ProcessResolver.AddExecEntry(event.ProcessCacheEntry)
@@ -656,7 +655,7 @@ func (p *Probe) handleEvent(CPU int, data []byte) {
 		event.Exec.Process = &event.ProcessCacheEntry.Process
 	case model.ExitEventType:
 		if _, err = event.Exit.UnmarshalBinary(data[offset:]); err != nil {
-			log.Errorf("failed to decode exit event: %s (offset %d, len %d)", err, offset, len(data))
+			seclog.Errorf("failed to decode exit event: %s (offset %d, len %d)", err, offset, len(data))
 			return
 		}
 
@@ -668,35 +667,35 @@ func (p *Probe) handleEvent(CPU int, data []byte) {
 		event.Exit.Process = &event.ProcessCacheEntry.Process
 	case model.SetuidEventType:
 		if _, err = event.SetUID.UnmarshalBinary(data[offset:]); err != nil {
-			log.Errorf("failed to decode setuid event: %s (offset %d, len %d)", err, offset, len(data))
+			seclog.Errorf("failed to decode setuid event: %s (offset %d, len %d)", err, offset, len(data))
 			return
 		}
 		defer p.resolvers.ProcessResolver.UpdateUID(event.PIDContext.Pid, event)
 	case model.SetgidEventType:
 		if _, err = event.SetGID.UnmarshalBinary(data[offset:]); err != nil {
-			log.Errorf("failed to decode setgid event: %s (offset %d, len %d)", err, offset, len(data))
+			seclog.Errorf("failed to decode setgid event: %s (offset %d, len %d)", err, offset, len(data))
 			return
 		}
 		defer p.resolvers.ProcessResolver.UpdateGID(event.PIDContext.Pid, event)
 	case model.CapsetEventType:
 		if _, err = event.Capset.UnmarshalBinary(data[offset:]); err != nil {
-			log.Errorf("failed to decode capset event: %s (offset %d, len %d)", err, offset, len(data))
+			seclog.Errorf("failed to decode capset event: %s (offset %d, len %d)", err, offset, len(data))
 			return
 		}
 		defer p.resolvers.ProcessResolver.UpdateCapset(event.PIDContext.Pid, event)
 	case model.SELinuxEventType:
 		if _, err = event.SELinux.UnmarshalBinary(data[offset:]); err != nil {
-			log.Errorf("failed to decode selinux event: %s (offset %d, len %d)", err, offset, len(data))
+			seclog.Errorf("failed to decode selinux event: %s (offset %d, len %d)", err, offset, len(data))
 			return
 		}
 	case model.BPFEventType:
 		if _, err = event.BPF.UnmarshalBinary(data[offset:]); err != nil {
-			log.Errorf("failed to decode bpf event: %s (offset %d, len %d)", err, offset, len(data))
+			seclog.Errorf("failed to decode bpf event: %s (offset %d, len %d)", err, offset, len(data))
 			return
 		}
 	case model.PTraceEventType:
 		if _, err = event.PTrace.UnmarshalBinary(data[offset:]); err != nil {
-			log.Errorf("failed to decode ptrace event: %s (offset %d, len %d)", err, offset, len(data))
+			seclog.Errorf("failed to decode ptrace event: %s (offset %d, len %d)", err, offset, len(data))
 			return
 		}
 		// resolve tracee process context
@@ -706,7 +705,7 @@ func (p *Probe) handleEvent(CPU int, data []byte) {
 		}
 	case model.MMapEventType:
 		if _, err = event.MMap.UnmarshalBinary(data[offset:]); err != nil {
-			log.Errorf("failed to decode mmap event: %s (offset %d, len %d)", err, offset, len(data))
+			seclog.Errorf("failed to decode mmap event: %s (offset %d, len %d)", err, offset, len(data))
 			return
 		}
 
@@ -717,12 +716,12 @@ func (p *Probe) handleEvent(CPU int, data []byte) {
 		}
 	case model.MProtectEventType:
 		if _, err = event.MProtect.UnmarshalBinary(data[offset:]); err != nil {
-			log.Errorf("failed to decode mprotect event: %s (offset %d, len %d)", err, offset, len(data))
+			seclog.Errorf("failed to decode mprotect event: %s (offset %d, len %d)", err, offset, len(data))
 			return
 		}
 	case model.LoadModuleEventType:
 		if _, err = event.LoadModule.UnmarshalBinary(data[offset:]); err != nil {
-			log.Errorf("failed to decode load_module event: %s (offset %d, len %d)", err, offset, len(data))
+			seclog.Errorf("failed to decode load_module event: %s (offset %d, len %d)", err, offset, len(data))
 			return
 		}
 
@@ -733,11 +732,11 @@ func (p *Probe) handleEvent(CPU int, data []byte) {
 		}
 	case model.UnloadModuleEventType:
 		if _, err = event.UnloadModule.UnmarshalBinary(data[offset:]); err != nil {
-			log.Errorf("failed to decode unload_module event: %s (offset %d, len %d)", err, offset, len(data))
+			seclog.Errorf("failed to decode unload_module event: %s (offset %d, len %d)", err, offset, len(data))
 		}
 	case model.SignalEventType:
 		if _, err = event.Signal.UnmarshalBinary(data[offset:]); err != nil {
-			log.Errorf("failed to decode signal event: %s (offset %d, len %d)", err, offset, len(data))
+			seclog.Errorf("failed to decode signal event: %s (offset %d, len %d)", err, offset, len(data))
 			return
 		}
 		// resolve target process context
@@ -747,38 +746,38 @@ func (p *Probe) handleEvent(CPU int, data []byte) {
 		}
 	case model.SpliceEventType:
 		if _, err = event.Splice.UnmarshalBinary(data[offset:]); err != nil {
-			log.Errorf("failed to decode splice event: %s (offset %d, len %d)", err, offset, len(data))
+			seclog.Errorf("failed to decode splice event: %s (offset %d, len %d)", err, offset, len(data))
 			return
 		}
 	case model.NetDeviceEventType:
 		if _, err = event.NetDevice.UnmarshalBinary(data[offset:]); err != nil {
-			log.Errorf("failed to decode net_device event: %s (offset %d, len %d)", err, offset, len(data))
+			seclog.Errorf("failed to decode net_device event: %s (offset %d, len %d)", err, offset, len(data))
 			return
 		}
 		_ = p.setupNewTCClassifier(event.NetDevice.Device)
 	case model.VethPairEventType:
 		if _, err = event.VethPair.UnmarshalBinary(data[offset:]); err != nil {
-			log.Errorf("failed to decode veth_pair event: %s (offset %d, len %d)", err, offset, len(data))
+			seclog.Errorf("failed to decode veth_pair event: %s (offset %d, len %d)", err, offset, len(data))
 			return
 		}
 		_ = p.setupNewTCClassifier(event.VethPair.PeerDevice)
 	case model.DNSEventType:
 		if _, err = event.DNS.UnmarshalBinary(data[offset:]); err != nil {
-			log.Errorf("failed to decode DNS event: %s (offset %d, len %d)", err, offset, len(data))
+			seclog.Errorf("failed to decode DNS event: %s (offset %d, len %d)", err, offset, len(data))
 			return
 		}
 	case model.BindEventType:
 		if _, err = event.Bind.UnmarshalBinary(data[offset:]); err != nil {
-			log.Errorf("failed to decode bind event: %s (offset %d, len %d)", err, offset, len(data))
+			seclog.Errorf("failed to decode bind event: %s (offset %d, len %d)", err, offset, len(data))
 			return
 		}
 	case model.SyscallsEventType:
 		if _, err = event.Syscalls.UnmarshalBinary(data[offset:]); err != nil {
-			log.Errorf("failed to decode syscalls event: %s (offset %d, len %d)", err, offset, len(data))
+			seclog.Errorf("failed to decode syscalls event: %s (offset %d, len %d)", err, offset, len(data))
 			return
 		}
 	default:
-		log.Errorf("unsupported event type %d", eventType)
+		seclog.Errorf("unsupported event type %d", eventType)
 		return
 	}
 
@@ -838,7 +837,7 @@ func (p *Probe) OnNewDiscarder(rs *rules.RuleSet, event *Event, field eval.Field
 
 // ApplyFilterPolicy is called when a passing policy for an event type is applied
 func (p *Probe) ApplyFilterPolicy(eventType eval.EventType, mode PolicyMode, flags PolicyFlag) error {
-	log.Infof("Setting in-kernel filter policy to `%s` for `%s`", mode, eventType)
+	seclog.Infof("Setting in-kernel filter policy to `%s` for `%s`", mode, eventType)
 	table, err := p.Map("filter_policy")
 	if err != nil {
 		return fmt.Errorf("unable to find policy table: %w", err)
@@ -866,7 +865,7 @@ func (p *Probe) SetApprovers(eventType eval.EventType, approvers rules.Approvers
 
 	newApprovers, err := handler(p, approvers)
 	if err != nil {
-		log.Errorf("Error while adding approvers fallback in-kernel policy to `%s` for `%s`: %s", PolicyModeAccept, eventType, err)
+		seclog.Errorf("Error while adding approvers fallback in-kernel policy to `%s` for `%s`: %s", PolicyModeAccept, eventType, err)
 	}
 
 	for _, newApprover := range newApprovers {
@@ -996,7 +995,7 @@ func (p *Probe) SelectProbes(rs *rules.RuleSet) error {
 	}
 	defer func() {
 		if err := p.eventStream.Resume(); err != nil {
-			log.Errorf("failed to resume event stream: %s", err)
+			seclog.Errorf("failed to resume event stream: %s", err)
 		}
 	}()
 
@@ -1009,7 +1008,7 @@ func (p *Probe) SelectProbes(rs *rules.RuleSet) error {
 
 // DumpDiscarders removes all the discarders
 func (p *Probe) DumpDiscarders() (string, error) {
-	log.Debug("Dumping discarders")
+	seclog.Debugf("Dumping discarders")
 
 	dump, err := os.CreateTemp("/tmp", "discarder-dump-")
 	if err != nil {
@@ -1034,7 +1033,7 @@ Discarder Count: Discardee Parameters
 	discardedInodeCount := 0
 	inodeDiscardersInfo, inodeDiscardersErr := p.inodeDiscarders.Info()
 	if inodeDiscardersErr != nil {
-		log.Errorf("could not get info about inode discarders: %s", inodeDiscardersErr)
+		seclog.Errorf("could not get info about inode discarders: %s", inodeDiscardersErr)
 	} else {
 		var inode inodeDiscarderMapEntry
 		var inodeParams inodeDiscarderParams
@@ -1049,7 +1048,7 @@ Discarder Count: Discardee Parameters
 			}
 			printDiscardee(dump, fmt.Sprintf("%s %+v", path, inode), fmt.Sprintf("%+v", inodeParams), discardedInodeCount)
 			if discardedInodeCount == maxInodeDiscarders {
-				log.Infof("Discarded inode count has reached max discarder map size")
+				seclog.Infof("Discarded inode count has reached max discarder map size")
 				break
 			}
 		}
@@ -1060,7 +1059,7 @@ Discarder Count: Discardee Parameters
 	discardedPIDCount := 0
 	pidDiscardersInfo, pidDiscardersErr := p.pidDiscarders.Info()
 	if pidDiscardersErr != nil {
-		log.Errorf("could not get info about PID discarders: %s", pidDiscardersErr)
+		seclog.Errorf("could not get info about PID discarders: %s", pidDiscardersErr)
 	} else {
 		var pid uint32
 		var pidParams pidDiscarderParams
@@ -1070,7 +1069,7 @@ Discarder Count: Discardee Parameters
 			discardedPIDCount++
 			printDiscardee(dump, fmt.Sprintf("%+v", pid), fmt.Sprintf("%+v", pidParams), discardedPIDCount)
 			if discardedPIDCount == maxPIDDiscarders {
-				log.Infof("Discarded PID count has reached max discarder map size")
+				seclog.Infof("Discarded PID count has reached max discarder map size")
 				break
 			}
 		}
@@ -1079,24 +1078,24 @@ Discarder Count: Discardee Parameters
 	fmt.Fprintf(dump, "\nDiscarder Stats - Front Buffer\n")
 	frontBufferPrintErr := p.printDiscarderStats(dump, frontBufferDiscarderStatsMapName)
 	if frontBufferPrintErr != nil {
-		_ = log.Errorf("could not dump discarder stats map %s: %s", frontBufferDiscarderStatsMapName, frontBufferPrintErr)
+		seclog.Errorf("could not dump discarder stats map %s: %s", frontBufferDiscarderStatsMapName, frontBufferPrintErr)
 	}
 
 	fmt.Fprintf(dump, "\nDiscarder Stats - Back Buffer\n")
 	backBufferPrintErr := p.printDiscarderStats(dump, backBufferDiscarderStatsMapName)
 	if backBufferPrintErr != nil {
-		_ = log.Errorf("could not dump discarder stats map %s: %s", backBufferDiscarderStatsMapName, backBufferPrintErr)
+		seclog.Errorf("could not dump discarder stats map %s: %s", backBufferDiscarderStatsMapName, backBufferPrintErr)
 	}
 
 	fmt.Fprintf(dump, "\nEnd Discarder Dump\n")
 
-	log.Infof("%d inode discarders found, %d pid discarders found", discardedInodeCount, discardedPIDCount)
+	seclog.Infof("%d inode discarders found, %d pid discarders found", discardedInodeCount, discardedPIDCount)
 	return dump.Name(), nil
 }
 
 // FlushDiscarders removes all the discarders
 func (p *Probe) FlushDiscarders() error {
-	log.Debug("Freezing discarders")
+	seclog.Debugf("Freezing discarders")
 
 	flushingMap, err := p.Map("flushing_discarders")
 	if err != nil {
@@ -1111,10 +1110,10 @@ func (p *Probe) FlushDiscarders() error {
 		p.flushingDiscarders.Store(false)
 
 		if err := flushingMap.Put(ebpf.ZeroUint32MapItem, uint32(0)); err != nil {
-			log.Errorf("Failed to reset flush_discarders flag: %s", err)
+			seclog.Errorf("Failed to reset flush_discarders flag: %s", err)
 		}
 
-		log.Debugf("Unfreezing discarders")
+		seclog.Debugf("Unfreezing discarders")
 	}
 	defer unfreezeDiscarders()
 
@@ -1139,7 +1138,7 @@ func (p *Probe) FlushDiscarders() error {
 
 	discarderCount := len(discardedInodes) + len(discardedPids)
 	if discarderCount == 0 {
-		log.Debugf("No discarder found")
+		seclog.Debugf("No discarder found")
 		return nil
 	}
 
@@ -1147,7 +1146,7 @@ func (p *Probe) FlushDiscarders() error {
 	delay := flushWindow / time.Duration(discarderCount)
 
 	flushDiscarders := func() {
-		log.Debugf("Flushing discarders")
+		seclog.Debugf("Flushing discarders")
 
 		var req ERPCRequest
 
@@ -1377,11 +1376,11 @@ func NewProbe(config *config.Config, statsdClient statsd.ClientInterface) (*Prob
 	}
 
 	if err := p.VerifyOSVersion(); err != nil {
-		log.Warnf("the current kernel isn't officially supported, some features might not work properly: %v", err)
+		seclog.Warnf("the current kernel isn't officially supported, some features might not work properly: %v", err)
 	}
 
 	if err := p.VerifyEnvironment(); err != nil {
-		log.Warnf("the current environment may be misconfigured: %v", err)
+		seclog.Warnf("the current environment may be misconfigured: %v", err)
 	}
 
 	useRingBuffers := p.UseRingBuffers()
@@ -1404,7 +1403,7 @@ func NewProbe(config *config.Config, statsdClient statsd.ClientInterface) (*Prob
 	)
 
 	if !p.config.EnableKernelFilters {
-		log.Warn("Forcing in-kernel filter policy to `pass`: filtering not enabled")
+		seclog.Warnf("Forcing in-kernel filter policy to `pass`: filtering not enabled")
 	}
 
 	if p.config.ActivityDumpSyscallMonitor && p.config.ActivityDumpEnabled {
@@ -1414,7 +1413,7 @@ func NewProbe(config *config.Config, statsdClient statsd.ClientInterface) (*Prob
 
 	p.constantOffsets, err = p.GetOffsetConstants()
 	if err != nil {
-		log.Warnf("constant fetcher failed: %v", err)
+		seclog.Warnf("constant fetcher failed: %v", err)
 		return nil, err
 	}
 	// the constant fetching mechanism can be quite memory intensive, between kernel header downloading,

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -1221,7 +1221,7 @@ func (p *Probe) NewRuleSet(opts *rules.Opts, evalOpts *eval.Opts, macroStore *ev
 	eventCtor := func() eval.Event {
 		return NewEvent(p.resolvers, p.scrubber, p)
 	}
-	opts.WithLogger(&seclog.PatternLogger{})
+	opts.WithLogger(seclog.DefaultLogger)
 
 	return rules.NewRuleSet(&Model{probe: p}, eventCtor, opts, evalOpts, macroStore)
 }


### PR DESCRIPTION
### What does this PR do?

When working on another PR I saw 2 issues:
- we were constructing new seclog objects, but without any tags or patterns (thus having no value)
- we were using both seclog and util/log (the underlying logger of seclog) sometime in the same file

This PR fixes the first point by passing the logger with actual tags and patterns, and fixes a part of the second point by migrating all those mixed files to seclog. Other files using only util/log are still using util/log

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
