### PR TITLE
Separate network tracer start from init

### DIFF
--- a/pkg/network/netlink/conntracker_integration_test.go
+++ b/pkg/network/netlink/conntracker_integration_test.go
@@ -45,6 +45,8 @@ func TestConnTrackerCrossNamespaceAllNsDisabled(t *testing.T) {
 	cfg.EnableConntrackAllNamespaces = false
 	ct, err := NewConntracker(cfg)
 	require.NoError(t, err)
+	err = ct.Start()
+	require.NoError(t, err)
 	time.Sleep(time.Second)
 
 	closer := nettestutil.StartServerTCPNs(t, net.ParseIP("2.2.2.4"), 8080, ns)

--- a/pkg/network/netlink/noop.go
+++ b/pkg/network/netlink/noop.go
@@ -21,6 +21,10 @@ func NewNoOpConntracker() Conntracker {
 	return &noOpConntracker{}
 }
 
+func (*noOpConntracker) Start() error {
+	return nil
+}
+
 func (*noOpConntracker) GetTranslationForConn(c network.ConnectionStats) *network.IPTranslation {
 	return nil
 }

--- a/pkg/network/tracer/conntracker_test.go
+++ b/pkg/network/tracer/conntracker_test.go
@@ -86,13 +86,21 @@ func TestConntrackers(t *testing.T) {
 func setupEBPFConntracker(cfg *config.Config) (netlink.Conntracker, error) {
 	cfg.EnableRuntimeCompiler = true
 	cfg.AllowPrecompiledFallback = false
-	return NewEBPFConntracker(cfg, nil)
+	ct, err := NewEBPFConntracker(cfg, nil)
+	if err != nil {
+		return nil, err
+	}
+	return ct, ct.Start()
 }
 
 func setupNetlinkConntracker(cfg *config.Config) (netlink.Conntracker, error) {
 	cfg.ConntrackMaxStateSize = 100
 	cfg.ConntrackRateLimit = 500
 	ct, err := netlink.NewConntracker(cfg)
+	if err != nil {
+		return nil, err
+	}
+	err = ct.Start()
 	time.Sleep(100 * time.Millisecond)
 	return ct, err
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Splits network tracer startup into two steps: init and start

### Motivation

Flaky test for `TestGatewayLookupSubnetLookupError`

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
