### PR TITLE
[DCA][Admission] Inject variables and volume mounts to init containers

### DIFF
--- a/pkg/clusteragent/admission/mutate/common.go
+++ b/pkg/clusteragent/admission/mutate/common.go
@@ -83,6 +83,16 @@ func injectEnv(pod *corev1.Pod, env corev1.EnvVar) bool {
 		pod.Spec.Containers[i].Env = append([]corev1.EnvVar{env}, pod.Spec.Containers[i].Env...)
 		injected = true
 	}
+	for i, ctr := range pod.Spec.InitContainers {
+		if contains(ctr.Env, env.Name) {
+			log.Debugf("Ignoring init container '%s' in pod %s: env var '%s' already exist", ctr.Name, podStr, env.Name)
+			continue
+		}
+		// prepend rather than append so that our new vars precede container vars in the final list, so that they
+		// can be referenced in other env vars downstream.  (see:  Kubernetes dependent environment variables.)
+		pod.Spec.InitContainers[i].Env = append([]corev1.EnvVar{env}, pod.Spec.InitContainers[i].Env...)
+		injected = true
+	}
 	return injected
 }
 
@@ -99,6 +109,9 @@ func injectVolume(pod *corev1.Pod, volume corev1.Volume, volumeMount corev1.Volu
 	pod.Spec.Volumes = append(pod.Spec.Volumes, volume)
 	for i := range pod.Spec.Containers {
 		pod.Spec.Containers[i].VolumeMounts = append(pod.Spec.Containers[i].VolumeMounts, volumeMount)
+	}
+	for i := range pod.Spec.InitContainers {
+		pod.Spec.InitContainers[i].VolumeMounts = append(pod.Spec.InitContainers[i].VolumeMounts, volumeMount)
 	}
 
 	return true

--- a/pkg/clusteragent/admission/mutate/common_test.go
+++ b/pkg/clusteragent/admission/mutate/common_test.go
@@ -120,6 +120,19 @@ func Test_injectEnv(t *testing.T) {
 			},
 			injected: true,
 		},
+		{
+			name: "init containers",
+			args: args{
+				pod: fakePodWithInitContainer("foo-pod", fakeContainer("foo-init-container")),
+				env: fakeEnv("inject-me"),
+			},
+			wantPodFunc: func() corev1.Pod {
+				pod := fakePodWithInitContainer("foo-pod", fakeContainer("foo-init-container"))
+				pod.Spec.InitContainers[0].Env = append([]corev1.EnvVar{fakeEnv("inject-me")}, pod.Spec.InitContainers[0].Env...)
+				return *pod
+			},
+			injected: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/clusteragent/admission/mutate/test_utils.go
+++ b/pkg/clusteragent/admission/mutate/test_utils.go
@@ -59,6 +59,17 @@ func fakePodWithContainer(name string, containers ...corev1.Container) *corev1.P
 	}
 }
 
+func fakePodWithInitContainer(name string, containers ...corev1.Container) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: corev1.PodSpec{
+			InitContainers: containers,
+		},
+	}
+}
+
 func withLabels(pod *corev1.Pod, labels map[string]string) *corev1.Pod {
 	pod.Labels = labels
 	return pod

--- a/releasenotes-dca/notes/admission-init-containers-9ab4783dbd736e5f.yaml
+++ b/releasenotes-dca/notes/admission-init-containers-9ab4783dbd736e5f.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG-DCA.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The admission controller now injects variables and volume mounts to init containers in addition to regular one.

--- a/releasenotes-dca/notes/admission-init-containers-9ab4783dbd736e5f.yaml
+++ b/releasenotes-dca/notes/admission-init-containers-9ab4783dbd736e5f.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    The admission controller now injects variables and volume mounts to init containers in addition to regular one.
+    The admission controller now injects variables and volume mounts to init containers in addition to regular containers.


### PR DESCRIPTION
### What does this PR do?

Enhance the cluster-agent admission controller to inject variables and volume mounts to the init containers in addition to the regular ones.

### Motivation

The init containers might also benefit from the injected variables and auto-instrumentation.

### Additional Notes

[Datadog admission controller documentation](https://docs.datadoghq.com/containers/cluster_agent/admission_controller/)

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Enable the cluster agent admission controller and start a pod annotated with `admission.datadoghq.com/enabled=true`.
Check that the injected variables and instrumentation appears not only on regular containers, but also on the init containers.

### Reviewer's Checklist


- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
