### PR TITLE
Reduce one call to containerd Spec endpoint

### DIFF
--- a/pkg/util/containerd/containerd_util.go
+++ b/pkg/util/containerd/containerd_util.go
@@ -218,6 +218,9 @@ func (c *ContainerdUtil) EnvVars(ctn containerd.Container) (map[string]string, e
 // EnvVarsFromSpec returns the env variables of a containerd container from its Spec
 func EnvVarsFromSpec(spec *oci.Spec) (map[string]string, error) {
 	envs := make(map[string]string)
+	if spec == nil || spec.Process == nil {
+		return envs, nil
+	}
 
 	for _, env := range spec.Process.Env {
 		envSplit := strings.SplitN(env, "=", 2)

--- a/pkg/util/containerd/containerd_util.go
+++ b/pkg/util/containerd/containerd_util.go
@@ -212,7 +212,11 @@ func (c *ContainerdUtil) EnvVars(ctn containerd.Container) (map[string]string, e
 	if err != nil {
 		return nil, err
 	}
+	return EnvVarsFromSpec(spec)
+}
 
+// EnvVarsFromSpec returns the env variables of a containerd container from its Spec
+func EnvVarsFromSpec(spec *oci.Spec) (map[string]string, error) {
 	envs := make(map[string]string)
 
 	for _, env := range spec.Process.Env {

--- a/pkg/workloadmeta/collectors/internal/containerd/container_builder.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/container_builder.go
@@ -36,7 +36,7 @@ func buildWorkloadMetaContainer(container containerd.Container, containerdClient
 		return workloadmeta.Container{}, err
 	}
 
-	envs, err := containerdClient.EnvVars(container)
+	envs, err := cutil.EnvVarsFromSpec(spec)
 	if err != nil {
 		return workloadmeta.Container{}, err
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Reuses the existing `oci.Spec` to get the environment variables.

### Motivation

I noticed a duplicate call to the `Spec` endpoint in performance profiles.

### Additional Notes

I'm not fully aware of all the implications to this change, so feel free to reject.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
