### PR TITLE
Add system-probe testing for Amazon Linux 2022

### DIFF
--- a/.gitlab/functional_test/system_probe.yml
+++ b/.gitlab/functional_test/system_probe.yml
@@ -41,6 +41,24 @@ kitchen_test_system_probe_linux_x64:
         KITCHEN_OSVERS: "centos-76,rhel-81"
 
 
+kitchen_test_system_probe_linux_x64_ec2:
+  extends:
+    - .kitchen_test_system_probe
+    - .kitchen_ec2_location_us_east_1
+    - .kitchen_ec2_spot_instances
+  needs: [ "tests_ebpf_x64" ]
+  variables:
+    KITCHEN_ARCH: x86_64
+    KITCHEN_EC2_INSTANCE_TYPE: "t2.xlarge"
+  before_script:
+    - cd $DD_AGENT_TESTING_DIR
+    - bash -l tasks/kitchen_setup.sh
+  parallel:
+    matrix:
+      - KITCHEN_PLATFORM: "amazonlinux"
+        KITCHEN_OSVERS: "amazonlinux2-4-14,amazonlinux2-5-10,amazonlinux2022-5-15"
+
+
 kitchen_test_system_probe_linux_arm64:
   extends:
     - .kitchen_test_system_probe
@@ -62,7 +80,7 @@ kitchen_test_system_probe_linux_arm64:
       - KITCHEN_PLATFORM: "centos"
         KITCHEN_OSVERS: "centos-78,rhel-83"
       - KITCHEN_PLATFORM: "amazonlinux"
-        KITCHEN_OSVERS: "amazonlinux2-4-14,amazonlinux2-5-10"
+        KITCHEN_OSVERS: "amazonlinux2-4-14,amazonlinux2-5-10,amazonlinux2022-5-15"
 
 kitchen_test_system_probe_windows_x64:
   extends:

--- a/pkg/network/netlink/conntrack_integration_test.go
+++ b/pkg/network/netlink/conntrack_integration_test.go
@@ -10,7 +10,6 @@ package netlink
 
 import (
 	"fmt"
-	"io"
 	"net"
 	"testing"
 	"time"
@@ -96,10 +95,15 @@ func TestConntrackExists6(t *testing.T) {
 }
 
 func TestConntrackExistsRootDNAT(t *testing.T) {
-	ns := testutil.SetupCrossNsDNAT(t)
+	destIP := "10.10.1.1"
+	destPort := 80
+	listenIP := "2.2.2.4"
+	listenPort := 8080
+	ns := testutil.SetupCrossNsDNATWithPorts(t, destPort, listenPort)
+
 	t.Cleanup(func() {
 		nettestutil.RunCommands(t, []string{
-			"iptables --table nat --delete CLUSTERIPS --destination 10.10.1.1 --protocol tcp --match tcp --dport 80 --jump DNAT --to-destination 2.2.2.4:80",
+			fmt.Sprintf("iptables --table nat --delete CLUSTERIPS --destination %s --protocol tcp --match tcp --dport %d --jump DNAT --to-destination %s:%d", destIP, destPort, listenIP, destPort),
 			"iptables --table nat --delete PREROUTING --jump CLUSTERIPS",
 			"iptables --table nat --delete OUTPUT --jump CLUSTERIPS",
 			"iptables --table nat --delete-chain CLUSTERIPS",
@@ -109,7 +113,8 @@ func TestConntrackExistsRootDNAT(t *testing.T) {
 		"iptables --table nat --new-chain CLUSTERIPS",
 		"iptables --table nat --append PREROUTING --jump CLUSTERIPS",
 		"iptables --table nat --append OUTPUT --jump CLUSTERIPS",
-		"iptables --table nat --append CLUSTERIPS --destination 10.10.1.1 --protocol tcp --match tcp --dport 80 --jump DNAT --to-destination 2.2.2.4:80",
+		fmt.Sprintf("iptables --table nat --append CLUSTERIPS --destination %s --protocol tcp --match tcp --dport %d --jump DNAT --to-destination %s:%d", destIP, destPort, listenIP, destPort),
+		fmt.Sprintf("ip route add %s dev veth1", destIP),
 	}, false)
 
 	testNs, err := netns.GetFromName(ns)
@@ -120,13 +125,7 @@ func TestConntrackExistsRootDNAT(t *testing.T) {
 	require.NoError(t, err)
 	defer rootNs.Close()
 
-	destIP := "10.10.1.1"
-	destPort := 80
-	var tcpCloser io.Closer
-	_ = util.WithNS("/proc", testNs, func() error {
-		tcpCloser = nettestutil.StartServerTCP(t, net.ParseIP("2.2.2.4"), 8080)
-		return nil
-	})
+	tcpCloser := nettestutil.StartServerTCPNs(t, net.ParseIP(listenIP), listenPort, ns)
 	defer tcpCloser.Close()
 
 	tcpConn := nettestutil.PingTCP(t, net.ParseIP(destIP), destPort)

--- a/pkg/network/testutil/server.go
+++ b/pkg/network/testutil/server.go
@@ -9,6 +9,7 @@
 package testutil
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -54,7 +55,11 @@ func StartServerTCP(t *testing.T, ip net.IP, port int) io.Closer {
 		for {
 			conn, err := l.Accept()
 			if err != nil {
-				return
+				if errors.Is(err, net.ErrClosed) {
+					return
+				}
+				t.Logf("accept error: %s", err)
+				continue
 			}
 
 			_, _ = conn.Write([]byte("hello"))

--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -97,12 +97,12 @@
             "x86_64": {
                 "amazonlinux2-4-14": "ami-038b3df3312ddf25d",
                 "amazonlinux2-5-10": "ami-033b95fb8079dc481",
-                "amazonlinux2022-5-15": "ami-0a0cf2b8bc4634fe1"
+                "amazonlinux2022-5-15": "ami-0309aede310b9cc1f"
             },
             "arm64": {
                 "amazonlinux2-4-14": "ami-090230ed0c6b13c74",
                 "amazonlinux2-5-10": "ami-0e449176cecc3e577",
-                "amazonlinux2022-5-15": "ami-00bca6c8c9d0e6f92"
+                "amazonlinux2022-5-15": "ami-0a8495f6303122235"
             }
         }
     },

--- a/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
+++ b/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
@@ -66,6 +66,8 @@ package 'curl' do
   end
 end
 
+package 'iptables'
+
 # Enable IPv6 support
 kernel_module 'ipv6' do
   action :load

--- a/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
+++ b/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
@@ -52,7 +52,19 @@ package 'socat'
 
 package 'wget'
 
-package 'curl'
+package 'curl' do
+  case node[:platform]
+  when 'amazon'
+    case node[:platform_version]
+    when '2022'
+      package_name 'curl-minimal'
+    else
+      package_name 'curl'
+    end
+  else
+    package_name 'curl'
+  end
+end
 
 # Enable IPv6 support
 kernel_module 'ipv6' do


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

- Adds Amazon Linux 2022 to testing suite for `arm64`.
- Adds Amazon Linux 2 and 2022 to testing suite for `x64`.

### Motivation

Ensure our products work on Amazon Linux kernels

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
