### PR TITLE
[corechecks/helm] Add option to set config values as tags

### DIFF
--- a/pkg/collector/corechecks/cluster/helm/events.go
+++ b/pkg/collector/corechecks/cluster/helm/events.go
@@ -22,28 +22,27 @@ const (
 )
 
 type eventsManager struct {
-	events             []coreMetrics.Event
-	eventsMutex        sync.Mutex
-	configParamsAsTags map[string]string
+	events      []coreMetrics.Event
+	eventsMutex sync.Mutex
 }
 
-func (em *eventsManager) addEventForNewRelease(rel *release, storage helmStorage) {
-	event := em.eventForRelease(rel, storage, textForAddEvent(rel), false)
+func (em *eventsManager) addEventForNewRelease(rel *release, tags []string) {
+	event := eventForRelease(rel, textForAddEvent(rel), tags)
 	em.storeEvent(event)
 }
 
-func (em *eventsManager) addEventForDeletedRelease(rel *release, storage helmStorage) {
-	event := em.eventForRelease(rel, storage, textForDeleteEvent(rel), true)
+func (em *eventsManager) addEventForDeletedRelease(rel *release, tags []string) {
+	event := eventForRelease(rel, textForDeleteEvent(rel), tags)
 	em.storeEvent(event)
 }
 
-func (em *eventsManager) addEventForUpdatedRelease(old *release, updated *release, storage helmStorage) {
+func (em *eventsManager) addEventForUpdatedRelease(old *release, updated *release, tags []string) {
 	// nil Info should not happen, so let's ignore those at least for now.
 	if (old.Info == nil || updated.Info == nil) || (old.Info.Status == updated.Info.Status) {
 		return
 	}
 
-	event := em.eventForRelease(updated, storage, textForChangedStatus(old.Info.Status, updated), false)
+	event := eventForRelease(updated, textForChangedStatus(old.Info.Status, updated), tags)
 	em.storeEvent(event)
 }
 
@@ -64,7 +63,7 @@ func (em *eventsManager) storeEvent(event coreMetrics.Event) {
 	em.events = append(em.events, event)
 }
 
-func (em *eventsManager) eventForRelease(rel *release, storage helmStorage, text string, isDelete bool) coreMetrics.Event {
+func eventForRelease(rel *release, text string, tags []string) coreMetrics.Event {
 	return coreMetrics.Event{
 		Title:          eventTitle,
 		Text:           text,
@@ -73,9 +72,7 @@ func (em *eventsManager) eventForRelease(rel *release, storage helmStorage, text
 		SourceTypeName: checkName,
 		EventType:      checkName,
 		AggregationKey: fmt.Sprintf("helm_release:%s", rel.namespacedName()),
-
-		// The revision tag is not included in delete events, because we generate a single event for all the revisions.
-		Tags: tagsForMetricsAndEvents(rel, storage, !isDelete, em.configParamsAsTags),
+		Tags:           tags,
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/helm/events_test.go
+++ b/pkg/collector/corechecks/cluster/helm/events_test.go
@@ -52,7 +52,7 @@ func TestAddEventForNewRelease(t *testing.T) {
 			SourceTypeName: "helm",
 			EventType:      "helm",
 			AggregationKey: "helm_release:default/my_datadog",
-			Tags:           tagsForMetricsAndEvents(&rel, k8sSecrets, true),
+			Tags:           tagsForMetricsAndEvents(&rel, k8sSecrets, true, nil),
 		},
 		storedEvent,
 	)
@@ -72,7 +72,7 @@ func TestAddEventForNewRelease(t *testing.T) {
 			SourceTypeName: "helm",
 			EventType:      "helm",
 			AggregationKey: "helm_release:default/my_datadog",
-			Tags:           tagsForMetricsAndEvents(&rel, k8sSecrets, true),
+			Tags:           tagsForMetricsAndEvents(&rel, k8sSecrets, true, nil),
 		},
 		storedEvent,
 	)
@@ -111,7 +111,7 @@ func TestAddEventForDeletedRelease(t *testing.T) {
 			SourceTypeName: "helm",
 			EventType:      "helm",
 			AggregationKey: "helm_release:default/my_datadog",
-			Tags:           tagsForMetricsAndEvents(&rel, k8sSecrets, false),
+			Tags:           tagsForMetricsAndEvents(&rel, k8sSecrets, false, nil),
 		},
 		storedEvent,
 	)
@@ -182,7 +182,7 @@ func TestAddEventForUpdatedRelease(t *testing.T) {
 				SourceTypeName: "helm",
 				EventType:      "helm",
 				AggregationKey: "helm_release:default/my_datadog",
-				Tags:           tagsForMetricsAndEvents(&exampleReleaseWithFailedStatus, k8sSecrets, true),
+				Tags:           tagsForMetricsAndEvents(&exampleReleaseWithFailedStatus, k8sSecrets, true, nil),
 			},
 		},
 		{
@@ -257,7 +257,7 @@ func TestSendEvents(t *testing.T) {
 			SourceTypeName: "helm",
 			EventType:      "helm",
 			AggregationKey: "helm_release:default/my_datadog",
-			Tags:           tagsForMetricsAndEvents(&rel, k8sSecrets, true),
+			Tags:           tagsForMetricsAndEvents(&rel, k8sSecrets, true, nil),
 		},
 		10*time.Second,
 	)

--- a/pkg/collector/corechecks/cluster/helm/events_test.go
+++ b/pkg/collector/corechecks/cluster/helm/events_test.go
@@ -37,7 +37,7 @@ func TestAddEventForNewRelease(t *testing.T) {
 		Namespace: "default",
 	}
 
-	events.addEventForNewRelease(&rel, k8sSecrets)
+	events.addEventForNewRelease(&rel, testTags())
 
 	// Test new release with revision 1.
 	storedEvent := events.events[0]
@@ -52,14 +52,14 @@ func TestAddEventForNewRelease(t *testing.T) {
 			SourceTypeName: "helm",
 			EventType:      "helm",
 			AggregationKey: "helm_release:default/my_datadog",
-			Tags:           tagsForMetricsAndEvents(&rel, k8sSecrets, true, nil),
+			Tags:           testTags(),
 		},
 		storedEvent,
 	)
 
 	// Test release with upgraded revision (Notice that the text of the events is different).
 	rel.Version = 2
-	events.addEventForNewRelease(&rel, k8sSecrets)
+	events.addEventForNewRelease(&rel, testTags())
 	storedEvent = events.events[1]
 	storedEvent.Ts = 0 // Can't control it, so don't check.
 	assert.Equal(
@@ -72,7 +72,7 @@ func TestAddEventForNewRelease(t *testing.T) {
 			SourceTypeName: "helm",
 			EventType:      "helm",
 			AggregationKey: "helm_release:default/my_datadog",
-			Tags:           tagsForMetricsAndEvents(&rel, k8sSecrets, true, nil),
+			Tags:           testTags(),
 		},
 		storedEvent,
 	)
@@ -97,7 +97,7 @@ func TestAddEventForDeletedRelease(t *testing.T) {
 		Namespace: "default",
 	}
 
-	events.addEventForDeletedRelease(&rel, k8sSecrets)
+	events.addEventForDeletedRelease(&rel, testTags())
 
 	storedEvent := events.events[0]
 	storedEvent.Ts = 0 // Can't control it, so don't check.
@@ -111,7 +111,7 @@ func TestAddEventForDeletedRelease(t *testing.T) {
 			SourceTypeName: "helm",
 			EventType:      "helm",
 			AggregationKey: "helm_release:default/my_datadog",
-			Tags:           tagsForMetricsAndEvents(&rel, k8sSecrets, false, nil),
+			Tags:           testTags(),
 		},
 		storedEvent,
 	)
@@ -182,7 +182,7 @@ func TestAddEventForUpdatedRelease(t *testing.T) {
 				SourceTypeName: "helm",
 				EventType:      "helm",
 				AggregationKey: "helm_release:default/my_datadog",
-				Tags:           tagsForMetricsAndEvents(&exampleReleaseWithFailedStatus, k8sSecrets, true, nil),
+				Tags:           testTags(),
 			},
 		},
 		{
@@ -209,7 +209,7 @@ func TestAddEventForUpdatedRelease(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			events := eventsManager{}
 
-			events.addEventForUpdatedRelease(test.oldRelease, test.updatedRelease, k8sSecrets)
+			events.addEventForUpdatedRelease(test.oldRelease, test.updatedRelease, testTags())
 
 			if test.expectedEvent == nil {
 				assert.Empty(t, events.events)
@@ -241,7 +241,7 @@ func TestSendEvents(t *testing.T) {
 		Namespace: "default",
 	}
 
-	events.addEventForNewRelease(&rel, k8sSecrets)
+	events.addEventForNewRelease(&rel, testTags())
 
 	sender := mocksender.NewMockSender("1")
 	sender.SetupAcceptAll()
@@ -257,8 +257,12 @@ func TestSendEvents(t *testing.T) {
 			SourceTypeName: "helm",
 			EventType:      "helm",
 			AggregationKey: "helm_release:default/my_datadog",
-			Tags:           tagsForMetricsAndEvents(&rel, k8sSecrets, true, nil),
+			Tags:           testTags(),
 		},
 		10*time.Second,
 	)
+}
+
+func testTags() []string {
+	return []string{"helm_release:my_datadog"}
 }

--- a/pkg/collector/corechecks/cluster/helm/helm.go
+++ b/pkg/collector/corechecks/cluster/helm/helm.go
@@ -71,7 +71,7 @@ type HelmCheck struct {
 
 type checkConfig struct {
 	CollectEvents                  bool              `yaml:"collect_events"`
-	ConfigParamsAsTags             map[string]string `yaml:"config_params_as_tags"`
+	HelmValuesAsTags               map[string]string `yaml:"helm_values_as_tags"`
 	ExtraSyncTimeoutSeconds        int               `yaml:"extra_sync_timeout_seconds"`
 	InformersResyncIntervalMinutes int               `yaml:"informers_resync_interval_minutes"`
 }
@@ -80,7 +80,7 @@ type checkConfig struct {
 func (cc *checkConfig) Parse(data []byte) error {
 	// default values
 	cc.CollectEvents = false
-	cc.ConfigParamsAsTags = make(map[string]string)
+	cc.HelmValuesAsTags = make(map[string]string)
 
 	return yaml.Unmarshal(data, cc)
 }
@@ -237,10 +237,10 @@ func (hc *HelmCheck) tagsForMetricsAndEvents(release *release, includeRevision b
 		tags = append(tags, fmt.Sprintf("helm_status:%s", release.Info.Status))
 	}
 
-	for configParam, tagName := range hc.instance.ConfigParamsAsTags {
-		value, err := release.getConfigValue(configParam)
+	for helmValue, tagName := range hc.instance.HelmValuesAsTags {
+		value, err := release.getConfigValue(helmValue)
 		if err != nil {
-			log.Tracef("Value for %s specified in config_params_as_tags not found", configParam)
+			log.Tracef("Value for %s specified in helm_values_as_tags not found", helmValue)
 			continue
 		}
 		tags = append(tags, fmt.Sprintf("%s:%s", tagName, value))

--- a/pkg/collector/corechecks/cluster/helm/helm.go
+++ b/pkg/collector/corechecks/cluster/helm/helm.go
@@ -108,8 +108,6 @@ func (hc *HelmCheck) Configure(config, initConfig integration.Data, source strin
 		return err
 	}
 
-	hc.eventsManager.configParamsAsTags = hc.instance.ConfigParamsAsTags
-
 	apiCtx, apiCancel := context.WithTimeout(context.Background(), maximumWaitForAPIServer)
 	defer apiCancel()
 
@@ -154,7 +152,8 @@ func (hc *HelmCheck) Run() error {
 
 	for _, storageDriver := range []helmStorage{k8sConfigmaps, k8sSecrets} {
 		for _, rel := range hc.store.getAll(storageDriver) {
-			sender.Gauge("helm.release", 1, "", tagsForMetricsAndEvents(rel, storageDriver, true, hc.instance.ConfigParamsAsTags))
+			tags := append(rel.commonTags, rel.tagsForMetricsAndEvents...)
+			sender.Gauge("helm.release", 1, "", tags)
 		}
 	}
 
@@ -205,8 +204,15 @@ func (hc *HelmCheck) setSharedInformerFactory(apiClient *apiserver.APIClient) {
 	)
 }
 
-func tagsForMetricsAndEvents(release *release, storageDriver helmStorage, includeRevision bool, configParamsAsTags map[string]string) []string {
-	tags := tagsForServiceCheck(release, storageDriver)
+func (hc *HelmCheck) allTags(release *release, storageDriver helmStorage, includeRevision bool) []string {
+	return append(
+		commonTags(release, storageDriver),
+		hc.tagsForMetricsAndEvents(release, includeRevision)...,
+	)
+}
+
+func (hc *HelmCheck) tagsForMetricsAndEvents(release *release, includeRevision bool) []string {
+	var tags []string
 
 	if includeRevision {
 		tags = append(tags, fmt.Sprintf("helm_revision:%d", release.Version))
@@ -231,7 +237,7 @@ func tagsForMetricsAndEvents(release *release, storageDriver helmStorage, includ
 		tags = append(tags, fmt.Sprintf("helm_status:%s", release.Info.Status))
 	}
 
-	for configParam, tagName := range configParamsAsTags {
+	for configParam, tagName := range hc.instance.ConfigParamsAsTags {
 		value, err := release.getConfigValue(configParam)
 		if err != nil {
 			log.Tracef("Value for %s specified in config_params_as_tags not found", configParam)
@@ -243,9 +249,10 @@ func tagsForMetricsAndEvents(release *release, storageDriver helmStorage, includ
 	return tags
 }
 
-// tagsForServiceCheck returns the tags needed for the service check which
-// are the ones that don't change between revisions
-func tagsForServiceCheck(release *release, storageDriver helmStorage) []string {
+// commonTags returns the common tags that are included in service checks, the
+// metrics, and the events. These are the tags that don't change between
+// revisions
+func commonTags(release *release, storageDriver helmStorage) []string {
 	tags := []string{
 		fmt.Sprintf("helm_release:%s", release.Name),
 		fmt.Sprintf("helm_storage:%s", storageDriver),
@@ -390,15 +397,19 @@ func (hc *HelmCheck) addRelease(encodedRelease string, creationTS metav1.Time, s
 
 	needToEmitEvent := hc.instance.CollectEvents && creationTS.After(hc.startTS)
 
+	genericTags := commonTags(decodedRelease, storageDriver)
+	tagsMetricsAndEvents := hc.tagsForMetricsAndEvents(decodedRelease, true)
+	allTags := append(genericTags, tagsMetricsAndEvents...)
+
 	if needToEmitEvent {
 		if previous := hc.store.get(decodedRelease.namespacedName(), decodedRelease.revision(), storageDriver); previous != nil {
-			hc.eventsManager.addEventForUpdatedRelease(previous, decodedRelease, storageDriver)
+			hc.eventsManager.addEventForUpdatedRelease(previous.release, decodedRelease, allTags)
 		} else {
-			hc.eventsManager.addEventForNewRelease(decodedRelease, storageDriver)
+			hc.eventsManager.addEventForNewRelease(decodedRelease, allTags)
 		}
 	}
 
-	hc.store.add(decodedRelease, storageDriver)
+	hc.store.add(decodedRelease, storageDriver, genericTags, tagsMetricsAndEvents)
 }
 
 func (hc *HelmCheck) deleteRelease(encodedRelease string, storageDriver helmStorage) {
@@ -414,7 +425,8 @@ func (hc *HelmCheck) deleteRelease(encodedRelease string, storageDriver helmStor
 	// time. To avoid generating many events with the same info, we just emit
 	// one when there are no more revisions left.
 	if hc.instance.CollectEvents && !moreRevisionsLeft {
-		hc.eventsManager.addEventForDeletedRelease(decodedRelease, storageDriver)
+		tags := hc.allTags(decodedRelease, storageDriver, false)
+		hc.eventsManager.addEventForDeletedRelease(decodedRelease, tags)
 	}
 }
 
@@ -441,10 +453,10 @@ func isLeader() (bool, error) {
 
 func (hc *HelmCheck) sendServiceCheck(sender aggregator.Sender) {
 	for _, storageDriver := range []helmStorage{k8sConfigmaps, k8sSecrets} {
-		for _, rel := range hc.store.getLatestRevisions(storageDriver) {
-			tags := tagsForServiceCheck(rel, storageDriver)
+		for _, taggedRel := range hc.store.getLatestRevisions(storageDriver) {
+			tags := taggedRel.commonTags
 
-			if rel.Info != nil && rel.Info.Status == "failed" {
+			if taggedRel.release.Info != nil && taggedRel.release.Info.Status == "failed" {
 				sender.ServiceCheck(serviceCheckName, coreMetrics.ServiceCheckCritical, "", tags, "Release in \"failed\" state")
 			} else {
 				sender.ServiceCheck(serviceCheckName, coreMetrics.ServiceCheckOK, "", tags, "")

--- a/pkg/collector/corechecks/cluster/helm/helm_test.go
+++ b/pkg/collector/corechecks/cluster/helm/helm_test.go
@@ -322,9 +322,10 @@ func TestRun_withCollectEvents(t *testing.T) {
 	assert.Eventually(t, func() bool {
 		err = check.Run()
 		assert.NoError(t, err)
+		expectedTags := check.allTags(&rel, k8sSecrets, true)
 		return mockedSender.AssertEvent(
 			t,
-			check.eventsManager.eventForRelease(&rel, k8sSecrets, "New Helm release \"my_datadog\" has been deployed in \"default\" namespace. Its status is \"deployed\".", false),
+			eventForRelease(&rel, "New Helm release \"my_datadog\" has been deployed in \"default\" namespace. Its status is \"deployed\".", expectedTags),
 			10*time.Second,
 		)
 	}, 5*time.Second, time.Millisecond*100)
@@ -339,9 +340,10 @@ func TestRun_withCollectEvents(t *testing.T) {
 	assert.Eventually(t, func() bool {
 		err = check.Run()
 		assert.NoError(t, err)
+		expectedTags := check.allTags(&rel, k8sSecrets, true)
 		return mockedSender.AssertEvent(
 			t,
-			check.eventsManager.eventForRelease(&rel, k8sSecrets, "Helm release \"my_datadog\" in \"default\" namespace upgraded to revision 2. Its status is \"deployed\".", false),
+			eventForRelease(&rel, "Helm release \"my_datadog\" in \"default\" namespace upgraded to revision 2. Its status is \"deployed\".", expectedTags),
 			10*time.Second,
 		)
 	}, 5*time.Second, time.Millisecond*100)
@@ -355,9 +357,10 @@ func TestRun_withCollectEvents(t *testing.T) {
 	assert.Eventually(t, func() bool {
 		err = check.Run()
 		assert.NoError(t, err)
+		expectedTags := check.allTags(&rel, k8sSecrets, false)
 		return mockedSender.AssertEvent(
 			t,
-			check.eventsManager.eventForRelease(&rel, k8sSecrets, "Helm release \"my_datadog\" in \"default\" namespace has been deleted.", true),
+			eventForRelease(&rel, "Helm release \"my_datadog\" in \"default\" namespace has been deleted.", expectedTags),
 			10*time.Second,
 		)
 	}, 5*time.Second, time.Millisecond*100)
@@ -522,7 +525,7 @@ func TestRun_ServiceCheck(t *testing.T) {
 			check.runLeaderElection = false
 
 			for _, rel := range releases {
-				check.store.add(rel, test.storage)
+				check.store.add(rel, test.storage, commonTags(rel, test.storage), check.tagsForMetricsAndEvents(rel, true))
 			}
 
 			mockedSender := mocksender.NewMockSender(checkName)

--- a/pkg/collector/corechecks/cluster/helm/helm_test.go
+++ b/pkg/collector/corechecks/cluster/helm/helm_test.go
@@ -99,8 +99,8 @@ func TestRun(t *testing.T) {
 			Namespace: "default",
 		},
 		{
-			// Release with config param set
-			Name: "with_config_param",
+			// Release with helm values set
+			Name: "with_helm_values",
 			Info: &info{
 				Status: "deployed",
 			},
@@ -109,7 +109,7 @@ func TestRun(t *testing.T) {
 			},
 			Chart: &chart{
 				Metadata: &metadata{
-					Name:       "with_config_param",
+					Name:       "with_helm_values",
 					Version:    "1.0.0",
 					AppVersion: "1",
 				},
@@ -191,16 +191,16 @@ func TestRun(t *testing.T) {
 			"helm_chart:foo-2_30_5",
 		},
 		{
-			"helm_release:with_config_param",
-			"helm_chart_name:with_config_param",
+			"helm_release:with_helm_values",
+			"helm_chart_name:with_helm_values",
 			"kube_namespace:default",
 			"helm_namespace:default",
 			"helm_revision:1",
 			"helm_status:deployed",
 			"helm_chart_version:1.0.0",
 			"helm_app_version:1",
-			"helm_chart:with_config_param-1.0.0",
-			"option_value:2", // Because "ConfigParamsAsTags" is set with "option" => "option_value" in the test check
+			"helm_chart:with_helm_values-1.0.0",
+			"option_value:2", // Because "HelmValuesAsTags" is set with "option" => "option_value" in the test check
 		},
 	}
 
@@ -263,7 +263,7 @@ func TestRun(t *testing.T) {
 			check := factory().(*HelmCheck)
 			check.runLeaderElection = false
 
-			check.instance.ConfigParamsAsTags = map[string]string{
+			check.instance.HelmValuesAsTags = map[string]string{
 				"option": "option_value",
 			}
 

--- a/pkg/collector/corechecks/cluster/helm/map_utils.go
+++ b/pkg/collector/corechecks/cluster/helm/map_utils.go
@@ -1,0 +1,58 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+// +build kubeapiserver
+
+package helm
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// gets a value from a map[string]interface{} using a dot-separated key like
+// "agents.image.tag".
+// Returns an error when there isn't a value associated for the key. It also
+// returns an error if the provided key is "incomplete", meaning that there's a
+// value associated for the key, but it is a map. For example, if the input map
+// is:
+// map[string]interface{}{
+//   "agents": map[string]interface{}{
+//     "image": map[string]string{
+//	     "tag": "7.39.0",
+//       "pullPolicy": "IfNotPresent",
+//	   },
+//	  },
+// }
+// "agents.image.tag" and "agents.image.pullPolicy" are valid keys, but
+// "agents.image" is not.
+func getValue(m map[string]interface{}, dotSeparatedKey string) (string, error) {
+	keys := strings.Split(dotSeparatedKey, ".")
+	var obj interface{} = m
+
+	for _, key := range keys {
+		if reflect.TypeOf(obj).Kind() != reflect.Map {
+			return "", fmt.Errorf("not found")
+		}
+
+		mapValue := reflect.ValueOf(obj)
+
+		objValue := mapValue.MapIndex(reflect.ValueOf(key))
+
+		if !objValue.IsValid() {
+			return "", fmt.Errorf("not found")
+		}
+
+		obj = objValue.Interface()
+	}
+
+	if reflect.TypeOf(obj).Kind() == reflect.Map {
+		return "", fmt.Errorf("not found")
+	}
+
+	return fmt.Sprintf("%v", reflect.ValueOf(obj)), nil
+}

--- a/pkg/collector/corechecks/cluster/helm/map_utils_test.go
+++ b/pkg/collector/corechecks/cluster/helm/map_utils_test.go
@@ -1,0 +1,115 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+// +build kubeapiserver
+
+package helm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetValue(t *testing.T) {
+	tests := []struct {
+		name            string
+		inputMap        map[string]interface{}
+		dotSeparatedKey string
+		expectedValue   string
+		expectsError    bool
+	}{
+		{
+			name: "standard case",
+			inputMap: map[string]interface{}{
+				"agents": map[string]interface{}{
+					"image": map[string]string{
+						"tag": "7.39.0",
+					},
+				},
+			},
+			dotSeparatedKey: "agents.image.tag",
+			expectedValue:   "7.39.0",
+		},
+		{
+			name: "non-string value",
+			inputMap: map[string]interface{}{
+				"agents": map[string]interface{}{
+					"image": map[string]int{
+						"tag": 1,
+					},
+				},
+			},
+			dotSeparatedKey: "agents.image.tag",
+			expectedValue:   "1",
+		},
+		{
+			name: "result is a map",
+			inputMap: map[string]interface{}{
+				"agents": map[string]interface{}{
+					"image": map[string]string{
+						"tag": "7.39.0",
+					},
+				},
+			},
+			dotSeparatedKey: "agents.image",
+			expectsError:    true,
+		},
+		{
+			name: "input map has less levels than key",
+			inputMap: map[string]interface{}{
+				"agents": map[string]interface{}{
+					"image": "datadog/agent:7.39.0",
+				},
+			},
+			dotSeparatedKey: "agents.image.tag",
+			expectsError:    true,
+		},
+		{
+			name:            "input map is empty",
+			inputMap:        map[string]interface{}{},
+			dotSeparatedKey: "agents.image.tag",
+			expectsError:    true,
+		},
+		{
+			name: "first element of the key not found",
+			inputMap: map[string]interface{}{
+				"agents": map[string]interface{}{
+					"image": map[string]string{
+						"tag": "7.39.0",
+					},
+				},
+			},
+			dotSeparatedKey: "abc.image.tag",
+			expectsError:    true,
+		},
+		{
+			name: "some element of the key other than the first not found",
+			inputMap: map[string]interface{}{
+				"agents": map[string]interface{}{
+					"image": map[string]string{
+						"tag": "7.39.0",
+					},
+				},
+			},
+			dotSeparatedKey: "agents.image.abc",
+			expectsError:    true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := getValue(test.inputMap, test.dotSeparatedKey)
+
+			if test.expectsError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, test.expectedValue, result)
+			}
+		})
+	}
+}

--- a/pkg/collector/corechecks/cluster/helm/release_test.go
+++ b/pkg/collector/corechecks/cluster/helm/release_test.go
@@ -1,0 +1,78 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+// +build kubeapiserver
+
+package helm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetConfigValue(t *testing.T) {
+	testRelease := release{
+		Name: "test release",
+		Chart: &chart{
+			Values: map[string]interface{}{
+				"agents": map[string]interface{}{
+					"image": map[string]string{
+						"tag":        "7.39.0",
+						"repository": "datadog/agent", // not overridden
+					},
+				},
+			},
+		},
+		Config: map[string]interface{}{
+			"agents": map[string]interface{}{
+				"image": map[string]string{
+					"tag": "latest", // overrides default value
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name            string
+		rel             release
+		dotSeparatedKey string
+		expectedValue   string
+		expectsError    bool
+	}{
+		{
+			name:            "config param has been set",
+			rel:             testRelease,
+			dotSeparatedKey: "agents.image.tag",
+			expectedValue:   "latest",
+		},
+		{
+			name:            "config param has a default value in the chart",
+			rel:             testRelease,
+			dotSeparatedKey: "agents.image.repository",
+			expectedValue:   "datadog/agent",
+		},
+		{
+			name:            "config param not set",
+			rel:             testRelease,
+			dotSeparatedKey: "agents.abc",
+			expectsError:    true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := test.rel.getConfigValue(test.dotSeparatedKey)
+
+			if test.expectsError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, test.expectedValue, result)
+			}
+		})
+	}
+}

--- a/releasenotes/notes/helm-configparams-as-tags-a3aff7c51fff6d99.yaml
+++ b/releasenotes/notes/helm-configparams-as-tags-a3aff7c51fff6d99.yaml
@@ -8,7 +8,6 @@
 ---
 features:
   - |
-    Added the "config_params_as_tags" configuration option in the Helm check.
-    It allows users to collect configuration parameters from a Helm release and
-    use them as tags to attach to the metrics and events emitted by the Helm
-    check.
+    Added the "helm_values_as_tags" configuration option in the Helm check.  It
+    allows users to collect helm values from a Helm release and use them as
+    tags to attach to the metrics and events emitted by the Helm check.

--- a/releasenotes/notes/helm-configparams-as-tags-a3aff7c51fff6d99.yaml
+++ b/releasenotes/notes/helm-configparams-as-tags-a3aff7c51fff6d99.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Added the "config_params_as_tags" configuration option in the Helm check.
+    It allows users to collect configuration parameters from a Helm release and
+    use them as tags to attach to the metrics and events emitted by the Helm
+    check.


### PR DESCRIPTION
### What does this PR do?

Adds a new configuration option, "helm_values_as_tags", in the Helm check.

This new configuration option allows to collect configuration parameters from a Helm release and use them as tags to attach to the metrics and events emitted by the Helm check. It's similar to the existing "container labels as tags" and "container envs as tags" functionality.

So for example, if we deploy the agent using the Helm chart, and define in the check config:
```
      helm_values_as_tags:
        agents.image.tag: custom_tag
```
The metrics and events emitted by the Helm check will include the "custom_tag" tag and its value will be the "agents.image.tag" value set when installing the chart, or the default value defined in the chart.

### Describe how to test/QA your changes

Install the agent using the Helm chart with the helm check enabled and the option to collect events enabled too (it's disabled by default). There isn't a way to provide the "helm_values_as_tags" option yet but it should be there when this needs to be QA'd.

We can use the "hello world" chart from the Helm repo: https://github.com/helm/examples

For example, we know that the chart includes the "image.pullPolicy" config param, so we can define something like:
```
      helm_values_as_tags:
        image.pullPolicy: custom_tag
```

First, try installing the chart without setting a value for `image.pullPolicy`. The default will apply ("IfNotPresent"). So the metrics and events emitted by the helm check should include the tag "custom_tag" with the value "IfNotPresent".

Now try the same but providing a value `--set image.pullPolicy=Always` when installing the chart. Now the "custom_tag" tag should bet set to "Always". 



### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
