### PR TITLE
[WA-26] Add user selection window in installer

### DIFF
--- a/omnibus/resources/agent/msi/assets/ddagentuserdlg.wxi
+++ b/omnibus/resources/agent/msi/assets/ddagentuserdlg.wxi
@@ -1,0 +1,82 @@
+<Include>
+  <Dialog Id="DDAgentUserDlg" Width="370" Height="270" Title="!(loc.DDAgentUserDialog_Title)">
+
+    <!-- Username and Password fields
+         Sets the same property as the command line options
+           - DDAGENTUSER_NAME
+           - DDAGENTUSER_PASSWORD
+         If the properties are set on the command line, the controls will be pre-filled
+    -->
+    <Control Id="EnterUserName" Type="Text" Height="15" Width="320" X="25" Y="70"
+             Text="!(loc.DDAgentUserDialogUserNameLabel)" />
+    <Control Id="UserNameFromDefault" Type="Edit" Height="15" Width="320" X="25" Y="86"
+             Property="DDAGENTUSER_NAME" />
+    <Control Id="EnterPassword" Type="Text" Height="15" Width="320" X="25" Y="118"
+             Text="!(loc.DDAgentUserDialogPasswordLabel)" />
+    <Control Id="PasswordFromDefault" Type="Edit" Height="15" Width="320" X="25" Y="134"
+             Password="yes"
+             Property="DDAGENTUSER_PASSWORD" />
+
+    <!-- back button -->
+    <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17"
+             Text="Back">
+      <Publish Event="NewDialog" Value="SiteDlg" />
+    </Control>
+
+    <!-- next button -->
+    <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes"
+               Text="Next">
+      <!-- Validate account credentials -->
+      <Publish Event="DoAction" Value="ValidateDDAgentUserDlgInput">1</Publish>
+      <!-- If creds are valid go to next dialog -->
+      <Publish Event="NewDialog" Value="VerifyReadyDlg">DDAgentUser_Valid = "True"</Publish>
+      <!-- If creds are invalid, display error -->
+      <Publish Event="NewDialog" Value="DDAgentUserInvalidDlg">DDAgentUser_Valid = "False"</Publish>
+    </Control>
+
+    <!-- cancel button -->
+    <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes"
+               Text="Cancel">
+      <Publish Event="EndDialog" Value="Exit">1</Publish>
+    </Control>
+
+    <!-- Title + Banner -->
+    <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="!(loc.LicenseAgreementDlgBannerBitmap)" />
+    <Control Id="BannerLine" Type="Line" X="0" Y="44" Width="370" Height="0" />
+    <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" />
+    <Control Id="Title" Type="Text" X="15" Y="6" Width="340" Height="15"
+             Transparent="yes" NoPrefix="yes" Text="!(loc.DDAgentUserDialogTitle)" />
+    <Control Id="Description" Type="Text" X="25" Y="23" Width="340" Height="15"
+             Transparent="yes" NoPrefix="yes" Text="!(loc.DDAgentUserDialogDescription)" />
+
+  </Dialog>
+
+  <Dialog Id="DDAgentUserInvalidDlg" Width="370" Height="270" Title="!(loc.DDAgentUserDialog_Title)">
+
+    <!-- Show error message from ValidateDDAgentUserDlgInput action -->
+    <Control Id="ValidateErrorMessage" Type="Text" Height="64" Width="320" X="25" Y="70"
+             Text="[DDAgentUser_ResultMessage]" />
+
+    <!-- back button -->
+    <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17"
+             Text="Back">
+      <Publish Event="NewDialog" Value="DDAgentUserDlg" />
+    </Control>
+
+    <!-- cancel button -->
+    <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes"
+               Text="Cancel">
+      <Publish Event="EndDialog" Value="Exit">1</Publish>
+    </Control>
+
+    <!-- Title + Banner -->
+    <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="!(loc.LicenseAgreementDlgBannerBitmap)" />
+    <Control Id="BannerLine" Type="Line" X="0" Y="44" Width="370" Height="0" />
+    <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" />
+    <Control Id="Title" Type="Text" X="15" Y="6" Width="340" Height="15"
+             Transparent="yes" NoPrefix="yes" Text="!(loc.DDAgentUserDialogTitle)" />
+    <Control Id="Description" Type="Text" X="25" Y="23" Width="340" Height="15"
+             Transparent="yes" NoPrefix="yes" Text="!(loc.DDAgentUserInvalidDialogDescription)" />
+
+  </Dialog>
+</Include>

--- a/omnibus/resources/agent/msi/assets/sitedlg.wxi
+++ b/omnibus/resources/agent/msi/assets/sitedlg.wxi
@@ -15,7 +15,7 @@
     </Control>
     <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes"
              Text="Next">
-      <Publish Event="NewDialog" Value="VerifyReadyDlg" />
+      <Publish Event="NewDialog" Value="DDAgentUserDlg" />
 
     </Control>
     <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes"

--- a/omnibus/resources/agent/msi/localization-en-us.wxl.erb
+++ b/omnibus/resources/agent/msi/localization-en-us.wxl.erb
@@ -59,6 +59,14 @@
   <String Id ="SiteDialogKeyLabel" Overridable="yes" Localizable="yes">Which [ShortCompanyName] region do you want the Agent to send data to?</String>
   <String Id ="SiteSampleKey" Overridable="yes" Localizable="yes"></String>
 
+  <!-- these strings for the agent user dialog -->
+  <String Id ="DDAgentUserDialog_Title" Overridable="yes" Localizable="yes">[ProductName] Setup</String>
+  <String Id ="DDAgentUserDialogDescription" Overridable="yes" Localizable="yes">{\WixUI_Font_Normal_White}Enter the agent user account</String>
+  <String Id ="DDAgentUserDialogTitle"  Overridable="yes" Localizable="yes">{\WixUI_Font_Title_White}[ShortCompanyName] Agent User Account</String>
+  <String Id ="DDAgentUserDialogUserNameLabel" Overridable="yes" Localizable="yes">Please enter the username (leave blank to use ddagentuser):</String>
+  <String Id ="DDAgentUserDialogPasswordLabel" Overridable="yes" Localizable="yes">Please enter the password (leave blank to use random password):</String>
+  <String Id ="DDAgentUserInvalidDialogDescription" Overridable="yes" Localizable="yes">{\WixUI_Font_Normal_White}Invalid user account</String>
+
   <String Id="Caption">[WixBundleName] Setup</String>
   <String Id="Title">[WixBundleName]</String>
   <String Id="ConfirmCancelMessage">Are you sure you want to cancel?</String>

--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -563,6 +563,7 @@
       </Publish>
       <?include Resources\assets\apikeydlg.wxi ?>
       <?include Resources\assets\sitedlg.wxi ?>
+      <?include Resources\assets\ddagentuserdlg.wxi ?>
       <DialogRef Id="ErrorDlg" />
       <DialogRef Id="FatalError" />
       <DialogRef Id="FilesInUse" />
@@ -574,6 +575,8 @@
       <DialogRef Id="WelcomeDlg" />
       <DialogRef Id="ApiKeyDlg"/>
       <DialogRef Id="SiteDlg"/>
+      <DialogRef Id="DDAgentUserDlg"/>
+      <DialogRef Id="DDAgentUserInvalidDlg"/>
       <DialogRef Id="LicenseAgreementDlg"/>
       <?if $(var.IncludeSysprobe) = true ?>
       <DialogRef Id="CustomizeDlg"/>
@@ -588,6 +591,7 @@
            Customize IF APPLICABLE
            Apikey
            Site
+           DDAgentUser
            VerifyReady
 
            -->
@@ -624,7 +628,7 @@
       <Publish Dialog="SiteDlg" Control="Back" Event="NewDialog" Value="ApiKeyDlg">NOT PREVIOUSFOUND</Publish>
 
       <!-- if the previous installation or the datadog.yaml file exists, implying the API key and Site are known, go back to the CustomizeDlg or LicenseAgreementDlg -->
-      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="SiteDlg">(NOT PREVIOUSFOUND) AND (NOT DATADOGYAMLEXISTS)</Publish>
+      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="DDAgentUserDlg">(NOT PREVIOUSFOUND) AND (NOT DATADOGYAMLEXISTS)</Publish>
 
       <Publish Dialog="MaintenanceWelcomeDlg" Control="Next" Event="NewDialog" Value="MaintenanceTypeDlg">1</Publish>
 
@@ -637,7 +641,6 @@
       <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="MaintenanceTypeDlg">WixUI_InstallMode = "Repair" OR WixUI_InstallMode = "Remove"</Publish>
 
       <Publish Dialog="MaintenanceTypeDlg" Control="RemoveButton" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
-
 
       <AdminUISequence>
         <Show Dialog="FatalError" OnExit="error" />
@@ -717,6 +720,7 @@
     <CustomAction Id='DoUninstall' BinaryKey='wixcadll' DllEntry='DoUninstall' Execute='deferred' Return='check' Impersonate='no'/>
     <CustomAction Id='DoRollback' BinaryKey='wixcadll' DllEntry='DoRollback' Execute='rollback' Impersonate='no' />
 
+    <CustomAction Id='ValidateDDAgentUserDlgInput' BinaryKey='wixcadll' DllEntry='ValidateDDAgentUserDlgInput' Execute='immediate' Return='check' />
 
     <!--
     <CustomAction Id='adddduser' BinaryKey='wixcadll' DllEntry='CreateOrUpdateDDUser' Execute='immediate' Return='check'/>

--- a/releasenotes/notes/add-user-selection-window-to-windows-installer-75f7c1efca3083da.yaml
+++ b/releasenotes/notes/add-user-selection-window-to-windows-installer-75f7c1efca3083da.yaml
@@ -1,0 +1,3 @@
+features:
+  - |
+    Add a username and password dialog window to the Windows Installer

--- a/tools/windows/install-help/cal/CustomAction.cpp
+++ b/tools/windows/install-help/cal/CustomAction.cpp
@@ -21,7 +21,7 @@ extern "C" UINT __stdcall FinalizeInstall(MSIHANDLE hInstall)
         auto propertyView = std::make_shared<DeferredCAPropertyView>(hInstall);
         data.emplace(propertyView);
     }
-    catch (...)
+    catch (std::exception &ex)
     {
         WcaLog(LOGMSG_STANDARD, "Failed to load custom action property data");
         er = ERROR_INSTALL_FAILURE;
@@ -179,7 +179,7 @@ extern "C" UINT __stdcall ValidateDDAgentUserDlgInput(MSIHANDLE hInstall)
         auto propertyView = std::make_shared<ImmediateCAPropertyView>(hInstall);
         data.emplace(propertyView);
     }
-    catch (...)
+    catch (std::exception &ex)
     {
         WcaLog(LOGMSG_STANDARD, "Failed to load installer property data");
         return WcaFinalize(ERROR_INSTALL_FAILURE);

--- a/tools/windows/install-help/cal/CustomAction.cpp
+++ b/tools/windows/install-help/cal/CustomAction.cpp
@@ -21,7 +21,7 @@ extern "C" UINT __stdcall FinalizeInstall(MSIHANDLE hInstall)
         auto propertyView = std::make_shared<DeferredCAPropertyView>(hInstall);
         data.emplace(propertyView);
     }
-    catch (std::exception &ex)
+    catch (std::exception &)
     {
         WcaLog(LOGMSG_STANDARD, "Failed to load custom action property data");
         er = ERROR_INSTALL_FAILURE;
@@ -179,7 +179,7 @@ extern "C" UINT __stdcall ValidateDDAgentUserDlgInput(MSIHANDLE hInstall)
         auto propertyView = std::make_shared<ImmediateCAPropertyView>(hInstall);
         data.emplace(propertyView);
     }
