### PR TITLE
[CWS] simplify `send_event` code

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewAsset("runtime-security.c", "5f6087cc0cb9e55ae69732a8245c135a86821dff70fca4b27e95bcf49f7d401a")
+var RuntimeSecurity = NewAsset("runtime-security.c", "3b3f290ad43464a389377078d4b9e56c93950f8e62e0cece0f3a6a8b6e27b2d4")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewAsset("runtime-security.c", "af68905477e4c070aaf290a610da857d940a38e6bc35efd847f1874e70119cb4")
+var RuntimeSecurity = NewAsset("runtime-security.c", "5f6087cc0cb9e55ae69732a8245c135a86821dff70fca4b27e95bcf49f7d401a")

--- a/pkg/security/ebpf/c/defs.h
+++ b/pkg/security/ebpf/c/defs.h
@@ -383,147 +383,107 @@ struct bpf_map_def SEC("maps/events_stats") events_stats = {
     .namespace = "",
 };
 
-#define send_event_with_size_ptr_perf(ctx, event_type, kernel_event, kernel_event_size)                                \
-    kernel_event->event.type = event_type;                                                                             \
-    kernel_event->event.cpu = bpf_get_smp_processor_id();                                                              \
-    kernel_event->event.timestamp = bpf_ktime_get_ns();                                                                \
-                                                                                                                       \
-    perf_ret = bpf_perf_event_output(ctx, &events, kernel_event->event.cpu, kernel_event, kernel_event_size);      \
-                                                                                                                       \
-    if (kernel_event->event.type < EVENT_MAX) {                                                                        \
-        u64 lookup_type = event_type;                                                                                  \
-        struct perf_map_stats_t *stats = bpf_map_lookup_elem(&events_stats, &lookup_type);                             \
-        if (stats != NULL) {                                                                                           \
-            if (!perf_ret) {                                                                                           \
-                __sync_fetch_and_add(&stats->bytes, kernel_event_size + 4);                                            \
-                __sync_fetch_and_add(&stats->count, 1);                                                                \
-            } else {                                                                                                   \
-                __sync_fetch_and_add(&stats->lost, 1);                                                                 \
-            }                                                                                                          \
-        }                                                                                                              \
-    }                                                                                                                  \
-
-#define send_event_with_size_ptr_ringbuf(ctx, event_type, kernel_event, kernel_event_size)                             \
-    kernel_event->event.type = event_type;                                                                             \
-    kernel_event->event.cpu = bpf_get_smp_processor_id();                                                              \
-    kernel_event->event.timestamp = bpf_ktime_get_ns();                                                                \
-                                                                                                                       \
-    perf_ret = bpf_ringbuf_output(&events, kernel_event, kernel_event_size, 0);                                    \
-                                                                                                                       \
-    if (kernel_event->event.type < EVENT_MAX) {                                                                        \
-        u64 lookup_type = event_type;                                                                                  \
-        struct perf_map_stats_t *stats = bpf_map_lookup_elem(&events_stats, &lookup_type);                             \
-        if (stats != NULL) {                                                                                           \
-            if (!perf_ret) {                                                                                           \
-                __sync_fetch_and_add(&stats->bytes, kernel_event_size + 4);                                            \
-                __sync_fetch_and_add(&stats->count, 1);                                                                \
-            } else {                                                                                                   \
-                __sync_fetch_and_add(&stats->lost, 1);                                                                 \
-            }                                                                                                          \
-        }                                                                                                              \
-    }                                                                                                                  \
-
-#define send_event_with_size_perf(ctx, event_type, kernel_event, kernel_event_size)                                    \
-    kernel_event.event.type = event_type;                                                                              \
-    kernel_event.event.cpu = bpf_get_smp_processor_id();                                                               \
-    kernel_event.event.timestamp = bpf_ktime_get_ns();                                                                 \
-                                                                                                                       \
-    perf_ret = bpf_perf_event_output(ctx, &events, kernel_event.event.cpu, &kernel_event, kernel_event_size);      \
-                                                                                                                       \
-    if (kernel_event.event.type < EVENT_MAX) {                                                                         \
-        struct perf_map_stats_t *stats = bpf_map_lookup_elem(&events_stats, &kernel_event.event.type);                 \
-        if (stats != NULL) {                                                                                           \
-            if (!perf_ret) {                                                                                           \
-                __sync_fetch_and_add(&stats->bytes, kernel_event_size + 4);                                            \
-                __sync_fetch_and_add(&stats->count, 1);                                                                \
-            } else {                                                                                                   \
-                __sync_fetch_and_add(&stats->lost, 1);                                                                 \
-            }                                                                                                          \
-        }                                                                                                              \
-    }                                                                                                                  \
-
-#define send_event_with_size_ringbuf(ctx, event_type, kernel_event, kernel_event_size)                                 \
-    kernel_event.event.type = event_type;                                                                              \
-    kernel_event.event.cpu = bpf_get_smp_processor_id();                                                               \
-    kernel_event.event.timestamp = bpf_ktime_get_ns();                                                                 \
-                                                                                                                       \
-    perf_ret = bpf_ringbuf_output(&events, &kernel_event, kernel_event_size, 0);                                   \
-                                                                                                                       \
-    if (kernel_event.event.type < EVENT_MAX) {                                                                         \
-        struct perf_map_stats_t *stats = bpf_map_lookup_elem(&events_stats, &kernel_event.event.type);                 \
-        if (stats != NULL) {                                                                                           \
-            if (!perf_ret) {                                                                                           \
-                __sync_fetch_and_add(&stats->bytes, kernel_event_size + 4);                                            \
-                __sync_fetch_and_add(&stats->count, 1);                                                                \
-            } else {                                                                                                   \
-                __sync_fetch_and_add(&stats->lost, 1);                                                                 \
-            }                                                                                                          \
-        }                                                                                                              \
-    }                                                                                                                  \
-
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)
-#define send_event(ctx, event_type, kernel_event)                                                                      \
-    u64 size = sizeof(kernel_event);                                                                                   \
-    u64 use_ring_buffer;                                                                                               \
-    LOAD_CONSTANT("use_ring_buffer", use_ring_buffer);                                                                 \
-    int perf_ret;                                                                                                      \
-    if (use_ring_buffer) {                                                                                             \
-        send_event_with_size_ringbuf(ctx, event_type, kernel_event, size)                                              \
-    } else {                                                                                                           \
-        send_event_with_size_perf(ctx, event_type, kernel_event, size)                                                 \
-    }                                                                                                                  \
+#define send_event_with_size_ptr(ctx, event_type, kernel_event, kernel_event_size)                                \
+    kernel_event->event.type = event_type;                                                                        \
+    kernel_event->event.cpu = bpf_get_smp_processor_id();                                                         \
+    kernel_event->event.timestamp = bpf_ktime_get_ns();                                                           \
+                                                                                                                  \
+    u64 use_ring_buffer;                                                                                          \
+    LOAD_CONSTANT("use_ring_buffer", use_ring_buffer);                                                            \
+    int perf_ret;                                     \
+    if (use_ring_buffer) {                                                                                        \
+        perf_ret = bpf_ringbuf_output(&events, kernel_event, kernel_event_size, 0);                               \
+    } else {                                                                                                      \
+        perf_ret = bpf_perf_event_output(ctx, &events, kernel_event->event.cpu, kernel_event, kernel_event_size); \
+    }                                                                                                             \
+                                                                                                                  \
+    if (kernel_event->event.type < EVENT_MAX) {                                                                   \
+        u64 lookup_type = event_type;                                                                             \
+        struct perf_map_stats_t *stats = bpf_map_lookup_elem(&events_stats, &lookup_type);                        \
+        if (stats != NULL) {                                                                                      \
+            if (!perf_ret) {                                                                                      \
+                __sync_fetch_and_add(&stats->bytes, kernel_event_size + 4);                                       \
+                __sync_fetch_and_add(&stats->count, 1);                                                           \
+            } else {                                                                                              \
+                __sync_fetch_and_add(&stats->lost, 1);                                                            \
+            }                                                                                                     \
+        }                                                                                                         \
+    }
 
