### PR TITLE
Proper fix for integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ experimental:
 templates:
   job_template: &job_template
     docker:
-      - image: datadog/datadog-agent-runner-circle:go1185
+      - image: datadog/datadog-agent-runner-circle:go1185-1
         environment:
           USE_SYSTEM_LIBS: "1"
     working_directory: /go/src/github.com/DataDog/datadog-agent
@@ -29,11 +29,11 @@ templates:
           # If incremental dep fails, increase the cache gen number
           # in restore_deps AND save_deps
           # See https://github.com/DataDog/datadog-agent/pull/2384
-          - gen19-godeps-{{ checksum "requirements.txt" }}-{{ checksum ".circleci/requirements.txt" }}-{{ .Branch }}-{{ .Revision }}
-          - gen19-godeps-{{ checksum "requirements.txt" }}-{{ checksum ".circleci/requirements.txt" }}-{{ .Branch }}-
-          - gen19-godeps-{{ checksum "requirements.txt" }}-{{ checksum ".circleci/requirements.txt" }}-main-
+          - gen19-godeps-{{ checksum "requirements.txt" }}-{{ checksum ".circleci/requirements.txt" }}-{{ checksum ".circleci/images/runner/Dockerfile" }}-{{ .Branch }}-{{ .Revision }}
+          - gen19-godeps-{{ checksum "requirements.txt" }}-{{ checksum ".circleci/requirements.txt" }}-{{ checksum ".circleci/images/runner/Dockerfile" }}-{{ .Branch }}-
+          - gen19-godeps-{{ checksum "requirements.txt" }}-{{ checksum ".circleci/requirements.txt" }}-{{ checksum ".circleci/images/runner/Dockerfile" }}-main-
     - save_cache: &save_deps
-        key: gen19-godeps-{{ checksum "requirements.txt" }}-{{ checksum ".circleci/requirements.txt" }}-{{ .Branch }}-{{ .Revision }}
+        key: gen19-godeps-{{ checksum "requirements.txt" }}-{{ checksum ".circleci/requirements.txt" }}-{{ checksum ".circleci/images/runner/Dockerfile" }}-{{ .Branch }}-{{ .Revision }}
     - restore_cache: &restore_source
         keys:
           # Cache retrieval is faster than full git checkout
@@ -91,7 +91,7 @@ jobs:
             - /go/pkg/mod
             - /go/bin
             - /go/src/github.com/DataDog/datadog-agent/dev
-            - /usr/local/lib/python3.6/dist-packages
+            - /usr/local/lib/python3.8/dist-packages
             - /usr/local/bin
 
   unit_tests:
@@ -113,8 +113,7 @@ jobs:
     steps:
       - restore_cache: *restore_source
       - restore_cache: *restore_deps
-      - setup_remote_docker:
-          version: 17.09.0-ce
+      - setup_remote_docker
       - run:
           name: run integration tests
           command: inv -e integration-tests --race --remote-docker

--- a/.circleci/images/runner/Dockerfile
+++ b/.circleci/images/runner/Dockerfile
@@ -1,9 +1,15 @@
-FROM ubuntu:18.04
+# We cannot use Ubuntu 22.04 because the E2E tests
+# are currently using a Docker Compose v1 imaged based on Debian.
+# The glibc version is too old to allow running CGO binaries built on Ubuntu 22.04
+# We'll be able to migrate when we get rid of Docker Compose or use Docker Compose v2
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND noninteractive
 
 # Pre-requisites
-# python3.7-dev is required by rtloader
+# Python 3 dev is required for rtloader
 RUN set -ex \
-    && apt-get update \
+    && apt-get update && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
         curl \
         doxygen \
@@ -20,13 +26,15 @@ RUN set -ex \
         libsystemd-dev \
         make \
         pkg-config \
-        python3.7-dev \
+        python3 \
+        python3-dev \
         python3-distutils \
         python3-pip \
         python3-setuptools \
         python3-yaml \
         snmp-mibs-downloader \
-        ssh
+        ssh \
+        xz-utils
 
 # Golang
 ENV GIMME_GO_VERSION 1.18.5
@@ -51,12 +59,12 @@ RUN set -ex \
 
 # Other dependencies
 RUN set -ex \
-    # clang-format v8
-    && echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-8 main" >> /etc/apt/sources.list \
+    # clang-format
+    && echo "deb http://apt.llvm.org/focal/ llvm-toolchain-focal main" >> /etc/apt/sources.list \
     && curl -sL https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
     && apt-get update \
-    && apt-get -t llvm-toolchain-bionic-8 install -y --no-install-recommends \
-        clang-format-8
+    && apt-get -t llvm-toolchain-focal install -y --no-install-recommends \
+        clang-format
 
 # Setup entrypoint
 WORKDIR $GOPATH

--- a/.circleci/requirements.txt
+++ b/.circleci/requirements.txt
@@ -1,8 +1,8 @@
 black==22.8.0
 codecov==2.1.12
 flake8-bugbear==22.8.23
