### PR TITLE
[CWS] fix interpreter serialization

### DIFF
--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -701,8 +701,7 @@ func (p *ProcessResolver) ResolveNewProcessCacheEntry(entry *model.ProcessCacheE
 		return fmt.Errorf("failed to resolve exec path: %w", err)
 	}
 
-	// TODO: Is there a better way to determine if there's no interpreter?
-	if (entry.LinuxBinprm.FileEvent.Inode != 0 && entry.LinuxBinprm.FileEvent.MountID != 0) && (entry.LinuxBinprm.FileEvent.Inode != entry.FileEvent.Inode) {
+	if entry.HasInterpreter() {
 		if _, err := p.SetProcessPath(&entry.LinuxBinprm.FileEvent); err != nil {
 			return fmt.Errorf("failed to resolve interpreter path: %w", err)
 		}

--- a/pkg/security/probe/serializers.go
+++ b/pkg/security/probe/serializers.go
@@ -616,7 +616,7 @@ func newProcessSerializer(ps *model.Process, e *Event) *ProcessSerializer {
 		IsKworker:     ps.IsKworker,
 	}
 
-	if ps.LinuxBinprm.FileEvent.Inode != 0 {
+	if ps.HasInterpreter() {
 		psSerializer.Interpreter = newFileSerializer(&ps.LinuxBinprm.FileEvent, e)
 	}
 

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -318,11 +318,16 @@ type Credentials struct {
 }
 
 // GetPathResolutionError returns the path resolution error as a string if there is one
-func (e *Process) GetPathResolutionError() string {
-	if e.FileEvent.PathResolutionError != nil {
-		return e.FileEvent.PathResolutionError.Error()
+func (p *Process) GetPathResolutionError() string {
+	if p.FileEvent.PathResolutionError != nil {
+		return p.FileEvent.PathResolutionError.Error()
 	}
 	return ""
+}
+
+// HasInterpreter returns whether the process uses an interpreter
+func (p *Process) HasInterpreter() bool {
+	return p.LinuxBinprm.FileEvent.Inode != 0 && p.LinuxBinprm.FileEvent.MountID != 0
 }
 
 // LinuxBinprm contains content from the linux_binprm struct, which holds the arguments used for loading binaries

--- a/pkg/security/secl/model/unmarshallers.go
+++ b/pkg/security/secl/model/unmarshallers.go
@@ -242,9 +242,12 @@ func (e *Process) UnmarshalBinary(data []byte) (int, error) {
 		return 0, ErrNotEnoughData
 	}
 
-	e.LinuxBinprm.FileEvent.Inode = ByteOrder.Uint64(data[read : read+8])
-	e.LinuxBinprm.FileEvent.MountID = ByteOrder.Uint32(data[read+8 : read+12])
-	e.LinuxBinprm.FileEvent.PathID = ByteOrder.Uint32(data[read+12 : read+16])
+	// TODO: Is there a better way to determine if there's no interpreter?
+	inode, mountID := ByteOrder.Uint64(data[read:read+8]), ByteOrder.Uint32(data[read+8:read+12])
+	if e.FileEvent.Inode != inode && e.FileEvent.MountID != mountID {
+		e.LinuxBinprm.FileEvent.Inode, e.LinuxBinprm.FileEvent.MountID = inode, mountID
+		e.LinuxBinprm.FileEvent.PathID = ByteOrder.Uint32(data[read+12 : read+16])
+	}
 
 	read += 16
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR fixes interpreter presence check so that we don't resolve twice the same file during the serialization is there is no interpreter.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
