### PR TITLE
[util/containerd] Pass namespace explicitly to methods that need it

### DIFF
--- a/pkg/collector/corechecks/containers/containerd/check.go
+++ b/pkg/collector/corechecks/containers/containerd/check.go
@@ -113,7 +113,7 @@ func (c *ContainerdCheck) Run() error {
 		_ = c.Warnf("Error collecting metrics: %s", err)
 	}
 
-	if err := c.runContainerdCustom(sender, c.client); err != nil {
+	if err := c.runContainerdCustom(sender); err != nil {
 		_ = c.Warnf("Error collecting metrics: %s", err)
 	}
 
@@ -126,15 +126,14 @@ func (c *ContainerdCheck) runProcessor(sender aggregator.Sender) error {
 	return c.processor.Run(sender, cacheValidity)
 }
 
-func (c *ContainerdCheck) runContainerdCustom(sender aggregator.Sender, cl cutil.ContainerdItf) error {
+func (c *ContainerdCheck) runContainerdCustom(sender aggregator.Sender) error {
 	namespaces, err := cutil.NamespacesToWatch(context.TODO(), c.client)
 	if err != nil {
 		return err
 	}
 
 	for _, namespace := range namespaces {
-		c.client.SetCurrentNamespace(namespace)
-		if err := c.collectImageSizes(sender, c.client); err != nil {
+		if err := c.collectImageSizes(sender, c.client, namespace); err != nil {
 			log.Infof("Failed to collect images size, err: %s", err)
 		}
 	}
@@ -142,9 +141,9 @@ func (c *ContainerdCheck) runContainerdCustom(sender aggregator.Sender, cl cutil
 	return nil
 }
 
-func (c *ContainerdCheck) collectImageSizes(sender aggregator.Sender, cl cutil.ContainerdItf) error {
+func (c *ContainerdCheck) collectImageSizes(sender aggregator.Sender, cl cutil.ContainerdItf, namespace string) error {
 	// Report images size
-	images, err := cl.ListImages()
+	images, err := cl.ListImages(namespace)
 	if err != nil {
 		return err
 	}
@@ -152,7 +151,7 @@ func (c *ContainerdCheck) collectImageSizes(sender aggregator.Sender, cl cutil.C
 	for _, image := range images {
 		var size int64
 
-		if err := cl.CallWithClientContext(func(c context.Context) error {
+		if err := cl.CallWithClientContext(namespace, func(c context.Context) error {
 			size, err = image.Size(c)
 			return err
 		}); err != nil {
@@ -173,9 +172,6 @@ func (c *ContainerdCheck) collectEvents(sender aggregator.Sender) {
 
 	if !c.subscriber.isRunning() {
 		// Keep track of the health of the Containerd socket.
-		//
-		// Check events does not rely on the "namespace" attribute of the
-		// client, so we can share it.
 		c.subscriber.CheckEvents(c.client)
 	}
 	events := c.subscriber.Flush(time.Now().Unix())

--- a/pkg/util/containerd/containerd_util_test.go
+++ b/pkg/util/containerd/containerd_util_test.go
@@ -84,6 +84,8 @@ func (i *mockImage) Size(ctx context.Context) (int64, error) {
 	return i.size, nil
 }
 
+const TestNamespace = "default"
+
 func TestEnvVars(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -117,7 +119,7 @@ func TestEnvVars(t *testing.T) {
 				},
 			}
 
-			envVars, err := mockUtil.EnvVars(container)
+			envVars, err := mockUtil.EnvVars(TestNamespace, container)
 
 			if test.expectsErr {
 				require.Error(t, err)
@@ -140,7 +142,7 @@ func TestInfo(t *testing.T) {
 		},
 	}
 	ctn := containerd.Container(cs)
-	c, err := mockUtil.Info(ctn)
+	c, err := mockUtil.Info(TestNamespace, ctn)
 	require.NoError(t, err)
 	require.Equal(t, "foo", c.Image)
 }
@@ -158,7 +160,7 @@ func TestImage(t *testing.T) {
 		},
 	}
 
-	resultImage, err := mockUtil.Image(container)
+	resultImage, err := mockUtil.Image(TestNamespace, container)
 	require.NoError(t, err)
 	require.Equal(t, resultImage, image)
 }
@@ -174,7 +176,7 @@ func TestImageSize(t *testing.T) {
 		},
 	}
 	ctn := containerd.Container(cs)
-	c, err := mockUtil.ImageSize(ctn)
+	c, err := mockUtil.ImageSize(TestNamespace, ctn)
 	require.NoError(t, err)
 	require.Equal(t, int64(12), c)
 }
@@ -236,7 +238,7 @@ func TestTaskMetrics(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			cton := makeCtn(test.values, test.typeURL, test.taskMetricError)
 
-			m, e := mockUtil.TaskMetrics(cton)
+			m, e := mockUtil.TaskMetrics(TestNamespace, cton)
 			if e != nil {
 				require.Equal(t, e, test.taskMetricError)
 				return
@@ -274,7 +276,7 @@ func TestStatus(t *testing.T) {
 		},
 	}
 
-	resultStatus, err := mockUtil.Status(container)
+	resultStatus, err := mockUtil.Status(TestNamespace, container)
 	require.NoError(t, err)
 	require.Equal(t, resultStatus, status)
 }
@@ -291,7 +293,7 @@ func TestIsSandbox(t *testing.T) {
 		},
 	}
 
-	isSandbox, err := mockUtil.IsSandbox(withSandboxLabel)
+	isSandbox, err := mockUtil.IsSandbox(TestNamespace, withSandboxLabel)
 	require.NoError(t, err)
 	require.True(t, isSandbox)
 
@@ -304,7 +306,7 @@ func TestIsSandbox(t *testing.T) {
 		},
 	}
 
-	isSandbox, err = mockUtil.IsSandbox(withSandboxAnnotation)
+	isSandbox, err = mockUtil.IsSandbox(TestNamespace, withSandboxAnnotation)
 	require.NoError(t, err)
 	require.True(t, isSandbox)
 
@@ -317,7 +319,7 @@ func TestIsSandbox(t *testing.T) {
 		},
 	}
 
-	isSandbox, err = mockUtil.IsSandbox(notSandbox)
+	isSandbox, err = mockUtil.IsSandbox(TestNamespace, notSandbox)
 	require.NoError(t, err)
 	require.False(t, isSandbox)
 }

--- a/pkg/util/containerd/fake/containerd_util.go
+++ b/pkg/util/containerd/fake/containerd_util.go
@@ -25,28 +25,26 @@ type MockedContainerdClient struct {
 	MockClose                 func() error
 	MockCheckConnectivity     func() *retry.Error
 	MockEvents                func() containerd.EventService
-	MockContainers            func() ([]containerd.Container, error)
-	MockContainer             func(id string) (containerd.Container, error)
-	MockContainerWithCtx      func(ctx context.Context, id string) (containerd.Container, error)
-	MockEnvVars               func(ctn containerd.Container) (map[string]string, error)
+	MockContainers            func(namespace string) ([]containerd.Container, error)
+	MockContainer             func(namespace string, id string) (containerd.Container, error)
+	MockContainerWithCtx      func(ctx context.Context, namespace string, id string) (containerd.Container, error)
+	MockEnvVars               func(namespace string, ctn containerd.Container) (map[string]string, error)
 	MockMetadata              func() (containerd.Version, error)
-	MockListImages            func() ([]containerd.Image, error)
-	MockImage                 func(ctn containerd.Container) (containerd.Image, error)
-	MockImageSize             func(ctn containerd.Container) (int64, error)
-	MockTaskMetrics           func(ctn containerd.Container) (*types.Metric, error)
-	MockTaskPids              func(ctn containerd.Container) ([]containerd.ProcessInfo, error)
-	MockInfo                  func(ctn containerd.Container) (containers.Container, error)
-	MockLabels                func(ctn containerd.Container) (map[string]string, error)
-	MockLabelsWithContext     func(ctx context.Context, ctn containerd.Container) (map[string]string, error)
-	MockCurrentNamespace      func() string
-	MockSetCurrentNamespace   func(namespace string)
+	MockListImages            func(namespace string) ([]containerd.Image, error)
+	MockImage                 func(namespace string, ctn containerd.Container) (containerd.Image, error)
+	MockImageSize             func(namespace string, ctn containerd.Container) (int64, error)
+	MockTaskMetrics           func(namespace string, ctn containerd.Container) (*types.Metric, error)
+	MockTaskPids              func(namespace string, ctn containerd.Container) ([]containerd.ProcessInfo, error)
+	MockInfo                  func(namespace string, ctn containerd.Container) (containers.Container, error)
+	MockLabels                func(namespace string, ctn containerd.Container) (map[string]string, error)
+	MockLabelsWithContext     func(ctx context.Context, namespace string, ctn containerd.Container) (map[string]string, error)
 	MockNamespaces            func(ctx context.Context) ([]string, error)
-	MockSpec                  func(ctn containerd.Container) (*oci.Spec, error)
-	MockSpecWithContext       func(ctx context.Context, ctn containerd.Container) (*oci.Spec, error)
-	MockStatus                func(ctn containerd.Container) (containerd.ProcessStatus, error)
-	MockCallWithClientContext func(f func(context.Context) error) error
-	MockAnnotations           func(ctn containerd.Container) (map[string]string, error)
-	MockIsSandbox             func(ctn containerd.Container) (bool, error)
+	MockSpec                  func(namespace string, ctn containerd.Container) (*oci.Spec, error)
+	MockSpecWithContext       func(ctx context.Context, namespace string, ctn containerd.Container) (*oci.Spec, error)
+	MockStatus                func(namespace string, ctn containerd.Container) (containerd.ProcessStatus, error)
+	MockCallWithClientContext func(namespace string, f func(context.Context) error) error
+	MockAnnotations           func(namespace string, ctn containerd.Container) (map[string]string, error)
+	MockIsSandbox             func(namespace string, ctn containerd.Container) (bool, error)
 }
 
 // Close is a mock method
@@ -60,58 +58,48 @@ func (client *MockedContainerdClient) CheckConnectivity() *retry.Error {
 }
 
 // ListImages is a mock method
-func (client *MockedContainerdClient) ListImages() ([]containerd.Image, error) {
-	return client.MockListImages()
+func (client *MockedContainerdClient) ListImages(namespace string) ([]containerd.Image, error) {
+	return client.MockListImages(namespace)
 }
 
 // Image is a mock method
-func (client *MockedContainerdClient) Image(ctn containerd.Container) (containerd.Image, error) {
-	return client.MockImage(ctn)
+func (client *MockedContainerdClient) Image(namespace string, ctn containerd.Container) (containerd.Image, error) {
+	return client.MockImage(namespace, ctn)
 }
 
 // ImageSize is a mock method
-func (client *MockedContainerdClient) ImageSize(ctn containerd.Container) (int64, error) {
-	return client.MockImageSize(ctn)
+func (client *MockedContainerdClient) ImageSize(namespace string, ctn containerd.Container) (int64, error) {
+	return client.MockImageSize(namespace, ctn)
 }
 
 // Labels is a mock method
-func (client *MockedContainerdClient) Labels(ctn containerd.Container) (map[string]string, error) {
-	return client.MockLabels(ctn)
+func (client *MockedContainerdClient) Labels(namespace string, ctn containerd.Container) (map[string]string, error) {
+	return client.MockLabels(namespace, ctn)
 }
 
 // LabelsWithContext is a mock method
-func (client *MockedContainerdClient) LabelsWithContext(ctx context.Context, ctn containerd.Container) (map[string]string, error) {
-	return client.MockLabelsWithContext(ctx, ctn)
+func (client *MockedContainerdClient) LabelsWithContext(ctx context.Context, namespace string, ctn containerd.Container) (map[string]string, error) {
+	return client.MockLabelsWithContext(ctx, namespace, ctn)
 }
 
 // Info is a mock method
-func (client *MockedContainerdClient) Info(ctn containerd.Container) (containers.Container, error) {
-	return client.MockInfo(ctn)
+func (client *MockedContainerdClient) Info(namespace string, ctn containerd.Container) (containers.Container, error) {
+	return client.MockInfo(namespace, ctn)
 }
 
 // TaskMetrics is a mock method
-func (client *MockedContainerdClient) TaskMetrics(ctn containerd.Container) (*types.Metric, error) {
-	return client.MockTaskMetrics(ctn)
+func (client *MockedContainerdClient) TaskMetrics(namespace string, ctn containerd.Container) (*types.Metric, error) {
+	return client.MockTaskMetrics(namespace, ctn)
 }
 
 // TaskPids is a mock method
-func (client *MockedContainerdClient) TaskPids(ctn containerd.Container) ([]containerd.ProcessInfo, error) {
-	return client.MockTaskPids(ctn)
+func (client *MockedContainerdClient) TaskPids(namespace string, ctn containerd.Container) ([]containerd.ProcessInfo, error) {
+	return client.MockTaskPids(namespace, ctn)
 }
 
 // Metadata is a mock method
 func (client *MockedContainerdClient) Metadata() (containerd.Version, error) {
 	return client.MockMetadata()
-}
-
-// CurrentNamespace is a mock method
-func (client *MockedContainerdClient) CurrentNamespace() string {
-	return client.MockCurrentNamespace()
-}
-
-// SetCurrentNamespace is a mock method
-func (client *MockedContainerdClient) SetCurrentNamespace(namespace string) {
-	client.MockSetCurrentNamespace(namespace)
 }
 
 // Namespaces is a mock method
@@ -120,18 +108,18 @@ func (client *MockedContainerdClient) Namespaces(ctx context.Context) ([]string,
 }
 
 // Containers is a mock method
-func (client *MockedContainerdClient) Containers() ([]containerd.Container, error) {
-	return client.MockContainers()
+func (client *MockedContainerdClient) Containers(namespace string) ([]containerd.Container, error) {
+	return client.MockContainers(namespace)
 }
 
 // Container is a mock method
-func (client *MockedContainerdClient) Container(id string) (containerd.Container, error) {
-	return client.MockContainer(id)
+func (client *MockedContainerdClient) Container(namespace string, id string) (containerd.Container, error) {
+	return client.MockContainer(namespace, id)
 }
 
 // ContainerWithContext is a mock method
-func (client *MockedContainerdClient) ContainerWithContext(ctx context.Context, id string) (containerd.Container, error) {
-	return client.MockContainerWithCtx(ctx, id)
+func (client *MockedContainerdClient) ContainerWithContext(ctx context.Context, namespace string, id string) (containerd.Container, error) {
+	return client.MockContainerWithCtx(ctx, namespace, id)
 }
 
 // GetEvents is a mock method
@@ -140,36 +128,36 @@ func (client *MockedContainerdClient) GetEvents() containerd.EventService {
 }
 
 // Spec is a mock method
-func (client *MockedContainerdClient) Spec(ctn containerd.Container) (*oci.Spec, error) {
-	return client.MockSpec(ctn)
+func (client *MockedContainerdClient) Spec(namespace string, ctn containerd.Container) (*oci.Spec, error) {
+	return client.MockSpec(namespace, ctn)
 }
 
 // SpecWithContext is a mock method
-func (client *MockedContainerdClient) SpecWithContext(ctx context.Context, ctn containerd.Container) (*oci.Spec, error) {
-	return client.MockSpecWithContext(ctx, ctn)
+func (client *MockedContainerdClient) SpecWithContext(ctx context.Context, namespace string, ctn containerd.Container) (*oci.Spec, error) {
+	return client.MockSpecWithContext(ctx, namespace, ctn)
 }
 
 // EnvVars is a mock method
-func (client *MockedContainerdClient) EnvVars(ctn containerd.Container) (map[string]string, error) {
-	return client.MockEnvVars(ctn)
+func (client *MockedContainerdClient) EnvVars(namespace string, ctn containerd.Container) (map[string]string, error) {
+	return client.MockEnvVars(namespace, ctn)
 }
 
 // Status is a mock method
-func (client *MockedContainerdClient) Status(ctn containerd.Container) (containerd.ProcessStatus, error) {
-	return client.MockStatus(ctn)
+func (client *MockedContainerdClient) Status(namespace string, ctn containerd.Container) (containerd.ProcessStatus, error) {
+	return client.MockStatus(namespace, ctn)
 }
 
 // CallWithClientContext is a mock method
-func (client *MockedContainerdClient) CallWithClientContext(f func(context.Context) error) error {
-	return client.MockCallWithClientContext(f)
+func (client *MockedContainerdClient) CallWithClientContext(namespace string, f func(context.Context) error) error {
+	return client.MockCallWithClientContext(namespace, f)
 }
 
 // Annotations is a mock method
-func (client *MockedContainerdClient) Annotations(ctn containerd.Container) (map[string]string, error) {
-	return client.MockAnnotations(ctn)
+func (client *MockedContainerdClient) Annotations(namespace string, ctn containerd.Container) (map[string]string, error) {
+	return client.MockAnnotations(namespace, ctn)
 }
 
 // IsSandbox is a mock method
-func (client *MockedContainerdClient) IsSandbox(ctn containerd.Container) (bool, error) {
-	return client.MockIsSandbox(ctn)
+func (client *MockedContainerdClient) IsSandbox(namespace string, ctn containerd.Container) (bool, error) {
+	return client.MockIsSandbox(namespace, ctn)
 }

--- a/pkg/util/containers/v2/metrics/containerd/collector_test.go
+++ b/pkg/util/containers/v2/metrics/containerd/collector_test.go
@@ -43,14 +43,13 @@ func TestGetContainerIDForPID(t *testing.T) {
 		MockNamespaces: func(ctx context.Context) ([]string, error) {
 			return []string{"ns"}, nil
 		},
-		MockSetCurrentNamespace: func(namespace string) {},
-		MockContainers: func() ([]containerd.Container, error) {
+		MockContainers: func(namespace string) ([]containerd.Container, error) {
 			return []containerd.Container{
 				mockedContainer{id: "cID1"},
 				mockedContainer{id: "cID2"},
 			}, nil
 		},
-		MockTaskPids: func(ctn containerd.Container) ([]containerd.ProcessInfo, error) {
+		MockTaskPids: func(namespace string, ctn containerd.Container) ([]containerd.ProcessInfo, error) {
 			return pidMap[ctn.ID()], nil
 		},
 	}
@@ -83,21 +82,20 @@ func TestGetContainerIDForPID(t *testing.T) {
 //   - 2) Define functions like Info, Spec, etc. so they don't return errors.
 func containerdClient(metrics *types.Metric) *fake.MockedContainerdClient {
 	return &fake.MockedContainerdClient{
-		MockTaskMetrics: func(ctn containerd.Container) (*types.Metric, error) {
+		MockTaskMetrics: func(namespace string, ctn containerd.Container) (*types.Metric, error) {
 			return metrics, nil
 		},
-		MockContainer: func(id string) (containerd.Container, error) {
+		MockContainer: func(namespace string, id string) (containerd.Container, error) {
 			return mockedContainer{}, nil
 		},
-		MockInfo: func(ctn containerd.Container) (containers.Container, error) {
+		MockInfo: func(namespace string, ctn containerd.Container) (containers.Container, error) {
 			return containers.Container{}, nil
 		},
-		MockSpec: func(ctn containerd.Container) (*oci.Spec, error) {
+		MockSpec: func(namespace string, ctn containerd.Container) (*oci.Spec, error) {
 			return nil, nil
 		},
-		MockTaskPids: func(ctn containerd.Container) ([]containerd.ProcessInfo, error) {
+		MockTaskPids: func(namespace string, ctn containerd.Container) ([]containerd.ProcessInfo, error) {
 			return nil, nil
 		},
-		MockSetCurrentNamespace: func(namespace string) {},
 	}
 }

--- a/pkg/workloadmeta/collectors/internal/containerd/container_builder.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/container_builder.go
@@ -21,17 +21,17 @@ import (
 )
 
 // buildWorkloadMetaContainer generates a workloadmeta.Container from a containerd.Container
-func buildWorkloadMetaContainer(container containerd.Container, containerdClient cutil.ContainerdItf) (workloadmeta.Container, error) {
+func buildWorkloadMetaContainer(namespace string, container containerd.Container, containerdClient cutil.ContainerdItf) (workloadmeta.Container, error) {
 	if container == nil {
 		return workloadmeta.Container{}, fmt.Errorf("cannot build workloadmeta container from nil containerd container")
 	}
 
-	info, err := containerdClient.Info(container)
+	info, err := containerdClient.Info(namespace, container)
 	if err != nil {
 		return workloadmeta.Container{}, err
 	}
 
-	spec, err := containerdClient.Spec(container)
+	spec, err := containerdClient.Spec(namespace, container)
 	if err != nil {
 		return workloadmeta.Container{}, err
 	}
@@ -46,7 +46,7 @@ func buildWorkloadMetaContainer(container containerd.Container, containerdClient
 		log.Debugf("cannot split image name %q: %s", info.Image, err)
 	}
 
-	status, err := containerdClient.Status(container)
+	status, err := containerdClient.Status(namespace, container)
 	if err != nil {
 		if !errdefs.IsNotFound(err) {
 			return workloadmeta.Container{}, err
@@ -59,7 +59,7 @@ func buildWorkloadMetaContainer(container containerd.Container, containerdClient
 	}
 
 	networkIPs := make(map[string]string)
-	ip, err := extractIP(container, containerdClient)
+	ip, err := extractIP(namespace, container, containerdClient)
 	if err != nil {
 		log.Debugf("cannot get IP of container %s", err)
 	} else if ip == "" {

--- a/pkg/workloadmeta/collectors/internal/containerd/container_builder_test.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/container_builder_test.go
@@ -42,6 +42,7 @@ func (m *mockedImage) Name() string {
 }
 
 func TestBuildWorkloadMetaContainer(t *testing.T) {
+	namespace := "default"
 	containerID := "10"
 	labels := map[string]string{
 		"some_label": "some_val",
@@ -69,28 +70,28 @@ func TestBuildWorkloadMetaContainer(t *testing.T) {
 	}
 
 	client := fake.MockedContainerdClient{
-		MockEnvVars: func(ctn containerd.Container) (map[string]string, error) {
+		MockEnvVars: func(namespace string, ctn containerd.Container) (map[string]string, error) {
 			return envVars, nil
 		},
-		MockInfo: func(ctn containerd.Container) (containers.Container, error) {
+		MockInfo: func(namespace string, ctn containerd.Container) (containers.Container, error) {
 			return containers.Container{
 				Labels:    labels,
 				CreatedAt: createdAt,
 				Image:     imgName,
 			}, nil
 		},
-		MockSpec: func(ctn containerd.Container) (*oci.Spec, error) {
+		MockSpec: func(namespace string, ctn containerd.Container) (*oci.Spec, error) {
 			return &oci.Spec{Hostname: hostName, Process: &specs.Process{Env: envVarStrs}}, nil
 		},
-		MockStatus: func(ctn containerd.Container) (containerd.ProcessStatus, error) {
+		MockStatus: func(namespace string, ctn containerd.Container) (containerd.ProcessStatus, error) {
 			return containerd.Running, nil
 		},
-		MockTaskPids: func(ctn containerd.Container) ([]containerd.ProcessInfo, error) {
+		MockTaskPids: func(namespace string, ctn containerd.Container) ([]containerd.ProcessInfo, error) {
 			return nil, nil
 		},
 	}
 
-	result, err := buildWorkloadMetaContainer(&container, &client)
+	result, err := buildWorkloadMetaContainer(namespace, &container, &client)
 	assert.NoError(t, err)
 
 	expected := workloadmeta.Container{

--- a/pkg/workloadmeta/collectors/internal/containerd/containerd_test.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/containerd_test.go
@@ -64,12 +64,12 @@ func TestIgnoreContainer(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			client := fake.MockedContainerdClient{
-				MockInfo: func(containerd.Container) (containerdcontainers.Container, error) {
+				MockInfo: func(namespace string, ctn containerd.Container) (containerdcontainers.Container, error) {
 					return containerdcontainers.Container{
 						Image: test.imgName,
 					}, nil
 				},
-				MockIsSandbox: func(ctn containerd.Container) (bool, error) {
+				MockIsSandbox: func(namespace string, ctn containerd.Container) (bool, error) {
 					return test.isSandbox, nil
 				},
 			}
@@ -79,7 +79,7 @@ func TestIgnoreContainer(t *testing.T) {
 				filterPausedContainers: pauseFilter,
 			}
 
-			ignored, err := containerdCollector.ignoreContainer(test.container)
+			ignored, err := containerdCollector.ignoreContainer("default", test.container)
 			assert.NoError(t, err)
 
 			if test.expectsIgnored {

--- a/pkg/workloadmeta/collectors/internal/containerd/event_builder.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/event_builder.go
@@ -70,7 +70,7 @@ func createSetEvent(container containerd.Container, namespace string, containerd
 		return workloadmeta.CollectorEvent{}, errNoContainer
 	}
 
-	entity, err := buildWorkloadMetaContainer(container, containerdClient)
+	entity, err := buildWorkloadMetaContainer(namespace, container, containerdClient)
 	if err != nil {
 		return workloadmeta.CollectorEvent{}, fmt.Errorf("could not fetch info for container %s: %s", container.ID(), err)
 	}

--- a/pkg/workloadmeta/collectors/internal/containerd/event_builder_test.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/event_builder_test.go
@@ -42,7 +42,7 @@ func TestBuildCollectorEvent(t *testing.T) {
 
 	client := containerdClient(&container)
 
-	workloadMetaContainer, err := buildWorkloadMetaContainer(&container, &client)
+	workloadMetaContainer, err := buildWorkloadMetaContainer(namespace, &container, &client)
 	workloadMetaContainer.Namespace = namespace
 	assert.NoError(t, err)
 
@@ -284,32 +284,32 @@ func containerdClient(container containerd.Container) fake.MockedContainerdClien
 	createdAt, _ := time.Parse("2006-01-02", "2021-10-11")
 
 	return fake.MockedContainerdClient{
-		MockContainerWithCtx: func(ctx context.Context, id string) (containerd.Container, error) {
+		MockContainerWithCtx: func(ctx context.Context, namespace string, id string) (containerd.Container, error) {
 			return container, nil
 		},
-		MockLabels: func(ctn containerd.Container) (map[string]string, error) {
+		MockLabels: func(namespace string, ctn containerd.Container) (map[string]string, error) {
 			return labels, nil
 		},
-		MockImage: func(ctn containerd.Container) (containerd.Image, error) {
+		MockImage: func(namespace string, ctn containerd.Container) (containerd.Image, error) {
 			return &mockedImage{
 				mockName: func() string {
 					return imgName
 				},
 			}, nil
 		},
-		MockEnvVars: func(ctn containerd.Container) (map[string]string, error) {
+		MockEnvVars: func(namespace string, ctn containerd.Container) (map[string]string, error) {
 			return envVars, nil
 		},
-		MockInfo: func(ctn containerd.Container) (containers.Container, error) {
+		MockInfo: func(namespace string, ctn containerd.Container) (containers.Container, error) {
 			return containers.Container{CreatedAt: createdAt}, nil
 		},
-		MockSpec: func(ctn containerd.Container) (*oci.Spec, error) {
+		MockSpec: func(namespace string, ctn containerd.Container) (*oci.Spec, error) {
 			return &oci.Spec{Hostname: hostName}, nil
 		},
-		MockStatus: func(ctn containerd.Container) (containerd.ProcessStatus, error) {
+		MockStatus: func(namespace string, ctn containerd.Container) (containerd.ProcessStatus, error) {
 			return containerd.Running, nil
 		},
-		MockTaskPids: func(ctn containerd.Container) ([]containerd.ProcessInfo, error) {
+		MockTaskPids: func(namespace string, ctn containerd.Container) ([]containerd.ProcessInfo, error) {
 			return nil, nil
 		},
 	}

--- a/pkg/workloadmeta/collectors/internal/containerd/network_linux.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/network_linux.go
@@ -29,12 +29,12 @@ import (
 //   - If the container exposes multiple IPs, this function just returns one of
 //   them. That means that if a container is attached to multiple networks this
 //   might not work as expected.
-func extractIP(container containerd.Container, containerdClient cutil.ContainerdItf) (string, error) {
+func extractIP(namespace string, container containerd.Container, containerdClient cutil.ContainerdItf) (string, error) {
 	if !config.IsHostProcAvailable() {
 		return "", nil
 	}
 
-	taskPids, err := containerdClient.TaskPids(container)
+	taskPids, err := containerdClient.TaskPids(namespace, container)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/workloadmeta/collectors/internal/containerd/network_stub.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/network_stub.go
@@ -16,6 +16,6 @@ import (
 	cutil "github.com/DataDog/datadog-agent/pkg/util/containerd"
 )
 
-func extractIP(container containerd.Container, containerdClient cutil.ContainerdItf) (string, error) {
+func extractIP(namespace string, container containerd.Container, containerdClient cutil.ContainerdItf) (string, error) {
 	return "", errors.New("can't get the IPs on this OS")
 }

--- a/releasenotes/notes/containerd-client-namespace-e2f413fe7a594d95.yaml
+++ b/releasenotes/notes/containerd-client-namespace-e2f413fe7a594d95.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed a problem that could trigger in the containerd collector when
+    fetching containers from multiple namespaces.


### PR DESCRIPTION
### What does this PR do?

Changes the containerd client so that every function that needs a namespace receives in the params.

We had the namespace in the struct. This was error prone and caused some problems like this one:
https://github.com/DataDog/datadog-agent/blob/aae51ab2aa410eae1c4fc78e1bafd2bd48da953a/pkg/util/containers/v2/metrics/containerd/collector.go#L76

### Describe how to test/QA your changes

This is a refactor related with containerd using multiple namespaces, so we need to test that everything related to that still works.

Filter some namespaces using `DD_CONTAINERD_NAMESPACES` and check that everything works as expected:
- `agent workload-list` doesn't show containers from excluded namespaces.
- `containerd.*` and `container.*` metrics are reported, but not for containers that belong to excluded namespaces.
- Datadog events reported by containerd still work. Make sure that no events come from excluded namespaces.

Note: to make sure that `container.*` metrics are reported by the `containerd` collector and not the system one, start the agent without mounting the cgroups directory. You should see `Using metrics collector: containerd for runtime: containerd` in the logs.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
