### PR TITLE
[CWS][SEC-4878] add agent version support to macros

### DIFF
--- a/cmd/security-agent/app/runtime.go
+++ b/cmd/security-agent/app/runtime.go
@@ -625,6 +625,15 @@ func generateEncodingFromActivityDump(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+func newAgentVersionFilter() (*rules.AgentVersionFilter, error) {
+	agentVersion, err := utils.GetAgentSemverVersion()
+	if err != nil {
+		return nil, err
+	}
+
+	return rules.NewAgentVersionFilter(agentVersion)
+}
+
 func checkPoliciesInner(dir string) error {
 	cfg := &secconfig.Config{
 		PoliciesDir:         dir,
@@ -653,17 +662,15 @@ func checkPoliciesInner(dir string) error {
 	model := &model.Model{}
 	ruleSet := rules.NewRuleSet(model, model.NewEvent, &opts, &evalOpts, &eval.MacroStore{})
 
-	agentVersion, err := utils.GetAgentSemverVersion()
-	if err != nil {
-		return err
-	}
-
-	agentVersionFilter, err := rules.NewAgentVersionFilter(agentVersion)
+	agentVersionFilter, err := newAgentVersionFilter()
 	if err != nil {
 		return fmt.Errorf("failed to create agent version filter: %w", err)
 	}
 
 	loaderOpts := rules.PolicyLoaderOpts{
+		MacroFilters: []rules.MacroFilter{
+			agentVersionFilter,
+		},
 		RuleFilters: []rules.RuleFilter{
 			agentVersionFilter,
 		},
@@ -788,7 +795,15 @@ func evalRule(cmd *cobra.Command, args []string) error {
 	model := &model.Model{}
 	ruleSet := rules.NewRuleSet(model, model.NewEvent, &opts, &evalOpts, &eval.MacroStore{})
 
+	agentVersionFilter, err := newAgentVersionFilter()
+	if err != nil {
+		return fmt.Errorf("failed to create agent version filter: %w", err)
+	}
+
 	loaderOpts := rules.PolicyLoaderOpts{
+		MacroFilters: []rules.MacroFilter{
+			agentVersionFilter,
+		},
 		RuleFilters: []rules.RuleFilter{
 			&rules.RuleIDFilter{
 				ID: evalArgs.ruleID,

--- a/pkg/security/module/module.go
+++ b/pkg/security/module/module.go
@@ -167,16 +167,20 @@ func (m *Module) Start() error {
 		seclog.Errorf("failed to parse agent version: %v", err)
 	}
 
-	filters := make([]rules.RuleFilter, 0, 1)
+	var macroFilters []rules.MacroFilter
+	var ruleFilters []rules.RuleFilter
+
 	agentVersionFilter, err := rules.NewAgentVersionFilter(agentVersion)
 	if err != nil {
 		seclog.Errorf("failed to create agent version filter: %v", err)
 	} else {
-		filters = append(filters, agentVersionFilter)
+		macroFilters = append(macroFilters, agentVersionFilter)
+		ruleFilters = append(ruleFilters, agentVersionFilter)
 	}
 
 	m.policyOpts = rules.PolicyLoaderOpts{
-		RuleFilters: filters,
+		MacroFilters: macroFilters,
+		RuleFilters:  ruleFilters,
 	}
 
 	// directory policy provider

--- a/pkg/security/probe/selftests/tester.go
+++ b/pkg/security/probe/selftests/tester.go
@@ -86,7 +86,7 @@ func (t *SelfTester) GetStatus() *api.SelfTestsStatus {
 }
 
 // LoadPolicies implements the PolicyProvider interface
-func (t *SelfTester) LoadPolicies(filters []rules.RuleFilter) ([]*rules.Policy, *multierror.Error) {
+func (t *SelfTester) LoadPolicies(macroFilters []rules.MacroFilter, ruleFilters []rules.RuleFilter) ([]*rules.Policy, *multierror.Error) {
 	p := &rules.Policy{
 		Name:    policyName,
 		Source:  policySource,

--- a/pkg/security/rconfig/rconfig.go
+++ b/pkg/security/rconfig/rconfig.go
@@ -77,7 +77,7 @@ func normalize(policy *rules.Policy) {
 }
 
 // LoadPolicies implements the PolicyProvider interface
-func (r *RCPolicyProvider) LoadPolicies(filters []rules.RuleFilter) ([]*rules.Policy, *multierror.Error) {
+func (r *RCPolicyProvider) LoadPolicies(macroFilters []rules.MacroFilter, ruleFilters []rules.RuleFilter) ([]*rules.Policy, *multierror.Error) {
 	var policies []*rules.Policy
 	var errs *multierror.Error
 
@@ -87,7 +87,7 @@ func (r *RCPolicyProvider) LoadPolicies(filters []rules.RuleFilter) ([]*rules.Po
 	for _, c := range r.lastConfigs {
 		reader := bytes.NewReader(c.Config)
 
-		policy, err := rules.LoadPolicy(c.Metadata.ID, "remote-config", reader, filters)
+		policy, err := rules.LoadPolicy(c.Metadata.ID, "remote-config", reader, macroFilters, ruleFilters)
 		if err != nil {
 			errs = multierror.Append(errs, err)
 		} else {

--- a/pkg/security/secl/rules/policy_dir.go
+++ b/pkg/security/secl/rules/policy_dir.go
@@ -37,7 +37,7 @@ func (p *PoliciesDirProvider) SetOnNewPoliciesReadyCb(cb func()) {
 // Start starts the policy dir provider
 func (p *PoliciesDirProvider) Start() {}
 
-func (p *PoliciesDirProvider) loadPolicy(filename string, filters []RuleFilter) (*Policy, error) {
+func (p *PoliciesDirProvider) loadPolicy(filename string, macroFilters []MacroFilter, ruleFilters []RuleFilter) (*Policy, error) {
 	f, err := os.Open(filename)
 	if err != nil {
 		return nil, &ErrPolicyLoad{Name: filename, Err: err}
@@ -46,7 +46,7 @@ func (p *PoliciesDirProvider) loadPolicy(filename string, filters []RuleFilter) 
 
 	name := filepath.Base(filename)
 
-	policy, err := LoadPolicy(name, "file", f, filters)
+	policy, err := LoadPolicy(name, "file", f, macroFilters, ruleFilters)
 	if err != nil {
 		return nil, &ErrPolicyLoad{Name: name, Err: err}
 	}
@@ -84,7 +84,7 @@ func (p *PoliciesDirProvider) getPolicyFiles() ([]string, error) {
 }
 
 // LoadPolicies implements the policy provider interface
-func (p *PoliciesDirProvider) LoadPolicies(filters []RuleFilter) ([]*Policy, *multierror.Error) {
+func (p *PoliciesDirProvider) LoadPolicies(macroFilters []MacroFilter, ruleFilters []RuleFilter) ([]*Policy, *multierror.Error) {
 	var errs *multierror.Error
 
 	var policies []*Policy
@@ -104,7 +104,7 @@ func (p *PoliciesDirProvider) LoadPolicies(filters []RuleFilter) ([]*Policy, *mu
 
 	// Load and parse policies
 	for _, filename := range policyFiles {
-		policy, err := p.loadPolicy(filename, filters)
+		policy, err := p.loadPolicy(filename, macroFilters, ruleFilters)
 		if err != nil {
 			errs = multierror.Append(errs, err)
 		} else {

--- a/pkg/security/secl/rules/policy_loader.go
+++ b/pkg/security/secl/rules/policy_loader.go
@@ -19,7 +19,8 @@ var (
 
 // PolicyLoaderOpts options used during the loading
 type PolicyLoaderOpts struct {
-	RuleFilters []RuleFilter
+	MacroFilters []MacroFilter
+	RuleFilters  []RuleFilter
 }
 
 // PolicyLoader defines a policy loader
@@ -45,7 +46,7 @@ func (p *PolicyLoader) LoadPolicies(opts PolicyLoaderOpts) ([]*Policy, *multierr
 
 	// use the provider in the order of insertion, keep the very last default policy
 	for _, provider := range p.Providers {
-		policies, err := provider.LoadPolicies(opts.RuleFilters)
+		policies, err := provider.LoadPolicies(opts.MacroFilters, opts.RuleFilters)
 		if err.ErrorOrNil() != nil {
 			errs = multierror.Append(errs, err)
 		}

--- a/pkg/security/secl/rules/policy_provider.go
+++ b/pkg/security/secl/rules/policy_provider.go
@@ -15,7 +15,7 @@ const DefaultPolicyName = "default.policy"
 
 // PolicyProvider defines a rule provider
 type PolicyProvider interface {
-	LoadPolicies([]RuleFilter) ([]*Policy, *multierror.Error)
+	LoadPolicies([]MacroFilter, []RuleFilter) ([]*Policy, *multierror.Error)
 	SetOnNewPoliciesReadyCb(func())
 
 	Start()

--- a/pkg/security/secl/rules/policy_test.go
+++ b/pkg/security/secl/rules/policy_test.go
@@ -464,7 +464,7 @@ func TestRuleErrorLoading(t *testing.T) {
 	rs, err := loadPolicy(t, testPolicy, PolicyLoaderOpts{})
 	assert.NotNil(t, err)
 	assert.Len(t, err.Errors, 2)
-	assert.ErrorContains(t, err.Errors[0], "rule `testA` definition error: internal rule ID conflict")
+	assert.ErrorContains(t, err.Errors[0], "rule `testA` definition error: multiple definition with the same ID")
 	assert.ErrorContains(t, err.Errors[1], "rule `testB` definition error: syntax error: 1:16: unexpected token")
 
 	assert.Contains(t, rs.rules, "testA")
@@ -472,75 +472,142 @@ func TestRuleErrorLoading(t *testing.T) {
 }
 
 func TestRuleAgentConstraint(t *testing.T) {
-	testEntries := []struct {
-		name           string
-		agentVersion   string
-		ruleConstraint string
-		expectLoad     bool
-	}{
-		{
-			name:           "basic",
-			agentVersion:   "7.38",
-			ruleConstraint: "< 7.37",
-			expectLoad:     false,
+	testPolicy := &PolicyDef{
+		Macros: []*MacroDefinition{
+			{
+				ID:         "macro1",
+				Expression: `[1, 2]`,
+			},
+			{
+				ID:                     "macro2",
+				Expression:             `[3, 4]`,
+				AgentVersionConstraint: ">= 7.37, < 7.38",
+			},
+			{
+				ID:                     "macro2",
+				Expression:             `[3, 4, 5]`,
+				AgentVersionConstraint: ">= 7.38",
+			},
 		},
-		{
-			name:           "basic2",
-			agentVersion:   "7.35",
-			ruleConstraint: "< 7.37",
-			expectLoad:     true,
-		},
-		{
-			name:           "range",
-			agentVersion:   "7.35",
-			ruleConstraint: ">= 7.30, < 7.37",
-			expectLoad:     true,
-		},
-		{
-			name:           "range_not",
-			agentVersion:   "7.35",
-			ruleConstraint: ">= 7.30, < 7.37, != 7.35",
-			expectLoad:     false,
-		},
-		{
-			name:           "rc_prerelease",
-			agentVersion:   "7.38.0-rc.2",
-			ruleConstraint: ">= 7.38",
-			expectLoad:     true,
+		Rules: []*RuleDefinition{
+			{
+				ID:         "no_constraint",
+				Expression: `open.filename == "/tmp/test"`,
+			},
+			{
+				ID:                     "conflict",
+				Expression:             `open.filename == "/tmp/test1"`,
+				AgentVersionConstraint: "< 7.37",
+			},
+			{
+				ID:                     "conflict",
+				Expression:             `open.filename == "/tmp/test2"`,
+				AgentVersionConstraint: ">= 7.37",
+			},
+			{
+				ID:                     "basic",
+				Expression:             `open.filename == "/tmp/test"`,
+				AgentVersionConstraint: "< 7.37",
+			},
+			{
+				ID:                     "basic2",
+				Expression:             `open.filename == "/tmp/test"`,
+				AgentVersionConstraint: "> 7.37",
+			},
+			{
+				ID:                     "range",
+				Expression:             `open.filename == "/tmp/test"`,
+				AgentVersionConstraint: ">= 7.30, < 7.39",
+			},
+			{
+				ID:                     "range_not",
+				Expression:             `open.filename == "/tmp/test"`,
+				AgentVersionConstraint: ">= 7.30, < 7.39, != 7.38",
+			},
+			{
+				ID:                     "rc_prerelease",
+				Expression:             `open.filename == "/tmp/test"`,
+				AgentVersionConstraint: ">= 7.38",
+			},
+			{
+				ID:                     "with_macro1",
+				Expression:             `open.filename == "/tmp/test" && open.mode in macro1`,
+				AgentVersionConstraint: ">= 7.38",
+			},
+			{
+				ID:                     "with_macro2",
+				Expression:             `open.filename == "/tmp/test" && open.mode in macro2`,
+				AgentVersionConstraint: ">= 7.38",
+			},
 		},
 	}
 
-	for _, entry := range testEntries {
-		t.Run(entry.name, func(t *testing.T) {
-			ruleID := fmt.Sprintf("test_rule_%s", entry.name)
+	expected := []struct {
+		ruleID       string
+		expectedLoad bool
+	}{
+		{
+			ruleID:       "no_constraint",
+			expectedLoad: true,
+		},
+		{
+			ruleID:       "conflict",
+			expectedLoad: true,
+		},
+		{
+			ruleID:       "basic",
+			expectedLoad: false,
+		},
+		{
+			ruleID:       "basic2",
+			expectedLoad: true,
+		},
+		{
+			ruleID:       "range",
+			expectedLoad: true,
+		},
+		{
+			ruleID:       "range_not",
+			expectedLoad: false,
+		},
+		{
+			ruleID:       "rc_prerelease",
+			expectedLoad: true,
+		},
+		{
+			ruleID:       "with_macro1",
+			expectedLoad: true,
+		},
+		{
+			ruleID:       "with_macro2",
+			expectedLoad: true,
+		},
+	}
 
-			testPolicy := &PolicyDef{
-				Rules: []*RuleDefinition{{
-					ID:                     ruleID,
-					Expression:             `open.filename == "/tmp/test"`,
-					AgentVersionConstraint: entry.ruleConstraint,
-				}},
-			}
+	agentVersion, err := semver.NewVersion("7.38")
+	assert.Nil(t, err)
 
-			agentVersion, err := semver.NewVersion(entry.agentVersion)
-			assert.Nil(t, err)
+	agentVersionFilter, err := NewAgentVersionFilter(agentVersion)
+	assert.Nil(t, err)
 
-			agentVersionFilter, err := NewAgentVersionFilter(agentVersion)
-			assert.Nil(t, err)
+	policyOpts := PolicyLoaderOpts{
+		MacroFilters: []MacroFilter{
+			agentVersionFilter,
+		},
+		RuleFilters: []RuleFilter{
+			agentVersionFilter,
+		},
+	}
 
-			policyOpts := PolicyLoaderOpts{
-				RuleFilters: []RuleFilter{
-					agentVersionFilter,
-				},
-			}
+	rs, err := loadPolicy(t, testPolicy, policyOpts)
+	assert.Nil(t, err)
 
-			rs, err := loadPolicy(t, testPolicy, policyOpts)
-			assert.Nil(t, err)
-
-			if entry.expectLoad {
-				assert.Contains(t, rs.rules, ruleID)
+	for _, exp := range expected {
+		t.Run(exp.ruleID, func(t *testing.T) {
+			if exp.expectedLoad {
+				assert.Contains(t, rs.rules, exp.ruleID)
 			} else {
-				assert.NotContains(t, rs.rules, ruleID)
+				assert.NotContains(t, rs.rules, exp.ruleID)
 			}
 		})
 	}

--- a/pkg/security/secl/rules/rule_filters.go
+++ b/pkg/security/secl/rules/rule_filters.go
@@ -14,7 +14,12 @@ import (
 
 // RuleFilter definition of a rule filter
 type RuleFilter interface {
-	IsAccepted(rule *RuleDefinition) (bool, error)
+	IsRuleAccepted(*RuleDefinition) (bool, error)
+}
+
+// MacroFilter definition of a macro filter
+type MacroFilter interface {
+	IsMacroAccepted(*MacroDefinition) (bool, error)
 }
 
 // RuleIDFilter defines a ID based filter
@@ -22,8 +27,8 @@ type RuleIDFilter struct {
 	ID string
 }
 
-// IsAccepted checks whether the rule is accepted
-func (r *RuleIDFilter) IsAccepted(rule *RuleDefinition) (bool, error) {
+// IsRuleAccepted checks whether the rule is accepted
+func (r *RuleIDFilter) IsRuleAccepted(rule *RuleDefinition) (bool, error) {
 	return r.ID == rule.ID, nil
 }
 
@@ -49,9 +54,19 @@ func NewAgentVersionFilter(version *semver.Version) (*AgentVersionFilter, error)
 	}, nil
 }
 
-// IsAccepted checks whether the rule is accepted
-func (r *AgentVersionFilter) IsAccepted(rule *RuleDefinition) (bool, error) {
+// IsRuleAccepted checks whether the rule is accepted
+func (r *AgentVersionFilter) IsRuleAccepted(rule *RuleDefinition) (bool, error) {
 	constraint, err := validators.ValidateAgentVersionConstraint(rule.AgentVersionConstraint)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse agent version constraint: %v", err)
+	}
+
+	return constraint.Check(r.version), nil
+}
+
+// IsMacroAccepted checks whether the macro is accepted
+func (r *AgentVersionFilter) IsMacroAccepted(macro *MacroDefinition) (bool, error) {
+	constraint, err := validators.ValidateAgentVersionConstraint(macro.AgentVersionConstraint)
 	if err != nil {
 		return false, fmt.Errorf("failed to parse agent version constraint: %v", err)
 	}

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -33,10 +33,12 @@ const (
 
 // MacroDefinition holds the definition of a macro
 type MacroDefinition struct {
-	ID         MacroID       `yaml:"id"`
-	Expression string        `yaml:"expression"`
-	Values     []string      `yaml:"values"`
-	Combine    CombinePolicy `yaml:"combine"`
+	ID                     MacroID       `yaml:"id"`
+	Expression             string        `yaml:"expression"`
+	Description            string        `yaml:"description"`
+	AgentVersionConstraint string        `yaml:"agent_version"`
+	Values                 []string      `yaml:"values"`
+	Combine                CombinePolicy `yaml:"combine"`
 }
 
 // MergeWith merges macro m2 into m
@@ -50,7 +52,7 @@ func (m *MacroDefinition) MergeWith(m2 *MacroDefinition) error {
 	case OverridePolicy:
 		m.Values = m2.Values
 	default:
-		return &ErrMacroLoad{Definition: m2, Err: ErrInternalIDConflict}
+		return &ErrMacroLoad{Definition: m2, Err: ErrDefinitionIDConflict}
 	}
 	return nil
 }
@@ -96,7 +98,7 @@ func (rd *RuleDefinition) MergeWith(rd2 *RuleDefinition) error {
 		rd.Expression = rd2.Expression
 	default:
 		if !rd2.Disabled {
-			return &ErrRuleLoad{Definition: rd2, Err: ErrInternalIDConflict}
+			return &ErrRuleLoad{Definition: rd2, Err: ErrDefinitionIDConflict}
 		}
 	}
 	rd.Disabled = rd2.Disabled

--- a/releasenotes/notes/cws-add-macro-agent-version-support-317539fb49fa7584.yaml
+++ b/releasenotes/notes/cws-add-macro-agent-version-support-317539fb49fa7584.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Cloud Workload Security now has Agent version constraints for Macros in SECL expressions.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR add the agent version constraint for macros. It uses the same syntax as for the rules.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
