### PR TITLE
[CWS] use `strings.Cut` when appropriate

### DIFF
--- a/pkg/security/probe/mount_resolver.go
+++ b/pkg/security/probe/mount_resolver.go
@@ -42,9 +42,8 @@ func parseGroupID(mnt *mountinfo.Info) (uint32, error) {
 	// Example: shared:2 master:7
 	if len(mnt.Optional) > 0 {
 		for _, field := range strings.Split(mnt.Optional, " ") {
-			optionSplit := strings.SplitN(field, ":", 2)
-			if len(optionSplit) == 2 {
-				target, value := optionSplit[0], optionSplit[1]
+			target, value, found := strings.Cut(field, ":")
+			if found {
 				if target == "shared" || target == "master" {
 					groupID, err := strconv.ParseUint(value, 10, 32)
 					return uint32(groupID), err

--- a/pkg/security/rconfig/rconfig.go
+++ b/pkg/security/rconfig/rconfig.go
@@ -70,9 +70,9 @@ func (r *RCPolicyProvider) rcConfigUpdateCallback(configs map[string]state.Confi
 
 func normalize(policy *rules.Policy) {
 	// remove the version
-	els := strings.SplitN(policy.Name, ".", 2)
-	if len(els) > 1 {
-		policy.Name = els[1]
+	_, normalized, found := strings.Cut(policy.Name, ".")
+	if found {
+		policy.Name = normalized
 	}
 }
 

--- a/pkg/security/secl/compiler/generators/accessors/accessors.go
+++ b/pkg/security/secl/compiler/generators/accessors/accessors.go
@@ -182,9 +182,7 @@ type seclField struct {
 
 func parseFieldDef(def string) (seclField, error) {
 	def = strings.TrimSpace(def)
-	splitted := strings.SplitN(def, ",", 2)
-
-	alias := splitted[0]
+	alias, options, splitted := strings.Cut(def, ",")
 	field := seclField{name: alias}
 
 	if alias == "-" {
@@ -192,8 +190,8 @@ func parseFieldDef(def string) (seclField, error) {
 	}
 
 	// arguments
-	if len(splitted) > 1 {
-		for _, el := range strings.Split(splitted[1], ",") {
+	if splitted {
+		for _, el := range strings.Split(options, ",") {
 			kv := strings.Split(el, ":")
 
 			key, value := kv[0], kv[1]

--- a/pkg/security/secl/compiler/generators/accessors/doc/doc.go
+++ b/pkg/security/secl/compiler/generators/accessors/doc/doc.go
@@ -231,12 +231,12 @@ func parseConstantsFile(filepath string, tags []string) ([]constants, error) {
 						continue
 					}
 
-					meta := strings.SplitN(strings.TrimPrefix(comment.Text, generateConstantsAnnotationPrefix), ",", 2)
-					if len(meta) != 2 {
+					name, description, found := strings.Cut(strings.TrimPrefix(comment.Text, generateConstantsAnnotationPrefix), ",")
+					if !found {
 						continue
 					}
-					consts.Name = meta[0]
-					consts.Description = meta[1]
+					consts.Name = name
+					consts.Description = description
 					break
 				}
 				if len(consts.Name) == 0 || len(consts.Description) == 0 {

--- a/pkg/security/secl/model/process_cache_entry.go
+++ b/pkg/security/secl/model/process_cache_entry.go
@@ -337,15 +337,15 @@ func (p *EnvsEntry) FilterEnvs(envsWithValue map[string]bool) ([]string, bool) {
 
 	var i int
 	for _, value := range values {
-		kv := strings.SplitN(value, "=", 2)
-		if len(kv) != 2 {
+		k, _, found := strings.Cut(value, "=")
+		if !found {
 			continue
 		}
 
-		if envsWithValue[kv[0]] {
+		if envsWithValue[k] {
 			p.filteredEnvs[i] = value
 		} else {
-			p.filteredEnvs[i] = kv[0]
+			p.filteredEnvs[i] = k
 		}
 		i++
 	}
@@ -362,11 +362,9 @@ func (p *EnvsEntry) toMap() {
 	p.kv = make(map[string]string, len(values))
 
 	for _, value := range values {
-		kv := strings.SplitN(value, "=", 2)
-		k := kv[0]
-
-		if len(kv) == 2 {
-			p.kv[k] = kv[1]
+		k, v, found := strings.Cut(value, "=")
+		if found {
+			p.kv[k] = v
 		}
 	}
 }

--- a/pkg/security/utils/proc.go
+++ b/pkg/security/utils/proc.go
@@ -101,22 +101,21 @@ func CapEffCapEprm(pid int32) (uint64, uint64, error) {
 	}
 	lines := strings.Split(string(contents), "\n")
 	for _, line := range lines {
-		tabParts := strings.SplitN(line, "\t", 2)
-		if len(tabParts) < 2 {
+		capKind, value, found := strings.Cut(line, "\t")
+		if !found {
 			continue
 		}
-		value := tabParts[1]
-		switch strings.TrimRight(tabParts[0], ":") {
+
+		parsedValue, err := strconv.ParseUint(value, 16, 64)
+		if err != nil {
+			return 0, 0, err
+		}
+
+		switch strings.TrimRight(capKind, ":") {
 		case "CapEff":
-			capEff, err = strconv.ParseUint(value, 16, 64)
-			if err != nil {
-				return 0, 0, err
-			}
+			capEff = parsedValue
 		case "CapPrm":
-			capPrm, err = strconv.ParseUint(value, 16, 64)
-			if err != nil {
-				return 0, 0, err
-			}
+			capPrm = parsedValue
 		}
 	}
 	return capEff, capPrm, nil

--- a/pkg/security/utils/tags.go
+++ b/pkg/security/utils/tags.go
@@ -12,12 +12,13 @@ import (
 // GetTagValue returns the value of the given tag in the given list
 func GetTagValue(tagName string, tags []string) string {
 	for _, tag := range tags {
-		kv := strings.SplitN(tag, ":", 2)
-		if len(kv) != 2 {
+		key, value, found := strings.Cut(tag, ":")
+		if !found {
 			continue
 		}
-		if kv[0] == tagName {
-			return kv[1]
+
+		if key == tagName {
+			return value
 		}
 	}
 	return ""
@@ -25,9 +26,10 @@ func GetTagValue(tagName string, tags []string) string {
 
 // GetTagName returns the key of a tag in the tag_name:tag_value format
 func GetTagName(tag string) string {
-	kv := strings.SplitN(tag, ":", 2)
-	if len(kv) != 2 {
+	key, _, found := strings.Cut(tag, ":")
+	if !found {
 		return ""
 	}
-	return kv[0]
+
+	return key
 }


### PR DESCRIPTION
### What does this PR do?

With go 1.18 we can now use `strings.Cut` instead of `strings.SplitN(_, _, 2)` making the code cleaner.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
