### PR TITLE
[CWS] remove all usages of `DD_AGENT_TESTING_DIR`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -103,7 +103,6 @@ variables:
   # avoids accidentally overwriting files when downloading artifacts from
   # both RPM and SUSE rpm jobs.
   OMNIBUS_PACKAGE_DIR_SUSE: $CI_PROJECT_DIR/omnibus/suse/pkg
-  DD_AGENT_TESTING_DIR: $CI_PROJECT_DIR/test/kitchen
   STATIC_BINARIES_DIR: bin/static
   DOGSTATSD_BINARIES_DIR: bin/dogstatsd
   AGENT_BINARIES_DIR: bin/agent

--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -29,7 +29,7 @@ kitchen_test_security_agent_x64:
   variables:
     KITCHEN_ARCH: x86_64
   before_script:
-    - cd $DD_AGENT_TESTING_DIR
+    - cd $CI_PROJECT_DIR/test/kitchen
     - bash -l tasks/kitchen_setup.sh
   parallel:
     matrix:
@@ -60,7 +60,7 @@ kitchen_test_security_agent_arm64:
     KITCHEN_ARCH: arm64
     KITCHEN_EC2_INSTANCE_TYPE: "t4g.xlarge"
   before_script:
-    - cd $DD_AGENT_TESTING_DIR
+    - cd $CI_PROJECT_DIR/test/kitchen
     - bash -l tasks/kitchen_setup.sh
   parallel:
     matrix:
@@ -79,7 +79,7 @@ kitchen_test_security_agent_amazonlinux_x64:
     KITCHEN_ARCH: x86_64
     KITCHEN_EC2_INSTANCE_TYPE: "t2.medium"
   before_script:
-    - cd $DD_AGENT_TESTING_DIR
+    - cd $CI_PROJECT_DIR/test/kitchen
     - bash -l tasks/kitchen_setup.sh
   parallel:
     matrix:
@@ -100,7 +100,7 @@ kitchen_stress_security_agent:
     AGENT_MAJOR_VERSION: 7
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a7
   before_script:
-    - cd $DD_AGENT_TESTING_DIR
+    - cd $CI_PROJECT_DIR/test/kitchen
     - bash -l tasks/kitchen_setup.sh
   script:
     - bash -l tasks/run-test-kitchen.sh security-agent-stress $AGENT_MAJOR_VERSION

--- a/.gitlab/functional_test/system_probe.yml
+++ b/.gitlab/functional_test/system_probe.yml
@@ -29,7 +29,7 @@ kitchen_test_system_probe_linux_x64:
     KITCHEN_ARCH: x86_64
     KITCHEN_IMAGE_SIZE: Standard_D2_v2
   before_script:
-    - cd $DD_AGENT_TESTING_DIR
+    - cd $CI_PROJECT_DIR/test/kitchen
     - bash -l tasks/kitchen_setup.sh
   parallel:
     matrix:
@@ -51,7 +51,7 @@ kitchen_test_system_probe_linux_arm64:
     KITCHEN_ARCH: arm64
     KITCHEN_EC2_INSTANCE_TYPE: "t4g.xlarge"
   before_script:
-    - cd $DD_AGENT_TESTING_DIR
+    - cd $CI_PROJECT_DIR/test/kitchen
     - bash -l tasks/kitchen_setup.sh
   parallel:
     matrix:
@@ -80,7 +80,7 @@ kitchen_test_system_probe_windows_x64:
     - export WINDOWS_DDNPM_DRIVER=$(inv release.get-release-json-value "$RELEASE_VERSION_7::WINDOWS_DDNPM_DRIVER")
     - export WINDOWS_DDNPM_VERSION=$(inv release.get-release-json-value "$RELEASE_VERSION_7::WINDOWS_DDNPM_VERSION")
     - export WINDOWS_DDNPM_SHASUM=$(inv release.get-release-json-value "$RELEASE_VERSION_7::WINDOWS_DDNPM_SHASUM")
-    - cd $DD_AGENT_TESTING_DIR
+    - cd $CI_PROJECT_DIR/test/kitchen
     - bash -l tasks/kitchen_setup.sh
   script:
     - bash -l tasks/run-test-kitchen.sh windows-sysprobe-test $AGENT_MAJOR_VERSION

