### PR TITLE
[kubeapiserver] Allow allow-listing of source component

### DIFF
--- a/cmd/agent/dist/conf.d/kubernetes_apiserver.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/kubernetes_apiserver.d/conf.yaml.example
@@ -19,24 +19,25 @@ instances:
     # unbundle_events: true
 
     ## @param collected_event_types - map of array of strings - optional
-    ## Specify which events to be collected. Map of Kind as key, array of event
-    ## reasons as value. Keys are case-insensitive, values are case-sensitive.
-    ## Only effective when unbundle_events is true, otherwise
-    ## filtered_event_types is used.
+    ## Specify which events to be collected by kind, source, and reasons.
+    ## Either kind or source are required, reasons is optional. Only effective
+    ## when unbundle_events is true, otherwise filtered_event_types is used.
     #
     collected_event_types:
-      pod:
-        - Failed
-        - BackOff
-        - Unhealthy
-        - FailedScheduling
-        - FailedMount
-        - FailedAttachVolume
-      node:
-        - TerminatingEvictedPod
-        - NodeNotReady
-        - Rebooted
-        - HostPortConflict
+      - kind: Pod
+        reasons:
+          - Failed
+          - BackOff
+          - Unhealthy
+          - FailedScheduling
+          - FailedMount
+          - FailedAttachVolume
+      - kind: Node
+        reasons:
+          - TerminatingEvictedPod
+          - NodeNotReady
+          - Rebooted
+          - HostPortConflict
 
     ## @param filtered_event_types - array of strings - optional
     ## Specify a list of exclusion filters over the event type, involvedObject.kind, reason, following the Kubernetes field-selector format.

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
@@ -78,9 +78,15 @@ type KubeASConfig struct {
 	// UnbundleEvents = false
 	FilteredEventTypes []string `yaml:"filtered_event_types"`
 
-	// CollectedEventTypes is a map of Kind => Reason of events to collect.
+	// CollectedEventTypes specifies which events to collect.
 	// Only effective when UnbundleEvents = true
-	CollectedEventTypes map[string][]string `yaml:"collected_event_types"`
+	CollectedEventTypes []collectedEventType `yaml:"collected_event_types"`
+}
+
+type collectedEventType struct {
+	Kind    string   `yaml:"kind"`
+	Source  string   `yaml:"source"`
+	Reasons []string `yaml:"reasons"`
 }
 
 type eventTransformer interface {


### PR DESCRIPTION
### What does this PR do?

Extends the configuration language to also allow sources. Instead of:

```
collected_event_types:
  pod:
    - Failed
    - BackOff
    - Unhealthy
    - FailedScheduling
    - FailedMount
    - FailedAttachVolume
  node:
    - TerminatingEvictedPod
    - NodeNotReady
    - Rebooted
    - HostPortConflict
```

Now we have:

```
collected_event_types:
  - kind: Pod
    reasons:
      - Failed
      - BackOff
      - Unhealthy
      - FailedScheduling
      - FailedMount
      - FailedAttachVolume
  - kind: Node
    reasons:
      - TerminatingEvictedPod
      - NodeNotReady
      - Rebooted
      - HostPortConflict
  - source: watermarkpodautoscaler
```

### Describe how to test/QA your changes

Ensure that the different filters work. To ease QA though, I'm applying `skip-qa`, and updating #13158 to add instructions to test the changes here as well.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
