### PR TITLE
[kubeapiserver] Allow unbundling of events

### DIFF
--- a/cmd/agent/dist/conf.d/kubernetes_apiserver.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/kubernetes_apiserver.d/conf.yaml.example
@@ -13,16 +13,16 @@ instances:
     #   - <KEY_2>:<VALUE_2>
 
     ## @param unbundle_events - boolean - optional - default: false
-    ## Makes each collected Kubernetes event be transformed into its own
-    ## Datadog event, instead of grouping them together by InvolvedObject.
+    ## Transforms each collected Kubernetes event into its own Datadog
+    ## event, instead of grouping them together by InvolvedObject.
     #
     # unbundle_events: true
 
     ## @param collected_event_types - map of array of strings - optional
     ## Specify which events to be collected. Map of Kind as key, array of event
     ## reasons as value. Keys are case-insensitive, values are case-sensitive.
-    ## Only effective is unbundle_events is true, otherwise filtered_event_types
-    ## is used.
+    ## Only effective when unbundle_events is true, otherwise
+    ## filtered_event_types is used.
     #
     collected_event_types:
       pod:
@@ -40,8 +40,8 @@ instances:
 
     ## @param filtered_event_types - array of strings - optional
     ## Specify a list of exclusion filters over the event type, involvedObject.kind, reason, following the Kubernetes field-selector format.
-    ## Only effective is unbundle_events is false, otherwise collected_event_types
-    ## is used.
+    ## Only effective hen unbundle_events is false, otherwise
+    ## collected_event_types  is used.
     #
     # filtered_event_types: ["reason!=FailedGetScale","involvedObject.kind==Pod","type==Normal"]
 

--- a/cmd/agent/dist/conf.d/kubernetes_apiserver.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/kubernetes_apiserver.d/conf.yaml.example
@@ -12,8 +12,36 @@ instances:
     #   - <KEY_1>:<VALUE_1>
     #   - <KEY_2>:<VALUE_2>
 
+    ## @param unbundle_events - boolean - optional - default: false
+    ## Makes each collected Kubernetes event be transformed into its own
+    ## Datadog event, instead of grouping them together by InvolvedObject.
+    #
+    # unbundle_events: true
+
+    ## @param collected_event_types - map of array of strings - optional
+    ## Specify which events to be collected. Map of Kind as key, array of event
+    ## reasons as value. Keys are case-insensitive, values are case-sensitive.
+    ## Only effective is unbundle_events is true, otherwise filtered_event_types
+    ## is used.
+    #
+    collected_event_types:
+      pod:
+        - Failed
+        - BackOff
+        - Unhealthy
+        - FailedScheduling
+        - FailedMount
+        - FailedAttachVolume
+      node:
+        - TerminatingEvictedPod
+        - NodeNotReady
+        - Rebooted
+        - HostPortConflict
+
     ## @param filtered_event_types - array of strings - optional
     ## Specify a list of exclusion filters over the event type, involvedObject.kind, reason, following the Kubernetes field-selector format.
+    ## Only effective is unbundle_events is false, otherwise collected_event_types
+    ## is used.
     #
     # filtered_event_types: ["reason!=FailedGetScale","involvedObject.kind==Pod","type==Normal"]
 

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/bundled_events.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/bundled_events.go
@@ -37,6 +37,13 @@ func (c *bundledTransformer) Transform(events []*v1.Event) ([]metrics.Event, []e
 			continue
 		}
 
+		kubeEvents.Inc(
+			event.InvolvedObject.Kind,
+			event.Source.Component,
+			event.Type,
+			event.Reason,
+		)
+
 		id := buildBundleID(event)
 
 		bundle, found := bundlesByObject[id]
@@ -50,13 +57,6 @@ func (c *bundledTransformer) Transform(events []*v1.Event) ([]metrics.Event, []e
 			errors = append(errors, err)
 			continue
 		}