--- a/.gitlab/kitchen_common/cleanup.yml
+++ b/.gitlab/kitchen_common/cleanup.yml
@@ -24,5 +24,5 @@
   dependencies: []
   before_script:
   script:
-    - cd $DD_AGENT_TESTING_DIR
+    - cd $CI_PROJECT_DIR/test/kitchen
     - bash -l tasks/clean.sh

--- a/.gitlab/kitchen_testing/amazonlinux.yml
+++ b/.gitlab/kitchen_testing/amazonlinux.yml
@@ -13,7 +13,7 @@
   variables:
     KITCHEN_PLATFORM: "amazonlinux"
   before_script:
-    - cd $DD_AGENT_TESTING_DIR
+    - cd $CI_PROJECT_DIR/test/kitchen
     - bash -l tasks/kitchen_setup.sh
 
 # Kitchen: scenarios (os * agent * (cloud + arch))

--- a/.gitlab/kitchen_testing/centos.yml
+++ b/.gitlab/kitchen_testing/centos.yml
@@ -16,7 +16,7 @@
     KITCHEN_PLATFORM: "centos"
     KITCHEN_OSVERS: "centos-610,centos-77,rhel-81"
   before_script:
-    - cd $DD_AGENT_TESTING_DIR
+    - cd $CI_PROJECT_DIR/test/kitchen
     - bash -l tasks/kitchen_setup.sh
 
 .kitchen_os_centos_6_7_non_fips:
@@ -24,7 +24,7 @@
     KITCHEN_PLATFORM: "centos"
     KITCHEN_OSVERS: "centos-610,centos-77"
   before_script:
-    - cd $DD_AGENT_TESTING_DIR
+    - cd $CI_PROJECT_DIR/test/kitchen
     - bash -l tasks/kitchen_setup.sh
 
 .kitchen_os_centos_8_fips:
@@ -36,7 +36,7 @@
     DEFAULT_KITCHEN_OSVERS: "rhel-81"
   before_script:
     - export KITCHEN_PLATFORM_SUFFIX="${KITCHEN_PLATFORM_SUFFIX}fips"
-    - cd $DD_AGENT_TESTING_DIR
+    - cd $CI_PROJECT_DIR/test/kitchen
     - bash -l tasks/kitchen_setup.sh
 
 # Kitchen: scenarios (os * agent * (cloud + arch))

--- a/.gitlab/kitchen_testing/debian.yml
+++ b/.gitlab/kitchen_testing/debian.yml
@@ -13,7 +13,7 @@
   variables:
     KITCHEN_PLATFORM: "debian"
   before_script:
-    - cd $DD_AGENT_TESTING_DIR
+    - cd $CI_PROJECT_DIR/test/kitchen
     - bash -l tasks/kitchen_setup.sh
 
 # Kitchen: scenarios (os * agent * (cloud + arch))

--- a/.gitlab/kitchen_testing/suse.yml
+++ b/.gitlab/kitchen_testing/suse.yml
@@ -15,7 +15,7 @@
     KITCHEN_OSVERS: "sles-12,sles-15"
     DEFAULT_KITCHEN_OSVERS: "sles-15"
   before_script:
-    - cd $DD_AGENT_TESTING_DIR
+    - cd $CI_PROJECT_DIR/test/kitchen
     - bash -l tasks/kitchen_setup.sh
 
 # Kitchen: scenarios (os * agent * (cloud + arch))

--- a/.gitlab/kitchen_testing/ubuntu.yml
+++ b/.gitlab/kitchen_testing/ubuntu.yml
@@ -12,7 +12,7 @@
   variables:
     KITCHEN_PLATFORM: "ubuntu"
   before_script:
-    - cd $DD_AGENT_TESTING_DIR
+    - cd $CI_PROJECT_DIR/test/kitchen
     - bash -l tasks/kitchen_setup.sh
 
 # Kitchen: scenarios (os * agent * (cloud + arch))

--- a/.gitlab/kitchen_testing/windows.yml
+++ b/.gitlab/kitchen_testing/windows.yml
@@ -17,7 +17,7 @@
     DEFAULT_KITCHEN_OSVERS: "win2022"
   before_script:  # Note: if you are changing this, remember to also change .kitchen_test_windows_installer, which has a copy of this with less TEST_PLATFORMS defined.
     - if [ $AGENT_MAJOR_VERSION == "7" ]; then export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A7; else export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A6; fi
