### PR TITLE
[gitlab] Update container jobs owners

### DIFF
--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -32,20 +32,17 @@ dca_scan_*_docker_hub*               @DataDog/container-integrations
 check_already_deployed_version_*     @DataDog/do-not-notify
 
 # Dev container deploy
-# HACK: Silenced for now, uncomment and remove the next section once
-# public-images is fixed.
-# dca_dev_branch*                      @DataDog/container-integrations
-# dev_branch*                          @DataDog/container-integrations
-# dev_master*                          @DataDog/container-integrations
-# dev_nightly*                         @DataDog/container-integrations
-# docker_trigger_internal*             @DataDog/container-integrations
+dca_dev_branch*                        @DataDog/container-integrations
+dev_branch*                            @DataDog/container-integrations
+dev_master*                            @DataDog/container-integrations
+dev_nightly*                           @DataDog/container-integrations
 
-dca_dev_branch*                        @DataDog/do-not-notify
-dev_branch*                            @DataDog/do-not-notify
-dev_master*                            @DataDog/do-not-notify
-dev_nightly*                           @DataDog/do-not-notify
-docker_trigger_internal*               @DataDog/do-not-notify
-docker_trigger_cluster_agent_internal* @DataDog/do-not-notify
+# Internal image deploy
+docker_trigger_internal*               @DataDog/container-integrations
+docker_trigger_cluster_agent_internal* @DataDog/container-integrations
+
+# Internal kubernetes deploy
+internal_kubernetes_deploy*           @DataDog/container-integrations
 
 # Deploy
 deploy_containers*                   @DataDog/container-integrations


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Update the list of owners for container deploy-related jobs which use `public-images` and `k8s-datadog-agent-ops`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Notify the correct owners when errors happen on these jobs.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

n/a

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

n/a

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
