### PR TITLE
Silence no service errors when processing integration config

### DIFF
--- a/pkg/autodiscovery/providers/config_reader.go
+++ b/pkg/autodiscovery/providers/config_reader.go
@@ -402,10 +402,13 @@ func GetIntegrationConfigFromFile(name, fpath string) (integration.Config, error
 		return conf, errors.New("the 'docker_images' section is deprecated, please use 'ad_identifiers' instead")
 	}
 
-	// Interpolate env vars. Returns an error a variable wasn't subsituted, ignore it.
+	// Interpolate env vars. Returns an error a variable wasn't substituted, ignore it.
 	e := configresolver.SubstituteTemplateEnvVars(&conf)
 	if e != nil {
-		log.Errorf("Failed to substitute template var %s", e)
+		// Ignore NoServiceError since service is always nil for integration configs from files.
+		if _, ok := e.(*configresolver.NoServiceError); !ok {
+			log.Errorf("Failed to substitute template var %s", e)
+		}
 	}
 
 	conf.Source = "file:" + fpath


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

[This PR](https://github.com/DataDog/datadog-agent/pull/13259) exposed these errors so they are visible in the logs. However - some of these errors are thrown all the time (when `svc` is nil)

This PR silences the `Failed to substitute template` when processing integration config files. `svc` is always nil in this case, so these errors are not useful. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Noisy logs found in QA

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Run a fresh install of the agent, check the logs. you should no longer see logs like `Failed to substitute template var No service. %%host%% is not allowed`

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
