### PR TITLE
Fix HPA e2e tests

### DIFF
--- a/test/e2e/argo-workflows/default-workflow.yaml
+++ b/test/e2e/argo-workflows/default-workflow.yaml
@@ -75,14 +75,14 @@ spec:
                 - name: namespace
                   value: "{{workflow.namespace}}"
 
-          # - name: start-nginx
-          #   templateRef:
-          #     name: nginx
-          #     template: create
-          #   arguments:
-          #     parameters:
-          #       - name: namespace
-          #         value: "{{workflow.namespace}}"
+          - name: start-nginx
+            templateRef:
+              name: nginx
+              template: create
+            arguments:
+              parameters:
+                - name: namespace
+                  value: "{{workflow.namespace}}"
 
         - - name: fake-dd-reset
             templateRef:
@@ -174,14 +174,14 @@ spec:
                 - name: namespace
                   value: "{{workflow.namespace}}"
 
-          # - name: test-nginx
-          #   templateRef:
-          #     name: nginx
-          #     template: test
-          #   arguments:
-          #     parameters:
-          #       - name: namespace
-          #         value: "{{workflow.namespace}}"
+          - name: test-nginx
+            templateRef:
+              name: nginx
+              template: test
+            arguments:
+              parameters:
+                - name: namespace
+                  value: "{{workflow.namespace}}"
 
           - name: test-busybox
             templateRef:
@@ -201,14 +201,14 @@ spec:
                 - name: namespace
                   value: "{{workflow.namespace}}"
 
-          # - name: stop-nginx
-          #   templateRef:
-          #     name: nginx
-          #     template: delete
-          #   arguments:
-          #     parameters:
-          #       - name: namespace
-          #         value: "{{workflow.namespace}}"
+          - name: stop-nginx
+            templateRef:
+              name: nginx
+              template: delete
+            arguments:
+              parameters:
+                - name: namespace
+                  value: "{{workflow.namespace}}"
 
         - - name: no-more-redis
             templateRef:
@@ -219,14 +219,14 @@ spec:
                 - name: namespace
                   value: "{{workflow.namespace}}"
 
-          # - name: no-more-nginx
-          #   templateRef:
-          #     name: nginx
-          #     template: no-more-metrics
-          #   arguments:
-          #     parameters:
-          #       - name: namespace
-          #         value: "{{workflow.namespace}}"
+          - name: no-more-nginx
+            templateRef:
+              name: nginx
+              template: no-more-metrics
+            arguments:
+              parameters:
+                - name: namespace
+                  value: "{{workflow.namespace}}"
 
     - name: exit-handler
       steps:
@@ -285,14 +285,14 @@ spec:
                 - name: namespace
                   value: "{{workflow.namespace}}"
 
-          # - name: stop-nginx
-          #   templateRef:
-          #     name: nginx
-          #     template: delete
-          #   arguments:
-          #     parameters:
-          #       - name: namespace
-          #         value: "{{workflow.namespace}}"
+          - name: stop-nginx
+            templateRef:
+              name: nginx
+              template: delete
+            arguments:
+              parameters:
+                - name: namespace
+                  value: "{{workflow.namespace}}"
 
           - name: stop-fake-datadog
             templateRef:
@@ -330,14 +330,14 @@ spec:
               parameters:
                 - name: namespace
                   value: "{{workflow.namespace}}"
-          # - name: diagnose-nginx
-          #   templateRef:
-          #     name: nginx
-          #     template: diagnose
-          #   arguments:
-          #     parameters:
-          #       - name: namespace
-          #         value: "{{workflow.namespace}}"
+          - name: diagnose-nginx
+            templateRef:
+              name: nginx
+              template: diagnose
+            arguments:
+              parameters:
+                - name: namespace
+                  value: "{{workflow.namespace}}"
           - name: diagnose-busybox
             templateRef:
               name: busybox

--- a/test/e2e/argo-workflows/templates/nginx.yaml
+++ b/test/e2e/argo-workflows/templates/nginx.yaml
@@ -112,7 +112,7 @@ spec:
       resource:
         action: apply
         manifest: |
-          apiVersion: autoscaling/v2beta1
+          apiVersion: autoscaling/v2
           kind: HorizontalPodAutoscaler
           metadata:
             name: nginxext
@@ -127,11 +127,14 @@ spec:
             metrics:
             - type: External
               external:
-                metricName: nginx.net.request_per_s
-                metricSelector:
-                  matchLabels:
+                metric:
+                  name: nginx.net.request_per_s
+                  selector:
+                    matchLabels:
                       kube_container_name: nginx
-                targetAverageValue: 9
+                target:
+                  type: AverageValue
+                  averageValue: 9
 
     - name: delete-service
       inputs:


### PR DESCRIPTION
### What does this PR do?

Revert #13340 and migrate HPA definition in the e2e tests to `autoscaling/v2`

### Motivation

Support latest Kubernetes versions.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Run e2e tests

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
