### PR TITLE
[SLS-1934] Add warmup:true/false metadata on serverless warmup events

### DIFF
--- a/pkg/serverless/executioncontext/executioncontext_test.go
+++ b/pkg/serverless/executioncontext/executioncontext_test.go
@@ -107,3 +107,13 @@ func TestUpdateFromRuntimeDoneLog(t *testing.T) {
 
 	assert.Equal(endTime, ec.endTime)
 }
+
+func TestUpdateFromEventPayload(t *testing.T) {
+	assert := assert.New(t)
+
+	warmupPayloadString := `{"source": "serverless-plugin-warmup"}`
+	ec := ExecutionContext{}
+	ec.UpdateFromEventPayload(warmupPayloadString)
+
+	assert.True(ec.warmup)
+}

--- a/pkg/serverless/invocationlifecycle/lifecycle_test.go
+++ b/pkg/serverless/invocationlifecycle/lifecycle_test.go
@@ -866,6 +866,27 @@ func TestTriggerTypesLifecycleEventForEventBridge(t *testing.T) {
 	}, testProcessor.GetTags())
 }
 
+func TestTriggerTypesLifecycleEventForWarmup(t *testing.T) {
+	startDetails := &InvocationStartDetails{
+		InvokeEventRawPayload: getEventFromFile("warmup.json"),
+		InvokedFunctionARN:    "arn:aws:lambda:us-east-1:123456789012:function:my-function",
+	}
+
+	testProcessor := &LifecycleProcessor{
+		DetectLambdaLibrary: func() bool { return false },
+		ProcessTrace:        func(*api.Payload) {},
+	}
+
+	testProcessor.OnInvokeStart(startDetails)
+	testProcessor.OnInvokeEnd(&InvocationEndDetails{
+		RequestID: "test-request-id",
+	})
+	assert.Equal(t, map[string]string{
+		"request_id": "test-request-id",
+		"warmup":     "true",
+	}, testProcessor.GetTags())
+}
+
 // Helper function for reading test file
 func getEventFromFile(filename string) string {
 	event, err := os.ReadFile("../trace/testdata/event_samples/" + filename)

--- a/pkg/serverless/invocationlifecycle/trace.go
+++ b/pkg/serverless/invocationlifecycle/trace.go
@@ -139,7 +139,7 @@ func endExecutionSpan(executionContext *ExecutionStartInfo, triggerTags map[stri
 // parseLambdaFunction removes extra data sent by the proxy that surrounds
 // a JSON payload. For example, for `a5a{"event":"aws_lambda"...}0` it would remove
 // a5a at the front and 0 at the end, and just leave a correct JSON payload.
-func parseLambdaPayload(rawPayload string) string {
+func ParseLambdaPayload(rawPayload string) string {
 	leftIndex := strings.Index(rawPayload, "{")
 	rightIndex := strings.LastIndex(rawPayload, "}")
 	if leftIndex == -1 || rightIndex == -1 {

--- a/pkg/serverless/invocationlifecycle/trace_test.go
+++ b/pkg/serverless/invocationlifecycle/trace_test.go
@@ -342,14 +342,14 @@ func TestConvertRawPayloadWithOutHeaders(t *testing.T) {
 }
 
 func TestParseLambdaPayload(t *testing.T) {
-	assert.Equal(t, "", parseLambdaPayload(""))
-	assert.Equal(t, "{}", parseLambdaPayload("{}"))
-	assert.Equal(t, "{}", parseLambdaPayload("a{}a"))
-	assert.Equal(t, "{a}", parseLambdaPayload("{a}a"))
-	assert.Equal(t, "{a}", parseLambdaPayload("a{a}"))
-	assert.Equal(t, "{a}", parseLambdaPayload("}{a}a{"))
-	assert.Equal(t, "{}{}", parseLambdaPayload("{}{}"))
-	assert.Equal(t, "{a}", parseLambdaPayload("a{a}a"))
-	assert.Equal(t, "{", parseLambdaPayload("{"))
-	assert.Equal(t, "}", parseLambdaPayload("}"))
+	assert.Equal(t, "", ParseLambdaPayload(""))
+	assert.Equal(t, "{}", ParseLambdaPayload("{}"))
+	assert.Equal(t, "{}", ParseLambdaPayload("a{}a"))
+	assert.Equal(t, "{a}", ParseLambdaPayload("{a}a"))
+	assert.Equal(t, "{a}", ParseLambdaPayload("a{a}"))
+	assert.Equal(t, "{a}", ParseLambdaPayload("}{a}a{"))
+	assert.Equal(t, "{}{}", ParseLambdaPayload("{}{}"))
+	assert.Equal(t, "{a}", ParseLambdaPayload("a{a}a"))
+	assert.Equal(t, "{", ParseLambdaPayload("{"))
+	assert.Equal(t, "}", ParseLambdaPayload("}"))
 }

--- a/pkg/serverless/logs/logs_test.go
+++ b/pkg/serverless/logs/logs_test.go
@@ -768,7 +768,7 @@ func TestRuntimeMetricsMatchLogs(t *testing.T) {
 		Name:       "aws.lambda.enhanced.runtime_duration",
 		Value:      runtimeDurationMs, // in milliseconds
 		Mtype:      metrics.DistributionType,
-		Tags:       []string{"cold_start:true"},
+		Tags:       []string{"cold_start:true", "warmup:false"},
 		SampleRate: 1,
 		Timestamp:  runtimeMetricTimestamp,
 	})
@@ -776,7 +776,7 @@ func TestRuntimeMetricsMatchLogs(t *testing.T) {
 		Name:       "aws.lambda.enhanced.duration",
 		Value:      durationMs / 1000, // in seconds
 		Mtype:      metrics.DistributionType,
-		Tags:       []string{"cold_start:true"},
+		Tags:       []string{"cold_start:true", "warmup:false"},
 		SampleRate: 1,
 		Timestamp:  postRuntimeMetricTimestamp,
 	})
@@ -784,7 +784,7 @@ func TestRuntimeMetricsMatchLogs(t *testing.T) {
 		Name:       "aws.lambda.enhanced.post_runtime_duration",
 		Value:      postRuntimeDurationMs, // in milliseconds
 		Mtype:      metrics.DistributionType,
-		Tags:       []string{"cold_start:true"},
+		Tags:       []string{"cold_start:true", "warmup:false"},
 		SampleRate: 1,
 		Timestamp:  postRuntimeMetricTimestamp,
 	})

--- a/pkg/serverless/serverless.go
+++ b/pkg/serverless/serverless.go
@@ -170,6 +170,7 @@ func WaitForNextInvocation(stopCh chan struct{}, daemon *daemon.Daemon, id regis
 		if isTimeout {
 			ecs := daemon.ExecutionContext.GetCurrentState()
 			metricTags := tags.AddColdStartTag(daemon.ExtraTags.Tags, ecs.Coldstart)
+			metricTags = tags.AddWarmupTag(metricTags, ecs.Warmup)
 			metrics.SendTimeoutEnhancedMetric(metricTags, daemon.MetricAgent.Demux)
 			metrics.SendErrorsEnhancedMetric(metricTags, time.Now(), daemon.MetricAgent.Demux)
 		}
@@ -210,6 +211,7 @@ func handleInvocation(doneChannel chan bool, daemon *daemon.Daemon, arn string, 
 
 	if daemon.MetricAgent != nil {
 		metricTags := tags.AddColdStartTag(daemon.ExtraTags.Tags, ecs.Coldstart)
+		metricTags = tags.AddWarmupTag(metricTags, ecs.Warmup)
 		metrics.SendInvocationEnhancedMetric(metricTags, daemon.MetricAgent.Demux)
 	} else {
 		log.Error("Could not send the invocation enhanced metric")

--- a/pkg/serverless/tags/tags.go
+++ b/pkg/serverless/tags/tags.go
@@ -158,6 +158,12 @@ func AddColdStartTag(tags []string, coldStart bool) []string {
 	return tags
 }
 
+// AddWarmupTag appends the warmup tag to existing tags
+func AddWarmupTag(tags []string, warmup bool) []string {
+	tags = append(tags, fmt.Sprintf("warmup:%v", warmup))
+	return tags
+}
+
 // GetExtensionVersion returns the extension version which is fed at build time
 func GetExtensionVersion() string {
 	return currentExtensionVersion

--- a/pkg/serverless/tags/tags_test.go
+++ b/pkg/serverless/tags/tags_test.go
@@ -275,6 +275,32 @@ func TestAddColdStartTagWithColdStart(t *testing.T) {
 	})
 }
 
+func TestAddWarmupTagWithoutWarmup(t *testing.T) {
+	generatedTags := AddWarmupTag([]string{
+		"myTagName0:myTagValue0",
+		"myTagName1:myTagValue1",
+	}, false)
+
+	assert.Equal(t, generatedTags, []string{
+		"myTagName0:myTagValue0",
+		"myTagName1:myTagValue1",
+		"warmup:false",
+	})
+}
+
+func TestWarmupStartTagWithWarmup(t *testing.T) {
+	generatedTags := AddWarmupTag([]string{
+		"myTagName0:myTagValue0",
+		"myTagName1:myTagValue1",
+	}, true)
+
+	assert.Equal(t, generatedTags, []string{
+		"myTagName0:myTagValue0",
+		"myTagName1:myTagValue1",
+		"warmup:true",
+	})
+}
+
 func TestBuildTagMapWithRuntimeAndMemoryTag(t *testing.T) {
 	os.Setenv("AWS_EXECUTION_ENV", "AWS_Lambda_java")
 	os.Setenv("AWS_LAMBDA_FUNCTION_MEMORY_SIZE", "128")

--- a/pkg/serverless/trace/testdata/event_samples/warmup.json
+++ b/pkg/serverless/trace/testdata/event_samples/warmup.json
@@ -1,0 +1,3 @@
+{
+    "source": "serverless-plugin-warmup"
+}

--- a/pkg/serverless/trigger/events.go
+++ b/pkg/serverless/trigger/events.go
@@ -152,6 +152,12 @@ func Unmarshal(payload string) (map[string]interface{}, error) {
 	return jsonPayload, nil
 }
 
+// IsWarmupEvent checks if the event payload is from the serverless warmup plugin
+func IsWarmupEvent(event map[string]interface{}) bool {
+	source, ok := event["source"].(string)
+	return ok && source == "serverless-plugin-warmup"
+}
+
 func isAPIGatewayEvent(event map[string]interface{}) bool {
 	return json.GetNestedValue(event, "requestcontext", "stage") != nil &&
 		json.GetNestedValue(event, "httpmethod") != nil &&

--- a/test/integration/serverless/snapshots/error-csharp
+++ b/test/integration/serverless/snapshots/error-csharp
@@ -20,7 +20,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -45,7 +46,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -70,7 +72,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -95,7 +98,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -168,7 +172,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -193,7 +198,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -218,7 +224,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -243,7 +250,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -268,7 +276,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -293,7 +302,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -318,7 +328,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -343,7 +354,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -368,7 +380,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -393,7 +406,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -418,7 +432,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -443,7 +458,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -468,7 +484,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   }

--- a/test/integration/serverless/snapshots/error-java
+++ b/test/integration/serverless/snapshots/error-java
@@ -20,7 +20,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -45,7 +46,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -70,7 +72,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -95,7 +98,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -120,7 +124,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -145,7 +150,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -170,7 +176,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -195,7 +202,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -220,7 +228,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -245,7 +254,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -270,7 +280,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -295,7 +306,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -320,7 +332,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -345,7 +358,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -370,7 +384,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -395,7 +410,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -420,7 +436,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   }

--- a/test/integration/serverless/snapshots/error-node
+++ b/test/integration/serverless/snapshots/error-node
@@ -20,7 +20,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -45,7 +46,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -70,7 +72,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -95,7 +98,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -172,7 +176,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -197,7 +202,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -222,7 +228,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -247,7 +254,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -272,7 +280,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -297,7 +306,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -322,7 +332,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -347,7 +358,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -372,7 +384,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -397,7 +410,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -422,7 +436,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -447,7 +462,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -472,7 +488,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   }

--- a/test/integration/serverless/snapshots/error-proxy
+++ b/test/integration/serverless/snapshots/error-proxy
@@ -20,7 +20,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -45,7 +46,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -70,7 +72,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -95,7 +98,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -168,7 +172,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -193,7 +198,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -218,7 +224,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -243,7 +250,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -268,7 +276,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -293,7 +302,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -318,7 +328,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -343,7 +354,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -368,7 +380,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -393,7 +406,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -418,7 +432,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -443,7 +458,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -468,7 +484,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   }

--- a/test/integration/serverless/snapshots/error-python
+++ b/test/integration/serverless/snapshots/error-python
@@ -20,7 +20,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -45,7 +46,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -70,7 +72,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -95,7 +98,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -174,7 +178,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -199,7 +204,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -224,7 +230,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -249,7 +256,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -274,7 +282,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -299,7 +308,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -324,7 +334,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -349,7 +360,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -374,7 +386,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -399,7 +412,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -424,7 +438,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -449,7 +464,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -474,7 +490,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   }

--- a/test/integration/serverless/snapshots/metric-csharp
+++ b/test/integration/serverless/snapshots/metric-csharp
@@ -20,7 +20,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -45,7 +46,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -70,7 +72,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -95,7 +98,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -120,7 +124,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -145,7 +150,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -170,7 +176,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -195,7 +202,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -220,7 +228,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -245,7 +254,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -270,7 +280,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -295,7 +306,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -320,7 +332,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -345,7 +358,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -370,7 +384,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -395,7 +410,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -420,7 +436,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   }

--- a/test/integration/serverless/snapshots/metric-go
+++ b/test/integration/serverless/snapshots/metric-go
@@ -20,7 +20,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -45,7 +46,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -70,7 +72,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -95,7 +98,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -120,7 +124,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -145,7 +150,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -170,7 +176,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -195,7 +202,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -220,7 +228,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -245,7 +254,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -270,7 +280,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -295,7 +306,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -320,7 +332,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -345,7 +358,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -370,7 +384,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -395,7 +410,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -420,7 +436,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },

