### PR TITLE
[CWS] Fix discarders for folder rename events

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "c0407396709dc3377aa9aa798540298ddbf657805c8ed3071a7c5069ad344ccb")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "188baf66755b4e0a7f2aa93741cdf3e949d34cb19e544c77e630d7dfefa7ffe2")

--- a/pkg/security/ebpf/c/erpc.h
+++ b/pkg/security/ebpf/c/erpc.h
@@ -67,7 +67,7 @@ int __attribute__((always_inline)) handle_expire_inode_discarder(void *data) {
     struct expire_inode_discarder_t discarder;
     bpf_probe_read(&discarder, sizeof(discarder), data);
 
-    expire_inode_discarder(discarder.mount_id, discarder.inode);
+    expire_inode_discarders(discarder.mount_id, discarder.inode);
 
     return 0;
 }

--- a/pkg/security/ebpf/c/rename.h
+++ b/pkg/security/ebpf/c/rename.h
@@ -142,6 +142,12 @@ int __attribute__((always_inline)) sys_rename_ret(void *ctx, int retval, int dr_
     // invalidate user space inode, so no need to bump the discarder revision in the event
     if (retval >= 0) {
         invalidate_inode(ctx, syscall->rename.target_file.path_key.mount_id, syscall->rename.target_file.path_key.ino, !pass_to_userspace);
+
+        if (S_ISDIR(syscall->rename.target_file.metadata.mode)) {
+            // remove all discarders on the mount point as the rename could invalidate a child discarder in case of a
+            // folder rename. For the inode the discarder is invalidated in the ret.
+            bump_discarder_revision(syscall->rename.target_file.path_key.mount_id);
+        }
     }
 
     if (pass_to_userspace) {

--- a/pkg/security/probe/discarders.go
+++ b/pkg/security/probe/discarders.go
@@ -197,7 +197,7 @@ type inodeDiscarders struct {
 	recentlyAddedEntries [maxRecentlyAddedCacheSize]inodeDiscarderEntry
 }
 
-func newInodeDiscarders(inodesMap, revisionsMap *lib.Map, erpc *ERPC, dentryResolver *DentryResolver) *inodeDiscarders {
+func newInodeDiscarders(inodesMap *lib.Map, erpc *ERPC, dentryResolver *DentryResolver) *inodeDiscarders {
 	id := &inodeDiscarders{
 		Map:            inodesMap,
 		erpc:           erpc,

--- a/pkg/security/probe/discarders_test.go
+++ b/pkg/security/probe/discarders_test.go
@@ -37,7 +37,7 @@ func addRuleExpr(t testing.TB, rs *rules.RuleSet, exprs ...string) {
 }
 
 func TestIsParentDiscarder(t *testing.T) {
-	id := newInodeDiscarders(nil, nil, nil, nil)
+	id := newInodeDiscarders(nil, nil, nil)
 
 	enabled := map[eval.EventType]bool{"*": true}
 
@@ -212,7 +212,7 @@ func TestIsParentDiscarder(t *testing.T) {
 }
 
 func TestIsGrandParentDiscarder(t *testing.T) {
-	id := newInodeDiscarders(nil, nil, nil, nil)
+	id := newInodeDiscarders(nil, nil, nil)
 
 	enabled := map[eval.EventType]bool{"*": true}
 
@@ -387,7 +387,7 @@ func TestIsDiscarderOverride(t *testing.T) {
 }
 
 func BenchmarkParentDiscarder(b *testing.B) {
-	id := newInodeDiscarders(nil, nil, nil, nil)
+	id := newInodeDiscarders(nil, nil, nil)
 
 	enabled := map[eval.EventType]bool{"*": true}
 

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -295,12 +295,7 @@ func (p *Probe) Init() error {
 		return err
 	}
 
-	discarderRevisionsMap, err := p.Map("discarder_revisions")
-	if err != nil {
-		return err
-	}
-
-	p.inodeDiscarders = newInodeDiscarders(inodeDiscardersMap, discarderRevisionsMap, p.erpc, p.resolvers.DentryResolver)
+	p.inodeDiscarders = newInodeDiscarders(inodeDiscardersMap, p.erpc, p.resolvers.DentryResolver)
 
 	if err := p.resolvers.Start(p.ctx); err != nil {
 		return err
@@ -1397,7 +1392,7 @@ func NewProbe(config *config.Config, statsdClient statsd.ClientInterface) (*Prob
 		erpcRequest:          &ERPCRequest{},
 		tcPrograms:           make(map[NetDeviceKey]*manager.Probe),
 		statsdClient:         statsdClient,
-		discarderRateLimiter: rate.NewLimiter(rate.Every(time.Second), 100),
+		discarderRateLimiter: rate.NewLimiter(rate.Every(time.Second/5), 100),
 		flushingDiscarders:   atomic.NewBool(false),
 		isRuntimeDiscarded:   os.Getenv("RUNTIME_SECURITY_TESTSUITE") != "true",
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fix discarders not invalidated for rename of folder. This PR add also few more tests

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
