### PR TITLE
[CWS] fix missing logger cases and agent constraint filter creation

### DIFF
--- a/cmd/security-agent/app/runtime.go
+++ b/cmd/security-agent/app/runtime.go
@@ -658,12 +658,16 @@ func checkPoliciesInner(dir string) error {
 		return err
 	}
 
+	filters := make([]rules.RuleFilter, 0, 1)
+	agentVersionFilter, err := rules.NewAgentVersionFilter(agentVersion)
+	if err != nil {
+		return fmt.Errorf("failed to create agent version filter: %w", err)
+	} else {
+		filters = append(filters, agentVersionFilter)
+	}
+
 	loaderOpts := rules.PolicyLoaderOpts{
-		RuleFilters: []rules.RuleFilter{
-			&rules.AgentVersionFilter{
-				Version: agentVersion,
-			},
-		},
+		RuleFilters: filters,
 	}
 
 	provider, err := rules.NewPoliciesDirProvider(cfg.PoliciesDir, false)

--- a/cmd/security-agent/app/runtime.go
+++ b/cmd/security-agent/app/runtime.go
@@ -648,7 +648,7 @@ func checkPoliciesInner(dir string) error {
 		WithSupportedDiscarders(sprobe.SupportedDiscarders).
 		WithEventTypeEnabled(enabled).
 		WithReservedRuleIDs(sprobe.AllCustomRuleIDs()).
-		WithLogger(&seclog.PatternLogger{})
+		WithLogger(seclog.DefaultLogger)
 
 	model := &model.Model{}
 	ruleSet := rules.NewRuleSet(model, model.NewEvent, &opts, &evalOpts, &eval.MacroStore{})
@@ -780,7 +780,7 @@ func evalRule(cmd *cobra.Command, args []string) error {
 		WithSupportedDiscarders(sprobe.SupportedDiscarders).
 		WithEventTypeEnabled(enabled).
 		WithReservedRuleIDs(sprobe.AllCustomRuleIDs()).
-		WithLogger(&seclog.PatternLogger{})
+		WithLogger(seclog.DefaultLogger)
 
 	model := &model.Model{}
 	ruleSet := rules.NewRuleSet(model, model.NewEvent, &opts, &evalOpts, &eval.MacroStore{})

--- a/cmd/security-agent/app/runtime.go
+++ b/cmd/security-agent/app/runtime.go
@@ -658,16 +658,15 @@ func checkPoliciesInner(dir string) error {
 		return err
 	}
 
-	filters := make([]rules.RuleFilter, 0, 1)
 	agentVersionFilter, err := rules.NewAgentVersionFilter(agentVersion)
 	if err != nil {
 		return fmt.Errorf("failed to create agent version filter: %w", err)
-	} else {
-		filters = append(filters, agentVersionFilter)
 	}
 
 	loaderOpts := rules.PolicyLoaderOpts{
-		RuleFilters: filters,
+		RuleFilters: []rules.RuleFilter{
+			agentVersionFilter,
+		},
 	}
 
 	provider, err := rules.NewPoliciesDirProvider(cfg.PoliciesDir, false)

--- a/pkg/security/secl/rules/rule_filters.go
+++ b/pkg/security/secl/rules/rule_filters.go
@@ -29,7 +29,7 @@ func (r *RuleIDFilter) IsAccepted(rule *RuleDefinition) (bool, error) {
 
 // AgentVersionFilter defines a agent version filter
 type AgentVersionFilter struct {
-	Version *semver.Version
+	version *semver.Version
 }
 
 // NewAgentVersionFilter returns a new agent version based rule filter
@@ -45,7 +45,7 @@ func NewAgentVersionFilter(version *semver.Version) (*AgentVersionFilter, error)
 	}
 
 	return &AgentVersionFilter{
-		Version: &cleanAgentVersion,
+		version: &cleanAgentVersion,
 	}, nil
 }
 
@@ -56,5 +56,5 @@ func (r *AgentVersionFilter) IsAccepted(rule *RuleDefinition) (bool, error) {
 		return false, fmt.Errorf("failed to parse agent version constraint: %v", err)
 	}
 
-	return constraint.Check(r.Version), nil
+	return constraint.Check(r.version), nil
 }


### PR DESCRIPTION
### What does this PR do?

This PR:
- fixes some missing cases of seclog creation from https://github.com/DataDog/datadog-agent/pull/13137
- fixes missing creation of agent version constraint from https://github.com/DataDog/datadog-agent/pull/13115

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
