### PR TITLE
Limit number of kernel header download attempts

### DIFF
--- a/pkg/ebpf/bytecode/runtime/asset.go
+++ b/pkg/ebpf/bytecode/runtime/asset.go
@@ -53,11 +53,10 @@ func (a *asset) Compile(config *ebpf.Config, additionalFlags []string, client st
 		}
 	}()
 
-	kernelHeaders, fetchResult, err := kernel.GetKernelHeaders(config.EnableKernelHeaderDownload, config.KernelHeadersDirs, config.KernelHeadersDownloadDir, config.AptConfigDir, config.YumReposDir, config.ZypperReposDir)
-	a.tm.headerFetchResult = fetchResult
-	if err != nil {
+	kernelHeaders := kernel.GetKernelHeaders(config, client)
+	if len(kernelHeaders) == 0 {
 		a.tm.compilationResult = headerFetchErr
-		return nil, fmt.Errorf("unable to find kernel headers: %w", err)
+		return nil, fmt.Errorf("unable to find kernel headers")
 	}
 
 	outputDir := config.RuntimeCompilerOutputDir

--- a/pkg/ebpf/bytecode/runtime/generated_asset.go
+++ b/pkg/ebpf/bytecode/runtime/generated_asset.go
@@ -49,11 +49,10 @@ func (a *generatedAsset) Compile(config *ebpf.Config, inputCode string, addition
 		}
 	}()
 
