### PR TITLE
system-probe: output totals line since kitchen rerun relies on it

### DIFF
--- a/test/kitchen/test/integration/system-probe-test/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/system-probe-test/rspec/spec_helper.rb
@@ -44,6 +44,7 @@ class CustomFormatter
 
   def dump_summary(notification)
     @output << KernelOut.format("Finished in #{RSpec::Core::Formatters::Helpers.format_duration(notification.duration)}.\n")
+    @output << KernelOut.format(notification.totals_line)
     @output << KernelOut.format("Platform: #{`uname -a`}\n\n")
   end
 

--- a/test/kitchen/test/integration/system-probe-test/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/system-probe-test/rspec/spec_helper.rb
@@ -44,7 +44,7 @@ class CustomFormatter
 
   def dump_summary(notification)
     @output << KernelOut.format("Finished in #{RSpec::Core::Formatters::Helpers.format_duration(notification.duration)}.\n")
-    @output << KernelOut.format(notification.totals_line)
+    @output << KernelOut.format("#{notification.totals_line}\n")
     @output << KernelOut.format("Platform: #{`uname -a`}\n\n")
   end
 


### PR DESCRIPTION
### What does this PR do?

The kitchen infrastructure currently relies on https://github.com/DataDog/datadog-agent/blob/f928992f5fc4684ec5aa861ea9cfef76bd323ec7/test/kitchen/tasks/kitchen.py#L162 to select if a re-run must be launched. The goal is to re-run the test suite internally (not using gitlab retry) in the case of an infrastructure issue.

This check relies on the presence of `X examples, Y failures` in the logs, which is usually output by the default formatter.
With the usage of the custom formatter based on `KernelOut` (great feature BTW, I found this bug while trying to use the same thing for the security agent) this line is not output anymore triggering a re-run in all cases where there is a failed test.

This PR fixes the issue by ensuring that the expected line is in the logs

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
