### PR TITLE
process-agent: Add X-DD-REQUEST-ID header

### DIFF
--- a/cmd/process-agent/collector_test.go
+++ b/cmd/process-agent/collector_test.go
@@ -455,8 +455,7 @@ func TestCollectorMessagesToCheckResult(t *testing.T) {
 	now := time.Now()
 	agentVersion, _ := version.Agent()
 
-	requestID, err := c.getRequestID(now, 0)
-	assert.NoError(t, err)
+	requestID := c.getRequestID(now, 0)
 
 	tests := []struct {
 		name          string
@@ -575,15 +574,12 @@ func Test_getRequestID(t *testing.T) {
 	assert.NoError(t, err)
 
 	fixedDate1 := time.Date(2022, 9, 1, 0, 0, 1, 0, time.Local)
-	id1, err := c.getRequestID(fixedDate1, 1)
-	assert.NoError(t, err)
-	id2, err := c.getRequestID(fixedDate1, 1)
-	assert.NoError(t, err)
+	id1 := c.getRequestID(fixedDate1, 1)
+	id2 := c.getRequestID(fixedDate1, 1)
 	// The calculation should be deterministic, so making sure the parameters generates the same id.
 	assert.Equal(t, id1, id2)
 	fixedDate2 := time.Date(2022, 9, 1, 0, 0, 2, 0, time.Local)
-	id3, err := c.getRequestID(fixedDate2, 1)
-	assert.NoError(t, err)
+	id3 := c.getRequestID(fixedDate2, 1)
 
 	// The request id is based on time, so if the difference it only the time, then the new ID should be greater.
 	id1Num, _ := strconv.ParseUint(id1, 10, 64)
@@ -591,14 +587,13 @@ func Test_getRequestID(t *testing.T) {
 	assert.Greater(t, id3Num, id1Num)
 
 	// Increasing the chunk index should increase the id.
-	id4, err := c.getRequestID(fixedDate2, 3)
-	assert.NoError(t, err)
+	id4 := c.getRequestID(fixedDate2, 3)
 	id4Num, _ := strconv.ParseUint(id4, 10, 64)
 	assert.Equal(t, id3Num+2, id4Num)
 
 	// Changing the host -> changing the hash.
 	cfg.HostName = "host2"
-	id5, err := c.getRequestID(fixedDate1, 1)
-	assert.NoError(t, err)
+	c.requestIDCachedHash = nil
+	id5 := c.getRequestID(fixedDate1, 1)
 	assert.NotEqual(t, id1, id5)
 }

--- a/pkg/process/util/api/headers/headers.go
+++ b/pkg/process/util/api/headers/headers.go
@@ -28,4 +28,6 @@ const (
 	ContentEncodingHeader = "Content-Encoding"
 	// ZSTDContentEncoding contains that the encoding type is zstd
 	ZSTDContentEncoding = "zstd"
+	// RequestIDHeader contains a unique identifier per payloads being sent to the intake servers
+	RequestIDHeader = "X-DD-Request-ID"
 )


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Add a unique identifier attached for each message being send to the backend for (`/api/v1/connections` and `/api/v1/collector`)
The unique identifier lives within a new header called `X-DD-REQUEST-ID`.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

The identifier will allow us to detect the route of a payload from the agent within our backend services and understand its life cycle and when and where it failed to process.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
