### PR TITLE
[RCM] Allow the backend to override the agent's refresh interval

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -291,7 +291,7 @@ func InitConfig(config Config) {
 	config.BindEnv("remote_configuration.rc_dd_url", "")
 	config.BindEnvAndSetDefault("remote_configuration.config_root", "")
 	config.BindEnvAndSetDefault("remote_configuration.director_root", "")
-	config.BindEnvAndSetDefault("remote_configuration.refresh_interval", 1*time.Minute)
+	config.BindEnv("remote_configuration.refresh_interval")
 	config.BindEnvAndSetDefault("remote_configuration.max_backoff_interval", 5*time.Minute)
 	config.BindEnvAndSetDefault("remote_configuration.clients.ttl_seconds", 30*time.Second)
 	// Remote config products

--- a/pkg/config/remote/service/service.go
+++ b/pkg/config/remote/service/service.go
@@ -35,6 +35,7 @@ import (
 )
 
 const (
+	defaultRefreshInterval = 1 * time.Minute
 	minimalRefreshInterval = 5 * time.Second
 	defaultClientsTTL      = 30 * time.Second
 	maxClientsTTL          = 60 * time.Second
@@ -53,7 +54,8 @@ type Service struct {
 	sync.Mutex
 	firstUpdate bool
 
-	defaultRefreshInterval time.Duration
+	defaultRefreshInterval         time.Duration
+	refreshIntervalOverrideAllowed bool
 
 	// The backoff policy used for retries when errors are encountered
 	backoffPolicy backoff.Policy
@@ -89,10 +91,17 @@ type uptaneClient interface {
 
 // NewService instantiates a new remote configuration management service
 func NewService() (*Service, error) {
+	refreshIntervalOverrideAllowed := false // If a user provides a value we don't want to override
 	refreshInterval := config.Datadog.GetDuration("remote_configuration.refresh_interval")
+	if refreshInterval == 0 {
+		refreshInterval = defaultRefreshInterval
+		refreshIntervalOverrideAllowed = true
+	}
+
 	if refreshInterval < minimalRefreshInterval {
-		log.Warnf("remote_configuration.refresh_interval is set to %v which is bellow the minimum of %v", refreshInterval, minimalRefreshInterval)
+		log.Warnf("remote_configuration.refresh_interval is set to %v which is below the minimum of %v", refreshInterval, minimalRefreshInterval)
 		refreshInterval = minimalRefreshInterval
+		refreshIntervalOverrideAllowed = true
 	}
 
 	maxBackoffTime := config.Datadog.GetDuration("remote_configuration.max_backoff_interval")
@@ -156,19 +165,20 @@ func NewService() (*Service, error) {
 	}
 	clock := clock.New()
 	return &Service{
-		ctx:                    context.Background(),
-		firstUpdate:            true,
-		defaultRefreshInterval: refreshInterval,
-		backoffErrorCount:      0,
-		backoffPolicy:          backoffPolicy,
-		products:               make(map[rdata.Product]struct{}),
-		newProducts:            make(map[rdata.Product]struct{}),
-		hostname:               hname,
-		clock:                  clock,
-		db:                     db,
-		api:                    http,
-		uptane:                 uptaneClient,
-		clients:                newClients(clock, clientsTTL),
+		ctx:                            context.Background(),
+		firstUpdate:                    true,
+		defaultRefreshInterval:         refreshInterval,
+		refreshIntervalOverrideAllowed: refreshIntervalOverrideAllowed,
+		backoffErrorCount:              0,
+		backoffPolicy:                  backoffPolicy,
+		products:                       make(map[rdata.Product]struct{}),
+		newProducts:                    make(map[rdata.Product]struct{}),
+		hostname:                       hname,
+		clock:                          clock,
+		db:                             db,
+		api:                            http,
+		uptane:                         uptaneClient,
+		clients:                        newClients(clock, clientsTTL),
 		newActiveClients: newActiveClients{
 			clock:    clock,
 			requests: make(chan chan struct{}),
@@ -253,6 +263,17 @@ func (s *Service) refresh() error {
 		s.lastUpdateErr = fmt.Errorf("tuf: %v", err)
 		return err
 	}
+
+	// If a user hasn't explicitly set the refresh interval, allow the backend to override it based
+	// on the contents of our update request
+	if s.refreshIntervalOverrideAllowed {
+		ri, err := s.getRefreshInterval()
+		if err == nil && ri > 0 && s.defaultRefreshInterval != ri {
+			s.defaultRefreshInterval = ri
+			log.Info("Overriding agent's base refresh interval to %v due to backend recommendation", ri)
+		}
+	}
+
 	s.firstUpdate = false
 	for product := range s.newProducts {
 		s.products[product] = struct{}{}
@@ -288,6 +309,25 @@ func (s *Service) getClientState() ([]byte, error) {
 		return nil, err
 	}
 	return custom.OpaqueBackendState, nil
+}
+
+func (s *Service) getRefreshInterval() (time.Duration, error) {
+	rawTargetsCustom, err := s.uptane.TargetsCustom()
+	if err != nil {
+		return 0, err
+	}
+	custom, err := parseTargetsCustom(rawTargetsCustom)
+	if err != nil {
+		return 0, err
+	}
+
+	// We only allow intervals to be overridden if they are between [1s, 1m]
+	value := time.Second * time.Duration(custom.AgentRefreshInterval)
+	if value < time.Second || value > time.Minute {
+		return 0, nil
+	}
+
+	return value, nil
 }
 
 // ClientGetConfigs is the polling API called by tracers and agents to get the latest configurations

--- a/pkg/config/remote/service/util.go
+++ b/pkg/config/remote/service/util.go
@@ -148,7 +148,8 @@ func buildLatestConfigsRequest(hostname string, state uptane.TUFVersions, active
 }
 
 type targetsCustom struct {
-	OpaqueBackendState []byte `json:"opaque_backend_state"`
+	OpaqueBackendState   []byte `json:"opaque_backend_state"`
+	AgentRefreshInterval int64  `json:"agent_refresh_interval"`
 }
 
 func parseTargetsCustom(rawTargetsCustom []byte) (targetsCustom, error) {


### PR DESCRIPTION
Certain products want the agent to refresh at a more frequent interval in order to ensure config updates propagate in a timely manner. In order to accommodate this, we'll allow the backend to send refresh interval hints to the agent via the TUF director targets custom field. If the agent wasn't given a manual refresh interval by a user (this always takes priority) the agent will adjust its default refresh interval to the backend provided value, assuming it is in valid range.

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
