### PR TITLE
Reducing the number of none preallocated slices in process-agent

### DIFF
--- a/cmd/process-agent/collector.go
+++ b/cmd/process-agent/collector.go
@@ -337,7 +337,14 @@ func (l *Collector) run(exit chan struct{}) error {
 		eventsEps = append(eventsEps, e.Endpoint.String())
 	}
 
-	var checkNames []string
+	checkNamesLength := len(l.enabledChecks)
+	if !ddconfig.Datadog.GetBool("process_config.disable_realtime_checks") {
+		// checkNamesLength is double when realtime checks is enabled as we append the Process real time name
+		// as well as the original check name
+		checkNamesLength = checkNamesLength * 2
+	}
+
+	checkNames := make([]string, 0, checkNamesLength)
 	for _, check := range l.enabledChecks {
 		checkNames = append(checkNames, check.Name())
 

--- a/cmd/process-agent/collector_api_test.go
+++ b/cmd/process-agent/collector_api_test.go
@@ -533,13 +533,13 @@ func runCollectorTestWithAPIKeys(t *testing.T, check checks.Check, cfg *config.A
 	collectorAddr, eventsAddr, orchestratorAddr := ep.start()
 	defer ep.stop()
 
-	var eps []apicfg.Endpoint
+	eps := make([]apicfg.Endpoint, 0, len(apiKeys))
 	for _, key := range apiKeys {
 		eps = append(eps, apicfg.Endpoint{APIKey: key, Endpoint: collectorAddr})
 	}
 	setProcessEndpointsForTest(mockConfig, eps...)
 
-	var eventsEps []apicfg.Endpoint
+	eventsEps := make([]apicfg.Endpoint, 0, len(apiKeys))
 	for _, key := range apiKeys {
 		eventsEps = append(eventsEps, apicfg.Endpoint{APIKey: key, Endpoint: eventsAddr})
 	}

--- a/pkg/process/checks/format.go
+++ b/pkg/process/checks/format.go
@@ -96,10 +96,9 @@ func humanFormatProcess(msgs []model.MessageBody, w io.Writer) error {
 	}
 
 	var (
-		processes    = map[int32]*model.Process{}
-		containers   = map[string]*model.Container{}
-		pids         []int
-		containerIDs []string
+		processes  = map[int32]*model.Process{}
+		containers = map[string]*model.Container{}
+		pids       []int
 	)
 
 	for _, m := range msgs {
@@ -120,18 +119,21 @@ func humanFormatProcess(msgs []model.MessageBody, w io.Writer) error {
 		}
 	}
 
+	containerIDs := make([]string, 0, len(containers))
 	for cid := range containers {
 		containerIDs = append(containerIDs, cid)
 	}
 
 	pidsSorted := sort.IntSlice(pids)
 	pidsSorted.Sort()
+	data.Processes = make([]*model.Process, 0, len(pidsSorted))
 	for _, pid := range pidsSorted {
 		data.Processes = append(data.Processes, processes[int32(pid)])
 	}
 
 	containerIDsSorted := sort.StringSlice(containerIDs)
 	containerIDsSorted.Sort()
+	data.Containers = make([]*model.Container, 0, len(containerIDsSorted))
 	for _, cid := range containerIDsSorted {
 		data.Containers = append(data.Containers, containers[cid])
 	}


### PR DESCRIPTION

### What does this PR do?

This reduces the number of none preallocated slices in the process-agent. With the move to go `1.18`, there has been a change in the [slice growth formula](https://github.com/golang/go/commit/2dda92ff6f9f07eeb110ecbf0fc2d7a0ddd27f9d) that could cause issues when slices grow.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Check that the process agent behaves as normal.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
