### PR TITLE
[CWS][SEC-4682] Add the possibility to set at runtime some activity dumps configuration fields

### DIFF
--- a/cmd/system-probe/app/config.go
+++ b/cmd/system-probe/app/config.go
@@ -54,5 +54,27 @@ func getSettingsClient(cmd *cobra.Command, _ []string) (settings.Client, error) 
 // initRuntimeSettings builds the map of runtime settings configurable at runtime.
 func initRuntimeSettings() error {
 	// Runtime-editable settings must be registered here to dynamically populate command-line information
-	return settings.RegisterRuntimeSetting(settings.LogLevelRuntimeSetting{ConfigKey: config.Namespace + ".log_level"})
+	err := settings.RegisterRuntimeSetting(settings.LogLevelRuntimeSetting{ConfigKey: config.Namespace + ".log_level"})
+	if err != nil {
+		return err
+	}
+
+	err = settings.RegisterRuntimeSetting(settings.ActivityDumpRuntimeSetting{ConfigKey: settings.TracedEventTypesConfKey})
+	if err != nil {
+		return err
+	}
+	err = settings.RegisterRuntimeSetting(settings.ActivityDumpRuntimeSetting{ConfigKey: settings.CgroupDumpTimeoutConfKey})
+	if err != nil {
+		return err
+	}
+	err = settings.RegisterRuntimeSetting(settings.ActivityDumpRuntimeSetting{ConfigKey: settings.RateLimiterConfKey})
+	if err != nil {
+		return err
+	}
+	err = settings.RegisterRuntimeSetting(settings.ActivityDumpRuntimeSetting{ConfigKey: settings.MaxDumpSizeConfKey})
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/config/settings/runtime_setting_activity_dump.go
+++ b/pkg/config/settings/runtime_setting_activity_dump.go
@@ -1,0 +1,96 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package settings
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/metadata/inventories"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const (
+	// TracedEventTypesConfKey defines the full config key for traced_event_types
+	TracedEventTypesConfKey = "runtime_security_config.activity_dump.traced_event_types"
+	// CgroupDumpTimeoutConfKey defines the full config key for cgroup_dump_timeout
+	CgroupDumpTimeoutConfKey = "runtime_security_config.activity_dump.cgroup_dump_timeout"
+	// RateLimiterConfKey defines the full config key for rate_limiter
+	RateLimiterConfKey = "runtime_security_config.activity_dump.rate_limiter"
+	// MaxDumpSizeConfKey defines the full config key for rate_limiter
+	MaxDumpSizeConfKey = "runtime_security_config.activity_dump.max_dump_size"
+)
+
+// ActivityDumpRuntimeSetting wraps operations to change activity dumps settings at runtime
+type ActivityDumpRuntimeSetting struct {
+	ConfigKey string
+}
+
+// Description returns the runtime setting's description
+func (l ActivityDumpRuntimeSetting) Description() string {
+	return "Set/get the corresponding field."
+}
+
+// Hidden returns whether or not this setting is hidden from the list of runtime settings
+func (l ActivityDumpRuntimeSetting) Hidden() bool {
+	return false
+}
+
+// Name returns the name of the runtime setting
+func (l ActivityDumpRuntimeSetting) Name() string {
+	return l.ConfigKey
+}
+
+// Get returns the current value of the runtime setting
+func (l ActivityDumpRuntimeSetting) Get() (interface{}, error) {
+	val := config.Datadog.Get(l.ConfigKey)
+	return val, nil
+}
+
+func (l ActivityDumpRuntimeSetting) setTracedEventTypes(v interface{}) {
+	sliceVar := strings.Split(v.(string), ",")
+	config.Datadog.Set(l.ConfigKey, sliceVar)
+}
+
+func (l ActivityDumpRuntimeSetting) setCgroupDumpTimeout(v interface{}) {
+	intVar, _ := strconv.Atoi(v.(string))
+	config.Datadog.Set(l.ConfigKey, intVar)
+}
+
+func (l ActivityDumpRuntimeSetting) setRateLimiter(v interface{}) {
+	intVar, _ := strconv.Atoi(v.(string))
+	config.Datadog.Set(l.ConfigKey, intVar)
+}
+
+func (l ActivityDumpRuntimeSetting) setMaxDumpSize(v interface{}) {
+	intVar, _ := strconv.Atoi(v.(string))
+	config.Datadog.Set(l.ConfigKey, intVar)
+}
+
+// Set changes the value of the runtime setting
+func (l ActivityDumpRuntimeSetting) Set(v interface{}) error {
+	val := v.(string)
+	log.Infof("ActivityDumpRuntimeSetting Set %s = %s\n", l.ConfigKey, val)
+
+	switch l.ConfigKey {
+	case TracedEventTypesConfKey:
+		l.setTracedEventTypes(v)
+	case CgroupDumpTimeoutConfKey:
+		l.setCgroupDumpTimeout(v)
+	case RateLimiterConfKey:
+		l.setRateLimiter(v)
+	case MaxDumpSizeConfKey:
+		l.setMaxDumpSize(v)
+	default:
+		return fmt.Errorf("Field %s does not exist", l.ConfigKey)
+	}
+
+	// we trigger a new inventory metadata payload since the configuration was updated by the user.
+	inventories.Refresh()
+	return nil
+}

