### PR TITLE
When IMDSv1 fails, try IMDSv2.

### DIFF
--- a/releasenotes/notes/fallback_imdsv2_to_v1-0f5e17ca28a1f721.yaml
+++ b/releasenotes/notes/fallback_imdsv2_to_v1-0f5e17ca28a1f721.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    When ``ec2_prefer_imdsv2`` is ``false``, the Agent tries IMDSv2 when IMDSv1
+    access fails.


### PR DESCRIPTION
### What does this PR do?

When `ec2_prefer_imdsv2` is true, the agent tries IMDSv2 and, failing that, tries IMDSv1.

This adds the corresponding fallback from v1 to v2 when `ec2_prefer_imdsv2` is false.

### Motivation

Find instance metadata one way or another.

### Possible Drawbacks / Trade-offs

* In cases where the Agent cannot reach _any_ IMDS endpoint, this will increase the timeout before it gives up and falls back to the os hostname
* In cases where the Agent is configured with `ec2_prefer_imdsv2: false`, with IMDSv2 disabled in the EC2 API, this will change the behavior from falling back to the os hostname to using the AWS instance ID.

### Describe how to test/QA your changes

#### With v1 Disabled

Create a new EC2 instance with only IMDSv2 enabled (in the "advanced" section at the bottom of the launch wizard) and run an agent on the host (not in a container).

* `ec2_prefer_imdsv2: false` - should get an aws hostname (`i-xxx`), should log "ec2_prefer_imdsv2 is set to false in the configuration but..."
* `ec2_prefer_imdsv2: true` - should get an aws hostname (`i-xxx`), should _not_ log "ec2_prefer_imdsv2 is set to true in the configuration but..."

#### With v1 Enabled, V2 not accessible

Create a new EC2 instance with both IMDSv1 and IMDSv2 enabled.  Set the hop limit to 1.  Run an agent in a docker container on the host, _without_ the `--net=host` option to `docker run`.  In the container, verify that IMDSv2 isn't available in the container (`docker exec -ti dd-agent bash`) with `curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"`, which should hang.

* `ec2_prefer_imdsv2: false` - should get an aws hostname (`i-xxx`), should _log_ "ec2_prefer_imdsv2 is set to false in the configuration but..."
* `ec2_prefer_imdsv2: true` - should get an aws hostname (`i-xxx`), should not log "ec2_prefer_imdsv2 is set to true in the configuration but..."

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
