### PR TITLE
[docker] Allow unbundling of events

### DIFF
--- a/cmd/agent/common/tests/a6_conf/conf.d/docker.d/conf.yaml
+++ b/cmd/agent/common/tests/a6_conf/conf.d/docker.d/conf.yaml
@@ -11,3 +11,5 @@ instances:
   collect_events: true
   filtered_event_types: []
   capped_metrics: {}
+  unbundle_events: false
+  collected_event_types: []

--- a/cmd/agent/dist/conf.d/docker.d/conf.yaml.default
+++ b/cmd/agent/dist/conf.d/docker.d/conf.yaml.default
@@ -16,9 +16,26 @@ instances:
     #
     # collect_events: true
 
+    ## @param unbundle_events - boolean - optional - default: false
+    ## Transforms each collected Docker event into its own Datadog
+    ## event, instead of grouping them together by container image.
+    #
+    # unbundle_events: true
+
+    ## @param collected_event_types - array of strings - optional
+    ## Specify which docker events will be collected. Only effective when
+    ## unbundle_events is true, otherwise filtered_event_types is used.
+    ## A list of available types can be found at:
+    ## https://docs.docker.com/engine/reference/commandline/events/#object-types
+    #
+    collected_event_types:
+      - "oom"
+      - "kill"
+
     ## @param filtered_event_types - list of strings - optional - default: ['top', 'exec_start', 'exec_create', 'exec_die']
     ## List of excluded (filtered out) event types. Docker events of this type are not collected.
-    ## A list of available statuses can be found at:
+    ## Only effective when unbundle_events is true, otherwise filtered_event_types is used.
+    ## A list of available types can be found at:
     ## https://docs.docker.com/engine/reference/commandline/events/#object-types
     #
     # filtered_event_types:

--- a/pkg/collector/corechecks/containers/docker/bundled_events.go
+++ b/pkg/collector/corechecks/containers/docker/bundled_events.go
@@ -1,0 +1,83 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build docker
+// +build docker
+
+package docker
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/util/docker"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// newBundledTransformer returns a transformer that bundles together docker
+// events from containers that share the same image. that's a behavior that no
+// longer makes sense, and we'd like to remove it in Agent 8.
+func newBundledTransformer(hostname string, types []string) eventTransformer {
+	filteredEventTypes := make(map[string]struct{}, len(types))
+	for _, t := range types {
+		filteredEventTypes[t] = struct{}{}
+	}
+
+	return &bundledTransformer{
+		hostname:           hostname,
+		filteredEventTypes: filteredEventTypes,
+	}
+}
+
+type bundledTransformer struct {
+	hostname           string
+	filteredEventTypes map[string]struct{}
+}
+
+func (t *bundledTransformer) Transform(events []*docker.ContainerEvent) ([]metrics.Event, []error) {
+	var errs []error
+
+	bundles := t.aggregateEvents(events)
+	datadogEvs := make([]metrics.Event, 0, len(bundles))
+
+	for _, bundle := range bundles {
+		ddEv, err := bundle.toDatadogEvent(t.hostname)
+		if err != nil {
+			errs = append(errs, err)
+		}
+
+		datadogEvs = append(datadogEvs, ddEv)
+
+		emittedEvents.Inc(string(bundle.alertType))
+	}
+
+	return datadogEvs, errs
+}
+
+// aggregateEvents converts a bunch of ContainerEvent to bundles aggregated by
+// image name. It also filters out unwanted event types.
+func (t *bundledTransformer) aggregateEvents(events []*docker.ContainerEvent) map[string]*dockerEventBundle {
+	eventsByImage := make(map[string]*dockerEventBundle)
+
+	for _, event := range events {
+		dockerEvents.Inc(event.Action)
+
+		if _, ok := t.filteredEventTypes[event.Action]; ok {
+			continue
+		}
+
+		bundle, found := eventsByImage[event.ImageName]
+		if found == false {
+			bundle = newDockerEventBundler(event.ImageName)
+			eventsByImage[event.ImageName] = bundle
+		}
+
+		err := bundle.addEvent(event)
+		if err != nil {
+			log.Warnf("Error while bundling events, %s.", err.Error())
+			continue
+		}
+	}
+
+	return eventsByImage
+}

