### PR TITLE
Publish tagged releases to internal ECR registry

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -332,7 +332,7 @@ variables:
     variables:
       AGENT_REPOSITORY: agent
       DSD_REPOSITORY: dogstatsd
-      IMG_REGISTRIES: public
+      IMG_REGISTRIES: internal-aws-ddbuild,public
 
 .on_deploy_a6_manual:
   - <<: *if_not_version_6
@@ -349,7 +349,7 @@ variables:
     allow_failure: true
     variables:
       AGENT_REPOSITORY: agent
-      IMG_REGISTRIES: public
+      IMG_REGISTRIES: internal-aws-ddbuild,public
 
 # Same as on_deploy_a6_manual, except the job would not run on pipelines
 # using beta branch, it would only run for the final release.
@@ -370,7 +370,7 @@ variables:
     allow_failure: true
     variables:
       AGENT_REPOSITORY: agent
-      IMG_REGISTRIES: public
+      IMG_REGISTRIES: internal-aws-ddbuild,public
 
 # This rule is a variation of on_deploy_a6_manual where
 # the job is usually run manually, except when the pipeline
@@ -393,12 +393,12 @@ variables:
     variables:
       AGENT_REPOSITORY: agent
       DSD_REPOSITORY: dogstatsd
-      IMG_REGISTRIES: public
+      IMG_REGISTRIES: internal-aws-ddbuild,public
   - when: manual
     allow_failure: true
     variables:
       AGENT_REPOSITORY: agent
-      IMG_REGISTRIES: public
+      IMG_REGISTRIES: internal-aws-ddbuild,public
 
 .on_deploy_a7:
   - <<: *if_not_version_7
@@ -415,7 +415,7 @@ variables:
     variables:
       AGENT_REPOSITORY: agent
       DSD_REPOSITORY: dogstatsd
-      IMG_REGISTRIES: public
+      IMG_REGISTRIES: internal-aws-ddbuild,public
 
 .on_deploy_a7_manual:
   - <<: *if_not_version_7
@@ -434,7 +434,7 @@ variables:
     variables:
       AGENT_REPOSITORY: agent
       DSD_REPOSITORY: dogstatsd
-      IMG_REGISTRIES: public
+      IMG_REGISTRIES: internal-aws-ddbuild,public
 
 # Same as on_deploy_a7_manual, except the job would not run on pipelines
 # using beta branch, it would only run for the final release.
@@ -457,7 +457,7 @@ variables:
     variables:
       AGENT_REPOSITORY: agent
       DSD_REPOSITORY: dogstatsd
-      IMG_REGISTRIES: public
+      IMG_REGISTRIES: internal-aws-ddbuild,public
 
 # This rule is a variation of on_deploy_a7_manual where
 # the job is usually run manually, except when the pipeline
@@ -481,13 +481,13 @@ variables:
     variables:
       AGENT_REPOSITORY: agent
       DSD_REPOSITORY: dogstatsd
-      IMG_REGISTRIES: public
+      IMG_REGISTRIES: internal-aws-ddbuild,public
   - when: manual
     allow_failure: true
     variables:
       AGENT_REPOSITORY: agent
       DSD_REPOSITORY: dogstatsd
-      IMG_REGISTRIES: public
+      IMG_REGISTRIES: internal-aws-ddbuild,public
 
 .on_deploy_nightly_repo_branch_a6:
   - <<: *if_not_version_6


### PR DESCRIPTION
### What does this PR do?

This publishes tagged releases (like 7.40.0, 7, 6, latest) also to our
internal ECR registry on ddbuild. This is to allow image-vuln-scans to
always target those, instead of having to be manually updated on every
release with [PRs like these](https://github.com/DataDog/image-vuln-scans/pull/499).


### Describe how to test/QA your changes

Images exist in ECR at the time of release.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
