### PR TITLE
pkg/trace/api: Upgrade debugger proxy to use logs V2 intake

### DIFF
--- a/pkg/trace/api/debugger.go
+++ b/pkg/trace/api/debugger.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/log"
 	"github.com/DataDog/datadog-agent/pkg/trace/metrics"
@@ -21,7 +23,7 @@ import (
 
 const (
 	// logsIntakeURLTemplate specifies the template for obtaining the intake URL along with the site.
-	logsIntakeURLTemplate = "https://http-intake.logs.%s/v1/input"
+	logsIntakeURLTemplate = "https://http-intake.logs.%s/api/v2/logs"
 )
 
 // debuggerProxyHandler returns an http.Handler proxying requests to the logs intake. If the logs intake url cannot be
@@ -75,6 +77,8 @@ func newDebuggerProxy(conf *config.AgentConfig, target *url.URL, key string, tag
 		newTarget := *target
 		newTarget.RawQuery = q.Encode()
 		req.Header.Set("DD-API-KEY", key)
+		req.Header.Set("DD-REQUEST-ID", uuid.New().String())
+		req.Header.Set("DD-EVP-ORIGIN", "agent-debugger")
 		req.URL = &newTarget
 		req.Host = target.Host
 	}

--- a/pkg/trace/go.mod
+++ b/pkg/trace/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/protobuf v1.5.2
 	github.com/google/gofuzz v1.2.0
+	github.com/google/uuid v1.1.2
 	github.com/pkg/errors v0.9.1
 	github.com/shirou/gopsutil/v3 v3.22.6
 	github.com/stretchr/testify v1.8.0

--- a/pkg/trace/go.sum
+++ b/pkg/trace/go.sum
@@ -115,6 +115,7 @@ github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
+github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gnostic v0.5.1/go.mod h1:6U4PtQXGIEt/Z3h5MAT7FNofLnw9vXk2cUuW7uA/OeU=
 github.com/googleapis/gnostic v0.5.5/go.mod h1:7+EbHbldMins07ALC74bsA81Ovc97DwqyJO1AENw9kA=

--- a/releasenotes/notes/upgrade-debugger-logs-intake-963210e615404bdd.yaml
+++ b/releasenotes/notes/upgrade-debugger-logs-intake-963210e615404bdd.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+upgrade:
+  - |
+    Upgrade tracer_agent debugger proxy to use logs intake API v2 
+    for uploading snapshots 


### PR DESCRIPTION

### What does this PR do?

Upgrade the debugger proxy to upload snapshots and probe status using logs intake API V2

### Motivation

Ensure we are using the latest API version

### Describe how to test/QA your changes

* Testing debugger api endpoint and see messages appear on datadog portal
* Testing on staging to ensure everything works as expected

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
