### PR TITLE
Add device string into `resource` field in metric apiv2 format 

### DIFF
--- a/pkg/metrics/series.go
+++ b/pkg/metrics/series.go
@@ -35,7 +35,7 @@ type Serie struct {
 	Points         []Point              `json:"points"`
 	Tags           tagset.CompositeTags `json:"tags"`
 	Host           string               `json:"host"`
-	Device         string               `json:"device,omitempty"` // FIXME(olivier): remove as soon as the v1 API can handle `device` as a regular tag
+	Device         string               `json:"device,omitempty"`
 	MType          APIMetricType        `json:"type"`
 	Interval       int64                `json:"interval"`
 	SourceTypeName string               `json:"source_type_name,omitempty"`

--- a/pkg/serializer/internal/metrics/iterable_series.go
+++ b/pkg/serializer/internal/metrics/iterable_series.go
@@ -190,7 +190,6 @@ func marshalSplitCompress(iterator metrics.SerieSource, bufferContext *marshaler
 
 				return nil
 			})
-
 			if err != nil {
 				return err
 			}
@@ -209,7 +208,6 @@ func marshalSplitCompress(iterator metrics.SerieSource, bufferContext *marshaler
 
 					return nil
 				})
-
 				if err != nil {
 					return err
 				}

--- a/pkg/serializer/internal/metrics/iterable_series.go
+++ b/pkg/serializer/internal/metrics/iterable_series.go
@@ -191,22 +191,24 @@ func marshalSplitCompress(iterator metrics.SerieSource, bufferContext *marshaler
 				return nil
 			})
 
-			err = ps.Embedded(seriesResources, func(ps *molecule.ProtoStream) error {
-				err = ps.String(resourceType, "device")
+			if serie.Device != "" {
+				err = ps.Embedded(seriesResources, func(ps *molecule.ProtoStream) error {
+					err = ps.String(resourceType, "device")
+					if err != nil {
+						return err
+					}
+
+					err = ps.String(resourceName, serie.Device)
+					if err != nil {
+						return err
+					}
+
+					return nil
+				})
+
 				if err != nil {
 					return err
 				}
-
-				err = ps.String(resourceName, serie.Device)
-				if err != nil {
-					return err
-				}
-
-				return nil
-			})
-
-			if err != nil {
-				return err
 			}
 
 			err = ps.String(seriesMetric, serie.Name)

--- a/pkg/serializer/internal/metrics/iterable_series.go
+++ b/pkg/serializer/internal/metrics/iterable_series.go
@@ -191,6 +191,10 @@ func marshalSplitCompress(iterator metrics.SerieSource, bufferContext *marshaler
 				return nil
 			})
 
+			if err != nil {
+				return err
+			}
+
 			if serie.Device != "" {
 				err = ps.Embedded(seriesResources, func(ps *molecule.ProtoStream) error {
 					err = ps.String(resourceType, "device")

--- a/pkg/serializer/internal/metrics/iterable_series.go
+++ b/pkg/serializer/internal/metrics/iterable_series.go
@@ -190,6 +190,21 @@ func marshalSplitCompress(iterator metrics.SerieSource, bufferContext *marshaler
 
 				return nil
 			})
+
+			err = ps.Embedded(seriesResources, func(ps *molecule.ProtoStream) error {
+				err = ps.String(resourceType, "device")
+				if err != nil {
+					return err
+				}
+
+				err = ps.String(resourceName, serie.Device)
+				if err != nil {
+					return err
+				}
+
+				return nil
+			})
+
 			if err != nil {
 				return err
 			}

--- a/pkg/serializer/internal/metrics/series_test.go
+++ b/pkg/serializer/internal/metrics/series_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/DataDog/agent-payload/v5/gogen"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/forwarder"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
@@ -297,6 +298,7 @@ func makeSeries(numItems, numPoints int) *IterableSeries {
 			Name:     "test.metrics",
 			Interval: 15,
 			Host:     "localHost",
+			Device:   "SomeDevice",
 			Tags:     tagset.CompositeTagsFromSlice([]string{"tag1", "tag2:yes"}),
 		})
 	}
@@ -311,10 +313,12 @@ func TestMarshalSplitCompress(t *testing.T) {
 	// check that we got multiple payloads, so splitting occurred
 	require.Greater(t, len(payloads), 1)
 	for _, compressedPayload := range payloads {
-		_, err := decompressPayload(*compressedPayload)
+		payload, err := decompressPayload(*compressedPayload)
 		require.NoError(t, err)
 
-		// TODO: unmarshal these when agent-payload has support
+		pl := new(gogen.MetricPayload)
+		err = pl.Unmarshal(payload)
+		require.NoError(t, err)
 	}
 }
 

--- a/releasenotes/notes/add-device-to-resource-v2api-aa52c6b28e08a30c.yaml
+++ b/releasenotes/notes/add-device-to-resource-v2api-aa52c6b28e08a30c.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Add the device field to the ``MetricPayload`` to ensure the device 
+    tag is properly handled by the backend. 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Add the `device` string to the `MetricsPayload` resources so the tag is correctly handled on the backend. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

There was a bug where the `device` when set as a `tag` was not being scrubbed the same way as when it is set as a `resource` which was causing inconsistencies. 

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

1. add invalid UTF8 characters in your device name, and ensure they are replaced with `_` in the UI. 
2. UT covers that the payload is encoded correctly. 

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
