### PR TITLE
Use process probe in place of gopsutil for dockerproxy filter

### DIFF
--- a/pkg/process/checks/net.go
+++ b/pkg/process/checks/net.go
@@ -21,7 +21,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/dockerproxy"
 	"github.com/DataDog/datadog-agent/pkg/process/net"
 	"github.com/DataDog/datadog-agent/pkg/process/net/resolver"
-	procutil "github.com/DataDog/datadog-agent/pkg/process/util"
+	"github.com/DataDog/datadog-agent/pkg/process/procutil"
+	putil "github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -46,15 +47,17 @@ var (
 type ConnectionsCheck struct {
 	tracerClientID         string
 	networkID              string
-	notInitializedLogLimit *procutil.LogLimit
+	notInitializedLogLimit *putil.LogLimit
 	// store the last collection result by PID, currently used to populate network data for processes
 	// it's in format map[int32][]*model.Connections
 	lastConnsByPID *atomic.Value
+	probe          procutil.Probe
 }
 
 // Init initializes a ConnectionsCheck instance.
 func (c *ConnectionsCheck) Init(cfg *config.AgentConfig, _ *model.SystemInfo) {
-	c.notInitializedLogLimit = procutil.NewLogLimit(1, time.Minute*10)
+	c.probe = getProcessProbe()
+	c.notInitializedLogLimit = putil.NewLogLimit(1, time.Minute*10)
 
 	// We use the current process PID as the system-probe client ID
 	c.tracerClientID = ProcessAgentClientID
@@ -108,7 +111,12 @@ func (c *ConnectionsCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.
 	}
 
 	// Filter out (in-place) connection data associated with docker-proxy
-	dockerproxy.NewFilter().Filter(conns)
+	procs, err := c.probe.ProcessesByPID(time.Now(), false)
+	if err != nil {
+		log.Warnf("error collecting processes for proxy filter: %s", err)
+	} else {
+		dockerproxy.NewFilter(procs).Filter(conns)
+	}
 	// Resolve the Raddr side of connections for local containers
 	LocalResolver.Resolve(conns)
 

--- a/pkg/process/dockerproxy/filter.go
+++ b/pkg/process/dockerproxy/filter.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 
 	model "github.com/DataDog/agent-payload/v5/process"
-	"github.com/DataDog/gopsutil/process"
 
+	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -29,19 +29,14 @@ type proxy struct {
 }
 
 // NewFilter instantiates a new filter loaded with docker-proxy instance information
-func NewFilter() *Filter {
+func NewFilter(procs map[int32]*procutil.Process) *Filter {
 	filter := new(Filter)
-	if procs, err := process.AllProcesses(); err == nil {
-		filter.LoadProxies(procs)
-	} else {
-		log.Errorf("error initiating proxy filter: %s", err)
-	}
-
+	filter.LoadProxies(procs)
 	return filter
 }
 
 // LoadProxies by inspecting processes information
-func (f *Filter) LoadProxies(procs map[int32]*process.FilledProcess) {
+func (f *Filter) LoadProxies(procs map[int32]*procutil.Process) {
 	f.proxyByPID = make(map[int32]*proxy)
 	f.proxyByTarget = make(map[model.ContainerAddr]*proxy)
 
@@ -127,7 +122,7 @@ func (f *Filter) discoverProxyIP(p *proxy, c *model.Connection) string {
 	return ""
 }
 
-func extractProxyTarget(p *process.FilledProcess) *proxy {
+func extractProxyTarget(p *procutil.Process) *proxy {
 	if len(p.Cmdline) == 0 {
 		return nil
 	}

--- a/pkg/process/dockerproxy/filter_test.go
+++ b/pkg/process/dockerproxy/filter_test.go
@@ -9,8 +9,9 @@ import (
 	"testing"
 
 	model "github.com/DataDog/agent-payload/v5/process"
-	"github.com/DataDog/gopsutil/process"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 )
 
 // The example below represents the following scenario:
@@ -36,9 +37,7 @@ import (
 // The purpose of this package is to filter flows like (3) and (4) in order to
 // avoid double counting traffic represented similar to flows (1) and (2)
 func TestProxyFiltering(t *testing.T) {
-	assert := assert.New(t)
-	filter := NewFilter()
-	filter.LoadProxies(processData())
+	filter := NewFilter(processData())
 
 	// (1) This represents the *outgoing* connection from redis client to redis rerver (via host IP)
 	// It should be *kept*
@@ -103,13 +102,13 @@ func TestProxyFiltering(t *testing.T) {
 	// Filter docker-proxy traffic in place
 	payload := &model.Connections{Conns: []*model.Connection{c1, c2, c3, c4}}
 	filter.Filter(payload)
-	assert.Len(payload.Conns, 2)
-	assert.Equal(c1, payload.Conns[0])
-	assert.Equal(c2, payload.Conns[1])
+	assert.Len(t, payload.Conns, 2)
+	assert.Equal(t, c1, payload.Conns[0])
+	assert.Equal(t, c2, payload.Conns[1])
 }
 
-func processData() map[int32]*process.FilledProcess {
-	return map[int32]*process.FilledProcess{
+func processData() map[int32]*procutil.Process {
+	return map[int32]*procutil.Process{
 		1: {
 			Pid: 1,
 			Cmdline: []string{


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Uses the existing code in process-agent to get the process information we need for the `docker-proxy` filter.

### Motivation

`gopsutil` allocates a lot of memory during `process.AllProcesses()`

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Left/green is 7.39.0-rc.5, right/red is this branch

![Screen Shot 2022-08-22 at 9 11 17 AM](https://user-images.githubusercontent.com/1010430/185968271-8e695828-9023-474e-8433-18ee97d04288.png)
![Screen Shot 2022-08-22 at 9 16 43 AM](https://user-images.githubusercontent.com/1010430/185969424-be06d87f-1321-4cc7-ace5-54d36dd421db.png)

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
