### PR TITLE
pkg/trace/metrics: make the statsd client thread-safe to access.

### DIFF
--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -79,7 +79,7 @@ func NewAgent(ctx context.Context, conf *config.AgentConfig) *Agent {
 
 	oconf := conf.Obfuscation.Export()
 	if oconf.Statsd == nil {
-		oconf.Statsd = metrics.Client
+		oconf.Statsd = metrics.Client()
 	}
 	agnt := &Agent{
 		Concentrator:          stats.NewConcentrator(conf, statsChan, time.Now()),

--- a/pkg/trace/api/evp_proxy_test.go
+++ b/pkg/trace/api/evp_proxy_test.go
@@ -63,8 +63,8 @@ func TestEVPProxyForwarder(t *testing.T) {
 	rand.Read(randBodyBuf)
 
 	stats := &testutil.TestStatsClient{}
-	defer func(old metrics.StatsClient) { metrics.Client = old }(metrics.Client)
-	metrics.Client = stats
+	defer func(old metrics.StatsClient) { metrics.SetClient(old) }(metrics.Client())
+	metrics.SetClient(stats)
 
 	t.Run("ok", func(t *testing.T) {
 		stats.Reset()

--- a/pkg/trace/api/listener_test.go
+++ b/pkg/trace/api/listener_test.go
@@ -117,8 +117,8 @@ func TestMockListener(t *testing.T) {
 func TestMeasuredListener(t *testing.T) {
 	assert := assert.New(t)
 	stats := &testutil.TestStatsClient{}
-	defer func(old metrics.StatsClient) { metrics.Client = old }(metrics.Client)
-	metrics.Client = stats
+	defer func(old metrics.StatsClient) { metrics.SetClient(old) }(metrics.Client())
+	metrics.SetClient(stats)
 
 	var mockln mockListener
 	ln := NewMeasuredListener(&mockln, "test-metric").(*measuredListener)

--- a/pkg/trace/api/otlp_test.go
+++ b/pkg/trace/api/otlp_test.go
@@ -92,8 +92,8 @@ func TestOTLPMetrics(t *testing.T) {
 	stats := &testutil.TestStatsClient{}
 	cfg := config.New()
 
-	defer func(old metrics.StatsClient) { metrics.Client = old }(metrics.Client)
-	metrics.Client = stats
+	defer func(old metrics.StatsClient) { metrics.SetClient(old) }(metrics.Client())
+	metrics.SetClient(stats)
 	out := make(chan *Payload, 1)
 	rcv := NewOTLPReceiver(out, cfg)
 	rspans := testutil.NewOTLPTracesRequest([]testutil.OTLPResourceSpan{

--- a/pkg/trace/appsec/appsec_test.go
+++ b/pkg/trace/appsec/appsec_test.go
@@ -409,8 +409,8 @@ func TestRoundTripper(t *testing.T) {
 			tc := tc
 			t.Run(tc.name, func(t *testing.T) {
 				stats := &testutil.TestStatsClient{}
-				defer func(old metrics.StatsClient) { metrics.Client = old }(metrics.Client)
-				metrics.Client = stats
+				defer func(old metrics.StatsClient) { metrics.SetClient(old) }(metrics.Client())
+				metrics.SetClient(stats)
 
 				// Wrap a test round-tripper with metrics
 				rt := withMetrics(roundTripperFunc(func(req *http.Request) (*http.Response, error) {

--- a/pkg/trace/info/stats_test.go
+++ b/pkg/trace/info/stats_test.go
@@ -190,8 +190,8 @@ func (ts *testStatsClient) Flush() error { return nil }
 
 func TestReceiverStats(t *testing.T) {
 	statsclient := &testStatsClient{}
-	defer func(old metrics.StatsClient) { metrics.Client = statsclient }(metrics.Client)
-	metrics.Client = statsclient
+	defer func(old metrics.StatsClient) { metrics.SetClient(statsclient) }(metrics.Client())
+	metrics.SetClient(statsclient)
 
 	tags := Tags{
 		Lang:            "go",

--- a/pkg/trace/metrics/client_test.go
+++ b/pkg/trace/metrics/client_test.go
@@ -44,8 +44,8 @@ func (ts *testStatsClient) Flush() error {
 
 func TestForwarding(t *testing.T) {
 	t.Run("nil", func(t *testing.T) {
-		defer func(old StatsClient) { Client = old }(Client)
-		Client = nil
+		defer func(old StatsClient) { SetClient(old) }(Client())
+		SetClient(nil)
 		assert.NoError(t, Gauge("stat", 1, nil, 1))
 		assert.NoError(t, Count("stat", 1, nil, 1))
 		assert.NoError(t, Histogram("stat", 1, nil, 1))
@@ -54,9 +54,9 @@ func TestForwarding(t *testing.T) {
 	})
 
 	t.Run("valid", func(t *testing.T) {
-		defer func(old StatsClient) { Client = old }(Client)
+		defer func(old StatsClient) { SetClient(old) }(Client())
 		var testclient testStatsClient
-		Client = &testclient
+		SetClient(&testclient)
 		assert.NoError(t, Gauge("stat", 1, nil, 1))
 		assert.NoError(t, Count("stat", 1, nil, 1))
 		assert.NoError(t, Histogram("stat", 1, nil, 1))

--- a/pkg/trace/metrics/metrics.go
+++ b/pkg/trace/metrics/metrics.go
@@ -46,6 +46,6 @@ func Configure(conf *config.AgentConfig, tags []string) error {
 	if err != nil {
 		return err
 	}
-	Client = client
+	SetClient(client)
 	return nil
 }

--- a/pkg/trace/metrics/timing/timing_test.go
+++ b/pkg/trace/metrics/timing/timing_test.go
@@ -22,8 +22,8 @@ func TestTiming(t *testing.T) {
 	assert := assert.New(t)
 	stats := &testutil.TestStatsClient{}
 
-	defer func(old metrics.StatsClient) { metrics.Client = old }(metrics.Client)
-	metrics.Client = stats
+	defer func(old metrics.StatsClient) { metrics.SetClient(old) }(metrics.Client())
+	metrics.SetClient(stats)
 
 	t.Run("report", func(t *testing.T) {
 		stats.Reset()


### PR DESCRIPTION

### What does this PR do?
This commit adds a RWMutex around the client to serialize access.

### Motivation
We discovered a race on setting/accessing the metrics client which occurred while running tests. 

### Describe how to test/QA your changes

Run the agent and make sure metrics continue to show up in the UI as expected.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
