### PR TITLE
[CWS][SEC-4631] Fix discarder functional tests

### DIFF
--- a/pkg/security/probe/discarders.go
+++ b/pkg/security/probe/discarders.go
@@ -82,10 +82,10 @@ func (e ErrDiscarderNotSupported) Error() string {
 	return fmt.Sprintf("discarder not supported for `%s`", e.Field)
 }
 
-type onDiscarderHandler func(rs *rules.RuleSet, event *Event, probe *Probe, discarder Discarder) error
+type onDiscarderHandler func(rs *rules.RuleSet, event *Event, probe *Probe, discarder Discarder) (string, error)
 
 var (
-	allDiscarderHandlers = make(map[eval.EventType]onDiscarderHandler)
+	allDiscarderHandlers = make(map[eval.EventType][]onDiscarderHandler)
 	// SupportedDiscarders lists all field which supports discarders
 	SupportedDiscarders = make(map[eval.Field]bool)
 )
@@ -507,28 +507,28 @@ func (id *inodeDiscarders) discardParentInode(req *ERPCRequest, rs *rules.RuleSe
 // function used to retrieve discarder information, *.file.path, FileEvent, file deleted
 type inodeEventGetter = func(event *Event) (eval.Field, *model.FileEvent, bool)
 
-func filenameDiscarderWrapper(eventType model.EventType, handler onDiscarderHandler, getter inodeEventGetter) onDiscarderHandler {
-	return func(rs *rules.RuleSet, event *Event, probe *Probe, discarder Discarder) error {
+func filenameDiscarderWrapper(eventType model.EventType, getter inodeEventGetter) onDiscarderHandler {
+	return func(rs *rules.RuleSet, event *Event, probe *Probe, discarder Discarder) (string, error) {
 		field, fileEvent, isDeleted := getter(event)
 
 		if fileEvent.PathResolutionError != nil {
-			return fileEvent.PathResolutionError
+			return "", fileEvent.PathResolutionError
 		}
 		mountID, inode, pathID := fileEvent.MountID, fileEvent.Inode, fileEvent.PathID
 
 		if discarder.Field == field {
 			value, err := event.GetFieldValue(field)
 			if err != nil {
-				return err
+				return "", err
 			}
 			filename := value.(string)
 
 			if filename == "" {
-				return nil
+				return "", nil
 			}
 
 			if isInvalidDiscarder(field, filename) {
-				return nil
+				return "", nil
 			}
 
 			isDiscarded, _, parentInode, err := probe.inodeDiscarders.discardParentInode(probe.erpcRequest, rs, eventType, field, filename, mountID, inode, pathID, event.TimestampRaw)
@@ -549,14 +549,10 @@ func filenameDiscarderWrapper(eventType model.EventType, handler onDiscarderHand
 				err = fmt.Errorf("unable to set inode discarders for `%s` for event `%s`, inode: %d: %w", filename, eventType, parentInode, err)
 			}
 
-			return err
+			return filename, err
 		}
 
-		if handler != nil {
-			return handler(rs, event, probe, discarder)
-		}
-
-		return nil
+		return "", nil
 	}
 }
 
@@ -588,24 +584,23 @@ func createInvalidDiscardersCache() map[eval.Field]map[interface{}]bool {
 	return invalidDiscarders
 }
 
-func processDiscarderWrapper(eventType model.EventType, fnc onDiscarderHandler) onDiscarderHandler {
-	return func(rs *rules.RuleSet, event *Event, probe *Probe, discarder Discarder) error {
+func processDiscarderWrapper(eventType model.EventType) onDiscarderHandler {
+	return func(rs *rules.RuleSet, event *Event, probe *Probe, discarder Discarder) (string, error) {
 		if discarder.Field == "process.file.path" {
 			seclog.Tracef("Apply process.file.path discarder for event `%s`, inode: %d, pid: %d", eventType, event.ProcessContext.FileEvent.Inode, event.ProcessContext.Pid)
 
 			// discard by PID for long running process
 			if err := probe.pidDiscarders.discardPid(probe.erpcRequest, eventType, event.ProcessContext.Pid); err != nil {
-				return err
+				return "", err
 			}
 
-			return probe.inodeDiscarders.discardInode(probe.erpcRequest, eventType, event.ProcessContext.FileEvent.MountID, event.ProcessContext.FileEvent.Inode, true)
+			value, _ := event.GetFieldValue(discarder.Field)
+			processPath := value.(string)
+
+			return processPath, probe.inodeDiscarders.discardInode(probe.erpcRequest, eventType, event.ProcessContext.FileEvent.MountID, event.ProcessContext.FileEvent.Inode, true)
 		}
 
-		if fnc != nil {
-			return fnc(rs, event, probe, discarder)
-		}
-
-		return nil
+		return "", nil
 	}
 }
 
@@ -616,93 +611,93 @@ func init() {
 
 	SupportedDiscarders["process.file.path"] = true
 
-	allDiscarderHandlers["open"] = processDiscarderWrapper(model.FileOpenEventType,
-		filenameDiscarderWrapper(model.FileOpenEventType, nil,
-			func(event *Event) (eval.Field, *model.FileEvent, bool) {
-				return "open.file.path", &event.Open.File, false
-			}))
+	allDiscarderHandlers["open"] = append(allDiscarderHandlers["open"], processDiscarderWrapper(model.FileOpenEventType))
+	allDiscarderHandlers["open"] = append(allDiscarderHandlers["open"], filenameDiscarderWrapper(model.FileOpenEventType,
+		func(event *Event) (eval.Field, *model.FileEvent, bool) {
+			return "open.file.path", &event.Open.File, false
+		}))
 	SupportedDiscarders["open.file.path"] = true
 
-	allDiscarderHandlers["mkdir"] = processDiscarderWrapper(model.FileMkdirEventType,
-		filenameDiscarderWrapper(model.FileMkdirEventType, nil,
-			func(event *Event) (eval.Field, *model.FileEvent, bool) {
-				return "mkdir.file.path", &event.Mkdir.File, false
-			}))
+	allDiscarderHandlers["mkdir"] = append(allDiscarderHandlers["mkdir"], processDiscarderWrapper(model.FileMkdirEventType))
+	allDiscarderHandlers["mkdir"] = append(allDiscarderHandlers["mkdir"], filenameDiscarderWrapper(model.FileMkdirEventType,
+		func(event *Event) (eval.Field, *model.FileEvent, bool) {
+			return "mkdir.file.path", &event.Mkdir.File, false
+		}))
 	SupportedDiscarders["mkdir.file.path"] = true
 
-	allDiscarderHandlers["link"] = processDiscarderWrapper(model.FileLinkEventType, nil)
+	allDiscarderHandlers["link"] = []onDiscarderHandler{processDiscarderWrapper(model.FileLinkEventType)}
 
-	allDiscarderHandlers["rename"] = processDiscarderWrapper(model.FileRenameEventType, nil)
+	allDiscarderHandlers["rename"] = []onDiscarderHandler{processDiscarderWrapper(model.FileRenameEventType)}
 
-	allDiscarderHandlers["unlink"] = processDiscarderWrapper(model.FileUnlinkEventType,
-		filenameDiscarderWrapper(model.FileUnlinkEventType, nil,
-			func(event *Event) (eval.Field, *model.FileEvent, bool) {
-				return "unlink.file.path", &event.Unlink.File, true
-			}))
+	allDiscarderHandlers["unlink"] = append(allDiscarderHandlers["unlink"], processDiscarderWrapper(model.FileUnlinkEventType))
+	allDiscarderHandlers["unlink"] = append(allDiscarderHandlers["unlink"], filenameDiscarderWrapper(model.FileUnlinkEventType,
+		func(event *Event) (eval.Field, *model.FileEvent, bool) {
+			return "unlink.file.path", &event.Unlink.File, true
+		}))
 	SupportedDiscarders["unlink.file.path"] = true
 
-	allDiscarderHandlers["rmdir"] = processDiscarderWrapper(model.FileRmdirEventType,
-		filenameDiscarderWrapper(model.FileRmdirEventType, nil,
-			func(event *Event) (eval.Field, *model.FileEvent, bool) {
-				return "rmdir.file.path", &event.Rmdir.File, false
-			}))
+	allDiscarderHandlers["rmdir"] = append(allDiscarderHandlers["rmdir"], processDiscarderWrapper(model.FileRmdirEventType))
+	allDiscarderHandlers["rmdir"] = append(allDiscarderHandlers["rmdir"], filenameDiscarderWrapper(model.FileRmdirEventType,
+		func(event *Event) (eval.Field, *model.FileEvent, bool) {
+			return "rmdir.file.path", &event.Rmdir.File, false
+		}))
 	SupportedDiscarders["rmdir.file.path"] = true
 
-	allDiscarderHandlers["chmod"] = processDiscarderWrapper(model.FileChmodEventType,
-		filenameDiscarderWrapper(model.FileChmodEventType, nil,
-			func(event *Event) (eval.Field, *model.FileEvent, bool) {
-				return "chmod.file.path", &event.Chmod.File, false
-			}))
+	allDiscarderHandlers["chmod"] = append(allDiscarderHandlers["chmod"], processDiscarderWrapper(model.FileChmodEventType))
+	allDiscarderHandlers["chmod"] = append(allDiscarderHandlers["chmod"], filenameDiscarderWrapper(model.FileChmodEventType,
+		func(event *Event) (eval.Field, *model.FileEvent, bool) {
+			return "chmod.file.path", &event.Chmod.File, false
+		}))
 	SupportedDiscarders["chmod.file.path"] = true
 
-	allDiscarderHandlers["chown"] = processDiscarderWrapper(model.FileChownEventType,
-		filenameDiscarderWrapper(model.FileChownEventType, nil,
-			func(event *Event) (eval.Field, *model.FileEvent, bool) {
-				return "chown.file.path", &event.Chown.File, false
-			}))
+	allDiscarderHandlers["chown"] = append(allDiscarderHandlers["chown"], processDiscarderWrapper(model.FileChownEventType))
+	allDiscarderHandlers["chown"] = append(allDiscarderHandlers["chown"], filenameDiscarderWrapper(model.FileChownEventType,
+		func(event *Event) (eval.Field, *model.FileEvent, bool) {
+			return "chown.file.path", &event.Chown.File, false
+		}))
 	SupportedDiscarders["chown.file.path"] = true
 
-	allDiscarderHandlers["utimes"] = processDiscarderWrapper(model.FileUtimesEventType,
-		filenameDiscarderWrapper(model.FileUtimesEventType, nil,
-			func(event *Event) (eval.Field, *model.FileEvent, bool) {
-				return "utimes.file.path", &event.Utimes.File, false
-			}))
+	allDiscarderHandlers["utimes"] = append(allDiscarderHandlers["utimes"], processDiscarderWrapper(model.FileUtimesEventType))
+	allDiscarderHandlers["utimes"] = append(allDiscarderHandlers["utimes"], filenameDiscarderWrapper(model.FileUtimesEventType,
+		func(event *Event) (eval.Field, *model.FileEvent, bool) {
+			return "utimes.file.path", &event.Utimes.File, false
+		}))
 	SupportedDiscarders["utimes.file.path"] = true
 
-	allDiscarderHandlers["setxattr"] = processDiscarderWrapper(model.FileSetXAttrEventType,
-		filenameDiscarderWrapper(model.FileSetXAttrEventType, nil,
-			func(event *Event) (eval.Field, *model.FileEvent, bool) {
-				return "setxattr.file.path", &event.SetXAttr.File, false
-			}))
+	allDiscarderHandlers["setxattr"] = append(allDiscarderHandlers["setxattr"], processDiscarderWrapper(model.FileSetXAttrEventType))
+	allDiscarderHandlers["setxattr"] = append(allDiscarderHandlers["setxattr"], filenameDiscarderWrapper(model.FileSetXAttrEventType,
+		func(event *Event) (eval.Field, *model.FileEvent, bool) {
+			return "setxattr.file.path", &event.SetXAttr.File, false
+		}))
 	SupportedDiscarders["setxattr.file.path"] = true
 
-	allDiscarderHandlers["removexattr"] = processDiscarderWrapper(model.FileRemoveXAttrEventType,
-		filenameDiscarderWrapper(model.FileRemoveXAttrEventType, nil,
-			func(event *Event) (eval.Field, *model.FileEvent, bool) {
-				return "removexattr.file.path", &event.RemoveXAttr.File, false
-			}))
+	allDiscarderHandlers["removexattr"] = append(allDiscarderHandlers["removexattr"], processDiscarderWrapper(model.FileRemoveXAttrEventType))
+	allDiscarderHandlers["removexattr"] = append(allDiscarderHandlers["removexattr"], filenameDiscarderWrapper(model.FileRemoveXAttrEventType,
+		func(event *Event) (eval.Field, *model.FileEvent, bool) {
+			return "removexattr.file.path", &event.RemoveXAttr.File, false
+		}))
 	SupportedDiscarders["removexattr.file.path"] = true
 
-	allDiscarderHandlers["bpf"] = processDiscarderWrapper(model.BPFEventType, nil)
+	allDiscarderHandlers["bpf"] = []onDiscarderHandler{processDiscarderWrapper(model.BPFEventType)}
 
-	allDiscarderHandlers["mmap"] = processDiscarderWrapper(model.MMapEventType,
-		filenameDiscarderWrapper(model.MMapEventType, nil,
-			func(event *Event) (eval.Field, *model.FileEvent, bool) {
-				return "mmap.file.path", &event.MMap.File, false
-			}))
+	allDiscarderHandlers["mmap"] = append(allDiscarderHandlers["mmap"], processDiscarderWrapper(model.MMapEventType))
+	allDiscarderHandlers["mmap"] = append(allDiscarderHandlers["mmap"], filenameDiscarderWrapper(model.MMapEventType,
+		func(event *Event) (eval.Field, *model.FileEvent, bool) {
+			return "mmap.file.path", &event.MMap.File, false
+		}))
 	SupportedDiscarders["mmap.file.path"] = true
 
-	allDiscarderHandlers["splice"] = processDiscarderWrapper(model.SpliceEventType,
-		filenameDiscarderWrapper(model.SpliceEventType, nil,
-			func(event *Event) (eval.Field, *model.FileEvent, bool) {
-				return "splice.file.path", &event.Splice.File, false
-			}))
+	allDiscarderHandlers["splice"] = append(allDiscarderHandlers["splice"], processDiscarderWrapper(model.SpliceEventType))
+	allDiscarderHandlers["splice"] = append(allDiscarderHandlers["splice"], filenameDiscarderWrapper(model.SpliceEventType,
+		func(event *Event) (eval.Field, *model.FileEvent, bool) {
+			return "splice.file.path", &event.Splice.File, false
+		}))
 	SupportedDiscarders["splice.file.path"] = true
 
-	allDiscarderHandlers["mprotect"] = processDiscarderWrapper(model.MProtectEventType, nil)
-	allDiscarderHandlers["ptrace"] = processDiscarderWrapper(model.PTraceEventType, nil)
-	allDiscarderHandlers["load_module"] = processDiscarderWrapper(model.LoadModuleEventType, nil)
-	allDiscarderHandlers["unload_module"] = processDiscarderWrapper(model.UnloadModuleEventType, nil)
-	allDiscarderHandlers["signal"] = processDiscarderWrapper(model.SignalEventType, nil)
-	allDiscarderHandlers["bind"] = processDiscarderWrapper(model.BindEventType, nil)
+	allDiscarderHandlers["mprotect"] = []onDiscarderHandler{processDiscarderWrapper(model.MProtectEventType)}
+	allDiscarderHandlers["ptrace"] = []onDiscarderHandler{processDiscarderWrapper(model.PTraceEventType)}
+	allDiscarderHandlers["load_module"] = []onDiscarderHandler{processDiscarderWrapper(model.LoadModuleEventType)}
+	allDiscarderHandlers["unload_module"] = []onDiscarderHandler{processDiscarderWrapper(model.UnloadModuleEventType)}
+	allDiscarderHandlers["signal"] = []onDiscarderHandler{processDiscarderWrapper(model.SignalEventType)}
+	allDiscarderHandlers["bind"] = []onDiscarderHandler{processDiscarderWrapper(model.BindEventType)}
 }

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -67,6 +67,7 @@ type EventStream interface {
 	Resume() error
 }
 
+// NotifyDiscarderPushedCallback describe the callback used to retrieve pushed discarders information
 type NotifyDiscarderPushedCallback func(eventType string, event *Event, field string)
 
 // Probe represents the runtime security eBPF probe in charge of
@@ -823,6 +824,7 @@ func (p *Probe) OnRuleMatch(rule *rules.Rule, event *Event) {
 	event.ResolveContainerTags(&event.ContainerContext)
 }
 
+// AddNewNotifyDiscarderPushedCallback add a callback to the list of func that have to be called when a discarder is pushed to kernel
 func (p *Probe) AddNewNotifyDiscarderPushedCallback(cb NotifyDiscarderPushedCallback) {
 	p.notifyDiscarderPushedCallbacksLock.Lock()
 	defer p.notifyDiscarderPushedCallbacksLock.Unlock()

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -67,7 +67,7 @@ type EventStream interface {
 	Resume() error
 }
 
-type NotifyDiscarderPushedCallback func(eventType string, event *Event, field string, fieldValue string)
+type NotifyDiscarderPushedCallback func(eventType string, event *Event, field string)
 
 // Probe represents the runtime security eBPF probe in charge of
 // setting up the required kProbes and decoding events sent from the kernel
@@ -852,13 +852,13 @@ func (p *Probe) OnNewDiscarder(rs *rules.RuleSet, event *Event, field eval.Field
 
 	if handlers, ok := allDiscarderHandlers[eventType]; ok {
 		for _, handler := range handlers {
-			fieldValue, _ := handler(rs, event, p, Discarder{Field: field})
+			discarderPushed, _ := handler(rs, event, p, Discarder{Field: field})
 
-			if fieldValue != "" {
+			if discarderPushed {
 				p.notifyDiscarderPushedCallbacksLock.Lock()
 				defer p.notifyDiscarderPushedCallbacksLock.Unlock()
 				for _, cb := range p.notifyDiscarderPushedCallbacks {
-					cb(eventType, event, field, fieldValue)
+					cb(eventType, event, field)
 				}
 			}
 		}

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -803,7 +803,7 @@ func (tm *testModule) RegisterEventDiscarderHandler(cb eventDiscarderHandler) {
 	tm.eventDiscarderHandler.Unlock()
 }
 
-func (tm *testModule) NotifyDiscarderPushedCallback(eventType string, event *sprobe.Event, field string, fieldValue string) {
+func (tm *testModule) NotifyDiscarderPushedCallback(eventType string, event *sprobe.Event, field string) {
 	tm.eventDiscarderHandler.RLock()
 	callback := tm.eventDiscarderHandler.callback
 	tm.eventDiscarderHandler.RUnlock()


### PR DESCRIPTION
### What does this PR do?

It fixes the discarders functional tests (using GetEventDiscarder helper) that were flaky due to bad hook point, leading to a race:
The helper was hooked when we (ruleset) detected that an event should trigger a new discarder, not where a new discarder is actually pushed to kernel.
And, as the function that have to push discarders is hooked on the same point, there was a race leading to some flakiness.

Now the GetEventDiscarder helper is correctly hooked after that discarders were actually pushed.


### Motivation

Make the CI great again

### Additional Notes

We now have another hook that could be used if needed, not only for tests.

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

As discarders were actually working properly (that was only a test issue), the only way to validate it is to run related tests, for exemple:

`inv -e security-agent.functional-tests --testflags "-test.v -test.run 'TestDiscarderRetentionFilter' -test.count 9999 -test.failfast"`

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
