### PR TITLE
[7.39] Fix dead containers kept in metadata service (#13167)

### DIFF
--- a/pkg/workloadmeta/collectors/internal/docker/docker.go
+++ b/pkg/workloadmeta/collectors/internal/docker/docker.go
@@ -189,11 +189,15 @@ func (c *collector) buildCollectorEvent(ctx context.Context, ev *docker.Containe
 			return event, fmt.Errorf("could not inspect container %q: %s", ev.ContainerID, err)
 		}
 
+		if ev.Action != docker.ContainerEventActionStart && !container.State.Running {
+			return event, fmt.Errorf("received event: %s on dead container: %q, discarding", ev.Action, ev.ContainerID)
+		}
+
 		var createdAt time.Time
 		if container.Created != "" {
 			createdAt, err = time.Parse(time.RFC3339, container.Created)
 			if err != nil {
-				log.Debugf("could not parse creation time '%q' for container %q: %s", container.Created, container.ID, err)
+				log.Debugf("Could not parse creation time '%q' for container %q: %s", container.Created, container.ID, err)
 			}
 		}
 
@@ -201,7 +205,7 @@ func (c *collector) buildCollectorEvent(ctx context.Context, ev *docker.Containe
 		if container.State.StartedAt != "" {
 			startedAt, err = time.Parse(time.RFC3339, container.State.StartedAt)
 			if err != nil {
-				log.Debugf("cannot parse StartedAt %q for container %q: %s", container.State.StartedAt, container.ID, err)
+				log.Debugf("Cannot parse StartedAt %q for container %q: %s", container.State.StartedAt, container.ID, err)
 			}
 		}
 
@@ -209,7 +213,7 @@ func (c *collector) buildCollectorEvent(ctx context.Context, ev *docker.Containe
 		if container.State.FinishedAt != "" {
 			finishedAt, err = time.Parse(time.RFC3339, container.State.FinishedAt)
 			if err != nil {
-				log.Debugf("cannot parse FinishedAt %q for container %q: %s", container.State.FinishedAt, container.ID, err)
+				log.Debugf("Cannot parse FinishedAt %q for container %q: %s", container.State.FinishedAt, container.ID, err)
 			}
 		}
 

--- a/releasenotes/notes/fix-old-containers-docker-compose-4f1b5c9a688cfb74.yaml
+++ b/releasenotes/notes/fix-old-containers-docker-compose-4f1b5c9a688cfb74.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix duplicated check or logs configuration targeting dead containers when containers are re-created by Docker Compose.

--- a/releasenotes/notes/fix-old-containers-docker-compose-4f1b5c9a688cfb74.yaml
+++ b/releasenotes/notes/fix-old-containers-docker-compose-4f1b5c9a688cfb74.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    Fix duplicated check or logs configuration targeting dead containers when containers are re-created by Docker Compose.
+    Fix duplicated check or logs configurations, targeting dead containers when containers are re-created by Docker Compose.


### PR DESCRIPTION
### What does this PR do?

Backport #13167

### Motivation

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

See #13167

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