-    - cd $DD_AGENT_TESTING_DIR
+    - cd $CI_PROJECT_DIR/test/kitchen
     - bash -l tasks/kitchen_setup.sh
   # Windows kitchen tests are slower and more fragile (lots of WinRM::WinRMAuthorizationError and/or execution expired errors)
   # Give them one more chance before failing.
@@ -35,7 +35,7 @@
     KITCHEN_OSVERS: "win2012r2"
   before_script:  # Use a smaller set of TEST_PLATFORMS than .kitchen_os_windows
     - if [ $AGENT_MAJOR_VERSION == "7" ]; then export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A7; else export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A6; fi
-    - cd $DD_AGENT_TESTING_DIR
+    - cd $CI_PROJECT_DIR/test/kitchen
     - bash -l tasks/kitchen_setup.sh
   script:
     - export LAST_STABLE_VERSION=$(cd ../.. && invoke release.get-release-json-value "last_stable::$AGENT_MAJOR_VERSION")
@@ -52,7 +52,7 @@
     - if [ $AGENT_MAJOR_VERSION == "7" ]; then export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A7; else export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A6; fi
     - if [ $AGENT_MAJOR_VERSION == "7" ]; then export RELEASE_VERSION=$RELEASE_VERSION_7; else export RELEASE_VERSION=$RELEASE_VERSION_6; fi
     - export WINDOWS_DDNPM_DRIVER=$(inv release.get-release-json-value "$RELEASE_VERSION::WINDOWS_DDNPM_DRIVER")
-    - cd $DD_AGENT_TESTING_DIR
+    - cd $CI_PROJECT_DIR/test/kitchen
     - bash -l tasks/kitchen_setup.sh
   script:
     - bash -l tasks/run-test-kitchen.sh windows-npmdriver $AGENT_MAJOR_VERSION
@@ -67,7 +67,7 @@
     - if [ $AGENT_MAJOR_VERSION == "7" ]; then export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A7; else export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A6; fi
     - if [ $AGENT_MAJOR_VERSION == "7" ]; then export RELEASE_VERSION=$RELEASE_VERSION_7; else export RELEASE_VERSION=$RELEASE_VERSION_6; fi
     - export WINDOWS_DDNPM_DRIVER=$(inv release.get-release-json-value "$RELEASE_VERSION::WINDOWS_DDNPM_DRIVER")
-    - cd $DD_AGENT_TESTING_DIR
+    - cd $CI_PROJECT_DIR/test/kitchen
     - bash -l tasks/kitchen_setup.sh
   script:
     - export LAST_STABLE_VERSION=$(cd ../.. && invoke release.get-release-json-value "last_stable::$AGENT_MAJOR_VERSION")

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -12,20 +12,20 @@
 .build_sysprobe_artifacts:
   # kitchen prepare also builds object files
   - inv -e system-probe.kitchen-prepare
