### PR TITLE
[CWS] Adding nil check for a policy that could not be parsed correctly

### DIFF
--- a/pkg/security/secl/rules/policy_dir.go
+++ b/pkg/security/secl/rules/policy_dir.go
@@ -103,6 +103,11 @@ func (p *PoliciesDirProvider) LoadPolicies(macroFilters []MacroFilter, ruleFilte
 		if err != nil {
 			errs = multierror.Append(errs, err)
 		}
+
+		if policy == nil {
+			continue
+		}
+
 		policies = append(policies, policy)
 
 		if p.watcher != nil {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Previously, if your policy was structured like this:
```
Policy
rules:
- id: my_chained_rule
  expression: exec.file.path == "/usr/bin/python3.8"
  actions:
  - set:
        name: python_executed
        scope: process
        value: true
- id: python_file_opened
  expression: open.file.name == "myfile.py" && ${process.python_executed}
```

You'd get a panic.
```
vagrant@celia-dev:~/dd/datadog-agent$ sudo ./bin/security-agent/security-agent runtime policy check
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x3705410]

goroutine 1 [running]:
github.com/DataDog/datadog-agent/pkg/security/secl/rules.(*PolicyLoader).LoadPolicies(0x380?, {{0xc000a0b680, 0x1, 0x1}, {0xc000a0b690, 0x1, 0x1}})
    /home/vagrant/dd/datadog-agent/pkg/security/secl/rules/policy_loader.go:59 +0x470
github.com/DataDog/datadog-agent/pkg/security/secl/rules.(*RuleSet).LoadPolicies(0xc0006e1040, 0x1?, {{0xc000a0b680, 0x1, 0x1}, {0xc000a0b690, 0x1, 0x1}})
    /home/vagrant/dd/datadog-agent/pkg/security/secl/rules/ruleset.go:635 +0x16c
github.com/DataDog/datadog-agent/cmd/security-agent/app.checkPoliciesInner({0x42bfd80, 0x25})
    /home/vagrant/dd/datadog-agent/cmd/security-agent/app/runtime.go:694 +0x652
github.com/DataDog/datadog-agent/cmd/security-agent/app.checkPolicies(0x60200c0?, {0x42504a0?, 0x0?, 0x0?})
    /home/vagrant/dd/datadog-agent/cmd/security-agent/app/runtime.go:717 +0x27
github.com/spf13/cobra.(*Command).execute(0x60200c0, {0x6235008, 0x0, 0x0})
    /home/vagrant/go/pkg/mod/github.com/spf13/cobra@v1.5.0/command.go:872 +0x694
github.com/spf13/cobra.(*Command).ExecuteC(0x601ddc0)
    /home/vagrant/go/pkg/mod/github.com/spf13/cobra@v1.5.0/command.go:990 +0x3b4
github.com/spf13/cobra.(*Command).Execute(...)
    /home/vagrant/go/pkg/mod/github.com/spf13/cobra@v1.5.0/command.go:918
main.main()
    /home/vagrant/dd/datadog-agent/cmd/security-agent/main_nix.go:26 +0x57
```

This PR adds a nil check to prevent this panic.


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Discovered during testing of this PR: https://github.com/DataDog/datadog-agent/pull/13364

Testing notes: https://trello.com/c/OW7w6RWc/12060-cwssec-4697-handle-check-of-policies-with-process-scope-variables.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
