### PR TITLE
Fix HTTPS for curl due to EFAULT

### DIFF
--- a/pkg/ebpf/bytecode/runtime/http.go
+++ b/pkg/ebpf/bytecode/runtime/http.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Http = NewAsset("http.c", "ef4d7eb92ce01543438433ebfcb35f38913092352222bd62dc25d220314a1e3d")
+var Http = NewAsset("http.c", "b9d9f6897e57f7896b7169142a1dfbee36e40f18ea4e49669b3c41206e80d892")

--- a/pkg/ebpf/bytecode/runtime/http.go
+++ b/pkg/ebpf/bytecode/runtime/http.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Http = NewAsset("http.c", "b9d9f6897e57f7896b7169142a1dfbee36e40f18ea4e49669b3c41206e80d892")
+var Http = NewAsset("http.c", "2c5f42529fd3a344e5d924ddf5727634747bd0093cb9ee60fd35672be3bcb3d5")

--- a/pkg/ebpf/bytecode/runtime/http.go
+++ b/pkg/ebpf/bytecode/runtime/http.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Http = NewAsset("http.c", "aae17509c6176f47a4f96a4f9bcc43afcdb0fd9bdcccd082c9d33e4669ec8367")
+var Http = NewAsset("http.c", "fe61afe06c49e856dd4f61695f95a96d658bc7d08935451fc2f5fd476ef23067")

--- a/pkg/ebpf/bytecode/runtime/http.go
+++ b/pkg/ebpf/bytecode/runtime/http.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Http = NewAsset("http.c", "82784696a8413068427094d996aa725601bc84470413006c4eb455f130779438")
+var Http = NewAsset("http.c", "aae17509c6176f47a4f96a4f9bcc43afcdb0fd9bdcccd082c9d33e4669ec8367")

--- a/pkg/ebpf/bytecode/runtime/http.go
+++ b/pkg/ebpf/bytecode/runtime/http.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Http = NewAsset("http.c", "2c5f42529fd3a344e5d924ddf5727634747bd0093cb9ee60fd35672be3bcb3d5")
+var Http = NewAsset("http.c", "82784696a8413068427094d996aa725601bc84470413006c4eb455f130779438")

--- a/pkg/ebpf/bytecode/runtime/runtime_compilation_helpers.go
+++ b/pkg/ebpf/bytecode/runtime/runtime_compilation_helpers.go
@@ -161,6 +161,7 @@ func (rc *Compiler) CompileObjectFile(config *ebpf.Config, cflags []string, inpu
 		return nil, err
 	}
 