-  - cp $SRC_PATH/pkg/ebpf/bytecode/build/tracer.o $CI_PROJECT_DIR/.tmp/binary-ebpf/tracer.o
-  - cp $SRC_PATH/pkg/ebpf/bytecode/build/tracer-debug.o $CI_PROJECT_DIR/.tmp/binary-ebpf/tracer-debug.o
-  - cp $SRC_PATH/pkg/ebpf/bytecode/build/offset-guess.o $CI_PROJECT_DIR/.tmp/binary-ebpf/offset-guess.o
-  - cp $SRC_PATH/pkg/ebpf/bytecode/build/offset-guess-debug.o $CI_PROJECT_DIR/.tmp/binary-ebpf/offset-guess-debug.o
-  - cp $SRC_PATH/pkg/ebpf/bytecode/build/http.o $CI_PROJECT_DIR/.tmp/binary-ebpf/http.o
-  - cp $SRC_PATH/pkg/ebpf/bytecode/build/http-debug.o $CI_PROJECT_DIR/.tmp/binary-ebpf/http-debug.o
-  - cp $SRC_PATH/pkg/ebpf/bytecode/build/dns.o $CI_PROJECT_DIR/.tmp/binary-ebpf/dns.o
-  - cp $SRC_PATH/pkg/ebpf/bytecode/build/dns-debug.o $CI_PROJECT_DIR/.tmp/binary-ebpf/dns-debug.o
-  - cp $SRC_PATH/pkg/ebpf/bytecode/build/runtime/tracer.c $CI_PROJECT_DIR/.tmp/binary-ebpf/tracer.c
-  - cp $SRC_PATH/pkg/ebpf/bytecode/build/runtime/http.c $CI_PROJECT_DIR/.tmp/binary-ebpf/http.c
-  - cp $SRC_PATH/pkg/ebpf/bytecode/build/runtime/runtime-security.c $CI_PROJECT_DIR/.tmp/binary-ebpf/runtime-security.c
-  - cp $SRC_PATH/pkg/ebpf/bytecode/build/runtime/conntrack.c $CI_PROJECT_DIR/.tmp/binary-ebpf/conntrack.c
-  - cp $SRC_PATH/pkg/ebpf/bytecode/build/runtime/oom-kill.c $CI_PROJECT_DIR/.tmp/binary-ebpf/oom-kill.c
-  - cp $SRC_PATH/pkg/ebpf/bytecode/build/runtime/tcp-queue-length.c $CI_PROJECT_DIR/.tmp/binary-ebpf/tcp-queue-length.c
+  - cp $CI_PROJECT_DIR/pkg/ebpf/bytecode/build/tracer.o $CI_PROJECT_DIR/.tmp/binary-ebpf/tracer.o
+  - cp $CI_PROJECT_DIR/pkg/ebpf/bytecode/build/tracer-debug.o $CI_PROJECT_DIR/.tmp/binary-ebpf/tracer-debug.o
+  - cp $CI_PROJECT_DIR/pkg/ebpf/bytecode/build/offset-guess.o $CI_PROJECT_DIR/.tmp/binary-ebpf/offset-guess.o
+  - cp $CI_PROJECT_DIR/pkg/ebpf/bytecode/build/offset-guess-debug.o $CI_PROJECT_DIR/.tmp/binary-ebpf/offset-guess-debug.o
+  - cp $CI_PROJECT_DIR/pkg/ebpf/bytecode/build/http.o $CI_PROJECT_DIR/.tmp/binary-ebpf/http.o
+  - cp $CI_PROJECT_DIR/pkg/ebpf/bytecode/build/http-debug.o $CI_PROJECT_DIR/.tmp/binary-ebpf/http-debug.o
+  - cp $CI_PROJECT_DIR/pkg/ebpf/bytecode/build/dns.o $CI_PROJECT_DIR/.tmp/binary-ebpf/dns.o
+  - cp $CI_PROJECT_DIR/pkg/ebpf/bytecode/build/dns-debug.o $CI_PROJECT_DIR/.tmp/binary-ebpf/dns-debug.o
+  - cp $CI_PROJECT_DIR/pkg/ebpf/bytecode/build/runtime/tracer.c $CI_PROJECT_DIR/.tmp/binary-ebpf/tracer.c
+  - cp $CI_PROJECT_DIR/pkg/ebpf/bytecode/build/runtime/http.c $CI_PROJECT_DIR/.tmp/binary-ebpf/http.c
+  - cp $CI_PROJECT_DIR/pkg/ebpf/bytecode/build/runtime/runtime-security.c $CI_PROJECT_DIR/.tmp/binary-ebpf/runtime-security.c
+  - cp $CI_PROJECT_DIR/pkg/ebpf/bytecode/build/runtime/conntrack.c $CI_PROJECT_DIR/.tmp/binary-ebpf/conntrack.c
+  - cp $CI_PROJECT_DIR/pkg/ebpf/bytecode/build/runtime/oom-kill.c $CI_PROJECT_DIR/.tmp/binary-ebpf/oom-kill.c
+  - cp $CI_PROJECT_DIR/pkg/ebpf/bytecode/build/runtime/tcp-queue-length.c $CI_PROJECT_DIR/.tmp/binary-ebpf/tcp-queue-length.c
 
 # Run tests for eBPF code
 .tests_linux_ebpf:
@@ -62,7 +62,6 @@ tests_ebpf_x64:
     - !reference [.retrieve_linux_go_deps]
     - !reference [.retrieve_linux_go_tools_deps]
     - mkdir -p $CI_PROJECT_DIR/.tmp/binary-ebpf
