### PR TITLE
[install_mac_os] Install proper Agent version based on macOS version

### DIFF
--- a/cmd/agent/install_mac_os.sh
+++ b/cmd/agent/install_mac_os.sh
@@ -88,13 +88,18 @@ else
 fi
 
 dmg_version=
-if [ "${macos_major_version}" -lt 10 ] || { [ "${macos_major_version}" -eq 10 ] && [ "${macos_minor_version}" -le 12 ]; }; then
+if [ "${macos_major_version}" -lt 10 ] || { [ "${macos_major_version}" -eq 10 ] && [ "${macos_minor_version}" -lt 12 ]; }; then
+    echo -e "\033[31mDatadog Agent doesn't support macOS < 10.12.\033[0m\n"
+    exit 1
+elif [ "${macos_major_version}" -eq 10 ] && [ "${macos_minor_version}" -eq 12 ]; then
+    echo -e "\033[33mWarning: Agent ${agent_major_version}.34.0 is the last supported version for macOS 10.12. Selecting it for installation.\033[0m"
     dmg_version="${agent_major_version}.34.0-1"
 elif [ "${macos_major_version}" -eq 10 ] && [ "${macos_minor_version}" -eq 13 ]; then
+    echo -e "\033[33mWarning: Agent ${agent_major_version}.38.2 is the last supported version for macOS 10.13. Selecting it for installation.\033[0m"
     dmg_version="${agent_major_version}.38.2-1"
 else
     if [ "${agent_major_version}" -eq 6 ]; then
-        printf "\033[31mThe latest Agent 6 is no longer built for for macOS $macos_full_version. Please invoke again with DD_AGENT_MAJOR_VERSION=7\033[0m\n"
+        echo -e "\033[31mThe latest Agent 6 is no longer built for for macOS $macos_full_version. Please invoke again with DD_AGENT_MAJOR_VERSION=7\033[0m\n"
         exit 1
     else
         dmg_version="7-latest"

--- a/cmd/agent/install_mac_os.sh
+++ b/cmd/agent/install_mac_os.sh
@@ -72,7 +72,11 @@ if [ -n "$DD_SYSTEMDAEMON_INSTALL" ]; then
     fi
 fi
 
-agent_major_version=6
+macos_full_version=$(sw_vers -productVersion)
+macos_major_version=$(echo "${macos_full_version}" | cut -d '.' -f 1)
+macos_minor_version=$(echo "${macos_full_version}" | cut -d '.' -f 2)
+
+agent_major_version=7
 if [ -n "$DD_AGENT_MAJOR_VERSION" ]; then
   if [ "$DD_AGENT_MAJOR_VERSION" != "6" ] && [ "$DD_AGENT_MAJOR_VERSION" != "7" ]; then
     echo "DD_AGENT_MAJOR_VERSION must be either 6 or 7. Current value: $DD_AGENT_MAJOR_VERSION"
@@ -80,14 +84,24 @@ if [ -n "$DD_AGENT_MAJOR_VERSION" ]; then
   fi
   agent_major_version=$DD_AGENT_MAJOR_VERSION
 else
-  echo -e "\033[33mWarning: DD_AGENT_MAJOR_VERSION not set. Installing Agent version 6 by default.\033[0m"
+  echo -e "\033[33mWarning: DD_AGENT_MAJOR_VERSION not set. Installing Agent version 7 by default.\033[0m"
 fi
 
-dmg_remote_file="datadogagent.dmg"
-if [ "$agent_major_version" = "7" ]; then
-    dmg_remote_file="datadog-agent-7-latest.dmg"
+dmg_version=
+if [ "${macos_major_version}" -lt 10 ] || { [ "${macos_major_version}" -eq 10 ] && [ "${macos_minor_version}" -le 12 ]; }; then
+    dmg_version="${agent_major_version}.34.0-1"
+elif [ "${macos_major_version}" -eq 10 ] && [ "${macos_minor_version}" -eq 13 ]; then
+    dmg_version="${agent_major_version}.38.2-1"
+else
+    if [ "${agent_major_version}" -eq 6 ]; then
+        printf "\033[31mThe latest Agent 6 is no longer built for for macOS $macos_full_version. Please invoke again with DD_AGENT_MAJOR_VERSION=7\033[0m\n"
+        exit 1
+    else
+        dmg_version="7-latest"
+    fi
 fi
-dmg_url="$dmg_base_url/$dmg_remote_file"
+
+dmg_url="$dmg_base_url/datadog-agent-${dmg_version}.dmg"
 
 if [ "$upgrade" ]; then
     if [ ! -f $etc_dir/datadog.conf ]; then


### PR DESCRIPTION
### What does this PR do?

Updates macOS install script to install the proper Agent version based on macOS version.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

Starting with 7.39.0, Agent 6 is not built for macOS. Since (at least for now) the script is always meant to install the latest supported version, we don't consider Agent 6 the latest for macOS >= 10.14 and fail the installation explicitly. 

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Ideally, test on all these macOS versions (expected results attached):
* on macOS < 10.12 => error gets printed about system no longer supported, script fails and nothing gets installed
* macOS 10.12 => warning gets printed and agent 7.34.0 (or 6.34.0 based on DD_AGENT_MAJOR_VERSION) gets installed
* macOS 10.13 => warning gets printed and agent 7.38.2 (or 6.38.2 based on DD_AGENT_MAJOR_VERSION) gets installed
* macOS > 10.13 => if DD_AGENT_MAJOR_VERSION==7, installs the latest agent release; if DD_AGENT_MAJOR_VERSION==6, error gets printed, script fails and nothing gets installed

If you can't get your hands on some of these systems, manually change the value of `macos_minor_version` variable inside the script and run the tests with that.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
