### PR TITLE
[CWS] make netnspath computation lazy

### DIFF
--- a/pkg/security/probe/namespace_resolver.go
+++ b/pkg/security/probe/namespace_resolver.go
@@ -87,7 +87,7 @@ func NewNetworkNamespace(nsID uint32) *NetworkNamespace {
 }
 
 // NewNetworkNamespaceWithPath returns a new NetworkNamespace instance from a path.
-func NewNetworkNamespaceWithPath(nsID uint32, nsPath string) (*NetworkNamespace, error) {
+func NewNetworkNamespaceWithPath(nsID uint32, nsPath *utils.NetNSPath) (*NetworkNamespace, error) {
 	netns := NewNetworkNamespace(nsID)
 	if err := netns.openHandle(nsPath); err != nil {
 		return nil, err
@@ -96,12 +96,12 @@ func NewNetworkNamespaceWithPath(nsID uint32, nsPath string) (*NetworkNamespace,
 }
 
 // openHandle tries to create a network namespace handle with the provided thread ID
-func (nn *NetworkNamespace) openHandle(nsPath string) error {
+func (nn *NetworkNamespace) openHandle(nsPath *utils.NetNSPath) error {
 	nn.Lock()
 	defer nn.Unlock()
 
 	// check that the handle matches the expected netns ID
-	threadNetnsID, err := utils.GetProcessNetworkNamespace(nsPath)
+	threadNetnsID, err := nsPath.GetProcessNetworkNamespace()
 	if err != nil {
 		return err
 	}
@@ -114,7 +114,7 @@ func (nn *NetworkNamespace) openHandle(nsPath string) error {
 		return fmt.Errorf("the provided doesn't match the expected netns ID: got %d, expected %d", threadNetnsID, nn.nsID)
 	}
 
-	handle, err := os.Open(nsPath)
+	handle, err := os.Open(nsPath.GetPath())
 	if err != nil {
 		return err
 	}
@@ -231,8 +231,8 @@ func (nr *NamespaceResolver) GetState() int64 {
 
 // SaveNetworkNamespaceHandle inserts the provided process network namespace in the list of tracked network. Returns
 // true if a new entry was added.
-func (nr *NamespaceResolver) SaveNetworkNamespaceHandle(nsID uint32, nsPath string) (*NetworkNamespace, bool) {
-	if !nr.probe.config.NetworkEnabled || nsID == 0 || nsPath == "" {
+func (nr *NamespaceResolver) SaveNetworkNamespaceHandle(nsID uint32, nsPath *utils.NetNSPath) (*NetworkNamespace, bool) {
+	if !nr.probe.config.NetworkEnabled || nsID == 0 || nsPath == nil {
 		return nil, false
 	}
 
@@ -351,7 +351,7 @@ func (nr *NamespaceResolver) SyncCache(proc *process.Process) bool {
 	}
 
 	nsPath := utils.NetNSPathFromPid(uint32(proc.Pid))
-	nsID, err := utils.GetProcessNetworkNamespace(nsPath)
+	nsID, err := nsPath.GetProcessNetworkNamespace()
 	if err != nil {
 		return false
 	}

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -549,7 +549,8 @@ func (p *Probe) handleEvent(CPU int, data []byte) {
 		if event.Mount.GetFSType() == "nsfs" {
 			nsid := uint32(event.Mount.RootInode)
 			_, mountPath, _, _ := p.resolvers.MountResolver.GetMountPath(event.Mount.MountID)
-			_, _ = p.resolvers.NamespaceResolver.SaveNetworkNamespaceHandle(nsid, mountPath)
+			mountNetNSPath := utils.NetNSPathFromPath(mountPath)
+			_, _ = p.resolvers.NamespaceResolver.SaveNetworkNamespaceHandle(nsid, mountNetNSPath)
 		}
 	case model.FileUmountEventType:
 		if _, err = event.Umount.UnmarshalBinary(data[offset:]); err != nil {

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -479,7 +479,7 @@ func (p *ProcessResolver) enrichEventFromProc(entry *model.ProcessCacheEntry, pr
 	}
 
 	// add netns
-	entry.NetNS, _ = utils.GetProcessNetworkNamespace(utils.NetNSPathFromPid(pid))
+	entry.NetNS, _ = utils.NetNSPathFromPid(pid).GetProcessNetworkNamespace()
 
 	if p.probe.config.NetworkEnabled {
 		// snapshot pid routes in kernel space

--- a/pkg/security/tests/network_device_test.go
+++ b/pkg/security/tests/network_device_test.go
@@ -49,7 +49,7 @@ func TestNetDevice(t *testing.T) {
 	}
 	defer test.Close()
 
-	currentNetns, err := utils.GetProcessNetworkNamespace(utils.NetNSPathFromPid(uint32(utils.Getpid())))
+	currentNetns, err := utils.NetNSPathFromPid(uint32(utils.Getpid())).GetProcessNetworkNamespace()
 	if err != nil {
 		t.Errorf("couldn't retrieve current network namespace ID: %v", err)
 	}

--- a/pkg/security/utils/proc.go
+++ b/pkg/security/utils/proc.go
@@ -37,18 +37,21 @@ func Getpid() int32 {
 
 var networkNamespacePattern = regexp.MustCompile(`net:\[(\d+)\]`)
 
+// NetNSPath represents a network namespace path
 type NetNSPath struct {
 	mu         sync.Mutex
 	pid        uint32
 	cachedPath string
 }
 
+// NetNSPathFromPid returns a new NetNSPath from the given Pid
 func NetNSPathFromPid(pid uint32) *NetNSPath {
 	return &NetNSPath{
 		pid: pid,
 	}
 }
 
+// GetPath returns the path for the given network namespace
 func (path *NetNSPath) GetPath() string {
 	path.mu.Lock()
 	defer path.mu.Unlock()

--- a/pkg/security/utils/proc.go
+++ b/pkg/security/utils/proc.go
@@ -17,6 +17,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/DataDog/gopsutil/process"
 
@@ -36,10 +37,32 @@ func Getpid() int32 {
 
 var networkNamespacePattern = regexp.MustCompile(`net:\[(\d+)\]`)
 
+type NetNSPath struct {
+	mu         sync.Mutex
+	pid        uint32
+	cachedPath string
+}
+
+func NetNSPathFromPid(pid uint32) *NetNSPath {
+	return &NetNSPath{
+		pid: pid,
+	}
+}
+
+func (path *NetNSPath) GetPath() string {
+	path.mu.Lock()
+	defer path.mu.Unlock()
+
+	if path.cachedPath == "" {
+		path.cachedPath = filepath.Join(util.HostProc(), fmt.Sprintf("%d/ns/net", path.pid))
+	}
+	return path.cachedPath
+}
+
 // GetProcessNetworkNamespace returns the network namespace of a pid after parsing /proc/[pid]/ns/net
-func GetProcessNetworkNamespace(nsPath string) (uint32, error) {
+func (path *NetNSPath) GetProcessNetworkNamespace() (uint32, error) {
 	// open netns
-	f, err := os.Open(nsPath)
+	f, err := os.Open(path.GetPath())
 	if err != nil {
 		return 0, err
 	}
@@ -70,11 +93,6 @@ func CgroupTaskPath(tgid, pid uint32) string {
 // ProcExePath returns the path to the exe file of a pid in /proc
 func ProcExePath(pid int32) string {
 	return filepath.Join(util.HostProc(), fmt.Sprintf("%d/exe", pid))
-}
-
-// NetNSPathFromPid returns the path to the net ns file of a pid in /proc
-func NetNSPathFromPid(pid uint32) string {
-	return filepath.Join(util.HostProc(), fmt.Sprintf("%d/ns/net", pid))
 }
 
 // StatusPath returns the path to the status file of a pid in /proc

--- a/pkg/security/utils/proc.go
+++ b/pkg/security/utils/proc.go
@@ -51,6 +51,13 @@ func NetNSPathFromPid(pid uint32) *NetNSPath {
 	}
 }
 
+// NetNSPathFromPath returns a new NetNSPath from the given path
+func NetNSPathFromPath(path string) *NetNSPath {
+	return &NetNSPath{
+		cachedPath: path,
+	}
+}
+
 // GetPath returns the path for the given network namespace
 func (path *NetNSPath) GetPath() string {
 	path.mu.Lock()


### PR DESCRIPTION
### What does this PR do?

The netnspath is computed for each event, even if not used. This means:
- mapalloc for the getenv
- alloc for the join
- separate alloc for the sprintf

This PR makes all of this lazy, computing the path once when needed

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
