### PR TITLE
[CWS] release cgroup spot when release is done from userspace

### DIFF
--- a/pkg/security/probe/activity_dump.go
+++ b/pkg/security/probe/activity_dump.go
@@ -329,9 +329,11 @@ func (ad *ActivityDump) Stop() {
 	if len(ad.DumpMetadata.ContainerID) > 0 {
 		containerIDB := make([]byte, model.ContainerIDLen)
 		copy(containerIDB, ad.DumpMetadata.ContainerID)
-		err := ad.adm.tracedCgroupsMap.Delete(containerIDB)
-		if err != nil {
+		if err := ad.adm.tracedCgroupsMap.Delete(containerIDB); err != nil {
 			seclog.Debugf("couldn't delete activity dump filter containerID(%s): %v", ad.DumpMetadata.ContainerID, err)
+		}
+		if err := ad.adm.loadController.releaseTracedCgroupSpot(); err != nil {
+			seclog.Debugf("couldn't release one traced cgroup spot for containerID(%s): %v", ad.DumpMetadata.ContainerID, err)
 		}
 	}
 

--- a/pkg/security/probe/activity_dump_load_controller.go
+++ b/pkg/security/probe/activity_dump_load_controller.go
@@ -219,9 +219,9 @@ func (lc *ActivityDumpLoadController) releaseTracedCgroupSpot() error {
 	})
 }
 
-type CgroupsCounterEditor = func(*tracedCgroupsCounter) error
+type cgroupsCounterEditor = func(*tracedCgroupsCounter) error
 
-func (lc *ActivityDumpLoadController) editCgroupsCounter(editor CgroupsCounterEditor) error {
+func (lc *ActivityDumpLoadController) editCgroupsCounter(editor cgroupsCounterEditor) error {
 	if err := lc.tracedCgroupsLockMap.Update(ebpfutils.ZeroUint32MapItem, uint32(1), ebpf.UpdateNoExist); err != nil {
 		return fmt.Errorf("failed to lock traced cgroup counter: %w", err)
 	}

--- a/pkg/security/probe/activity_dump_load_controller.go
+++ b/pkg/security/probe/activity_dump_load_controller.go
@@ -203,6 +203,25 @@ func (lc *ActivityDumpLoadController) propagateLoadSettingsRaw() error {
 	}
 
 	// traced cgroups count
+	return lc.editCgroupsCounter(func(counter *tracedCgroupsCounter) error {
+		log.Debugf("AD: got counter = %v, when propagating config", counter)
+		counter.Max = lcConfig.tracedCgroupsCount
+		return nil
+	})
+}
+
+func (lc *ActivityDumpLoadController) releaseTracedCgroupSpot() error {
+	return lc.editCgroupsCounter(func(counter *tracedCgroupsCounter) error {
+		if counter.Counter > 0 {
+			counter.Counter--
+		}
+		return nil
+	})
+}
+
+type CgroupsCounterEditor = func(*tracedCgroupsCounter) error
+
+func (lc *ActivityDumpLoadController) editCgroupsCounter(editor CgroupsCounterEditor) error {
 	if err := lc.tracedCgroupsLockMap.Update(ebpfutils.ZeroUint32MapItem, uint32(1), ebpf.UpdateNoExist); err != nil {
 		return fmt.Errorf("failed to lock traced cgroup counter: %w", err)
 	}
@@ -217,13 +236,14 @@ func (lc *ActivityDumpLoadController) propagateLoadSettingsRaw() error {
 	if err := lc.tracedCgroupsCounterMap.Lookup(ebpfutils.ZeroUint32MapItem, &counter); err != nil {
 		return fmt.Errorf("failed to get traced cgroup counter: %w", err)
 	}
-	log.Debugf("AD: got counter = %v, when propagating config", counter)
 
-	counter.Max = lcConfig.tracedCgroupsCount
+	if err := editor(&counter); err != nil {
+		return err
+	}
+
 	if err := lc.tracedCgroupsCounterMap.Put(ebpfutils.ZeroUint32MapItem, counter); err != nil {
 		return fmt.Errorf("failed to change counter max: %w", err)
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
### What does this PR do?

To release (or to reserve a spot) for a traced cgroup, you must first acquire the lock on the counter, update the counter value (with respect to the counter max), edit the currently traced cgroups map/timeout, and then release the lock.
This was done correctly when done in kernelspace, but not when done from userspace where only the "edit the currently traced cgroups map/timeout" step was done. This meant that the spot was never released with regards to the counter, thus limiting the ability to traced new cgroups.

This PR fixes this issue.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
