### PR TITLE
[CWS] improve dd-service computation

### DIFF
--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -532,7 +532,7 @@ func bestGuessServiceTag(serviceValues []string) string {
 
 	// first we sort base on len, biggest len first
 	sort.Slice(serviceValues, func(i, j int) bool {
-		return serviceValues[j] < serviceValues[i] // reverse
+		return len(serviceValues[j]) < len(serviceValues[i]) // reverse
 	})
 
 	// we then compare [i] and [i + 1] to check if [i + 1] is a prefix of [i]

--- a/pkg/security/probe/model_test.go
+++ b/pkg/security/probe/model_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSetFieldValue(t *testing.T) {
@@ -175,5 +176,52 @@ func TestProcessArgsOptions(t *testing.T) {
 
 	if len(options) != 5 {
 		t.Errorf("expected 5 options, got %d", len(options))
+	}
+}
+
+func TestBestGuessServiceValues(t *testing.T) {
+
+	type testEntry struct {
+		name     string
+		values   []string
+		expected string
+	}
+
+	entries := []testEntry{
+		{
+			name: "basic",
+			values: []string{
+				"datadog-agent",
+				"d",
+				"datadog-a",
+			},
+			expected: "datadog-agent",
+		},
+		{
+			name: "single",
+			values: []string{
+				"aa",
+			},
+			expected: "aa",
+		},
+		{
+			name:     "empty",
+			values:   []string{},
+			expected: "",
+		},
+		{
+			name: "divergent",
+			values: []string{
+				"aa",
+				"bb",
+			},
+			expected: "aa",
+		},
+	}
+
+	for _, entry := range entries {
+		t.Run(entry.name, func(t *testing.T) {
+			assert.Equal(t, entry.expected, bestGuessServiceTag(entry.values))
+		})
 	}
 }

--- a/pkg/security/probe/model_test.go
+++ b/pkg/security/probe/model_test.go
@@ -217,6 +217,14 @@ func TestBestGuessServiceValues(t *testing.T) {
 			},
 			expected: "aa",
 		},
+		{
+			name: "divergent-2",
+			values: []string{
+				"bb",
+				"aa",
+			},
+			expected: "bb",
+		},
 	}
 
 	for _, entry := range entries {


### PR DESCRIPTION
### What does this PR do?

This PR improves the computation of the dd-service tag value by merging the env values from the whole tree instead of looking at just the current process

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
