### PR TITLE
Fix invalid release note to pass `release_note` on the CircleCI

### DIFF
--- a/releasenotes/notes/add-aws_lambda_enhanced_post_runtime_duration-metric-7ffcc4892c5e8474.yaml
+++ b/releasenotes/notes/add-aws_lambda_enhanced_post_runtime_duration-metric-7ffcc4892c5e8474.yaml
@@ -12,7 +12,7 @@ enhancements:
     functions. This gauge metric measures the elapsed milliseconds from when
     the function returns the response to when the extensions finishes. This
     includes performing activities like sending telemetry data to a preferred
-    destination after the function’s response is returned. Note that
+    destination after the function's response is returned. Note that
     `aws.lambda.enhanced.duration` is equivalent to the sum of
     `aws.lambda.enhanced.runtime_duration` and
     `aws.lambda.enhanced.post_runtime_duration`.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fix this error.

```
Traceback (most recent call last):
  File "/usr/local/bin/reno", line 11, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.6/dist-packages/reno/main.py", line 228, in main
    return args.func(args, conf)
  File "/usr/local/lib/python3.6/dist-packages/reno/linter.py", line 40, in lint_cmd
    content = ldr.parse_note_file(f, None)
  File "/usr/local/lib/python3.6/dist-packages/reno/loader.py", line 129, in parse_note_file
    body = self._scanner.get_file_at_commit(filename, sha)
  File "/usr/local/lib/python3.6/dist-packages/reno/scanner.py", line 838, in get_file_at_commit
    encoding=self._encoding)
  File "/usr/local/lib/python3.6/dist-packages/reno/scanner.py", line 479, in get_file_at_commit
    return f.read()
  File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 737: ordinal not in range(128)
```

### Motivation

https://github.com/DataDog/datadog-agent/issues/13152

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Using this Dockerfile to reproduce the environment of CircleCI according to [.circleci/config.yaml](https://github.com/DataDog/datadog-agent/blob/92fe97ba32dc392ccbc8a25105beb56423083b93/.circleci/config.yml#L17-L21).

```Dockerfile
FROM datadog/datadog-agent-runner-circle:go11711
ENV USE_SYSTEM_LIBS="1"
WORKDIR /go/src/github.com/DataDog/datadog-agent
COPY requirements.txt requirements.txt
RUN python3 -m pip install -r requirements.txt
COPY . .
```

Build and Run.

```bash
$ docker build -t lint-releasenote -f ./Dockerfile . 
$ docker run --rm lint-releasenote inv -e lint-releasenote
```

#### Before this change

```bash
$ git switch --detach 92fe97ba32dc392ccbc8a25105beb56423083b93
```

It fails.

#### After this change

```bash
$ git switch --detach 35ab740dc1ceffe340a5c32264c6159b1046f1b8
```

It passed.


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
