### PR TITLE
pkg/trace/api: evp proxy support for app keys

### DIFF
--- a/cmd/trace-agent/config/config.go
+++ b/cmd/trace-agent/config/config.go
@@ -439,6 +439,12 @@ func applyDatadogConfig(c *config.AgentConfig) error {
 	if k := "evp_proxy_config.api_key"; coreconfig.Datadog.IsSet(k) {
 		c.EVPProxy.APIKey = coreconfig.Datadog.GetString(k)
 	}
+	if k := "evp_proxy_config.app_key"; coreconfig.Datadog.IsSet(k) {
+		c.EVPProxy.ApplicationKey = coreconfig.Datadog.GetString(k)
+	} else {
+		// Default to the agent-wide app_key if set
+		c.EVPProxy.ApplicationKey = coreconfig.Datadog.GetString("app_key")
+	}
 	if k := "evp_proxy_config.additional_endpoints"; coreconfig.Datadog.IsSet(k) {
 		c.EVPProxy.AdditionalEndpoints = coreconfig.Datadog.GetStringMapStringSlice(k)
 	}

--- a/pkg/trace/api/evp_proxy.go
+++ b/pkg/trace/api/evp_proxy.go
@@ -118,6 +118,7 @@ func (t *evpProxyTransport) RoundTrip(req *http.Request) (rresp *http.Response, 
 	containerID := req.Header.Get(headerContainerID)
 	contentType := req.Header.Get("Content-Type")
 	userAgent := req.Header.Get("User-Agent")
+	needsAppKey := (req.Header.Get("X-Datadog-NeedsAppKey") == "true")
 
 	// Sanitize the input, don't accept any valid URL but just some limited subset
 	if len(subdomain) == 0 {
@@ -132,6 +133,10 @@ func (t *evpProxyTransport) RoundTrip(req *http.Request) (rresp *http.Response, 
 	}
 	if !isValidQueryString(req.URL.RawQuery) {
 		return nil, fmt.Errorf("EVPProxy: invalid query string: %s", req.URL.RawQuery)
+	}
+
+	if needsAppKey && t.conf.EVPProxy.ApplicationKey == "" {
+		return nil, fmt.Errorf("EVPProxy: ApplicationKey needed but not set")
 	}
 
 	// We don't want to forward arbitrary headers, clear them
@@ -151,6 +156,9 @@ func (t *evpProxyTransport) RoundTrip(req *http.Request) (rresp *http.Response, 
 	req.Header.Set("X-Datadog-Hostname", t.conf.Hostname)
 	req.Header.Set("X-Datadog-AgentDefaultEnv", t.conf.DefaultEnv)
 	req.Header.Set(headerContainerID, containerID)
+	if needsAppKey {
+		req.Header.Set("DD-APPLICATION-KEY", t.conf.EVPProxy.ApplicationKey)
+	}
 
 	// Set target URL and API key header (per domain)
 	req.URL.Scheme = "https"

--- a/pkg/trace/api/evp_proxy.go
+++ b/pkg/trace/api/evp_proxy.go
@@ -118,7 +118,7 @@ func (t *evpProxyTransport) RoundTrip(req *http.Request) (rresp *http.Response, 
 	containerID := req.Header.Get(headerContainerID)
 	contentType := req.Header.Get("Content-Type")
 	userAgent := req.Header.Get("User-Agent")
-	needsAppKey := (req.Header.Get("X-Datadog-NeedsAppKey") == "true")
+	needsAppKey := (strings.ToLower(req.Header.Get("X-Datadog-NeedsAppKey")) == "true")
 
 	// Sanitize the input, don't accept any valid URL but just some limited subset
 	if len(subdomain) == 0 {

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -266,7 +266,7 @@ type EVPProxy struct {
 	DDURL string
 	// APIKey is the main API Key (defaults to the main API key).
 	APIKey string
-	// APIKey is the main API Key (defaults to the main API key).
+	// ApplicationKey to be used for requests with the X-Datadog-NeedsAppKey set (defaults to the top-level Application Key).
 	ApplicationKey string
 	// AdditionalEndpoints is a map of additional Datadog sites to API keys.
 	AdditionalEndpoints map[string][]string

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -266,6 +266,8 @@ type EVPProxy struct {
 	DDURL string
 	// APIKey is the main API Key (defaults to the main API key).
 	APIKey string
+	// APIKey is the main API Key (defaults to the main API key).
+	ApplicationKey string
 	// AdditionalEndpoints is a map of additional Datadog sites to API keys.
 	AdditionalEndpoints map[string][]string
 	// MaxPayloadSize indicates the size at which payloads will be rejected, in bytes.


### PR DESCRIPTION
### What does this PR do?

Allows the EVPProxy to be used against Datadog APIs that require an Application Key in addition to an API Key.

### Motivation

Needed for an upcoming CI Visibility product.

### Additional Notes

* This is not the first usage of an app key in the Agent, the security agent is [already using them](https://github.com/DataDog/datadog-agent/blob/b3df4adca9362d677bcbdce59a2e641fe4bcac8c/cmd/security-agent/app/runtime.go#L692).
* I haven't added support for dual-shipping using two app keys. It would require a larger change and we don't need it as of now.

### Describe how to test/QA your changes

Can be tested the same way as the PR where the EVP proxy was introduced: https://github.com/DataDog/datadog-agent/pull/12271

