### PR TITLE
Add flare command to the Cloud Foundry cluster agent

### DIFF
--- a/cmd/cluster-agent-cloudfoundry/app/flare.go
+++ b/cmd/cluster-agent-cloudfoundry/app/flare.go
@@ -1,0 +1,130 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build clusterchecks
+// +build clusterchecks
+
+package app
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/pkg/api/util"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/flare"
+	"github.com/DataDog/datadog-agent/pkg/util/input"
+)
+
+var (
+	customerEmail string
+	autoconfirm   bool
+)
+
+func init() {
+	ClusterAgentCmd.AddCommand(flareCmd)
+
+	flareCmd.Flags().StringVarP(&customerEmail, "email", "e", "", "Your email")
+	flareCmd.Flags().BoolVarP(&autoconfirm, "send", "s", false, "Automatically send flare (don't prompt for confirmation)")
+	flareCmd.SetArgs([]string{"caseID"})
+}
+
+var flareCmd = &cobra.Command{
+	Use:   "flare [caseID]",
+	Short: "Collect a flare and send it to Datadog",
+	Long:  ``,
+	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if flagNoColor {
+			color.NoColor = true
+		}
+
+		// we'll search for a config file named `datadog-cluster.yaml`
+		config.Datadog.SetConfigName("datadog-cluster")
+		err := common.SetupConfig(confPath)
+		if err != nil {
+			return fmt.Errorf("unable to set up global cluster agent configuration: %v", err)
+		}
+
+		// The flare command should not log anything, all errors should be reported directly to the console without the log format
+		err = config.SetupLogger(loggerName, "off", "", "", false, true, false)
+		if err != nil {
+			fmt.Printf("Cannot setup logger, exiting: %v\n", err)
+			return err
+		}
+
+		caseID := ""
+		if len(args) > 0 {
+			caseID = args[0]
+		}
+
+		if customerEmail == "" {
+			var err error
+			customerEmail, err = input.AskForEmail()
+			if err != nil {
+				fmt.Println("Error reading email, please retry or contact support")
+				return err
+			}
+		}
+
+		return requestFlare(caseID)
+	},
+}
+
+func requestFlare(caseID string) error {
+	fmt.Fprintln(color.Output, color.BlueString("Asking the Cluster Agent to build the flare archive."))
+	var e error
+	c := util.GetClient(false) // FIX: get certificates right then make this true
+	urlstr := fmt.Sprintf("https://localhost:%v/flare", config.Datadog.GetInt("cluster_agent.cmd_port"))
+
+	logFile := config.Datadog.GetString("log_file")
+	if logFile == "" {
+		logFile = common.DefaultDCALogFile
+	}
+
+	// Set session token
+	e = util.SetAuthToken()
+	if e != nil {
+		return e
+	}
+
+	r, e := util.DoPost(c, urlstr, "application/json", bytes.NewBuffer([]byte{}))
+	var filePath string
+	if e != nil {
+		if r != nil && string(r) != "" {
+			fmt.Fprintln(color.Output, fmt.Sprintf("The agent ran into an error while making the flare: %s", color.RedString(string(r))))
+		} else {
+			fmt.Fprintln(color.Output, color.RedString("The agent was unable to make a full flare: %s.", e.Error()))
+		}
+		fmt.Fprintln(color.Output, color.YellowString("Initiating flare locally, some logs will be missing."))
+		filePath, e = flare.CreateDCAArchive(true, common.GetDistPath(), logFile)
+		if e != nil {
+			fmt.Printf("The flare zipfile failed to be created: %s\n", e)
+			return e
+		}
+	} else {
+		filePath = string(r)
+	}
+
+	fmt.Fprintln(color.Output, fmt.Sprintf("%s is going to be uploaded to Datadog", color.YellowString(filePath)))
+	if !autoconfirm {
+		confirmation := input.AskForConfirmation("Are you sure you want to upload a flare? [Y/N]")
+		if !confirmation {
+			fmt.Fprintln(color.Output, fmt.Sprintf("Aborting. (You can still use %s)", color.YellowString(filePath)))
+			return nil
+		}
+	}
+
+	response, e := flare.SendFlare(filePath, caseID, customerEmail)
+	fmt.Println(response)
+	if e != nil {
+		return e
+	}
+	return nil
+}

--- a/releasenotes/notes/add-flare-command-to-cloudfoundry-cluster-agent-11347d431a7dea13.yaml
+++ b/releasenotes/notes/add-flare-command-to-cloudfoundry-cluster-agent-11347d431a7dea13.yaml
@@ -1,5 +1,5 @@
 ---
 enhancements:
   - |
-    Add the `flare` command to the Cloud Foundry `cluster agent`` to improve support
+    Add the `flare` command to the Cloud Foundry `cluster agent` to improve support
     experience.

--- a/releasenotes/notes/add-flare-command-to-cloudfoundry-cluster-agent-11347d431a7dea13.yaml
+++ b/releasenotes/notes/add-flare-command-to-cloudfoundry-cluster-agent-11347d431a7dea13.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Add the `flare` command to the Cloud Foundry `cluster agent`` to improve support
+    experience.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Adds the flare command to the cloudfoundry-cluster-agent.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Improve customer support experience.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

The added `flare.go` file is an exact replica of the `datadog-agent/cmd/cluster-agent/app/flare.go`.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
