### PR TITLE
[netflow] Use trace level log instead of log_payloads

### DIFF
--- a/pkg/netflow/config/config.go
+++ b/pkg/netflow/config/config.go
@@ -19,7 +19,6 @@ type NetflowConfig struct {
 	AggregatorFlushInterval       int              `mapstructure:"aggregator_flush_interval"`
 	AggregatorFlowContextTTL      int              `mapstructure:"aggregator_flow_context_ttl"`
 	AggregatorPortRollupThreshold int              `mapstructure:"aggregator_port_rollup_threshold"`
-	LogPayloads                   bool             `mapstructure:"log_payloads"`
 
 	// AggregatorRollupTrackerRefreshInterval is useful to speed up testing to avoid wait for 1h default
 	AggregatorRollupTrackerRefreshInterval uint `mapstructure:"aggregator_rollup_tracker_refresh_interval"`

--- a/pkg/netflow/config/config_test.go
+++ b/pkg/netflow/config/config_test.go
@@ -55,7 +55,6 @@ network_devices:
 				AggregatorFlowContextTTL:               40,
 				AggregatorPortRollupThreshold:          20,
 				AggregatorRollupTrackerRefreshInterval: 60,
-				LogPayloads:                            true,
 				Listeners: []ListenerConfig{
 					{
 						FlowType:  common.TypeNetFlow9,
@@ -90,7 +89,6 @@ network_devices:
 				AggregatorFlowContextTTL:               300,
 				AggregatorPortRollupThreshold:          10,
 				AggregatorRollupTrackerRefreshInterval: 3600,
-				LogPayloads:                            false,
 				Listeners: []ListenerConfig{
 					{
 						FlowType:  common.TypeNetFlow9,
@@ -119,7 +117,6 @@ network_devices:
 				AggregatorFlowContextTTL:               50,
 				AggregatorPortRollupThreshold:          10,
 				AggregatorRollupTrackerRefreshInterval: 3600,
-				LogPayloads:                            false,
 				Listeners: []ListenerConfig{
 					{
 						FlowType:  common.TypeNetFlow9,

--- a/pkg/netflow/flowaggregator/aggregator.go
+++ b/pkg/netflow/flowaggregator/aggregator.go
@@ -29,7 +29,6 @@ type FlowAggregator struct {
 	flowAcc                      *flowAccumulator
 	sender                       aggregator.Sender
 	stopChan                     chan struct{}
-	logPayload                   bool
 	receivedFlowCount            *atomic.Uint64
 	flushedFlowCount             *atomic.Uint64
 	hostname                     string
@@ -47,7 +46,6 @@ func NewFlowAggregator(sender aggregator.Sender, config *config.NetflowConfig, h
 		rollupTrackerRefreshInterval: rollupTrackerRefreshInterval,
 		sender:                       sender,
 		stopChan:                     make(chan struct{}),
-		logPayload:                   config.LogPayloads,
 		receivedFlowCount:            atomic.NewUint64(0),
 		flushedFlowCount:             atomic.NewUint64(0),
 		hostname:                     hostname,
@@ -92,12 +90,10 @@ func (agg *FlowAggregator) sendFlows(flows []*common.Flow) {
 			log.Errorf("Error marshalling device metadata: %s", err)
 			continue
 		}
-		agg.sender.EventPlatformEvent(string(payloadBytes), epforwarder.EventTypeNetworkDevicesNetFlow)
 
-		// For debug purposes print out all flows
-		if agg.logPayload {
-			log.Debugf("flushed flow: %s", string(payloadBytes))
-		}
+		payloadStr := string(payloadBytes)
+		log.Tracef("flushed flow: %s", payloadStr)
+		agg.sender.EventPlatformEvent(payloadStr, epforwarder.EventTypeNetworkDevicesNetFlow)
 	}
 }
 

--- a/pkg/netflow/flowaggregator/aggregator_test.go
+++ b/pkg/netflow/flowaggregator/aggregator_test.go
@@ -34,7 +34,6 @@ func TestAggregator(t *testing.T) {
 		AggregatorFlushInterval:                1,
 		AggregatorPortRollupThreshold:          10,
 		AggregatorRollupTrackerRefreshInterval: 3600,
-		LogPayloads:                            true,
 		Listeners: []config.ListenerConfig{
 			{
 				FlowType: common.TypeNetFlow9,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

[netflow] Use trace level log instead of log_payloads

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

It's more convenient to just use `trace` log level, than using/asking for debug log level + `log_payloads:true`

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
