### PR TITLE
Fix lingering metadata in inventory for stopped containers

### DIFF
--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -463,10 +463,8 @@ func StartAgent() error {
 		return err
 	}
 
-	if config.Datadog.GetBool("inventories_enabled") {
-		if err := metadata.SetupInventories(common.MetadataScheduler, common.Coll); err != nil {
-			return err
-		}
+	if err := metadata.SetupInventories(common.MetadataScheduler, common.Coll); err != nil {
+		return err
 	}
 
 	// start dependent services

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -219,10 +219,8 @@ func runAgent(ctx context.Context) (err error) {
 		return
 	}
 
-	if config.Datadog.GetBool("inventories_enabled") {
-		if err = metadata.SetupInventories(metaScheduler, nil); err != nil {
-			return
-		}
+	if err = metadata.SetupInventories(metaScheduler, nil); err != nil {
+		return
 	}
 
 	// container tagging initialisation if origin detection is on

--- a/pkg/metadata/inventories/inventories.go
+++ b/pkg/metadata/inventories/inventories.go
@@ -116,6 +116,10 @@ func Refresh() {
 
 // SetAgentMetadata updates the agent metadata value in the cache
 func SetAgentMetadata(name AgentMetadataName, value interface{}) {
+	if !config.Datadog.GetBool("inventories_enabled") {
+		return
+	}
+
 	inventoryMutex.Lock()
 	defer inventoryMutex.Unlock()
 
@@ -128,6 +132,10 @@ func SetAgentMetadata(name AgentMetadataName, value interface{}) {
 
 // SetHostMetadata updates the host metadata value in the cache
 func SetHostMetadata(name AgentMetadataName, value interface{}) {
+	if !config.Datadog.GetBool("inventories_enabled") {
+		return
+	}
+
 	inventoryMutex.Lock()
 	defer inventoryMutex.Unlock()
 
@@ -140,7 +148,7 @@ func SetHostMetadata(name AgentMetadataName, value interface{}) {
 
 // SetCheckMetadata updates a metadata value for one check instance in the cache.
 func SetCheckMetadata(checkID, key string, value interface{}) {
-	if checkID == "" {
+	if checkID == "" || !config.Datadog.GetBool("inventories_enabled") {
 		return
 	}
 
@@ -166,6 +174,10 @@ func SetCheckMetadata(checkID, key string, value interface{}) {
 // RemoveCheckMetadata removes metadata for a check a trigger a new payload. This need to be called when a check is
 // unscheduled.
 func RemoveCheckMetadata(checkID string) {
+	if !config.Datadog.GetBool("inventories_enabled") {
+		return
+	}
+
 	inventoryMutex.Lock()
 	defer inventoryMutex.Unlock()
 
@@ -282,6 +294,10 @@ func createPayload(ctx context.Context, hostname string, coll CollectorInterface
 
 // GetCheckMetadata returns metadata for a check instance
 func GetCheckMetadata(c check.Check) *CheckInstanceMetadata {
+	if !config.Datadog.GetBool("inventories_enabled") {
+		return nil
+	}
+
 	inventoryMutex.Lock()
 	defer inventoryMutex.Unlock()
 
@@ -300,6 +316,10 @@ func GetCheckMetadata(c check.Check) *CheckInstanceMetadata {
 
 // GetPayload returns a new inventory metadata payload and updates lastGetPayload
 func GetPayload(ctx context.Context, hostname string, coll CollectorInterface, withConfigs bool) *Payload {
+	if !config.Datadog.GetBool("inventories_enabled") {
+		return nil
+	}
+
 	inventoryMutex.Lock()
 	defer inventoryMutex.Unlock()
 
@@ -325,6 +345,10 @@ func GetLastPayload() ([]byte, error) {
 // StartMetadataUpdatedGoroutine starts a routine that listens to the metadataUpdatedC
 // signal to run the collector out of its regular interval.
 func StartMetadataUpdatedGoroutine(sc schedulerInterface, minSendInterval time.Duration) error {
+	if !config.Datadog.GetBool("inventories_enabled") {
+		return nil
+	}
+
 	go func() {
 		for {
 			<-metadataUpdatedC
@@ -343,6 +367,10 @@ func StartMetadataUpdatedGoroutine(sc schedulerInterface, minSendInterval time.D
 
 // InitializeData inits the inventories payload with basic and static information (agent version, flavor name, ...)
 func InitializeData() {
+	if !config.Datadog.GetBool("inventories_enabled") {
+		return
+	}
+
 	SetAgentMetadata(AgentVersion, version.AgentVersion)
 	SetAgentMetadata(AgentFlavor, flavor.GetFlavor())
 

--- a/pkg/metadata/inventories/inventories_test.go
+++ b/pkg/metadata/inventories/inventories_test.go
@@ -160,7 +160,7 @@ func TestGetPayload(t *testing.T) {
 
 	SetCheckMetadata("check1_instance1", "check_provided_key1", 123)
 	SetCheckMetadata("check1_instance1", "check_provided_key2", "Hi")
-	SetCheckMetadata("non_running_checkid", "check_provided_key1", "this_should_be_kept")
+	SetCheckMetadata("non_running_checkid", "check_provided_key1", "this_should_not_be_kept")
 
 	p := GetPayload(ctx, "testHostname", coll, true)
 

--- a/pkg/metadata/inventories/inventories_test.go
+++ b/pkg/metadata/inventories/inventories_test.go
@@ -64,17 +64,15 @@ func waitForCalledSignal(calledSignal chan interface{}) bool {
 }
 
 func TestRemoveCheckMetadata(t *testing.T) {
-	ctx := context.Background()
 	defer func() { clearMetadata() }()
 
 	SetCheckMetadata("check1", "check_provided_key1", 123)
 	SetCheckMetadata("check2", "check_provided_key1", 123)
+
 	RemoveCheckMetadata("check1")
 
-	p := GetPayload(ctx, "testHostname", nil, true)
-	checks := *p.CheckMetadata
-	assert.Len(t, checks, 1)
-	assert.Len(t, checks["check2"], 1)
+	assert.Len(t, checkMetadata, 1)
+	assert.Contains(t, checkMetadata, "check2")
 }
 
 type mockCollector struct {
@@ -159,6 +157,7 @@ func TestGetPayload(t *testing.T) {
 	}}
 
 	SetAgentMetadata("test", true)
+
 	SetCheckMetadata("check1_instance1", "check_provided_key1", 123)
 	SetCheckMetadata("check1_instance1", "check_provided_key2", "Hi")
 	SetCheckMetadata("non_running_checkid", "check_provided_key1", "this_should_be_kept")
@@ -172,7 +171,7 @@ func TestGetPayload(t *testing.T) {
 	assert.Equal(t, true, agentMetadata["test"])
 
 	checkMeta := *p.CheckMetadata
-	assert.Len(t, checkMeta, 3)
+	assert.Len(t, checkMeta, 2)           // 'non_running_checkid' should have been cleaned
 	assert.Len(t, checkMeta["check1"], 2) // check1 has two instances
 
 	check1Instance1 := *checkMeta["check1"][0]
@@ -219,7 +218,7 @@ func TestGetPayload(t *testing.T) {
 	delete(agentMetadata, "full_configuration")
 
 	checkMeta = *p.CheckMetadata
-	assert.Len(t, checkMeta, 3)
+	assert.Len(t, checkMeta, 2)
 	check1Instance1 = *checkMeta["check1"][0]
 	assert.Equal(t, "check1_instance1", check1Instance1["config.hash"])
 	assert.Equal(t, "provider1", check1Instance1["config.provider"])
@@ -266,16 +265,6 @@ func TestGetPayload(t *testing.T) {
 					"config.provider": "provider2",
 					"init_config": "",
 					"instance_config": "{}"
-				}
-			],
-			"non_running_checkid":
-			[
-				{
-					"check_provided_key1": "this_should_be_kept",
-					"config.hash": "non_running_checkid",
-					"config.provider": "",
-					"init_config": "",
-					"instance_config": ""
 				}
 			]
 		},


### PR DESCRIPTION
### What does this PR do?

* Avoid sending inventory data for unscheduled check.
    In a k8s environment the container linked to a check instance might be stop/killed while the check is running. Since we don't have a way to stop a Python thread we unschedule the check but let it finish its last run. This means that inventories might receive metadata for a check that no longer exists in the collector and will never be cleaned.
    This commit cleans the check metadata cache every time we generate the payload. This means we no longer send information about checks not in the collector. Therefore, the `check` command has to manually print metadata instead of relying on the status page.
* Check if inventory is enabled in all public methods.  We don't want to store data in inventory when the collector is disabled.

### Describe how to test/QA your changes

1. Create a python instance that sleep X second before registering metadata.

ex:
```python
from time import sleep
from datadog_checks.base import AgentCheck
import datadog_agent

class Inv(AgentCheck):

    def check(self, _):
        self.log.error("sleeping")
        sleep(5)
        self.log.error("sending metadata")
        self.set_metadata("version", "1.0.0")
        self.log.error("Check run done")
```
2. Create a auto_conf config to link this check to a container (for example redis):
    ex inv.yaml: 
```yaml
ad_identifiers:
  - redis

instances:
  - host: "%%host%%"
```
3. Start the agent, start a redis container, wait for the check to start and print `sleeping`, kill the container, watch the collector stop/clean the check. After 5s the check will still register some metadata. After the last run is completed wait `inventories_min_interval` and check that the inventory payload doesn't contain any info about the `inv` check (with the command `troubleshooting metadata_inventories`).

As a second test: disable inventory completely with `inventories_enabled: false` and check that no payload is sent for inventory.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
