### PR TITLE
[windows] update npm driver to 2.0.4

### DIFF
--- a/release.json
+++ b/release.json
@@ -11,9 +11,9 @@
         "JMXFETCH_VERSION": "0.47.1",
         "JMXFETCH_HASH": "4cbbff73abfa0e6baaa1e3cad57497abcbb0e1570a022eecb7828dce3a14a3d9",
         "MACOS_BUILD_VERSION": "master",
-        "WINDOWS_DDNPM_DRIVER": "testsigned",
+        "WINDOWS_DDNPM_DRIVER": "release-signed",
         "WINDOWS_DDNPM_VERSION": "2.0.5",
-        "WINDOWS_DDNPM_SHASUM": "52a4bc07b6e203a27a20c38bb522d46ca7015ad378f3aac912032319c5eb91a0",
+        "WINDOWS_DDNPM_SHASUM": "2df99754d1fb1bd1d7d33c125a9303faf9d35423545123589985e186d499d9dd",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "nightly-a7": {
@@ -23,9 +23,9 @@
         "JMXFETCH_VERSION": "0.47.1",
         "JMXFETCH_HASH": "4cbbff73abfa0e6baaa1e3cad57497abcbb0e1570a022eecb7828dce3a14a3d9",
         "MACOS_BUILD_VERSION": "master",
-        "WINDOWS_DDNPM_DRIVER": "testsigned",
+        "WINDOWS_DDNPM_DRIVER": "release-signed",
         "WINDOWS_DDNPM_VERSION": "2.0.5",
-        "WINDOWS_DDNPM_SHASUM": "52a4bc07b6e203a27a20c38bb522d46ca7015ad378f3aac912032319c5eb91a0",
+        "WINDOWS_DDNPM_SHASUM": "2df99754d1fb1bd1d7d33c125a9303faf9d35423545123589985e186d499d9dd",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "release-a6": {
@@ -37,8 +37,8 @@
         "SECURITY_AGENT_POLICIES_VERSION": "v0.29.0",
         "MACOS_BUILD_VERSION": "6.40.0-rc.1",
         "WINDOWS_DDNPM_DRIVER": "release-signed",
-        "WINDOWS_DDNPM_VERSION": "2.0.3",
-        "WINDOWS_DDNPM_SHASUM": "cd953f8e663cd77b2a9ad1b299e0bbb89082a3a37d2ab3a4cf85e97ac53265b8"
+        "WINDOWS_DDNPM_VERSION": "2.0.5",
+        "WINDOWS_DDNPM_SHASUM": "2df99754d1fb1bd1d7d33c125a9303faf9d35423545123589985e186d499d9dd"
     },
     "release-a7": {
         "INTEGRATIONS_CORE_VERSION": "7.40.0-rc.2",
@@ -49,8 +49,8 @@
         "SECURITY_AGENT_POLICIES_VERSION": "v0.29.0",
         "MACOS_BUILD_VERSION": "7.40.0-rc.1",
         "WINDOWS_DDNPM_DRIVER": "release-signed",
-        "WINDOWS_DDNPM_VERSION": "2.0.3",
-        "WINDOWS_DDNPM_SHASUM": "cd953f8e663cd77b2a9ad1b299e0bbb89082a3a37d2ab3a4cf85e97ac53265b8"
+        "WINDOWS_DDNPM_VERSION": "2.0.5",
+        "WINDOWS_DDNPM_SHASUM": "2df99754d1fb1bd1d7d33c125a9303faf9d35423545123589985e186d499d9dd"
     },
     "dca-1.17.0": {
         "SECURITY_AGENT_POLICIES_VERSION": "v0.18.6"

--- a/release.json
+++ b/release.json
@@ -11,9 +11,9 @@
         "JMXFETCH_VERSION": "0.47.1",
         "JMXFETCH_HASH": "4cbbff73abfa0e6baaa1e3cad57497abcbb0e1570a022eecb7828dce3a14a3d9",
         "MACOS_BUILD_VERSION": "master",
-        "WINDOWS_DDNPM_DRIVER": "release-signed",
-        "WINDOWS_DDNPM_VERSION": "2.0.4",
-        "WINDOWS_DDNPM_SHASUM": "7f1f7500d561283f2c731d1a97f3596fe0f5ae7e2453b387ad2735ebd6b1d5fa",
+        "WINDOWS_DDNPM_DRIVER": "testsigned",
+        "WINDOWS_DDNPM_VERSION": "2.0.5",
+        "WINDOWS_DDNPM_SHASUM": "52a4bc07b6e203a27a20c38bb522d46ca7015ad378f3aac912032319c5eb91a0",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "nightly-a7": {
@@ -23,9 +23,9 @@
         "JMXFETCH_VERSION": "0.47.1",
         "JMXFETCH_HASH": "4cbbff73abfa0e6baaa1e3cad57497abcbb0e1570a022eecb7828dce3a14a3d9",
         "MACOS_BUILD_VERSION": "master",
-        "WINDOWS_DDNPM_DRIVER": "release-signed",
-        "WINDOWS_DDNPM_VERSION": "2.0.4",
-        "WINDOWS_DDNPM_SHASUM": "7f1f7500d561283f2c731d1a97f3596fe0f5ae7e2453b387ad2735ebd6b1d5fa",
+        "WINDOWS_DDNPM_DRIVER": "testsigned",
+        "WINDOWS_DDNPM_VERSION": "2.0.5",
+        "WINDOWS_DDNPM_SHASUM": "52a4bc07b6e203a27a20c38bb522d46ca7015ad378f3aac912032319c5eb91a0",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "release-a6": {
@@ -37,8 +37,8 @@
         "SECURITY_AGENT_POLICIES_VERSION": "v0.29.0",
         "MACOS_BUILD_VERSION": "6.40.0-rc.1",
         "WINDOWS_DDNPM_DRIVER": "release-signed",
-        "WINDOWS_DDNPM_VERSION": "2.0.4",
-        "WINDOWS_DDNPM_SHASUM": "7f1f7500d561283f2c731d1a97f3596fe0f5ae7e2453b387ad2735ebd6b1d5fa"
+        "WINDOWS_DDNPM_VERSION": "2.0.3",
+        "WINDOWS_DDNPM_SHASUM": "cd953f8e663cd77b2a9ad1b299e0bbb89082a3a37d2ab3a4cf85e97ac53265b8"
     },
     "release-a7": {
         "INTEGRATIONS_CORE_VERSION": "7.40.0-rc.2",
@@ -49,8 +49,8 @@
         "SECURITY_AGENT_POLICIES_VERSION": "v0.29.0",
         "MACOS_BUILD_VERSION": "7.40.0-rc.1",
         "WINDOWS_DDNPM_DRIVER": "release-signed",
-        "WINDOWS_DDNPM_VERSION": "2.0.4",
-        "WINDOWS_DDNPM_SHASUM": "7f1f7500d561283f2c731d1a97f3596fe0f5ae7e2453b387ad2735ebd6b1d5fa"
+        "WINDOWS_DDNPM_VERSION": "2.0.3",
+        "WINDOWS_DDNPM_SHASUM": "cd953f8e663cd77b2a9ad1b299e0bbb89082a3a37d2ab3a4cf85e97ac53265b8"
     },
     "dca-1.17.0": {
         "SECURITY_AGENT_POLICIES_VERSION": "v0.18.6"

--- a/release.json
+++ b/release.json
@@ -11,9 +11,9 @@
         "JMXFETCH_VERSION": "0.47.1",
         "JMXFETCH_HASH": "4cbbff73abfa0e6baaa1e3cad57497abcbb0e1570a022eecb7828dce3a14a3d9",
         "MACOS_BUILD_VERSION": "master",
-        "WINDOWS_DDNPM_DRIVER": "testsigned",
+        "WINDOWS_DDNPM_DRIVER": "release-signed",
         "WINDOWS_DDNPM_VERSION": "2.0.4",
-        "WINDOWS_DDNPM_SHASUM": "79e1f9860da2d295eb8309da406a62f5fc0b1d346ee6579747f9053dbc53610c",
+        "WINDOWS_DDNPM_SHASUM": "7f1f7500d561283f2c731d1a97f3596fe0f5ae7e2453b387ad2735ebd6b1d5fa",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "nightly-a7": {
@@ -23,9 +23,9 @@
         "JMXFETCH_VERSION": "0.47.1",
         "JMXFETCH_HASH": "4cbbff73abfa0e6baaa1e3cad57497abcbb0e1570a022eecb7828dce3a14a3d9",
         "MACOS_BUILD_VERSION": "master",
-        "WINDOWS_DDNPM_DRIVER": "testsigned",
+        "WINDOWS_DDNPM_DRIVER": "release-signed",
         "WINDOWS_DDNPM_VERSION": "2.0.4",
-        "WINDOWS_DDNPM_SHASUM": "79e1f9860da2d295eb8309da406a62f5fc0b1d346ee6579747f9053dbc53610c",
+        "WINDOWS_DDNPM_SHASUM": "7f1f7500d561283f2c731d1a97f3596fe0f5ae7e2453b387ad2735ebd6b1d5fa",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "release-a6": {
@@ -37,8 +37,8 @@
         "SECURITY_AGENT_POLICIES_VERSION": "v0.29.0",
         "MACOS_BUILD_VERSION": "6.40.0-rc.1",
         "WINDOWS_DDNPM_DRIVER": "release-signed",
-        "WINDOWS_DDNPM_VERSION": "2.0.3",
-        "WINDOWS_DDNPM_SHASUM": "cd953f8e663cd77b2a9ad1b299e0bbb89082a3a37d2ab3a4cf85e97ac53265b8"
+        "WINDOWS_DDNPM_VERSION": "2.0.4",
+        "WINDOWS_DDNPM_SHASUM": "7f1f7500d561283f2c731d1a97f3596fe0f5ae7e2453b387ad2735ebd6b1d5fa"
     },
     "release-a7": {
         "INTEGRATIONS_CORE_VERSION": "7.40.0-rc.2",
@@ -49,8 +49,8 @@
         "SECURITY_AGENT_POLICIES_VERSION": "v0.29.0",
         "MACOS_BUILD_VERSION": "7.40.0-rc.1",
         "WINDOWS_DDNPM_DRIVER": "release-signed",
-        "WINDOWS_DDNPM_VERSION": "2.0.3",
-        "WINDOWS_DDNPM_SHASUM": "cd953f8e663cd77b2a9ad1b299e0bbb89082a3a37d2ab3a4cf85e97ac53265b8"
+        "WINDOWS_DDNPM_VERSION": "2.0.4",
+        "WINDOWS_DDNPM_SHASUM": "7f1f7500d561283f2c731d1a97f3596fe0f5ae7e2453b387ad2735ebd6b1d5fa"
     },
     "dca-1.17.0": {
         "SECURITY_AGENT_POLICIES_VERSION": "v0.18.6"

--- a/release.json
+++ b/release.json
@@ -11,9 +11,9 @@
         "JMXFETCH_VERSION": "0.47.1",
         "JMXFETCH_HASH": "4cbbff73abfa0e6baaa1e3cad57497abcbb0e1570a022eecb7828dce3a14a3d9",
         "MACOS_BUILD_VERSION": "master",
-        "WINDOWS_DDNPM_DRIVER": "release-signed",
-        "WINDOWS_DDNPM_VERSION": "2.0.3",
-        "WINDOWS_DDNPM_SHASUM": "cd953f8e663cd77b2a9ad1b299e0bbb89082a3a37d2ab3a4cf85e97ac53265b8",
+        "WINDOWS_DDNPM_DRIVER": "testsigned",
+        "WINDOWS_DDNPM_VERSION": "2.0.4",
+        "WINDOWS_DDNPM_SHASUM": "79e1f9860da2d295eb8309da406a62f5fc0b1d346ee6579747f9053dbc53610c",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "nightly-a7": {
@@ -23,9 +23,9 @@
         "JMXFETCH_VERSION": "0.47.1",
         "JMXFETCH_HASH": "4cbbff73abfa0e6baaa1e3cad57497abcbb0e1570a022eecb7828dce3a14a3d9",
         "MACOS_BUILD_VERSION": "master",
-        "WINDOWS_DDNPM_DRIVER": "release-signed",
-        "WINDOWS_DDNPM_VERSION": "2.0.3",
-        "WINDOWS_DDNPM_SHASUM": "cd953f8e663cd77b2a9ad1b299e0bbb89082a3a37d2ab3a4cf85e97ac53265b8",
+        "WINDOWS_DDNPM_DRIVER": "testsigned",
+        "WINDOWS_DDNPM_VERSION": "2.0.4",
+        "WINDOWS_DDNPM_SHASUM": "79e1f9860da2d295eb8309da406a62f5fc0b1d346ee6579747f9053dbc53610c",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "release-a6": {


### PR DESCRIPTION
Fixes (unreleased) deadlock in driver when querying flows.

### What does this PR do?

Integrates new 2.0.5 driver; resolves deadlock caused when the system-probe retrieves flows.

(note that while the branch says 2.0.4, internal testing showed the fix was not complete in 2.0.4, hence the ultimate upgrade to 2.0.5)
### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Install previous version.  Run fairly high load (vegeta at 1500 conns/sec will do it).  Wait.  sooner or later the machine will hang.

Install this version.  Same instructions.  Won't hang (or shouldn't)

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
