### PR TITLE
[networks] Fix batch overwriting regression

### DIFF
--- a/pkg/ebpf/bytecode/runtime/http.go
+++ b/pkg/ebpf/bytecode/runtime/http.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Http = NewAsset("http.c", "fe61afe06c49e856dd4f61695f95a96d658bc7d08935451fc2f5fd476ef23067")
+var Http = NewAsset("http.c", "5c1e4cb4ab1ad39b023323dcbbc119fc1f5a8ef2c9d16f9ec71e72c46dd1d09a")

--- a/pkg/ebpf/bytecode/runtime/http.go
+++ b/pkg/ebpf/bytecode/runtime/http.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Http = NewAsset("http.c", "5c1e4cb4ab1ad39b023323dcbbc119fc1f5a8ef2c9d16f9ec71e72c46dd1d09a")
+var Http = NewAsset("http.c", "9725a8188d39fba30e5d5f02ba30fd50b92e733f971aeeedc2dcd0ea66dc7ba0")

--- a/pkg/network/ebpf/c/http-types.h
+++ b/pkg/network/ebpf/c/http-types.h
@@ -75,8 +75,6 @@ typedef struct {
     // this is useful for detecting race conditions that result in a batch being overrriden
     // before it gets consumed from userspace
     __u64 idx;
-    // pos indicates the batch slot where the next http transaction should be written to
-    __u8 pos;
     // idx_to_flush is used to track which batches were flushed to userspace
     // * if idx_to_flush == idx, the current index is still being appended to;
     // * if idx_to_flush < idx, the batch at idx_to_notify needs to be sent to userspace;

--- a/pkg/network/ebpf/c/prebuilt/http.c
+++ b/pkg/network/ebpf/c/prebuilt/http.c
@@ -53,9 +53,9 @@ int kprobe__tcp_sendmsg(struct pt_regs* ctx) {
     return 0;
 }
 
-SEC("kretprobe/security_sock_rcv_skb")
-int kretprobe__security_sock_rcv_skb(struct pt_regs* ctx) {
-    log_debug("kretprobe/security_sock_rcv_skb:\n");
+SEC("tracepoint/net/netif_receive_skb")
+int tracepoint__net__netif_receive_skb(struct pt_regs* ctx) {
+    log_debug("tracepoint/net/netif_receive_skb\n");
     // flush batch to userspace
     // because perf events can't be sent from socket filter programs
     http_flush_batch(ctx);

--- a/pkg/network/ebpf/c/runtime/http.c
+++ b/pkg/network/ebpf/c/runtime/http.c
@@ -54,9 +54,9 @@ int kprobe__tcp_sendmsg(struct pt_regs *ctx) {
     return 0;
 }
 
-SEC("kretprobe/security_sock_rcv_skb")
-int kretprobe__security_sock_rcv_skb(struct pt_regs* ctx) {
-    log_debug("kretprobe/security_sock_rcv_skb:\n");
+SEC("tracepoint/net/netif_receive_skb")
+int tracepoint__net__netif_receive_skb(struct pt_regs* ctx) {
+    log_debug("tracepoint/net/netif_receive_skb\n");
     // flush batch to userspace
     // because perf events can't be sent from socket filter programs
     http_flush_batch(ctx);

--- a/pkg/network/http/ebpf_main.go
+++ b/pkg/network/http/ebpf_main.go
@@ -110,8 +110,8 @@ func newEBPFProgram(c *config.Config, offsets []manager.ConstantEditor, sockFD *
 			},
 			{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  "kretprobe/security_sock_rcv_skb",
-					EBPFFuncName: "kretprobe__security_sock_rcv_skb",
+					EBPFSection:  "tracepoint/net/netif_receive_skb",
+					EBPFFuncName: "tracepoint__net__netif_receive_skb",
 					UID:          probeUID,
 				},
 				KProbeMaxActive: maxActive,
@@ -196,8 +196,8 @@ func (e *ebpfProgram) Init() error {
 			},
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  "kretprobe/security_sock_rcv_skb",
-					EBPFFuncName: "kretprobe__security_sock_rcv_skb",
+					EBPFSection:  "tracepoint/net/netif_receive_skb",
+					EBPFFuncName: "tracepoint__net__netif_receive_skb",
 					UID:          probeUID,
 				},
 			},

--- a/pkg/network/http/ebpf_main.go
+++ b/pkg/network/http/ebpf_main.go
@@ -114,7 +114,6 @@ func newEBPFProgram(c *config.Config, offsets []manager.ConstantEditor, sockFD *
 					EBPFFuncName: "tracepoint__net__netif_receive_skb",
 					UID:          probeUID,
 				},
-				KProbeMaxActive: maxActive,
 			},
 			{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{

--- a/pkg/network/http/http_types_linux.go
+++ b/pkg/network/http/http_types_linux.go
@@ -16,7 +16,6 @@ type httpConnTuple struct {
 }
 type httpBatchState struct {
 	Idx      uint64
-	Pos      uint8
 	To_flush uint64
 }
 type sslSock struct {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fix regression recently introduced by https://github.com/DataDog/datadog-agent/pull/13464/commits/9ee7f59b4361f2d78869677eba04fcc601b1bce2

The aforementioned commit reduced the number of `HTTP_BATCH_PAGES` based on the assumption that the previous probe used to flush batches (`security_sock_rcv_skb`) would be executed often enough, but there are codepaths in the kernel in which a socket filter program can be executed without triggering it.

This in turn caused HTTP batch pages to be overwritten in some situations (which results in data loss). This PR addresses this by picking a better probe for flushing batches and by adding more visibility to this kind problem if it ever happens again.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
