### PR TITLE
[CWS] build object files before running functional tests

### DIFF
--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -71,9 +71,9 @@ tests_ebpf_x64:
     - invoke -e security-agent.build-embed-syscall-tester
     - invoke -e security-agent.build-embed-latency-tools
     # Compile runtime security functional tests to be executed in kitchen tests
-    - inv -e security-agent.build-functional-tests --no-bundle-ebpf --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/testsuite --race --nikos-embedded-path=$NIKOS_EMBEDDED_PATH
+    - inv -e security-agent.build-functional-tests --no-bundle-ebpf --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/testsuite --race --nikos-embedded-path=$NIKOS_EMBEDDED_PATH --skip-object-files
     # Compile runtime security stress tests to be executed in kitchen tests
-    - inv -e security-agent.build-stress-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/stresssuite
+    - inv -e security-agent.build-stress-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/stresssuite --skip-object-files
     # Copy nikos archive to be extracted in kitchen tests
     - cp /tmp/nikos.tar.gz $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/nikos.tar.gz
      # Copy files needed for runtime compilation
@@ -105,9 +105,9 @@ tests_ebpf_arm64:
     - invoke -e security-agent.build-embed-syscall-tester --arch arm64
     - invoke -e security-agent.build-embed-latency-tools
     # Compile runtime security functional tests to be executed in kitchen tests
-    - inv -e security-agent.build-functional-tests --no-bundle-ebpf --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/testsuite --race --nikos-embedded-path=$NIKOS_EMBEDDED_PATH
+    - inv -e security-agent.build-functional-tests --no-bundle-ebpf --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/testsuite --race --nikos-embedded-path=$NIKOS_EMBEDDED_PATH --skip-object-files
     # Compile runtime security stress tests to be executed in kitchen tests
-    - inv -e security-agent.build-stress-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/stresssuite
+    - inv -e security-agent.build-stress-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/stresssuite --skip-object-files
     # Copy nikos archive to be extracted in kitchen tests
     - cp /tmp/nikos.tar.gz $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/nikos.tar.gz
     # Copy files needed for runtime compilation

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -68,8 +68,6 @@ tests_ebpf_x64:
     - !reference [.build_sysprobe_artifacts]
     - inv -e install-tools
     - export PATH=$PATH:$GOPATH/bin
-    - invoke -e security-agent.build-embed-syscall-tester
-    - invoke -e security-agent.build-embed-latency-tools
     # Compile runtime security functional tests to be executed in kitchen tests
     - inv -e security-agent.build-functional-tests --no-bundle-ebpf --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/testsuite --race --nikos-embedded-path=$NIKOS_EMBEDDED_PATH --skip-object-files
     # Compile runtime security stress tests to be executed in kitchen tests
@@ -102,8 +100,6 @@ tests_ebpf_arm64:
     - !reference [.build_sysprobe_artifacts]
     - inv -e install-tools
     - export PATH=$PATH:$GOPATH/bin
-    - invoke -e security-agent.build-embed-syscall-tester --arch arm64
-    - invoke -e security-agent.build-embed-latency-tools
     # Compile runtime security functional tests to be executed in kitchen tests
     - inv -e security-agent.build-functional-tests --no-bundle-ebpf --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/testsuite --race --nikos-embedded-path=$NIKOS_EMBEDDED_PATH --skip-object-files
     # Compile runtime security stress tests to be executed in kitchen tests

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -69,9 +69,9 @@ tests_ebpf_x64:
     - inv -e install-tools
     - export PATH=$PATH:$GOPATH/bin
     # Compile runtime security functional tests to be executed in kitchen tests
-    - inv -e security-agent.build-functional-tests --no-bundle-ebpf --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/testsuite --race --nikos-embedded-path=$NIKOS_EMBEDDED_PATH --skip-object-files
+    - inv -e security-agent.build-functional-tests --no-bundle-ebpf --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/testsuite --race --nikos-embedded-path=$NIKOS_EMBEDDED_PATH
     # Compile runtime security stress tests to be executed in kitchen tests
-    - inv -e security-agent.build-stress-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/stresssuite --skip-object-files
+    - inv -e security-agent.build-stress-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/stresssuite
     # Copy nikos archive to be extracted in kitchen tests
     - cp /tmp/nikos.tar.gz $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/nikos.tar.gz
      # Copy files needed for runtime compilation
@@ -101,9 +101,9 @@ tests_ebpf_arm64:
     - inv -e install-tools
     - export PATH=$PATH:$GOPATH/bin
     # Compile runtime security functional tests to be executed in kitchen tests
-    - inv -e security-agent.build-functional-tests --no-bundle-ebpf --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/testsuite --race --nikos-embedded-path=$NIKOS_EMBEDDED_PATH --skip-object-files
+    - inv -e security-agent.build-functional-tests --no-bundle-ebpf --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/testsuite --race --nikos-embedded-path=$NIKOS_EMBEDDED_PATH
     # Compile runtime security stress tests to be executed in kitchen tests
