### PR TITLE
[netflow] Bump goflow2 to v1.1.1-0.20220825033856-d6caeaacddbb

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -397,7 +397,7 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-require github.com/netsampler/goflow2 v1.1.0
+require github.com/netsampler/goflow2 v1.1.1-0.20220825033856-d6caeaacddbb
 
 require (
 	github.com/DataDog/aptly v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1383,6 +1383,8 @@ github.com/ncw/swift v1.0.30/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
 github.com/netsampler/goflow2 v1.1.0 h1:izXi00eRpyaGgjbIr6IDdVe1xjzIK+7e65vxK9u3jBQ=
 github.com/netsampler/goflow2 v1.1.0/go.mod h1:yqw2cLe+lbnDN1+JKBqxoj2FKOA83iB8wV0aCKnlesg=
+github.com/netsampler/goflow2 v1.1.1-0.20220825033856-d6caeaacddbb h1:4Zzp+I9TvRo9OufYGl9lK67mkEjlT+YROxj6oWbD788=
+github.com/netsampler/goflow2 v1.1.1-0.20220825033856-d6caeaacddbb/go.mod h1:C9f54WtFVVbGpPWnpLMz+/hS3c7wc4L0g9ZzdIFAcuM=
 github.com/networkplumbing/go-nft v0.2.0/go.mod h1:HnnM+tYvlGAsMU7yoYwXEVLLiDW9gdMmb5HoGcwpuQs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/npillmayer/nestext v0.1.3/go.mod h1:h2lrijH8jpicr25dFY+oAJLyzlya6jhnuG+zWp9L0Uk=

--- a/go.sum
+++ b/go.sum
@@ -1381,8 +1381,6 @@ github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/ncw/swift v1.0.30/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
-github.com/netsampler/goflow2 v1.1.0 h1:izXi00eRpyaGgjbIr6IDdVe1xjzIK+7e65vxK9u3jBQ=
-github.com/netsampler/goflow2 v1.1.0/go.mod h1:yqw2cLe+lbnDN1+JKBqxoj2FKOA83iB8wV0aCKnlesg=
 github.com/netsampler/goflow2 v1.1.1-0.20220825033856-d6caeaacddbb h1:4Zzp+I9TvRo9OufYGl9lK67mkEjlT+YROxj6oWbD788=
 github.com/netsampler/goflow2 v1.1.1-0.20220825033856-d6caeaacddbb/go.mod h1:C9f54WtFVVbGpPWnpLMz+/hS3c7wc4L0g9ZzdIFAcuM=
 github.com/networkplumbing/go-nft v0.2.0/go.mod h1:HnnM+tYvlGAsMU7yoYwXEVLLiDW9gdMmb5HoGcwpuQs=


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

[netflow] Bump goflow2 to v1.1.1-0.20220825033856-d6caeaacddbb


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Mainly to include this bug fix https://github.com/netsampler/goflow2/pull/118

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

TEST 1: Test that NetFlow server won't panic when being shutdown while high traffic of netflow is being received by agent at the same time.

1/ Update datadog.yaml with

Example:

```
network_devices:
  netflow:
    enabled: true
    listeners:
      - flow_type: netflow5   # netflow, sflow, ipfix
        bind_host: 0.0.0.0
        port: 9995 # default 2055 for netflow
```

2/ Restart the Agent

```
launchctl stop com.datadoghq.agent
launchctl start com.datadoghq.agent
```

3/ Send high volume of netflow traffic

```
git clone git@github.com:AlexandreYang/nflow-generator.git
cd nflow-generator
git checkout alex/mod_netflow_generator
go build
 ./nflow-generator -t 127.0.0.1 -p 9995 --duration 0 --flow-count 20000
```

4/ Shutdown the Agent

Example:

```
launchctl stop com.datadoghq.agent
```

5/ Check in agent logs that there is no panic during agent shutdown

Repeat steps 2-5 about 10 times, to check there is no panic anymore.

TEST 2: Check that NetFlow flows are still working as before on QA env by looking at QA dashboard.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
