### PR TITLE
Fix TestOpenLeafDiscarderFilter

### DIFF
--- a/pkg/security/tests/filters_test.go
+++ b/pkg/security/tests/filters_test.go
@@ -26,7 +26,6 @@ import (
 )
 
 func openTestFile(test *testModule, testFile string, flags int) (int, error) {
-	fmt.Println("celia", testFile)
 	testFilePtr, err := syscall.BytePtrFromString(testFile)
 	if err != nil {
 		return 0, err
@@ -43,7 +42,6 @@ func openTestFile(test *testModule, testFile string, flags int) (int, error) {
 		return 0, error(errno)
 	}
 
-	fmt.Println("yuen", testFile)
 	return int(fd), nil
 }
 
@@ -103,15 +101,13 @@ func TestOpenBasenameApproverFilter(t *testing.T) {
 }
 
 func TestOpenLeafDiscarderFilter(t *testing.T) {
-	// We need to write a rule with no approver on the file path, and that won't match the real opened file (so that
-	// a discarder is created).
+	// Catch open events on files that have basename of no-approver-* at root AND have flags of O_CREAT or O_SYNC.
+	// There are no approvers for this rule because of the wildcard in the basename.
+	// Opening `test-obc-2` should create a discarder because it definitely does not match the rule.
 	rule := &rules.RuleDefinition{
 		ID:         "test_rule",
 		Expression: `open.filename =~ "{{.Root}}/no-approver-*" && open.flags & (O_CREAT | O_SYNC) > 0`,
 	}
-	// Catch open events on files that have basename of no-approver-* at {root}/ AND have flags of O_CREAT or O_SYNC
-	// No approvers for this rule because of the wildcard in the basename
-	// Opening `test-obc-2` should create a discarder because it definitely does not match the rule
 
 	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{})
 	if err != nil {
@@ -153,7 +149,9 @@ func TestOpenLeafDiscarderFilter(t *testing.T) {
 		t.Fatalf("event inode: %d, parent inode: %d, error: %v", inode, parentInode, err)
 	}
 
-	// expects an error because there should be NO event
+	// The func pushing the discarder needs to complete before testing the discarder
+	time.Sleep(time.Second * 2)
+
 	if err := waitForOpenProbeEvent(test, func() error {
 		fd, err = openTestFile(test, testFile, syscall.O_CREAT|syscall.O_SYNC)
 		if err != nil {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Add sleep to TestOpenLeafDiscarderFilter to ensure discarder is pushed before the discarder is tested.

This test has been flaky, and last was failing on 

SUSE Linux Enterprise Server 15 SP2 (host)
Amazon Linux 2 (2.4.14) (host)
Ubuntu 20.04.2 LTS (Focal Fossa) (host)
Ubuntu 20.04.2 LTS (Focal Fossa) (container)
Ubuntu 22.04 LTS (Jammy Jellyfish) (host)

and locally. But with the sleep, all the above passes, along with spot-checked distributions that were previously passing.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
