### PR TITLE
pkg/trace/api: make dogstatsd proxy always use UDP

### DIFF
--- a/pkg/trace/api/dogstatsd.go
+++ b/pkg/trace/api/dogstatsd.go
@@ -26,11 +26,11 @@ func (r *HTTPReceiver) dogstatsdProxyHandler() http.Handler {
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		var network, address string
-		if r.conf.StatsdSocket != "" {
-			network, address = "unix", r.conf.StatsdSocket
-		} else {
-			network, address = "udp", fmt.Sprintf("%s:%d", r.conf.StatsdHost, r.conf.StatsdPort)
+		if r.conf.StatsdPort == 0 {
+			http.Error(w, "Agent dogstatsd UDP port not configured, but required for dogstatsd proxy.", http.StatusServiceUnavailable)
+			return
 		}
+		network, address = "udp", fmt.Sprintf("%s:%d", r.conf.StatsdHost, r.conf.StatsdPort)
 		conn, err := net.Dial(network, address)
 		if err != nil {
 			log.Errorf("Error connecting to %s endpoint at %q: %v", network, address, err)

--- a/pkg/trace/api/dogstatsd_test.go
+++ b/pkg/trace/api/dogstatsd_test.go
@@ -46,13 +46,6 @@ func TestDogStatsDReverseProxy(t *testing.T) {
 			},
 			http.StatusInternalServerError,
 		},
-		{
-			"bad statsd socket",
-			func(cfg *config.AgentConfig) {
-				cfg.StatsdSocket = "this is invalid"
-			},
-			http.StatusInternalServerError,
-		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/trace/api/dogstatsd_uds_test.go
+++ b/pkg/trace/api/dogstatsd_uds_test.go
@@ -28,9 +28,9 @@ func TestDogStatsDReverseProxyEndToEndUDS(t *testing.T) {
 	sock := "/tmp/com.datadoghq.datadog-agent.trace-agent.dogstatsd.test.sock"
 
 	cfg := config.New()
-	cfg.StatsdSocket = sock            // this should take precedence
+	cfg.StatsdSocket = sock            // this should get ignored
 	cfg.StatsdHost = "this is invalid" // this should get ignored
-	cfg.StatsdPort = 8080              // this should get ignored
+	cfg.StatsdPort = 0                 // this should trigger 503
 	receiver := newTestReceiverFromConfig(cfg)
 	proxy := receiver.dogstatsdProxyHandler()
 	require.NotNil(t, proxy)
@@ -50,5 +50,5 @@ func TestDogStatsDReverseProxyEndToEndUDS(t *testing.T) {
 	// Test metrics
 	body := ioutil.NopCloser(bytes.NewBufferString("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2"))
 	proxy.ServeHTTP(rec, httptest.NewRequest("POST", "/", body))
-	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
 }


### PR DESCRIPTION
The dogstatsd proxy should not use the unix socket for dogstatsd.

When sending over a unix socket, dogstatsd may attempt to determine the origin of a stats payload by process ID and container ID, and apply tags to the metrics messages based on that. If the proxy connects over the unix socket, any attempt by dogstatsd to detect the origin of the metrics and apply tags will result in the trace agent's tags being detected and applied.

In order to avoid this, the Trace Agent should only ever deliver proxied metrics to dogstatsd over UDP.

This is a follow-on to #13393 