### PR TITLE
process-agent: Add X-DD-REQUEST-ID header

### DIFF
--- a/cmd/process-agent/collector.go
+++ b/cmd/process-agent/collector.go
@@ -7,8 +7,10 @@ package main
 
 import (
 	"fmt"
+	"hash/fnv"
 	"math/rand"
 	"net/http"
+	"os"
 	"strconv"
 	"sync"
 	"time"
@@ -258,6 +260,35 @@ func (l *Collector) messagesToResultsQueue(start time.Time, name string, message
 	updateProcContainerCount(messages)
 }
 
+// getRequestID generates a unique identifier (string representation of 64 bits integer) that is composed as follows:
+//	1. 22 bits of the seconds in the current month.
+//	2. 28 bits of hash of the hostname and process agent pid.
+// 	3. 14 bits of the current message in the batch being sent to the server.
+func (l *Collector) getRequestID(start time.Time, chunkIndex int) (string, error) {
+	// The epoch is the beginning of the month of the `start` variable.
+	epoch := time.Date(start.Year(), start.Month(), 1, 0, 0, 0, 0, start.Location())
+	// We are taking the seconds in the current month, and representing them under 22 bits.
+	// In a month we have 60 seconds per minute * 60 minutes per hour * 24 hours per day * maximum 31 days a month
+	// which is 2678400, and it can be represented with log2(2678400) = 21.35 bits.
+	requestID := fmt.Sprintf("%022b", int64(start.Sub(epoch).Seconds()))[:22]
+
+	// Next, we want 28 bits of hashed hostname & process agent pid.
+	hash := fnv.New32()
+	hash.Write([]byte(l.cfg.HostName))
+	hash.Write([]byte(strconv.Itoa(os.Getpid())))
+	requestID += fmt.Sprintf("%032b", hash.Sum32())[:28]
+
+	// Next, we take up to 14 bits to represent the message index in the batch.
+	// It means that we support up to 16384 (2 ^ 14) different messages being sent on the same batch.
+	requestID += fmt.Sprintf("%014b", chunkIndex)
+	parseNumber, err := strconv.ParseInt(requestID, 2, 64)
+	if err != nil {
+		return "", err
+	}
+	// Converting the number into string representation.
+	return strconv.FormatInt(parseNumber, 10), nil
+}
+
 func (l *Collector) messagesToCheckResult(start time.Time, name string, messages []model.MessageBody) *checkResult {
 	if len(messages) == 0 {
 		return nil
@@ -266,7 +297,7 @@ func (l *Collector) messagesToCheckResult(start time.Time, name string, messages
 	payloads := make([]checkPayload, 0, len(messages))
 	sizeInBytes := 0
 
-	for _, m := range messages {
+	for messageIndex, m := range messages {
 		body, err := api.EncodePayload(m)
 		if err != nil {
 			log.Errorf("Unable to encode message: %s", err)
@@ -280,6 +311,13 @@ func (l *Collector) messagesToCheckResult(start time.Time, name string, messages
 		extraHeaders.Set(headers.ProcessVersionHeader, agentVersion.GetNumber())
 		extraHeaders.Set(headers.ContainerCountHeader, strconv.Itoa(getContainerCount(m)))
 		extraHeaders.Set(headers.ContentTypeHeader, headers.ProtobufContentType)
+		requestID, err := l.getRequestID(start, messageIndex)
+		if err != nil {
+			log.Errorf("failed calculating request id due to: %w", err)
+		} else {
+			log.Debugf("the request id of the current message: %s", requestID)
+			extraHeaders.Set(headers.RequestIDHeader, requestID)
+		}
 
 		if l.cfg.Orchestrator.OrchestrationCollectionEnabled {
 			if cid, err := clustername.GetClusterID(); err == nil && cid != "" {

--- a/pkg/process/util/api/headers/headers.go
+++ b/pkg/process/util/api/headers/headers.go
@@ -28,4 +28,6 @@ const (
 	ContentEncodingHeader = "Content-Encoding"
 	// ZSTDContentEncoding contains that the encoding type is zstd
 	ZSTDContentEncoding = "zstd"
+	// RequestIDHeader contains a unique identifier per payloads being sent to the intake servers
+	RequestIDHeader = "X-DD-Request-ID"
 )


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Implementing the RFC https://datadoghq.atlassian.net/wiki/spaces/NET/pages/2580448137/RFC+Message+tracing+in+Networks+USM
which describes how to generate `X-DD-REQUEST-ID` parameter to enable tracing messages from the agent to the backend.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
