### PR TITLE
Explicitly pass debug flag to runtime compiler

### DIFF
--- a/pkg/collector/corechecks/ebpf/probe/oom_kill.go
+++ b/pkg/collector/corechecks/ebpf/probe/oom_kill.go
@@ -41,7 +41,7 @@ type OOMKillProbe struct {
 }
 
 func NewOOMKillProbe(cfg *ebpf.Config) (*OOMKillProbe, error) {
-	compiledOutput, err := runtime.OomKill.Compile(cfg, nil, statsd.Client)
+	compiledOutput, err := runtime.OomKill.Compile(cfg, []string{"-g"}, statsd.Client)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/collector/corechecks/ebpf/probe/oom_kill_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/oom_kill_test.go
@@ -62,7 +62,7 @@ func TestOOMKillCompile(t *testing.T) {
 
 	cfg := ebpf.NewConfig()
 	cfg.BPFDebug = true
-	_, err = runtime.OomKill.Compile(cfg, nil, statsd.Client)
+	_, err = runtime.OomKill.Compile(cfg, []string{"-g"}, statsd.Client)
 	require.NoError(t, err)
 }
 

--- a/pkg/collector/corechecks/ebpf/probe/tcp_queue_length.go
+++ b/pkg/collector/corechecks/ebpf/probe/tcp_queue_length.go
@@ -44,7 +44,7 @@ type TCPQueueLengthTracer struct {
 }
 
 func NewTCPQueueLengthTracer(cfg *ebpf.Config) (*TCPQueueLengthTracer, error) {
-	compiledOutput, err := runtime.TcpQueueLength.Compile(cfg, nil, statsd.Client)
+	compiledOutput, err := runtime.TcpQueueLength.Compile(cfg, []string{"-g"}, statsd.Client)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/collector/corechecks/ebpf/probe/tcp_queue_length_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/tcp_queue_length_test.go
@@ -33,7 +33,7 @@ func TestTCPQueueLengthCompile(t *testing.T) {
 
 	cfg := ebpf.NewConfig()
 	cfg.BPFDebug = true
-	_, err = runtime.TcpQueueLength.Compile(cfg, nil, statsd.Client)
+	_, err = runtime.TcpQueueLength.Compile(cfg, []string{"-g"}, statsd.Client)
 	require.NoError(t, err)
 }
 

--- a/pkg/ebpf/compiler/compiler.go
+++ b/pkg/ebpf/compiler/compiler.go
@@ -68,7 +68,7 @@ func CompileToObjectFile(in io.Reader, outputFile string, cflags []string, heade
 		)
 	}
 	cflags = append(cflags, fmt.Sprintf("-isystem%s", tmpIncludeDir))
-	cflags = append(cflags, "-g", "-c", "-x", "c", "-o", "-", "-")
+	cflags = append(cflags, "-c", "-x", "c", "-o", "-", "-")
 
 	var clangOut, clangErr, llcErr bytes.Buffer
 

--- a/pkg/network/http/compile.go
+++ b/pkg/network/http/compile.go
@@ -30,5 +30,6 @@ func getCFlags(config *config.Config) []string {
 	if config.BPFDebug {
 		cflags = append(cflags, "-DDEBUG=1")
 	}
+	cflags = append(cflags, "-g")
 	return cflags
 }

--- a/pkg/network/tracer/compile.go
+++ b/pkg/network/tracer/compile.go
@@ -29,5 +29,6 @@ func getCFlags(config *config.Config) []string {
 	if config.BPFDebug {
 		cflags = append(cflags, "-DDEBUG=1")
 	}
+	cflags = append(cflags, "-g")
 	return cflags
 }

--- a/pkg/network/tracer/connection/kprobe/compile.go
+++ b/pkg/network/tracer/connection/kprobe/compile.go
@@ -29,5 +29,6 @@ func getCFlags(config *config.Config) []string {
 	if config.BPFDebug {
 		cflags = append(cflags, "-DDEBUG=1")
 	}
+	cflags = append(cflags, "-g")
 	return cflags
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR changes the way the debug flag "-g" is passed for runtime compiled files. The flag is passed explicitly for the object files which require it.

This PR fixes a problem introduced by [PR#12922](https://github.com/DataDog/datadog-agent/pull/12922), which always passed '-g' when compiling at runtime.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
