### PR TITLE
[process-agent] Run check once before entering ticker loop

### DIFF
--- a/pkg/process/checks/runner.go
+++ b/pkg/process/checks/runner.go
@@ -55,6 +55,11 @@ func (r *runnerWithRealTime) run() {
 		return
 	}
 
+	// Run the check the first time to prime the caches.
+	r.RunCheck(RunOptions{
+		RunStandard: true,
+	})
+
 	ticker := r.newTicker(r.RtInterval)
 	for {
 		select {

--- a/pkg/process/checks/runner_test.go
+++ b/pkg/process/checks/runner_test.go
@@ -38,6 +38,7 @@ func TestRunnerWithRealTime(t *testing.T) {
 			desc:      "rt-enabled",
 			rtEnabled: true,
 			expectRuns: []RunOptions{
+				runOptionsWithStandard,
 				runOptionsWithBoth,
 				runOptionsWithRealTime,
 				runOptionsWithRealTime,
@@ -51,6 +52,7 @@ func TestRunnerWithRealTime(t *testing.T) {
 			desc:      "rt-disabled",
 			rtEnabled: false,
 			expectRuns: []RunOptions{
+				runOptionsWithStandard,
 				runOptionsWithStandard,
 				runOptionsWithStandard,
 			},


### PR DESCRIPTION
### What does this PR do?

- Corrects behavior of the `runnerWithRealTime` to run checks once before entering the loop on ticker performing combined runs of standard and realtime data collection.
- Brings this inline with the functionality of the basic runner here https://github.com/DataDog/datadog-agent/blob/611beb6066af5dacc28351c766b492a40c56c251/cmd/process-agent/collector.go#L543-L553

### Motivation

- Alignment of check runner implementation
- Shorten the time it takes to start reporting process data

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Test that process collection functions correctly in standard and realtime mode.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
