### PR TITLE
[CWS][SEC-4633] fix iouring prep hook

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "28bc77a35a91c78b957dd57b25416c6faa519a3dbd79dfe9a0ec7827f6e3cd49")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "468f951fa03700d80cf2b0d32e8cd9c578070501f9100e321bd0d803f101d978")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "1313874cfd8db909f8cb01d7a1e25314d69c7407165a71e26d33a592f209ebf2")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "86196366e6be80fcbb96cdcfc9058e80aa50f1005683d76a69fc4d1af5fd7a72")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "f65cad75f957841750be4e9f55cf5039b4c8099e67d4216352ab0a7a3d5c598f")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "3ad8894e5a0c22c8a3c8f244a8d8369e418ceb5387cb2e152b59c2dee694fa04")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "26cda763e174923f8253b009a1cfcae19bbe205ddce2190b40d1e983539a3f23")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "80473dd61ca8774239fa6351397ae0d5f78ea4f7a6dfb14f5d207667a5877174")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "468f951fa03700d80cf2b0d32e8cd9c578070501f9100e321bd0d803f101d978")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "3ab973eb20fc330c6278eb1799287e1dcb984219c9bd9d5819ccd2b0c612ae37")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "86196366e6be80fcbb96cdcfc9058e80aa50f1005683d76a69fc4d1af5fd7a72")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "28bc77a35a91c78b957dd57b25416c6faa519a3dbd79dfe9a0ec7827f6e3cd49")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "3ad8894e5a0c22c8a3c8f244a8d8369e418ceb5387cb2e152b59c2dee694fa04")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "26cda763e174923f8253b009a1cfcae19bbe205ddce2190b40d1e983539a3f23")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "3ab973eb20fc330c6278eb1799287e1dcb984219c9bd9d5819ccd2b0c612ae37")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "0bf6779077a5e555315fc52e5d945349bed0f9e77a86f6e8919be1056e228d2c")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "80473dd61ca8774239fa6351397ae0d5f78ea4f7a6dfb14f5d207667a5877174")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "94d9914261d9db4f33cd2d7a2423b4e2b94a44e5aae3a7b3531e75e8008614d8")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "0bf6779077a5e555315fc52e5d945349bed0f9e77a86f6e8919be1056e228d2c")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "f65cad75f957841750be4e9f55cf5039b4c8099e67d4216352ab0a7a3d5c598f")

--- a/pkg/security/ebpf/c/iouring.h
+++ b/pkg/security/ebpf/c/iouring.h
@@ -20,6 +20,27 @@ void __attribute__((always_inline)) cache_ioctx_pid_tgid(void *ioctx) {
     bpf_map_update_elem(&io_uring_ctx_pid, &ioctx, &pid_tgid, BPF_ANY);
 }
 
