### PR TITLE
Use buildimages image instead of internal docker for serverless tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -146,7 +146,6 @@ variables:
   DATADOG_AGENT_SYSPROBE_BUILDIMAGES: v9472974-a8f8b46
   DATADOG_AGENT_NIKOS_BUILDIMAGES:  v9472974-a8f8b46
   DATADOG_AGENT_EMBEDDED_PATH: /opt/datadog-agent/embedded
-  DOCKER_X64_BUILDER: v2718644-9ce6565-18.09.6-py3
   NIKOS_INSTALL_DIR: /opt/datadog-agent/embedded/nikos
   NIKOS_EMBEDDED_PATH: /opt/datadog-agent/embedded/nikos/embedded
   DEB_GPG_KEY_ID: ad9589b7

--- a/.gitlab/functional_test/serverless.yml
+++ b/.gitlab/functional_test/serverless.yml
@@ -1,6 +1,6 @@
 serverless_cold_start_performance-deb_x64:
   stage: functional_test
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/docker-x64:$DATADOG_AGENT_BUILDIMAGES
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/docker_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:docker"]
   needs: ["go_deps", "build_serverless-deb_x64"]
   before_script:

--- a/.gitlab/functional_test/serverless.yml
+++ b/.gitlab/functional_test/serverless.yml
@@ -1,6 +1,6 @@
 serverless_cold_start_performance-deb_x64:
   stage: functional_test
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:$DOCKER_X64_BUILDER
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/docker-x64:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:docker"]
   needs: ["go_deps", "build_serverless-deb_x64"]
   before_script:


### PR DESCRIPTION
### What does this PR do?

Currently the serverless tests use the `docker` internal image instead of the one from buildimages (which is built on the exact same image, but also includes the installation of python dependencies from `requirements.txt`).

### Motivation

My end goal is https://github.com/DataDog/datadog-agent/pull/12925. To do this for serverless tests I need to install zstd in the build image which is not easy with the global internal image.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