-    - inv -e security-agent.build-stress-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/stresssuite --skip-object-files
+    - inv -e security-agent.build-stress-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/stresssuite
     # Copy nikos archive to be extracted in kitchen tests
     - cp /tmp/nikos.tar.gz $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/nikos.tar.gz
     # Copy files needed for runtime compilation

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -14,6 +14,7 @@ from .go import golangci_lint
 from .libs.ninja_syntax import NinjaWriter
 from .system_probe import (
     CURRENT_ARCH,
+    build_object_files,
     check_for_ninja,
     generate_runtime_files,
     ninja_define_ebpf_compiler,
@@ -319,7 +320,17 @@ def build_functional_tests(
     static=False,
     skip_linters=False,
     race=False,
+    kernel_release=None,
+    skip_object_files=False,
 ):
+    if not skip_object_files:
+        build_object_files(
+            ctx,
+            major_version=major_version,
+            arch=arch,
+            kernel_release=kernel_release,
+        )
+
     ldflags, _, env = get_build_flags(
         ctx, major_version=major_version, nikos_embedded_path=nikos_embedded_path, static=static
     )
@@ -374,6 +385,8 @@ def build_stress_tests(
     major_version='7',
     bundle_ebpf=True,
     skip_linters=False,
+    kernel_release=None,
+    skip_object_files=False,
 ):
     build_functional_tests(
         ctx,
@@ -384,6 +397,8 @@ def build_stress_tests(
         build_tags='stresstests',
         bundle_ebpf=bundle_ebpf,
         skip_linters=skip_linters,
+        kernel_release=kernel_release,
+        skip_object_files=skip_object_files,
     )
 
 

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -331,6 +331,8 @@ def build_functional_tests(
             kernel_release=kernel_release,
         )
 
+    build_embed_syscall_tester(ctx)
+
     ldflags, _, env = get_build_flags(
         ctx, major_version=major_version, nikos_embedded_path=nikos_embedded_path, static=static
     )
@@ -388,6 +390,7 @@ def build_stress_tests(
     kernel_release=None,
     skip_object_files=False,
 ):
+    build_embed_latency_tools(ctx)
     build_functional_tests(
         ctx,
         output=output,
@@ -414,8 +417,6 @@ def stress_tests(
     testflags='',
     skip_linters=False,
 ):
-    build_embed_latency_tools(ctx)
-
     build_stress_tests(
         ctx,
         go_version=go_version,

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -321,15 +321,13 @@ def build_functional_tests(
     skip_linters=False,
     race=False,
     kernel_release=None,
-    skip_object_files=False,
 ):
-    if not skip_object_files:
-        build_object_files(
-            ctx,
-            major_version=major_version,
-            arch=arch,
-            kernel_release=kernel_release,
-        )
+    build_object_files(
+        ctx,
+        major_version=major_version,
+        arch=arch,
+        kernel_release=kernel_release,
+    )
 
     build_embed_syscall_tester(ctx)
 
@@ -388,7 +386,6 @@ def build_stress_tests(
     bundle_ebpf=True,
     skip_linters=False,
     kernel_release=None,
-    skip_object_files=False,
 ):
     build_embed_latency_tools(ctx)
     build_functional_tests(
@@ -401,7 +398,6 @@ def build_stress_tests(
         bundle_ebpf=bundle_ebpf,
         skip_linters=skip_linters,
         kernel_release=kernel_release,
-        skip_object_files=skip_object_files,
     )
 
 
@@ -416,6 +412,7 @@ def stress_tests(
     bundle_ebpf=True,
     testflags='',
     skip_linters=False,
+    kernel_release=None,
 ):
     build_stress_tests(
         ctx,
@@ -425,6 +422,7 @@ def stress_tests(
         output=output,
         bundle_ebpf=bundle_ebpf,
         skip_linters=skip_linters,
+        kernel_release=kernel_release,
     )
 
     run_functional_tests(
@@ -447,6 +445,7 @@ def functional_tests(
     bundle_ebpf=True,
     testflags='',
     skip_linters=False,
+    kernel_release=None,
 ):
     build_functional_tests(
         ctx,
@@ -457,6 +456,7 @@ def functional_tests(
         bundle_ebpf=bundle_ebpf,
         skip_linters=skip_linters,
         race=race,
+        kernel_release=kernel_release,
     )
 
     run_functional_tests(
@@ -508,6 +508,7 @@ def docker_functional_tests(
     static=False,
     bundle_ebpf=True,
     skip_linters=False,
+    kernel_release=None,
 ):
     build_functional_tests(
         ctx,
@@ -518,6 +519,7 @@ def docker_functional_tests(
         bundle_ebpf=bundle_ebpf,
         static=static,
         skip_linters=skip_linters,
+        kernel_release=kernel_release,
     )
 
     dockerfile = """


### PR DESCRIPTION
### What does this PR do?

This PR makes it so that object files are built before building functional tests. Before this you had to think to rebuild object files, and we can now do it automatically with ninja speed.

This PR makes the same change for syscall testers (and latency tools), ensuring that they are always up to date.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
