### PR TITLE
Delete configuration database on version change

### DIFF
--- a/pkg/config/remote/service/util.go
+++ b/pkg/config/remote/service/util.go
@@ -68,29 +68,28 @@ func openCacheDB(path string) (*bbolt.DB, error) {
 		bucket := tx.Bucket([]byte(metaBucket))
 		if bucket == nil {
 			log.Infof("Missing meta bucket")
-			db, err = recreate(path)
 			return err
 		}
 		metadataBytes := bucket.Get([]byte(metaFile))
 		if metadataBytes == nil {
 			log.Infof("Missing meta file in meta bucket")
-			db, err = recreate(path)
 			return err
 		}
 		err = json.Unmarshal(metadataBytes, metadata)
 		if err != nil {
 			log.Infof("Invalid metadata")
-			db, err = recreate(path)
 			return err
 		}
 		return nil
 	})
 	if err != nil {
+		_ = db.Close()
 		return recreate(path)
 	}
 
 	if metadata.Version != version.AgentVersion {
 		log.Infof("Different agent version detected")
+		_ = db.Close()
 		return recreate(path)
 	}
 

--- a/pkg/config/remote/service/util.go
+++ b/pkg/config/remote/service/util.go
@@ -79,7 +79,7 @@ func openCacheDB(path string) (*bbolt.DB, error) {
 			return err
 		}
 
-		if metadata.Version == version.AgentVersion {
+		if metadata.Version != version.AgentVersion {
 			return fmt.Errorf("Database needs to be cleared")
 		}
 		return nil

--- a/pkg/config/remote/service/util.go
+++ b/pkg/config/remote/service/util.go
@@ -30,7 +30,7 @@ type AgentMetadata struct {
 }
 
 func reopen(path string) (*bbolt.DB, error) {
-	log.Infof("Clear configuration database")
+	log.Infof("Clear remote configuration database")
 	if err := os.Remove(path); err != nil {
 		return nil, fmt.Errorf("failed to remove corrupted database: %w", err)
 	}

--- a/pkg/config/remote/service/util_test.go
+++ b/pkg/config/remote/service/util_test.go
@@ -6,12 +6,20 @@
 package service
 
 import (
+	"bytes"
 	"encoding/base32"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/bbolt"
 
 	"github.com/DataDog/datadog-agent/pkg/proto/msgpgo"
+	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
 func TestRemoteConfigKey(t *testing.T) {
@@ -49,4 +57,122 @@ func generateKey(t *testing.T, orgID int64, datacenter string, appKey string) st
 		t.Fatal(err)
 	}
 	return base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(rawKey)
+}
+
+func addData(db *bbolt.DB) error {
+	return db.Update(func(tx *bbolt.Tx) error {
+		bucket, err := tx.CreateBucket([]byte("test"))
+		if err != nil {
+			return err
+		}
+
+		return bucket.Put([]byte("test"), []byte("test"))
+	})
+}
+
+func checkData(db *bbolt.DB) error {
+	return db.View(func(tx *bbolt.Tx) error {
+		bucket := tx.Bucket([]byte("test"))
+		if bucket == nil {
+			return fmt.Errorf("Bucket not present")
+		}
+
+		data := bucket.Get([]byte("test"))
+		if !bytes.Equal(data, []byte("test")) {
+			return fmt.Errorf("Invalid test data")
+		}
+		return nil
+	})
+}
+
+func getVersion(db *bbolt.DB) (*AgentMetadata, error) {
+	tx, err := db.Begin(false)
+	defer tx.Rollback()
+	if err != nil {
+		return nil, err
+	}
+	bucket := tx.Bucket([]byte(metaBucket))
+	if bucket == nil {
+		return nil, fmt.Errorf("No bucket")
+	}
+	metaBytes := bucket.Get([]byte(metaFile))
+	if metaBytes == nil {
+		return nil, fmt.Errorf("No meta file")
+	}
+	metadata := new(AgentMetadata)
+	err = json.Unmarshal(metaBytes, metadata)
+	return metadata, err
+}
+
+func TestRemoteConfigNewDB(t *testing.T) {
+	dir, err := os.MkdirTemp("", "remote-config-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	// should add the version to newly created databases
+	db, err := openCacheDB(filepath.Join(dir, "remote-config.db"))
+	require.NoError(t, err)
+	defer db.Close()
+
+	metadata, err := getVersion(db)
+	require.NoError(t, err)
+
+	assert.Equal(t, version.AgentVersion, metadata.Version)
+}
+
+func TestRemoteConfigReopenNoVersionChange(t *testing.T) {
+	dir, err := os.MkdirTemp("", "remote-config-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	// should add the version to newly created databases
+	db, err := openCacheDB(filepath.Join(dir, "remote-config.db"))
+	require.NoError(t, err)
+
+	metadata, err := getVersion(db)
+	require.NoError(t, err)
+
+	assert.Equal(t, version.AgentVersion, metadata.Version)
+	require.NoError(t, addData(db))
+	require.NoError(t, db.Close())
+
+	db, err = openCacheDB(filepath.Join(dir, "remote-config.db"))
+	require.NoError(t, err)
+	defer db.Close()
+	require.NoError(t, checkData(db))
+}
+
+func TestRemoteConfigOldDB(t *testing.T) {
+	dir, err := os.MkdirTemp("", "remote-config-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	dbPath := filepath.Join(dir, "remote-config.db")
+
+	// create database with current version
+	db, err := openCacheDB(dbPath)
+	require.NoError(t, err)
+
+	require.NoError(t, addData(db))
+
+	// set it to another version
+	metadata, err := json.Marshal(AgentMetadata{Version: "old-version"})
+	require.NoError(t, err)
+	err = db.Update(func(tx *bbolt.Tx) error {
+		bucket := tx.Bucket([]byte(metaBucket))
+		return bucket.Put([]byte(metaFile), []byte(metadata))
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	// reopen database
+	db, err = openCacheDB(dbPath)
+	require.NoError(t, err)
+
+	// check version after the database opens
+	parsedMeta, err := getVersion(db)
+	require.NoError(t, err)
+
+	assert.Equal(t, version.AgentVersion, parsedMeta.Version)
+	assert.Error(t, checkData(db))
 }


### PR DESCRIPTION
### What does this PR do?

In case there's a datadog-agent version change we have to reset the remote configuration database to ensure it's consistent with our embedded root certificates.

To test it either create a database without the metadata file or put one with a different version than the current one

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
