### PR TITLE
pkg/logs: add 128-bit TraceID processor

### DIFF
--- a/pkg/logs/internal/processor/processor_test.go
+++ b/pkg/logs/internal/processor/processor_test.go
@@ -70,6 +70,58 @@ func TestReplaceTraceID(t *testing.T) {
 	}
 }
 
+// Avoid benchmark compiler optimisations, see:
+// https://dave.cheney.net/2013/06/30/how-to-write-benchmarks-in-go#compiler-optimisation
+var result1, result2 []byte
+
+func BenchmarkReplaceTraceID(b *testing.B) {
+	for name, in := range map[string]string{
+		"regular":  "log message without a date or any sort of trace id contained within it",
+		"short":    "log message with a weird trace id contained at the end that is not long enough trace_id=12387987ds",
+		"uint64":   "log message with a weird trace id contained at the end that is not long enough trace_id=123879879 span_id=123 other_field=3",
+		"128bit":   "log message with a weird trace id contained at the end that is not long enough trace_id=1b8c31d6d2fa97a97d0763ab555c1d19",
+		"128bit/2": "log message with a weird trace id contained at the end that is not long enough trace_id=1b8c31d6d2fa97a97d0763ab555c1d19 span_id=123 other_field=3",
+	} {
+		content := []byte(in)
+		b.Run(name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				result1 = replaceTraceID(content)
+			}
+		})
+	}
+}
+
+func BenchmarkApplyRedactingRules(b *testing.B) {
+	source := &sources.LogSource{Config: &config.LogsConfig{}}
+	p := &Processor{
+		processingRules: []*config.ProcessingRule{
+			newProcessingRule(config.MaskSequences, "world", "Matt"),
+		},
+	}
+	base := "this is a log message that doesn't report anything interesting but does say hello to Matt without any trace ids or anything special !"
+	content := []byte(base)
+	msg := newMessage([]byte(content), source, "")
+	b.Run("off", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_, result2 = p.applyRedactingRules(msg)
+		}
+	})
+	p.traceIDRule = true
+	for name, in := range map[string]string{
+		"on":     base,
+		"uint64": "this is a log message that doesn't report anything interesting but does say hello to Matt with an old styl dd.trace_id=12387889321 !",
+		"128bit": "this is a log message that doesn't report anything interesting but does say hello to Matt with a trace_id=1b8c31d6d2fa97a97d0763ab555c1d19 !",
+	} {
+		content := []byte(in)
+		msg := newMessage([]byte(content), source, "")
+		b.Run(name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, result2 = p.applyRedactingRules(msg)
+			}
+		})
+	}
+}
+
 func TestInclusion(t *testing.T) {
 	p := &Processor{processingRules: []*config.ProcessingRule{newProcessingRule("include_at_match", "", "world")}}
 

--- a/releasenotes/notes/logs-processor-otel-traceid-f88e7ee2c91d4831.yaml
+++ b/releasenotes/notes/logs-processor-otel-traceid-f88e7ee2c91d4831.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    When using OTLP Ingest, the logs intake will automatically transform the trace_id attribute from 128-bits to a Datadog valid 64-bit TraceID to aid with Trace correlation.


### PR DESCRIPTION
### Description

This change adds a hook which converts the trace_id log field from a 128-bit hex number to a 64-bit unsigned integer in order to help with logs/trace correlation.

### Benchmarks

All benchmarks contain a simple `mask_sequence` rule. Results:
```
$ go test -run=ApplyRe -bench=ApplyRe -benchmem -benchtime=5s
goos: darwin
goarch: arm64
pkg: github.com/DataDog/datadog-agent/pkg/logs/internal/processor
BenchmarkApplyRedactingRules/off-10         	25301593	       228.2 ns/op	     315 B/op	       4 allocs/op
BenchmarkApplyRedactingRules/on-10          	17520423	       349.7 ns/op	     316 B/op	       4 allocs/op
BenchmarkApplyRedactingRules/uint64-10      	17584282	       342.7 ns/op	     316 B/op	       4 allocs/op
BenchmarkApplyRedactingRules/128bit-10      	13837239	       430.5 ns/op	     340 B/op	       5 allocs/op
PASS
ok  	github.com/DataDog/datadog-agent/pkg/logs/internal/processor	25.508s
```
The benchmarks represent:
* `off` - 128-bit TraceID processing is off. This is the current state of the repository.
* `on` - 128-bit TraceID processing is on. In this benchmark, nothing gets processed. Only the trace_id is sought after by `bytes.Index`
* `uint64` - 128-bit TraceID processing is on. The benchmark contains the old 64-bit trace ID
* `128bit` - 128-bit TraceID processing is on. The benchmark contains the the 128-bit trace ID and the full conversion happens

#### Conclusions

* When `otlp_config` is in use, and the redacting rule runs without replacing anything, operation time is **increased by 53.2%**.
* When a 128-bit trace ID is found, operation time is **increased by 88.6%**.

TODO:
- [x] Benchmarks
- [ ] Tests to validate effect of `otlp_config` on processor activity