### PR TITLE
Fix indentation and file paths

### DIFF
--- a/tools/agent_QA/test_cases/xplat/file_tests.py
+++ b/tools/agent_QA/test_cases/xplat/file_tests.py
@@ -15,7 +15,7 @@ class TailFile(TestCase):
             f"""
 ```
 logs: 
-- type: file
+  - type: file
     path: {path}
     service: test-file-tailing
     source: hello-world
@@ -51,7 +51,7 @@ class TailFileMultiLine(TestCase):
             f"""
 ```
 logs: 
-- type: file
+  - type: file
     path: {path}
     service: test-file-tailing
     source: multiline
@@ -64,9 +64,9 @@ logs:
         )
 
         self.append(
-            """
+            f"""
 - Start the agent
-- generate some multi-line logs `docker run -it bfloerschddog/java-excepton-logger` > hello-world.log`
+- generate some multi-line logs `docker run -it bfloerschddog/java-excepton-logger > {path}`
 
 # Test
 - Validate that the logs show up in app correctly. Look for the multi-line exception logs and ensure they are combined into a single log line. 
@@ -87,7 +87,7 @@ class TailFileUTF16(TestCase):
             f"""
 ```
 logs: 
-- type: file
+  - type: file
     path: {path}
     service: test-file-tailing
     source: hello-world
@@ -97,14 +97,14 @@ logs:
         )
 
         self.append(
-            """
+            f"""
 - Start the agent
 
 # Test
-- Generate UTF16-le logs `python -c "f = open('hello-utf16.log', 'ab'); t='This is just sample text2\n'.encode('utf-16'); f.write(t); f.close()"`
+- Generate UTF16-le logs `python -c "f = open('{path}', 'ab'); t='This is just sample text2\n'.encode('utf-16'); f.write(t); f.close()"`
 - check that the logs look correct in app
 - delete the log file, change the config to `encoding: utf-16-be`, and restart the agent
-- Generate UTF16-be logs `python -c "f = open('hello-utf16.log', 'ab'); t='This is just sample text2\n'.encode('utf-16be'); f.write(t); f.close()"`
+- Generate UTF16-be logs `python -c "f = open('{path}', 'ab'); t='This is just sample text2\n'.encode('utf-16be'); f.write(t); f.close()"`
 - check that the logs look correct in app
 """
         )
@@ -123,7 +123,7 @@ class TailFileWildcard(TestCase):
             f"""
 ```
 logs:
-  -type: file
+  - type: file
     path: {path}
     service: test-wildcard
     source: wildcard

--- a/tools/agent_QA/test_cases/xplat/helpers.py
+++ b/tools/agent_QA/test_cases/xplat/helpers.py
@@ -6,7 +6,7 @@ def confDir(config):
         return "in `/etc/datadog-agent/conf.d/qa.d/conf.yaml`"
 
     if config.platform == Platform.mac:
-        return "in `~/.datadog-agent/conf.d/conf.d/qa.d/conf.yaml`"
+        return "in `~/.datadog-agent/conf.d/qa.d/conf.yaml`"
 
     if config.platform == Platform.windows:
         return "in `C:\\programdata\\datadog\\conf.d\\qa.d\\conf.yaml` (you may need to enable showing hidden files to see `c:\\programdata`):"

--- a/tools/agent_QA/test_cases/xplat/helpers.py
+++ b/tools/agent_QA/test_cases/xplat/helpers.py
@@ -3,7 +3,7 @@ from test_builder import Platform
 
 def confDir(config):
     if config.platform == Platform.linux:
-        return "in `/etc/datadog/conf.d/qa.d/conf.yaml`"
+        return "in `/etc/datadog-agent/conf.d/qa.d/conf.yaml`"
 
     if config.platform == Platform.mac:
         return "in `~/.datadog-agent/conf.d/conf.d/qa.d/conf.yaml`"


### PR DESCRIPTION
### What does this PR do?

Minor fixes to the logs agent QA cards: indentation, use full path in logging commands.

### Motivation

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
