### PR TITLE
[dogstatsd] enable the no-aggregation pipeline by default.

### DIFF
--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -368,6 +368,7 @@ func StartAgent() error {
 	// Enable core agent specific features like persistence-to-disk
 	forwarderOpts.EnabledFeatures = forwarder.SetFeature(forwarderOpts.EnabledFeatures, forwarder.CoreFeatures)
 	opts := aggregator.DefaultAgentDemultiplexerOptions(forwarderOpts)
+	opts.EnableNoAggregationPipeline = config.Datadog.GetBool("dogstatsd_no_aggregation_pipeline")
 	opts.UseContainerLifecycleForwarder = config.Datadog.GetBool("container_lifecycle.enabled")
 	demux = aggregator.InitAndStartAgentDemultiplexer(opts, hostnameDetected)
 

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -203,6 +203,7 @@ func runAgent(ctx context.Context) (err error) {
 	opts.UseOrchestratorForwarder = false
 	opts.UseEventPlatformForwarder = false
 	opts.UseContainerLifecycleForwarder = false
+	opts.EnableNoAggregationPipeline = config.Datadog.GetBool("dogstatsd_no_aggregation_pipeline")
 	hname, err := hostname.Get(context.TODO())
 	if err != nil {
 		log.Warnf("Error getting hostname: %s", err)

--- a/docs/dogstatsd/internals.md
+++ b/docs/dogstatsd/internals.md
@@ -98,6 +98,6 @@ Input: slice of MetricSamples
 
 The NoAggregationStreamWorker runs an infinite loop in a goroutine. It receives metric samples with timestamps, and it batches them to be sent as quickly as possible to the intake. It performs no aggregation nor extra processing, except from adding tags to the metrics.
 
-It is running only when `dogstatsd_no_aggregation_pipeline` is set to `true`.
+It runs only when `dogstatsd_no_aggregation_pipeline` is set to `true`.
 
 The payload being sent to the intake (through the normal `Serializer`/`Forwarder` pieces) contains, at maximum, `dogstatsd_no_aggregation_pipeline_batch_size` metrics. This value defaults to `256`.

--- a/docs/dogstatsd/internals.md
+++ b/docs/dogstatsd/internals.md
@@ -92,3 +92,12 @@ The following calculations determine the number of TimeSamplerWorker and TimeSam
     * If `dogstatsd_pipeline_count` has a value, the number of TimeSampler pipelines equals that value.
     * If neither condition above is true, one TimeSampler pipeline runs.
 
+## NoAggregationStreamWorker
+
+Input: slice of MetricSamples
+
+The NoAggregationStreamWorker runs an infinite loop in a goroutine. It receives metric samples with timestamps, and it batches them to be sent as quickly as possible to the intake. It performs no aggregation nor extra processing, except from adding tags to the metrics.
+
+It is running only when `dogstatsd_no_aggregation_pipeline` is set to `true`.
+
+The payload being sent to the intake (through the normal `Serializer`/`Forwarder` pieces) contains, at maximum, `dogstatsd_no_aggregation_pipeline_batch_size` metrics. This value defaults to `256`.

--- a/pkg/aggregator/demultiplexer_agent.go
+++ b/pkg/aggregator/demultiplexer_agent.go
@@ -83,7 +83,8 @@ func DefaultAgentDemultiplexerOptions(options *forwarder.Options) AgentDemultipl
 		UseNoopEventPlatformForwarder:  false,
 		UseNoopOrchestratorForwarder:   false,
 		UseContainerLifecycleForwarder: false,
-		EnableNoAggregationPipeline:    config.Datadog.GetBool("dogstatsd_no_aggregation_pipeline"),
+		// the different agents/binaries enable it on a per-need basis
+		EnableNoAggregationPipeline: false,
 	}
 }
 

--- a/pkg/aggregator/demultiplexer_mock.go
+++ b/pkg/aggregator/demultiplexer_mock.go
@@ -127,17 +127,22 @@ func (a *TestAgentDemultiplexer) Reset() {
 	a.Unlock()
 }
 
+// InitTestAgentDemultiplexerWithFlushInterval inits a TestAgentDemultiplexer with the given options.
+func InitTestAgentDemultiplexerWithOpts(opts AgentDemultiplexerOptions) *TestAgentDemultiplexer {
+	demux := InitAndStartAgentDemultiplexer(opts, "hostname")
+	testAgent := TestAgentDemultiplexer{
+		AgentDemultiplexer: demux,
+	}
+	return &testAgent
+}
+
 // InitTestAgentDemultiplexerWithFlushInterval inits a TestAgentDemultiplexer with the given flush interval.
 func InitTestAgentDemultiplexerWithFlushInterval(flushInterval time.Duration) *TestAgentDemultiplexer {
 	opts := DefaultAgentDemultiplexerOptions(nil)
 	opts.FlushInterval = flushInterval
 	opts.DontStartForwarders = true
 	opts.UseNoopEventPlatformForwarder = true
-	demux := InitAndStartAgentDemultiplexer(opts, "hostname")
-	testAgent := TestAgentDemultiplexer{
-		AgentDemultiplexer: demux,
-	}
-	return &testAgent
+	return InitTestAgentDemultiplexerWithOpts(opts)
 }
 
 // InitTestAgentDemultiplexer inits a TestAgentDemultiplexer with a long flush interval.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -530,8 +530,9 @@ func InitConfig(config Config) {
 	// Depth of the channel the capture writer reads before persisting to disk.
 	// Default is 0 - blocking channel
 	config.BindEnvAndSetDefault("dogstatsd_capture_depth", 0)
-	// enable the no-aggregation pipeline
-	config.BindEnvAndSetDefault("dogstatsd_no_aggregation_pipeline", false)
+	// Enable the no-aggregation pipeline.
+	config.BindEnvAndSetDefault("dogstatsd_no_aggregation_pipeline", true)
+	// How many metrics maximum in payloads sent by the no-aggregation pipeline to the intake.
 	config.BindEnvAndSetDefault("dogstatsd_no_aggregation_pipeline_batch_size", 256)
 
 	// To enable the following feature, GODEBUG must contain `madvdontneed=1`

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1786,6 +1786,21 @@ api_key:
 #
 # dogstatsd_entity_id_precedence: false
 
+
+## @param dogstatsd_no_aggregation_pipeline - boolean - optional - default: true
+## @env DD_DOGSTATSD_NO_AGGREGATION_PIPELINE - boolean - optional - default: true
+## Enable the no-aggregation pipeline in DogStatsD: a pipeline receiving metrics
+## with timestamp and forwarding them to the intake without extra processing except
+## from tagging.
+#
+# dogstatsd_no_aggregation_pipeline: true
+
+## @param dogstatsd_no_aggregation_pipeline_batch_size - integer - optional - default: 256
+## @env DD_DOGSTATSD_NO_AGGREGATION_PIPELINE_BATCH_SIZE - integer - optional - default: 256
+## How many metrics maximum in payloads sent by the no-aggregation pipeline to the intake.
+#
+# dogstatsd_no_aggregation_pipeline_batch_size: 256
+
 ## @param statsd_forward_host - string - optional - default: ""
 ## @env DD_STATSD_FORWARD_HOST - string - optional - default: ""
 ## Forward every packet received by the DogStatsD server to another statsd server.

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1791,7 +1791,7 @@ api_key:
 ## @env DD_DOGSTATSD_NO_AGGREGATION_PIPELINE - boolean - optional - default: true
 ## Enable the no-aggregation pipeline in DogStatsD: a pipeline receiving metrics
 ## with timestamp and forwarding them to the intake without extra processing except
-## from tagging.
+## for tagging.
 #
 # dogstatsd_no_aggregation_pipeline: true
 

--- a/pkg/dogstatsd/parse_metrics_test.go
+++ b/pkg/dogstatsd/parse_metrics_test.go
@@ -329,6 +329,10 @@ func TestParseMetricError(t *testing.T) {
 }
 
 func TestParseGaugeWithTimestamp(t *testing.T) {
+	// disable the no agg pipeline
+
+	config.Datadog.Set("dogstatsd_no_aggregation_pipeline", false)
+
 	// no timestamp should be read when the no agg pipeline is off
 
 	sample, err := parseMetricSample([]byte("metric:1234|g|#onetag|T1657100430"))
@@ -344,10 +348,9 @@ func TestParseGaugeWithTimestamp(t *testing.T) {
 	assert.InEpsilon(t, 1.0, sample.sampleRate, epsilon)
 	assert.Zero(t, sample.ts)
 
-	// enable the no aggregation pipeline
+	// re-enable the no aggregation pipeline
 
 	config.Datadog.Set("dogstatsd_no_aggregation_pipeline", true)
-	defer config.Datadog.Set("dogstatsd_no_aggregation_pipeline", false)
 
 	// with tags and timestamp
 

--- a/releasenotes/notes/no-aggregation-pipeline-enabled-3a8de91a965263d7.yaml
+++ b/releasenotes/notes/no-aggregation-pipeline-enabled-3a8de91a965263d7.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Enable the new DogStatsD no-aggregation pipeline, capable of processing metrics
+    with timestamps.
+    Set `dogstatsd_no_aggregation_pipeline` to `false` to disable it.


### PR DESCRIPTION
### What does this PR do?

Enable the DogStatsD no-aggregation pipeline by default in the core agent and in the DogStatsD server binary.

### Motivation

Remove friction for users to enable this feature.

### Possible Drawbacks / Trade-offs

It has been benchmarked to have no impact on existing DogStatsD pipelines when the no-aggregation pipeline is enabled but doesn't receive traffic.

### Describe how to test/QA your changes


* Make sure the Datadog Agent is still processing DogStatsD traffic.
* Send a DogStatsD packet 2h late `echo -n "custom_metric:60|g|#env:test,dev:remy|T$(( $(date +%s) - 7200 ))" | nc -4u -w0 127.0.0.1 8125`
* Validate your metric appear in the Datadog app
* Generate a flare of the running Agent and validate that the file `expvar/no_aggregation` contains sensible information.


### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