-flake8-comprehensions==3.7.0
-flake8-unused-arguments==0.0.11 
+flake8-comprehensions==3.10.0
+flake8-unused-arguments==0.0.11
 flake8-use-fstring==1.4
 flake8==5.0.4
 isort==5.10.1

--- a/pkg/config/legacy/tests/config.py
+++ b/pkg/config/legacy/tests/config.py
@@ -296,7 +296,7 @@ def get_config(options=None):
 
         # Endpoints
         dd_urls = map(clean_dd_url, config.get('Main', 'dd_url').split(','))
-        api_keys = map(lambda el: el.strip(), config.get('Main', 'api_key').split(','))
+        api_keys = (el.strip() for el in config.get('Main', 'api_key').split(','))
 
         # For collector and dogstatsd
         agentConfig['dd_url'] = dd_urls[0]

--- a/tasks/docker.py
+++ b/tasks/docker.py
@@ -54,7 +54,7 @@ def dockerize_test(ctx, binary, skip_cleanup=False):
 
     with open(f"{temp_folder}/Dockerfile", 'w') as stream:
         stream.write(
-            """FROM docker/compose:debian-1.28.3
+            """FROM docker/compose:debian-1.29.2
 ENV DOCKER_DD_AGENT=yes
 WORKDIR /
 CMD /test.bin
@@ -74,6 +74,7 @@ COPY test.bin /test.bin
         test_image.id,
         detach=True,
         pid_mode="host",  # For origin detection
+        cgroupns="host",  # To allow proper network mode detection in integration tests
         environment=["SCRATCH_VOLUME_NAME=" + scratch_volume.name, "SCRATCH_VOLUME_PATH=/tmp/scratch"],
         volumes={
             '/var/run/docker.sock': {'bind': '/var/run/docker.sock', 'mode': 'ro'},

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -699,10 +699,10 @@ def get_linux_header_dirs(kernel_release=None, minimal_kernel_release=None):
 
     if kernel_release and minimal_kernel_release:
         match = re.compile(r'(\d+)\.(\d+)(\.(\d+))?').match(kernel_release)
-        version_tuple = list(map(int, map(lambda x: x or '0', match.group(1, 2, 4))))
+        version_tuple = [int(x) or 0 for x in match.group(1, 2, 4)]
         if version_tuple < minimal_kernel_release:
             print(
-                f"You need to have kernel headers for at least {'.'.join(map(lambda x: str(x), minimal_kernel_release))} to enable all system-probe features"
+                f"You need to have kernel headers for at least {'.'.join([str(x) for x in minimal_kernel_release])} to enable all system-probe features"
             )
 
     src_kernels_dir = "/usr/src/kernels"

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -118,7 +118,7 @@ def get_nikos_linker_flags(nikos_libs_path):
         'zstd',
     ]
     # hardcode the path to each library to ensure we link against the version which was built by omnibus-nikos
-    linker_flags = map(lambda lib: nikos_libs_path + '/lib' + lib + '.a', nikos_libs)
+    linker_flags = [nikos_libs_path + '/lib' + lib + '.a' for lib in nikos_libs]
 
     return ' -L' + nikos_libs_path + ' ' + ' '.join(linker_flags) + ' -static-libstdc++ -pthread -ldl -lm'
 

--- a/test/integration/corechecks/docker/basemetrics_test.go
+++ b/test/integration/corechecks/docker/basemetrics_test.go
@@ -48,8 +48,8 @@ func TestContainerMetricsTagging(t *testing.T) {
 			"docker.cpu.user",
 			"docker.cpu.usage",
 			"docker.cpu.throttled",
-			"docker.io.read_bytes",
-			"docker.io.write_bytes",
+			// "docker.io.read_bytes", // With cgroupv2 the io.stat file is not filled if no IO has been made
+			// "docker.io.write_bytes", // Our containers (redis) are not making any IO, thus the file is empty and metrics not generated
 			"docker.net.bytes_sent",
 			"docker.net.bytes_rcvd",
 		},
@@ -84,5 +84,4 @@ func TestContainerMetricsTagging(t *testing.T) {
 	// redis:3.2 runs one process with 3 threads
 	sender.AssertCalled(t, "Gauge", "docker.thread.count", 3.0, "", mocksender.MatchTagsContains(expectedTags))
 	sender.AssertCalled(t, "Gauge", "docker.thread.limit", 25.0, "", mocksender.MatchTagsContains(expectedTags))
-
 }

--- a/test/integration/util/kube_apiserver/testdata/apiserver-compose.yaml
+++ b/test/integration/util/kube_apiserver/testdata/apiserver-compose.yaml
@@ -12,9 +12,8 @@ services:
       retries: 30
 
   apiserver:
-    image: "datadog/docker-library:hyperkube_1_8_3"
-    command: "/hyperkube
-        apiserver
+    image: "k8s.gcr.io/hyperkube:v1.18.6"
+    command: "kube-apiserver
         --apiserver-count=1
         --insecure-bind-address=0.0.0.0
         --insecure-port=8080

--- a/test/integration/util/kubelet/testdata/Dockerfile
+++ b/test/integration/util/kubelet/testdata/Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/docker-library:hyperkube_1_8_3
+FROM datadog/docker-library:kubelet_1.25
 
 COPY cert.pem /etc/secrets/cert.pem
 COPY key.pem /etc/secrets/key.pem

--- a/test/integration/util/kubelet/testdata/Dockerfile.base
+++ b/test/integration/util/kubelet/testdata/Dockerfile.base
@@ -1,0 +1,14 @@
+# This file is used to build datadog/docker-library:kubelet_1.25 manually
+# From this folder: docker build -f Dockerfile.base -t datadog/docker-library:kubelet_1.25 .
+FROM psdn/kubelet:v1.25.0
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt update && \
+    apt install curl -y && \
+    curl -L -o cri-docker.deb https://github.com/Mirantis/cri-dockerd/releases/download/v0.2.5/cri-dockerd_0.2.5.3-0.debian-bullseye_amd64.deb && \
+    apt install -y ./cri-docker.deb
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/test/integration/util/kubelet/testdata/entrypoint.sh
+++ b/test/integration/util/kubelet/testdata/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Need to symlink /dev/kmsg
+ln -s /dev/console /dev/kmsg
+
+(trap 'kill 0' SIGINT; cri-dockerd & sleep 3; kubelet "$@")

--- a/test/integration/util/kubelet/testdata/insecure-kubelet-compose.yaml
+++ b/test/integration/util/kubelet/testdata/insecure-kubelet-compose.yaml
@@ -1,18 +1,20 @@
 version: '2.3'
 services:
   kubelet:
-    image: "datadog/docker-library:hyperkube_1_8_3"
-    command: "/hyperkube
-        kubelet
-        --cloud-provider=''
+    image: "datadog/docker-library:kubelet_1.25"
+    command: "--cloud-provider=''
         --fail-swap-on=false
         --make-iptables-util-chains=false
         --hairpin-mode=none
-        --pod-manifest-path=/opt
-        "
+        --container-runtime-endpoint=unix:///run/cri-dockerd.sock
+        --pod-manifest-path=/opt"
     network_mode: ${network_mode}
     volumes:
-        - /var/run/docker.sock:/var/run/docker.sock
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /sys:/sys
+      - vardata:/var
+    tty: true
+    privileged: true
     healthcheck:
       test: ["CMD", "/bin/ls", "/var/lib/kubelet/pki/kubelet.crt"]
       interval: 1s
@@ -29,3 +31,5 @@ services:
       kubelet:
         condition: service_healthy
     network_mode: none
+volumes:
+  vardata:

--- a/test/integration/util/kubelet/testdata/secure-kubelet-compose.yaml
+++ b/test/integration/util/kubelet/testdata/secure-kubelet-compose.yaml
@@ -2,19 +2,17 @@ version: '2.3'
 services:
   kubelet:
     build: ./
-    command: "/hyperkube
-        kubelet
-        --cloud-provider=''
+    command: "--cloud-provider=''
         --hostname-override=localhost
         --fail-swap-on=false
         --make-iptables-util-chains=false
         --hairpin-mode=none
+        --container-runtime-endpoint=unix:///run/cri-dockerd.sock
         --read-only-port 0
         --anonymous-auth=true
         --tls-cert-file=/etc/secrets/cert.pem
         --tls-private-key-file=/etc/secrets/key.pem
-        --pod-manifest-path=/opt
-        "
+        --pod-manifest-path=/opt"
         # Removed --client-ca-file=/etc/secrets/cert.pem as it
         # depends on an apiserver running to verify the username
     network_mode: ${network_mode}
@@ -24,7 +22,11 @@ services:
       timeout: 1s
       retries: 10
     volumes:
-        - /var/run/docker.sock:/var/run/docker.sock
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /sys:/sys
+      - vardata:/var
+    tty: true
+    privileged: true
 
   pause:
     #
@@ -36,3 +38,5 @@ services:
       kubelet:
         condition: service_healthy
     network_mode: none
+volumes:
+  vardata:

--- a/test/integration/util/leaderelection/testdata/apiserver-compose.yaml
+++ b/test/integration/util/leaderelection/testdata/apiserver-compose.yaml
@@ -12,9 +12,8 @@ services:
       retries: 30
 
   apiserver:
-    image: "datadog/docker-library:hyperkube_1_8_3"
-    command: "/hyperkube
-        apiserver
+    image: "k8s.gcr.io/hyperkube:v1.18.6"
+    command: "kube-apiserver
         --apiserver-count=1
         --insecure-bind-address=0.0.0.0
         --insecure-port=8080


### PR DESCRIPTION
### What does this PR do?

Properly fix integration tests due to CircleCI migrating to newer Docker version with underlying Kernel using cgroupv2.

### Motivation

Bugfix.

### Additional Notes

Requires https://github.com/DataDog/datadog-agent-buildimages/pull/278.

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
