### PR TITLE
[admission][auto-instrumentation] Add e2e tests for JS

### DIFF
--- a/test/e2e/argo-workflows/templates/mutate-busybox.yaml
+++ b/test/e2e/argo-workflows/templates/mutate-busybox.yaml
@@ -55,7 +55,7 @@ spec:
                 image: busybox
                 name: busybox
 
-    - name: create-busybox-with-auto-instru
+    - name: create-busybox-with-auto-instru-java
       inputs:
         parameters:
           - name: namespace
@@ -65,13 +65,38 @@ spec:
           apiVersion: v1
           kind: Pod
           metadata:
-            name: busybox-auto-instru
+            name: busybox-auto-instru-java
             namespace: {{inputs.parameters.namespace}}
             labels:
               "app": "busybox"
               "admission.datadoghq.com/enabled": "true"
             annotations:
               admission.datadoghq.com/java-lib.custom-image: "gcr.io/datadoghq/dd-java-agent-init:latest"  # TODO: Use the default repo when ready
+          spec:
+            containers:
+              - command:
+                  - sleep
+                  - "3600"
+                image: busybox
+                name: busybox
+
+    - name: create-busybox-with-auto-instru-js
+      inputs:
+        parameters:
+          - name: namespace
+      resource:
+        action: apply
+        manifest: |
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: busybox-auto-instru-js
+            namespace: {{inputs.parameters.namespace}}
+            labels:
+              "app": "busybox"
+              "admission.datadoghq.com/enabled": "true"
+            annotations:
+              admission.datadoghq.com/js-lib.custom-image: "ghcr.io/datadog/dd-trace-js/dd-lib-js-init:e1043d06c7b25f5494a80d3c95e43029ac5cefff"  # TODO: Use the default repo when ready
           spec:
             containers:
               - command:
@@ -115,8 +140,14 @@ spec:
               parameters:
                 - name: namespace
                   value: "{{inputs.parameters.namespace}}"
-          - name: busybox-auto-instru
-            template: create-busybox-with-auto-instru
+          - name: busybox-auto-instru-java
+            template: create-busybox-with-auto-instru-java
+            arguments:
+              parameters:
+                - name: namespace
+                  value: "{{inputs.parameters.namespace}}"
+          - name: busybox-auto-instru-js
+            template: create-busybox-with-auto-instru-js
             arguments:
               parameters:
                 - name: namespace
@@ -386,7 +417,7 @@ spec:
                   value: DD_VERSION
                 - name: target
                   value: busybox-tags
-          - name: env-auto-instru
+          - name: env-auto-instru-java
             template: test-env-value
             arguments:
               parameters:
@@ -397,8 +428,8 @@ spec:
                 - name: envKey
                   value: JAVA_TOOL_OPTIONS
                 - name: target
-                  value: busybox-auto-instru
-          - name: volume-mount-auto-instru
+                  value: busybox-auto-instru-java
+          - name: volume-mount-auto-instru-java
             template: test-volume-mount
             arguments:
               parameters:
@@ -411,8 +442,8 @@ spec:
                 - name: withInitContainers
                   value: "true"
                 - name: target
-                  value: busybox-auto-instru
-          - name: empty-dir-auto-instru
+                  value: busybox-auto-instru-java
+          - name: empty-dir-auto-instru-java
             template: test-empty-dir
             arguments:
               parameters:
@@ -423,7 +454,45 @@ spec:
                 - name: volumePath
                   value: "/datadog-lib"
                 - name: target
-                  value: busybox-auto-instru
+                  value: busybox-auto-instru-java
+          - name: env-auto-instru-js
+            template: test-env-value
+            arguments:
+              parameters:
+                - name: namespace
+                  value: "{{inputs.parameters.namespace}}"
+                - name: envValue
+                  value: " --require=/datadog-lib/node_modules/dd-trace/init"
+                - name: envKey
+                  value: NODE_OPTIONS
+                - name: target
+                  value: busybox-auto-instru-js
+          - name: volume-mount-auto-instru-js
+            template: test-volume-mount
+            arguments:
+              parameters:
+                - name: namespace
+                  value: "{{inputs.parameters.namespace}}"
+                - name: volumeName
+                  value: datadog-auto-instrumentation
+                - name: volumePath
+                  value: "/datadog-lib"
+                - name: withInitContainers
+                  value: "true"
+                - name: target
+                  value: busybox-auto-instru-js
+          - name: empty-dir-auto-instru-js
+            template: test-empty-dir
+            arguments:
+              parameters:
+                - name: namespace
+                  value: "{{inputs.parameters.namespace}}"
+                - name: volumeName
+                  value: datadog-auto-instrumentation
+                - name: volumePath
+                  value: "/datadog-lib"
+                - name: target
+                  value: busybox-auto-instru-js
 
     - name: diagnose
       inputs:


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

- Add e2e tests for JS auto instrumentation
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

- Better test coverage
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

- Tests will be updated to use the default repos when the official images are published
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

E2e tests are green

```
 │ └─✔ test-busybox                            busybox/test                                                                                                                        
 │   └─┬─✔ agent-host-hostip                   test-env-fieldPath                    argo-datadog-agent-s9jpd-3424934782  31s                                                      
 │     ├─✔ agent-host-service                  test-env-value                        argo-datadog-agent-s9jpd-4288703820  22s                                                      
 │     ├─✔ empty-dir-auto-instru-java          test-empty-dir                        argo-datadog-agent-s9jpd-2008975088  32s                                                      
 │     ├─✔ empty-dir-auto-instru-js            test-empty-dir                        argo-datadog-agent-s9jpd-4149991655  27s                                                      
 │     ├─✔ entity-id-hostip                    test-env-fieldPath                    argo-datadog-agent-s9jpd-3415161661  25s                                                      
 │     ├─✔ entity-id-service                   test-env-fieldPath                    argo-datadog-agent-s9jpd-2553352425  29s                                                      
 │     ├─✔ entity-id-socket                    test-env-fieldPath                    argo-datadog-agent-s9jpd-1452870763  23s                                                      
 │     ├─✔ env-auto-instru-java                test-env-value                        argo-datadog-agent-s9jpd-3138254428  20s                                                      
 │     ├─✔ env-auto-instru-js                  test-env-value                        argo-datadog-agent-s9jpd-3888225067  25s                                                      
 │     ├─✔ env-tag                             test-env-value                        argo-datadog-agent-s9jpd-885290818   24s                                                      
 │     ├─✔ host-volume-socket                  test-host-volume                      argo-datadog-agent-s9jpd-2625074283  23s                                                      
 │     ├─✔ service-tag                         test-env-value                        argo-datadog-agent-s9jpd-3475782238  25s                                                      
 │     ├─✔ trace-url-socket                    test-env-value                        argo-datadog-agent-s9jpd-2216622877  31s                                                      
 │     ├─✔ version-tag                         test-env-value                        argo-datadog-agent-s9jpd-3301459861  20s                                                      
 │     ├─✔ volume-mount-auto-instru-java       test-volume-mount                     argo-datadog-agent-s9jpd-3388050683  30s                                                      
 │     ├─✔ volume-mount-auto-instru-js         test-volume-mount                     argo-datadog-agent-s9jpd-600182664   21s                                                      
 │     └─✔ volume-mount-socket                 test-volume-mount                     argo-datadog-agent-s9jpd-3683593840  30s                                     
```

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
