### PR TITLE
[CWS] reduce size of `dd-security-agent-check` cookbooks

### DIFF
--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -51,15 +51,6 @@
     paths:
       - $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files
 
-.build_cws_tests:
-  - invoke -e security-agent.kitchen-prepare
-  # Copy nikos archive to be extracted in kitchen tests
-  - cp /tmp/nikos.tar.gz $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/nikos.tar.gz
-  - mkdir -p $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/ebpf_bytecode/runtime
-  - cp $SRC_PATH/pkg/ebpf/bytecode/build/runtime-security* $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/ebpf_bytecode/
-  - cp $SRC_PATH/pkg/ebpf/bytecode/build/runtime/runtime-security* $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/ebpf_bytecode/runtime/
-
-
 tests_ebpf_x64:
   extends: .tests_linux_ebpf
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
@@ -77,7 +68,7 @@ tests_ebpf_x64:
     - !reference [.build_sysprobe_artifacts]
     - inv -e install-tools
     - export PATH=$PATH:$GOPATH/bin
-    - !reference [.build_cws_tests]
+    - invoke -e security-agent.kitchen-prepare
 
 tests_ebpf_arm64:
   extends: .tests_linux_ebpf
@@ -99,8 +90,7 @@ tests_ebpf_arm64:
     - !reference [.build_sysprobe_artifacts]
     - inv -e install-tools
     - export PATH=$PATH:$GOPATH/bin
-    - !reference [.build_cws_tests]
-
+    - invoke -e security-agent.kitchen-prepare
 
 tests_windows_sysprobe_x64:
   extends: .tests_windows_sysprobe

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -51,6 +51,15 @@
     paths:
       - $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files
 
+.build_cws_tests:
+  - invoke -e security-agent.kitchen-prepare
+  # Copy nikos archive to be extracted in kitchen tests
+  - cp /tmp/nikos.tar.gz $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/nikos.tar.gz
+  - mkdir -p $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/ebpf_bytecode/runtime
+  - cp $SRC_PATH/pkg/ebpf/bytecode/build/runtime-security* $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/ebpf_bytecode/
+  - cp $SRC_PATH/pkg/ebpf/bytecode/build/runtime/runtime-security* $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/ebpf_bytecode/runtime/
+
+
 tests_ebpf_x64:
   extends: .tests_linux_ebpf
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
@@ -68,21 +77,7 @@ tests_ebpf_x64:
     - !reference [.build_sysprobe_artifacts]
     - inv -e install-tools
     - export PATH=$PATH:$GOPATH/bin
-    # Compile runtime security functional tests to be executed in kitchen tests
-    - inv -e security-agent.build-functional-tests --no-bundle-ebpf --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/testsuite --race --nikos-embedded-path=$NIKOS_EMBEDDED_PATH
-    # Compile runtime security stress tests to be executed in kitchen tests
-    - inv -e security-agent.build-stress-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/stresssuite
-    # Copy nikos archive to be extracted in kitchen tests
-    - cp /tmp/nikos.tar.gz $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/nikos.tar.gz
-     # Copy files needed for runtime compilation
-    - cp /tmp/clang-bpf $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/clang-bpf
-    - cp /tmp/llc-bpf $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/llc-bpf
-    - cp /tmp/clang-bpf $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/clang-bpf
-    - cp /tmp/llc-bpf $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/llc-bpf
-
-    - mkdir -p $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/ebpf_bytecode/runtime
-    - cp $SRC_PATH/pkg/ebpf/bytecode/build/runtime-security* $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/ebpf_bytecode/
-    - cp $SRC_PATH/pkg/ebpf/bytecode/build/runtime/runtime-security* $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/ebpf_bytecode/runtime/
+    - !reference [.build_cws_tests]
 
 tests_ebpf_arm64:
   extends: .tests_linux_ebpf
@@ -104,21 +99,8 @@ tests_ebpf_arm64:
     - !reference [.build_sysprobe_artifacts]
     - inv -e install-tools
     - export PATH=$PATH:$GOPATH/bin
