### PR TITLE
Update snowflake-connector-python version in omnibus

### DIFF
--- a/omnibus/config/software/snowflake-connector-python-py3.rb
+++ b/omnibus/config/software/snowflake-connector-python-py3.rb
@@ -1,5 +1,5 @@
 name "snowflake-connector-python-py3"
-default_version "2.6.0"
+default_version "2.7.12"
 
 dependency "pip3"
 

--- a/omnibus/config/software/snowflake-connector-python-py3.rb
+++ b/omnibus/config/software/snowflake-connector-python-py3.rb
@@ -1,5 +1,5 @@
 name "snowflake-connector-python-py3"
-default_version "2.7.12"
+default_version "2.7.3"
 
 dependency "pip3"
 

--- a/omnibus/config/software/snowflake-connector-python-py3.rb
+++ b/omnibus/config/software/snowflake-connector-python-py3.rb
@@ -4,7 +4,7 @@ default_version "2.7.3"
 dependency "pip3"
 
 source :url => "https://github.com/snowflakedb/snowflake-connector-python/archive/refs/tags/v#{version}.tar.gz",
-       :sha256 => "80d9a43ff29dfbcdc5d40d52c469db1ae47eff8b276e60b63deee674676bea74",
+       :sha256 => "b5ca1e9957321b5c5422c2333d7d155e2412e63ea583065d56d3371305ef8116",
        :extract => :seven_zip
 
 relative_path "snowflake-connector-python-#{version}"

--- a/omnibus/config/software/snowflake-connector-python-py3.rb
+++ b/omnibus/config/software/snowflake-connector-python-py3.rb
@@ -4,7 +4,7 @@ default_version "2.7.12"
 dependency "pip3"
 
 source :url => "https://github.com/snowflakedb/snowflake-connector-python/archive/refs/tags/v#{version}.tar.gz",
-       :sha256 => "bb7af6933bdd6b8b105dac304de66fdb03e0b17378d588b5be6f1026b6ce3674",
+       :sha256 => "80d9a43ff29dfbcdc5d40d52c469db1ae47eff8b276e60b63deee674676bea74",
        :extract => :seven_zip
 
 relative_path "snowflake-connector-python-#{version}"

--- a/omnibus/config/software/snowflake-connector-python-py3.rb
+++ b/omnibus/config/software/snowflake-connector-python-py3.rb
@@ -1,10 +1,10 @@
 name "snowflake-connector-python-py3"
-default_version "2.7.3"
+default_version "2.7.12"
 
 dependency "pip3"
 
 source :url => "https://github.com/snowflakedb/snowflake-connector-python/archive/refs/tags/v#{version}.tar.gz",
-       :sha256 => "b5ca1e9957321b5c5422c2333d7d155e2412e63ea583065d56d3371305ef8116",
+       :sha256 => "80d9a43ff29dfbcdc5d40d52c469db1ae47eff8b276e60b63deee674676bea74",
        :extract => :seven_zip
 
 relative_path "snowflake-connector-python-#{version}"

--- a/omnibus/config/software/snowflake-connector-python-py3.rb
+++ b/omnibus/config/software/snowflake-connector-python-py3.rb
@@ -22,5 +22,7 @@ build do
     pip = "#{install_dir}/embedded/bin/pip3"
   end
 
-  command "#{pip} install ."
+  # Adding pyopenssl==21.0.0 here is a temporary workaround so that we don't get
+  # pyopenssl>=22.0.0 which requires a higher version of cryptography
+  command "#{pip} install pyopenssl==21.0.0 ."
 end


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR increments the current version of the `snowflake-connector-python` dependency in the omnibus to 2.7.3 (which requires pyopenssl < 22.0). 

I will also update the cryptography library in integrations-core after this PR, and then submit another PR to datadog-agent to match the actual version [currently used in the Snowflake check](https://github.com/DataDog/integrations-core/blob/master/datadog_checks_base/datadog_checks/base/data/agent_requirements.in#L107).

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
The Snowflake check no longer uses the 2.6.0 version of the check, and that version restricted `cryptography` library versions to <4.0.0, but `cryptography` changed how it increments release numbers (the current version is 38.0.1). 

This is currently blocking updating the the version of the [`securesystemslib`](https://github.com/DataDog/integrations-core/blob/master/datadog_checks_base/datadog_checks/base/data/agent_requirements.in#L99) library from 0.20.1 to 0.24.0, because `securesystemslib` now requires [a minimum `cryptography` version of 37.0.0](https://github.com/secure-systems-lab/securesystemslib/blob/v0.24.0/requirements.txt#L34)

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
~~I wasn't too sure if I needed to also change the `sha256` value on line 7.~~ Nevermind, I needed to change it otherwise it fails the CI.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
