### PR TITLE
[7.39] Deactivate HTTP2 on DCA, CLC

### DIFF
--- a/cmd/agent/internal/clcrunnerapi/clc_runner_server.go
+++ b/cmd/agent/internal/clcrunnerapi/clc_runner_server.go
@@ -85,6 +85,8 @@ func StartCLCRunnerServer(extraHandlers map[string]http.Handler) error {
 	logWriter, _ := config.NewLogWriter(4, seelog.WarnLvl)
 
 	srv := &http.Server{
+		// Disable HTTP2 by setting TLSNextProto explicitly
+		TLSNextProto:      map[string]func(*http.Server, *tls.Conn, http.Handler){},
 		Handler:           r,
 		ErrorLog:          stdLog.New(logWriter, "Error from the clc runner http API server: ", 0), // log errors to seelog,
 		TLSConfig:         &tlsConfig,

--- a/cmd/cluster-agent/admission/server.go
+++ b/cmd/cluster-agent/admission/server.go
@@ -93,6 +93,8 @@ func (s *Server) Run(mainCtx context.Context, client kubernetes.Interface) error
 				return cert, nil
 			},
 		},
+		// Disable HTTP2 by setting TLSNextProto explicitly
+		TLSNextProto: map[string]func(*http.Server, *tls.Conn, http.Handler){},
 	}
 	go func() error {
 		return log.Error(server.ListenAndServeTLS("", ""))

--- a/cmd/cluster-agent/api/server.go
+++ b/cmd/cluster-agent/api/server.go
@@ -97,6 +97,8 @@ func StartServer() error {
 	logWriter, _ := config.NewLogWriter(4, seelog.WarnLvl)
 
 	srv := &http.Server{
+		// Disable HTTP2 by setting TLSNextProto explicitly
+		TLSNextProto: map[string]func(*http.Server, *tls.Conn, http.Handler){},
 		Handler:      router,
 		ErrorLog:     stdLog.New(logWriter, "Error from the agent http API server: ", 0), // log errors to seelog,
 		TLSConfig:    &tlsConfig,

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -185,7 +185,7 @@ func start(cmd *cobra.Command, args []string) error {
 	}()
 
 	// Setup healthcheck port
-	var healthPort = config.Datadog.GetInt("health_port")
+	healthPort := config.Datadog.GetInt("health_port")
 	if healthPort > 0 {
 		err := healthprobe.Serve(mainCtx, healthPort)
 		if err != nil {

--- a/cmd/cluster-agent/custommetrics/server.go
+++ b/cmd/cluster-agent/custommetrics/server.go
@@ -86,6 +86,10 @@ func RunServer(ctx context.Context, apiCl *as.APIClient) error {
 	if err != nil {
 		return err
 	}
+
+	// Disabling HTTP2
+	server.GenericAPIServer.SecureServingInfo.DisableHTTP2 = true
+
 	// TODO Add extra logic to only tear down the External Metrics Server if only some components fail.
 	return server.GenericAPIServer.PrepareRun().Run(ctx.Done())
 }


### PR DESCRIPTION
### What does this PR do?

Disable HTTP2 on DCA, CLC.

### Motivation

Security fix.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Deploy Agent, Cluster Agent with Admission Controller, CLC with Advanced Dispatching and external metrics.
Verify that Agent<>Cluster Agent communication is still working.
Verify that Cluster Agent<>CLC communication is still working.
Verify that Admission Controller is still working.
Verify that the External Metrics server is still working.

Verify that these 3 endpoints to not offer HTTP2 with:
```
curl -k -v --http2-prior-knowledge https://<endpoint>
```

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
