### PR TITLE
system-probe: create phony targets for CWS object files and runtime compilation files

### DIFF
--- a/tasks/libs/ninja_syntax.py
+++ b/tasks/libs/ninja_syntax.py
@@ -134,14 +134,6 @@ class NinjaWriter(object):
 
         return outputs
 
-    def phony(
-        self,
-        name,
-        inputs=None,
-    ):
-        all_inputs = [escape_path(x) for x in as_list(inputs)]
-        self._line(f"build {name}: phony {' '.join(all_inputs)}")
-
     def include(self, path):
         self._line(f"include {path}")
 

--- a/tasks/libs/ninja_syntax.py
+++ b/tasks/libs/ninja_syntax.py
@@ -134,6 +134,14 @@ class NinjaWriter(object):
 
         return outputs
 
+    def phony(
+        self,
+        name,
+        inputs=None,
+    ):
+        all_inputs = [escape_path(x) for x in as_list(inputs)]
+        self._line(f"build {name}: phony {' '.join(all_inputs)}")
+
     def include(self, path):
         self._line(f"include {path}")
 

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -14,7 +14,7 @@ from .go import golangci_lint
 from .libs.ninja_syntax import NinjaWriter
 from .system_probe import (
     CURRENT_ARCH,
-    build_object_files,
+    build_cws_object_files,
     check_for_ninja,
     generate_runtime_files,
     ninja_define_ebpf_compiler,
@@ -322,7 +322,7 @@ def build_functional_tests(
     race=False,
     kernel_release=None,
 ):
-    build_object_files(
+    build_cws_object_files(
         ctx,
         major_version=major_version,
         arch=arch,

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -922,7 +922,6 @@ def clean_object_files(
 
 
 # deprecated: this function is only kept to prevent breaking security-agent.go-generate-check
-@task
 def generate_runtime_files(ctx):
     run_ninja(ctx, explain=True, target="runtime-compilation")
 

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -159,7 +159,7 @@ def ninja_security_ebpf_programs(nw, build_dir, debug, kernel_release):
     )
     outfiles.append(offset_guesser_outfile)
 
-    nw.phony("cws", inputs=outfiles)
+    nw.build(rule="phony", inputs=outfiles, outputs=["cws"])
 
 
 def ninja_network_ebpf_program(nw, infile, outfile, flags):
@@ -208,7 +208,7 @@ def ninja_runtime_compilation_files(nw):
             rule="headerincl",
         )
         rc_outputs.extend([c_file, hash_file])
-    nw.phony("runtime-compilation", inputs=rc_outputs)
+    nw.build(rule="phony", inputs=rc_outputs, outputs=["runtime-compilation"])
 
 
 def ninja_cgo_type_files(nw, windows):

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -116,6 +116,9 @@ def ninja_security_ebpf_programs(nw, build_dir, debug, kernel_release):
     debugdef = "-DDEBUG=1" if debug else ""
     security_flags = f"-I{security_agent_c_dir} {debugdef}"
 
+    outfiles = []
+
+    # basic
     infile = os.path.join(security_agent_prebuilt_dir, "probe.c")
     outfile = os.path.join(build_dir, "runtime-security.o")
     ninja_ebpf_program(
@@ -127,25 +130,36 @@ def ninja_security_ebpf_programs(nw, build_dir, debug, kernel_release):
             "kheaders": kheaders,
         },
     )
+    outfiles.append(outfile)
+
+    # syscall wrapper
     root, ext = os.path.splitext(outfile)
+    syscall_wrapper_outfile = f"{root}-syscall-wrapper{ext}"
     ninja_ebpf_program(
         nw,
         infile=infile,
-        outfile=f"{root}-syscall-wrapper{ext}",
+        outfile=syscall_wrapper_outfile,
         variables={
             "flags": security_flags + " -DUSE_SYSCALL_WRAPPER=1",
             "kheaders": kheaders,
         },
     )
+    outfiles.append(syscall_wrapper_outfile)
+
+    # offset guesser
+    offset_guesser_outfile = os.path.join(build_dir, "runtime-security-offset-guesser.o")
     ninja_ebpf_program(
         nw,
         infile=os.path.join(security_agent_prebuilt_dir, "offset-guesser.c"),
-        outfile=os.path.join(build_dir, "runtime-security-offset-guesser.o"),
+        outfile=offset_guesser_outfile,
         variables={
             "flags": security_flags,
             "kheaders": kheaders,
         },
     )
+    outfiles.append(offset_guesser_outfile)
+
+    nw.phony("cws", inputs=outfiles)
 
 
 def ninja_network_ebpf_program(nw, infile, outfile, flags):
@@ -183,6 +197,7 @@ def ninja_runtime_compilation_files(nw):
     nw.rule(name="headerincl", command="go generate -mod=mod -tags linux_bpf $in", depfile="$out.d")
     hash_dir = os.path.join(bc_dir, "runtime")
     rc_dir = os.path.join(build_dir, "runtime")
+    rc_outputs = []
     for in_path, out_filename in runtime_compiler_files.items():
         c_file = os.path.join(rc_dir, f"{out_filename}.c")
         hash_file = os.path.join(hash_dir, f"{out_filename}.go")
@@ -192,6 +207,8 @@ def ninja_runtime_compilation_files(nw):
             implicit_outputs=[hash_file],
             rule="headerincl",
         )
