### PR TITLE
Fix disabling http2

### DIFF
--- a/cmd/agent/internal/clcrunnerapi/clc_runner_server.go
+++ b/cmd/agent/internal/clcrunnerapi/clc_runner_server.go
@@ -79,14 +79,14 @@ func StartCLCRunnerServer(extraHandlers map[string]http.Handler) error {
 
 	tlsConfig := tls.Config{
 		Certificates: []tls.Certificate{rootTLSCert},
+		// Disable HTTP2 by setting TLSNextProto explicitly
+		NextProtos: []string{"http/1.1"},
 	}
 
 	// Use a stack depth of 4 on top of the default one to get a relevant filename in the stdlib
 	logWriter, _ := config.NewLogWriter(4, seelog.WarnLvl)
 
 	srv := &http.Server{
-		// Disable HTTP2 by setting TLSNextProto explicitly
-		TLSNextProto:      map[string]func(*http.Server, *tls.Conn, http.Handler){},
 		Handler:           r,
 		ErrorLog:          stdLog.New(logWriter, "Error from the clc runner http API server: ", 0), // log errors to seelog,
 		TLSConfig:         &tlsConfig,

--- a/cmd/cluster-agent/api/server.go
+++ b/cmd/cluster-agent/api/server.go
@@ -87,6 +87,8 @@ func StartServer() error {
 	tlsConfig := tls.Config{
 		Certificates: []tls.Certificate{rootTLSCert},
 		MinVersion:   tls.VersionTLS13,
+		// Disable HTTP2 by setting TLSNextProto explicitly
+		NextProtos: []string{"http/1.1"},
 	}
 
 	if config.Datadog.GetBool("cluster_agent.allow_legacy_tls") {
@@ -97,8 +99,6 @@ func StartServer() error {
 	logWriter, _ := config.NewLogWriter(4, seelog.WarnLvl)
 
 	srv := &http.Server{
-		// Disable HTTP2 by setting TLSNextProto explicitly
-		TLSNextProto: map[string]func(*http.Server, *tls.Conn, http.Handler){},
 		Handler:      router,
 		ErrorLog:     stdLog.New(logWriter, "Error from the agent http API server: ", 0), // log errors to seelog,
 		TLSConfig:    &tlsConfig,


### PR DESCRIPTION
### What does this PR do?

See #13566
Fix was not working for CLC and DCA command servers.

### Motivation

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

See #13566

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
