### PR TITLE
[netflow] Add set configs as known

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -670,7 +670,9 @@ func InitConfig(config Config) {
 	config.SetKnown("network_devices.netflow.stop_timeout")
 	config.SetKnown("network_devices.netflow.aggregator_buffer_size")
 	config.SetKnown("network_devices.netflow.aggregator_flush_interval")
-	config.SetKnown("network_devices.netflow.log_payloads")
+	config.SetKnown("network_devices.netflow.aggregator_flow_context_ttl")
+	config.SetKnown("network_devices.netflow.aggregator_port_rollup_threshold")
+	config.SetKnown("network_devices.netflow.aggregator_rollup_tracker_refresh_interval")
 	config.BindEnvAndSetDefault("network_devices.netflow.enabled", "false")
 	bindEnvAndSetLogsConfigKeys(config, "network_devices.netflow.forwarder.")
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

[netflow] Add set configs as known


Add
```
	config.SetKnown("network_devices.netflow.aggregator_flow_context_ttl")
	config.SetKnown("network_devices.netflow.aggregator_port_rollup_threshold")
	config.SetKnown("network_devices.netflow.aggregator_rollup_tracker_refresh_interval")
```
See https://github.com/DataDog/datadog-agent/pull/13226
and https://github.com/DataDog/datadog-agent/pull/13367

Remove:
```
	config.SetKnown("network_devices.netflow.log_payloads")
```

See see https://github.com/DataDog/datadog-agent/pull/13501

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Configs must be set as known to avoid warnings.

```
2022-09-20 11:29:53 CEST | CORE | WARN | (pkg/util/log/log.go:616 in func1) | Unknown key in config file: network_devices.netflow.aggregator_port_rollup_threshold
2022-09-20 11:29:53 CEST | CORE | WARN | (pkg/util/log/log.go:616 in func1) | Unknown key in config file: network_devices.netflow.aggregator_flow_context_ttl
2022-09-20 11:29:53 CEST | CORE | WARN | (pkg/util/log/log.go:616 in func1) | Unknown key in config file: network_devices.netflow.aggregator_rollup_tracker_refresh_interval
```

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
