### PR TITLE
[CWS] Fallback to /proc for missing mounts

### DIFF
--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -149,6 +149,19 @@ var (
 	// Tags: -
 	MetricProcessResolverEnvsSize = newRuntimeMetric(".process_resolver.envs.size")
 
+	// Mount resolver metrics
+
+	// MetricMountResolverCacheSize is the name of the metric used to report the size of the user space
+	// mount cache
+	// Tags: -
+	MetricMountResolverCacheSize = newRuntimeMetric(".mount_resolver.cache_size")
+	// MetricMountResolverHits is the counter of successful mount resolution
+	// Tags: cache, procfs
+	MetricMountResolverHits = newRuntimeMetric(".mount_resolver.hits")
+	// MetricDentryResolverMiss is the counter of unsuccessful mount resolution
+	// Tags: cache, procfs
+	MetricMountResolverMiss = newRuntimeMetric(".mount_resolver.miss")
+
 	// Activity dump metrics
 
 	// MetricActivityDumpEventProcessed is the name of the metric used to count the number of events processed while

--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -105,7 +105,7 @@ func (ev *Event) GetPathResolutionError() error {
 // ResolveFilePath resolves the inode to a full path
 func (ev *Event) ResolveFilePath(f *model.FileEvent) string {
 	if !f.IsPathnameStrResolved && len(f.PathnameStr) == 0 {
-		path, err := ev.resolvers.resolveFileFieldsPath(&f.FileFields)
+		path, err := ev.resolvers.resolveFileFieldsPath(&f.FileFields, &ev.PIDContext)
 		if err != nil {
 			switch err.(type) {
 			case ErrDentryPathKeyNotFound:
@@ -135,7 +135,7 @@ func (ev *Event) ResolveFileBasename(f *model.FileEvent) string {
 // ResolveFileFilesystem resolves the filesystem a file resides in
 func (ev *Event) ResolveFileFilesystem(f *model.FileEvent) string {
 	if f.Filesystem == "" {
-		f.Filesystem = ev.resolvers.MountResolver.GetFilesystem(f.FileFields.MountID)
+		f.Filesystem = ev.resolvers.MountResolver.GetFilesystem(f.FileFields.MountID, ev.PIDContext.Pid)
 	}
 	return f.Filesystem
 }

--- a/pkg/security/probe/mount_resolver_test.go
+++ b/pkg/security/probe/mount_resolver_test.go
@@ -328,7 +328,7 @@ func TestMountResolver(t *testing.T) {
 			mr.dequeue(time.Now().Add(1 * time.Minute))
 
 			for _, testC := range tt.args.cases {
-				_, p, _, err := mr.GetMountPath(testC.mountID)
+				_, p, _, err := mr.GetMountPath(testC.mountID, 0)
 				if err != nil {
 					if testC.expectedError != nil {
 						assert.Equal(t, testC.expectedError.Error(), err.Error())

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -538,7 +538,7 @@ func (p *Probe) handleEvent(CPU int, data []byte) {
 
 		if event.Mount.GetFSType() == "nsfs" {
 			nsid := uint32(event.Mount.RootInode)
-			_, mountPath, _, _ := p.resolvers.MountResolver.GetMountPath(event.Mount.MountID)
+			_, mountPath, _, _ := p.resolvers.MountResolver.GetMountPath(event.Mount.MountID, event.PIDContext.Pid)
 			mountNetNSPath := utils.NetNSPathFromPath(mountPath)
 			_, _ = p.resolvers.NamespaceResolver.SaveNetworkNamespaceHandle(nsid, mountNetNSPath)
 		}
@@ -548,7 +548,7 @@ func (p *Probe) handleEvent(CPU int, data []byte) {
 			return
 		}
 
-		mount := p.resolvers.MountResolver.Get(event.Umount.MountID)
+		mount := p.resolvers.MountResolver.Get(event.Umount.MountID, event.PIDContext.Pid)
 		if mount != nil && mount.GetFSType() == "nsfs" {
 			nsid := uint32(mount.RootInode)
 			if namespace := p.resolvers.NamespaceResolver.ResolveNetworkNamespace(nsid); namespace != nil {
@@ -1077,7 +1077,7 @@ Discarder Count: Discardee Parameters
 		for entries := p.inodeDiscarders.Iterate(); entries.Next(&inode, &inodeParams); {
 			discardedInodeCount++
 			fields := model.FileFields{MountID: inode.PathKey.MountID, Inode: inode.PathKey.Inode, PathID: inode.PathKey.PathID}
-			path, err := p.resolvers.resolveFileFieldsPath(&fields)
+			path, err := p.resolvers.resolveFileFieldsPath(&fields, &model.PIDContext{Pid: 1, Tid: 1})
 			if err != nil {
 				path = err.Error()
 			}

--- a/pkg/security/probe/probe_monitor.go
+++ b/pkg/security/probe/probe_monitor.go
@@ -116,6 +116,9 @@ func (m *Monitor) SendStats() error {
 		if err := resolvers.NamespaceResolver.SendStats(); err != nil {
 			return fmt.Errorf("failed to send namespace_resolver stats: %w", err)
 		}
+		if err := resolvers.MountResolver.SendStats(); err != nil {
+			return fmt.Errorf("failed to send mount_resolver stats: %w", err)
+		}
 	}
 
 	if err := m.perfBufferMonitor.SendStats(); err != nil {

--- a/pkg/security/tests/filters_test.go
+++ b/pkg/security/tests/filters_test.go
@@ -603,7 +603,7 @@ func TestFilterDiscarderRetention(t *testing.T) {
 		Expression: `open.file.path =~ "{{.Root}}/no-approver-*" && open.flags & (O_CREAT | O_SYNC) > 0`,
 	}
 
-	testDrive, err := newTestDrive(t, "xfs", nil)
+	testDrive, err := newTestDrive(t, "xfs", nil, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/overlayfs_test.go
+++ b/pkg/security/tests/overlayfs_test.go
@@ -91,7 +91,7 @@ func TestOverlayFS(t *testing.T) {
 		},
 	}
 
-	testDrive, err := newTestDrive(t, "xfs", nil)
+	testDrive, err := newTestDrive(t, "xfs", nil, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/rename_test.go
+++ b/pkg/security/tests/rename_test.go
@@ -268,7 +268,7 @@ func TestRenameReuseInode(t *testing.T) {
 		Expression: `open.file.path == "{{.Root}}/test-rename-new"`,
 	}}
 
-	testDrive, err := newTestDrive(t, "xfs", nil)
+	testDrive, err := newTestDrive(t, "xfs", nil, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/testdrive.go
+++ b/pkg/security/tests/testdrive.go
@@ -43,8 +43,8 @@ func (td *testDrive) Path(filename ...string) (string, unsafe.Pointer, error) {
 	return path, unsafe.Pointer(filenamePtr), nil
 }
 
-func newTestDrive(tb testing.TB, fsType string, mountOpts []string) (*testDrive, error) {
-	return newTestDriveWithMountPoint(tb, fsType, mountOpts, "")
+func newTestDrive(tb testing.TB, fsType string, mountOpts []string, mountPoint string) (*testDrive, error) {
+	return newTestDriveWithMountPoint(tb, fsType, mountOpts, mountPoint)
 }
 
 func newTestDriveWithMountPoint(tb testing.TB, fsType string, mountOpts []string, mountPoint string) (*testDrive, error) {

--- a/pkg/security/tests/xattr_test.go
+++ b/pkg/security/tests/xattr_test.go
@@ -27,7 +27,7 @@ func TestSetXAttr(t *testing.T) {
 		Expression: `((setxattr.file.path == "{{.Root}}/test-setxattr" && setxattr.file.uid == 98 && setxattr.file.gid == 99) || setxattr.file.path == "{{.Root}}/test-setxattr-link") && setxattr.file.destination.namespace == "user" && setxattr.file.destination.name == "user.test_xattr"`,
 	}
 
-	testDrive, err := newTestDrive(t, "ext4", []string{"user_xattr"})
+	testDrive, err := newTestDrive(t, "ext4", []string{"user_xattr"}, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -152,7 +152,7 @@ func TestRemoveXAttr(t *testing.T) {
 		},
 	}
 
-	testDrive, err := newTestDrive(t, "ext4", []string{"user_xattr"})
+	testDrive, err := newTestDrive(t, "ext4", []string{"user_xattr"}, "")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

When an event with an unknown mount id is received, update the cache with the content
of /proc/<pid>/mountinfo  as a fallback.
This PR also add metrics on the number of entries in the cache and the resolution hits and misses.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
