### PR TITLE
[Windows installer] Fix navigating back from the Ready Remove dialog to the Maintenance type dialog

### DIFF
--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -635,7 +635,7 @@
       <Publish Dialog="MaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="SiteDlg">APIKEY AND (NOT SITE)</Publish>
       <Publish Dialog="MaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="VerifyReadyDlg">APIKEY AND SITE</Publish>
 
-      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="MaintenanceTypeDlg">WixUI_InstallMode = "Repair"</Publish>
+      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="MaintenanceTypeDlg">WixUI_InstallMode = "Repair" OR WixUI_InstallMode = "Remove"</Publish>
 
       <Publish Dialog="MaintenanceTypeDlg" Control="RemoveButton" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
 


### PR DESCRIPTION
### What does this PR do?

The installer currently does not navigate back from the “Ready to Remove Datadog Agent“ dialog to the “Change, repair or remove installation“ dialog. This PR adds a fix for the same.

### Motivation

See above

### Additional Notes

You can refer to Wix built-in dialogs here: https://wixtoolset.org//documentation/manual/v3/wixui/dialog_reference/wixui_dialogs.html

### Possible Drawbacks / Trade-offs

N/A

### Describe how to test/QA your changes

* Install the Datadog Windows Agent.
* From Programs and Features window, right click on Datadog Agent and select “Change“.
* Click “Next“ on the Welcome screen.
* Click on the “Remove” button in the “Change, repair or remove installation“ dialog which navigates to “Ready to Remove Datadog Agent“ dialog.
* Click “Back“ button in the “Ready to Remove Datadog Agent“.

Result (without this fix)

The “Back“ button has no effect on clicking, that is, it does not navigate away from the “Ready to Remove Datadog Agent“ dialog.

Result (with this fix)
The installer navigates back to the “Change, repair or remove installation“ dialog.

### Reviewer's Checklist

- [X] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [X] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [X] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
