### PR TITLE
[CWS/CSPM] fix security agent shutdown if all features are disabled

### DIFF
--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -7,6 +7,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -164,6 +165,9 @@ func start(cmd *cobra.Command, args []string) error {
 	go handleSignals(stopCh)
 
 	err := RunAgent(ctx)
+	if errors.Is(err, allComponentsDisabledErr) {
+		return nil
+	}
 	if err != nil {
 		return err
 	}
@@ -173,6 +177,8 @@ func start(cmd *cobra.Command, args []string) error {
 
 	return nil
 }
+
+var allComponentsDisabledErr = errors.New("all security-agent component are disabled")
 
 // RunAgent initialized resources and starts API server
 func RunAgent(ctx context.Context) (err error) {
@@ -219,7 +225,7 @@ func RunAgent(ctx context.Context) (err error) {
 		// to startup because of an error. Only applies on Debian 7.
 		time.Sleep(5 * time.Second)
 
-		return nil
+		return allComponentsDisabledErr
 	}
 
 	if !coreconfig.Datadog.IsSet("api_key") {

--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -165,7 +165,7 @@ func start(cmd *cobra.Command, args []string) error {
 	go handleSignals(stopCh)
 
 	err := RunAgent(ctx)
-	if errors.Is(err, allComponentsDisabledErr) {
+	if errors.Is(err, errAllComponentsDisabled) {
 		return nil
 	}
 	if err != nil {
@@ -178,7 +178,7 @@ func start(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-var allComponentsDisabledErr = errors.New("all security-agent component are disabled")
+var errAllComponentsDisabled = errors.New("all security-agent component are disabled")
 
 // RunAgent initialized resources and starts API server
 func RunAgent(ctx context.Context) (err error) {
@@ -225,7 +225,7 @@ func RunAgent(ctx context.Context) (err error) {
 		// to startup because of an error. Only applies on Debian 7.
 		time.Sleep(5 * time.Second)
 
-		return allComponentsDisabledErr
+		return errAllComponentsDisabled
 	}
 
 	if !coreconfig.Datadog.IsSet("api_key") {


### PR DESCRIPTION
### What does this PR do?

Currently the security agent successfully detects that all features are disabled, but it does not shutdown correctly because of the signal handler.
This PR fixes this issue.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

```
sudo DD_RUNTIME_SECURITY_CONFIG_ENABLED=false DD_COMPLIANCE_CONFIG_ENABLED=false security-agent start
```
should shutdown correctly.

The 2 settings are:
- compliance_config.enabled
- runtime_security_config.enabled

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
