### PR TITLE
SLS-2484: Use DD_SOURCE for log source instead of CloudRun

### DIFF
--- a/cmd/serverless-init/log/log.go
+++ b/cmd/serverless-init/log/log.go
@@ -51,7 +51,7 @@ type CustomWriter struct {
 // CreateConfig builds and returns a log config
 func CreateConfig(metadata *metadata.Metadata) *Config {
 	var source string
-	if source = os.Getenv(sourceEnvVar); source == "" {
+	if source = strings.ToLower(os.Getenv(sourceEnvVar)); source == "" {
 		source = defaultSource
 	}
 	return &Config{

--- a/cmd/serverless-init/log/log.go
+++ b/cmd/serverless-init/log/log.go
@@ -26,7 +26,7 @@ const (
 	loggerName          = "DD_CLOUDRUN_LOG_AGENT"
 	logLevelEnvVar      = "DD_LOG_LEVEL"
 	logEnabledEnvVar    = "DD_LOGS_ENABLED"
-	source              = "cloudrun"
+	sourceEnvVar        = "DD_SOURCE"
 	sourceName          = "Google Cloud Run"
 )
 
@@ -53,7 +53,7 @@ func CreateConfig(metadata *metadata.Metadata) *Config {
 		FlushTimeout: defaultFlushTimeout,
 		Metadata:     metadata,
 		channel:      make(chan *logConfig.ChannelMessage),
-		source:       source,
+		source:       os.Getenv(sourceEnvVar),
 		loggerName:   loggerName,
 		isEnabled:    isEnabled(os.Getenv(logEnabledEnvVar)),
 	}
@@ -89,7 +89,7 @@ func SetupLog(conf *Config) {
 			log.Errorf("Unable to change the log level: %s", err)
 		}
 	}
-	serverlessLogs.SetupLogAgent(conf.channel, sourceName, source)
+	serverlessLogs.SetupLogAgent(conf.channel, sourceName, conf.Source)
 	serverlessLogs.SetLogsTags(tag.GetBaseTagsArrayWithMetadataTags(conf.Metadata.TagMap()))
 }
 

--- a/cmd/serverless-init/log/log.go
+++ b/cmd/serverless-init/log/log.go
@@ -23,6 +23,7 @@ import (
 
 const (
 	defaultFlushTimeout = 5 * time.Second
+	defaultSource       = "cloudrun"
 	loggerName          = "DD_CLOUDRUN_LOG_AGENT"
 	logLevelEnvVar      = "DD_LOG_LEVEL"
 	logEnabledEnvVar    = "DD_LOGS_ENABLED"
@@ -49,11 +50,15 @@ type CustomWriter struct {
 
 // CreateConfig builds and returns a log config
 func CreateConfig(metadata *metadata.Metadata) *Config {
+	var source string
+	if source = os.Getenv(sourceEnvVar); source == "" {
+		source = defaultSource
+	}
 	return &Config{
 		FlushTimeout: defaultFlushTimeout,
 		Metadata:     metadata,
 		channel:      make(chan *logConfig.ChannelMessage),
-		source:       os.Getenv(sourceEnvVar),
+		source:       source,
 		loggerName:   loggerName,
 		isEnabled:    isEnabled(os.Getenv(logEnabledEnvVar)),
 	}
@@ -89,7 +94,7 @@ func SetupLog(conf *Config) {
 			log.Errorf("Unable to change the log level: %s", err)
 		}
 	}
-	serverlessLogs.SetupLogAgent(conf.channel, sourceName, conf.Source)
+	serverlessLogs.SetupLogAgent(conf.channel, sourceName, conf.source)
 	serverlessLogs.SetLogsTags(tag.GetBaseTagsArrayWithMetadataTags(conf.Metadata.TagMap()))
 }
 

--- a/cmd/serverless-init/log/log_test.go
+++ b/cmd/serverless-init/log/log_test.go
@@ -109,6 +109,7 @@ func TestCreateConfig(t *testing.T) {
 
 func TestCreateConfigWithSource(t *testing.T) {
 	os.Setenv("DD_SOURCE", "python")
+	defer os.Unsetenv("DD_SOURCE")
 	metadata := &metadata.Metadata{}
 	config := CreateConfig(metadata)
 	assert.Equal(t, 5*time.Second, config.FlushTimeout)

--- a/cmd/serverless-init/log/log_test.go
+++ b/cmd/serverless-init/log/log_test.go
@@ -7,6 +7,7 @@ package log
 
 import (
 	"bytes"
+	"os"
 	"testing"
 	"time"
 
@@ -102,6 +103,16 @@ func TestCreateConfig(t *testing.T) {
 	config := CreateConfig(metadata)
 	assert.Equal(t, 5*time.Second, config.FlushTimeout)
 	assert.Equal(t, "cloudrun", config.source)
+	assert.Equal(t, "DD_CLOUDRUN_LOG_AGENT", string(config.loggerName))
+	assert.Equal(t, metadata, config.Metadata)
+}
+
+func TestCreateConfigWithSource(t *testing.T) {
+	os.Setenv("DD_SOURCE", "python")
+	metadata := &metadata.Metadata{}
+	config := CreateConfig(metadata)
+	assert.Equal(t, 5*time.Second, config.FlushTimeout)
+	assert.Equal(t, "python", config.source)
 	assert.Equal(t, "DD_CLOUDRUN_LOG_AGENT", string(config.loggerName))
 	assert.Equal(t, metadata, config.Metadata)
 }


### PR DESCRIPTION
Use `DD_SOURCE` as the log source instead of `source:cloudrun`. If the user doesn't specify a source, default to `cloudrun`.