-#define send_event_with_size(ctx, event_type, kernel_event, size)                                                      \
-    u64 use_ring_buffer;                                                                                               \
-    LOAD_CONSTANT("use_ring_buffer", use_ring_buffer);                                                                 \
-    int perf_ret;                                                                                                      \
-    if (use_ring_buffer) {                                                                                             \
-        send_event_with_size_ringbuf(ctx, event_type, kernel_event, size)                                              \
-    } else {                                                                                                           \
-        send_event_with_size_perf(ctx, event_type, kernel_event, size)                                                 \
+#define send_event_with_size(ctx, event_type, kernel_event, kernel_event_size)                                    \
+    kernel_event.event.type = event_type;                                                                         \
+    kernel_event.event.cpu = bpf_get_smp_processor_id();                                                          \
+    kernel_event.event.timestamp = bpf_ktime_get_ns();                                                            \
+                                                                                                                  \
+    u64 use_ring_buffer;                                                                                          \
+    LOAD_CONSTANT("use_ring_buffer", use_ring_buffer);                                                            \
+    int perf_ret;                                 \
+    if (use_ring_buffer) {                                                                                        \
+        perf_ret = bpf_ringbuf_output(&events, &kernel_event, kernel_event_size, 0);                              \
+    } else {                                                                                                      \
+        perf_ret = bpf_perf_event_output(ctx, &events, kernel_event.event.cpu, &kernel_event, kernel_event_size); \
+    }                                                                                                             \
+                                                                                                                  \
+    if (kernel_event.event.type < EVENT_MAX) {                                                                    \
+        struct perf_map_stats_t *stats = bpf_map_lookup_elem(&events_stats, &kernel_event.event.type);            \
+        if (stats != NULL) {                                                                                      \
+            if (!perf_ret) {                                                                                      \
+                __sync_fetch_and_add(&stats->bytes, kernel_event_size + 4);                                       \
+                __sync_fetch_and_add(&stats->count, 1);                                                           \
+            } else {                                                                                              \
+                __sync_fetch_and_add(&stats->lost, 1);                                                            \
+            }                                                                                                     \
+        }                                                                                                         \
     }
 #else
-#define send_event(ctx, event_type, kernel_event)                                                                      \
-    int perf_ret;                                                                                                      \
-    send_event_with_size_perf(ctx, event_type, kernel_event, sizeof(kernel_event))
-
-#define send_event_with_size(ctx, event_type, kernel_event, size)                                                      \
-    int perf_ret;                                                                                                      \
-    send_event_with_size_perf(ctx, event_type, kernel_event, size)
-#endif
-
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)
-#define send_event_ptr(ctx, event_type, kernel_event)                                                                  \
-    u64 size = sizeof(*kernel_event);                                                                                  \
-    u64 use_ring_buffer;                                                                                               \
-    int perf_ret;                                                                                                      \
-    LOAD_CONSTANT("use_ring_buffer", use_ring_buffer);                                                                 \
-    if (use_ring_buffer) {                                                                                             \
-        send_event_with_size_ptr_ringbuf(ctx, event_type, kernel_event, size)                                          \
-    } else {                                                                                                           \
-        send_event_with_size_ptr_perf(ctx, event_type, kernel_event, size)                                             \
+#define send_event_with_size_ptr(ctx, event_type, kernel_event, kernel_event_size)                                \
+    kernel_event->event.type = event_type;                                                                        \
+    kernel_event->event.cpu = bpf_get_smp_processor_id();                                                         \
+    kernel_event->event.timestamp = bpf_ktime_get_ns();                                                           \
+                                                                                                                  \
+    int perf_ret = bpf_perf_event_output(ctx, &events, kernel_event->event.cpu, kernel_event, kernel_event_size); \
+                                                                                                                  \
+    if (kernel_event->event.type < EVENT_MAX) {                                                                   \
+        u64 lookup_type = event_type;                                                                             \
+        struct perf_map_stats_t *stats = bpf_map_lookup_elem(&events_stats, &lookup_type);                        \
+        if (stats != NULL) {                                                                                      \
+            if (!perf_ret) {                                                                                      \
+                __sync_fetch_and_add(&stats->bytes, kernel_event_size + 4);                                       \
+                __sync_fetch_and_add(&stats->count, 1);                                                           \
+            } else {                                                                                              \
+                __sync_fetch_and_add(&stats->lost, 1);                                                            \
+            }                                                                                                     \
+        }                                                                                                         \
     }
-#else
-#define send_event_ptr(ctx, event_type, kernel_event)                                                                  \
-    int perf_ret;                                                                                                      \
-    send_event_with_size_ptr_perf(ctx, event_type, kernel_event, sizeof(*kernel_event))
+
+#define send_event_with_size(ctx, event_type, kernel_event, kernel_event_size)                                    \
+    kernel_event.event.type = event_type;                                                                         \
+    kernel_event.event.cpu = bpf_get_smp_processor_id();                                                          \
+    kernel_event.event.timestamp = bpf_ktime_get_ns();                                                            \
+                                                                                                                  \
+    int perf_ret = bpf_perf_event_output(ctx, &events, kernel_event.event.cpu, &kernel_event, kernel_event_size); \
+                                                                                                                  \
+    if (kernel_event.event.type < EVENT_MAX) {                                                                    \
+        struct perf_map_stats_t *stats = bpf_map_lookup_elem(&events_stats, &kernel_event.event.type);            \
+        if (stats != NULL) {                                                                                      \
+            if (!perf_ret) {                                                                                      \
+                __sync_fetch_and_add(&stats->bytes, kernel_event_size + 4);                                       \
+                __sync_fetch_and_add(&stats->count, 1);                                                           \
+            } else {                                                                                              \
+                __sync_fetch_and_add(&stats->lost, 1);                                                            \
+            }                                                                                                     \
+        }                                                                                                         \
+    }
 #endif
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)
-#define send_event_with_size_ptr(ctx, event_type, kernel_event, size)                                                  \
-    u64 use_ring_buffer;                                                                                               \
-    int perf_ret;                                                                                                      \
-    LOAD_CONSTANT("use_ring_buffer", use_ring_buffer);                                                                 \
-    if (use_ring_buffer) {                                                                                             \
-        send_event_with_size_ptr_ringbuf(ctx, event_type, kernel_event, size)                                          \
-    } else {                                                                                                           \
-        send_event_with_size_ptr_perf(ctx, event_type, kernel_event, size)                                             \
-    }
-#else
-#define send_event_with_size_ptr(ctx, event_type, kernel_event, size)                                                  \
-    int perf_ret;                                                                                                      \
-    send_event_with_size_ptr_perf(ctx, event_type, kernel_event, size)
-#endif
+#define send_event(ctx, event_type, kernel_event) \
+    u64 size = sizeof(kernel_event);              \
+    send_event_with_size(ctx, event_type, kernel_event, size)
+
+#define send_event_ptr(ctx, event_type, kernel_event) \
+    u64 size = sizeof(*kernel_event);                 \
+    send_event_with_size_ptr(ctx, event_type, kernel_event, size)
 
 // implemented in the discarder.h file
 int __attribute__((always_inline)) bump_discarder_revision(u32 mount_id);

