### PR TITLE
[backport] [dogstatsd] do not read timestamp when the no aggregation pipeline is off (13192)

### DIFF
--- a/pkg/dogstatsd/parse_metrics_test.go
+++ b/pkg/dogstatsd/parse_metrics_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -328,9 +329,29 @@ func TestParseMetricError(t *testing.T) {
 }
 
 func TestParseGaugeWithTimestamp(t *testing.T) {
-	// with tags and timestamp
+	// no timestamp should be read when the no agg pipeline is off
 
 	sample, err := parseMetricSample([]byte("metric:1234|g|#onetag|T1657100430"))
+
+	assert.NoError(t, err)
+
+	assert.Equal(t, "metric", sample.name)
+	assert.InEpsilon(t, 1234.0, sample.value, epsilon)
+	require.Nil(t, sample.values)
+	assert.Equal(t, gaugeType, sample.metricType)
+	require.Equal(t, 1, len(sample.tags))
+	assert.Equal(t, "onetag", sample.tags[0])
+	assert.InEpsilon(t, 1.0, sample.sampleRate, epsilon)
+	assert.Zero(t, sample.ts)
+
+	// enable the no aggregation pipeline
+
+	config.Datadog.Set("dogstatsd_no_aggregation_pipeline", true)
+	defer config.Datadog.Set("dogstatsd_no_aggregation_pipeline", false)
+
+	// with tags and timestamp
+
+	sample, err = parseMetricSample([]byte("metric:1234|g|#onetag|T1657100430"))
 
 	assert.NoError(t, err)
 
@@ -442,6 +463,11 @@ func TestParseGaugeWithTimestamp(t *testing.T) {
 }
 
 func TestParseGaugeTimestampMalformed(t *testing.T) {
+	// enable the no aggregation pipeline
+
+	config.Datadog.Set("dogstatsd_no_aggregation_pipeline", true)
+	defer config.Datadog.Set("dogstatsd_no_aggregation_pipeline", false)
+
 	// bad value
 
 	_, err := parseMetricSample([]byte("metric:1234|g|#onetag|TABCD"))

--- a/pkg/dogstatsd/server_test.go
+++ b/pkg/dogstatsd/server_test.go
@@ -92,9 +92,9 @@ func TestUDPReceive(t *testing.T) {
 	port, err := getAvailableUDPPort()
 	require.NoError(t, err)
 	config.Datadog.SetDefault("dogstatsd_port", port)
-	config.Datadog.SetDefault("dogstatsd_no_aggregation_pipeline", true)
+	config.Datadog.Set("dogstatsd_no_aggregation_pipeline", true)
 	defer func() {
-		config.Datadog.SetDefault("dogstatsd_no_aggregation_pipeline", false)
+		config.Datadog.Set("dogstatsd_no_aggregation_pipeline", false)
 	}()
 
 	demux := aggregator.InitTestAgentDemultiplexerWithFlushInterval(10 * time.Millisecond)


### PR DESCRIPTION
### What does this PR do?

Backport  #13192

### Describe how to test/QA your changes

See #13192 

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
