### PR TITLE
Fix flaky CloudFoundry tests

### DIFF
--- a/pkg/util/cloudproviders/cloudfoundry/cccache.go
+++ b/pkg/util/cloudproviders/cloudfoundry/cccache.go
@@ -898,4 +898,5 @@ func (ccc *CCCache) reset() {
 	ccc.orgQuotasByGUID = make(map[string]*CFOrgQuota)
 	ccc.processesByAppGUID = make(map[string][]*cfclient.Process)
 	ccc.cfApplicationsByGUID = make(map[string]*CFApplication)
+	ccc.lastUpdated = time.Time{}
 }

--- a/pkg/util/cloudproviders/cloudfoundry/cccache_test.go
+++ b/pkg/util/cloudproviders/cloudfoundry/cccache_test.go
@@ -14,6 +14,7 @@ import (
 	"sort"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/cloudfoundry-community/go-cfclient"
 	"github.com/stretchr/testify/assert"
@@ -261,6 +262,8 @@ func TestCCCache_GetProcesses(t *testing.T) {
 func TestCCCache_RefreshCacheOnMiss_GetProcesses(t *testing.T) {
 	cc.refreshCacheOnMiss = true
 	cc.reset()
+	// mark the cccache as updated once to trigger the refresh behaviour
+	cc.lastUpdated = time.Now().Add(time.Second)
 	globalCCClientCounter.Reset()
 
 	wg := sync.WaitGroup{}
@@ -283,6 +286,8 @@ func TestCCCache_RefreshCacheOnMiss_GetProcesses(t *testing.T) {
 func TestCCCache_RefreshCacheOnMiss_GetApp(t *testing.T) {
 	cc.refreshCacheOnMiss = true
 	cc.reset()
+	// mark the cccache as updated once to trigger the refresh behaviour
+	cc.lastUpdated = time.Now().Add(time.Second)
 	globalCCClientCounter.Reset()
 
 	wg := sync.WaitGroup{}
@@ -305,6 +310,8 @@ func TestCCCache_RefreshCacheOnMiss_GetApp(t *testing.T) {
 func TestCCCache_RefreshCacheOnMiss_GetSpace(t *testing.T) {
 	cc.refreshCacheOnMiss = true
 	cc.reset()
+	// mark the cccache as updated once to trigger the refresh behaviour
+	cc.lastUpdated = time.Now().Add(time.Second)
 	globalCCClientCounter.Reset()
 
 	wg := sync.WaitGroup{}
@@ -326,6 +333,8 @@ func TestCCCache_RefreshCacheOnMiss_GetSpace(t *testing.T) {
 func TestCCCache_RefreshCacheOnMiss_GetOrg(t *testing.T) {
 	cc.refreshCacheOnMiss = true
 	cc.reset()
+	// mark the cccache as updated once to trigger the refresh behaviour
+	cc.lastUpdated = time.Now().Add(time.Second)
 	globalCCClientCounter.Reset()
 
 	wg := sync.WaitGroup{}
@@ -347,6 +356,8 @@ func TestCCCache_RefreshCacheOnMiss_GetOrg(t *testing.T) {
 func TestCCCache_RefreshCacheOnMiss_GetCFApplication(t *testing.T) {
 	cc.refreshCacheOnMiss = true
 	cc.reset()
+	// mark the cccache as updated once to trigger the refresh behaviour
+	cc.lastUpdated = time.Now().Add(time.Second)
 	globalCCClientCounter.Reset()
 
 	wg := sync.WaitGroup{}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fix flaky test `TestCCCache_RefreshCacheOnMiss_GetCFApplication` and similar tests.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

CCCache `reset` method is only used in tests.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