-    - cd $SRC_PATH
     - !reference [.retrieve_sysprobe_deps]
   script:
     - inv -e install-tools
@@ -83,10 +82,6 @@ tests_ebpf_arm64:
     - !reference [.retrieve_linux_go_deps]
     - !reference [.retrieve_linux_go_tools_deps]
     - mkdir -p $CI_PROJECT_DIR/.tmp/binary-ebpf
-    # Hack to work around the cloning issue with arm runners
-    - mkdir -p $GOPATH/src/github.com/DataDog
-    - cp -R $GOPATH/src/github.com/*/*/DataDog/datadog-agent $GOPATH/src/github.com/DataDog
-    - cd $SRC_PATH
     - !reference [.retrieve_sysprobe_deps]
   script:
     - inv -e install-tools

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -34,8 +34,8 @@
     when: always
     paths:
       - $CI_PROJECT_DIR/.tmp/binary-ebpf
-      - $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files
-      - $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files
+      - $CI_PROJECT_DIR/test/kitchen/site-cookbooks/dd-security-agent-check/files
+      - $CI_PROJECT_DIR/test/kitchen/site-cookbooks/dd-system-probe-check/files
 
 .tests_windows_sysprobe:
   stage: source_test
@@ -49,7 +49,7 @@
   artifacts:
     when: always
     paths:
-      - $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files
+      - $CI_PROJECT_DIR/test/kitchen/site-cookbooks/dd-system-probe-check/files
 
 tests_ebpf_x64:
   extends: .tests_linux_ebpf
@@ -69,8 +69,8 @@ tests_ebpf_x64:
     - invoke -e golangci-lint --build system-probe ./pkg
     - !reference [.build_sysprobe_artifacts]
     - invoke -e security-agent.kitchen-prepare
-    - cp /tmp/clang-bpf $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/clang-bpf
-    - cp /tmp/llc-bpf $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/llc-bpf
+    - cp /tmp/clang-bpf $CI_PROJECT_DIR/test/kitchen/site-cookbooks/dd-system-probe-check/files/clang-bpf
+    - cp /tmp/llc-bpf $CI_PROJECT_DIR/test/kitchen/site-cookbooks/dd-system-probe-check/files/llc-bpf
 
 tests_ebpf_arm64:
   extends: .tests_linux_ebpf
@@ -93,8 +93,8 @@ tests_ebpf_arm64:
     - invoke -e golangci-lint --build system-probe ./pkg
     - !reference [.build_sysprobe_artifacts]
     - invoke -e security-agent.kitchen-prepare
-    - cp /tmp/clang-bpf $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/clang-bpf
-    - cp /tmp/llc-bpf $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/llc-bpf
+    - cp /tmp/clang-bpf $CI_PROJECT_DIR/test/kitchen/site-cookbooks/dd-system-probe-check/files/clang-bpf
+    - cp /tmp/llc-bpf $CI_PROJECT_DIR/test/kitchen/site-cookbooks/dd-system-probe-check/files/llc-bpf
 
 tests_windows_sysprobe_x64:
   extends: .tests_windows_sysprobe

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -712,7 +712,9 @@ def kitchen_prepare(ctx):
     ci_project_dir = os.environ.get("CI_PROJECT_DIR", ".")
 
     nikos_embedded_path = os.environ.get("NIKOS_EMBEDDED_PATH", None)