-
-		kubeEvents.Inc(
-			event.InvolvedObject.Kind,
-			event.Source.Component,
-			event.Type,
-			event.Reason,
-		)
 	}
 
 	datadogEvs := make([]metrics.Event, 0, len(bundlesByObject))

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/bundled_events.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/bundled_events.go
@@ -1,0 +1,93 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+// +build kubeapiserver
+
+package kubernetesapiserver
+
+import (
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+)
+
+func newBundledTransformer(clusterName string) eventTransformer {
+	return &bundledTransformer{
+		clusterName: clusterName,
+	}
+}
+
+type bundledTransformer struct {
+	clusterName string
+}
+
+func (c *bundledTransformer) Transform(events []*v1.Event) ([]metrics.Event, []error) {
+	var errors []error
+
+	bundlesByObject := make(map[bundleID]*kubernetesEventBundle)
+
+	for _, event := range events {
+		if event.InvolvedObject.Kind == "" ||
+			event.InvolvedObject.Name == "" ||
+			event.Reason == "" ||
+			event.Message == "" {
+			continue
+		}
+
+		id := buildBundleID(event)
+
+		bundle, found := bundlesByObject[id]
+		if !found {
+			bundle = newKubernetesEventBundler(c.clusterName, event)
+			bundlesByObject[id] = bundle
+		}
+
+		err := bundle.addEvent(event)
+		if err != nil {
+			errors = append(errors, err)
+			continue
+		}
+
+		kubeEvents.Inc(
+			event.InvolvedObject.Kind,
+			event.Source.Component,
+			event.Type,
+			event.Reason,
+		)
+	}
+
+	datadogEvs := make([]metrics.Event, 0, len(bundlesByObject))
+
+	for id, bundle := range bundlesByObject {
+		datadogEv, err := bundle.formatEvents()
+		if err != nil {
+			errors = append(errors, err)
+			continue
+		}
+
+		emittedEvents.Inc(id.kind, id.evType)
+
+		datadogEvs = append(datadogEvs, datadogEv)
+	}
+
+	return datadogEvs, errors
+}
+
+type bundleID struct {
+	kind   string
+	uid    string
+	evType string
+}
+
+// buildBundleID generates a unique ID to separate k8s events
+// based on their InvolvedObject UIDs and event Types
+func buildBundleID(e *v1.Event) bundleID {
+	return bundleID{
+		kind:   e.InvolvedObject.Kind,
+		uid:    string(e.InvolvedObject.UID),
+		evType: e.Type,
+	}
+}

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/events_common.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/events_common.go
@@ -1,0 +1,147 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017-present Datadog, Inc.
+
+//go:build kubeapiserver
+// +build kubeapiserver
+
+package kubernetesapiserver
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+var (
+	hostProviderIDMutex sync.Mutex
+	hostProviderIDCache map[string]string
+)
+
+type eventHostInfo struct {
+	hostname   string
+	nodename   string
+	providerID string
+}
+
+// getDDAlertType converts kubernetes event types into datadog alert types
+func getDDAlertType(k8sType string) metrics.EventAlertType {
+	switch k8sType {
+	case v1.EventTypeNormal:
+		return metrics.EventAlertTypeInfo
+	case v1.EventTypeWarning:
+		return metrics.EventAlertTypeWarning
+	default:
+		log.Debugf("Unknown event type '%s'", k8sType)
+		return metrics.EventAlertTypeInfo
+	}
+}
+
+func getInvolvedObjectTags(involvedObject v1.ObjectReference) []string {
+	tags := []string{
+		fmt.Sprintf("kubernetes_kind:%s", involvedObject.Kind),
+		fmt.Sprintf("name:%s", involvedObject.Name),
+	}
+
+	if involvedObject.Namespace != "" {
+		tags = append(tags,
+			// TODO remove the deprecated namespace tag, we should
+			// only rely on kube_namespace
+			fmt.Sprintf("namespace:%s", involvedObject.Namespace),
+			fmt.Sprintf("kube_namespace:%s", involvedObject.Namespace),
+		)
+	}
+
+	kindTag := getKindTag(involvedObject.Kind, involvedObject.Name)
+	if kindTag != "" {
+		tags = append(tags, kindTag)
+	}
+
+	return tags
+}
+
+func getEventHostInfo(clusterName string, ev *v1.Event) eventHostInfo {
+	info := eventHostInfo{}
+
+	if ev.InvolvedObject.Kind != "Pod" && ev.InvolvedObject.Kind != "Node" {
+		return info
+	}
+
+	info.nodename = ev.Source.Host
+	info.hostname = info.nodename
+	if info.hostname != "" {
+		info.providerID = getHostProviderID(info.hostname)
+
+		if clusterName != "" {
+			info.hostname += "-" + clusterName
+		}
+	}
+
+	return info
+}
+
+func getHostProviderID(nodename string) string {
+	hostProviderIDMutex.Lock()
+	defer hostProviderIDMutex.Unlock()
+
+	if hostProviderID, hit := hostProviderIDCache[nodename]; hit {
+		return hostProviderID
+	}
+
+	cl, err := apiserver.GetAPIClient()
+	if err != nil {
+		log.Warnf("Can't create client to query the API Server: %v", err)
+		return ""
+	}
+
+	node, err := apiserver.GetNode(cl, nodename)
+	if err != nil {
+		log.Warnf("Can't get node from API Server: %v", err)
+		return ""
+	}
+
+	providerID := node.Spec.ProviderID
+	if providerID == "" {
+		log.Warnf("ProviderID for nodename %q not found", nodename)
+		return ""
+	}
+
+	// e.g. gce://datadog-test-cluster/us-east1-a/some-instance-id or
+	// aws:///us-east-1e/i-instanceid
+	s := strings.Split(providerID, "/")
+	hostProviderID := s[len(s)-1]
+
+	hostProviderIDCache[nodename] = hostProviderID
+
+	return hostProviderID
+}
+
+// getKindTag returns the kube_<kind>:<name> tag. The exact same tag names and
+// object kinds are supported by the tagger. It returns an empty string if the
+// kind doesn't correspond to a known/supported kind tag.
+func getKindTag(kind, name string) string {
+	if tagName, found := kubernetes.KindToTagName[kind]; found {
+		return fmt.Sprintf("%s:%s", tagName, name)
+	}
+	return ""
+}
+
+func buildReadableKey(obj v1.ObjectReference) string {
+	if obj.Namespace != "" {
+		return fmt.Sprintf("%s %s/%s", obj.Kind, obj.Namespace, obj.Name)
+	}
+
+	return fmt.Sprintf("%s %s", obj.Kind, obj.Name)
+}
+
+func init() {
+	hostProviderIDCache = make(map[string]string)
+}

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/events_common_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/events_common_test.go
@@ -1,0 +1,46 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+// +build kubeapiserver
+
+package kubernetesapiserver
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetDDAlertType(t *testing.T) {
+	tests := []struct {
+		name    string
+		k8sType string
+		want    metrics.EventAlertType
+	}{
+		{
+			name:    "normal",
+			k8sType: "Normal",
+			want:    metrics.EventAlertTypeInfo,
+		},
+		{
+			name:    "warning",
+			k8sType: "Warning",
+			want:    metrics.EventAlertTypeWarning,
+		},
+		{
+			name:    "unknown",
+			k8sType: "Unknown",
+			want:    metrics.EventAlertTypeInfo,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getDDAlertType(tt.k8sType)
+			assert.Equal(t, got, tt.want)
+		})
+	}
+}

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver_test.go
@@ -9,22 +9,15 @@ package kubernetesapiserver
 
 import (
 	"fmt"
-	"sort"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	v1 "k8s.io/api/core/v1"
 	obj "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"k8s.io/apimachinery/pkg/types"
-
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
-	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
 )
 
 func TestParseComponentStatus(t *testing.T) {
@@ -121,154 +114,6 @@ func TestParseComponentStatus(t *testing.T) {
 	mocked.AssertExpectations(t)
 }
 
-func createEvent(count int32, namespace, objname, objkind, objuid, component, hostname, reason, message, typ string, timestamp int64) *v1.Event {
-	return &v1.Event{
-		InvolvedObject: v1.ObjectReference{
-			Name:      objname,
-			Kind:      objkind,
-			UID:       types.UID(objuid),
-			Namespace: namespace,
-		},
-		Count: count,
-		Source: v1.EventSource{
-			Component: component,
-			Host:      hostname,
-		},
-		Reason: reason,
-		FirstTimestamp: obj.Time{
-			Time: time.Unix(timestamp, 0),
-		},
-		LastTimestamp: obj.Time{
-			Time: time.Unix(timestamp, 0),
-		},
-		Message: message,
-		Type:    typ,
-	}
-}
-
-func TestProcessBundledEvents(t *testing.T) {
-	// We want to check if the format of several new events and several modified events creates DD events accordingly
-	// We also want to check that a modified event with an existing key is aggregated (i.e. the key is already known)
-	ev1 := createEvent(2, "default", "dca-789976f5d7-2ljx6", "Pod", "e6417a7f-f566-11e7-9749-0e4863e1cbf4", "default-scheduler", "machine-blue", "Scheduled", "Successfully assigned dca-789976f5d7-2ljx6 to ip-10-0-0-54", "Normal", 709662600)
-	ev2 := createEvent(3, "default", "dca-789976f5d7-2ljx6", "Pod", "e6417a7f-f566-11e7-9749-0e4863e1cbf4", "default-scheduler", "machine-blue", "Started", "Started container", "Normal", 709662600)
-	ev3 := createEvent(1, "default", "localhost", "Node", "e63e74fa-f566-11e7-9749-0e4863e1cbf4", "kubelet", "machine-blue", "MissingClusterDNS", "MountVolume.SetUp succeeded", "Normal", 709662600)
-	ev4 := createEvent(29, "default", "localhost", "Node", "e63e74fa-f566-11e7-9749-0e4863e1cbf4", "kubelet", "machine-blue", "MissingClusterDNS", "MountVolume.SetUp succeeded", "Normal", 709675200)
-	// (As Object kinds are Pod and Node here, the event should take the remote hostname `machine-blue`)
-
-	kubeASCheck := NewKubeASCheck(core.NewCheckBase(kubernetesAPIServerCheckName), &KubeASConfig{})
-	// Several new events, testing aggregation
-	// Not testing full match of the event message as the order of the actions in the summary isn't guaranteed
-
-	newKubeEventsBundle := []*v1.Event{
-		ev1,
-		ev2,
-	}
-	mocked := mocksender.NewMockSender(kubeASCheck.ID())
-	mocked.On("Event", mock.AnythingOfType("metrics.Event"))
-
-	kubeASCheck.processEvents(mocked, newKubeEventsBundle)
-
-	// We are only expecting one bundle event.
-	// We need to check that the countByAction concatenated string contains the source events.
-	// As the order is not guaranteed we want to use contains.
-	res := (mocked.Calls[0].Arguments.Get(0)).(metrics.Event).Text
-	assert.Contains(t, res, "2 **Scheduled**")
-	assert.Contains(t, res, "3 **Started**")
-	mocked.AssertNumberOfCalls(t, "Event", 1)
-	mocked.AssertExpectations(t)
-
-	// Several modified events, timestamp is the latest, event submitted has the correct key and count.
-	modifiedKubeEventsBundle := []*v1.Event{
-		ev3,
-		ev4,
-	}
-	modifiedNewDatadogEvents := metrics.Event{
-		Title:          "Events from the Node machine-blue",
-		Text:           "%%% \n30 **MissingClusterDNS**: MountVolume.SetUp succeeded\n \n _Events emitted by the kubelet seen at " + time.Unix(709675200, 0).String() + "_ \n\n %%%",
-		Priority:       "normal",
-		Tags:           []string{"namespace:default", "source_component:kubelet"},
-		AggregationKey: "kubernetes_apiserver:e63e74fa-f566-11e7-9749-0e4863e1cbf4",
-		SourceTypeName: "kubernetes",
-		Ts:             709675200,
-		Host:           "machine-blue",
-		EventType:      "kubernetes_apiserver",
-	}
-	mocked = mocksender.NewMockSender(kubeASCheck.ID())
-	mocked.On("Event", mock.AnythingOfType("metrics.Event"))
-
-	kubeASCheck.processEvents(mocked, modifiedKubeEventsBundle)
-
-	mocked.AssertEvent(t, modifiedNewDatadogEvents, 0)
-	mocked.AssertExpectations(t)
-
-	// Test the hostname change when a cluster name is set
-	var testClusterName = "laika"
-	mockConfig := config.Mock(t)
-	mockConfig.Set("cluster_name", testClusterName)
-	clustername.ResetClusterName() // reset state as clustername was already read
-	// defer a reset of the state so that future hostname fetches are not impacted
-	defer mockConfig.Set("cluster_name", nil)
-	defer clustername.ResetClusterName()
-
-	modifiedNewDatadogEventsWithClusterName := metrics.Event{
-		Title:          "Events from the Node machine-blue",
-		Text:           "%%% \n30 **MissingClusterDNS**: MountVolume.SetUp succeeded\n \n _Events emitted by the kubelet seen at " + time.Unix(709675200, 0).String() + "_ \n\n %%%",
-		Priority:       "normal",
-		Tags:           []string{"namespace:default", "source_component:kubelet"},
-		AggregationKey: "kubernetes_apiserver:e63e74fa-f566-11e7-9749-0e4863e1cbf4",
-		SourceTypeName: "kubernetes",
-		Ts:             709675200,
-		Host:           "machine-blue-" + testClusterName,
-		EventType:      "kubernetes_apiserver",
-	}
-
-	mocked = mocksender.NewMockSender(kubeASCheck.ID())
-	mocked.On("Event", mock.AnythingOfType("metrics.Event"))
-
-	kubeASCheck.processEvents(mocked, modifiedKubeEventsBundle)
-
-	mocked.AssertEvent(t, modifiedNewDatadogEventsWithClusterName, 0)
-	mocked.AssertExpectations(t)
-}
-
-func TestProcessEvent(t *testing.T) {
-	// We want to check if the format of 1 New event creates a DD event accordingly.
-	// We also want to check that filtered and empty events aren't submitted
-	ev1 := createEvent(2, "default", "dca-789976f5d7-2ljx6", "ReplicaSet", "e6417a7f-f566-11e7-9749-0e4863e1cbf4", "default-scheduler", "machine-blue", "Scheduled", "Successfully assigned dca-789976f5d7-2ljx6 to ip-10-0-0-54", "Warning", 709662600)
-	// (Object kind was changed from Pod to ReplicaSet to test the choice of hostname: it should take here the local hostname below `hostname`)
-
-	kubeASCheck := NewKubeASCheck(core.NewCheckBase(kubernetesAPIServerCheckName), &KubeASConfig{})
-	mocked := mocksender.NewMockSender(kubeASCheck.ID())
-
-	newKubeEventBundle := []*v1.Event{
-		ev1,
-	}
-	// 1 Scheduled:
-	newDatadogEvent := metrics.Event{
-		Title:          "Events from the ReplicaSet default/dca-789976f5d7-2ljx6",
-		Text:           "%%% \n2 **Scheduled**: Successfully assigned dca-789976f5d7-2ljx6 to ip-10-0-0-54\n \n _New events emitted by the default-scheduler seen at " + time.Unix(709662600000, 0).String() + "_ \n\n %%%",
-		Priority:       "normal",
-		Tags:           []string{"source_component:default-scheduler", "namespace:default"},
-		AggregationKey: "kubernetes_apiserver:e6417a7f-f566-11e7-9749-0e4863e1cbf4",
-		SourceTypeName: "kubernetes",
-		Ts:             709662600,
-		Host:           "",
-		EventType:      "kubernetes_apiserver",
-		AlertType:      metrics.EventAlertTypeWarning,
-	}
-	mocked.On("Event", mock.AnythingOfType("metrics.Event"))
-	kubeASCheck.processEvents(mocked, newKubeEventBundle)
-	mocked.AssertEvent(t, newDatadogEvent, 0)
-	mocked.AssertExpectations(t)
-
-	// No events
-	empty := []*v1.Event{}
-	mocked = mocksender.NewMockSender(kubeASCheck.ID())
-	kubeASCheck.processEvents(mocked, empty)
-	mocked.AssertNotCalled(t, "Event")
-	mocked.AssertExpectations(t)
-}
-
 func TestConvertFilter(t *testing.T) {
 	for n, tc := range []struct {
 		caseName string
@@ -292,46 +137,8 @@ func TestConvertFilter(t *testing.T) {
 		},
 	} {
 		t.Run(fmt.Sprintf("case %d: %s", n, tc.caseName), func(t *testing.T) {
-			output := convertFilter(tc.filters)
+			output := convertFilters(tc.filters)
 			assert.Equal(t, tc.output, output)
 		})
 	}
-}
-
-func TestProcessEventsType(t *testing.T) {
-	ev1 := createEvent(2, "default", "dca-789976f5d7-2ljx6", "Pod", "e6417a7f-f566-11e7-9749-0e4863e1cbf4", "default-scheduler", "machine-blue", "Scheduled", "Successfully assigned dca-789976f5d7-2ljx6 to ip-10-0-0-54", "Normal", 709662600)
-	ev2 := createEvent(3, "default", "dca-789976f5d7-2ljx6", "Pod", "e6417a7f-f566-11e7-9749-0e4863e1cbf4", "default-scheduler", "machine-blue", "Started", "Started container", "Normal", 709662600)
-	ev3 := createEvent(4, "default", "dca-789976f5d7-2ljx6", "Pod", "e6417a7f-f566-11e7-9749-0e4863e1cbf4", "default-scheduler", "machine-blue", "BackOff", "Back-off restarting failed container", "Warning", 709662600)
-
-	kubeASCheck := NewKubeASCheck(core.NewCheckBase(kubernetesAPIServerCheckName), &KubeASConfig{})
-
-	newKubeEventsBundle := []*v1.Event{
-		ev1,
-		ev2,
-		ev3,
-	}
-	mocked := mocksender.NewMockSender(kubeASCheck.ID())
-	mocked.On("Event", mock.AnythingOfType("metrics.Event"))
-
-	kubeASCheck.processEvents(mocked, newKubeEventsBundle)
-
-	// We are only expecting two bundle events from the 3 kubernetes events because the event types differ.
-	// We need to check that the countByAction concatenated string contains the source events.
-	// As the order is not guaranteed we want to use contains.
-	calls := []string{
-		(mocked.Calls[0].Arguments.Get(0)).(metrics.Event).Text,
-		(mocked.Calls[1].Arguments.Get(0)).(metrics.Event).Text,
-	}
-
-	// The order of calls is random in processEvents because of the map eventsByObject
-	// Mocked calls need to be sorted before making assertions
-	sort.Strings(calls)
-
-	assert.Contains(t, calls[0], "2 **Scheduled**")
-	assert.Contains(t, calls[0], "3 **Started**")
-
-	assert.Contains(t, calls[1], "4 **BackOff**")
-
-	mocked.AssertNumberOfCalls(t, "Event", 2)
-	mocked.AssertExpectations(t)
 }

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_eventbundle.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_eventbundle.go
@@ -2,6 +2,7 @@
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2017-present Datadog, Inc.
+
 //go:build kubeapiserver
 // +build kubeapiserver
 
@@ -11,50 +12,39 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"sort"
 	"strings"
 	"time"
 
-	cache "github.com/patrickmn/go-cache"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/DataDog/datadog-agent/pkg/metrics"
-	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
-	as "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 type kubernetesEventBundle struct {
-	objUID        types.UID              // Unique object Identifier used as the Aggregation key
-	namespace     string                 // namespace of the bundle
-	readableKey   string                 // Formated key used in the Title in the events
-	component     string                 // Used to identify the Kubernetes component which generated the event
-	events        []*v1.Event            // List of events in the bundle
-	name          string                 // name of the bundle
-	kind          string                 // kind of the bundle
-	timeStamp     float64                // Used for the new events in the bundle to specify when they first occurred
-	lastTimestamp float64                // Used for the modified events in the bundle to specify when they last occurred
-	countByAction map[string]int         // Map of count per action to aggregate several events from the same ObjUid in one event
-	nodename      string                 // Stores the nodename that should be used to submit the events
-	alertType     metrics.EventAlertType // The Datadog event type
+	involvedObject v1.ObjectReference     // Parent object for this event bundle
+	component      string                 // Used to identify the Kubernetes component which generated the event
+	timeStamp      float64                // Used for the new events in the bundle to specify when they first occurred
+	lastTimestamp  float64                // Used for the modified events in the bundle to specify when they last occurred
+	countByAction  map[string]int         // Map of count per action to aggregate several events from the same ObjUid in one event
+	alertType      metrics.EventAlertType // The Datadog event type
+	hostInfo       eventHostInfo          // Host information extracted from the event, where applicable
 }
 
