### PR TITLE
[CWS] compress activity dump payload with gzip instead of zstd

### DIFF
--- a/pkg/security/probe/activity_dump_remote_storage.go
+++ b/pkg/security/probe/activity_dump_remote_storage.go
@@ -10,6 +10,7 @@ package probe
 
 import (
 	"bytes"
+	"compress/gzip"
 	"fmt"
 	"mime/multipart"
 	"net/http"
@@ -26,7 +27,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/probe/dump"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	ddhttputil "github.com/DataDog/datadog-agent/pkg/util/http"
-	"github.com/DataDog/zstd"
 )
 
 func getEndpointURL(endpoint logsconfig.Endpoint, uri string) string {
@@ -146,9 +146,9 @@ func (storage *ActivityDumpRemoteStorage) buildBody(request dump.StorageRequest,
 	var multipartWriter *multipart.Writer
 
 	if request.Compression {
-		zstdWriter := zstd.NewWriter(body)
-		defer zstdWriter.Close()
-		multipartWriter = multipart.NewWriter(zstdWriter)
+		compressor := gzip.NewWriter(body)
+		defer compressor.Close()
+		multipartWriter = multipart.NewWriter(compressor)
 	} else {
 		multipartWriter = multipart.NewWriter(body)
 	}
@@ -176,7 +176,7 @@ func (storage *ActivityDumpRemoteStorage) sendToEndpoint(url string, apiKey stri
 	r.Header.Add("dd-api-key", apiKey)
 
 	if request.Compression {
-		r.Header.Set("Content-Encoding", "zstd")
+		r.Header.Set("Content-Encoding", "gzip")
 	}
 
 	resp, err := storage.client.Do(r)


### PR DESCRIPTION
### What does this PR do?

The zstd compressor is currently leaking some memory. This PR reverts back to use gzip for now

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
