### PR TITLE
[CWS] run functional tests on amazonlinux2022

### DIFF
--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -84,7 +84,7 @@ kitchen_test_security_agent_amazonlinux_x64:
   parallel:
     matrix:
       - KITCHEN_PLATFORM: "amazonlinux"
-        KITCHEN_OSVERS: "amazonlinux2-4-14,amazonlinux2-5-10"
+        KITCHEN_OSVERS: "amazonlinux2-4-14,amazonlinux2-5-10,amazonlinux2022-5-15"
 
 kitchen_stress_security_agent:
   extends:

--- a/pkg/security/ebpf/kernel/kernel.go
+++ b/pkg/security/ebpf/kernel/kernel.go
@@ -243,6 +243,11 @@ func (k *Version) IsAmazonLinuxKernel() bool {
 	return k.OsRelease["ID"] == "amzn"
 }
 
+// IsAmazonLinuxKernel returns whether the kernel is an amazon kernel
+func (k *Version) IsAmazonLinux2022Kernel() bool {
+	return k.IsAmazonLinuxKernel() && k.OsRelease["VERSION_ID"] == "2022"
+}
+
 // IsInRangeCloseOpen returns whether the kernel version is between the begin
 // version (included) and the end version (excluded)
 func (k *Version) IsInRangeCloseOpen(begin kernel.Version, end kernel.Version) bool {

--- a/pkg/security/probe/constantfetch/fallback.go
+++ b/pkg/security/probe/constantfetch/fallback.go
@@ -156,6 +156,8 @@ func getSizeOfStructInode(kv *kernel.Version) uint64 {
 		sizeOf = 584
 	case kv.IsAmazonLinuxKernel() && kv.IsInRangeCloseOpen(kernel.Kernel5_10, kernel.Kernel5_11):
 		sizeOf = 584
+	case kv.IsAmazonLinuxKernel() && kv.IsInRangeCloseOpen(kernel.Kernel5_15, kernel.Kernel5_16):
+		sizeOf = 616
 	case kv.IsInRangeCloseOpen(kernel.Kernel4_15, kernel.Kernel4_16):
 		if ubuntuAbiVersionCheck(kv, increaseSizeAbiMinVersion) {
 			sizeOf = 608

--- a/pkg/security/tests/constants_test.go
+++ b/pkg/security/tests/constants_test.go
@@ -54,6 +54,10 @@ func TestOctogonConstants(t *testing.T) {
 			return kv.IsSLESKernel() || kv.IsOracleUEKKernel()
 		})
 
+		checkKernelCompatibility(t, "AL2022", func(kv *kernel.Version) bool {
+			return kv.IsAmazonLinux2022Kernel()
+		})
+
 		fallbackFetcher := constantfetch.NewFallbackConstantFetcher(kv)
 		rcFetcher := constantfetch.NewRuntimeCompilationConstantFetcher(&config.Config, nil)
 
@@ -63,6 +67,10 @@ func TestOctogonConstants(t *testing.T) {
 	t.Run("btfhub-vs-rc", func(t *testing.T) {
 		checkKernelCompatibility(t, "SLES and Oracle kernels", func(kv *kernel.Version) bool {
 			return kv.IsSLESKernel() || kv.IsOracleUEKKernel()
+		})
+
+		checkKernelCompatibility(t, "AL2022", func(kv *kernel.Version) bool {
+			return kv.IsAmazonLinux2022Kernel()
 		})
 
 		btfhubFetcher, err := constantfetch.NewBTFHubConstantFetcher(kv)
@@ -92,6 +100,10 @@ func TestOctogonConstants(t *testing.T) {
 	t.Run("guesser-vs-rc", func(t *testing.T) {
 		checkKernelCompatibility(t, "SLES and Oracle kernels", func(kv *kernel.Version) bool {
 			return kv.IsSLESKernel() || kv.IsOracleUEKKernel()
+		})
+
+		checkKernelCompatibility(t, "AL2022", func(kv *kernel.Version) bool {
+			return kv.IsAmazonLinux2022Kernel()
 		})
 
 		rcFetcher := constantfetch.NewRuntimeCompilationConstantFetcher(&config.Config, nil)

--- a/test/kitchen/drivers/ec2-driver.yml
+++ b/test/kitchen/drivers/ec2-driver.yml
@@ -101,7 +101,7 @@ platforms:
       <% end %>
         ebs:
           volume_type: gp2
-          volume_size: 40
+          volume_size: 50
           delete_on_termination: true
     <% if allow_rsa_key || al2022 %>
     user_data: |

--- a/test/kitchen/drivers/ec2-driver.yml
+++ b/test/kitchen/drivers/ec2-driver.yml
@@ -101,7 +101,7 @@ platforms:
       <% end %>
         ebs:
           volume_type: gp2
-          volume_size: 50
+          volume_size: 40
           delete_on_termination: true
     <% if allow_rsa_key || al2022 %>
     user_data: |

--- a/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
@@ -102,6 +102,17 @@ if node['platform_family'] != 'windows'
       service 'docker' do
         action [ :enable, :start ]
       end
+    elsif ['amazon'].include?(node[:platform])
+      docker_installation_package 'default' do
+        action :create
+        setup_docker_repo false
+        package_name 'docker'
+        package_options %q|-y|
+      end
+
+      service 'docker' do
+        action [ :enable, :start ]
+      end
     elsif ['ubuntu'].include?(node[:platform])
       docker_installation_package 'default' do
         action :create

--- a/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
@@ -53,6 +53,14 @@ if node['platform_family'] != 'windows'
     mode '755'
   end
 
+  if node[:platform] == "amazon" and node[:platform_version] == "2022"
+    execute "increase /tmp size" do
+      command "mount -o remount,size=5G /tmp/"
+      live_stream true
+      action :run
+    end
+  end
+
   execute "Extract nikos.tar.gz" do
     command "mkdir -p /opt/datadog-agent/embedded/nikos/embedded/ && tar -xzvf #{wrk_dir}/nikos.tar.gz -C /opt/datadog-agent/embedded/nikos/embedded/"
     action :run


### PR DESCRIPTION
### What does this PR do?

This PR adds amazonlinux2022 to the set of OS on which CWS runs functional tests.

This needed to remount the `/tmp` mount point with more space. This fix is specific to amazon2022 (other do not have a separate mount point for `/tmp`)

The RC octogon tests are currently disabled on AL2022 while Nikos is not fixed to support this platform (this will come in a later PR).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
