### PR TITLE
fix: K8s Discovery Client initialisation in certain cases

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -316,6 +316,26 @@ func (k *KSMCheck) discoverCustomResources(c *apiserver.APIClient, collectors []
 		customresources.NewExtendedJobFactory(),
 	}
 
+	factories = manageResourcesReplacement(c, factories)
+
+	clients := make(map[string]interface{}, len(factories))
+	for _, f := range factories {
+		clients[f.Name()] = c.Cl
+	}
+
+	return customResources{
+		collectors: collectors,
+		clients:    clients,
+		factories:  factories,
+	}
+}
+
+func manageResourcesReplacement(c *apiserver.APIClient, factories []customresource.RegistryFactory) []customresource.RegistryFactory {
+	if c.DiscoveryCl == nil {
+		log.Warnf("kubernetes discovery client has not been properly initialized")
+		return factories
+	}
+
 	_, resources, err := c.DiscoveryCl.ServerGroupsAndResources()
 	if err != nil {
 		if !discovery.IsGroupDiscoveryFailedError(err) {
@@ -367,16 +387,7 @@ func (k *KSMCheck) discoverCustomResources(c *apiserver.APIClient, collectors []
 		}
 	}
 
-	clients := make(map[string]interface{}, len(factories))
-	for _, f := range factories {
-		clients[f.Name()] = c.Cl
-	}
-
-	return customResources{
-		collectors: collectors,
-		clients:    clients,
-		factories:  factories,
-	}
+	return factories
 }
 
 // Run runs the KSM check

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -332,7 +332,7 @@ func (k *KSMCheck) discoverCustomResources(c *apiserver.APIClient, collectors []
 
 func manageResourcesReplacement(c *apiserver.APIClient, factories []customresource.RegistryFactory) []customresource.RegistryFactory {
 	if c.DiscoveryCl == nil {
-		log.Warnf("kubernetes discovery client has not been properly initialized")
+		log.Warn("Kubernetes discovery client has not been properly initialized")
 		return factories
 	}
 

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -284,6 +284,12 @@ func (c *APIClient) connect() error {
 		return err
 	}
 
+	c.DiscoveryCl, err = getKubeDiscoveryClient(time.Duration(c.timeoutSeconds) * time.Second)
+	if err != nil {
+		log.Infof("Could not get apiserver discovery client: %v", err)
+		return err
+	}
+
 	c.VPAClient, err = getKubeVPAClient(time.Duration(c.timeoutSeconds) * time.Second)
 	if err != nil {
 		log.Infof("Could not get apiserver vpa client: %v", err)
@@ -292,16 +298,11 @@ func (c *APIClient) connect() error {
 
 	if config.Datadog.GetBool("admission_controller.enabled") ||
 		config.Datadog.GetBool("compliance_config.enabled") ||
-		config.Datadog.GetBool("orchestrator_explorer.enabled") {
+		config.Datadog.GetBool("orchestrator_explorer.enabled") ||
+		config.Datadog.GetBool("cluster_checks.enabled") {
 		c.DynamicCl, err = getKubeDynamicClient(time.Duration(c.timeoutSeconds) * time.Second)
 		if err != nil {
 			log.Infof("Could not get apiserver dynamic client: %v", err)
-			return err
-		}
-
-		c.DiscoveryCl, err = getKubeDiscoveryClient(time.Duration(c.timeoutSeconds) * time.Second)
-		if err != nil {
-			log.Infof("Could not get apiserver discovery client: %v", err)
 			return err
 		}
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

The DiscoveryCl was only enabled for specific configuration options
that didn't cover all the possible usage of it.
For example `kubernetes_state_core` on CLC runner needs to have it
enable, but it wasn't the case.

Without this fix, the kubernetes_state_check panic

### Motivation

Allow `kubernetes_state_core` check to run properly on CLC runner with agent version 7.40.0-rc.2

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Deploy the Datadog-Agent with the helm chart: enable the `clustercheckrunner` and enable `kubernetes_state_core` to run as clustercheck.

With 7.40.0-rc.2 the check should panic.
With this fix the check should run properly.


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
