### PR TITLE
[CWS] use trace proxy for ruleset logger

### DIFF
--- a/pkg/security/log/logger.go
+++ b/pkg/security/log/logger.go
@@ -119,7 +119,7 @@ func (l *PatternLogger) TraceTag(tag fmt.Stringer, v interface{}) {
 
 // TraceTagf is used to print a trace level log
 func (l *PatternLogger) TraceTagf(tag fmt.Stringer, format string, params ...interface{}) {
-	if logLevel, err := log.GetLogLevel(); err != nil || logLevel != seelog.TraceLvl {
+	if !l.IsTracing() {
 		return
 	}
 
@@ -128,11 +128,18 @@ func (l *PatternLogger) TraceTagf(tag fmt.Stringer, format string, params ...int
 
 // Tracef is used to print a trace level log
 func (l *PatternLogger) Tracef(format string, params ...interface{}) {
-	if logLevel, err := log.GetLogLevel(); err != nil || logLevel != seelog.TraceLvl {
+	if !l.IsTracing() {
 		return
 	}
 
 	l.trace(&TagStringer{}, format, params...)
+}
+
+func (l *PatternLogger) IsTracing() bool {
+	if logLevel, err := log.GetLogLevel(); err != nil || logLevel != seelog.TraceLvl {
+		return false
+	}
+	return true
 }
 
 // Debugf is used to print a trace level log

--- a/pkg/security/log/logger.go
+++ b/pkg/security/log/logger.go
@@ -135,6 +135,7 @@ func (l *PatternLogger) Tracef(format string, params ...interface{}) {
 	l.trace(&TagStringer{}, format, params...)
 }
 
+// IsTracing is used to check if TraceF would actually log
 func (l *PatternLogger) IsTracing() bool {
 	if logLevel, err := log.GetLogLevel(); err != nil || logLevel != seelog.TraceLvl {
 		return false

--- a/pkg/security/secl/log/logger.go
+++ b/pkg/security/secl/log/logger.go
@@ -38,6 +38,7 @@ func (l NullLogger) Errorf(format string, params ...interface{}) {
 func (l NullLogger) Infof(format string, params ...interface{}) {
 }
 
+// IsTracing is used to check if TraceF would actually log
 func (l NullLogger) IsTracing() bool {
 	return false
 }

--- a/pkg/security/secl/log/logger.go
+++ b/pkg/security/secl/log/logger.go
@@ -15,6 +15,8 @@ type Logger interface {
 	Debugf(format string, params ...interface{})
 	// Errorf is used to print an error
 	Errorf(format string, params ...interface{})
+
+	IsTracing() bool
 }
 
 // NullLogger is a default implementation of the Logger interface
@@ -34,6 +36,10 @@ func (l NullLogger) Errorf(format string, params ...interface{}) {
 
 // Infof is used to print an info
 func (l NullLogger) Infof(format string, params ...interface{}) {
+}
+
+func (l NullLogger) IsTracing() bool {
+	return false
 }
 
 // OrNullLogger ensures that the provided logger is non-nil by returning a NullLogger if it is

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -521,9 +521,26 @@ func (rs *RuleSet) runRuleActions(ctx *eval.Context, rule *Rule) error {
 	return nil
 }
 
-func (rs *RuleSet) tracefProxy(format string, params ...interface{}) {
+// Since the logger is passed to the ruleset as an interface coming from an external package
+// the call to `Tracef` cannot be inlined, requiring the passing of all its argument as an
+// array on the heap. To fight this, and keep a low-overhead `Tracef`, we use those 2 functions
+// that will first check if tracing is actually enabled before passing the arguments to the trace
+// function. Because the go inliner is stupid, we cannot use a trace proxy with variadic parameters
+// because it disables the inlining of the proxy function. We thus need to define those 2 horrible
+// functions.
+// To ensure that those 2 functions are actually inlined, you can use
+// gcflags = `github.com/DataDog/datadog-agent/pkg/security/secl/rules=-m`
+// when compiling the system probe and look at the optimizer output
+
+func (rs *RuleSet) tracefProxy1(format string, param1 interface{}) {
 	if rs.logger.IsTracing() {
-		rs.logger.Tracef(format, params...)
+		rs.logger.Tracef(format, param1)
+	}
+}
+
+func (rs *RuleSet) tracefProxy2(format string, param1, param2 interface{}) {
+	if rs.logger.IsTracing() {
+		rs.logger.Tracef(format, param1, param2)
 	}
 }
 
@@ -539,11 +556,11 @@ func (rs *RuleSet) Evaluate(event eval.Event) bool {
 	if !exists {
 		return result
 	}
-	rs.tracefProxy("Evaluating event of type `%s` against set of %d rules", eventType, len(bucket.rules))
+	rs.tracefProxy2("Evaluating event of type `%s` against set of %d rules", eventType, len(bucket.rules))
 
 	for _, rule := range bucket.rules {
 		if rule.GetEvaluator().Eval(ctx) {
-			rs.tracefProxy("Rule `%s` matches with event `%s`\n", rule.ID, event)
+			rs.tracefProxy2("Rule `%s` matches with event `%s`\n", rule.ID, event)
 
 			rs.NotifyRuleMatch(rule, event)
 			result = true
@@ -555,7 +572,7 @@ func (rs *RuleSet) Evaluate(event eval.Event) bool {
 	}
 
 	if !result {
-		rs.tracefProxy("Looking for discarders for event of type `%s`", eventType)
+		rs.tracefProxy1("Looking for discarders for event of type `%s`", eventType)
 
 		for _, field := range bucket.fields {
 			if rs.opts.SupportedDiscarders != nil {

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -523,7 +523,7 @@ func (rs *RuleSet) runRuleActions(ctx *eval.Context, rule *Rule) error {
 
 func (rs *RuleSet) tracefProxy(format string, params ...interface{}) {
 	if rs.logger.IsTracing() {
-		rs.logger.Tracef(format, params)
+		rs.logger.Tracef(format, params...)
 	}
 }
 

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -521,6 +521,12 @@ func (rs *RuleSet) runRuleActions(ctx *eval.Context, rule *Rule) error {
 	return nil
 }
 
+func (rs *RuleSet) tracefProxy(format string, params ...interface{}) {
+	if rs.logger.IsTracing() {
+		rs.logger.Tracef(format, params)
+	}
+}
+
 // Evaluate the specified event against the set of rules
 func (rs *RuleSet) Evaluate(event eval.Event) bool {
 	ctx := rs.pool.Get(event.GetPointer())
@@ -533,11 +539,11 @@ func (rs *RuleSet) Evaluate(event eval.Event) bool {
 	if !exists {
 		return result
 	}
-	rs.logger.Tracef("Evaluating event of type `%s` against set of %d rules", eventType, len(bucket.rules))
+	rs.tracefProxy("Evaluating event of type `%s` against set of %d rules", eventType, len(bucket.rules))
 
 	for _, rule := range bucket.rules {
 		if rule.GetEvaluator().Eval(ctx) {
-			rs.logger.Tracef("Rule `%s` matches with event `%s`\n", rule.ID, event)
+			rs.tracefProxy("Rule `%s` matches with event `%s`\n", rule.ID, event)
 
 			rs.NotifyRuleMatch(rule, event)
 			result = true
@@ -549,7 +555,7 @@ func (rs *RuleSet) Evaluate(event eval.Event) bool {
 	}
 
 	if !result {
-		rs.logger.Tracef("Looking for discarders for event of type `%s`", eventType)
+		rs.tracefProxy("Looking for discarders for event of type `%s`", eventType)
 
 		for _, field := range bucket.fields {
 			if rs.opts.SupportedDiscarders != nil {


### PR DESCRIPTION
### What does this PR do?

The ruleset evaluator uses a logger that is stored as an interface. This means that calls to tracef cannot be inlined, and thus we need to construct the whole array of function arguments.
This PR improves the situation by checking for `trace` log level in the ruleset code, before creating the array.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