+        rc_outputs.extend([c_file, hash_file])
+    nw.phony("runtime-compilation", inputs=rc_outputs)
 
 
 def ninja_cgo_type_files(nw, windows):
@@ -807,6 +824,28 @@ def ebpf_check_source_file(ctx, parallel_build, src_file):
     return ctx.run(CHECK_SOURCE_CMD.format(src_file=src_file), echo=False, asynchronous=parallel_build)
 
 
+def run_ninja(
+    ctx,
+    task="",
+    target="",
+    explain=False,
+    windows=is_windows,
+    major_version='7',
+    arch=CURRENT_ARCH,
+    kernel_release=None,
+    debug=False,
+    strip_object_files=False,
+):
+    check_for_ninja(ctx)
+    nf_path = os.path.join(ctx.cwd, 'system-probe.ninja')
+    ninja_generate(ctx, nf_path, windows, major_version, arch, debug, strip_object_files, kernel_release)
+    explain_opt = "-d explain" if explain else ""
+    if task:
+        ctx.run(f"ninja {explain_opt} -f {nf_path} -t {task}")
+    else:
+        ctx.run(f"ninja {explain_opt} -f {nf_path} {target}")
+
+
 def build_object_files(
     ctx,
     windows=is_windows,
@@ -816,7 +855,6 @@ def build_object_files(
     debug=False,
     strip_object_files=False,
 ):
-    check_for_ninja(ctx)
     build_dir = os.path.join("pkg", "ebpf", "bytecode", "build")
 
     if not windows:
@@ -831,15 +869,36 @@ def build_object_files(
         check_for_inline(ctx)
         ctx.run(f"mkdir -p {build_dir}/runtime")
 
-    nf_path = os.path.join(ctx.cwd, 'system-probe.ninja')
-    ninja_generate(ctx, nf_path, windows, major_version, arch, debug, strip_object_files, kernel_release)
-    ctx.run(f"ninja -d explain -f {nf_path}")
+    run_ninja(
+        ctx,
+        explain=True,
+        windows=windows,
+        major_version=major_version,
+        arch=arch,
+        kernel_release=kernel_release,
+        debug=debug,
+        strip_object_files=strip_object_files,
+    )
 
     if not windows:
         sudo = "" if is_root() else "sudo"
         ctx.run(f"{sudo} mkdir -p {EMBEDDED_SHARE_DIR}")
         ctx.run(f"{sudo} cp -R {build_dir}/* {EMBEDDED_SHARE_DIR}")
         ctx.run(f"{sudo} chown root:root -R {EMBEDDED_SHARE_DIR}")
+
+
+def build_cws_object_files(
+    ctx, major_version='7', arch=CURRENT_ARCH, kernel_release=None, debug=False, strip_object_files=False
+):
+    run_ninja(
+        ctx,
+        target="cws",
+        major_version=major_version,
+        arch=arch,
+        debug=debug,
+        strip_object_files=strip_object_files,
+        kernel_release=kernel_release,
+    )
 
 
 @task
@@ -850,22 +909,22 @@ def object_files(ctx, kernel_release=None):
 def clean_object_files(
     ctx, windows, major_version='7', arch=CURRENT_ARCH, kernel_release=None, debug=False, strip_object_files=False
 ):
-    check_for_ninja(ctx)
-    nf_path = os.path.join(ctx.cwd, 'system-probe.ninja')
-    ninja_generate(ctx, nf_path, windows, major_version, arch, debug, strip_object_files, kernel_release)
-
-    ctx.run(f"ninja -f {nf_path} -t clean")
+    run_ninja(
+        ctx,
+        task="clean",
+        windows=windows,
+        major_version=major_version,
+        arch=arch,
+        debug=debug,
+        strip_object_files=strip_object_files,
+        kernel_release=kernel_release,
+    )
 
 
 # deprecated: this function is only kept to prevent breaking security-agent.go-generate-check
+@task
 def generate_runtime_files(ctx):
-    check_for_ninja(ctx)
-    nf_path = os.path.join(ctx.cwd, 'runtime-only.ninja')
-    with open(nf_path, 'w') as ninja_file:
-        nw = NinjaWriter(ninja_file, width=120)
-        ninja_runtime_compilation_files(nw)
-
-    ctx.run(f"ninja -f {nf_path}")
+    run_ninja(ctx, explain=True, target="runtime-compilation")
 
 
 @task


### PR DESCRIPTION
### What does this PR do?

This PR creates 2 phony targets:
- `cws` for cws object files
- `runtime-compilation` for `.c` and `.go` runtime compilation files

The idea behind this is to centralize the ninja file creation to one place, and to then run the phony task instead of building different ninja files for specific tasks.

This will allow some specific CWS tasks (like functional tests) to only build CWS related object files instead of all of them.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
