### PR TITLE
[WA-34] Execute FinalizeInstall when removing features with Windows installer

### DIFF
--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -102,7 +102,7 @@
     <SetProperty Id="PROJECTLOCATIONONCMDLINESLASH" Value="[PROJECTLOCATION]\" Before="AppSearch">PROJECTLOCATION </SetProperty>
     <SetProperty Id="CONFDIRONCOMMANDLINE" Value="[APPLICATIONDATADIRECTORY]" Before="AppSearch">APPLICATIONDATADIRECTORY </SetProperty>
     <SetProperty Id="CONFDIRONCOMMANDLINESLASH" Value="[APPLICATIONDATADIRECTORY]\" Before="AppSearch">APPLICATIONDATADIRECTORY </SetProperty>
-    
+
     <!--
       The following property is set to either C:\ProgramData\Datadog or to the value of [APPLICATIONDATADIRECTORY]
       if it is provided as installation parameter. This property will be used during AppSearch phase to detect
@@ -118,7 +118,7 @@
       "3" refers to the action state "on the local computer" (which is the only one we support besides "not present", which happens to be "2")
 
       So, the NPMFEATURESTATE property will be set to "off" if the NPM feature is no installed on the local computer
-      and will be set to "on" if it is used on the local computer.  
+      and will be set to "on" if it is used on the local computer.
 
       This flag will be used in the custom action to decide what service dependencies need to be set
 
@@ -174,7 +174,7 @@
       </Directory>
     </Directory>
 
-    <!-- Detect existence of datadog.yaml file -->    
+    <!-- Detect existence of datadog.yaml file -->
     <Property Id="DATADOGYAMLEXISTS">
       <DirectorySearch Id="DatadogYamlSearchDirId" Path="[APPLICATIONDATADIRECTORY_BEFORE_APPSEARCH]" Depth="0" AssignToProperty="yes">
         <FileSearch Id="DatadogYamlSearchFileId" Name="datadog.yaml"/>
@@ -466,8 +466,8 @@
            installer is called twice; the existing (previously installed)
            installer is called with _UPGRADE, and then the new installer
            is called with _INSTALL -->
-      <Custom Action='SetFinalizeProperty' Before='FinalizeInstall'> <![CDATA[Installed="" OR REMOVE="" ]]> </Custom>
-      <Custom Action='FinalizeInstall' Before='StartServices'>      <![CDATA[Installed="" OR REMOVE="" ]]> </Custom>
+      <Custom Action='SetFinalizeProperty' Before='FinalizeInstall'> <![CDATA[Installed="" OR REMOVE<>"ALL" ]]> </Custom>
+      <Custom Action='FinalizeInstall' Before='StartServices'>       <![CDATA[Installed="" OR REMOVE<>"ALL" ]]> </Custom>
 
       <!-- Same deal here -->
       <Custom Action='StartDDServices' After='StartServices'>  <![CDATA[REMOVE<>"ALL"]]></Custom>
@@ -678,7 +678,7 @@
       This does not affect the final artefact, as it seems to affects only the base string, not the expanded one.
       At runtime this limitation doesn\'t seem to apply.
     -->
-    
+
     <CustomAction Id='SetFinalizeProperty' Return='check' Property='FinalizeInstall'
         Value='
             UILevel=[UILevel]


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->
Modifies Windows installer's FinalizeInstall custom action condition to run when features are removed, for example `REMOVE="NPM"`, so that it can update the services.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Fix an issue where the `datadog-system-probe` service was left depending on the non-existent `ddnpm` service after the NPM feature was removed.

xref [WA-34](https://datadoghq.atlassian.net/browse/WA-34)

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
1. Install agent with NPM feature
2. Verify that `datadog-system-probe` service depends on `ddnpm`
   ```
   > sc.exe qc datadog-system-probe
   ...
   SERVICE_NAME: datadog-system-probe
   ...
   DEPENDENCIES       : datadogagent
                      : ddnpm
   ...
   ```
3. Re-run installer and remove the NPM feature
4. Verify that `datadog-system-probe` service does NOT depend on `ddnpm`
   ```
   > sc.exe qc datadog-system-probe
   ...
   SERVICE_NAME: datadog-system-probe
   ...
   DEPENDENCIES       : datadogagent
   ...
   ```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
