### PR TITLE
display current version in kernel version warning

### DIFF
--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -726,8 +726,10 @@ def get_linux_header_dirs(kernel_release=None, minimal_kernel_release=None):
     # fallback to non-release-specific directories
     if len(linux_headers) == 0:
         if os.path.isdir(src_kernels_dir):
+            print("ISDIR YES1")
             linux_headers = [os.path.join(src_kernels_dir, d) for d in os.listdir(src_kernels_dir)]
         else:
+            print("ISNOTDIR YES2")
             linux_headers = [os.path.join(src_dir, d) for d in os.listdir(src_dir) if d.startswith("linux-")]
 
     # fallback to /usr as a last report

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -692,6 +692,10 @@ def get_kernel_arch():
     )
 
 
+def stringify_version_tuple(version):
+    return '.'.join(map(lambda x: str(x), minimal_kernel_release))
+
+
 def get_linux_header_dirs(kernel_release=None, minimal_kernel_release=None):
     if not kernel_release:
         os_info = os.uname()
@@ -702,7 +706,7 @@ def get_linux_header_dirs(kernel_release=None, minimal_kernel_release=None):
         version_tuple = list(map(int, map(lambda x: x or '0', match.group(1, 2, 4))))
         if version_tuple < minimal_kernel_release:
             print(
-                f"You need to have kernel headers for at least {'.'.join(map(lambda x: str(x), minimal_kernel_release))} to enable all system-probe features"
+                f"You need to have kernel headers for at least {stringify_version_tuple(minimal_kernel_release)} to enable all system-probe features (currently using {stringify_version_tuple(version_tuple)})"
             )
 
     src_kernels_dir = "/usr/src/kernels"

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -693,7 +693,7 @@ def get_kernel_arch():
 
 
 def stringify_version_tuple(version):
-    return '.'.join(map(lambda x: str(x), minimal_kernel_release))
+    return '.'.join(map(lambda x: str(x), version))
 
 
 def get_linux_header_dirs(kernel_release=None, minimal_kernel_release=None):


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
