### PR TITLE
[ksm] Add support for discovering API versions

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/customresources/cronjob.go
+++ b/pkg/collector/corechecks/cluster/ksm/customresources/cronjob.go
@@ -37,23 +37,23 @@ var (
 	descCronJobLabelsDefaultLabels = []string{"namespace", "cronjob"}
 )
 
-// NewCronJobFactory returns a new CronJob metric family generator factory.
-func NewCronJobFactory() customresource.RegistryFactory {
-	return &cronjobFactory{}
+// NewCronJobV1Beta1Factory returns a new CronJob metric family generator factory.
+func NewCronJobV1Beta1Factory() customresource.RegistryFactory {
+	return &cronjobv1beta1Factory{}
 }
 
-type cronjobFactory struct{}
+type cronjobv1beta1Factory struct{}
 
-func (f *cronjobFactory) Name() string {
+func (f *cronjobv1beta1Factory) Name() string {
 	return "cronjobs"
 }
 
 // CreateClient is not implemented
-func (f *cronjobFactory) CreateClient(cfg *rest.Config) (interface{}, error) {
+func (f *cronjobv1beta1Factory) CreateClient(cfg *rest.Config) (interface{}, error) {
 	panic("not implemented")
 }
 
-func (f *cronjobFactory) MetricFamilyGenerators(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
+func (f *cronjobv1beta1Factory) MetricFamilyGenerators(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
 	return []generator.FamilyGenerator{
 		*generator.NewFamilyGenerator(
 			descCronJobAnnotationsName,
@@ -304,11 +304,11 @@ func wrapCronJobFunc(f func(*batchv1beta1.CronJob) *metric.Family) func(interfac
 	}
 }
 
-func (f *cronjobFactory) ExpectedType() interface{} {
+func (f *cronjobv1beta1Factory) ExpectedType() interface{} {
 	return &batchv1beta1.CronJob{}
 }
 
-func (f *cronjobFactory) ListWatch(customResourceClient interface{}, ns string, fieldSelector string) cache.ListerWatcher {
+func (f *cronjobv1beta1Factory) ListWatch(customResourceClient interface{}, ns string, fieldSelector string) cache.ListerWatcher {
 	client := customResourceClient.(kubernetes.Interface)
 	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {

--- a/pkg/collector/corechecks/cluster/ksm/customresources/hpa.go
+++ b/pkg/collector/corechecks/cluster/ksm/customresources/hpa.go
@@ -1,0 +1,325 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package customresources
+
+// This file has most of its logic copied from the KSM hpa metric family
+// generators available at
+// https://github.com/kubernetes/kube-state-metrics/blob/release-2.4/internal/store/horizontalpodautoscaler.go
+// It exists here to provide backwards compatibility with k8s >1.25, as KSM 2.4
+// uses API v2beta2 instead of v2.
+
+import (
+	"context"
+
+	autoscaling "k8s.io/api/autoscaling/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+
+	"k8s.io/kube-state-metrics/v2/pkg/customresource"
+	"k8s.io/kube-state-metrics/v2/pkg/metric"
+	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
+)
+
+type metricTargetType int
+
+const (
+	value metricTargetType = iota
+	utilization
+	average
+
+	metricTargetTypeCount // Used as a length argument to arrays
+)
+
+func (m metricTargetType) String() string {
+	return [...]string{"value", "utilization", "average"}[m]
+}
+
+var (
+	descHorizontalPodAutoscalerAnnotationsName     = "kube_horizontalpodautoscaler_annotations"
+	descHorizontalPodAutoscalerAnnotationsHelp     = "Kubernetes annotations converted to Prometheus labels."
+	descHorizontalPodAutoscalerLabelsName          = "kube_horizontalpodautoscaler_labels"
+	descHorizontalPodAutoscalerLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
+	descHorizontalPodAutoscalerLabelsDefaultLabels = []string{"namespace", "horizontalpodautoscaler"}
+
+	targetMetricLabels = []string{"metric_name", "metric_target_type"}
+)
+
+// NewHorizontalPodAutoscalerV2Factory returns a new HorizontalPodAutoscaler
+// metric family generator factory.
+func NewHorizontalPodAutoscalerV2Factory() customresource.RegistryFactory {
+	return &hpav2Factory{}
+}
+
+type hpav2Factory struct{}
+
+func (f *hpav2Factory) Name() string {
+	return "horizontalpodautoscalers"
+}
+
+// CreateClient is not implemented
+func (f *hpav2Factory) CreateClient(cfg *rest.Config) (interface{}, error) {
+	panic("not implemented")
+}
+
+func (f *hpav2Factory) MetricFamilyGenerators(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
+	return []generator.FamilyGenerator{
+		*generator.NewFamilyGenerator(
+			"kube_horizontalpodautoscaler_info",
+			"Information about this autoscaler.",
+			metric.Gauge,
+			"",
+			wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
+				labelKeys := []string{"scaletargetref_kind", "scaletargetref_name"}
+				labelValues := []string{a.Spec.ScaleTargetRef.Kind, a.Spec.ScaleTargetRef.Name}
+				if a.Spec.ScaleTargetRef.APIVersion != "" {
+					labelKeys = append([]string{"scaletargetref_api_version"}, labelKeys...)
+					labelValues = append([]string{a.Spec.ScaleTargetRef.APIVersion}, labelValues...)
+				}
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   labelKeys,
+							LabelValues: labelValues,
+							Value:       1,
+						},
+					},
+				}
+			}),
+		),
+		*generator.NewFamilyGenerator(
+			"kube_horizontalpodautoscaler_metadata_generation",
+			"The generation observed by the HorizontalPodAutoscaler controller.",
+			metric.Gauge,
+			"",
+			wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(a.ObjectMeta.Generation),
+						},
+					},
+				}
+			}),
+		),
+		*generator.NewFamilyGenerator(
+			"kube_horizontalpodautoscaler_spec_max_replicas",
+			"Upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.",
+			metric.Gauge,
+			"",
+			wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(a.Spec.MaxReplicas),
+						},
+					},
+				}
+			}),
+		),
+		*generator.NewFamilyGenerator(
+			"kube_horizontalpodautoscaler_spec_min_replicas",
+			"Lower limit for the number of pods that can be set by the autoscaler, default 1.",
+			metric.Gauge,
+			"",
+			wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(*a.Spec.MinReplicas),
+						},
+					},
+				}
+			}),
+		),
+		*generator.NewFamilyGenerator(
+			"kube_horizontalpodautoscaler_spec_target_metric",
+			"The metric specifications used by this autoscaler when calculating the desired replica count.",
+			metric.Gauge,
+			"",
+			wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
+				ms := make([]*metric.Metric, 0, len(a.Spec.Metrics))
+				for _, m := range a.Spec.Metrics {
+					var metricName string
+
+					var v [metricTargetTypeCount]int64
+					var ok [metricTargetTypeCount]bool
+
+					switch m.Type {
+					case autoscaling.ObjectMetricSourceType:
+						metricName = m.Object.Metric.Name
+
+						v[value], ok[value] = m.Object.Target.Value.AsInt64()
+						if m.Object.Target.AverageValue != nil {
+							v[average], ok[average] = m.Object.Target.AverageValue.AsInt64()
+						}
+					case autoscaling.PodsMetricSourceType:
+						metricName = m.Pods.Metric.Name
+
+						v[average], ok[average] = m.Pods.Target.AverageValue.AsInt64()
+					case autoscaling.ResourceMetricSourceType:
+						metricName = string(m.Resource.Name)
+
+						if ok[utilization] = (m.Resource.Target.AverageUtilization != nil); ok[utilization] {
+							v[utilization] = int64(*m.Resource.Target.AverageUtilization)
+						}
+
+						if m.Resource.Target.AverageValue != nil {
+							v[average], ok[average] = m.Resource.Target.AverageValue.AsInt64()
+						}
+					case autoscaling.ExternalMetricSourceType:
+						metricName = m.External.Metric.Name
+
+						if m.External.Target.Value != nil {
+							v[value], ok[value] = m.External.Target.Value.AsInt64()
+						}
+						if m.External.Target.AverageValue != nil {
+							v[average], ok[average] = m.External.Target.AverageValue.AsInt64()
+						}
+					default:
+						// Skip unsupported metric type
+						continue
+					}
+
+					for i := range ok {
+						if ok[i] {
+							ms = append(ms, &metric.Metric{
+								LabelKeys:   targetMetricLabels,
+								LabelValues: []string{metricName, metricTargetType(i).String()},
+								Value:       float64(v[i]),
+							})
+						}
+					}
+				}
+				return &metric.Family{Metrics: ms}
+			}),
+		),
+		*generator.NewFamilyGenerator(
+			"kube_horizontalpodautoscaler_status_current_replicas",
+			"Current number of replicas of pods managed by this autoscaler.",
+			metric.Gauge,
+			"",
+			wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(a.Status.CurrentReplicas),
+						},
+					},
+				}
+			}),
+		),
+		*generator.NewFamilyGenerator(
+			"kube_horizontalpodautoscaler_status_desired_replicas",
+			"Desired number of replicas of pods managed by this autoscaler.",
+			metric.Gauge,
+			"",
+			wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(a.Status.DesiredReplicas),
+						},
+					},
+				}
+			}),
+		),
+		*generator.NewFamilyGenerator(
+			descHorizontalPodAutoscalerAnnotationsName,
+			descHorizontalPodAutoscalerAnnotationsHelp,
+			metric.Gauge,
+			"",
+			wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
+				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", a.Annotations, allowAnnotationsList)
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   annotationKeys,
+							LabelValues: annotationValues,
+							Value:       1,
+						},
+					},
+				}
+			}),
+		),
+		*generator.NewFamilyGenerator(
+			descHorizontalPodAutoscalerLabelsName,
+			descHorizontalPodAutoscalerLabelsHelp,
+			metric.Gauge,
+			"",
+			wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
+				labelKeys, labelValues := createPrometheusLabelKeysValues("label", a.Labels, allowLabelsList)
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   labelKeys,
+							LabelValues: labelValues,
+							Value:       1,
+						},
+					},
+				}
+			}),
+		),
+		*generator.NewFamilyGenerator(
+			"kube_horizontalpodautoscaler_status_condition",
+			"The condition of this autoscaler.",
+			metric.Gauge,
+			"",
+			wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
+				ms := make([]*metric.Metric, 0, len(a.Status.Conditions)*len(conditionStatuses))
+
+				for _, c := range a.Status.Conditions {
+					metrics := addConditionMetrics(c.Status)
+
+					for _, m := range metrics {
+						metric := m
+						metric.LabelKeys = []string{"condition", "status"}
+						metric.LabelValues = append([]string{string(c.Type)}, metric.LabelValues...)
+						ms = append(ms, metric)
+					}
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		),
+	}
+}
+func (f *hpav2Factory) ExpectedType() interface{} {
+	return &autoscaling.HorizontalPodAutoscaler{}
+}
+
+func (f *hpav2Factory) ListWatch(customResourceClient interface{}, ns string, fieldSelector string) cache.ListerWatcher {
+	client := customResourceClient.(kubernetes.Interface)
+	return &cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			opts.FieldSelector = fieldSelector
+			return client.AutoscalingV2().HorizontalPodAutoscalers(ns).List(context.TODO(), opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			opts.FieldSelector = fieldSelector
+			return client.AutoscalingV2().HorizontalPodAutoscalers(ns).Watch(context.TODO(), opts)
+		},
+	}
+}
+
+func wrapHPAFunc(f func(*autoscaling.HorizontalPodAutoscaler) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
+		hpa := obj.(*autoscaling.HorizontalPodAutoscaler)
+
+		metricFamily := f(hpa)
+
+		for _, m := range metricFamily.Metrics {
+			m.LabelKeys, m.LabelValues = mergeKeyValues(descHorizontalPodAutoscalerLabelsDefaultLabels, []string{hpa.Namespace, hpa.Name}, m.LabelKeys, m.LabelValues)
+		}
+
+		return metricFamily
+	}
+}

