### PR TITLE
pkg/trace/api: update info endpoint test to check only keys.

### DIFF
--- a/pkg/trace/api/info_test.go
+++ b/pkg/trace/api/info_test.go
@@ -52,7 +52,7 @@ func ensureKeys(expect, result map[string]interface{}, prefix string) error {
 			}
 		}
 	}
-	for k, _ := range result {
+	for k := range result {
 		_, ok := expect[k]
 		if !ok {
 			path := k

--- a/pkg/trace/api/info_test.go
+++ b/pkg/trace/api/info_test.go
@@ -66,7 +66,6 @@ func ensureKeys(expect, result map[string]interface{}, prefix string) error {
 // * In case a field name gets modified, the `json:""` struct field tag
 // should be used to ensure the old key is marshalled for this endpoint.
 func TestInfoHandler(t *testing.T) {
-	t.Skip("https://github.com/DataDog/datadog-agent/issues/13569")
 	u, err := url.Parse("http://localhost:8888/proxy")
 	if err != nil {
 		log.Fatal(err)

--- a/pkg/trace/api/info_test.go
+++ b/pkg/trace/api/info_test.go
@@ -21,14 +21,21 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/testutil"
 )
 
+// ensureKeys takes 2 maps, expect and result, and ensures that the set of keys in expect and
+// result match. For each key (k) in expect, if expect[k] is of type map[string]interface{}, then
+// ensureKeys recurses on expect[k], result[k], prefix + "." + k.
+// 
+// This should ensure that whatever keys and maps are defined in expect are exactly mirrored in
+// result, but without checking for specific values in result.
 func ensureKeys(expect, result map[string]interface{}, prefix string) error {
 	for k, ev := range expect {
 		rv, ok := result[k]
 		if !ok {
+			path := k
 			if prefix != "" {
-				k = prefix + "." + k
+				path = prefix + "." + k
 			}
-			return fmt.Errorf("Expected key %s, but it is not present in the output.\n", k)
+			return fmt.Errorf("Expected key %s, but it is not present in the output.\n", path)
 		}
 
 		if em, ok := ev.(map[string]interface{}); ok {
@@ -49,10 +56,11 @@ func ensureKeys(expect, result map[string]interface{}, prefix string) error {
 	for k, _ := range result {
 		_, ok := expect[k]
 		if !ok {
+			path := k
 			if prefix != "" {
-				k = prefix + "." + k
-				return fmt.Errorf("Found key %s, but it is not expected in the output. If you've added a new key to the /info endpoint, please add it to the tests.\n", k)
+				path = prefix + "." + k
 			}
+			return fmt.Errorf("Found key %s, but it is not expected in the output. If you've added a new key to the /info endpoint, please add it to the tests.\n", path)
 		}
 	}
 	return nil

--- a/pkg/trace/api/info_test.go
+++ b/pkg/trace/api/info_test.go
@@ -8,7 +8,6 @@ package api
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http/httptest"
 	"net/url"
@@ -337,11 +336,7 @@ func TestInfoHandler(t *testing.T) {
 	req := httptest.NewRequest("GET", "/info", nil)
 	h.ServeHTTP(rec, req)
 	var m map[string]interface{}
-	b, err := ioutil.ReadAll(rec.Body)
-	if !assert.NoError(t, err) {
-		return
-	}
-	if !assert.NoError(t, json.Unmarshal(b, &m)) {
+	if !assert.NoError(t, json.NewDecoder(rec.Body).Decode(&m)) {
 		return
 	}
 	assert.NoError(t, ensureKeys(expectedKeys, m, ""))

--- a/pkg/trace/api/info_test.go
+++ b/pkg/trace/api/info_test.go
@@ -84,8 +84,8 @@ func TestEnsureKeys(t *testing.T) {
 		},
 		{
 			expect: map[string]interface{}{
-				"one": nil,
-				"two": nil,
+				"one":   nil,
+				"two":   nil,
 				"three": nil,
 			},
 			result: map[string]interface{}{
@@ -100,8 +100,8 @@ func TestEnsureKeys(t *testing.T) {
 				"two": nil,
 			},
 			result: map[string]interface{}{
-				"one": 1,
-				"two": "two",
+				"one":   1,
+				"two":   "two",
 				"three": 3,
 			},
 			err: true,
@@ -110,7 +110,7 @@ func TestEnsureKeys(t *testing.T) {
 			expect: map[string]interface{}{
 				"one": nil,
 				"two": nil,
-				"sub": map[string]interface{} {
+				"sub": map[string]interface{}{
 					"subone": nil,
 					"subtwo": nil,
 				},
@@ -118,7 +118,7 @@ func TestEnsureKeys(t *testing.T) {
 			result: map[string]interface{}{
 				"one": 1,
 				"two": "two",
-				"sub": map[string]interface{} {
+				"sub": map[string]interface{}{
 					"subone": 1,
 					"subtwo": 2,
 				},
@@ -128,18 +128,18 @@ func TestEnsureKeys(t *testing.T) {
 			expect: map[string]interface{}{
 				"one": nil,
 				"two": nil,
-				"sub": map[string]interface{} {
+				"sub": map[string]interface{}{
 					"subone": nil,
 					"subtwo": nil,
 				},
 			},
 			result: map[string]interface{}{
 				"one": 1,
-				"two": map[string]interface{} { // Map values not described in expect are NOT checked, so this is OK.
+				"two": map[string]interface{}{ // Map values not described in expect are NOT checked, so this is OK.
 					"subone": 1,
 					"subtwo": 2,
 				},
-				"sub": map[string]interface{} {
+				"sub": map[string]interface{}{
 					"subone": 1,
 					"subtwo": 2,
 				},
@@ -149,19 +149,19 @@ func TestEnsureKeys(t *testing.T) {
 			expect: map[string]interface{}{
 				"one": nil,
 				"two": nil,
-				"sub": map[string]interface{} {
-					"subone": nil,
-					"subtwo": nil,
+				"sub": map[string]interface{}{
+					"subone":   nil,
+					"subtwo":   nil,
 					"subthree": nil,
 				},
 			},
 			result: map[string]interface{}{
 				"one": 1,
-				"two": map[string]interface{} { // Map values not described in expect are NOT checked, so this is OK.
+				"two": map[string]interface{}{ // Map values not described in expect are NOT checked, so this is OK.
 					"subone": 1,
 					"subtwo": 2,
 				},
-				"sub": map[string]interface{} {
+				"sub": map[string]interface{}{
 					"subone": 1,
 					"subtwo": 2,
 				},
@@ -172,20 +172,20 @@ func TestEnsureKeys(t *testing.T) {
 			expect: map[string]interface{}{
 				"one": nil,
 				"two": nil,
-				"sub": map[string]interface{} {
+				"sub": map[string]interface{}{
 					"subone": nil,
 					"subtwo": nil,
 				},
 			},
 			result: map[string]interface{}{
 				"one": 1,
-				"two": map[string]interface{} { // Map values not described in expect are NOT checked, so this is OK.
+				"two": map[string]interface{}{ // Map values not described in expect are NOT checked, so this is OK.
 					"subone": 1,
 					"subtwo": 2,
 				},
-				"sub": map[string]interface{} {
-					"subone": 1,
-					"subtwo": 2,
+				"sub": map[string]interface{}{
+					"subone":   1,
+					"subtwo":   2,
 					"subthree": 3,
 				},
 			},

--- a/pkg/trace/api/info_test.go
+++ b/pkg/trace/api/info_test.go
@@ -24,7 +24,7 @@ import (
 // ensureKeys takes 2 maps, expect and result, and ensures that the set of keys in expect and
 // result match. For each key (k) in expect, if expect[k] is of type map[string]interface{}, then
 // ensureKeys recurses on expect[k], result[k], prefix + "." + k.
-// 
+//
 // This should ensure that whatever keys and maps are defined in expect are exactly mirrored in
 // result, but without checking for specific values in result.
 func ensureKeys(expect, result map[string]interface{}, prefix string) error {
@@ -64,6 +64,143 @@ func ensureKeys(expect, result map[string]interface{}, prefix string) error {
 		}
 	}
 	return nil
+}
+
+func TestEnsureKeys(t *testing.T) {
+	for _, tt := range []struct {
+		expect map[string]interface{}
+		result map[string]interface{}
+		err    bool
+	}{
+		{
+			expect: map[string]interface{}{
+				"one": nil,
+				"two": nil,
+			},
+			result: map[string]interface{}{
+				"one": 1,
+				"two": "two",
+			},
+		},
+		{
+			expect: map[string]interface{}{
+				"one": nil,
+				"two": nil,
+				"three": nil,
+			},
+			result: map[string]interface{}{
+				"one": 1,
+				"two": "two",
+			},
+			err: true,
+		},
+		{
+			expect: map[string]interface{}{
+				"one": nil,
+				"two": nil,
+			},
+			result: map[string]interface{}{
+				"one": 1,
+				"two": "two",
+				"three": 3,
+			},
+			err: true,
+		},
+		{
+			expect: map[string]interface{}{
+				"one": nil,
+				"two": nil,
+				"sub": map[string]interface{} {
+					"subone": nil,
+					"subtwo": nil,
+				},
+			},
+			result: map[string]interface{}{
+				"one": 1,
+				"two": "two",
+				"sub": map[string]interface{} {
+					"subone": 1,
+					"subtwo": 2,
+				},
+			},
+		},
+		{
+			expect: map[string]interface{}{
+				"one": nil,
+				"two": nil,
+				"sub": map[string]interface{} {
+					"subone": nil,
+					"subtwo": nil,
+				},
+			},
+			result: map[string]interface{}{
+				"one": 1,
+				"two": map[string]interface{} { // Map values not described in expect are NOT checked, so this is OK.
+					"subone": 1,
+					"subtwo": 2,
+				},
+				"sub": map[string]interface{} {
+					"subone": 1,
+					"subtwo": 2,
+				},
+			},
+		},
+		{
+			expect: map[string]interface{}{
+				"one": nil,
+				"two": nil,
+				"sub": map[string]interface{} {
+					"subone": nil,
+					"subtwo": nil,
+					"subthree": nil,
+				},
+			},
+			result: map[string]interface{}{
+				"one": 1,
+				"two": map[string]interface{} { // Map values not described in expect are NOT checked, so this is OK.
+					"subone": 1,
+					"subtwo": 2,
+				},
+				"sub": map[string]interface{} {
+					"subone": 1,
+					"subtwo": 2,
+				},
+			},
+			err: true,
+		},
+		{
+			expect: map[string]interface{}{
+				"one": nil,
+				"two": nil,
+				"sub": map[string]interface{} {
+					"subone": nil,
+					"subtwo": nil,
+				},
+			},
+			result: map[string]interface{}{
+				"one": 1,
+				"two": map[string]interface{} { // Map values not described in expect are NOT checked, so this is OK.
+					"subone": 1,
+					"subtwo": 2,
+				},
+				"sub": map[string]interface{} {
+					"subone": 1,
+					"subtwo": 2,
+					"subthree": 3,
+				},
+			},
+			err: true,
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			err := ensureKeys(tt.expect, tt.result, "")
+			if tt.err {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }
 
 // TestInfoHandler ensures that the keys returned by the /info handler do not


### PR DESCRIPTION
The tests for the info endpoint over-specify the output, making them fail and need to be updated whenever anything changes, rather than when a new key is added or removed.

This change ensures that the exact keys are present in the output, rather than checking specific values.

Fixes #13569

