### PR TITLE
[Serverless] Remove extra alloc when adding enhanced metrics.

### DIFF
--- a/pkg/serverless/metrics/enhanced_metrics.go
+++ b/pkg/serverless/metrics/enhanced_metrics.go
@@ -102,63 +102,63 @@ func GenerateEnhancedMetricsFromReportLog(args GenerateEnhancedMetricsFromReport
 	billedDuration := float64(args.BilledDurationMs)
 	memorySize := float64(args.MemorySizeMb)
 	postRuntimeDuration := args.DurationMs - float64(args.RuntimeEnd.Sub(args.RuntimeStart).Milliseconds())
-	enhancedMetrics := []metrics.MetricSample{{
+	args.Demux.AddTimeSample(metrics.MetricSample{
 		Name:       maxMemoryUsedMetric,
 		Value:      float64(args.MaxMemoryUsedMb),
 		Mtype:      metrics.DistributionType,
 		Tags:       args.Tags,
 		SampleRate: 1,
 		Timestamp:  timestamp,
-	}, {
+	})
+	args.Demux.AddTimeSample(metrics.MetricSample{
 		Name:       memorySizeMetric,
 		Value:      memorySize,
 		Mtype:      metrics.DistributionType,
 		Tags:       args.Tags,
 		SampleRate: 1,
 		Timestamp:  timestamp,
-	}, {
+	})
+	args.Demux.AddTimeSample(metrics.MetricSample{
 		Name:       billedDurationMetric,
 		Value:      billedDuration * msToSec,
 		Mtype:      metrics.DistributionType,
 		Tags:       args.Tags,
 		SampleRate: 1,
 		Timestamp:  timestamp,
-	}, {
+	})
+	args.Demux.AddTimeSample(metrics.MetricSample{
 		Name:       durationMetric,
 		Value:      args.DurationMs * msToSec,
 		Mtype:      metrics.DistributionType,
 		Tags:       args.Tags,
 		SampleRate: 1,
 		Timestamp:  timestamp,
-	}, {
+	})
+	args.Demux.AddTimeSample(metrics.MetricSample{
 		Name:       estimatedCostMetric,
 		Value:      calculateEstimatedCost(billedDuration, memorySize, serverlessTags.ResolveRuntimeArch()),
 		Mtype:      metrics.DistributionType,
 		Tags:       args.Tags,
 		SampleRate: 1,
 		Timestamp:  timestamp,
-	}, {
+	})
+	args.Demux.AddTimeSample(metrics.MetricSample{
 		Name:       postRuntimeDurationMetric,
 		Value:      postRuntimeDuration,
 		Mtype:      metrics.DistributionType,
 		Tags:       args.Tags,
 		SampleRate: 1,
 		Timestamp:  timestamp,
-	}}
+	})
 	if args.InitDurationMs > 0 {
-		initDurationMetric := metrics.MetricSample{
+		args.Demux.AddTimeSample(metrics.MetricSample{
 			Name:       initDurationMetric,
 			Value:      args.InitDurationMs * msToSec,
 			Mtype:      metrics.DistributionType,
 			Tags:       args.Tags,
 			SampleRate: 1,
 			Timestamp:  timestamp,
-		}
-		enhancedMetrics = append(enhancedMetrics, initDurationMetric)
-	}
-
-	for _, metric := range enhancedMetrics {
-		args.Demux.AddTimeSample(metric)
+		})
 	}
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

This pull request removes an unnecessary creation of a slice.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Allocating memory when creating a slice is very slow in Go. Removing extra allocs will speed up the code.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Make sure tests pass.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