+	log.Debugf("looking for output file: %s", outputFile)
 	if _, err := os.Stat(outputFile); err != nil {
 		if !os.IsNotExist(err) {
 			rc.telemetry.compilationResult = outputFileErr

--- a/pkg/network/ebpf/c/http-buffer.h
+++ b/pkg/network/ebpf/c/http-buffer.h
@@ -10,11 +10,13 @@
 // This function is used for the uprobe-based HTTPS monitoring (eg. OpenSSL, GnuTLS etc)
 static __always_inline void read_into_buffer(char *buffer, char *data, size_t data_size) {
     __builtin_memset(buffer, 0, HTTP_BUFFER_SIZE);
+    if (data_size >= HTTP_BUFFER_SIZE) {
+        data_size = HTTP_BUFFER_SIZE - 1;
+    }
 
     // we read HTTP_BUFFER_SIZE-1 bytes to ensure that the string is always null terminated
-    if (bpf_probe_read_user(buffer, HTTP_BUFFER_SIZE - 1, data) < 0) {
-// note: arm64 bpf_probe_read_user() could page fault if the HTTP_BUFFER_SIZE overlap a page
-#if defined(__aarch64__)
+    if (unlikely(bpf_probe_read_user(buffer, data_size, data) < 0)) {
+// note: bpf_probe_read_user() could page fault if the HTTP_BUFFER_SIZE overlap a page
 #pragma unroll
         for (int i = 0; i < HTTP_BUFFER_SIZE - 1; i++) {
             bpf_probe_read_user(&buffer[i], 1, &data[i]);
@@ -22,7 +24,6 @@ static __always_inline void read_into_buffer(char *buffer, char *data, size_t da
                 return;
             }
         }
-#endif
     }
 }
 

--- a/pkg/network/ebpf/c/http-buffer.h
+++ b/pkg/network/ebpf/c/http-buffer.h
@@ -1,6 +1,7 @@
 #ifndef __HTTP_BUFFER_H
 #define __HTTP_BUFFER_H
 
+#include <linux/err.h>
 #include "http-types.h"
 
 // This function reads a constant number of bytes into the fragment buffer of the http
@@ -14,8 +15,8 @@ static __always_inline void read_into_buffer(char *buffer, char *data, size_t da
         data_size = HTTP_BUFFER_SIZE - 1;
     }
 
-    // we read HTTP_BUFFER_SIZE-1 bytes to ensure that the string is always null terminated
-    if (unlikely(bpf_probe_read_user(buffer, data_size, data) < 0)) {
+    // we read at most HTTP_BUFFER_SIZE-1 bytes to ensure that the string is always null terminated
+    if (unlikely(bpf_probe_read_user(buffer, data_size, data) == -EFAULT)) {
 // note: bpf_probe_read_user() could page fault if the HTTP_BUFFER_SIZE overlap a page
 #pragma unroll
         for (int i = 0; i < HTTP_BUFFER_SIZE - 1; i++) {

--- a/pkg/network/ebpf/c/http-maps.h
+++ b/pkg/network/ebpf/c/http-maps.h
@@ -25,6 +25,8 @@ BPF_LRU_MAP(ssl_sock_by_ctx, void *, ssl_sock_t, 1)
 
 BPF_LRU_MAP(ssl_read_args, u64, ssl_read_args_t, 1024)
 
+BPF_LRU_MAP(ssl_write_args, u64, ssl_write_args_t, 1024)
+
 BPF_LRU_MAP(bio_new_socket_args, __u64, __u32, 1024)
 
 BPF_LRU_MAP(fd_by_ssl_bio, __u32, void *, 1024)

--- a/pkg/network/ebpf/c/http-types.h
+++ b/pkg/network/ebpf/c/http-types.h
@@ -97,6 +97,11 @@ typedef struct {
 } ssl_read_args_t;
 
 typedef struct {
+    void *ctx;
+    void *buf;
+} ssl_write_args_t;
+
+typedef struct {
     conn_tuple_t tup;
     __u32 fd;
 } ssl_sock_t;

--- a/pkg/network/ebpf/c/https.h
+++ b/pkg/network/ebpf/c/https.h
@@ -21,6 +21,7 @@ static __always_inline void https_process(conn_tuple_t *t, void *buffer, size_t 
     __builtin_memcpy(&http.tup, t, sizeof(conn_tuple_t));
     read_into_buffer((char *)http.request_fragment, buffer, len);
     http.owned_by_src_port = http.tup.sport;
+    log_debug("https_process: htx=%llx sport=%d\n", &http, http.owned_by_src_port);
     http_process(&http, NULL, tags);
 }
 

--- a/pkg/network/ebpf/c/https.h
+++ b/pkg/network/ebpf/c/https.h
@@ -19,7 +19,7 @@ static __always_inline void https_process(conn_tuple_t *t, void *buffer, size_t 
     http_transaction_t http;
     __builtin_memset(&http, 0, sizeof(http));
     __builtin_memcpy(&http.tup, t, sizeof(conn_tuple_t));
-    read_into_buffer((char *)http.request_fragment, buffer, len);
+    read_into_buffer(http.request_fragment, buffer, len);
     http.owned_by_src_port = http.tup.sport;
     log_debug("https_process: htx=%llx sport=%d\n", &http, http.owned_by_src_port);
     http_process(&http, NULL, tags);

--- a/pkg/network/ebpf/c/prebuilt/http.c
+++ b/pkg/network/ebpf/c/prebuilt/http.c
@@ -142,7 +142,7 @@ int uprobe__SSL_set_bio(struct pt_regs* ctx) {
     void *bio = (void *)PT_REGS_PARM2(ctx);
     log_debug("uprobe/SSL_set_bio: ctx=%llx bio=%llx\n", ssl_ctx, bio);
     u32 *socket_fd = bpf_map_lookup_elem(&fd_by_ssl_bio, &bio);
-    if (socket_fd == NULL)  {
+    if (socket_fd == NULL) {
         return 0;
     }
     init_ssl_sock(ssl_ctx, *socket_fd);
@@ -164,6 +164,12 @@ int uprobe__SSL_read(struct pt_regs* ctx) {
 SEC("uretprobe/SSL_read")
 int uretprobe__SSL_read(struct pt_regs* ctx) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
+    int len = (int)PT_REGS_RC(ctx);
+    if (len <= 0) {
+        log_debug("uretprobe/SSL_read: pid_tgid=%llx ret=%d\n", pid_tgid, len);
+        goto cleanup;
+    }
+
     log_debug("uretprobe/SSL_read: pid_tgid=%llx\n", pid_tgid);
     ssl_read_args_t *args = bpf_map_lookup_elem(&ssl_read_args, &pid_tgid);
     if (args == NULL) {
@@ -177,12 +183,6 @@ int uretprobe__SSL_read(struct pt_regs* ctx) {
         goto cleanup;
     }
 
-    int len = (int)PT_REGS_RC(ctx);
-    if (len <= 0) {
-        log_debug("uretprobe/SSL_read: pid_tgid=%llx ctx=%llx ret=%d\n", pid_tgid, ssl_ctx, len);
-        goto cleanup;
-    }
-
     https_process(t, args->buf, len, LIBSSL);
 cleanup:
     bpf_map_delete_elem(&ssl_read_args, &pid_tgid);
@@ -191,17 +191,37 @@ cleanup:
 
 SEC("uprobe/SSL_write")
 int uprobe__SSL_write(struct pt_regs* ctx) {
-    void *ssl_ctx = (void *)PT_REGS_PARM1(ctx);
+    ssl_write_args_t args = {0};
+    args.ctx = (void *)PT_REGS_PARM1(ctx);
+    args.buf = (void *)PT_REGS_PARM2(ctx);
     u64 pid_tgid = bpf_get_current_pid_tgid();
-    log_debug("uprobe/SSL_write: pid_tgid=%llx ctx=%llx\n", pid_tgid, ssl_ctx);
-    conn_tuple_t *t = tup_from_ssl_ctx(ssl_ctx, pid_tgid);
-    if (t == NULL) {
+    log_debug("uprobe/SSL_write: pid_tgid=%llx ctx=%llx\n", pid_tgid, args.ctx);
+    bpf_map_update_elem(&ssl_write_args, &pid_tgid, &args, BPF_ANY);
+    return 0;
+}
+
+SEC("uretprobe/SSL_write")
+int uretprobe_SSL_write(struct pt_regs* ctx) {
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    int write_len = (int)PT_REGS_RC(ctx);
+    log_debug("uretprobe/SSL_write: pid_tgid=%llx len=%d\n", pid_tgid, write_len);
+    if (write_len <= 0) {
+        goto cleanup;
+    }
+
+    ssl_write_args_t *args = bpf_map_lookup_elem(&ssl_write_args, &pid_tgid);
+    if (args == NULL) {
         return 0;
     }
 
-    void *ssl_buffer = (void *)PT_REGS_PARM2(ctx);
-    int len = (int)PT_REGS_PARM3(ctx);
-    https_process(t, ssl_buffer, len, LIBSSL);
+    conn_tuple_t *t = tup_from_ssl_ctx(args->ctx, pid_tgid);
+    if (t == NULL) {
+        goto cleanup;
+    }
+
+    https_process(t, args->buf, write_len, LIBSSL);
+cleanup:
+    bpf_map_delete_elem(&ssl_write_args, &pid_tgid);
     return 0;
 }
 
@@ -300,9 +320,12 @@ int uprobe__gnutls_record_recv(struct pt_regs *ctx) {
 // ssize_t gnutls_record_recv (gnutls_session_t session, void * data, size_t data_size)
 SEC("uretprobe/gnutls_record_recv")
 int uretprobe__gnutls_record_recv(struct pt_regs *ctx) {
-    ssize_t read_len = (ssize_t)PT_REGS_RC(ctx);
-
     u64 pid_tgid = bpf_get_current_pid_tgid();
+    ssize_t read_len = (ssize_t)PT_REGS_RC(ctx);
+    if (read_len <= 0) {
+        goto cleanup;
+    }
+
     // Re-use the map for SSL_read
     ssl_read_args_t *args = bpf_map_lookup_elem(&ssl_read_args, &pid_tgid);
     if (args == NULL) {
@@ -316,9 +339,6 @@ int uretprobe__gnutls_record_recv(struct pt_regs *ctx) {
         goto cleanup;
     }
 
-    if (read_len <= 0) {
-        goto cleanup;
-    }
     https_process(t, args->buf, read_len, LIBGNUTLS);
 cleanup:
     bpf_map_delete_elem(&ssl_read_args, &pid_tgid);
@@ -328,18 +348,37 @@ cleanup:
 // ssize_t gnutls_record_send (gnutls_session_t session, const void * data, size_t data_size)
 SEC("uprobe/gnutls_record_send")
 int uprobe__gnutls_record_send(struct pt_regs *ctx) {
-    void *ssl_session = (void *)PT_REGS_PARM1(ctx);
-    void *data = (void *)PT_REGS_PARM2(ctx);
-    size_t data_size = (size_t)PT_REGS_PARM3(ctx);
-
+    ssl_write_args_t args = {0};
+    args.ctx = (void *)PT_REGS_PARM1(ctx);
+    args.buf = (void *)PT_REGS_PARM2(ctx);
     u64 pid_tgid = bpf_get_current_pid_tgid();
-    log_debug("gnutls_record_send: pid=%llu ctx=%llx\n", pid_tgid, ssl_session);
-    conn_tuple_t *t = tup_from_ssl_ctx(ssl_session, pid_tgid);
+    log_debug("uprobe/gnutls_record_send: pid=%llu ctx=%llx\n", pid_tgid, args.ctx);
+    bpf_map_update_elem(&ssl_write_args, &pid_tgid, &args, BPF_ANY);
+    return 0;
+}
+
+SEC("uretprobe/gnutls_record_send")
+int uretprobe__gnutls_record_send(struct pt_regs *ctx) {
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    ssize_t write_len = (ssize_t)PT_REGS_RC(ctx);
+    log_debug("uretprobe/gnutls_record_send: pid=%llu len=%d\n", pid_tgid, write_len);
+    if (write_len <= 0) {
+        goto cleanup;
+    }
+
+    ssl_write_args_t *args = bpf_map_lookup_elem(&ssl_write_args, &pid_tgid);
+    if (args == NULL) {
+        goto cleanup;
+    }
+
+    conn_tuple_t *t = tup_from_ssl_ctx(args->ctx, pid_tgid);
     if (t == NULL) {
         return 0;
     }
 
-    https_process(t, data, data_size, LIBGNUTLS);
+    https_process(t, args->buf, write_len, LIBGNUTLS);
+cleanup:
+    bpf_map_delete_elem(&ssl_write_args, &pid_tgid);
     return 0;
 }
 

--- a/pkg/network/ebpf/c/prebuilt/http.c
+++ b/pkg/network/ebpf/c/prebuilt/http.c
@@ -368,12 +368,12 @@ int uretprobe__gnutls_record_send(struct pt_regs *ctx) {
 
     ssl_write_args_t *args = bpf_map_lookup_elem(&ssl_write_args, &pid_tgid);
     if (args == NULL) {
-        goto cleanup;
+        return 0;
     }
 
     conn_tuple_t *t = tup_from_ssl_ctx(args->ctx, pid_tgid);
     if (t == NULL) {
-        return 0;
+        goto cleanup;
     }
 
     https_process(t, args->buf, write_len, LIBGNUTLS);

--- a/pkg/network/ebpf/c/prebuilt/http.c
+++ b/pkg/network/ebpf/c/prebuilt/http.c
@@ -201,7 +201,7 @@ int uprobe__SSL_write(struct pt_regs* ctx) {
 }
 
 SEC("uretprobe/SSL_write")
-int uretprobe_SSL_write(struct pt_regs* ctx) {
+int uretprobe__SSL_write(struct pt_regs* ctx) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     int write_len = (int)PT_REGS_RC(ctx);
     log_debug("uretprobe/SSL_write: pid_tgid=%llx len=%d\n", pid_tgid, write_len);

--- a/pkg/network/ebpf/c/runtime/http.c
+++ b/pkg/network/ebpf/c/runtime/http.c
@@ -368,12 +368,12 @@ int uretprobe__gnutls_record_send(struct pt_regs *ctx) {
 
     ssl_write_args_t *args = bpf_map_lookup_elem(&ssl_write_args, &pid_tgid);
     if (args == NULL) {
-        goto cleanup;
+        return 0;
     }
 
     conn_tuple_t *t = tup_from_ssl_ctx(args->ctx, pid_tgid);
     if (t == NULL) {
-        return 0;
+        goto cleanup;
     }
 
     https_process(t, args->buf, write_len, LIBGNUTLS);

--- a/pkg/network/ebpf/c/runtime/http.c
+++ b/pkg/network/ebpf/c/runtime/http.c
@@ -48,6 +48,7 @@ int socket__http_filter(struct __sk_buff *skb) {
 
 SEC("kprobe/tcp_sendmsg")
 int kprobe__tcp_sendmsg(struct pt_regs *ctx) {
+    log_debug("kprobe/tcp_sendmsg: sk=%llx\n", PT_REGS_PARM1(ctx));
     // map connection tuple during SSL_do_handshake(ctx)
     init_ssl_sock_from_do_handshake((struct sock *)PT_REGS_PARM1(ctx));
     return 0;
@@ -55,6 +56,7 @@ int kprobe__tcp_sendmsg(struct pt_regs *ctx) {
 
 SEC("kretprobe/security_sock_rcv_skb")
 int kretprobe__security_sock_rcv_skb(struct pt_regs* ctx) {
+    log_debug("kretprobe/security_sock_rcv_skb:\n");
     // flush batch to userspace
     // because perf events can't be sent from socket filter programs
     http_flush_batch(ctx);
@@ -65,6 +67,7 @@ SEC("uprobe/SSL_do_handshake")
 int uprobe__SSL_do_handshake(struct pt_regs *ctx) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     void *ssl_ctx = (void *)PT_REGS_PARM1(ctx);
+    log_debug("uprobe/SSL_do_handshake: pid_tgid=%llx ssl_ctx=%llx\n", pid_tgid, ssl_ctx);
     bpf_map_update_elem(&ssl_ctx_by_pid_tgid, &pid_tgid, &ssl_ctx, BPF_ANY);
     return 0;
 }
@@ -72,6 +75,7 @@ int uprobe__SSL_do_handshake(struct pt_regs *ctx) {
 SEC("uretprobe/SSL_do_handshake")
 int uretprobe__SSL_do_handshake(struct pt_regs *ctx) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
+    log_debug("uretprobe/SSL_do_handshake: pid_tgid=%llx\n", pid_tgid);
     bpf_map_delete_elem(&ssl_ctx_by_pid_tgid, &pid_tgid);
     return 0;
 }
@@ -80,6 +84,7 @@ SEC("uprobe/SSL_connect")
 int uprobe__SSL_connect(struct pt_regs *ctx) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     void *ssl_ctx = (void *)PT_REGS_PARM1(ctx);
+    log_debug("uprobe/SSL_connect: pid_tgid=%llx ssl_ctx=%llx\n", pid_tgid, ssl_ctx);
     bpf_map_update_elem(&ssl_ctx_by_pid_tgid, &pid_tgid, &ssl_ctx, BPF_ANY);
     return 0;
 }
@@ -87,6 +92,7 @@ int uprobe__SSL_connect(struct pt_regs *ctx) {
 SEC("uretprobe/SSL_connect")
 int uretprobe__SSL_connect(struct pt_regs *ctx) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
+    log_debug("uretprobe/SSL_connect: pid_tgid=%llx\n", pid_tgid);
     bpf_map_delete_elem(&ssl_ctx_by_pid_tgid, &pid_tgid);
     return 0;
 }
@@ -96,6 +102,7 @@ SEC("uprobe/SSL_set_fd")
 int uprobe__SSL_set_fd(struct pt_regs *ctx) {
     void *ssl_ctx = (void *)PT_REGS_PARM1(ctx);
     u32 socket_fd = (u32)PT_REGS_PARM2(ctx);
+    log_debug("uprobe/SSL_set_fd: ctx=%llx fd=%d\n", ssl_ctx, socket_fd);
     init_ssl_sock(ssl_ctx, socket_fd);
     return 0;
 }
@@ -104,6 +111,7 @@ SEC("uprobe/BIO_new_socket")
 int uprobe__BIO_new_socket(struct pt_regs *ctx) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     u32 socket_fd = (u32)PT_REGS_PARM1(ctx);
+    log_debug("uprobe/BIO_new_socket: pid_tgid=%llx fd=%d\n", pid_tgid, socket_fd);
     bpf_map_update_elem(&bio_new_socket_args, &pid_tgid, &socket_fd, BPF_ANY);
     return 0;
 }
@@ -111,6 +119,7 @@ int uprobe__BIO_new_socket(struct pt_regs *ctx) {
 SEC("uretprobe/BIO_new_socket")
 int uretprobe__BIO_new_socket(struct pt_regs *ctx) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
+    log_debug("uretprobe/BIO_new_socket: pid_tgid=%llx\n", pid_tgid);
     u32 *socket_fd = bpf_map_lookup_elem(&bio_new_socket_args, &pid_tgid);
     if (socket_fd == NULL) {
         return 0;
@@ -131,6 +140,7 @@ SEC("uprobe/SSL_set_bio")
 int uprobe__SSL_set_bio(struct pt_regs *ctx) {
     void *ssl_ctx = (void *)PT_REGS_PARM1(ctx);
     void *bio = (void *)PT_REGS_PARM2(ctx);
+    log_debug("uprobe/SSL_set_bio: ctx=%llx bio=%llx\n", ssl_ctx, bio);
     u32 *socket_fd = bpf_map_lookup_elem(&fd_by_ssl_bio, &bio);
     if (socket_fd == NULL) {
         return 0;
@@ -146,6 +156,7 @@ int uprobe__SSL_read(struct pt_regs *ctx) {
     args.ctx = (void *)PT_REGS_PARM1(ctx);
     args.buf = (void *)PT_REGS_PARM2(ctx);
     u64 pid_tgid = bpf_get_current_pid_tgid();
+    log_debug("uprobe/SSL_read: pid_tgid=%llx ctx=%llx\n", pid_tgid, args.ctx);
     bpf_map_update_elem(&ssl_read_args, &pid_tgid, &args, BPF_ANY);
     return 0;
 }
@@ -153,6 +164,7 @@ int uprobe__SSL_read(struct pt_regs *ctx) {
 SEC("uretprobe/SSL_read")
 int uretprobe__SSL_read(struct pt_regs *ctx) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
+    log_debug("uretprobe/SSL_read: pid_tgid=%llx\n", pid_tgid);
     ssl_read_args_t *args = bpf_map_lookup_elem(&ssl_read_args, &pid_tgid);
     if (args == NULL) {
         return 0;
@@ -164,7 +176,12 @@ int uretprobe__SSL_read(struct pt_regs *ctx) {
         goto cleanup;
     }
 
-    u32 len = (u32)PT_REGS_RC(ctx);
+    int len = (int)PT_REGS_RC(ctx);
+    if (len <= 0) {
+        log_debug("uretprobe/SSL_read: pid_tgid=%llx ctx=%llx ret=%d\n", pid_tgid, ssl_ctx, len);
+        goto cleanup;
+    }
+
     https_process(t, args->buf, len, LIBSSL);
 cleanup:
     bpf_map_delete_elem(&ssl_read_args, &pid_tgid);
@@ -175,13 +192,14 @@ SEC("uprobe/SSL_write")
 int uprobe__SSL_write(struct pt_regs *ctx) {
     void *ssl_ctx = (void *)PT_REGS_PARM1(ctx);
     u64 pid_tgid = bpf_get_current_pid_tgid();
+    log_debug("uprobe/SSL_write: pid_tgid=%llx ctx=%llx\n", pid_tgid, ssl_ctx);
     conn_tuple_t *t = tup_from_ssl_ctx(ssl_ctx, pid_tgid);
     if (t == NULL) {
         return 0;
     }
 
     void *ssl_buffer = (void *)PT_REGS_PARM2(ctx);
-    size_t len = (size_t)PT_REGS_PARM3(ctx);
+    int len = (int)PT_REGS_PARM3(ctx);
     https_process(t, ssl_buffer, len, LIBSSL);
     return 0;
 }
@@ -190,6 +208,7 @@ SEC("uprobe/SSL_shutdown")
 int uprobe__SSL_shutdown(struct pt_regs *ctx) {
     void *ssl_ctx = (void *)PT_REGS_PARM1(ctx);
     u64 pid_tgid = bpf_get_current_pid_tgid();
+    log_debug("uprobe/SSL_shutdown: pid_tgid=%llx ctx=%llx\n", pid_tgid, ssl_ctx);
     conn_tuple_t *t = tup_from_ssl_ctx(ssl_ctx, pid_tgid);
     if (t == NULL) {
         return 0;
@@ -296,6 +315,9 @@ int uretprobe__gnutls_record_recv(struct pt_regs *ctx) {
         goto cleanup;
     }
 
+    if (read_len <= 0) {
+        goto cleanup;
+    }
     https_process(t, args->buf, read_len, LIBGNUTLS);
 cleanup:
     bpf_map_delete_elem(&ssl_read_args, &pid_tgid);

--- a/pkg/network/ebpf/c/runtime/http.c
+++ b/pkg/network/ebpf/c/runtime/http.c
@@ -201,7 +201,7 @@ int uprobe__SSL_write(struct pt_regs* ctx) {
 }
 
 SEC("uretprobe/SSL_write")
-int uretprobe_SSL_write(struct pt_regs* ctx) {
+int uretprobe__SSL_write(struct pt_regs* ctx) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     int write_len = (int)PT_REGS_RC(ctx);
     log_debug("uretprobe/SSL_write: pid_tgid=%llx len=%d\n", pid_tgid, write_len);

--- a/pkg/network/http/ebpf_ssl.go
+++ b/pkg/network/http/ebpf_ssl.go
@@ -34,6 +34,7 @@ var openSSLProbes = map[string]string{
 	"uprobe/SSL_read":            "uprobe__SSL_read",
 	"uretprobe/SSL_read":         "uretprobe__SSL_read",
 	"uprobe/SSL_write":           "uprobe__SSL_write",
+	"uretprobe/SSL_write":        "uretprobe__SSL_write",
 	"uprobe/SSL_shutdown":        "uprobe__SSL_shutdown",
 }
 
@@ -51,6 +52,7 @@ var gnuTLSProbes = map[string]string{
 	"uprobe/gnutls_record_recv":        "uprobe__gnutls_record_recv",
 	"uretprobe/gnutls_record_recv":     "uretprobe__gnutls_record_recv",
 	"uprobe/gnutls_record_send":        "uprobe__gnutls_record_send",
+	"uretprobe/gnutls_record_send":     "uretprobe__gnutls_record_send",
 	"uprobe/gnutls_bye":                "uprobe__gnutls_bye",
 	"uprobe/gnutls_deinit":             "uprobe__gnutls_deinit",
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

The code is attempting to read `HTTP_BUFFER_SIZE - 1`, no matter how large `data_size` was. This can result in an `EFAULT` (page fault) even on `x64`. By removing the `pragma` constraining the fallback to `arm64` only, this should consistently work now.

This code also checks the return values from the write functions of OpenSSL/gnuTLS before processing the writes.

### Motivation

HTTPS tests failing for `curl` when ran on EC2.

### Additional Notes

Added some debug logs that were helpful when diagnosing the issue.

I also tried to convince the verifier that using `data_size` (length checked to be below `HTTP_BUFFER_SIZE`) was OK as the read length. This works on newer kernels, but was failing on 4.14. There may still be a way to convince the verifier, but it didn't seem to understand the size of `http_transaction_t.request_fragment`.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

1. Launch an Ubuntu 22.04 x64 instance on EC2.
2. Install agent, enable USM, restart system-probe
3. Issue HTTPS request using `curl --http1.1 -k -o /dev/null https://httpbin.org/status/200`
4. `sudo curl -s --unix /opt/datadog-agent/run/sysprobe.sock http://unix/network_tracer/debug/http_monitoring | jq '.[] | select(.Server.Port==443)'` and make sure you see the request in the output.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
