### PR TITLE
[RCM] Support filtering expired configs in agent

### DIFF
--- a/pkg/config/remote/service/client_predicates.go
+++ b/pkg/config/remote/service/client_predicates.go
@@ -7,6 +7,7 @@ package service
 
 import (
 	"encoding/json"
+	"time"
 
 	"github.com/Masterminds/semver"
 	"github.com/theupdateframework/go-tuf/data"
@@ -16,8 +17,9 @@ import (
 )
 
 // DirectorTargetsCustomMetadata TODO (<remote-config>): RCM-228
-type DirectorTargetsCustomMetadata struct {
+type ConfigFileMetaCustom struct {
 	Predicates *pbgo.TracerPredicates `json:"tracer-predicates,omitempty"`
+	Expires    int64                  `json:"expires"`
 }
 
 // Given the hostname and state will parse predicates and execute them
@@ -41,12 +43,16 @@ func executeClientPredicates(
 		if _, productRequested := productsMap[pathMeta.Product]; !productRequested {
 			continue
 		}
-		tracerPredicates, err := parsePredicates(meta.Custom)
+		configMetadata, err := parseFileMetaCustom(meta.Custom)
 		if err != nil {
 			return nil, err
 		}
+		if configExpired(configMetadata.Expires) {
+			continue
+		}
 
-		var matched bool
+		tracerPredicates := configMetadata.Predicates
+		matched := false
 		nullPredicates := tracerPredicates == nil || tracerPredicates.TracerPredicatesV1 == nil
 		if !nullPredicates {
 			matched, err = executePredicate(client, tracerPredicates.TracerPredicatesV1)
@@ -64,16 +70,19 @@ func executeClientPredicates(
 	return configs, nil
 }
 
-func parsePredicates(customJSON *json.RawMessage) (*pbgo.TracerPredicates, error) {
+func parseFileMetaCustom(customJSON *json.RawMessage) (ConfigFileMetaCustom, error) {
+	var metadata ConfigFileMetaCustom
+
 	if customJSON == nil {
-		return nil, nil
+		return metadata, nil
 	}
-	metadata := new(DirectorTargetsCustomMetadata)
-	err := json.Unmarshal(*customJSON, metadata)
+
+	err := json.Unmarshal(*customJSON, &metadata)
 	if err != nil {
-		return nil, err
+		return metadata, err
 	}
-	return metadata.Predicates, nil
+
+	return metadata, nil
 }
 
 func executePredicate(client *pbgo.Client, predicates []*pbgo.TracerPredicateV1) (bool, error) {
@@ -124,4 +133,15 @@ func executePredicate(client *pbgo.Client, predicates []*pbgo.TracerPredicateV1)
 	}
 
 	return false, nil
+}
+
+func configExpired(expiration int64) bool {
+	// A value of 0 means "no expiration"
+	if expiration == 0 {
+		return false
+	}
+
+	expirationTime := time.Unix(expiration, 0)
+
+	return time.Now().After(expirationTime)
 }


### PR DESCRIPTION
Adds the ability for the backend to indicate the expiration time for a given configuration ID. If the config is expired, the agent will not deliver that configuration to downstream clients. This allows config that might be time sensitive to expire even if the connection to the Datadog backend is not active to receive updates.

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
