### PR TITLE
Add Windows Process Isolation container PID to CID mapping

### DIFF
--- a/pkg/util/containers/metrics/docker/collector.go
+++ b/pkg/util/containers/metrics/docker/collector.go
@@ -81,13 +81,18 @@ func (d *dockerCollector) GetContainerStats(containerNS, containerID string, cac
 	}
 	outStats := convertContainerStats(&stats.Stats)
 
+	// Try to collect the container's PIDs via Docker API, if we can't spec() will fill in the entry PID
+	outStats.PID.PIDs, err = d.pids(containerID)
+	if err != nil {
+		log.Warnf("Unable to collect container's PIDs via Docker API, PID list will be incomplete, cid: %s, err: %v", containerID, err)
+	}
+
 	contSpec, err := d.spec(containerID)
 	if err == nil {
 		fillStatsFromSpec(outStats, contSpec)
 	} else {
 		log.Debugf("Unable to inspect container some metrics will be missing, cid: %s, err: %v", containerID, err)
 	}
-
 	return outStats, nil
 }
 
@@ -153,6 +158,11 @@ func (d *dockerCollector) stats(containerID string) (*types.StatsJSON, error) {
 	}
 
 	return stats, nil
+}
+
+// pids returns a list of the specified container's PIDs
+func (d *dockerCollector) pids(containerID string) ([]int, error) {
+	return d.du.GetContainerPIDs(context.TODO(), containerID)
 }
 
 func (d *dockerCollector) spec(containerID string) (*types.ContainerJSON, error) {

--- a/releasenotes/notes/windows-docker-process-isolation-containers-606a8e11daea3349.yaml
+++ b/releasenotes/notes/windows-docker-process-isolation-containers-606a8e11daea3349.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Windows: Adds support for Windows Docker "Process Isolation" containers running on a Windows host.


### PR DESCRIPTION
### What does this PR do?
This PR expands support for Windows Docker container information collection (Windows host running Windows Process Isolation Docker containers) by mapping inner-container PIDs to their respective container ID.

### Motivation
This association enables inner-container process inspection and allows `system-probe` to map connections to PIDs within the containers.

### Additional Notes
Right now, on the Windows container host, Docker "Process Isolation" Windows container types are supported (i.e. Windows containers on a Windows host). Linux containers on a Windows host are not supported at this time.

### Possible Drawbacks / Trade-offs
- If the underlying Docker API fails, we revert back to the original code, which shows the container's entry point process, but no additional processes.
- Adds support for Windows containers on Windows. Linux containers are not supported.

### Describe how to test/QA your changes

1. Provision a Windows Server VM.
2. Install Docker on the VM.
3. Download and run a Windows Python3 container.
4. Attach to the container and start a Python HTTP server.
5. Make a connection to the HTTP server.
6. Install the Datadog Agent - ensure NPM is enabled.
7. From within the container, run `tasklist`, and record the processes and PIDs.
8. From the container host, in PowerShell, list all the processes via: `docker top [container-id]`, and record the processes and PIDs.
9. Find your container host in the Datadog GUI, navigate to the "Containers" page, and verify that the reported PIDs match with the PIDs from 7. and 8. .
10. Observe the network connections to the container host in the GUI.
11. Verify that the reported connections are associated with the HTTP server's PID.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
