### PR TITLE
[CWS] move to ghcr base image for centos7 container tests

### DIFF
--- a/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
@@ -120,7 +120,7 @@ if node['platform_family'] != 'windows'
     # to DataDog/datadog-agent-buildimages.
     file "#{wrk_dir}/Dockerfile" do
       content <<-EOF
-      FROM ghcr.io/paulcacheux/cws-centos7:latest
+      FROM ghcr.io/paulcacheux/cws-centos7@sha256:4fc1aac178b5c1690ce71c37f22b8a23cedfb969c7056702c21be50e848e554f
 
       ADD nikos.tar.gz /opt/datadog-agent/embedded/nikos/embedded/
 

--- a/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
@@ -114,19 +114,17 @@ if node['platform_family'] != 'windows'
       end
     end
 
+    # Please see https://github.com/paulcacheux/cws-buildimages/blob/main/Dockerfile
+    # for the definition of this base image
     file "#{wrk_dir}/Dockerfile" do
       content <<-EOF
-      FROM public.ecr.aws/docker/library/centos:centos7
-
-      ENV DOCKER_DD_AGENT=yes
+      FROM ghcr.io/paulcacheux/cws-centos7:latest
 
       ADD nikos.tar.gz /opt/datadog-agent/embedded/nikos/embedded/
 
-      RUN mkdir -p /opt/datadog-agent/embedded/bin
       COPY clang-bpf /opt/datadog-agent/embedded/bin/
       COPY llc-bpf /opt/datadog-agent/embedded/bin/
 
-      RUN yum -y install xfsprogs e2fsprogs iproute perl
       CMD sleep 7200
       EOF
       action :create

--- a/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
@@ -115,7 +115,9 @@ if node['platform_family'] != 'windows'
     end
 
     # Please see https://github.com/paulcacheux/cws-buildimages/blob/main/Dockerfile
-    # for the definition of this base image
+    # for the definition of this base image.
+    # If this successfully helps in reducing the amount of rate limits, this should be moved
+    # to DataDog/datadog-agent-buildimages.
     file "#{wrk_dir}/Dockerfile" do
       content <<-EOF
       FROM ghcr.io/paulcacheux/cws-centos7:latest


### PR DESCRIPTION
### What does this PR do?

Rate limits are still an issue when creating the docker container in which we want to run functional tests. Here is the current situation:
- we cannot use the same round robin idea implemented in https://github.com/DataDog/datadog-agent/pull/13399 because chef does not handle failing step correctly
- both dockerhub and aws ecr have rate limits, so we cannot use them as provider

On the other hand github container registry for public images is free (https://github.com/features/packages#pricing).

This PR uses public image from https://github.com/paulcacheux/cws-buildimages, meaning no rate limits and even faster run because the yum install step is done ahead of time.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
