### PR TITLE
system-probe: check for binaries only once

### DIFF
--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -15,7 +15,7 @@ from .libs.ninja_syntax import NinjaWriter
 from .system_probe import (
     CURRENT_ARCH,
     build_cws_object_files,
-    check_for_ninja,
+    check_for,
     generate_runtime_files,
     ninja_define_ebpf_compiler,
     ninja_define_exe_compiler,
@@ -255,7 +255,7 @@ def ninja_latency_tools(ctx, build_dir, static=True):
 
 @task
 def build_embed_latency_tools(ctx, static=True):
-    check_for_ninja(ctx)
+    check_for(ctx, "ninja")
     build_dir = os.path.join("pkg", "security", "tests", "latency", "bin")
     create_dir_if_needed(build_dir)
 
@@ -286,7 +286,7 @@ def create_dir_if_needed(dir):
 
 @task
 def build_embed_syscall_tester(ctx, arch=CURRENT_ARCH, static=True):
-    check_for_ninja(ctx)
+    check_for(ctx, "ninja")
     build_dir = os.path.join("pkg", "security", "tests", "syscall_tester", "bin")
     go_dir = os.path.join("pkg", "security", "tests", "syscall_tester", "go")
     create_dir_if_needed(build_dir)

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -836,7 +836,7 @@ def run_ninja(
     debug=False,
     strip_object_files=False,
 ):
-    check_for_ninja(ctx)
+    check_for(ctx, "ninja")
     nf_path = os.path.join(ctx.cwd, 'system-probe.ninja')
     ninja_generate(ctx, nf_path, windows, major_version, arch, debug, strip_object_files, kernel_release)
     explain_opt = "-d explain" if explain else ""

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -607,7 +607,7 @@ def clang_format(ctx, targets=None, fix=False, fail_on_issue=False):
     """
     Format C code using clang-format
     """
-    ctx.run("which clang-format")
+    check_for(ctx, "clang-format")
     if isinstance(targets, str):
         # when this function is called from the command line, targets are passed
         # as comma separated tokens in a string
@@ -638,7 +638,7 @@ def clang_tidy(ctx, fix=False, fail_on_issue=False, kernel_release=None):
     """
 
     print("checking for clang-tidy executable...")
-    ctx.run("which clang-tidy")
+    check_for(ctx, "clang-tidy")
 
     build_flags = get_ebpf_build_flags()
     build_flags.append("-DDEBUG=1")
@@ -860,11 +860,11 @@ def build_object_files(
     if not windows:
         # if clang is missing, subsequent calls to ctx.run("clang ...") will fail silently
         print("checking for clang executable...")
-        ctx.run("which clang")
+        check_for(ctx, "clang")
 
         if strip_object_files:
             print("checking for llvm-strip...")
-            ctx.run("which llvm-strip")
+            check_for(ctx, "llvm-strip")
 
         check_for_inline(ctx)
         ctx.run(f"mkdir -p {build_dir}/runtime")
@@ -943,11 +943,16 @@ def is_root():
     return os.getuid() == 0
 
 
-def check_for_ninja(ctx):
+check_for_cache = set()
+def check_for(ctx, binary):
+    key = (ctx.cwd, binary)
+    if key in check_for_cache:
+        return
     if is_windows:
-        ctx.run("where ninja")
+        ctx.run(f"where {binary}")
     else:
-        ctx.run("which ninja")
+        ctx.run(f"which {binary}")
+    check_for_cache.add(key)
 
 
 @contextlib.contextmanager

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -944,6 +944,8 @@ def is_root():
 
 
 check_for_cache = set()
+
+
 def check_for(ctx, binary):
     key = (ctx.cwd, binary)
     if key in check_for_cache:


### PR DESCRIPTION
### What does this PR do?

We usually check for the presence of some binaries (like clang, ninja) but in some paths we can check multiple times for the presence of the same binaries, creating some noise. This PR fixes this by caching the results per (cwd, binary) entry.
I choose to include the cwd so that correct results can be obtained if the binary is local to the current directory (not used for now).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
