### PR TITLE
[corechecks/helm] Don't store the Helm values

### DIFF
--- a/pkg/collector/corechecks/cluster/helm/helm.go
+++ b/pkg/collector/corechecks/cluster/helm/helm.go
@@ -409,6 +409,16 @@ func (hc *HelmCheck) addRelease(encodedRelease string, creationTS metav1.Time, s
 		}
 	}
 
+	// The Helm values stored in "Config" and "Chart.Values" are needed only for
+	// the "helm values as tags" option. We've already generated the tags that
+	// we need, so we don't need to store the Helm values. This is important
+	// because the Helm values might need a lot of memory on clusters with many
+	// helm charts and configuration options.
+	decodedRelease.Config = nil
+	if decodedRelease.Chart != nil {
+		decodedRelease.Chart.Values = nil
+	}
+
 	hc.store.add(decodedRelease, storageDriver, genericTags, tagsMetricsAndEvents)
 }
 


### PR DESCRIPTION
### What does this PR do?

Reduces memory usage of the Helm check.

We were storing the Helm values of the Helm releases deployed, but that's not really needed.

### Describe how to test/QA your changes

Check that the memory consumption of the agent running the check is more or less the same as in the previous version of the agent.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
