### PR TITLE
[RCM-374] Add RC db to the flare

### DIFF
--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -369,6 +369,13 @@ func createArchive(confSearchPaths SearchPaths, local bool, zipFilePath string, 
 		log.Errorf("Could not export Windows Datadog Registry: %s", err)
 	}
 
+	if config.Datadog.GetBool("remote_configuration.enabled") {
+		err = zipRemoteConfigDB(tempDir, hostname)
+		if err != nil {
+			log.Errorf("Could not export remote-config database: %s", err)
+		}
+	}
+
 	// force a log flush before zipping them
 	log.Flush()
 	for _, logFilePath := range logFilePaths {

--- a/pkg/flare/remote_config.go
+++ b/pkg/flare/remote_config.go
@@ -1,0 +1,19 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package flare
+
+import (
+	"path/filepath"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util"
+)
+
+func zipRemoteConfigDB(tempDir, hostname string) error {
+	srcPath := filepath.Join(config.Datadog.GetString("run_path"), "remote-config.db")
+	dstPath := filepath.Join(tempDir, hostname, "remote-config.db")
+	return util.CopyFileAll(srcPath, dstPath)
+}

--- a/pkg/flare/remote_config.go
+++ b/pkg/flare/remote_config.go
@@ -7,7 +7,6 @@ package flare
 
 import (
 	"crypto/sha256"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -41,33 +40,17 @@ func zipRemoteConfigDB(tempDir, hostname string) error {
 	defer dstDB.Close()
 
 	err = dstDB.Update(func(tx *bbolt.Tx) error {
-		var targetFilesBuckets [][]byte
-		err := tx.ForEach(func(name []byte, b *bbolt.Bucket) error {
+		return tx.ForEach(func(name []byte, b *bbolt.Bucket) error {
 			if strings.HasSuffix(string(name), "_targets") {
-				newBucket, err := tx.CreateBucket([]byte(fmt.Sprintf("%s_hashed", string(name))))
-				if err != nil {
-					return err
-				}
 				cursor := b.Cursor()
 				for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
-					if err := newBucket.Put(k, hashedRCTargets(v)); err != nil {
+					if err := b.Put(k, hashedRCTargets(v)); err != nil {
 						return err
 					}
 				}
-				targetFilesBuckets = append(targetFilesBuckets, name)
 			}
 			return nil
 		})
-		if err != nil {
-			return err
-		}
-		// Delete the buckets with target files content
-		for _, name := range targetFilesBuckets {
-			if err := tx.DeleteBucket(name); err != nil {
-				return err
-			}
-		}
-		return nil
 	})
 	if err != nil {
 		// Prevent from having a clear db here

--- a/pkg/flare/remote_config.go
+++ b/pkg/flare/remote_config.go
@@ -17,7 +17,7 @@ import (
 	"go.etcd.io/bbolt"
 )
 
-func stripRCTargets(raw []byte) []byte {
+func hashRCTargets(raw []byte) []byte {
 	hash := sha256.Sum256(raw)
 	// Convert it to readable hex
 	s := hex.EncodeToString(hash[:])
@@ -60,7 +60,7 @@ func zipRemoteConfigDB(tempDir, hostname string) error {
 				}
 				return tempBucket.ForEach(func(k, v []byte) error {
 					if strings.HasSuffix(string(bucketName), "_targets") {
-						return dstBucket.Put(k, stripRCTargets(v))
+						return dstBucket.Put(k, hashRCTargets(v))
 					}
 					return dstBucket.Put(k, v)
 				})

--- a/pkg/flare/remote_config.go
+++ b/pkg/flare/remote_config.go
@@ -6,14 +6,65 @@
 package flare
 
 import (
+	"crypto/sha256"
+	"fmt"
+	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"go.etcd.io/bbolt"
 )
 
+func hashedRCTargets(raw []byte) []byte {
+	hash := sha256.Sum256(raw)
+	return hash[:]
+}
+
 func zipRemoteConfigDB(tempDir, hostname string) error {
-	srcPath := filepath.Join(config.Datadog.GetString("run_path"), "remote-config.db")
 	dstPath := filepath.Join(tempDir, hostname, "remote-config.db")
-	return util.CopyFileAll(srcPath, dstPath)
+	srcPath := filepath.Join(config.Datadog.GetString("run_path"), "remote-config.db")
+
+	err := util.CopyFileAll(srcPath, dstPath)
+	if err != nil {
+		// Prevent from having a clear db here
+		os.Remove(dstPath)
+		return err
+	}
+
+	dstDB, err := bbolt.Open(dstPath, 0600, &bbolt.Options{})
+	if err != nil {
+		os.Remove(dstPath)
+		return err
+	}
+	defer dstDB.Close()
+
+	err = dstDB.Update(func(tx *bbolt.Tx) error {
+		return tx.ForEach(func(name []byte, b *bbolt.Bucket) error {
+			if strings.HasSuffix(string(name), "_targets") {
+				log.Errorf("replacing targets")
+				newBucket, err := tx.CreateBucket([]byte(fmt.Sprintf("%s_hashed", string(name))))
+				if err != nil {
+					return err
+				}
+				cursor := b.Cursor()
+				for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
+					if err := newBucket.Put(k, hashedRCTargets(v)); err != nil {
+						return err
+					}
+				}
+				b.DeleteBucket(name)
+			}
+			return nil
+		})
+	})
+	if err != nil {
+		// Prevent from having a clear db here
+		os.Remove(dstPath)
+		return err
+	}
+
+	return nil
 }

--- a/pkg/flare/remote_config.go
+++ b/pkg/flare/remote_config.go
@@ -61,9 +61,8 @@ func zipRemoteConfigDB(tempDir, hostname string) error {
 				return tempBucket.ForEach(func(k, v []byte) error {
 					if strings.HasSuffix(string(bucketName), "_targets") {
 						return dstBucket.Put(k, stripRCTargets(v))
-					} else {
-						return dstBucket.Put(k, v)
 					}
+					return dstBucket.Put(k, v)
 				})
 			})
 		})

--- a/pkg/flare/remote_config.go
+++ b/pkg/flare/remote_config.go
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-present Datadog, Inc.
+// Copyright 2022-present Datadog, Inc.
 
 package flare
 
@@ -19,7 +19,7 @@ import (
 
 func stripRCTargets(raw []byte) []byte {
 	hash := sha256.Sum256(raw)
-	// Convert it to readable hexa
+	// Convert it to readable hex
 	s := hex.EncodeToString(hash[:])
 
 	return []byte(s)

--- a/pkg/flare/remote_config.go
+++ b/pkg/flare/remote_config.go
@@ -7,6 +7,7 @@ package flare
 
 import (
 	"crypto/sha256"
+	"encoding/hex"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,9 +17,12 @@ import (
 	"go.etcd.io/bbolt"
 )
 
-func hashedRCTargets(raw []byte) []byte {
+func stripRCTargets(raw []byte) []byte {
 	hash := sha256.Sum256(raw)
-	return hash[:]
+	// Convert it to readable hexa
+	s := hex.EncodeToString(hash[:])
+
+	return []byte(s)
 }
 
 func zipRemoteConfigDB(tempDir, hostname string) error {
@@ -44,7 +48,7 @@ func zipRemoteConfigDB(tempDir, hostname string) error {
 			if strings.HasSuffix(string(name), "_targets") {
 				cursor := b.Cursor()
 				for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
-					if err := b.Put(k, hashedRCTargets(v)); err != nil {
+					if err := b.Put(k, stripRCTargets(v)); err != nil {
 						return err
 					}
 				}

--- a/pkg/flare/remote_config.go
+++ b/pkg/flare/remote_config.go
@@ -55,7 +55,9 @@ func zipRemoteConfigDB(tempDir, hostname string) error {
 						return err
 					}
 				}
-				b.DeleteBucket(name)
+				if err := b.DeleteBucket(name); err != nil {
+					return err
+				}
 			}
 			return nil
 		})


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Add remote-config.db to the flare, but without the target files.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
* Start an agent with RC enabled
* Start a tracer requesting any RC product
* Run `agent flare`
* Make sure there is a `remote-config.db` file in the zip flare
* Make sure this file does not contain target files

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
