### PR TITLE
[process-agent] Fix CPU Count on MacOS

### DIFF
--- a/pkg/process/checks/system_info.go
+++ b/pkg/process/checks/system_info.go
@@ -3,8 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !windows
-// +build !windows
+//go:build !windows && !darwin
+// +build !windows,!darwin
 
 package checks
 

--- a/pkg/process/checks/system_info_darwin.go
+++ b/pkg/process/checks/system_info_darwin.go
@@ -1,0 +1,109 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build darwin
+// +build darwin
+
+package checks
+
+import (
+	"fmt"
+
+	model "github.com/DataDog/agent-payload/v5/process"
+	"github.com/DataDog/gopsutil/cpu"
+	"github.com/DataDog/gopsutil/host"
+	"github.com/DataDog/gopsutil/mem"
+	"golang.org/x/sys/unix"
+
+	"github.com/DataDog/datadog-agent/pkg/process/config"
+)
+
+type statsProvider interface {
+	getThreadCount() (int32, error)
+}
+
+type sysctlStatsProvider struct{}
+
+func (_ *sysctlStatsProvider) getThreadCount() (int32, error) {
+	threadCount, err := unix.SysctlUint32("machdep.cpu.thread_count")
+	return int32(threadCount), err
+}
+
+var macosStatsProvider statsProvider = &sysctlStatsProvider{}
+
+// patchCPUInfo returns the cpuInfo for the current host.
+// On macOS, gopsutil returns incorrect results for the cpu count, so we need to patch it
+// We do this in two steps, first we duplicate gopsutilCPUInfo[0] n times, where n is equal to the number of physical cores
+// Then we retrieve the thread count and modify the copies using this new information.
+func patchCPUInfo(gopsutilCPUInfo []cpu.InfoStat) ([]cpu.InfoStat, error) {
+	// gopsutil only returns one cpu for macos, this is safe, and documented behavior
+	cpuInfo := gopsutilCPUInfo[0]
+
+	physicalCoreCount := int(cpuInfo.Cores)
+	threadCount, err := macosStatsProvider.getThreadCount()
+	if err != nil {
+		return nil, fmt.Errorf("could not get thread count")
+	}
+
+	cpuStat := make([]cpu.InfoStat, 0, physicalCoreCount)
+	for i := 0; i < physicalCoreCount; i++ {
+		currentCpuInfo := cpuInfo
+		currentCpuInfo.Cores = threadCount / int32(physicalCoreCount)
+		cpuStat = append(cpuStat, currentCpuInfo)
+
+	}
+	return cpuStat, nil
+}
+
+// CollectSystemInfo collects a set of system-level information that will not
+// change until a restart. This bit of information should be passed along with
+// the process messages.
+func CollectSystemInfo(_ *config.AgentConfig) (*model.SystemInfo, error) {
+	hi, err := host.Info()
+	if err != nil {
+		return nil, err
+	}
+
+	cpuInfo, err := cpu.Info()
+	if err != nil {
+		return nil, err
+	}
+	cpuInfo, err = patchCPUInfo(cpuInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	mi, err := mem.VirtualMemory()
+	if err != nil {
+		return nil, err
+	}
+	cpus := make([]*model.CPUInfo, 0, len(cpuInfo))
+	for _, c := range cpuInfo {
+		cpus = append(cpus, &model.CPUInfo{
+			Number:     c.CPU,
+			Vendor:     c.VendorID,
+			Family:     c.Family,
+			Model:      c.Model,
+			PhysicalId: c.PhysicalID,
+			CoreId:     c.CoreID,
+			Cores:      c.Cores,
+			Mhz:        int64(c.Mhz),
+			CacheSize:  c.CacheSize,
+		})
+	}
+
+	return &model.SystemInfo{
+		Uuid: hi.HostID,
+		Os: &model.OSInfo{
+			Name:          hi.OS,
+			Platform:      hi.Platform,
+			Family:        hi.PlatformFamily,
+			Version:       hi.PlatformVersion,
+			KernelVersion: hi.KernelVersion,
+		},
+		Cpus:        cpus,
+		TotalMemory: int64(mi.Total),
+	}, nil
+}

--- a/pkg/process/checks/system_info_darwin_test.go
+++ b/pkg/process/checks/system_info_darwin_test.go
@@ -1,0 +1,38 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build darwin
+// +build darwin
+
+package checks
+
+import (
+	"github.com/DataDog/gopsutil/cpu"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+var _ statsProvider = &mockStatsProvider{}
+
+type mockStatsProvider struct{}
+
+func (_ *mockStatsProvider) getThreadCount() (int32, error) {
+	return 32, nil
+}
+
+func TestPatchCPUInfo(t *testing.T) {
+	// Monkey patch the stats provider to always produce the same result
+	realStatsProvider := macosStatsProvider
+	macosStatsProvider = &mockStatsProvider{}
+	defer func() { macosStatsProvider = realStatsProvider }()
+
+	mockGopsutilOutput := []cpu.InfoStat{{Cores: 16}}
+
+	patchedCPUInfo, _ := patchCPUInfo(mockGopsutilOutput)
+	assert.Len(t, patchedCPUInfo, 16)
+	for _, c := range patchedCPUInfo {
+		assert.Equal(t, int32(2), c.Cores)
+	}
+}

--- a/releasenotes/notes/fix-cpu-count-00c4dd75fc3e7308.yaml
+++ b/releasenotes/notes/fix-cpu-count-00c4dd75fc3e7308.yaml
@@ -1,0 +1,3 @@
+---
+fixes:
+  - Fixed issue with CPU count on MacOS


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

This PR fixes an issue with CPU count collection on MacOS. Currently, gopsutil, the library we use to collect host information and processes on macos, only returns a single `cpu.InfoStat` [here](https://github.com/DataDog/gopsutil/blob/dd/cpu/cpu_darwin.go#L32-L33). At the moment, we use the length of this array to get the number of physical cpus on the host. This PR patches the value returned to provide an accurate logical and physical core count.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Run `process-agent check process` and make sure the core count is equal to the number of physical cores on your machine.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
