### PR TITLE
[Serverless] Filter spans with DogStatsD urls in the extension

### DIFF
--- a/pkg/serverless/trace/trace.go
+++ b/pkg/serverless/trace/trace.go
@@ -43,6 +43,9 @@ const lambdaRuntimeURLPrefix = "http://127.0.0.1:9001"
 // lambdaExtensionURLPrefix is the first part of a URL for a call from the Datadog Lambda Library to the Lambda Extension
 const lambdaExtensionURLPrefix = "http://127.0.0.1:8124"
 
+// lambdaStatsDURLPrefix is the first part of a URL for a call from Statsd
+const lambdaStatsDURLPrefix = "http://127.0.0.1:8125"
+
 const invocationSpanResource = "dd-tracer-serverless-span"
 
 // Load loads the config from a file path
@@ -114,6 +117,12 @@ func filterSpanFromLambdaLibraryOrRuntime(span *pb.Span) bool {
 			log.Debugf("Detected span with http url %s, removing it", val)
 			return true
 		}
+
+		if strings.HasPrefix(val, lambdaStatsDURLPrefix) {
+			log.Debugf("Detected span with http url %s, removing it", val)
+			return true
+		}
+
 		if strings.HasPrefix(val, lambdaRuntimeURLPrefix) {
 			log.Debugf("Detected span with http url %s, removing it", val)
 			return true

--- a/pkg/serverless/trace/trace_test.go
+++ b/pkg/serverless/trace/trace_test.go
@@ -89,6 +89,12 @@ func TestFilterSpanFromLambdaLibraryOrRuntime(t *testing.T) {
 		},
 	}
 
+	spanFromStatsD := pb.Span{
+		Meta: map[string]string{
+			"http.url": "http://127.0.0.1:8125/",
+		},
+	}
+
 	legitimateSpan := pb.Span{
 		Meta: map[string]string{
 			"http.url": "http://www.datadoghq.com",
@@ -97,5 +103,6 @@ func TestFilterSpanFromLambdaLibraryOrRuntime(t *testing.T) {
 
 	assert.True(t, filterSpanFromLambdaLibraryOrRuntime(&spanFromLambdaLibrary))
 	assert.True(t, filterSpanFromLambdaLibraryOrRuntime(&spanFromLambdaRuntime))
+	assert.True(t, filterSpanFromLambdaLibraryOrRuntime(&spanFromStatsD))
 	assert.False(t, filterSpanFromLambdaLibraryOrRuntime(&legitimateSpan))
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Filters out any local spans containing the DogStatsD endpoint of 8125. This pattern was missed in #11687
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
https://github.com/DataDog/datadog-lambda-extension/issues/78
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
