### PR TITLE
Make TestConsumerKeepsRunningAfterCircuitBreakerTrip less flaky

### DIFF
--- a/pkg/network/config/config.go
+++ b/pkg/network/config/config.go
@@ -146,6 +146,9 @@ type Config struct {
 	// Setting it to -1 disables the limit and can result in a high CPU usage.
 	ConntrackRateLimit int
 
+	// ConntrackRateLimitInterval specifies the interval at which the rate limiter is updated
+	ConntrackRateLimitInterval time.Duration
+
 	// ConntrackInitTimeout specifies how long we wait for conntrack to initialize before failing
 	ConntrackInitTimeout time.Duration
 
@@ -242,6 +245,7 @@ func New() *Config {
 		EnableConntrack:              cfg.GetBool(join(spNS, "enable_conntrack")),
 		ConntrackMaxStateSize:        cfg.GetInt(join(spNS, "conntrack_max_state_size")),
 		ConntrackRateLimit:           cfg.GetInt(join(spNS, "conntrack_rate_limit")),
+		ConntrackRateLimitInterval:   3 * time.Second,
 		EnableConntrackAllNamespaces: cfg.GetBool(join(spNS, "enable_conntrack_all_namespaces")),
 		IgnoreConntrackInitFailure:   cfg.GetBool(join(netNS, "ignore_conntrack_init_failure")),
 		ConntrackInitTimeout:         cfg.GetDuration(join(netNS, "conntrack_init_timeout")),

--- a/pkg/network/netlink/circuit_breaker.go
+++ b/pkg/network/netlink/circuit_breaker.go
@@ -15,8 +15,6 @@ import (
 )
 
 const (
-	tickInterval = 3 * time.Second
-
 	// The lower this number is the more amortized the average is
 	// For example, if ewmaWeight is 1, a single burst of events might
 	// cause the breaker to trip.
@@ -48,7 +46,7 @@ type CircuitBreaker struct {
 
 // NewCircuitBreaker instantiates a new CircuitBreaker that only allows
 // a maxEventsPerSec to pass. The rate of events is calculated using an EWMA.
-func NewCircuitBreaker(maxEventsPerSec int64) *CircuitBreaker {
+func NewCircuitBreaker(maxEventsPerSec int64, tickInterval time.Duration) *CircuitBreaker {
 	// -1 will virtually disable the circuit breaker
 	if maxEventsPerSec == -1 {
 		maxEventsPerSec = math.MaxInt64

--- a/pkg/network/netlink/consumer.go
+++ b/pkg/network/netlink/consumer.go
@@ -135,7 +135,7 @@ func NewConsumer(cfg *config.Config) (*Consumer, error) {
 		procRoot:            cfg.ProcRoot,
 		pool:                newBufferPool(),
 		targetRateLimit:     cfg.ConntrackRateLimit,
-		breaker:             NewCircuitBreaker(int64(cfg.ConntrackRateLimit)),
+		breaker:             NewCircuitBreaker(int64(cfg.ConntrackRateLimit), cfg.ConntrackRateLimitInterval),
 		netlinkSeqNumber:    1,
 		listenAllNamespaces: cfg.EnableConntrackAllNamespaces,
 		enobufs:             atomic.NewInt64(0),


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fixes `TestConsumerKeepsRunningAfterCircuitBreakerTrip` test to be less flaky

### Motivation

Flaky tests in CI

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
