### PR TITLE
[CWS][SEC-4975] user space discarders

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "bb05855223d8f10edaf250166af59a4f162cb28d493f2173246122d145a9241c")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "5b46a23feefea0cee00a532942944df52ae6816347525c10e6bcc2831f1199b5")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "fcc8624ed2d8faee2724e8e2182ee260500a4c55b52e87a5cc50a8c3071017b1")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "356023d991ee11704a6d9ec7cd482b40c478b4015b4f6d1e8b2ba54d4b533476")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "f9307a08fccf863a2beec0bc4fa0366c437e7a131873d66d430f53721133d6ea")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "6c29b62b44983691d7ad40e63396326c9ba1a8f4386badf7d68a2d69e6d0384a")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "356023d991ee11704a6d9ec7cd482b40c478b4015b4f6d1e8b2ba54d4b533476")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "e0f43746b12306775db85b187d73f7edfd568c056ee949b1d5db6f576662f47e")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "e0f43746b12306775db85b187d73f7edfd568c056ee949b1d5db6f576662f47e")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "a9dc379bd80cba4ac8b0c0649049aa4d4d1a85fa592771232f662d4f11c520a3")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "a9dc379bd80cba4ac8b0c0649049aa4d4d1a85fa592771232f662d4f11c520a3")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "f9307a08fccf863a2beec0bc4fa0366c437e7a131873d66d430f53721133d6ea")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "2472c34399f31dc4821d19538a21ddb3e325391d04438e3058d4747a1bc44bf3")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "bb05855223d8f10edaf250166af59a4f162cb28d493f2173246122d145a9241c")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "6c29b62b44983691d7ad40e63396326c9ba1a8f4386badf7d68a2d69e6d0384a")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "2472c34399f31dc4821d19538a21ddb3e325391d04438e3058d4747a1bc44bf3")

--- a/pkg/security/ebpf/c/defs.h
+++ b/pkg/security/ebpf/c/defs.h
@@ -238,7 +238,7 @@ struct kevent_t {
     u64 timestamp;
     u32 type;
     u8 async;
-    u8 ad_saved;
+    u8 saved_by_ad;
     u8 padding[2];
 };
 