-    # Compile runtime security functional tests to be executed in kitchen tests
-    - inv -e security-agent.build-functional-tests --no-bundle-ebpf --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/testsuite --race --nikos-embedded-path=$NIKOS_EMBEDDED_PATH
-    # Compile runtime security stress tests to be executed in kitchen tests
-    - inv -e security-agent.build-stress-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/stresssuite
-    # Copy nikos archive to be extracted in kitchen tests
-    - cp /tmp/nikos.tar.gz $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/nikos.tar.gz
-    # Copy files needed for runtime compilation
-    - cp /tmp/clang-bpf $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/clang-bpf
-    - cp /tmp/llc-bpf $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/llc-bpf
-    - cp /tmp/clang-bpf $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/clang-bpf
-    - cp /tmp/llc-bpf $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/llc-bpf
+    - !reference [.build_cws_tests]
 
-    - mkdir -p $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/ebpf_bytecode/runtime
-    - cp $SRC_PATH/pkg/ebpf/bytecode/build/runtime-security* $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/ebpf_bytecode/
-    - cp $SRC_PATH/pkg/ebpf/bytecode/build/runtime/runtime-security* $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/ebpf_bytecode/runtime/
 
 tests_windows_sysprobe_x64:
   extends: .tests_windows_sysprobe

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -69,6 +69,8 @@ tests_ebpf_x64:
     - inv -e install-tools
     - export PATH=$PATH:$GOPATH/bin
     - invoke -e security-agent.kitchen-prepare
+    - cp /tmp/clang-bpf $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/clang-bpf
+    - cp /tmp/llc-bpf $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/llc-bpf
 
 tests_ebpf_arm64:
   extends: .tests_linux_ebpf
@@ -91,6 +93,8 @@ tests_ebpf_arm64:
     - inv -e install-tools
     - export PATH=$PATH:$GOPATH/bin
     - invoke -e security-agent.kitchen-prepare
+    - cp /tmp/clang-bpf $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/clang-bpf
+    - cp /tmp/llc-bpf $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/llc-bpf
 
 tests_windows_sysprobe_x64:
   extends: .tests_windows_sysprobe

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -80,6 +80,10 @@ tests_ebpf_x64:
     - cp /tmp/clang-bpf $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/clang-bpf
     - cp /tmp/llc-bpf $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/llc-bpf
 
+    - mkdir -p $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/ebpf_bytecode/runtime
+    - cp $SRC_PATH/pkg/ebpf/bytecode/build/runtime-security* $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/ebpf_bytecode/
+    - cp $SRC_PATH/pkg/ebpf/bytecode/build/runtime/runtime-security* $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/ebpf_bytecode/runtime/
+
 tests_ebpf_arm64:
   extends: .tests_linux_ebpf
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_arm64:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
@@ -111,6 +115,10 @@ tests_ebpf_arm64:
     - cp /tmp/llc-bpf $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/llc-bpf
     - cp /tmp/clang-bpf $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/clang-bpf
     - cp /tmp/llc-bpf $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/llc-bpf
+
+    - mkdir -p $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/ebpf_bytecode/runtime
+    - cp $SRC_PATH/pkg/ebpf/bytecode/build/runtime-security* $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/ebpf_bytecode/
+    - cp $SRC_PATH/pkg/ebpf/bytecode/build/runtime/runtime-security* $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/ebpf_bytecode/runtime/
 
 tests_windows_sysprobe_x64:
   extends: .tests_windows_sysprobe

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -723,5 +723,17 @@ def kitchen_prepare(ctx):
     stresssuite_out_path = os.path.join(cookbook_files_dir, "stresssuite")
     build_stress_tests(ctx, output=stresssuite_out_path)
 
+    # Copy clang binaries
     for bin in ["clang-bpf", "llc-bpf"]:
         ctx.run(f"cp /tmp/{bin} {cookbook_files_dir}/{bin}")
+
+    ctx.run(f"cp /tmp/nikos.tar.gz {cookbook_files_dir}/")
+
+    ebpf_bytecode_dir = os.path.join(cookbook_files_dir, "ebpf_bytecode")
+    ebpf_runtime_dir = os.path.join(ebpf_bytecode_dir, "runtime")
+    src_path = os.environ.get("SRC_PATH", ".")
+    bytecode_build_dir = os.path.join(src_path, "pkg", "ebpf", "bytecode", "build")
+
+    ctx.run(f"mkdir -p {ebpf_runtime_dir}")
+    ctx.run(f"cp {bytecode_build_dir}/runtime-security* {ebpf_bytecode_dir}")
+    ctx.run(f"cp {bytecode_build_dir}/runtime/runtime-security* {ebpf_runtime_dir}")

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -705,3 +705,20 @@ def go_generate_check(ctx):
             for file in ft.dirty_files:
                 print(f"* {file}")
             raise Exit(code=1)
