### PR TITLE
Fix gnuTLS on newer kernels

### DIFF
--- a/pkg/ebpf/bytecode/runtime/http.go
+++ b/pkg/ebpf/bytecode/runtime/http.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Http = NewRuntimeAsset("http.c", "f3731a76597e367750a01ebe6bcd32b9531b5ed07298baba47dd2e768896afa6")
+var Http = NewRuntimeAsset("http.c", "ccefe8593220a087886fd62d3448b974a70d6ad2419b35cdad5b69fe1284e316")

--- a/pkg/ebpf/bytecode/runtime/http.go
+++ b/pkg/ebpf/bytecode/runtime/http.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Http = NewRuntimeAsset("http.c", "7cc8f79550882d29d1dfd42946d844d76a7e0f0376d80c0e8e0ea8dba1d92f88")
+var Http = NewRuntimeAsset("http.c", "5b3d452e675b07c8ab4a87bc0581ec78ebaad491f0e399655c8e90eedc38c3f8")

--- a/pkg/ebpf/bytecode/runtime/http.go
+++ b/pkg/ebpf/bytecode/runtime/http.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Http = NewRuntimeAsset("http.c", "ccefe8593220a087886fd62d3448b974a70d6ad2419b35cdad5b69fe1284e316")
+var Http = NewRuntimeAsset("http.c", "7cc8f79550882d29d1dfd42946d844d76a7e0f0376d80c0e8e0ea8dba1d92f88")

