### PR TITLE
[CWS][SEC-4739] replace usage of `strings.Trim` with `strings.(Pre|Suf)fix`

### DIFF
--- a/pkg/security/probe/activity_dump_local_storage.go
+++ b/pkg/security/probe/activity_dump_local_storage.go
@@ -107,7 +107,7 @@ func NewActivityDumpLocalStorage(p *Probe) (ActivityDumpStorage, error) {
 				continue
 			}
 			// retrieve the basename of the dump
-			dumpName := strings.Trim(filepath.Base(f.Name()), ext)
+			dumpName := strings.TrimSuffix(filepath.Base(f.Name()), ext)
 			// insert the file in the list of dumps
 			ad, ok := localDumps[dumpName]
 			if !ok {
@@ -153,7 +153,7 @@ func (storage *ActivityDumpLocalStorage) Persist(request dump.StorageRequest, ad
 	if request.Compression {
 		var tmpBuf bytes.Buffer
 		zw := gzip.NewWriter(&tmpBuf)
-		zw.Name = strings.Trim(path.Base(outputPath), ".gz")
+		zw.Name = strings.TrimSuffix(path.Base(outputPath), ".gz")
 		zw.ModTime = time.Now()
 		if _, err := zw.Write(raw.Bytes()); err != nil {
 			return fmt.Errorf("couldn't compress activity dump: %w", err)

--- a/pkg/security/probe/activity_dump_remote_storage_forwarder.go
+++ b/pkg/security/probe/activity_dump_remote_storage_forwarder.go
@@ -45,7 +45,7 @@ func (storage *ActivityDumpRemoteStorageForwarder) Persist(request dump.StorageR
 	if request.Compression {
 		var tmpBuf bytes.Buffer
 		zw := gzip.NewWriter(&tmpBuf)
-		zw.Name = strings.Trim(path.Base(request.GetOutputPath(ad.DumpMetadata.Name)), ".gz")
+		zw.Name = strings.TrimSuffix(path.Base(request.GetOutputPath(ad.DumpMetadata.Name)), ".gz")
 		zw.ModTime = time.Now()
 		if _, err := zw.Write(raw.Bytes()); err != nil {
 			return fmt.Errorf("couldn't compress activity dump: %w", err)

--- a/pkg/security/utils/proc.go
+++ b/pkg/security/utils/proc.go
@@ -312,7 +312,7 @@ func FetchLoadedModules() (map[string]ProcFSModule, error) {
 			}
 		}
 
-		newModule.Address, err = strconv.ParseInt(strings.Trim(split[5], "0x"), 16, 64)
+		newModule.Address, err = strconv.ParseInt(strings.TrimPrefix(split[5], "0x"), 16, 64)
 		if err != nil {
 			// set to 0 by default
 			newModule.Address = 0


### PR DESCRIPTION
### What does this PR do?

`strings.Trim` takes a cutset and not a litteral as the argument of things to remove. It's thus not useful to remove extensions for example. This PR fixes this issue.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