--- a/pkg/security/ebpf/c/defs.h
+++ b/pkg/security/ebpf/c/defs.h
@@ -383,107 +383,47 @@ struct bpf_map_def SEC("maps/events_stats") events_stats = {
     .namespace = "",
 };
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)
-#define send_event_with_size_ptr(ctx, event_type, kernel_event, kernel_event_size)                                \
-    kernel_event->event.type = event_type;                                                                        \
-    kernel_event->event.cpu = bpf_get_smp_processor_id();                                                         \
-    kernel_event->event.timestamp = bpf_ktime_get_ns();                                                           \
-                                                                                                                  \
-    u64 use_ring_buffer;                                                                                          \
-    LOAD_CONSTANT("use_ring_buffer", use_ring_buffer);                                                            \
-    int perf_ret;                                     \
-    if (use_ring_buffer) {                                                                                        \
-        perf_ret = bpf_ringbuf_output(&events, kernel_event, kernel_event_size, 0);                               \
-    } else {                                                                                                      \
-        perf_ret = bpf_perf_event_output(ctx, &events, kernel_event->event.cpu, kernel_event, kernel_event_size); \
-    }                                                                                                             \
-                                                                                                                  \
-    if (kernel_event->event.type < EVENT_MAX) {                                                                   \
-        u64 lookup_type = event_type;                                                                             \
-        struct perf_map_stats_t *stats = bpf_map_lookup_elem(&events_stats, &lookup_type);                        \
-        if (stats != NULL) {                                                                                      \
-            if (!perf_ret) {                                                                                      \
-                __sync_fetch_and_add(&stats->bytes, kernel_event_size + 4);                                       \
-                __sync_fetch_and_add(&stats->count, 1);                                                           \
-            } else {                                                                                              \
-                __sync_fetch_and_add(&stats->lost, 1);                                                            \
-            }                                                                                                     \
-        }                                                                                                         \
-    }
+void __attribute__((always_inline)) send_event_with_size_ptr(void *ctx, u64 event_type, void *kernel_event, u64 kernel_event_size) {
+    struct kevent_t *header = kernel_event;
+    header->type = event_type;
+    header->cpu = bpf_get_smp_processor_id();
+    header->timestamp = bpf_ktime_get_ns();
 
-#define send_event_with_size(ctx, event_type, kernel_event, kernel_event_size)                                    \
-    kernel_event.event.type = event_type;                                                                         \
-    kernel_event.event.cpu = bpf_get_smp_processor_id();                                                          \
-    kernel_event.event.timestamp = bpf_ktime_get_ns();                                                            \
-                                                                                                                  \
-    u64 use_ring_buffer;                                                                                          \
-    LOAD_CONSTANT("use_ring_buffer", use_ring_buffer);                                                            \
-    int perf_ret;                                 \
-    if (use_ring_buffer) {                                                                                        \
-        perf_ret = bpf_ringbuf_output(&events, &kernel_event, kernel_event_size, 0);                              \
-    } else {                                                                                                      \
-        perf_ret = bpf_perf_event_output(ctx, &events, kernel_event.event.cpu, &kernel_event, kernel_event_size); \
-    }                                                                                                             \
-                                                                                                                  \
-    if (kernel_event.event.type < EVENT_MAX) {                                                                    \
-        struct perf_map_stats_t *stats = bpf_map_lookup_elem(&events_stats, &kernel_event.event.type);            \
-        if (stats != NULL) {                                                                                      \
-            if (!perf_ret) {                                                                                      \
-                __sync_fetch_and_add(&stats->bytes, kernel_event_size + 4);                                       \
-                __sync_fetch_and_add(&stats->count, 1);                                                           \
-            } else {                                                                                              \
-                __sync_fetch_and_add(&stats->lost, 1);                                                            \
-            }                                                                                                     \
-        }                                                                                                         \
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)
+    u64 use_ring_buffer;
+    LOAD_CONSTANT("use_ring_buffer", use_ring_buffer);
+    int perf_ret;
+    if (use_ring_buffer) {
+        perf_ret = bpf_ringbuf_output(&events, kernel_event, kernel_event_size, 0);
+    } else {
+        perf_ret = bpf_perf_event_output(ctx, &events, header->cpu, kernel_event, kernel_event_size);
     }
 #else
-#define send_event_with_size_ptr(ctx, event_type, kernel_event, kernel_event_size)                                \
-    kernel_event->event.type = event_type;                                                                        \
-    kernel_event->event.cpu = bpf_get_smp_processor_id();                                                         \
-    kernel_event->event.timestamp = bpf_ktime_get_ns();                                                           \
-                                                                                                                  \
-    int perf_ret = bpf_perf_event_output(ctx, &events, kernel_event->event.cpu, kernel_event, kernel_event_size); \
-                                                                                                                  \
-    if (kernel_event->event.type < EVENT_MAX) {                                                                   \
-        u64 lookup_type = event_type;                                                                             \
-        struct perf_map_stats_t *stats = bpf_map_lookup_elem(&events_stats, &lookup_type);                        \
-        if (stats != NULL) {                                                                                      \
-            if (!perf_ret) {                                                                                      \
-                __sync_fetch_and_add(&stats->bytes, kernel_event_size + 4);                                       \
-                __sync_fetch_and_add(&stats->count, 1);                                                           \
-            } else {                                                                                              \
-                __sync_fetch_and_add(&stats->lost, 1);                                                            \
-            }                                                                                                     \
-        }                                                                                                         \
-    }
-
-#define send_event_with_size(ctx, event_type, kernel_event, kernel_event_size)                                    \
-    kernel_event.event.type = event_type;                                                                         \
-    kernel_event.event.cpu = bpf_get_smp_processor_id();                                                          \
-    kernel_event.event.timestamp = bpf_ktime_get_ns();                                                            \
-                                                                                                                  \
-    int perf_ret = bpf_perf_event_output(ctx, &events, kernel_event.event.cpu, &kernel_event, kernel_event_size); \
-                                                                                                                  \
-    if (kernel_event.event.type < EVENT_MAX) {                                                                    \
-        struct perf_map_stats_t *stats = bpf_map_lookup_elem(&events_stats, &kernel_event.event.type);            \
-        if (stats != NULL) {                                                                                      \
-            if (!perf_ret) {                                                                                      \
-                __sync_fetch_and_add(&stats->bytes, kernel_event_size + 4);                                       \
-                __sync_fetch_and_add(&stats->count, 1);                                                           \
-            } else {                                                                                              \
-                __sync_fetch_and_add(&stats->lost, 1);                                                            \
-            }                                                                                                     \
-        }                                                                                                         \
-    }
+    int perf_ret = bpf_perf_event_output(ctx, &events, header->cpu, kernel_event, kernel_event_size);
 #endif
 
-#define send_event(ctx, event_type, kernel_event) \
-    u64 size = sizeof(kernel_event);              \
-    send_event_with_size(ctx, event_type, kernel_event, size)
+    if (event_type < EVENT_MAX) {
+        struct perf_map_stats_t *stats = bpf_map_lookup_elem(&events_stats, &event_type);
+        if (stats != NULL) {
+            if (!perf_ret) {
+                __sync_fetch_and_add(&stats->bytes, kernel_event_size + 4);
+                __sync_fetch_and_add(&stats->count, 1);
+            } else {
+                __sync_fetch_and_add(&stats->lost, 1);
+            }
+        }
+    }
+}
 