+struct tracepoint_io_uring_io_uring_create_t
+{
+    unsigned short common_type;
+    unsigned char common_flags;
+    unsigned char common_preempt_count;
+    int common_pid;
+
+    int fd;
+	void *ctx;
+	u32 sq_entries;
+	u32 cq_entries;
+	u32 flags;
+};
+
+SEC("tracepoint/io_uring/io_uring_create")
+int io_uring_create(struct tracepoint_io_uring_io_uring_create_t *args) {
+    void *ioctx = args->ctx;
+    cache_ioctx_pid_tgid(ioctx);
+    return 0;
+}
+
 SEC("kretprobe/io_ring_ctx_alloc")
 int kretprobe_io_ring_ctx_alloc(struct pt_regs *ctx) {
     void *ioctx = (void *)PT_REGS_RC(ctx);

--- a/pkg/security/ebpf/c/iouring.h
+++ b/pkg/security/ebpf/c/iouring.h
@@ -14,18 +14,28 @@ SEC("kretprobe/io_ring_ctx_alloc")
 int kretprobe_io_ring_ctx_alloc(struct pt_regs *ctx) {
     void *ioctx = (void *)PT_REGS_RC(ctx);
     u64 pid_tgid = bpf_get_current_pid_tgid();
+#ifdef DEBUG
+    bpf_printk("pid = %d", (u32)pid_tgid);
+    bpf_printk("tgid = %d", pid_tgid >> 32);
+    bpf_printk("ioctx in = %p", ioctx);
+#endif
     bpf_map_update_elem(&io_uring_ctx_pid, &ioctx, &pid_tgid, BPF_ANY);
     return 0;
 }
 
 u64 __attribute__((always_inline)) get_pid_tgid_from_iouring(void *req) {
     void *ioctx;
-    bpf_probe_read(&ioctx, sizeof(void*), req + 80); // TODO constantify
+    int ret = bpf_probe_read(&ioctx, sizeof(void*), req + 80); // TODO constantify
+    if (ret < 0) {
+        return 0;
+    }
+
+    bpf_printk("ioctx out = %p", ioctx);
     u64 *pid_tgid_ptr = bpf_map_lookup_elem(&io_uring_ctx_pid, &ioctx);
     if (pid_tgid_ptr) {
         return *pid_tgid_ptr;
     } else {
-        return bpf_get_current_pid_tgid();
+        return 0;
     }
 }
 

--- a/pkg/security/ebpf/c/iouring.h
+++ b/pkg/security/ebpf/c/iouring.h
@@ -1,0 +1,32 @@
+#ifndef _IOURING_H_
+#define _IOURING_H_
+
+struct bpf_map_def SEC("maps/io_uring_ctx_pid") io_uring_ctx_pid = {
+    .type = BPF_MAP_TYPE_LRU_HASH,
+    .key_size = sizeof(void*),
+    .value_size = sizeof(u64),
+    .max_entries = 2048,
+    .pinning = 0,
+    .namespace = "",
+};
+
+SEC("kretprobe/io_ring_ctx_alloc")
+int kretprobe_io_ring_ctx_alloc(struct pt_regs *ctx) {
+    void *ioctx = (void *)PT_REGS_RC(ctx);
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    bpf_map_update_elem(&io_uring_ctx_pid, &ioctx, &pid_tgid, BPF_ANY);
+    return 0;
+}
+
+u64 __attribute__((always_inline)) get_pid_tgid_from_iouring(void *req) {
+    void *ioctx;
+    bpf_probe_read(&ioctx, sizeof(void*), req + 80); // TODO constantify
+    u64 *pid_tgid_ptr = bpf_map_lookup_elem(&io_uring_ctx_pid, &ioctx);
+    if (pid_tgid_ptr) {
+        return *pid_tgid_ptr;
+    } else {
+        return bpf_get_current_pid_tgid();
+    }
+}
+
+#endif

--- a/pkg/security/ebpf/c/iouring.h
+++ b/pkg/security/ebpf/c/iouring.h
@@ -63,8 +63,11 @@ int kprobe_io_sq_offload_start(struct pt_regs *ctx) {
 }
 
 u64 __attribute__((always_inline)) get_pid_tgid_from_iouring(void *req) {
+    u64 ioctx_offset;
+    LOAD_CONSTANT("iokiocb_ctx_offset", ioctx_offset);
+
     void *ioctx;
-    int ret = bpf_probe_read(&ioctx, sizeof(void*), req + 80); // TODO constantify
+    int ret = bpf_probe_read(&ioctx, sizeof(void*), req + ioctx_offset);
     if (ret < 0) {
         return 0;
     }
@@ -77,7 +80,7 @@ u64 __attribute__((always_inline)) get_pid_tgid_from_iouring(void *req) {
     if (pid_tgid_ptr) {
         return *pid_tgid_ptr;
     } else {
-        return -1;
+        return 0;
     }
 }
 

--- a/pkg/security/ebpf/c/open.h
+++ b/pkg/security/ebpf/c/open.h
@@ -204,11 +204,27 @@ struct io_open {
     struct openat2_open_how how;
 };
 
-SEC("kprobe/__io_openat_prep")
-int kprobe___io_openat_prep(struct pt_regs *ctx) {
+void __attribute__((always_inline)) cache_io_openat_prep_pid(struct pt_regs *ctx) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     void *raw_req = (void*) PT_REGS_PARM1(ctx);
     bpf_map_update_elem(&io_uring_req_pid, &raw_req, &pid_tgid, BPF_ANY);
+}
+
+SEC("kprobe/__io_openat_prep")
+int kprobe___io_openat_prep(struct pt_regs *ctx) {
+    cache_io_openat_prep_pid(ctx);
+    return 0;
+}
+
+SEC("kprobe/io_openat_prep")
+int kprobe_io_openat_prep(struct pt_regs *ctx) {
+    cache_io_openat_prep_pid(ctx);
+    return 0;
+}
+
+SEC("kprobe/io_openat2_prep")
+int kprobe_io_openat2_prep(struct pt_regs *ctx) {
+    cache_io_openat_prep_pid(ctx);
     return 0;
 }
 

--- a/pkg/security/ebpf/c/open.h
+++ b/pkg/security/ebpf/c/open.h
@@ -363,6 +363,8 @@ int kretprobe_io_openat2(struct pt_regs *ctx) {
     u64 pid_tgid = 0;
     if (pid_tgid_ptr != NULL) {
         pid_tgid = *pid_tgid_ptr;
+    } else {
+        pid_tgid = bpf_get_current_pid_tgid();
     }
 
     return sys_open_ret_with_pid_tgid(ctx, retval, DR_KPROBE, pid_tgid);

--- a/pkg/security/ebpf/c/prebuilt/probe.c
+++ b/pkg/security/ebpf/c/prebuilt/probe.c
@@ -26,6 +26,7 @@
 #include "activity_dump.h"
 #include "approvers.h"
 #include "discarders.h"
+#include "iouring.h"
 #include "dentry.h"
 #include "dentry_resolver.h"
 #include "pipe.h"

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -67,6 +67,7 @@ func AllProbes() []*manager.Probe {
 	allProbes = append(allProbes, getRenameProbes()...)
 	allProbes = append(allProbes, getRmdirProbe()...)
 	allProbes = append(allProbes, sharedProbes...)
+	allProbes = append(allProbes, iouringProbes...)
 	allProbes = append(allProbes, getUnlinkProbes()...)
 	allProbes = append(allProbes, getXattrProbes()...)
 	allProbes = append(allProbes, getIoctlProbes()...)

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -123,7 +123,6 @@ func AllMaps() []*manager.Map {
 		{Name: "exec_file_cache"},
 		// Open tables
 		{Name: "open_flags_approvers"},
-		{Name: "io_uring_req_pid"},
 		// Exec tables
 		{Name: "proc_cache"},
 		{Name: "pid_cache"},

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -218,9 +218,7 @@ func GetSelectorsPerEventType() map[eval.EventType][]manager.ProbesSelector {
 					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "open_by_handle_at"}, EntryAndExit, true),
 				},
 				&manager.BestEffort{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/__io_openat_prep", EBPFFuncName: "kprobe___io_openat_prep"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/io_openat_prep", EBPFFuncName: "kprobe_io_openat_prep"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/io_openat2_prep", EBPFFuncName: "kprobe_io_openat2_prep"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kretprobe/io_ring_ctx_alloc", EBPFFuncName: "kretprobe_io_ring_ctx_alloc"}},
 					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/io_openat2", EBPFFuncName: "kprobe_io_openat2"}},
 					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kretprobe/io_openat", EBPFFuncName: "kretprobe_io_openat"}},
 					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kretprobe/io_openat2", EBPFFuncName: "kretprobe_io_openat2"}},

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -219,6 +219,7 @@ func GetSelectorsPerEventType() map[eval.EventType][]manager.ProbesSelector {
 				},
 				&manager.BestEffort{Selectors: []manager.ProbesSelector{
 					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kretprobe/io_ring_ctx_alloc", EBPFFuncName: "kretprobe_io_ring_ctx_alloc"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/io_openat", EBPFFuncName: "kprobe_io_openat"}},
 					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/io_openat2", EBPFFuncName: "kprobe_io_openat2"}},
 					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kretprobe/io_openat2", EBPFFuncName: "kretprobe_io_openat2"}},
 				}},

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -219,6 +219,8 @@ func GetSelectorsPerEventType() map[eval.EventType][]manager.ProbesSelector {
 				},
 				&manager.BestEffort{Selectors: []manager.ProbesSelector{
 					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/__io_openat_prep", EBPFFuncName: "kprobe___io_openat_prep"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/io_openat_prep", EBPFFuncName: "kprobe_io_openat_prep"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/io_openat2_prep", EBPFFuncName: "kprobe_io_openat2_prep"}},
 					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/io_openat2", EBPFFuncName: "kprobe_io_openat2"}},
 					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kretprobe/io_openat2", EBPFFuncName: "kretprobe_io_openat2"}},
 				}},

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -228,6 +228,7 @@ func GetSelectorsPerEventType() map[eval.EventType][]manager.ProbesSelector {
 
 				// iouring
 				&manager.BestEffort{Selectors: []manager.ProbesSelector{
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "tracepoint/io_uring/io_uring_create", EBPFFuncName: "io_uring_create"}},
 					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kretprobe/io_ring_ctx_alloc", EBPFFuncName: "kretprobe_io_ring_ctx_alloc"}},
 					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/io_allocate_scq_urings", EBPFFuncName: "kprobe_io_allocate_scq_urings"}},
 					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/io_sq_offload_start", EBPFFuncName: "kprobe_io_sq_offload_start"}},

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -222,6 +222,7 @@ func GetSelectorsPerEventType() map[eval.EventType][]manager.ProbesSelector {
 					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/io_openat_prep", EBPFFuncName: "kprobe_io_openat_prep"}},
 					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/io_openat2_prep", EBPFFuncName: "kprobe_io_openat2_prep"}},
 					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/io_openat2", EBPFFuncName: "kprobe_io_openat2"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kretprobe/io_openat", EBPFFuncName: "kretprobe_io_openat"}},
 					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kretprobe/io_openat2", EBPFFuncName: "kretprobe_io_openat2"}},
 				}},
 				&manager.AllOf{Selectors: []manager.ProbesSelector{

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -229,9 +229,11 @@ func GetSelectorsPerEventType() map[eval.EventType][]manager.ProbesSelector {
 				// iouring
 				&manager.BestEffort{Selectors: []manager.ProbesSelector{
 					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "tracepoint/io_uring/io_uring_create", EBPFFuncName: "io_uring_create"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kretprobe/io_ring_ctx_alloc", EBPFFuncName: "kretprobe_io_ring_ctx_alloc"}},
+				}},
+				&manager.OneOf{Selectors: []manager.ProbesSelector{
 					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/io_allocate_scq_urings", EBPFFuncName: "kprobe_io_allocate_scq_urings"}},
 					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/io_sq_offload_start", EBPFFuncName: "kprobe_io_sq_offload_start"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kretprobe/io_ring_ctx_alloc", EBPFFuncName: "kretprobe_io_ring_ctx_alloc"}},
 				}},
 
 				// Mount probes

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -220,7 +220,6 @@ func GetSelectorsPerEventType() map[eval.EventType][]manager.ProbesSelector {
 				&manager.BestEffort{Selectors: []manager.ProbesSelector{
 					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kretprobe/io_ring_ctx_alloc", EBPFFuncName: "kretprobe_io_ring_ctx_alloc"}},
 					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/io_openat2", EBPFFuncName: "kprobe_io_openat2"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kretprobe/io_openat", EBPFFuncName: "kretprobe_io_openat"}},
 					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kretprobe/io_openat2", EBPFFuncName: "kretprobe_io_openat2"}},
 				}},
 				&manager.AllOf{Selectors: []manager.ProbesSelector{

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -229,11 +229,11 @@ func GetSelectorsPerEventType() map[eval.EventType][]manager.ProbesSelector {
 				// iouring
 				&manager.BestEffort{Selectors: []manager.ProbesSelector{
 					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "tracepoint/io_uring/io_uring_create", EBPFFuncName: "io_uring_create"}},
-				}},
-				&manager.OneOf{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/io_allocate_scq_urings", EBPFFuncName: "kprobe_io_allocate_scq_urings"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/io_sq_offload_start", EBPFFuncName: "kprobe_io_sq_offload_start"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kretprobe/io_ring_ctx_alloc", EBPFFuncName: "kretprobe_io_ring_ctx_alloc"}},
+					&manager.OneOf{Selectors: []manager.ProbesSelector{
+						&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/io_allocate_scq_urings", EBPFFuncName: "kprobe_io_allocate_scq_urings"}},
+						&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/io_sq_offload_start", EBPFFuncName: "kprobe_io_sq_offload_start"}},
+						&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kretprobe/io_ring_ctx_alloc", EBPFFuncName: "kretprobe_io_ring_ctx_alloc"}},
+					}},
 				}},
 
 				// Mount probes

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -218,13 +218,19 @@ func GetSelectorsPerEventType() map[eval.EventType][]manager.ProbesSelector {
 					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "open_by_handle_at"}, EntryAndExit, true),
 				},
 				&manager.BestEffort{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kretprobe/io_ring_ctx_alloc", EBPFFuncName: "kretprobe_io_ring_ctx_alloc"}},
 					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/io_openat", EBPFFuncName: "kprobe_io_openat"}},
 					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/io_openat2", EBPFFuncName: "kprobe_io_openat2"}},
 					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kretprobe/io_openat2", EBPFFuncName: "kretprobe_io_openat2"}},
 				}},
 				&manager.AllOf{Selectors: []manager.ProbesSelector{
 					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/filp_close", EBPFFuncName: "kprobe_filp_close"}},
+				}},
+
+				// iouring
+				&manager.BestEffort{Selectors: []manager.ProbesSelector{
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kretprobe/io_ring_ctx_alloc", EBPFFuncName: "kretprobe_io_ring_ctx_alloc"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/io_allocate_scq_urings", EBPFFuncName: "kprobe_io_allocate_scq_urings"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/io_sq_offload_start", EBPFFuncName: "kprobe_io_sq_offload_start"}},
 				}},
 
 				// Mount probes

