### PR TITLE
[process-agent] Add support for `disable_file_logging` setting

### DIFF
--- a/cmd/process-agent/app/check.go
+++ b/cmd/process-agent/app/check.go
@@ -64,6 +64,9 @@ func runCheckCmd(cmd *cobra.Command, args []string) error {
 		ddconfig.Datadog.Set("log_to_console", false)
 	}
 
+	// Override the disable_file_logging setting so that the check command doesn't dump so much noise into the log file.
+	ddconfig.Datadog.Set("disable_file_logging", true)
+
 	// We need to load in the system probe environment variables before we load the config, otherwise an
 	// "Unknown environment variable" warning will show up whenever valid system probe environment variables are defined.
 	ddconfig.InitSystemProbeConfig(ddconfig.Datadog)

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -201,7 +201,7 @@ func NewAgentConfig(loggerName config.LoggerName, yamlPath string, syscfg *sysco
 
 	// (Re)configure the logging from our configuration
 	logFile := config.Datadog.GetString("process_config.log_file")
-	if err := setupLogger(loggerName, logFile, cfg); err != nil {
+	if err := setupLogger(loggerName, logFile); err != nil {
 		log.Errorf("failed to setup configured logger: %s", err)
 		return nil, err
 	}
@@ -442,7 +442,11 @@ func constructProxy(host, scheme string, port int, user, password string) (proxy
 	return http.ProxyURL(u), nil
 }
 
-func setupLogger(loggerName config.LoggerName, logFile string, cfg *AgentConfig) error {
+func setupLogger(loggerName config.LoggerName, logFile string) error {
+	if config.Datadog.GetBool("disable_file_logging") {
+		logFile = ""
+	}
+
 	return config.SetupLogger(
 		loggerName,
 		config.Datadog.GetString("log_level"),

--- a/releasenotes/notes/process-agent-disable-file-logging-4194ca8ba1a7c1a3.yaml
+++ b/releasenotes/notes/process-agent-disable-file-logging-4194ca8ba1a7c1a3.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   - The `disable_file_logging` setting is now respected in the process-agent.
-  - `process-agent check [check-name]` no longer outputs to the configured log file.
+  - The `process-agent check [check-name]` command no longer outputs to the configured log file to reduce noise in the log file.

--- a/releasenotes/notes/process-agent-disable-file-logging-4194ca8ba1a7c1a3.yaml
+++ b/releasenotes/notes/process-agent-disable-file-logging-4194ca8ba1a7c1a3.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - The `disable_file_logging` setting is now respected in the process-agent.
+  - `process-agent check [check-name]` no longer outputs to the configured log file.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

This PR adds support in the process-agent for the `disable_file_logging` setting, which disables outputting logs to a file. Additionally, this setting is now overridden in the `process-agent check` command to avoid outputting unnecessary noise.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Test that setting `disable_file_logging` in your `datadog.yaml` disables writing to the log file. By default the log file can be found at `/var/log/datadog/process-agent.log`.

Additionally, with `disable_file_logging: false`, ensure that the `process-agent check process` command does not dump any text to the log file. 

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