-func newKubernetesEventBundler(event *v1.Event) *kubernetesEventBundle {
+func newKubernetesEventBundler(clusterName string, event *v1.Event) *kubernetesEventBundle {
 	return &kubernetesEventBundle{
-		objUID:        event.InvolvedObject.UID,
-		component:     event.Source.Component,
-		countByAction: make(map[string]int),
-		alertType:     getDDAlertType(event.Type),
+		involvedObject: event.InvolvedObject,
+		component:      event.Source.Component,
+		countByAction:  make(map[string]int),
+		alertType:      getDDAlertType(event.Type),
+		hostInfo:       getEventHostInfo(clusterName, event),
 	}
 }
 
 func (b *kubernetesEventBundle) addEvent(event *v1.Event) error {
-	if event.InvolvedObject.UID != b.objUID {
-		return fmt.Errorf("mismatching Object UIDs: %s != %s", event.InvolvedObject.UID, b.objUID)
+	if event.InvolvedObject.UID != b.involvedObject.UID {
+		return fmt.Errorf("mismatching Object UIDs: %s != %s", event.InvolvedObject.UID, b.involvedObject.UID)
 	}
-
-	b.events = append(b.events, event)
-	b.namespace = event.InvolvedObject.Namespace
 
 	// We do not process the events in chronological order necessarily.
 	// We only care about the first time they occurred, the last time and the count.
@@ -62,76 +52,33 @@ func (b *kubernetesEventBundle) addEvent(event *v1.Event) error {
 	b.lastTimestamp = math.Max(b.lastTimestamp, float64(event.LastTimestamp.Unix()))
 
 	b.countByAction[fmt.Sprintf("**%s**: %s\n", event.Reason, event.Message)] += int(event.Count)
-	b.kind = event.InvolvedObject.Kind
-	b.name = event.InvolvedObject.Name
-
-	if event.InvolvedObject.Kind == "Pod" || event.InvolvedObject.Kind == "Node" {
-		b.nodename = event.Source.Host
-	}
-
-	if event.InvolvedObject.Namespace == "" {
-		b.readableKey = fmt.Sprintf("%s %s", event.InvolvedObject.Kind, event.InvolvedObject.Name)
-	} else {
-		b.readableKey = fmt.Sprintf("%s %s/%s", event.InvolvedObject.Kind, event.InvolvedObject.Namespace, event.InvolvedObject.Name)
-	}
 
 	return nil
 }
 
-func (b *kubernetesEventBundle) formatEvents(clusterName string, providerIDCache *cache.Cache) (metrics.Event, error) {
-	if len(b.events) == 0 {
+func (b *kubernetesEventBundle) formatEvents() (metrics.Event, error) {
+	if len(b.countByAction) == 0 {
 		return metrics.Event{}, errors.New("no event to export")
 	}
 
-	tags := []string{
-		fmt.Sprintf("source_component:%s", b.component),
-		fmt.Sprintf("kubernetes_kind:%s", b.kind),
-		fmt.Sprintf("name:%s", b.name),
-	}
+	readableKey := buildReadableKey(b.involvedObject)
+	tags := getInvolvedObjectTags(b.involvedObject)
+	tags = append(tags, fmt.Sprintf("source_component:%s", b.component))
 
-	if kindTag := getKindTag(b.kind, b.name); kindTag != "" {
-		tags = append(tags, kindTag)
-	}
-
-	hostname := b.nodename
-	if b.nodename != "" {
-		// Adding the clusterName to the nodename if present
-		if clusterName != "" {
-			hostname = hostname + "-" + clusterName
-		}
-
-		// Find provider ID from cache or find via node spec from APIserver
-		hostProviderID, hit := providerIDCache.Get(b.nodename)
-		if hit {
-			tags = append(tags, fmt.Sprintf("host_provider_id:%s", hostProviderID))
-		} else {
-			hostProviderID := getHostProviderID(b.nodename)
-			if hostProviderID != "" {
-				providerIDCache.Set(b.nodename, hostProviderID, cache.NoExpiration)
-				tags = append(tags, fmt.Sprintf("host_provider_id:%s", hostProviderID))
-			}
-		}
-	}
-
-	if b.namespace != "" {
-		tags = append(tags,
-			// TODO remove the deprecated namespace tag, we should
-			// only rely on kube_namespace
-			fmt.Sprintf("namespace:%s", b.namespace),
-			fmt.Sprintf("kube_namespace:%s", b.namespace),
-		)
+	if b.hostInfo.providerID != "" {
+		tags = append(tags, fmt.Sprintf("host_provider_id:%s", b.hostInfo.providerID))
 	}
 
 	// If hostname was not defined, the aggregator will then set the local hostname
 	output := metrics.Event{
-		Title:          fmt.Sprintf("Events from the %s", b.readableKey),
+		Title:          fmt.Sprintf("Events from the %s", readableKey),
 		Priority:       metrics.EventPriorityNormal,
-		Host:           hostname,
+		Host:           b.hostInfo.hostname,
 		SourceTypeName: "kubernetes",
 		EventType:      kubernetesAPIServerCheckName,
 		Ts:             int64(b.lastTimestamp),
 		Tags:           tags,
-		AggregationKey: fmt.Sprintf("kubernetes_apiserver:%s", b.objUID),
+		AggregationKey: fmt.Sprintf("kubernetes_apiserver:%s", b.involvedObject.UID),
 		AlertType:      b.alertType,
 		Text:           b.formatEventText(),
 	}
@@ -154,57 +101,20 @@ func (b *kubernetesEventBundle) formatEventText() string {
 	return eventText
 }
 
-// getKindTag returns the kube_<kind>:<name> tag.
-// The exact same tag names and object kinds are supported by the tagger.
-// It returns an empty string if the kind doesn't correspond to a known/supported kind tag.
-func getKindTag(kind, name string) string {
-	if tagName, found := kubernetes.KindToTagName[kind]; found {
-		return fmt.Sprintf("%s:%s", tagName, name)
-	}
-	return ""
-}
-
-func getHostProviderID(nodename string) string {
-	cl, err := as.GetAPIClient()
-	if err != nil {
-		log.Warnf("Can't create client to query the API Server: %v", err)
-		return ""
-	}
-
-	node, err := as.GetNode(cl, nodename)
-	if err != nil {
-		log.Warnf("Can't get node from API Server: %v", err)
-		return ""
-	}
-
-	providerID := node.Spec.ProviderID
-	if providerID == "" {
-		log.Warnf("ProviderID not found")
-		return ""
-	}
-
-	// e.g. gce://datadog-test-cluster/us-east1-a/some-instance-id or aws:///us-east-1e/i-instanceid
-	s := strings.Split(providerID, "/")
-	return s[len(s)-1]
-}
-
 func formatStringIntMap(input map[string]int) string {
-	var parts []string
-	for k, v := range input {
+	parts := make([]string, 0, len(input))
+	keys := make([]string, 0, len(input))
+
+	for k := range input {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		v := input[k]
 		parts = append(parts, fmt.Sprintf("%d %s", v, k))
 	}
-	return strings.Join(parts, " ")
-}
 
-// getDDAlertType converts kubernetes event types into datadog alert types
-func getDDAlertType(k8sType string) metrics.EventAlertType {
-	switch k8sType {
-	case v1.EventTypeNormal:
-		return metrics.EventAlertTypeInfo
-	case v1.EventTypeWarning:
-		return metrics.EventAlertTypeWarning
-	default:
-		log.Debugf("Unknown event type '%s'", k8sType)
-		return metrics.EventAlertTypeInfo
-	}
+	return strings.Join(parts, " ")
 }

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_openshift_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_openshift_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
 func TestReportClusterQuotas(t *testing.T) {
@@ -26,6 +27,10 @@ func TestReportClusterQuotas(t *testing.T) {
 	list := osq.ClusterResourceQuotaList{}
 	json.Unmarshal(raw, &list)
 	require.Len(t, list.Items, 1)
+
+	prevClusterName := config.Datadog.GetString("cluster_name")
+	config.Datadog.Set("cluster_name", "test-cluster-name")
+	defer config.Datadog.Set("cluster_name", prevClusterName)
 
 	var instanceCfg = []byte("")
 	var initCfg = []byte("")

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/unbundled_events.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/unbundled_events.go
@@ -1,0 +1,94 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+// +build kubeapiserver
+
+package kubernetesapiserver
+
+import (
+	"fmt"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+)
+
+func newUnbundledTransformer(clusterName string, types map[string][]string) eventTransformer {
+	collectedTypes := make(map[string]map[string]struct{}, len(types))
+	for kind, reasons := range types {
+		collectedTypes[strings.ToLower(kind)] = make(map[string]struct{}, len(reasons))
+		for _, reason := range reasons {
+			collectedTypes[strings.ToLower(kind)][reason] = struct{}{}
+		}
+	}
+
+	return &unbundledTransformer{
+		clusterName:    clusterName,
+		collectedTypes: collectedTypes,
+	}
+}
+
+type unbundledTransformer struct {
+	clusterName    string
+	collectedTypes map[string]map[string]struct{}
+}
+
+func (c *unbundledTransformer) Transform(events []*v1.Event) ([]metrics.Event, []error) {
+	var (
+		datadogEvs []metrics.Event
+		errors     []error
+	)
+
+	for _, ev := range events {
+		if !c.shouldCollect(ev) {
+			continue
+		}
+
+		involvedObject := ev.InvolvedObject
+		hostInfo := getEventHostInfo(c.clusterName, ev)
+		readableKey := buildReadableKey(involvedObject)
+
+		tags := getInvolvedObjectTags(involvedObject)
+		tags = append(tags,
+			fmt.Sprintf("source_component:%s", ev.Source.Component),
+			fmt.Sprintf("event_reason:%s", ev.Reason),
+		)
+
+		if hostInfo.providerID != "" {
+			tags = append(tags, fmt.Sprintf("host_provider_id:%s", hostInfo.providerID))
+		}
+
+		datadogEvs = append(datadogEvs, metrics.Event{
+			Title:          fmt.Sprintf("%s: %s", readableKey, ev.Reason),
+			Priority:       metrics.EventPriorityNormal,
+			Host:           hostInfo.hostname,
+			SourceTypeName: "kubernetes",
+			EventType:      kubernetesAPIServerCheckName,
+			Ts:             int64(ev.LastTimestamp.Unix()),
+			Tags:           tags,
+			AggregationKey: fmt.Sprintf("kubernetes_apiserver:%s", involvedObject.UID),
+			AlertType:      getDDAlertType(ev.Type),
+			Text:           ev.Message,
+		})
+	}
+
+	return datadogEvs, errors
+}
+
+func (c *unbundledTransformer) shouldCollect(ev *v1.Event) bool {
+	involvedObject := ev.InvolvedObject
+
+	kind := strings.ToLower(involvedObject.Kind)
+	reasonsByKind, ok := c.collectedTypes[kind]
+	if !ok {
+		return false
+	}
+
+	_, shouldCollect := reasonsByKind[ev.Reason]
+
+	return shouldCollect
+}

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/unbundled_events.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/unbundled_events.go
@@ -44,6 +44,13 @@ func (c *unbundledTransformer) Transform(events []*v1.Event) ([]metrics.Event, [
 	)
 
 	for _, ev := range events {
+		kubeEvents.Inc(
+			ev.InvolvedObject.Kind,
+			ev.Source.Component,
+			ev.Type,
+			ev.Reason,
+		)
+
 		if !c.shouldCollect(ev) {
 			continue
 		}
@@ -61,6 +68,8 @@ func (c *unbundledTransformer) Transform(events []*v1.Event) ([]metrics.Event, [
 		if hostInfo.providerID != "" {
 			tags = append(tags, fmt.Sprintf("host_provider_id:%s", hostInfo.providerID))
 		}
+
+		emittedEvents.Inc(involvedObject.Kind, ev.Type)
 
 		datadogEvs = append(datadogEvs, metrics.Event{
 			Title:          fmt.Sprintf("%s: %s", readableKey, ev.Reason),

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/unbundled_events_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/unbundled_events_test.go
@@ -1,0 +1,106 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+// +build kubeapiserver
+
+package kubernetesapiserver
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+)
+
+func TestUnbundledEventsTransform(t *testing.T) {
+	ts := metav1.Time{Time: time.Now()}
+	pod := v1.ObjectReference{
+		UID:       "foobar",
+		Kind:      "Pod",
+		Namespace: "default",
+		Name:      "redis",
+	}
+
+	tests := []struct {
+		name     string
+		event    *v1.Event
+		expected []metrics.Event
+	}{
+		{
+			name: "event is filtered out",
+			event: &v1.Event{
+				InvolvedObject: pod,
+				Type:           "Info",
+				Reason:         "SandboxChanged",
+				Message:        "Pod sandbox changed, it will be killed and re-created.",
+				Source: v1.EventSource{
+					Component: "kubelet",
+					Host:      "test-host",
+				},
+				FirstTimestamp: ts,
+				LastTimestamp:  ts,
+				Count:          1,
+			},
+			expected: nil,
+		},
+		{
+			name: "event is collected",
+			event: &v1.Event{
+				InvolvedObject: pod,
+				Type:           "Warning",
+				Reason:         "Failed",
+				Message:        "All containers terminated",
+				Source: v1.EventSource{
+					Component: "kubelet",
+					Host:      "test-host",
+				},
+				FirstTimestamp: ts,
+				LastTimestamp:  ts,
+				Count:          1,
+			},
+			expected: []metrics.Event{
+				{
+					Title:    "Pod default/redis: Failed",
+					Text:     "All containers terminated",
+					Ts:       ts.Time.Unix(),
+					Priority: metrics.EventPriorityNormal,
+					Host:     "test-host-test-cluster",
+					Tags: []string{
+						"kubernetes_kind:Pod",
+						"name:redis",
+						"namespace:default",
+						"kube_namespace:default",
+						"pod_name:redis",
+						"source_component:kubelet",
+						"event_reason:Failed",
+					},
+					AlertType:      metrics.EventAlertTypeWarning,
+					AggregationKey: "kubernetes_apiserver:foobar",
+					SourceTypeName: "kubernetes",
+					EventType:      "kubernetes_apiserver",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			collectedTypes := map[string][]string{
+				"pod": {"Failed"},
+			}
+			transformer := newUnbundledTransformer("test-cluster", collectedTypes)
+
+			events, errors := transformer.Transform([]*v1.Event{tt.event})
+
+			assert.Empty(t, errors)
+			assert.Equal(t, tt.expected, events)
+		})
+	}
+}

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/unbundled_events_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/unbundled_events_test.go
@@ -73,10 +73,12 @@ func TestUnbundledEventsTransform(t *testing.T) {
 					Priority: metrics.EventPriorityNormal,
 					Host:     "test-host-test-cluster",
 					Tags: []string{
+						"kube_kind:Pod",
+						"kube_name:redis",
 						"kubernetes_kind:Pod",
 						"name:redis",
-						"namespace:default",
 						"kube_namespace:default",
+						"namespace:default",
 						"pod_name:redis",
 						"source_component:kubelet",
 						"event_reason:Failed",

--- a/releasenotes/notes/unbundles-k8s-events-cd22c12e53d9960d.yaml
+++ b/releasenotes/notes/unbundles-k8s-events-cd22c12e53d9960d.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    Introduces an `unbundle_events` config to the `kubernetes_apiserver`
+    integration. When set to `true`, Kubernetes events are no longer bundled
+    together by InvolvedObject, and instead generate separate Datadog events.


### PR DESCRIPTION
### What does this PR do?

When `unbundled_events` is set to `true` in the `kubernetes_apiserver`
integration, Kubernetes events are no longer bundled together by
InvolvedObject, and instead each will generate a separate Datadog event.

### Describe how to test/QA your changes

With `unbundle_events` in `conf.d/kubernetes_apiserver.d/conf.yaml` set to `true` and `false`, check that kubernetes event collection works as expected in the DCA.

Also test that the different types of filters work as expected. Filters were changed in #13484, so check that PR for how to use them.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
