### PR TITLE
[CWS] Add kernel rate limiter for activity dumps events

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1110,6 +1110,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.traced_cgroups_count", 3)
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.traced_event_types", []string{"exec", "open", "dns", "bind"})
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.cgroup_dump_timeout", 20)
+	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.rate_limiter", 100)
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.cgroup_wait_list_size", 0)
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.cgroup_differentiate_args", true)
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.local_storage.max_dumps_count", 100)

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "6cc2b1eff78e38acd1ba0bbb4f49a9d9afda63a081d927a506f5289b0f94576a")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "2e40c1dadd6290d2f0f416904993c0a01fc575fa072fdf2def245ba98a690ba7")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "2e40c1dadd6290d2f0f416904993c0a01fc575fa072fdf2def245ba98a690ba7")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "3023b2fdabb1090b054fdd4c59cda4d97069a6216ef27721d08f4defeb1358f4")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "e9394f81278b4ee7a912fb41d5e12367cb2b2aec6339009f1250c351ea0ead3f")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "6cc2b1eff78e38acd1ba0bbb4f49a9d9afda63a081d927a506f5289b0f94576a")

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -122,6 +122,8 @@ type Config struct {
 	ActivityDumpTracedEventTypes []model.EventType
 	// ActivityDumpCgroupDumpTimeout defines the cgroup activity dumps timeout.
 	ActivityDumpCgroupDumpTimeout time.Duration
+	// ActivityDumpRateLimiter defines the kernel rate of max events per sec for activity dumps.
+	ActivityDumpRateLimiter int
 	// ActivityDumpCgroupWaitListSize defines the size of the cgroup wait list. The wait list is used to introduce a
 	// delay between 2 activity dumps of the same cgroup.
 	ActivityDumpCgroupWaitListSize int
@@ -245,6 +247,7 @@ func NewConfig(cfg *config.Config) (*Config, error) {
 		ActivityDumpTracedCgroupsCount:        coreconfig.Datadog.GetInt("runtime_security_config.activity_dump.traced_cgroups_count"),
 		ActivityDumpTracedEventTypes:          model.ParseEventTypeStringSlice(coreconfig.Datadog.GetStringSlice("runtime_security_config.activity_dump.traced_event_types")),
 		ActivityDumpCgroupDumpTimeout:         time.Duration(coreconfig.Datadog.GetInt("runtime_security_config.activity_dump.cgroup_dump_timeout")) * time.Minute,
+		ActivityDumpRateLimiter:               coreconfig.Datadog.GetInt("runtime_security_config.activity_dump.rate_limiter"),
 		ActivityDumpCgroupWaitListSize:        coreconfig.Datadog.GetInt("runtime_security_config.activity_dump.cgroup_wait_list_size"),
 		ActivityDumpCgroupDifferentiateArgs:   coreconfig.Datadog.GetBool("runtime_security_config.activity_dump.cgroup_differentiate_args"),
 		ActivityDumpLocalStorageDirectory:     coreconfig.Datadog.GetString("runtime_security_config.activity_dump.local_storage.output_directory"),

--- a/pkg/security/ebpf/c/syscalls.h
+++ b/pkg/security/ebpf/c/syscalls.h
@@ -309,14 +309,17 @@ int __attribute__((always_inline)) filter_syscall(struct syscall_cache_t *syscal
         return 0;
     }
 
-    u32 tgid = bpf_get_current_pid_tgid() >> 32;
     u64 now = bpf_ktime_get_ns();
-    struct activity_dump_config *config = lookup_or_delete_traced_pid(tgid, now);
-    if (config != NULL) {
-        // is this event type traced ?
-        if (mask_has_event(config->event_mask, syscall->type)
-            && activity_dump_rate_limiter_allow(config, now, 0)) {
-            return 0;
+    u32 tgid = bpf_get_current_pid_tgid() >> 32;
+    u32 *cookie = bpf_map_lookup_elem(&traced_pids, &tgid);
+    if (cookie != NULL) {
+        struct activity_dump_config *config = lookup_or_delete_traced_pid(tgid, now, cookie);
+        if (config != NULL) {
+            // is this event type traced ?
+            if (mask_has_event(config->event_mask, syscall->type)
+                && activity_dump_rate_limiter_allow(config, *cookie, now, 0)) {
+                return 0;
+            }
         }
     }
 

--- a/pkg/security/ebpf/c/syscalls.h
+++ b/pkg/security/ebpf/c/syscalls.h
@@ -314,8 +314,8 @@ int __attribute__((always_inline)) filter_syscall(struct syscall_cache_t *syscal
     struct activity_dump_config *config = lookup_or_delete_traced_pid(tgid, now);
     if (config != NULL) {
         // is this event type traced ?
-        if (mask_has_event(config->event_mask, syscall->type)) {
-            // TODO(rate_limiter): check if this event should be rate limited but do not count this event; it will be counted in the dentry resolver
+        if (mask_has_event(config->event_mask, syscall->type)
+            && activity_dump_rate_limiter_allow(config, now, 0)) {
             return 0;
         }
     }

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -175,7 +175,7 @@ func AllMapSpecEditors(numCPU int, cgroupWaitListSize int, supportMmapableMaps, 
 			MaxEntries: MaxTracedCgroupsCount,
 			EditorFlag: manager.EditMaxEntries,
 		},
-		"activity_dump_rate_limiter_ctx": {
+		"activity_dump_rate_limiters": {
 			MaxEntries: MaxTracedCgroupsCount,
 			EditorFlag: manager.EditMaxEntries,
 		},

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -175,6 +175,10 @@ func AllMapSpecEditors(numCPU int, cgroupWaitListSize int, supportMmapableMaps, 
 			MaxEntries: MaxTracedCgroupsCount,
 			EditorFlag: manager.EditMaxEntries,
 		},
+		"activity_dump_rate_limiter_ctx": {
+			MaxEntries: MaxTracedCgroupsCount,
+			EditorFlag: manager.EditMaxEntries,
+		},
 		"cgroup_wait_list": {
 			MaxEntries: uint32(cgroupWaitListSize),
 			EditorFlag: manager.EditMaxEntries,

--- a/pkg/security/probe/activity_dump.go
+++ b/pkg/security/probe/activity_dump.go
@@ -53,6 +53,8 @@ const (
 	ProtobufVersion = "v1"
 	// ActivityDumpSource defines the source of activity dumps
 	ActivityDumpSource = "runtime-security-agent"
+	// DefaultFilesRateLimiter defines the default rate limiter of files events
+	DefaultFilesRateLimiter = 100
 )
 
 // ActivityDumpStatus defines the state of an activity dump
@@ -128,9 +130,7 @@ func NewActivityDumpLoadConfig(evt []model.EventType, timeout time.Duration, sta
 	adlc := &model.ActivityDumpLoadConfig{
 		TracedEventTypes: evt,
 		Timeout:          timeout,
-
-		// TODO(rate_limiter): initialize rate limiter from config
-
+		Rate:             DefaultFilesRateLimiter,
 	}
 	if resolver != nil {
 		adlc.StartTimestampRaw = uint64(resolver.ComputeMonotonicTimestamp(start))

--- a/pkg/security/probe/activity_dump.go
+++ b/pkg/security/probe/activity_dump.go
@@ -358,7 +358,7 @@ func (ad *ActivityDump) Matches(entry *model.ProcessCacheEntry) bool {
 // flowing in from kernel space
 func (ad *ActivityDump) enable() error {
 	// insert load config now (it might already exist, do not update in that case)
-	if err := ad.adm.activityDumpLoadConfigMap.Update(ad.LoadConfigCookie, ad.LoadConfig, ebpf.UpdateNoExist); err != nil && !errors.Is(err, ebpf.ErrKeyExist) {
+	if err := ad.adm.activityDumpsConfigMap.Update(ad.LoadConfigCookie, ad.LoadConfig, ebpf.UpdateNoExist); err != nil && !errors.Is(err, ebpf.ErrKeyExist) {
 		return fmt.Errorf("couldn't push activity dump load config: %w", err)
 	}
 
@@ -418,7 +418,7 @@ func (ad *ActivityDump) disable() error {
 	}
 
 	// remove activity dump
-	if err := ad.adm.activityDumpLoadConfigMap.Delete(ad.LoadConfigCookie); err != nil {
+	if err := ad.adm.activityDumpsConfigMap.Delete(ad.LoadConfigCookie); err != nil {
 		return fmt.Errorf("couldn't delete activity dump load config: %w", err)
 	}
 	return nil

--- a/pkg/security/probe/activity_dump_load_controller.go
+++ b/pkg/security/probe/activity_dump_load_controller.go
@@ -88,6 +88,7 @@ func (lc *ActivityDumpLoadController) PushCurrentConfig() error {
 	defaults := NewActivityDumpLoadConfig(
 		lc.adm.probe.config.ActivityDumpTracedEventTypes,
 		lc.adm.probe.config.ActivityDumpCgroupDumpTimeout,
+		lc.adm.probe.config.ActivityDumpRateLimiter,
 		time.Now(),
 		lc.adm.probe.resolvers.TimeResolver,
 	)

--- a/pkg/security/probe/activity_dump_load_controller.go
+++ b/pkg/security/probe/activity_dump_load_controller.go
@@ -142,9 +142,11 @@ func (lc *ActivityDumpLoadController) NextPartialDump(ad *ActivityDump) *Activit
 	newDump.LoadConfig.SetTimeout(ad.LoadConfig.Timeout - timeToThreshold)
 	newDump.LoadConfig.TracedEventTypes = make([]model.EventType, len(ad.LoadConfig.TracedEventTypes))
 	copy(newDump.LoadConfig.TracedEventTypes, ad.LoadConfig.TracedEventTypes)
-	// TODO(rate_limiter): inherit normal rate limiter values
+	newDump.LoadConfig.Rate = ad.LoadConfig.Rate
 
-	// TODO(rate_limiter): reduce rate limiter by 25% if timeToThreshold < MinDumpTimeout
+	if timeToThreshold < MinDumpTimeout {
+		newDump.LoadConfig.Rate = newDump.LoadConfig.Rate / 4 * 3
+	}
 
 	if timeToThreshold < MinDumpTimeout/2 {
 		if err := lc.reduceTracedEventTypes(ad, newDump); err != nil {

--- a/pkg/security/secl/model/marshallers.go
+++ b/pkg/security/secl/model/marshallers.go
@@ -142,7 +142,7 @@ func (e *Process) MarshalPidCache(data []byte) (int, error) {
 
 // MarshalBinary marshals a binary representation of itself
 func (adlc *ActivityDumpLoadConfig) MarshalBinary() ([]byte, error) {
-	raw := make([]byte, 36)
+	raw := make([]byte, 40)
 
 	var eventMask uint64
 	for _, evt := range adlc.TracedEventTypes {
@@ -153,6 +153,7 @@ func (adlc *ActivityDumpLoadConfig) MarshalBinary() ([]byte, error) {
 	ByteOrder.PutUint64(raw[16:24], adlc.StartTimestampRaw)
 	ByteOrder.PutUint64(raw[24:32], adlc.EndTimestampRaw)
 	ByteOrder.PutUint32(raw[32:36], adlc.Rate)
+	// padding 4 bytes
 
 	return raw, nil
 }

--- a/pkg/security/secl/model/marshallers.go
+++ b/pkg/security/secl/model/marshallers.go
@@ -142,7 +142,7 @@ func (e *Process) MarshalPidCache(data []byte) (int, error) {
 
 // MarshalBinary marshals a binary representation of itself
 func (adlc *ActivityDumpLoadConfig) MarshalBinary() ([]byte, error) {
-	raw := make([]byte, 32)
+	raw := make([]byte, 36)
 
 	var eventMask uint64
 	for _, evt := range adlc.TracedEventTypes {
@@ -152,8 +152,7 @@ func (adlc *ActivityDumpLoadConfig) MarshalBinary() ([]byte, error) {
 	ByteOrder.PutUint64(raw[8:16], uint64(adlc.Timeout))
 	ByteOrder.PutUint64(raw[16:24], adlc.StartTimestampRaw)
 	ByteOrder.PutUint64(raw[24:32], adlc.EndTimestampRaw)
-
-	// TODO(rate_limiter): marshal rate limiter config
+	ByteOrder.PutUint32(raw[32:36], adlc.Rate)
 
 	return raw, nil
 }

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -863,9 +863,7 @@ type ActivityDumpLoadConfig struct {
 	Timeout           time.Duration
 	StartTimestampRaw uint64
 	EndTimestampRaw   uint64
-
-	// TODO(rate_limiter): add rate limiter config
-
+	Rate              uint32 // max number of events per sec
 }
 
 // SetTimeout updates the timeout of an activity dump

--- a/pkg/security/secl/model/unmarshallers.go
+++ b/pkg/security/secl/model/unmarshallers.go
@@ -844,7 +844,7 @@ func (e *CgroupTracingEvent) UnmarshalBinary(data []byte) (int, error) {
 
 // UnmarshalBinary unmarshals a binary representation of itself
 func (adlc *ActivityDumpLoadConfig) UnmarshalBinary(data []byte) (int, error) {
-	if len(data) < 36 {
+	if len(data) < 40 {
 		return 0, ErrNotEnoughData
 	}
 
@@ -858,8 +858,8 @@ func (adlc *ActivityDumpLoadConfig) UnmarshalBinary(data []byte) (int, error) {
 	adlc.StartTimestampRaw = ByteOrder.Uint64(data[16:24])
 	adlc.EndTimestampRaw = ByteOrder.Uint64(data[24:32])
 	adlc.Rate = ByteOrder.Uint32(data[32:36])
-
-	return 36, nil
+	// padding 4 bytes
+	return 40, nil
 }
 
 // UnmarshalBinary unmarshalls a binary representation of itself

--- a/pkg/security/secl/model/unmarshallers.go
+++ b/pkg/security/secl/model/unmarshallers.go
@@ -844,7 +844,7 @@ func (e *CgroupTracingEvent) UnmarshalBinary(data []byte) (int, error) {
 
 // UnmarshalBinary unmarshals a binary representation of itself
 func (adlc *ActivityDumpLoadConfig) UnmarshalBinary(data []byte) (int, error) {
-	if len(data) < 32 {
+	if len(data) < 36 {
 		return 0, ErrNotEnoughData
 	}
 
@@ -857,10 +857,9 @@ func (adlc *ActivityDumpLoadConfig) UnmarshalBinary(data []byte) (int, error) {
 	adlc.Timeout = time.Duration(ByteOrder.Uint64(data[8:16]))
 	adlc.StartTimestampRaw = ByteOrder.Uint64(data[16:24])
 	adlc.EndTimestampRaw = ByteOrder.Uint64(data[24:32])
+	adlc.Rate = ByteOrder.Uint32(data[32:36])
 
-	// TODO(rate_limiter): parse rate limiter config from kernel space
-
-	return 32, nil
+	return 36, nil
 }
 
 // UnmarshalBinary unmarshalls a binary representation of itself

--- a/pkg/security/tests/activity_dumps_test.go
+++ b/pkg/security/tests/activity_dumps_test.go
@@ -27,7 +27,7 @@ import (
 var expectedFormats = []string{"json", "protobuf"}
 
 func TestActivityDumps(t *testing.T) {
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{}, testOpts{enableActivityDump: true})
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{}, testOpts{enableActivityDump: true, activityDumpRateLimiter: 10})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -215,6 +215,56 @@ func TestActivityDumps(t *testing.T) {
 			return exitOK && execveOK
 		})
 	})
+
+	test.Run(t, "activity-dump-comm-rate-limiter", func(t *testing.T, kind wrapperType,
+		cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+
+		outputFiles, err := test.StartActivityDumpComm(t, "testsuite", outputDir, expectedFormats)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		time.Sleep(1 * time.Second) // a quick sleep to let starts and snapshot events to be added to the dump
+
+		for i := 0; i < 200; i++ {
+			temp, err := os.CreateTemp("/tmp", "ad-test-create")
+			fmt.Printf("Create %s\n", temp.Name())
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.Remove(temp.Name())
+		}
+
+		time.Sleep(1 * time.Second) // a quick sleep to let events to be added to the dump
+
+		err = test.StopActivityDumpComm(t, "testsuite")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		validateActivityDumpOutputs(t, test, expectedFormats, outputFiles, func(ad *probe.ActivityDump) bool {
+			nodes := ad.FindMatchingNodes("testsuite")
+			if nodes == nil {
+				t.Fatal("Node not found in activity dump")
+			}
+
+			for _, node := range nodes {
+				tmp := node.Files["tmp"]
+				if tmp == nil {
+					continue
+				}
+				for _, file := range tmp.Children {
+					fmt.Printf("Found root: %s\n", file.Name)
+				}
+				fmt.Printf("Found %d files\n", len(tmp.Children))
+				if len(tmp.Children) > 10 {
+					return false
+				}
+			}
+			return true
+		})
+	})
+
 }
 
 func validateActivityDumpOutputs(t *testing.T, test *testModule, expectedFormats []string, outputFiles []string, msgpValidator func(ad *probe.ActivityDump) bool) {

--- a/pkg/security/tests/activity_dumps_test.go
+++ b/pkg/security/tests/activity_dumps_test.go
@@ -18,9 +18,6 @@ import (
 	"testing"
 	"time"
 
-	"google.golang.org/protobuf/proto"
-
-	adproto "github.com/DataDog/datadog-agent/pkg/security/adproto/v1"
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
 	"github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
@@ -249,12 +246,16 @@ func validateActivityDumpOutputs(t *testing.T, test *testModule, expectedFormats
 			if err != nil {
 				t.Fatal(err)
 			}
-			ad := &adproto.ActivityDump{}
-			err = proto.Unmarshal(content, ad)
-			if err != nil {
-				t.Error(err)
+
+			// adm = test.
+			ad := probe.NewEmptyActivityDump()
+			ad.DecodeProtobuf(strings.NewReader(string(content)))
+
+			found := msgpValidator(ad)
+			if !found {
+				t.Error("Invalid activity dump")
 			}
-			perExtOK[ext] = true
+			perExtOK[ext] = found
 
 		default:
 			t.Fatal("Unexpected output file")

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -90,6 +90,7 @@ runtime_security_config:
     syscall_monitor:
       enabled: true
     enabled: true
+    rate_limiter: {{ .ActivityDumpRateLimiter }}
 {{end}}
   load_controller:
     events_count_threshold: {{ .EventsCountThreshold }}
@@ -171,6 +172,7 @@ type testOpts struct {
 	disableFilters              bool
 	disableApprovers            bool
 	enableActivityDump          bool
+	activityDumpRateLimiter     int
 	disableDiscarders           bool
 	eventsCountThreshold        int
 	reuseProbeHandler           bool
@@ -192,6 +194,7 @@ func (to testOpts) Equal(opts testOpts) bool {
 	return to.testDir == opts.testDir &&
 		to.disableApprovers == opts.disableApprovers &&
 		to.enableActivityDump == opts.enableActivityDump &&
+		to.activityDumpRateLimiter == opts.activityDumpRateLimiter &&
 		to.disableDiscarders == opts.disableDiscarders &&
 		to.disableFilters == opts.disableFilters &&
 		to.eventsCountThreshold == opts.eventsCountThreshold &&
@@ -601,6 +604,10 @@ func genTestConfig(dir string, opts testOpts) (*config.Config, error) {
 		opts.eventsCountThreshold = 100000000
 	}
 
+	if opts.activityDumpRateLimiter == 0 {
+		opts.activityDumpRateLimiter = 100
+	}
+
 	erpcDentryResolutionEnabled := true
 	if opts.disableERPCDentryResolution {
 		erpcDentryResolutionEnabled = false
@@ -616,6 +623,7 @@ func genTestConfig(dir string, opts testOpts) (*config.Config, error) {
 		"TestPoliciesDir":             dir,
 		"DisableApprovers":            opts.disableApprovers,
 		"EnableActivityDump":          opts.enableActivityDump,
+		"ActivityDumpRateLimiter":     opts.activityDumpRateLimiter,
 		"EventsCountThreshold":        opts.eventsCountThreshold,
 		"ErpcDentryResolutionEnabled": erpcDentryResolutionEnabled,
 		"MapDentryResolutionEnabled":  mapDentryResolutionEnabled,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
