### PR TITLE
Filter connections with zeroes for all stats

### DIFF
--- a/pkg/network/event_common.go
+++ b/pkg/network/event_common.go
@@ -206,6 +206,11 @@ type StatCounters struct {
 	TCPClosed      uint32
 }
 
+// IsZero returns whether all the stat counter values are zeroes
+func (s StatCounters) IsZero() bool {
+	return s == StatCounters{}
+}
+
 // StatCountersByCookie stores StatCounters by unique cookie
 type StatCountersByCookie []*struct {
 	StatCounters

--- a/pkg/network/state_test.go
+++ b/pkg/network/state_test.go
@@ -1173,11 +1173,12 @@ func TestStatsResetOnUnderflow(t *testing.T) {
 	m := conn.Monotonic[0]
 	m.SentBytes--
 	conn.Monotonic.Put(0, m.StatCounters)
+	conn.Monotonic.Put(1, StatCounters{SentBytes: 1})
 
 	conns = state.GetDelta(client, latestEpochTime(), []ConnectionStats{conn}, nil, nil).Conns
 	require.Len(t, conns, 1)
 	expected := conn
-	expected.Last.SentBytes = 0
+	expected.Last.SentBytes = 1
 	// We expect the LastStats to be 0
 	assert.Equal(t, expected, conns[0])
 }
@@ -1367,6 +1368,7 @@ func TestDNSStatsWithMultipleClients(t *testing.T) {
 	assert.Len(t, state.GetDelta(client1, latestEpochTime(), nil, nil, nil).Conns, 0)
 	assert.Len(t, state.GetDelta(client2, latestEpochTime(), nil, nil, nil).Conns, 0)
 
+	c.Monotonic.Put(1, StatCounters{SentBytes: 100, RecvBytes: 200})
 	c.LastUpdateEpoch = latestEpochTime()
 
 	delta := state.GetDelta(client1, latestEpochTime(), []ConnectionStats{c}, getStats(), nil)

--- a/pkg/network/tracer/testdata/fork.py
+++ b/pkg/network/tracer/testdata/fork.py
@@ -18,6 +18,7 @@ else:
     # parent
     s.recv(256)
     os.wait()
+    signal.pause()
     s.send(b'bar')
     signal.pause()
 

--- a/pkg/network/tracer/testdata/fork.py
+++ b/pkg/network/tracer/testdata/fork.py
@@ -19,7 +19,5 @@ else:
     s.recv(256)
     os.wait()
     signal.pause()
-    s.send(b'bar')
-    signal.pause()
 
 s.close()

--- a/pkg/network/tracer/testdata/fork.py
+++ b/pkg/network/tracer/testdata/fork.py
@@ -18,6 +18,7 @@ else:
     # parent
     s.recv(256)
     os.wait()
+    s.send(b'bar')
     signal.pause()
 
 s.close()

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -1091,6 +1091,9 @@ func TestSelfConnect(t *testing.T) {
 		return len(conns) == 2
 	}, 5*time.Second, time.Second, "could not find expected number of tcp connections, expected: 2")
 
+	err = cmd.Process.Signal(syscall.SIGCONT)
+	require.NoError(t, err)
+
 	// forked child should have exited, and only the parent should remain
 	require.Eventually(t, func() bool {
 		conns := searchConnections(getConnections(t, tr), func(cs network.ConnectionStats) bool {

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -1090,19 +1090,6 @@ func TestSelfConnect(t *testing.T) {
 		t.Logf("connections: %v", conns)
 		return len(conns) == 2
 	}, 5*time.Second, time.Second, "could not find expected number of tcp connections, expected: 2")
-
-	err = cmd.Process.Signal(syscall.SIGCONT)
-	require.NoError(t, err)
-
-	// forked child should have exited, and only the parent should remain
-	require.Eventually(t, func() bool {
-		conns := searchConnections(getConnections(t, tr), func(cs network.ConnectionStats) bool {
-			return cs.SPort == uint16(port) && cs.DPort == uint16(port) && cs.Source.IsLoopback() && cs.Dest.IsLoopback()
-		})
-
-		t.Logf("connections: %v", conns)
-		return len(conns) == 1
-	}, 5*time.Second, time.Second, "could not find expected number of tcp connections, expected: 1")
 }
 
 func TestUDPPeekCount(t *testing.T) {

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -750,14 +750,15 @@ func TestShouldSkipExcludedConnection(t *testing.T) {
 	initTracerState(t, tr)
 
 	// Make sure we're not picking up 127.0.0.1:80
-	for _, c := range getConnections(t, tr).Conns {
+	cxs := getConnections(t, tr)
+	for _, c := range cxs.Conns {
 		assert.False(t, c.Source.String() == "127.0.0.1" && c.SPort == 80, "connection %s should be excluded", c)
 		assert.False(t, c.Dest.String() == "127.0.0.1" && c.DPort == 80 && c.Type == network.TCP, "connection %s should be excluded", c)
 	}
 
 	// ensure one of the connections is UDP to 127.0.0.1:80
 	assert.Condition(t, func() bool {
-		for _, c := range getConnections(t, tr).Conns {
+		for _, c := range cxs.Conns {
 			if c.Dest.String() == "127.0.0.1" && c.DPort == 80 && c.Type == network.UDP {
 				return true
 			}

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -767,6 +767,51 @@ func TestShouldSkipExcludedConnection(t *testing.T) {
 	}, "Unable to find UDP connection to 127.0.0.1:80")
 }
 
+func TestShouldExcludeEmptyStatsConnection(t *testing.T) {
+	cfg := testConfig()
+	tr, err := NewTracer(cfg)
+	require.NoError(t, err)
+	defer tr.Stop()
+
+	// Connect to 127.0.0.1:80
+	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:80")
+	assert.NoError(t, err)
+
+	cn, err := net.DialUDP("udp", nil, addr)
+	assert.NoError(t, err)
+	defer cn.Close()
+
+	// Write anything
+	_, err = cn.Write([]byte("test"))
+	assert.NoError(t, err)
+
+	initTracerState(t, tr)
+	var zeroConn network.ConnectionStats
+	require.Eventually(t, func() bool {
+		cxs := getConnections(t, tr)
+		for _, c := range cxs.Conns {
+			if c.Dest.String() == "127.0.0.1" && c.DPort == 80 {
+				zeroConn = c
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second, time.Second)
+
+	// next call should not have the same connection
+	cxs := getConnections(t, tr)
+	found := false
+	for _, c := range cxs.Conns {
+		if c.Source == zeroConn.Source && c.SPort == zeroConn.SPort &&
+			c.Dest == zeroConn.Dest && c.DPort == zeroConn.DPort &&
+			c.Pid == zeroConn.Pid {
+			found = true
+			break
+		}
+	}
+	require.False(t, found, "empty connections should be filtered out")
+}
+
 func TestSkipConnectionDNS(t *testing.T) {
 	t.Run("CollectLocalDNS disabled", func(t *testing.T) {
 		tr := &Tracer{config: &config.Config{CollectLocalDNS: false}}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Filters out connections, where the delta values end up being zero.

### Motivation

A high percentage (up to ~30% internally) have connections with zero stats. We are still studying *why* this is happening, but we should be filtering them regardless in the agent.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