-    cookbook_files_dir = os.path.join(ci_project_dir, "test", "kitchen", "site-cookbooks", "dd-security-agent-check", "files")
+    cookbook_files_dir = os.path.join(
+        ci_project_dir, "test", "kitchen", "site-cookbooks", "dd-security-agent-check", "files"
+    )
 
     testsuite_out_path = os.path.join(cookbook_files_dir, "testsuite")
     build_functional_tests(

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -709,9 +709,10 @@ def go_generate_check(ctx):
 
 @task
 def kitchen_prepare(ctx):
+    ci_project_dir = os.environ.get("CI_PROJECT_DIR", ".")
+
     nikos_embedded_path = os.environ.get("NIKOS_EMBEDDED_PATH", None)
-    testing_dir = os.environ.get("DD_AGENT_TESTING_DIR", "./test/kitchen")
-    cookbook_files_dir = os.path.join(testing_dir, "site-cookbooks", "dd-security-agent-check", "files")
+    cookbook_files_dir = os.path.join(ci_project_dir, "test", "kitchen", "site-cookbooks", "dd-security-agent-check", "files")
 
     testsuite_out_path = os.path.join(cookbook_files_dir, "testsuite")
     build_functional_tests(
@@ -728,8 +729,7 @@ def kitchen_prepare(ctx):
 
     ebpf_bytecode_dir = os.path.join(cookbook_files_dir, "ebpf_bytecode")
     ebpf_runtime_dir = os.path.join(ebpf_bytecode_dir, "runtime")
-    src_path = os.environ.get("SRC_PATH", ".")
-    bytecode_build_dir = os.path.join(src_path, "pkg", "ebpf", "bytecode", "build")
+    bytecode_build_dir = os.path.join(ci_project_dir, "pkg", "ebpf", "bytecode", "build")
 
     ctx.run(f"mkdir -p {ebpf_runtime_dir}")
     ctx.run(f"cp {bytecode_build_dir}/runtime-security* {ebpf_bytecode_dir}")

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -28,7 +28,7 @@ DNF_TAG = "dnf"
 
 CHECK_SOURCE_CMD = "grep -v '^//' {src_file} | if grep -q ' inline ' ; then echo -e '\u001b[7mPlease use __always_inline instead of inline in {src_file}\u001b[0m';exit 1;fi"
 
-KITCHEN_DIR = os.getenv('DD_AGENT_TESTING_DIR') or os.path.normpath(os.path.join(os.getcwd(), "test", "kitchen"))
+KITCHEN_DIR = os.path.normpath(os.path.join(os.getenv('CI_PROJECT_DIR') or os.getcwd(), "test", "kitchen"))
 KITCHEN_ARTIFACT_DIR = os.path.join(KITCHEN_DIR, "site-cookbooks", "dd-system-probe-check", "files", "default", "tests")
 TEST_PACKAGES_LIST = ["./pkg/ebpf/...", "./pkg/network/...", "./pkg/collector/corechecks/ebpf/..."]
 TEST_PACKAGES = " ".join(TEST_PACKAGES_LIST)

--- a/test/kitchen/tasks/kitchen_setup.sh
+++ b/test/kitchen/tasks/kitchen_setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -l
 
 rm -rf "$CI_PROJECT_DIR/kitchen_logs"
-rm -rf "$DD_AGENT_TESTING_DIR/.kitchen"
+rm -rf "$CI_PROJECT_DIR/test/kitchen/.kitchen"
 mkdir "$CI_PROJECT_DIR/kitchen_logs"
-ln -s "$CI_PROJECT_DIR/kitchen_logs" "$DD_AGENT_TESTING_DIR/.kitchen"
+ln -s "$CI_PROJECT_DIR/kitchen_logs" "$CI_PROJECT_DIR/test/kitchen/.kitchen"

--- a/test/kitchen/tasks/run-test-kitchen.sh
+++ b/test/kitchen/tasks/run-test-kitchen.sh
@@ -167,7 +167,7 @@ for attempt in $(seq 0 "${KITCHEN_INFRASTRUCTURE_FLAKES_RETRY:-2}"); do
       # if kitchen test failed and shouldn't be rerun, exit with 1
       exit 1
     else
-      cp -R "${DD_AGENT_TESTING_DIR}"/.kitchen/logs "${DD_AGENT_TESTING_DIR}/.kitchen/logs-${attempt}"
+      cp -R "${CI_PROJECT_DIR}/test/kitchen/.kitchen/logs" "${CI_PROJECT_DIR}/test/kitchen/.kitchen/logs-${attempt}"
       # Only keep test suites that have a non-null error code
       # Build the result as a regexp: "test_suite1|test_suite2|test_suite3", as kitchen only
       # supports one instance name or a regexp as argument.


### PR DESCRIPTION
### What does this PR do?

`DD_AGENT_TESTING_DIR` was based on `CI_PROJECT_DIR` but this value cannot be trusted out of actual scripts/jobs because it depends on the runner type (arm64 and k8s based runners actually contain a random part in it).
This PR removes all usages of `DD_AGENT_TESTING_DIR` and use `CI_PROJECT_DIR` directly instead.

`SRC_PATH` is basically the same story and some usages were removed in this PR to ensure that CWS and NPM related jobs were still working

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