-#define send_event_ptr(ctx, event_type, kernel_event) \
-    u64 size = sizeof(*kernel_event);                 \
-    send_event_with_size_ptr(ctx, event_type, kernel_event, size)
+#define send_event(ctx, event_type, kernel_event) ({                  \
+    u64 size = sizeof(kernel_event);                                  \
+    send_event_with_size_ptr(ctx, event_type, &kernel_event, size); \
+})
+
+#define send_event_ptr(ctx, event_type, kernel_event) ({              \
+    u64 size = sizeof(*kernel_event);                                 \
+    send_event_with_size_ptr(ctx, event_type, kernel_event, size); \
+})
 
 // implemented in the discarder.h file
 int __attribute__((always_inline)) bump_discarder_revision(u32 mount_id);

--- a/pkg/security/ebpf/c/raw_syscalls.h
+++ b/pkg/security/ebpf/c/raw_syscalls.h
@@ -141,7 +141,7 @@ shoud_send_event:
         entry->dirty = 0;
 
         // remove last_sent and dirty from the event size, we don't care about these fields
-        send_event_with_size(args, EVENT_SYSCALLS, event, offsetof(struct syscall_monitor_event_t, syscalls) + SYSCALL_ENCODING_TABLE_SIZE);
+        send_event_with_size_ptr(args, EVENT_SYSCALLS, &event, offsetof(struct syscall_monitor_event_t, syscalls) + SYSCALL_ENCODING_TABLE_SIZE);
     }
 
     key.syscall_key = EXECVE_SYSCALL_KEY;


### PR DESCRIPTION
### What does this PR do?

This PR fixes the errno 524 (-ENOTSUP) issue when loading eBPF code on AL2 5.10.
The main issue is that the code was too complex (too long or too many states), on this specific kernel.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
