### PR TITLE
validate caseID in GUI /agent/flare handler

### DIFF
--- a/cmd/agent/gui/agent.go
+++ b/cmd/agent/gui/agent.go
@@ -135,6 +135,9 @@ func makeFlare(w http.ResponseWriter, r *http.Request) {
 	} else if payload.Email == "" || payload.CaseID == "" {
 		w.Write([]byte("Error creating flare: missing information"))
 		return
+	} else if _, err := strconv.ParseInt(payload.CaseID, 10, 0); err != nil {
+		w.Write([]byte("Invalid CaseID (must be a number)"))
+		return
 	}
 
 	logFile := config.Datadog.GetString("log_file")

--- a/cmd/agent/gui/gui.go
+++ b/cmd/agent/gui/gui.go
@@ -10,6 +10,7 @@ import (
 	"embed"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"html/template"
 	"io/ioutil"
@@ -230,6 +231,11 @@ func parseBody(r *http.Request) (Payload, error) {
 	e = json.Unmarshal(body, &p)
 	if e != nil {
 		return p, e
+	}
+
+	// perform some validation of the input
+	if _, err := strconv.ParseInt(p.CaseID, 10, 0); err != nil {
+		return Payload{}, errors.New("Invalid CaseID (must be a number)")
 	}
 
 	return p, nil

--- a/cmd/agent/gui/gui.go
+++ b/cmd/agent/gui/gui.go
@@ -10,7 +10,6 @@ import (
 	"embed"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"html/template"
 	"io/ioutil"
@@ -231,11 +230,6 @@ func parseBody(r *http.Request) (Payload, error) {
 	e = json.Unmarshal(body, &p)
 	if e != nil {
 		return p, e
-	}
-
-	// perform some validation of the input
-	if _, err := strconv.ParseInt(p.CaseID, 10, 0); err != nil {
-		return Payload{}, errors.New("Invalid CaseID (must be a number)")
 	}
 
 	return p, nil


### PR DESCRIPTION
### What does this PR do?

Adds some validation of the format of the caseID passed to the GUI's flare endpoint.

### Motivation

This is eventually interpolated into a URL, and is simple to validate.  This will also surface errors to the user better.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Start an agent, launch the gui, and submit a flare with an empty caseID via the GUI.  Verify that the agent does not crash.  Submit another flare using the same caseID that you got on the first try, and verify it does not crash.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
