### PR TITLE
Support new wildcard file matching behavior

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -896,17 +896,7 @@ func InitConfig(config Config) {
 	// Controls how wildcard file log source are prioritized when there are more files
 	// that match wildcard log configurations than the `logs_config.open_files_limit`
 	//
-	// Choices are 'by_name' and 'by_modification_time'.
-	//
-	// 'by_name' means that each log source is considered and the matching files are ordered
-	// in reverse name order. While there are less than `logs_config.open_files_limit` files
-	// being tailed, this process repeats, iterating through each log source.
-	//
-	// 'by_modification_time' takes all log sources and first adds any log sources that
-	// point to a specific file. Next, it resolves all wildcard sources into the list of
-	// files that matches. This resulting list is ordered by which files have been most
-	// recently modified and the top `logs_config.open_files_limit` most recently modified
-	// files are chosen for tailing.
+	// Choices are 'by_name' and 'by_modification_time'. See config_template.yaml for full details.
 	//
 	// WARNING: 'by_modification_time' is less performant than 'by_name' and will trigger
 	// more disk I/O at the wildcard log paths

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -895,10 +895,22 @@ func InitConfig(config Config) {
 
 	// Controls how wildcard file log source are prioritized when there are more files
 	// that match wildcard log configurations than the `logs_config.open_files_limit`
-	// Choices are 'prioritizeNewest', 'simpleAlpha'
-	// WARNING: 'prioritizeNewest' is less performant than 'simpleAlpha' and will trigger
+	//
+	// Choices are 'by_name' and 'by_modification_time'.
+	//
+	// 'by_name' means that each log source is considered and the matching files are ordered
+	// in reverse name order. While there are less than `logs_config.open_files_limit` files
+	// being tailed, this process repeats, iterating through each log source.
+	//
+	// 'by_modification_time' takes all log sources and first adds any log sources that
+	// point to a specific file. Next, it resolves all wildcard sources into the list of
+	// files that matches. This resulting list is ordered by which files have been most
+	// recently modified and the top `logs_config.open_files_limit` most recently modified
+	// files are chosen for tailing.
+	//
+	// WARNING: 'by_modification_time' is less performant than 'by_name' and will trigger
 	// more disk I/O at the wildcard log paths
-	config.BindEnvAndSetDefault("logs_config.file_wildcard_selection_mode", "simpleAlpha")
+	config.BindEnvAndSetDefault("logs_config.file_wildcard_selection_mode", "by_name")
 
 	// temporary feature flag until this becomes the only option
 	config.BindEnvAndSetDefault("logs_config.cca_in_ad", false)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -893,6 +893,13 @@ func InitConfig(config Config) {
 	// Time in seconds
 	config.BindEnvAndSetDefault("logs_config.file_scan_period", 10.0)
 
+	// Controls how wildcard file log source are prioritized when there are more files
+	// that match wildcard log configurations than the `logs_config.open_files_limit`
+	// Choices are 'prioritizeNewest', 'simpleAlpha'
+	// WARNING: 'prioritizeNewest' is less performant than 'simpleAlpha' and will trigger
+	// more disk I/O at the wildcard log paths
+	config.BindEnvAndSetDefault("logs_config.file_wildcard_selection_mode", "simpleAlpha")
+
 	// temporary feature flag until this becomes the only option
 	config.BindEnvAndSetDefault("logs_config.cca_in_ad", false)
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -883,7 +883,7 @@ api_key:
   ## This controls the interval in seconds for which windows performance counters are refreshed by the agent.
   ## Refreshes are necessary for the discovery of new counters/countersets and instances for integrations that
   ## rely on performance counters. Checks include active_directory, aspdotnet, dotnetclr, exchange_server, hyperv,
-  ## iis and windows_performance_counters. 
+  ## iis and windows_performance_counters.
   ## Refresh can be disabled by setting the interval to 0.
   #
   # windows_counter_refresh_interval: 60
@@ -1012,6 +1012,27 @@ api_key:
   #
   # open_files_limit: 500
 
+  ## @param file_wildcard_selection_mode - string - optional - default: 'by_name'
+  ## @env DD_LOGS_CONFIG_FILE_WILDCARD_SELECTION_MODE - string - optional - default: 'by_name'
+  ## The strategy used to prioritize wildcard matches if they exceed the open file limit.
+  #
+  # Choices are 'by_name' and 'by_modification_time'.
+  #
+  # 'by_name' means that each log source is considered and the matching files are ordered
+  # in reverse name order. While there are less than `logs_config.open_files_limit` files
+  # being tailed, this process repeats, collecting from each configured source.
+  #
+  # 'by_modification_time' takes all log sources and first adds any log sources that
+  # point to a specific file. Next, it finds matches for all wildcard sources.
+  # This resulting list is ordered by which files have been most recently modified
+  # and the top `logs_config.open_files_limit` most recently modified files are
+  # chosen for tailing.
+  #
+  # WARNING: 'by_modification_time' is less performant than 'by_name' and will trigger
+  # more disk I/O at the configured wildcard log paths
+  #
+  # file_wildcard_selection_mode: 'by_name'
+
 {{ end -}}
 {{- if .TraceAgent }}
 
@@ -1073,7 +1094,7 @@ api_key:
   ## @env DD_APM_MAX_TPS - integer - optional - default: 10
   ## The target traces per second to sample. Sampling rates to apply are adjusted given
   ## the received traffic and communicated to tracers. This configures head base sampling.
-  ## As of 7.35.0 sampling cannot be disabled and setting 'max_traces_per_second' to 0 no longer 
+  ## As of 7.35.0 sampling cannot be disabled and setting 'max_traces_per_second' to 0 no longer
   ## disables sampling, but instead sends no traces to the intake. To avoid rate limiting, set this
   ## value sufficiently high for your traffic pattern.
   #

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1012,26 +1012,26 @@ api_key:
   #
   # open_files_limit: 500
 
-  ## @param file_wildcard_selection_mode - string - optional - default: 'by_name'
-  ## @env DD_LOGS_CONFIG_FILE_WILDCARD_SELECTION_MODE - string - optional - default: 'by_name'
+  ## @param file_wildcard_selection_mode - string - optional - default: `by_name`
+  ## @env DD_LOGS_CONFIG_FILE_WILDCARD_SELECTION_MODE - string - optional - default: `by_name`
   ## The strategy used to prioritize wildcard matches if they exceed the open file limit.
   #
-  # Choices are 'by_name' and 'by_modification_time'.
+  # Choices are `by_name` and `by_modification_time`.
   #
-  # 'by_name' means that each log source is considered and the matching files are ordered
+  # `by_name` means that each log source is considered and the matching files are ordered
   # in reverse name order. While there are less than `logs_config.open_files_limit` files
   # being tailed, this process repeats, collecting from each configured source.
   #
-  # 'by_modification_time' takes all log sources and first adds any log sources that
+  # `by_modification_time` takes all log sources and first adds any log sources that
   # point to a specific file. Next, it finds matches for all wildcard sources.
   # This resulting list is ordered by which files have been most recently modified
   # and the top `logs_config.open_files_limit` most recently modified files are
   # chosen for tailing.
   #
-  # WARNING: 'by_modification_time' is less performant than 'by_name' and will trigger
+  # WARNING: `by_modification_time` is less performant than `by_name` and will trigger
   # more disk I/O at the configured wildcard log paths
   #
-  # file_wildcard_selection_mode: 'by_name'
+  # file_wildcard_selection_mode: `by_name`
 
 {{ end -}}
 {{- if .TraceAgent }}

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1015,21 +1015,21 @@ api_key:
   ## @param file_wildcard_selection_mode - string - optional - default: `by_name`
   ## @env DD_LOGS_CONFIG_FILE_WILDCARD_SELECTION_MODE - string - optional - default: `by_name`
   ## The strategy used to prioritize wildcard matches if they exceed the open file limit.
-  #
-  # Choices are `by_name` and `by_modification_time`.
-  #
-  # `by_name` means that each log source is considered and the matching files are ordered
-  # in reverse name order. While there are less than `logs_config.open_files_limit` files
-  # being tailed, this process repeats, collecting from each configured source.
-  #
-  # `by_modification_time` takes all log sources and first adds any log sources that
-  # point to a specific file. Next, it finds matches for all wildcard sources.
-  # This resulting list is ordered by which files have been most recently modified
-  # and the top `logs_config.open_files_limit` most recently modified files are
-  # chosen for tailing.
-  #
-  # WARNING: `by_modification_time` is less performant than `by_name` and will trigger
-  # more disk I/O at the configured wildcard log paths
+  ##
+  ## Choices are `by_name` and `by_modification_time`.
+  ##
+  ## `by_name` means that each log source is considered and the matching files are ordered
+  ## in reverse name order. While there are less than `logs_config.open_files_limit` files
+  ## being tailed, this process repeats, collecting from each configured source.
+  ##
+  ## `by_modification_time` takes all log sources and first adds any log sources that
+  ## point to a specific file. Next, it finds matches for all wildcard sources.
+  ## This resulting list is ordered by which files have been most recently modified
+  ## and the top `logs_config.open_files_limit` most recently modified files are
+  ## chosen for tailing.
+  ##
+  ## WARNING: `by_modification_time` is less performant than `by_name` and will trigger
+  ## more disk I/O at the configured wildcard log paths.
   #
   # file_wildcard_selection_mode: `by_name`
 

--- a/pkg/logs/agent.go
+++ b/pkg/logs/agent.go
@@ -75,7 +75,8 @@ func NewAgent(sources *sources.LogSources, services *service.Services, processin
 		coreConfig.Datadog.GetInt("logs_config.open_files_limit"),
 		filelauncher.DefaultSleepDuration,
 		coreConfig.Datadog.GetBool("logs_config.validate_pod_container_id"),
-		time.Duration(coreConfig.Datadog.GetFloat64("logs_config.file_scan_period")*float64(time.Second))))
+		time.Duration(coreConfig.Datadog.GetFloat64("logs_config.file_scan_period")*float64(time.Second)),
+		coreConfig.Datadog.GetString("logs_config.file_wildcard_selection_mode")))
 	lnchrs.AddLauncher(listener.NewLauncher(coreConfig.Datadog.GetInt("logs_config.frame_size")))
 	lnchrs.AddLauncher(journald.NewLauncher())
 	lnchrs.AddLauncher(windowsevent.NewLauncher())

--- a/pkg/logs/internal/launchers/file/launcher.go
+++ b/pkg/logs/internal/launchers/file/launcher.go
@@ -68,7 +68,7 @@ func NewLauncher(tailingLimit int, tailerSleepDuration time.Duration, validatePo
 	} else if wildcardMode == "simpleAlpha" {
 		prov = fileprovider.NewFileProvider(tailingLimit, fileprovider.WildcardReverseLexicographical, fileprovider.GreedySelection)
 	} else {
-		log.Warnf("Unknown wildcard mode specified: %q, defaulting to 'simpleAlpha' strategy.\n", wildcardMode)
+		log.Warnf("Unknown wildcard mode specified: %q, defaulting to 'simpleAlpha' strategy.", wildcardMode)
 		prov = fileprovider.NewFileProvider(tailingLimit, fileprovider.WildcardReverseLexicographical, fileprovider.GreedySelection)
 	}
 