--- a/test/integration/serverless/snapshots/metric-java
+++ b/test/integration/serverless/snapshots/metric-java
@@ -20,7 +20,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -45,7 +46,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -70,7 +72,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -95,7 +98,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -120,7 +124,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -145,7 +150,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -170,7 +176,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -195,7 +202,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -220,7 +228,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -245,7 +254,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -270,7 +280,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -295,7 +306,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -320,7 +332,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -345,7 +358,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -370,7 +384,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -395,7 +410,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -420,7 +436,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   }

--- a/test/integration/serverless/snapshots/metric-node
+++ b/test/integration/serverless/snapshots/metric-node
@@ -20,7 +20,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -45,7 +46,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -70,7 +72,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -95,7 +98,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -120,7 +124,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -145,7 +150,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -170,7 +176,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -195,7 +202,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -220,7 +228,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -245,7 +254,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -270,7 +280,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -295,7 +306,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -320,7 +332,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -345,7 +358,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -370,7 +384,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -395,7 +410,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -420,7 +436,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },

--- a/test/integration/serverless/snapshots/metric-proxy
+++ b/test/integration/serverless/snapshots/metric-proxy
@@ -20,7 +20,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -45,7 +46,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -70,7 +72,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -95,7 +98,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -120,7 +124,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -145,7 +150,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -170,7 +176,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -195,7 +202,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -220,7 +228,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -245,7 +254,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -270,7 +280,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -295,7 +306,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -320,7 +332,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -345,7 +358,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -370,7 +384,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -395,7 +410,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -420,7 +436,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   }

