### PR TITLE
Fix tracemalloc doc options

### DIFF
--- a/docs/dev/agent_memory.md
+++ b/docs/dev/agent_memory.md
@@ -173,26 +173,27 @@ of flags you may want to apply to your check's config on a check by check basis
 via their respective config files, by using the following directives in the
 `init_config` section:
 
-- `frames`: the number of stack frames to consider. Please note that this is the total
+- `profile_memory`: optional directory in which to dump the snapshot files.
+- `profile_memory_frames`: the number of stack frames to consider. Please note that this is the total
 number of frames considered, not the depth of the call-tree. Therefore, in some cases,
 you may need to set this value to a considerably high value to get a good enough
 understanding of how your agent is behaving. Default: 100.
-- `gc`: whether or not to run the garbage collector before each snapshot to remove noise.
+- `profile_memory_gc`: whether or not to run the garbage collector before each snapshot to remove noise.
 Garbage collections will not run by default (?) while tracemalloc is in action. That is
 to allow us to more easily identify sources of allocations without the interference of
 the GC. Note that the GC is not permanently disabled, this is only enforced during the
 check run while tracemalloc is tracking allocations. Default: disabled.
-- `combine`: whether or not to aggregate over all traceback frames. useful only to tell
+- `profile_memory_combine`: whether or not to aggregate over all traceback frames. useful only to tell
 which particular usage of a function triggered areas of interest.
-- `sort`: what to group results by between: `lineno` | `filename` | `traceback`. Default:
+- `profile_memory_sort`: what to group results by between: `lineno` | `filename` | `traceback`. Default:
 `lineno`.
-- `limit`: the maximum number of sorted results to show. Default: 30.
-- `diff`: how to order diff results between:
+- `profile_memory_limit`: the maximum number of sorted results to show. Default: 30.
+- `profile_memory_diff`: how to order diff results between:
     * `absolute`: absolute value of the difference between consecutive snapshots. Default.
     * `positive`: same as absolute, but memory increases will be shown first.
-- `filters`: comma-separated list of file path glob patterns to filter by.
-- `unit`: the binary unit to represent memory usage (kib, mb, etc.). Default: dynamic.
-- `verbose`: whether or not to include potentially noisy sources. Default: false.
+- `profile_memory_filters`: comma-separated list of file path glob patterns to filter by.
+- `profile_memory_unit`: the binary unit to represent memory usage (kib, mb, etc.). Default: dynamic.
+- `profile_memory_verbose`: whether or not to include potentially noisy sources. Default: false.
 
 
 You may also want to run tracemalloc and take a look at the actual debug


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fixes the prefixes for tracemalloc options, which require `profile_memory` prefixes: https://github.com/DataDog/integrations-core/blob/master/datadog_checks_base/datadog_checks/base/utils/agent/memory.py#L183-L187
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
