### PR TITLE
[CWS] Fix span/open-docker when running it twice (+ some cleanup)

### DIFF
--- a/pkg/security/tests/syscall_tester/c/syscall_tester.c
+++ b/pkg/security/tests/syscall_tester/c/syscall_tester.c
@@ -57,12 +57,13 @@ void *register_tls() {
         return NULL;
     tls->max_threads = max_threads;
     tls->base = base;
+    tls->format = 0; // format is not needed
 
     uint8_t request[257];
     bzero(request, sizeof(request));
 
-    memcpy(&request[sizeof(uint8_t)], tls, sizeof(struct span_tls_t));
     request[0] = REGISTER_SPAN_TLS_OP;
+    memcpy(&request[1], tls, sizeof(struct span_tls_t));
     ioctl(0, RPC_CMD, &request);
 
     return tls;
@@ -112,13 +113,14 @@ static void *thread_open(void *data) {
         return NULL;
     }
     close(fd);
+    unlink(opts->argv[3]);
 
     return NULL;
 }
 
 int span_open(int argc, char **argv) {
     if (argc < 4) {
-        fprintf(stderr, "Please pass a span Id and a trace Id to exec_span and a command\n");
+        fprintf(stderr, "Please pass a span Id, a trace Id and a file path to span-open\n");
         return EXIT_FAILURE;
     }
 


### PR DESCRIPTION
### What does this PR do?

Fix the span/open-docker test

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
