### PR TITLE
AML-421: Updated dogstatsd mapper to preallocate slice capacity for tags

### DIFF
--- a/pkg/dogstatsd/internal/mapper/mapper.go
+++ b/pkg/dogstatsd/internal/mapper/mapper.go
@@ -53,7 +53,7 @@ type MapResult struct {
 
 // NewMetricMapper creates, validates, prepares a new MetricMapper
 func NewMetricMapper(configProfiles []config.MappingProfile, cacheSize int) (*MetricMapper, error) {
-	var profiles []MappingProfile
+	profiles := make([]MappingProfile, 0, len(configProfiles))
 	for profileIndex, configProfile := range configProfiles {
 		if configProfile.Name == "" {
 			return nil, fmt.Errorf("missing profile name %d", profileIndex)
@@ -61,7 +61,11 @@ func NewMetricMapper(configProfiles []config.MappingProfile, cacheSize int) (*Me
 		if configProfile.Prefix == "" {
 			return nil, fmt.Errorf("missing prefix for profile: %s", configProfile.Name)
 		}
-		profile := MappingProfile{Name: configProfile.Name, Prefix: configProfile.Prefix}
+		profile := MappingProfile{
+			Name:     configProfile.Name,
+			Prefix:   configProfile.Prefix,
+			Mappings: make([]*MetricMapping, 0, len(configProfile.Mappings)),
+		}
 		for i, currentMapping := range configProfile.Mappings {
 			matchType := currentMapping.MatchType
 			if matchType == "" {
@@ -135,7 +139,7 @@ func (m *MetricMapper) Map(metricName string) *MapResult {
 				matches,
 			))
 
-			var tags []string
+			tags := make([]string, 0, len(mapping.tags))
 			for tagKey, tagValueExpr := range mapping.tags {
 				tagValue := string(mapping.regex.ExpandString([]byte{}, tagValueExpr, metricName, matches))
 				tags = append(tags, tagKey+":"+tagValue)

--- a/pkg/dogstatsd/internal/mapper/mapper_test.go
+++ b/pkg/dogstatsd/internal/mapper/mapper_test.go
@@ -71,7 +71,7 @@ dogstatsd_mapper_profiles:
 			},
 			expectedResults: []MapResult{
 				{Name: "test.job.duration", Tags: []string{"job_type:my_job_type"}, matched: true},
-				{Name: "test.task.duration", Tags: nil, matched: true},
+				{Name: "test.task.duration", Tags: make([]string, 0), matched: true},
 			},
 		},
 		{
@@ -150,8 +150,8 @@ dogstatsd_mapper_profiles:
 				"test.my-worker.stop.worker-name",
 			},
 			expectedResults: []MapResult{
-				{Name: "test.worker.start", Tags: nil, matched: true},
-				{Name: "test.worker.stop", Tags: nil, matched: true},
+				{Name: "test.worker.start", Tags: make([]string, 0), matched: true},
+				{Name: "test.worker.stop", Tags: make([]string, 0), matched: true},
 			},
 		},
 		{
@@ -168,7 +168,7 @@ dogstatsd_mapper_profiles:
 				"test.abcdefghijklmnopqrstuvwxyz_ABCDEFGHIJKLMNOPQRSTUVWXYZ-01234567.123",
 			},
 			expectedResults: []MapResult{
-				{Name: "test.alphabet", Tags: nil, matched: true},
+				{Name: "test.alphabet", Tags: make([]string, 0), matched: true},
 			},
 		},
 		{

--- a/pkg/metrics/context_metrics_flusher.go
+++ b/pkg/metrics/context_metrics_flusher.go
@@ -45,7 +45,7 @@ func (f *ContextMetricsFlusher) FlushAndClear(callback func([]*Serie)) map[ckey.
 	errors := make(map[ckey.ContextKey][]error)
 	var series []*Serie
 
-	var contextMetricsCollection []ContextMetrics
+	contextMetricsCollection := make([]ContextMetrics, 0, len(f.metrics))
 	for _, m := range f.metrics {
 		contextMetricsCollection = append(contextMetricsCollection, m.contextMetrics)
 	}

--- a/pkg/metrics/histogram.go
+++ b/pkg/metrics/histogram.go
@@ -163,7 +163,7 @@ func (h *Histogram) flush(timestamp float64) ([]*Serie, error) {
 	}
 
 	// Compute percentiles
-	var target []int64
+	target := make([]int64, 0, len(h.percentiles))
 	for _, percentile := range h.percentiles {
 		target = append(target, (int64(percentile)*h.count-1)/100)
 	}

--- a/pkg/serializer/internal/metrics/events.go
+++ b/pkg/serializer/internal/metrics/events.go
@@ -235,7 +235,7 @@ func writeEvent(event *metrics.Event, writer *utiljson.RawObjectWriter) error {
 // is composed of all events for a specific source type name.
 func (events Events) CreateSingleMarshaler() marshaler.StreamJSONMarshaler {
 	eventsBySourceType := events.getEventsBySourceType()
-	var values []eventsSourceType
+	values := make([]eventsSourceType, 0, len(eventsBySourceType))
 	for sourceType, events := range eventsBySourceType {
 		values = append(values, eventsSourceType{sourceType, events})
 	}
@@ -291,14 +291,15 @@ func (e *eventsMarshaler) DescribeItem(i int) string {
 // Each StreamJSONMarshaler is composed of all events for a specific source type name.
 func (events Events) CreateMarshalersBySourceType() []marshaler.StreamJSONMarshaler {
 	e := events.getEventsBySourceType()
-	var values []marshaler.StreamJSONMarshaler
-	for k, v := range e {
-		values = append(values, &eventsMarshaler{k, v})
-	}
 
 	// Make sure we return at least one marshaler to have non-empty JSON.
-	if len(values) == 0 {
-		values = append(values, &eventsBySourceTypeMarshaler{events, nil})
+	if len(e) == 0 {
+		return []marshaler.StreamJSONMarshaler{&eventsBySourceTypeMarshaler{events, nil}}
+	}
+
+	values := make([]marshaler.StreamJSONMarshaler, 0, len(e))
+	for k, v := range e {
+		values = append(values, &eventsMarshaler{k, v})
 	}
 	return values
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This reduces the number of none preallocated slices in DogStatsD. With the move to go `1.18`, there has been a change in the [slice growth formula](https://github.com/golang/go/commit/2dda92ff6f9f07eeb110ecbf0fc2d7a0ddd27f9d) that could cause issues when slices grow.

### Motivation

The change was made in an attempt to improve the performance of the Agent in general. The changes here have show a ~5% decrease in CPU usage under our benchmark loads.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

- Start the Agent with DogStatsD enabled
- Send some metrics through and check they can be seen in DD
- (optional) Run the Agent under heavy load by sending it a large number of metrics

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