-    catch (std::exception &ex)
+    catch (std::exception &)
     {
         WcaLog(LOGMSG_STANDARD, "Failed to load installer property data");
         return WcaFinalize(ERROR_INSTALL_FAILURE);

--- a/tools/windows/install-help/cal/CustomAction.def
+++ b/tools/windows/install-help/cal/CustomAction.def
@@ -2,9 +2,9 @@ LIBRARY customaction
 
 EXPORTS
 	DllMain
-    FinalizeInstall
+	FinalizeInstall
 	PreStopServices
 	PostStartServices
 	DoUninstall
-    DoRollback
-	
+	DoRollback
+	ValidateDDAgentUserDlgInput

--- a/tools/windows/install-help/cal/FinalizeInstall.cpp
+++ b/tools/windows/install-help/cal/FinalizeInstall.cpp
@@ -171,7 +171,7 @@ UINT doFinalizeInstall(CustomActionData &data)
     // new installation or an upgrade, and what steps need to be taken
     ddUserExists = data.DoesUserExist();
 
-    if (!canInstall(data.GetTargetMachine()->IsDomainController(), ddUserExists, ddServiceExists, data, bResetPassword))
+    if (!canInstall(data, bResetPassword))
     {
         er = ERROR_INSTALL_FAILURE;
         goto LExit;

--- a/tools/windows/install-help/cal/FinalizeInstall.cpp
+++ b/tools/windows/install-help/cal/FinalizeInstall.cpp
@@ -171,7 +171,7 @@ UINT doFinalizeInstall(CustomActionData &data)
     // new installation or an upgrade, and what steps need to be taken
     ddUserExists = data.DoesUserExist();
 
-    if (!canInstall(data, bResetPassword))
+    if (!canInstall(data, bResetPassword, NULL))
     {
         er = ERROR_INSTALL_FAILURE;
         goto LExit;

--- a/tools/windows/install-help/cal/PropertyView.cpp
+++ b/tools/windows/install-help/cal/PropertyView.cpp
@@ -26,7 +26,7 @@ void parseKeyValueString(const std::wstring kvstring, std::map<std::wstring, std
 
 bool StaticPropertyView::present(const std::wstring &key) const
 {
-    return this->values.count(key) != 0 ? true : false;
+    return this->values.count(key) != 0;
 }
 
 bool StaticPropertyView::value(const std::wstring &key, std::wstring &val) const

--- a/tools/windows/install-help/cal/PropertyView.cpp
+++ b/tools/windows/install-help/cal/PropertyView.cpp
@@ -24,12 +24,12 @@ void parseKeyValueString(const std::wstring kvstring, std::map<std::wstring, std
     }
 }
 
-bool PropertyView::present(const std::wstring &key) const
+bool StaticPropertyView::present(const std::wstring &key) const
 {
     return this->values.count(key) != 0 ? true : false;
 }
 
-bool PropertyView::value(const std::wstring &key, std::wstring &val) const
+bool StaticPropertyView::value(const std::wstring &key, std::wstring &val) const
 {
     const auto kvp = values.find(key);
     if (kvp == values.end())
@@ -45,24 +45,29 @@ CAPropertyView::CAPropertyView(MSIHANDLE hi)
 {
 }
 
+bool ImmediateCAPropertyView::present(const std::wstring &key) const
+{
+    std::wstring val;
+    return this->value(key, val);
+}
+
+bool ImmediateCAPropertyView::value(const std::wstring &key, std::wstring &val) const
+{
+    std::wstring propertyValue;
+    if (loadPropertyString(this->_hInstall, key.c_str(), propertyValue))
+    {
+        if (!propertyValue.empty())
+        {
+            val = propertyValue;
+            return true;
+        }
+    }
+    return false;
+}
+
 ImmediateCAPropertyView::ImmediateCAPropertyView(MSIHANDLE hi)
     : CAPropertyView(hi)
 {
-    std::wstring propertyNames[] = {
-        propertyDDAgentUserName, propertyDDAgentUserPassword, L"SYSPROBE_PRESENT", L"NPM", L"NPMFEATURE",
-    };
-
-    for (auto propertyName : propertyNames)
-    {
-        std::wstring propertyValue;
-        if (loadPropertyString(this->_hInstall, propertyName.c_str(), propertyValue))
-        {
-            if (!propertyValue.empty())
-            {
-                this->values[propertyName] = propertyValue;
-            }
-        }
-    }
 }
 
 DeferredCAPropertyView::DeferredCAPropertyView(MSIHANDLE hi)

--- a/tools/windows/install-help/cal/PropertyView.cpp
+++ b/tools/windows/install-help/cal/PropertyView.cpp
@@ -1,0 +1,85 @@
+#include "stdafx.h"
+
+void parseKeyValueString(const std::wstring kvstring, std::map<std::wstring, std::wstring> &values)
+{
+    // Parse values out of property
+    std::wstringstream ss(kvstring);
+    std::wstring token;
+
+    while (std::getline(ss, token))
+    {
+        // 'token' contains "<key>=<value>"
+        std::wstringstream instream(token);
+        std::wstring key, val;
+        if (std::getline(instream, key, L'='))
+        {
+            trim_string(key);
+            std::getline(instream, val);
+            trim_string(val);
+            if (!key.empty() && !val.empty())
+            {
+                values[key] = val;
+            }
+        }
+    }
+}
+
+bool PropertyView::present(const std::wstring &key) const
+{
+    return this->values.count(key) != 0 ? true : false;
+}
+
+bool PropertyView::value(const std::wstring &key, std::wstring &val) const
+{
+    const auto kvp = values.find(key);
+    if (kvp == values.end())
+    {
+        return false;
+    }
+    val = kvp->second;
+    return true;
+}
+
+CAPropertyView::CAPropertyView(MSIHANDLE hi)
+    : _hInstall(hi)
+{
+}
+
+ImmediateCAPropertyView::ImmediateCAPropertyView(MSIHANDLE hi)
+    : CAPropertyView(hi)
+{
+    std::wstring propertyNames[] = {
+        propertyDDAgentUserName, propertyDDAgentUserPassword, L"SYSPROBE_PRESENT", L"NPM", L"NPMFEATURE",
+    };
+
+    for (auto propertyName : propertyNames)
+    {
+        std::wstring propertyValue;
+        if (loadPropertyString(this->_hInstall, propertyName.c_str(), propertyValue))
+        {
+            if (!propertyValue.empty())
+            {
+                this->values[propertyName] = propertyValue;
+            }
+        }
+    }
+}
+
+DeferredCAPropertyView::DeferredCAPropertyView(MSIHANDLE hi)
+    : CAPropertyView(hi)
+{
+    /*
+     * Deferred custom actions have limited access to installation
+     * details, so we must load our properties from the CustomActionData propety.
+     * https://docs.microsoft.com/en-us/windows/win32/msi/obtaining-context-information-for-deferred-execution-custom-actions
+     */
+
+    // Load CustomActionData property
+    std::wstring data;
+    if (!loadPropertyString(this->_hInstall, propertyCustomActionData.c_str(), data))
+    {
+        throw;
+    }
+
+    parseKeyValueString(data, this->values);
+}

--- a/tools/windows/install-help/cal/PropertyView.cpp
+++ b/tools/windows/install-help/cal/PropertyView.cpp
@@ -78,7 +78,7 @@ DeferredCAPropertyView::DeferredCAPropertyView(MSIHANDLE hi)
     std::wstring data;
     if (!loadPropertyString(this->_hInstall, propertyCustomActionData.c_str(), data))
     {
-        throw;
+        throw std::exception("Failed to load CustomActionData property");
     }
 
     parseKeyValueString(data, this->values);

--- a/tools/windows/install-help/cal/PropertyView.h
+++ b/tools/windows/install-help/cal/PropertyView.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <string>
+#include <map>
+#include <Msi.h>
+
+void parseKeyValueString(const std::wstring kvstring, std::map<std::wstring, std::wstring> &values);
+
+class IPropertyView
+{
+  public:
+    virtual bool present(const std::wstring &key) const = 0;
+    virtual bool value(const std::wstring &key, std::wstring &val) const = 0;
+
+  protected:
+    virtual ~IPropertyView() { }
+};
+
+class PropertyView : public IPropertyView
+{
+  public:
+    bool present(const std::wstring &key) const;
+    bool value(const std::wstring &key, std::wstring &val) const;
+
+  protected:
+    std::map<std::wstring, std::wstring> values;
+    virtual ~PropertyView() { }
+};
+
+class CAPropertyView : public PropertyView
+{
+  public:
+    CAPropertyView(MSIHANDLE hInstall);
+  protected:
+    MSIHANDLE _hInstall;
+    virtual ~CAPropertyView() { }
+};
+
+class ImmediateCAPropertyView : public CAPropertyView
+{
+  public:
+    ImmediateCAPropertyView(MSIHANDLE hInstall);
+};
+
+class DeferredCAPropertyView : public CAPropertyView
+{
+  public:
+    DeferredCAPropertyView(MSIHANDLE hInstall);
+};
+

--- a/tools/windows/install-help/cal/PropertyView.h
+++ b/tools/windows/install-help/cal/PropertyView.h
@@ -16,7 +16,11 @@ class IPropertyView
     virtual ~IPropertyView() { }
 };
 
-class PropertyView : public IPropertyView
+/*
+ * Used by classes that must load values once at init time
+ * and store them into the @values attribute for later access.
+ */
+class StaticPropertyView : public IPropertyView
 {
   public:
     bool present(const std::wstring &key) const override;
@@ -24,10 +28,10 @@ class PropertyView : public IPropertyView
 
   protected:
     std::map<std::wstring, std::wstring> values;
-    virtual ~PropertyView() { }
+    virtual ~StaticPropertyView() { }
 };
 
-class CAPropertyView : public PropertyView
+class CAPropertyView
 {
   public:
     CAPropertyView(MSIHANDLE hInstall);
@@ -36,13 +40,15 @@ class CAPropertyView : public PropertyView
     virtual ~CAPropertyView() { }
 };
 
-class ImmediateCAPropertyView : public CAPropertyView
+class ImmediateCAPropertyView : public CAPropertyView, public IPropertyView
 {
   public:
     ImmediateCAPropertyView(MSIHANDLE hInstall);
+    bool present(const std::wstring &key) const override;
+    bool value(const std::wstring &key, std::wstring &val) const override;
 };
 
-class DeferredCAPropertyView : public CAPropertyView
+class DeferredCAPropertyView : public CAPropertyView, public StaticPropertyView
 {
   public:
     DeferredCAPropertyView(MSIHANDLE hInstall);

--- a/tools/windows/install-help/cal/PropertyView.h
+++ b/tools/windows/install-help/cal/PropertyView.h
@@ -19,8 +19,8 @@ class IPropertyView
 class PropertyView : public IPropertyView
 {
   public:
-    bool present(const std::wstring &key) const;
-    bool value(const std::wstring &key, std::wstring &val) const;
+    bool present(const std::wstring &key) const override;
+    bool value(const std::wstring &key, std::wstring &val) const override;
 
   protected:
     std::map<std::wstring, std::wstring> values;

--- a/tools/windows/install-help/cal/caninstall.cpp
+++ b/tools/windows/install-help/cal/caninstall.cpp
@@ -23,18 +23,24 @@ bool canInstall(const CustomActionData &data, bool &bResetPassword, std::wstring
     // ddServiceExists
     {
         auto result = doesServiceExist(agentService);
-        if (-1 == result) {
+        if (-1 == result)
+        {
             // error, call it false?
             ddServiceExists = false;
-        } else if (0 == result) {
+        }
+        else if (0 == result)
+        {
             ddServiceExists = false;
-        } else if (1 == result) {
+        }
+        else if (1 == result)
+        {
             ddServiceExists = true;
         }
     }
 
     // isNtAuthority
-    if (ddUserExists) {
+    if (ddUserExists)
+    {
         const auto ntAuthoritySid = WellKnownSID::NTAuthority();
         if (!ntAuthoritySid.has_value())
         {
@@ -44,8 +50,6 @@ bool canInstall(const CustomActionData &data, bool &bResetPassword, std::wstring
         {
             isNtAuthority = EqualPrefixSid(data.Sid(), ntAuthoritySid.value().get());
         }
-    } else {
-        isNtAuthority = false;
     }
 
     // isUserDomainUser
@@ -66,19 +70,8 @@ bool canInstall(const CustomActionData &data, bool &bResetPassword, std::wstring
     // computerDomain
     computerDomain = data.GetTargetMachine()->JoinedDomainName().c_str();
 
-    return canInstall(
-        isDC,
-        isReadOnlyDC,
-        ddUserExists,
-        isServiceAccount,
-        isNtAuthority,
-        isUserDomainUser,
-        haveUserPassword,
-        userDomain,
-        computerDomain,
-        ddServiceExists,
-        bResetPassword,
-        resultMessage);
+    return canInstall(isDC, isReadOnlyDC, ddUserExists, isServiceAccount, isNtAuthority, isUserDomainUser,
+                      haveUserPassword, userDomain, computerDomain, ddServiceExists, bResetPassword, resultMessage);
 }
 
 /**
@@ -95,19 +88,9 @@ bool canInstall(const CustomActionData &data, bool &bResetPassword, std::wstring
  * @param bResetPassword on return, set to true if the password needs to be reset based on configuration,
  *                       otherwise false.
  */
-bool canInstall(
-    bool isDC,
-    bool isReadOnlyDC,
-    bool ddUserExists,
-    bool isServiceAccount,
-    bool isNtAuthority,
-    bool isUserDomainUser,
-    bool haveUserPassword,
-    std::wstring userDomain,
-    std::wstring computerDomain,
-    bool ddServiceExists,
-    bool &bResetPassword,
-    std::wstring *resultMessage)
+bool canInstall(bool isDC, bool isReadOnlyDC, bool ddUserExists, bool isServiceAccount, bool isNtAuthority,
+                bool isUserDomainUser, bool haveUserPassword, std::wstring userDomain, std::wstring computerDomain,
+                bool ddServiceExists, bool &bResetPassword, std::wstring *resultMessage)
 {
     std::wstring errorMessage;
     bResetPassword = false;
@@ -149,14 +132,16 @@ bool canInstall(
         {
             WcaLog(LOGMSG_STANDARD,
                    "(Configuration Error) Can't create user on RODC; install on a writable domain controller first");
-            errorMessage = L"User does not exist and cannot be created from a read-only Domain Controller (RODC). Please create the user from a writeable domain controller first.";
+            errorMessage = L"User does not exist and cannot be created from a read-only Domain Controller (RODC). "
+                           L"Please create the user from a writeable domain controller first.";
             bRet = false;
         }
         if (!ddUserExists && ddServiceExists)
         {
             // case (3) above
             WcaLog(LOGMSG_STANDARD, "(Configuration Error) Invalid configuration; no DD user, but service exists");
-            errorMessage = L"The agent service exists but the user account does not. Please contact support for assistance.";
+            errorMessage =
+                L"The agent service exists but the user account does not. Please contact support for assistance.";
             bRet = false;
         }
         if ((!ddUserExists || !ddServiceExists) && !isServiceAccount)
@@ -169,11 +154,16 @@ bool canInstall(
                 // must have the password to install the service for an existing user
                 WcaLog(LOGMSG_STANDARD, "(Configuration Error)  Must supply password for dd-agent-user to create user "
                                         "and/or install service in a domain");
-                if (ddUserExists) {
-                    errorMessage = L"A password was not provided for the existing user account. A password is required to create the agent services.";
-                } else {
+                if (ddUserExists)
+                {
+                    errorMessage = L"A password was not provided for the existing user account. A password is required "
+                                   L"to create the agent services.";
+                }
+                else
+                {
                     // TODO: This contradicts the online docs. Check which is correct.
-                    errorMessage = L"A password is required for creating domain accounts. Please provide a password for the user account.";
+                    errorMessage = L"A password is required for creating domain accounts. Please provide a password "
+                                   L"for the user account.";
                 }
                 bRet = false;
             }
@@ -186,7 +176,9 @@ bool canInstall(
 
             WcaLog(LOGMSG_STANDARD,
                    "(Configuration Error) Can't create a user that's not in this Domain Controller's domain.");
-            errorMessage = L"The user account does not exist and cannot be created from this domain controller because the domain name provided for the user does not match the domain name managed by this Domain Controller. Please create the user account or provide an existing user account.";
+            errorMessage = L"The user account does not exist and cannot be created from this domain controller because "
+                           L"the domain name provided for the user does not match the domain name managed by this "
+                           L"Domain Controller. Please create the user account or provide an existing user account.";
             bRet = false;
         }
     }
@@ -198,7 +190,8 @@ bool canInstall(
             WcaLog(LOGMSG_STANDARD,
                    "(Configuration Error) Install Datadog Agent on the domain controller for the %S domain",
                    userDomain.c_str());
-            errorMessage = L"The user account does not exist and cannot be created because this computer is not a domain controller. Please create the user account or provide an existing user account.";
+            errorMessage = L"The user account does not exist and cannot be created because this computer is not a "
+                           L"domain controller. Please create the user account or provide an existing user account.";
             bRet = false;
         }
         if (ddUserExists)
@@ -213,7 +206,8 @@ bool canInstall(
                     // the password
                     WcaLog(LOGMSG_STANDARD,
                            "(Configuration Error) Must supply the password to allow service registration");
-                    errorMessage = L"A password was not provided for the existing user account. A password is required to create the agent services.";
+                    errorMessage = L"A password was not provided for the existing user account. A password is required "
+                                   L"to create the agent services.";
                     bRet = false;
                 }
             }
@@ -234,13 +228,15 @@ bool canInstall(
         {
             // error case of (7)
             WcaLog(LOGMSG_STANDARD, "(Configuration Error) Invalid configuration; no DD user, but service exists");
-            errorMessage = L"The agent service exists but the user account does not. Please contact support for assistance.";
+            errorMessage =
+                L"The agent service exists but the user account does not. Please contact support for assistance.";
             bRet = false;
         }
     }
     // case (1), case (2) if password provided, case (4) if password provided
     // case (5), case (6) but reset password, case (8) are all success.
-    if (NULL != resultMessage) {
+    if (NULL != resultMessage)
+    {
         *resultMessage = errorMessage;
     }
     return bRet;

--- a/tools/windows/install-help/cal/customaction-tests/CustomActionData_CanInstall.cpp
+++ b/tools/windows/install-help/cal/customaction-tests/CustomActionData_CanInstall.cpp
@@ -6,85 +6,80 @@
 #include "customaction.h"
 
 // Case 2
-TEST_F(CustomActionDataTest, When_ServiceDoesNotExists_And_UserExists_WithPassword_ReturnsTrue) {
+TEST_F(CustomActionDataTest, When_ServiceDoesNotExists_And_UserExists_WithPassword_ReturnsTrue)
+{
     bool shouldResetPass;
 
-    bool result = canInstall(
-        true,  /*isDC*/
-        false, /*isReadOnlyDC*/
-        true,  /*ddUserExists*/
-        false, /*isServiceAccount*/
-        false, /*isNtAuthority*/
-        true,  /*isUserDomainUser*/
-        true,  /*haveUserPassword*/
-        L"",   /*userDomain*/
-        L"",   /*computerDomain*/
-        false, /*ddServiceExists*/
-        shouldResetPass,
-        NULL);
+    bool result = canInstall(true,  /*isDC*/
+                             false, /*isReadOnlyDC*/
+                             true,  /*ddUserExists*/
+                             false, /*isServiceAccount*/
+                             false, /*isNtAuthority*/
+                             true,  /*isUserDomainUser*/
+                             true,  /*haveUserPassword*/
+                             L"",   /*userDomain*/
+                             L"",   /*computerDomain*/
+                             false, /*ddServiceExists*/
+                             shouldResetPass, NULL);
     EXPECT_TRUE(result);
     EXPECT_FALSE(shouldResetPass);
 }
 
-TEST_F(CustomActionDataTest, When_ServiceExists_And_NoUser_ReturnsFalse) {
+TEST_F(CustomActionDataTest, When_ServiceExists_And_NoUser_ReturnsFalse)
+{
     bool shouldResetPass;
 
-    bool result = canInstall(
-        true,  /*isDC*/
-        false, /*isReadOnlyDC*/
-        false, /*ddUserExists*/
-        false, /*isServiceAccount*/
-        false, /*isNtAuthority*/
-        false, /*isUserDomainUser*/
-        false, /*haveUserPassword*/
-        L"",   /*userDomain*/
-        L"",   /*computerDomain*/
-        true,  /*ddServiceExists*/
-        shouldResetPass,
-        NULL);
+    bool result = canInstall(true,  /*isDC*/
+                             false, /*isReadOnlyDC*/
+                             false, /*ddUserExists*/
+                             false, /*isServiceAccount*/
+                             false, /*isNtAuthority*/
+                             false, /*isUserDomainUser*/
+                             false, /*haveUserPassword*/
+                             L"",   /*userDomain*/
+                             L"",   /*computerDomain*/
+                             true,  /*ddServiceExists*/
+                             shouldResetPass, NULL);
 
     EXPECT_FALSE(result);
     EXPECT_FALSE(shouldResetPass);
 }
 
-TEST_F(CustomActionDataTest, When_ServiceExists_And_UserDoesNotExists_WithUserInDifferentDomain_ReturnsFalse) {
+TEST_F(CustomActionDataTest, When_ServiceExists_And_UserDoesNotExists_WithUserInDifferentDomain_ReturnsFalse)
+{
     bool shouldResetPass;
 
-    bool result = canInstall(
-        true,  /*isDC*/
-        false, /*isReadOnlyDC*/
-        false, /*ddUserExists*/
-        false, /*isServiceAccount*/
-        false, /*isNtAuthority*/
-        true,  /*isUserDomainUser*/
-        false,  /*haveUserPassword*/
-        L"a",  /*userDomain*/
-        L"b",  /*computerDomain*/
-        true,  /*ddServiceExists*/
-        shouldResetPass,
-        NULL);
+    bool result = canInstall(true,  /*isDC*/
+                             false, /*isReadOnlyDC*/
+                             false, /*ddUserExists*/
+                             false, /*isServiceAccount*/
+                             false, /*isNtAuthority*/
+                             true,  /*isUserDomainUser*/
+                             false, /*haveUserPassword*/
+                             L"a",  /*userDomain*/
+                             L"b",  /*computerDomain*/
+                             true,  /*ddServiceExists*/
+                             shouldResetPass, NULL);
 
     EXPECT_FALSE(result);
     EXPECT_FALSE(shouldResetPass);
 }
 
-
-TEST_F(CustomActionDataTest, When_ServiceDoesNotExists_And_UserDoesNotExists_WithUserInSameDomain_ReturnsTrue) {
+TEST_F(CustomActionDataTest, When_ServiceDoesNotExists_And_UserDoesNotExists_WithUserInSameDomain_ReturnsTrue)
+{
     bool shouldResetPass;
 
-    bool result = canInstall(
-        true,  /*isDC*/
-        false, /*isReadOnlyDC*/
-        false, /*ddUserExists*/
-        false, /*isServiceAccount*/
-        false, /*isNtAuthority*/
-        true,  /*isUserDomainUser*/
-        true,  /*haveUserPassword*/
-        L"a",  /*userDomain*/
-        L"a",  /*computerDomain*/
-        false, /*ddServiceExists*/
-        shouldResetPass,
-        NULL);
+    bool result = canInstall(true,  /*isDC*/
+                             false, /*isReadOnlyDC*/
+                             false, /*ddUserExists*/
+                             false, /*isServiceAccount*/
+                             false, /*isNtAuthority*/
+                             true,  /*isUserDomainUser*/
+                             true,  /*haveUserPassword*/
+                             L"a",  /*userDomain*/
+                             L"a",  /*computerDomain*/
+                             false, /*ddServiceExists*/
+                             shouldResetPass, NULL);
 
     EXPECT_TRUE(result);
     EXPECT_FALSE(shouldResetPass);
@@ -94,19 +89,17 @@ TEST_F(CustomActionDataTest, When_User_Is_NTAUTHORITY_Dont_Reset_Password)
 {
     bool shouldResetPass;
 
-    bool result = canInstall(
-        true,  /*isDC*/
-        false, /*isReadOnlyDC*/
-        true,  /*ddUserExists*/
-        false, /*isServiceAccount*/
-        true,  /*isNtAuthority*/
-        false, /*isUserDomainUser*/
-        false, /*haveUserPassword*/
-        L"",   /*userDomain*/
-        L"",   /*computerDomain*/
-        false, /*ddServiceExists*/
-        shouldResetPass,
-        NULL);
+    bool result = canInstall(true,  /*isDC*/
+                             false, /*isReadOnlyDC*/
+                             true,  /*ddUserExists*/
+                             false, /*isServiceAccount*/
+                             true,  /*isNtAuthority*/
+                             false, /*isUserDomainUser*/
+                             false, /*haveUserPassword*/
+                             L"",   /*userDomain*/
+                             L"",   /*computerDomain*/
+                             false, /*ddServiceExists*/
+                             shouldResetPass, NULL);
 
     EXPECT_TRUE(result);
     EXPECT_FALSE(shouldResetPass);

--- a/tools/windows/install-help/cal/customaction-tests/CustomActionData_CanInstall.cpp
+++ b/tools/windows/install-help/cal/customaction-tests/CustomActionData_CanInstall.cpp
@@ -7,47 +7,38 @@
 
 // Case 2
 TEST_F(CustomActionDataTest, When_ServiceDoesNotExists_And_UserExists_WithPassword_ReturnsTrue) {
-    auto tm = std::make_shared<TargetMachineMock>();
-    ON_CALL(*tm, Detect).WillByDefault(testing::Return(ERROR_SUCCESS));
-    CustomActionData customActionCtx(tm);
-
-    customActionCtx.init(LR"(
-DDAGENTUSER_NAME=different_domain\test
-DDAGENTUSER_PASSWORD=1234
-)");
-
-    // Since "different_domain\test" is a bogus domain\user,
-    // we allocate a LOCAL_SID that is guaranteed to not match NT_AUTHORITY
-    SID_IDENTIFIER_AUTHORITY sidIdAuthority = SECURITY_LOCAL_SID_AUTHORITY;
-    PSID sid = nullptr;
-    EXPECT_TRUE(AllocateAndInitializeSid(&sidIdAuthority, 1, 0, 0, 0, 0, 0, 0, 0, 0, &sid));
-    sid_ptr sid_ptr(static_cast<SID *>(sid));
-    // and set it on the CustomActionData so that the test has a valid SID to use.
-    customActionCtx.Sid(sid_ptr);
     bool shouldResetPass;
 
     bool result = canInstall(
-        true    /*isDC*/,
-        true    /*ddUserExists*/,
-        false   /*ddServiceExists*/,
-        customActionCtx,
+        true,  /*isDC*/
+        false, /*isReadOnlyDC*/
+        true,  /*ddUserExists*/
+        false, /*isServiceAccount*/
+        false, /*isNtAuthority*/
+        true,  /*isUserDomainUser*/
+        true,  /*haveUserPassword*/
+        L"",   /*userDomain*/
+        L"",   /*computerDomain*/
+        false, /*ddServiceExists*/
         shouldResetPass);
-
     EXPECT_TRUE(result);
     EXPECT_FALSE(shouldResetPass);
 }
 
 TEST_F(CustomActionDataTest, When_ServiceExists_And_NoUser_ReturnsFalse) {
-    auto tm = std::make_shared<TargetMachineMock>();
-    ON_CALL(*tm, Detect).WillByDefault(testing::Return(ERROR_SUCCESS));
-    CustomActionData customActionCtx(tm);
     bool shouldResetPass;
 
     bool result = canInstall(
-        true    /*isDC*/,
-        false   /*ddUserExists*/,
-        true    /*ddServiceExists*/,
-        customActionCtx,
+        true,  /*isDC*/
+        false, /*isReadOnlyDC*/
+        false, /*ddUserExists*/
+        false, /*isServiceAccount*/
+        false, /*isNtAuthority*/
+        false, /*isUserDomainUser*/
+        false, /*haveUserPassword*/
+        L"",   /*userDomain*/
+        L"",   /*computerDomain*/
+        true,  /*ddServiceExists*/
         shouldResetPass);
 
     EXPECT_FALSE(result);
@@ -55,19 +46,19 @@ TEST_F(CustomActionDataTest, When_ServiceExists_And_NoUser_ReturnsFalse) {
 }
 
 TEST_F(CustomActionDataTest, When_ServiceExists_And_UserDoesNotExists_WithUserInDifferentDomain_ReturnsFalse) {
-    auto tm = std::make_shared<TargetMachineMock>();
-    ON_CALL(*tm, Detect).WillByDefault(testing::Return(ERROR_SUCCESS));
-    CustomActionData customActionCtx(tm);
-    customActionCtx.init(L"DDAGENTUSER_NAME=different_domain\\test");
-    //ddAgentUserDomain = L"domain";
-
     bool shouldResetPass;
 
     bool result = canInstall(
-        true    /*isDC*/,
-        false   /*ddUserExists*/,
-        true    /*ddServiceExists*/,
-        customActionCtx,
+        true,  /*isDC*/
+        false, /*isReadOnlyDC*/
+        false, /*ddUserExists*/
+        false, /*isServiceAccount*/
+        false, /*isNtAuthority*/
+        true,  /*isUserDomainUser*/
+        false,  /*haveUserPassword*/
+        L"a",  /*userDomain*/
+        L"b",  /*computerDomain*/
+        true,  /*ddServiceExists*/
         shouldResetPass);
 
     EXPECT_FALSE(result);
@@ -75,23 +66,20 @@ TEST_F(CustomActionDataTest, When_ServiceExists_And_UserDoesNotExists_WithUserIn
 }
 
 
-TEST_F(CustomActionDataTest, When_ServiceDoesNotExists_And_UserDoesNotExists_WithUserInDotLocalDomain_ReturnsTrue) {
-    auto tm = std::make_shared<TargetMachineMock>();
-    ON_CALL(*tm, Detect).WillByDefault(testing::Return(ERROR_SUCCESS));
-    CustomActionData customActionCtx(tm);
-    customActionCtx.init(LR"(
-DDAGENTUSER_NAME=TEST.LOCAL\username
-DDAGENTUSER_PASSWORD=pass
-)");
-    //ddAgentUserDomain = L"domain";
-
+TEST_F(CustomActionDataTest, When_ServiceDoesNotExists_And_UserDoesNotExists_WithUserInSameDomain_ReturnsTrue) {
     bool shouldResetPass;
 
     bool result = canInstall(
-        true    /*isDC*/,
-        false   /*ddUserExists*/,
-        false    /*ddServiceExists*/,
-        customActionCtx,
+        true,  /*isDC*/
+        false, /*isReadOnlyDC*/
+        false, /*ddUserExists*/
+        false, /*isServiceAccount*/
+        false, /*isNtAuthority*/
+        true,  /*isUserDomainUser*/
+        true,  /*haveUserPassword*/
+        L"a",  /*userDomain*/
+        L"a",  /*computerDomain*/
+        false, /*ddServiceExists*/
         shouldResetPass);
 
     EXPECT_TRUE(result);
@@ -100,17 +88,20 @@ DDAGENTUSER_PASSWORD=pass
 
 TEST_F(CustomActionDataTest, When_User_Is_NTAUTHORITY_Dont_Reset_Password)
 {
-    auto tm = std::make_shared<TargetMachineMock>();
-    ON_CALL(*tm, Detect).WillByDefault(testing::Return(ERROR_SUCCESS));
-    CustomActionData customActionCtx(tm);
-    customActionCtx.init(LR"(
-DDAGENTUSER_NAME=NT AUTHORITY\SYSTEM
-)");
-
     bool shouldResetPass;
 
-    bool result =
-        canInstall(true /*isDC*/, true /*ddUserExists*/, false /*ddServiceExists*/, customActionCtx, shouldResetPass);
+    bool result = canInstall(
+        true,  /*isDC*/
+        false, /*isReadOnlyDC*/
+        true,  /*ddUserExists*/
+        false, /*isServiceAccount*/
+        true,  /*isNtAuthority*/
+        false, /*isUserDomainUser*/
+        false, /*haveUserPassword*/
+        L"",   /*userDomain*/
+        L"",   /*computerDomain*/
+        false, /*ddServiceExists*/
+        shouldResetPass);
 
     EXPECT_TRUE(result);
     EXPECT_FALSE(shouldResetPass);

--- a/tools/windows/install-help/cal/customaction-tests/CustomActionData_CanInstall.cpp
+++ b/tools/windows/install-help/cal/customaction-tests/CustomActionData_CanInstall.cpp
@@ -20,7 +20,8 @@ TEST_F(CustomActionDataTest, When_ServiceDoesNotExists_And_UserExists_WithPasswo
         L"",   /*userDomain*/
         L"",   /*computerDomain*/
         false, /*ddServiceExists*/
-        shouldResetPass);
+        shouldResetPass,
+        NULL);
     EXPECT_TRUE(result);
     EXPECT_FALSE(shouldResetPass);
 }
@@ -39,7 +40,8 @@ TEST_F(CustomActionDataTest, When_ServiceExists_And_NoUser_ReturnsFalse) {
         L"",   /*userDomain*/
         L"",   /*computerDomain*/
         true,  /*ddServiceExists*/
-        shouldResetPass);
+        shouldResetPass,
+        NULL);
 
     EXPECT_FALSE(result);
     EXPECT_FALSE(shouldResetPass);
@@ -59,7 +61,8 @@ TEST_F(CustomActionDataTest, When_ServiceExists_And_UserDoesNotExists_WithUserIn
         L"a",  /*userDomain*/
         L"b",  /*computerDomain*/
         true,  /*ddServiceExists*/
-        shouldResetPass);
+        shouldResetPass,
+        NULL);
 
     EXPECT_FALSE(result);
     EXPECT_FALSE(shouldResetPass);
@@ -80,7 +83,8 @@ TEST_F(CustomActionDataTest, When_ServiceDoesNotExists_And_UserDoesNotExists_Wit
         L"a",  /*userDomain*/
         L"a",  /*computerDomain*/
         false, /*ddServiceExists*/
-        shouldResetPass);
+        shouldResetPass,
+        NULL);
 
     EXPECT_TRUE(result);
     EXPECT_FALSE(shouldResetPass);
@@ -101,7 +105,8 @@ TEST_F(CustomActionDataTest, When_User_Is_NTAUTHORITY_Dont_Reset_Password)
         L"",   /*userDomain*/
         L"",   /*computerDomain*/
         false, /*ddServiceExists*/
-        shouldResetPass);
+        shouldResetPass,
+        NULL);
 
     EXPECT_TRUE(result);
     EXPECT_FALSE(shouldResetPass);

--- a/tools/windows/install-help/cal/customaction-tests/CustomActionData_Init.cpp
+++ b/tools/windows/install-help/cal/customaction-tests/CustomActionData_Init.cpp
@@ -3,6 +3,7 @@
 #include "CustomActionDataTest.h"
 #include "customactiondata.h"
 #include "TargetMachineMock.h"
+#include "PropertyViewMock.h"
 
 TEST_F(CustomActionDataTest, With_DomainUser_Parse_Correctly)
 {
@@ -40,7 +41,8 @@ TEST_F(CustomActionDataTest, With_NTAuthority_Is_Not_DomainAccount)
     EXPECT_TRUE(customActionCtx.isUserLocalUser());
 }
 
-void expect_string_equal(CustomActionData const &customActionData, std::wstring const &prop, std::wstring const &expected)
+void expect_string_equal(CustomActionData const &customActionData, std::wstring const &prop,
+                         std::wstring const &expected)
 {
     std::wstring val;
     customActionData.value(prop, val);

--- a/tools/windows/install-help/cal/customaction-tests/CustomActionData_Init.cpp
+++ b/tools/windows/install-help/cal/customaction-tests/CustomActionData_Init.cpp
@@ -8,11 +8,11 @@ TEST_F(CustomActionDataTest, With_DomainUser_Parse_Correctly)
 {
     auto tm = std::make_shared<TargetMachineMock>();
     ON_CALL(*tm, Detect).WillByDefault(testing::Return(ERROR_SUCCESS));
-    CustomActionData customActionCtx(tm);
 
-    customActionCtx.init(LR"(
+    auto propertyView = std::make_shared<TestPropertyView>(std::wstring(LR"(
     DDAGENTUSER_NAME=TEST\username
-)");
+)"));
+    CustomActionData customActionCtx(propertyView, tm);
 
     EXPECT_EQ(customActionCtx.FullyQualifiedUsername(), L"TEST\\username");
     EXPECT_EQ(customActionCtx.UnqualifiedUsername(), L"username");
@@ -27,11 +27,11 @@ TEST_F(CustomActionDataTest, With_NTAuthority_Is_Not_DomainAccount)
 {
     auto tm = std::make_shared<TargetMachineMock>();
     ON_CALL(*tm, Detect).WillByDefault(testing::Return(ERROR_SUCCESS));
-    CustomActionData customActionCtx(tm);
 
-    customActionCtx.init(LR"(
+    auto propertyView = std::make_shared<TestPropertyView>(std::wstring(LR"(
     DDAGENTUSER_NAME=NT AUTHORITY\SYSTEM
-)");
+)"));
+    CustomActionData customActionCtx(propertyView, tm);
 
     EXPECT_EQ(customActionCtx.FullyQualifiedUsername(), L"NT AUTHORITY\\SYSTEM");
     EXPECT_EQ(customActionCtx.UnqualifiedUsername(), L"SYSTEM");
@@ -51,11 +51,12 @@ TEST_F(CustomActionDataTest, With_SingleEmptyProperty_Parse_Correctly)
 {
     auto tm = std::make_shared<TargetMachineMock>();
     ON_CALL(*tm, Detect).WillByDefault(testing::Return(ERROR_SUCCESS));
-    CustomActionData customActionCtx(tm);
 
-    customActionCtx.init(LR"(
+    auto propertyView = std::make_shared<TestPropertyView>(std::wstring(LR"(
         TEST_PROPERTY=
-)");
+)"));
+    CustomActionData customActionCtx(propertyView, tm);
+
     expect_string_equal(customActionCtx, L"TEST_PROPERTY", L"");
 }
 
@@ -63,11 +64,11 @@ TEST_F(CustomActionDataTest, With_SinglePropertyWithSpacea_Parse_Correctly)
 {
     auto tm = std::make_shared<TargetMachineMock>();
     ON_CALL(*tm, Detect).WillByDefault(testing::Return(ERROR_SUCCESS));
-    CustomActionData customActionCtx(tm);
 
-    customActionCtx.init(LR"(
-        PROP_WITH_SPACE=    
-)");
+    auto propertyView = std::make_shared<TestPropertyView>(std::wstring(LR"(
+        PROP_WITH_SPACE=    )"));
+    CustomActionData customActionCtx(propertyView, tm);
+
     expect_string_equal(customActionCtx, L"PROP_WITH_SPACE", L"");
 }
 
@@ -75,13 +76,14 @@ TEST_F(CustomActionDataTest, With_ManyEmptyProperties_Parse_Correctly)
 {
     auto tm = std::make_shared<TargetMachineMock>();
     ON_CALL(*tm, Detect).WillByDefault(testing::Return(ERROR_SUCCESS));
-    CustomActionData customActionCtx(tm);
 
-    customActionCtx.init(LR"(
+    auto propertyView = std::make_shared<TestPropertyView>(std::wstring(LR"(
         PROXY_HOST=
         PROXY_PORT=
         PROXY_USER=
-)");
+)"));
+    CustomActionData customActionCtx(propertyView, tm);
+
     expect_string_equal(customActionCtx, L"PROXY_HOST", L"");
     expect_string_equal(customActionCtx, L"PROXY_PORT", L"");
     expect_string_equal(customActionCtx, L"PROXY_USER", L"");
@@ -91,9 +93,8 @@ TEST_F(CustomActionDataTest, With_Properties_Parse_Correctly)
 {
     auto tm = std::make_shared<TargetMachineMock>();
     ON_CALL(*tm, Detect).WillByDefault(testing::Return(ERROR_SUCCESS));
-    CustomActionData customActionCtx(tm);
 
-    customActionCtx.init(LR"(
+    auto propertyView = std::make_shared<TestPropertyView>(std::wstring(LR"(
     TAGS=k1:v1,k2:v2
     HOSTNAME=dd-agent-installopts
     CMD_PORT=4999
@@ -106,7 +107,9 @@ TEST_F(CustomActionDataTest, With_Properties_Parse_Correctly)
     LOGS_DD_URL=https://logs.someurl.datadoghq.com
     PROCESS_DD_URL=https://process.someurl.datadoghq.com
     TRACE_DD_URL=https://trace.someurl.datadoghq.com
-)");
+)"));
+    CustomActionData customActionCtx(propertyView, tm);
+
     expect_string_equal(customActionCtx, L"TAGS", L"k1:v1,k2:v2");
     expect_string_equal(customActionCtx, L"HOSTNAME", L"dd-agent-installopts");
     expect_string_equal(customActionCtx, L"CMD_PORT", L"4999");

--- a/tools/windows/install-help/cal/customaction-tests/FinalizeInstall_InstallInfo.cpp
+++ b/tools/windows/install-help/cal/customaction-tests/FinalizeInstall_InstallInfo.cpp
@@ -2,6 +2,7 @@
 #include "customaction-tests.h"
 #include "customaction.h"
 #include "customactiondata.h"
+#include "PropertyViewMock.h"
 #undef min
 #undef max
 #include <optional>

--- a/tools/windows/install-help/cal/customaction-tests/FinalizeInstall_InstallInfo.cpp
+++ b/tools/windows/install-help/cal/customaction-tests/FinalizeInstall_InstallInfo.cpp
@@ -21,29 +21,36 @@ bool writeInstallInfo(const CustomActionData &customActionData);
 
 TEST_F(InstallInfoTest, When_UILevel_NotSpecified_Install_Fails)
 {
-    CustomActionData data;
-    data.init(L"");
+    auto propertyView = std::make_shared<TestPropertyView>(std::wstring(L""));
+    CustomActionData data(propertyView);
     EXPECT_FALSE(writeInstallInfo(data));
 }
 
 TEST_F(InstallInfoTest, When_UILevel_Specified_Doesnt_Fail_Install)
 {
-    CustomActionData data;
-    data.init(L"UILevel=2");
+    auto propertyView = std::make_shared<TestPropertyView>(std::wstring(LR"(
+        UILevel=2
+    )"));
+    CustomActionData data(propertyView);
     EXPECT_TRUE(writeInstallInfo(data));
 }
 
 TEST_F(InstallInfoTest, When_UILevel_NotSpecified_But_With_Override_Doesnt_Fail_Install)
 {
-    CustomActionData data;
-    data.init(L"OVERRIDE_INSTALLATION_METHOD=test");
+    auto propertyView = std::make_shared<TestPropertyView>(std::wstring(LR"(
+        OVERRIDE_INSTALLATION_METHOD=test
+    )"));
+    CustomActionData data(propertyView);
     EXPECT_TRUE(writeInstallInfo(data));
 }
 
 TEST_F(InstallInfoTest, When_UILevel_And_Override_Specified_Doesnt_Fail_Install)
 {
-    CustomActionData data;
-    data.init(L"UILevel=42\r\nOVERRIDE_INSTALLATION_METHOD=test");
+    auto propertyView = std::make_shared<TestPropertyView>(std::wstring(LR"(
+        UILevel=42
+        OVERRIDE_INSTALLATION_METHOD=test
+    )"));
+    CustomActionData data(propertyView);
     EXPECT_TRUE(writeInstallInfo(data));
 }
 
@@ -51,19 +58,19 @@ std::optional<std::wstring> GetInstallMethod(const CustomActionData &customActio
 
 TEST_F(InstallInfoTest, When_UILevel_NotSpecified_GetInstallMethod_Returns_Empty)
 {
-    CustomActionData data;
-    data.init(L"");
+    auto propertyView = std::make_shared<TestPropertyView>(std::wstring(L""));
+    CustomActionData data(propertyView);
     const auto installMethod = GetInstallMethod(data);
     EXPECT_FALSE(installMethod.has_value());
 }
 
 TEST_F(InstallInfoTest, When_UILevel_Less_Or_Eq_2_GetInstallMethod_Returns_Quiet)
 {
-    CustomActionData data;
     const int uiLevel = getRandomUiLevel(0, 2);
     std::wstringstream params;
     params << L"UILevel=" << uiLevel;
-    data.init(params.str());
+    auto propertyView = std::make_shared<TestPropertyView>(params.str());
+    CustomActionData data(propertyView);
     auto installMethod = GetInstallMethod(data);
     EXPECT_TRUE(installMethod.has_value());
     EXPECT_EQ(installMethod.value(), L"windows_msi_quiet");
@@ -71,11 +78,11 @@ TEST_F(InstallInfoTest, When_UILevel_Less_Or_Eq_2_GetInstallMethod_Returns_Quiet
 
 TEST_F(InstallInfoTest, When_UILevel_Greater_Than_2_GetInstallMethod_Returns_Gui)
 {
-    CustomActionData data;
     const int uiLevel = getRandomUiLevel(3);
     std::wstringstream params;
     params << L"UILevel=" << uiLevel;
-    data.init(params.str());
+    auto propertyView = std::make_shared<TestPropertyView>(params.str());
+    CustomActionData data(propertyView);
     auto installMethod = GetInstallMethod(data);
     EXPECT_TRUE(installMethod.has_value());
     EXPECT_EQ(installMethod.value(), L"windows_msi_gui");
@@ -83,11 +90,11 @@ TEST_F(InstallInfoTest, When_UILevel_Greater_Than_2_GetInstallMethod_Returns_Gui
 
 TEST_F(InstallInfoTest, When_UILevel_And_Override_Specified_GetInstallMethod_Returns_Override)
 {
-    CustomActionData data;
     const int uiLevel = getRandomUiLevel(0);
     std::wstringstream params;
     params << L"UILevel=" << uiLevel << L"\r\nOVERRIDE_INSTALLATION_METHOD=test";
-    data.init(params.str());
+    auto propertyView = std::make_shared<TestPropertyView>(params.str());
+    CustomActionData data(propertyView);
     auto installMethod = GetInstallMethod(data);
     EXPECT_TRUE(installMethod.has_value());
     EXPECT_EQ(installMethod.value(), L"test");

--- a/tools/windows/install-help/cal/customaction-tests/PropertyViewMock.h
+++ b/tools/windows/install-help/cal/customaction-tests/PropertyViewMock.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <PropertyView.h>
+
+class TestPropertyView : public PropertyView
+{
+  public:
+    TestPropertyView::TestPropertyView(std::wstring &data)
+    {
+        parseKeyValueString(data, this->values);
+    }
+};

--- a/tools/windows/install-help/cal/customaction-tests/PropertyViewMock.h
+++ b/tools/windows/install-help/cal/customaction-tests/PropertyViewMock.h
@@ -4,7 +4,7 @@
 
 #include <PropertyView.h>
 
-class TestPropertyView : public PropertyView
+class TestPropertyView : public StaticPropertyView
 {
   public:
     TestPropertyView::TestPropertyView(std::wstring &data)

--- a/tools/windows/install-help/cal/customaction.h
+++ b/tools/windows/install-help/cal/customaction.h
@@ -85,7 +85,21 @@ BOOL DeleteFilesInDirectory(const wchar_t *dirname, const wchar_t *ext, bool dir
 BOOL DeleteHomeDirectory(const std::wstring &user, PSID userSID);
 
 // caninstall.cpp
-bool canInstall(BOOL isDC, int ddUserExists, int ddServiceExists, const CustomActionData &data, bool &bResetPassword);
+bool canInstall(
+    const CustomActionData &data,
+    bool &bResetPassword);
+bool canInstall(
+    bool isDC,
+    bool isReadOnlyDC,
+    bool ddUserExists,
+    bool isServiceAccount,
+    bool isNtAuthority,
+    bool isUserDomainUser,
+    bool haveUserPassword,
+    std::wstring userDomain,
+    std::wstring computerDomain,
+    bool ddServiceExists,
+    bool &bResetPassword);
 extern HMODULE hDllModule;
 // rights we might be interested in
 /*

--- a/tools/windows/install-help/cal/customaction.h
+++ b/tools/windows/install-help/cal/customaction.h
@@ -77,7 +77,7 @@ VOID DoStopAllServices();
 DWORD DoStartSvc(std::wstring &svcName);
 int doesServiceExist(std::wstring &svcName);
 int installServices(CustomActionData &data, PSID sid, const wchar_t *password);
-int uninstallServices(CustomActionData &data);
+int uninstallServices();
 int verifyServices(CustomActionData &data);
 
 // delfiles.cpp

--- a/tools/windows/install-help/cal/customaction.h
+++ b/tools/windows/install-help/cal/customaction.h
@@ -87,7 +87,8 @@ BOOL DeleteHomeDirectory(const std::wstring &user, PSID userSID);
 // caninstall.cpp
 bool canInstall(
     const CustomActionData &data,
-    bool &bResetPassword);
+    bool &bResetPassword,
+    std::wstring *resultMessage);
 bool canInstall(
     bool isDC,
     bool isReadOnlyDC,
@@ -99,7 +100,8 @@ bool canInstall(
     std::wstring userDomain,
     std::wstring computerDomain,
     bool ddServiceExists,
-    bool &bResetPassword);
+    bool &bResetPassword,
+    std::wstring *resultMessage);
 extern HMODULE hDllModule;
 // rights we might be interested in
 /*

--- a/tools/windows/install-help/cal/customaction.vcxproj
+++ b/tools/windows/install-help/cal/customaction.vcxproj
@@ -164,6 +164,7 @@
   <ItemGroup>
     <ClCompile Include="CustomAction.cpp" />
     <ClCompile Include="customactiondata.cpp" />
+    <ClCompile Include="PropertyView.cpp" />
     <ClCompile Include="ddreg.cpp" />
     <ClCompile Include="delfiles.cpp" />
     <ClCompile Include="doUninstall.cpp" />
@@ -194,6 +195,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="customactiondata.h" />
+    <ClInclude Include="PropertyView.h" />
     <ClInclude Include="ddreg.h" />
     <ClInclude Include="Error.h" />
     <ClInclude Include="lmerr_str.h" />

--- a/tools/windows/install-help/cal/customaction.vcxproj.filters
+++ b/tools/windows/install-help/cal/customaction.vcxproj.filters
@@ -1,8 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <ClCompile Include="CustomAction.cpp" />
     <ClCompile Include="customactiondata.cpp" />
+    <ClCompile Include="PropertyView.cpp" />
     <ClCompile Include="delfiles.cpp" />
     <ClCompile Include="doUninstall.cpp" />
     <ClCompile Include="FinalizeInstall.cpp" />
@@ -45,6 +46,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="customactiondata.h" />
+    <ClInclude Include="PropertyView.h" />
     <ClInclude Include="customaction.h" />
     <ClInclude Include="decompress.h">
       <Filter>archive</Filter>

--- a/tools/windows/install-help/cal/customactiondata.cpp
+++ b/tools/windows/install-help/cal/customactiondata.cpp
@@ -4,110 +4,15 @@
 #include "PropertyReplacer.h"
 #include "LogonCli.h"
 
-static void parseKeyValueString(
-    const std::wstring kvstring,
-    std::map<std::wstring, std::wstring> &values)
-{
-    // Parse values out of property
-    std::wstringstream ss(kvstring);
-    std::wstring token;
-
-    while (std::getline(ss, token))
-    {
-        // 'token' contains "<key>=<value>"
-        std::wstringstream instream(token);
-        std::wstring key, val;
-        if (std::getline(instream, key, L'='))
-        {
-            trim_string(key);
-            std::getline(instream, val);
-            trim_string(val);
-            if (!key.empty() && !val.empty())
-            {
-                values[key] = val;
-            }
-        }
-    }
-
-}
-
-bool IPropertyView::present(const std::wstring &key) const
-{
-    return this->values.count(key) != 0 ? true : false;
-}
-
-bool IPropertyView::value(const std::wstring &key, std::wstring &val) const
-{
-    const auto kvp = values.find(key);
-    if (kvp == values.end())
-    {
-        return false;
-    }
-    val = kvp->second;
-    return true;
-}
-
-CAPropertyView::CAPropertyView(MSIHANDLE hi)
-: _hInstall(hi)
-{
-}
-
-ImmediateCAPropertyView::ImmediateCAPropertyView(MSIHANDLE hi)
-: CAPropertyView(hi)
-{
-    std::wstring propertyNames[] = {
-        propertyDDAgentUserName,
-        propertyDDAgentUserPassword,
-        L"SYSPROBE_PRESENT",
-        L"NPM",
-        L"NPMFEATURE",
-    };
-
-    for ( auto propertyName : propertyNames ) {
-        std::wstring propertyValue;
-        if (loadPropertyString(this->_hInstall, propertyName.c_str(), propertyValue)) {
-            if (!propertyValue.empty()) {
-                this->values[propertyName] = propertyValue;
-            }
-        }
-    }
-}
-
-DeferredCAPropertyView::DeferredCAPropertyView(MSIHANDLE hi)
-: CAPropertyView(hi)
-{
-    /*
-     * Deferred custom actions have limited access to installation
-     * details, so we must load our properties from the CustomActionData propety.
-     * https://docs.microsoft.com/en-us/windows/win32/msi/obtaining-context-information-for-deferred-execution-custom-actions
-     */
-
-    // Load CustomActionData property
-    std::wstring data;
-    if (!loadPropertyString(this->_hInstall, propertyCustomActionData.c_str(), data))
-    {
-        throw;
-    }
-
-    parseKeyValueString(data, this->values);
-}
-
-
-TestPropertyView::TestPropertyView(std::wstring &data)
-{
-    parseKeyValueString(data, this->values);
-}
-
-CustomActionData::CustomActionData(
-    std::shared_ptr<IPropertyView> propertyView,
-    std::shared_ptr<ITargetMachine> targetMachine)
-: _domainUser(false)
-, _doInstallSysprobe(true)
-, _ddnpmPresent(false)
-, _ddUserExists(false)
-, _targetMachine(std::move(targetMachine))
-, _propertyView(std::move(propertyView))
-, _logonCli(nullptr)
+CustomActionData::CustomActionData(std::shared_ptr<IPropertyView> propertyView,
+                                   std::shared_ptr<ITargetMachine> targetMachine)
+    : _domainUser(false)
+    , _doInstallSysprobe(true)
+    , _ddnpmPresent(false)
+    , _ddUserExists(false)
+    , _targetMachine(std::move(targetMachine))
+    , _propertyView(std::move(propertyView))
+    , _logonCli(nullptr)
 {
     try
     {
@@ -126,15 +31,15 @@ CustomActionData::CustomActionData(
     }
 
     // Process some data now
-    if (!parseUsernameData() || !parseSysprobeData()) {
+    if (!parseUsernameData() || !parseSysprobeData())
+    {
         throw;
     }
 }
 
 CustomActionData::CustomActionData(std::shared_ptr<IPropertyView> propertyView)
-: CustomActionData(std::move(propertyView), std::make_shared<TargetMachine>())
+    : CustomActionData(std::move(propertyView), std::make_shared<TargetMachine>())
 {
-
 }
 
 CustomActionData::~CustomActionData()
@@ -239,7 +144,7 @@ bool CustomActionData::parseSysprobeData()
     }
     this->_doInstallSysprobe = true;
 
-    if(!this->_propertyView->value(L"NPM", npm))
+    if (!this->_propertyView->value(L"NPM", npm))
     {
         WcaLog(LOGMSG_STANDARD, "NPM property not present");
     }
@@ -248,7 +153,6 @@ bool CustomActionData::parseSysprobeData()
         WcaLog(LOGMSG_STANDARD, "NPM enabled via NPM property");
         this->_ddnpmPresent = true;
     }
-
 
     if (this->_propertyView->value(L"NPMFEATURE", npmFeature))
     {
@@ -279,7 +183,8 @@ std::optional<CustomActionData::User> CustomActionData::findPreviousUserInfo()
         WcaLog(LOGMSG_STANDARD, "previous user information not found in registry");
         return std::nullopt;
     }
-    WcaLog(LOGMSG_STANDARD, "found previous user \"%S\\%S\" information in registry", user.Domain.c_str(), user.Name.c_str());
+    WcaLog(LOGMSG_STANDARD, "found previous user \"%S\\%S\" information in registry", user.Domain.c_str(),
+           user.Name.c_str());
     return std::optional<User>(user);
 }
 
@@ -295,7 +200,8 @@ std::optional<CustomActionData::User> CustomActionData::findSuppliedUserInfo()
 
     if (std::wstring::npos == tmpName.find(L'\\'))
     {
-        WcaLog(LOGMSG_STANDARD, "supplied username \"%S\" doesn't have domain specifier, assuming local", tmpName.c_str());
+        WcaLog(LOGMSG_STANDARD, "supplied username \"%S\" doesn't have domain specifier, assuming local",
+               tmpName.c_str());
         tmpName = L".\\" + tmpName;
     }
 
@@ -391,7 +297,7 @@ bool CustomActionData::parseUsernameData()
         WcaLog(LOGMSG_STANDARD, "Using default username");
         // Didn't find a user in the registry nor from the command line
         // use default value. Order of construction is Domain then Name
-        _user = {L".", ddAgentUserName };
+        _user = {L".", ddAgentUserName};
     }
 
     ensureDomainHasCorrectFormat();
@@ -408,7 +314,8 @@ bool CustomActionData::parseUsernameData()
     {
         if (sidResult.Result == ERROR_SUCCESS && sidResult.Sid != nullptr)
         {
-            WcaLog(LOGMSG_STANDARD, R"(Found SID for "%S" in "%S")", FullyQualifiedUsername().c_str(), sidResult.Domain.c_str());
+            WcaLog(LOGMSG_STANDARD, R"(Found SID for "%S" in "%S")", FullyQualifiedUsername().c_str(),
+                   sidResult.Domain.c_str());
             _ddUserExists = true;
             _sid = std::move(sidResult.Sid);
 
@@ -425,8 +332,8 @@ bool CustomActionData::parseUsernameData()
                 _isServiceAccount = isServiceAccount ? true : false;
             }
 
-            WcaLog(LOGMSG_STANDARD, R"("%S" %S a managed service account)",
-                   FullyQualifiedUsername().c_str(), _isServiceAccount ? L"is" : L"is not");
+            WcaLog(LOGMSG_STANDARD, R"("%S" %S a managed service account)", FullyQualifiedUsername().c_str(),
+                   _isServiceAccount ? L"is" : L"is not");
             // Use the domain returned by <see cref="LookupAccountName" /> because
             // it might be != from the one the user passed in.
             _user.Domain = sidResult.Domain;

--- a/tools/windows/install-help/cal/customactiondata.cpp
+++ b/tools/windows/install-help/cal/customactiondata.cpp
@@ -52,6 +52,27 @@ CAPropertyView::CAPropertyView(MSIHANDLE hi)
 {
 }
 
+ImmediateCAPropertyView::ImmediateCAPropertyView(MSIHANDLE hi)
+: CAPropertyView(hi)
+{
+    std::wstring propertyNames[] = {
+        propertyDDAgentUserName,
+        propertyDDAgentUserPassword,
+        L"SYSPROBE_PRESENT",
+        L"NPM",
+        L"NPMFEATURE",
+    };
+
+    for ( auto propertyName : propertyNames ) {
+        std::wstring propertyValue;
+        if (loadPropertyString(this->_hInstall, propertyName.c_str(), propertyValue)) {
+            if (!propertyValue.empty()) {
+                this->values[propertyName] = propertyValue;
+            }
+        }
+    }
+}
+
 DeferredCAPropertyView::DeferredCAPropertyView(MSIHANDLE hi)
 : CAPropertyView(hi)
 {

--- a/tools/windows/install-help/cal/customactiondata.cpp
+++ b/tools/windows/install-help/cal/customactiondata.cpp
@@ -27,13 +27,13 @@ CustomActionData::CustomActionData(std::shared_ptr<IPropertyView> propertyView,
     if (errCode != ERROR_SUCCESS)
     {
         WcaLog(LOGMSG_STANDARD, "Could not determine machine information: %S", FormatErrorMessage(errCode).c_str());
-        throw;
+        throw std::exception("Could not determine machine information");
     }
 
     // Process some data now
     if (!parseUsernameData() || !parseSysprobeData())
     {
-        throw;
+        throw std::exception("Error parsing machine information");
     }
 }
 

--- a/tools/windows/install-help/cal/customactiondata.h
+++ b/tools/windows/install-help/cal/customactiondata.h
@@ -32,6 +32,38 @@ class ICustomActionData
 
 class LogonCli;
 
+class IPropertyView
+{
+  public:
+    bool present(const std::wstring &key) const;
+    bool value(const std::wstring &key, std::wstring &val) const;
+
+  protected:
+    std::map<std::wstring, std::wstring> values;
+    virtual ~IPropertyView() { }
+};
+
+class CAPropertyView : public IPropertyView
+{
+  public:
+    CAPropertyView(MSIHANDLE hInstall);
+  protected:
+    MSIHANDLE _hInstall;
+    virtual ~CAPropertyView() { }
+};
+
+class DeferredCAPropertyView : public CAPropertyView
+{
+  public:
+    DeferredCAPropertyView(MSIHANDLE hInstall);
+};
+
+class TestPropertyView : public IPropertyView
+{
+  public:
+   TestPropertyView(std::wstring &data);
+};
+
 class CustomActionData : ICustomActionData
 {
   private:
@@ -41,13 +73,11 @@ class CustomActionData : ICustomActionData
         std::wstring Name;
     };
   public:
-    CustomActionData(std::shared_ptr<ITargetMachine> targetMachine);
-    CustomActionData();
+    CustomActionData(
+        std::shared_ptr<IPropertyView> propertyView,
+        std::shared_ptr<ITargetMachine> targetMachine);
+    CustomActionData(std::shared_ptr<IPropertyView> propertyView);
     ~CustomActionData();
-
-    bool init(MSIHANDLE hInstall);
-
-    bool init(const std::wstring &initstring);
 
     bool present(const std::wstring &key) const;
     bool value(const std::wstring &key, std::wstring &val) const;
@@ -67,9 +97,7 @@ class CustomActionData : ICustomActionData
     bool npmPresent() const;
 
   private:
-    MSIHANDLE _hInstall;
     bool _domainUser;
-    std::map<std::wstring, std::wstring> values;
     User _user;
     std::wstring _fullyQualifiedUsername;
     sid_ptr _sid;
@@ -79,9 +107,11 @@ class CustomActionData : ICustomActionData
     bool _isServiceAccount;
     LogonCli *_logonCli;
     std::shared_ptr<ITargetMachine> _targetMachine;
+    std::shared_ptr<IPropertyView> _propertyView;
     std::optional<User> findPreviousUserInfo();
     std::optional<User> findSuppliedUserInfo();
     void ensureDomainHasCorrectFormat();
     bool parseUsernameData();
     bool parseSysprobeData();
 };
+

--- a/tools/windows/install-help/cal/customactiondata.h
+++ b/tools/windows/install-help/cal/customactiondata.h
@@ -52,6 +52,12 @@ class CAPropertyView : public IPropertyView
     virtual ~CAPropertyView() { }
 };
 
+class ImmediateCAPropertyView : public CAPropertyView
+{
+  public:
+    ImmediateCAPropertyView(MSIHANDLE hInstall);
+};
+
 class DeferredCAPropertyView : public CAPropertyView
 {
   public:

--- a/tools/windows/install-help/cal/customactiondata.h
+++ b/tools/windows/install-help/cal/customactiondata.h
@@ -2,6 +2,7 @@
 
 #include "SID.h"
 #include "TargetMachine.h"
+#include "PropertyView.h"
 
 #include <map>
 #include <Msi.h>
@@ -31,44 +32,6 @@ class ICustomActionData
 };
 
 class LogonCli;
-
-class IPropertyView
-{
-  public:
-    bool present(const std::wstring &key) const;
-    bool value(const std::wstring &key, std::wstring &val) const;
-
-  protected:
-    std::map<std::wstring, std::wstring> values;
-    virtual ~IPropertyView() { }
-};
-
-class CAPropertyView : public IPropertyView
-{
-  public:
-    CAPropertyView(MSIHANDLE hInstall);
-  protected:
-    MSIHANDLE _hInstall;
-    virtual ~CAPropertyView() { }
-};
-
-class ImmediateCAPropertyView : public CAPropertyView
-{
-  public:
-    ImmediateCAPropertyView(MSIHANDLE hInstall);
-};
-
-class DeferredCAPropertyView : public CAPropertyView
-{
-  public:
-    DeferredCAPropertyView(MSIHANDLE hInstall);
-};
-
-class TestPropertyView : public IPropertyView
-{
-  public:
-   TestPropertyView(std::wstring &data);
-};
 
 class CustomActionData : ICustomActionData
 {

--- a/tools/windows/install-help/cal/doUninstall.cpp
+++ b/tools/windows/install-help/cal/doUninstall.cpp
@@ -62,7 +62,6 @@ UINT doUninstallAs(UNINSTALL_TYPE t)
 {
 
     DWORD er = ERROR_SUCCESS;
-    CustomActionData data;
     LSA_HANDLE hLsa = NULL;
     std::wstring propval;
     ddRegKey regkey;
@@ -189,7 +188,7 @@ UINT doUninstallAs(UNINSTALL_TYPE t)
     if (installState.getStringValue(installInstalledServices.c_str(), svcsInstalled))
     {
         // uninstall the services
-        uninstallServices(data);
+        uninstallServices();
     }
     else
     {

--- a/tools/windows/install-help/cal/doUninstall.cpp
+++ b/tools/windows/install-help/cal/doUninstall.cpp
@@ -15,12 +15,12 @@ void cleanupFolders()
     std::filesystem::remove(installPath / "embedded", ec);
     if (ec)
     {
-        WcaLog(LOGMSG_STANDARD, "Could not remove embedded folder: %s",ec.message().c_str());
+        WcaLog(LOGMSG_STANDARD, "Could not remove embedded folder: %s", ec.message().c_str());
     }
 
     // Nuke the embedded2/3 folders since we don't support patching the Python installation
     // and it's not tracked by the MSI installer anymore
-    for (const auto &folder : {"embedded2","embedded3"})
+    for (const auto &folder : {"embedded2", "embedded3"})
     {
         std::filesystem::path folderPath = installPath / folder;
         if (!exists(folderPath))

--- a/tools/windows/install-help/cal/precompiled/stdafx.h
+++ b/tools/windows/install-help/cal/precompiled/stdafx.h
@@ -35,6 +35,7 @@
 // TODO: reference additional headers your program requires here
 #include "../Error.h"
 #include "../customaction.h"
+#include "../PropertyView.h"
 #include "../customactiondata.h"
 #include "../ddreg.h"
 #include "../resource.h"

--- a/tools/windows/install-help/cal/stopservices.cpp
+++ b/tools/windows/install-help/cal/stopservices.cpp
@@ -856,21 +856,15 @@ int uninstallServices()
 #ifdef __REGISTER_ALL_SERVICES
 #define NUM_SERVICES 4
     serviceDef services[NUM_SERVICES] = {
-        serviceDef(agentService.c_str(), L"Datadog Agent", L"Send metrics to Datadog", agent_exe.c_str(),
-                   L"winmgmt\0\0", SERVICE_AUTO_START, NULL, NULL),
-        serviceDef(traceService.c_str(), L"Datadog Trace Agent", L"Send tracing metrics to Datadog", trace_exe.c_str(),
-                   L"datadogagent\0\0", SERVICE_DEMAND_START, NULL, NULL),
-        serviceDef(processService.c_str(), L"Datadog Process Agent", L"Send process metrics to Datadog",
-                   process_exe.c_str(), L"datadogagent\0\0", SERVICE_DEMAND_START, NULL, NULL),
-        serviceDef(systemProbeService.c_str(), L"Datadog System Probe", L"Send network metrics to Datadog",
-                   sysprobe_exe.c_str(), L"\0\0", SERVICE_DEMAND_START, NULL, NULL)
-
+        serviceDef(agentService.c_str()),
+        serviceDef(traceService.c_str()),
+        serviceDef(processService.c_str()),
+        serviceDef(systemProbeService.c_str()),
     };
 #else
 #define NUM_SERVICES 1
     serviceDef services[NUM_SERVICES] = {
-        serviceDef(agentService.c_str(), L"Datadog Agent", L"Send metrics to Datadog", agent_exe.c_str(),
-                   L"winmgmt\0\0", SERVICE_AUTO_START, NULL, NULL),
+        serviceDef(agentService.c_str()),
     };
 #endif
     WcaLog(LOGMSG_STANDARD, "Uninstalling services");

--- a/tools/windows/install-help/cal/stopservices.cpp
+++ b/tools/windows/install-help/cal/stopservices.cpp
@@ -491,7 +491,8 @@ DWORD DoStartSvc(std::wstring &svcname)
             if (GetTickCount() - dwStartTickCount > ssStatus.dwWaitHint)
             {
                 // No progress made within the wait hint.
-                WcaLog(LOGMSG_STANDARD, "Exiting start loop; no progress made after %d ms", (int)(GetTickCount() - dwStartTickCount) );
+                WcaLog(LOGMSG_STANDARD, "Exiting start loop; no progress made after %d ms",
+                       (int)(GetTickCount() - dwStartTickCount));
                 break;
             }
         }
@@ -501,15 +502,17 @@ DWORD DoStartSvc(std::wstring &svcname)
 
     if (ssStatus.dwCurrentState == SERVICE_RUNNING)
     {
-        WcaLog(LOGMSG_STANDARD, "Service started successfully (Elapsed %d)\n", (int)(GetTickCount() - dwStartTickCount) );
+        WcaLog(LOGMSG_STANDARD, "Service started successfully (Elapsed %d)\n",
+               (int)(GetTickCount() - dwStartTickCount));
     }
-    else if(ssStatus.dwCurrentState == SERVICE_START_PENDING)
+    else if (ssStatus.dwCurrentState == SERVICE_START_PENDING)
     {
-        WcaLog(LOGMSG_STANDARD, "Service start in progress, continuing install (Elapsed %d)\n", (int)(GetTickCount() - dwStartTickCount) );
+        WcaLog(LOGMSG_STANDARD, "Service start in progress, continuing install (Elapsed %d)\n",
+               (int)(GetTickCount() - dwStartTickCount));
     }
     else
     {
-        WcaLog(LOGMSG_STANDARD, "Service not started. (Elapsed %d)\n", (int)(GetTickCount() - dwStartTickCount) );
+        WcaLog(LOGMSG_STANDARD, "Service not started. (Elapsed %d)\n", (int)(GetTickCount() - dwStartTickCount));
         WcaLog(LOGMSG_STANDARD, "  Current State: %d\n", ssStatus.dwCurrentState);
         WcaLog(LOGMSG_STANDARD, "  Exit Code: %d\n", ssStatus.dwWin32ExitCode);
         WcaLog(LOGMSG_STANDARD, "  Check Point: %d\n", ssStatus.dwCheckPoint);
@@ -715,15 +718,16 @@ class serviceDef
         }
         {
             WcaLog(LOGMSG_STANDARD, "Resetting dependencies");
-            BOOL bRet = ChangeServiceConfigW(hService, SERVICE_NO_CHANGE, SERVICE_NO_CHANGE, SERVICE_NO_CHANGE,
-                                             NULL, NULL, NULL, this->lpDependencies, NULL, NULL, NULL);
+            BOOL bRet = ChangeServiceConfigW(hService, SERVICE_NO_CHANGE, SERVICE_NO_CHANGE, SERVICE_NO_CHANGE, NULL,
+                                             NULL, NULL, this->lpDependencies, NULL, NULL, NULL);
             if (!bRet)
             {
                 retval = GetLastError();
                 WcaLog(LOGMSG_STANDARD, "Failed to update service dependency config %d\n", retval);
                 goto done_verify;
             }
-            WcaLog(LOGMSG_STANDARD, "Updated dependencies for existing service, dependencies now %S", this->lpDependencies);
+            WcaLog(LOGMSG_STANDARD, "Updated dependencies for existing service, dependencies now %S",
+                   this->lpDependencies);
         }
 
     done_verify:
@@ -735,11 +739,14 @@ class serviceDef
 
         return retval;
     }
-    const wchar_t* getServiceName() const { return this->svcName;  }
+    const wchar_t *getServiceName() const
+    {
+        return this->svcName;
+    }
 };
 
-static    wchar_t * probeDepsNoNPM = L"datadogagent\0\0";
-static    wchar_t * probeDepsWithNPM = L"datadogagent\0ddnpm\0\0";
+static wchar_t *probeDepsNoNPM = L"datadogagent\0\0";
+static wchar_t *probeDepsWithNPM = L"datadogagent\0ddnpm\0\0";
 
 int installServices(CustomActionData &data, PSID sid, const wchar_t *password)
 {
@@ -758,7 +765,8 @@ int installServices(CustomActionData &data, PSID sid, const wchar_t *password)
         serviceDef(processService.c_str(), L"Datadog Process Agent", L"Send process metrics to Datadog",
                    process_exe.c_str(), L"datadogagent\0\0", SERVICE_DEMAND_START, NULL, NULL),
         serviceDef(systemProbeService.c_str(), L"Datadog System Probe", L"Send network metrics to Datadog",
-                   sysprobe_exe.c_str(), data.npmPresent() ? probeDepsWithNPM : probeDepsNoNPM, SERVICE_DEMAND_START, NULL, NULL)
+                   sysprobe_exe.c_str(), data.npmPresent() ? probeDepsWithNPM : probeDepsNoNPM, SERVICE_DEMAND_START,
+                   NULL, NULL)
 
     };
     // by default, don't add sysprobe
@@ -906,7 +914,8 @@ int verifyServices(CustomActionData &data)
         serviceDef(processService.c_str(), L"Datadog Process Agent", L"Send process metrics to Datadog",
                    process_exe.c_str(), L"datadogagent\0\0", SERVICE_DEMAND_START, NULL, NULL),
         serviceDef(systemProbeService.c_str(), L"Datadog System Probe", L"Send network metrics to Datadog",
-                   sysprobe_exe.c_str(), data.npmPresent() ? probeDepsWithNPM : probeDepsNoNPM, SERVICE_DEMAND_START, NULL, NULL)
+                   sysprobe_exe.c_str(), data.npmPresent() ? probeDepsWithNPM : probeDepsNoNPM, SERVICE_DEMAND_START,
+                   NULL, NULL)
 
     };
     // by default, don't add sysprobe
@@ -939,7 +948,7 @@ int verifyServices(CustomActionData &data)
         retval = services[i].verify(hScManager);
         if (retval != 0)
         {
-            if(ERROR_SERVICE_DOES_NOT_EXIST == retval && i > 1)
+            if (ERROR_SERVICE_DOES_NOT_EXIST == retval && i > 1)
             {
                 // i > 1 b/c we can't do this for core or trace, since they run as
                 // ddagentuser and we don't have the password.  process & npm run
@@ -954,11 +963,12 @@ int verifyServices(CustomActionData &data)
                 // than ddagentuser; otherwise, we wouldn't have the password at this
                 // point and this wouldn't work.
                 retval = services[i].create(hScManager);
-                if(0 != retval)
+                if (0 != retval)
                 {
                     // if we can't create it, don't fail the upgrade,just log and
                     // continue on.  The existing services can/should still function
-                    WcaLog(LOGMSG_STANDARD, "Failed to create new service during upgrade %S %d %d 0x%x", services[i].getServiceName(), i, retval, retval);
+                    WcaLog(LOGMSG_STANDARD, "Failed to create new service during upgrade %S %d %d 0x%x",
+                           services[i].getServiceName(), i, retval, retval);
                     WcaLog(LOGMSG_STANDARD, "Allowing upgrade to proceed");
                     // since we're allowing the upgrade to continue, reset the error code to zero
                     // in case this is the last one. Don't want to fail the upgrade by mistake
@@ -970,15 +980,17 @@ int verifyServices(CustomActionData &data)
                 // since we just created this service, we need to allow the datadog
                 // agent core service to start/stop it
                 retval = EnableServiceForUser(data.Sid(), services[i].getServiceName());
-                if(0 != retval)
+                if (0 != retval)
                 {
-                    WcaLog(LOGMSG_STANDARD, "Failed to modify service permissions for %S", services[i].getServiceName());
+                    WcaLog(LOGMSG_STANDARD, "Failed to modify service permissions for %S",
+                           services[i].getServiceName());
                     // since we're allowing the upgrade to continue, reset the error code to zero
                     // in case this is the last one. Don't want to fail the upgrade by mistake
                     retval = 0;
                     continue;
                 }
-            } else
+            }
+            else
             {
                 WcaLog(LOGMSG_STANDARD, "Failed to verify service %d %d 0x%x, rolling back", i, retval, retval);
                 break;

--- a/tools/windows/install-help/install-cmd/install-cmd.cpp
+++ b/tools/windows/install-help/install-cmd/install-cmd.cpp
@@ -26,6 +26,15 @@ UINT WINAPI MsiGetPropertyW(MSIHANDLE hInstall,
     return ERROR_INVALID_FUNCTION;
 }
 
+class TextPropertyView : public PropertyView
+{
+  public:
+    TextPropertyView::TextPropertyView(std::wstring &data)
+    {
+        parseKeyValueString(data, this->values);
+    }
+};
+
 int wmain(int argc, wchar_t **argv)
 {
     hDllModule = GetModuleHandle(NULL);
@@ -33,9 +42,20 @@ int wmain(int argc, wchar_t **argv)
     std::wstring defaultData;
     parseArgs(argc - 1, &(argv[1]), defaultData);
     wprintf(L"%s\n", defaultData.c_str());
-    CustomActionData data;
-    data.init(defaultData);
-    doFinalizeInstall(data);
+    std::optional<CustomActionData> data;
+
+    try
+    {
+        auto propertyView = std::make_shared<TextPropertyView>(defaultData);
+        data.emplace(propertyView);
+    }
+    catch (...)
+    {
+        wprintf(L"Failed to load property data");
+        return EXIT_FAILURE;
+    }
+
+    doFinalizeInstall(data.value());
 }
 
 // Run program: Ctrl + F5 or Debug > Start Without Debugging menu

--- a/tools/windows/install-help/install-cmd/install-cmd.cpp
+++ b/tools/windows/install-help/install-cmd/install-cmd.cpp
@@ -49,7 +49,7 @@ int wmain(int argc, wchar_t **argv)
         auto propertyView = std::make_shared<TextPropertyView>(defaultData);
         data.emplace(propertyView);
     }
-    catch (...)
+    catch (std::exception &)
     {
         wprintf(L"Failed to load property data");
         return EXIT_FAILURE;

--- a/tools/windows/install-help/install-cmd/install-cmd.cpp
+++ b/tools/windows/install-help/install-cmd/install-cmd.cpp
@@ -26,7 +26,7 @@ UINT WINAPI MsiGetPropertyW(MSIHANDLE hInstall,
     return ERROR_INVALID_FUNCTION;
 }
 
-class TextPropertyView : public PropertyView
+class TextPropertyView : public StaticPropertyView
 {
   public:
     TextPropertyView::TextPropertyView(std::wstring &data)

--- a/tools/windows/install-help/install-cmd/install-cmd.vcxproj
+++ b/tools/windows/install-help/install-cmd/install-cmd.vcxproj
@@ -179,6 +179,7 @@
   <ItemGroup>
     <ClCompile Include="..\cal\caninstall.cpp" />
     <ClCompile Include="..\cal\customactiondata.cpp" />
+    <ClCompile Include="..\cal\PropertyView.cpp" />
     <ClCompile Include="..\cal\ddreg.cpp" />
     <ClCompile Include="..\cal\Error.cpp" />
     <ClCompile Include="..\cal\Logoncli.cpp" />

--- a/tools/windows/install-help/install-cmd/install-cmd.vcxproj.filters
+++ b/tools/windows/install-help/install-cmd/install-cmd.vcxproj.filters
@@ -10,6 +10,9 @@
     <ClCompile Include="..\cal\customactiondata.cpp">
       <Filter>cal_imported</Filter>
     </ClCompile>
+    <ClCompile Include="..\cal\PropertyView.cpp">
+      <Filter>cal_imported</Filter>
+    </ClCompile>
     <ClCompile Include="..\cal\ddreg.cpp">
       <Filter>cal_imported</Filter>
     </ClCompile>

--- a/tools/windows/install-help/uninstall-cmd/uninstall-cmd.cpp
+++ b/tools/windows/install-help/uninstall-cmd/uninstall-cmd.cpp
@@ -25,6 +25,7 @@ UINT WINAPI MsiGetPropertyW(MSIHANDLE hInstall,
 {
     return ERROR_INVALID_FUNCTION;
 }
+
 int wmain(int argc, wchar_t **argv)
 {
     hDllModule = GetModuleHandle(NULL);
@@ -32,8 +33,7 @@ int wmain(int argc, wchar_t **argv)
     std::wstring defaultData;
     parseArgs(argc - 1, &(argv[1]), defaultData);
     wprintf(L"%s\n", defaultData.c_str());
-    CustomActionData data;
-    data.init(defaultData);
+
     doUninstallAs(UNINSTALL_UNINSTALL);
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Adds a dialog to the Windows MSI installer that allows the user to input the agent username and/or password.

![image](https://user-images.githubusercontent.com/2266830/188731427-9dc90f65-3747-4af8-959b-19fa291cf04a.png)

The input fields are linked to the `DDAGENTUSER_NAME` and `DDAGENTUSER_PASSWORD` properties and will be pre-filled if these options are supplied on the command line.

Upon clicking "next" a custom action will validate the input, and display an error dialog if an error is detected.

![image](https://user-images.githubusercontent.com/2266830/188732232-a0928db4-cd5b-476e-9eaf-67ac64b72f75.png)

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

customer requests

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Dialog is only present during first install. Not on upgrade/change/repair.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Supply `DDAGENTUSER_NAME` and `DDAGENTUSER_PASSWORD` on the command line, check input fields are pre-filled

Check each of the cases from `canInstall()` and verify the corresponding `errorMessage` appears after clicking the "Next" button

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
