### PR TITLE
Fix tokenization of negative numeric values in SQL obfuscator to remove extra characters prepended

### DIFF
--- a/pkg/obfuscate/sql_tokenizer.go
+++ b/pkg/obfuscate/sql_tokenizer.go
@@ -358,13 +358,11 @@ func (tkn *SQLTokenizer) Scan() (TokenKind, []byte) {
 				}
 				fallthrough
 			case isDigit(tkn.lastChar):
-				kind, tokenBytes := tkn.scanNumber(false)
-				return kind, append([]byte{'-'}, tokenBytes...)
+				return tkn.scanNumber(false)
 			case tkn.lastChar == '.':
 				tkn.advance()
 				if isDigit(tkn.lastChar) {
-					kind, tokenBytes := tkn.scanNumber(true)
-					return kind, append([]byte{'-', '.'}, tokenBytes...)
+					return tkn.scanNumber(true)
 				}
 				tkn.lastChar = '.'
 				tkn.pos--

--- a/pkg/obfuscate/sql_tokenizer_test.go
+++ b/pkg/obfuscate/sql_tokenizer_test.go
@@ -6,6 +6,8 @@
 package obfuscate
 
 import (
+	"math"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,4 +31,67 @@ func TestSQLTokenizerPosition(t *testing.T) {
 		tok.SkipBlank()
 	}
 	assert.Equal(10, tokenCount)
+}
+
+func TestTokenizeDecimalWithoutIntegerPart(t *testing.T) {
+	inputs := []string{
+		".001",
+		".21341",
+		"-.1234",
+		"-.0003",
+	}
+
+	for _, input := range inputs {
+		testTokenizeNumber(t, input)
+	}
+}
+
+func FuzzTokenizeIntegerStrings(f *testing.F) {
+	f.Add(int64(123456789))
+	f.Add(int64(0))
+	f.Add(int64(-1))
+	f.Add(int64(-2018))
+	f.Add(int64(math.MinInt64))
+	f.Add(int64(math.MaxInt64))
+	f.Add(int64(39))
+	f.Add(int64(7))
+	f.Add(int64(-83))
+	f.Add(int64(-9223372036854775807))
+	f.Add(int64(9))
+	f.Add(int64(-108))
+	f.Add(int64(-71))
+	f.Add(int64(-9223372036854775675))
+
+	f.Fuzz(func(t *testing.T, i int64) {
+		for _, base := range []int{8, 10} {
+			value := strconv.FormatInt(i, base)
+			testTokenizeNumber(t, value)
+		}
+	})
+}
+
+func FuzzTokenizeFloatStrings(f *testing.F) {
+	f.Add(float64(0))
+	f.Add(float64(0.123456789))
+	f.Add(float64(-0.123456789))
+	f.Add(float64(-.0123456789))
+	f.Add(float64(12.3456789))
+	f.Add(float64(-12.3456789))
+
+	f.Fuzz(func(t *testing.T, f float64) {
+		for _, format := range []byte{'e', 'E', 'f'} {
+			value := strconv.FormatFloat(f, format, -1, 64)
+			testTokenizeNumber(t, value)
+		}
+	})
+}
+
+func testTokenizeNumber(t *testing.T, input string) {
+	tok := NewSQLTokenizer(input, false, nil)
+	kind, buf := tok.Scan()
+	if kind != Number {
+		t.Errorf("the value [%s] was not interpreted as a number", input)
+	} else if input != string(buf) {
+		t.Errorf("the value [%s] was incorrectly parsed to [%s]", input, string(buf))
+	}
 }

--- a/releasenotes/notes/sql-obfuscator-correct-negative-number-parsing-3402ef6635f05694.yaml
+++ b/releasenotes/notes/sql-obfuscator-correct-negative-number-parsing-3402ef6635f05694.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Fix tokenization of negative numeric values in SQL obfuscator to remove extra characters prepended to the byte array
+    Fix tokenization of negative numeric values in the SQL obfuscator to remove extra characters prepended to the byte array.

--- a/releasenotes/notes/sql-obfuscator-correct-negative-number-parsing-3402ef6635f05694.yaml
+++ b/releasenotes/notes/sql-obfuscator-correct-negative-number-parsing-3402ef6635f05694.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix tokenization of negative numeric values in SQL obfuscator to remove extra characters prepended to the byte array


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Fix tokenization of negative numeric values in SQL obfuscator to remove extra characters prepended to the byte array, and adds fuzzing tests to catch any future issues with tokenizing numeric input.

### Motivation
The issue in https://datadoghq.atlassian.net/browse/DBM-964 was caused by incorrect handling of specific negative integers which were incorrectly assumed to be octal values. To prevent such issues from reoccurring, fuzzing tests were added. The fuzzing tests caught a minor problem that should not impact the behavior of SQL obfuscation, but the fix may slightly improve the performance.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Run the tests to ensure that negative numbers are still correctly obfuscated as before. 
In addition, the fuzzing tests can be run using `go test` with the `go test -fuzz=FuzzTestName` command.


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