--- a/pkg/security/ebpf/probes/iouring.go
+++ b/pkg/security/ebpf/probes/iouring.go
@@ -10,34 +10,33 @@ package probes
 
 import manager "github.com/DataDog/ebpf-manager"
 
-// sharedProbes is the list of probes that are shared across multiple events
-var sharedProbes = []*manager.Probe{
+// iouringProbes is the list of probes that are used for iouring monitoring
+var iouringProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/filename_create",
-			EBPFFuncName: "kprobe_filename_create",
+			EBPFSection:  "tracepoint/io_uring/io_uring_create",
+			EBPFFuncName: "io_uring_create"},
+	},
+	{
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kretprobe/io_ring_ctx_alloc",
+			EBPFFuncName: "kretprobe_io_ring_ctx_alloc",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/mnt_want_write",
-			EBPFFuncName: "kprobe_mnt_want_write",
+			EBPFSection:  "kprobe/io_allocate_scq_urings",
+			EBPFFuncName: "kprobe_io_allocate_scq_urings",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/mnt_want_write_file",
-			EBPFFuncName: "kprobe_mnt_want_write_file",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/mnt_want_write_file_path",
-			EBPFFuncName: "kprobe_mnt_want_write_file_path",
+			EBPFSection:  "kprobe/io_sq_offload_start",
+			EBPFFuncName: "kprobe_io_sq_offload_start",
 		},
 	},
 }

