### PR TITLE
[NetFlow] Reduce Flow Context TTL

### DIFF
--- a/pkg/netflow/common/constants.go
+++ b/pkg/netflow/common/constants.go
@@ -12,6 +12,9 @@ const (
 	// DefaultAggregatorFlushInterval is the default flush interval in seconds
 	DefaultAggregatorFlushInterval = 300 // 5min
 
+	// DefaultAggregatorFlowContextTTL is the default flow context TTL in seconds
+	DefaultAggregatorFlowContextTTL = 300 // 5min
+
 	// DefaultAggregatorBufferSize is the default aggregator buffer size interval
 	DefaultAggregatorBufferSize = 100
 

--- a/pkg/netflow/common/constants.go
+++ b/pkg/netflow/common/constants.go
@@ -12,9 +12,6 @@ const (
 	// DefaultAggregatorFlushInterval is the default flush interval in seconds
 	DefaultAggregatorFlushInterval = 300 // 5min
 
-	// DefaultAggregatorFlowContextTTL is the default flow context TTL in seconds
-	DefaultAggregatorFlowContextTTL = 300 // 5min
-
 	// DefaultAggregatorBufferSize is the default aggregator buffer size interval
 	DefaultAggregatorBufferSize = 100
 

--- a/pkg/netflow/config/config.go
+++ b/pkg/netflow/config/config.go
@@ -14,11 +14,12 @@ import (
 
 // NetflowConfig contains configuration for NetFlow collector.
 type NetflowConfig struct {
-	Listeners               []ListenerConfig `mapstructure:"listeners"`
-	StopTimeout             int              `mapstructure:"stop_timeout"`
-	AggregatorBufferSize    int              `mapstructure:"aggregator_buffer_size"`
-	AggregatorFlushInterval int              `mapstructure:"aggregator_flush_interval"`
-	LogPayloads             bool             `mapstructure:"log_payloads"`
+	Listeners                []ListenerConfig `mapstructure:"listeners"`
+	StopTimeout              int              `mapstructure:"stop_timeout"`
+	AggregatorBufferSize     int              `mapstructure:"aggregator_buffer_size"`
+	AggregatorFlushInterval  int              `mapstructure:"aggregator_flush_interval"`
+	AggregatorFlowContextTTL int              `mapstructure:"aggregator_flow_context_ttl"`
+	LogPayloads              bool             `mapstructure:"log_payloads"`
 }
 
 // ListenerConfig contains configuration for a single flow listener
@@ -68,6 +69,9 @@ func ReadConfig() (*NetflowConfig, error) {
 	}
 	if mainConfig.AggregatorFlushInterval == 0 {
 		mainConfig.AggregatorFlushInterval = common.DefaultAggregatorFlushInterval
+	}
+	if mainConfig.AggregatorFlowContextTTL == 0 {
+		mainConfig.AggregatorFlowContextTTL = common.DefaultAggregatorFlowContextTTL
 	}
 	if mainConfig.AggregatorBufferSize == 0 {
 		mainConfig.AggregatorBufferSize = common.DefaultAggregatorBufferSize

--- a/pkg/netflow/config/config.go
+++ b/pkg/netflow/config/config.go
@@ -71,7 +71,9 @@ func ReadConfig() (*NetflowConfig, error) {
 		mainConfig.AggregatorFlushInterval = common.DefaultAggregatorFlushInterval
 	}
 	if mainConfig.AggregatorFlowContextTTL == 0 {
-		mainConfig.AggregatorFlowContextTTL = common.DefaultAggregatorFlowContextTTL
+		// Set AggregatorFlowContextTTL to AggregatorFlushInterval to keep flow context around
+		// for 1 flush-interval time after a flush.
+		mainConfig.AggregatorFlowContextTTL = mainConfig.AggregatorFlushInterval
 	}
 	if mainConfig.AggregatorBufferSize == 0 {
 		mainConfig.AggregatorBufferSize = common.DefaultAggregatorBufferSize

--- a/pkg/netflow/config/config_test.go
+++ b/pkg/netflow/config/config_test.go
@@ -32,6 +32,7 @@ network_devices:
     stop_timeout: 10
     aggregator_buffer_size: 20
     aggregator_flush_interval: 30
+    aggregator_flow_context_ttl: 40
     log_payloads: true
     listeners:
       - flow_type: netflow9
@@ -46,10 +47,11 @@ network_devices:
         namespace: my-ns2
 `,
 			expectedConfig: NetflowConfig{
-				StopTimeout:             10,
-				AggregatorBufferSize:    20,
-				AggregatorFlushInterval: 30,
-				LogPayloads:             true,
+				StopTimeout:              10,
+				AggregatorBufferSize:     20,
+				AggregatorFlushInterval:  30,
+				AggregatorFlowContextTTL: 40,
+				LogPayloads:              true,
 				Listeners: []ListenerConfig{
 					{
 						FlowType:  common.TypeNetFlow9,
@@ -78,10 +80,11 @@ network_devices:
       - flow_type: netflow9
 `,
 			expectedConfig: NetflowConfig{
-				StopTimeout:             5,
-				AggregatorBufferSize:    100,
-				AggregatorFlushInterval: 300,
-				LogPayloads:             false,
+				StopTimeout:              5,
+				AggregatorBufferSize:     100,
+				AggregatorFlushInterval:  300,
+				AggregatorFlowContextTTL: 300,
+				LogPayloads:              false,
 				Listeners: []ListenerConfig{
 					{
 						FlowType:  common.TypeNetFlow9,

--- a/pkg/netflow/config/config_test.go
+++ b/pkg/netflow/config/config_test.go
@@ -97,6 +97,33 @@ network_devices:
 			},
 		},
 		{
+			name: "flow context ttl equal to flush interval if not defined",
+			configYaml: `
+network_devices:
+  netflow:
+    enabled: true
+    aggregator_flush_interval: 50
+    listeners:
+      - flow_type: netflow9
+`,
+			expectedConfig: NetflowConfig{
+				StopTimeout:              5,
+				AggregatorBufferSize:     100,
+				AggregatorFlushInterval:  50,
+				AggregatorFlowContextTTL: 50,
+				LogPayloads:              false,
+				Listeners: []ListenerConfig{
+					{
+						FlowType:  common.TypeNetFlow9,
+						BindHost:  "0.0.0.0",
+						Port:      uint16(2055),
+						Workers:   1,
+						Namespace: "default",
+					},
+				},
+			},
+		},
+		{
 			name: "invalid flow type",
 			configYaml: `
 network_devices:

--- a/pkg/netflow/flowaggregator/aggregator.go
+++ b/pkg/netflow/flowaggregator/aggregator.go
@@ -36,9 +36,11 @@ type FlowAggregator struct {
 
 // NewFlowAggregator returns a new FlowAggregator
 func NewFlowAggregator(sender aggregator.Sender, config *config.NetflowConfig, hostname string) *FlowAggregator {
+	flushInterval := time.Duration(config.AggregatorFlushInterval) * time.Second
+	flowContextTTL := time.Duration(config.AggregatorFlowContextTTL) * time.Second
 	return &FlowAggregator{
 		flowIn:            make(chan *common.Flow, config.AggregatorBufferSize),
-		flowAcc:           newFlowAccumulator(time.Duration(config.AggregatorFlushInterval) * time.Second),
+		flowAcc:           newFlowAccumulator(flushInterval, flowContextTTL),
 		flushInterval:     flowAggregatorFlushInterval,
 		sender:            sender,
 		stopChan:          make(chan struct{}),

--- a/pkg/netflow/flowaggregator/aggregator.go
+++ b/pkg/netflow/flowaggregator/aggregator.go
@@ -121,7 +121,7 @@ func (agg *FlowAggregator) flushLoop() {
 
 // Flush flushes the aggregator
 func (agg *FlowAggregator) flush() int {
-	flowsContexts := len(agg.flowAcc.flows)
+	flowsContexts := agg.flowAcc.getFlowContextCount()
 	now := time.Now()
 	flowsToFlush := agg.flowAcc.flush()
 	log.Debugf("Flushing %d flows to the forwarder (flush_duration=%d, flow_contexts_before_flush=%d)", len(flowsToFlush), time.Since(now).Milliseconds(), flowsContexts)

--- a/pkg/netflow/flowaggregator/aggregator.go
+++ b/pkg/netflow/flowaggregator/aggregator.go
@@ -121,8 +121,10 @@ func (agg *FlowAggregator) flushLoop() {
 
 // Flush flushes the aggregator
 func (agg *FlowAggregator) flush() int {
+	flowsContexts := len(agg.flowAcc.flows)
+	now := time.Now()
 	flowsToFlush := agg.flowAcc.flush()
-	log.Debugf("Flushing %d flows to the forwarder", len(flowsToFlush))
+	log.Debugf("Flushing %d flows to the forwarder (flush_duration=%d, flow_contexts_before_flush=%d)", len(flowsToFlush), time.Since(now).Milliseconds(), flowsContexts)
 	if len(flowsToFlush) == 0 {
 		return 0
 	}

--- a/pkg/netflow/flowaggregator/flowaccumulator.go
+++ b/pkg/netflow/flowaggregator/flowaccumulator.go
@@ -16,8 +16,8 @@ import (
 
 var timeNow = time.Now
 
-// floWrapper contains flow information and additional flush related data
-type flowWrapper struct {
+// flowContext contains flow information and additional flush related data
+type flowContext struct {
 	flow                *common.Flow
 	nextFlush           time.Time
 	lastSuccessfulFlush time.Time
@@ -25,15 +25,15 @@ type flowWrapper struct {
 
 // flowAccumulator is used to accumulate aggregated flows
 type flowAccumulator struct {
-	flows             map[uint64]flowWrapper
+	flows             map[uint64]flowContext
 	mu                sync.Mutex
 	flowFlushInterval time.Duration
 	flowContextTTL    time.Duration
 }
 
-func newFlowWrapper(flow *common.Flow) flowWrapper {
+func newFlowContext(flow *common.Flow) flowContext {
 	now := timeNow()
-	return flowWrapper{
+	return flowContext{
 		flow:      flow,
 		nextFlush: now,
 	}
@@ -41,7 +41,7 @@ func newFlowWrapper(flow *common.Flow) flowWrapper {
 
 func newFlowAccumulator(aggregatorFlushInterval time.Duration, aggregatorFlowContextTTL time.Duration) *flowAccumulator {
 	return &flowAccumulator{
-		flows:             make(map[uint64]flowWrapper),
+		flows:             make(map[uint64]flowContext),
 		flowFlushInterval: aggregatorFlushInterval,
 		flowContextTTL:    aggregatorFlowContextTTL,
 	}
@@ -49,29 +49,35 @@ func newFlowAccumulator(aggregatorFlushInterval time.Duration, aggregatorFlowCon
 
 // flush will flush specific flow context (distinct hash) if nextFlush is reached
 // once a flow context is flushed nextFlush will be updated to the next flush time
-// Specific flow context in `flowAccumulator.flows` map will be deleted if `flowContextTTL`
+//
+// flowContextTTL:
+// flowContextTTL defines the duration we should keep a specific flowContext in `flowAccumulator.flows`
+// after `lastSuccessfulFlush`. // Flow context in `flowAccumulator.flows` map will be deleted if `flowContextTTL`
 // is reached to avoid keeping flow context that are not seen anymore.
+// We need to keep flowContext (contains `nextFlush` and `lastSuccessfulFlush`) after flush
+// to be able to flush at regular interval (`flowFlushInterval`).
+// Example, after a flush, flowContext will have a new nextFlush, that will be the next flush time for new flows being added.
 func (f *flowAccumulator) flush() []*common.Flow {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
 	var flowsToFlush []*common.Flow
-	for key, flow := range f.flows {
+	for key, flowCtx := range f.flows {
 		now := timeNow()
-		if flow.nextFlush.After(now) {
+		if flowCtx.nextFlush.After(now) {
 			continue
 		}
-		if flow.flow != nil {
-			flowsToFlush = append(flowsToFlush, flow.flow)
-			flow.lastSuccessfulFlush = now
-			flow.flow = nil
-		} else if flow.lastSuccessfulFlush.Add(f.flowContextTTL).Before(now) {
-			// delete flow wrapper if there is no successful flushes since `flowContextTTL`
+		if flowCtx.flow != nil {
+			flowsToFlush = append(flowsToFlush, flowCtx.flow)
+			flowCtx.lastSuccessfulFlush = now
+			flowCtx.flow = nil
+		} else if flowCtx.lastSuccessfulFlush.Add(f.flowContextTTL).Before(now) {
+			// delete flowCtx wrapper if there is no successful flushes since `flowContextTTL`
 			delete(f.flows, key)
 			continue
 		}
-		flow.nextFlush = flow.nextFlush.Add(f.flowFlushInterval)
-		f.flows[key] = flow
+		flowCtx.nextFlush = flowCtx.nextFlush.Add(f.flowFlushInterval)
+		f.flows[key] = flowCtx
 	}
 	return flowsToFlush
 }
@@ -88,7 +94,7 @@ func (f *flowAccumulator) add(flowToAdd *common.Flow) {
 
 	aggFlow, ok := f.flows[aggHash]
 	if !ok {
-		f.flows[aggHash] = newFlowWrapper(flowToAdd)
+		f.flows[aggHash] = newFlowContext(flowToAdd)
 		return
 	}
 	if aggFlow.flow == nil {

--- a/pkg/netflow/flowaggregator/flowaccumulator.go
+++ b/pkg/netflow/flowaggregator/flowaccumulator.go
@@ -64,6 +64,12 @@ func (f *flowAccumulator) flush() []*common.Flow {
 	var flowsToFlush []*common.Flow
 	for key, flowCtx := range f.flows {
 		now := timeNow()
+		if flowCtx.flow == nil && (flowCtx.lastSuccessfulFlush.Add(f.flowContextTTL).Before(now)) {
+			log.Tracef("Delete flow context (key=%d, lastSuccessfulFlush=%s, nextFlush=%s)", key, flowCtx.lastSuccessfulFlush.String(), flowCtx.nextFlush.String())
+			// delete flowCtx wrapper if there is no successful flushes since `flowContextTTL`
+			delete(f.flows, key)
+			continue
+		}
 		if flowCtx.nextFlush.After(now) {
 			continue
 		}
@@ -71,11 +77,6 @@ func (f *flowAccumulator) flush() []*common.Flow {
 			flowsToFlush = append(flowsToFlush, flowCtx.flow)
 			flowCtx.lastSuccessfulFlush = now
 			flowCtx.flow = nil
-		} else if flowCtx.lastSuccessfulFlush.Add(f.flowContextTTL).Before(now) || flowCtx.lastSuccessfulFlush.Add(f.flowContextTTL).Equal(now) {
-			log.Tracef("Delete flow context (key=%d, lastSuccessfulFlush=%s, nextFlush=%s)", key, flowCtx.lastSuccessfulFlush.String(), flowCtx.nextFlush.String())
-			// delete flowCtx wrapper if there is no successful flushes since `flowContextTTL`
-			delete(f.flows, key)
-			continue
 		}
 		flowCtx.nextFlush = flowCtx.nextFlush.Add(f.flowFlushInterval)
 		f.flows[key] = flowCtx

--- a/pkg/netflow/flowaggregator/flowaccumulator.go
+++ b/pkg/netflow/flowaggregator/flowaccumulator.go
@@ -64,7 +64,7 @@ func (f *flowAccumulator) flush() []*common.Flow {
 	var flowsToFlush []*common.Flow
 	for key, flowCtx := range f.flows {
 		now := timeNow()
-		if flowCtx.flow == nil && (flowCtx.lastSuccessfulFlush.Add(f.flowContextTTL).Before(now) || flowCtx.lastSuccessfulFlush.Add(f.flowContextTTL).Equal(now)) {
+		if flowCtx.flow == nil && (flowCtx.lastSuccessfulFlush.Add(f.flowContextTTL).Before(now)) {
 			log.Tracef("Delete flow context (key=%d, lastSuccessfulFlush=%s, nextFlush=%s)", key, flowCtx.lastSuccessfulFlush.String(), flowCtx.nextFlush.String())
 			// delete flowCtx wrapper if there is no successful flushes since `flowContextTTL`
 			delete(f.flows, key)

--- a/pkg/netflow/flowaggregator/flowaccumulator.go
+++ b/pkg/netflow/flowaggregator/flowaccumulator.go
@@ -39,11 +39,11 @@ func newFlowWrapper(flow *common.Flow) flowWrapper {
 	}
 }
 
-func newFlowAccumulator(aggregatorFlushInterval time.Duration) *flowAccumulator {
+func newFlowAccumulator(aggregatorFlushInterval time.Duration, aggregatorFlowContextTTL time.Duration) *flowAccumulator {
 	return &flowAccumulator{
 		flows:             make(map[uint64]flowWrapper),
 		flowFlushInterval: aggregatorFlushInterval,
-		flowContextTTL:    aggregatorFlushInterval * 5,
+		flowContextTTL:    aggregatorFlowContextTTL,
 	}
 }
 

--- a/pkg/netflow/flowaggregator/flowaccumulator.go
+++ b/pkg/netflow/flowaggregator/flowaccumulator.go
@@ -71,8 +71,8 @@ func (f *flowAccumulator) flush() []*common.Flow {
 			flowsToFlush = append(flowsToFlush, flowCtx.flow)
 			flowCtx.lastSuccessfulFlush = now
 			flowCtx.flow = nil
-		} else if flowCtx.lastSuccessfulFlush.Add(f.flowContextTTL).Before(now) {
-			log.Tracef("Delete flow context (key=%d, lastSuccessfulFlush=%d, nextFlush=%d)", key, flowCtx.lastSuccessfulFlush, flowCtx.nextFlush)
+		} else if flowCtx.lastSuccessfulFlush.Add(f.flowContextTTL).Before(now) || flowCtx.lastSuccessfulFlush.Add(f.flowContextTTL).Equal(now) {
+			log.Tracef("Delete flow context (key=%d, lastSuccessfulFlush=%s, nextFlush=%s)", key, flowCtx.lastSuccessfulFlush.String(), flowCtx.nextFlush.String())
 			// delete flowCtx wrapper if there is no successful flushes since `flowContextTTL`
 			delete(f.flows, key)
 			continue

--- a/pkg/netflow/flowaggregator/flowaccumulator.go
+++ b/pkg/netflow/flowaggregator/flowaccumulator.go
@@ -72,6 +72,7 @@ func (f *flowAccumulator) flush() []*common.Flow {
 			flowCtx.lastSuccessfulFlush = now
 			flowCtx.flow = nil
 		} else if flowCtx.lastSuccessfulFlush.Add(f.flowContextTTL).Before(now) {
+			log.Tracef("Delete flow context (key=%d, lastSuccessfulFlush=%d, nextFlush=%d)", key, flowCtx.lastSuccessfulFlush, flowCtx.nextFlush)
 			// delete flowCtx wrapper if there is no successful flushes since `flowContextTTL`
 			delete(f.flows, key)
 			continue

--- a/pkg/netflow/flowaggregator/flowaccumulator_test.go
+++ b/pkg/netflow/flowaggregator/flowaccumulator_test.go
@@ -78,7 +78,7 @@ func Test_flowAccumulator_add(t *testing.T) {
 	}
 
 	// When
-	acc := newFlowAccumulator(60)
+	acc := newFlowAccumulator(60, 60)
 	acc.add(flowA1)
 	acc.add(flowA2)
 	acc.add(flowB1)
@@ -121,7 +121,7 @@ func Test_flowAccumulator_flush(t *testing.T) {
 	}
 
 	// When
-	acc := newFlowAccumulator(flushInterval)
+	acc := newFlowAccumulator(flushInterval, 60*time.Second)
 	acc.add(flow)
 
 	// Then

--- a/pkg/netflow/flowaggregator/flowaccumulator_test.go
+++ b/pkg/netflow/flowaggregator/flowaccumulator_test.go
@@ -169,7 +169,7 @@ func Test_flowAccumulator_flush(t *testing.T) {
 	assert.Equal(t, flushTime4, wrappedFlow.lastSuccessfulFlush)
 
 	// test flush with TTL reached (now+ttl is equal last successful flush) to clean up entry
-	flushTime5 := flushTime4.Add(flowContextTTL)
+	flushTime5 := flushTime4.Add(flowContextTTL + 1*time.Second)
 	setMockTimeNow(flushTime5)
 	acc.flush()
 	_, ok := acc.flows[flow.AggregationHash()]

--- a/pkg/netflow/flowaggregator/flowaccumulator_test.go
+++ b/pkg/netflow/flowaggregator/flowaccumulator_test.go
@@ -78,7 +78,7 @@ func Test_flowAccumulator_add(t *testing.T) {
 	}
 
 	// When
-	acc := newFlowAccumulator(60, 60)
+	acc := newFlowAccumulator(common.DefaultAggregatorFlushInterval, common.DefaultAggregatorFlowContextTTL)
 	acc.add(flowA1)
 	acc.add(flowA2)
 	acc.add(flowB1)
@@ -104,6 +104,7 @@ func Test_flowAccumulator_flush(t *testing.T) {
 	timeNow = MockTimeNow
 	zeroTime := time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC)
 	flushInterval := 60 * time.Second
+	flowContextTTL := 60 * time.Second
 
 	// Given
 	flow := &common.Flow{
@@ -121,7 +122,7 @@ func Test_flowAccumulator_flush(t *testing.T) {
 	}
 
 	// When
-	acc := newFlowAccumulator(flushInterval, 60*time.Second)
+	acc := newFlowAccumulator(flushInterval, flowContextTTL)
 	acc.add(flow)
 
 	// Then
@@ -168,7 +169,7 @@ func Test_flowAccumulator_flush(t *testing.T) {
 	assert.Equal(t, flushTime4, wrappedFlow.lastSuccessfulFlush)
 
 	// test flush with TTL reached to clean up entry
-	flushTime5 := flushTime4.Add((acc.flowContextTTL + 1) * time.Second)
+	flushTime5 := flushTime4.Add(flowContextTTL + 1*time.Second)
 	setMockTimeNow(flushTime5)
 	acc.flush()
 	_, ok := acc.flows[flow.AggregationHash()]

--- a/pkg/netflow/flowaggregator/flowaccumulator_test.go
+++ b/pkg/netflow/flowaggregator/flowaccumulator_test.go
@@ -78,7 +78,7 @@ func Test_flowAccumulator_add(t *testing.T) {
 	}
 
 	// When
-	acc := newFlowAccumulator(common.DefaultAggregatorFlushInterval, common.DefaultAggregatorFlowContextTTL)
+	acc := newFlowAccumulator(common.DefaultAggregatorFlushInterval, common.DefaultAggregatorFlushInterval)
 	acc.add(flowA1)
 	acc.add(flowA2)
 	acc.add(flowB1)

--- a/pkg/netflow/server.go
+++ b/pkg/netflow/server.go
@@ -47,6 +47,7 @@ func NewNetflowServer(sender aggregator.Sender) (*Server, error) {
 	flowAgg := flowaggregator.NewFlowAggregator(sender, mainConfig, hostnameDetected)
 	go flowAgg.Start()
 
+	log.Debugf("NetFlow Server configs (aggregator_buffer_size=%d, aggregator_flush_interval=%d, aggregator_flow_context_ttl=%d)", mainConfig.AggregatorBufferSize, mainConfig.AggregatorFlushInterval, mainConfig.AggregatorFlowContextTTL)
 	for _, listenerConfig := range mainConfig.Listeners {
 		log.Infof("Starting Netflow listener for flow type %s on %s", listenerConfig.FlowType, listenerConfig.Addr())
 		listener, err := startFlowListener(listenerConfig, flowAgg)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

1/ Update flowContextTTL to have default value of 1x flush interval (instead of previous 5x flush interval)
2/ Update flowContextTTL to be configurable (this config will not be documented, making it configurable just in case we need to suggest it to some users)

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Reducing `flowContextTTL` from 5x to 1x flush interval reduces memory usage.

Benchmark data:

Reducing flowContextTTL from 25min (5*5min aggregation) to 5min can lower Agent Memory usage by half.

Benchmark with 10k flows per sec:

- With 25min flowContextTTL: in_use memory is 2.33Gb
- With 5min flowContextTTL: in_use memory is 1.15Gb


<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

A/ Check `aggregator_flow_context_ttl` is passed correctly by setting it and checking the debug log `NetFlow Server configs`

B/ Check that flow contexts are deleted after when flowContextTTL is reached.

0/ Install Agent locally (e.g. on your Mac)

1/ change `network_devices.netflow.forwarder.batch_max_size` so something low like `50`

Example:

```
network_devices:
  netflow:
    enabled: true
    aggregator_flow_context_ttl: 180
    listeners:
      - flow_type: netflow9   # netflow, sflow, ipfix
        bind_host: 0.0.0.0
        port: 9999 # default 2055 for netflow
      - flow_type: netflow5   # netflow, sflow, ipfix
        bind_host: 0.0.0.0
        port: 9995 # default 2055 for netflow
        workers: 2
```

2/ Send this 1 single netflow data using

```
git clone git@github.com:AlexandreYang/nflow-generator.git
cd nflow-generator
git checkout alex/mod_netflow_generator
go build
 ./nflow-generator -t 127.0.0.1 -p 9995 --duration 1000 --flow-count 1
```

3/ verify in agent logs that the log `Delete flow context` happens approx. `aggregator_flow_context_ttl` seconds after the log `Flushing 1 flows to the forwarder`.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
