### PR TITLE
[dogstatsd] correctly set the metric type on no aggregation pipeline metrics

### DIFF
--- a/pkg/aggregator/no_aggregation_stream_worker.go
+++ b/pkg/aggregator/no_aggregation_stream_worker.go
@@ -152,7 +152,8 @@ func (w *noAggregationStreamWorker) run() {
 							serie.Points = []metrics.Point{{Ts: sample.Timestamp, Value: sample.Value}}
 							serie.Tags = tagset.CompositeTagsFromSlice(w.metricBuffer.Copy())
 							serie.Host = sample.Host
-							// ignored when late but mimic dogstatsd traffic here anyway
+							serie.MType = sample.Mtype.ToAPIType()
+							// ignored by the intake when late but mimic dogstatsd traffic here anyway
 							serie.Interval = 10
 							w.seriesSink.Append(&serie)
 

--- a/pkg/dogstatsd/server_test.go
+++ b/pkg/dogstatsd/server_test.go
@@ -266,13 +266,26 @@ func TestUDPReceive(t *testing.T) {
 	assert.Equal(t, sample.Name, "daemon2")
 	demux.Reset()
 
-	// Late metric
+	// Late gauge
 	conn.Write([]byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2|T1658328888"))
 	samples, timedSamples = demux.WaitForSamples(time.Second * 2)
 	require.Len(t, samples, 0)
 	require.Len(t, timedSamples, 1)
 	sample = timedSamples[0]
 	require.NotNil(t, sample)
+	assert.Equal(t, sample.Mtype, metrics.GaugeType)
+	assert.Equal(t, sample.Name, "daemon")
+	assert.Equal(t, sample.Timestamp, float64(1658328888))
+	demux.Reset()
+
+	// Late count
+	conn.Write([]byte("daemon:666|c|#sometag1:somevalue1,sometag2:somevalue2|T1658328888"))
+	samples, timedSamples = demux.WaitForSamples(time.Second * 2)
+	require.Len(t, samples, 0)
+	require.Len(t, timedSamples, 1)
+	sample = timedSamples[0]
+	require.NotNil(t, sample)
+	assert.Equal(t, sample.Mtype, metrics.CounterType)
 	assert.Equal(t, sample.Name, "daemon")
 	assert.Equal(t, sample.Timestamp, float64(1658328888))
 	demux.Reset()
@@ -285,6 +298,7 @@ func TestUDPReceive(t *testing.T) {
 	sample = timedSamples[0]
 	require.NotNil(t, sample)
 	assert.Equal(t, sample.Name, "daemon")
+	assert.Equal(t, sample.Mtype, metrics.GaugeType)
 	assert.Equal(t, sample.Timestamp, float64(1658328888))
 	sample = samples[0]
 	require.NotNil(t, sample)

--- a/pkg/metrics/metric_sample.go
+++ b/pkg/metrics/metric_sample.go
@@ -62,6 +62,23 @@ func (m MetricType) String() string {
 	}
 }
 
+// ToAPIType returns the equivalent of MetricType in APIMetricType type.
+// APIMetricType only supports gauges, counts and rates and will default on gauges
+// for every other inputs.
+// This is used by the no-aggregation pipeline to infer an API type from a MetricType.
+func (m MetricType) ToAPIType() APIMetricType {
+	switch m {
+	case GaugeType:
+		return APIGaugeType
+	case CounterType:
+		return APICountType
+	case RateType:
+		return APIRateType
+	default:
+		return APIGaugeType
+	}
+}
+
 // MetricSampleContext allows to access a sample context data
 type MetricSampleContext interface {
 	GetName() string


### PR DESCRIPTION
### What does this PR do?

This pipeline is manually creating the series it is sending to serialization, it then has to manually set he serie type as well.
This was missing from current implementation which is sending all no-aggregation metrics as gauges.

### Additional notes

Note that the no aggregation pipeline only supports gauges & counts.

### Motivation

Correct metric types for counts when sent through the no-aggregation pipeline.

### Describe how to test/QA your changes

* _With the feature enabled_ (set `dogstatsd_no_aggregation_pipeline: true` or use `DD_DOGSTATSD_NO_AGGREGATION_PIPELINE=true`):
  * make sure usual DogStatsD traffic is working as usual
  * send a count with a timestamp 2 hours in the past through UDP using your shell: `echo -n "custom_metric:60|c|#env:test,dev:remy|T$(( $(date +%s) - 7200 ))" | nc -4u -w0 127.0.0.1 8125`
  * validate that your metrics is visible at the correct time and with the correct type/value in a dashboard or in the metrics explorer

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