--- a/pkg/security/ebpf/probes/open.go
+++ b/pkg/security/ebpf/probes/open.go
@@ -64,6 +64,13 @@ var openProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
+			EBPFSection:  "kretprobe/io_openat",
+			EBPFFuncName: "kretprobe_io_openat",
+		},
+	},
+	{
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
 			EBPFSection:  "kretprobe/io_openat2",
 			EBPFFuncName: "kretprobe_io_openat2",
 		},

--- a/pkg/security/ebpf/probes/open.go
+++ b/pkg/security/ebpf/probes/open.go
@@ -43,6 +43,13 @@ var openProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/io_openat",
+			EBPFFuncName: "kprobe_io_openat",
+		},
+	},
+	{
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
 			EBPFSection:  "kprobe/io_openat2",
 			EBPFFuncName: "kprobe_io_openat2",
 		},

--- a/pkg/security/ebpf/probes/open.go
+++ b/pkg/security/ebpf/probes/open.go
@@ -36,13 +36,6 @@ var openProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kretprobe/io_ring_ctx_alloc",
-			EBPFFuncName: "kretprobe_io_ring_ctx_alloc",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
 			EBPFSection:  "kprobe/io_openat",
 			EBPFFuncName: "kprobe_io_openat",
 		},

--- a/pkg/security/ebpf/probes/open.go
+++ b/pkg/security/ebpf/probes/open.go
@@ -43,6 +43,20 @@ var openProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/io_openat_prep",
+			EBPFFuncName: "kprobe_io_openat_prep",
+		},
+	},
+	{
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/io_openat2_prep",
+			EBPFFuncName: "kprobe_io_openat2_prep",
+		},
+	},
+	{
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
 			EBPFSection:  "kprobe/io_openat2",
 			EBPFFuncName: "kprobe_io_openat2",
 		},

