### PR TITLE
[backport] [omnibus] upgrade Python3 to `3.8.14`.

### DIFF
--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -1,7 +1,7 @@
 name "python3"
 
 if ohai["platform"] != "windows"
-  default_version "3.8.13"
+  default_version "3.8.14"
   dependency "libffi"
   dependency "ncurses"
   dependency "zlib"
@@ -13,7 +13,7 @@ if ohai["platform"] != "windows"
   dependency "libyaml"
 
   source :url => "https://python.org/ftp/python/#{version}/Python-#{version}.tgz",
-         :sha256 => "903b92d76354366b1d9c4434d0c81643345cef87c1600adfa36095d7b00eede4"
+         :sha256 => "41f959c480c59211feb55d5a28851a56c7e22d02ef91035606ebb21011723c31"
 
   relative_path "Python-#{version}"
 
@@ -64,19 +64,19 @@ if ohai["platform"] != "windows"
   end
 
 else
-  default_version "3.8.13-f42eb31"
+  default_version "3.8.14-4e8b020"
   dependency "vc_redist_14"
 
   if windows_arch_i386?
     dependency "vc_ucrt_redist"
 
     source :url => "https://dd-agent-omnibus.s3.amazonaws.com/python-windows-#{version}-x86.zip",
-            :sha256 => "8FB8D4BC7D49CF081904E5EBE4137E877D152FDDBD038F4C62D762CF94543802".downcase
+            :sha256 => "5234E8506BCD00C99B044845298B8E8AE23078D9A69650D373053E9ADB006612".downcase
   else
 
     # note that startring with 3.7.3 on Windows, the zip should be created without the built-in pip
     source :url => "https://dd-agent-omnibus.s3.amazonaws.com/python-windows-#{version}-x64.zip",
-         :sha256 => "ABD557EA0FA923CDC321E0E6828DF5269023994BA96F9E64DA9BB058AE429A26".downcase
+         :sha256 => "ADE9A2CFD7EF66BB3488350A80C8EBFE1C322784CDC17E5A6783216F8EA89181".downcase
 
   end
   vcrt140_root = "#{Omnibus::Config.source_dir()}/vc_redist_140/expanded"

--- a/releasenotes/notes/update_python_3_8_14-04749cfb970dc060.yaml
+++ b/releasenotes/notes/update_python_3_8_14-04749cfb970dc060.yaml
@@ -1,0 +1,3 @@
+other:
+  - |
+    Bump embedded Python3 to `3.8.14`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 # To edit the requirements file, open a PR on github.com/DataDog/datadog-agent-buildimages
--r https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/main/requirements.txt
+-r https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/7.39.x/requirements.txt


### PR DESCRIPTION
### What does this PR do?

Backport PR to upgrade embedded CPython3 to version `3.8.14` in order to address [CVE-2020-10735](https://nvd.nist.gov/vuln/detail/CVE-2020-10735).

### Additional notes

`integrations-tests` CI job will fail because of the python requirements commit of the PR.

### Describe how to test/QA your changes

Make sure Python integrations are still working.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
