### PR TITLE
[CWS] Fix traced cgroups lock in kernel space

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "74831b735547a54166290066e74781cfa57137e44d96f4987eb8c47790755f74")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "e3d5c82b18da92a9ef5dbdf0c773d1cfcb8abdbedad2fa519664b41f81a7d0c6")

--- a/pkg/security/ebpf/c/activity_dump.h
+++ b/pkg/security/ebpf/c/activity_dump.h
@@ -141,13 +141,14 @@ __attribute__((always_inline)) void unlock_cgroups_counter() {
     bpf_map_delete_elem(&traced_cgroups_lock, &key);
 }
 
-__attribute__((always_inline)) bool reserve_traced_cgroup_spot(char cgroup[CONTAINER_ID_LEN]) {
-    void *already_in = bpf_map_lookup_elem(&traced_cgroups, &cgroup[0]);
-    if (already_in) {
+__attribute__((always_inline)) bool reserve_traced_cgroup_spot(char cgroup[CONTAINER_ID_LEN], u64 timeout) {
+    if (!lock_cgroups_counter()) {
         return false;
     }
 
-    if (!lock_cgroups_counter()) {
+    void *already_in = bpf_map_lookup_elem(&traced_cgroups, &cgroup[0]);
+    if (already_in) {
+        unlock_cgroups_counter();
         return false;
     }
 
@@ -162,6 +163,13 @@ __attribute__((always_inline)) bool reserve_traced_cgroup_spot(char cgroup[CONTA
     if (counter->counter < counter->max) {
         counter->counter++;
         res = true;
+    }
+
+    int ret = bpf_map_update_elem(&traced_cgroups, &cgroup[0], &timeout, BPF_NOEXIST);
+    if (ret < 0) {
+        // this should be caught earlier but we're already tracing too many cgroups concurrently, ignore this one for now
+        unlock_cgroups_counter();
+        return false;
     }
 
     unlock_cgroups_counter();
@@ -187,19 +195,12 @@ __attribute__((always_inline)) void freeup_traced_cgroup_spot(char cgroup[CONTAI
 __attribute__((always_inline)) u64 trace_new_cgroup(void *ctx, char cgroup[CONTAINER_ID_LEN]) {
     u64 timeout = bpf_ktime_get_ns() + get_dump_timeout();
 
-    if (!reserve_traced_cgroup_spot(cgroup)) {
+    if (!reserve_traced_cgroup_spot(cgroup, timeout)) {
         // we're already tracing too many cgroups concurrently, ignore this one for now
         return 0;
     }
 
-
-    // try to lock an entry in traced_cgroups
-    int ret = bpf_map_update_elem(&traced_cgroups, &cgroup[0], &timeout, BPF_NOEXIST);
-    if (ret < 0) {
-        // this should be caught earlier but we're already tracing too many cgroups concurrently, ignore this one for now
-        return 0;
-    }
-    // lock acquired ! send cgroup tracing event
+    // send cgroup tracing event
     struct cgroup_tracing_event_t *evt = get_cgroup_tracing_event();
     if (evt == NULL) {
         // should never happen, ignore


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

This PR fixes 2 races in kernel space that might fill the `traced_cgroups` map over time. This race happened because of the way LRU maps are implemented in kernel space. Kernel space LRU maps aren't "perfect" LRUs: some entries might get popped from the list even though they shouldn't have (depending on the pressure on the map and the sizes of the entries). In this PR, we move away from LRU maps for this specific feature as we can implement it without them.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Fixing these races is critical for the newly introduced Activity Dump feature of CWS: they slowly but surely prevent the creation of new dumps over time.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
