### PR TITLE
system-probe: use regular cp to move compiled ebpf file to /opt

### DIFF
--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -832,14 +832,10 @@ def build_object_files(
     ninja_generate(ctx, nf_path, windows, major_version, arch, debug, strip_object_files, kernel_release)
     ctx.run(f"ninja -d explain -f {nf_path}")
 
-    if not is_root():
-        ctx.sudo(f"mkdir -p {EMBEDDED_SHARE_DIR}")
-        ctx.sudo(f"cp -R {build_dir} {EMBEDDED_SHARE_DIR}")
-        ctx.sudo(f"chown root:root -R {EMBEDDED_SHARE_DIR}")
-    else:
-        ctx.run(f"mkdir -p {EMBEDDED_SHARE_DIR}")
-        ctx.run(f"cp -R {build_dir} {EMBEDDED_SHARE_DIR}")
-        ctx.run(f"chown root:root -R {EMBEDDED_SHARE_DIR}")
+    runner = ctx.run if is_root() else ctx.sudo
+    runner(f"mkdir -p {EMBEDDED_SHARE_DIR}")
+    runner(f"cp -R {build_dir} {EMBEDDED_SHARE_DIR}")
+    runner(f"chown root:root -R {EMBEDDED_SHARE_DIR}")
 
 
 @task

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -63,7 +63,6 @@ def ninja_define_windows_resources(ctx, nw, major_version):
     )
 
 
-
 def ninja_define_ebpf_compiler(nw, strip_object_files=False, kernel_release=None):
     nw.variable("target", "-emit-llvm")
     nw.variable("ebpfflags", get_ebpf_build_flags())

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -832,10 +832,11 @@ def build_object_files(
     ninja_generate(ctx, nf_path, windows, major_version, arch, debug, strip_object_files, kernel_release)
     ctx.run(f"ninja -d explain -f {nf_path}")
 
-    runner = ctx.run if is_root() else ctx.sudo
-    runner(f"mkdir -p {EMBEDDED_SHARE_DIR}")
-    runner(f"cp -R {build_dir} {EMBEDDED_SHARE_DIR}")
-    runner(f"chown root:root -R {EMBEDDED_SHARE_DIR}")
+    if not windows:
+        runner = ctx.run if is_root() else ctx.sudo
+        runner(f"mkdir -p {EMBEDDED_SHARE_DIR}")
+        runner(f"cp -R {build_dir} {EMBEDDED_SHARE_DIR}")
+        runner(f"chown root:root -R {EMBEDDED_SHARE_DIR}")
 
 
 @task


### PR DESCRIPTION
### What does this PR do?

This PR uses the old `cp` based workflow to move the compiled object files to `/opt` instead of using ninja to do it.
Using ninja was problematic because of permission issues.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
