### PR TITLE
Fix flaky integration tests

### DIFF
--- a/test/integration/util/kube_apiserver/testdata/apiserver-compose.yaml
+++ b/test/integration/util/kube_apiserver/testdata/apiserver-compose.yaml
@@ -12,7 +12,7 @@ services:
       retries: 30
 
   apiserver:
-    image: "k8s.gcr.io/hyperkube:v1.18.6"
+    image: registry.k8s.io/hyperkube:v1.18.20
     command: "kube-apiserver
         --apiserver-count=1
         --insecure-bind-address=0.0.0.0
@@ -26,7 +26,7 @@ services:
       etcd:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "/hyperkube", "kubectl", "get", "cs"]
+      test: ["CMD-SHELL", "kubectl get cs && kubectl get ns default"]
       interval: 5s
       timeout: 5s
       retries: 30

--- a/test/integration/util/leaderelection/testdata/apiserver-compose.yaml
+++ b/test/integration/util/leaderelection/testdata/apiserver-compose.yaml
@@ -12,7 +12,7 @@ services:
       retries: 30
 
   apiserver:
-    image: "k8s.gcr.io/hyperkube:v1.18.6"
+    image: registry.k8s.io/hyperkube:v1.18.20
     command: "kube-apiserver
         --apiserver-count=1
         --insecure-bind-address=0.0.0.0
@@ -26,7 +26,7 @@ services:
       etcd:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "/hyperkube", "kubectl", "get", "cs"]
+      test: ["CMD-SHELL", "kubectl get cs && kubectl get ns default"]
       interval: 5s
       timeout: 5s
       retries: 30


### PR DESCRIPTION
### What does this PR do?

Fix flaky integration tests (`default` namespace missing in apiserver)

### Motivation

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