+
+@task
+def kitchen_prepare(ctx):
+    build_embed_syscall_tester(ctx)
+    build_embed_latency_tools(ctx)
+
+    nikos_embedded_path = os.environ.get("NIKOS_EMBEDDED_PATH", None)
+    testing_dir = os.environ.get("DD_AGENT_TESTING_DIR", "./test/kitchen")
+    cookbook_files_dir = os.path.join(testing_dir, "site-cookbooks", "dd-security-agent-check", "files")
+
+    testsuite_out_path = os.path.join(cookbook_files_dir, "testsuite")
+    build_functional_tests(ctx, bundle_ebpf=False, race=True, output=testsuite_out_path, nikos_embedded_path=nikos_embedded_path)
+    stresssuite_out_path = os.path.join(cookbook_files_dir, "stresssuite")
+    build_stress_tests(ctx, output=stresssuite_out_path)
+
+    for bin in ["clang-bpf", "llc-bpf"]:
+        ctx.run(f"cp /tmp/{bin} {cookbook_files_dir}/{bin}")

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -709,9 +709,6 @@ def go_generate_check(ctx):
 
 @task
 def kitchen_prepare(ctx):
-    build_embed_syscall_tester(ctx)
-    build_embed_latency_tools(ctx)
-
     nikos_embedded_path = os.environ.get("NIKOS_EMBEDDED_PATH", None)
     testing_dir = os.environ.get("DD_AGENT_TESTING_DIR", "./test/kitchen")
     cookbook_files_dir = os.path.join(testing_dir, "site-cookbooks", "dd-security-agent-check", "files")

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -706,6 +706,7 @@ def go_generate_check(ctx):
                 print(f"* {file}")
             raise Exit(code=1)
 
+
 @task
 def kitchen_prepare(ctx):
     build_embed_syscall_tester(ctx)
@@ -716,7 +717,9 @@ def kitchen_prepare(ctx):
     cookbook_files_dir = os.path.join(testing_dir, "site-cookbooks", "dd-security-agent-check", "files")
 
     testsuite_out_path = os.path.join(cookbook_files_dir, "testsuite")
-    build_functional_tests(ctx, bundle_ebpf=False, race=True, output=testsuite_out_path, nikos_embedded_path=nikos_embedded_path)
+    build_functional_tests(
+        ctx, bundle_ebpf=False, race=True, output=testsuite_out_path, nikos_embedded_path=nikos_embedded_path
+    )
     stresssuite_out_path = os.path.join(cookbook_files_dir, "stresssuite")
     build_stress_tests(ctx, output=stresssuite_out_path)
 

--- a/test/kitchen/site-cookbooks/dd-security-agent-check/chefignore
+++ b/test/kitchen/site-cookbooks/dd-security-agent-check/chefignore
@@ -34,7 +34,6 @@ mkmf.log
 ## COMPILED ##
 ##############
 a.out
-*.o
 *.pyc
 *.so
 *.com

--- a/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
@@ -10,10 +10,9 @@ if node['platform_family'] != 'windows'
 
   remote_directory "#{wrk_dir}/ebpf_bytecode" do
     source 'ebpf_bytecode'
-    mode '755'
-    files_mode '755'
     sensitive true
     files_owner 'root'
+    owner 'root'
   end
 
   cookbook_file "#{wrk_dir}/testsuite" do

--- a/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
@@ -8,16 +8,12 @@
 if node['platform_family'] != 'windows'
   wrk_dir = '/tmp/security-agent'
 
-  remote_directory wrk_dir do
-    cookbook 'dd-system-probe-check'
-    source 'tests'
+  remote_directory "#{wrk_dir}/ebpf_bytecode" do
+    source 'ebpf_bytecode'
     mode '755'
     files_mode '755'
     sensitive true
-    case
-    when !platform?('windows')
-      files_owner 'root'
-    end
+    files_owner 'root'
   end
 
   cookbook_file "#{wrk_dir}/testsuite" do

