### PR TITLE
[netflow] Fix config doc for flow_type: `sflow` should be `sflow5`

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -3202,9 +3202,9 @@ api_key:
     ## This section configures one or more listeners ports that will receive flow traffic.
     ## Each listener have the following options:
     ##  * flow_type    - string - The flow type correspond to the incoming flow protocol.
-    ##                            Choices are: netflow5, netflow9, ipfix, sflow
+    ##                            Choices are: netflow5, netflow9, ipfix, sflow5
     ##  * port         - string - (Optional) The port used to receive incoming flow traffic.
-    ##                            Default port differ by flow type: netflow5(2055), netflow9(2055), ipfix(4739), sflow(6343)
+    ##                            Default port differ by flow type: netflow5(2055), netflow9(2055), ipfix(4739), sflow5(6343)
     ##  * bind_host    - string - (Optional) The hostname to listen on for incoming netflow packets.
     ##                            Binds to 0.0.0.0 by default (accepting all packets).
     ##  * workers      - string - (Optional) Number of workers to use for this listener.
@@ -3217,7 +3217,7 @@ api_key:
     #   port: 2056
     # - flow_type: ipfix
     #   port: 4739
-    # - flow_type: sflow
+    # - flow_type: sflow5
     #   port: 6343
 
     ## stop_timeout - integer - optional - default: 5


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

[netflow] Fix config doc for flow_type: `sflow` should be `sflow5`

Fix related to this initial PR https://github.com/DataDog/datadog-agent/pull/12508

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Valid flow types are defined here: https://github.com/DataDog/datadog-agent/blob/f09cb39ca6f2bfea21f3d0f137eb46c2ea659eca/pkg/netflow/common/flowtype.go#L17-L20



<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
