### PR TITLE
remove unused function

### DIFF
--- a/cmd/agent/app/snmp.go
+++ b/cmd/agent/app/snmp.go
@@ -325,19 +325,3 @@ func printValue(pdu gosnmp.SnmpPDU) error {
 
 	return nil
 }
-
-var strippableSpecialChars = map[byte]bool{'\r': true, '\n': true, '\t': true}
-
-// IsStringPrintable returns true if the provided byte array is only composed of printable characeters
-func IsStringPrintable(bytesValue []byte) bool {
-	for _, bit := range bytesValue {
-		if bit < 32 || bit > 126 {
-			// The char is not a printable ASCII char but it might be a character that
-			// can be stripped like `\n`
-			if _, ok := strippableSpecialChars[bit]; !ok {
-				return false
-			}
-		}
-	}
-	return true
-}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->
Remove the definition of the function `IsStringPrintable` as it is already imported through `utilFunc`. 
### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
1. start `snmp sim`:
in `integrations-core` run 
`ddev env start snmp py38`
`ddev env shell snmp`
inside docker container run
`apt-get update`
`apt-get install snmp -y`
2. test the command by running in `datadog-agent`
`./bin/agent/agent snmp walk 127.0.0.1:1161 1.3.6.1.2.1.1 -v 2c -C public`
### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