--- a/test/kitchen/test/integration/security-agent-test/rspec/security-agent-test_spec.rb
+++ b/test/kitchen/test/integration/security-agent-test/rspec/security-agent-test_spec.rb
@@ -24,7 +24,8 @@ print KernelOut.format(`cat /etc/os-release`)
 print KernelOut.format(`uname -a`)
 
 Dir.glob('/tmp/security-agent/ebpf_bytecode/*.o').each do |f|
-  FileUtils.chmod 0644, f, :verbose => true
+  # FileUtils.chmod 0644, f, :verbose => true
+  puts f
 end
 
 describe 'functional test running directly on host' do

--- a/test/kitchen/test/integration/security-agent-test/rspec/security-agent-test_spec.rb
+++ b/test/kitchen/test/integration/security-agent-test/rspec/security-agent-test_spec.rb
@@ -23,11 +23,6 @@ end
 print KernelOut.format(`cat /etc/os-release`)
 print KernelOut.format(`uname -a`)
 
-Dir.glob('/tmp/security-agent/ebpf_bytecode/*.o').each do |f|
-  # FileUtils.chmod 0644, f, :verbose => true
-  puts f
-end
-
 describe 'functional test running directly on host' do
   it 'successfully runs' do
     Open3.popen2e({"DD_TESTS_RUNTIME_COMPILED"=>"1", "DD_SYSTEM_PROBE_BPF_DIR"=>"/tmp/security-agent/ebpf_bytecode"}, "sudo", "-E", "/tmp/security-agent/testsuite", "-test.v", "-status-metrics") do |_, output, wait_thr|

--- a/test/kitchen/test/integration/security-agent-test/rspec/security-agent-test_spec.rb
+++ b/test/kitchen/test/integration/security-agent-test/rspec/security-agent-test_spec.rb
@@ -23,13 +23,13 @@ end
 print KernelOut.format(`cat /etc/os-release`)
 print KernelOut.format(`uname -a`)
 
-Dir.glob('/tmp/security-agent/pkg/ebpf/bytecode/build/*.o').each do |f|
+Dir.glob('/tmp/security-agent/ebpf_bytecode/*.o').each do |f|
   FileUtils.chmod 0644, f, :verbose => true
 end
 
 describe 'functional test running directly on host' do
   it 'successfully runs' do
-    Open3.popen2e({"DD_TESTS_RUNTIME_COMPILED"=>"1", "DD_SYSTEM_PROBE_BPF_DIR"=>"/tmp/security-agent/pkg/ebpf/bytecode/build"}, "sudo", "-E", "/tmp/security-agent/testsuite", "-test.v", "-status-metrics") do |_, output, wait_thr|
+    Open3.popen2e({"DD_TESTS_RUNTIME_COMPILED"=>"1", "DD_SYSTEM_PROBE_BPF_DIR"=>"/tmp/security-agent/ebpf_bytecode"}, "sudo", "-E", "/tmp/security-agent/testsuite", "-test.v", "-status-metrics") do |_, output, wait_thr|
       test_failures = check_output(output, wait_thr, "h")
       expect(test_failures).to be_empty, test_failures.join("\n")
     end
@@ -39,7 +39,7 @@ end
 if File.readlines("/etc/os-release").grep(/SUSE/).size == 0 and !File.exists?('/etc/rhsm')
   describe 'functional test running inside a container' do
     it 'successfully runs' do
-      Open3.popen2e("sudo", "docker", "exec", "-e", "DD_SYSTEM_PROBE_BPF_DIR=/tmp/security-agent/pkg/ebpf/bytecode/build", "docker-testsuite", "/tmp/security-agent/testsuite", "-test.v", "-status-metrics", "--env", "docker") do |_, output, wait_thr|
+      Open3.popen2e("sudo", "docker", "exec", "-e", "DD_SYSTEM_PROBE_BPF_DIR=/tmp/security-agent/ebpf_bytecode", "docker-testsuite", "/tmp/security-agent/testsuite", "-test.v", "-status-metrics", "--env", "docker") do |_, output, wait_thr|
         test_failures = check_output(output, wait_thr, "d")
         expect(test_failures).to be_empty, test_failures.join("\n")
       end


### PR DESCRIPTION
### What does this PR do?

Currently the security agent functional tests fetch `*.o` files from the system probe cookbook files.
This PR:
- implements all setup required for kitchen preparation of security agent in an invoke task, like it's already done for system probe
- copy the runtime security object files in the correct cookbook directly
- do the `chmod` operation of object files directly in the chef file, instead of post-facto in the tests

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
