### PR TITLE
[CWS] add task to generate CWS protobuf code

### DIFF
--- a/pkg/security/api/README.md
+++ b/pkg/security/api/README.md
@@ -12,4 +12,6 @@ to install the correct version of required tools
 From the repository root run the following:
 ```
 protoc -I. --go_out=plugins=grpc,paths=source_relative:. pkg/security/api/api.proto
+# or
+inv -e generate-cws-proto
 ```

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -616,7 +616,7 @@ def generate_ad_proto(ctx):
 @task
 def generate_cws_proto(ctx):
     # API
-    ctx.run(f"protoc -I. --go_out=plugins=grpc,paths=source_relative:. pkg/security/api/api.proto")
+    ctx.run("protoc -I. --go_out=plugins=grpc,paths=source_relative:. pkg/security/api/api.proto")
 
     # Activity Dumps
     generate_ad_proto(ctx)

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -612,12 +612,11 @@ def generate_ad_proto(ctx):
                 f"protoc -I. --go_out=paths=source_relative:. --go-vtproto_out=. {plugin_opts} --go-vtproto_opt=features=pool+marshal+unmarshal+size {pool_opts} pkg/security/adproto/v1/activity_dump.proto"
             )
 
+
 @task
 def generate_cws_proto(ctx):
     # API
-    ctx.run(
-        f"protoc -I. --go_out=plugins=grpc,paths=source_relative:. pkg/security/api/api.proto"
-    )
+    ctx.run(f"protoc -I. --go_out=plugins=grpc,paths=source_relative:. pkg/security/api/api.proto")
 
     # Activity Dumps
     generate_ad_proto(ctx)
@@ -646,7 +645,13 @@ class FailingTask:
 
 @task
 def go_generate_check(ctx):
-    tasks = [[cws_go_generate], [generate_cws_documentation], [gen_mocks], [generate_runtime_files]]
+    tasks = [
+        [cws_go_generate],
+        [generate_cws_proto],
+        [generate_cws_documentation],
+        [gen_mocks],
+        [generate_runtime_files],
+    ]
     failing_tasks = []
 
     for task_entry in tasks:

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -647,7 +647,6 @@ class FailingTask:
 def go_generate_check(ctx):
     tasks = [
         [cws_go_generate],
-        [generate_cws_proto],
         [generate_cws_documentation],
         [gen_mocks],
         [generate_runtime_files],

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -612,6 +612,16 @@ def generate_ad_proto(ctx):
                 f"protoc -I. --go_out=paths=source_relative:. --go-vtproto_out=. {plugin_opts} --go-vtproto_opt=features=pool+marshal+unmarshal+size {pool_opts} pkg/security/adproto/v1/activity_dump.proto"
             )
 
+@task
+def generate_cws_proto(ctx):
+    # API
+    ctx.run(
+        f"protoc -I. --go_out=plugins=grpc,paths=source_relative:. pkg/security/api/api.proto"
+    )
+
+    # Activity Dumps
+    generate_ad_proto(ctx)
+
 
 def get_git_dirty_files():
     dirty_stats = check_output(["git", "status", "--porcelain=v1"]).decode('utf-8')


### PR DESCRIPTION
### What does this PR do?

Currently, the command line used to generate API protobuf is described in the readme. This PR adds a task to help with running this code, ~and also adds this task to the `security_go_generate_check` CI job to ensure that we stay in sync~ (not possible since protoc is not available in CI for now)

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
