### PR TITLE
[CWS] improve args functional tests

### DIFF
--- a/pkg/security/secl/model/process_cache_entry.go
+++ b/pkg/security/secl/model/process_cache_entry.go
@@ -14,7 +14,8 @@ import (
 )
 
 const (
-	maxArgEnvSize = 256
+	// MaxArgEnvSize maximum size of one argument or environment variable
+	MaxArgEnvSize = 256
 )
 
 // SetSpan sets the span
@@ -141,7 +142,7 @@ func (pc *ProcessCacheEntry) Equals(entry *ProcessCacheEntry) bool {
 type ArgsEnvs struct {
 	ID        uint32
 	Size      uint32
-	ValuesRaw [maxArgEnvSize]byte
+	ValuesRaw [MaxArgEnvSize]byte
 }
 
 // ArgsEnvsCacheEntry defines a args/envs base entry
@@ -223,7 +224,7 @@ func (p *ArgsEnvsCacheEntry) toArray() ([]string, bool) {
 
 	for entry != nil {
 		v, err := UnmarshalStringArray(entry.ValuesRaw[:entry.Size])
-		if err != nil || entry.Size == maxArgEnvSize {
+		if err != nil || entry.Size == MaxArgEnvSize {
 			if len(v) > 0 {
 				v[len(v)-1] = v[len(v)-1] + "..."
 			}

--- a/pkg/security/secl/model/unmarshallers.go
+++ b/pkg/security/secl/model/unmarshallers.go
@@ -287,18 +287,18 @@ func (e *InvalidateDentryEvent) UnmarshalBinary(data []byte) (int, error) {
 
 // UnmarshalBinary unmarshalls a binary representation of itself
 func (e *ArgsEnvsEvent) UnmarshalBinary(data []byte) (int, error) {
-	if len(data) < maxArgEnvSize+8 {
+	if len(data) < MaxArgEnvSize+8 {
 		return 0, ErrNotEnoughData
 	}
 
 	e.ID = ByteOrder.Uint32(data[0:4])
 	e.Size = ByteOrder.Uint32(data[4:8])
-	if e.Size > maxArgEnvSize {
-		e.Size = maxArgEnvSize
+	if e.Size > MaxArgEnvSize {
+		e.Size = MaxArgEnvSize
 	}
-	SliceToArray(data[8:maxArgEnvSize+8], unsafe.Pointer(&e.ValuesRaw))
+	SliceToArray(data[8:MaxArgEnvSize+8], unsafe.Pointer(&e.ValuesRaw))
 
-	return maxArgEnvSize + 8, nil
+	return MaxArgEnvSize + 8, nil
 }
 
 // UnmarshalBinary unmarshalls a binary representation of itself

--- a/pkg/security/secl/model/utils.go
+++ b/pkg/security/secl/model/utils.go
@@ -46,7 +46,7 @@ func UnmarshalStringArray(data []byte) ([]string, error) {
 
 		if i+n > len {
 			// truncated
-			arg := nullTerminatedString(data[i : len-1])
+			arg := nullTerminatedString(data[i:len])
 			return append(result, arg), ErrStringArrayOverflow
 		}
 

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"math/rand"
 	"os"
 	"os/exec"
 	"path"
@@ -30,6 +31,7 @@ import (
 	"github.com/syndtr/gocapability/capability"
 
 	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 )
@@ -340,7 +342,7 @@ func TestProcessContext(t *testing.T) {
 		}))
 	})
 
-	test.Run(t, "args-overflow", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+	test.Run(t, "args-overflow-single", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
 		args := []string{"-al"}
 		envs := []string{"LD_LIBRARY_PATH=/tmp/lib"}
 
@@ -364,8 +366,17 @@ func TestProcessContext(t *testing.T) {
 
 			argv := strings.Split(args.(string), " ")
 			assert.Equal(t, 2, len(argv), "incorrect number of args: %s", argv)
-			assert.Equal(t, 254, len(argv[1]), "wrong arg length")
+			assert.Equal(t, 255, len(argv[1]), "wrong arg length")
 			assert.Equal(t, true, strings.HasSuffix(argv[1], "..."), "args not truncated")
+
+			// truncated is reported if a single argument is truncated or if the list is truncated
+			truncated, err := event.GetFieldValue("exec.args_truncated")
+			if err != nil {
+				t.Errorf("not able to get args truncated")
+			}
+			if !truncated.(bool) {
+				t.Errorf("arg not truncated: %s", args.(string))
+			}
 
 			argv0, err := event.GetFieldValue("exec.argv0")
 			if err != nil {
@@ -373,16 +384,18 @@ func TestProcessContext(t *testing.T) {
 			}
 			assert.Equal(t, "ls", argv0, "incorrect argv0: %s", argv0)
 		}))
+	})
 
-		var arg string
-		for i := 0; i != 300; i++ {
-			arg += "a"
-		}
+	test.Run(t, "args-overflow-list-50", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+		envs := []string{"LD_LIBRARY_PATH=/tmp/lib"}
+
+		// force seed to have something we can reproduce
+		rand.Seed(1)
 
 		// number of args overflow
-		nArgs, args := 200, []string{"-al"}
+		nArgs, args := 1024, []string{"-al"}
 		for i := 0; i != nArgs; i++ {
-			args = append(args, arg)
+			args = append(args, eval.RandString(50))
 		}
 
 		test.WaitSignal(t, func() error {
@@ -391,20 +404,70 @@ func TestProcessContext(t *testing.T) {
 			_ = cmd.Run()
 			return nil
 		}, validateExecEvent(t, kind, func(event *sprobe.Event, rule *rules.Rule) {
-			args, err := event.GetFieldValue("exec.args")
+			execArgs, err := event.GetFieldValue("exec.args")
 			if err != nil {
 				t.Errorf("not able to get args")
 			}
 
-			argv := strings.Split(args.(string), " ")
-			assert.Equal(t, 159, len(argv), "incorrect number of args: %s", argv)
+			argv := strings.Split(execArgs.(string), " ")
+			assert.Equal(t, 132, len(argv), "incorrect number of args: %s", argv)
 
+			for i := 0; i != 132; i++ {
+				assert.Equal(t, args[i], argv[i], "expected arg not found")
+			}
+
+			// truncated is reported if a single argument is truncated or if the list is truncated
 			truncated, err := event.GetFieldValue("exec.args_truncated")
 			if err != nil {
 				t.Errorf("not able to get args truncated")
 			}
 			if !truncated.(bool) {
-				t.Errorf("arg not truncated: %s", args.(string))
+				t.Errorf("arg not truncated: %s", execArgs.(string))
+			}
+		}))
+	})
+
+	test.Run(t, "args-overflow-list-500", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+		envs := []string{"LD_LIBRARY_PATH=/tmp/lib"}
+
+		// force seed to have something we can reproduce
+		rand.Seed(1)
+
+		// number of args overflow
+		nArgs, args := 1024, []string{"-al"}
+		for i := 0; i != nArgs; i++ {
+			args = append(args, eval.RandString(500))
+		}
+
+		test.WaitSignal(t, func() error {
+			cmd := cmdFunc("ls", args, envs)
+			// we need to ignore the error because the string of "a" generates a "File name too long" error
+			_ = cmd.Run()
+			return nil
+		}, validateExecEvent(t, kind, func(event *sprobe.Event, rule *rules.Rule) {
+			execArgs, err := event.GetFieldValue("exec.args")
+			if err != nil {
+				t.Errorf("not able to get args")
+			}
+
+			argv := strings.Split(execArgs.(string), " ")
+			assert.Equal(t, 159, len(argv), "incorrect number of args: %s", argv)
+
+			for i := 0; i != 159; i++ {
+				expected := args[i]
+				if len(expected) > model.MaxArgEnvSize {
+					expected = args[i][:model.MaxArgEnvSize-4] + "..." // 4 is the size number of the string
+				}
+				assert.Equal(t, expected, argv[i], "expected arg not found")
+			}
+
+			// truncated is reported if a single argument is truncated or if the list is truncated
+			truncated, err := event.GetFieldValue("exec.args_truncated")
+			if err != nil {
+				t.Errorf("not able to get args truncated")
+			}
+			if !truncated.(bool) {
+				t.Errorf("arg not truncated: %s", execArgs.(string))
 			}
 		}))
 	})


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR improves the functional tests for the args, especially adding more truncation checks

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
