### PR TITLE
[CWS] add option to tag output (used for host/docker)

### DIFF
--- a/test/kitchen/test/integration/common/rspec/kernel_out_spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/kernel_out_spec_helper.rb
@@ -13,8 +13,9 @@ class KernelOut
   color_idx = File.read('/tmp/system-probe-tests/color_idx').strip.to_i - 1
   @@color = COLORS[color_idx]
 
-  def self.format(text)
-    RSpec::Core::Formatters::ConsoleCodes.wrap("[#{@@release}] #{text}", @@color)
+  def self.format(text, tag="")
+    tag = "[#{tag}]" if tag != ""
+    RSpec::Core::Formatters::ConsoleCodes.wrap("[#{@@release}]#{tag} #{text}", @@color)
   end
 end
 

--- a/test/kitchen/test/integration/security-agent-test/rspec/security-agent-test_spec.rb
+++ b/test/kitchen/test/integration/security-agent-test/rspec/security-agent-test_spec.rb
@@ -4,16 +4,17 @@ require 'open3'
 
 GOLANG_TEST_FAILURE = /FAIL:/
 
-def check_output(output, wait_thr)
+def check_output(output, wait_thr, tag="")
   test_failures = []
 
   output.each_line do |line|
-    puts KernelOut.format(line.strip)
-    test_failures << KernelOut.format(line.strip) if line =~ GOLANG_TEST_FAILURE
+    striped_line = line.strip
+    puts KernelOut.format(striped_line, tag)
+    test_failures << KernelOut.format(striped_line, tag) if line =~ GOLANG_TEST_FAILURE
   end
 
   if test_failures.empty? && !wait_thr.value.success?
-    test_failures << KernelOut.format("Test command exited with status (#{wait_thr.value.exitstatus}) but no failures were captured.")
+    test_failures << KernelOut.format("Test command exited with status (#{wait_thr.value.exitstatus}) but no failures were captured.", tag)
   end
 
   test_failures
@@ -29,7 +30,7 @@ end
 describe 'functional test running directly on host' do
   it 'successfully runs' do
     Open3.popen2e({"DD_TESTS_RUNTIME_COMPILED"=>"1", "DD_SYSTEM_PROBE_BPF_DIR"=>"/tmp/security-agent/pkg/ebpf/bytecode/build"}, "sudo", "-E", "/tmp/security-agent/testsuite", "-test.v", "-status-metrics") do |_, output, wait_thr|
-      test_failures = check_output(output, wait_thr)
+      test_failures = check_output(output, wait_thr, "h")
       expect(test_failures).to be_empty, test_failures.join("\n")
     end
   end
@@ -39,7 +40,7 @@ if File.readlines("/etc/os-release").grep(/SUSE/).size == 0 and !File.exists?('/
   describe 'functional test running inside a container' do
     it 'successfully runs' do
       Open3.popen2e("sudo", "docker", "exec", "-e", "DD_SYSTEM_PROBE_BPF_DIR=/tmp/security-agent/pkg/ebpf/bytecode/build", "docker-testsuite", "/tmp/security-agent/testsuite", "-test.v", "-status-metrics", "--env", "docker") do |_, output, wait_thr|
-        test_failures = check_output(output, wait_thr)
+        test_failures = check_output(output, wait_thr, "d")
         expect(test_failures).to be_empty, test_failures.join("\n")
       end
     end


### PR DESCRIPTION
### What does this PR do?

This PR adds a parameter to `KernelOut.format` to add a tag to the output. This PR also uses this new feature to add a tag in CWS functional tests representing if the test is ran on the host on in a docker container.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
