### PR TITLE
[CWS] do not log dns compression unmarshalling error as error

### DIFF
--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -774,7 +774,12 @@ func (p *Probe) handleEvent(CPU int, data []byte) {
 		_ = p.setupNewTCClassifier(event.VethPair.PeerDevice)
 	case model.DNSEventType:
 		if _, err = event.DNS.UnmarshalBinary(data[offset:]); err != nil {
-			seclog.Errorf("failed to decode DNS event: %s (offset %d, len %d)", err, offset, len(data))
+			if errors.Is(err, model.ErrDNSNamePointerNotSupported) {
+				seclog.Tracef("failed to decode DNS event: %s (offset %d, len %d)", err, offset, len(data))
+			} else {
+				seclog.Errorf("failed to decode DNS event: %s (offset %d, len %d)", err, offset, len(data))
+			}
+
 			return
 		}
 	case model.BindEventType:

--- a/pkg/security/secl/model/dns_helpers.go
+++ b/pkg/security/secl/model/dns_helpers.go
@@ -11,9 +11,12 @@ import (
 )
 
 var (
-	errDNSNamePointerNotSupported = errors.New("dns name pointer compression is not supported")
-	errDNSNameOutOfBounds         = errors.New("dns name out of bound")
-	errDNSNameNonPrintableASCII   = errors.New("dns name non-printable ascii")
+	// ErrDNSNamePointerNotSupported reported because pointer compression is not supported
+	ErrDNSNamePointerNotSupported = errors.New("dns name pointer compression is not supported")
+	// ErrDNSNameOutOfBounds reported because name out of bound
+	ErrDNSNameOutOfBounds = errors.New("dns name out of bound")
+	// ErrDNSNameNonPrintableASCII reported because name non-printable ascii
+	ErrDNSNameNonPrintableASCII = errors.New("dns name non-printable ascii")
 )
 
 func decodeDNSName(raw []byte) (string, error) {
@@ -38,13 +41,13 @@ LOOP:
 
 		if labelLen&0xC0 != 0 {
 			// pointer compression, we do not support this yet
-			err = errDNSNamePointerNotSupported
+			err = ErrDNSNamePointerNotSupported
 			break
 		}
 
 		if rawLen < i+labelLen {
 			// out of bounds
-			err = errDNSNameOutOfBounds
+			err = ErrDNSNameOutOfBounds
 			break
 		}
 
@@ -56,7 +59,7 @@ LOOP:
 		for _, c := range labelRaw {
 			if c < ' ' || '~' < c {
 				// non-printable ascii char
-				err = errDNSNameNonPrintableASCII
+				err = ErrDNSNameNonPrintableASCII
 				break LOOP
 			}
 		}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Use trace level for unsupported DNS compression feature instead of error as it can be noisy on system using DNS compression

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
