### PR TITLE
[external metrics] Support HPA v2beta2, v2

### DIFF
--- a/pkg/clusteragent/externalmetrics/autoscaler_watcher.go
+++ b/pkg/clusteragent/externalmetrics/autoscaler_watcher.go
@@ -100,10 +100,10 @@ func NewAutoscalerWatcher(
 			genericInformerFactory, err := informer.ForResource(hpaGVR)
 			if err != nil {
 				log.Errorf("error creating generic informer: %s", err)
+			} else {
+				autoscalerLister = genericInformerFactory.Lister()
+				autoscalerListerSynced = genericInformerFactory.Informer().HasSynced
 			}
-
-			autoscalerLister = genericInformerFactory.Lister()
-			autoscalerListerSynced = genericInformerFactory.Informer().HasSynced
 		}
 
 	}

--- a/pkg/clusteragent/externalmetrics/autoscaler_watcher.go
+++ b/pkg/clusteragent/externalmetrics/autoscaler_watcher.go
@@ -13,19 +13,23 @@ import (
 	"strings"
 	"time"
 
-	autoscaler "k8s.io/api/autoscaling/v2beta1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	autoscalingv2beta1 "k8s.io/api/autoscaling/v2beta1"
+	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamic_informer "k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/informers"
-	autoscaler_lister "k8s.io/client-go/listers/autoscaling/v2beta1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1"
 
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/externalmetrics/model"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/autoscalers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -43,7 +47,7 @@ type AutoscalerWatcher struct {
 	autogenEnabled          bool
 	autogenExpirationPeriod time.Duration
 	autogenNamespace        string
-	autoscalerLister        autoscaler_lister.HorizontalPodAutoscalerLister
+	autoscalerLister        cache.GenericLister
 	autoscalerListerSynced  cache.InformerSynced
 	wpaLister               cache.GenericLister
 	wpaListerSynced         cache.InformerSynced
@@ -57,7 +61,7 @@ type externalMetric struct {
 	autoscalerReferences []string
 }
 
-var gvr = &schema.GroupVersionResource{
+var gvr = schema.GroupVersionResource{
 	Group:    "datadoghq.com",
 	Version:  "v1alpha1",
 	Resource: "watermarkpodautoscalers",
@@ -65,7 +69,17 @@ var gvr = &schema.GroupVersionResource{
 
 // NewAutoscalerWatcher returns a new AutoscalerWatcher, giving nil `autoscalerInformer` or nil `wpaInformer` disables watching HPA or WPA
 // We need at least one of them
-func NewAutoscalerWatcher(refreshPeriod int64, autogenEnabled bool, autogenExpirationPeriodHours int64, autogenNamespace string, informer informers.SharedInformerFactory, wpaInformer dynamic_informer.DynamicSharedInformerFactory, isLeader func() bool, store *DatadogMetricsInternalStore) (*AutoscalerWatcher, error) {
+func NewAutoscalerWatcher(
+	refreshPeriod int64,
+	autogenEnabled bool,
+	autogenExpirationPeriodHours int64,
+	autogenNamespace string,
+	client kubernetes.Interface,
+	informer informers.SharedInformerFactory,
+	wpaInformer dynamic_informer.DynamicSharedInformerFactory,
+	isLeader func() bool,
+	store *DatadogMetricsInternalStore,
+) (*AutoscalerWatcher, error) {
 	if store == nil {
 		return nil, fmt.Errorf("Store must be initialized")
 	}
@@ -76,19 +90,30 @@ func NewAutoscalerWatcher(refreshPeriod int64, autogenEnabled bool, autogenExpir
 	}
 
 	// Setup HPA
-	var autoscalerLister autoscaler_lister.HorizontalPodAutoscalerLister
+	var autoscalerLister cache.GenericLister
 	var autoscalerListerSynced cache.InformerSynced
 	if informer != nil {
-		autoscalerLister = informer.Autoscaling().V2beta1().HorizontalPodAutoscalers().Lister()
-		autoscalerListerSynced = informer.Autoscaling().V2beta1().HorizontalPodAutoscalers().Informer().HasSynced
+		hpaGVR, err := autoscalers.DiscoverHPAGroupVersionResource(client)
+		if err != nil {
+			log.Errorf("unable to discover HPA GroupVersionResource: %s", err)
+		} else {
+			genericInformerFactory, err := informer.ForResource(hpaGVR)
+			if err != nil {
+				log.Errorf("error creating generic informer: %s", err)
+			}
+
+			autoscalerLister = genericInformerFactory.Lister()
+			autoscalerListerSynced = genericInformerFactory.Informer().HasSynced
+		}
+
 	}
 
 	// Setup WPA
 	var wpaLister cache.GenericLister
 	var wpaListerSynced cache.InformerSynced
 	if wpaInformer != nil {
-		wpaLister = wpaInformer.ForResource(*gvr).Lister()
-		wpaListerSynced = wpaInformer.ForResource(*gvr).Informer().HasSynced
+		wpaLister = wpaInformer.ForResource(gvr).Lister()
+		wpaListerSynced = wpaInformer.ForResource(gvr).Informer().HasSynced
 	}
 
 	autoscalerWatcher := &AutoscalerWatcher{
@@ -228,28 +253,13 @@ func (w *AutoscalerWatcher) getAutoscalerReferences() (map[string]*externalMetri
 	}
 
 	if w.autoscalerLister != nil {
-		hpaList, err := w.autoscalerLister.HorizontalPodAutoscalers(metav1.NamespaceAll).List(labels.Everything())
+		hpaList, err := w.autoscalerLister.List(labels.Everything())
 		if err != nil {
 			return nil, fmt.Errorf("Could not list HPAs (to update DatadogMetric active status): %v", err)
 		}
 
-		for _, hpa := range hpaList {
-			for _, metric := range hpa.Spec.Metrics {
-				if metric.Type == autoscaler.ExternalMetricSourceType && metric.External != nil {
-					autoscalerReference := autoscalerHPAKindKey + autoscalerReferencesKindSep + hpa.Namespace + kubernetesNamespaceSep + hpa.Name
-					if datadogMetricID, parsed, hasPrefix := metricNameToDatadogMetricID(metric.External.MetricName); parsed {
-						addAutoscalerReference(datadogMetricID, autoscalerReference, "", nil)
-					} else if !hasPrefix && w.autogenEnabled {
-						// We were not able to parse name as DatadogMetric ID. It will be considered as a normal metricName + labels
-						var labels map[string]string
-						if metric.External.MetricSelector != nil {
-							labels = metric.External.MetricSelector.MatchLabels
-						}
-
-						addAutoscalerReference("", autoscalerReference, metric.External.MetricName, labels)
-					}
-				}
-			}
+		for _, obj := range hpaList {
+			w.processHPAReference(addAutoscalerReference, obj)
 		}
 	}
 
@@ -266,24 +276,129 @@ func (w *AutoscalerWatcher) getAutoscalerReferences() (map[string]*externalMetri
 				log.Errorf("Error converting wpa from the cache %v", err)
 				continue
 			}
-			for _, metric := range wpa.Spec.Metrics {
-				autoscalerReference := autoscalerWPAKindKey + autoscalerReferencesKindSep + wpa.Namespace + kubernetesNamespaceSep + wpa.Name
-				if metric.External != nil {
-					if datadogMetricID, parsed, hasPrefix := metricNameToDatadogMetricID(metric.External.MetricName); parsed {
-						addAutoscalerReference(datadogMetricID, autoscalerReference, "", nil)
-					} else if !hasPrefix && w.autogenEnabled {
-						// We were not able to parse name as DatadogMetric ID. It will be considered as a normal metricName + labels
-						var labels map[string]string
-						if metric.External.MetricSelector != nil {
-							labels = metric.External.MetricSelector.MatchLabels
-						}
 
-						addAutoscalerReference("", autoscalerReference, metric.External.MetricName, labels)
-					}
+			for _, metric := range wpa.Spec.Metrics {
+				if metric.External == nil {
+					continue
+				}
+
+				external := metric.External
+				ref := buildAutoscalerReference(autoscalerWPAKindKey, wpa.ObjectMeta)
+				ddMetricID, metricName, labels, ok := w.extractAutoscalerReference(external.MetricName, external.MetricSelector)
+				if ok {
+					addAutoscalerReference(ddMetricID, ref, metricName, labels)
 				}
 			}
 		}
 	}
 
 	return datadogMetricReferences, nil
+}
+
+type addAutoscalerReferenceFn func(
+	datadogMetricID string,
+	autoscalerReference string,
+	metricName string,
+	labels map[string]string,
+)
+
+func (w *AutoscalerWatcher) processHPAReference(addAutoscalerReference addAutoscalerReferenceFn, obj runtime.Object) {
+	switch hpa := obj.(type) {
+	case *autoscalingv2beta1.HorizontalPodAutoscaler:
+		w.processHPAv2beta1Reference(addAutoscalerReference, hpa)
+	case *autoscalingv2beta2.HorizontalPodAutoscaler:
+		w.processHPAv2beta2Reference(addAutoscalerReference, hpa)
+	case *autoscalingv2.HorizontalPodAutoscaler:
+		w.processHPAv2Reference(addAutoscalerReference, hpa)
+	default:
+		log.Errorf("object is not a HorizontalPodAutoscaler, %T instead", obj)
+	}
+}
+
+func (w *AutoscalerWatcher) processHPAv2beta1Reference(addAutoscalerReference addAutoscalerReferenceFn, hpa *autoscalingv2beta1.HorizontalPodAutoscaler) {
+	for _, metric := range hpa.Spec.Metrics {
+		if metric.Type != autoscalingv2beta1.ExternalMetricSourceType {
+			continue
+		}
+
+		if metric.External == nil {
+			continue
+		}
+
+		external := metric.External
+		ref := buildAutoscalerReference(autoscalerHPAKindKey, hpa.ObjectMeta)
+		ddMetricID, metricName, labels, ok := w.extractAutoscalerReference(external.MetricName, external.MetricSelector)
+		if ok {
+			addAutoscalerReference(ddMetricID, ref, metricName, labels)
+		}
+	}
+}
+
+func (w *AutoscalerWatcher) processHPAv2beta2Reference(addAutoscalerReference addAutoscalerReferenceFn, hpa *autoscalingv2beta2.HorizontalPodAutoscaler) {
+	for _, metric := range hpa.Spec.Metrics {
+		if metric.Type != autoscalingv2beta2.ExternalMetricSourceType {
+			continue
+		}
+
+		if metric.External == nil {
+			continue
+		}
+
+		external := metric.External
+		ref := buildAutoscalerReference(autoscalerHPAKindKey, hpa.ObjectMeta)
+		ddMetricID, metricName, labels, ok := w.extractAutoscalerReference(external.Metric.Name, external.Metric.Selector)
+		if ok {
+			addAutoscalerReference(ddMetricID, ref, metricName, labels)
+		}
+	}
+}
+
+func (w *AutoscalerWatcher) processHPAv2Reference(addAutoscalerReference addAutoscalerReferenceFn, hpa *autoscalingv2.HorizontalPodAutoscaler) {
+	for _, metric := range hpa.Spec.Metrics {
+		if metric.Type != autoscalingv2.ExternalMetricSourceType {
+			continue
+		}
+
+		if metric.External == nil {
+			continue
+		}
+
+		external := metric.External
+		ref := buildAutoscalerReference(autoscalerHPAKindKey, hpa.ObjectMeta)
+		ddMetricID, metricName, labels, ok := w.extractAutoscalerReference(external.Metric.Name, external.Metric.Selector)
+		if ok {
+			addAutoscalerReference(ddMetricID, ref, metricName, labels)
+		}
+	}
+}
+
+func (w *AutoscalerWatcher) extractAutoscalerReference(
+	externalMetricName string,
+	externalMetricSelector *metav1.LabelSelector,
+) (
+	ddMetricID string,
+	metricName string,
+	labels map[string]string,
+	ok bool,
+) {
+	ddMetricID, parsed, hasPrefix := metricNameToDatadogMetricID(externalMetricName)
+	if parsed {
+		return ddMetricID, "", nil, true
+	} else if !hasPrefix && w.autogenEnabled {
+		// We were not able to parse name as DatadogMetric ID.
+		// It will be considered as a normal metricName +
+		// labels
+		var labels map[string]string
+		if externalMetricSelector != nil {
+			labels = externalMetricSelector.MatchLabels
+		}
+
+		return "", externalMetricName, labels, true
+	}
+
+	return "", "", nil, false
+}
+
+func buildAutoscalerReference(kind string, obj metav1.ObjectMeta) string {
+	return kind + autoscalerReferencesKindSep + obj.Namespace + kubernetesNamespaceSep + obj.Name
 }

--- a/pkg/clusteragent/externalmetrics/autoscaler_watcher.go
+++ b/pkg/clusteragent/externalmetrics/autoscaler_watcher.go
@@ -95,16 +95,16 @@ func NewAutoscalerWatcher(
 	if informer != nil {
 		hpaGVR, err := autoscalers.DiscoverHPAGroupVersionResource(client)
 		if err != nil {
-			log.Errorf("unable to discover HPA GroupVersionResource: %s", err)
-		} else {
-			genericInformerFactory, err := informer.ForResource(hpaGVR)
-			if err != nil {
-				log.Errorf("error creating generic informer: %s", err)
-			} else {
-				autoscalerLister = genericInformerFactory.Lister()
-				autoscalerListerSynced = genericInformerFactory.Informer().HasSynced
-			}
+			return nil, fmt.Errorf("unable to discover HPA GroupVersionResource: %s", err)
 		}
+
+		genericInformerFactory, err := informer.ForResource(hpaGVR)
+		if err != nil {
+			return nil, fmt.Errorf("error creating generic informer: %s", err)
+		}
+
+		autoscalerLister = genericInformerFactory.Lister()
+		autoscalerListerSynced = genericInformerFactory.Informer().HasSynced
 
 	}
 

--- a/pkg/clusteragent/externalmetrics/provider.go
+++ b/pkg/clusteragent/externalmetrics/provider.go
@@ -77,7 +77,17 @@ func NewDatadogMetricProvider(ctx context.Context, apiCl *apiserver.APIClient) (
 
 	// Start AutoscalerWatcher, only leader will flag DatadogMetrics as Active/Inactive
 	// WPAInformerFactory is nil when WPA is not used. AutoscalerWatcher will check value itself.
-	autoscalerWatcher, err := NewAutoscalerWatcher(refreshPeriod, autogenEnabled, autogenExpirationPeriodHours, autogenNamespace, apiCl.InformerFactory, apiCl.WPAInformerFactory, le.IsLeader, &provider.store)
+	autoscalerWatcher, err := NewAutoscalerWatcher(
+		refreshPeriod,
+		autogenEnabled,
+		autogenExpirationPeriodHours,
+		autogenNamespace,
+		apiCl.Cl,
+		apiCl.InformerFactory,
+		apiCl.WPAInformerFactory,
+		le.IsLeader,
+		&provider.store,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("Unabled to create DatadogMetricProvider as AutoscalerWatcher failed with: %v", err)
 	}

--- a/pkg/util/kubernetes/apiserver/controllers.go
+++ b/pkg/util/kubernetes/apiserver/controllers.go
@@ -148,8 +148,8 @@ func startAutoscalersController(ctx ControllerContext, c chan error) {
 	if ctx.WPAInformerFactory != nil {
 		go autoscalersController.RunWPA(ctx.StopCh, ctx.WPAClient, ctx.WPAInformerFactory)
 	}
-	// mutate the Autoscaler controller to embed an informer against the HPAs
-	autoscalersController.EnableHPA(ctx.InformerFactory.Autoscaling().V2beta1().HorizontalPodAutoscalers())
+
+	autoscalersController.enableHPA(ctx.Client, ctx.InformerFactory)
 	go autoscalersController.RunHPA(ctx.StopCh)
 
 	autoscalersController.RunControllerLoop(ctx.StopCh)

--- a/pkg/util/kubernetes/apiserver/util.go
+++ b/pkg/util/kubernetes/apiserver/util.go
@@ -57,8 +57,8 @@ func UnstructuredIntoWPA(obj interface{}, structDest *v1alpha1.WatermarkPodAutos
 	return runtime.DefaultUnstructuredConverter.FromUnstructured(unstrObj.UnstructuredContent(), structDest)
 }
 
-// UnstructuredFromWPA converts a WPA object into an Unstructured
-func UnstructuredFromWPA(structIn *v1alpha1.WatermarkPodAutoscaler, unstructOut *unstructured.Unstructured) error {
+// UnstructuredFromAutoscaler converts a WPA object into an Unstructured
+func UnstructuredFromAutoscaler(structIn runtime.Object, unstructOut *unstructured.Unstructured) error {
 	content, err := runtime.DefaultUnstructuredConverter.ToUnstructured(structIn)
 	if err != nil {
 		return fmt.Errorf("Unable to convert WatermarkPodAutoscaler %v: %w", structIn, err)

--- a/pkg/util/kubernetes/apiserver/wpa_controller.go
+++ b/pkg/util/kubernetes/apiserver/wpa_controller.go
@@ -58,9 +58,8 @@ func (h *AutoscalersController) RunWPA(stopCh <-chan struct{}, wpaClient dynamic
 	if !cache.WaitForCacheSync(stopCh, h.wpaListerSynced) {
 		return
 	}
-	// TODO remove go routine here ?
-	go wait.Until(h.workerWPA, time.Second, stopCh)
-	<-stopCh
+
+	wait.Until(h.workerWPA, time.Second, stopCh)
 }
 
 type checkAPI func() error
@@ -248,7 +247,7 @@ func (h *AutoscalersController) updateWPAutoscaler(old, obj interface{}) {
 		return
 	}
 
-	if !autoscalers.WPAutoscalerMetricsUpdate(newAutoscaler, oldAutoscaler) {
+	if !autoscalers.AutoscalerMetricsUpdate(newAutoscaler.GetObjectMeta(), oldAutoscaler.GetObjectMeta()) {
 		log.Tracef("Update received for the %s/%s, without a relevant change to the configuration", newAutoscaler.Namespace, newAutoscaler.Name)
 		return
 	}

--- a/pkg/util/kubernetes/apiserver/wpa_controller_test.go
+++ b/pkg/util/kubernetes/apiserver/wpa_controller_test.go
@@ -213,7 +213,7 @@ func newFakeWatermarkPodAutoscaler(name, ns string, uid types.UID, metricName st
 		},
 	}
 
-	if err := UnstructuredFromWPA(wpa, obj); err != nil {
+	if err := UnstructuredFromAutoscaler(wpa, obj); err != nil {
 		panic("Failed to construct unstructured WPA")
 	}
 

--- a/pkg/util/kubernetes/autoscalers/discover.go
+++ b/pkg/util/kubernetes/autoscalers/discover.go
@@ -1,0 +1,42 @@
+package autoscalers
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	autoscalingGroup = "autoscaling"
+	hpaResource      = "horizontalpodautoscalers"
+)
+
+func DiscoverHPAGroupVersionResource(client kubernetes.Interface) (schema.GroupVersionResource, error) {
+	groups, _, err := client.Discovery().ServerGroupsAndResources()
+	if err != nil {
+		if !discovery.IsGroupDiscoveryFailedError(err) {
+			return schema.GroupVersionResource{}, err
+		} else {
+			for group, apiGroupErr := range err.(*discovery.ErrGroupDiscoveryFailed).Groups {
+				log.Warnf("unable to perform resource discovery for group %s: %s", group, apiGroupErr)
+			}
+		}
+	}
+
+	for _, group := range groups {
+		if group.Name != autoscalingGroup {
+			continue
+		}
+
+		return schema.GroupVersionResource{
+			Group:    autoscalingGroup,
+			Version:  group.PreferredVersion.Version,
+			Resource: hpaResource,
+		}, nil
+	}
+
+	return schema.GroupVersionResource{}, fmt.Errorf("cannot find group %q", autoscalingGroup)
+}

--- a/pkg/util/kubernetes/autoscalers/discover.go
+++ b/pkg/util/kubernetes/autoscalers/discover.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
 package autoscalers
 
 import (

--- a/pkg/util/kubernetes/autoscalers/processor.go
+++ b/pkg/util/kubernetes/autoscalers/processor.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"gopkg.in/zorkian/go-datadog-api.v2"
-	autoscalingv2 "k8s.io/api/autoscaling/v2beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilserror "k8s.io/apimachinery/pkg/util/errors"
 
@@ -85,7 +84,7 @@ func (p *Processor) ProcessEMList(emList []custommetrics.ExternalMetricValue) ma
 }
 
 // ProcessHPAs processes the HorizontalPodAutoscalers into a list of ExternalMetricValues.
-func (p *Processor) ProcessHPAs(hpa *autoscalingv2.HorizontalPodAutoscaler) map[string]custommetrics.ExternalMetricValue {
+func (p *Processor) ProcessHPAs(hpa interface{}) map[string]custommetrics.ExternalMetricValue {
 	externalMetrics := make(map[string]custommetrics.ExternalMetricValue)
 	emList := InspectHPA(hpa)
 	for _, em := range emList {

--- a/pkg/util/system/network_stub.go
+++ b/pkg/util/system/network_stub.go
@@ -8,10 +8,20 @@
 
 package system
 
+import "net"
+
 // ParseProcessRoutes is just a stub for platforms where that's currently not
 // defined (like MacOS). This allows code that refers to this (like the docker
 // check) to at least compile in those platforms, and that's useful for things
 // like running unit tests.
 func ParseProcessRoutes(procPath string, pid int) ([]NetworkRoute, error) {
 	panic("ParseProcessRoutes is not implemented in this environment")
+}
+
+// GetDefaultGateway is just a stub for platforms where that's currently not
+// defined (like MacOS). This allows code that refers to this (like the cluster
+// agent) to at least compile in those platforms, and that's useful for things
+// like running unit tests.
+func GetDefaultGateway(procPath string) (net.IP, error) {
+	panic("GetDefaultGateway is not implemented in this environment")
 }

--- a/test/e2e/argo-workflows/default-workflow.yaml
+++ b/test/e2e/argo-workflows/default-workflow.yaml
@@ -75,14 +75,14 @@ spec:
                 - name: namespace
                   value: "{{workflow.namespace}}"
 
-          # - name: start-nginx
-          #   templateRef:
-          #     name: nginx
-          #     template: create
-          #   arguments:
-          #     parameters:
-          #       - name: namespace
-          #         value: "{{workflow.namespace}}"
+          - name: start-nginx
+            templateRef:
+              name: nginx
+              template: create
+            arguments:
+              parameters:
+                - name: namespace
+                  value: "{{workflow.namespace}}"
 
         - - name: fake-dd-reset
             templateRef:
@@ -174,14 +174,14 @@ spec:
                 - name: namespace
                   value: "{{workflow.namespace}}"
 
-          # - name: test-nginx
-          #   templateRef:
-          #     name: nginx
-          #     template: test
-          #   arguments:
-          #     parameters:
-          #       - name: namespace
-          #         value: "{{workflow.namespace}}"
+          - name: test-nginx
+            templateRef:
+              name: nginx
+              template: test
+            arguments:
+              parameters:
+                - name: namespace
+                  value: "{{workflow.namespace}}"
 
           - name: test-busybox
             templateRef:
@@ -201,14 +201,14 @@ spec:
                 - name: namespace
                   value: "{{workflow.namespace}}"
 
-          # - name: stop-nginx
-          #   templateRef:
-          #     name: nginx
-          #     template: delete
-          #   arguments:
-          #     parameters:
-          #       - name: namespace
-          #         value: "{{workflow.namespace}}"
+          - name: stop-nginx
+            templateRef:
+              name: nginx
+              template: delete
+            arguments:
+              parameters:
+                - name: namespace
+                  value: "{{workflow.namespace}}"
 
         - - name: no-more-redis
             templateRef:
@@ -219,14 +219,14 @@ spec:
                 - name: namespace
                   value: "{{workflow.namespace}}"
 
-          # - name: no-more-nginx
-          #   templateRef:
-          #     name: nginx
-          #     template: no-more-metrics
-          #   arguments:
-          #     parameters:
-          #       - name: namespace
-          #         value: "{{workflow.namespace}}"
+          - name: no-more-nginx
+            templateRef:
+              name: nginx
+              template: no-more-metrics
+            arguments:
+              parameters:
+                - name: namespace
+                  value: "{{workflow.namespace}}"
 
     - name: exit-handler
       steps:
@@ -285,14 +285,14 @@ spec:
                 - name: namespace
                   value: "{{workflow.namespace}}"
 
-          # - name: stop-nginx
-          #   templateRef:
-          #     name: nginx
-          #     template: delete
-          #   arguments:
-          #     parameters:
-          #       - name: namespace
-          #         value: "{{workflow.namespace}}"
+          - name: stop-nginx
+            templateRef:
+              name: nginx
+              template: delete
+            arguments:
+              parameters:
+                - name: namespace
+                  value: "{{workflow.namespace}}"
 
           - name: stop-fake-datadog
             templateRef:
@@ -330,14 +330,14 @@ spec:
               parameters:
                 - name: namespace
                   value: "{{workflow.namespace}}"
-          # - name: diagnose-nginx
-          #   templateRef:
-          #     name: nginx
-          #     template: diagnose
-          #   arguments:
-          #     parameters:
-          #       - name: namespace
-          #         value: "{{workflow.namespace}}"
+          - name: diagnose-nginx
+            templateRef:
+              name: nginx
+              template: diagnose
+            arguments:
+              parameters:
+                - name: namespace
+                  value: "{{workflow.namespace}}"
           - name: diagnose-busybox
             templateRef:
               name: busybox

--- a/test/e2e/argo-workflows/templates/nginx.yaml
+++ b/test/e2e/argo-workflows/templates/nginx.yaml
@@ -132,7 +132,9 @@ spec:
                   selector:
                     matchLabels:
                         kube_container_name: nginx
-                targetAverageValue: 9
+                target:
+                  type: AverageValue
+                  averageValue: 9
 
     - name: delete-service
       inputs:

--- a/test/e2e/argo-workflows/templates/nginx.yaml
+++ b/test/e2e/argo-workflows/templates/nginx.yaml
@@ -112,7 +112,7 @@ spec:
       resource:
         action: apply
         manifest: |
-          apiVersion: autoscaling/v2beta1
+          apiVersion: autoscaling/v2
           kind: HorizontalPodAutoscaler
           metadata:
             name: nginxext
@@ -127,10 +127,11 @@ spec:
             metrics:
             - type: External
               external:
-                metricName: nginx.net.request_per_s
-                metricSelector:
-                  matchLabels:
-                      kube_container_name: nginx
+                metric:
+                  name: nginx.net.request_per_s
+                  selector:
+                    matchLabels:
+                        kube_container_name: nginx
                 targetAverageValue: 9
 
     - name: delete-service
@@ -179,7 +180,7 @@ spec:
       resource:
         action: delete
         manifest: |
-          apiVersion: autoscaling/v2beta1
+          apiVersion: autoscaling/v2
           kind: HorizontalPodAutoscaler
           metadata:
             name: nginxext


### PR DESCRIPTION
### What does this PR do?

Adds support for v2beta2 and v2 HorizontalPodAutoscalers in the external metrics server, effectively adding support for Kubernetes 1.25+, where support for v2beta1 has been removed.

### Describe how to test/QA your changes

Test that HorizontalPodAutoscaler support works in the external metrics server ([docs](https://docs.datadoghq.com/containers/cluster_agent/external_metrics/?tab=helm)). This needs to be tested in Kubernetes < 1.12 (to use v2beta1), < 1.23 (to use v2beta2), >= 1.23 (to use v2), and >= 1.25 (to ensure that the removed v2beta1 doesn't break).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
