### PR TITLE
Kubernetes resource discovery

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
@@ -9,6 +9,7 @@
 package orchestrator
 
 import (
+	"strings"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
@@ -28,12 +29,13 @@ const (
 // CollectorBundle is a container for a group of collectors. It provides a way
 // to easily run them all.
 type CollectorBundle struct {
-	check            *OrchestratorCheck
-	collectors       []collectors.Collector
-	extraSyncTimeout time.Duration
-	inventory        *inventory.CollectorInventory
-	stopCh           chan struct{}
-	runCfg           *collectors.CollectorRunConfig
+	check              *OrchestratorCheck
+	collectors         []collectors.Collector
+	discoverCollectors bool
+	extraSyncTimeout   time.Duration
+	inventory          *inventory.CollectorInventory
+	stopCh             chan struct{}
+	runCfg             *collectors.CollectorRunConfig
 }
 
 // NewCollectorBundle creates a new bundle from the check configuration.
@@ -48,8 +50,9 @@ type CollectorBundle struct {
 // marked as stable.
 func NewCollectorBundle(chk *OrchestratorCheck) *CollectorBundle {
 	bundle := &CollectorBundle{
-		check:     chk,
-		inventory: inventory.NewCollectorInventory(),
+		discoverCollectors: chk.orchestratorConfig.CollectorDiscoveryEnabled,
+		check:              chk,
+		inventory:          inventory.NewCollectorInventory(),
 		runCfg: &collectors.CollectorRunConfig{
 			APIClient:   chk.apiClient,
 			ClusterID:   chk.clusterID,
@@ -72,25 +75,65 @@ func (cb *CollectorBundle) prepare() {
 
 // prepareCollectors initializes the bundle collector list.
 func (cb *CollectorBundle) prepareCollectors() {
-	// No collector configured in the check configuration.
-	// Use the list of stable collectors as the default.
-	if len(cb.check.instance.Collectors) == 0 {
-		cb.collectors = cb.inventory.StableCollectors()
+	// Custom collector list provided in the check configuration.
+	if len(cb.check.instance.Collectors) > 0 {
+		for _, c := range cb.check.instance.Collectors {
+			cb.addCollectorFromConfig(c)
+		}
 		return
 	}
 
-	// Collectors configured in the check configuration.
-	// Build the custom list of collectors.
-	for _, name := range cb.check.instance.Collectors {
-		if collector, err := cb.inventory.CollectorByName(name); err == nil {
-			if !collector.Metadata().IsStable {
-				_ = cb.check.Warnf("Using unstable collector: %s", name)
-			}
-			cb.collectors = append(cb.collectors, collector)
-		} else {
-			_ = cb.check.Warnf("Unsupported collector: %s", name)
+	// Discover collectors from the list of resources exposed by the API server.
+	if cb.discoverCollectors {
+		provider := NewAPIServerDiscoveryProvider()
+
+		if collectors, err := provider.Discover(cb.inventory); err != nil {
+			_ = cb.check.Warnf("Collector discovery failed: %s", err)
+		} else if len(cb.collectors) > 0 {
+			cb.collectors = append(cb.collectors, collectors...)
+			return
 		}
 	}
+
+	// Finally, fall back to the list of stable collectors with default
+	// versions.
+	cb.collectors = cb.inventory.StableCollectors()
+	return
+}
+
+// addCollectorFromConfig appends a collector to the bundle based on the
+// collector name specified in the check configuration.
+//
+// The following configuration keys are accepted:
+//   - <collector_name> (e.g "cronjobs")
+//   - <apigroup_and_version>/<collector_name> (e.g. "batch/v1/cronjobs")
+//
+// Note that in the versionless case the collector version that'll be used is
+// the one declared as the default version in the inventory.
+func (cb *CollectorBundle) addCollectorFromConfig(collectorName string) {
+	var (
+		collector collectors.Collector
+		err       error
+	)
+
+	if idx := strings.LastIndex(collectorName, "/"); idx != -1 {
+		version := collectorName[:idx]
+		name := collectorName[idx+1:]
+		collector, err = cb.inventory.CollectorForVersion(name, version)
+	} else {
+		collector, err = cb.inventory.CollectorForDefaultVersion(collectorName)
+	}
+
+	if err != nil {
+		_ = cb.check.Warnf("Unsupported collector: %s", collectorName)
+		return
+	}
+
+	if !collector.Metadata().IsStable {
+		_ = cb.check.Warnf("Using unstable collector: %s", collector.Metadata().FullName())
+	}
+
+	cb.collectors = append(cb.collectors, collector)
 }
 
 // prepareExtraSyncTimeout initializes the bundle extra sync timeout.
@@ -115,10 +158,11 @@ func (cb *CollectorBundle) Initialize() error {
 	// informerSynced is a helper map which makes sure that we don't initialize the same informer twice.
 	// i.e. the cluster and nodes resources share the same informer and using both can lead to a race condition activating both concurrently.
 	informerSynced := map[cache.SharedInformer]struct{}{}
+
 	for _, collector := range cb.collectors {
 		collector.Init(cb.runCfg)
 		if !collector.IsAvailable() {
-			_ = cb.check.Warnf("Collector %q is unavailable, skipping it", collector.Metadata().Name)
+			_ = cb.check.Warnf("Collector %q is unavailable, skipping it", collector.Metadata().FullName())
 			continue
 		}
 
@@ -127,7 +171,7 @@ func (cb *CollectorBundle) Initialize() error {
 		informer := collector.Informer()
 
 		if _, found := informerSynced[informer]; !found {
-			informersToSync[apiserver.InformerName(collector.Metadata().Name)] = informer
+			informersToSync[apiserver.InformerName(collector.Metadata().FullName())] = informer
 			informerSynced[informer] = struct{}{}
 			// we run each enabled informer individually, because starting them through the factory
 			// would prevent us from restarting them again if the check is unscheduled/rescheduled
@@ -152,12 +196,12 @@ func (cb *CollectorBundle) Run(sender aggregator.Sender) {
 
 		result, err := collector.Run(cb.runCfg)
 		if err != nil {
-			_ = cb.check.Warnf("Collector %s failed to run: %s", collector.Metadata().Name, err.Error())
+			_ = cb.check.Warnf("Collector %s failed to run: %s", collector.Metadata().FullName(), err.Error())
 			continue
 		}
 
 		runDuration := time.Since(runStartTime)
-		log.Debugf("Collector %s run stats: listed=%d processed=%d messages=%d duration=%s", collector.Metadata().Name, result.ResourcesListed, result.ResourcesProcessed, len(result.Result.MetadataMessages), runDuration)
+		log.Debugf("Collector %s run stats: listed=%d processed=%d messages=%d duration=%s", collector.Metadata().FullName(), result.ResourcesListed, result.ResourcesProcessed, len(result.Result.MetadataMessages), runDuration)
 
 		orchestrator.SetCacheStats(result.ResourcesListed, len(result.Result.MetadataMessages), collector.Metadata().NodeType)
 		sender.OrchestratorMetadata(result.Result.MetadataMessages, cb.check.clusterID, int(collector.Metadata().NodeType))

--- a/pkg/collector/corechecks/cluster/orchestrator/collector_discovery.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collector_discovery.go
@@ -1,0 +1,99 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver && orchestrator
+// +build kubeapiserver,orchestrator
+
+package orchestrator
+
+import (
+	"context"
+	"time"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors/inventory"
+	"github.com/DataDog/datadog-agent/pkg/orchestrator"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const (
+	defaultAPIServerTimeout = 20 * time.Second
+)
+
+// APIServerDiscoveryProvider is a discovery provider that uses the Kubernetes
+// API Server as its data source.
+type APIServerDiscoveryProvider struct {
+	result []collectors.Collector
+	seen   map[string]struct{}
+}
+
+// NewAPIServerDiscoveryProvider returns a new instance of the APIServer
+// discovery provider.
+func NewAPIServerDiscoveryProvider() *APIServerDiscoveryProvider {
+	return &APIServerDiscoveryProvider{
+		seen: make(map[string]struct{}),
+	}
+}
+
+// Discover returns collectors to enable based on information exposed by the API server.
+func (kp *APIServerDiscoveryProvider) Discover(inventory *inventory.CollectorInventory) ([]collectors.Collector, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultAPIServerTimeout)
+	defer cancel()
+
+	client, err := apiserver.WaitForAPIClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	preferredResources, err := client.DiscoveryCl.ServerPreferredResources()
+	if err != nil {
+		return nil, err
+	}
+
+	_, allResources, err := client.DiscoveryCl.ServerGroupsAndResources()
+	if err != nil {
+		return nil, err
+	}
+
+	// First pass to enable server-preferred resources
+	kp.walkAPIResources(inventory, preferredResources)
+
+	// Second pass to enable non-preferred resources
+	kp.walkAPIResources(inventory, allResources)
+
+	return kp.result, nil
+}
+
+func (kp *APIServerDiscoveryProvider) addCollector(collector collectors.Collector) {
+	if _, found := kp.seen[collector.Metadata().Name]; found {
+		return
+	}
+
+	kp.result = append(kp.result, collector)
+	kp.seen[collector.Metadata().Name] = struct{}{}
+	log.Debugf("Discovered collector %s", collector.Metadata().FullName())
+}
+
+func (kp *APIServerDiscoveryProvider) walkAPIResources(inventory *inventory.CollectorInventory, apis []*v1.APIResourceList) {
+	for _, api := range apis {
+		for _, resource := range api.APIResources {
+			collector, err := inventory.CollectorForVersion(resource.Name, api.GroupVersion)
+			if err != nil {
+				continue
+			}
+
+			// Enable the cluster collector when the node resource is discovered.
+			if collector.Metadata().NodeType == orchestrator.K8sNode {
+				clusterCollector, _ := inventory.CollectorForDefaultVersion("clusters")
+				kp.addCollector(clusterCollector)
+			}
+
+			kp.addCollector(collector)
+		}
+	}
+}

--- a/pkg/collector/corechecks/cluster/orchestrator/collector_discovery_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collector_discovery_test.go
@@ -1,0 +1,72 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver && orchestrator
+// +build kubeapiserver,orchestrator
+
+package orchestrator
+
+import (
+	"testing"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors/inventory"
+)
+
+func TestWalkAPIResources(t *testing.T) {
+	inventory := inventory.NewCollectorInventory()
+	provider := NewAPIServerDiscoveryProvider()
+
+	preferredResources := []*v1.APIResourceList{
+		{
+			GroupVersion: "batch/v1",
+			APIResources: []v1.APIResource{
+				{
+					Name: "cronjobs",
+				},
+			},
+		},
+	}
+	allResources := []*v1.APIResourceList{
+		{
+			GroupVersion: "batch/v1",
+			APIResources: []v1.APIResource{
+				{
+					Name: "cronjobs",
+				},
+			},
+		},
+		{
+			GroupVersion: "batch/v1beta1",
+			APIResources: []v1.APIResource{
+				{
+					Name: "cronjobs",
+				},
+			},
+		},
+		{
+			GroupVersion: "apps/v1",
+			APIResources: []v1.APIResource{
+				{
+					Name: "deployments",
+				},
+			},
+		},
+	}
+
+	provider.walkAPIResources(inventory, preferredResources)
+	assert.EqualValues(t, map[string]struct{}{"cronjobs": {}}, provider.seen)
+
+	provider.walkAPIResources(inventory, allResources)
+	assert.EqualValues(t, map[string]struct{}{"cronjobs": {}, "deployments": {}}, provider.seen)
+
+	require.Len(t, provider.result, 2)
+	assert.True(t, provider.result[0].Metadata().FullName() == "batch/v1/cronjobs")
+	assert.True(t, provider.result[1].Metadata().FullName() == "apps/v1/deployments")
+}

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/cluster.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/cluster.go
@@ -20,6 +20,13 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+// NewClusterCollectorVersions builds the group of collector versions.
+func NewClusterCollectorVersions() collectors.CollectorVersions {
+	return collectors.NewCollectorVersions(
+		NewClusterCollector(),
+	)
+}
+
 // ClusterCollector is a collector for Kubernetes clusters.
 type ClusterCollector struct {
 	informer  corev1Informers.NodeInformer
@@ -33,9 +40,10 @@ type ClusterCollector struct {
 func NewClusterCollector() *ClusterCollector {
 	return &ClusterCollector{
 		metadata: &collectors.CollectorMetadata{
-			IsStable: true,
-			Name:     "clusters",
-			NodeType: orchestrator.K8sCluster,
+			IsDefaultVersion: true,
+			IsStable:         true,
+			Name:             "clusters",
+			NodeType:         orchestrator.K8sCluster,
 		},
 		processor: k8sProcessors.NewClusterProcessor(),
 	}

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/clusterrole.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/clusterrole.go
@@ -20,6 +20,13 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+// NewClusterRoleCollectorVersions builds the group of collector versions.
+func NewClusterRoleCollectorVersions() collectors.CollectorVersions {
+	return collectors.NewCollectorVersions(
+		NewClusterRoleCollector(),
+	)
+}
+
 // ClusterRoleCollector is a collector for Kubernetes ClusterRoles.
 type ClusterRoleCollector struct {
 	informer  rbacv1Informers.ClusterRoleInformer
@@ -33,9 +40,11 @@ type ClusterRoleCollector struct {
 func NewClusterRoleCollector() *ClusterRoleCollector {
 	return &ClusterRoleCollector{
 		metadata: &collectors.CollectorMetadata{
-			IsStable: true,
-			Name:     "clusterroles",
-			NodeType: orchestrator.K8sClusterRole,
+			IsDefaultVersion: true,
+			IsStable:         true,
+			Name:             "clusterroles",
+			NodeType:         orchestrator.K8sClusterRole,
+			Version:          "rbac.authorization.k8s.io/v1",
 		},
 		processor: processors.NewProcessor(new(k8sProcessors.ClusterRoleHandlers)),
 	}

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/clusterrolebinding.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/clusterrolebinding.go
@@ -20,6 +20,13 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+// NewClusterRoleBindingCollectorVersions builds the group of collector versions.
+func NewClusterRoleBindingCollectorVersions() collectors.CollectorVersions {
+	return collectors.NewCollectorVersions(
+		NewClusterRoleBindingCollector(),
+	)
+}
+
 // ClusterRoleBindingCollector is a collector for Kubernetes ClusterRoleBindings.
 type ClusterRoleBindingCollector struct {
 	informer  rbacv1Informers.ClusterRoleBindingInformer
@@ -33,9 +40,11 @@ type ClusterRoleBindingCollector struct {
 func NewClusterRoleBindingCollector() *ClusterRoleBindingCollector {
 	return &ClusterRoleBindingCollector{
 		metadata: &collectors.CollectorMetadata{
-			IsStable: true,
-			Name:     "clusterrolebindings",
-			NodeType: orchestrator.K8sClusterRoleBinding,
+			IsDefaultVersion: true,
+			IsStable:         true,
+			Name:             "clusterrolebindings",
+			NodeType:         orchestrator.K8sClusterRoleBinding,
+			Version:          "rbac.authorization.k8s.io/v1",
 		},
 		processor: processors.NewProcessor(new(k8sProcessors.ClusterRoleBindingHandlers)),
 	}

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/cronjob.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/cronjob.go
@@ -10,81 +10,12 @@ package k8s
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors"
-	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
-	k8sProcessors "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors/k8s"
-	"github.com/DataDog/datadog-agent/pkg/orchestrator"
-
-	"k8s.io/apimachinery/pkg/labels"
-	batchv1Informers "k8s.io/client-go/informers/batch/v1beta1"
-	batchv1Listers "k8s.io/client-go/listers/batch/v1beta1"
-	"k8s.io/client-go/tools/cache"
 )
 
-// CronJobCollector is a collector for Kubernetes CronJobs.
-type CronJobCollector struct {
-	informer  batchv1Informers.CronJobInformer
-	lister    batchv1Listers.CronJobLister
-	metadata  *collectors.CollectorMetadata
-	processor *processors.Processor
-}
-
-// NewCronJobCollector creates a new collector for the Kubernetes Job resource.
-func NewCronJobCollector() *CronJobCollector {
-	return &CronJobCollector{
-		metadata: &collectors.CollectorMetadata{
-			IsStable: true,
-			Name:     "cronjobs",
-			NodeType: orchestrator.K8sCronJob,
-		},
-		processor: processors.NewProcessor(new(k8sProcessors.CronJobHandlers)),
-	}
-}
-
-// Informer returns the shared informer.
-func (c *CronJobCollector) Informer() cache.SharedInformer {
-	return c.informer.Informer()
-}
-
-// Init is used to initialize the collector.
-func (c *CronJobCollector) Init(rcfg *collectors.CollectorRunConfig) {
-	c.informer = rcfg.APIClient.InformerFactory.Batch().V1beta1().CronJobs()
-	c.lister = c.informer.Lister()
-}
-
-// IsAvailable returns whether the collector is available.
-func (c *CronJobCollector) IsAvailable() bool { return true }
-
-// Metadata is used to access information about the collector.
-func (c *CronJobCollector) Metadata() *collectors.CollectorMetadata {
-	return c.metadata
-}
-
-// Run triggers the collection process.
-func (c *CronJobCollector) Run(rcfg *collectors.CollectorRunConfig) (*collectors.CollectorRunResult, error) {
-	list, err := c.lister.List(labels.Everything())
-	if err != nil {
-		return nil, collectors.NewListingError(err)
-	}
-
-	ctx := &processors.ProcessorContext{
-		APIClient:  rcfg.APIClient,
-		Cfg:        rcfg.Config,
-		ClusterID:  rcfg.ClusterID,
-		MsgGroupID: rcfg.MsgGroupRef.Inc(),
-		NodeType:   c.metadata.NodeType,
-	}
-
-	processResult, processed := c.processor.Process(ctx, list)
-
-	if processed == -1 {
-		return nil, collectors.ErrProcessingPanic
-	}
-
-	result := &collectors.CollectorRunResult{
-		Result:             processResult,
-		ResourcesListed:    len(list),
-		ResourcesProcessed: processed,
-	}
-
-	return result, nil
+// NewCronJobCollectorVersions builds the group of collector versions for
+func NewCronJobCollectorVersions() collectors.CollectorVersions {
+	return collectors.NewCollectorVersions(
+		NewCronJobV1Collector(),
+		NewCronJobV1Beta1Collector(),
+	)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/cronjob_v1.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/cronjob_v1.go
@@ -15,62 +15,54 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/orchestrator"
 
 	"k8s.io/apimachinery/pkg/labels"
-	appsv1Informers "k8s.io/client-go/informers/apps/v1"
-	appsv1Listers "k8s.io/client-go/listers/apps/v1"
+	batchv1Informers "k8s.io/client-go/informers/batch/v1"
+	batchv1Listers "k8s.io/client-go/listers/batch/v1"
 	"k8s.io/client-go/tools/cache"
 )
 
-// NewStatefulSetCollectorVersions builds the group of collector versions.
-func NewStatefulSetCollectorVersions() collectors.CollectorVersions {
-	return collectors.NewCollectorVersions(
-		NewStatefulSetCollector(),
-	)
-}
-
-// StatefulSetCollector is a collector for Kubernetes StatefulSets.
-type StatefulSetCollector struct {
-	informer  appsv1Informers.StatefulSetInformer
-	lister    appsv1Listers.StatefulSetLister
+// CronJobV1Collector is a collector for Kubernetes CronJobs.
+type CronJobV1Collector struct {
+	informer  batchv1Informers.CronJobInformer
+	lister    batchv1Listers.CronJobLister
 	metadata  *collectors.CollectorMetadata
 	processor *processors.Processor
 }
 
-// NewStatefulSetCollector creates a new collector for the Kubernetes
-// StatefulSet resource.
-func NewStatefulSetCollector() *StatefulSetCollector {
-	return &StatefulSetCollector{
+// NewCronJobV1Collector creates a new collector for the Kubernetes Job resource.
+func NewCronJobV1Collector() *CronJobV1Collector {
+	return &CronJobV1Collector{
 		metadata: &collectors.CollectorMetadata{
 			IsDefaultVersion: true,
 			IsStable:         true,
-			Name:             "statefulsets",
-			NodeType:         orchestrator.K8sStatefulSet,
-			Version:          "apps/v1",
+			Name:             "cronjobs",
+			NodeType:         orchestrator.K8sCronJob,
+			Version:          "batch/v1",
 		},
-		processor: processors.NewProcessor(new(k8sProcessors.StatefulSetHandlers)),
+		processor: processors.NewProcessor(new(k8sProcessors.CronJobV1Handlers)),
 	}
 }
 
 // Informer returns the shared informer.
-func (c *StatefulSetCollector) Informer() cache.SharedInformer {
+func (c *CronJobV1Collector) Informer() cache.SharedInformer {
 	return c.informer.Informer()
 }
 
 // Init is used to initialize the collector.
-func (c *StatefulSetCollector) Init(rcfg *collectors.CollectorRunConfig) {
-	c.informer = rcfg.APIClient.InformerFactory.Apps().V1().StatefulSets()
+func (c *CronJobV1Collector) Init(rcfg *collectors.CollectorRunConfig) {
+	c.informer = rcfg.APIClient.InformerFactory.Batch().V1().CronJobs()
 	c.lister = c.informer.Lister()
 }
 
 // IsAvailable returns whether the collector is available.
-func (c *StatefulSetCollector) IsAvailable() bool { return true }
+func (c *CronJobV1Collector) IsAvailable() bool { return true }
 
 // Metadata is used to access information about the collector.
-func (c *StatefulSetCollector) Metadata() *collectors.CollectorMetadata {
+func (c *CronJobV1Collector) Metadata() *collectors.CollectorMetadata {
 	return c.metadata
 }
 
 // Run triggers the collection process.
-func (c *StatefulSetCollector) Run(rcfg *collectors.CollectorRunConfig) (*collectors.CollectorRunResult, error) {
+func (c *CronJobV1Collector) Run(rcfg *collectors.CollectorRunConfig) (*collectors.CollectorRunResult, error) {
 	list, err := c.lister.List(labels.Everything())
 	if err != nil {
 		return nil, collectors.NewListingError(err)

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/cronjob_v1beta1.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/cronjob_v1beta1.go
@@ -15,62 +15,53 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/orchestrator"
 
 	"k8s.io/apimachinery/pkg/labels"
-	appsv1Informers "k8s.io/client-go/informers/apps/v1"
-	appsv1Listers "k8s.io/client-go/listers/apps/v1"
+	batchv1Informers "k8s.io/client-go/informers/batch/v1beta1"
+	batchv1Listers "k8s.io/client-go/listers/batch/v1beta1"
 	"k8s.io/client-go/tools/cache"
 )
 
-// NewStatefulSetCollectorVersions builds the group of collector versions.
-func NewStatefulSetCollectorVersions() collectors.CollectorVersions {
-	return collectors.NewCollectorVersions(
-		NewStatefulSetCollector(),
-	)
-}
-
-// StatefulSetCollector is a collector for Kubernetes StatefulSets.
-type StatefulSetCollector struct {
-	informer  appsv1Informers.StatefulSetInformer
-	lister    appsv1Listers.StatefulSetLister
+// CronJobV1Beta1Collector is a collector for Kubernetes CronJobs.
+type CronJobV1Beta1Collector struct {
+	informer  batchv1Informers.CronJobInformer
+	lister    batchv1Listers.CronJobLister
 	metadata  *collectors.CollectorMetadata
 	processor *processors.Processor
 }
 
-// NewStatefulSetCollector creates a new collector for the Kubernetes
-// StatefulSet resource.
-func NewStatefulSetCollector() *StatefulSetCollector {
-	return &StatefulSetCollector{
+// NewCronJobV1Beta1Collector creates a new collector for the Kubernetes Job resource.
+func NewCronJobV1Beta1Collector() *CronJobV1Beta1Collector {
+	return &CronJobV1Beta1Collector{
 		metadata: &collectors.CollectorMetadata{
-			IsDefaultVersion: true,
-			IsStable:         true,
-			Name:             "statefulsets",
-			NodeType:         orchestrator.K8sStatefulSet,
-			Version:          "apps/v1",
+			IsStable: true,
+			Name:     "cronjobs",
+			NodeType: orchestrator.K8sCronJob,
+			Version:  "batch/v1beta1",
 		},
-		processor: processors.NewProcessor(new(k8sProcessors.StatefulSetHandlers)),
+		processor: processors.NewProcessor(new(k8sProcessors.CronJobV1Beta1Handlers)),
 	}
 }
 
 // Informer returns the shared informer.
-func (c *StatefulSetCollector) Informer() cache.SharedInformer {
+func (c *CronJobV1Beta1Collector) Informer() cache.SharedInformer {
 	return c.informer.Informer()
 }
 
 // Init is used to initialize the collector.
-func (c *StatefulSetCollector) Init(rcfg *collectors.CollectorRunConfig) {
-	c.informer = rcfg.APIClient.InformerFactory.Apps().V1().StatefulSets()
+func (c *CronJobV1Beta1Collector) Init(rcfg *collectors.CollectorRunConfig) {
+	c.informer = rcfg.APIClient.InformerFactory.Batch().V1beta1().CronJobs()
 	c.lister = c.informer.Lister()
 }
 
 // IsAvailable returns whether the collector is available.
-func (c *StatefulSetCollector) IsAvailable() bool { return true }
+func (c *CronJobV1Beta1Collector) IsAvailable() bool { return true }
 
 // Metadata is used to access information about the collector.
-func (c *StatefulSetCollector) Metadata() *collectors.CollectorMetadata {
+func (c *CronJobV1Beta1Collector) Metadata() *collectors.CollectorMetadata {
 	return c.metadata
 }
 
 // Run triggers the collection process.
-func (c *StatefulSetCollector) Run(rcfg *collectors.CollectorRunConfig) (*collectors.CollectorRunResult, error) {
+func (c *CronJobV1Beta1Collector) Run(rcfg *collectors.CollectorRunConfig) (*collectors.CollectorRunResult, error) {
 	list, err := c.lister.List(labels.Everything())
 	if err != nil {
 		return nil, collectors.NewListingError(err)

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/cronjob_v1beta1.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/cronjob_v1beta1.go
@@ -32,10 +32,11 @@ type CronJobV1Beta1Collector struct {
 func NewCronJobV1Beta1Collector() *CronJobV1Beta1Collector {
 	return &CronJobV1Beta1Collector{
 		metadata: &collectors.CollectorMetadata{
-			IsStable: true,
-			Name:     "cronjobs",
-			NodeType: orchestrator.K8sCronJob,
-			Version:  "batch/v1beta1",
+			IsDefaultVersion: false,
+			IsStable:         true,
+			Name:             "cronjobs",
+			NodeType:         orchestrator.K8sCronJob,
+			Version:          "batch/v1beta1",
 		},
 		processor: processors.NewProcessor(new(k8sProcessors.CronJobV1Beta1Handlers)),
 	}

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/daemonset.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/daemonset.go
@@ -20,6 +20,13 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+// NewDaemonSetCollectorVersions builds the group of collector versions.
+func NewDaemonSetCollectorVersions() collectors.CollectorVersions {
+	return collectors.NewCollectorVersions(
+		NewDaemonSetCollector(),
+	)
+}
+
 // DaemonSetCollector is a collector for Kubernetes DaemonSets.
 type DaemonSetCollector struct {
 	informer  appsv1Informers.DaemonSetInformer
@@ -33,9 +40,11 @@ type DaemonSetCollector struct {
 func NewDaemonSetCollector() *DaemonSetCollector {
 	return &DaemonSetCollector{
 		metadata: &collectors.CollectorMetadata{
-			IsStable: true,
-			Name:     "daemonsets",
-			NodeType: orchestrator.K8sDaemonSet,
+			IsDefaultVersion: true,
+			IsStable:         true,
+			Name:             "daemonsets",
+			NodeType:         orchestrator.K8sDaemonSet,
+			Version:          "apps/v1",
 		},
 		processor: processors.NewProcessor(new(k8sProcessors.DaemonSetHandlers)),
 	}

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/deployment.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/deployment.go
@@ -20,6 +20,13 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+// NewDeploymentCollectorVersions builds the group of collector versions.
+func NewDeploymentCollectorVersions() collectors.CollectorVersions {
+	return collectors.NewCollectorVersions(
+		NewDeploymentCollector(),
+	)
+}
+
 // DeploymentCollector is a collector for Kubernetes Deployments.
 type DeploymentCollector struct {
 	informer  appsv1Informers.DeploymentInformer
@@ -33,9 +40,11 @@ type DeploymentCollector struct {
 func NewDeploymentCollector() *DeploymentCollector {
 	return &DeploymentCollector{
 		metadata: &collectors.CollectorMetadata{
-			IsStable: true,
-			Name:     "deployments",
-			NodeType: orchestrator.K8sDeployment,
+			IsDefaultVersion: true,
+			IsStable:         true,
+			Name:             "deployments",
+			NodeType:         orchestrator.K8sDeployment,
+			Version:          "apps/v1",
 		},
 		processor: processors.NewProcessor(new(k8sProcessors.DeploymentHandlers)),
 	}

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/ingress.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/ingress.go
@@ -27,6 +27,13 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+// NewIngressCollectorVersions builds the group of collector versions.
+func NewIngressCollectorVersions() collectors.CollectorVersions {
+	return collectors.NewCollectorVersions(
+		NewIngressCollector(),
+	)
+}
+
 // IngressCollector is a collector for Kubernetes Ingresss.
 type IngressCollector struct {
 	informer    netv1Informers.IngressInformer
@@ -41,9 +48,11 @@ type IngressCollector struct {
 func NewIngressCollector() *IngressCollector {
 	return &IngressCollector{
 		metadata: &collectors.CollectorMetadata{
-			IsStable: true,
-			Name:     "ingresses",
-			NodeType: orchestrator.K8sIngress,
+			IsDefaultVersion: true,
+			IsStable:         true,
+			Name:             "ingresses",
+			NodeType:         orchestrator.K8sIngress,
+			Version:          "networking.k8s.io/v1",
 		},
 		processor: processors.NewProcessor(new(k8sProcessors.IngressHandlers)),
 	}

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/job.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/job.go
@@ -20,6 +20,13 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+// NewJobCollectorVersions builds the group of collector versions.
+func NewJobCollectorVersions() collectors.CollectorVersions {
+	return collectors.NewCollectorVersions(
+		NewJobCollector(),
+	)
+}
+
 // JobCollector is a collector for Kubernetes Jobs.
 type JobCollector struct {
 	informer  batchv1Informers.JobInformer
@@ -32,9 +39,11 @@ type JobCollector struct {
 func NewJobCollector() *JobCollector {
 	return &JobCollector{
 		metadata: &collectors.CollectorMetadata{
-			IsStable: true,
-			Name:     "jobs",
-			NodeType: orchestrator.K8sJob,
+			IsDefaultVersion: true,
+			IsStable:         true,
+			Name:             "jobs",
+			NodeType:         orchestrator.K8sJob,
+			Version:          "batch/v1",
 		},
 		processor: processors.NewProcessor(new(k8sProcessors.JobHandlers)),
 	}

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/node.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/node.go
@@ -20,6 +20,13 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+// NewNodeCollectorVersions builds the group of collector versions.
+func NewNodeCollectorVersions() collectors.CollectorVersions {
+	return collectors.NewCollectorVersions(
+		NewNodeCollector(),
+	)
+}
+
 // NodeCollector is a collector for Kubernetes Nodes.
 type NodeCollector struct {
 	informer  corev1Informers.NodeInformer
@@ -32,9 +39,11 @@ type NodeCollector struct {
 func NewNodeCollector() *NodeCollector {
 	return &NodeCollector{
 		metadata: &collectors.CollectorMetadata{
-			IsStable: true,
-			Name:     "nodes",
-			NodeType: orchestrator.K8sNode,
+			IsDefaultVersion: true,
+			IsStable:         true,
+			Name:             "nodes",
+			NodeType:         orchestrator.K8sNode,
+			Version:          "v1",
 		},
 		processor: processors.NewProcessor(new(k8sProcessors.NodeHandlers)),
 	}

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/persistentvolume.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/persistentvolume.go
@@ -20,6 +20,13 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+// NewPersistentVolumeCollectorVersions builds the group of collector versions.
+func NewPersistentVolumeCollectorVersions() collectors.CollectorVersions {
+	return collectors.NewCollectorVersions(
+		NewPersistentVolumeCollector(),
+	)
+}
+
 // PersistentVolumeCollector is a collector for Kubernetes PersistentVolumes.
 type PersistentVolumeCollector struct {
 	informer  corev1Informers.PersistentVolumeInformer
@@ -33,9 +40,11 @@ type PersistentVolumeCollector struct {
 func NewPersistentVolumeCollector() *PersistentVolumeCollector {
 	return &PersistentVolumeCollector{
 		metadata: &collectors.CollectorMetadata{
-			IsStable: true,
-			Name:     "persistentvolumes",
-			NodeType: orchestrator.K8sPersistentVolume,
+			IsDefaultVersion: true,
+			IsStable:         true,
+			Name:             "persistentvolumes",
+			NodeType:         orchestrator.K8sPersistentVolume,
+			Version:          "v1",
 		},
 		processor: processors.NewProcessor(new(k8sProcessors.PersistentVolumeHandlers)),
 	}

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/persistentvolumeclaim.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/persistentvolumeclaim.go
@@ -20,6 +20,13 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+// NewPersistentVolumeClaimCollectorVersions builds the group of collector versions.
+func NewPersistentVolumeClaimCollectorVersions() collectors.CollectorVersions {
+	return collectors.NewCollectorVersions(
+		NewPersistentVolumeClaimCollector(),
+	)
+}
+
 // PersistentVolumeClaimCollector is a collector for Kubernetes PersistentVolumeClaims.
 type PersistentVolumeClaimCollector struct {
 	informer  corev1Informers.PersistentVolumeClaimInformer
@@ -33,9 +40,11 @@ type PersistentVolumeClaimCollector struct {
 func NewPersistentVolumeClaimCollector() *PersistentVolumeClaimCollector {
 	return &PersistentVolumeClaimCollector{
 		metadata: &collectors.CollectorMetadata{
-			IsStable: true,
-			Name:     "persistentvolumeclaims",
-			NodeType: orchestrator.K8sPersistentVolumeClaim,
+			IsDefaultVersion: true,
+			IsStable:         true,
+			Name:             "persistentvolumeclaims",
+			NodeType:         orchestrator.K8sPersistentVolumeClaim,
+			Version:          "v1",
 		},
 		processor: processors.NewProcessor(new(k8sProcessors.PersistentVolumeClaimHandlers)),
 	}

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/pod_unassigned.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/pod_unassigned.go
@@ -20,6 +20,13 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+// NewUnassignedPodCollectorVersions builds the group of collector versions.
+func NewUnassignedPodCollectorVersions() collectors.CollectorVersions {
+	return collectors.NewCollectorVersions(
+		NewUnassignedPodCollector(),
+	)
+}
+
 // UnassignedPodCollector is a collector for Kubernetes Pods that are not
 // assigned to a node yet.
 type UnassignedPodCollector struct {
@@ -34,9 +41,11 @@ type UnassignedPodCollector struct {
 func NewUnassignedPodCollector() *UnassignedPodCollector {
 	return &UnassignedPodCollector{
 		metadata: &collectors.CollectorMetadata{
-			IsStable: true,
-			Name:     "pods",
-			NodeType: orchestrator.K8sPod,
+			IsDefaultVersion: true,
+			IsStable:         true,
+			Name:             "pods",
+			NodeType:         orchestrator.K8sPod,
+			Version:          "v1",
 		},
 		processor: processors.NewProcessor(new(k8sProcessors.PodHandlers)),
 	}

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/replicaset.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/replicaset.go
@@ -20,6 +20,13 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+// NewReplicaSetCollectorVersions builds the group of collector versions.
+func NewReplicaSetCollectorVersions() collectors.CollectorVersions {
+	return collectors.NewCollectorVersions(
+		NewReplicaSetCollector(),
+	)
+}
+
 // ReplicaSetCollector is a collector for Kubernetes ReplicaSets.
 type ReplicaSetCollector struct {
 	informer  appsv1Informers.ReplicaSetInformer
@@ -33,9 +40,11 @@ type ReplicaSetCollector struct {
 func NewReplicaSetCollector() *ReplicaSetCollector {
 	return &ReplicaSetCollector{
 		metadata: &collectors.CollectorMetadata{
-			IsStable: true,
-			Name:     "replicasets",
-			NodeType: orchestrator.K8sReplicaSet,
+			IsDefaultVersion: true,
+			IsStable:         true,
+			Name:             "replicasets",
+			NodeType:         orchestrator.K8sReplicaSet,
+			Version:          "apps/v1",
 		},
 		processor: processors.NewProcessor(new(k8sProcessors.ReplicaSetHandlers)),
 	}

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/role.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/role.go
@@ -20,6 +20,13 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+// NewRoleCollectorVersions builds the group of collector versions.
+func NewRoleCollectorVersions() collectors.CollectorVersions {
+	return collectors.NewCollectorVersions(
+		NewRoleCollector(),
+	)
+}
+
 // RoleCollector is a collector for Kubernetes Roles.
 type RoleCollector struct {
 	informer  rbacv1Informers.RoleInformer
@@ -32,9 +39,11 @@ type RoleCollector struct {
 func NewRoleCollector() *RoleCollector {
 	return &RoleCollector{
 		metadata: &collectors.CollectorMetadata{
-			IsStable: true,
-			Name:     "roles",
-			NodeType: orchestrator.K8sRole,
+			IsDefaultVersion: true,
+			IsStable:         true,
+			Name:             "roles",
+			NodeType:         orchestrator.K8sRole,
+			Version:          "rbac.authorization.k8s.io/v1",
 		},
 		processor: processors.NewProcessor(new(k8sProcessors.RoleHandlers)),
 	}

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/rolebinding.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/rolebinding.go
@@ -20,6 +20,13 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+// NewRoleBindingCollectorVersions builds the group of collector versions.
+func NewRoleBindingCollectorVersions() collectors.CollectorVersions {
+	return collectors.NewCollectorVersions(
+		NewRoleBindingCollector(),
+	)
+}
+
 // RoleBindingCollector is a collector for Kubernetes RoleBindings.
 type RoleBindingCollector struct {
 	informer  rbacv1Informers.RoleBindingInformer
@@ -33,9 +40,11 @@ type RoleBindingCollector struct {
 func NewRoleBindingCollector() *RoleBindingCollector {
 	return &RoleBindingCollector{
 		metadata: &collectors.CollectorMetadata{
-			IsStable: true,
-			Name:     "rolebindings",
-			NodeType: orchestrator.K8sRoleBinding,
+			IsDefaultVersion: true,
+			IsStable:         true,
+			Name:             "rolebindings",
+			NodeType:         orchestrator.K8sRoleBinding,
+			Version:          "rbac.authorization.k8s.io/v1",
 		},
 		processor: processors.NewProcessor(new(k8sProcessors.RoleBindingHandlers)),
 	}

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/service.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/service.go
@@ -20,6 +20,13 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+// NewServiceCollectorVersions builds the group of collector versions.
+func NewServiceCollectorVersions() collectors.CollectorVersions {
+	return collectors.NewCollectorVersions(
+		NewServiceCollector(),
+	)
+}
+
 // ServiceCollector is a collector for Kubernetes Services.
 type ServiceCollector struct {
 	informer  corev1Informers.ServiceInformer
@@ -33,9 +40,11 @@ type ServiceCollector struct {
 func NewServiceCollector() *ServiceCollector {
 	return &ServiceCollector{
 		metadata: &collectors.CollectorMetadata{
-			IsStable: true,
-			Name:     "services",
-			NodeType: orchestrator.K8sService,
+			IsDefaultVersion: true,
+			IsStable:         true,
+			Name:             "services",
+			NodeType:         orchestrator.K8sService,
+			Version:          "v1",
 		},
 		processor: processors.NewProcessor(new(k8sProcessors.ServiceHandlers)),
 	}

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/serviceaccount.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/serviceaccount.go
@@ -20,6 +20,13 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+// NewServiceAccountCollectorVersions builds the group of collector versions.
+func NewServiceAccountCollectorVersions() collectors.CollectorVersions {
+	return collectors.NewCollectorVersions(
+		NewServiceAccountCollector(),
+	)
+}
+
 // ServiceAccountCollector is a collector for Kubernetes ServiceAccounts.
 type ServiceAccountCollector struct {
 	informer  corev1Informers.ServiceAccountInformer
@@ -33,9 +40,11 @@ type ServiceAccountCollector struct {
 func NewServiceAccountCollector() *ServiceAccountCollector {
 	return &ServiceAccountCollector{
 		metadata: &collectors.CollectorMetadata{
-			IsStable: true,
-			Name:     "serviceaccounts",
-			NodeType: orchestrator.K8sServiceAccount,
+			IsDefaultVersion: true,
+			IsStable:         true,
+			Name:             "serviceaccounts",
+			NodeType:         orchestrator.K8sServiceAccount,
+			Version:          "v1",
 		},
 		processor: processors.NewProcessor(new(k8sProcessors.ServiceAccountHandlers)),
 	}

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1.go
@@ -1,0 +1,103 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build orchestrator
+// +build orchestrator
+
+package k8s
+
+import (
+	model "github.com/DataDog/agent-payload/v5/process"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
+	k8sTransformers "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s"
+	"github.com/DataDog/datadog-agent/pkg/orchestrator/redact"
+
+	batchv1 "k8s.io/api/batch/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// CronJobV1Handlers implements the Handlers interface for Kubernetes CronJobs.
+type CronJobV1Handlers struct{}
+
+// AfterMarshalling is a handler called after resource marshalling.
+func (h *CronJobV1Handlers) AfterMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}, yaml []byte) (skip bool) {
+	m := resourceModel.(*model.CronJob)
+	m.Yaml = yaml
+	return
+}
+
+// BeforeCacheCheck is a handler called before cache lookup.
+func (h *CronJobV1Handlers) BeforeCacheCheck(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
+	return
+}
+
+// BeforeMarshalling is a handler called before resource marshalling.
+func (h *CronJobV1Handlers) BeforeMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
+	return
+}
+
+// BuildMessageBody is a handler called to build a message body out of a list of
+// extracted resources.
+func (h *CronJobV1Handlers) BuildMessageBody(ctx *processors.ProcessorContext, resourceModels []interface{}, groupSize int) model.MessageBody {
+	models := make([]*model.CronJob, 0, len(resourceModels))
+
+	for _, m := range resourceModels {
+		models = append(models, m.(*model.CronJob))
+	}
+
+	return &model.CollectorCronJob{
+		ClusterName: ctx.Cfg.KubeClusterName,
+		ClusterId:   ctx.ClusterID,
+		GroupId:     ctx.MsgGroupID,
+		GroupSize:   int32(groupSize),
+		CronJobs:    models,
+		Tags:        ctx.Cfg.ExtraTags,
+	}
+}
+
+// ExtractResource is a handler called to extract the resource model out of a raw resource.
+func (h *CronJobV1Handlers) ExtractResource(ctx *processors.ProcessorContext, resource interface{}) (resourceModel interface{}) {
+	r := resource.(*batchv1.CronJob)
+	return k8sTransformers.ExtractCronJobV1(r)
+}
+
+// ResourceList is a handler called to convert a list passed as a generic
+// interface to a list of generic interfaces.
+func (h *CronJobV1Handlers) ResourceList(ctx *processors.ProcessorContext, list interface{}) (resources []interface{}) {
+	resourceList := list.([]*batchv1.CronJob)
+	resources = make([]interface{}, 0, len(resourceList))
+
+	for _, resource := range resourceList {
+		resources = append(resources, resource)
+	}
+
+	return resources
+}
+
+// ResourceUID is a handler called to retrieve the resource UID.
+func (h *CronJobV1Handlers) ResourceUID(ctx *processors.ProcessorContext, resource, resourceModel interface{}) types.UID {
+	return resource.(*batchv1.CronJob).UID
+}
+
+// ResourceVersion is a handler called to retrieve the resource version.
+func (h *CronJobV1Handlers) ResourceVersion(ctx *processors.ProcessorContext, resource, resourceModel interface{}) string {
+	return resource.(*batchv1.CronJob).ResourceVersion
+}
+
+// ScrubBeforeExtraction is a handler called to redact the raw resource before
+// it is extracted as an internal resource model.
+func (h *CronJobV1Handlers) ScrubBeforeExtraction(ctx *processors.ProcessorContext, resource interface{}) {
+	r := resource.(*batchv1.CronJob)
+	redact.RemoveLastAppliedConfigurationAnnotation(r.Annotations)
+}
+
+// ScrubBeforeMarshalling is a handler called to redact the raw resource before
+// it is marshalled to generate a manifest.
+func (h *CronJobV1Handlers) ScrubBeforeMarshalling(ctx *processors.ProcessorContext, resource interface{}) {
+	r := resource.(*batchv1.CronJob)
+	if ctx.Cfg.IsScrubbingEnabled {
+		redact.ScrubPodTemplateSpec(&r.Spec.JobTemplate.Spec.Template, ctx.Cfg.Scrubber)
+	}
+}

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1beta1.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1beta1.go
@@ -19,29 +19,29 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-// CronJobHandlers implements the Handlers interface for Kubernetes CronJobs.
-type CronJobHandlers struct{}
+// CronJobV1Beta1Handlers implements the Handlers interface for Kubernetes CronJobs.
+type CronJobV1Beta1Handlers struct{}
 
 // AfterMarshalling is a handler called after resource marshalling.
-func (h *CronJobHandlers) AfterMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}, yaml []byte) (skip bool) {
+func (h *CronJobV1Beta1Handlers) AfterMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}, yaml []byte) (skip bool) {
 	m := resourceModel.(*model.CronJob)
 	m.Yaml = yaml
 	return
 }
 
 // BeforeCacheCheck is a handler called before cache lookup.
-func (h *CronJobHandlers) BeforeCacheCheck(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
+func (h *CronJobV1Beta1Handlers) BeforeCacheCheck(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	return
 }
 
 // BeforeMarshalling is a handler called before resource marshalling.
-func (h *CronJobHandlers) BeforeMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
+func (h *CronJobV1Beta1Handlers) BeforeMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	return
 }
 
 // BuildMessageBody is a handler called to build a message body out of a list of
 // extracted resources.
-func (h *CronJobHandlers) BuildMessageBody(ctx *processors.ProcessorContext, resourceModels []interface{}, groupSize int) model.MessageBody {
+func (h *CronJobV1Beta1Handlers) BuildMessageBody(ctx *processors.ProcessorContext, resourceModels []interface{}, groupSize int) model.MessageBody {
 	models := make([]*model.CronJob, 0, len(resourceModels))
 
 	for _, m := range resourceModels {
@@ -59,14 +59,14 @@ func (h *CronJobHandlers) BuildMessageBody(ctx *processors.ProcessorContext, res
 }
 
 // ExtractResource is a handler called to extract the resource model out of a raw resource.
-func (h *CronJobHandlers) ExtractResource(ctx *processors.ProcessorContext, resource interface{}) (resourceModel interface{}) {
+func (h *CronJobV1Beta1Handlers) ExtractResource(ctx *processors.ProcessorContext, resource interface{}) (resourceModel interface{}) {
 	r := resource.(*batchv1beta1.CronJob)
-	return k8sTransformers.ExtractCronJob(r)
+	return k8sTransformers.ExtractCronJobV1Beta1(r)
 }
 
 // ResourceList is a handler called to convert a list passed as a generic
 // interface to a list of generic interfaces.
-func (h *CronJobHandlers) ResourceList(ctx *processors.ProcessorContext, list interface{}) (resources []interface{}) {
+func (h *CronJobV1Beta1Handlers) ResourceList(ctx *processors.ProcessorContext, list interface{}) (resources []interface{}) {
 	resourceList := list.([]*batchv1beta1.CronJob)
 	resources = make([]interface{}, 0, len(resourceList))
 
@@ -78,25 +78,25 @@ func (h *CronJobHandlers) ResourceList(ctx *processors.ProcessorContext, list in
 }
 
 // ResourceUID is a handler called to retrieve the resource UID.
-func (h *CronJobHandlers) ResourceUID(ctx *processors.ProcessorContext, resource, resourceModel interface{}) types.UID {
+func (h *CronJobV1Beta1Handlers) ResourceUID(ctx *processors.ProcessorContext, resource, resourceModel interface{}) types.UID {
 	return resource.(*batchv1beta1.CronJob).UID
 }
 
 // ResourceVersion is a handler called to retrieve the resource version.
-func (h *CronJobHandlers) ResourceVersion(ctx *processors.ProcessorContext, resource, resourceModel interface{}) string {
+func (h *CronJobV1Beta1Handlers) ResourceVersion(ctx *processors.ProcessorContext, resource, resourceModel interface{}) string {
 	return resource.(*batchv1beta1.CronJob).ResourceVersion
 }
 
 // ScrubBeforeExtraction is a handler called to redact the raw resource before
 // it is extracted as an internal resource model.
-func (h *CronJobHandlers) ScrubBeforeExtraction(ctx *processors.ProcessorContext, resource interface{}) {
+func (h *CronJobV1Beta1Handlers) ScrubBeforeExtraction(ctx *processors.ProcessorContext, resource interface{}) {
 	r := resource.(*batchv1beta1.CronJob)
 	redact.RemoveLastAppliedConfigurationAnnotation(r.Annotations)
 }
 
 // ScrubBeforeMarshalling is a handler called to redact the raw resource before
 // it is marshalled to generate a manifest.
-func (h *CronJobHandlers) ScrubBeforeMarshalling(ctx *processors.ProcessorContext, resource interface{}) {
+func (h *CronJobV1Beta1Handlers) ScrubBeforeMarshalling(ctx *processors.ProcessorContext, resource interface{}) {
 	r := resource.(*batchv1beta1.CronJob)
 	if ctx.Cfg.IsScrubbingEnabled {
 		redact.ScrubPodTemplateSpec(&r.Spec.JobTemplate.Spec.Template, ctx.Cfg.Scrubber)

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/processor.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/processor.go
@@ -164,23 +164,24 @@ func (p *Processor) Process(ctx *ProcessorContext, list interface{}) (processRes
 			ContentType:     "json",
 		})
 	}
-	// Split messages in chunks
-	chunkCount := orchestrator.GroupSize(len(resourceMetadataModels), ctx.Cfg.MaxPerMessage)
 
-	// chunk orchestrator metadata and manifest
+	// Split messages in chunks for orchestrator metadata and manifest data.
+	chunkCount := orchestrator.GroupSize(len(resourceMetadataModels), ctx.Cfg.MaxPerMessage)
 	metadataChunks := chunkResources(resourceMetadataModels, chunkCount, ctx.Cfg.MaxPerMessage)
 	manifestChunks := chunkResources(resourceManifestModels, chunkCount, ctx.Cfg.MaxPerMessage)
-
 	metadataMessages := make([]model.MessageBody, 0, chunkCount)
 	manifestMessages := make([]model.MessageBody, 0, chunkCount)
+
 	for i := 0; i < chunkCount; i++ {
 		metadataMessages = append(metadataMessages, p.h.BuildMessageBody(ctx, metadataChunks[i], chunkCount))
 		manifestMessages = append(manifestMessages, buildManifestMessageBody(ctx.Cfg.KubeClusterName, ctx.ClusterID, ctx.MsgGroupID, manifestChunks[i], chunkCount))
 	}
+
 	processResult = ProcessResult{
 		MetadataMessages: metadataMessages,
 		ManifestMessages: manifestMessages,
 	}
+
 	return processResult, len(resourceMetadataModels)
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/cronjob_v1.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/cronjob_v1.go
@@ -1,0 +1,58 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build orchestrator
+// +build orchestrator
+
+package k8s
+
+import (
+	model "github.com/DataDog/agent-payload/v5/process"
+
+	batchv1 "k8s.io/api/batch/v1"
+)
+
+// ExtractCronJobV1 returns the protobuf model corresponding to a Kubernetes
+// CronJob resource.
+func ExtractCronJobV1(cj *batchv1.CronJob) *model.CronJob {
+	cronJob := model.CronJob{
+		Metadata: extractMetadata(&cj.ObjectMeta),
+		Spec: &model.CronJobSpec{
+			ConcurrencyPolicy: string(cj.Spec.ConcurrencyPolicy),
+			Schedule:          cj.Spec.Schedule,
+		},
+		Status: &model.CronJobStatus{},
+	}
+
+	if cj.Spec.FailedJobsHistoryLimit != nil {
+		cronJob.Spec.FailedJobsHistoryLimit = *cj.Spec.FailedJobsHistoryLimit
+	}
+	if cj.Spec.StartingDeadlineSeconds != nil {
+		cronJob.Spec.StartingDeadlineSeconds = *cj.Spec.StartingDeadlineSeconds
+	}
+	if cj.Spec.SuccessfulJobsHistoryLimit != nil {
+		cronJob.Spec.SuccessfulJobsHistoryLimit = *cj.Spec.SuccessfulJobsHistoryLimit
+	}
+	if cj.Spec.Suspend != nil {
+		cronJob.Spec.Suspend = *cj.Spec.Suspend
+	}
+
+	if cj.Status.LastScheduleTime != nil {
+		cronJob.Status.LastScheduleTime = cj.Status.LastScheduleTime.Unix()
+	}
+	for _, job := range cj.Status.Active {
+		cronJob.Status.Active = append(cronJob.Status.Active, &model.ObjectReference{
+			ApiVersion:      job.APIVersion,
+			FieldPath:       job.FieldPath,
+			Kind:            job.Kind,
+			Name:            job.Name,
+			Namespace:       job.Namespace,
+			ResourceVersion: job.ResourceVersion,
+			Uid:             string(job.UID),
+		})
+	}
+
+	return &cronJob
+}

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/cronjob_v1_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/cronjob_v1_test.go
@@ -16,22 +16,21 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	batchv1 "k8s.io/api/batch/v1"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func TestExtractCronJob(t *testing.T) {
+func TestExtractCronJobV1(t *testing.T) {
 	creationTime := metav1.NewTime(time.Date(2021, time.April, 16, 14, 30, 0, 0, time.UTC))
 	lastScheduleTime := metav1.NewTime(time.Date(2021, time.April, 16, 14, 30, 0, 0, time.UTC))
 
 	tests := map[string]struct {
-		input    batchv1beta1.CronJob
+		input    batchv1.CronJob
 		expected model.CronJob
 	}{
 		"full cron job (active)": {
-			input: batchv1beta1.CronJob{
+			input: batchv1.CronJob{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						"annotation": "my-annotation",
@@ -45,15 +44,15 @@ func TestExtractCronJob(t *testing.T) {
 					ResourceVersion: "220593670",
 					UID:             types.UID("0ff96226-578d-4679-b3c8-72e8a485c0ef"),
 				},
-				Spec: batchv1beta1.CronJobSpec{
-					ConcurrencyPolicy:          batchv1beta1.ForbidConcurrent,
+				Spec: batchv1.CronJobSpec{
+					ConcurrencyPolicy:          batchv1.ForbidConcurrent,
 					FailedJobsHistoryLimit:     int32Ptr(4),
 					Schedule:                   "*/5 * * * *",
 					StartingDeadlineSeconds:    int64Ptr(120),
 					SuccessfulJobsHistoryLimit: int32Ptr(2),
 					Suspend:                    boolPtr(false),
 				},
-				Status: batchv1beta1.CronJobStatus{
+				Status: batchv1.CronJobStatus{
 					Active: []corev1.ObjectReference{
 						{
 							APIVersion:      "batch/v1",
@@ -100,26 +99,10 @@ func TestExtractCronJob(t *testing.T) {
 				},
 			},
 		},
-		"cronjob with resources": {
-			input: batchv1beta1.CronJob{
-				Spec: batchv1beta1.CronJobSpec{
-					JobTemplate: batchv1beta1.JobTemplateSpec{
-						Spec: batchv1.JobSpec{Template: getTemplateWithResourceRequirements()},
-					},
-				},
-			},
-			expected: model.CronJob{
-				Metadata: &model.Metadata{},
-				Spec: &model.CronJobSpec{
-					ResourceRequirements: getExpectedModelResourceRequirements(),
-				},
-				Status: &model.CronJobStatus{},
-			},
-		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, &tc.expected, ExtractCronJob(&tc.input))
+			assert.Equal(t, &tc.expected, ExtractCronJobV1(&tc.input))
 		})
 	}
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/cronjob_v1beta1.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/cronjob_v1beta1.go
@@ -14,9 +14,9 @@ import (
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 )
 
-// ExtractCronJob returns the protobuf model corresponding to a Kubernetes
+// ExtractCronJobV1Beta1 returns the protobuf model corresponding to a Kubernetes
 // CronJob resource.
-func ExtractCronJob(cj *batchv1beta1.CronJob) *model.CronJob {
+func ExtractCronJobV1Beta1(cj *batchv1beta1.CronJob) *model.CronJob {
 	cronJob := model.CronJob{
 		Metadata: extractMetadata(&cj.ObjectMeta),
 		Spec: &model.CronJobSpec{

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/cronjob_v1beta1_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/cronjob_v1beta1_test.go
@@ -1,0 +1,125 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build orchestrator
+// +build orchestrator
+
+package k8s
+
+import (
+	"testing"
+	"time"
+
+	model "github.com/DataDog/agent-payload/v5/process"
+
+	"github.com/stretchr/testify/assert"
+	batchv1 "k8s.io/api/batch/v1"
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestExtractCronJobV1Beta1(t *testing.T) {
+	creationTime := metav1.NewTime(time.Date(2021, time.April, 16, 14, 30, 0, 0, time.UTC))
+	lastScheduleTime := metav1.NewTime(time.Date(2021, time.April, 16, 14, 30, 0, 0, time.UTC))
+
+	tests := map[string]struct {
+		input    batchv1beta1.CronJob
+		expected model.CronJob
+	}{
+		"full cron job (active)": {
+			input: batchv1beta1.CronJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"annotation": "my-annotation",
+					},
+					CreationTimestamp: creationTime,
+					Labels: map[string]string{
+						"app": "my-app",
+					},
+					Name:            "cronjob",
+					Namespace:       "project",
+					ResourceVersion: "220593670",
+					UID:             types.UID("0ff96226-578d-4679-b3c8-72e8a485c0ef"),
+				},
+				Spec: batchv1beta1.CronJobSpec{
+					ConcurrencyPolicy:          batchv1beta1.ForbidConcurrent,
+					FailedJobsHistoryLimit:     int32Ptr(4),
+					Schedule:                   "*/5 * * * *",
+					StartingDeadlineSeconds:    int64Ptr(120),
+					SuccessfulJobsHistoryLimit: int32Ptr(2),
+					Suspend:                    boolPtr(false),
+				},
+				Status: batchv1beta1.CronJobStatus{
+					Active: []corev1.ObjectReference{
+						{
+							APIVersion:      "batch/v1",
+							Kind:            "Job",
+							Name:            "cronjob-1618585500",
+							Namespace:       "project",
+							ResourceVersion: "220593669",
+							UID:             "644a62fe-783f-4609-bd2b-a9ec1212c07b",
+						},
+					},
+					LastScheduleTime: &lastScheduleTime,
+				},
+			},
+			expected: model.CronJob{
+				Metadata: &model.Metadata{
+					Annotations:       []string{"annotation:my-annotation"},
+					CreationTimestamp: creationTime.Unix(),
+					Labels:            []string{"app:my-app"},
+					Name:              "cronjob",
+					Namespace:         "project",
+					ResourceVersion:   "220593670",
+					Uid:               "0ff96226-578d-4679-b3c8-72e8a485c0ef",
+				},
+				Spec: &model.CronJobSpec{
+					ConcurrencyPolicy:          "Forbid",
+					FailedJobsHistoryLimit:     4,
+					Schedule:                   "*/5 * * * *",
+					StartingDeadlineSeconds:    120,
+					SuccessfulJobsHistoryLimit: 2,
+					Suspend:                    false,
+				},
+				Status: &model.CronJobStatus{
+					Active: []*model.ObjectReference{
+						{
+							ApiVersion:      "batch/v1",
+							Kind:            "Job",
+							Name:            "cronjob-1618585500",
+							Namespace:       "project",
+							ResourceVersion: "220593669",
+							Uid:             "644a62fe-783f-4609-bd2b-a9ec1212c07b",
+						},
+					},
+					LastScheduleTime: lastScheduleTime.Unix(),
+				},
+			},
+		},
+		"cronjob with resources": {
+			input: batchv1beta1.CronJob{
+				Spec: batchv1beta1.CronJobSpec{
+					JobTemplate: batchv1beta1.JobTemplateSpec{
+						Spec: batchv1.JobSpec{Template: getTemplateWithResourceRequirements()},
+					},
+				},
+			},
+			expected: model.CronJob{
+				Metadata: &model.Metadata{},
+				Spec: &model.CronJobSpec{
+					ResourceRequirements: getExpectedModelResourceRequirements(),
+				},
+				Status: &model.CronJobStatus{},
+			},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, &tc.expected, ExtractCronJobV1Beta1(&tc.input))
+		})
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1005,6 +1005,7 @@ func InitConfig(config Config) {
 	// this option will potentially impact the CPU usage of the agent
 	config.BindEnvAndSetDefault("orchestrator_explorer.container_scrubbing.enabled", true)
 	config.BindEnvAndSetDefault("orchestrator_explorer.custom_sensitive_words", []string{})
+	config.BindEnvAndSetDefault("orchestrator_explorer.collector_discovery.enabled", true)
 	config.BindEnv("orchestrator_explorer.max_per_message")
 	config.BindEnv("orchestrator_explorer.orchestrator_dd_url")
 	config.BindEnv("orchestrator_explorer.orchestrator_additional_endpoints")

--- a/pkg/orchestrator/config/config.go
+++ b/pkg/orchestrator/config/config.go
@@ -32,6 +32,7 @@ const (
 // OrchestratorConfig is the global config for the Orchestrator related packages. This information
 // is sourced from config files and the environment variables.
 type OrchestratorConfig struct {
+	CollectorDiscoveryEnabled      bool
 	OrchestrationCollectionEnabled bool
 	KubeClusterName                string
 	IsScrubbingEnabled             bool
@@ -112,6 +113,8 @@ func (oc *OrchestratorConfig) Load() error {
 			oc.KubeClusterName = clusterName
 		}
 	}
+
+	oc.CollectorDiscoveryEnabled = config.Datadog.GetBool(key(orchestratorNS, "collector_discovery.enabled"))
 	oc.IsScrubbingEnabled = config.Datadog.GetBool(key(orchestratorNS, "container_scrubbing.enabled"))
 	oc.ExtraTags = config.Datadog.GetStringSlice(key(orchestratorNS, "extra_tags"))
 	oc.IsManifestCollectionEnabled = config.Datadog.GetBool(key(orchestratorNS, "manifest_collection.enabled"))

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -290,7 +290,9 @@ func (c *APIClient) connect() error {
 		return err
 	}
 
-	if config.Datadog.GetBool("admission_controller.enabled") || config.Datadog.GetBool("compliance_config.enabled") {
+	if config.Datadog.GetBool("admission_controller.enabled") ||
+		config.Datadog.GetBool("compliance_config.enabled") ||
+		config.Datadog.GetBool("orchestrator_explorer.enabled") {
 		c.DynamicCl, err = getKubeDynamicClient(time.Duration(c.timeoutSeconds) * time.Second)
 		if err != nil {
 			log.Infof("Could not get apiserver dynamic client: %v", err)

--- a/pkg/util/kubernetes/apiserver/types.go
+++ b/pkg/util/kubernetes/apiserver/types.go
@@ -26,11 +26,11 @@ const (
 type InformerName string
 
 const (
-	endpointsInformer InformerName = "endpoints"
+	endpointsInformer InformerName = "v1/endpoints"
 	// SecretsInformer holds the name of the informer
-	SecretsInformer InformerName = "secrets"
+	SecretsInformer InformerName = "v1/secrets"
 	// WebhooksInformer holds the name of the informer
-	WebhooksInformer InformerName = "webhooks"
+	WebhooksInformer InformerName = "admissionregistration.k8s.io/v1/mutatingwebhookconfigurations"
 	// ServicesInformer holds the name of the informer
-	ServicesInformer InformerName = "services"
+	ServicesInformer InformerName = "v1/services"
 )

--- a/releasenotes-dca/notes/orchestrator-collector-discovery-09f9dbfe4dbc2269.yaml
+++ b/releasenotes-dca/notes/orchestrator-collector-discovery-09f9dbfe4dbc2269.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG-DCA.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    The orchestrator is now able to discover resources to collect based on API
+    groups available in the Kubernetes cluster.

--- a/releasenotes-dca/notes/orchestrator-collector-discovery-09f9dbfe4dbc2269.yaml
+++ b/releasenotes-dca/notes/orchestrator-collector-discovery-09f9dbfe4dbc2269.yaml
@@ -8,5 +8,5 @@
 ---
 features:
   - |
-    The orchestrator is now able to discover resources to collect based on API
-    groups available in the Kubernetes cluster.
+    The orchestrator check is now able to discover resources to collect based
+    on API groups available in the Kubernetes cluster.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

- Bring support for `batch/v1/cronjobs` that has been available since 1.21 and make it the default version for cronjob collection, moving away from `batch/v1beta1/cronjobs` that is [deprecated in 1.25](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#cronjob-v125).

- In order to handle those transitions with greater flexibility, we also want to improve the way we support and enable resource collection across different API versions. The main goal of this PR is to make the orchestrator check able to configure the collector list itself based on APIs available in the cluster.
  - Configuration of the check instance has precedence over this feature.
  - When multiple API versions are available for the same resource, the one advertised as `Preferred` by the API server will be used. Otherwise, the chosen version will be the first one that is present both in the API list and the inventory.
  - In addition to the versionless form (that will now resolve to the default version defined in the inventory), the check configuration will allow picking up a specific version:

```yaml
init_config:
instances:
  - collectors:
    - batch/v1/cronjobs
    - ...
```

Note: we are keeping the `IsAvailable()` method introduced on the collector interface for now so that disabling the feature falls back to running the same code as we had before. We will remove it once collector discovery has been the default for some time.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