--- a/pkg/security/probe/activity_dump_easyjson.go
+++ b/pkg/security/probe/activity_dump_easyjson.go
@@ -7,10 +7,12 @@ package probe
 
 import (
 	json "encoding/json"
+	model "github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	easyjson "github.com/mailru/easyjson"
 	jlexer "github.com/mailru/easyjson/jlexer"
 	jwriter "github.com/mailru/easyjson/jwriter"
 	sync "sync"
+	time "time"
 )
 
 // suppress unused package warning
@@ -49,6 +51,8 @@ func easyjson9a9a4de6DecodeGithubComDataDogDatadogAgentPkgSecurityProbe(in *jlex
 			out.Source = string(in.String())
 		case "ddtags":
 			out.DDTags = string(in.String())
+		case "StartLoadConfigParams":
+			easyjson9a9a4de6DecodeGithubComDataDogDatadogAgentPkgSecuritySeclModel(in, &out.StartLoadConfigParams)
 		case "agent_version":
 			out.AgentVersion = string(in.String())
 		case "agent_commit":
@@ -130,13 +134,18 @@ func easyjson9a9a4de6EncodeGithubComDataDogDatadogAgentPkgSecurityProbe(out *jwr
 		out.String(string(in.DDTags))
 	}
 	{
-		const prefix string = ",\"agent_version\":"
+		const prefix string = ",\"StartLoadConfigParams\":"
 		if first {
 			first = false
 			out.RawString(prefix[1:])
 		} else {
 			out.RawString(prefix)
 		}
+		easyjson9a9a4de6EncodeGithubComDataDogDatadogAgentPkgSecuritySeclModel(out, in.StartLoadConfigParams)
+	}
+	{
+		const prefix string = ",\"agent_version\":"
+		out.RawString(prefix)
 		out.String(string(in.AgentVersion))
 	}
 	{
@@ -210,4 +219,92 @@ func (v ActivityDump) MarshalEasyJSON(w *jwriter.Writer) {
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *ActivityDump) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjson9a9a4de6DecodeGithubComDataDogDatadogAgentPkgSecurityProbe(l, v)
+}
+func easyjson9a9a4de6DecodeGithubComDataDogDatadogAgentPkgSecuritySeclModel(in *jlexer.Lexer, out *model.ActivityDumpLoadParams) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "TracedEventTypes":
+			if in.IsNull() {
+				in.Skip()
+				out.TracedEventTypes = nil
+			} else {
+				in.Delim('[')
+				if out.TracedEventTypes == nil {
+					if !in.IsDelim(']') {
+						out.TracedEventTypes = make([]model.EventType, 0, 16)
+					} else {
+						out.TracedEventTypes = []model.EventType{}
+					}
+				} else {
+					out.TracedEventTypes = (out.TracedEventTypes)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v1 model.EventType
+					v1 = model.EventType(in.Uint32())
+					out.TracedEventTypes = append(out.TracedEventTypes, v1)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
+		case "Timeout":
+			out.Timeout = time.Duration(in.Int64())
+		case "Rate":
+			out.Rate = uint32(in.Uint32())
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjson9a9a4de6EncodeGithubComDataDogDatadogAgentPkgSecuritySeclModel(out *jwriter.Writer, in model.ActivityDumpLoadParams) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	{
+		const prefix string = ",\"TracedEventTypes\":"
+		out.RawString(prefix[1:])
+		if in.TracedEventTypes == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+			out.RawString("null")
+		} else {
+			out.RawByte('[')
+			for v2, v3 := range in.TracedEventTypes {
+				if v2 > 0 {
+					out.RawByte(',')
+				}
+				out.Uint32(uint32(v3))
+			}
+			out.RawByte(']')
+		}
+	}
+	{
+		const prefix string = ",\"Timeout\":"
+		out.RawString(prefix)
+		out.Int64(int64(in.Timeout))
+	}
+	{
+		const prefix string = ",\"Rate\":"
+		out.RawString(prefix)
+		out.Uint32(uint32(in.Rate))
+	}
+	out.RawByte('}')
 }

--- a/pkg/security/probe/activity_dump_manager_test.go
+++ b/pkg/security/probe/activity_dump_manager_test.go
@@ -352,7 +352,9 @@ func TestActivityDumpManager_getOverweightDumps(t *testing.T) {
 				probe: &Probe{
 					statsdClient: metrics.NewStatsdClient(),
 					config: &config.Config{
-						ActivityDumpMaxDumpSize: 2048,
+						ActivityDumpMaxDumpSize: func() int {
+							return 2048
+						},
 					},
 				},
 				ignoreFromSnapshot: make(map[string]bool),

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -944,8 +944,8 @@ func (p *Probe) selectTCProbes() manager.ProbesSelector {
 
 func (p *Probe) isNeededForActivityDump(eventType eval.EventType) bool {
 	if p.config.ActivityDumpEnabled {
-		for _, e := range p.config.ActivityDumpTracedEventTypes {
-			if e.String() == eventType {
+		for _, e := range config.GetAllPossibleActivityDumpTracedEvents() {
+			if e == eventType {
 				return true
 			}
 		}
@@ -983,12 +983,7 @@ func (p *Probe) SelectProbes(rs *rules.RuleSet) error {
 
 	// Add syscall monitor probes
 	if p.config.ActivityDumpEnabled {
-		for _, e := range p.config.ActivityDumpTracedEventTypes {
-			if e == model.SyscallsEventType {
-				activatedProbes = append(activatedProbes, probes.SyscallMonitorSelectors...)
-				break
-			}
-		}
+		activatedProbes = append(activatedProbes, probes.SyscallMonitorSelectors...)
 	}
 
 	// Print the list of unique probe identification IDs that are registered
@@ -1443,13 +1438,8 @@ func NewProbe(config *config.Config, statsdClient statsd.ClientInterface) (*Prob
 	}
 
 	if p.config.ActivityDumpEnabled {
-		for _, e := range p.config.ActivityDumpTracedEventTypes {
-			if e == model.SyscallsEventType {
-				// Add syscall monitor probes
-				p.managerOptions.ActivatedProbes = append(p.managerOptions.ActivatedProbes, probes.SyscallMonitorSelectors...)
-				break
-			}
-		}
+		// Add syscall monitor probes
+		p.managerOptions.ActivatedProbes = append(p.managerOptions.ActivatedProbes, probes.SyscallMonitorSelectors...)
 	}
 
 	p.constantOffsets, err = p.GetOffsetConstants()
@@ -1512,7 +1502,7 @@ func NewProbe(config *config.Config, statsdClient statsd.ClientInterface) (*Prob
 		},
 		manager.ConstantEditor{
 			Name:  "cgroup_activity_dumps_enabled",
-			Value: utils.BoolTouint64(config.ActivityDumpEnabled && areCGroupADsEnabled(config)),
+			Value: utils.BoolTouint64(config.ActivityDumpEnabled),
 		},
 		manager.ConstantEditor{
 			Name:  "net_struct_type",

--- a/pkg/security/secl/model/marshallers.go
+++ b/pkg/security/secl/model/marshallers.go
@@ -145,15 +145,15 @@ func (adlc *ActivityDumpLoadConfig) MarshalBinary() ([]byte, error) {
 	raw := make([]byte, 48)
 
 	var eventMask uint64
-	for _, evt := range adlc.TracedEventTypes {
+	for _, evt := range adlc.Params.TracedEventTypes {
 		eventMask |= 1 << (evt - FirstDiscarderEventType)
 	}
 	ByteOrder.PutUint64(raw[0:8], eventMask)
-	ByteOrder.PutUint64(raw[8:16], uint64(adlc.Timeout))
+	ByteOrder.PutUint64(raw[8:16], uint64(adlc.Params.Timeout))
 	ByteOrder.PutUint64(raw[16:24], adlc.WaitListTimestampRaw)
 	ByteOrder.PutUint64(raw[24:32], adlc.StartTimestampRaw)
 	ByteOrder.PutUint64(raw[32:40], adlc.EndTimestampRaw)
-	ByteOrder.PutUint32(raw[40:44], adlc.Rate)
+	ByteOrder.PutUint32(raw[40:44], adlc.Params.Rate)
 	ByteOrder.PutUint32(raw[44:48], adlc.Paused)
 
 	return raw, nil

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -859,21 +859,27 @@ type CgroupTracingEvent struct {
 	ConfigCookie     uint32
 }
 
+// ActivityDumpLoadParams represents the parameters of an activity dump
+//msgp:ignore ActivityDumpLoadParams
+type ActivityDumpLoadParams struct {
+	TracedEventTypes []EventType
+	Timeout          time.Duration
+	Rate             uint32 // max number of events per sec
+}
+
 // ActivityDumpLoadConfig represents the load configuration of an activity dump
 //msgp:ignore ActivityDumpLoadConfig
 type ActivityDumpLoadConfig struct {
-	TracedEventTypes     []EventType
-	Timeout              time.Duration
+	Params               ActivityDumpLoadParams
 	WaitListTimestampRaw uint64
 	StartTimestampRaw    uint64
 	EndTimestampRaw      uint64
-	Rate                 uint32 // max number of events per sec
 	Paused               uint32
 }
 
 // SetTimeout updates the timeout of an activity dump
 func (adlc *ActivityDumpLoadConfig) SetTimeout(duration time.Duration) {
-	adlc.Timeout = duration
+	adlc.Params.Timeout = duration
 	adlc.EndTimestampRaw = adlc.StartTimestampRaw + uint64(duration)
 }
 

--- a/pkg/security/secl/model/unmarshallers.go
+++ b/pkg/security/secl/model/unmarshallers.go
@@ -859,14 +859,14 @@ func (adlc *ActivityDumpLoadConfig) EventUnmarshalBinary(data []byte) (int, erro
 	eventMask := ByteOrder.Uint64(data[0:8])
 	for i := uint64(0); i < 64; i++ {
 		if eventMask&(1<<i) == (1 << i) {
-			adlc.TracedEventTypes = append(adlc.TracedEventTypes, EventType(i)+FirstDiscarderEventType)
+			adlc.Params.TracedEventTypes = append(adlc.Params.TracedEventTypes, EventType(i)+FirstDiscarderEventType)
 		}
 	}
-	adlc.Timeout = time.Duration(ByteOrder.Uint64(data[8:16]))
+	adlc.Params.Timeout = time.Duration(ByteOrder.Uint64(data[8:16]))
 	adlc.WaitListTimestampRaw = ByteOrder.Uint64(data[16:24])
 	adlc.StartTimestampRaw = ByteOrder.Uint64(data[24:32])
 	adlc.EndTimestampRaw = ByteOrder.Uint64(data[32:40])
-	adlc.Rate = ByteOrder.Uint32(data[40:44])
+	adlc.Params.Rate = ByteOrder.Uint32(data[40:44])
 	adlc.Paused = ByteOrder.Uint32(data[44:48])
 	return 48, nil
 }


### PR DESCRIPTION
### What does this PR do?

Add the possibility to set at runtime some activity dumps configuration fields:

- runtime_security_config.activity_dump.traced_event_types
- runtime_security_config.activity_dump.cgroup_dump_timeout
- runtime_security_config.activity_dump.max_dump_size
- runtime_security_config.activity_dump.rate_limiter

If one of these values changes, it will be taken into effect on the next load controller period (2min)

Other changes:
- All probes needed for all possible AD traced events are now loaded at startup



### Motivation

Being able to tweak at runtime some AD configs

### Additional Notes



### Possible Drawbacks / Trade-offs



### Describe how to test/QA your changes

First, you can list the new available runtime fields:
```
$ sudo ./bin/system-probe/system-probe config list-runtime
=== Settings that can be changed at runtime ===
runtime_security_config.activity_dump.traced_event_types Set/get the corresponding field.
log_level                      Set/get the log level, valid values are: trace, debug, info, warn, error, critical and off
runtime_security_config.activity_dump.cgroup_dump_timeout Set/get the corresponding field.
runtime_security_config.activity_dump.max_dump_size Set/get the corresponding field.
runtime_security_config.activity_dump.rate_limiter Set/get the corresponding field.
```

Then, try to update some fields:
```
$ sudo ./bin/system-probe/system-probe config set runtime_security_config.activity_dump.cgroup_dump_timeout 42
Configuration setting runtime_security_config.activity_dump.cgroup_dump_timeout is now set to: 42
$ sudo ./bin/system-probe/system-probe config set runtime_security_config.activity_dump.rate_limiter 666
Configuration setting runtime_security_config.activity_dump.rate_limiter is now set to: 666
$ sudo ./bin/system-probe/system-probe config set runtime_security_config.activity_dump.traced_event_types exec,open,bind,syscalls
Configuration setting runtime_security_config.activity_dump.traced_event_types is now set to: exec,open,bind,syscalls
```

And you should see after some time on system-probe side something like:

```
2022-09-29 15:03:38 UTC | SYS-PROBE [...] |  runtimeConfigChanged detected a runtime configuration change.
2022-09-29 15:03:38 UTC | SYS-PROBE [...] |  	Previous params:
2022-09-29 15:03:38 UTC | SYS-PROBE [...] |  	  Rate: 500
2022-09-29 15:03:38 UTC | SYS-PROBE [...] |  	  CgroupDumpTimeout: 1800000000000
2022-09-29 15:03:38 UTC | SYS-PROBE [...] |  	  TracedEventTypes: [exec open dns]
2022-09-29 15:03:38 UTC | SYS-PROBE [...] |  	Current base params:
2022-09-29 15:03:38 UTC | SYS-PROBE [...] |  	  Rate: 666
2022-09-29 15:03:38 UTC | SYS-PROBE [...] |  	  CgroupDumpTimeout: 2520000000000
2022-09-29 15:03:38 UTC | SYS-PROBE [...] |  	  TracedEventTypes: [exec open bind syscalls]
2022-09-29 15:03:38 UTC | SYS-PROBE [...] | tracing paused for [container_id:7908d56d56c2487e9f4b7789ba83f2afcd0a5f6efd70a32e6a58a88eaa671091,host:dev,source:runtime-security-agent]
2022-09-29 15:03:38 UTC | SYS-PROBE [...] | [json] file for [container_id:7908d56d56c2487e9f4b7789ba83f2afcd0a5f6efd70a32e6a58a88eaa671091,host:dev,source:runtime-security-agent] written at: [/tmp/activity_dumps/activity-dump-bMENGfspYr.json]
2022-09-29 15:03:38 UTC | SYS-PROBE [...] | tracing started for [container_id:7908d56d56c2487e9f4b7789ba83f2afcd0a5f6efd70a32e6a58a88eaa671091,host:dev,source:runtime-security-agent]
```


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
