### PR TITLE
Fix module definitions for `pkg/util/{cgroups,log,scrubber}`

### DIFF
--- a/docs/dev/modules.md
+++ b/docs/dev/modules.md
@@ -25,7 +25,7 @@ After you have refactored, if needed, and listed the packages that you want to e
  	    github.com/DataDog/datadog-agent/path/to/module => ./path/to/module
     )
     ```
-1. Update the `DEFAULT_MODULES` dictionary on the `tasks/modules.py` file. You need to create a new module, specifying the path, targets and a condition to run tests (if any).
+1. Update the `DEFAULT_MODULES` dictionary in the `tasks/modules.py` file. You need to create a new module, specifying the path, targets, and a condition to run tests (if any).
    For example, if `pkg/A` depends on `pkg/B` and `pkg/B` is Windows only, we would specify:
    ```python
    DEFAULT_MODULES = {

--- a/docs/dev/modules.md
+++ b/docs/dev/modules.md
@@ -25,16 +25,15 @@ After you have refactored, if needed, and listed the packages that you want to e
  	    github.com/DataDog/datadog-agent/path/to/module => ./path/to/module
     )
     ```
-1. Update the `DEFAULT_MODULES` dictionary on the `tasks/modules.py` file. You need to:
-    - create a new module, specifying the path, targets, dependencies and a condition to run tests (if any) and
-    - update the dependencies of other modules if they depend on this one.
+1. Update the `DEFAULT_MODULES` dictionary on the `tasks/modules.py` file. You need to create a new module, specifying the path, targets and a condition to run tests (if any).
    For example, if `pkg/A` depends on `pkg/B` and `pkg/B` is Windows only, we would specify:
    ```python
    DEFAULT_MODULES = {
-    "pkg/A": GoModule("pkg/A", dependencies=["pkg/B"]),
+    "pkg/A": GoModule("pkg/A"),
     "pkg/B": GoModule("pkg/B", condition=lambda: sys.platform == "win32")
    }
    ```
+   The dependencies are computed automatically.
 
 ## Go nested modules tooling
 

--- a/go.mod
+++ b/go.mod
@@ -47,8 +47,12 @@ require (
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.39.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/otlp/model v0.39.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/quantile v0.39.0-rc.3
+	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.39.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/security/secl v0.39.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/trace v0.39.0-rc.3
+	github.com/DataDog/datadog-agent/pkg/util/cgroups v0.0.0
+	github.com/DataDog/datadog-agent/pkg/util/log v0.0.0
+	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.0.0
 	github.com/DataDog/datadog-go/v5 v5.1.1
 	github.com/DataDog/datadog-operator v0.7.1-0.20220602134901-4f6af09bf54f
 	github.com/DataDog/ebpf-manager v0.0.0-20220627174516-12adb97b679e
@@ -97,6 +101,7 @@ require (
 	github.com/elastic/go-libaudit v0.4.0
 	github.com/fatih/color v1.13.0
 	github.com/freddierice/go-losetup v0.0.0-20170407175016-fc9adea44124
+	github.com/go-delve/delve v1.9.0
 	github.com/go-ini/ini v1.66.6
 	github.com/go-ole/go-ole v1.2.6
 	github.com/gobwas/glob v0.2.3
@@ -106,7 +111,6 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.2
 	github.com/google/go-cmp v0.5.8
-	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/gopacket v1.1.19
 	github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1
 	github.com/gorilla/mux v1.8.0
@@ -125,7 +129,6 @@ require (
 	github.com/itchyny/gojq v0.12.8
 	github.com/json-iterator/go v1.1.12
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0
-	github.com/karrick/godirwalk v1.17.0 // indirect
 	github.com/lxn/walk v0.0.0-20191128110447-55ccb3a9f5c1
 	github.com/lxn/win v0.0.0-20191128105842-2da648fda5b4
 	github.com/mailru/easyjson v0.7.7
@@ -135,6 +138,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/moby/sys/mountinfo v0.6.2
 	github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
+	github.com/netsampler/goflow2 v1.1.1-0.20220825033856-d6caeaacddbb
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/open-policy-agent/opa v0.43.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.56.0
@@ -148,7 +152,6 @@ require (
 	github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da
 	github.com/shirou/gopsutil/v3 v3.22.6
 	github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4
-	github.com/skydive-project/go-debouncer v1.0.0 // indirect
 	github.com/spf13/afero v1.8.2
 	github.com/spf13/cobra v1.5.0
 	github.com/spf13/pflag v1.0.5
@@ -169,7 +172,7 @@ require (
 	go.uber.org/automaxprocs v1.5.1
 	go.uber.org/multierr v1.8.0
 	go.uber.org/zap v1.22.0
-	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e // indirect
+	golang.org/x/arch v0.0.0-20190927153633-4e8777c89be4
 	golang.org/x/mobile v0.0.0-20201217150744-e6ae53a27f4f
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
@@ -222,6 +225,7 @@ require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.1 // indirect
 	github.com/AlekSi/pointer v1.1.0 // indirect
 	github.com/BurntSushi/toml v1.1.0 // indirect
+	github.com/DataDog/aptly v1.5.0 // indirect
 	github.com/DataDog/extendeddaemonset v0.7.1-0.20220530183123-9c60ea5abbc6 // indirect
 	github.com/DataDog/gostackparse v0.5.0 // indirect
 	github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 // indirect
@@ -232,6 +236,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8 // indirect
 	github.com/Sirupsen/logrus v1.0.6 // indirect
 	github.com/StackExchange/wmi v1.2.1 // indirect
+	github.com/agnivade/levenshtein v1.0.1 // indirect
 	github.com/andybalholm/brotli v1.0.2 // indirect
 	github.com/arduino/go-apt-client v0.0.0-20190812130613-5613f843fdc8 // indirect
 	github.com/armon/go-metrics v0.3.10 // indirect
@@ -239,6 +244,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40 // indirect
+	github.com/cavaliergopher/grab/v3 v3.0.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.1.3 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/containerd/continuity v0.2.2 // indirect
@@ -247,6 +253,7 @@ require (
 	github.com/containernetworking/plugins v1.1.1 // indirect
 	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f // indirect
+	github.com/dgraph-io/ristretto v0.1.0 // indirect
 	github.com/dgryski/go-jump v0.0.0-20211018200510-ba001c3ffce0 // indirect
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c // indirect
@@ -270,6 +277,7 @@ require (
 	github.com/gogo/googleapis v1.4.0 // indirect
 	github.com/golang/glog v1.0.0 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
+	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.3.0 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
@@ -294,10 +302,12 @@ require (
 	github.com/jonboulle/clockwork v0.3.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/josharian/native v1.0.0 // indirect
+	github.com/karrick/godirwalk v1.17.0 // indirect
 	github.com/kjk/lzma v0.0.0-20161016003348-3fd93898850d // indirect
 	github.com/klauspost/compress v1.15.8 // indirect
 	github.com/klauspost/pgzip v1.2.5 // indirect
 	github.com/knadh/koanf v1.4.2 // indirect
+	github.com/libp2p/go-reuseport v0.1.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20220517141722-cf486979b281 // indirect
 	github.com/magiconair/properties v1.8.6 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
@@ -339,6 +349,7 @@ require (
 	github.com/sassoftware/go-rpmutils v0.2.0 // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.3.1
 	github.com/sirupsen/logrus v1.9.0
+	github.com/skydive-project/go-debouncer v1.0.0 // indirect
 	github.com/smira/go-ftp-protocol v0.0.0-20140829150050-066b75c2b70d // indirect
 	github.com/smira/go-xz v0.0.0-20150414201226-0c531f070014
 	github.com/spf13/cast v1.5.0 // indirect
@@ -352,6 +363,7 @@ require (
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75 // indirect
 	github.com/ugorji/go/codec v1.2.7 // indirect
 	github.com/ulikunitz/xz v0.5.10 // indirect
+	github.com/vektah/gqlparser/v2 v2.4.6 // indirect
 	github.com/vito/go-sse v1.0.0 // indirect
 	github.com/vmihailenco/tagparser v0.1.2 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
@@ -377,10 +389,12 @@ require (
 	go.uber.org/atomic v1.9.0
 	go4.org/intern v0.0.0-20211027215823-ae77deb06f29 // indirect
 	go4.org/unsafe/assume-no-moving-gc v0.0.0-20211027215541-db492cf91b37 // indirect
+	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
 	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5 // indirect
 	golang.org/x/term v0.0.0-20220411215600-e5f449aeb171 // indirect
 	golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f // indirect
+	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	gomodules.xyz/orderedmap v0.1.0 // indirect
 	google.golang.org/api v0.75.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
@@ -388,6 +402,7 @@ require (
 	gopkg.in/Knetic/govaluate.v3 v3.0.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
+	k8s.io/apiextensions-apiserver v0.23.5 // indirect
 	k8s.io/component-base v0.23.8 // indirect
 	k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.30 // indirect
@@ -395,28 +410,6 @@ require (
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
-)
-
-require github.com/netsampler/goflow2 v1.1.1-0.20220825033856-d6caeaacddbb
-
-require (
-	github.com/DataDog/aptly v1.5.0 // indirect
-	github.com/agnivade/levenshtein v1.0.1 // indirect
-	github.com/cavaliergopher/grab/v3 v3.0.1 // indirect
-	github.com/dgraph-io/ristretto v0.1.0 // indirect
-	github.com/libp2p/go-reuseport v0.1.0 // indirect
-	github.com/vektah/gqlparser/v2 v2.4.6 // indirect
-	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
-	k8s.io/apiextensions-apiserver v0.23.5 // indirect
-)
-
-require (
-	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.39.0-rc.3
-	github.com/DataDog/datadog-agent/pkg/util/cgroups v0.0.0
-	github.com/DataDog/datadog-agent/pkg/util/log v0.0.0
-	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.0.0
-	github.com/go-delve/delve v1.9.0
-	golang.org/x/arch v0.0.0-20190927153633-4e8777c89be4
 )
 
 // Fixing a CVE on a transitive dep of k8s/etcd, should be cleaned-up once k8s.io/apiserver dep is removed (but double-check with `go mod why` that no other dep pulls it)

--- a/go.mod
+++ b/go.mod
@@ -412,9 +412,9 @@ require (
 
 require (
 	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.39.0-rc.3
-	github.com/DataDog/datadog-agent/pkg/util/cgroups v0.0.0-00010101000000-000000000000
-	github.com/DataDog/datadog-agent/pkg/util/log v0.36.1
-	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.36.1
+	github.com/DataDog/datadog-agent/pkg/util/cgroups v0.0.0
+	github.com/DataDog/datadog-agent/pkg/util/log v0.0.0
+	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.0.0
 	github.com/go-delve/delve v1.9.0
 	golang.org/x/arch v0.0.0-20190927153633-4e8777c89be4
 )

--- a/pkg/util/cgroups/go.mod
+++ b/pkg/util/cgroups/go.mod
@@ -4,6 +4,7 @@ go 1.17
 
 replace (
 	github.com/DataDog/datadog-agent/pkg/util/log => ../log
+	github.com/DataDog/datadog-agent/pkg/util/scrubber => ../scrubber
 )
 
 require (
@@ -15,7 +16,7 @@ require (
 )
 
 require (
-	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.36.1 // indirect
+	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.0.0 // indirect
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 // indirect
 	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/pkg/util/cgroups/go.mod
+++ b/pkg/util/cgroups/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/cgroups
 
-go 1.19
+go 1.17
 
 require (
 	github.com/DataDog/datadog-agent/pkg/util/log v0.36.1

--- a/pkg/util/cgroups/go.mod
+++ b/pkg/util/cgroups/go.mod
@@ -2,8 +2,12 @@ module github.com/DataDog/datadog-agent/pkg/util/cgroups
 
 go 1.17
 
+replace (
+	github.com/DataDog/datadog-agent/pkg/util/log => ../log
+)
+
 require (
-	github.com/DataDog/datadog-agent/pkg/util/log v0.36.1
+	github.com/DataDog/datadog-agent/pkg/util/log v0.0.0
 	github.com/containerd/cgroups v1.0.4
 	github.com/google/go-cmp v0.5.8
 	github.com/karrick/godirwalk v1.17.0

--- a/pkg/util/cgroups/go.sum
+++ b/pkg/util/cgroups/go.sum
@@ -1,7 +1,3 @@
-github.com/DataDog/datadog-agent/pkg/util/log v0.36.1 h1:ZeE3xmPNrGbChozNCnnFOMx4q09WLnwzE0AujxVwm/o=
-github.com/DataDog/datadog-agent/pkg/util/log v0.36.1/go.mod h1:tk7e/vE8FWe4mN7ZjFBE0SRoEFjmsVtyOLOy8aB0B5E=
-github.com/DataDog/datadog-agent/pkg/util/scrubber v0.36.1 h1:WSe5C4MewgVzKLqcF8r9Ai94Fl0w1X1tD70ynUQHiUY=
-github.com/DataDog/datadog-agent/pkg/util/scrubber v0.36.1/go.mod h1:tNM5dDxDAHATiazmsa+hQZpS7uUb1PMHOBA3W5S1ZDM=
 github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 h1:kHaBemcxl8o/pQ5VM1c8PVE1PubbNx3mjUr09OqWGCs=
 github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575/go.mod h1:9d6lWj8KzO/fd/NrVaLscBKmPigpZpn5YawRPw+e3Yo=
 github.com/containerd/cgroups v1.0.4 h1:jN/mbWBEaz+T1pi5OFtnkQ+8qnmEbAr1Oo1FRm5B0dA=
@@ -23,8 +19,6 @@ github.com/karrick/godirwalk v1.17.0 h1:b4kY7nqDdioR/6qnbHQyDvmA17u5G1cZ6J+CZXwS
 github.com/karrick/godirwalk v1.17.0/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
-github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/opencontainers/runtime-spec v1.0.2 h1:UfAcuLBJB9Coz72x1hgl8O5RVzTdNiaglX6v2DM6FI0=
 github.com/opencontainers/runtime-spec v1.0.2/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -63,8 +57,9 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/util/log/go.mod
+++ b/pkg/util/log/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/log
 
-go 1.19
+go 1.17
 
 require (
 	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.36.1

--- a/pkg/util/log/go.mod
+++ b/pkg/util/log/go.mod
@@ -2,8 +2,10 @@ module github.com/DataDog/datadog-agent/pkg/util/log
 
 go 1.17
 
+replace github.com/DataDog/datadog-agent/pkg/util/scrubber => ../scrubber
+
 require (
-	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.36.1
+	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.0.0
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575
 	github.com/stretchr/testify v1.8.0
 	go.uber.org/zap v1.22.0

--- a/pkg/util/log/go.sum
+++ b/pkg/util/log/go.sum
@@ -1,5 +1,3 @@
-github.com/DataDog/datadog-agent/pkg/util/scrubber v0.36.1 h1:WSe5C4MewgVzKLqcF8r9Ai94Fl0w1X1tD70ynUQHiUY=
-github.com/DataDog/datadog-agent/pkg/util/scrubber v0.36.1/go.mod h1:tNM5dDxDAHATiazmsa+hQZpS7uUb1PMHOBA3W5S1ZDM=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 h1:kHaBemcxl8o/pQ5VM1c8PVE1PubbNx3mjUr09OqWGCs=
 github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575/go.mod h1:9d6lWj8KzO/fd/NrVaLscBKmPigpZpn5YawRPw+e3Yo=
@@ -24,6 +22,7 @@ go.uber.org/zap v1.22.0 h1:Zcye5DUgBloQ9BaT4qc9BnjOFog5TvBSAGkJ3Nf70c0=
 go.uber.org/zap v1.22.0/go.mod h1:H4siCOZOrAolnUPJEkfaSjDqyP+BDS0DdDWzwcgt3+U=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/util/scrubber/go.mod
+++ b/pkg/util/scrubber/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/scrubber
 
-go 1.19
+go 1.17
 
 require (
 	github.com/stretchr/testify v1.8.0

--- a/tasks/modules.py
+++ b/tasks/modules.py
@@ -118,8 +118,8 @@ DEFAULT_MODULES = {
     "pkg/otlp/model": GoModule("pkg/otlp/model", independent=True),
     "pkg/security/secl": GoModule("pkg/security/secl", independent=True),
     "pkg/remoteconfig/state": GoModule("pkg/remoteconfig/state", independent=True),
-    "pkg/util/cgroups": GoModule("pkg/util/cgroups", condition=lambda: sys.platform == "linux"),
-    "pkg/util/log": GoModule("pkg/util/log"),
+    "pkg/util/cgroups": GoModule("pkg/util/cgroups", independent=True, condition=lambda: sys.platform == "linux"),
+    "pkg/util/log": GoModule("pkg/util/log", independent=True),
     "pkg/util/scrubber": GoModule("pkg/util/scrubber", independent=True),
 }
 

--- a/tasks/modules.py
+++ b/tasks/modules.py
@@ -117,9 +117,9 @@ DEFAULT_MODULES = {
     "pkg/otlp/model": GoModule("pkg/otlp/model", independent=True),
     "pkg/security/secl": GoModule("pkg/security/secl", independent=True),
     "pkg/remoteconfig/state": GoModule("pkg/remoteconfig/state", independent=True),
-    "pkg/util/cgroups": GoModule("pkg/util/cgroups", independent=True),
-    "pkg/util/log": GoModule("pkg/util/log", independent=True),
-    "pkg/util/scrubber": GoModule("pkg/util/log", independent=True),
+    "pkg/util/cgroups": GoModule("pkg/util/cgroups"),
+    "pkg/util/log": GoModule("pkg/util/log"),
+    "pkg/util/scrubber": GoModule("pkg/util/scrubber", independent=True),
 }
 
 MAIN_TEMPLATE = """package main

--- a/tasks/modules.py
+++ b/tasks/modules.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import sys
 from contextlib import contextmanager
 
 
@@ -117,7 +118,7 @@ DEFAULT_MODULES = {
     "pkg/otlp/model": GoModule("pkg/otlp/model", independent=True),
     "pkg/security/secl": GoModule("pkg/security/secl", independent=True),
     "pkg/remoteconfig/state": GoModule("pkg/remoteconfig/state", independent=True),
-    "pkg/util/cgroups": GoModule("pkg/util/cgroups"),
+    "pkg/util/cgroups": GoModule("pkg/util/cgroups", condition=lambda: sys.platform == "linux"),
     "pkg/util/log": GoModule("pkg/util/log"),
     "pkg/util/scrubber": GoModule("pkg/util/scrubber", independent=True),
 }

--- a/tasks/modules.py
+++ b/tasks/modules.py
@@ -119,7 +119,7 @@ DEFAULT_MODULES = {
     "pkg/remoteconfig/state": GoModule("pkg/remoteconfig/state", independent=True),
     "pkg/util/cgroups": GoModule("pkg/util/cgroups", independent=True),
     "pkg/util/log": GoModule("pkg/util/log", independent=True),
-    "pkg/util/scrubber": GoModule("pkg/util/log", independent=True)
+    "pkg/util/scrubber": GoModule("pkg/util/log", independent=True),
 }
 
 MAIN_TEMPLATE = """package main

--- a/tasks/modules.py
+++ b/tasks/modules.py
@@ -117,7 +117,7 @@ DEFAULT_MODULES = {
     "pkg/otlp/model": GoModule("pkg/otlp/model", independent=True),
     "pkg/security/secl": GoModule("pkg/security/secl", independent=True),
     "pkg/remoteconfig/state": GoModule("pkg/remoteconfig/state", independent=True),
-    "pkg/util/log": GoModule("pkg/util/log", independent=True),
+    "pkg/util/cgroups": GoModule("pkg/util/cgroups", independent=True),
     "pkg/util/log": GoModule("pkg/util/log", independent=True),
     "pkg/util/scrubber": GoModule("pkg/util/log", independent=True)
 }

--- a/tasks/modules.py
+++ b/tasks/modules.py
@@ -117,6 +117,9 @@ DEFAULT_MODULES = {
     "pkg/otlp/model": GoModule("pkg/otlp/model", independent=True),
     "pkg/security/secl": GoModule("pkg/security/secl", independent=True),
     "pkg/remoteconfig/state": GoModule("pkg/remoteconfig/state", independent=True),
+    "pkg/util/log": GoModule("pkg/util/log", independent=True),
+    "pkg/util/log": GoModule("pkg/util/log", independent=True),
+    "pkg/util/scrubber": GoModule("pkg/util/log", independent=True)
 }
 
 MAIN_TEMPLATE = """package main


### PR DESCRIPTION
### What does this PR do?

This PR fixes the definition of the new modules following the documentation https://github.com/DataDog/datadog-agent/blob/main/docs/dev/modules.md. This will allow them to be included in functions like `inv -e tidy-all`, tests etc.

This PR also cleans up the `go.mod` file

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
