### PR TITLE
[CWS][SEC-4419] remove `tracepoint/syscalls/sys_exit_*` hooks

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = newAsset("runtime-security.c", "7a67a596e8be5c0a042123c63915a3f577ef2aab494dbc75cbcaa537ca53e962")
+var RuntimeSecurity = newAsset("runtime-security.c", "609b09e7f1de2bd1d7af44243c78696c8e963399a280408b55324ca2ee635062")

--- a/pkg/security/ebpf/c/bind.h
+++ b/pkg/security/ebpf/c/bind.h
@@ -71,11 +71,6 @@ SYSCALL_KRETPROBE(bind) {
     return sys_bind_ret(ctx, retval);
 }
 
-SEC("tracepoint/syscalls/sys_exit_bind")
-int tracepoint_syscalls_sys_exit_bind(struct tracepoint_syscalls_sys_exit_t *args) {
-    return sys_bind_ret(args, args->ret);
-}
-
 SEC("kprobe/security_socket_bind")
 int kprobe_security_socket_bind(struct pt_regs *ctx) {
     struct socket *sk = (struct socket *)PT_REGS_PARM1(ctx);
@@ -131,6 +126,11 @@ int kprobe_security_socket_bind(struct pt_regs *ctx) {
 #endif
     }
     return 0;
+}
+
+SEC("tracepoint/handle_sys_bind_exit")
+int tracepoint_handle_sys_bind_exit(struct tracepoint_raw_syscalls_sys_exit_t *args) {
+    return sys_bind_ret(args, args->ret);
 }
 
 #endif /* _BIND_H_ */

--- a/pkg/security/ebpf/c/bpf.h
+++ b/pkg/security/ebpf/c/bpf.h
@@ -359,11 +359,6 @@ SYSCALL_KRETPROBE(bpf) {
     return sys_bpf_ret(ctx, (int)PT_REGS_RC(ctx));
 }
 
-SEC("tracepoint/syscalls/sys_exit_bpf")
-int tracepoint_syscalls_sys_exit_bpf(struct tracepoint_syscalls_sys_exit_t *args) {
-    return sys_bpf_ret(args, args->ret);
-}
-
 SEC("kprobe/security_bpf_map")
 int kprobe_security_bpf_map(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_BPF);
@@ -445,6 +440,11 @@ int kprobe_check_helper_call(struct pt_regs *ctx) {
         syscall->bpf.helpers[0] |= (u64) 1 << (func_id);
     }
     return 0;
+}
+
+SEC("tracepoint/handle_sys_bpf_exit")
+int tracepoint_handle_sys_bpf_exit(struct tracepoint_raw_syscalls_sys_exit_t *args) {
+    return sys_bpf_ret(args, args->ret);
 }
 
 #endif

--- a/pkg/security/ebpf/c/chmod.h
+++ b/pkg/security/ebpf/c/chmod.h
@@ -87,27 +87,12 @@ int __attribute__((always_inline)) kprobe_sys_chmod_ret(struct pt_regs *ctx) {
     return sys_chmod_ret(ctx, retval);
 }
 
-SEC("tracepoint/syscalls/sys_exit_chmod")
-int tracepoint_syscalls_sys_exit_chmod(struct tracepoint_syscalls_sys_exit_t *args) {
-    return sys_chmod_ret(args, args->ret);
-}
-
 SYSCALL_KRETPROBE(chmod) {
     return kprobe_sys_chmod_ret(ctx);
 }
 
