### PR TITLE
[CWS] improve info extraction reorderer

### DIFF
--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -447,12 +447,15 @@ func (ev *Event) MarshalJSON() ([]byte, error) {
 }
 
 // ExtractEventInfo extracts cpu and timestamp from the raw data event
-func ExtractEventInfo(record *perf.Record) (uint64, uint64, error) {
+func ExtractEventInfo(record *perf.Record) (QuickInfo, error) {
 	if len(record.RawSample) < 16 {
-		return 0, 0, model.ErrNotEnoughData
+		return QuickInfo{}, model.ErrNotEnoughData
 	}
 
-	return model.ByteOrder.Uint64(record.RawSample[0:8]), model.ByteOrder.Uint64(record.RawSample[8:16]), nil
+	return QuickInfo{
+		cpu:       model.ByteOrder.Uint64(record.RawSample[0:8]),
+		timestamp: model.ByteOrder.Uint64(record.RawSample[8:16]),
+	}, nil
 }
 
 // ResolveEventTimestamp resolves the monolitic kernel event timestamp to an absolute time

--- a/pkg/security/probe/reorderer.go
+++ b/pkg/security/probe/reorderer.go
@@ -257,11 +257,13 @@ func (r *ReOrderer) HandleEvent(record *perf.Record, perfMap *manager.PerfMap, m
 	}
 }
 
+// QuickInfo represents the info quickly extractable from an event, that can be used for reordering
 type QuickInfo struct {
 	cpu       uint64
 	timestamp uint64
 }
 
+// QuickInfoExtractor represents a function that takes a record, and returns the quick infos
 type QuickInfoExtractor = func(record *perf.Record) (QuickInfo, error)
 
 // NewReOrderer returns a new ReOrderer

--- a/pkg/security/probe/reorderer.go
+++ b/pkg/security/probe/reorderer.go
@@ -184,7 +184,7 @@ type ReOrderer struct {
 	queue       chan *perf.Record
 	handler     func(*perf.Record)
 	heap        *reOrdererHeap
-	extractInfo func(*perf.Record) (uint64, uint64, error) // timestamp
+	extractInfo QuickInfoExtractor // timestamp
 	opts        ReOrdererOpts
 	metric      ReOrdererMetric
 	Metrics     chan ReOrdererMetric
@@ -202,15 +202,16 @@ func (r *ReOrderer) Start(wg *sync.WaitGroup) {
 	defer metricTicker.Stop()
 
 	var lastTm, tm uint64
-	var err error
 
 	for {
 		select {
 		case record := <-r.queue:
 			if len(record.RawSample) > 0 {
-				if _, tm, err = r.extractInfo(record); err != nil {
+				info, err := r.extractInfo(record)
+				if err != nil {
 					continue
 				}
+				tm = info.timestamp
 			} else {
 				tm = lastTm
 			}
@@ -256,8 +257,15 @@ func (r *ReOrderer) HandleEvent(record *perf.Record, perfMap *manager.PerfMap, m
 	}
 }
 
+type QuickInfo struct {
+	cpu       uint64
+	timestamp uint64
+}
+
+type QuickInfoExtractor = func(record *perf.Record) (QuickInfo, error)
+
 // NewReOrderer returns a new ReOrderer
-func NewReOrderer(ctx context.Context, handler func(record *perf.Record), extractInfo func(record *perf.Record) (uint64, uint64, error), opts ReOrdererOpts) *ReOrderer {
+func NewReOrderer(ctx context.Context, handler func(record *perf.Record), extractInfo QuickInfoExtractor, opts ReOrdererOpts) *ReOrderer {
 	return &ReOrderer{
 		ctx:     ctx,
 		queue:   make(chan *perf.Record, opts.QueueSize),

--- a/pkg/security/probe/reorderer_test.go
+++ b/pkg/security/probe/reorderer_test.go
@@ -107,8 +107,11 @@ func TestOrderRate(t *testing.T) {
 		event = append(event, record.RawSample[2])
 		lock.Unlock()
 	},
-		func(record *perf.Record) (uint64, uint64, error) {
-			return uint64(record.RawSample[0]), uint64(record.RawSample[1]), nil
+		func(record *perf.Record) (QuickInfo, error) {
+			return QuickInfo{
+				cpu:       uint64(record.RawSample[0]),
+				timestamp: uint64(record.RawSample[1]),
+			}, nil
 		},
 		ReOrdererOpts{
 			QueueSize:  100,


### PR DESCRIPTION
### What does this PR do?

This PR adds structs with fields for quick info extraction (used in reorderer): cpu and timestamp

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
