### PR TITLE
[RCM-432] fix(remote-config): Clean remote state on error & use fixed fork of go-tuf

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ replace (
 	github.com/lxn/walk => github.com/lxn/walk v0.0.0-20180521183810-02935bac0ab8
 	github.com/mholt/archiver => github.com/mholt/archiver v2.0.1-0.20171012052341-26cf5bb32d07+incompatible
 	github.com/spf13/cast => github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3
+	github.com/theupdateframework/go-tuf => github.com/DataDog/go-tuf v0.3.0--fix-localmeta
 	github.com/ugorji/go => github.com/ugorji/go v1.1.7
 )
 

--- a/go.sum
+++ b/go.sum
@@ -148,6 +148,8 @@ github.com/DataDog/ebpf-manager v0.0.0-20220627174516-12adb97b679e h1:MsSGtI99s8
 github.com/DataDog/ebpf-manager v0.0.0-20220627174516-12adb97b679e/go.mod h1:8bqjDI64T80GHECNIJp9nY4+0mgX4Tc+Kcdk3p0NeIA=
 github.com/DataDog/extendeddaemonset v0.7.1-0.20220530183123-9c60ea5abbc6 h1:XDD6SEIEpe5CAa7esIWlgdXLQgLKN4hvPw+Wd8pJQFU=
 github.com/DataDog/extendeddaemonset v0.7.1-0.20220530183123-9c60ea5abbc6/go.mod h1:YxkO6rhI37nstfxBAdk4fVi5kheKJRMk9AtqDdl/mSQ=
+github.com/DataDog/go-tuf v0.3.0--fix-localmeta h1:lM/fRQNIaJpsnLU7edjV3jYHylCym0Ah+kvoJWRTzsk=
+github.com/DataDog/go-tuf v0.3.0--fix-localmeta/go.mod h1:E5XP0wXitrFUHe4b8cUcAAdxBW4LbfnqF4WXXGLgWNo=
 github.com/DataDog/gohai v0.0.0-20220823152657-b201b8a4ebec h1:BB0E2Ij4/rO6RANy91r9ND27PtPLcdrwUJJ27B2CbIY=
 github.com/DataDog/gohai v0.0.0-20220823152657-b201b8a4ebec/go.mod h1:oyPC4jWHHjVVNjslDAKp8EqfQBaSmODjHt4HCX+C+9Q=
 github.com/DataDog/gopsutil v0.0.0-20200624212600-1b53412ef321/go.mod h1:tGQp6XG4XpOyy67WG/YWXVxzOY6LejK35e8KcQhtRIQ=
@@ -1649,8 +1651,6 @@ github.com/tedsuo/ifrit v0.0.0-20191009134036-9a97d0632f00 h1:mujcChM89zOHwgZBBN
 github.com/tedsuo/ifrit v0.0.0-20191009134036-9a97d0632f00/go.mod h1:eyZnKCc955uh98WQvzOm0dgAeLnf2O0Rz0LPoC5ze+0=
 github.com/tedsuo/rata v1.0.0 h1:Sf9aZrYy6ElSTncjnGkyC2yuVvz5YJetBIUKJ4CmeKE=
 github.com/tedsuo/rata v1.0.0/go.mod h1:X47ELzhOoLbfFIY0Cql9P6yo3Cdwf2CMX3FVZxRzJPc=
-github.com/theupdateframework/go-tuf v0.3.0 h1:od2sc5+BSkKZhmUG2o2rmruy0BGSmhrbDhCnpxh87X8=
-github.com/theupdateframework/go-tuf v0.3.0/go.mod h1:E5XP0wXitrFUHe4b8cUcAAdxBW4LbfnqF4WXXGLgWNo=
 github.com/tidwall/assert v0.1.0/go.mod h1:QLYtGyeqse53vuELQheYl9dngGCJQ+mTtlxcktb+Kj8=
 github.com/tidwall/btree v0.3.0/go.mod h1:huei1BkDWJ3/sLXmO+bsCNELL+Bp2Kks9OLyQFkzvA8=
 github.com/tidwall/btree v1.1.0/go.mod h1:TzIRzen6yHbibdSfK6t8QimqbUnoxUSrZfeW7Uob0q4=

--- a/pkg/config/remote/uptane/client.go
+++ b/pkg/config/remote/uptane/client.go
@@ -18,7 +18,6 @@ import (
 
 	rdata "github.com/DataDog/datadog-agent/pkg/config/remote/data"
 	"github.com/DataDog/datadog-agent/pkg/proto/pbgo"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // Client is an uptane client
@@ -70,28 +69,30 @@ func NewClient(cacheDB *bbolt.DB, cacheKey string, orgID int64) (*Client, error)
 	return c, nil
 }
 