--- a/pkg/security/ebpf/probes/open.go
+++ b/pkg/security/ebpf/probes/open.go
@@ -36,22 +36,8 @@ var openProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/__io_openat_prep",
-			EBPFFuncName: "kprobe___io_openat_prep",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/io_openat_prep",
-			EBPFFuncName: "kprobe_io_openat_prep",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/io_openat2_prep",
-			EBPFFuncName: "kprobe_io_openat2_prep",
+			EBPFSection:  "kretprobe/io_ring_ctx_alloc",
+			EBPFFuncName: "kretprobe_io_ring_ctx_alloc",
 		},
 	},
 	{

--- a/pkg/security/ebpf/probes/open.go
+++ b/pkg/security/ebpf/probes/open.go
@@ -50,13 +50,6 @@ var openProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kretprobe/io_openat",
-			EBPFFuncName: "kretprobe_io_openat",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
 			EBPFSection:  "kretprobe/io_openat2",
 			EBPFFuncName: "kretprobe_io_openat2",
 		},

--- a/pkg/security/ebpf/probes/shared.go
+++ b/pkg/security/ebpf/probes/shared.go
@@ -40,4 +40,25 @@ var sharedProbes = []*manager.Probe{
 			EBPFFuncName: "kprobe_mnt_want_write_file_path",
 		},
 	},