-	kernelHeaders, fetchResult, err := kernel.GetKernelHeaders(config.EnableKernelHeaderDownload, config.KernelHeadersDirs, config.KernelHeadersDownloadDir, config.AptConfigDir, config.YumReposDir, config.ZypperReposDir)
-	a.tm.headerFetchResult = fetchResult
-	if err != nil {
+	kernelHeaders := kernel.GetKernelHeaders(config, client)
+	if len(kernelHeaders) == 0 {
 		a.tm.compilationResult = headerFetchErr
-		return nil, fmt.Errorf("unable to find kernel headers: %w", err)
+		return nil, fmt.Errorf("unable to find kernel headers")
 	}
 
 	outputDir := config.RuntimeCompilerOutputDir

--- a/pkg/network/encoding/encoding.go
+++ b/pkg/network/encoding/encoding.go
@@ -97,6 +97,7 @@ func modelConnections(conns *network.Connections) *model.Connections {
 	payload.Dns = dnsFormatter.DNS()
 	payload.ConnTelemetryMap = FormatConnectionTelemetry(conns.ConnTelemetry)
 	payload.CompilationTelemetryByAsset = FormatCompilationTelemetry(conns.CompilationTelemetryByAsset)
+	payload.KernelHeaderFetchResult = model.KernelHeaderFetchResult(conns.KernelHeaderFetchResult)
 	payload.Routes = routes
 	payload.Tags = tagsSet.GetStrings()
 

--- a/pkg/network/encoding/format.go
+++ b/pkg/network/encoding/format.go
@@ -101,7 +101,6 @@ func FormatCompilationTelemetry(telByAsset map[string]network.RuntimeCompilation
 		t := &model.RuntimeCompilationTelemetry{}
 		t.RuntimeCompilationEnabled = tel.RuntimeCompilationEnabled
 		t.RuntimeCompilationResult = model.RuntimeCompilationResult(tel.RuntimeCompilationResult)
-		t.KernelHeaderFetchResult = model.KernelHeaderFetchResult(tel.KernelHeaderFetchResult)
 		t.RuntimeCompilationDuration = tel.RuntimeCompilationDuration
 		ret[asset] = t
 	}

--- a/pkg/network/event_common.go
+++ b/pkg/network/event_common.go
@@ -121,6 +121,7 @@ type Connections struct {
 	DNS                         map[util.Address][]dns.Hostname
 	ConnTelemetry               map[ConnTelemetryType]int64
 	CompilationTelemetryByAsset map[string]RuntimeCompilationTelemetry
+	KernelHeaderFetchResult     int32
 	HTTP                        map[http.Key]*http.RequestStats
 	DNSStats                    dns.StatsByKeyByNameByType
 }
@@ -185,7 +186,6 @@ var (
 type RuntimeCompilationTelemetry struct {
 	RuntimeCompilationEnabled  bool
 	RuntimeCompilationResult   int32
-	KernelHeaderFetchResult    int32
 	RuntimeCompilationDuration int64
 }
 

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -363,6 +363,7 @@ func (t *Tracer) GetActiveConnections(clientID string) (*network.Connections, er
 	names := t.reverseDNS.Resolve(ips)
 	ctm := t.state.GetTelemetryDelta(clientID, t.getConnTelemetry(len(active)))
 	rctm := t.getRuntimeCompilationTelemetry()
+	khfr := int32(kernel.HeaderProvider.GetResult())
 	t.lastCheck.Store(time.Now().Unix())
 
 	return &network.Connections{
@@ -371,6 +372,7 @@ func (t *Tracer) GetActiveConnections(clientID string) (*network.Connections, er
 		DNSStats:                    delta.DNSStats,
 		HTTP:                        delta.HTTP,
 		ConnTelemetry:               ctm,
+		KernelHeaderFetchResult:     khfr,
 		CompilationTelemetryByAsset: rctm,
 	}, nil
 }
@@ -459,7 +461,6 @@ func (t *Tracer) getRuntimeCompilationTelemetry() map[string]network.RuntimeComp
 			RuntimeCompilationEnabled:  telemetry.CompilationEnabled(),
 			RuntimeCompilationResult:   telemetry.CompilationResult(),
 			RuntimeCompilationDuration: telemetry.CompilationDurationNS(),
-			KernelHeaderFetchResult:    telemetry.KernelHeaderFetchResult(),
 		}
 		result[assetName] = tm
 	}

--- a/pkg/util/kernel/find_headers_test.go
+++ b/pkg/util/kernel/find_headers_test.go
@@ -14,17 +14,22 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/ebpf"
 )
 
 func TestGetKernelHeaders(t *testing.T) {
 	if _, ok := os.LookupEnv("INTEGRATION"); !ok {
 		t.Skip("set INTEGRATION environment variable to run")
 	}
-	dirs, _, err := GetKernelHeaders(false, nil, "", "", "", "")
-	require.NoError(t, err)
+
+	cfg := testConfig()
+	dirs := GetKernelHeaders(cfg, nil)
 	assert.NotZero(t, len(dirs), "expected to find header directories")
 	t.Log(dirs)
+
+	result := HeaderProvider.GetResult()
+	assert.Equal(t, result.IsSuccess(), true)
 }
 
 func TestParseHeaderVersion(t *testing.T) {
@@ -49,5 +54,16 @@ func TestParseHeaderVersion(t *testing.T) {
 				assert.Equal(t, c.v, hv, "version mismatch of `%s`", c.body)
 			}
 		}
+	}
+}
+
+func testConfig() *ebpf.Config {
+	return &ebpf.Config{
+		EnableKernelHeaderDownload: false,
+		KernelHeadersDirs:          nil,
+		KernelHeadersDownloadDir:   "",
+		AptConfigDir:               "",
+		YumReposDir:                "",
+		ZypperReposDir:             "",
 	}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Limits the number of times kernel header downloading can be attempted to a maximum of 2 times by creating a `HeaderProvider` object which manages the fetching of kernel headers for all eBPF assets.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Every time an eBPF asset is runtime compiled, kernel headers need to be fetched. Currently, in the event that local headers can't be found and kernel header downloading fails, all subsequent attempts to fetch kernel headers will re-attempt the download. If all eBPF runtime compilable assets are enabled, this means we can attempt to download kernel headers up to 7 times. Since kernel header downloading can be a resource intensive process, we should limit the number of times which kernel header downloading can be attempted.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

1) Enable all runtime compilable assets and debug logging:
```
system_probe_config:
  log_level: debug
  enable_runtime_compiler: true
  enable_oom_kill: true
  enable_tcp_queue_length: true
network_config:
  enabled: true
service_monitoring_config:
  enabled: true
runtime_security_config:
  enabled: true
  runtime_compilation:
    enabled: true
    compiled_constants_enabled: true
```
1) a) If you have previously performed runtime compilation, remove any previously compiled assets:
```
sudo rm -rf /var/tmp/datadog-agent/system-probe/build
```
2) Run the system-probe, and verify in the logs that headers were fetched during runtime compilation of the first asset, but not for subsequent assets:
```
| starting runtime compilation of tracer.c
| beginning search for kernel headers
| found valid kernel headers at [some location]
| successfully compiled runtime version of tracer.c
...
| starting runtime compilation of [conntrack.c, http.c, tcp-queue-length.c, oom-kill.c, constant_fetcher.c, runtime-security.c]
| kernel headers requested: returning result of previous search
| successfully compiled runtime version of [conntrack.c, http.c, tcp-queue-length.c, oom-kill.c, constant_fetcher.c, runtime-security.c]
```
3) In a separate window, query the connections endpoint and verify that `kernelHeaderFetchResult` indicates the correct result:
```
sudo curl -s --unix-socket /opt/datadog-agent/run/sysprobe.sock http://unix/network_tracer/connections?client_id=1 | jq .kernelHeaderFetchResult
```
4) Stop the system-probe. Remove the compiled assets:
```
sudo rm -rf /var/tmp/datadog-agent/system-probe/build
```
5) Force kernel header downloading to occur by adding the following to your configuration:
```
system_probe_config:
  kernel_header_dirs: /dev/null
```
6) Turn off your wi-fi
7) Run the system-probe and verify in the logs that kernel header downloading was attempted and retried exactly once during compilation of the first asset, but not for subsequent assets:
```
| starting runtime compilation of tracer.c
| beginning search for kernel headers
| Downloading kernel headers for [host details]
| unable to download kernel headers: failed to download kernel headers: [some error]. Waiting 5 seconds and retrying kernel header download.
| Downloading kernel headers for [host details]
| Unable to find kernel headers: [some error]
| error compiling network tracer, falling back to pre-compiled: unable to find kernel headers
... 
| starting runtime compilation of [conntrack.c, http.c, tcp-queue-length.c, oom-kill.c, constant_fetcher.c, runtime-security.c]
| kernel headers requested: returning result of previous search
| unable to compile [asset]: unable to find kernel headers
``` 
8) In a separate window, query the connections endpoint again and verify that `kernelHeaderFetchResult` and `.compilationTelemetryByAsset` indicate the correct results:
```
sudo curl -s --unix-socket /opt/datadog-agent/run/sysprobe.sock http://unix/network_tracer/connections?client_id=1 | jq .kernelHeaderFetchResult,.compilationTelemetryByAsset
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
