### PR TITLE
[CSPM] update cspm e2e

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -130,6 +130,18 @@ updates:
     milestone: 22
     schedule:
       interval: "monthly"
+  - package-ecosystem: "pip"
+    directory: "/test/e2e/cws-tests"
+    labels:
+      - dependencies
+      - python
+      - team/agent-security
+      - changelog/no-changelog
+      - qa/skip-qa
+      - dev/tooling
+    milestone: 22
+    schedule:
+      interval: "monthly"
   - package-ecosystem: "github-actions"
     directory: "/"
     labels:

--- a/test/e2e/cws-tests/requirements.txt
+++ b/test/e2e/cws-tests/requirements.txt
@@ -1,5 +1,5 @@
 kubernetes==24.2.0
-datadog-api-client==1.10.0
+datadog-api-client==2.3.0
 pyaml==21.10.1
 docker==6.0.0
 retry==0.9.2

--- a/test/e2e/cws-tests/requirements.txt
+++ b/test/e2e/cws-tests/requirements.txt
@@ -1,7 +1,7 @@
-kubernetes==20.13.0
+kubernetes==24.2.0
 datadog-api-client==1.10.0
 pyaml==21.10.1
-docker==5.0.3
+docker==6.0.0
 retry==0.9.2
-emoji==1.6.1
-requests==2.26.0
+emoji==2.0.0
+requests==2.28.1

--- a/test/e2e/cws-tests/tests/lib/cws/app.py
+++ b/test/e2e/cws-tests/tests/lib/cws/app.py
@@ -84,8 +84,6 @@ class App(common.App):
         common.App.__init__(self)
 
         configuration = Configuration()
-        configuration.unstable_operations["search_security_monitoring_signals"] = True
-
         self.api_client = ApiClient(configuration)
 
     def __exit__(self):

--- a/test/e2e/cws-tests/tests/test_e2e_cspm.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cspm.py
@@ -18,8 +18,7 @@ def expect_findings(test_case, findings, expected_findings):
                     found = True
                     break
 
-            if not found:
-                test_case.assert_(found, f"unexpected finding {finding} for rule {rule_id}")
+            test_case.assertTrue(found, f"unexpected finding {finding} for rule {rule_id}")
             del findings_by_rule[rule_id]
 
     for rule_id, rule_findings in findings_by_rule.items():


### PR DESCRIPTION
### What does this PR do?

This PR was at first an investigation into why CSPM e2e tests were not broken anymore. It's now just some cleanup and dependency bumps.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