+	{
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kretprobe/io_ring_ctx_alloc",
+			EBPFFuncName: "kretprobe_io_ring_ctx_alloc",
+		},
+	},
+	{
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/io_allocate_scq_urings",
+			EBPFFuncName: "kprobe_io_allocate_scq_urings",
+		},
+	},
+	{
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/io_sq_offload_start",
+			EBPFFuncName: "kprobe_io_sq_offload_start",
+		},
+	},
 }

--- a/pkg/security/probe/constantfetch/constant_names.go
+++ b/pkg/security/probe/constantfetch/constant_names.go
@@ -55,4 +55,7 @@ const (
 
 	// Interpreter constants
 	OffsetNameLinuxBinprmStructFile = "binprm_file_offset"
+
+	// iouring constants
+	OffsetNameIoKiocbStructCtx = "iokiocb_ctx_offset"
 )

--- a/pkg/security/probe/constantfetch/fallback.go
+++ b/pkg/security/probe/constantfetch/fallback.go
@@ -100,6 +100,8 @@ func (f *FallbackConstantFetcher) appendRequest(id string) {
 		value = getFlowi6ULIOffset(f.kernelVersion)
 	case OffsetNameLinuxBinprmStructFile:
 		value = getBinPrmFileFieldOffset(f.kernelVersion)
+	case OffsetNameIoKiocbStructCtx:
+		value = getIoKcbCtxOffset(f.kernelVersion)
 	}
 	f.res[id] = value
 }
@@ -701,4 +703,8 @@ func getBinPrmFileFieldOffset(kv *kernel.Version) uint64 {
 
 	// `struct file *executable` and `struct file *interpreter` are introduced in v5.8-rc1
 	return 64
+}
+
+func getIoKcbCtxOffset(kv *kernel.Version) uint64 {
+	return 80
 }

