### PR TITLE
[networks] Fix HTTPS overcount for `httpd`

### DIFF
--- a/pkg/ebpf/bytecode/runtime/http.go
+++ b/pkg/ebpf/bytecode/runtime/http.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Http = NewRuntimeAsset("http.c", "4e83e6edc63551e648c8e4005fdcb6d07b591c4775a130d3ccb71e732949f513")
+var Http = NewRuntimeAsset("http.c", "ff096240586287a909a0acec766bb1b9bbc1ef7425b33f86a28c9d261d55f509")

--- a/pkg/network/ebpf/c/http.h
+++ b/pkg/network/ebpf/c/http.h
@@ -100,12 +100,9 @@ static __always_inline void http_enqueue(http_transaction_t *http) {
     }
 }
 
-static __always_inline void http_begin_request(http_transaction_t *http, http_method_t method, char *buffer) {
+static __always_inline void http_begin_request(http_transaction_t *http, http_method_t method) {
     http->request_method = method;
     http->request_started = bpf_ktime_get_ns();
-    http->response_last_seen = 0;
-    http->response_status_code = 0;
-    __builtin_memcpy(&http->request_fragment, buffer, HTTP_BUFFER_SIZE);
 }
 
 static __always_inline void http_begin_response(http_transaction_t *http, const char *buffer) {
@@ -143,8 +140,27 @@ static __always_inline void http_parse_data(char const *p, http_packet_t *packet
     }
 }
 
+static __always_inline bool http_seen_before(http_transaction_t *http, skb_info_t *skb_info) {
+    if (!skb_info || !skb_info->tcp_seq) {
+        return false;
+    }
 
-static __always_inline http_transaction_t *http_fetch_state(http_transaction_t *http, skb_info_t *skb_info, http_packet_t packet_type) {
+    // check if we've seen this TCP segment before. this can happen in the
+    // context of localhost traffic where the same TCP segment can be seen
+    // multiple times coming in and out from different interfaces
+    return http->tcp_seq == skb_info->tcp_seq;
+}
+
+static __always_inline void http_update_seen_before(http_transaction_t *http, skb_info_t *skb_info) {
+    if (!skb_info || !skb_info->tcp_seq) {
+        return;
+    }
+
+    http->tcp_seq = skb_info->tcp_seq;
+}
+
+
+static __always_inline http_transaction_t *http_fetch_state(http_transaction_t *http, http_packet_t packet_type) {
     if (packet_type == HTTP_PACKET_UNKNOWN) {
         return bpf_map_lookup_elem(&http_in_flight, &http->tup);
     }
@@ -152,20 +168,7 @@ static __always_inline http_transaction_t *http_fetch_state(http_transaction_t *
     // We detected either a request or a response
     // In this case we initialize (or fetch) state associated to this tuple
     bpf_map_update_elem(&http_in_flight, &http->tup, http, BPF_NOEXIST);
-    http_transaction_t *http_ebpf = bpf_map_lookup_elem(&http_in_flight, &http->tup);
-    if (http_ebpf == NULL || skb_info == NULL) {
-        return http_ebpf;
-    }
-
-    // Bail out if we've seen this TCP segment before
-    // This can happen in the context of localhost traffic where the same TCP segment
-    // can be seen multiple times coming in and out from different interfaces
-    if (http_ebpf->tcp_seq == skb_info->tcp_seq) {
-        return NULL;
-    }
-
-    http_ebpf->tcp_seq = skb_info->tcp_seq;
-    return http_ebpf;
+    return bpf_map_lookup_elem(&http_in_flight, &http->tup);
 }
 
 static __always_inline http_transaction_t* http_should_flush_previous_state(http_transaction_t *http, http_packet_t packet_type) {
@@ -210,16 +213,22 @@ static __always_inline int http_process(http_transaction_t *http_stack, skb_info
     http_method_t method = HTTP_METHOD_UNKNOWN;
     http_parse_data(buffer, &packet_type, &method);
 
-    http_transaction_t *http = http_fetch_state(http_stack, skb_info, packet_type);
-    if (http == NULL) {
+    http_transaction_t *http = http_fetch_state(http_stack, packet_type);
+    if (!http || http_seen_before(http, skb_info)) {
         return 0;
     }
 
     http_transaction_t *to_flush = http_should_flush_previous_state(http, packet_type);
+    if (to_flush) {
+        __builtin_memcpy(http, http_stack, sizeof(http_transaction_t));
+    }
+
     if (packet_type == HTTP_REQUEST) {
-        http_begin_request(http, method, buffer);
+        http_begin_request(http, method);
+        http_update_seen_before(http, skb_info);
     } else if (packet_type == HTTP_RESPONSE) {
         http_begin_response(http, buffer);
+        http_update_seen_before(http, skb_info);
     }
 
     http->tags |= tags;


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fix an issue that was resulting in an overcount of HTTPS requests when tracing multiple instances of apache (`httpd`) servers in the same node.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

During the investigation of this problem I identified 2 distinct issues:

#### OpenSSL/GNUTLS library call sequence

One issue has to do with the way `httpd` integrates with OpenSSL/GNUTLS. For a reason that still eludes me (I haven't gone over the actual source code of the apache module `mod_ssl.so`), each incoming HTTPS request (say, `GET /foo HTTP/1.1`) results in a rather unusual sequence of `SSL_{read,write}` calls:

1. `SSL_read (GET /foo HTTP/1.1)`
2. `SSL_write (HTTP/1.1 200 OK)`
3. `SSL_read (GET /foo HTTP/1.1)`
4. `SSL_read (GET /foo HTTP/1.1)`

This breaks the HTTP eBPF "state-machine" code because when function call `3` is called the program thinks that a new request is being made for a keep-alive socket. It will then flush data corresponding to 1&2 and will start tracking a new HTTP transaction (`http_begin_request`). This is where the bug comes in: we would only override the request part (`request_fragment` and `request_method`), but we would leave `http_response_status` among other response fields with their previous values from `2`.
Finally, when `4` is called, the eBPF program would see think that again a new request was starting, and would flush _again_ a transaction to userspace, which resulted in the overcount.

#### Multiple instances of the same container

Prior to this change we were effectively attaching the same uprobes multiple times when running multiple instances of the same container in the same host. This was happening because the each instance container instance would have its own (overlay) filesytem, with its own unique shared library paths, but they actually share the same underlying inode. In this change we're updating `http/shared_libraries.go` to take inodes into account.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
