### PR TITLE
[CWS] prefix all the filter tests by Filter

### DIFF
--- a/pkg/security/tests/filters_test.go
+++ b/pkg/security/tests/filters_test.go
@@ -45,7 +45,7 @@ func openTestFile(test *testModule, testFile string, flags int) (int, error) {
 	return int(fd), nil
 }
 
-func TestOpenBasenameApproverFilter(t *testing.T) {
+func TestFilterOpenBasenameApprover(t *testing.T) {
 	// generate a basename up to the current limit of the agent
 	var basename string
 	for i := 0; i < model.MaxSegmentLength; i++ {
@@ -100,7 +100,7 @@ func TestOpenBasenameApproverFilter(t *testing.T) {
 	}
 }
 
-func TestOpenLeafDiscarderFilter(t *testing.T) {
+func TestFilterOpenLeafDiscarder(t *testing.T) {
 	// We need to write a rule with no approver on the file path, and that won't match the real opened file (so that
 	// a discarder is created).
 	rule := &rules.RuleDefinition{
@@ -159,7 +159,7 @@ func TestOpenLeafDiscarderFilter(t *testing.T) {
 	}
 }
 
-func testOpenParentDiscarderFilter(t *testing.T, parents ...string) {
+func testFilterOpenParentDiscarder(t *testing.T, parents ...string) {
 	// We need to write a rule with no approver on the file path, and that won't match the real opened file (so that
 	// a discarder is created).
 	rule := &rules.RuleDefinition{
@@ -224,15 +224,15 @@ func testOpenParentDiscarderFilter(t *testing.T, parents ...string) {
 	}
 }
 
-func TestOpenParentDiscarderFilter(t *testing.T) {
-	testOpenParentDiscarderFilter(t, "parent")
+func TestFilterOpenParentDiscarder(t *testing.T) {
+	testFilterOpenParentDiscarder(t, "parent")
 }
 
-func TestOpenGrandParentDiscarderFilter(t *testing.T) {
-	testOpenParentDiscarderFilter(t, "grandparent", "parent")
+func TestFilterOpenGrandParentDiscarder(t *testing.T) {
+	testFilterOpenParentDiscarder(t, "grandparent", "parent")
 }
 
-func TestDiscarderFilterMask(t *testing.T) {
+func TestFilterDiscarderMask(t *testing.T) {
 	ruleDefs := []*rules.RuleDefinition{
 		{
 			ID:         "test_mask_open_rule",
@@ -304,7 +304,7 @@ func TestDiscarderFilterMask(t *testing.T) {
 	}))
 }
 
-func TestOpenFlagsApproverFilter(t *testing.T) {
+func TestFilterOpenFlagsApprover(t *testing.T) {
 	rule := &rules.RuleDefinition{
 		ID:         "test_rule",
 		Expression: `open.flags & (O_SYNC | O_NOCTTY) > 0`,
@@ -357,7 +357,7 @@ func TestOpenFlagsApproverFilter(t *testing.T) {
 	}
 }
 
-func TestOpenProcessPidDiscarder(t *testing.T) {
+func TestFilterOpenProcessPidDiscarder(t *testing.T) {
 	rule := &rules.RuleDefinition{
 		ID:         "test_rule",
 		Expression: `open.file.path == "{{.Root}}/test-oba-1" && process.file.path == "/bin/aaa"`,
@@ -421,7 +421,7 @@ func TestOpenProcessPidDiscarder(t *testing.T) {
 	}
 }
 
-func TestDiscarderRetentionFilter(t *testing.T) {
+func TestFilterDiscarderRetention(t *testing.T) {
 	// We need to write a rule with no approver on the file path, and that won't match the real opened file (so that
 	// a discarder is created).
 	rule := &rules.RuleDefinition{


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Prefix all the filter tests by Filter so that it is easier to run all of them at once

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