-SEC("tracepoint/syscalls/sys_exit_fchmod")
-int tracepoint_syscalls_sys_exit_fchmod(struct tracepoint_syscalls_sys_exit_t *args) {
-    return sys_chmod_ret(args, args->ret);
-}
-
 SYSCALL_KRETPROBE(fchmod) {
     return kprobe_sys_chmod_ret(ctx);
-}
-
-SEC("tracepoint/syscalls/sys_exit_fchmodat")
-int tracepoint_syscalls_sys_exit_fchmodat(struct tracepoint_syscalls_sys_exit_t *args) {
-    return sys_chmod_ret(args, args->ret);
 }
 
 SYSCALL_KRETPROBE(fchmodat) {

--- a/pkg/security/ebpf/c/chown.h
+++ b/pkg/security/ebpf/c/chown.h
@@ -104,63 +104,28 @@ int __attribute__((always_inline)) kprobe_sys_chown_ret(struct pt_regs *ctx) {
     return sys_chown_ret(ctx, retval);
 }
 
-SEC("tracepoint/syscalls/sys_exit_lchown")
-int tracepoint_syscalls_sys_exit_lchown(struct tracepoint_syscalls_sys_exit_t *args) {
-    return sys_chown_ret(args, args->ret);
-}
-
 SYSCALL_KRETPROBE(lchown) {
     return kprobe_sys_chown_ret(ctx);
-}
-
-SEC("tracepoint/syscalls/sys_exit_fchown")
-int tracepoint_syscalls_sys_exit_fchown(struct tracepoint_syscalls_sys_exit_t *args) {
-    return sys_chown_ret(args, args->ret);
 }
 
 SYSCALL_KRETPROBE(fchown) {
     return kprobe_sys_chown_ret(ctx);
 }
 
-SEC("tracepoint/syscalls/sys_exit_chown")
-int tracepoint_syscalls_sys_exit_chown(struct tracepoint_syscalls_sys_exit_t *args) {
-    return sys_chown_ret(args, args->ret);
-}
-
 SYSCALL_KRETPROBE(chown) {
     return kprobe_sys_chown_ret(ctx);
-}
-
-SEC("tracepoint/syscalls/sys_exit_lchown16")
-int tracepoint_syscalls_sys_exit_lchown16(struct tracepoint_syscalls_sys_exit_t *args) {
-    return sys_chown_ret(args, args->ret);
 }
 
 SYSCALL_KRETPROBE(lchown16) {
     return kprobe_sys_chown_ret(ctx);
 }
 
-SEC("tracepoint/syscalls/sys_exit_fchown16")
-int tracepoint_syscalls_sys_exit_fchown16(struct tracepoint_syscalls_sys_exit_t *args) {
-    return sys_chown_ret(args, args->ret);
-}
-
 SYSCALL_KRETPROBE(fchown16) {
     return kprobe_sys_chown_ret(ctx);
 }
 
-SEC("tracepoint/syscalls/sys_exit_chown16")
-int tracepoint_syscalls_sys_exit_chown16(struct tracepoint_syscalls_sys_exit_t *args) {
-    return sys_chown_ret(args, args->ret);
-}
-
 SYSCALL_KRETPROBE(chown16) {
     return kprobe_sys_chown_ret(ctx);
-}
-
-SEC("tracepoint/syscalls/sys_exit_fchownat")
-int tracepoint_syscalls_sys_exit_fchownat(struct tracepoint_syscalls_sys_exit_t *args) {
-    return sys_chown_ret(args, args->ret);
 }
 
 SYSCALL_KRETPROBE(fchownat) {

--- a/pkg/security/ebpf/c/commit_creds.h
+++ b/pkg/security/ebpf/c/commit_creds.h
@@ -113,22 +113,12 @@ SYSCALL_KRETPROBE(setuid) {
     return kprobe_credentials_update_ret(ctx);
 }
 
-SEC("tracepoint/syscalls/sys_exit_setuid")
-int tracepoint_syscalls_sys_exit_setuid(struct tracepoint_syscalls_sys_exit_t *args) {
-    return credentials_update_ret(args, args->ret);
-}
-
 SYSCALL_KPROBE0(seteuid) {
     return credentials_update(EVENT_SETUID);
 }
 
 SYSCALL_KRETPROBE(seteuid) {
     return kprobe_credentials_update_ret(ctx);
-}
-
-SEC("tracepoint/syscalls/sys_exit_seteuid")
-int tracepoint_syscalls_sys_exit_seteuid(struct tracepoint_syscalls_sys_exit_t *args) {
-    return credentials_update_ret(args, args->ret);
 }
 
 SYSCALL_KPROBE0(setfsuid) {
@@ -139,22 +129,12 @@ SYSCALL_KRETPROBE(setfsuid) {
     return kprobe_credentials_update_ret(ctx);
 }
 
-SEC("tracepoint/syscalls/sys_exit_setfsuid")
-int tracepoint_syscalls_sys_exit_setfsuid(struct tracepoint_syscalls_sys_exit_t *args) {
-    return credentials_update_ret(args, args->ret);
-}
-
 SYSCALL_KPROBE0(setreuid) {
     return credentials_update(EVENT_SETUID);
 }
 
 SYSCALL_KRETPROBE(setreuid) {
     return kprobe_credentials_update_ret(ctx);
-}
-
-SEC("tracepoint/syscalls/sys_exit_setreuid")
-int tracepoint_syscalls_sys_exit_setreuid(struct tracepoint_syscalls_sys_exit_t *args) {
-    return credentials_update_ret(args, args->ret);
 }
 
 SYSCALL_KPROBE0(setresuid) {
@@ -165,22 +145,12 @@ SYSCALL_KRETPROBE(setresuid) {
     return kprobe_credentials_update_ret(ctx);
 }
 
-SEC("tracepoint/syscalls/sys_exit_setresuid")
-int tracepoint_syscalls_sys_exit_setresuid(struct tracepoint_syscalls_sys_exit_t *args) {
-    return credentials_update_ret(args, args->ret);
-}
-
 SYSCALL_KPROBE0(setuid16) {
     return credentials_update(EVENT_SETUID);
 }
 
 SYSCALL_KRETPROBE(setuid16) {
     return kprobe_credentials_update_ret(ctx);
-}
-
-SEC("tracepoint/syscalls/sys_exit_setuid16")
-int tracepoint_syscalls_sys_exit_setuid16(struct tracepoint_syscalls_sys_exit_t *args) {
-    return credentials_update_ret(args, args->ret);
 }
 
 SYSCALL_KPROBE0(seteuid16) {
@@ -191,22 +161,12 @@ SYSCALL_KRETPROBE(seteuid16) {
     return kprobe_credentials_update_ret(ctx);
 }
 
-SEC("tracepoint/syscalls/sys_exit_seteuid16")
-int tracepoint_syscalls_sys_exit_seteuid16(struct tracepoint_syscalls_sys_exit_t *args) {
-    return credentials_update_ret(args, args->ret);
-}
-
 SYSCALL_KPROBE0(setfsuid16) {
     return credentials_update(EVENT_SETUID);
 }
 
 SYSCALL_KRETPROBE(setfsuid16) {
     return kprobe_credentials_update_ret(ctx);
-}
-
-SEC("tracepoint/syscalls/sys_exit_setfsuid16")
-int tracepoint_syscalls_sys_exit_setfsuid16(struct tracepoint_syscalls_sys_exit_t *args) {
-    return credentials_update_ret(args, args->ret);
 }
 
 SYSCALL_KPROBE0(setreuid16) {
@@ -217,22 +177,12 @@ SYSCALL_KRETPROBE(setreuid16) {
     return kprobe_credentials_update_ret(ctx);
 }
 
-SEC("tracepoint/syscalls/sys_exit_setreuid16")
-int tracepoint_syscalls_sys_exit_setreuid16(struct tracepoint_syscalls_sys_exit_t *args) {
-    return credentials_update_ret(args, args->ret);
-}
-
 SYSCALL_KPROBE0(setresuid16) {
     return credentials_update(EVENT_SETUID);
 }
 
 SYSCALL_KRETPROBE(setresuid16) {
     return kprobe_credentials_update_ret(ctx);
-}
-
-SEC("tracepoint/syscalls/sys_exit_setresuid16")
-int tracepoint_syscalls_sys_exit_setresuid16(struct tracepoint_syscalls_sys_exit_t *args) {
-    return credentials_update_ret(args, args->ret);
 }
 
 SYSCALL_KPROBE0(setgid) {
@@ -243,22 +193,12 @@ SYSCALL_KRETPROBE(setgid) {
     return kprobe_credentials_update_ret(ctx);
 }
 
-SEC("tracepoint/syscalls/sys_exit_setgid")
-int tracepoint_syscalls_sys_exit_setgid(struct tracepoint_syscalls_sys_exit_t *args) {
-    return credentials_update_ret(args, args->ret);
-}
-
 SYSCALL_KPROBE0(setegid) {
     return credentials_update(EVENT_SETGID);
 }
 
 SYSCALL_KRETPROBE(setegid) {
     return kprobe_credentials_update_ret(ctx);
-}
-
-SEC("tracepoint/syscalls/sys_exit_setegid")
-int tracepoint_syscalls_sys_exit_setegid(struct tracepoint_syscalls_sys_exit_t *args) {
-    return credentials_update_ret(args, args->ret);
 }
 
 SYSCALL_KPROBE0(setfsgid) {
@@ -269,22 +209,12 @@ SYSCALL_KRETPROBE(setfsgid) {
     return kprobe_credentials_update_ret(ctx);
 }
 
-SEC("tracepoint/syscalls/sys_exit_setfsgid")
-int tracepoint_syscalls_sys_exit_setfsgid(struct tracepoint_syscalls_sys_exit_t *args) {
-    return credentials_update_ret(args, args->ret);
-}
-
 SYSCALL_KPROBE0(setregid) {
     return credentials_update(EVENT_SETGID);
 }
 
 SYSCALL_KRETPROBE(setregid) {
     return kprobe_credentials_update_ret(ctx);
-}
-
-SEC("tracepoint/syscalls/sys_exit_setregid")
-int tracepoint_syscalls_sys_exit_setregid(struct tracepoint_syscalls_sys_exit_t *args) {
-    return credentials_update_ret(args, args->ret);
 }
 
 SYSCALL_KPROBE0(setresgid) {
@@ -295,22 +225,12 @@ SYSCALL_KRETPROBE(setresgid) {
     return kprobe_credentials_update_ret(ctx);
 }
 
-SEC("tracepoint/syscalls/sys_exit_setresgid")
-int tracepoint_syscalls_sys_exit_setresgid(struct tracepoint_syscalls_sys_exit_t *args) {
-    return credentials_update_ret(args, args->ret);
-}
-
 SYSCALL_KPROBE0(setgid16) {
     return credentials_update(EVENT_SETGID);
 }
 
 SYSCALL_KRETPROBE(setgid16) {
     return kprobe_credentials_update_ret(ctx);
-}
-
-SEC("tracepoint/syscalls/sys_exit_setgid16")
-int tracepoint_syscalls_sys_exit_setgid16(struct tracepoint_syscalls_sys_exit_t *args) {
-    return credentials_update_ret(args, args->ret);
 }
 
 SYSCALL_KPROBE0(setegid16) {
@@ -321,22 +241,12 @@ SYSCALL_KRETPROBE(setegid16) {
     return kprobe_credentials_update_ret(ctx);
 }
 
-SEC("tracepoint/syscalls/sys_exit_setegid16")
-int tracepoint_syscalls_sys_exit_setegid16(struct tracepoint_syscalls_sys_exit_t *args) {
-    return credentials_update_ret(args, args->ret);
-}
-
 SYSCALL_KPROBE0(setfsgid16) {
     return credentials_update(EVENT_SETGID);
 }
 
 SYSCALL_KRETPROBE(setfsgid16) {
     return kprobe_credentials_update_ret(ctx);
-}
-
-SEC("tracepoint/syscalls/sys_exit_setfsgid16")
-int tracepoint_syscalls_sys_exit_setfsgid16(struct tracepoint_syscalls_sys_exit_t *args) {
-    return credentials_update_ret(args, args->ret);
 }
 
 SYSCALL_KPROBE0(setregid16) {
@@ -347,11 +257,6 @@ SYSCALL_KRETPROBE(setregid16) {
     return kprobe_credentials_update_ret(ctx);
 }
 
-SEC("tracepoint/syscalls/sys_exit_setregid16")
-int tracepoint_syscalls_sys_exit_setregid16(struct tracepoint_syscalls_sys_exit_t *args) {
-    return credentials_update_ret(args, args->ret);
-}
-
 SYSCALL_KPROBE0(setresgid16) {
     return credentials_update(EVENT_SETGID);
 }
@@ -360,22 +265,12 @@ SYSCALL_KRETPROBE(setresgid16) {
     return kprobe_credentials_update_ret(ctx);
 }
 
-SEC("tracepoint/syscalls/sys_exit_setresgid16")
-int tracepoint_syscalls_sys_exit_setresgid16(struct tracepoint_syscalls_sys_exit_t *args) {
-    return credentials_update_ret(args, args->ret);
-}
-
 SYSCALL_KPROBE0(capset) {
     return credentials_update(EVENT_CAPSET);
 }
 
 SYSCALL_KRETPROBE(capset) {
     return kprobe_credentials_update_ret(ctx);
-}
-
-SEC("tracepoint/syscalls/sys_exit_capset")
-int tracepoint_syscalls_sys_exit_capset(struct tracepoint_syscalls_sys_exit_t *args) {
-    return credentials_update_ret(args, args->ret);
 }
 
 SEC("tracepoint/handle_sys_commit_creds_exit")

--- a/pkg/security/ebpf/c/link.h
+++ b/pkg/security/ebpf/c/link.h
@@ -164,18 +164,8 @@ int __attribute__((always_inline)) kprobe_sys_link_ret(struct pt_regs *ctx) {
     return sys_link_ret(ctx, retval, DR_KPROBE);
 }
 
-SEC("tracepoint/syscalls/sys_exit_link")
-int tracepoint_syscalls_sys_exit_link(struct tracepoint_syscalls_sys_exit_t *args) {
-    return sys_link_ret(args, args->ret, DR_TRACEPOINT);
-}
-
 SYSCALL_KRETPROBE(link) {
     return kprobe_sys_link_ret(ctx);
-}
-
-SEC("tracepoint/syscalls/sys_exit_linkat")
-int tracepoint_syscalls_sys_exit_linkat(struct tracepoint_syscalls_sys_exit_t *args) {
-    return sys_link_ret(args, args->ret, DR_TRACEPOINT);
 }
 
 SYSCALL_KRETPROBE(linkat) {

--- a/pkg/security/ebpf/c/mkdir.h
+++ b/pkg/security/ebpf/c/mkdir.h
@@ -124,19 +124,9 @@ int __attribute__((always_inline)) kprobe_sys_mkdir_ret(struct pt_regs *ctx) {
     return sys_mkdir_ret(ctx, retval, DR_KPROBE);
 }
 
-SEC("tracepoint/syscalls/sys_exit_mkdir")
-int tracepoint_syscalls_sys_exit_mkdir(struct tracepoint_syscalls_sys_exit_t *args) {
-    return sys_mkdir_ret(args, args->ret, DR_TRACEPOINT);
-}
-
 SYSCALL_KRETPROBE(mkdir)
 {
     return kprobe_sys_mkdir_ret(ctx);
-}
-
-SEC("tracepoint/syscalls/sys_exit_mkdirat")
-int tracepoint_syscalls_sys_exit_mkdirat(struct tracepoint_syscalls_sys_exit_t *args) {
-    return sys_mkdir_ret(args, args->ret, DR_TRACEPOINT);
 }
 
 SYSCALL_KRETPROBE(mkdirat) {

--- a/pkg/security/ebpf/c/mmap.h
+++ b/pkg/security/ebpf/c/mmap.h
@@ -151,11 +151,6 @@ SYSCALL_KRETPROBE(mmap) {
     return sys_mmap_ret(ctx, (int)PT_REGS_RC(ctx), (u64)PT_REGS_RC(ctx));
 }
 
-SEC("tracepoint/syscalls/sys_exit_mmap")
-int tracepoint_syscalls_sys_exit_mmap(struct tracepoint_syscalls_sys_exit_t *args) {
-    return sys_mmap_ret(args, (int)args->ret, (u64)args->ret);
-}
-
 SEC("kretprobe/fget")
 int kretprobe_fget(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_MMAP);
@@ -176,6 +171,11 @@ int kretprobe_fget(struct pt_regs *ctx) {
 
     resolve_dentry(ctx, DR_KPROBE);
     return 0;
+}
+
+SEC("tracepoint/handle_sys_mmap_exit")
+int tracepoint_handle_sys_mmap_exit(struct tracepoint_raw_syscalls_sys_exit_t *args) {
+    return sys_mmap_ret(args, (int)args->ret, (u64)args->ret);
 }
 
 #endif

--- a/pkg/security/ebpf/c/module.h
+++ b/pkg/security/ebpf/c/module.h
@@ -123,18 +123,8 @@ SYSCALL_KRETPROBE(init_module) {
     return trace_init_module_ret(ctx, (int)PT_REGS_RC(ctx));
 }
 
-SEC("tracepoint/syscalls/sys_exit_init_module")
-int tracepoint_syscalls_sys_exit_init_module(struct tracepoint_syscalls_sys_exit_t *args) {
-    return trace_init_module_ret(args, (int)args->ret);
-}
-
 SYSCALL_KRETPROBE(finit_module) {
     return trace_init_module_ret(ctx, (int)PT_REGS_RC(ctx));
-}
-
-SEC("tracepoint/syscalls/sys_exit_finit_module")
-int tracepoint_syscalls_sys_exit_finit_module(struct tracepoint_syscalls_sys_exit_t *args) {
-    return trace_init_module_ret(args, (int)args->ret);
 }
 
 struct delete_module_event_t {
@@ -188,9 +178,14 @@ SYSCALL_KRETPROBE(delete_module) {
     return trace_delete_module_ret(ctx, (int)PT_REGS_RC(ctx));
 }
 
-SEC("tracepoint/syscalls/sys_exit_delete_module")
-int tracepoint_syscalls_sys_exit_delete_module(struct tracepoint_syscalls_sys_exit_t *args) {
-    return trace_delete_module_ret(args, (int)args->ret);
+SEC("tracepoint/handle_sys_init_module_exit")
+int tracepoint_handle_sys_init_module_exit(struct tracepoint_raw_syscalls_sys_exit_t *args) {
+    return trace_init_module_ret(args, args->ret);
+}
+
+SEC("tracepoint/handle_sys_delete_module_exit")
+int tracepoint_handle_sys_delete_module_exit(struct tracepoint_raw_syscalls_sys_exit_t *args) {
+    return trace_delete_module_ret(args, args->ret);
 }
 
 #endif

--- a/pkg/security/ebpf/c/mount.h
+++ b/pkg/security/ebpf/c/mount.h
@@ -124,11 +124,6 @@ int __attribute__((always_inline)) sys_mount_ret(void *ctx, int retval, int dr_t
     return 0;
 }
 
-SEC("tracepoint/syscalls/sys_exit_mount")
-int tracepoint_syscalls_sys_exit_mount(struct tracepoint_syscalls_sys_exit_t *args) {
-    return sys_mount_ret(args, args->ret, DR_TRACEPOINT);
-}
-
 SYSCALL_COMPAT_KRETPROBE(mount) {
     int retval = PT_REGS_RC(ctx);
     return sys_mount_ret(ctx, retval, DR_KPROBE);

--- a/pkg/security/ebpf/c/mprotect.h
+++ b/pkg/security/ebpf/c/mprotect.h
@@ -122,9 +122,9 @@ SYSCALL_KRETPROBE(mprotect) {
     return sys_mprotect_ret(ctx, (int)PT_REGS_RC(ctx));
 }
 
-SEC("tracepoint/syscalls/sys_exit_mprotect")
-int tracepoint_syscalls_sys_exit_mprotect(struct tracepoint_syscalls_sys_exit_t *args) {
-    return sys_mprotect_ret(args, (int)args->ret);
+SEC("tracepoint/handle_sys_mprotect_exit")
+int tracepoint_handle_sys_mprotect_exit(struct tracepoint_raw_syscalls_sys_exit_t *args) {
+    return sys_mprotect_ret(args, args->ret);
 }
 
 #endif

--- a/pkg/security/ebpf/c/open.h
+++ b/pkg/security/ebpf/c/open.h
@@ -279,54 +279,24 @@ int __attribute__((always_inline)) kprobe_sys_open_ret(struct pt_regs *ctx) {
     return sys_open_ret(ctx, retval, DR_KPROBE);
 }
 
-SEC("tracepoint/syscalls/sys_exit_creat")
-int tracepoint_syscalls_sys_exit_creat(struct tracepoint_syscalls_sys_exit_t *args) {
-    return sys_open_ret(args, args->ret, DR_TRACEPOINT);
-}
-
 SYSCALL_KRETPROBE(creat) {
     return kprobe_sys_open_ret(ctx);
-}
-
-SEC("tracepoint/syscalls/sys_exit_open_by_handle_at")
-int tracepoint_syscalls_sys_exit_open_by_handle_at(struct tracepoint_syscalls_sys_exit_t *args) {
-    return sys_open_ret(args, args->ret, DR_TRACEPOINT);
 }
 
 SYSCALL_COMPAT_KRETPROBE(open_by_handle_at) {
     return kprobe_sys_open_ret(ctx);
 }
 
-SEC("tracepoint/syscalls/sys_exit_truncate")
-int tracepoint_syscalls_sys_exit_truncate(struct tracepoint_syscalls_sys_exit_t *args) {
-    return sys_open_ret(args, args->ret, DR_TRACEPOINT);
-}
-
 SYSCALL_COMPAT_KRETPROBE(truncate) {
     return kprobe_sys_open_ret(ctx);
-}
-
-SEC("tracepoint/syscalls/sys_exit_open")
-int tracepoint_syscalls_sys_exit_open(struct tracepoint_syscalls_sys_exit_t *args) {
-    return sys_open_ret(args, args->ret, DR_TRACEPOINT);
 }
 
 SYSCALL_COMPAT_KRETPROBE(open) {
     return kprobe_sys_open_ret(ctx);
 }
 
-SEC("tracepoint/syscalls/sys_exit_openat")
-int tracepoint_syscalls_sys_exit_openat(struct tracepoint_syscalls_sys_exit_t *args) {
-    return sys_open_ret(args, args->ret, DR_TRACEPOINT);
-}
-
 SYSCALL_COMPAT_KRETPROBE(openat) {
     return kprobe_sys_open_ret(ctx);
-}
-
-SEC("tracepoint/syscalls/sys_exit_openat2")
-int tracepoint_syscalls_sys_exit_openat2(struct tracepoint_syscalls_sys_exit_t *args) {
-    return sys_open_ret(args, args->ret, DR_TRACEPOINT);
 }
 
 SYSCALL_KRETPROBE(openat2) {

--- a/pkg/security/ebpf/c/ptrace.h
+++ b/pkg/security/ebpf/c/ptrace.h
@@ -64,9 +64,9 @@ SYSCALL_KRETPROBE(ptrace) {
     return sys_ptrace_ret(ctx, (int)PT_REGS_RC(ctx));
 }
 
-SEC("tracepoint/syscalls/sys_exit_ptrace")
-int tracepoint_syscalls_sys_exit_ptrace(struct tracepoint_syscalls_sys_exit_t *args) {
-    return sys_ptrace_ret(args, (int)args->ret);
+SEC("tracepoint/handle_sys_ptrace_exit")
+int tracepoint_handle_sys_ptrace_exit(struct tracepoint_raw_syscalls_sys_exit_t *args) {
+    return sys_ptrace_ret(args, args->ret);
 }
 
 #endif

--- a/pkg/security/ebpf/c/rename.h
+++ b/pkg/security/ebpf/c/rename.h
@@ -178,27 +178,12 @@ int __attribute__((always_inline)) kprobe_sys_rename_ret(struct pt_regs *ctx) {
     return sys_rename_ret(ctx, retval, DR_KPROBE);
 }
 
-SEC("tracepoint/syscalls/sys_exit_rename")
-int tracepoint_syscalls_sys_exit_rename(struct tracepoint_syscalls_sys_exit_t *args) {
-    return sys_rename_ret(args, args->ret, DR_TRACEPOINT);
-}
-
 SYSCALL_KRETPROBE(rename) {
     return kprobe_sys_rename_ret(ctx);
 }
 
-SEC("tracepoint/syscalls/sys_exit_renameat")
-int tracepoint_syscalls_sys_exit_renameat(struct tracepoint_syscalls_sys_exit_t *args) {
-    return sys_rename_ret(args, args->ret, DR_TRACEPOINT);
-}
-
 SYSCALL_KRETPROBE(renameat) {
     return kprobe_sys_rename_ret(ctx);
-}
-
-SEC("tracepoint/syscalls/sys_exit_renameat2")
-int tracepoint_syscalls_sys_exit_renameat2(struct tracepoint_syscalls_sys_exit_t *args) {
-    return sys_rename_ret(args, args->ret, DR_TRACEPOINT);
 }
 
 SYSCALL_KRETPROBE(renameat2) {

--- a/pkg/security/ebpf/c/rmdir.h
+++ b/pkg/security/ebpf/c/rmdir.h
@@ -170,11 +170,6 @@ int kretprobe_do_rmdir(struct pt_regs *ctx) {
     return sys_rmdir_ret(ctx, retval);
 }
 
-SEC("tracepoint/syscalls/sys_exit_rmdir")
-int tracepoint_syscalls_sys_exit_rmdir(struct tracepoint_syscalls_sys_exit_t *args) {
-    return sys_rmdir_ret(args, args->ret);
-}
-
 SYSCALL_KRETPROBE(rmdir) {
     int retval = PT_REGS_RC(ctx);
     return sys_rmdir_ret(ctx, retval);

--- a/pkg/security/ebpf/c/setxattr.h
+++ b/pkg/security/ebpf/c/setxattr.h
@@ -171,27 +171,12 @@ int __attribute__((always_inline)) kprobe_sys_setxattr_ret(struct pt_regs *ctx) 
     return sys_xattr_ret(ctx, retval, EVENT_SETXATTR);
 }
 
-SEC("tracepoint/syscalls/sys_exit_setxattr")
-int tracepoint_syscalls_sys_exit_setxattr(struct tracepoint_syscalls_sys_exit_t *args) {
-    return sys_xattr_ret(args, args->ret, EVENT_SETXATTR);
-}
-
 SYSCALL_KRETPROBE(setxattr) {
     return kprobe_sys_setxattr_ret(ctx);
 }
 
-SEC("tracepoint/syscalls/sys_exit_fsetxattr")
-int tracepoint_syscalls_sys_exit_fsetxattr(struct tracepoint_syscalls_sys_exit_t *args) {
-    return sys_xattr_ret(args, args->ret, EVENT_SETXATTR);
-}
-
 SYSCALL_KRETPROBE(fsetxattr) {
     return kprobe_sys_setxattr_ret(ctx);
-}
-
-SEC("tracepoint/syscalls/sys_exit_lsetxattr")
-int tracepoint_syscalls_sys_exit_lsetxattr(struct tracepoint_syscalls_sys_exit_t *args) {
-    return sys_xattr_ret(args, args->ret, EVENT_SETXATTR);
 }
 
 SYSCALL_KRETPROBE(lsetxattr) {
@@ -208,27 +193,12 @@ int __attribute__((always_inline)) kprobe_sys_removexattr_ret(struct pt_regs *ct
     return sys_xattr_ret(ctx, retval, EVENT_REMOVEXATTR);
 }
 
-SEC("tracepoint/syscalls/sys_exit_removexattr")
-int tracepoint_syscalls_sys_exit_removexattr(struct tracepoint_syscalls_sys_exit_t *args) {
-    return sys_xattr_ret(args, args->ret, EVENT_REMOVEXATTR);
-}
-
 SYSCALL_KRETPROBE(removexattr) {
     return kprobe_sys_removexattr_ret(ctx);
 }
 
-SEC("tracepoint/syscalls/sys_exit_lremovexattr")
-int tracepoint_syscalls_sys_exit_lremovexattr(struct tracepoint_syscalls_sys_exit_t *args) {
-    return sys_xattr_ret(args, args->ret, EVENT_REMOVEXATTR);
-}
-
 SYSCALL_KRETPROBE(lremovexattr) {
     return kprobe_sys_removexattr_ret(ctx);
-}
-
-SEC("tracepoint/syscalls/sys_exit_fremovexattr")
-int tracepoint_syscalls_sys_exit_fremovexattr(struct tracepoint_syscalls_sys_exit_t *args) {
-    return sys_xattr_ret(args, args->ret, EVENT_REMOVEXATTR);
 }
 
 SYSCALL_KRETPROBE(fremovexattr) {

--- a/pkg/security/ebpf/c/splice.h
+++ b/pkg/security/ebpf/c/splice.h
@@ -175,9 +175,9 @@ SYSCALL_KRETPROBE(splice) {
     return sys_splice_ret(ctx, (int)PT_REGS_RC(ctx));
 }
 
-SEC("tracepoint/syscalls/sys_exit_splice")
-int tracepoint_syscalls_sys_exit_splice(struct tracepoint_syscalls_sys_exit_t *args) {
-    return sys_splice_ret(args, (int)args->ret);
+SEC("tracepoint/handle_sys_splice_exit")
+int tracepoint_handle_sys_splice_exit(struct tracepoint_raw_syscalls_sys_exit_t *args) {
+    return sys_splice_ret(args, args->ret);
 }
 
 #endif

--- a/pkg/security/ebpf/c/umount.h
+++ b/pkg/security/ebpf/c/umount.h
@@ -58,11 +58,6 @@ int __attribute__((always_inline)) sys_umount_ret(void *ctx, int retval) {
     return 0;
 }
 
-SEC("tracepoint/syscalls/sys_exit_umount")
-int tracepoint_syscalls_sys_exit_umount(struct tracepoint_syscalls_sys_exit_t *args) {
-    return sys_umount_ret(args, args->ret);
-}
-
 SYSCALL_KRETPROBE(umount) {
     int retval = PT_REGS_RC(ctx);
     return sys_umount_ret(ctx, retval);

--- a/pkg/security/ebpf/c/unlink.h
+++ b/pkg/security/ebpf/c/unlink.h
@@ -176,18 +176,8 @@ int __attribute__((always_inline)) kprobe_sys_unlink_ret(struct pt_regs *ctx) {
     return sys_unlink_ret(ctx, retval);
 }
 
-SEC("tracepoint/syscalls/sys_exit_unlink")
-int tracepoint_syscalls_sys_exit_unlink(struct tracepoint_syscalls_sys_exit_t *args) {
-    return sys_unlink_ret(args, args->ret);
-}
-
 SYSCALL_KRETPROBE(unlink) {
     return kprobe_sys_unlink_ret(ctx);
-}
-
-SEC("tracepoint/syscalls/sys_exit_unlinkat")
-int tracepoint_syscalls_sys_exit_unlinkat(struct tracepoint_syscalls_sys_exit_t *args) {
-    return sys_unlink_ret(args, args->ret);
 }
 
 SYSCALL_KRETPROBE(unlinkat) {

--- a/pkg/security/ebpf/c/utimes.h
+++ b/pkg/security/ebpf/c/utimes.h
@@ -95,45 +95,20 @@ int __attribute__((always_inline)) kprobe_sys_utimes_ret(struct pt_regs *ctx) {
     return sys_utimes_ret(ctx, retval);
 }
 
-SEC("tracepoint/syscalls/sys_exit_utime")
-int tracepoint_syscalls_sys_exit_utime(struct tracepoint_syscalls_sys_exit_t *args) {
-    return sys_utimes_ret(args, args->ret);
-}
-
 SYSCALL_COMPAT_KRETPROBE(utime) {
     return kprobe_sys_utimes_ret(ctx);
-}
-
-SEC("tracepoint/syscalls/sys_exit_utime32")
-int tracepoint_syscalls_sys_exit_utime32(struct tracepoint_syscalls_sys_exit_t *args) {
-    return sys_utimes_ret(args, args->ret);
 }
 
 SYSCALL_KRETPROBE(utime32) {
     return kprobe_sys_utimes_ret(ctx);
 }
 
-SEC("tracepoint/syscalls/sys_exit_utimes")
-int tracepoint_syscalls_sys_exit_utimes(struct tracepoint_syscalls_sys_exit_t *args) {
-    return sys_utimes_ret(args, args->ret);
-}
-
 SYSCALL_COMPAT_TIME_KRETPROBE(utimes) {
     return kprobe_sys_utimes_ret(ctx);
 }
 
-SEC("tracepoint/syscalls/sys_exit_utimensat")
-int tracepoint_syscalls_sys_exit_utimensat(struct tracepoint_syscalls_sys_exit_t *args) {
-    return sys_utimes_ret(args, args->ret);
-}
-
 SYSCALL_COMPAT_TIME_KRETPROBE(utimensat) {
     return kprobe_sys_utimes_ret(ctx);
-}
-
-SEC("tracepoint/syscalls/sys_exit_futimesat")
-int tracepoint_syscalls_sys_exit_futimesat(struct tracepoint_syscalls_sys_exit_t *args) {
-    return sys_utimes_ret(args, args->ret);
 }
 
 SYSCALL_COMPAT_TIME_KRETPROBE(futimesat) {

--- a/pkg/security/ebpf/probes/raw_sys_exit.go
+++ b/pkg/security/ebpf/probes/raw_sys_exit.go
@@ -144,5 +144,69 @@ func getSysExitTailCallRoutes() []manager.TailCallRoute {
 				EBPFFuncName: "tracepoint_handle_sys_commit_creds_exit",
 			},
 		},
+		{
+			ProgArrayName: "sys_exit_progs",
+			Key:           uint32(model.MMapEventType),
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFSection:  "tracepoint/handle_sys_mmap_exit",
+				EBPFFuncName: "tracepoint_handle_sys_mmap_exit",
+			},
+		},
+		{
+			ProgArrayName: "sys_exit_progs",
+			Key:           uint32(model.MProtectEventType),
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFSection:  "tracepoint/handle_sys_mprotect_exit",
+				EBPFFuncName: "tracepoint_handle_sys_mprotect_exit",
+			},
+		},
+		{
+			ProgArrayName: "sys_exit_progs",
+			Key:           uint32(model.PTraceEventType),
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFSection:  "tracepoint/handle_sys_ptrace_exit",
+				EBPFFuncName: "tracepoint_handle_sys_ptrace_exit",
+			},
+		},
+		{
+			ProgArrayName: "sys_exit_progs",
+			Key:           uint32(model.SpliceEventType),
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFSection:  "tracepoint/handle_sys_splice_exit",
+				EBPFFuncName: "tracepoint_handle_sys_splice_exit",
+			},
+		},
+		{
+			ProgArrayName: "sys_exit_progs",
+			Key:           uint32(model.BPFEventType),
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFSection:  "tracepoint/handle_sys_bpf_exit",
+				EBPFFuncName: "tracepoint_handle_sys_bpf_exit",
+			},
+		},
+		{
+			ProgArrayName: "sys_exit_progs",
+			Key:           uint32(model.BindEventType),
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFSection:  "tracepoint/handle_sys_bind_exit",
+				EBPFFuncName: "tracepoint_handle_sys_bind_exit",
+			},
+		},
+		{
+			ProgArrayName: "sys_exit_progs",
+			Key:           uint32(model.LoadModuleEventType),
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFSection:  "tracepoint/handle_sys_init_module_exit",
+				EBPFFuncName: "tracepoint_handle_sys_init_module_exit",
+			},
+		},
+		{
+			ProgArrayName: "sys_exit_progs",
+			Key:           uint32(model.UnloadModuleEventType),
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFSection:  "tracepoint/handle_sys_delete_module_exit",
+				EBPFFuncName: "tracepoint_handle_sys_delete_module_exit",
+			},
+		},
 	}
 }


### PR DESCRIPTION
### What does this PR do?

This PR removes `tracepoint/syscalls/sys_exit_*` hooks in favor of `raw_syscalls`.
This PR also adds missing handler for new event types.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
