### PR TITLE
[PCF] Improve CCCache performance on cache miss

### DIFF
--- a/pkg/util/cloudproviders/cloudfoundry/cccache.go
+++ b/pkg/util/cloudproviders/cloudfoundry/cccache.go
@@ -196,7 +196,7 @@ func (ccc *CCCache) setResourceActive(guid string) error {
 
 	// resource is already active
 	if ok {
-		return fmt.Errorf("resouce with guid %s is already active", guid)
+		return fmt.Errorf("resource with guid %s is already active", guid)
 	}
 
 	// creating a channel will make consequent reads blocking

--- a/pkg/util/cloudproviders/cloudfoundry/cccache.go
+++ b/pkg/util/cloudproviders/cloudfoundry/cccache.go
@@ -276,6 +276,7 @@ func (ccc *CCCache) GetProcesses(appGUID string) ([]*cfclient.Process, error) {
 		// wait in case the resource is currently being fetched
 		ccc.waitForResource(appGUID)
 
+		// check the cache in case the resource was fetched while we were waiting
 		ccc.RLock()
 		processes, ok = ccc.processesByAppGUID[appGUID]
 		ccc.RUnlock()
@@ -332,12 +333,13 @@ func (ccc *CCCache) GetCFApplication(guid string) (*CFApplication, error) {
 			return nil, fmt.Errorf("refreshCacheOnMiss is disabled, could not find CF application %s in cloud controller cache", guid)
 		}
 
-		// Apps and CFApplication share the same guid which causes a deadlock in the ccc.activeResources map if not properly handled
+		// cfclient.V3App and CFApplication share the same guid which causes a deadlock in the ccc.activeResources map if not properly handled
 		cfappGUID := "cfapp" + guid
 
 		// wait in case the resource is currently being fetched
 		ccc.waitForResource(cfappGUID)
 
+		// check the cache in case the resource was fetched while we were waiting
 		ccc.RLock()
 		cfapp, ok = ccc.cfApplicationsByGUID[guid]
 		ccc.RUnlock()
@@ -439,6 +441,15 @@ func (ccc *CCCache) GetApp(guid string) (*cfclient.V3App, error) {
 		// wait in case the resource is currently being fetched
 		ccc.waitForResource(guid)
 
+		// check the cache in case the resource was fetched while we were waiting
+		ccc.RLock()
+		app, ok = ccc.appsByGUID[guid]
+		ccc.RUnlock()
+
+		if ok {
+			return app, nil
+		}
+
 		// set the resource as active to prevent other goroutines from fetching it
 		err := ccc.setResourceActive(guid)
 		if err != nil {
@@ -477,6 +488,7 @@ func (ccc *CCCache) GetSpace(guid string) (*cfclient.V3Space, error) {
 		// wait in case the resource is currently being fetched
 		ccc.waitForResource(guid)
 
+		// check the cache in case the resource was fetched while we were waiting
 		ccc.RLock()
 		space, ok = ccc.spacesByGUID[guid]
 		ccc.RUnlock()
@@ -523,6 +535,7 @@ func (ccc *CCCache) GetOrg(guid string) (*cfclient.V3Organization, error) {
 		// wait in case the resource is currently being fetched
 		ccc.waitForResource(guid)
 
+		// check the cache in case the resource was fetched while we were waiting
 		ccc.RLock()
 		org, ok = ccc.orgsByGUID[guid]
 		ccc.RUnlock()

--- a/pkg/util/cloudproviders/cloudfoundry/cccache.go
+++ b/pkg/util/cloudproviders/cloudfoundry/cccache.go
@@ -48,6 +48,9 @@ type CCCacheI interface {
 	// GetOrgQuotas returns all orgs quotas in the cache
 	GetOrgQuotas() ([]*CFOrgQuota, error)
 
+	// GetProcesses returns all processes for the given app guid in the cache
+	GetProcesses(appGUID string) ([]*cfclient.Process, error)
+
 	// GetCFApplication looks for a CF application with the given GUID in the cache
 	GetCFApplication(string) (*CFApplication, error)
 
@@ -87,6 +90,7 @@ type CCCache struct {
 	segmentBySpaceGUID   map[string]*cfclient.IsolationSegment
 	segmentByOrgGUID     map[string]*cfclient.IsolationSegment
 	appsBatchSize        int
+	activeResources      map[string]chan interface{}
 }
 
 // CCClientI is an interface for a Cloud Foundry Client that queries the Cloud Foundry API
@@ -100,6 +104,10 @@ type CCClientI interface {
 	ListIsolationSegmentsByQuery(url.Values) ([]cfclient.IsolationSegment, error)
 	GetIsolationSegmentSpaceGUID(string) (string, error)
 	GetIsolationSegmentOrganizationGUID(string) (string, error)
+	GetV3AppByGUID(string) (*cfclient.V3App, error)
+	GetV3SpaceByGUID(string) (*cfclient.V3Space, error)
+	GetV3OrganizationByGUID(string) (*cfclient.V3Organization, error)
+	ListProcessByAppGUID(url.Values, string) ([]cfclient.Process, error)
 }
 
 var globalCCCache = &CCCache{}
@@ -140,6 +148,7 @@ func ConfigureGlobalCCCache(ctx context.Context, ccURL, ccClientID, ccClientSecr
 	globalCCCache.serveNozzleData = serveNozzleData
 	globalCCCache.sidecarsTags = sidecarsTags
 	globalCCCache.segmentsTags = segmentsTags
+	globalCCCache.activeResources = make(map[string]chan interface{})
 
 	go globalCCCache.start()
 
@@ -169,6 +178,41 @@ func (ccc *CCCache) LastUpdated() time.Time {
 // will never close.
 func (ccc *CCCache) UpdatedOnce() <-chan struct{} {
 	return ccc.updatedOnce
+}
+
+func (ccc *CCCache) waitForResource(guid string) {
+	ccc.RLock()
+	ch, ok := ccc.activeResources[guid]
+	ccc.RUnlock()
+	if ok {
+		<-ch
+	}
+}
+
+func (ccc *CCCache) setResourceActive(guid string) error {
+	ccc.RLock()
+	_, ok := ccc.activeResources[guid]
+	ccc.RUnlock()
+
+	// resource is already active
+	if ok {
+		return fmt.Errorf("resouce with guid %s is already active", guid)
+	}
+
+	// creating a channel will make consequent reads blocking
+	ccc.Lock()
+	defer ccc.Unlock()
+	ccc.activeResources[guid] = make(chan interface{})
+
+	return nil
+}
+
+func (ccc *CCCache) setResourceInactive(guid string) {
+	ccc.RLock()
+	defer ccc.RUnlock()
+	if ch, ok := ccc.activeResources[guid]; ok {
+		close(ch)
+	}
 }
 
 // GetOrgs returns all orgs in the cache
@@ -210,6 +254,54 @@ func (ccc *CCCache) GetCFApplications() ([]*CFApplication, error) {
 	return cfapps, nil
 }
 
+// GetProcesses returns all processes for the given app guid in the cache
+func (ccc *CCCache) GetProcesses(appGUID string) ([]*cfclient.Process, error) {
+	ccc.RLock()
+	processes, ok := ccc.processesByAppGUID[appGUID]
+	ccc.RUnlock()
+
+	if !ok {
+		if !ccc.refreshCacheOnMiss {
+			return nil, fmt.Errorf("refreshCacheOnMiss is disabled, could not find processes for the app %s in cloud controller cache", appGUID)
+		}
+
+		// wait in case the resource is currently being fetched
+		ccc.waitForResource(appGUID)
+
+		// set the resource as active to prevent other goroutines from fetching it
+		err := ccc.setResourceActive(appGUID)
+		if err != nil {
+			return nil, err
+		}
+
+		// unblock other goroutines as the resource is fetched
+		defer ccc.setResourceInactive(appGUID)
+
+		query := url.Values{}
+		query.Add("per_page", fmt.Sprintf("%d", ccc.appsBatchSize))
+
+		// fetch processes for the appGUID from the CAPI
+		processes, err := ccc.ccAPIClient.ListProcessByAppGUID(query, appGUID)
+		if err != nil {
+			return nil, err
+		}
+
+		// convert to array of pointers
+		res := make([]*cfclient.Process, 0, len(processes))
+		for _, process := range processes {
+			res = append(res, &process)
+		}
+
+		// update cache
+		ccc.Lock()
+		ccc.processesByAppGUID[appGUID] = res
+		ccc.Unlock()
+
+		return res, nil
+	}
+	return processes, nil
+}
+
 // GetCFApplication looks for a CF application with the given GUID in the cache
 func (ccc *CCCache) GetCFApplication(guid string) (*CFApplication, error) {
 	var cfapp *CFApplication
@@ -218,17 +310,82 @@ func (ccc *CCCache) GetCFApplication(guid string) (*CFApplication, error) {
 	ccc.RLock()
 	cfapp, ok = ccc.cfApplicationsByGUID[guid]
 	ccc.RUnlock()
+
 	if !ok {
 		if !ccc.refreshCacheOnMiss {
-			return nil, fmt.Errorf("could not find CF application %s in cloud controller cache", guid)
+			return nil, fmt.Errorf("refreshCacheOnMiss is disabled, could not find CF application %s in cloud controller cache", guid)
 		}
-		ccc.readData()
-		ccc.RLock()
-		cfapp, ok = ccc.cfApplicationsByGUID[guid]
-		ccc.RUnlock()
-		if !ok {
-			return nil, fmt.Errorf("could not find CF application %s in cloud controller cache", guid)
+
+		// app and cfapps share the same guid which would cause a deadlock in the ccc.activeResources map if not properly handle
+		cfappGUID := "cfapp" + guid
+
+		// wait in case the resource is currently being fetched
+		ccc.waitForResource(cfappGUID)
+
+		// set the resource as active to prevent other goroutines from fetching it
+		err := ccc.setResourceActive(cfappGUID)
+		if err != nil {
+			return nil, err
 		}
+
+		// unblock other goroutines as the resource is fetched
+		defer ccc.setResourceInactive(cfappGUID)
+
+		// fetch app from the CAPI
+		app, err := ccc.GetApp(guid)
+		if err != nil {
+			return nil, err
+		}
+
+		// fill app data
+		cfapp := CFApplication{}
+		cfapp.extractDataFromV3App(*app)
+
+		// extract GUIDs
+		appGUID := cfapp.GUID
+		spaceGUID := cfapp.SpaceGUID
+		orgGUID := cfapp.OrgGUID
+
+		// fill processes data
+		processes, err := ccc.GetProcesses(appGUID)
+		if err != nil {
+			log.Info(err)
+		} else {
+			cfapp.extractDataFromV3Process(processes)
+		}
+
+		// fill space then org data. Order matters for labels and annotations.
+		space, err := ccc.GetSpace(spaceGUID)
+		if err != nil {
+			log.Info(err)
+		} else {
+			cfapp.extractDataFromV3Space(space)
+		}
+
+		// fill org data
+		org, err := ccc.GetOrg(orgGUID)
+		if err != nil {
+			log.Info(err)
+		} else {
+			cfapp.extractDataFromV3Org(org)
+		}
+
+		// fill sidecars data
+		sidecars, err := ccc.GetSidecars(appGUID)
+		if err != nil {
+			log.Info(err)
+		} else {
+			for _, sidecar := range sidecars {
+				cfapp.Sidecars = append(cfapp.Sidecars, *sidecar)
+			}
+		}
+
+		// update CC cache
+		ccc.Lock()
+		ccc.cfApplicationsByGUID[appGUID] = &cfapp
+		ccc.Unlock()
+
+		return &cfapp, nil
 	}
 	return cfapp, nil
 }
@@ -248,11 +405,38 @@ func (ccc *CCCache) GetSidecars(guid string) ([]*CFSidecar, error) {
 // GetApp looks for an app with the given GUID in the cache
 func (ccc *CCCache) GetApp(guid string) (*cfclient.V3App, error) {
 	ccc.RLock()
-	defer ccc.RUnlock()
-
 	app, ok := ccc.appsByGUID[guid]
+	ccc.RUnlock()
+
 	if !ok {
-		return nil, fmt.Errorf("could not find app %s in cloud controller cache", guid)
+		if !ccc.refreshCacheOnMiss {
+			return nil, fmt.Errorf("refreshCacheOnMiss is disabled, could not find application %s in cloud controller cache", guid)
+		}
+
+		// wait in case the resource is currently being fetched
+		ccc.waitForResource(guid)
+
+		// set the resource as active to prevent other goroutines from fetching it
+		err := ccc.setResourceActive(guid)
+		if err != nil {
+			return nil, err
+		}
+
+		// unblock other goroutines as the resource is fetched
+		defer ccc.setResourceInactive(guid)
+
+		// fetch app from the CAPI
+		app, err := ccc.ccAPIClient.GetV3AppByGUID(guid)
+		if err != nil {
+			return nil, err
+		}
+
+		// update CC cache
+		ccc.Lock()
+		ccc.appsByGUID[guid] = app
+		ccc.Unlock()
+
+		return app, nil
 	}
 	return app, nil
 }
@@ -260,10 +444,37 @@ func (ccc *CCCache) GetApp(guid string) (*cfclient.V3App, error) {
 // GetSpace looks for a space with the given GUID in the cache
 func (ccc *CCCache) GetSpace(guid string) (*cfclient.V3Space, error) {
 	ccc.RLock()
-	defer ccc.RUnlock()
 	space, ok := ccc.spacesByGUID[guid]
+	ccc.RUnlock()
 	if !ok {
-		return nil, fmt.Errorf("could not find space %s in cloud controller cache", guid)
+		if !ccc.refreshCacheOnMiss {
+			return nil, fmt.Errorf("refreshCacheOnMiss is disabled, could not find space %s in cloud controller cache", guid)
+		}
+
+		// wait in case the resource is currently being fetched
+		ccc.waitForResource(guid)
+
+		// set the resource as active to prevent other goroutines from fetching it
+		err := ccc.setResourceActive(guid)
+		if err != nil {
+			return nil, err
+		}
+
+		// unblock other goroutines as the resource is fetched
+		defer ccc.setResourceInactive(guid)
+
+		// fetch space from the CAPI
+		space, err := ccc.ccAPIClient.GetV3SpaceByGUID(guid)
+		if err != nil {
+			return nil, err
+		}
+
+		// update CC cache
+		ccc.Lock()
+		ccc.spacesByGUID[guid] = space
+		ccc.Unlock()
+
+		return space, nil
 	}
 	return space, nil
 }
@@ -271,10 +482,37 @@ func (ccc *CCCache) GetSpace(guid string) (*cfclient.V3Space, error) {
 // GetOrg looks for an org with the given GUID in the cache
 func (ccc *CCCache) GetOrg(guid string) (*cfclient.V3Organization, error) {
 	ccc.RLock()
-	defer ccc.RUnlock()
 	org, ok := ccc.orgsByGUID[guid]
+	ccc.RUnlock()
 	if !ok {
-		return nil, fmt.Errorf("could not find org %s in cloud controller cache", guid)
+		if !ccc.refreshCacheOnMiss {
+			return nil, fmt.Errorf("refreshCacheOnMiss is disabled, could not find org %s in cloud controller cache", guid)
+		}
+
+		// wait in case the resource is currently being fetched
+		ccc.waitForResource(guid)
+
+		// set the resource as active to prevent other goroutines from fetching it
+		err := ccc.setResourceActive(guid)
+		if err != nil {
+			return nil, err
+		}
+
+		// unblock other goroutines as the resource is fetched
+		defer ccc.setResourceInactive(guid)
+
+		// fetch org from the CAPI
+		org, err := ccc.ccAPIClient.GetV3OrganizationByGUID(guid)
+		if err != nil {
+			return nil, err
+		}
+
+		// update CC cache
+		ccc.Lock()
+		ccc.orgsByGUID[guid] = org
+		ccc.Unlock()
+
+		return org, nil
 	}
 	return org, nil
 }

--- a/pkg/util/cloudproviders/cloudfoundry/cccache_test.go
+++ b/pkg/util/cloudproviders/cloudfoundry/cccache_test.go
@@ -9,30 +9,80 @@
 package cloudfoundry
 
 import (
+	"fmt"
 	"net/url"
 	"sort"
+	"sync"
 	"testing"
 
 	"github.com/cloudfoundry-community/go-cfclient"
 	"github.com/stretchr/testify/assert"
 )
 
+type testCCClientCounter struct {
+	sync.RWMutex
+	hitsByMethod map[string]int
+}
+
+var globalCCClientCounter = testCCClientCounter{}
+
+func (t *testCCClientCounter) UpdateHits(method string) {
+	t.RLock()
+	if t.hitsByMethod == nil {
+		t.RUnlock()
+		t.Lock()
+		t.hitsByMethod = make(map[string]int)
+		t.Unlock()
+	} else {
+		t.RUnlock()
+	}
+
+	t.Lock()
+	defer t.Unlock()
+	t.hitsByMethod[method]++
+}
+
+func (t *testCCClientCounter) GetHits(method string) int {
+	t.RLock()
+	if t.hitsByMethod == nil {
+		t.RUnlock()
+		t.Lock()
+		t.hitsByMethod = make(map[string]int)
+		t.Unlock()
+	} else {
+		t.RUnlock()
+	}
+	return t.hitsByMethod[method]
+}
+
+func (t *testCCClientCounter) Reset() {
+	t.Lock()
+	defer t.Unlock()
+	t.hitsByMethod = nil
+}
+
 func (t testCCClient) ListV3AppsByQuery(_ url.Values) ([]cfclient.V3App, error) {
+	globalCCClientCounter.UpdateHits("ListV3AppsByQuery")
 	return []cfclient.V3App{v3App1, v3App2}, nil
 }
 func (t testCCClient) ListV3OrganizationsByQuery(_ url.Values) ([]cfclient.V3Organization, error) {
+	globalCCClientCounter.UpdateHits("ListV3OrganizationsByQuery")
 	return []cfclient.V3Organization{v3Org1, v3Org2}, nil
 }
 func (t testCCClient) ListV3SpacesByQuery(_ url.Values) ([]cfclient.V3Space, error) {
+	globalCCClientCounter.UpdateHits("ListV3SpacesByQuery")
 	return []cfclient.V3Space{v3Space1, v3Space2}, nil
 }
 func (t testCCClient) ListAllProcessesByQuery(_ url.Values) ([]cfclient.Process, error) {
+	globalCCClientCounter.UpdateHits("ListAllProcessesByQuery")
 	return []cfclient.Process{cfProcess1, cfProcess2}, nil
 }
 func (t testCCClient) ListOrgQuotasByQuery(_ url.Values) ([]cfclient.OrgQuota, error) {
+	globalCCClientCounter.UpdateHits("ListOrgQuotasByQuery")
 	return []cfclient.OrgQuota{cfOrgQuota1, cfOrgQuota2}, nil
 }
 func (t testCCClient) ListSidecarsByApp(_ url.Values, guid string) ([]CFSidecar, error) {
+	globalCCClientCounter.UpdateHits("ListSidecarsByApp")
 	if guid == "random_app_guid" {
 		return []CFSidecar{cfSidecar1}, nil
 	} else if guid == "guid2" {
@@ -41,10 +91,12 @@ func (t testCCClient) ListSidecarsByApp(_ url.Values, guid string) ([]CFSidecar,
 	return nil, nil
 }
 func (t testCCClient) ListIsolationSegmentsByQuery(_ url.Values) ([]cfclient.IsolationSegment, error) {
+	globalCCClientCounter.UpdateHits("ListIsolationSegmentsByQuery")
 	return []cfclient.IsolationSegment{cfIsolationSegment1, cfIsolationSegment2}, nil
 }
 
 func (t testCCClient) GetIsolationSegmentSpaceGUID(guid string) (string, error) {
+	globalCCClientCounter.UpdateHits("GetIsolationSegmentSpaceGUID")
 	if guid == "isolation_segment_guid_1" {
 		return "space_guid_1", nil
 	} else if guid == "isolation_segment_guid_2" {
@@ -54,12 +106,54 @@ func (t testCCClient) GetIsolationSegmentSpaceGUID(guid string) (string, error) 
 }
 
 func (t testCCClient) GetIsolationSegmentOrganizationGUID(guid string) (string, error) {
+	globalCCClientCounter.UpdateHits("GetIsolationSegmentOrganizationGUID")
 	if guid == "isolation_segment_guid_1" {
 		return "org_guid_1", nil
 	} else if guid == "isolation_segment_guid_2" {
 		return "org_guid_2", nil
 	}
 	return "", nil
+}
+
+func (t testCCClient) GetV3AppByGUID(guid string) (*cfclient.V3App, error) {
+	globalCCClientCounter.UpdateHits("GetV3AppByGUID")
+	switch guid {
+	case v3App1.GUID:
+		return &v3App1, nil
+	case v3App2.GUID:
+		return &v3App2, nil
+	}
+	return nil, fmt.Errorf("could not find V3App with guid %s", guid)
+}
+
+func (t testCCClient) GetV3SpaceByGUID(guid string) (*cfclient.V3Space, error) {
+	globalCCClientCounter.UpdateHits("GetV3SpaceByGUID")
+	switch guid {
+	case v3Space1.GUID:
+		return &v3Space1, nil
+	case v3Space2.GUID:
+		return &v3Space2, nil
+	}
+	return nil, fmt.Errorf("could not find V3Space with guid %s", guid)
+}
+
+func (t testCCClient) GetV3OrganizationByGUID(guid string) (*cfclient.V3Organization, error) {
+	globalCCClientCounter.UpdateHits("GetV3OrganizationByGUID")
+	switch guid {
+	case v3Org1.GUID:
+		return &v3Org1, nil
+	case v3Org2.GUID:
+		return &v3Org2, nil
+	}
+	return nil, fmt.Errorf("could not find V3Organization with guid %s", guid)
+}
+
+func (t testCCClient) ListProcessByAppGUID(query url.Values, guid string) ([]cfclient.Process, error) {
+	globalCCClientCounter.UpdateHits("ListProcessByAppGUID")
+	if guid == v3App1.GUID {
+		return []cfclient.Process{cfProcess1, cfProcess2}, nil
+	}
+	return nil, fmt.Errorf("could not find processes for app with guid %s", guid)
 }
 
 func TestCCCachePolling(t *testing.T) {
@@ -144,4 +238,117 @@ func TestCCCache_GetIsolationSegmentForOrg(t *testing.T) {
 	assert.EqualValues(t, &cfIsolationSegment2, segment2)
 	_, err := cc.GetIsolationSegmentForOrg("invalid_org_guid")
 	assert.NotNil(t, err)
+}
+
+func TestCCCache_GetProcesses(t *testing.T) {
+	cc.readData()
+	processes, err := cc.GetProcesses("random_app_guid")
+	assert.Nil(t, err)
+
+	expected := []cfclient.Process{cfProcess1, cfProcess2}
+	// maps in go do not guarantee order
+	sort.Slice(expected, func(i, j int) bool {
+		return expected[i].GUID > expected[j].GUID
+	})
+
+	assert.EqualValues(t, &cfProcess1, processes[0])
+	assert.EqualValues(t, &cfProcess2, processes[1])
+
+	_, err = cc.GetProcesses("missing_app_guid")
+	assert.NotNil(t, err)
+}
+
+func TestCCCache_RefreshCacheOnMiss_GetProcesses(t *testing.T) {
+	cc.refreshCacheOnMiss = true
+	cc.readData()
+	globalCCClientCounter.Reset()
+	wg := sync.WaitGroup{}
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			cc.GetProcesses("missing_app_guid")
+		}()
+	}
+	wg.Wait()
+	assert.EqualValues(t, 1, globalCCClientCounter.GetHits("ListProcessByAppGUID"))
+	cc.refreshCacheOnMiss = false
+}
+
+func TestCCCache_RefreshCacheOnMiss_GetApp(t *testing.T) {
+	cc.refreshCacheOnMiss = true
+	cc.readData()
+	globalCCClientCounter.Reset()
+	wg := sync.WaitGroup{}
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			cc.GetApp("RefreshCacheOnMiss_GetApp")
+		}()
+	}
+	wg.Wait()
+	assert.EqualValues(t, 1, globalCCClientCounter.GetHits("GetV3AppByGUID"))
+	cc.refreshCacheOnMiss = false
+}
+
+func TestCCCache_RefreshCacheOnMiss_GetSpace(t *testing.T) {
+	cc.refreshCacheOnMiss = true
+	cc.readData()
+	globalCCClientCounter.Reset()
+	wg := sync.WaitGroup{}
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			cc.GetSpace("RefreshCacheOnMiss_GetSpace")
+		}()
+	}
+	wg.Wait()
+	assert.EqualValues(t, 1, globalCCClientCounter.GetHits("GetV3SpaceByGUID"))
+	cc.refreshCacheOnMiss = false
+}
+
+func TestCCCache_RefreshCacheOnMiss_GetOrg(t *testing.T) {
+	cc.refreshCacheOnMiss = true
+	cc.readData()
+	globalCCClientCounter.Reset()
+	wg := sync.WaitGroup{}
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			cc.GetOrg("RefreshCacheOnMiss_GetOrg")
+		}()
+	}
+	wg.Wait()
+	assert.EqualValues(t, 1, globalCCClientCounter.GetHits("GetV3OrganizationByGUID"))
+	cc.refreshCacheOnMiss = false
+}
+
+func TestCCCache_RefreshCacheOnMiss_GetCFApplication(t *testing.T) {
+	cc.refreshCacheOnMiss = true
+	cc.readData()
+	globalCCClientCounter.Reset()
+	wg := sync.WaitGroup{}
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			cc.GetCFApplication("RefreshCacheOnMiss_GetCFApplication")
+		}()
+	}
+	wg.Wait()
+
+	assert.EqualValues(t, 0, globalCCClientCounter.GetHits("ListV3OrganizationsByQuery"))
+	assert.EqualValues(t, 0, globalCCClientCounter.GetHits("ListV3SpacesByQuery"))
+	assert.EqualValues(t, 0, globalCCClientCounter.GetHits("ListV3AppsByQuery"))
+	assert.EqualValues(t, 0, globalCCClientCounter.GetHits("ListSidecarsByApp"))
+	assert.EqualValues(t, 0, globalCCClientCounter.GetHits("ListAllProcessesByQuery"))
+	assert.EqualValues(t, 1, globalCCClientCounter.GetHits("GetV3AppByGUID"))
+	assert.EqualValues(t, 0, globalCCClientCounter.GetHits("GetV3OrganizationByGUID"))
+	assert.EqualValues(t, 0, globalCCClientCounter.GetHits("GetV3SpaceByGUID"))
+	assert.EqualValues(t, 0, globalCCClientCounter.GetHits("ListProcessByAppGUID"))
+	
+	cc.refreshCacheOnMiss = false
 }

--- a/pkg/util/cloudproviders/cloudfoundry/cccache_test.go
+++ b/pkg/util/cloudproviders/cloudfoundry/cccache_test.go
@@ -349,6 +349,6 @@ func TestCCCache_RefreshCacheOnMiss_GetCFApplication(t *testing.T) {
 	assert.EqualValues(t, 0, globalCCClientCounter.GetHits("GetV3OrganizationByGUID"))
 	assert.EqualValues(t, 0, globalCCClientCounter.GetHits("GetV3SpaceByGUID"))
 	assert.EqualValues(t, 0, globalCCClientCounter.GetHits("ListProcessByAppGUID"))
-	
+
 	cc.refreshCacheOnMiss = false
 }

--- a/pkg/util/cloudproviders/cloudfoundry/cccache_test.go
+++ b/pkg/util/cloudproviders/cloudfoundry/cccache_test.go
@@ -273,7 +273,9 @@ func TestCCCache_RefreshCacheOnMiss_GetProcesses(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+
 	assert.EqualValues(t, 1, globalCCClientCounter.GetHits("ListProcessByAppGUID"))
+
 	cc.refreshCacheOnMiss = false
 	cc.readData()
 }
@@ -282,6 +284,7 @@ func TestCCCache_RefreshCacheOnMiss_GetApp(t *testing.T) {
 	cc.refreshCacheOnMiss = true
 	cc.reset()
 	globalCCClientCounter.Reset()
+
 	wg := sync.WaitGroup{}
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
@@ -292,7 +295,9 @@ func TestCCCache_RefreshCacheOnMiss_GetApp(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+
 	assert.EqualValues(t, 1, globalCCClientCounter.GetHits("GetV3AppByGUID"))
+
 	cc.refreshCacheOnMiss = false
 	cc.readData()
 }
@@ -301,6 +306,7 @@ func TestCCCache_RefreshCacheOnMiss_GetSpace(t *testing.T) {
 	cc.refreshCacheOnMiss = true
 	cc.reset()
 	globalCCClientCounter.Reset()
+
 	wg := sync.WaitGroup{}
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
@@ -310,7 +316,9 @@ func TestCCCache_RefreshCacheOnMiss_GetSpace(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+
 	assert.EqualValues(t, 1, globalCCClientCounter.GetHits("GetV3SpaceByGUID"))
+
 	cc.refreshCacheOnMiss = false
 	cc.readData()
 }
@@ -319,6 +327,7 @@ func TestCCCache_RefreshCacheOnMiss_GetOrg(t *testing.T) {
 	cc.refreshCacheOnMiss = true
 	cc.reset()
 	globalCCClientCounter.Reset()
+
 	wg := sync.WaitGroup{}
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
@@ -328,7 +337,9 @@ func TestCCCache_RefreshCacheOnMiss_GetOrg(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+
 	assert.EqualValues(t, 1, globalCCClientCounter.GetHits("GetV3OrganizationByGUID"))
+
 	cc.refreshCacheOnMiss = false
 	cc.readData()
 }
@@ -337,12 +348,13 @@ func TestCCCache_RefreshCacheOnMiss_GetCFApplication(t *testing.T) {
 	cc.refreshCacheOnMiss = true
 	cc.reset()
 	globalCCClientCounter.Reset()
+
 	wg := sync.WaitGroup{}
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_, err := cc.GetCFApplication(fmt.Sprintf(cfApp1.GUID))
+			_, err := cc.GetCFApplication(cfApp1.GUID)
 			assert.Nil(t, err)
 		}()
 	}

--- a/pkg/util/cloudproviders/cloudfoundry/main_test.go
+++ b/pkg/util/cloudproviders/cloudfoundry/main_test.go
@@ -34,7 +34,7 @@ func TestMain(m *testing.M) {
 	// the BBSCache depends on the CCCache, so initialize the CCache first.  In
 	// production code, any discrepancies would work out after a few polls;
 	// this is just needed for tests.
-	cc, _ = ConfigureGlobalCCCache(ctx, "url", "", "", false, time.Second, 1, true, true, true, true, &testCCClient{})
+	cc, _ = ConfigureGlobalCCCache(ctx, "url", "", "", false, time.Second, 1, false, true, true, true, &testCCClient{})
 	<-cc.UpdatedOnce()
 	bc, _ = ConfigureGlobalBBSCache(ctx, "url", "", "", "", time.Second, []*regexp.Regexp{}, []*regexp.Regexp{}, &testBBSClient{})
 	<-bc.UpdatedOnce()

--- a/releasenotes/notes/pcf-improve-ccache-performance-on-cache-miss-80ea03690434093a.yaml
+++ b/releasenotes/notes/pcf-improve-ccache-performance-on-cache-miss-80ea03690434093a.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Improve CCCache performance on cache miss reducing significantly
+    the number of API calls to the CAPI.

--- a/releasenotes/notes/pcf-improve-ccache-performance-on-cache-miss-80ea03690434093a.yaml
+++ b/releasenotes/notes/pcf-improve-ccache-performance-on-cache-miss-80ea03690434093a.yaml
@@ -8,5 +8,5 @@
 ---
 enhancements:
   - |
-    Improve CCCache performance on cache miss reducing significantly
+    Improve CCCache performance on cache miss, significantly reducing
     the number of API calls to the CAPI.

--- a/releasenotes/notes/pcf-improve-ccache-performance-on-cache-miss-80ea03690434093a.yaml
+++ b/releasenotes/notes/pcf-improve-ccache-performance-on-cache-miss-80ea03690434093a.yaml
@@ -1,11 +1,3 @@
-# Each section from every release note are combined when the
-# CHANGELOG.rst is rendered. So the text needs to be worded so that
-# it does not depend on any information only available in another
-# section. This may mean repeating some details, but each section
-# must be readable independently of the other.
-#
-# Each section note must be formatted as reStructuredText.
----
 enhancements:
   - |
     Improve CCCache performance on cache miss, significantly reducing


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Improves the way we handle cache misses in the CCCache. We used to refresh the whole cache on every cache miss, which lead to some performance issues in some cases.

For one, this PR solves the issue of duplicate refreshes by introducing an `activeResources` map of channels that synchronizes all resources fetch/refresh behaviour. Second, this PR splits the cache refreshing logic among each resource independently, leading to less and smaller requests to the CAPI. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Reduce the number of API calls to the CAPI.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Possible Drawbacks / Trade-offs

This change doesn't impact the following CCCache functions because they're more likely to cause a cache refresh for the wrong reasons. (e.g. apps without sidecars, spaces/organizations that don't belong to an isolation segment).
```
ListSidecarsByApp(url.Values,string) ([]CFSidecar, error)
GetIsolationSegmentSpaceGUID(string) (string, error)
GetIsolationSegmentOrganizationGUID(string) (string, error)
```


<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

- Deploy a `cluster-agent-cloudfoundry` binary to a Cluster Agent VM in a PCF environment.
- Enable `serve_nozzle_data` in the  cluster agent config file `/var/vcap/jobs/datadog-cluster-agent/config/datadog-cluster.yml`.
- Enable `Use Cluster Agent API` in the Nozzle settings from the OpsManager UI.
- Monitor the metric `cloudfoundry.nozzle.gorouter.requests.CloudController`, we should notice an important decrease.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
