### PR TITLE
Memory allocations optimizations to scrubber

### DIFF
--- a/pkg/util/scrubber/scrubber.go
+++ b/pkg/util/scrubber/scrubber.go
@@ -97,13 +97,20 @@ func (c *Scrubber) ScrubFile(filePath string) ([]byte, error) {
 		return nil, err
 	}
 	defer file.Close()
-	return c.scrubReader(file)
+
+	var sizeHint int
+	stats, err := file.Stat()
+	if err == nil {
+		sizeHint = int(stats.Size())
+	}
+
+	return c.scrubReader(file, sizeHint)
 }
 
 // ScrubBytes scrubs credentials from slice of bytes
 func (c *Scrubber) ScrubBytes(file []byte) ([]byte, error) {
 	r := bytes.NewReader(file)
-	return c.scrubReader(r)
+	return c.scrubReader(r, r.Len())
 }
 
 // ScrubLine scrubs credentials from a single line of text.  It can be safely
@@ -114,8 +121,11 @@ func (c *Scrubber) ScrubLine(message string) string {
 }
 
 // scrubReader applies the cleaning algorithm to a Reader
-func (c *Scrubber) scrubReader(file io.Reader) ([]byte, error) {
-	var cleanedFile []byte
+func (c *Scrubber) scrubReader(file io.Reader, sizeHint int) ([]byte, error) {
+	var cleanedBuffer bytes.Buffer
+	if sizeHint > 0 {
+		cleanedBuffer.Grow(sizeHint)
+	}
 
 	scanner := bufio.NewScanner(file)
 
@@ -125,14 +135,14 @@ func (c *Scrubber) scrubReader(file io.Reader) ([]byte, error) {
 	for scanner.Scan() {
 		b := scanner.Bytes()
 		if blankRegex.Match(b) {
-			cleanedFile = append(cleanedFile, byte('\n'))
+			cleanedBuffer.WriteRune('\n')
 		} else if !commentRegex.Match(b) {
 			b = c.scrub(b, c.singleLineReplacers)
 			if !first {
-				cleanedFile = append(cleanedFile, byte('\n'))
+				cleanedBuffer.WriteRune('\n')
 			}
 
-			cleanedFile = append(cleanedFile, b...)
+			cleanedBuffer.Write(b)
 			first = false
 		}
 	}
@@ -142,7 +152,7 @@ func (c *Scrubber) scrubReader(file io.Reader) ([]byte, error) {
 	}
 
 	// Then we apply multiline replacers on the cleaned file
-	cleanedFile = c.scrub(cleanedFile, c.multiLineReplacers)
+	cleanedFile := c.scrub(cleanedBuffer.Bytes(), c.multiLineReplacers)
 
 	return cleanedFile, nil
 }

--- a/pkg/util/scrubber/scrubber.go
+++ b/pkg/util/scrubber/scrubber.go
@@ -17,7 +17,6 @@ import (
 	"io"
 	"os"
 	"regexp"
-	"strings"
 )
 
 // Replacer represents a replacement of sensitive information with a "clean" version.
@@ -153,7 +152,7 @@ func (c *Scrubber) scrub(data []byte, replacers []Replacer) []byte {
 	for _, repl := range replacers {
 		containsHint := false
 		for _, hint := range repl.Hints {
-			if strings.Contains(string(data), hint) {
+			if bytes.Contains(data, []byte(hint)) {
 				containsHint = true
 				break
 			}


### PR DESCRIPTION
### What does this PR do?

The scrubber allocates a lot of memory, this PR improves a bit the situation by:
- not allocating a copy of the whole data when looking for hints (we instead copy the hint, this could be improved further by providing the hint directly as `[]byte` but would require an API change)
- pre-allocating the result buffer in `scrubReader`

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
