### PR TITLE
[Windows] Always use the DDAGENTUSER_PASSWORD property if specified

### DIFF
--- a/releasenotes/notes/fix_domain_pass_ignored-3b6520c0c7b918f4.yaml
+++ b/releasenotes/notes/fix_domain_pass_ignored-3b6520c0c7b918f4.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    The Windows installer uses the DDAGENTUSER_PASSWORD correctly when installing services on Domain Controller.
+    The Windows installer will now respect the DDAGENTUSER_PASSWORD option and update the services passwords when the user already exists.

--- a/releasenotes/notes/fix_domain_pass_ignored-3b6520c0c7b918f4.yaml
+++ b/releasenotes/notes/fix_domain_pass_ignored-3b6520c0c7b918f4.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    The Windows installer uses the DDAGENTUSER_PASSWORD correctly when installing services on Domain Controller.

--- a/tools/windows/install-help/cal/FinalizeInstall.cpp
+++ b/tools/windows/install-help/cal/FinalizeInstall.cpp
@@ -177,6 +177,11 @@ UINT doFinalizeInstall(CustomActionData &data)
         goto LExit;
     }
 
+    if (data.value(propertyDDAgentUserPassword, providedPassword))
+    {
+        passToUse = providedPassword.c_str();
+    }
+
     // ok.  If we get here, we should be in a sane state (all installation conditions met)
     WcaLog(LOGMSG_STANDARD, "custom action initialization complete.  Processing");
     // first, let's decide if we need to create the dd-agent-user
@@ -186,11 +191,7 @@ UINT doFinalizeInstall(CustomActionData &data)
         // generate one
         passbuflen = MAX_PASS_LEN + 2;
 
-        if (data.value(propertyDDAgentUserPassword, providedPassword))
-        {
-            passToUse = providedPassword.c_str();
-        }
-        else
+        if (!data.value(propertyDDAgentUserPassword, providedPassword))
         {
             passbuf = new wchar_t[passbuflen];
             if (!generatePassword(passbuf, passbuflen))


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR fixes a bug introduced in 7.38 in https://github.com/DataDog/datadog-agent/pull/12372 where if the user exists when the install runs, the installer ignores the `DDAGENTUSER_PASSWORD` property.
This PR makes it so that if this property is specified on the command line, it is always used.
This affects all installs with a pre-existing user.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
The installer should not ignore the `DDAGENTUSER_PASSWORD`.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Install the Agent on a machine with a pre-existing user. The install will always succeed, but in the logs the error `1069` should *not* be present. Furthermore in the `Services` window it should be possible to start the Datadog Agent without getting an invalid credentials message.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
