### PR TITLE
[CWS][SEC-5015] fix discarders with std secl variables

### DIFF
--- a/pkg/security/probe/discarders_test.go
+++ b/pkg/security/probe/discarders_test.go
@@ -44,7 +44,8 @@ func TestIsParentDiscarder(t *testing.T) {
 	var evalOpts eval.Opts
 	evalOpts.
 		WithConstants(model.SECLConstants).
-		WithLegacyFields(model.SECLLegacyFields)
+		WithLegacyFields(model.SECLLegacyFields).
+		WithVariables(model.SECLVariables)
 
 	var opts rules.Opts
 	opts.
@@ -207,6 +208,13 @@ func TestIsParentDiscarder(t *testing.T) {
 	addRuleExpr(t, rs, `open.file.path =~ "/etc/**"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/etc/conf.d/dir/aaa", 1); is {
+		t.Error("shouldn't be a parent discarder")
+	}
+
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
+	addRuleExpr(t, rs, `open.file.path == "/proc/${process.pid}/maps"`)
+
+	if is, _ := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/proc/1/maps", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 }

--- a/pkg/security/secl/compiler/eval/eval.go
+++ b/pkg/security/secl/compiler/eval/eval.go
@@ -298,6 +298,7 @@ func stringEvaluatorFromVariable(str string, pos lexer.Position, replCtx Replace
 	}
 
 	return &StringEvaluator{
+		Value:     str,
 		ValueType: VariableValueType,
 		EvalFnc: func(ctx *Context) string {
 			var result string

--- a/pkg/security/secl/compiler/eval/model_test.go
+++ b/pkg/security/secl/compiler/eval/model_test.go
@@ -7,7 +7,7 @@ package eval
 
 import (
 	"container/list"
-	"errors"
+	"fmt"
 	"net"
 	"reflect"
 	"syscall"
@@ -143,18 +143,15 @@ func (m *testModel) NewEvent() Event {
 
 func (m *testModel) ValidateField(key string, value FieldValue) error {
 	switch key {
-
 	case "process.uid":
-
 		uid, ok := value.Value.(int)
 		if !ok {
-			return errors.New("invalid type for process.ui")
+			return fmt.Errorf("invalid type for process.ui: %v", reflect.TypeOf(value.Value))
 		}
 
 		if uid < 0 {
-			return errors.New("process.uid cannot be negative")
+			return fmt.Errorf("process.uid cannot be negative: %d", uid)
 		}
-
 	}
 
 	return nil

--- a/pkg/security/secl/compiler/eval/operators.go
+++ b/pkg/security/secl/compiler/eval/operators.go
@@ -32,7 +32,233 @@ func isArithmDeterministic(a Evaluator, b Evaluator, state *State) bool {
 	return isDc
 }
 
-// IntNot - ^int operator
+// Or operator
+func Or(a *BoolEvaluator, b *BoolEvaluator, state *State) (*BoolEvaluator, error) {
+
+	isDc := a.IsDeterministicFor(state.field) || b.IsDeterministicFor(state.field)
+
+	if a.EvalFnc != nil && b.EvalFnc != nil {
+		ea, eb := a.EvalFnc, b.EvalFnc
+
+		if state.field != "" {
+			if !a.IsDeterministicFor(state.field) && !a.IsStatic() {
+				ea = func(ctx *Context) bool {
+					return true
+				}
+			}
+			if !b.IsDeterministicFor(state.field) && !b.IsStatic() {
+				eb = func(ctx *Context) bool {
+					return true
+				}
+			}
+		}
+
+		if a.Weight > b.Weight {
+			tmp := ea
+			ea = eb
+			eb = tmp
+		}
+
+		evalFnc := func(ctx *Context) bool {
+			return ea(ctx) || eb(ctx)
+		}
+
+		return &BoolEvaluator{
+			EvalFnc:         evalFnc,
+			Weight:          a.Weight + b.Weight,
+			isDeterministic: isDc,
+		}, nil
+	}
+
+	if a.EvalFnc == nil && b.EvalFnc == nil {
+		ea, eb := a.Value, b.Value
+
+		ctx := NewContext(nil)
+		_ = ctx
+
+		return &BoolEvaluator{
+			Value:           ea || eb,
+			isDeterministic: isDc,
+		}, nil
+	}
+
+	if a.EvalFnc != nil {
+		ea, eb := a.EvalFnc, b.Value
+
+		if a.Field != "" {
+			if err := state.UpdateFieldValues(a.Field, FieldValue{Value: eb, Type: ScalarValueType}); err != nil {
+				return nil, err
+			}
+		}
+
+		if state.field != "" {
+			if !a.IsDeterministicFor(state.field) && !a.IsStatic() {
+				ea = func(ctx *Context) bool {
+					return true
+				}
+			}
+			if !b.IsDeterministicFor(state.field) && !b.IsStatic() {
+				eb = true
+			}
+		}
+
+		evalFnc := func(ctx *Context) bool {
+			return ea(ctx) || eb
+		}
+
+		return &BoolEvaluator{
+			EvalFnc:         evalFnc,
+			Field:           a.Field,
+			Weight:          a.Weight,
+			isDeterministic: isDc,
+		}, nil
+	}
+
+	ea, eb := a.Value, b.EvalFnc
+
+	if b.Field != "" {
+		if err := state.UpdateFieldValues(b.Field, FieldValue{Value: ea, Type: ScalarValueType}); err != nil {
+			return nil, err
+		}
+	}
+
+	if state.field != "" {
+		if !a.IsDeterministicFor(state.field) && !a.IsStatic() {
+			ea = true
+		}
+		if !b.IsDeterministicFor(state.field) && !b.IsStatic() {
+			eb = func(ctx *Context) bool {
+				return true
+			}
+		}
+	}
+
+	evalFnc := func(ctx *Context) bool {
+		return ea || eb(ctx)
+	}
+
+	return &BoolEvaluator{
+		EvalFnc:         evalFnc,
+		Field:           b.Field,
+		Weight:          b.Weight,
+		isDeterministic: isDc,
+	}, nil
+}
+
+// And operator
+func And(a *BoolEvaluator, b *BoolEvaluator, state *State) (*BoolEvaluator, error) {
+
+	isDc := a.IsDeterministicFor(state.field) || b.IsDeterministicFor(state.field)
+
+	if a.EvalFnc != nil && b.EvalFnc != nil {
+		ea, eb := a.EvalFnc, b.EvalFnc
+
+		if state.field != "" {
+			if !a.IsDeterministicFor(state.field) && !a.IsStatic() {
+				ea = func(ctx *Context) bool {
+					return true
+				}
+			}
+			if !b.IsDeterministicFor(state.field) && !b.IsStatic() {
+				eb = func(ctx *Context) bool {
+					return true
+				}
+			}
+		}
+
+		if a.Weight > b.Weight {
+			tmp := ea
+			ea = eb
+			eb = tmp
+		}
+
+		evalFnc := func(ctx *Context) bool {
+			return ea(ctx) && eb(ctx)
+		}
+
+		return &BoolEvaluator{
+			EvalFnc:         evalFnc,
+			Weight:          a.Weight + b.Weight,
+			isDeterministic: isDc,
+		}, nil
+	}
+
+	if a.EvalFnc == nil && b.EvalFnc == nil {
+		ea, eb := a.Value, b.Value
+
+		ctx := NewContext(nil)
+		_ = ctx
+
+		return &BoolEvaluator{
+			Value:           ea && eb,
+			isDeterministic: isDc,
+		}, nil
+	}
+
+	if a.EvalFnc != nil {
+		ea, eb := a.EvalFnc, b.Value
+
+		if a.Field != "" {
+			if err := state.UpdateFieldValues(a.Field, FieldValue{Value: eb, Type: ScalarValueType}); err != nil {
+				return nil, err
+			}
+		}
+
+		if state.field != "" {
+			if !a.IsDeterministicFor(state.field) && !a.IsStatic() {
+				ea = func(ctx *Context) bool {
+					return true
+				}
+			}
+			if !b.IsDeterministicFor(state.field) && !b.IsStatic() {
+				eb = true
+			}
+		}
+
+		evalFnc := func(ctx *Context) bool {
+			return ea(ctx) && eb
+		}
+
+		return &BoolEvaluator{
+			EvalFnc:         evalFnc,
+			Field:           a.Field,
+			Weight:          a.Weight,
+			isDeterministic: isDc,
+		}, nil
+	}
+
+	ea, eb := a.Value, b.EvalFnc
+
+	if b.Field != "" {
+		if err := state.UpdateFieldValues(b.Field, FieldValue{Value: ea, Type: ScalarValueType}); err != nil {
+			return nil, err
+		}
+	}
+
+	if state.field != "" {
+		if !a.IsDeterministicFor(state.field) && !a.IsStatic() {
+			ea = true
+		}
+		if !b.IsDeterministicFor(state.field) && !b.IsStatic() {
+			eb = func(ctx *Context) bool {
+				return true
+			}
+		}
+	}
+
+	evalFnc := func(ctx *Context) bool {
+		return ea && eb(ctx)
+	}
+
+	return &BoolEvaluator{
+		EvalFnc:         evalFnc,
+		Field:           b.Field,
+		Weight:          b.Weight,
+		isDeterministic: isDc,
+	}, nil
+}
+
+// IntNot ^int operator
 func IntNot(a *IntEvaluator, state *State) *IntEvaluator {
 	isDc := a.IsDeterministicFor(state.field)
 
@@ -60,6 +286,18 @@ func IntNot(a *IntEvaluator, state *State) *IntEvaluator {
 // StringEquals evaluates string
 func StringEquals(a *StringEvaluator, b *StringEvaluator, state *State) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
+
+	if a.Field != "" {
+		if err := state.UpdateFieldValues(a.Field, FieldValue{Value: b.Value, Type: b.ValueType}); err != nil {
+			return nil, err
+		}
+	}
+
+	if b.Field != "" {
+		if err := state.UpdateFieldValues(b.Field, FieldValue{Value: a.Value, Type: a.ValueType}); err != nil {
+			return nil, err
+		}
+	}
 
 	// default comparison
 	op := func(as string, bs string) bool {
@@ -121,12 +359,6 @@ func StringEquals(a *StringEvaluator, b *StringEvaluator, state *State) (*BoolEv
 	if a.EvalFnc != nil {
 		ea, eb := a.EvalFnc, b.Value
 
-		if a.Field != "" {
-			if err := state.UpdateFieldValues(a.Field, FieldValue{Value: eb, Type: b.ValueType}); err != nil {
-				return nil, err
-			}
-		}
-
 		evalFnc := func(ctx *Context) bool {
 			return op(ea(ctx), eb)
 		}
@@ -140,12 +372,6 @@ func StringEquals(a *StringEvaluator, b *StringEvaluator, state *State) (*BoolEv
 
 	ea, eb := a.Value, b.EvalFnc
 
-	if b.Field != "" {
-		if err := state.UpdateFieldValues(b.Field, FieldValue{Value: ea, Type: a.ValueType}); err != nil {
-			return nil, err
-		}
-	}
-
 	evalFnc := func(ctx *Context) bool {
 		return op(ea, eb(ctx))
 	}
@@ -157,7 +383,7 @@ func StringEquals(a *StringEvaluator, b *StringEvaluator, state *State) (*BoolEv
 	}, nil
 }
 
-// Not - !true operator
+// Not !true operator
 func Not(a *BoolEvaluator, state *State) *BoolEvaluator {
 	isDc := a.IsDeterministicFor(state.field)
 
@@ -186,7 +412,7 @@ func Not(a *BoolEvaluator, state *State) *BoolEvaluator {
 	}
 }
 
-// Minus - -int operator
+// Minus -int operator
 func Minus(a *IntEvaluator, state *State) *IntEvaluator {
 	isDc := a.IsDeterministicFor(state.field)
 
@@ -214,6 +440,20 @@ func Minus(a *IntEvaluator, state *State) *IntEvaluator {
 // StringArrayContains evaluates array of strings against a value
 func StringArrayContains(a *StringEvaluator, b *StringArrayEvaluator, state *State) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
+
+	if a.Field != "" {
+		for _, value := range b.Values {
+			if err := state.UpdateFieldValues(a.Field, FieldValue{Value: value, Type: ScalarValueType}); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if b.Field != "" {
+		if err := state.UpdateFieldValues(b.Field, FieldValue{Value: a.Value, Type: a.ValueType}); err != nil {
+			return nil, err
+		}
+	}
 
 	op := func(a string, b []string, cmp func(a, b string) bool) bool {
 		for _, bs := range b {
@@ -274,14 +514,6 @@ func StringArrayContains(a *StringEvaluator, b *StringArrayEvaluator, state *Sta
 	if a.EvalFnc != nil {
 		ea, eb := a.EvalFnc, b.Values
 
-		if a.Field != "" {
-			for _, value := range eb {
-				if err := state.UpdateFieldValues(a.Field, FieldValue{Value: value, Type: ScalarValueType}); err != nil {
-					return nil, err
-				}
-			}
-		}
-
 		evalFnc := func(ctx *Context) bool {
 			return op(ea(ctx), eb, cmp)
 		}
@@ -295,14 +527,8 @@ func StringArrayContains(a *StringEvaluator, b *StringArrayEvaluator, state *Sta
 
 	ea, eb := a.Value, b.EvalFnc
 
-	if b.Field != "" {
-		if err := state.UpdateFieldValues(b.Field, FieldValue{Value: ea, Type: a.ValueType}); err != nil {
-			return nil, err
-		}
-	}
-
 	evalFnc := func(ctx *Context) bool {
-		return op(a.Value, eb(ctx), cmp)
+		return op(ea, eb(ctx), cmp)
 	}
 
 	return &BoolEvaluator{
@@ -315,6 +541,14 @@ func StringArrayContains(a *StringEvaluator, b *StringArrayEvaluator, state *Sta
 // StringValuesContains evaluates a string against values
 func StringValuesContains(a *StringEvaluator, b *StringValuesEvaluator, state *State) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
+
+	if a.Field != "" {
+		for _, value := range b.Values.fieldValues {
+			if err := state.UpdateFieldValues(a.Field, value); err != nil {
+				return nil, err
+			}
+		}
+	}
 
 	if err := b.Compile(a.StringCmpOpts); err != nil {
 		return nil, err
@@ -348,14 +582,6 @@ func StringValuesContains(a *StringEvaluator, b *StringValuesEvaluator, state *S
 	if a.EvalFnc != nil {
 		ea, eb := a.EvalFnc, b.Values
 
-		if a.Field != "" {
-			for _, value := range eb.fieldValues {
-				if err := state.UpdateFieldValues(a.Field, value); err != nil {
-					return nil, err
-				}
-			}
-		}
-
 		evalFnc := func(ctx *Context) bool {
 			return eb.Matches(ea(ctx))
 		}
@@ -384,6 +610,14 @@ func StringValuesContains(a *StringEvaluator, b *StringValuesEvaluator, state *S
 // StringArrayMatches weak comparison, a least one element of a should be in b. a can't contain regexp
 func StringArrayMatches(a *StringArrayEvaluator, b *StringValuesEvaluator, state *State) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
+
+	if a.Field != "" {
+		for _, value := range b.Values.fieldValues {
+			if err := state.UpdateFieldValues(a.Field, value); err != nil {
+				return nil, err
+			}
+		}
+	}
 
 	if err := b.Compile(a.StringCmpOpts); err != nil {
 		return nil, err
@@ -425,14 +659,6 @@ func StringArrayMatches(a *StringArrayEvaluator, b *StringValuesEvaluator, state
 	if a.EvalFnc != nil {
 		ea, eb := a.EvalFnc, b.Values
 
-		if a.Field != "" {
-			for _, value := range eb.fieldValues {
-				if err := state.UpdateFieldValues(a.Field, value); err != nil {
-					return nil, err
-				}
-			}
-		}
-
 		evalFnc := func(ctx *Context) bool {
 			return arrayOp(ea(ctx), &eb)
 		}
@@ -460,6 +686,14 @@ func StringArrayMatches(a *StringArrayEvaluator, b *StringValuesEvaluator, state
 // IntArrayMatches weak comparison, a least one element of a should be in b
 func IntArrayMatches(a *IntArrayEvaluator, b *IntArrayEvaluator, state *State) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
+
+	if a.Field != "" {
+		for _, value := range b.Values {
+			if err := state.UpdateFieldValues(a.Field, FieldValue{Value: value}); err != nil {
+				return nil, err
+			}
+		}
+	}
 
 	arrayOp := func(a []int, b []int) bool {
 		for _, va := range a {
@@ -499,14 +733,6 @@ func IntArrayMatches(a *IntArrayEvaluator, b *IntArrayEvaluator, state *State) (
 	if a.EvalFnc != nil {
 		ea, eb := a.EvalFnc, b.Values
 
-		if a.Field != "" {
-			for _, value := range b.Values {
-				if err := state.UpdateFieldValues(a.Field, FieldValue{Value: value}); err != nil {
-					return nil, err
-				}
-			}
-		}
-
 		evalFnc := func(ctx *Context) bool {
 			return arrayOp(ea(ctx), eb)
 		}
@@ -534,6 +760,20 @@ func IntArrayMatches(a *IntArrayEvaluator, b *IntArrayEvaluator, state *State) (
 // ArrayBoolContains evaluates array of bool against a value
 func ArrayBoolContains(a *BoolEvaluator, b *BoolArrayEvaluator, state *State) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
+
+	if a.Field != "" {
+		for _, value := range b.Values {
+			if err := state.UpdateFieldValues(a.Field, FieldValue{Value: value}); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if b.Field != "" {
+		if err := state.UpdateFieldValues(b.Field, FieldValue{Value: a.Value}); err != nil {
+			return nil, err
+		}
+	}
 
 	arrayOp := func(a bool, b []bool) bool {
 		for _, v := range b {
@@ -570,14 +810,6 @@ func ArrayBoolContains(a *BoolEvaluator, b *BoolArrayEvaluator, state *State) (*
 	if a.EvalFnc != nil {
 		ea, eb := a.EvalFnc, b.Values
 
-		if a.Field != "" {
-			for _, value := range eb {
-				if err := state.UpdateFieldValues(a.Field, FieldValue{Value: value}); err != nil {
-					return nil, err
-				}
-			}
-		}
-
 		evalFnc := func(ctx *Context) bool {
 			return arrayOp(ea(ctx), eb)
 		}
@@ -590,12 +822,6 @@ func ArrayBoolContains(a *BoolEvaluator, b *BoolArrayEvaluator, state *State) (*
 	}
 
 	ea, eb := a.Value, b.EvalFnc
-
-	if b.Field != "" {
-		if err := state.UpdateFieldValues(b.Field, FieldValue{Value: ea}); err != nil {
-			return nil, err
-		}
-	}
 
 	evalFnc := func(ctx *Context) bool {
 		return arrayOp(ea, eb(ctx))
@@ -611,6 +837,18 @@ func ArrayBoolContains(a *BoolEvaluator, b *BoolArrayEvaluator, state *State) (*
 // CIDREquals evaluates CIDR ranges
 func CIDREquals(a *CIDREvaluator, b *CIDREvaluator, state *State) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
+
+	if a.Field != "" {
+		if err := state.UpdateFieldValues(a.Field, FieldValue{Value: b.Value, Type: b.ValueType}); err != nil {
+			return nil, err
+		}
+	}
+
+	if b.Field != "" {
+		if err := state.UpdateFieldValues(b.Field, FieldValue{Value: a.Value, Type: a.ValueType}); err != nil {
+			return nil, err
+		}
+	}
 
 	if a.EvalFnc != nil && b.EvalFnc != nil {
 		ea, eb := a.EvalFnc, b.EvalFnc
@@ -640,12 +878,6 @@ func CIDREquals(a *CIDREvaluator, b *CIDREvaluator, state *State) (*BoolEvaluato
 	if a.EvalFnc != nil {
 		ea, eb := a.EvalFnc, b.Value
 
-		if a.Field != "" {
-			if err := state.UpdateFieldValues(a.Field, FieldValue{Value: eb, Type: b.ValueType}); err != nil {
-				return nil, err
-			}
-		}
-
 		evalFnc := func(ctx *Context) bool {
 			a := ea(ctx)
 			return IPNetsMatch(&a, &eb)
@@ -659,12 +891,6 @@ func CIDREquals(a *CIDREvaluator, b *CIDREvaluator, state *State) (*BoolEvaluato
 	}
 
 	ea, eb := a.Value, b.EvalFnc
-
-	if b.Field != "" {
-		if err := state.UpdateFieldValues(b.Field, FieldValue{Value: ea, Type: a.ValueType}); err != nil {
-			return nil, err
-		}
-	}
 
 	evalFnc := func(ctx *Context) bool {
 		b := eb(ctx)
@@ -681,6 +907,14 @@ func CIDREquals(a *CIDREvaluator, b *CIDREvaluator, state *State) (*BoolEvaluato
 // CIDRValuesContains evaluates a CIDR against a list of CIDRs
 func CIDRValuesContains(a *CIDREvaluator, b *CIDRValuesEvaluator, state *State) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
+
+	if a.Field != "" {
+		for _, value := range b.Value.fieldValues {
+			if err := state.UpdateFieldValues(a.Field, value); err != nil {
+				return nil, err
+			}
+		}
+	}
 
 	if a.EvalFnc != nil && b.EvalFnc != nil {
 		ea, eb := a.EvalFnc, b.EvalFnc
@@ -710,14 +944,6 @@ func CIDRValuesContains(a *CIDREvaluator, b *CIDRValuesEvaluator, state *State) 
 	if a.EvalFnc != nil {
 		ea, eb := a.EvalFnc, b.Value
 
-		if a.Field != "" {
-			for _, value := range eb.fieldValues {
-				if err := state.UpdateFieldValues(a.Field, value); err != nil {
-					return nil, err
-				}
-			}
-		}
-
 		evalFnc := func(ctx *Context) bool {
 			ipnet := ea(ctx)
 			return eb.Contains(&ipnet)
@@ -746,6 +972,14 @@ func CIDRValuesContains(a *CIDREvaluator, b *CIDRValuesEvaluator, state *State) 
 func cidrArrayMatches(a *CIDRArrayEvaluator, b *CIDRValuesEvaluator, state *State, arrayOp func(a *CIDRValues, b []net.IPNet) bool) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
 
+	if a.Field != "" {
+		for _, value := range b.Value.fieldValues {
+			if err := state.UpdateFieldValues(a.Field, value); err != nil {
+				return nil, err
+			}
+		}
+	}
+
 	if a.EvalFnc != nil && b.EvalFnc != nil {
 		ea, eb := a.EvalFnc, b.EvalFnc
 
@@ -772,14 +1006,6 @@ func cidrArrayMatches(a *CIDRArrayEvaluator, b *CIDRValuesEvaluator, state *Stat
 
 	if a.EvalFnc != nil {
 		ea, eb := a.EvalFnc, b.Value
-
-		if a.Field != "" {
-			for _, value := range eb.fieldValues {
-				if err := state.UpdateFieldValues(a.Field, value); err != nil {
-					return nil, err
-				}
-			}
-		}
 
 		evalFnc := func(ctx *Context) bool {
 			return arrayOp(&eb, ea(ctx))
@@ -825,6 +1051,14 @@ func CIDRArrayMatchesAll(a *CIDRArrayEvaluator, b *CIDRValuesEvaluator, state *S
 func CIDRArrayContains(a *CIDREvaluator, b *CIDRArrayEvaluator, state *State) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
 
+	if a.Field != "" {
+		for _, value := range b.Value {
+			if err := state.UpdateFieldValues(a.Field, FieldValue{Type: IPNetValueType, Value: value}); err != nil {
+				return nil, err
+			}
+		}
+	}
+
 	arrayOp := func(a *net.IPNet, b []net.IPNet) bool {
 		for _, n := range b {
 			if IPNetsMatch(a, &n) {
@@ -861,14 +1095,6 @@ func CIDRArrayContains(a *CIDREvaluator, b *CIDRArrayEvaluator, state *State) (*
 
 	if a.EvalFnc != nil {
 		ea, eb := a.EvalFnc, b.Value
-
-		if a.Field != "" {
-			for _, value := range eb {
-				if err := state.UpdateFieldValues(a.Field, FieldValue{Type: IPNetValueType, Value: value}); err != nil {
-					return nil, err
-				}
-			}
-		}
 
 		evalFnc := func(ctx *Context) bool {
 			ipnet := ea(ctx)

--- a/pkg/security/secl/compiler/eval/variables.go
+++ b/pkg/security/secl/compiler/eval/variables.go
@@ -82,6 +82,7 @@ type StringVariable struct {
 // GetEvaluator returns the variable SECL evaluator
 func (s *StringVariable) GetEvaluator() interface{} {
 	return &StringEvaluator{
+		ValueType: VariableValueType,
 		EvalFnc: func(ctx *Context) string {
 			return s.strFnc(ctx)
 		},
@@ -269,6 +270,7 @@ type MutableStringVariable struct {
 // GetEvaluator returns the variable SECL evaluator
 func (m *MutableStringVariable) GetEvaluator() interface{} {
 	return &StringEvaluator{
+		ValueType: VariableValueType,
 		EvalFnc: func(ctx *Context) string {
 			return m.Value
 		},

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -45,6 +45,8 @@ func validatePath(field eval.Field, fieldValue eval.FieldValue) error {
 	// do not support regular expression on path, currently unable to support discarder for regex value
 	if fieldValue.Type == eval.RegexpValueType {
 		return fmt.Errorf("regexp not supported on path `%s`", field)
+	} else if fieldValue.Type == eval.VariableValueType {
+		return nil
 	}
 
 	if value, ok := fieldValue.Value.(string); ok {

--- a/pkg/security/secl/rules/model_test.go
+++ b/pkg/security/secl/rules/model_test.go
@@ -6,7 +6,7 @@
 package rules
 
 import (
-	"errors"
+	"fmt"
 	"reflect"
 	"syscall"
 	"unsafe"
@@ -62,18 +62,15 @@ func (m *testModel) NewEvent() eval.Event {
 
 func (m *testModel) ValidateField(key string, value eval.FieldValue) error {
 	switch key {
-
 	case "process.uid":
-
 		uid, ok := value.Value.(int)
 		if !ok {
-			return errors.New("invalid type for process.ui")
+			return fmt.Errorf("invalid type for process.ui: %v", reflect.TypeOf(value.Value))
 		}
 
 		if uid < 0 {
-			return errors.New("process.uid cannot be negative")
+			return fmt.Errorf("process.uid cannot be negative: %d", uid)
 		}
-
 	}
 
 	return nil
@@ -117,8 +114,9 @@ func (m *testModel) GetEvaluator(key string, regID eval.RegisterID) (eval.Evalua
 	case "open.filename":
 
 		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string { return (*testEvent)(ctx.Object).open.filename },
-			Field:   key,
+			EvalFnc:     func(ctx *eval.Context) string { return (*testEvent)(ctx.Object).open.filename },
+			Field:       key,
+			OpOverrides: eval.GlobCmp,
 		}, nil
 
 	case "open.flags":

--- a/pkg/security/secl/rules/ruleset_test.go
+++ b/pkg/security/secl/rules/ruleset_test.go
@@ -323,7 +323,7 @@ func TestRuleSetApprovers4(t *testing.T) {
 	caps = FieldCapabilities{
 		{
 			Field: "open.filename",
-			Types: eval.ScalarValueType | eval.PatternValueType,
+			Types: eval.ScalarValueType | eval.GlobValueType,
 		},
 	}
 
@@ -494,7 +494,7 @@ func TestRuleSetApprovers11(t *testing.T) {
 	caps := FieldCapabilities{
 		{
 			Field:        "open.filename",
-			Types:        eval.ScalarValueType | eval.PatternValueType,
+			Types:        eval.ScalarValueType | eval.GlobValueType,
 			FilterWeight: 3,
 		},
 	}
@@ -542,6 +542,29 @@ func TestRuleSetApprovers13(t *testing.T) {
 	approvers, _ := rs.GetEventApprovers("open", caps)
 	if len(approvers) != 0 {
 		t.Fatal("shouldn't get an approver for filename")
+	}
+}
+
+func TestRuleSetApprovers14(t *testing.T) {
+	exprs := []string{
+		`open.filename == "/etc/passwd"`,
+		`open.filename =~ "/etc/*/httpd"`,
+	}
+
+	rs := newRuleSet()
+	addRuleExpr(t, rs, exprs...)
+
+	caps := FieldCapabilities{
+		{
+			Field:        "open.filename",
+			Types:        eval.ScalarValueType | eval.GlobValueType,
+			FilterWeight: 3,
+		},
+	}
+
+	approvers, _ := rs.GetEventApprovers("open", caps)
+	if len(approvers) != 1 || len(approvers["open.filename"]) != 2 {
+		t.Fatalf("shouldn't get an approver for filename: %v", approvers)
 	}
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fix rule using variable generating abnormal discarders.

ex: 
```
open.file.path == "/proc/${process.pid}/maps"
```

Note that this fix doesn't fix mutable variables.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
