### PR TITLE
update Go1.18 changelog to reference memory-usage changes

### DIFF
--- a/releasenotes/notes/go1185-fd9d8b88c7c7a12e.yaml
+++ b/releasenotes/notes/go1185-fd9d8b88c7c7a12e.yaml
@@ -8,4 +8,10 @@
 ---
 enhancements:
   - |
-    Agents are now built with Go 1.18.5.
+    Agents are now built with Go 1.18.5.  This version of Go brings `changes to
+    the garbage collection runtime <https://go.dev/doc/go1.18#runtime>`_ that
+    may change the Agent's memory usage.  In internal testing, the RSS of agent
+    processes showed a minor increase of a few MiB, while CPU usage remained
+    consistent.  Reducing the value of ``GOGC`` as described in the Go
+    documentation was effective in reducing the memory usage at a modest cost
+    in CPU usage.

--- a/releasenotes/notes/go1185-fd9d8b88c7c7a12e.yaml
+++ b/releasenotes/notes/go1185-fd9d8b88c7c7a12e.yaml
@@ -10,7 +10,7 @@ enhancements:
   - |
     Agents are now built with Go 1.18.5.  This version of Go brings `changes to
     the garbage collection runtime <https://go.dev/doc/go1.18#runtime>`_ that
-    may change the Agent's memory usage.  In internal testing, the RSS of agent
+    may change the Agent's memory usage.  In internal testing, the RSS of Agent
     processes showed a minor increase of a few MiB, while CPU usage remained
     consistent.  Reducing the value of ``GOGC`` as described in the Go
     documentation was effective in reducing the memory usage at a modest cost


### PR DESCRIPTION
### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
