### PR TITLE
add exceptions for container scenarios

### DIFF
--- a/tools/agent_QA/release_qa.py
+++ b/tools/agent_QA/release_qa.py
@@ -73,6 +73,15 @@ Suite(
     ],
 ).build(kube.add_card)
 
+# exceptions are omitted from the generated test cases
+CONTAINER_EXCEPTIONS = set(
+    # (k8s, cfgsource, cca, kcuf, dcuf)
+    # These cases have never worked. See AML-240
+    ('containerd', 'annotation', True, False, False),
+    ('containerd', 'annotation', False, False, True),
+    ('containerd', 'annotation', False, False, False),
+)
+
 containers = board.add_list("Container Runtimes")
 Suite(
     LinuxConfig(),
@@ -93,6 +102,7 @@ Suite(
         for cca in (True, False)
         for kcuf in (True, False)
         for dcuf in (True, False)
+        if (k8s, cfgsource, cca, kcuf, dcuf) not in CONTAINER_EXCEPTIONS
     ],
 ).build(containers.add_card)
 


### PR DESCRIPTION
### What does this PR do?

Removes three QA cards that are known not to work.


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