--- a/pkg/security/probe/constantfetch/runtime_compiled.go
+++ b/pkg/security/probe/constantfetch/runtime_compiled.go
@@ -53,27 +53,29 @@ func (cf *RuntimeCompilationConstantFetcher) String() string {
 }
 
 func (cf *RuntimeCompilationConstantFetcher) AppendSizeofRequest(id, typeName, headerName string) {
-	if headerName != "" {
-		cf.headers = append(cf.headers, headerName)
+	cf.result[id] = ErrorSentinel
+	if headerName == "" {
+		return
 	}
 
+	cf.headers = append(cf.headers, headerName)
 	cf.symbolPairs = append(cf.symbolPairs, rcSymbolPair{
 		Id:        id,
 		Operation: fmt.Sprintf("sizeof(%s)", typeName),
 	})
-	cf.result[id] = ErrorSentinel
 }
 
 func (cf *RuntimeCompilationConstantFetcher) AppendOffsetofRequest(id, typeName, fieldName, headerName string) {
-	if headerName != "" {
-		cf.headers = append(cf.headers, headerName)
+	cf.result[id] = ErrorSentinel
+	if headerName == "" {
+		return
 	}
 
+	cf.headers = append(cf.headers, headerName)
 	cf.symbolPairs = append(cf.symbolPairs, rcSymbolPair{
 		Id:        id,
 		Operation: fmt.Sprintf("offsetof(%s, %s)", typeName, fieldName),
 	})
-	cf.result[id] = ErrorSentinel
 }
 
 const runtimeCompilationTemplate = `

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -1666,4 +1666,9 @@ func AppendProbeRequestsToFetcher(constantFetcher constantfetch.ConstantFetcher,
 	} else {
 		constantFetcher.AppendOffsetofRequest(constantfetch.OffsetNameNetStructNS, "struct net", "ns", "net/net_namespace.h")
 	}
+
+	// iouring
+	if kv.Code != 0 && (kv.Code >= kernel.Kernel5_1) {
+		constantFetcher.AppendOffsetofRequest(constantfetch.OffsetNameIoKiocbStructCtx, "struct io_kiocb", "ctx", "")
+	}
 }

--- a/pkg/security/tests/constants_test.go
+++ b/pkg/security/tests/constants_test.go
@@ -23,6 +23,10 @@ var BTFHubPossiblyMissingConstants = []string{
 	constantfetch.OffsetNameNFConnStructCTNet,
 }
 
+var RCMissingConstants = []string{
+	constantfetch.OffsetNameIoKiocbStructCtx,
+}
+
 func TestOctogonConstants(t *testing.T) {
 	if err := initLogger(); err != nil {
 		t.Fatal(err)
@@ -52,7 +56,7 @@ func TestOctogonConstants(t *testing.T) {
 		fallbackFetcher := constantfetch.NewFallbackConstantFetcher(kv)
 		rcFetcher := constantfetch.NewRuntimeCompilationConstantFetcher(&config.Config, nil)
 
-		assertConstantsEqual(t, rcFetcher, fallbackFetcher, kv, nil)
+		assertConstantsEqual(t, rcFetcher, fallbackFetcher, kv, RCMissingConstants)
 	})
 
 	t.Run("btfhub-vs-rc", func(t *testing.T) {
@@ -128,6 +132,11 @@ func assertConstantsEqual(t *testing.T, champion, challenger constantfetch.Const
 		}
 
 		if championValue != constantfetch.ErrorSentinel && challengerValue == constantfetch.ErrorSentinel {
+			delete(championConstants, possiblyMissingConstant)
+			delete(challengerConstants, possiblyMissingConstant)
+		}
+
+		if championValue == constantfetch.ErrorSentinel && challengerValue != constantfetch.ErrorSentinel {
 			delete(championConstants, possiblyMissingConstant)
 			delete(challengerConstants, possiblyMissingConstant)
 		}


### PR DESCRIPTION
### What does this PR do?

This PR improves the filling of the process context for iouring events. The base of the issue is that some parts of the iouring execution flow can happen not in the syscall path but through a different kernel thread executing requests from a queue. This means that simply calling `bpf_get_current_pid_tgid()` does not return the correct, interesting value.

Before this PR we already knew that and were building a mapping between the iouring req and the pid/tgid couple, but we were not correctly filling this mapping, because we were hooked at a place already running in the background thread.

To fix this issue this PR creates a mapping between the iouring context and the pid/tgid. The context is allocated during the syscall `iouring_create` running in all cases in the syscall function itself.
We hook multiples functions/tracepoint to support multiple kernels version.

At the end we get the context from the request and the pid/tgid from this context (via the mapping).

This PR also allows the definition of constants that cannot be computed with runtime compilation (`struct io_kiocb` is not in a public header). And fixes the infrastructure to work with that (octogon tests etc)

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
