### PR TITLE
Bump dependabot concurrent PR limit

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -33,7 +33,7 @@ updates:
       - dependency-name: github.com/DataDog/datadog-agent/*
     schedule:
       interval: weekly
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 100
   - package-ecosystem: gomod
     directory: /pkg/otlp/model
     labels:
@@ -47,7 +47,7 @@ updates:
       - dependency-name: github.com/DataDog/datadog-agent/*
     schedule:
       interval: weekly
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 100
   - package-ecosystem: gomod
     directory: /pkg/trace
     labels:
@@ -63,7 +63,7 @@ updates:
       - dependency-name: github.com/mailru/easyjson
     schedule:
       interval: weekly
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 100
   - package-ecosystem: gomod
     directory: /pkg/obfuscate
     labels:
@@ -79,7 +79,7 @@ updates:
       - dependency-name: github.com/mailru/easyjson
     schedule:
       interval: weekly
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 100
   - package-ecosystem: gomod
     directory: /pkg/quantile
     labels:
@@ -93,7 +93,7 @@ updates:
       - dependency-name: github.com/DataDog/datadog-agent/*
     schedule:
       interval: weekly
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 100
   - package-ecosystem: gomod
     directory: /pkg/security/secl
     labels:
@@ -107,7 +107,7 @@ updates:
       - dependency-name: github.com/DataDog/datadog-agent/*
     schedule:
       interval: weekly
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 100
   - package-ecosystem: gomod
     directory: /internal/tools
     labels:
@@ -124,7 +124,7 @@ updates:
     milestone: 22
     schedule:
       interval: monthly
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 100
   - package-ecosystem: "pip"
     directory: "/.circleci"
     labels:
@@ -137,7 +137,7 @@ updates:
     milestone: 22
     schedule:
       interval: "monthly"
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 100
   - package-ecosystem: "pip"
     directory: "/test/e2e/cws-tests"
     labels:
@@ -150,7 +150,7 @@ updates:
     milestone: 22
     schedule:
       interval: "monthly"
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 100
   - package-ecosystem: "github-actions"
     directory: "/"
     labels:
@@ -163,4 +163,4 @@ updates:
     milestone: 22
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 100

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -33,6 +33,7 @@ updates:
       - dependency-name: github.com/DataDog/datadog-agent/*
     schedule:
       interval: weekly
+    open-pull-requests-limit: 0
   - package-ecosystem: gomod
     directory: /pkg/otlp/model
     labels:
@@ -46,6 +47,7 @@ updates:
       - dependency-name: github.com/DataDog/datadog-agent/*
     schedule:
       interval: weekly
+    open-pull-requests-limit: 0
   - package-ecosystem: gomod
     directory: /pkg/trace
     labels:
@@ -61,6 +63,7 @@ updates:
       - dependency-name: github.com/mailru/easyjson
     schedule:
       interval: weekly
+    open-pull-requests-limit: 0
   - package-ecosystem: gomod
     directory: /pkg/obfuscate
     labels:
@@ -76,6 +79,7 @@ updates:
       - dependency-name: github.com/mailru/easyjson
     schedule:
       interval: weekly
+    open-pull-requests-limit: 0
   - package-ecosystem: gomod
     directory: /pkg/quantile
     labels:
@@ -89,6 +93,7 @@ updates:
       - dependency-name: github.com/DataDog/datadog-agent/*
     schedule:
       interval: weekly
+    open-pull-requests-limit: 0
   - package-ecosystem: gomod
     directory: /pkg/security/secl
     labels:
@@ -102,6 +107,7 @@ updates:
       - dependency-name: github.com/DataDog/datadog-agent/*
     schedule:
       interval: weekly
+    open-pull-requests-limit: 0
   - package-ecosystem: gomod
     directory: /internal/tools
     labels:
@@ -118,6 +124,7 @@ updates:
     milestone: 22
     schedule:
       interval: monthly
+    open-pull-requests-limit: 0
   - package-ecosystem: "pip"
     directory: "/.circleci"
     labels:
@@ -130,6 +137,7 @@ updates:
     milestone: 22
     schedule:
       interval: "monthly"
+    open-pull-requests-limit: 0
   - package-ecosystem: "pip"
     directory: "/test/e2e/cws-tests"
     labels:
@@ -142,6 +150,7 @@ updates:
     milestone: 22
     schedule:
       interval: "monthly"
+    open-pull-requests-limit: 0
   - package-ecosystem: "github-actions"
     directory: "/"
     labels:
@@ -154,3 +163,4 @@ updates:
     milestone: 22
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
### What does this PR do?

By default, dependabot opens a maximum of 5 PR per entry:
- https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit
- https://github.com/DataDog/datadog-agent/pulls?q=is%3Aopen+is%3Apr+label%3Adependencies+label%3Adependencies-go

This means that depending on the algorithm selection we may miss new bumps because of old PRs.

This issue should be fixed by 2 things:
- teams should merge or close PR more quickly
- this PR increases this limit to 100

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
