### PR TITLE
[admission][socket-mode] Ensure volumeMount uniqueness

### DIFF
--- a/pkg/clusteragent/admission/mutate/common_test.go
+++ b/pkg/clusteragent/admission/mutate/common_test.go
@@ -157,11 +157,47 @@ func Test_injectVolume(t *testing.T) {
 		{
 			name: "volume exists",
 			args: args{
-				pod:         fakePodWithVolume("podfoo", "volumefoo"),
+				pod:         fakePodWithVolume("podfoo", "volumefoo", "/foo"),
 				volume:      corev1.Volume{Name: "volumefoo"},
 				volumeMount: corev1.VolumeMount{Name: "volumefoo"},
 			},
 			injected: false,
+		},
+		{
+			name: "volume mount exists",
+			args: args{
+				pod:         fakePodWithVolume("podfoo", "volumefoo", "/foo"),
+				volume:      corev1.Volume{Name: "differentName"},
+				volumeMount: corev1.VolumeMount{Name: "volumefoo"},
+			},
+			injected: false,
+		},
+		{
+			name: "mount path exists in one container",
+			args: args{
+				pod:         withContainer(fakePodWithVolume("podfoo", "volumefoo", "/foo"), "second-container"),
+				volume:      corev1.Volume{Name: "differentName"},
+				volumeMount: corev1.VolumeMount{Name: "volumefoo"},
+			},
+			injected: true,
+		},
+		{
+			name: "mount path exists",
+			args: args{
+				pod:         fakePodWithVolume("podfoo", "volumefoo", "/foo"),
+				volume:      corev1.Volume{Name: "differentName"},
+				volumeMount: corev1.VolumeMount{Name: "differentName", MountPath: "/foo"},
+			},
+			injected: false,
+		},
+		{
+			name: "mount path exists in one container",
+			args: args{
+				pod:         withContainer(fakePodWithVolume("podfoo", "volumefoo", "/foo"), "-second-container"),
+				volume:      corev1.Volume{Name: "differentName"},
+				volumeMount: corev1.VolumeMount{Name: "differentName", MountPath: "/foo"},
+			},
+			injected: true,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/clusteragent/admission/mutate/test_utils.go
+++ b/pkg/clusteragent/admission/mutate/test_utils.go
@@ -96,15 +96,20 @@ func fakePodWithEnvFieldRefValue(name, envKey, path string) *corev1.Pod {
 	return fakePodWithContainer(name, corev1.Container{Name: name + "-container", Env: []corev1.EnvVar{fakeEnvWithFieldRefValue(envKey, path)}})
 }
 
-func fakePodWithVolume(podName, volumeName string) *corev1.Pod {
+func fakePodWithVolume(podName, volumeName, mountPath string) *corev1.Pod {
 	pod := fakePod(podName)
 	pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{Name: volumeName})
-	pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{Name: volumeName})
+	pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{Name: volumeName, MountPath: mountPath})
 	return pod
 }
 
 func fakePod(name string) *corev1.Pod {
 	return fakePodWithContainer(name, corev1.Container{Name: name + "-container"})
+}
+
+func withContainer(pod *corev1.Pod, nameSuffix string) *corev1.Pod {
+	pod.Spec.Containers = append(pod.Spec.Containers, corev1.Container{Name: pod.Name + nameSuffix})
+	return pod
 }
 
 func boolPointer(b bool) *bool {

--- a/releasenotes-dca/notes/admission-socket-fix-4e98f2c37ade8e77.yaml
+++ b/releasenotes-dca/notes/admission-socket-fix-4e98f2c37ade8e77.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed an edge case in the Admission Controller when ``mutateUnlabelled`` is enabled and ``configMode`` is set to ``socket``.
+    This combination could prevent the creation of new DaemonSet Agent pods.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

- Make sure we ignore containers that have predefined volume mounts with the same name or mount path
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

fixes https://github.com/DataDog/helm-charts/issues/722
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

The scenario is well explained in https://github.com/DataDog/helm-charts/issues/722 - A helm upgrade with `mutateUnlabelled: true` and `configMode: socket` must not block the creation of new agent pods
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
