### PR TITLE
[networks] Fix `http_batches` map size

### DIFF
--- a/pkg/ebpf/bytecode/runtime/conntrack.go
+++ b/pkg/ebpf/bytecode/runtime/conntrack.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Conntrack = NewRuntimeAsset("conntrack.c", "cb86c8228f72cc5e21c9fa2e61eff9e5e994358b8903b49a85e9119866269e30")
+var Conntrack = NewRuntimeAsset("conntrack.c", "ae54d92e003d6afd947fbedb9ea5b503833d161c9e80b5102483f18a5dbf1d41")

--- a/pkg/ebpf/bytecode/runtime/http.go
+++ b/pkg/ebpf/bytecode/runtime/http.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Http = NewRuntimeAsset("http.c", "65957c96f4e611b6e710e219ac5b8e76e184d6cf808b986f8863ec1a382880c4")
+var Http = NewRuntimeAsset("http.c", "bc8fe45de2f54868481c10c3f82f1adfd7f6250a31d9634461f39d6455e824b7")

--- a/pkg/ebpf/bytecode/runtime/http.go
+++ b/pkg/ebpf/bytecode/runtime/http.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Http = NewRuntimeAsset("http.c", "bc8fe45de2f54868481c10c3f82f1adfd7f6250a31d9634461f39d6455e824b7")
+var Http = NewRuntimeAsset("http.c", "27aadfa964904ddb89d98eccb7cb871faf1411a485c8e35788bee31d75ada0b4")

--- a/pkg/ebpf/bytecode/runtime/oom-kill.go
+++ b/pkg/ebpf/bytecode/runtime/oom-kill.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var OomKill = NewRuntimeAsset("oom-kill.c", "a6f49fea42fb2fbb121bad7180d3ad4ed7e00a6d338ea9f52cadbd6051d34638")
+var OomKill = NewRuntimeAsset("oom-kill.c", "5dcb629bf0dfe63368846ce069813f797015c76dfb9a5b2ffa8ec060dc4c75fb")

--- a/pkg/ebpf/bytecode/runtime/tcp-queue-length.go
+++ b/pkg/ebpf/bytecode/runtime/tcp-queue-length.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var TcpQueueLength = NewRuntimeAsset("tcp-queue-length.c", "7367457a07a36f7248270dbbc5a9d7fb8757fb28c5693163a7aa51a1569e5c61")
+var TcpQueueLength = NewRuntimeAsset("tcp-queue-length.c", "aa298d8b67da8a6b56e7307696ae68114b5411cd6e0ac6f2e1413f095972051d")

--- a/pkg/ebpf/bytecode/runtime/tracer.go
+++ b/pkg/ebpf/bytecode/runtime/tracer.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Tracer = NewRuntimeAsset("tracer.c", "c1437715f5c830e2f0f7c58ec13e924c67e04e2e11724fea736b60b3872d3697")
+var Tracer = NewRuntimeAsset("tracer.c", "01c59509da6b180c124ec280691685810e41c04916d9edd62bf01e3ab72b909d")

--- a/pkg/ebpf/c/map-defs.h
+++ b/pkg/ebpf/c/map-defs.h
@@ -44,4 +44,7 @@
 #define BPF_PERCPU_HASH_MAP(name, key_type, value_type, max_entries) \
     BPF_MAP(name, BPF_MAP_TYPE_PERCPU_HASH, key_type, value_type, max_entries, 0)
 
+#define BPF_PERCPU_ARRAY_MAP(name, key_type, value_type, max_entries) \
+    BPF_MAP(name, BPF_MAP_TYPE_PERCPU_ARRAY, key_type, value_type, max_entries, 0)
+
 #endif

--- a/pkg/network/ebpf/c/http-maps.h
+++ b/pkg/network/ebpf/c/http-maps.h
@@ -12,12 +12,15 @@ BPF_HASH_MAP(http_in_flight, conn_tuple_t, http_transaction_t, 1)
 /* This map used for notifying userspace that a HTTP batch is ready to be consumed */
 BPF_PERF_EVENT_ARRAY_MAP(http_notifications, __u32, 0)
 
-/* This map stores finished HTTP transactions in batches so they can be consumed by userspace*/
-BPF_HASH_MAP(http_batches, http_batch_key_t, http_batch_t, 1024)
+/*
+  This map stores finished HTTP transactions in batches so they can be consumed by userspace
+  Size is set dynamically during runtime and must be equal to CPUs*HTTP_BATCH_PAGES
+ */
+BPF_HASH_MAP(http_batches, http_batch_key_t, http_batch_t, 0)
 
 /* This map holds one entry per CPU storing state associated to current http batch*/
