### PR TITLE
[CWS] skip container tags resolution when resolving for ADs

### DIFF
--- a/pkg/security/module/process_monitor.go
+++ b/pkg/security/module/process_monitor.go
@@ -23,7 +23,7 @@ type ProcessMonitoring struct {
 // HandleEvent implement the EventHandler interface
 func (p *ProcessMonitoring) HandleEvent(event *sprobe.Event) {
 	// Force resolution of all event fields before exposing it through the API server
-	event.ResolveFields()
+	event.ResolveFields(false)
 	event.ResolveEventTimestamp()
 
 	entry := event.ResolveProcessCacheEntry()

--- a/pkg/security/probe/activity_dump.go
+++ b/pkg/security/probe/activity_dump.go
@@ -422,7 +422,7 @@ func (ad *ActivityDump) Insert(event *Event) (newEntry bool) {
 	}
 
 	// resolve fields
-	event.ResolveFields()
+	event.ResolveFields(true)
 
 	// the count of processed events is the count of events that matched the activity dump selector = the events for
 	// which we successfully found a process activity node

--- a/pkg/security/probe/fields_resolver.go
+++ b/pkg/security/probe/fields_resolver.go
@@ -12,7 +12,9 @@ package probe
 func (ev *Event) ResolveFields(forADs bool) {
 	// resolve context fields that are not related to any event type
 	_ = ev.ResolveContainerID(&ev.ContainerContext)
-	_ = ev.ResolveContainerTags(&ev.ContainerContext)
+	if !forADs {
+		_ = ev.ResolveContainerTags(&ev.ContainerContext)
+	}
 	_ = ev.ResolveNetworkDeviceIfName(&ev.NetworkContext.Device)
 	_ = ev.ResolveProcessArgs(&ev.ProcessContext.Process)
 	_ = ev.ResolveProcessArgsTruncated(&ev.ProcessContext.Process)

--- a/pkg/security/probe/fields_resolver.go
+++ b/pkg/security/probe/fields_resolver.go
@@ -9,7 +9,7 @@
 package probe
 
 // ResolveFields resolves all the fields associate to the event type. Context fields are automatically resolved.
-func (ev *Event) ResolveFields() {
+func (ev *Event) ResolveFields(forADs bool) {
 	// resolve context fields that are not related to any event type
 	_ = ev.ResolveContainerID(&ev.ContainerContext)
 	_ = ev.ResolveContainerTags(&ev.ContainerContext)

--- a/pkg/security/secl/compiler/generators/accessors/accessors.go
+++ b/pkg/security/secl/compiler/generators/accessors/accessors.go
@@ -176,6 +176,7 @@ type seclField struct {
 	iterator            string
 	handler             string
 	cachelessResolution bool
+	skipADResolution    bool
 	lengthField         bool
 	weight              int64
 }
@@ -214,6 +215,8 @@ func parseFieldDef(def string) (seclField, error) {
 						field.cachelessResolution = true
 					case "length":
 						field.lengthField = true
+					case "skip_ad":
+						field.skipADResolution = true
 					}
 				}
 			}
@@ -329,6 +332,7 @@ func handleSpec(module *common.Module, astFile *ast.File, spec interface{}, pref
 								OpOverrides:         opOverrides,
 								Constants:           constants,
 								CachelessResolution: seclField.cachelessResolution,
+								SkipADResolution:    seclField.skipADResolution,
 							}
 
 							fieldIterator = module.Iterators[alias]
@@ -355,6 +359,7 @@ func handleSpec(module *common.Module, astFile *ast.File, spec interface{}, pref
 								OpOverrides:         opOverrides,
 								Constants:           constants,
 								CachelessResolution: seclField.cachelessResolution,
+								SkipADResolution:    seclField.skipADResolution,
 								IsOrigTypePtr:       isPointer,
 							}
 

--- a/pkg/security/secl/compiler/generators/accessors/accessors.go
+++ b/pkg/security/secl/compiler/generators/accessors/accessors.go
@@ -569,9 +569,8 @@ func getFieldResolver(allFields map[string]*common.StructField, field *common.St
 func fieldADPrint(field *common.StructField, resolver string) string {
 	if field.SkipADResolution {
 		return fmt.Sprintf("if !forADs { _ = %s }", resolver)
-	} else {
-		return fmt.Sprintf("_ = %s", resolver)
 	}
+	return fmt.Sprintf("_ = %s", resolver)
 }
 
 func override(str string, mock bool) string {

--- a/pkg/security/secl/compiler/generators/accessors/accessors.go
+++ b/pkg/security/secl/compiler/generators/accessors/accessors.go
@@ -566,6 +566,14 @@ func getFieldResolver(allFields map[string]*common.StructField, field *common.St
 	return fmt.Sprintf("ev.%s(%sev.%s)", field.Handler, ptr, field.Prefix)
 }
 
+func fieldADPrint(field *common.StructField, resolver string) string {
+	if field.SkipADResolution {
+		return fmt.Sprintf("if !forADs { _ = %s }", resolver)
+	} else {
+		return fmt.Sprintf("_ = %s", resolver)
+	}
+}
+
 func override(str string, mock bool) string {
 	if !strings.Contains(str, ".") && !mock {
 		return "model." + str
@@ -579,6 +587,7 @@ var funcMap = map[string]interface{}{
 	"NewField":         newField,
 	"Override":         override,
 	"GetFieldResolver": getFieldResolver,
+	"FieldADPrint":     fieldADPrint,
 }
 
 //go:embed accessors.tmpl

--- a/pkg/security/secl/compiler/generators/accessors/accessors.go
+++ b/pkg/security/secl/compiler/generators/accessors/accessors.go
@@ -549,6 +549,23 @@ func newField(allFields map[string]*common.StructField, field *common.StructFiel
 	return result
 }
 
+func getFieldResolver(allFields map[string]*common.StructField, field *common.StructField) string {
+	if field.Handler == "" || field.Iterator != nil || field.CachelessResolution {
+		return ""
+	}
+
+	if field.Prefix == "" {
+		return fmt.Sprintf("ev.%s(ev)", field.Handler)
+	}
+
+	ptr := "&"
+	if allFields[field.Prefix].IsOrigTypePtr {
+		ptr = ""
+	}
+
+	return fmt.Sprintf("ev.%s(%sev.%s)", field.Handler, ptr, field.Prefix)
+}
+
 func override(str string, mock bool) string {
 	if !strings.Contains(str, ".") && !mock {
 		return "model." + str
@@ -557,10 +574,11 @@ func override(str string, mock bool) string {
 }
 
 var funcMap = map[string]interface{}{
-	"TrimPrefix": strings.TrimPrefix,
-	"TrimSuffix": strings.TrimSuffix,
-	"NewField":   newField,
-	"Override":   override,
+	"TrimPrefix":       strings.TrimPrefix,
+	"TrimSuffix":       strings.TrimSuffix,
+	"NewField":         newField,
+	"Override":         override,
+	"GetFieldResolver": getFieldResolver,
 }
 
 //go:embed accessors.tmpl

--- a/pkg/security/secl/compiler/generators/accessors/common/types.go
+++ b/pkg/security/secl/compiler/generators/accessors/common/types.go
@@ -44,6 +44,7 @@ type StructField struct {
 	Event               string
 	Handler             string
 	CachelessResolution bool
+	SkipADResolution    bool
 	OrigType            string
 	IsOrigTypePtr       bool
 	Iterator            *StructField

--- a/pkg/security/secl/compiler/generators/accessors/fields_resolver.tmpl
+++ b/pkg/security/secl/compiler/generators/accessors/fields_resolver.tmpl
@@ -20,7 +20,7 @@ func (ev *Event) ResolveFields(forADs bool) {
 {{- range $Key, $Field := .Fields}}
     {{- if and (eq $Field.Event "*") (ne $Field.Handler "") (not $Field.Iterator) (eq $Field.CachelessResolution false) }}
         {{- if (eq $Field.Prefix "") }}
-            _ = {{ print "ev." $Field.Handler "(ev)"}}
+            _ = ev.{{ $Field.Handler }}(ev)
         {{- else}}
             {{$Ptr := "&"}}
             {{$Parent := index $.AllFields $Field.Prefix}}
@@ -30,7 +30,7 @@ func (ev *Event) ResolveFields(forADs bool) {
 
             {{ $resolver := print "ev." $Field.Handler "(" $Ptr "ev." $Field.Prefix ")" }}
             {{ if not (hasKey $uniqueResolvers $resolver) }}
-            _ = {{ print $resolver }}
+            _ = {{ $resolver }}
             {{ $_ := set $uniqueResolvers $resolver "" }}
             {{ end }}
         {{- end}}
@@ -46,7 +46,7 @@ func (ev *Event) ResolveFields(forADs bool) {
             {{- $Field := index $.Fields $FieldName }}
                 {{- if and (ne $Field.Handler "") (not $Field.Iterator) (eq $Field.CachelessResolution false) }}
                     {{- if (eq $Field.Prefix "") }}
-                        _ = {{ print "ev." $Field.Handler "(ev)"}}
+                        _ = ev.{{ $Field.Handler }}(ev)
                     {{- else}}
                         {{$Ptr := "&"}}
                         {{$Parent := index $.AllFields $Field.Prefix}}
@@ -54,7 +54,7 @@ func (ev *Event) ResolveFields(forADs bool) {
                             {{$Ptr = ""}}
                         {{end}}
 
-                        _ = {{ print "ev." $Field.Handler "(" $Ptr "ev." $Field.Prefix ")"}}
+                        _ = ev.{{ $Field.Handler }}({{ $Ptr}}ev.{{ $Field.Prefix }})
                     {{- end}}
                 {{- end -}}
             {{end}}

--- a/pkg/security/secl/compiler/generators/accessors/fields_resolver.tmpl
+++ b/pkg/security/secl/compiler/generators/accessors/fields_resolver.tmpl
@@ -21,7 +21,7 @@ func (ev *Event) ResolveFields(forADs bool) {
     {{- if and (eq $Field.Event "*") }}
         {{ $resolver := $Field | GetFieldResolver $.AllFields }}
         {{ if and (ne $resolver "") (not (hasKey $uniqueResolvers $resolver)) }}
-        _ = {{ $resolver }}
+        {{ $resolver | FieldADPrint $Field }}
         {{ $_ := set $uniqueResolvers $resolver "" }}
         {{ end }}
     {{- end -}}
@@ -36,7 +36,7 @@ func (ev *Event) ResolveFields(forADs bool) {
             {{- $Field := index $.Fields $FieldName }}
                 {{ $resolver := $Field | GetFieldResolver $.AllFields }}
                 {{ if and (ne $resolver "") }}
-                _ = {{ $resolver }}
+                {{ $resolver | FieldADPrint $Field }}
                 {{ end }}
             {{end}}
         {{- end}}

--- a/pkg/security/secl/compiler/generators/accessors/fields_resolver.tmpl
+++ b/pkg/security/secl/compiler/generators/accessors/fields_resolver.tmpl
@@ -14,7 +14,7 @@ import (
 )
 
 // ResolveFields resolves all the fields associate to the event type. Context fields are automatically resolved.
-func (ev *Event) ResolveFields() {
+func (ev *Event) ResolveFields(forADs bool) {
     {{ $uniqueResolvers := dict }}
     // resolve context fields that are not related to any event type
 {{- range $Key, $Field := .Fields}}

--- a/pkg/security/secl/compiler/generators/accessors/fields_resolver.tmpl
+++ b/pkg/security/secl/compiler/generators/accessors/fields_resolver.tmpl
@@ -18,22 +18,12 @@ func (ev *Event) ResolveFields(forADs bool) {
     {{ $uniqueResolvers := dict }}
     // resolve context fields that are not related to any event type
 {{- range $Key, $Field := .Fields}}
-    {{- if and (eq $Field.Event "*") (ne $Field.Handler "") (not $Field.Iterator) (eq $Field.CachelessResolution false) }}
-        {{- if (eq $Field.Prefix "") }}
-            _ = ev.{{ $Field.Handler }}(ev)
-        {{- else}}
-            {{$Ptr := "&"}}
-            {{$Parent := index $.AllFields $Field.Prefix}}
-            {{- if $Parent.IsOrigTypePtr}}
-                {{$Ptr = ""}}
-            {{end}}
-
-            {{ $resolver := print "ev." $Field.Handler "(" $Ptr "ev." $Field.Prefix ")" }}
-            {{ if not (hasKey $uniqueResolvers $resolver) }}
-            _ = {{ $resolver }}
-            {{ $_ := set $uniqueResolvers $resolver "" }}
-            {{ end }}
-        {{- end}}
+    {{- if and (eq $Field.Event "*") }}
+        {{ $resolver := $Field | GetFieldResolver $.AllFields }}
+        {{ if and (ne $resolver "") (not (hasKey $uniqueResolvers $resolver)) }}
+        _ = {{ $resolver }}
+        {{ $_ := set $uniqueResolvers $resolver "" }}
+        {{ end }}
     {{- end -}}
 {{end}}
 
@@ -44,19 +34,10 @@ func (ev *Event) ResolveFields(forADs bool) {
         case "{{$Name}}":
             {{- range $Key, $FieldName := $EventType.Fields }}
             {{- $Field := index $.Fields $FieldName }}
-                {{- if and (ne $Field.Handler "") (not $Field.Iterator) (eq $Field.CachelessResolution false) }}
-                    {{- if (eq $Field.Prefix "") }}
-                        _ = ev.{{ $Field.Handler }}(ev)
-                    {{- else}}
-                        {{$Ptr := "&"}}
-                        {{$Parent := index $.AllFields $Field.Prefix}}
-                        {{- if $Parent.IsOrigTypePtr}}
-                            {{$Ptr = ""}}
-                        {{end}}
-
-                        _ = ev.{{ $Field.Handler }}({{ $Ptr}}ev.{{ $Field.Prefix }})
-                    {{- end}}
-                {{- end -}}
+                {{ $resolver := $Field | GetFieldResolver $.AllFields }}
+                {{ if and (ne $resolver "") }}
+                _ = {{ $resolver }}
+                {{ end }}
             {{end}}
         {{- end}}
     {{end}}

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -137,8 +137,8 @@ type ChownEvent struct {
 // ContainerContext holds the container context of an event
 //msgp:ignore ContainerContext
 type ContainerContext struct {
-	ID   string   `field:"id,handler:ResolveContainerID"`                 // ID of the container
-	Tags []string `field:"tags,handler:ResolveContainerTags,weight:9999"` // Tags of the container
+	ID   string   `field:"id,handler:ResolveContainerID"`                              // ID of the container
+	Tags []string `field:"tags,handler:ResolveContainerTags,opts:skip_ad,weight:9999"` // Tags of the container
 }
 
 // Event represents an event sent from the kernel


### PR DESCRIPTION
### What does this PR do?

This PR skips container tags resolution for each event when resolving for ADs

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