--- a/pkg/logs/internal/launchers/file/launcher.go
+++ b/pkg/logs/internal/launchers/file/launcher.go
@@ -137,9 +137,8 @@ func (s *Launcher) cleanup() {
 func (s *Launcher) scan() {
 	files := s.fileProvider.FilesToTail(s.activeSources)
 	filesTailed := make(map[string]bool)
-	tailersLen := len(s.tailers)
 
-	log.Debugf("Scan - got %d files from FilesToTail and currently tailing %d files\n", len(files), tailersLen)
+	log.Debugf("Scan - got %d files from FilesToTail and currently tailing %d files\n", len(files), len(s.tailers))
 
 	// Pass 1 - Compare 'files' to our current set of tailed files. If any no longer need to be tailed,
 	// stop the tailers.
@@ -192,8 +191,7 @@ func (s *Launcher) scan() {
 		}
 	}
 
-	// Recompute 'tailersLen' to take into account the tailers we stopped.
-	tailersLen = len(s.tailers)
+	tailersLen := len(s.tailers)
 	log.Debugf("After stopping tailers, there are %d tailers running.\n", tailersLen)
 
 	for _, file := range files {

--- a/pkg/logs/internal/launchers/file/launcher.go
+++ b/pkg/logs/internal/launchers/file/launcher.go
@@ -65,12 +65,12 @@ func NewLauncher(tailingLimit int, tailerSleepDuration time.Duration, validatePo
 
 	var wildcardStrategy fileprovider.WildcardSelectionStrategy
 	switch wildcardMode {
-	case "prioritizeNewest":
+	case "by_modification_time":
 		wildcardStrategy = fileprovider.WildcardUseFileModTime
-	case "simpleAlpha":
+	case "by_name":
 		wildcardStrategy = fileprovider.WildcardUseFileName
 	default:
-		log.Warnf("Unknown wildcard mode specified: %q, defaulting to 'simpleAlpha' strategy.", wildcardMode)
+		log.Warnf("Unknown wildcard mode specified: %q, defaulting to 'by_name' strategy.", wildcardMode)
 		wildcardStrategy = fileprovider.WildcardUseFileName
 	}
 

--- a/pkg/logs/internal/launchers/file/launcher_test.go
+++ b/pkg/logs/internal/launchers/file/launcher_test.go
@@ -501,7 +501,7 @@ func TestLauncherScanRecentFilesWithRemoval(t *testing.T) {
 		sleepDuration := 20 * time.Millisecond
 		launcher := &Launcher{
 			tailingLimit:           openFilesLimit,
-			fileProvider:           fileprovider.NewFileProvider(openFilesLimit, fileprovider.WildcardMtime, fileprovider.GlobalSelection),
+			fileProvider:           fileprovider.NewFileProvider(openFilesLimit, fileprovider.WildcardUseFileModTime),
 			tailers:                make(map[string]*tailer.Tailer),
 			tailerSleepDuration:    sleepDuration,
 			stop:                   make(chan struct{}),

--- a/pkg/logs/internal/launchers/file/launcher_test.go
+++ b/pkg/logs/internal/launchers/file/launcher_test.go
@@ -20,7 +20,9 @@ import (
 	auditor "github.com/DataDog/datadog-agent/pkg/logs/auditor/mock"
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/launchers"
+	fileprovider "github.com/DataDog/datadog-agent/pkg/logs/internal/launchers/file/provider"
 	filetailer "github.com/DataDog/datadog-agent/pkg/logs/internal/tailers/file"
+	tailer "github.com/DataDog/datadog-agent/pkg/logs/internal/tailers/file"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/util"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
@@ -389,9 +391,6 @@ func TestLauncherScanWithTooManyFiles(t *testing.T) {
 	assert.Nil(t, err)
 
 	launcher.scan()
-	assert.Equal(t, 1, len(launcher.tailers))
-
-	launcher.scan()
 	assert.Equal(t, 2, len(launcher.tailers))
 }
 
@@ -474,6 +473,184 @@ func TestLauncherUpdatesSourceForExistingTailer(t *testing.T) {
 
 	// Source is replaced with the new source on the same tailer
 	assert.Equal(t, tailer.Source(), source2)
+}
+
+func TestLauncherScanRecentFiles(t *testing.T) {
+	var err error
+
+	testDir := t.TempDir()
+	baseTime := time.Date(2010, time.August, 10, 25, 0, 0, 0, time.UTC)
+	openFilesLimit := 2
+
+	path := func(name string) string {
+		return fmt.Sprintf("%s/%s", testDir, name)
+	}
+
+	createFile := func(name string, time time.Time) {
+		_, err = os.Create(path(name))
+		assert.Nil(t, err)
+		err = os.Chtimes(path(name), time, time)
+		assert.Nil(t, err)
+	}
+	rmFile := func(name string) {
+		err = os.Remove(path(name))
+		assert.Nil(t, err)
+	}
+
+	createLauncher := func() *Launcher {
+		sleepDuration := 20 * time.Millisecond
+		launcher := &Launcher{
+			tailingLimit:           openFilesLimit,
+			fileProvider:           fileprovider.NewFileProvider(openFilesLimit, fileprovider.WildcardMtime, fileprovider.GlobalSelection),
+			tailers:                make(map[string]*tailer.Tailer),
+			tailerSleepDuration:    sleepDuration,
+			stop:                   make(chan struct{}),
+			validatePodContainerID: false,
+			scanPeriod:             10 * time.Second,
+		}
+		launcher.pipelineProvider = mock.NewMockProvider()
+		launcher.registry = auditor.NewRegistry()
+		logDirectory := fmt.Sprintf("%s/*.log", testDir)
+		source := sources.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: logDirectory})
+		launcher.activeSources = append(launcher.activeSources, source)
+		status.Clear()
+		status.InitStatus(util.CreateSources([]*sources.LogSource{source}))
+
+		return launcher
+	}
+
+	// Given 4 files with descending mtimes
+	createFile("1.log", baseTime.Add(time.Second*4))
+	createFile("2.log", baseTime.Add(time.Second*3))
+	createFile("3.log", baseTime.Add(time.Second*2))
+	createFile("4.log", baseTime.Add(time.Second*1))
+	launcher := createLauncher()
+	defer status.Clear()
+
+	launcher.scan()
+	assert.Equal(t, 2, len(launcher.tailers))
+	assert.Contains(t, launcher.tailers, path("1.log"))
+	assert.Contains(t, launcher.tailers, path("2.log"))
+
+	// When ... the newest file gets rm'd, the next newest should be chosen
+	rmFile("2.log")
+	launcher.scan()
+
+	assert.Equal(t, 2, len(launcher.tailers))
+	assert.Contains(t, launcher.tailers, path("1.log"))
+	assert.Contains(t, launcher.tailers, path("3.log"))
+
+	// When ... a newer file appears and an existing file is rm'd
+	createFile("2.log", baseTime.Add(time.Second*8))
+	rmFile("1.log")
+	launcher.scan()
+	assert.Equal(t, 2, len(launcher.tailers))
+	assert.Contains(t, launcher.tailers, path("2.log"))
+	assert.Contains(t, launcher.tailers, path("3.log"))
+}
+
+func TestLauncherFileRotation(t *testing.T) {
+	var err error
+
+	testDir := t.TempDir()
+	openFilesLimit := 2
+
+	path := func(name string) string {
+		return fmt.Sprintf("%s/%s", testDir, name)
+	}
+	createFile := func(name string) {
+		_, err = os.Create(path(name))
+		assert.Nil(t, err)
+	}
+
+	createLauncher := func() *Launcher {
+		sleepDuration := 20 * time.Millisecond
+		launcher := NewLauncher(openFilesLimit, sleepDuration, false, 10*time.Second)
+		launcher.pipelineProvider = mock.NewMockProvider()
+		launcher.registry = auditor.NewRegistry()
+		logDirectory := fmt.Sprintf("%s/*.log", testDir)
+		source := sources.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: logDirectory})
+		launcher.activeSources = append(launcher.activeSources, source)
+		status.Clear()
+		status.InitStatus(util.CreateSources([]*sources.LogSource{source}))
+
+		return launcher
+	}
+
+	createFile("a.log")
+	createFile("b.log")
+	createFile("c.log")
+	createFile("d.log")
+	launcher := createLauncher()
+	defer status.Clear()
+
+	launcher.scan()
+	assert.Equal(t, 2, len(launcher.tailers))
+	assert.Contains(t, launcher.tailers, path("c.log"))
+	assert.Contains(t, launcher.tailers, path("d.log"))
+
+	cTailer, isPresent := launcher.tailers[path("c.log")]
+	assert.True(t, isPresent)
+
+	// Do Rotation
+	err = os.Rename(path("c.log"), path("c.log.1"))
+	assert.Nil(t, err)
+	createFile("c.log")
+
+	didRotate, err := cTailer.DidRotate()
+	assert.Nil(t, err)
+	assert.True(t, didRotate)
+
+	launcher.scan()
+	assert.Len(t, launcher.tailers, 2)
+	assert.Contains(t, launcher.tailers, path("c.log"))
+	assert.Contains(t, launcher.tailers, path("d.log"))
+}
+
+func TestLauncherFileDetectionSingleScan(t *testing.T) {
+	var err error
+
+	testDir := t.TempDir()
+	openFilesLimit := 2
+
+	path := func(name string) string {
+		return fmt.Sprintf("%s/%s", testDir, name)
+	}
+	createFile := func(name string) {
+		_, err = os.Create(path(name))
+		assert.Nil(t, err)
+	}
+
+	createLauncher := func() *Launcher {
+		sleepDuration := 20 * time.Millisecond
+		launcher := NewLauncher(openFilesLimit, sleepDuration, false, 10*time.Second)
+		launcher.pipelineProvider = mock.NewMockProvider()
+		launcher.registry = auditor.NewRegistry()
+		logDirectory := fmt.Sprintf("%s/*.log", testDir)
+		source := sources.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: logDirectory})
+		launcher.activeSources = append(launcher.activeSources, source)
+		status.Clear()
+		status.InitStatus(util.CreateSources([]*sources.LogSource{source}))
+
+		return launcher
+	}
+
+	createFile("a.log")
+	createFile("b.log")
+	launcher := createLauncher()
+	defer status.Clear()
+
+	launcher.scan()
+	assert.Equal(t, 2, len(launcher.tailers))
+	assert.Contains(t, launcher.tailers, path("a.log"))
+	assert.Contains(t, launcher.tailers, path("b.log"))
+
+	createFile("z.log")
+
+	launcher.scan()
+	assert.Len(t, launcher.tailers, 2)
+	assert.Contains(t, launcher.tailers, path("z.log"))
+	assert.Contains(t, launcher.tailers, path("b.log"))
 }
 
 func getScanKey(path string, source *sources.LogSource) string {

--- a/pkg/logs/internal/launchers/file/launcher_test.go
+++ b/pkg/logs/internal/launchers/file/launcher_test.go
@@ -67,7 +67,7 @@ func (suite *LauncherTestSuite) SetupTest() {
 	suite.openFilesLimit = 100
 	suite.source = sources.NewLogSource("", &config.LogsConfig{Type: config.FileType, Identifier: suite.configID, Path: suite.testPath})
 	sleepDuration := 20 * time.Millisecond
-	suite.s = NewLauncher(suite.openFilesLimit, sleepDuration, false, 10*time.Second, "simpleAlpha")
+	suite.s = NewLauncher(suite.openFilesLimit, sleepDuration, false, 10*time.Second, "by_name")
 	suite.s.pipelineProvider = suite.pipelineProvider
 	suite.s.registry = auditor.NewRegistry()
 	suite.s.activeSources = append(suite.s.activeSources, suite.source)
@@ -222,7 +222,7 @@ func TestLauncherScanStartNewTailer(t *testing.T) {
 		path = fmt.Sprintf("%s/*.log", testDir)
 		openFilesLimit := 2
 		sleepDuration := 20 * time.Millisecond
-		launcher := NewLauncher(openFilesLimit, sleepDuration, false, 10*time.Second, "simpleAlpha")
+		launcher := NewLauncher(openFilesLimit, sleepDuration, false, 10*time.Second, "by_name")
 		launcher.pipelineProvider = mock.NewMockProvider()
 		launcher.registry = auditor.NewRegistry()
 		outputChan := launcher.pipelineProvider.NextPipelineChan()
@@ -260,7 +260,7 @@ func TestLauncherWithConcurrentContainerTailer(t *testing.T) {
 	// create launcher
 	openFilesLimit := 3
 	sleepDuration := 20 * time.Millisecond
-	launcher := NewLauncher(openFilesLimit, sleepDuration, false, 10*time.Second, "simpleAlpha")
+	launcher := NewLauncher(openFilesLimit, sleepDuration, false, 10*time.Second, "by_name")
 	launcher.pipelineProvider = mock.NewMockProvider()
 	launcher.registry = auditor.NewRegistry()
 	outputChan := launcher.pipelineProvider.NextPipelineChan()
@@ -307,7 +307,7 @@ func TestLauncherTailFromTheBeginning(t *testing.T) {
 	// create launcher
 	openFilesLimit := 3
 	sleepDuration := 20 * time.Millisecond
-	launcher := NewLauncher(openFilesLimit, sleepDuration, false, 10*time.Second, "simpleAlpha")
+	launcher := NewLauncher(openFilesLimit, sleepDuration, false, 10*time.Second, "by_name")
 	launcher.pipelineProvider = mock.NewMockProvider()
 	launcher.registry = auditor.NewRegistry()
 	outputChan := launcher.pipelineProvider.NextPipelineChan()
@@ -373,7 +373,7 @@ func TestLauncherScanWithTooManyFiles(t *testing.T) {
 	path = fmt.Sprintf("%s/*.log", testDir)
 	openFilesLimit := 2
 	sleepDuration := 20 * time.Millisecond
-	launcher := NewLauncher(openFilesLimit, sleepDuration, false, 10*time.Second, "simpleAlpha")
+	launcher := NewLauncher(openFilesLimit, sleepDuration, false, 10*time.Second, "by_name")
 	launcher.pipelineProvider = mock.NewMockProvider()
 	launcher.registry = auditor.NewRegistry()
 	source := sources.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: path})
@@ -453,7 +453,7 @@ func TestLauncherUpdatesSourceForExistingTailer(t *testing.T) {
 	os.Create(path)
 	openFilesLimit := 2
 	sleepDuration := 20 * time.Millisecond
-	launcher := NewLauncher(openFilesLimit, sleepDuration, false, 10*time.Second, "simpleAlpha")
+	launcher := NewLauncher(openFilesLimit, sleepDuration, false, 10*time.Second, "by_name")
 	launcher.pipelineProvider = mock.NewMockProvider()
 	launcher.registry = auditor.NewRegistry()
 
@@ -562,7 +562,7 @@ func TestLauncherScanRecentFilesWithNewFiles(t *testing.T) {
 
 	createLauncher := func() *Launcher {
 		sleepDuration := 20 * time.Millisecond
-		launcher := NewLauncher(openFilesLimit, sleepDuration, false, 10*time.Second, "prioritizeNewest")
+		launcher := NewLauncher(openFilesLimit, sleepDuration, false, 10*time.Second, "by_modification_time")
 		launcher.pipelineProvider = mock.NewMockProvider()
 		launcher.registry = auditor.NewRegistry()
 		logDirectory := fmt.Sprintf("%s/*.log", testDir)
@@ -622,7 +622,7 @@ func TestLauncherFileRotation(t *testing.T) {
 
 	createLauncher := func() *Launcher {
 		sleepDuration := 20 * time.Millisecond
-		launcher := NewLauncher(openFilesLimit, sleepDuration, false, 10*time.Second, "simpleAlpha")
+		launcher := NewLauncher(openFilesLimit, sleepDuration, false, 10*time.Second, "by_name")
 		launcher.pipelineProvider = mock.NewMockProvider()
 		launcher.registry = auditor.NewRegistry()
 		logDirectory := fmt.Sprintf("%s/*.log", testDir)
@@ -680,7 +680,7 @@ func TestLauncherFileDetectionSingleScan(t *testing.T) {
 
 	createLauncher := func() *Launcher {
 		sleepDuration := 20 * time.Millisecond
-		launcher := NewLauncher(openFilesLimit, sleepDuration, false, 10*time.Second, "simpleAlpha")
+		launcher := NewLauncher(openFilesLimit, sleepDuration, false, 10*time.Second, "by_name")
 		launcher.pipelineProvider = mock.NewMockProvider()
 		launcher.registry = auditor.NewRegistry()
 		logDirectory := fmt.Sprintf("%s/*.log", testDir)

--- a/pkg/logs/internal/launchers/file/provider/file_provider.go
+++ b/pkg/logs/internal/launchers/file/provider/file_provider.go
@@ -126,7 +126,6 @@ func (p *FileProvider) FilesToTail(inputSources []*sources.LogSource) []*tailer.
 		}
 	}
 
-	// Process sources, saving wildcard sources for later if they're found
 	for i := 0; i < len(inputSources); i++ {
 		source := inputSources[i]
 		isWildcardSource := config.ContainsWildcard(source.Config.Path)

--- a/pkg/logs/internal/launchers/file/provider/file_provider.go
+++ b/pkg/logs/internal/launchers/file/provider/file_provider.go
@@ -55,7 +55,7 @@ const (
 	// slots as is possible from that source before proceeding to the next one
 	greedySelection selectionStrategy = iota
 	// globalSelection will consider files from all sources together and will choose the
-	// top `filesLimit` files based on the `sortMode` ordering
+	// top `filesLimit` files based on the `wildcardOrder` ordering
 	globalSelection
 )
 
@@ -221,7 +221,7 @@ func (p *FileProvider) FilesToTail(inputSources []*sources.LogSource) []*tailer.
 }
 
 // CollectFiles takes a 'LogSource' and produces a list of tailers matching this source
-// with ordering defined by 'sortMode'
+// with ordering defined by 'wildcardOrder'
 func (p *FileProvider) CollectFiles(source *sources.LogSource) ([]*tailer.File, error) {
 	path := source.Config.Path
 	_, err := os.Stat(path)
@@ -280,7 +280,7 @@ func (p *FileProvider) filesMatchingSource(source *sources.LogSource) ([]*tailer
 	return files, nil
 }
 
-// applyOrdering sorts the 'files' slice in-place by the currently configured 'sortMode'
+// applyOrdering sorts the 'files' slice in-place by the currently configured 'wildcardOrder'
 func (p *FileProvider) applyOrdering(files []*tailer.File) {
 	if p.wildcardOrder == wildcardModTime {
 		statResults := make(map[*tailer.File]time.Time, len(files))

--- a/pkg/logs/internal/launchers/file/provider/file_provider.go
+++ b/pkg/logs/internal/launchers/file/provider/file_provider.go
@@ -24,25 +24,25 @@ import (
 const openFilesLimitWarningType = "open_files_limit_warning"
 
 // wildcardOrdering controls what ordering is applied to wildcard files
-type wildcardOrdering string
+type wildcardOrdering int
 
 const (
 	// WildcardReverseLexicographical is the default option and does a pseudo reverse alpha sort
-	WildcardReverseLexicographical = "SortReverseLexicographical"
+	WildcardReverseLexicographical wildcardOrdering = iota
 	// WildcardMtime sorts based on the most recently modified time for each matching wildcard file
-	WildcardMtime = "SortMtime"
+	WildcardMtime
 )
 
 // selectionStrategy controls how the `filesLimit` slots we have are filled given a list of sources
-type selectionStrategy string
+type selectionStrategy int
 
 const (
 	// GreedySelection will consider each source one-by-one, filling as many
 	// slots as is possible from that source before proceeding to the next one
-	GreedySelection = "ChooseGreedily"
+	GreedySelection selectionStrategy = iota
 	// GlobalSelection will consider files from all sources together and will choose the
 	// top `filesLimit` files based on the `sortMode` ordering
-	GlobalSelection = "ChooseGlobally"
+	GlobalSelection
 )
 
 // FileProvider implements the logic to retrieve at most filesLimit Files defined in sources

--- a/pkg/logs/internal/launchers/file/provider/file_provider.go
+++ b/pkg/logs/internal/launchers/file/provider/file_provider.go
@@ -159,10 +159,6 @@ func (p *FileProvider) FilesToTail(inputSources []*sources.LogSource) []*tailer.
 			} else {
 				files, err := p.CollectFiles(source)
 				if err != nil {
-					if isWildcardSource {
-						wildcardFileCounter.setTotal(source, len(files))
-					}
-
 					source.Status.Error(err)
 					if shouldLogErrors {
 						log.Warnf("Could not collect files: %v", err)

--- a/pkg/logs/internal/launchers/file/provider/file_provider_test.go
+++ b/pkg/logs/internal/launchers/file/provider/file_provider_test.go
@@ -6,7 +6,7 @@
 //go:build !windows
 // +build !windows
 
-package file_provider
+package fileprovider
 
 import (
 	"fmt"
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
+	tailer "github.com/DataDog/datadog-agent/pkg/logs/internal/tailers/file"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/util"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/logs/status"
@@ -77,7 +78,7 @@ func (suite *ProviderTestSuite) TearDownTest() {
 
 func (suite *ProviderTestSuite) TestFilesToTailReturnsSpecificFile() {
 	path := fmt.Sprintf("%s/1/1.log", suite.testDir)
-	fileProvider := NewFileProvider(suite.filesLimit, SortReverseLexicographical, GreedySelection)
+	fileProvider := NewFileProvider(suite.filesLimit, WildcardReverseLexicographical, GreedySelection)
 	logSources := suite.newLogSources(path)
 	util.CreateSources(logSources)
 	files := fileProvider.FilesToTail(logSources)
@@ -90,7 +91,7 @@ func (suite *ProviderTestSuite) TestFilesToTailReturnsSpecificFile() {
 
 func (suite *ProviderTestSuite) TestFilesToTailReturnsAllFilesFromDirectory() {
 	path := fmt.Sprintf("%s/1/*.log", suite.testDir)
-	fileProvider := NewFileProvider(suite.filesLimit, SortReverseLexicographical, GreedySelection)
+	fileProvider := NewFileProvider(suite.filesLimit, WildcardReverseLexicographical, GreedySelection)
 	logSources := suite.newLogSources(path)
 	status.InitStatus(util.CreateSources(logSources))
 	files := fileProvider.FilesToTail(logSources)
@@ -115,7 +116,7 @@ func (suite *ProviderTestSuite) TestCollectFilesWildcardFlag() {
 	// with wildcard
 
 	path := fmt.Sprintf("%s/1/*.log", suite.testDir)
-	fileProvider := NewFileProvider(suite.filesLimit, SortReverseLexicographical, GreedySelection)
+	fileProvider := NewFileProvider(suite.filesLimit, WildcardReverseLexicographical, GreedySelection)
 	logSources := suite.newLogSources(path)
 	files, err := fileProvider.CollectFiles(logSources[0])
 	suite.NoError(err, "searching for files in this directory shouldn't fail")
@@ -126,7 +127,7 @@ func (suite *ProviderTestSuite) TestCollectFilesWildcardFlag() {
 	// without wildcard
 
 	path = fmt.Sprintf("%s/1/1.log", suite.testDir)
-	fileProvider = NewFileProvider(suite.filesLimit, SortReverseLexicographical, GreedySelection)
+	fileProvider = NewFileProvider(suite.filesLimit, WildcardReverseLexicographical, GreedySelection)
 	logSources = suite.newLogSources(path)
 	files, err = fileProvider.CollectFiles(logSources[0])
 	suite.NoError(err, "searching for files in this directory shouldn't fail")
@@ -137,7 +138,7 @@ func (suite *ProviderTestSuite) TestCollectFilesWildcardFlag() {
 
 func (suite *ProviderTestSuite) TestFilesToTailReturnsAllFilesFromAnyDirectoryWithRightPermissions() {
 	path := fmt.Sprintf("%s/*/*1.log", suite.testDir)
-	fileProvider := NewFileProvider(suite.filesLimit, SortReverseLexicographical, GreedySelection)
+	fileProvider := NewFileProvider(suite.filesLimit, WildcardReverseLexicographical, GreedySelection)
 	logSources := suite.newLogSources(path)
 	util.CreateSources(logSources)
 	files := fileProvider.FilesToTail(logSources)
@@ -152,7 +153,7 @@ func (suite *ProviderTestSuite) TestFilesToTailReturnsAllFilesFromAnyDirectoryWi
 
 func (suite *ProviderTestSuite) TestFilesToTailReturnsSpecificFileWithWildcard() {
 	path := fmt.Sprintf("%s/1/?.log", suite.testDir)
-	fileProvider := NewFileProvider(suite.filesLimit, SortReverseLexicographical, GreedySelection)
+	fileProvider := NewFileProvider(suite.filesLimit, WildcardReverseLexicographical, GreedySelection)
 	logSources := suite.newLogSources(path)
 	status.InitStatus(util.CreateSources(logSources))
 	files := fileProvider.FilesToTail(logSources)
@@ -176,7 +177,7 @@ func (suite *ProviderTestSuite) TestFilesToTailReturnsSpecificFileWithWildcard()
 func (suite *ProviderTestSuite) TestWildcardPathsAreSorted() {
 	filesLimit := 6
 	path := fmt.Sprintf("%s/*/*.log", suite.testDir)
-	fileProvider := NewFileProvider(filesLimit, SortReverseLexicographical, GreedySelection)
+	fileProvider := NewFileProvider(filesLimit, WildcardReverseLexicographical, GreedySelection)
 	logSources := suite.newLogSources(path)
 	files := fileProvider.FilesToTail(logSources)
 	suite.Equal(5, len(files))
@@ -192,7 +193,7 @@ func (suite *ProviderTestSuite) TestWildcardPathsAreSorted() {
 
 func (suite *ProviderTestSuite) TestNumberOfFilesToTailDoesNotExceedLimit() {
 	path := fmt.Sprintf("%s/*/*.log", suite.testDir)
-	fileProvider := NewFileProvider(suite.filesLimit, SortReverseLexicographical, GreedySelection)
+	fileProvider := NewFileProvider(suite.filesLimit, WildcardReverseLexicographical, GreedySelection)
 	logSources := suite.newLogSources(path)
 	status.InitStatus(util.CreateSources(logSources))
 	files := fileProvider.FilesToTail(logSources)
@@ -208,7 +209,7 @@ func (suite *ProviderTestSuite) TestNumberOfFilesToTailDoesNotExceedLimit() {
 
 func (suite *ProviderTestSuite) TestAllWildcardPathsAreUpdated() {
 	filesLimit := 2
-	fileProvider := NewFileProvider(filesLimit, SortReverseLexicographical, GreedySelection)
+	fileProvider := NewFileProvider(filesLimit, WildcardReverseLexicographical, GreedySelection)
 	logSources := []*sources.LogSource{
 		sources.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: fmt.Sprintf("%s/1/*.log", suite.testDir)}),
 		sources.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: fmt.Sprintf("%s/2/*.log", suite.testDir)}),
@@ -259,7 +260,7 @@ func (suite *ProviderTestSuite) TestExcludePath() {
 	filesLimit := 6
 	path := fmt.Sprintf("%s/*/*.log", suite.testDir)
 	excludePaths := []string{fmt.Sprintf("%s/2/*.log", suite.testDir)}
-	fileProvider := NewFileProvider(filesLimit, SortReverseLexicographical, GreedySelection)
+	fileProvider := NewFileProvider(filesLimit, WildcardReverseLexicographical, GreedySelection)
 	logSources := []*sources.LogSource{
 		sources.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: path, ExcludePaths: excludePaths}),
 	}
@@ -280,7 +281,7 @@ func TestProviderTestSuite(t *testing.T) {
 
 func TestCollectFiles(t *testing.T) {
 	t.Run("Invalid Pattern", func(t *testing.T) {
-		fileProvider := NewFileProvider(2, SortReverseLexicographical, GreedySelection)
+		fileProvider := NewFileProvider(2, WildcardReverseLexicographical, GreedySelection)
 		source := sources.NewLogSource("wildcard", &config.LogsConfig{Type: config.FileType, Path: "//\\///*"})
 		files, err := fileProvider.CollectFiles(source)
 		assert.Len(t, files, 0)
@@ -300,7 +301,7 @@ func TestCollectFiles(t *testing.T) {
 		createFile("c")
 		createFile("d")
 
-		fileProvider := NewFileProvider(2, SortReverseLexicographical, GreedySelection)
+		fileProvider := NewFileProvider(2, WildcardReverseLexicographical, GreedySelection)
 		source := sources.NewLogSource("wildcard", &config.LogsConfig{Type: config.FileType, Path: path("*")})
 		files, err := fileProvider.CollectFiles(source)
 		assert.Nil(t, err)
@@ -331,7 +332,7 @@ func TestCollectFiles(t *testing.T) {
 		createFile("t.log", baseTime.Add(time.Second*2))
 		createFile("z.log", baseTime.Add(time.Second*1))
 
-		fileProvider := NewFileProvider(2, SortMtime, GreedySelection)
+		fileProvider := NewFileProvider(2, WildcardMtime, GreedySelection)
 		source := sources.NewLogSource("wildcard", &config.LogsConfig{Type: config.FileType, Path: path("*")})
 		files, err := fileProvider.CollectFiles(source)
 		assert.Nil(t, err)
@@ -367,7 +368,7 @@ func TestFilesToTail(t *testing.T) {
 		createFile("b/b")
 		createFile("b/z")
 
-		fileProvider := NewFileProvider(2, SortReverseLexicographical, GreedySelection)
+		fileProvider := NewFileProvider(2, WildcardReverseLexicographical, GreedySelection)
 		sources := []*sources.LogSource{
 			sources.NewLogSource("wildcard", &config.LogsConfig{Type: config.FileType, Path: path("a/*")}),
 			sources.NewLogSource("wildcardTwo", &config.LogsConfig{Type: config.FileType, Path: path("b/*")}),
@@ -378,7 +379,6 @@ func TestFilesToTail(t *testing.T) {
 		assert.Equal(t, path("a/b"), files[1].Path)
 	})
 	t.Run("Reverse Lexicographical - Global", func(t *testing.T) {
-		t.Skip()
 		testDir := t.TempDir()
 		path := func(name string) string {
 			return fmt.Sprintf("%s/%s", testDir, name)
@@ -401,7 +401,7 @@ func TestFilesToTail(t *testing.T) {
 		createFile("b/b")
 		createFile("b/z")
 
-		fileProvider := NewFileProvider(2, SortReverseLexicographical, GlobalSelection)
+		fileProvider := NewFileProvider(2, WildcardReverseLexicographical, GlobalSelection)
 		sources := []*sources.LogSource{
 			sources.NewLogSource("wildcard", &config.LogsConfig{Type: config.FileType, Path: path("a/*")}),
 			sources.NewLogSource("wildcardTwo", &config.LogsConfig{Type: config.FileType, Path: path("b/*")}),
@@ -409,7 +409,8 @@ func TestFilesToTail(t *testing.T) {
 		files := fileProvider.FilesToTail(sources)
 		assert.Len(t, files, 2)
 		assert.Equal(t, path("b/z"), files[0].Path)
-		assert.Equal(t, path("b/b"), files[1].Path)
+		// 2nd expected element is a/z because the lexicographical 'sort' is not a true alpha ordering. It sorts by filename _only_
+		assert.Equal(t, path("a/z"), files[1].Path)
 	})
 	t.Run("Mtime - Greedy", func(t *testing.T) {
 		testDir := t.TempDir()
@@ -432,7 +433,7 @@ func TestFilesToTail(t *testing.T) {
 		createFile("z.log", baseTime.Add(time.Second*1))
 		// TODO test behavior when time is equal
 
-		fileProvider := NewFileProvider(2, SortMtime, GreedySelection)
+		fileProvider := NewFileProvider(2, WildcardMtime, GreedySelection)
 		sources := []*sources.LogSource{
 			sources.NewLogSource("wildcard", &config.LogsConfig{Type: config.FileType, Path: path("*")}),
 		}
@@ -442,7 +443,6 @@ func TestFilesToTail(t *testing.T) {
 		assert.Equal(t, path("q.log"), files[1].Path)
 	})
 	t.Run("Mtime - Global", func(t *testing.T) {
-		t.Skip()
 		testDir := t.TempDir()
 		baseTime := time.Date(2010, time.August, 10, 25, 0, 0, 0, time.UTC)
 
@@ -470,7 +470,7 @@ func TestFilesToTail(t *testing.T) {
 		createFile("b/b", baseTime.Add(time.Second*7))
 		createFile("b/c", baseTime.Add(time.Second*8))
 
-		fileProvider := NewFileProvider(2, SortMtime, GreedySelection)
+		fileProvider := NewFileProvider(2, WildcardMtime, GlobalSelection)
 		sources := []*sources.LogSource{
 			sources.NewLogSource("wildcard", &config.LogsConfig{Type: config.FileType, Path: path("a/*")}),
 			sources.NewLogSource("wildcardTwo", &config.LogsConfig{Type: config.FileType, Path: path("b/*")}),
@@ -502,12 +502,12 @@ func BenchmarkApplyOrdering(b *testing.B) {
 		createFile("c.log", baseTime.Add(time.Second*5))
 		createFile("d.log", baseTime.Add(time.Second*5))
 
-		fileProvider := NewFileProvider(2, SortMtime, GreedySelection)
-		files := []string{
-			path("a.log"),
-			path("b.log"),
-			path("c.log"),
-			path("d.log"),
+		fileProvider := NewFileProvider(2, WildcardMtime, GreedySelection)
+		files := []*tailer.File{
+			{Path: path("a.log")},
+			{Path: path("b.log")},
+			{Path: path("c.log")},
+			{Path: path("d.log")},
 		}
 		for n := 0; n < b.N; n++ {
 			fileProvider.applyOrdering(files)
@@ -533,12 +533,12 @@ func BenchmarkApplyOrdering(b *testing.B) {
 		createFile("c.log", baseTime.Add(time.Second*5))
 		createFile("d.log", baseTime.Add(time.Second*5))
 
-		fileProvider := NewFileProvider(2, SortReverseLexicographical, GreedySelection)
-		files := []string{
-			path("a.log"),
-			path("b.log"),
-			path("c.log"),
-			path("d.log"),
+		fileProvider := NewFileProvider(2, WildcardReverseLexicographical, GreedySelection)
+		files := []*tailer.File{
+			{Path: path("a.log")},
+			{Path: path("b.log")},
+			{Path: path("c.log")},
+			{Path: path("d.log")},
 		}
 		for n := 0; n < b.N; n++ {
 			fileProvider.applyOrdering(files)
@@ -568,83 +568,83 @@ func TestApplyOrdering(t *testing.T) {
 		createFile("q.log", baseTime.Add(time.Second*3))
 		createFile("z.log", baseTime.Add(time.Second*1))
 
-		fileProvider := NewFileProvider(2, SortMtime, GreedySelection)
-		files := []string{
-			path("t.log"),
-			path("a.log"),
-			path("z.log"),
-			path("q.log"),
+		fileProvider := NewFileProvider(2, WildcardMtime, GreedySelection)
+		files := []*tailer.File{
+			{Path: path("t.log")},
+			{Path: path("a.log")},
+			{Path: path("z.log")},
+			{Path: path("q.log")},
 		}
 		// When we apply ordering
 		fileProvider.applyOrdering(files)
 		// Then we should see all files in descending mtime order
 		assert.Len(t, files, 4)
-		assert.Equal(t, path("a.log"), files[0])
-		assert.Equal(t, path("q.log"), files[1])
-		assert.Equal(t, path("t.log"), files[2])
-		assert.Equal(t, path("z.log"), files[3])
+		assert.Equal(t, path("a.log"), files[0].Path)
+		assert.Equal(t, path("q.log"), files[1].Path)
+		assert.Equal(t, path("t.log"), files[2].Path)
+		assert.Equal(t, path("z.log"), files[3].Path)
 	})
 
 	t.Run("Reverse Lexicographical", func(t *testing.T) {
-		fileProvider := NewFileProvider(0, SortReverseLexicographical, GreedySelection)
+		fileProvider := NewFileProvider(0, WildcardReverseLexicographical, GreedySelection)
 		// For lexicographical ordering, we don't actually need the files
 		// to exist on the FS, so that part is skipped for these tests
 		t.Run("Flat Directory", func(t *testing.T) {
-			files := []string{
-				"a.log",
-				"t.log",
-				"q.log",
-				"z.log",
+			files := []*tailer.File{
+				{Path: "a.log"},
+				{Path: "t.log"},
+				{Path: "q.log"},
+				{Path: "z.log"},
 			}
 			fileProvider.applyOrdering(files)
 
 			assert.Len(t, files, 4)
-			assert.Equal(t, "z.log", files[0])
-			assert.Equal(t, "t.log", files[1])
-			assert.Equal(t, "q.log", files[2])
-			assert.Equal(t, "a.log", files[3])
+			assert.Equal(t, "z.log", files[0].Path)
+			assert.Equal(t, "t.log", files[1].Path)
+			assert.Equal(t, "q.log", files[2].Path)
+			assert.Equal(t, "a.log", files[3].Path)
 		})
 		t.Run("Multiple Directories dated log file", func(t *testing.T) {
-			paths := []string{
-				"/tmp/1/2018.log",
-				"/tmp/1/2017.log",
-				"/tmp/2/2018.log",
-				"/tmp/1/2016.log",
+			files := []*tailer.File{
+				{Path: "/tmp/1/2018.log"},
+				{Path: "/tmp/1/2017.log"},
+				{Path: "/tmp/2/2018.log"},
+				{Path: "/tmp/1/2016.log"},
 			}
-			fileProvider.applyOrdering(paths)
-			assert.Equal(t, "/tmp/2/2018.log", paths[0])
-			assert.Equal(t, "/tmp/1/2018.log", paths[1])
-			assert.Equal(t, "/tmp/1/2017.log", paths[2])
-			assert.Equal(t, "/tmp/1/2016.log", paths[3])
+			fileProvider.applyOrdering(files)
+			assert.Equal(t, "/tmp/2/2018.log", files[0].Path)
+			assert.Equal(t, "/tmp/1/2018.log", files[1].Path)
+			assert.Equal(t, "/tmp/1/2017.log", files[2].Path)
+			assert.Equal(t, "/tmp/1/2016.log", files[3].Path)
 		})
 
 		t.Run("Multiple Directories - dated directory", func(t *testing.T) {
-			paths := []string{
-				"/tmp/2020-02-20/error.log",
-				"/tmp/2020-02-21/error.log",
-				"/tmp/2020-02-22/error.log",
+			files := []*tailer.File{
+				{Path: "/tmp/2020-02-20/error.log"},
+				{Path: "/tmp/2020-02-21/error.log"},
+				{Path: "/tmp/2020-02-22/error.log"},
 			}
-			fileProvider.applyOrdering(paths)
-			assert.Equal(t, "/tmp/2020-02-22/error.log", paths[0])
-			assert.Equal(t, "/tmp/2020-02-21/error.log", paths[1])
-			assert.Equal(t, "/tmp/2020-02-20/error.log", paths[2])
+			fileProvider.applyOrdering(files)
+			assert.Equal(t, "/tmp/2020-02-22/error.log", files[0].Path)
+			assert.Equal(t, "/tmp/2020-02-21/error.log", files[1].Path)
+			assert.Equal(t, "/tmp/2020-02-20/error.log", files[2].Path)
 		})
 		t.Run("Multiple Directories - Out of order input", func(t *testing.T) {
 			t.Skip() // See FIXME in 'applyOrdering', this test currently fails
-			paths := []string{
-				"/tmp/1/2018.log",
-				"/tmp/2/2018.log",
-				"/tmp/3/2016.log",
-				"/tmp/3/2018.log",
-				"/tmp/1/2017.log",
+			files := []*tailer.File{
+				{Path: "/tmp/1/2018.log"},
+				{Path: "/tmp/2/2018.log"},
+				{Path: "/tmp/3/2016.log"},
+				{Path: "/tmp/3/2018.log"},
+				{Path: "/tmp/1/2017.log"},
 			}
-			fileProvider.applyOrdering(paths)
+			fileProvider.applyOrdering(files)
 
-			assert.Equal(t, "/tmp/3/2018.log", paths[0])
-			assert.Equal(t, "/tmp/3/2016.log", paths[1])
-			assert.Equal(t, "/tmp/2/2018.log", paths[2])
-			assert.Equal(t, "/tmp/1/2018.log", paths[3])
-			assert.Equal(t, "/tmp/1/2017.log", paths[4])
+			assert.Equal(t, "/tmp/3/2018.log", files[0].Path)
+			assert.Equal(t, "/tmp/3/2016.log", files[1].Path)
+			assert.Equal(t, "/tmp/2/2018.log", files[2].Path)
+			assert.Equal(t, "/tmp/1/2018.log", files[3].Path)
+			assert.Equal(t, "/tmp/1/2017.log", files[4].Path)
 		})
 	})
 }

--- a/pkg/logs/internal/launchers/file/provider/file_provider_test.go
+++ b/pkg/logs/internal/launchers/file/provider/file_provider_test.go
@@ -120,7 +120,7 @@ func (suite *ProviderTestSuite) TearDownTest() {
 
 func (suite *ProviderTestSuite) TestFilesToTailReturnsSpecificFile() {
 	path := fmt.Sprintf("%s/1/1.log", suite.testDir)
-	fileProvider := NewFileProvider(suite.filesLimit, WildcardReverseLexicographical, GreedySelection)
+	fileProvider := NewFileProvider(suite.filesLimit, WildcardUseFileName)
 	logSources := suite.newLogSources(path)
 	util.CreateSources(logSources)
 	files := fileProvider.FilesToTail(logSources)
@@ -133,7 +133,7 @@ func (suite *ProviderTestSuite) TestFilesToTailReturnsSpecificFile() {
 
 func (suite *ProviderTestSuite) TestFilesToTailReturnsAllFilesFromDirectory() {
 	path := fmt.Sprintf("%s/1/*.log", suite.testDir)
-	fileProvider := NewFileProvider(suite.filesLimit, WildcardReverseLexicographical, GreedySelection)
+	fileProvider := NewFileProvider(suite.filesLimit, WildcardUseFileName)
 	logSources := suite.newLogSources(path)
 	status.InitStatus(util.CreateSources(logSources))
 	files := fileProvider.FilesToTail(logSources)
@@ -158,7 +158,7 @@ func (suite *ProviderTestSuite) TestCollectFilesWildcardFlag() {
 	// with wildcard
 
 	path := fmt.Sprintf("%s/1/*.log", suite.testDir)
-	fileProvider := NewFileProvider(suite.filesLimit, WildcardReverseLexicographical, GreedySelection)
+	fileProvider := NewFileProvider(suite.filesLimit, WildcardUseFileName)
 	logSources := suite.newLogSources(path)
 	files, err := fileProvider.CollectFiles(logSources[0])
 	suite.NoError(err, "searching for files in this directory shouldn't fail")
@@ -169,7 +169,7 @@ func (suite *ProviderTestSuite) TestCollectFilesWildcardFlag() {
 	// without wildcard
 
 	path = fmt.Sprintf("%s/1/1.log", suite.testDir)
-	fileProvider = NewFileProvider(suite.filesLimit, WildcardReverseLexicographical, GreedySelection)
+	fileProvider = NewFileProvider(suite.filesLimit, WildcardUseFileName)
 	logSources = suite.newLogSources(path)
 	files, err = fileProvider.CollectFiles(logSources[0])
 	suite.NoError(err, "searching for files in this directory shouldn't fail")
@@ -180,7 +180,7 @@ func (suite *ProviderTestSuite) TestCollectFilesWildcardFlag() {
 
 func (suite *ProviderTestSuite) TestFilesToTailReturnsAllFilesFromAnyDirectoryWithRightPermissions() {
 	path := fmt.Sprintf("%s/*/*1.log", suite.testDir)
-	fileProvider := NewFileProvider(suite.filesLimit, WildcardReverseLexicographical, GreedySelection)
+	fileProvider := NewFileProvider(suite.filesLimit, WildcardUseFileName)
 	logSources := suite.newLogSources(path)
 	util.CreateSources(logSources)
 	files := fileProvider.FilesToTail(logSources)
@@ -195,7 +195,7 @@ func (suite *ProviderTestSuite) TestFilesToTailReturnsAllFilesFromAnyDirectoryWi
 
 func (suite *ProviderTestSuite) TestFilesToTailReturnsSpecificFileWithWildcard() {
 	path := fmt.Sprintf("%s/1/?.log", suite.testDir)
-	fileProvider := NewFileProvider(suite.filesLimit, WildcardReverseLexicographical, GreedySelection)
+	fileProvider := NewFileProvider(suite.filesLimit, WildcardUseFileName)
 	logSources := suite.newLogSources(path)
 	status.InitStatus(util.CreateSources(logSources))
 	files := fileProvider.FilesToTail(logSources)
@@ -219,7 +219,7 @@ func (suite *ProviderTestSuite) TestFilesToTailReturnsSpecificFileWithWildcard()
 func (suite *ProviderTestSuite) TestWildcardPathsAreSorted() {
 	filesLimit := 6
 	path := fmt.Sprintf("%s/*/*.log", suite.testDir)
-	fileProvider := NewFileProvider(filesLimit, WildcardReverseLexicographical, GreedySelection)
+	fileProvider := NewFileProvider(filesLimit, WildcardUseFileName)
 	logSources := suite.newLogSources(path)
 	files := fileProvider.FilesToTail(logSources)
 	suite.Equal(5, len(files))
@@ -235,7 +235,7 @@ func (suite *ProviderTestSuite) TestWildcardPathsAreSorted() {
 
 func (suite *ProviderTestSuite) TestNumberOfFilesToTailDoesNotExceedLimit() {
 	path := fmt.Sprintf("%s/*/*.log", suite.testDir)
-	fileProvider := NewFileProvider(suite.filesLimit, WildcardReverseLexicographical, GreedySelection)
+	fileProvider := NewFileProvider(suite.filesLimit, WildcardUseFileName)
 	logSources := suite.newLogSources(path)
 	status.InitStatus(util.CreateSources(logSources))
 	files := fileProvider.FilesToTail(logSources)
@@ -251,7 +251,7 @@ func (suite *ProviderTestSuite) TestNumberOfFilesToTailDoesNotExceedLimit() {
 
 func (suite *ProviderTestSuite) TestAllWildcardPathsAreUpdated() {
 	filesLimit := 2
-	fileProvider := NewFileProvider(filesLimit, WildcardReverseLexicographical, GreedySelection)
+	fileProvider := NewFileProvider(filesLimit, WildcardUseFileName)
 	logSources := []*sources.LogSource{
 		sources.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: fmt.Sprintf("%s/1/*.log", suite.testDir)}),
 		sources.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: fmt.Sprintf("%s/2/*.log", suite.testDir)}),
@@ -302,7 +302,7 @@ func (suite *ProviderTestSuite) TestExcludePath() {
 	filesLimit := 6
 	path := fmt.Sprintf("%s/*/*.log", suite.testDir)
 	excludePaths := []string{fmt.Sprintf("%s/2/*.log", suite.testDir)}
-	fileProvider := NewFileProvider(filesLimit, WildcardReverseLexicographical, GreedySelection)
+	fileProvider := NewFileProvider(filesLimit, WildcardUseFileName)
 	logSources := []*sources.LogSource{
 		sources.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: path, ExcludePaths: excludePaths}),
 	}
@@ -323,7 +323,7 @@ func TestProviderTestSuite(t *testing.T) {
 
 func TestCollectFiles(t *testing.T) {
 	t.Run("Invalid Pattern", func(t *testing.T) {
-		fileProvider := NewFileProvider(2, WildcardReverseLexicographical, GreedySelection)
+		fileProvider := NewFileProvider(2, WildcardUseFileName)
 		source := sources.NewLogSource("wildcard", &config.LogsConfig{Type: config.FileType, Path: "//\\///*"})
 		files, err := fileProvider.CollectFiles(source)
 		assert.Len(t, files, 0)
@@ -336,7 +336,7 @@ func TestCollectFiles(t *testing.T) {
 		fs.createFile("c")
 		fs.createFile("d")
 
-		fileProvider := NewFileProvider(2, WildcardReverseLexicographical, GreedySelection)
+		fileProvider := NewFileProvider(2, WildcardUseFileName)
 		source := sources.NewLogSource("wildcard", &config.LogsConfig{Type: config.FileType, Path: fs.path("*")})
 		files, err := fileProvider.CollectFiles(source)
 		assert.Nil(t, err)
@@ -357,7 +357,7 @@ func TestCollectFiles(t *testing.T) {
 		fs.createFileWithTime("t.log", baseTime.Add(time.Second*2))
 		fs.createFileWithTime("z.log", baseTime.Add(time.Second*1))
 
-		fileProvider := NewFileProvider(2, WildcardMtime, GreedySelection)
+		fileProvider := NewFileProvider(2, WildcardUseFileModTime)
 		source := sources.NewLogSource("wildcard", &config.LogsConfig{Type: config.FileType, Path: fs.path("*")})
 		files, err := fileProvider.CollectFiles(source)
 		assert.Nil(t, err)
@@ -383,7 +383,7 @@ func TestFilesToTail(t *testing.T) {
 			fs.createFile("b/b")
 			fs.createFile("b/z")
 
-			fileProvider := NewFileProvider(2, WildcardReverseLexicographical, GreedySelection)
+			fileProvider := NewFileProvider(2, WildcardUseFileName)
 			sources := []*sources.LogSource{
 				sources.NewLogSource("wildcard", &config.LogsConfig{Type: config.FileType, Path: fs.path("a/*")}),
 				sources.NewLogSource("wildcardTwo", &config.LogsConfig{Type: config.FileType, Path: fs.path("b/*")}),
@@ -410,7 +410,7 @@ func TestFilesToTail(t *testing.T) {
 			fs.createFile("b/b")
 			fs.createFile("b/z")
 
-			fileProvider := NewFileProvider(2, WildcardReverseLexicographical, GreedySelection)
+			fileProvider := NewFileProvider(2, WildcardUseFileName)
 			sources := []*sources.LogSource{
 				sources.NewLogSource("wildcardA", &config.LogsConfig{Type: config.FileType, Path: fs.path("a/a*")}),
 				sources.NewLogSource("wildcardB", &config.LogsConfig{Type: config.FileType, Path: fs.path("a/b*")}),
@@ -423,30 +423,6 @@ func TestFilesToTail(t *testing.T) {
 			assert.Equal(t, fs.path("a/accc"), files[1].Path)
 		})
 	})
-	t.Run("Reverse Lexicographical - Global", func(t *testing.T) {
-		fs := newTempFs(t)
-
-		fs.mkDir("a")
-		fs.createFile("a/a")
-		fs.createFile("a/b")
-		fs.createFile("a/z")
-		fs.mkDir("b")
-		fs.createFile("b/a")
-		fs.createFile("b/b")
-		fs.createFile("b/z")
-
-		fileProvider := NewFileProvider(2, WildcardReverseLexicographical, GlobalSelection)
-		sources := []*sources.LogSource{
-			sources.NewLogSource("wildcard", &config.LogsConfig{Type: config.FileType, Path: fs.path("a/*")}),
-			sources.NewLogSource("wildcardTwo", &config.LogsConfig{Type: config.FileType, Path: fs.path("b/*")}),
-		}
-		files := fileProvider.FilesToTail(sources)
-		assert.Len(t, files, 2)
-		assert.Equal(t, fs.path("b/z"), files[0].Path)
-		// 2nd expected element is a/z because the lexicographical 'sort' is not a true alpha ordering. It sorts by filename _only_
-		// So this technically relies on the wildcard glob ordering
-		assert.Equal(t, fs.path("a/z"), files[1].Path)
-	})
 	t.Run("Mtime - Greedy", func(t *testing.T) {
 		t.Run("Single Source", func(t *testing.T) {
 			fs := newTempFs(t)
@@ -458,7 +434,7 @@ func TestFilesToTail(t *testing.T) {
 			fs.createFileWithTime("t.log", baseTime.Add(time.Second*2))
 			fs.createFileWithTime("z.log", baseTime.Add(time.Second*1))
 
-			fileProvider := NewFileProvider(2, WildcardMtime, GreedySelection)
+			fileProvider := NewFileProvider(2, WildcardUseFileModTime)
 			sources := []*sources.LogSource{
 				sources.NewLogSource("wildcard", &config.LogsConfig{Type: config.FileType, Path: fs.path("*")}),
 			}
@@ -477,7 +453,7 @@ func TestFilesToTail(t *testing.T) {
 			fs.createFileWithTime("bbb.log", baseTime.Add(time.Second*2))
 			fs.createFileWithTime("baa.log", baseTime.Add(time.Second*1))
 
-			fileProvider := NewFileProvider(2, WildcardMtime, GreedySelection)
+			fileProvider := NewFileProvider(2, WildcardUseFileModTime)
 			sources := []*sources.LogSource{
 				sources.NewLogSource("wildcard a", &config.LogsConfig{Type: config.FileType, Path: fs.path("a*")}),
 				sources.NewLogSource("wildcard b", &config.LogsConfig{Type: config.FileType, Path: fs.path("b*")}),
@@ -501,7 +477,7 @@ func TestFilesToTail(t *testing.T) {
 		fs.createFileWithTime("b/b", baseTime.Add(time.Second*7))
 		fs.createFileWithTime("b/c", baseTime.Add(time.Second*8))
 
-		fileProvider := NewFileProvider(2, WildcardMtime, GlobalSelection)
+		fileProvider := NewFileProvider(2, WildcardUseFileModTime)
 		sources := []*sources.LogSource{
 			sources.NewLogSource("wildcard", &config.LogsConfig{Type: config.FileType, Path: fs.path("a/*")}),
 			sources.NewLogSource("wildcardTwo", &config.LogsConfig{Type: config.FileType, Path: fs.path("b/*")}),
@@ -523,7 +499,7 @@ func BenchmarkApplyOrdering(b *testing.B) {
 		fs.createFileWithTime("c.log", baseTime.Add(time.Second*5))
 		fs.createFileWithTime("d.log", baseTime.Add(time.Second*5))
 
-		fileProvider := NewFileProvider(2, WildcardMtime, GreedySelection)
+		fileProvider := NewFileProvider(2, WildcardUseFileModTime)
 		files := []*tailer.File{
 			{Path: fs.path("a.log")},
 			{Path: fs.path("b.log")},
@@ -544,7 +520,7 @@ func BenchmarkApplyOrdering(b *testing.B) {
 		fs.createFileWithTime("c.log", baseTime.Add(time.Second*5))
 		fs.createFileWithTime("d.log", baseTime.Add(time.Second*5))
 
-		fileProvider := NewFileProvider(2, WildcardReverseLexicographical, GreedySelection)
+		fileProvider := NewFileProvider(2, WildcardUseFileName)
 		files := []*tailer.File{
 			{Path: fs.path("a.log")},
 			{Path: fs.path("b.log")},
@@ -572,7 +548,7 @@ func BenchmarkApplyOrderingManyFiles(b *testing.B) {
 		return files
 	}
 	b.Run("Mtime", func(b *testing.B) {
-		fileProvider := NewFileProvider(numFiles, WildcardMtime, GreedySelection)
+		fileProvider := NewFileProvider(numFiles, WildcardUseFileModTime)
 
 		files := setup()
 
@@ -582,7 +558,7 @@ func BenchmarkApplyOrderingManyFiles(b *testing.B) {
 	})
 
 	b.Run("ReverseLexicographical", func(b *testing.B) {
-		fileProvider := NewFileProvider(numFiles, WildcardReverseLexicographical, GreedySelection)
+		fileProvider := NewFileProvider(numFiles, WildcardUseFileName)
 		files := setup()
 
 		for n := 0; n < b.N; n++ {
@@ -602,7 +578,7 @@ func TestApplyOrdering(t *testing.T) {
 		fs.createFileWithTime("q.log", baseTime.Add(time.Second*3))
 		fs.createFileWithTime("z.log", baseTime.Add(time.Second*1))
 
-		fileProvider := NewFileProvider(2, WildcardMtime, GreedySelection)
+		fileProvider := NewFileProvider(2, WildcardUseFileModTime)
 		files := []*tailer.File{
 			{Path: fs.path("t.log")},
 			{Path: fs.path("a.log")},
@@ -620,7 +596,7 @@ func TestApplyOrdering(t *testing.T) {
 	})
 
 	t.Run("Reverse Lexicographical", func(t *testing.T) {
-		fileProvider := NewFileProvider(0, WildcardReverseLexicographical, GreedySelection)
+		fileProvider := NewFileProvider(0, WildcardUseFileName)
 		// For lexicographical ordering, we don't actually need the files
 		// to exist on the FS, so that part is skipped for these tests
 		t.Run("Flat Directory", func(t *testing.T) {

--- a/pkg/logs/internal/launchers/file/provider/file_provider_test.go
+++ b/pkg/logs/internal/launchers/file/provider/file_provider_test.go
@@ -54,6 +54,18 @@ func (fs *tempFs) createFileWithTime(name string, time time.Time) {
 	}
 }
 
+func (fs *tempFs) createFile(name string) {
+	_, err := os.Create(fs.path(name))
+	assert.Nil(fs.t, err)
+}
+
+func (fs *tempFs) mkDir(name string) {
+	err := os.Mkdir(fs.path(name), os.ModePerm)
+	if err != nil {
+		fs.t.Errorf("Failed to create directory at %q", fs.path(name))
+	}
+}
+
 type ProviderTestSuite struct {
 	suite.Suite
 	testDir    string
@@ -307,18 +319,6 @@ func (suite *ProviderTestSuite) TestExcludePath() {
 
 func TestProviderTestSuite(t *testing.T) {
 	suite.Run(t, new(ProviderTestSuite))
-}
-
-func (fs *tempFs) createFile(name string) {
-	_, err := os.Create(fs.path(name))
-	assert.Nil(fs.t, err)
-}
-
-func (fs *tempFs) mkDir(name string) {
-	err := os.Mkdir(fs.path(name), os.ModePerm)
-	if err != nil {
-		fs.t.Errorf("Failed to create directory at %q", fs.path(name))
-	}
 }
 
 func TestCollectFiles(t *testing.T) {

--- a/pkg/logs/internal/launchers/file/provider/file_provider_test.go
+++ b/pkg/logs/internal/launchers/file/provider/file_provider_test.go
@@ -544,7 +544,6 @@ func TestApplyOrdering(t *testing.T) {
 		fs.createFileWithTime("q.log", baseTime.Add(time.Second*3))
 		fs.createFileWithTime("z.log", baseTime.Add(time.Second*1))
 
-		fileProvider := NewFileProvider(2, WildcardUseFileModTime)
 		files := []*tailer.File{
 			{Path: fs.path("t.log")},
 			{Path: fs.path("a.log")},
@@ -552,7 +551,8 @@ func TestApplyOrdering(t *testing.T) {
 			{Path: fs.path("q.log")},
 		}
 		// When we apply ordering
-		fileProvider.applyOrdering(files)
+		applyModTimeOrdering(files)
+
 		// Then we should see all files in descending mtime order
 		assert.Len(t, files, 4)
 		assert.Equal(t, fs.path("a.log"), files[0].Path)
@@ -569,7 +569,6 @@ func TestApplyOrdering(t *testing.T) {
 		fs.createFileWithTime("b.log", baseTime.Add(time.Second*3))
 		fs.createFileWithTime("c.log", baseTime.Add(time.Second*1))
 
-		fileProvider := NewFileProvider(2, WildcardUseFileModTime)
 		files := []*tailer.File{
 			{Path: fs.path("z.log")},
 			{Path: fs.path("a.log")},
@@ -577,7 +576,7 @@ func TestApplyOrdering(t *testing.T) {
 			{Path: fs.path("b.log")},
 		}
 		// When we apply ordering
-		fileProvider.applyOrdering(files)
+		applyModTimeOrdering(files)
 		// Then we should see all files in descending mtime order
 		assert.Len(t, files, 4)
 		assert.Equal(t, fs.path("a.log"), files[0].Path)
@@ -588,9 +587,6 @@ func TestApplyOrdering(t *testing.T) {
 	})
 
 	t.Run("Reverse Lexicographical", func(t *testing.T) {
-		fileProvider := NewFileProvider(0, WildcardUseFileName)
-		// For lexicographical ordering, we don't actually need the files
-		// to exist on the FS, so that part is skipped for these tests
 		t.Run("Flat Directory", func(t *testing.T) {
 			files := []*tailer.File{
 				{Path: "a.log"},
@@ -598,7 +594,7 @@ func TestApplyOrdering(t *testing.T) {
 				{Path: "q.log"},
 				{Path: "z.log"},
 			}
-			fileProvider.applyOrdering(files)
+			applyReverseLexicographicalOrdering(files)
 
 			assert.Len(t, files, 4)
 			assert.Equal(t, "z.log", files[0].Path)
@@ -613,7 +609,7 @@ func TestApplyOrdering(t *testing.T) {
 				{Path: "/tmp/2/2018.log"},
 				{Path: "/tmp/1/2016.log"},
 			}
-			fileProvider.applyOrdering(files)
+			applyReverseLexicographicalOrdering(files)
 			assert.Equal(t, "/tmp/2/2018.log", files[0].Path)
 			assert.Equal(t, "/tmp/1/2018.log", files[1].Path)
 			assert.Equal(t, "/tmp/1/2017.log", files[2].Path)
@@ -626,7 +622,7 @@ func TestApplyOrdering(t *testing.T) {
 				{Path: "/tmp/2020-02-21/error.log"},
 				{Path: "/tmp/2020-02-22/error.log"},
 			}
-			fileProvider.applyOrdering(files)
+			applyReverseLexicographicalOrdering(files)
 			assert.Equal(t, "/tmp/2020-02-22/error.log", files[0].Path)
 			assert.Equal(t, "/tmp/2020-02-21/error.log", files[1].Path)
 			assert.Equal(t, "/tmp/2020-02-20/error.log", files[2].Path)
@@ -640,7 +636,7 @@ func TestApplyOrdering(t *testing.T) {
 				{Path: "/tmp/3/2018.log"},
 				{Path: "/tmp/1/2017.log"},
 			}
-			fileProvider.applyOrdering(files)
+			applyReverseLexicographicalOrdering(files)
 
 			assert.Equal(t, "/tmp/3/2018.log", files[0].Path)
 			assert.Equal(t, "/tmp/3/2016.log", files[1].Path)

--- a/pkg/logs/internal/launchers/file/provider/file_provider_test.go
+++ b/pkg/logs/internal/launchers/file/provider/file_provider_test.go
@@ -6,7 +6,7 @@
 //go:build !windows
 // +build !windows
 
-package file
+package file_provider
 
 import (
 	"fmt"
@@ -77,10 +77,10 @@ func (suite *ProviderTestSuite) TearDownTest() {
 
 func (suite *ProviderTestSuite) TestFilesToTailReturnsSpecificFile() {
 	path := fmt.Sprintf("%s/1/1.log", suite.testDir)
-	fileProvider := newFileProvider(suite.filesLimit, sortReverseLexicographical, greedySelection)
+	fileProvider := NewFileProvider(suite.filesLimit, SortReverseLexicographical, GreedySelection)
 	logSources := suite.newLogSources(path)
 	util.CreateSources(logSources)
-	files := fileProvider.filesToTail(logSources)
+	files := fileProvider.FilesToTail(logSources)
 
 	suite.Equal(1, len(files))
 	suite.False(files[0].IsWildcardPath)
@@ -90,10 +90,10 @@ func (suite *ProviderTestSuite) TestFilesToTailReturnsSpecificFile() {
 
 func (suite *ProviderTestSuite) TestFilesToTailReturnsAllFilesFromDirectory() {
 	path := fmt.Sprintf("%s/1/*.log", suite.testDir)
-	fileProvider := newFileProvider(suite.filesLimit, sortReverseLexicographical, greedySelection)
+	fileProvider := NewFileProvider(suite.filesLimit, SortReverseLexicographical, GreedySelection)
 	logSources := suite.newLogSources(path)
 	status.InitStatus(util.CreateSources(logSources))
-	files := fileProvider.filesToTail(logSources)
+	files := fileProvider.FilesToTail(logSources)
 
 	suite.Equal(3, len(files))
 	suite.True(files[0].IsWildcardPath)
@@ -115,9 +115,9 @@ func (suite *ProviderTestSuite) TestCollectFilesWildcardFlag() {
 	// with wildcard
 
 	path := fmt.Sprintf("%s/1/*.log", suite.testDir)
-	fileProvider := newFileProvider(suite.filesLimit, sortReverseLexicographical, greedySelection)
+	fileProvider := NewFileProvider(suite.filesLimit, SortReverseLexicographical, GreedySelection)
 	logSources := suite.newLogSources(path)
-	files, err := fileProvider.collectFiles(logSources[0])
+	files, err := fileProvider.CollectFiles(logSources[0])
 	suite.NoError(err, "searching for files in this directory shouldn't fail")
 	for _, file := range files {
 		suite.True(file.IsWildcardPath, "this file has been found with a wildcard pattern.")
@@ -126,9 +126,9 @@ func (suite *ProviderTestSuite) TestCollectFilesWildcardFlag() {
 	// without wildcard
 
 	path = fmt.Sprintf("%s/1/1.log", suite.testDir)
-	fileProvider = newFileProvider(suite.filesLimit, sortReverseLexicographical, greedySelection)
+	fileProvider = NewFileProvider(suite.filesLimit, SortReverseLexicographical, GreedySelection)
 	logSources = suite.newLogSources(path)
-	files, err = fileProvider.collectFiles(logSources[0])
+	files, err = fileProvider.CollectFiles(logSources[0])
 	suite.NoError(err, "searching for files in this directory shouldn't fail")
 	for _, file := range files {
 		suite.False(file.IsWildcardPath, "this file has not been found using a wildcard pattern.")
@@ -137,10 +137,10 @@ func (suite *ProviderTestSuite) TestCollectFilesWildcardFlag() {
 
 func (suite *ProviderTestSuite) TestFilesToTailReturnsAllFilesFromAnyDirectoryWithRightPermissions() {
 	path := fmt.Sprintf("%s/*/*1.log", suite.testDir)
-	fileProvider := newFileProvider(suite.filesLimit, sortReverseLexicographical, greedySelection)
+	fileProvider := NewFileProvider(suite.filesLimit, SortReverseLexicographical, GreedySelection)
 	logSources := suite.newLogSources(path)
 	util.CreateSources(logSources)
-	files := fileProvider.filesToTail(logSources)
+	files := fileProvider.FilesToTail(logSources)
 
 	suite.Equal(2, len(files))
 	suite.True(files[0].IsWildcardPath)
@@ -152,10 +152,10 @@ func (suite *ProviderTestSuite) TestFilesToTailReturnsAllFilesFromAnyDirectoryWi
 
 func (suite *ProviderTestSuite) TestFilesToTailReturnsSpecificFileWithWildcard() {
 	path := fmt.Sprintf("%s/1/?.log", suite.testDir)
-	fileProvider := newFileProvider(suite.filesLimit, sortReverseLexicographical, greedySelection)
+	fileProvider := NewFileProvider(suite.filesLimit, SortReverseLexicographical, GreedySelection)
 	logSources := suite.newLogSources(path)
 	status.InitStatus(util.CreateSources(logSources))
-	files := fileProvider.filesToTail(logSources)
+	files := fileProvider.FilesToTail(logSources)
 
 	suite.Equal(3, len(files))
 	suite.True(files[0].IsWildcardPath)
@@ -176,9 +176,9 @@ func (suite *ProviderTestSuite) TestFilesToTailReturnsSpecificFileWithWildcard()
 func (suite *ProviderTestSuite) TestWildcardPathsAreSorted() {
 	filesLimit := 6
 	path := fmt.Sprintf("%s/*/*.log", suite.testDir)
-	fileProvider := newFileProvider(filesLimit, sortReverseLexicographical, greedySelection)
+	fileProvider := NewFileProvider(filesLimit, SortReverseLexicographical, GreedySelection)
 	logSources := suite.newLogSources(path)
-	files := fileProvider.filesToTail(logSources)
+	files := fileProvider.FilesToTail(logSources)
 	suite.Equal(5, len(files))
 	for i := 0; i < len(files); i++ {
 		suite.Assert().True(files[i].IsWildcardPath)
@@ -192,10 +192,10 @@ func (suite *ProviderTestSuite) TestWildcardPathsAreSorted() {
 
 func (suite *ProviderTestSuite) TestNumberOfFilesToTailDoesNotExceedLimit() {
 	path := fmt.Sprintf("%s/*/*.log", suite.testDir)
-	fileProvider := newFileProvider(suite.filesLimit, sortReverseLexicographical, greedySelection)
+	fileProvider := NewFileProvider(suite.filesLimit, SortReverseLexicographical, GreedySelection)
 	logSources := suite.newLogSources(path)
 	status.InitStatus(util.CreateSources(logSources))
-	files := fileProvider.filesToTail(logSources)
+	files := fileProvider.FilesToTail(logSources)
 	suite.Equal(suite.filesLimit, len(files))
 	suite.Equal([]string{"3 files tailed out of 5 files matching"}, logSources[0].Messages.GetMessages())
 	suite.Equal(
@@ -208,13 +208,13 @@ func (suite *ProviderTestSuite) TestNumberOfFilesToTailDoesNotExceedLimit() {
 
 func (suite *ProviderTestSuite) TestAllWildcardPathsAreUpdated() {
 	filesLimit := 2
-	fileProvider := newFileProvider(filesLimit, sortReverseLexicographical, greedySelection)
+	fileProvider := NewFileProvider(filesLimit, SortReverseLexicographical, GreedySelection)
 	logSources := []*sources.LogSource{
 		sources.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: fmt.Sprintf("%s/1/*.log", suite.testDir)}),
 		sources.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: fmt.Sprintf("%s/2/*.log", suite.testDir)}),
 	}
 	status.InitStatus(util.CreateSources(logSources))
-	files := fileProvider.filesToTail(logSources)
+	files := fileProvider.FilesToTail(logSources)
 	suite.Equal(2, len(files))
 	suite.Equal([]string{"2 files tailed out of 3 files matching"}, logSources[0].Messages.GetMessages())
 	suite.Equal(
@@ -234,7 +234,7 @@ func (suite *ProviderTestSuite) TestAllWildcardPathsAreUpdated() {
 	os.Remove(fmt.Sprintf("%s/1/2.log", suite.testDir))
 	os.Remove(fmt.Sprintf("%s/1/3.log", suite.testDir))
 	os.Remove(fmt.Sprintf("%s/2/2.log", suite.testDir))
-	files = fileProvider.filesToTail(logSources)
+	files = fileProvider.FilesToTail(logSources)
 	suite.Equal(2, len(files))
 	suite.Equal([]string{"1 files tailed out of 1 files matching"}, logSources[0].Messages.GetMessages())
 
@@ -248,7 +248,7 @@ func (suite *ProviderTestSuite) TestAllWildcardPathsAreUpdated() {
 
 	os.Remove(fmt.Sprintf("%s/2/1.log", suite.testDir))
 
-	files = fileProvider.filesToTail(logSources)
+	files = fileProvider.FilesToTail(logSources)
 	suite.Equal(1, len(files))
 	suite.Equal([]string{"1 files tailed out of 1 files matching"}, logSources[0].Messages.GetMessages())
 
@@ -259,12 +259,12 @@ func (suite *ProviderTestSuite) TestExcludePath() {
 	filesLimit := 6
 	path := fmt.Sprintf("%s/*/*.log", suite.testDir)
 	excludePaths := []string{fmt.Sprintf("%s/2/*.log", suite.testDir)}
-	fileProvider := newFileProvider(filesLimit, sortReverseLexicographical, greedySelection)
+	fileProvider := NewFileProvider(filesLimit, SortReverseLexicographical, GreedySelection)
 	logSources := []*sources.LogSource{
 		sources.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: path, ExcludePaths: excludePaths}),
 	}
 
-	files := fileProvider.filesToTail(logSources)
+	files := fileProvider.FilesToTail(logSources)
 	suite.Equal(3, len(files))
 	for i := 0; i < len(files); i++ {
 		suite.Assert().True(files[i].IsWildcardPath)
@@ -280,9 +280,9 @@ func TestProviderTestSuite(t *testing.T) {
 
 func TestCollectFiles(t *testing.T) {
 	t.Run("Invalid Pattern", func(t *testing.T) {
-		fileProvider := newFileProvider(2, sortReverseLexicographical, greedySelection)
+		fileProvider := NewFileProvider(2, SortReverseLexicographical, GreedySelection)
 		source := sources.NewLogSource("wildcard", &config.LogsConfig{Type: config.FileType, Path: "//\\///*"})
-		files, err := fileProvider.collectFiles(source)
+		files, err := fileProvider.CollectFiles(source)
 		assert.Len(t, files, 0)
 		assert.Error(t, err)
 	})
@@ -300,9 +300,9 @@ func TestCollectFiles(t *testing.T) {
 		createFile("c")
 		createFile("d")
 
-		fileProvider := newFileProvider(2, sortReverseLexicographical, greedySelection)
+		fileProvider := NewFileProvider(2, SortReverseLexicographical, GreedySelection)
 		source := sources.NewLogSource("wildcard", &config.LogsConfig{Type: config.FileType, Path: path("*")})
-		files, err := fileProvider.collectFiles(source)
+		files, err := fileProvider.CollectFiles(source)
 		assert.Nil(t, err)
 		assert.Len(t, files, 4)
 		assert.Equal(t, path("d"), files[0].Path)
@@ -331,9 +331,9 @@ func TestCollectFiles(t *testing.T) {
 		createFile("t.log", baseTime.Add(time.Second*2))
 		createFile("z.log", baseTime.Add(time.Second*1))
 
-		fileProvider := newFileProvider(2, sortMtime, greedySelection)
+		fileProvider := NewFileProvider(2, SortMtime, GreedySelection)
 		source := sources.NewLogSource("wildcard", &config.LogsConfig{Type: config.FileType, Path: path("*")})
-		files, err := fileProvider.collectFiles(source)
+		files, err := fileProvider.CollectFiles(source)
 		assert.Nil(t, err)
 		assert.Len(t, files, 4)
 		assert.Equal(t, path("a.log"), files[0].Path)
@@ -367,12 +367,12 @@ func TestFilesToTail(t *testing.T) {
 		createFile("b/b")
 		createFile("b/z")
 
-		fileProvider := newFileProvider(2, sortReverseLexicographical, greedySelection)
+		fileProvider := NewFileProvider(2, SortReverseLexicographical, GreedySelection)
 		sources := []*sources.LogSource{
 			sources.NewLogSource("wildcard", &config.LogsConfig{Type: config.FileType, Path: path("a/*")}),
 			sources.NewLogSource("wildcardTwo", &config.LogsConfig{Type: config.FileType, Path: path("b/*")}),
 		}
-		files := fileProvider.filesToTail(sources)
+		files := fileProvider.FilesToTail(sources)
 		assert.Len(t, files, 2)
 		assert.Equal(t, path("a/z"), files[0].Path)
 		assert.Equal(t, path("a/b"), files[1].Path)
@@ -401,12 +401,12 @@ func TestFilesToTail(t *testing.T) {
 		createFile("b/b")
 		createFile("b/z")
 
-		fileProvider := newFileProvider(2, sortReverseLexicographical, globalSelection)
+		fileProvider := NewFileProvider(2, SortReverseLexicographical, GlobalSelection)
 		sources := []*sources.LogSource{
 			sources.NewLogSource("wildcard", &config.LogsConfig{Type: config.FileType, Path: path("a/*")}),
 			sources.NewLogSource("wildcardTwo", &config.LogsConfig{Type: config.FileType, Path: path("b/*")}),
 		}
-		files := fileProvider.filesToTail(sources)
+		files := fileProvider.FilesToTail(sources)
 		assert.Len(t, files, 2)
 		assert.Equal(t, path("b/z"), files[0].Path)
 		assert.Equal(t, path("b/b"), files[1].Path)
@@ -432,11 +432,11 @@ func TestFilesToTail(t *testing.T) {
 		createFile("z.log", baseTime.Add(time.Second*1))
 		// TODO test behavior when time is equal
 
-		fileProvider := newFileProvider(2, sortMtime, greedySelection)
+		fileProvider := NewFileProvider(2, SortMtime, GreedySelection)
 		sources := []*sources.LogSource{
 			sources.NewLogSource("wildcard", &config.LogsConfig{Type: config.FileType, Path: path("*")}),
 		}
-		files := fileProvider.filesToTail(sources)
+		files := fileProvider.FilesToTail(sources)
 		assert.Len(t, files, 2)
 		assert.Equal(t, path("a.log"), files[0].Path)
 		assert.Equal(t, path("q.log"), files[1].Path)
@@ -470,12 +470,12 @@ func TestFilesToTail(t *testing.T) {
 		createFile("b/b", baseTime.Add(time.Second*7))
 		createFile("b/c", baseTime.Add(time.Second*8))
 
-		fileProvider := newFileProvider(2, sortMtime, greedySelection)
+		fileProvider := NewFileProvider(2, SortMtime, GreedySelection)
 		sources := []*sources.LogSource{
 			sources.NewLogSource("wildcard", &config.LogsConfig{Type: config.FileType, Path: path("a/*")}),
 			sources.NewLogSource("wildcardTwo", &config.LogsConfig{Type: config.FileType, Path: path("b/*")}),
 		}
-		files := fileProvider.filesToTail(sources)
+		files := fileProvider.FilesToTail(sources)
 		assert.Len(t, files, 2)
 		assert.Equal(t, path("a/c"), files[0].Path)
 		assert.Equal(t, path("b/c"), files[1].Path)
@@ -502,7 +502,7 @@ func BenchmarkApplyOrdering(b *testing.B) {
 		createFile("c.log", baseTime.Add(time.Second*5))
 		createFile("d.log", baseTime.Add(time.Second*5))
 
-		fileProvider := newFileProvider(2, sortMtime, greedySelection)
+		fileProvider := NewFileProvider(2, SortMtime, GreedySelection)
 		files := []string{
 			path("a.log"),
 			path("b.log"),
@@ -533,7 +533,7 @@ func BenchmarkApplyOrdering(b *testing.B) {
 		createFile("c.log", baseTime.Add(time.Second*5))
 		createFile("d.log", baseTime.Add(time.Second*5))
 
-		fileProvider := newFileProvider(2, sortReverseLexicographical, greedySelection)
+		fileProvider := NewFileProvider(2, SortReverseLexicographical, GreedySelection)
 		files := []string{
 			path("a.log"),
 			path("b.log"),
@@ -568,7 +568,7 @@ func TestApplyOrdering(t *testing.T) {
 		createFile("q.log", baseTime.Add(time.Second*3))
 		createFile("z.log", baseTime.Add(time.Second*1))
 
-		fileProvider := newFileProvider(2, sortMtime, greedySelection)
+		fileProvider := NewFileProvider(2, SortMtime, GreedySelection)
 		files := []string{
 			path("t.log"),
 			path("a.log"),
@@ -586,7 +586,7 @@ func TestApplyOrdering(t *testing.T) {
 	})
 
 	t.Run("Reverse Lexicographical", func(t *testing.T) {
-		fileProvider := newFileProvider(0, sortReverseLexicographical, greedySelection)
+		fileProvider := NewFileProvider(0, SortReverseLexicographical, GreedySelection)
 		// For lexicographical ordering, we don't actually need the files
 		// to exist on the FS, so that part is skipped for these tests
 		t.Run("Flat Directory", func(t *testing.T) {

--- a/releasenotes/notes/file-tailing-wildcard-match-mode-73f58cbf7b2a0f73.yaml
+++ b/releasenotes/notes/file-tailing-wildcard-match-mode-73f58cbf7b2a0f73.yaml
@@ -1,0 +1,17 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    A new config option ``logs_config.file_wildcard_selection_mode`` has been added.
+    This option allows users to configure how log wildcard file matches are
+    prioritized if the number of matches exceeds ``logs_config.open_files_limit``
+
+    This defaults to ``by_name`` which is the current behavior.
+    The new option is ``by_modification_time`` which will prioritize more recently
+    modified files, but it comes with a performance penalty compared to ``by_name``.

--- a/releasenotes/notes/file-tailing-wildcard-match-mode-73f58cbf7b2a0f73.yaml
+++ b/releasenotes/notes/file-tailing-wildcard-match-mode-73f58cbf7b2a0f73.yaml
@@ -8,10 +8,10 @@
 ---
 enhancements:
   - |
-    A new config option ``logs_config.file_wildcard_selection_mode`` has been added.
-    This option allows users to configure how log wildcard file matches are
-    prioritized if the number of matches exceeds ``logs_config.open_files_limit``
+    A new config option, ``logs_config.file_wildcard_selection_mode``, 
+    allows you to configure how log wildcard file matches are
+    prioritized if the number of matches exceeds ``logs_config.open_files_limit``.
 
-    This defaults to ``by_name`` which is the current behavior.
-    The new option is ``by_modification_time`` which will prioritize more recently
-    modified files, but it comes with a performance penalty compared to ``by_name``.
+    The option defaults to ``by_name`` which is the previous behavior.
+    The new option is ``by_modification_time`` which prioritizes more recently
+    modified files, but using it can result in slower performance compared to using ``by_name``.


### PR DESCRIPTION
### What does this PR do?
In the current logs agent, if you configure file log sources with a wildcard path (eg, `my-log-dir/*.log`), the logs agent will resolve the wildcard every `scan` interval and decide if more files should be tailed.

There is a limit to the number of open files that is configurable, and once there are more files matching the wildcard than that limit, we need some way of deciding _which_ wildcard matches should be selected.

The goal of this PR is to provide a new matching behavior that selects based on the time a file was most recently modified.

This change provides a new config option `logs_config.file_wildcard_selection_mode` that has 2 possible values:
- `by_name` which is the existing behavior (described in more detail below)
- `by_modification_time` which is the new behavior

### Motivation
In the current behavior, the ordering is roughly alphabetical and therefore there is no way to select different files once the initial pass has been made without renaming files.

To make things worse, the existing behavior is to "greedily" fill the open file slots from each log source in turn.
This means if you have multiple wildcard log sources, say you're monitoring both `/var/serviceA/logs/*.log` and `/var/serviceB/logs/*.log`, if `/var/serviceA/logs/*.log` contains > `logs_config.open_file_limit` number of logs, `/var/serviceB/logs/*.log` will not be considered at all.

### Additional Notes
This PR creates 2 new "modes" that a `file_provider` can operate in, both allowing for a `global` mode that will consider all wildcard matches and a `mtime` mode that will order by the most recently modified file time instead of alpha ordering.

The config option `logs_config.file_wildcard_selection_mode` sets both of these options for the `file_provider`

(I changed too much of `file_provider` for git to recognize it as a rename, even when I put the rename in its own commit, sorry for the ugly diff!)

### Possible Drawbacks / Trade-offs
This mode is significantly less performant than the default. Every scan (default every 10 seconds) will now `stat` every single file that matches the glob, whereas before only the directory contents needed to be read.

Performance will be even worse in the case where the agent is monitoring a network mount of some kind, presumably those `stat` calls will be more expensive.

This is a trade-off that the user should be aware of when enabling this option.

**mbp m1 max - macos native**
```
goos: darwin
goarch: arm64
pkg: github.com/DataDog/datadog-agent/pkg/logs/internal/launchers/file/provider
BenchmarkApplyOrdering/Mtime-10                   194088              5984 ns/op
BenchmarkApplyOrdering/ReverseLexicographical-10                 7772708               158.7 ns/op
```

**mbp m1 max - linux vm**
```
goos: linux
goarch: arm64
pkg: github.com/DataDog/datadog-agent/pkg/logs/internal/launchers/file/provider
BenchmarkApplyOrdering/Mtime-4            200792              5733 ns/op
BenchmarkApplyOrdering/ReverseLexicographical-4                  7339722               166.6 ns/op
```


### Describe how to test/QA your changes
There are two goals for QA here:
1. Ensure that without the new config option set, things work as they did before
2. When there are more than `open_files_limit` matches, more recently modified files are prioritized.

Example `datadog.yaml`:
```
confd_path: /home/ubuntu/dev/datadog-config-scenarios/disk-log-listener/conf.d/
logs_enabled: true
logs_config:
  container_collect_all: false
  open_files_limit: 3
  file_wildcard_selection_mode: "by_modification_time"
  file_scan_period: 1.0
```

Example `conf.d/disk-log-listener/conf.d/conf.yaml`:
```
logs:
  - type: file
    path: /tmp/logfolder/*.log
    service: "my-service"
    source: "my-client-app"
```

1. With the config option _on_ (ie, set to `by_modification_time`), create 3 log files with some content. Ensure via `agent status` that these logs are being tailed. Then create a 4th log file with some new content. Ensure that the oldest of the 3 has been dropped and replaced by this new 4th log file.
2. With the config option _off_ (ie, set to `by_name`), create 3 log files with some content. Ensure via `agent status` that these logs are being tailed. Then create a 4th log file with a name alphabetically _less_ than the existing files. Ensure that there is no change to the set of files being tailed.


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
