### PR TITLE
Add a tag with branch name on nightlies

### DIFF
--- a/.gitlab/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/dev_container_deploy/docker_linux.yml
@@ -215,9 +215,9 @@ dev_nightly_docker_hub-a6:
   parallel:
     matrix:
       - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6-arm64
-        IMG_DESTINATIONS: agent-dev:nightly-${CI_COMMIT_SHORT_SHA},agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py2
+        IMG_DESTINATIONS: agent-dev:nightly-${CI_COMMIT_SHORT_SHA},agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py2,agent-dev:nightly-${CI_COMMIT_BRANCH}-py2
       - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6-jmx-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6-jmx-arm64
-        IMG_DESTINATIONS: agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-jmx,agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py2-jmx
+        IMG_DESTINATIONS: agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-jmx,agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py2-jmx,agent-dev:nightly-${CI_COMMIT_BRANCH}-py2-jmx
 
 # deploys nightlies to agent-dev
 dev_nightly-a7:
@@ -235,9 +235,9 @@ dev_nightly-a7:
   parallel:
     matrix:
       - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-arm64
-        IMG_DESTINATIONS: agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3
+        IMG_DESTINATIONS: agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3,agent-dev:nightly-${CI_COMMIT_BRANCH}-py3
       - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-arm64
-        IMG_DESTINATIONS: agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-jmx
+        IMG_DESTINATIONS: agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-jmx,agent-dev:nightly-${CI_COMMIT_BRANCH}-py3-jmx
 
 # deploys nightlies to agent-dev
 dev_nightly-dogstatsd:
@@ -251,4 +251,4 @@ dev_nightly-dogstatsd:
   variables:
     IMG_REGISTRIES: dev
     IMG_SOURCES: ${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64,${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64
-    IMG_DESTINATIONS: dogstatsd-dev:nightly-${CI_COMMIT_SHORT_SHA}
+    IMG_DESTINATIONS: dogstatsd-dev:nightly-${CI_COMMIT_SHORT_SHA},dogstatsd-dev:nightly-${CI_COMMIT_BRANCH}


### PR DESCRIPTION
### What does this PR do?

Add a fixed named tag on nightlies.

### Motivation

Ease testing.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

No QA required.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