--- a/pkg/security/ebpf/c/defs.h
+++ b/pkg/security/ebpf/c/defs.h
@@ -238,7 +238,8 @@ struct kevent_t {
     u64 timestamp;
     u32 type;
     u8 async;
-    u8 padding[3];
+    u8 ad_saved;
+    u8 padding[2];
 };
 
 struct syscall_t {

--- a/pkg/security/ebpf/c/dentry_resolver.h
+++ b/pkg/security/ebpf/c/dentry_resolver.h
@@ -154,8 +154,14 @@ int __attribute__((always_inline)) resolve_dentry_tail_call(void *ctx, struct de
             params->discarder.path_key.ino = key.ino;
             params->discarder.path_key.mount_id = key.mount_id;
             params->discarder.is_leaf = i == 0;
-            if (is_discarded_by_inode(params, NULL)) {
+
+            switch (is_discarded_by_inode(params)) {
+            case DISCARDED:
                 return DENTRY_DISCARDED;
+            case SAVED_BY_AD:
+                input->saved_by_ad = true;
+            default:
+                break;
             }
         }
 

--- a/pkg/security/ebpf/c/dentry_resolver.h
+++ b/pkg/security/ebpf/c/dentry_resolver.h
@@ -154,7 +154,7 @@ int __attribute__((always_inline)) resolve_dentry_tail_call(void *ctx, struct de
             params->discarder.path_key.ino = key.ino;
             params->discarder.path_key.mount_id = key.mount_id;
             params->discarder.is_leaf = i == 0;
-            if (is_discarded_by_inode(params)) {
+            if (is_discarded_by_inode(params, NULL)) {
                 return DENTRY_DISCARDED;
             }
         }

--- a/pkg/security/ebpf/c/discarders.h
+++ b/pkg/security/ebpf/c/discarders.h
@@ -248,17 +248,19 @@ int __attribute__((always_inline)) is_discarded_by_inode(struct is_discarded_by_
     }
 
     bool is_discarded = inode_params->revision == get_discarder_revision(params->discarder.path_key.mount_id);
+    if (!is_discarded) {
+        return 0;
+    }
 
     // should we ignore the discarder check because of an activity dump ?
     if (params->activity_dump_state == IGNORE_DISCARDER_CHECK) {
         // do not discard this event
-        if (should_be_discarded && is_discarded) {
+        if (should_be_discarded) {
             *should_be_discarded = true;
         }
         return 0;
-    } else {
-        return is_discarded;
     }
+    return 1;
 }
 
 void __attribute__((always_inline)) expire_inode_discarders(u32 mount_id, u64 inode) {

--- a/pkg/security/ebpf/c/discarders.h
+++ b/pkg/security/ebpf/c/discarders.h
@@ -246,7 +246,7 @@ typedef enum discard_check_state {
 } discard_check_state;
 
 discard_check_state __attribute__((always_inline)) is_discarded_by_inode(struct is_discarded_by_inode_t *params) {
-    // fall back to the "normal" discarder check
+    // start with the "normal" discarder check
     struct inode_discarder_t key = params->discarder;
     struct inode_discarder_params_t *inode_params = (struct inode_discarder_params_t *) is_discarded(&inode_discarders, &key, params->event_type, params->now);
     if (!inode_params) {

--- a/pkg/security/ebpf/c/discarders.h
+++ b/pkg/security/ebpf/c/discarders.h
@@ -129,6 +129,13 @@ u64* __attribute__((always_inline)) get_discarder_timestamp(struct discarder_par
     }
 }
 
+u64* __attribute__((always_inline)) get_discarder_timestamp_from_map(struct discarder_params_t *params, u64 event_type) {
+    if (EVENT_FIRST_DISCARDER <= event_type && event_type < EVENT_LAST_DISCARDER) {
+        return &params->timestamps[event_type-EVENT_FIRST_DISCARDER];
+    }
+    return NULL;
+}
+
 void * __attribute__((always_inline)) is_discarded(struct bpf_map_def *discarder_map, void *key, u64 event_type, u64 now) {
     void *entry = bpf_map_lookup_elem(discarder_map, key);
     if (entry == NULL) {
@@ -149,7 +156,7 @@ void * __attribute__((always_inline)) is_discarded(struct bpf_map_def *discarder
         return NULL;
     }
 
-    u64* pid_tm = get_discarder_timestamp(params, event_type);
+    u64* pid_tm = get_discarder_timestamp_from_map(params, event_type);
     if (pid_tm != NULL && *pid_tm && *pid_tm <= now) {
         return NULL;
     }
@@ -214,7 +221,7 @@ int __attribute__((always_inline)) discard_inode(u64 event_type, u32 mount_id, u
         }
         add_event_to_mask(&inode_params->params.event_mask, event_type);
 
-        if ((discarder_timestamp = get_discarder_timestamp(&inode_params->params, event_type)) != NULL) {
+        if ((discarder_timestamp = get_discarder_timestamp_from_map(&inode_params->params, event_type)) != NULL) {
             *discarder_timestamp = timestamp;
         }
 
@@ -345,7 +352,7 @@ int __attribute__((always_inline)) discard_pid(u64 event_type, u32 tgid, u64 tim
     if (pid_params) {
         add_event_to_mask(&pid_params->params.event_mask, event_type);
 
-        if ((discarder_timestamp = get_discarder_timestamp(&pid_params->params, event_type)) != NULL) {
+        if ((discarder_timestamp = get_discarder_timestamp_from_map(&pid_params->params, event_type)) != NULL) {
             *discarder_timestamp = timestamp;
         }
 

--- a/pkg/security/ebpf/c/discarders.h
+++ b/pkg/security/ebpf/c/discarders.h
@@ -129,6 +129,9 @@ u64* __attribute__((always_inline)) get_discarder_timestamp(struct discarder_par
     }
 }
 
+// This function is doing the same thing as the one before, but can only work if `params` is a pointer to a map value
+// and not a pointer to the stack since kernels < 4.15 does not allow this. On the other hand it is faster and needs less
+// instructions.
 u64* __attribute__((always_inline)) get_discarder_timestamp_from_map(struct discarder_params_t *params, u64 event_type) {
     if (EVENT_FIRST_DISCARDER <= event_type && event_type < EVENT_LAST_DISCARDER) {
         return &params->timestamps[event_type-EVENT_FIRST_DISCARDER];

--- a/pkg/security/ebpf/c/open.h
+++ b/pkg/security/ebpf/c/open.h
@@ -37,8 +37,7 @@ struct open_event_t {
 
 int __attribute__((always_inline)) trace__sys_openat(u8 async, int flags, umode_t mode) {
     struct policy_t policy = fetch_policy(EVENT_OPEN);
-    bool should_be_discarded = false;
-    if (is_discarded_by_process2(policy.mode, EVENT_OPEN, &should_be_discarded)) {
+    if (is_discarded_by_process(policy.mode, EVENT_OPEN)) {
         return 0;
     }
 
@@ -46,7 +45,6 @@ int __attribute__((always_inline)) trace__sys_openat(u8 async, int flags, umode_
         .type = EVENT_OPEN,
         .policy = policy,
         .async = async,
-        .ad_saved = should_be_discarded,
         .open = {
             .flags = flags,
             .mode = mode & S_IALLUGO,
@@ -387,7 +385,7 @@ int __attribute__((always_inline)) dr_open_callback(void *ctx, int retval) {
     struct open_event_t event = {
         .syscall.retval = retval,
         .event.async = syscall->async,
-        .event.ad_saved = syscall->ad_saved,
+        .event.saved_by_ad = syscall->resolver.saved_by_ad,
         .file = syscall->open.file,
         .flags = syscall->open.flags,
         .mode = syscall->open.mode,

--- a/pkg/security/ebpf/c/open.h
+++ b/pkg/security/ebpf/c/open.h
@@ -37,7 +37,8 @@ struct open_event_t {
 
 int __attribute__((always_inline)) trace__sys_openat(u8 async, int flags, umode_t mode) {
     struct policy_t policy = fetch_policy(EVENT_OPEN);
-    if (is_discarded_by_process(policy.mode, EVENT_OPEN)) {
+    bool should_be_discarded = false;
+    if (is_discarded_by_process2(policy.mode, EVENT_OPEN, &should_be_discarded)) {
         return 0;
     }
 
@@ -45,6 +46,7 @@ int __attribute__((always_inline)) trace__sys_openat(u8 async, int flags, umode_
         .type = EVENT_OPEN,
         .policy = policy,
         .async = async,
+        .ad_saved = should_be_discarded,
         .open = {
             .flags = flags,
             .mode = mode & S_IALLUGO,
@@ -385,6 +387,7 @@ int __attribute__((always_inline)) dr_open_callback(void *ctx, int retval) {
     struct open_event_t event = {
         .syscall.retval = retval,
         .event.async = syscall->async,
+        .event.ad_saved = syscall->ad_saved,
         .file = syscall->open.file,
         .flags = syscall->open.flags,
         .mode = syscall->open.mode,

--- a/pkg/security/ebpf/c/process.h
+++ b/pkg/security/ebpf/c/process.h
@@ -112,15 +112,13 @@ struct bpf_map_def SEC("maps/pid_ignored") pid_ignored = {
 struct proc_cache_t *get_proc_from_cookie(u32 cookie);
 
 struct proc_cache_t * __attribute__((always_inline)) get_proc_cache(u32 tgid) {
-    struct proc_cache_t *entry = NULL;
-
     struct pid_cache_t *pid_entry = (struct pid_cache_t *) bpf_map_lookup_elem(&pid_cache, &tgid);
-    if (pid_entry) {
-        // Select the cache entry
-        u32 cookie = pid_entry->cookie;
-        entry = get_proc_from_cookie(cookie);
+    if (!pid_entry) {
+        return NULL;
     }
-    return entry;
+
+    // Select the cache entry
+    return get_proc_from_cookie(pid_entry->cookie);
 }
 
 struct bpf_map_def SEC("maps/netns_cache") netns_cache = {

--- a/pkg/security/ebpf/c/syscalls.h
+++ b/pkg/security/ebpf/c/syscalls.h
@@ -46,8 +46,8 @@ struct linux_binprm_t {
 struct syscall_cache_t {
     struct policy_t policy;
     u64 type;
-    u16 discarded;
-    u16 ad_saved;
+    u8 discarded;
+    u8 ad_saved;
     u8 async;
 
     struct dentry_resolver_input_t resolver;

--- a/pkg/security/ebpf/c/syscalls.h
+++ b/pkg/security/ebpf/c/syscalls.h
@@ -46,7 +46,8 @@ struct linux_binprm_t {
 struct syscall_cache_t {
     struct policy_t policy;
     u64 type;
-    u32 discarded;
+    u16 discarded;
+    u16 ad_saved;
     u8 async;
 
     struct dentry_resolver_input_t resolver;

--- a/pkg/security/ebpf/c/syscalls.h
+++ b/pkg/security/ebpf/c/syscalls.h
@@ -26,6 +26,7 @@ struct dentry_resolver_input_t {
     int callback;
     int ret;
     int iteration;
+    u8 saved_by_ad;
 };
 
 union selinux_write_payload_t {
@@ -47,7 +48,6 @@ struct syscall_cache_t {
     struct policy_t policy;
     u64 type;
     u8 discarded;
-    u8 ad_saved;
     u8 async;
 
     struct dentry_resolver_input_t resolver;

--- a/pkg/security/module/module.go
+++ b/pkg/security/module/module.go
@@ -461,6 +461,11 @@ func (m *Module) EventDiscarderFound(rs *rules.RuleSet, event eval.Event, field 
 
 // HandleEvent is called by the probe when an event arrives from the kernel
 func (m *Module) HandleEvent(event *sprobe.Event) {
+	// if the event should have been discarded in kernel space, we don't need to evaluate it
+	if event.SavedByActivityDumps {
+		return
+	}
+
 	if ruleSet := m.GetRuleSet(); ruleSet != nil {
 		ruleSet.Evaluate(event)
 	}

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -145,11 +145,12 @@ type ContainerContext struct {
 //msgp:ignore Event
 // genaccessors
 type Event struct {
-	ID           string    `field:"-" json:"-"`
-	Type         uint32    `field:"-"`
-	Async        bool      `field:"async" event:"*"` // True if the syscall was asynchronous
-	TimestampRaw uint64    `field:"-" json:"-"`
-	Timestamp    time.Time `field:"-"` // Timestamp of the event
+	ID                   string    `field:"-" json:"-"`
+	Type                 uint32    `field:"-"`
+	Async                bool      `field:"async" event:"*"` // True if the syscall was asynchronous
+	SavedByActivityDumps bool      `field:"-"`               // True if the event should have been discarded if the AD were disabled
+	TimestampRaw         uint64    `field:"-" json:"-"`
+	Timestamp            time.Time `field:"-"` // Timestamp of the event
 
 	// context shared with all events
 	ProcessCacheEntry *ProcessCacheEntry `field:"-" json:"-"`

--- a/pkg/security/secl/model/unmarshallers.go
+++ b/pkg/security/secl/model/unmarshallers.go
@@ -80,12 +80,9 @@ func (e *Event) UnmarshalBinary(data []byte) (int, error) {
 
 	e.TimestampRaw = ByteOrder.Uint64(data[8:16])
 	e.Type = ByteOrder.Uint32(data[16:20])
-	if data[20] != 0 {
-		e.Async = true
-	} else {
-		e.Async = false
-	}
-	// 21-24: padding
+	e.Async = data[20] != 0
+	e.SavedByActivityDumps = data[21] != 0
+	// 22-24: padding
 
 	return 24, nil
 }


### PR DESCRIPTION
### What does this PR do?

This PR tags event that should have been discarded if the activity dumps were disabled, and use this tag to skip rule evaluation.
This currently only support open events as a PoC but will be extended to other events.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