--- a/pkg/network/ebpf/c/port_range.h
+++ b/pkg/network/ebpf/c/port_range.h
@@ -20,7 +20,7 @@ static __always_inline void normalize_tuple(conn_tuple_t *t) {
     if ((!is_ephemeral_port(t->sport) && is_ephemeral_port(t->dport)) || t->dport > t->sport) {
         // flip the tuple if:
         // 1) the tuple is currently in the (server, client) format;
-        // 2) unlikely: if both ports are in the same range we ensure that sport < dport to make
+        // 2) unlikely: if both ports are in the same range we ensure that sport > dport to make
         // this function return a deterministic result for a given pair of ports;
         flip_tuple(t);
     }

--- a/pkg/network/ebpf/c/port_range.h
+++ b/pkg/network/ebpf/c/port_range.h
@@ -17,7 +17,7 @@ static __always_inline void normalize_tuple(conn_tuple_t *t) {
         return;
     }
 
-    if ((!is_ephemeral_port(t->sport) && is_ephemeral_port(t->dport)) || t->sport > t->dport) {
+    if ((!is_ephemeral_port(t->sport) && is_ephemeral_port(t->dport)) || t->dport > t->sport) {
         // flip the tuple if:
         // 1) the tuple is currently in the (server, client) format;
         // 2) unlikely: if both ports are in the same range we ensure that sport < dport to make

--- a/pkg/network/ebpf/c/prebuilt/http.c
+++ b/pkg/network/ebpf/c/prebuilt/http.c
@@ -263,6 +263,21 @@ int uprobe__SSL_shutdown(struct pt_regs* ctx) {
     return 0;
 }
 
+SEC("uprobe/gnutls_handshake")
+int uprobe__gnutls_handshake(struct pt_regs* ctx) {
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    void *ssl_ctx = (void *)PT_REGS_PARM1(ctx);
+    bpf_map_update_elem(&ssl_ctx_by_pid_tgid, &pid_tgid, &ssl_ctx, BPF_ANY);
+    return 0;
+}
+
+SEC("uretprobe/gnutls_handshake")
+int uretprobe__gnutls_handshake(struct pt_regs* ctx) {
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    bpf_map_delete_elem(&ssl_ctx_by_pid_tgid, &pid_tgid);
+    return 0;
+}
+
 // void gnutls_transport_set_int (gnutls_session_t session, int fd)
 // Note: this function is implemented as a macro in gnutls
 // that calls gnutls_transport_set_int2, so no uprobe is needed

--- a/pkg/network/ebpf/c/prebuilt/http.c
+++ b/pkg/network/ebpf/c/prebuilt/http.c
@@ -269,11 +269,12 @@ int uprobe__SSL_shutdown(struct pt_regs* ctx) {
 
 // void gnutls_transport_set_int2 (gnutls_session_t session, int recv_fd, int send_fd)
 SEC("uprobe/gnutls_transport_set_int2")
-int uprobe__gnutls_transport_set_int2(struct pt_regs* ctx) {
+int uprobe__gnutls_transport_set_int2(struct pt_regs *ctx) {
     void *ssl_session = (void *)PT_REGS_PARM1(ctx);
     // Use the recv_fd and ignore the send_fd;
     // in most real-world scenarios, they are the same.
     int recv_fd = (int)PT_REGS_PARM2(ctx);
+    log_debug("gnutls_transport_set_int2: ctx=%llx fd=%d\n", ssl_session, recv_fd);
 
     init_ssl_sock(ssl_session, (u32)recv_fd);
     return 0;
@@ -282,10 +283,11 @@ int uprobe__gnutls_transport_set_int2(struct pt_regs* ctx) {
 // void gnutls_transport_set_ptr (gnutls_session_t session, gnutls_transport_ptr_t ptr)
 // "In berkeley style sockets this function will set the connection descriptor."
 SEC("uprobe/gnutls_transport_set_ptr")
-int uprobe__gnutls_transport_set_ptr(struct pt_regs* ctx) {
+int uprobe__gnutls_transport_set_ptr(struct pt_regs *ctx) {
     void *ssl_session = (void *)PT_REGS_PARM1(ctx);
     // This is a void*, but it might contain the socket fd cast as a pointer.
     int fd = (int)PT_REGS_PARM2(ctx);
+    log_debug("gnutls_transport_set_ptr: ctx=%llx fd=%d\n", ssl_session, fd);
 
     init_ssl_sock(ssl_session, (u32)fd);
     return 0;
@@ -294,12 +296,13 @@ int uprobe__gnutls_transport_set_ptr(struct pt_regs* ctx) {
 // void gnutls_transport_set_ptr2 (gnutls_session_t session, gnutls_transport_ptr_t recv_ptr, gnutls_transport_ptr_t send_ptr)
 // "In berkeley style sockets this function will set the connection descriptor."
 SEC("uprobe/gnutls_transport_set_ptr2")
-int uprobe__gnutls_transport_set_ptr2(struct pt_regs* ctx) {
+int uprobe__gnutls_transport_set_ptr2(struct pt_regs *ctx) {
     void *ssl_session = (void *)PT_REGS_PARM1(ctx);
     // Use the recv_ptr and ignore the send_ptr;
     // in most real-world scenarios, they are the same.
     // This is a void*, but it might contain the socket fd cast as a pointer.
     int recv_fd = (int)PT_REGS_PARM2(ctx);
+    log_debug("gnutls_transport_set_ptr2: ctx=%llx fd=%d\n", ssl_session, recv_fd);
 
     init_ssl_sock(ssl_session, (u32)recv_fd);
     return 0;
@@ -307,7 +310,7 @@ int uprobe__gnutls_transport_set_ptr2(struct pt_regs* ctx) {
 
 // ssize_t gnutls_record_recv (gnutls_session_t session, void * data, size_t data_size)
 SEC("uprobe/gnutls_record_recv")
-int uprobe__gnutls_record_recv(struct pt_regs* ctx) {
+int uprobe__gnutls_record_recv(struct pt_regs *ctx) {
     void *ssl_session = (void *)PT_REGS_PARM1(ctx);
     void *data = (void *)PT_REGS_PARM2(ctx);
 
@@ -317,13 +320,14 @@ int uprobe__gnutls_record_recv(struct pt_regs* ctx) {
         .buf = data,
     };
     u64 pid_tgid = bpf_get_current_pid_tgid();
+    log_debug("gnutls_record_recv: pid=%llu ctx=%llx\n", pid_tgid, ssl_session);
     bpf_map_update_elem(&ssl_read_args, &pid_tgid, &args, BPF_ANY);
     return 0;
 }
 
 // ssize_t gnutls_record_recv (gnutls_session_t session, void * data, size_t data_size)
 SEC("uretprobe/gnutls_record_recv")
-int uretprobe__gnutls_record_recv(struct pt_regs* ctx) {
+int uretprobe__gnutls_record_recv(struct pt_regs *ctx) {
     ssize_t read_len = (ssize_t)PT_REGS_RC(ctx);
 
     u64 pid_tgid = bpf_get_current_pid_tgid();
@@ -334,6 +338,7 @@ int uretprobe__gnutls_record_recv(struct pt_regs* ctx) {
     }
 
     void *ssl_session = args->ctx;
+    log_debug("uret/gnutls_record_recv: pid=%llu ctx=%llx\n", pid_tgid, ssl_session);
     conn_tuple_t *t = tup_from_ssl_ctx(ssl_session, pid_tgid);
     if (t == NULL) {
         goto cleanup;
@@ -347,12 +352,13 @@ cleanup:
 
 // ssize_t gnutls_record_send (gnutls_session_t session, const void * data, size_t data_size)
 SEC("uprobe/gnutls_record_send")
-int uprobe__gnutls_record_send(struct pt_regs* ctx) {
+int uprobe__gnutls_record_send(struct pt_regs *ctx) {
     void *ssl_session = (void *)PT_REGS_PARM1(ctx);
     void *data = (void *)PT_REGS_PARM2(ctx);
     size_t data_size = (size_t)PT_REGS_PARM3(ctx);
 
     u64 pid_tgid = bpf_get_current_pid_tgid();
+    log_debug("gnutls_record_send: pid=%llu ctx=%llx\n", pid_tgid, ssl_session);
     conn_tuple_t *t = tup_from_ssl_ctx(ssl_session, pid_tgid);
     if (t == NULL) {
         return 0;
@@ -364,11 +370,11 @@ int uprobe__gnutls_record_send(struct pt_regs* ctx) {
 
 static __always_inline void gnutls_goodbye(void *ssl_session) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
+    log_debug("gnutls_goodbye: pid=%llu ctx=%llx\n", pid_tgid, ssl_session);
     conn_tuple_t *t = tup_from_ssl_ctx(ssl_session, pid_tgid);
     if (t == NULL) {
         return;
     }
-
 
     https_finish(t);
     bpf_map_delete_elem(&ssl_sock_by_ctx, &ssl_session);
@@ -376,7 +382,7 @@ static __always_inline void gnutls_goodbye(void *ssl_session) {
 
 // int gnutls_bye (gnutls_session_t session, gnutls_close_request_t how)
 SEC("uprobe/gnutls_bye")
-int uprobe__gnutls_bye(struct pt_regs* ctx) {
+int uprobe__gnutls_bye(struct pt_regs *ctx) {
     void *ssl_session = (void *)PT_REGS_PARM1(ctx);
     gnutls_goodbye(ssl_session);
     return 0;
@@ -384,7 +390,7 @@ int uprobe__gnutls_bye(struct pt_regs* ctx) {
 
 // void gnutls_deinit (gnutls_session_t session)
 SEC("uprobe/gnutls_deinit")
-int uprobe__gnutls_deinit(struct pt_regs* ctx) {
+int uprobe__gnutls_deinit(struct pt_regs *ctx) {
     void *ssl_session = (void *)PT_REGS_PARM1(ctx);
     gnutls_goodbye(ssl_session);
     return 0;

--- a/pkg/network/ebpf/c/runtime/http.c
+++ b/pkg/network/ebpf/c/runtime/http.c
@@ -269,6 +269,21 @@ int uprobe__SSL_shutdown(struct pt_regs *ctx) {
     return 0;
 }
 
+SEC("uprobe/gnutls_handshake")
+int uprobe__gnutls_handshake(struct pt_regs* ctx) {
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    void *ssl_ctx = (void *)PT_REGS_PARM1(ctx);
+    bpf_map_update_elem(&ssl_ctx_by_pid_tgid, &pid_tgid, &ssl_ctx, BPF_ANY);
+    return 0;
+}
+
+SEC("uretprobe/gnutls_handshake")
+int uretprobe__gnutls_handshake(struct pt_regs* ctx) {
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    bpf_map_delete_elem(&ssl_ctx_by_pid_tgid, &pid_tgid);
+    return 0;
+}
+
 // void gnutls_transport_set_int (gnutls_session_t session, int fd)
 // Note: this function is implemented as a macro in gnutls
 // that calls gnutls_transport_set_int2, so no uprobe is needed

--- a/pkg/network/encoding/encoding_test.go
+++ b/pkg/network/encoding/encoding_test.go
@@ -86,7 +86,7 @@ func getExpectedConnections(encodedWithQueryType bool, httpOutBlob []byte) *mode
 				IpTranslation: &model.IPTranslation{
 					ReplSrcIP:   "20.1.1.1",
 					ReplDstIP:   "20.1.1.1",
-					ReplSrcPort: int32(40),
+					ReplSrcPort: int32(40000),
 					ReplDstPort: int32(80),
 				},
 
@@ -164,7 +164,7 @@ func TestSerialization(t *testing.T) {
 					IPTranslation: &network.IPTranslation{
 						ReplSrcIP:   util.AddressFromString("20.1.1.1"),
 						ReplDstIP:   util.AddressFromString("20.1.1.1"),
-						ReplSrcPort: 40,
+						ReplSrcPort: 40000,
 						ReplDstPort: 80,
 					},
 
@@ -213,7 +213,7 @@ func TestSerialization(t *testing.T) {
 			http.NewKey(
 				util.AddressFromString("20.1.1.1"),
 				util.AddressFromString("20.1.1.1"),
-				40,
+				40000,
 				80,
 				"/testpath",
 				true,

--- a/pkg/network/event_common.go
+++ b/pkg/network/event_common.go
@@ -388,10 +388,10 @@ func HTTPKeyTupleFromConn(c ConnectionStats) http.KeyTuple {
 
 	// HTTP data is always indexed as (client, server), so we account for that when generating the
 	// the lookup key using the port range heuristic.
-	// In the rare cases where both ports are within the same range we ensure that sport < dport
+	// In the rare cases where both ports are within the same range we ensure that sport > dport
 	// to mimic the normalization heuristic done in the eBPF side (see `port_range.h`)
 	if (IsEphemeralPort(int(lport)) && !IsEphemeralPort(int(rport))) ||
-		(IsEphemeralPort(int(lport)) == IsEphemeralPort(int(rport)) && lport < rport) {
+		(IsEphemeralPort(int(lport)) == IsEphemeralPort(int(rport)) && lport > rport) {
 		return http.NewKeyTuple(laddr, raddr, lport, rport)
 	}
 

--- a/pkg/network/http/ebpf_ssl.go
+++ b/pkg/network/http/ebpf_ssl.go
@@ -47,6 +47,8 @@ var cryptoProbes = map[string]string{
 }
 
 var gnuTLSProbes = map[string]string{
+	"uprobe/gnutls_handshake":          "uprobe__gnutls_handshake",
+	"uretprobe/gnutls_handshake":       "uretprobe__gnutls_handshake",
 	"uprobe/gnutls_transport_set_int2": "uprobe__gnutls_transport_set_int2",
 	"uprobe/gnutls_transport_set_ptr":  "uprobe__gnutls_transport_set_ptr",
 	"uprobe/gnutls_transport_set_ptr2": "uprobe__gnutls_transport_set_ptr2",

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -1735,6 +1735,8 @@ func testHTTPSLibrary(t *testing.T, fetchCmd []string) {
 	tr, err := NewTracer(cfg)
 	require.NoError(t, err)
 	defer tr.Stop()
+	err = tr.RegisterClient("1")
+	require.NoError(t, err)
 
 	// Run fetchCmd once to make sure the OpenSSL is detected and uprobes are attached
 	exec.Command(fetchCmd[0]).Run()

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -1687,43 +1687,46 @@ func TestHTTPSViaLibraryIntegration(t *testing.T) {
 		name  string
 		value bool
 	}{
-		{name: " without keep-alives", value: false},
-		{name: " with keep-alives", value: true},
+		{name: "without keep-alives", value: false},
+		{name: "with keep-alives", value: true},
 	} {
-		// Spin-up HTTPS server
-		serverDoneFn := testutil.HTTPServer(t, "127.0.0.1:443", testutil.Options{
-			EnableTLS:        true,
-			EnableKeepAlives: keepAlives.value,
-		})
-		for _, test := range tests {
-			t.Run(test.name+keepAlives.name, func(t *testing.T) {
-				fetch, err := exec.LookPath(test.fetchCmd[0])
-				if err != nil {
-					t.Skipf("%s not found; skipping test.", test.fetchCmd)
-				}
-				ldd, err := exec.LookPath("ldd")
-				if err != nil {
-					t.Skip("ldd not found; skipping test.")
-				}
-				linked, _ := exec.Command(ldd, fetch).Output()
-
-				foundSSLLib := false
-				for _, lib := range tlsLibs {
-					libSSLPath := lib.FindString(string(linked))
-					if _, err := os.Stat(libSSLPath); err == nil {
-						foundSSLLib = true
-						break
-					}
-				}
-				if !foundSSLLib {
-					t.Fatalf("%s not linked with any of these libs %v", test.name, tlsLibs)
-				}
-
-				testHTTPSLibrary(t, test.fetchCmd)
-
+		t.Run(keepAlives.name, func(t *testing.T) {
+			// Spin-up HTTPS server
+			serverDoneFn := testutil.HTTPServer(t, "127.0.0.1:443", testutil.Options{
+				EnableTLS:        true,
+				EnableKeepAlives: keepAlives.value,
 			})
-		}
-		serverDoneFn()
+			t.Cleanup(serverDoneFn)
+
+			for _, test := range tests {
+				t.Run(test.name, func(t *testing.T) {
+					fetch, err := exec.LookPath(test.fetchCmd[0])
+					if err != nil {
+						t.Skipf("%s not found; skipping test.", test.fetchCmd)
+					}
+					ldd, err := exec.LookPath("ldd")
+					if err != nil {
+						t.Skip("ldd not found; skipping test.")
+					}
+					linked, _ := exec.Command(ldd, fetch).Output()
+
+					foundSSLLib := false
+					for _, lib := range tlsLibs {
+						libSSLPath := lib.FindString(string(linked))
+						if _, err := os.Stat(libSSLPath); err == nil {
+							foundSSLLib = true
+							break
+						}
+					}
+					if !foundSSLLib {
+						t.Fatalf("%s not linked with any of these libs %v", test.name, tlsLibs)
+					}
+
+					testHTTPSLibrary(t, test.fetchCmd)
+
+				})
+			}
+		})
 	}
 }
 
@@ -1748,8 +1751,9 @@ func testHTTPSLibrary(t *testing.T, fetchCmd []string) {
 	const targetURL = "https://127.0.0.1:443/200/foobar"
 	cmd := append(fetchCmd, targetURL)
 	requestCmd := exec.Command(cmd[0], cmd[1:]...)
-	err = requestCmd.Run()
-	require.NoErrorf(t, err, "failed to issue request via %s: %s", fetchCmd, err)
+	var out []byte
+	out, err = requestCmd.CombinedOutput()
+	require.NoErrorf(t, err, "failed to issue request via %s: %s\n%s", fetchCmd, err, string(out))
 
 	require.Eventuallyf(t, func() bool {
 		payload, err := tr.GetActiveConnections("1")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

- Fixes gnuTLS support on newer kernels (5.5+) where `sockfd_lookup_light` is inlined. This is similar to the fix in #12078.
- Changes the tuple normalization to use the higher port number first. This is more likely to be `(client,server)` like we want. I ran into a kernel using ephemeral ports numbers > 60999, despite the range being configured to max out there. This change fixed those tests.
- Adds some basic BPF debug logging statements for gnuTLS.

### Motivation

Fixing tests that were failing running on a 5.10 kernel

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
