### PR TITLE
Improve error message when config file can't be acessed

### DIFF
--- a/cmd/agent/common/helpers.go
+++ b/cmd/agent/common/helpers.go
@@ -75,9 +75,9 @@ func setupConfig(confFilePath string, configName string, withoutSecrets bool, fa
 		// special-case permission-denied with a clearer error message
 		if errors.Is(err, fs.ErrPermission) {
 			if runtime.GOOS == "windows" {
-				err = fmt.Errorf(`cannot access the Datadog config file (%w); try running with "Run as Administrator"`, err)
+				err = fmt.Errorf(`cannot access the Datadog config file (%w); try running the command in an Administrator shell"`, err)
 			} else {
-				err = fmt.Errorf("cannot access the Datadog config file (%w); try running as the same user as the Datadog agent", err)
+				err = fmt.Errorf("cannot access the Datadog config file (%w); try running the command under the same user as the Datadog Agent", err)
 			}
 		} else {
 			err = fmt.Errorf("unable to load Datadog config file: %w", err)

--- a/cmd/agent/common/helpers.go
+++ b/cmd/agent/common/helpers.go
@@ -8,6 +8,8 @@ package common
 import (
 	"errors"
 	"fmt"
+	"io/fs"
+	"runtime"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
@@ -70,7 +72,17 @@ func setupConfig(confFilePath string, configName string, withoutSecrets bool, fa
 	// If `!failOnMissingFile`, do not issue an error if we cannot find the default config file.
 	var e viper.ConfigFileNotFoundError
 	if err != nil && (failOnMissingFile || !errors.As(err, &e) || confFilePath != "") {
-		return warnings, fmt.Errorf("unable to load Datadog config file: %w", err)
+		// special-case permission-denied with a clearer error message
+		if errors.Is(err, fs.ErrPermission) {
+			if runtime.GOOS == "windows" {
+				err = fmt.Errorf(`cannot access the Datadog config file (%w); try running with "Run as Administrator"`, err)
+			} else {
+				err = fmt.Errorf("cannot access the Datadog config file (%w); try running as the same user as the Datadog agent", err)
+			}
+		} else {
+			err = fmt.Errorf("unable to load Datadog config file: %w", err)
+		}
+		return warnings, err
 	}
 	return warnings, nil
 }


### PR DESCRIPTION
On Linux:

    Error: unable to set up global agent configuration: cannot access the
    Datadog config file (open /etc/datadog-agent/datadog.yaml: permission
    denied); try running as the same user as the Datadog agent

On Windows:

    Error: unable to set up global agent configuration: cannot
    access the Datadog config file (open
    C:\ProgramData\Datadog\datadog.yaml: Access is denied.); try
    running with "Run as Administrator"

### Motivation

Help users understand what to do when they get permission errors running things like `agent status`.

### Describe how to test/QA your changes

Configure your filesystem or login such that you cannot access the datadog config file, then run `agent status`.  There's no need to run the actual agent.  Confirm that the error message is helpful.

Do this on both Windows and Linux.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
