### PR TITLE
check if ebpf source file contain ' inline ' and should use __always_inline

### DIFF
--- a/pkg/ebpf/bytecode/runtime/conntrack.go
+++ b/pkg/ebpf/bytecode/runtime/conntrack.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Conntrack = NewRuntimeAsset("conntrack.c", "ade54b5aac756b13cd9f1458cbe1a1da62735dea41f07f79bbebdb433301a73c")
+var Conntrack = NewRuntimeAsset("conntrack.c", "cb86c8228f72cc5e21c9fa2e61eff9e5e994358b8903b49a85e9119866269e30")

--- a/pkg/ebpf/bytecode/runtime/http.go
+++ b/pkg/ebpf/bytecode/runtime/http.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Http = NewRuntimeAsset("http.c", "37643ed7b1d7230dff448cd779776be341e78deeddd6e13f6f978250757c89d9")
+var Http = NewRuntimeAsset("http.c", "65957c96f4e611b6e710e219ac5b8e76e184d6cf808b986f8863ec1a382880c4")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "ed719dd24bb66237b347f1fd9cf6c30bda1e15cd4bbd438163c9d4d96291434c")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "1645836e689a16e7a4d31e9afadfeaa67aa548326b27e579a7fc89cd18241b65")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "ccd67d94ab237951cd7853f7d97239b67144aca91f57cc944518ce786a75ae35")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "ed719dd24bb66237b347f1fd9cf6c30bda1e15cd4bbd438163c9d4d96291434c")

--- a/pkg/ebpf/bytecode/runtime/tracer.go
+++ b/pkg/ebpf/bytecode/runtime/tracer.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Tracer = NewRuntimeAsset("tracer.c", "a5783af949a0a752dac4b77b30944228170a3559a0ca40ba938d18288d5937db")
+var Tracer = NewRuntimeAsset("tracer.c", "c1437715f5c830e2f0f7c58ec13e924c67e04e2e11724fea736b60b3872d3697")

--- a/pkg/network/ebpf/c/conntrack.h
+++ b/pkg/network/ebpf/c/conntrack.h
@@ -135,7 +135,7 @@ static __always_inline int nf_conn_to_conntrack_tuples(struct nf_conn* ct, connt
     return 0;
 }
 