-func (c *Client) rollback(err error) {
-	c.transactionalStore.rollback()
+// Update updates the uptane client and rollbacks in case of error
+func (c *Client) Update(response *pbgo.LatestConfigsResponse) error {
+	c.Lock()
+	defer c.Unlock()
+	c.cachedVerify = false
+
+	// in case the commit is successful it is a no-op.
+	// the defer is present to be sure a transaction is never left behind.
+	defer c.transactionalStore.rollback()
+
+	err := c.update(response)
 	if err != nil {
 		c.configRemoteStore = newRemoteStoreConfig(c.targetStore)
 		c.directorRemoteStore = newRemoteStoreDirector(c.targetStore)
 		c.configTUFClient = client.NewClient(c.configLocalStore, c.configRemoteStore)
 		c.directorTUFClient = client.NewClient(c.directorLocalStore, c.directorRemoteStore)
+		return err
 	}
+	return c.transactionalStore.commit()
 }
 
-// Update updates the uptane client
-func (c *Client) Update(response *pbgo.LatestConfigsResponse) error {
-	c.Lock()
-	defer c.Unlock()
-	c.cachedVerify = false
-	var err error
-
-	// in case the commit is successful it is a no-op.
-	// the defer is present to be sure a transaction is never left behind.
-	defer func() { c.rollback(err) }()
-
-	err = c.updateRepos(response)
+// update updates the uptane client
+func (c *Client) update(response *pbgo.LatestConfigsResponse) error {
+	err := c.updateRepos(response)
 	if err != nil {
 		return err
 	}
@@ -99,14 +100,7 @@ func (c *Client) Update(response *pbgo.LatestConfigsResponse) error {
 	if err != nil {
 		return err
 	}
-	err = c.verify()
-	if err != nil {
-		return err
-	}
-	log.Infof("committing")
-
-	err = c.transactionalStore.commit()
-	return err
+	return c.verify()
 }
 
 // TargetsCustom returns the current targets custom of this uptane client

--- a/pkg/config/remote/uptane/remote_store.go
+++ b/pkg/config/remote/uptane/remote_store.go
@@ -58,7 +58,7 @@ func (s *remoteStore) latestVersion(r role) uint64 {
 	return latestVersion
 }
 
-// GetMeta implements go-tuf's RemoteStore.<
+// GetMeta implements go-tuf's RemoteStore.GetMeta
 // See https://pkg.go.dev/github.com/theupdateframework/go-tuf/client#RemoteStore
 func (s *remoteStore) GetMeta(path string) (io.ReadCloser, int64, error) {
 	metaPath, err := parseMetaPath(path)

--- a/pkg/config/remote/uptane/remote_store.go
+++ b/pkg/config/remote/uptane/remote_store.go
@@ -58,7 +58,7 @@ func (s *remoteStore) latestVersion(r role) uint64 {
 	return latestVersion
 }
 
-// GetMeta implements go-tuf's RemoteStore.GetMeta
+// GetMeta implements go-tuf's RemoteStore.<
 // See https://pkg.go.dev/github.com/theupdateframework/go-tuf/client#RemoteStore
 func (s *remoteStore) GetMeta(path string) (io.ReadCloser, int64, error) {
 	metaPath, err := parseMetaPath(path)


### PR DESCRIPTION
### What does this PR do?
It does two things:
- Fix an important bug where the remote state of Go-TUF was not cleaned on error, meaning that an erroneous state could be used by the app (which we don't ever want to happen)
- Make sure to use a back-port of a fix in Go-TUF where remote delegated targets were not cached properly cached in the localMeta structure (see https://github.com/theupdateframework/go-tuf/pull/384).

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Making sure that the agent is bug-less before important deadlines

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
We are now using a forked version of Go-TUF until we can properly upgrade (upgrade is blocked due to other issues that make Go-TUF non forward compatible).
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Backend has been fixed, so fixing this bug is hard. What you can do is revert https://github.com/DataDog/dd-go/pull/72706, and then do the following, making sure the agent update between each step.
- Create two configs with exactly the same content
- Delete one
- Re-create it

Connecting a client to the agent and continuously querying the agent for configuration **should never return an error 500**

Also, test restarting the agent locally while disabling WIFI -> Configs should be able to be queried from tracers as if nothing happened.
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
