### PR TITLE
Add backoff to agent client

### DIFF
--- a/pkg/config/remote/client.go
+++ b/pkg/config/remote/client.go
@@ -21,8 +21,16 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config/remote/meta"
 	"github.com/DataDog/datadog-agent/pkg/proto/pbgo"
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
+	"github.com/DataDog/datadog-agent/pkg/util/backoff"
 	"github.com/DataDog/datadog-agent/pkg/util/grpc"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// Constraints on the maximum backoff time when errors occur
+const (
+	maximalMaxBackoffTime = 2 * time.Minute
+	minBackoffFactor      = 2.0
+	recoveryInterval      = 2
 )
 
 // Client is a remote-configuration client to obtain configurations from the local API
@@ -39,8 +47,10 @@ type Client struct {
 	agentVersion string
 	products     []string
 
-	pollInterval    time.Duration
-	lastUpdateError error
+	pollInterval      time.Duration
+	lastUpdateError   error
+	backoffPolicy     backoff.Policy
+	backoffErrorCount int
 
 	state *state.Repository
 
@@ -65,19 +75,30 @@ func NewClient(agentName string, agentVersion string, products []data.Product, p
 		return nil, err
 	}
 
+	// A backoff is calculated as a range from which a random value will be selected. The formula is as follows.
+	//
+	// min = pollInterval * 2^<NumErrors> / minBackoffFactor
+	// max = min(maxBackoffTime, pollInterval * 2 ^<NumErrors>)
+	//
+	// The following values mean each range will always be [pollInterval*2^<NumErrors-1>, min(maxBackoffTime, pollInterval*2^<NumErrors>)].
+	// Every success will cause numErrors to shrink by 2.
+	backoffPolicy := backoff.NewPolicy(minBackoffFactor, pollInterval.Seconds(),
+		maximalMaxBackoffTime.Seconds(), recoveryInterval, false)
+
 	return &Client{
-		ID:           generateID(),
-		startupSync:  sync.Once{},
-		ctx:          ctx,
-		close:        close,
-		agentName:    agentName,
-		agentVersion: agentVersion,
-		products:     data.ProductListToString(products),
-		grpc:         grpcClient,
-		state:        repository,
-		pollInterval: pollInterval,
-		apmListeners: make([]func(update map[string]state.APMSamplingConfig), 0),
-		cwsListeners: make([]func(update map[string]state.ConfigCWSDD), 0),
+		ID:            generateID(),
+		startupSync:   sync.Once{},
+		ctx:           ctx,
+		close:         close,
+		agentName:     agentName,
+		agentVersion:  agentVersion,
+		products:      data.ProductListToString(products),
+		grpc:          grpcClient,
+		state:         repository,
+		pollInterval:  pollInterval,
+		backoffPolicy: backoffPolicy,
+		apmListeners:  make([]func(update map[string]state.APMSamplingConfig), 0),
+		cwsListeners:  make([]func(update map[string]state.ConfigCWSDD), 0),
 	}, nil
 }
 
@@ -106,13 +127,17 @@ func (c *Client) startFn() {
 // structure in startFn.
 func (c *Client) pollLoop() {
 	for {
+		interval := c.backoffPolicy.GetBackoffDuration(c.backoffErrorCount)
 		select {
 		case <-c.ctx.Done():
 			return
-		case <-time.After(c.pollInterval):
+		case <-time.After(c.pollInterval + interval):
 			c.lastUpdateError = c.update()
 			if c.lastUpdateError != nil {
+				c.backoffPolicy.IncError(c.backoffErrorCount)
 				log.Errorf("could not update remote-config state: %v", c.lastUpdateError)
+			} else {
+				c.backoffPolicy.DecError(c.backoffErrorCount)
 			}
 		}
 	}

--- a/pkg/config/remote/client.go
+++ b/pkg/config/remote/client.go
@@ -28,7 +28,7 @@ import (
 
 // Constraints on the maximum backoff time when errors occur
 const (
-	maximalMaxBackoffTime = 2 * time.Minute
+	maximalMaxBackoffTime = 90 * time.Second
 	minBackoffFactor      = 2.0
 	recoveryInterval      = 2
 )


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Add exponential backoff to the agent RC client when polling for a new config

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Max polling interval with the exponential backoff will be 2 minutes, open to suggestions

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