-static __always_inline bool proc_t_comm_prefix_equals(char* prefix, int prefix_len, proc_t c) {
+static __always_inline bool proc_t_comm_prefix_equals(const char* prefix, int prefix_len, proc_t c) {
     if (prefix_len > TASK_COMM_LEN) {
         return false;
     }

--- a/pkg/network/ebpf/c/prebuilt/http.c
+++ b/pkg/network/ebpf/c/prebuilt/http.c
@@ -25,7 +25,7 @@ static __always_inline void read_into_buffer_skb(char *buffer, struct __sk_buff*
 
 #pragma unroll
     for (; i < iter; i++) {
-        if (offset + BLK_SIZE - 1 >= len) break;
+        if (offset + BLK_SIZE - 1 >= len) { break; }
 
         // There was a bug in the bpf translatter that was incorrectly clobbering r2 register,
         // which led to erasing r1 value in that case:

--- a/pkg/network/ebpf/c/runtime/http.c
+++ b/pkg/network/ebpf/c/runtime/http.c
@@ -30,7 +30,7 @@ static __always_inline void read_into_buffer_skb(char *buffer, struct __sk_buff 
 
 #pragma unroll
     for (; i < iter; i++) {
-        if (offset + BLK_SIZE - 1 >= len) break;
+        if (offset + BLK_SIZE - 1 >= len) { break; }
 
         bpf_skb_load_bytes(skb, offset, &buffer[i * BLK_SIZE], BLK_SIZE);
         offset += BLK_SIZE;
@@ -44,36 +44,37 @@ static __always_inline void read_into_buffer_skb(char *buffer, struct __sk_buff 
     // we are doing `buffer[0]` here, there is not dynamic computation on that said register after this,
     // and thus the verifier is able to ensure that we are in-bound.
     void *buf = &buffer[i * BLK_SIZE];
-    if (offset + 14 < len)
+    if (offset + 14 < len) {
         bpf_skb_load_bytes(skb, offset, buf, 15);
-    else if (offset + 13 < len)
+    } else if (offset + 13 < len) {
         bpf_skb_load_bytes(skb, offset, buf, 14);
-    else if (offset + 12 < len)
+    } else if (offset + 12 < len) {
         bpf_skb_load_bytes(skb, offset, buf, 13);
-    else if (offset + 11 < len)
+    } else if (offset + 11 < len) {
         bpf_skb_load_bytes(skb, offset, buf, 12);
-    else if (offset + 10 < len)
+    } else if (offset + 10 < len) {
         bpf_skb_load_bytes(skb, offset, buf, 11);
-    else if (offset + 9 < len)
+    } else if (offset + 9 < len) {
         bpf_skb_load_bytes(skb, offset, buf, 10);
-    else if (offset + 8 < len)
+    } else if (offset + 8 < len) {
         bpf_skb_load_bytes(skb, offset, buf, 9);
-    else if (offset + 7 < len)
+    } else if (offset + 7 < len) {
         bpf_skb_load_bytes(skb, offset, buf, 8);
-    else if (offset + 6 < len)
+    } else if (offset + 6 < len) {
         bpf_skb_load_bytes(skb, offset, buf, 7);
-    else if (offset + 5 < len)
+    } else if (offset + 5 < len) {
         bpf_skb_load_bytes(skb, offset, buf, 6);
-    else if (offset + 4 < len)
+    } else if (offset + 4 < len) {
         bpf_skb_load_bytes(skb, offset, buf, 5);
-    else if (offset + 3 < len)
+    } else if (offset + 3 < len) {
         bpf_skb_load_bytes(skb, offset, buf, 4);
-    else if (offset + 2 < len)
+    } else if (offset + 2 < len) {
         bpf_skb_load_bytes(skb, offset, buf, 3);
-    else if (offset + 1 < len)
+    } else if (offset + 1 < len) {
         bpf_skb_load_bytes(skb, offset, buf, 2);
-    else if (offset < len)
+    } else if (offset < len) {
         bpf_skb_load_bytes(skb, offset, buf, 1);
+    }
 }
 
 // This entry point is needed to bypass a memory limit on socket filters

--- a/pkg/network/ebpf/c/runtime/skb.h
+++ b/pkg/network/ebpf/c/runtime/skb.h
@@ -107,7 +107,9 @@ static __always_inline int sk_buff_to_tuple(struct sk_buff *skb, conn_tuple_t *t
 
         //log_debug("udp recv: udphdr.len=%d\n", bpf_ntohs(udph.len));
         return (int)(bpf_ntohs(udph.len) - sizeof(struct udphdr));
-    } else if (proto == CONN_TYPE_TCP) {
+    }
+
+    if (proto == CONN_TYPE_TCP) {
         struct tcphdr tcph;
         __builtin_memset(&tcph, 0, sizeof(struct tcphdr));
         ret = bpf_probe_read_kernel(&tcph, sizeof(tcph), (struct tcphdr *)(head + trans_head));

--- a/pkg/security/ebpf/c/pipe.h
+++ b/pkg/security/ebpf/c/pipe.h
@@ -31,14 +31,13 @@ DECLARE_EQUAL_TO(pipefs);
 int __attribute__((always_inline)) get_pipefs_mount_id(void) {
     u32 key = 0;
     u32* val = bpf_map_lookup_elem(&pipefs_mountid, &key);
-    if (val) return *val;
+    if (val) { return *val; }
     return 0;
 }
 
 int __attribute__((always_inline)) is_pipefs_mount_id(u32 id) {
     u32 pipefs_id = get_pipefs_mount_id();
-    if (!pipefs_id)
-        return 0;
+    if (!pipefs_id) { return 0; }
     return (pipefs_id == id);
 }
 
@@ -48,8 +47,9 @@ int kprobe_mntget(struct pt_regs* ctx) {
     struct vfsmount* vfsm = (struct vfsmount*)PT_REGS_PARM1(ctx);
 
     // check if we already have the pipefs mount id
-    if (get_pipefs_mount_id())
+    if (get_pipefs_mount_id()) {
         return 0;
+    }
 
     struct super_block* sb;
     bpf_probe_read(&sb, sizeof(sb), &vfsm->mnt_sb);

--- a/pkg/security/ebpf/c/pipe.h
+++ b/pkg/security/ebpf/c/pipe.h
@@ -10,7 +10,7 @@ struct bpf_map_def SEC("maps/pipefs_mountid") pipefs_mountid = {
     .namespace = "",
 };
 
-#define DECLARE_EQUAL_TO_SUFFIXED(suffix, s) static inline int equal_to_##suffix(char *str) { \
+#define DECLARE_EQUAL_TO_SUFFIXED(suffix, s) static __attribute__((always_inline)) int equal_to_##suffix(char *str) { \
         char s1[sizeof(#s)];                                            \
         bpf_probe_read(&s1, sizeof(s1), str);                           \
         char s2[] = #s;                                                 \

--- a/pkg/security/ebpf/c/tc.h
+++ b/pkg/security/ebpf/c/tc.h
@@ -17,14 +17,16 @@ int classifier_egress(struct __sk_buff *skb) {
         return ACT_OK;
     }
 
-    if (!(parse_ethhdr(&c, &pkt->eth)))
+    if (!(parse_ethhdr(&c, &pkt->eth))) {
         return ACT_OK;
+    }
 
     switch (pkt->eth.h_proto) {
         case htons(ETH_P_IP):
             // parse IPv4 header
-            if (!(parse_iphdr(&c, &pkt->ipv4)))
+            if (!(parse_iphdr(&c, &pkt->ipv4))) {
                 return ACT_OK;
+            }
 
             // adjust cursor with variable ipv4 options
             if (pkt->ipv4.ihl > 5) {
@@ -42,8 +44,9 @@ int classifier_egress(struct __sk_buff *skb) {
         case htons(ETH_P_IPV6):
             // parse IPv6 header
             // TODO: handle multiple IPv6 extension headers
-            if (!(parse_ipv6hdr(&c, &pkt->ipv6)))
+            if (!(parse_ipv6hdr(&c, &pkt->ipv6))) {
                 return ACT_OK;
+            }
 
             pkt->l4_protocol = pkt->ipv6.nexthdr;
             pkt->ns_flow.flow.saddr[0] = *(u64*)&pkt->ipv6.saddr;
@@ -60,8 +63,9 @@ int classifier_egress(struct __sk_buff *skb) {
     switch (pkt->l4_protocol) {
         case IPPROTO_TCP:
             // parse TCP header
-            if (!(parse_tcphdr(&c, &pkt->tcp)))
+            if (!(parse_tcphdr(&c, &pkt->tcp))) {
                 return ACT_OK;
+            }
 
             // adjust cursor with variable tcp options
             c.pos += (pkt->tcp.doff << 2) - sizeof(struct tcphdr);
@@ -75,8 +79,9 @@ int classifier_egress(struct __sk_buff *skb) {
 
         case IPPROTO_UDP:
             // parse UDP header
-            if (!(parse_udphdr(&c, &pkt->udp)))
+            if (!(parse_udphdr(&c, &pkt->udp))) {
                 return ACT_OK;
+            }
 
             // save current offset within the packet
             pkt->offset = ((u32)(long)c.pos - skb->data);

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -825,9 +825,7 @@ def build_object_files(ctx, parallel_build, kernel_release=None, debug=False, st
 
     promises_check = []
     for f in get_ebpf_targets():
-        promises_check.append(
-            ebpf_check_source_file(ctx, parallel_build, f)
-        )
+        promises_check.append(ebpf_check_source_file(ctx, parallel_build, f))
 
     if parallel_build:
         for promise in promises_check:

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -452,8 +452,8 @@ def object_files(ctx, parallel_build=True, kernel_release=None):
 
 def get_ebpf_targets():
     files = glob.glob("pkg/ebpf/c/*.[c,h]")
-    files.extend(glob.glob("pkg/network/ebpf/c/*.[c,h]"))
-    files.extend(glob.glob("pkg/security/ebpf/c/*.[c,h]"))
+    files.extend(glob.glob("pkg/network/ebpf/c/**/*.[c,h]", recursive=True))
+    files.extend(glob.glob("pkg/security/ebpf/c/**/*.[c,h]", recursive=True))
     return files
 
 


### PR DESCRIPTION
### What does this PR do?

Sanity check if ebpf source file contain ' inline ' and we should use __always_inline

### Motivation

Inline macro is set/depend by the kernel header include/linux/compiler_types.h
Avoid failing CI a not inlining a function that generate bpf2bpf call
