### PR TITLE
system-probe: do not compile object files twice in `tests_ebpf`

### DIFF
--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -10,8 +10,8 @@
   - tar -xf /tmp/nikos.tar.gz -C $NIKOS_EMBEDDED_PATH
 
 .build_sysprobe_artifacts:
-  - inv -e system-probe.object-files
-  - inv -e system-probe.kitchen-prepare --skip-object-files
+  # kitchen prepare also builds object files
+  - inv -e system-probe.kitchen-prepare
   - cp $SRC_PATH/pkg/ebpf/bytecode/build/tracer.o $CI_PROJECT_DIR/.tmp/binary-ebpf/tracer.o
   - cp $SRC_PATH/pkg/ebpf/bytecode/build/tracer-debug.o $CI_PROJECT_DIR/.tmp/binary-ebpf/tracer-debug.o
   - cp $SRC_PATH/pkg/ebpf/bytecode/build/offset-guess.o $CI_PROJECT_DIR/.tmp/binary-ebpf/offset-guess.o

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -11,7 +11,7 @@
 
 .build_sysprobe_artifacts:
   - inv -e system-probe.object-files
-  - inv -e system-probe.kitchen-prepare
+  - inv -e system-probe.kitchen-prepare --skip-object-files
   - cp $SRC_PATH/pkg/ebpf/bytecode/build/tracer.o $CI_PROJECT_DIR/.tmp/binary-ebpf/tracer.o
   - cp $SRC_PATH/pkg/ebpf/bytecode/build/tracer-debug.o $CI_PROJECT_DIR/.tmp/binary-ebpf/tracer-debug.o
   - cp $SRC_PATH/pkg/ebpf/bytecode/build/offset-guess.o $CI_PROJECT_DIR/.tmp/binary-ebpf/offset-guess.o

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -189,7 +189,7 @@ def test(
 
 
 @task
-def kitchen_prepare(ctx, windows=is_windows, kernel_release=None):
+def kitchen_prepare(ctx, windows=is_windows, kernel_release=None, skip_object_files=False):
     """
     Compile test suite for kitchen
     """
@@ -231,7 +231,7 @@ def kitchen_prepare(ctx, windows=is_windows, kernel_release=None):
         test(
             ctx,
             packages=pkg,
-            skip_object_files=(i != 0),
+            skip_object_files=skip_object_files or (i != 0),
             skip_linters=True,
             bundle_ebpf=False,
             output_path=os.path.join(target_path, target_bin),

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -189,7 +189,7 @@ def test(
 
 
 @task
-def kitchen_prepare(ctx, windows=is_windows, kernel_release=None, skip_object_files=False):
+def kitchen_prepare(ctx, windows=is_windows, kernel_release=None):
     """
     Compile test suite for kitchen
     """
@@ -231,7 +231,7 @@ def kitchen_prepare(ctx, windows=is_windows, kernel_release=None, skip_object_fi
         test(
             ctx,
             packages=pkg,
-            skip_object_files=skip_object_files or (i != 0),
+            skip_object_files=(i != 0),
             skip_linters=True,
             bundle_ebpf=False,
             output_path=os.path.join(target_path, target_bin),


### PR DESCRIPTION
### What does this PR do?

In `tests_ebpf` we call `system-probe.object-files` before `system-probe.kitchen-prepare` meaning that we don't need to recompile object files in kitchen prepare. This PR fixes this issue, speeding up a bit the `tests_ebpf*` CI jobs.
 
### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