--- a/test/integration/serverless/snapshots/metric-python
+++ b/test/integration/serverless/snapshots/metric-python
@@ -20,7 +20,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -45,7 +46,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -70,7 +72,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -95,7 +98,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -120,7 +124,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -145,7 +150,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -170,7 +176,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -195,7 +202,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -220,7 +228,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -245,7 +254,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -270,7 +280,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -295,7 +306,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -320,7 +332,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -345,7 +358,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -370,7 +384,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -395,7 +410,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },
@@ -420,7 +436,8 @@
       "tagb:valueb",
       "tagc:valuec",
       "tagd:valued",
-      "version:integration-tests-version"
+      "version:integration-tests-version",
+      "warmup:false"
     ],
     "dogsketches": []
   },


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->
Adds a `warmup` tag to the Lambda span and enhanced metrics (*when possible) based on the warmup event sent by the `serverless-plugin-warmup` function: https://www.serverless.com/plugins/serverless-plugin-warmup. 

*`aws.lambda.enhanced.invocations` cannot properly tag `warmup:true` due to the extension's current process of parsing the triggering event payload _after_ the invocation metric is sent. This limitation would require us to make potentially complex changes to the extension to support tagging the invocations metrics properly, so we will defer this feature for now. 


![Image 2022-08-24 at 11 31 49 AM](https://user-images.githubusercontent.com/25290232/186460349-90187575-92f7-430f-bf1d-57a2dfea8174.jpg)

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Requested by customers that continue to use the serverless-plugin-warmup. 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