--- a/pkg/collector/corechecks/containers/docker/check.go
+++ b/pkg/collector/corechecks/containers/docker/check.go
@@ -39,17 +39,23 @@ const (
 	cacheValidity   = 2 * time.Second
 )
 
+type eventTransformer interface {
+	Transform([]*docker.ContainerEvent) ([]coreMetrics.Event, []error)
+}
+
 // DockerCheck grabs docker metrics
 type DockerCheck struct {
 	core.CheckBase
 	instance                    *DockerConfig
 	processor                   generic.Processor
 	networkProcessorExtension   *dockerNetworkExtension
-	lastEventTime               time.Time
 	dockerHostname              string
 	containerFilter             *containers.Filter
 	okExitCodes                 map[int]struct{}
 	collectContainerSizeCounter uint64
+
+	lastEventTime    time.Time
+	eventTransformer eventTransformer
 }
 
 func init() {
@@ -73,21 +79,28 @@ func (d *DockerCheck) Configure(config, initConfig integration.Data, source stri
 
 	d.instance.Parse(config) //nolint:errcheck
 
-	if len(d.instance.FilteredEventType) == 0 {
-		d.instance.FilteredEventType = []string{
-			"top",
-			"exec_create",
-			"exec_start",
-			"exec_die",
-		}
-	}
-
 	// Use the same hostname as the agent so that host tags (like `availability-zone:us-east-1b`)
 	// are attached to Docker events from this host. The hostname from the docker api may be
 	// different than the agent hostname depending on the environment (like EC2 or GCE).
 	d.dockerHostname, err = hostname.Get(context.TODO())
 	if err != nil {
 		log.Warnf("Can't get hostname from docker, events will not have it: %v", err)
+	}
+
+	if d.instance.UnbundleEvents {
+		d.eventTransformer = newUnbundledTransformer(d.dockerHostname, d.instance.CollectedEventTypes)
+	} else {
+		filteredEventTypes := d.instance.FilteredEventType
+		if len(filteredEventTypes) == 0 {
+			filteredEventTypes = []string{
+				"top",
+				"exec_create",
+				"exec_start",
+				"exec_die",
+			}
+		}
+
+		d.eventTransformer = newBundledTransformer(d.dockerHostname, filteredEventTypes)
 	}
 
 	d.containerFilter, err = containers.GetSharedMetricFilter()
@@ -312,16 +325,18 @@ func (d *DockerCheck) collectEvents(sender aggregator.Sender, du docker.Client) 
 		events, err := d.retrieveEvents(du)
 		if err != nil {
 			d.Warnf("Error collecting events: %s", err) //nolint:errcheck
-		} else {
-			if d.instance.CollectEvent {
-				err = d.reportEvents(events, sender)
-				if err != nil {
-					log.Warn(err.Error())
-				}
+			return
+		}
+
+		if d.instance.CollectEvent {
+			err = d.reportEvents(events, sender)
+			if err != nil {
+				log.Warn(err.Error())
 			}
-			if d.instance.CollectExitCodes {
-				d.reportExitCodes(events, sender)
-			}
+		}
+
+		if d.instance.CollectExitCodes {
+			d.reportExitCodes(events, sender)
 		}
 	}
 }

--- a/pkg/collector/corechecks/containers/docker/check_test.go
+++ b/pkg/collector/corechecks/containers/docker/check_test.go
@@ -196,7 +196,8 @@ func TestDockerCustomPart(t *testing.T) {
 			CollectVolumeCount: true,
 			CollectEvent:       true,
 		},
-		dockerHostname: "testhostname",
+		eventTransformer: newBundledTransformer("testhostname", []string{}),
+		dockerHostname:   "testhostname",
 		containerFilter: &containers.Filter{
 			Enabled:         true,
 			NameExcludeList: []*regexp.Regexp{regexp.MustCompile("agent-excluded")},

--- a/pkg/collector/corechecks/containers/docker/config.go
+++ b/pkg/collector/corechecks/containers/docker/config.go
@@ -27,9 +27,20 @@ type DockerConfig struct {
 	CollectDiskStats         bool               `yaml:"collect_disk_stats"`
 	CollectVolumeCount       bool               `yaml:"collect_volume_count"`
 	Tags                     []string           `yaml:"tags"` // Used only by the configuration converter v5 → v6
-	CollectEvent             bool               `yaml:"collect_events"`
-	FilteredEventType        []string           `yaml:"filtered_event_types"`
 	CappedMetrics            map[string]float64 `yaml:"capped_metrics"`
+
+	// Event collection configuration
+	CollectEvent   bool `yaml:"collect_events"`
+	UnbundleEvents bool `yaml:"unbundle_events"`
+
+	// FilteredEventTypes is a slice of docker event types that works as a
+	// deny list of events to filter out. Only effective when
+	// UnbundleEvents = false
+	FilteredEventType []string `yaml:"filtered_event_types"`
+
+	// CollectedEventTypes is a slice of docker event types to collect.
+	// Only effective when UnbundleEvents = true
+	CollectedEventTypes []string `yaml:"collected_event_types"`
 }
 
 // Parse reads the docker check configuration

--- a/pkg/collector/corechecks/containers/docker/events.go
+++ b/pkg/collector/corechecks/containers/docker/events.go
@@ -12,7 +12,6 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
@@ -97,71 +96,15 @@ func (d *DockerCheck) reportExitCodes(events []*docker.ContainerEvent, sender ag
 
 // reportEvents aggregates and sends events to the Datadog event feed
 func (d *DockerCheck) reportEvents(events []*docker.ContainerEvent, sender aggregator.Sender) error {
-	bundles := aggregateEvents(events, d.instance.FilteredEventType)
+	datadogEvs, errs := d.eventTransformer.Transform(events)
 
-	for _, bundle := range bundles {
-		ev, err := bundle.toDatadogEvent(d.dockerHostname)
-		if err != nil {
-			log.Warnf("can't submit event: %s", err)
-			continue
-		}
+	for _, err := range errs {
+		d.Warnf("Error transforming events: %s", err.Error()) //nolint:errcheck
+	}
 
+	for _, ev := range datadogEvs {
 		sender.Event(ev)
-
-		emittedEvents.Inc(string(bundle.alertType))
 	}
 
 	return nil
-}
-
-// aggregateEvents converts a bunch of ContainerEvent to bundles aggregated by
-// image name. It also filters out unwanted event types.
-func aggregateEvents(events []*docker.ContainerEvent, filteredActions []string) map[string]*dockerEventBundle {
-	// Pre-aggregate container events by image
-	eventsByImage := make(map[string]*dockerEventBundle)
-	filteredByType := make(map[string]int)
-
-	for _, event := range events {
-		if matchFilter(event.Action, filteredActions) {
-			filteredByType[event.Action] = filteredByType[event.Action] + 1
-			continue
-		}
-
-		bundle, found := eventsByImage[event.ImageName]
-		if found == false {
-			bundle = newDockerEventBundler(event.ImageName)
-			eventsByImage[event.ImageName] = bundle
-		}
-
-		err := bundle.addEvent(event)
-		if err != nil {
-			log.Warnf("Error while bundling events, %s.", err.Error())
-			continue
-		}
-
-		dockerEvents.Inc(event.Action)
-	}
-
-	if len(filteredByType) > 0 {
-		log.Debugf("filtered out the following events: %s", formatStringIntMap(filteredByType))
-	}
-
-	return eventsByImage
-}
-
-func matchFilter(item string, filterList []string) bool {
-	for _, filtered := range filterList {
-		if filtered == item {
-			return true
-		}
-	}
-	return false
-}
-
-func formatStringIntMap(input map[string]int) string {
-	var parts []string
-	for k, v := range input {
-		parts = append(parts, fmt.Sprintf("%d %s", v, k))
-	}
-	return strings.Join(parts, " ")
 }

--- a/pkg/collector/corechecks/containers/docker/events_test.go
+++ b/pkg/collector/corechecks/containers/docker/events_test.go
@@ -233,7 +233,8 @@ func TestAggregateEvents(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run("", func(t *testing.T) {
-			bundles := aggregateEvents(tc.events, tc.filteredActions)
+			transformer := newBundledTransformer("test-host", tc.filteredActions).(*bundledTransformer)
+			bundles := transformer.aggregateEvents(tc.events)
 			for _, b := range bundles {
 				// Strip underlying events to ease testing
 				// countByAction is enough for testing the

--- a/pkg/collector/corechecks/containers/docker/unbundled_events.go
+++ b/pkg/collector/corechecks/containers/docker/unbundled_events.go
@@ -1,0 +1,82 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build docker
+// +build docker
+
+package docker
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/tagger"
+	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
+	"github.com/DataDog/datadog-agent/pkg/util/docker"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+func newUnbundledTransformer(hostname string, types []string) eventTransformer {
+	collectedEventTypes := make(map[string]struct{}, len(types))
+	for _, t := range types {
+		collectedEventTypes[t] = struct{}{}
+	}
+
+	return &unbundledTransformer{
+		hostname:            hostname,
+		collectedEventTypes: collectedEventTypes,
+	}
+}
+
+type unbundledTransformer struct {
+	hostname            string
+	collectedEventTypes map[string]struct{}
+}
+
+func (t *unbundledTransformer) Transform(events []*docker.ContainerEvent) ([]metrics.Event, []error) {
+	var (
+		datadogEvs []metrics.Event
+		errors     []error
+	)
+
+	for _, ev := range events {
+		if _, ok := t.collectedEventTypes[ev.Action]; !ok {
+			continue
+		}
+
+		alertType := metrics.EventAlertTypeInfo
+		if isAlertTypeError(ev.Action) {
+			alertType = metrics.EventAlertTypeError
+		}
+
+		emittedEvents.Inc(string(alertType))
+
+		tags, err := tagger.Tag(
+			containers.BuildTaggerEntityName(ev.ContainerID),
+			collectors.HighCardinality,
+		)
+		if err != nil {
+			log.Debugf("no tags for container %q: %s", ev.ContainerID, err)
+		}
+
+		tags = append(tags, fmt.Sprintf("event_type:%s", ev.Action))
+
+		datadogEvs = append(datadogEvs, metrics.Event{
+			Title:          fmt.Sprintf("Container %s: %s", ev.ContainerID, ev.Action),
+			Text:           fmt.Sprintf("Container %s (running image %q): %s", ev.ContainerID, ev.ImageName, ev.Action),
+			Tags:           tags,
+			Priority:       metrics.EventPriorityNormal,
+			Host:           t.hostname,
+			SourceTypeName: dockerCheckName,
+			EventType:      dockerCheckName,
+			AlertType:      alertType,
+			Ts:             ev.Timestamp.Unix(),
+			AggregationKey: fmt.Sprintf("docker:%s", ev.ContainerID),
+		})
+	}
+
+	return datadogEvs, errors
+}

--- a/pkg/collector/corechecks/containers/docker/unbundled_events_test.go
+++ b/pkg/collector/corechecks/containers/docker/unbundled_events_test.go
@@ -1,0 +1,97 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build docker
+// +build docker
+
+package docker
+
+import (
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/tagger"
+	"github.com/DataDog/datadog-agent/pkg/tagger/local"
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
+	"github.com/DataDog/datadog-agent/pkg/util/docker"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnbundledEventsTransform(t *testing.T) {
+	ts := time.Now()
+	containerID := "foobar"
+	containerName := "foo"
+	containerTags := []string{"image_name:foo", "image_tag:latest"}
+	imageName := "foo:latest"
+	hostname := "test-host"
+
+	defaultTagger := tagger.GetDefaultTagger()
+	fakeTagger := local.NewFakeTagger()
+	tagger.SetDefaultTagger(fakeTagger)
+	defer tagger.SetDefaultTagger(defaultTagger)
+
+	fakeTagger.SetTags(
+		containers.BuildTaggerEntityName(containerID), "-",
+		containerTags, []string{}, []string{}, []string{},
+	)
+
+	tests := []struct {
+		name     string
+		event    *docker.ContainerEvent
+		expected []metrics.Event
+	}{
+		{
+			name: "event is filtered out",
+			event: &docker.ContainerEvent{
+				ContainerID:   containerID,
+				ContainerName: containerName,
+				ImageName:     imageName,
+				Action:        "create",
+				Timestamp:     ts,
+			},
+			expected: nil,
+		},
+		{
+			name: "event is filtered out",
+			event: &docker.ContainerEvent{
+				ContainerID:   containerID,
+				ContainerName: containerName,
+				ImageName:     imageName,
+				Action:        "oom",
+				Timestamp:     ts,
+			},
+			expected: []metrics.Event{
+				{
+					Title:          "Container foobar: oom",
+					Text:           "Container foobar (running image \"foo:latest\"): oom",
+					AlertType:      metrics.EventAlertTypeError,
+					AggregationKey: "docker:foobar",
+					Ts:             ts.Unix(),
+					Host:           hostname,
+					SourceTypeName: "docker",
+					EventType:      "docker",
+					Priority:       metrics.EventPriorityNormal,
+					Tags: []string{
+						"image_name:foo",
+						"image_tag:latest",
+						"event_type:oom",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			transformer := newUnbundledTransformer(hostname, []string{"oom", "kill"})
+
+			events, errors := transformer.Transform([]*docker.ContainerEvent{tt.event})
+
+			assert.Empty(t, errors)
+			assert.Equal(t, tt.expected, events)
+		})
+	}
+}

--- a/pkg/collector/corechecks/containers/docker/utils.go
+++ b/pkg/collector/corechecks/containers/docker/utils.go
@@ -54,3 +54,12 @@ func getImageTags(imageName string) ([]string, error) {
 		fmt.Sprintf("short_image:%s", short),
 	}, nil
 }
+
+const (
+	eventActionOOM  = "oom"
+	eventActionKill = "kill"
+)
+
+func isAlertTypeError(action string) bool {
+	return action == eventActionOOM || action == eventActionKill
+}

--- a/pkg/config/legacy/docker_test.go
+++ b/pkg/config/legacy/docker_test.go
@@ -68,14 +68,16 @@ instances:
   tags:
   - tag:value
   - value
+  capped_metrics:
+    docker.cpu.system: 1000
+    docker.cpu.user: 1000
   collect_events: false
+  unbundle_events: false
   filtered_event_types:
   - top
   - exec_start
   - exec_create
-  capped_metrics:
-    docker.cpu.system: 1000
-    docker.cpu.user: 1000
+  collected_event_types: []
 `
 )
 

--- a/pkg/util/system/network_stub.go
+++ b/pkg/util/system/network_stub.go
@@ -1,0 +1,17 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !linux && !windows
+// +build !linux,!windows
+
+package system
+
+// ParseProcessRoutes is just a stub for platforms where that's currently not
+// defined (like MacOS). This allows code that refers to this (like the docker
+// check) to at least compile in those platforms, and that's useful for things
+// like running unit tests.
+func ParseProcessRoutes(procPath string, pid int) ([]NetworkRoute, error) {
+	panic("ParseProcessRoutes is not implemented in this environment")
+}

--- a/releasenotes/notes/unbundles-docker-events-9bfc8fca05fa7d10.yaml
+++ b/releasenotes/notes/unbundles-docker-events-9bfc8fca05fa7d10.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Introduces an `unbundle_events` config to the `docker` integration. When
+    set to `true`, Docker events are no longer bundled together by image name,
+    and instead generate separate Datadog events.


### PR DESCRIPTION
### What does this PR do?

When `unbundled_events` is set to `true` in the `docker` integration,
Docker events are no longer bundled together by image name, and instead
each will generate a separate Datadog event.

### Describe how to test/QA your changes

With `unbundle_events` in `conf.d/docker.d/conf.yaml` set to `true` and `false`, check that docker event collection works.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
