### PR TITLE
Support waiting for _all_ checks from AD

### DIFF
--- a/cmd/agent/app/jmx.go
+++ b/cmd/agent/app/jmx.go
@@ -190,10 +190,10 @@ func runJmxCommandConsole(command string) error {
 	//       WaitForConfigsFromAD will timeout and return no AD configs.
 	waitCtx, cancelTimeout := context.WithTimeout(
 		context.Background(), time.Duration(discoveryTimeout)*time.Second)
-	allConfigs := common.WaitForConfigsFromAD(waitCtx, cliSelectedChecks, int(discoveryMinInstances))
+	allConfigs := common.WaitForAllConfigsFromAD(waitCtx)
 	cancelTimeout()
 
-	err = standalone.ExecJMXCommandConsole(command, cliSelectedChecks, logLevel, allConfigs)
+	err = standalone.ExecJMXCommandConsole(command, []string{}, logLevel, allConfigs)
 
 	if runtime.GOOS == "windows" {
 		standalone.PrintWindowsUserWarning("jmx")

--- a/cmd/agent/app/jmx.go
+++ b/cmd/agent/app/jmx.go
@@ -181,6 +181,7 @@ func runJmxCommandConsole(command string) error {
 	}
 
 	common.LoadComponents(context.Background(), config.Datadog.GetString("confd_path"))
+	common.AC.LoadAndRun(context.Background())
 
 	// Create the CheckScheduler, but do not attach it to
 	// AutoDiscovery.  NOTE: we do not start common.Coll, either.


### PR DESCRIPTION
The `agent jmx list everything` command needs this functionality.

### What does this PR do?

Adds a new WaitForAllConfigsFromAD to wait for all configs, not just matching configs.

### Motivation

The previous implementation of WaitForConfigs sort of quietly/accidentally did this, and it wasn't clear that it did so, nor that that functionality was important.  Turns out it does, and it was.

### Additional Notes

In review, verify that when wildcard=false, this function has the same behavior it did before.  When wildcard=true, it waits until the context is cancelled and gathers all configs that are scheduled during that time.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

* Run `agent check <somecheck>`
* Run `agent check <somecheck> --discovery-min-instances 100` and see that it waits for a timeout then gives the correct results
* Run `agent check <somecheck> --discovery-min-instances 2` for a check with two instances and see that it shows both instances.
* Run `agent jmx list everything` in a context where a JMX check is active and see that it does the right thing

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