-BPF_HASH_MAP(http_batch_state, __u32, http_batch_state_t, 1024)
-    
+BPF_PERCPU_ARRAY_MAP(http_batch_state, __u32, http_batch_state_t, 1)
+
 BPF_HASH_MAP(ssl_sock_by_ctx, void *, ssl_sock_t, 1)
 
 BPF_HASH_MAP(ssl_read_args, u64, ssl_read_args_t, 1024)
@@ -39,5 +42,5 @@ BPF_PROG_ARRAY(http_progs, 1)
 
 /* This map used for notifying userspace of a shared library being loaded */
 BPF_PERF_EVENT_ARRAY_MAP(shared_libraries, __u32, 0)
-    
+
 #endif

--- a/pkg/network/http/batch_manager.go
+++ b/pkg/network/http/batch_manager.go
@@ -36,17 +36,18 @@ type batchManager struct {
 	numCPUs    int
 }
 
-func newBatchManager(batchMap, batchStateMap *ebpf.Map, numCPUs int) *batchManager {
+func newBatchManager(batchMap, batchStateMap *ebpf.Map, numCPUs int) (*batchManager, error) {
 	batch := new(httpBatch)
-	state := new(C.http_batch_state_t)
 	stateByCPU := make([]usrBatchState, numCPUs)
 
 	for i := 0; i < numCPUs; i++ {
 		// Initialize eBPF maps
-		batchStateMap.Put(unsafe.Pointer(&i), unsafe.Pointer(state))
 		for j := 0; j < HTTPBatchPages; j++ {
 			key := &httpBatchKey{cpu: C.uint(i), page_num: C.uint(j)}
-			batchMap.Put(unsafe.Pointer(key), unsafe.Pointer(batch))
+			err := batchMap.Put(unsafe.Pointer(key), unsafe.Pointer(batch))
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -54,7 +55,7 @@ func newBatchManager(batchMap, batchStateMap *ebpf.Map, numCPUs int) *batchManag
 		batchMap:   batchMap,
 		stateByCPU: stateByCPU,
 		numCPUs:    numCPUs,
-	}
+	}, nil
 }
 
 func (m *batchManager) GetTransactionsFrom(notification httpNotification) ([]httpTX, error) {

--- a/pkg/network/http/batch_manager.go
+++ b/pkg/network/http/batch_manager.go
@@ -36,7 +36,7 @@ type batchManager struct {
 	numCPUs    int
 }
 
-func newBatchManager(batchMap, batchStateMap *ebpf.Map, numCPUs int) (*batchManager, error) {
+func newBatchManager(batchMap *ebpf.Map, numCPUs int) (*batchManager, error) {
 	batch := new(httpBatch)
 	stateByCPU := make([]usrBatchState, numCPUs)
 

--- a/pkg/network/http/ebpf_main.go
+++ b/pkg/network/http/ebpf_main.go
@@ -16,6 +16,7 @@ import (
 
 	manager "github.com/DataDog/ebpf-manager"
 	"github.com/cilium/ebpf"
+	"github.com/iovisor/gobpf/pkg/cpupossible"
 	"golang.org/x/sys/unix"
 
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
@@ -23,7 +24,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	netebpf "github.com/DataDog/datadog-agent/pkg/network/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
-	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -166,7 +166,7 @@ func (e *ebpfProgram) Init() error {
 	}
 	e.Manager.DumpHandler = dumpMapsHandler
 
-	numCPUs, err := utils.NumCPU()
+	onlineCPUs, err := cpupossible.Get()
 	if err != nil {
 		return fmt.Errorf("couldn't determine number of CPUs: %w", err)
 	}
@@ -184,7 +184,7 @@ func (e *ebpfProgram) Init() error {
 			},
 			httpBatchesMap: {
 				Type:       ebpf.Hash,
-				MaxEntries: uint32(numCPUs * HTTPBatchPages),
+				MaxEntries: uint32(len(onlineCPUs) * HTTPBatchPages),
 				EditorFlag: manager.EditMaxEntries,
 			},
 		},

--- a/pkg/network/http/ebpf_ssl.go
+++ b/pkg/network/http/ebpf_ssl.go
@@ -261,11 +261,14 @@ func removeHooks(m *manager.Manager, probes map[string]string) func(string) erro
 			}
 
 			program := p.Program()
-			m.DetachHook(manager.ProbeIdentificationPair{
+			err := m.DetachHook(manager.ProbeIdentificationPair{
 				EBPFSection:  sec,
 				EBPFFuncName: funcName,
 				UID:          uid,
 			})
+			if err != nil {
+				log.Debugf("detachhook %s/%s/%d : %w", sec, funcName, uid, err)
+			}
 			if program != nil {
 				program.Close()
 			}

--- a/pkg/network/http/monitor.go
+++ b/pkg/network/http/monitor.go
@@ -99,10 +99,15 @@ func NewMonitor(c *config.Config, offsets []manager.ConstantEditor, sockFD *ebpf
 		}
 	}
 
+	batchManager, err := newBatchManager(batchMap, batchStateMap, numCPUs)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't instantiate batch manager: %w", err)
+	}
+
 	return &Monitor{
 		handler:                handler,
 		ebpfProgram:            mgr,
-		batchManager:           newBatchManager(batchMap, batchStateMap, numCPUs),
+		batchManager:           batchManager,
 		batchCompletionHandler: mgr.batchCompletionHandler,
 		telemetry:              telemetry,
 		telemetrySnapshot:      nil,

--- a/pkg/network/http/monitor.go
+++ b/pkg/network/http/monitor.go
@@ -79,11 +79,6 @@ func NewMonitor(c *config.Config, offsets []manager.ConstantEditor, sockFD *ebpf
 		return nil, err
 	}
 
-	batchStateMap, _, err := mgr.GetMap(httpBatchStateMap)
-	if err != nil {
-		return nil, err
-	}
-
 	notificationMap, _, _ := mgr.GetMap(httpNotificationsPerfMap)
 	numCPUs := int(notificationMap.MaxEntries())
 
@@ -99,7 +94,7 @@ func NewMonitor(c *config.Config, offsets []manager.ConstantEditor, sockFD *ebpf
 		}
 	}
 
-	batchManager, err := newBatchManager(batchMap, batchStateMap, numCPUs)
+	batchManager, err := newBatchManager(batchMap, numCPUs)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't instantiate batch manager: %w", err)
 	}

--- a/pkg/network/http/monitor_test.go
+++ b/pkg/network/http/monitor_test.go
@@ -43,8 +43,8 @@ var (
 func skipTestIfKernelNotSupported(t *testing.T) {
 	currKernelVersion, err := kernel.HostVersion()
 	require.NoError(t, err)
-	if currKernelVersion < kernel.VersionCode(4, 1, 0) {
-		t.Skip("HTTP feature not available on pre 4.1.0 kernels")
+	if currKernelVersion < kernel.VersionCode(4, 14, 0) {
+		t.Skip("HTTP feature not available on pre 4.14.0 kernels")
 	}
 }
 

--- a/pkg/network/http/shared_libraries.go
+++ b/pkg/network/http/shared_libraries.go
@@ -185,7 +185,9 @@ func (w *soWatcher) sync(libraries []so.Library) {
 		}
 
 		log.Debugf("unregistering library=%s", path)
-		unregisterCB(path)
+		if err := unregisterCB(path); err != nil {
+			log.Debugf("unregisterCB %s : %w", path, err)
+		}
 	}
 }
 
@@ -193,7 +195,9 @@ func (w *soWatcher) register(libPath string, r soRule) {
 	err := r.registerCB(libPath)
 	if err != nil {
 		log.Debugf("error registering library=%s: %s", libPath, err)
-		r.unregisterCB(libPath)
+		if err := r.unregisterCB(libPath); err != nil {
+			log.Debugf("unregisterCB %s : %w", libPath, err)
+		}
 		w.registered[libPath] = nil
 		return
 	}

--- a/pkg/network/tracer/ebpf_conntracker.go
+++ b/pkg/network/tracer/ebpf_conntracker.go
@@ -153,7 +153,9 @@ func (e *ebpfConntracker) dumpInitialTables(ctx context.Context, cfg *config.Con
 			return err
 		}
 	}
-	e.m.DetachHook(manager.ProbeIdentificationPair{EBPFSection: string(probes.ConntrackFillInfo), EBPFFuncName: "kprobe_ctnetlink_fill_info"})
+	if err := e.m.DetachHook(manager.ProbeIdentificationPair{EBPFSection: string(probes.ConntrackFillInfo), EBPFFuncName: "kprobe_ctnetlink_fill_info"}); err != nil {
+		log.Debugf("detachHook %s/kprobe_ctnetlink_fill_info : %w", string(probes.ConntrackFillInfo), err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

* Fix size of `http_batches` eBPF map. Previously this map had `max_entries` hard-coded to 1024 which led to incorrect behavior on hosts with a large number of CPUs.
* Change `http_batch_state` map to `PERCPU_ARRAY`. This is possible now that we're raising our Kernel targets to 4.14;

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

1. Obtain the number of CPUs from your test host using `lscpu`;
2. strace system-probe using the following command: `sudo strace -e bpf -f bin/system-probe/system-probe 2>&1 | grep http_batches`
3. Verify that `max_active` is set to: `NUM_CPU_CORES` * `HTTP_BATCH_PAGES` (15)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