--- a/pkg/collector/corechecks/cluster/ksm/customresources/job.go
+++ b/pkg/collector/corechecks/cluster/ksm/customresources/job.go
@@ -25,25 +25,25 @@ import (
 
 var descJobLabelsDefaultLabels = []string{"namespace", "job_name"}
 
-// NewJobFactory returns a new Job metric family generator factory.
-func NewJobFactory() customresource.RegistryFactory {
-	return &jobFactory{}
+// NewExtendedJobFactory returns a new Job metric family generator factory.
+func NewExtendedJobFactory() customresource.RegistryFactory {
+	return &extendedJobFactory{}
 }
 
-type jobFactory struct{}
+type extendedJobFactory struct{}
 
 // Name is the name of the factory
-func (f *jobFactory) Name() string {
+func (f *extendedJobFactory) Name() string {
 	return "jobs_extended"
 }
 
 // CreateClient is not implemented
-func (f *jobFactory) CreateClient(cfg *rest.Config) (interface{}, error) {
+func (f *extendedJobFactory) CreateClient(cfg *rest.Config) (interface{}, error) {
 	panic("not implemented")
 }
 
 // MetricFamilyGenerators returns the extended job metric family generators
-func (f *jobFactory) MetricFamilyGenerators(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
+func (f *extendedJobFactory) MetricFamilyGenerators(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
 	return []generator.FamilyGenerator{
 		*generator.NewFamilyGenerator(
 			"kube_job_duration",
@@ -93,12 +93,12 @@ func wrapJobFunc(f func(*batchv1.Job) *metric.Family) func(interface{}) *metric.
 }
 
 // ExpectedType returns the type expected by the factory
-func (f *jobFactory) ExpectedType() interface{} {
+func (f *extendedJobFactory) ExpectedType() interface{} {
 	return &batchv1.Job{}
 }
 
 // ListWatch returns a ListerWatcher for batchv1.Job
-func (f *jobFactory) ListWatch(customResourceClient interface{}, ns string, fieldSelector string) cache.ListerWatcher {
+func (f *extendedJobFactory) ListWatch(customResourceClient interface{}, ns string, fieldSelector string) cache.ListerWatcher {
 	client := customResourceClient.(kubernetes.Interface)
 	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {

--- a/pkg/collector/corechecks/cluster/ksm/customresources/pdb.go
+++ b/pkg/collector/corechecks/cluster/ksm/customresources/pdb.go
@@ -35,23 +35,23 @@ var (
 	descPodDisruptionBudgetLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 )
 
-// NewPodDisruptionBudgetFactory returns a new PodDisruptionBudgets metric family generator factory.
-func NewPodDisruptionBudgetFactory() customresource.RegistryFactory {
-	return &pdbFactory{}
+// NewPodDisruptionBudgetV1Beta1Factory returns a new PodDisruptionBudgets metric family generator factory.
+func NewPodDisruptionBudgetV1Beta1Factory() customresource.RegistryFactory {
+	return &pdbv1beta1Factory{}
 }
 
-type pdbFactory struct{}
+type pdbv1beta1Factory struct{}
 
-func (f *pdbFactory) Name() string {
+func (f *pdbv1beta1Factory) Name() string {
 	return "poddisruptionbudgets"
 }
 
 // CreateClient is not implemented
-func (f *pdbFactory) CreateClient(cfg *rest.Config) (interface{}, error) {
+func (f *pdbv1beta1Factory) CreateClient(cfg *rest.Config) (interface{}, error) {
 	panic("not implemented")
 }
 
-func (f *pdbFactory) MetricFamilyGenerators(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
+func (f *pdbv1beta1Factory) MetricFamilyGenerators(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
 	return []generator.FamilyGenerator{
 		*generator.NewFamilyGenerator(
 			descPodDisruptionBudgetAnnotationsName,
@@ -186,11 +186,11 @@ func (f *pdbFactory) MetricFamilyGenerators(allowAnnotationsList, allowLabelsLis
 	}
 }
 
-func (f *pdbFactory) ExpectedType() interface{} {
+func (f *pdbv1beta1Factory) ExpectedType() interface{} {
 	return &policyv1beta1.PodDisruptionBudget{}
 }
 
-func (f *pdbFactory) ListWatch(customResourceClient interface{}, ns string, fieldSelector string) cache.ListerWatcher {
+func (f *pdbv1beta1Factory) ListWatch(customResourceClient interface{}, ns string, fieldSelector string) cache.ListerWatcher {
 	client := customResourceClient.(kubernetes.Interface)
 	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {

--- a/pkg/collector/corechecks/cluster/ksm/customresources/utils.go
+++ b/pkg/collector/corechecks/cluster/ksm/customresources/utils.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"strings"
 
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	"k8s.io/kube-state-metrics/v2/pkg/options"
 )
@@ -164,4 +165,24 @@ func mergeKeyValues(keyValues ...[]string) (keys, values []string) {
 	}
 
 	return keys, values
+}
+
+var (
+	conditionStatuses = []v1.ConditionStatus{v1.ConditionTrue, v1.ConditionFalse, v1.ConditionUnknown}
+)
+
+// addConditionMetrics generates one metric for each possible condition
+// status. For this function to work properly, the last label in the metric
+// description must be the condition.
+func addConditionMetrics(cs v1.ConditionStatus) []*metric.Metric {
+	ms := make([]*metric.Metric, len(conditionStatuses))
+
+	for i, status := range conditionStatuses {
+		ms[i] = &metric.Metric{
+			LabelValues: []string{strings.ToLower(string(status))},
+			Value:       boolFloat64(cs == status),
+		}
+	}
+
+	return ms
 }

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -32,6 +32,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"gopkg.in/yaml.v2"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/kube-state-metrics/v2/pkg/allowdenylist"
 	"k8s.io/kube-state-metrics/v2/pkg/customresource"
@@ -275,32 +276,13 @@ func (k *KSMCheck) Configure(config, initConfig integration.Data, source string)
 
 	builder.WithGenerateStoresFunc(builder.GenerateStores)
 
-	factories := []customresource.RegistryFactory{
-		customresources.NewJobFactory(),
-		customresources.NewCronJobFactory(),
-		customresources.NewPodDisruptionBudgetFactory(),
-	}
-
-	clients := make(map[string]interface{}, len(factories))
-	for _, f := range factories {
-		clients[f.Name()] = c.Cl
-	}
-
-	builder.WithCustomResourceStoreFactories(factories...)
-	builder.WithCustomResourceClients(clients)
+	// configure custom resources required for extended features and
+	// compatibility across deprecated/removed versions of APIs
+	cr := k.discoverCustomResources(c, collectors)
 	builder.WithGenerateCustomResourceStoresFunc(builder.GenerateCustomResourceStoresFunc)
-
-	// automatically add extended collectors if their standard ones are
-	// enabled
-	for _, c := range collectors {
-		if extended, ok := extendedCollectors[c]; ok {
-			collectors = append(collectors, extended)
-		}
-	}
-
-	// must call WithEnabledResources after custom resources have been
-	// registered, otherwise they will fail with "resource does not exist"
-	if err := builder.WithEnabledResources(collectors); err != nil {
+	builder.WithCustomResourceStoreFactories(cr.factories...)
+	builder.WithCustomResourceClients(cr.clients)
+	if err := builder.WithEnabledResources(cr.collectors); err != nil {
 		return err
 	}
 
@@ -312,6 +294,89 @@ func (k *KSMCheck) Configure(config, initConfig integration.Data, source string)
 
 func (c *KSMConfig) parse(data []byte) error {
 	return yaml.Unmarshal(data, c)
+}
+
+type customResources struct {
+	collectors []string
+	factories  []customresource.RegistryFactory
+	clients    map[string]interface{}
+}
+
+func (k *KSMCheck) discoverCustomResources(c *apiserver.APIClient, collectors []string) customResources {
+	// automatically add extended collectors if their standard ones are
+	// enabled
+	for _, c := range collectors {
+		if extended, ok := extendedCollectors[c]; ok {
+			collectors = append(collectors, extended)
+		}
+	}
+
+	// extended resource collectors always have a factory registered
+	factories := []customresource.RegistryFactory{
+		customresources.NewExtendedJobFactory(),
+	}
+
+	_, resources, err := c.DiscoveryCl.ServerGroupsAndResources()
+	if err != nil {
+		if !discovery.IsGroupDiscoveryFailedError(err) {
+			log.Warnf("unable to perform resource discovery: %s", err)
+		} else {
+			for group, apiGroupErr := range err.(*discovery.ErrGroupDiscoveryFailed).Groups {
+				log.Warnf("unable to perform resource discovery for group %s: %s", group, apiGroupErr)
+			}
+		}
+	}
+
+	// backwards/forwards compatibility resource factories are only
+	// registered if they're needed, otherwise they'd overwrite the default
+	// ones that ship with ksm
+	resourceReplacements := map[string]map[string]func() customresource.RegistryFactory{
+		// support for older k8s versions where the resources are no
+		// longer supported in KSM
+		"batch/v1": {
+			"CronJob": customresources.NewCronJobV1Beta1Factory,
+		},
+		"policy/v1": {
+			"PodDisruptionBudget": customresources.NewPodDisruptionBudgetV1Beta1Factory,
+		},
+
+		// support for newer k8s versions where the newer resources are
+		// not yet supported by KSM
+		"autoscaling/v2beta2": {
+			"HorizontalPodAutoscaler": customresources.NewHorizontalPodAutoscalerV2Factory,
+		},
+	}
+
+	for gv, resourceReplacement := range resourceReplacements {
+		for _, resource := range resources {
+			if resource.GroupVersion != gv {
+				continue
+			}
+
+			for _, apiResource := range resource.APIResources {
+				if _, ok := resourceReplacement[apiResource.Kind]; ok {
+					delete(resourceReplacement, apiResource.Kind)
+				}
+			}
+		}
+	}
+
+	for _, resourceReplacement := range resourceReplacements {
+		for _, factory := range resourceReplacement {
+			factories = append(factories, factory())
+		}
+	}
+
+	clients := make(map[string]interface{}, len(factories))
+	for _, f := range factories {
+		clients[f.Name()] = c.Cl
+	}
+
+	return customResources{
+		collectors: collectors,
+		clients:    clients,
+		factories:  factories,
+	}
 }
 
 // Run runs the KSM check


### PR DESCRIPTION
### What does this PR do?

Kubernetes 1.26 will no longer serve autoscaling/v2beta2
HorizontaPodAutoscaler. This change uses client-go's discovery client
to detect that this API is no longer supported, and provides a
replacement custom resource collector that uses autoscaling/v2 instead.

As a bonus, CronJob and PodDisruptionBudget get the same treatment, so
now any Kubernetes version new enough to support v1 of those APIs will
use the new collector that ships with KSM instead of the custom one that
provided legacy support. This fixes compatiblity with Kubernetes 1.25, as
it no longer serves the older APIs.

### Describe how to test/QA your changes

With Kubernetes 1.25 and KSM Core enabled, check that there are no errors like the following:

```
2022-09-06 07:45:22 UTC | CLUSTER | WARN | (client-go@v0.23.8/tools/cache/reflector.go:324 in func1) | pkg/mod/k8s.io/client-go@v0.23.8/tools/cache/reflector.go:167: failed to list *v1beta1.PodDisruptionBudget: the server could not find the requested resource
2022-09-06 07:45:22 UTC | CLUSTER | ERROR | (apimachinery@v0.23.8/pkg/util/runtime/runtime.go:108 in HandleError) | pkg/mod/k8s.io/client-go@v0.23.8/tools/cache/reflector.go:167: Failed to watch *v1beta1.PodDisruptionBudget: failed to list *v1beta1.PodDisruptionBudget: the server could not find the requested resource
2022-09-06 07:45:29 UTC | CLUSTER | WARN | (client-go@v0.23.8/tools/cache/reflector.go:324 in func1) | pkg/mod/k8s.io/client-go@v0.23.8/tools/cache/reflector.go:167: failed to list *v1beta1.CronJob: the server could not find the requested resource
2022-09-06 07:45:29 UTC | CLUSTER | ERROR | (apimachinery@v0.23.8/pkg/util/runtime/runtime.go:108 in HandleError) | pkg/mod/k8s.io/client-go@v0.23.8/tools/cache/reflector.go:167: Failed to watch *v1beta1.CronJob: failed to list *v1beta1.CronJob: the server could not find the requested resource
```

The following logs should also not be present:

```
2022-09-06 07:43:15 UTC | CLUSTER | WARN | (v2@v2.4.2/internal/store/builder.go:180 in WithCustomResourceStoreFactories) | The internal resource store named poddisruptionbudgets already exists and is overridden by a custom resource store with the same name, please make sure it meets your expectation
2022-09-06 07:43:15 UTC | CLUSTER | WARN | (v2@v2.4.2/internal/store/builder.go:180 in WithCustomResourceStoreFactories) | The internal resource store named cronjobs already exists and is overridden by a custom resource store with the same name, please make sure it meets your expectation
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
