### PR TITLE
pkg/trace/api: add warning log for out-of-cpu

### DIFF
--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -43,6 +43,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/watchdog"
 )
 
+// outOfCPULogThreshold is used to throttle the out-of-cpu warnning logs
+// i.e we log the warning on every outOfCPULogThreshold occurrences.
+// The value 10 is based on load test experiments and can be revisited in the future.
 const outOfCPULogThreshold uint32 = 10
 
 var bufferPool = sync.Pool{

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -43,7 +43,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/watchdog"
 )
 
-const outOfCPULogThreshold uint32 = 5
+const outOfCPULogThreshold uint32 = 10
 
 var bufferPool = sync.Pool{
 	New: func() interface{} {

--- a/releasenotes/notes/apm-cpu-warn-4930a3d52fe06014.yaml
+++ b/releasenotes/notes/apm-cpu-warn-4930a3d52fe06014.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    The APM Agent now logs a warning when it's falling behind.

--- a/releasenotes/notes/apm-cpu-warn-4930a3d52fe06014.yaml
+++ b/releasenotes/notes/apm-cpu-warn-4930a3d52fe06014.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   - |
-    The APM Agent now logs a warning when it's falling behind.
+    APM: A warning is now logged when the agent is under heavy load.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Log a warning the APM Agent is falling behind, and point users to resource usage troubleshooting guide.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Make it easier for customers and support to detect out-of-cpu situations
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

Related to https://github.com/DataDog/documentation/pull/15126
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

- This has been tested using a custom image with [smaller channel capacity](https://github.com/DataDog/datadog-agent/blob/7.39.0-rc.6/pkg/trace/agent/agent.go#L77) (2 instead of 1000) + load tester (11k spans/s)
```
| TRACE | WARN | (run.go:261 in Warnf) | The Agent is falling behind on processing traces, 1 extra threads have been created since the Agent started. See https://docs.datadoghq.com/tracing/troubleshooting/agent_apm_resource_usage
| TRACE | WARN | (run.go:261 in Warnf) | The Agent is falling behind on processing traces, 6 extra threads have been created since the Agent started. See https://docs.datadoghq.com/tracing/troubleshooting/agent_apm_resource_usage
| TRACE | WARN | (run.go:261 in Warnf) | The Agent is falling behind on processing traces, 11 extra threads have been created since the Agent started. See https://docs.datadoghq.com/tracing/troubleshooting/agent_apm_resource_usage
| TRACE | WARN | (run.go:261 in Warnf) | The Agent is falling behind on processing traces, 16 extra threads have been created since the Agent started. See https://docs.datadoghq.com/tracing/troubleshooting/agent_apm_resource_usage
```
- Unfortunately the unit tests don't cover that code path

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
