### PR TITLE
Remove obsolete Windows versions

### DIFF
--- a/.gitlab/container_build/docker_windows_agent6.yml
+++ b/.gitlab/container_build/docker_windows_agent6.yml
@@ -9,15 +9,6 @@ docker_build_agent6_windows1809_core:
     TAG_SUFFIX: -6
     WITH_JMX: "false"
 
-docker_build_agent6_windows1909_core:
-  extends:
-    - .docker_build_agent6_windows_servercore_common
-  tags: ["runner:windows-docker", "windowsversion:1909"]
-  variables:
-    VARIANT: 1909
-    TAG_SUFFIX: -6
-    WITH_JMX: "false"
-
 docker_build_agent6_windows2004_core:
   extends:
     - .docker_build_agent6_windows_servercore_common

--- a/.gitlab/container_build/docker_windows_agent6.yml
+++ b/.gitlab/container_build/docker_windows_agent6.yml
@@ -9,15 +9,6 @@ docker_build_agent6_windows1809_core:
     TAG_SUFFIX: -6
     WITH_JMX: "false"
 
-docker_build_agent6_windows2004_core:
-  extends:
-    - .docker_build_agent6_windows_servercore_common
-  tags: ["runner:windows-docker", "windowsversion:2004"]
-  variables:
-    VARIANT: 2004
-    TAG_SUFFIX: -6
-    WITH_JMX: "false"
-
 docker_build_agent6_windows20h2_core:
   extends:
     - .docker_build_agent6_windows_servercore_common

--- a/.gitlab/container_build/docker_windows_agent6.yml
+++ b/.gitlab/container_build/docker_windows_agent6.yml
@@ -9,15 +9,6 @@ docker_build_agent6_windows1809_core:
     TAG_SUFFIX: -6
     WITH_JMX: "false"
 
-docker_build_agent6_windows20h2_core:
-  extends:
-    - .docker_build_agent6_windows_servercore_common
-  tags: ["runner:windows-docker", "windowsversion:20h2"]
-  variables:
-    VARIANT: 20h2
-    TAG_SUFFIX: -6
-    WITH_JMX: "false"
-
 docker_build_agent6_windows2022_core:
   extends:
     - .docker_build_agent6_windows_servercore_common

--- a/.gitlab/container_build/docker_windows_agent7.yml
+++ b/.gitlab/container_build/docker_windows_agent7.yml
@@ -17,24 +17,6 @@ docker_build_agent7_windows1809_jmx:
     TAG_SUFFIX: -7-jmx
     WITH_JMX: "true"
 
-docker_build_agent7_windows1909:
-  extends:
-    - .docker_build_agent7_windows_common
-  tags: ["runner:windows-docker", "windowsversion:1909"]
-  variables:
-    VARIANT: 1909
-    TAG_SUFFIX: -7
-    WITH_JMX: "false"
-
-docker_build_agent7_windows1909_jmx:
-  extends:
-    - .docker_build_agent7_windows_common
-  tags: ["runner:windows-docker", "windowsversion:1909"]
-  variables:
-    VARIANT: 1909
-    TAG_SUFFIX: -7-jmx
-    WITH_JMX: "true"
-
 docker_build_agent7_windows2004:
   extends:
     - .docker_build_agent7_windows_common
@@ -107,24 +89,6 @@ docker_build_agent7_windows1809_core_jmx:
   tags: ["runner:windows-docker", "windowsversion:1809"]
   variables:
     VARIANT: 1809
-    TAG_SUFFIX: -7-jmx
-    WITH_JMX: "true"
-
-docker_build_agent7_windows1909_core:
-  extends:
-    - .docker_build_agent7_windows_servercore_common
-  tags: ["runner:windows-docker", "windowsversion:1909"]
-  variables:
-    VARIANT: 1909
-    TAG_SUFFIX: -7
-    WITH_JMX: "false"
-
-docker_build_agent7_windows1909_core_jmx:
-  extends:
-    - .docker_build_agent7_windows_servercore_common
-  tags: ["runner:windows-docker", "windowsversion:1909"]
-  variables:
-    VARIANT: 1909
     TAG_SUFFIX: -7-jmx
     WITH_JMX: "true"
 

--- a/.gitlab/container_build/docker_windows_agent7.yml
+++ b/.gitlab/container_build/docker_windows_agent7.yml
@@ -17,25 +17,6 @@ docker_build_agent7_windows1809_jmx:
     TAG_SUFFIX: -7-jmx
     WITH_JMX: "true"
 
-docker_build_agent7_windows2004:
-  extends:
-    - .docker_build_agent7_windows_common
-  tags: ["runner:windows-docker", "windowsversion:2004"]
-  variables:
-    VARIANT: 2004
-    TAG_SUFFIX: "-7"
-    WITH_JMX: "false"
-
-docker_build_agent7_windows2004_jmx:
-  extends:
-    - .docker_build_agent7_windows_common
-  tags: ["runner:windows-docker", "windowsversion:2004"]
-  needs: ["windows_msi_and_bosh_zip_x64-a7", "build_windows_container_entrypoint"]
-  variables:
-    VARIANT: 2004
-    TAG_SUFFIX: -7-jmx
-    WITH_JMX: "true"
-
 docker_build_agent7_windows20h2:
   extends:
     - .docker_build_agent7_windows_common
@@ -89,25 +70,6 @@ docker_build_agent7_windows1809_core_jmx:
   tags: ["runner:windows-docker", "windowsversion:1809"]
   variables:
     VARIANT: 1809
-    TAG_SUFFIX: -7-jmx
-    WITH_JMX: "true"
-
-docker_build_agent7_windows2004_core:
-  extends:
-    - .docker_build_agent7_windows_servercore_common
-  tags: ["runner:windows-docker", "windowsversion:2004"]
-  variables:
-    VARIANT: 2004
-    TAG_SUFFIX: "-7"
-    WITH_JMX: "false"
-
-docker_build_agent7_windows2004_core_jmx:
-  extends:
-    - .docker_build_agent7_windows_servercore_common
-  tags: ["runner:windows-docker", "windowsversion:2004"]
-  needs: ["windows_msi_and_bosh_zip_x64-a7", "build_windows_container_entrypoint"]
-  variables:
-    VARIANT: 2004
     TAG_SUFFIX: -7-jmx
     WITH_JMX: "true"
 

--- a/.gitlab/container_build/docker_windows_agent7.yml
+++ b/.gitlab/container_build/docker_windows_agent7.yml
@@ -17,15 +17,6 @@ docker_build_agent7_windows1809_jmx:
     TAG_SUFFIX: -7-jmx
     WITH_JMX: "true"
 
-docker_build_agent7_windows20h2:
-  extends:
-    - .docker_build_agent7_windows_common
-  tags: ["runner:windows-docker", "windowsversion:20h2"]
-  variables:
-    VARIANT: 20h2
-    TAG_SUFFIX: "-7"
-    WITH_JMX: "false"
-
 docker_build_agent7_windows2022_jmx:
   extends:
     - .docker_build_agent7_windows_common
@@ -45,16 +36,6 @@ docker_build_agent7_windows2022:
     TAG_SUFFIX: "-7"
     WITH_JMX: "false"
 
-docker_build_agent7_windows20h2_jmx:
-  extends:
-    - .docker_build_agent7_windows_common
-  tags: ["runner:windows-docker", "windowsversion:20h2"]
-  needs: ["windows_msi_and_bosh_zip_x64-a7", "build_windows_container_entrypoint"]
-  variables:
-    VARIANT: 20h2
-    TAG_SUFFIX: -7-jmx
-    WITH_JMX: "true"
-
 docker_build_agent7_windows1809_core:
   extends:
     - .docker_build_agent7_windows_servercore_common
@@ -70,25 +51,6 @@ docker_build_agent7_windows1809_core_jmx:
   tags: ["runner:windows-docker", "windowsversion:1809"]
   variables:
     VARIANT: 1809
-    TAG_SUFFIX: -7-jmx
-    WITH_JMX: "true"
-
-docker_build_agent7_windows20h2_core:
-  extends:
-    - .docker_build_agent7_windows_servercore_common
-  tags: ["runner:windows-docker", "windowsversion:20h2"]
-  variables:
-    VARIANT: 20h2
-    TAG_SUFFIX: "-7"
-    WITH_JMX: "false"
-
-docker_build_agent7_windows20h2_core_jmx:
-  extends:
-    - .docker_build_agent7_windows_servercore_common
-  tags: ["runner:windows-docker", "windowsversion:20h2"]
-  needs: ["windows_msi_and_bosh_zip_x64-a7", "build_windows_container_entrypoint"]
-  variables:
-    VARIANT: 20h2
     TAG_SUFFIX: -7-jmx
     WITH_JMX: "true"
 

--- a/.gitlab/deploy_7/container.yml
+++ b/.gitlab/deploy_7/container.yml
@@ -17,7 +17,7 @@
     - if [[ "$VERSION" == "" ]]; then export VERSION="$(inv -e agent.version --major-version 7 --url-safe)"; fi
     - export IMG_BASE_SRC="${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
     - export IMG_LINUX_SOURCES="${IMG_BASE_SRC}-7${JMX}-amd64,${IMG_BASE_SRC}-7${JMX}-arm64"
-    - export IMG_WINDOWS_SOURCES="${IMG_BASE_SRC}-7${JMX}-win1809${SERVERCORE}-amd64,${IMG_BASE_SRC}-7${JMX}-win1909${SERVERCORE}-amd64,${IMG_BASE_SRC}-7${JMX}-win2004${SERVERCORE}-amd64,${IMG_BASE_SRC}-7${JMX}-win20h2${SERVERCORE}-amd64,${IMG_BASE_SRC}-7${JMX}-winltsc2022${SERVERCORE}-amd64"
+    - export IMG_WINDOWS_SOURCES="${IMG_BASE_SRC}-7${JMX}-win1809${SERVERCORE}-amd64,${IMG_BASE_SRC}-7${JMX}-win2004${SERVERCORE}-amd64,${IMG_BASE_SRC}-7${JMX}-win20h2${SERVERCORE}-amd64,${IMG_BASE_SRC}-7${JMX}-winltsc2022${SERVERCORE}-amd64"
     - if [[ "$SERVERCORE" == "-servercore" ]]; then export IMG_SOURCES="${IMG_WINDOWS_SOURCES}"; else export IMG_SOURCES="${IMG_LINUX_SOURCES},${IMG_WINDOWS_SOURCES}"; fi
     - export IMG_DESTINATIONS="${AGENT_REPOSITORY}:${VERSION}${SERVERCORE}${JMX}"
   parallel:
@@ -69,16 +69,16 @@ deploy_containers_latest-a7:
   parallel:
     matrix:
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
-        IMG_SOURCES: "%BASE%-amd64,%BASE%-arm64,%BASE%-win1809-amd64,%BASE%-win1909-amd64,%BASE%-win2004-amd64,%BASE%-win20h2-amd64,%BASE%-winltsc2022-amd64"
+        IMG_SOURCES: "%BASE%-amd64,%BASE%-arm64,%BASE%-win1809-amd64,%BASE%-win2004-amd64,%BASE%-win20h2-amd64,%BASE%-winltsc2022-amd64"
         IMG_DESTINATIONS: ${AGENT_REPOSITORY}:7,${AGENT_REPOSITORY}:latest
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
-        IMG_SOURCES: "%BASE%-amd64,%BASE%-arm64,%BASE%-win1809-amd64,%BASE%-win1909-amd64,%BASE%-win2004-amd64,%BASE%-win20h2-amd64,%BASE%-winltsc2022-amd64"
+        IMG_SOURCES: "%BASE%-amd64,%BASE%-arm64,%BASE%-win1809-amd64,%BASE%-win2004-amd64,%BASE%-win20h2-amd64,%BASE%-winltsc2022-amd64"
         IMG_DESTINATIONS: ${AGENT_REPOSITORY}:7-jmx,${AGENT_REPOSITORY}:latest-jmx
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win1909-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
         IMG_DESTINATIONS: ${AGENT_REPOSITORY}:7-servercore,${AGENT_REPOSITORY}:latest-servercore
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win1909-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
         IMG_DESTINATIONS: ${AGENT_REPOSITORY}:7-servercore-jmx,${AGENT_REPOSITORY}:latest-servercore-jmx
 
 deploy_containers_latest-dogstatsd:

--- a/.gitlab/deploy_7/container.yml
+++ b/.gitlab/deploy_7/container.yml
@@ -17,7 +17,7 @@
     - if [[ "$VERSION" == "" ]]; then export VERSION="$(inv -e agent.version --major-version 7 --url-safe)"; fi
     - export IMG_BASE_SRC="${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
     - export IMG_LINUX_SOURCES="${IMG_BASE_SRC}-7${JMX}-amd64,${IMG_BASE_SRC}-7${JMX}-arm64"
-    - export IMG_WINDOWS_SOURCES="${IMG_BASE_SRC}-7${JMX}-win1809${SERVERCORE}-amd64,${IMG_BASE_SRC}-7${JMX}-win20h2${SERVERCORE}-amd64,${IMG_BASE_SRC}-7${JMX}-winltsc2022${SERVERCORE}-amd64"
+    - export IMG_WINDOWS_SOURCES="${IMG_BASE_SRC}-7${JMX}-win1809${SERVERCORE}-amd64,${IMG_BASE_SRC}-7${JMX}-winltsc2022${SERVERCORE}-amd64"
     - if [[ "$SERVERCORE" == "-servercore" ]]; then export IMG_SOURCES="${IMG_WINDOWS_SOURCES}"; else export IMG_SOURCES="${IMG_LINUX_SOURCES},${IMG_WINDOWS_SOURCES}"; fi
     - export IMG_DESTINATIONS="${AGENT_REPOSITORY}:${VERSION}${SERVERCORE}${JMX}"
   parallel:
@@ -69,16 +69,16 @@ deploy_containers_latest-a7:
   parallel:
     matrix:
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
-        IMG_SOURCES: "%BASE%-amd64,%BASE%-arm64,%BASE%-win1809-amd64,%BASE%-win20h2-amd64,%BASE%-winltsc2022-amd64"
+        IMG_SOURCES: "%BASE%-amd64,%BASE%-arm64,%BASE%-win1809-amd64,%BASE%-winltsc2022-amd64"
         IMG_DESTINATIONS: ${AGENT_REPOSITORY}:7,${AGENT_REPOSITORY}:latest
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
-        IMG_SOURCES: "%BASE%-amd64,%BASE%-arm64,%BASE%-win1809-amd64,%BASE%-win20h2-amd64,%BASE%-winltsc2022-amd64"
+        IMG_SOURCES: "%BASE%-amd64,%BASE%-arm64,%BASE%-win1809-amd64,%BASE%-winltsc2022-amd64"
         IMG_DESTINATIONS: ${AGENT_REPOSITORY}:7-jmx,${AGENT_REPOSITORY}:latest-jmx
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
         IMG_DESTINATIONS: ${AGENT_REPOSITORY}:7-servercore,${AGENT_REPOSITORY}:latest-servercore
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
         IMG_DESTINATIONS: ${AGENT_REPOSITORY}:7-servercore-jmx,${AGENT_REPOSITORY}:latest-servercore-jmx
 
 deploy_containers_latest-dogstatsd:

--- a/.gitlab/deploy_7/container.yml
+++ b/.gitlab/deploy_7/container.yml
@@ -17,7 +17,7 @@
     - if [[ "$VERSION" == "" ]]; then export VERSION="$(inv -e agent.version --major-version 7 --url-safe)"; fi
     - export IMG_BASE_SRC="${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
     - export IMG_LINUX_SOURCES="${IMG_BASE_SRC}-7${JMX}-amd64,${IMG_BASE_SRC}-7${JMX}-arm64"
-    - export IMG_WINDOWS_SOURCES="${IMG_BASE_SRC}-7${JMX}-win1809${SERVERCORE}-amd64,${IMG_BASE_SRC}-7${JMX}-win2004${SERVERCORE}-amd64,${IMG_BASE_SRC}-7${JMX}-win20h2${SERVERCORE}-amd64,${IMG_BASE_SRC}-7${JMX}-winltsc2022${SERVERCORE}-amd64"
+    - export IMG_WINDOWS_SOURCES="${IMG_BASE_SRC}-7${JMX}-win1809${SERVERCORE}-amd64,${IMG_BASE_SRC}-7${JMX}-win20h2${SERVERCORE}-amd64,${IMG_BASE_SRC}-7${JMX}-winltsc2022${SERVERCORE}-amd64"
     - if [[ "$SERVERCORE" == "-servercore" ]]; then export IMG_SOURCES="${IMG_WINDOWS_SOURCES}"; else export IMG_SOURCES="${IMG_LINUX_SOURCES},${IMG_WINDOWS_SOURCES}"; fi
     - export IMG_DESTINATIONS="${AGENT_REPOSITORY}:${VERSION}${SERVERCORE}${JMX}"
   parallel:
@@ -69,16 +69,16 @@ deploy_containers_latest-a7:
   parallel:
     matrix:
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
-        IMG_SOURCES: "%BASE%-amd64,%BASE%-arm64,%BASE%-win1809-amd64,%BASE%-win2004-amd64,%BASE%-win20h2-amd64,%BASE%-winltsc2022-amd64"
+        IMG_SOURCES: "%BASE%-amd64,%BASE%-arm64,%BASE%-win1809-amd64,%BASE%-win20h2-amd64,%BASE%-winltsc2022-amd64"
         IMG_DESTINATIONS: ${AGENT_REPOSITORY}:7,${AGENT_REPOSITORY}:latest
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
-        IMG_SOURCES: "%BASE%-amd64,%BASE%-arm64,%BASE%-win1809-amd64,%BASE%-win2004-amd64,%BASE%-win20h2-amd64,%BASE%-winltsc2022-amd64"
+        IMG_SOURCES: "%BASE%-amd64,%BASE%-arm64,%BASE%-win1809-amd64,%BASE%-win20h2-amd64,%BASE%-winltsc2022-amd64"
         IMG_DESTINATIONS: ${AGENT_REPOSITORY}:7-jmx,${AGENT_REPOSITORY}:latest-jmx
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
         IMG_DESTINATIONS: ${AGENT_REPOSITORY}:7-servercore,${AGENT_REPOSITORY}:latest-servercore
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
         IMG_DESTINATIONS: ${AGENT_REPOSITORY}:7-servercore-jmx,${AGENT_REPOSITORY}:latest-servercore-jmx
 
 deploy_containers_latest-dogstatsd:

--- a/.gitlab/dev_container_deploy/docker_windows.yml
+++ b/.gitlab/dev_container_deploy/docker_windows.yml
@@ -15,10 +15,6 @@ dev_branch-a7-windows:
     - docker_build_agent7_windows1809_jmx
     - docker_build_agent7_windows1809_core
     - docker_build_agent7_windows1809_core_jmx
-    - docker_build_agent7_windows1909
-    - docker_build_agent7_windows1909_jmx
-    - docker_build_agent7_windows1909_core
-    - docker_build_agent7_windows1909_core_jmx
     - docker_build_agent7_windows2004
     - docker_build_agent7_windows2004_jmx
     - docker_build_agent7_windows2004_core
@@ -36,16 +32,16 @@ dev_branch-a7-windows:
   parallel:
     matrix:
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
-        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win1909-amd64,%BASE%-win2004-amd64,%BASE%-win20h2-amd64,%BASE%-winltsc2022-amd64"
+        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win2004-amd64,%BASE%-win20h2-amd64,%BASE%-winltsc2022-amd64"
         IMG_DESTINATIONS: agent-dev:${CI_COMMIT_REF_SLUG}-py3-win
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
-        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win1909-amd64,%BASE%-win2004-amd64,%BASE%-win20h2-amd64,%BASE%-winltsc2022-amd64"
+        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win2004-amd64,%BASE%-win20h2-amd64,%BASE%-winltsc2022-amd64"
         IMG_DESTINATIONS: agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win1909-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:${CI_COMMIT_REF_SLUG}-py3-win-servercore
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win1909-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win-servercore
 
 dev_branch-a6-windows:
@@ -55,7 +51,6 @@ dev_branch-a6-windows:
     !reference [.on_a6_manual]
   needs:
     - docker_build_agent6_windows1809_core
-    - docker_build_agent6_windows1909_core
     - docker_build_agent6_windows2004_core
     - docker_build_agent6_windows20h2_core
     - docker_build_agent6_windows2022_core
@@ -64,7 +59,7 @@ dev_branch-a6-windows:
   parallel:
     matrix:
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win1909-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:${CI_COMMIT_REF_SLUG}-py2-win-servercore
 
 dev_master-a7-windows:
@@ -77,10 +72,6 @@ dev_master-a7-windows:
     - docker_build_agent7_windows1809_jmx
     - docker_build_agent7_windows1809_core
     - docker_build_agent7_windows1809_core_jmx
-    - docker_build_agent7_windows1909
-    - docker_build_agent7_windows1909_jmx
-    - docker_build_agent7_windows1909_core
-    - docker_build_agent7_windows1909_core_jmx
     - docker_build_agent7_windows2004
     - docker_build_agent7_windows2004_jmx
     - docker_build_agent7_windows2004_core
@@ -98,16 +89,16 @@ dev_master-a7-windows:
   parallel:
     matrix:
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
-        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win1909-amd64,%BASE%-win2004-amd64,%BASE%-win20h2-amd64,%BASE%-winltsc2022-amd64"
+        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win2004-amd64,%BASE%-win20h2-amd64,%BASE%-winltsc2022-amd64"
         IMG_DESTINATIONS: agent-dev:master-py3-win
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
-        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win1909-amd64,%BASE%-win2004-amd64,%BASE%-win20h2-amd64,%BASE%-winltsc2022-amd64"
+        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win2004-amd64,%BASE%-win20h2-amd64,%BASE%-winltsc2022-amd64"
         IMG_DESTINATIONS: agent-dev:master-py3-jmx-win
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win1909-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:master-py3-win-servercore
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win1909-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:master-py3-jmx-win-servercore
 
 dev_master-a6-windows:
@@ -117,7 +108,6 @@ dev_master-a6-windows:
     !reference [.on_main_a6]
   needs:
     - docker_build_agent6_windows1809_core
-    - docker_build_agent6_windows1909_core
     - docker_build_agent6_windows2004_core
     - docker_build_agent6_windows20h2_core
     - docker_build_agent6_windows2022_core
@@ -126,7 +116,7 @@ dev_master-a6-windows:
   parallel:
     matrix:
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win1909-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:master-py2-win-servercore
 
 dev_nightly-a7-windows:
@@ -139,10 +129,6 @@ dev_nightly-a7-windows:
     - docker_build_agent7_windows1809_jmx
     - docker_build_agent7_windows1809_core
     - docker_build_agent7_windows1809_core_jmx
-    - docker_build_agent7_windows1909
-    - docker_build_agent7_windows1909_jmx
-    - docker_build_agent7_windows1909_core
-    - docker_build_agent7_windows1909_core_jmx
     - docker_build_agent7_windows2004
     - docker_build_agent7_windows2004_jmx
     - docker_build_agent7_windows2004_core
@@ -160,16 +146,16 @@ dev_nightly-a7-windows:
   parallel:
     matrix:
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
-        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win1909-amd64,%BASE%-win2004-amd64,%BASE%-win20h2-amd64,%BASE%-winltsc2022-amd64"
+        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win2004-amd64,%BASE%-win20h2-amd64,%BASE%-winltsc2022-amd64"
         IMG_DESTINATIONS: agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-win
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
-        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win1909-amd64,%BASE%-win2004-amd64,%BASE%-win20h2-amd64,%BASE%-winltsc2022-amd64"
+        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win2004-amd64,%BASE%-win20h2-amd64,%BASE%-winltsc2022-amd64"
         IMG_DESTINATIONS: agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-jmx-win
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win1909-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-win-servercore
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win1909-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-jmx-win-servercore
 
 dev_nightly-a6-windows:
@@ -179,7 +165,6 @@ dev_nightly-a6-windows:
     !reference [.on_deploy_nightly_repo_branch_a6]
   needs:
     - docker_build_agent6_windows1809_core
-    - docker_build_agent6_windows1909_core
     - docker_build_agent6_windows2004_core
     - docker_build_agent6_windows20h2_core
     - docker_build_agent6_windows2022_core
@@ -188,5 +173,5 @@ dev_nightly-a6-windows:
   parallel:
     matrix:
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win1909-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py2-win-servercore

--- a/.gitlab/dev_container_deploy/docker_windows.yml
+++ b/.gitlab/dev_container_deploy/docker_windows.yml
@@ -15,10 +15,6 @@ dev_branch-a7-windows:
     - docker_build_agent7_windows1809_jmx
     - docker_build_agent7_windows1809_core
     - docker_build_agent7_windows1809_core_jmx
-    - docker_build_agent7_windows2004
-    - docker_build_agent7_windows2004_jmx
-    - docker_build_agent7_windows2004_core
-    - docker_build_agent7_windows2004_core_jmx
     - docker_build_agent7_windows20h2
     - docker_build_agent7_windows20h2_jmx
     - docker_build_agent7_windows20h2_core
@@ -32,16 +28,16 @@ dev_branch-a7-windows:
   parallel:
     matrix:
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
-        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win2004-amd64,%BASE%-win20h2-amd64,%BASE%-winltsc2022-amd64"
+        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win20h2-amd64,%BASE%-winltsc2022-amd64"
         IMG_DESTINATIONS: agent-dev:${CI_COMMIT_REF_SLUG}-py3-win
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
-        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win2004-amd64,%BASE%-win20h2-amd64,%BASE%-winltsc2022-amd64"
+        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win20h2-amd64,%BASE%-winltsc2022-amd64"
         IMG_DESTINATIONS: agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:${CI_COMMIT_REF_SLUG}-py3-win-servercore
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win-servercore
 
 dev_branch-a6-windows:
@@ -51,7 +47,6 @@ dev_branch-a6-windows:
     !reference [.on_a6_manual]
   needs:
     - docker_build_agent6_windows1809_core
-    - docker_build_agent6_windows2004_core
     - docker_build_agent6_windows20h2_core
     - docker_build_agent6_windows2022_core
   variables:
@@ -59,7 +54,7 @@ dev_branch-a6-windows:
   parallel:
     matrix:
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:${CI_COMMIT_REF_SLUG}-py2-win-servercore
 
 dev_master-a7-windows:
@@ -72,10 +67,6 @@ dev_master-a7-windows:
     - docker_build_agent7_windows1809_jmx
     - docker_build_agent7_windows1809_core
     - docker_build_agent7_windows1809_core_jmx
-    - docker_build_agent7_windows2004
-    - docker_build_agent7_windows2004_jmx
-    - docker_build_agent7_windows2004_core
-    - docker_build_agent7_windows2004_core_jmx
     - docker_build_agent7_windows20h2
     - docker_build_agent7_windows20h2_jmx
     - docker_build_agent7_windows20h2_core
@@ -89,16 +80,16 @@ dev_master-a7-windows:
   parallel:
     matrix:
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
-        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win2004-amd64,%BASE%-win20h2-amd64,%BASE%-winltsc2022-amd64"
+        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win20h2-amd64,%BASE%-winltsc2022-amd64"
         IMG_DESTINATIONS: agent-dev:master-py3-win
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
-        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win2004-amd64,%BASE%-win20h2-amd64,%BASE%-winltsc2022-amd64"
+        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win20h2-amd64,%BASE%-winltsc2022-amd64"
         IMG_DESTINATIONS: agent-dev:master-py3-jmx-win
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:master-py3-win-servercore
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:master-py3-jmx-win-servercore
 
 dev_master-a6-windows:
@@ -108,7 +99,6 @@ dev_master-a6-windows:
     !reference [.on_main_a6]
   needs:
     - docker_build_agent6_windows1809_core
-    - docker_build_agent6_windows2004_core
     - docker_build_agent6_windows20h2_core
     - docker_build_agent6_windows2022_core
   variables:
@@ -116,7 +106,7 @@ dev_master-a6-windows:
   parallel:
     matrix:
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:master-py2-win-servercore
 
 dev_nightly-a7-windows:
@@ -129,10 +119,6 @@ dev_nightly-a7-windows:
     - docker_build_agent7_windows1809_jmx
     - docker_build_agent7_windows1809_core
     - docker_build_agent7_windows1809_core_jmx
-    - docker_build_agent7_windows2004
-    - docker_build_agent7_windows2004_jmx
-    - docker_build_agent7_windows2004_core
-    - docker_build_agent7_windows2004_core_jmx
     - docker_build_agent7_windows20h2
     - docker_build_agent7_windows20h2_jmx
     - docker_build_agent7_windows20h2_core
@@ -146,16 +132,16 @@ dev_nightly-a7-windows:
   parallel:
     matrix:
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
-        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win2004-amd64,%BASE%-win20h2-amd64,%BASE%-winltsc2022-amd64"
+        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win20h2-amd64,%BASE%-winltsc2022-amd64"
         IMG_DESTINATIONS: agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-win
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
-        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win2004-amd64,%BASE%-win20h2-amd64,%BASE%-winltsc2022-amd64"
+        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win20h2-amd64,%BASE%-winltsc2022-amd64"
         IMG_DESTINATIONS: agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-jmx-win
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-win-servercore
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-jmx-win-servercore
 
 dev_nightly-a6-windows:
@@ -165,7 +151,6 @@ dev_nightly-a6-windows:
     !reference [.on_deploy_nightly_repo_branch_a6]
   needs:
     - docker_build_agent6_windows1809_core
-    - docker_build_agent6_windows2004_core
     - docker_build_agent6_windows20h2_core
     - docker_build_agent6_windows2022_core
   variables:
@@ -173,5 +158,5 @@ dev_nightly-a6-windows:
   parallel:
     matrix:
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py2-win-servercore

--- a/.gitlab/dev_container_deploy/docker_windows.yml
+++ b/.gitlab/dev_container_deploy/docker_windows.yml
@@ -15,10 +15,6 @@ dev_branch-a7-windows:
     - docker_build_agent7_windows1809_jmx
     - docker_build_agent7_windows1809_core
     - docker_build_agent7_windows1809_core_jmx
-    - docker_build_agent7_windows20h2
-    - docker_build_agent7_windows20h2_jmx
-    - docker_build_agent7_windows20h2_core
-    - docker_build_agent7_windows20h2_core_jmx
     - docker_build_agent7_windows2022
     - docker_build_agent7_windows2022_jmx
     - docker_build_agent7_windows2022_core
@@ -28,16 +24,16 @@ dev_branch-a7-windows:
   parallel:
     matrix:
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
-        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win20h2-amd64,%BASE%-winltsc2022-amd64"
+        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-winltsc2022-amd64"
         IMG_DESTINATIONS: agent-dev:${CI_COMMIT_REF_SLUG}-py3-win
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
-        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win20h2-amd64,%BASE%-winltsc2022-amd64"
+        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-winltsc2022-amd64"
         IMG_DESTINATIONS: agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:${CI_COMMIT_REF_SLUG}-py3-win-servercore
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win-servercore
 
 dev_branch-a6-windows:
@@ -47,14 +43,13 @@ dev_branch-a6-windows:
     !reference [.on_a6_manual]
   needs:
     - docker_build_agent6_windows1809_core
-    - docker_build_agent6_windows20h2_core
     - docker_build_agent6_windows2022_core
   variables:
     IMG_REGISTRIES: dev
   parallel:
     matrix:
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:${CI_COMMIT_REF_SLUG}-py2-win-servercore
 
 dev_master-a7-windows:
@@ -67,10 +62,6 @@ dev_master-a7-windows:
     - docker_build_agent7_windows1809_jmx
     - docker_build_agent7_windows1809_core
     - docker_build_agent7_windows1809_core_jmx
-    - docker_build_agent7_windows20h2
-    - docker_build_agent7_windows20h2_jmx
-    - docker_build_agent7_windows20h2_core
-    - docker_build_agent7_windows20h2_core_jmx
     - docker_build_agent7_windows2022
     - docker_build_agent7_windows2022_jmx
     - docker_build_agent7_windows2022_core
@@ -80,16 +71,16 @@ dev_master-a7-windows:
   parallel:
     matrix:
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
-        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win20h2-amd64,%BASE%-winltsc2022-amd64"
+        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-winltsc2022-amd64"
         IMG_DESTINATIONS: agent-dev:master-py3-win
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
-        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win20h2-amd64,%BASE%-winltsc2022-amd64"
+        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-winltsc2022-amd64"
         IMG_DESTINATIONS: agent-dev:master-py3-jmx-win
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:master-py3-win-servercore
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:master-py3-jmx-win-servercore
 
 dev_master-a6-windows:
@@ -99,14 +90,13 @@ dev_master-a6-windows:
     !reference [.on_main_a6]
   needs:
     - docker_build_agent6_windows1809_core
-    - docker_build_agent6_windows20h2_core
     - docker_build_agent6_windows2022_core
   variables:
     IMG_REGISTRIES: dev
   parallel:
     matrix:
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:master-py2-win-servercore
 
 dev_nightly-a7-windows:
@@ -119,10 +109,6 @@ dev_nightly-a7-windows:
     - docker_build_agent7_windows1809_jmx
     - docker_build_agent7_windows1809_core
     - docker_build_agent7_windows1809_core_jmx
-    - docker_build_agent7_windows20h2
-    - docker_build_agent7_windows20h2_jmx
-    - docker_build_agent7_windows20h2_core
-    - docker_build_agent7_windows20h2_core_jmx
     - docker_build_agent7_windows2022
     - docker_build_agent7_windows2022_jmx
     - docker_build_agent7_windows2022_core
@@ -132,16 +118,16 @@ dev_nightly-a7-windows:
   parallel:
     matrix:
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
-        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win20h2-amd64,%BASE%-winltsc2022-amd64"
+        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-winltsc2022-amd64"
         IMG_DESTINATIONS: agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-win
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
-        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win20h2-amd64,%BASE%-winltsc2022-amd64"
+        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-winltsc2022-amd64"
         IMG_DESTINATIONS: agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-jmx-win
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-win-servercore
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-jmx-win-servercore
 
 dev_nightly-a6-windows:
@@ -151,12 +137,11 @@ dev_nightly-a6-windows:
     !reference [.on_deploy_nightly_repo_branch_a6]
   needs:
     - docker_build_agent6_windows1809_core
-    - docker_build_agent6_windows20h2_core
     - docker_build_agent6_windows2022_core
   variables:
     IMG_REGISTRIES: dev
   parallel:
     matrix:
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py2-win-servercore

--- a/.gitlab/kitchen_testing/windows.yml
+++ b/.gitlab/kitchen_testing/windows.yml
@@ -46,7 +46,7 @@
     - .kitchen_azure_x64
   variables:
     KITCHEN_PLATFORM: "windows"
-    KITCHEN_OSVERS: "win2012r2,win2016,win2019,win2019cn,win1903,win2004,win20h2,win2022"
+    KITCHEN_OSVERS: "win2012r2,win2016,win2019,win2019cn,win1903,win20h2,win2022"
     DEFAULT_KITCHEN_OSVERS: "win2022"
   before_script:  # test all of the kernels to make sure the driver loads and runs properly
     - if [ $AGENT_MAJOR_VERSION == "7" ]; then export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A7; else export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A6; fi

--- a/.gitlab/kitchen_testing/windows.yml
+++ b/.gitlab/kitchen_testing/windows.yml
@@ -46,7 +46,7 @@
     - .kitchen_azure_x64
   variables:
     KITCHEN_PLATFORM: "windows"
-    KITCHEN_OSVERS: "win2012r2,win2016,win2019,win2019cn,win1903,win1909,win2004,win20h2,win2022"
+    KITCHEN_OSVERS: "win2012r2,win2016,win2019,win2019cn,win1903,win2004,win20h2,win2022"
     DEFAULT_KITCHEN_OSVERS: "win2022"
   before_script:  # test all of the kernels to make sure the driver loads and runs properly
     - if [ $AGENT_MAJOR_VERSION == "7" ]; then export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A7; else export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A6; fi

--- a/.gitlab/kitchen_testing/windows.yml
+++ b/.gitlab/kitchen_testing/windows.yml
@@ -46,7 +46,7 @@
     - .kitchen_azure_x64
   variables:
     KITCHEN_PLATFORM: "windows"
-    KITCHEN_OSVERS: "win2012r2,win2016,win2019,win2019cn,win1903,win2022"
+    KITCHEN_OSVERS: "win2012r2,win2016,win2019,win2019cn,win1903,win1909,win2004,win20h2,win2022"
     DEFAULT_KITCHEN_OSVERS: "win2022"
   before_script:  # test all of the kernels to make sure the driver loads and runs properly
     - if [ $AGENT_MAJOR_VERSION == "7" ]; then export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A7; else export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A6; fi

--- a/.gitlab/kitchen_testing/windows.yml
+++ b/.gitlab/kitchen_testing/windows.yml
@@ -46,7 +46,7 @@
     - .kitchen_azure_x64
   variables:
     KITCHEN_PLATFORM: "windows"
-    KITCHEN_OSVERS: "win2012r2,win2016,win2019,win2019cn,win1903,win20h2,win2022"
+    KITCHEN_OSVERS: "win2012r2,win2016,win2019,win2019cn,win1903,win2022"
     DEFAULT_KITCHEN_OSVERS: "win2022"
   before_script:  # test all of the kernels to make sure the driver loads and runs properly
     - if [ $AGENT_MAJOR_VERSION == "7" ]; then export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A7; else export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A6; fi

--- a/releasenotes/notes/remove_obsolete_docker_container-e446de73b02080c0.yaml
+++ b/releasenotes/notes/remove_obsolete_docker_container-e446de73b02080c0.yaml
@@ -1,4 +1,4 @@
 ---
 deprecations:
   - |
-    The following Windows Agent container versions are removed: 1909, 2004 and 20H2.
+    The following Windows Agent container versions are removed: 1909, 2004, and 20H2.

--- a/releasenotes/notes/remove_obsolete_docker_container-e446de73b02080c0.yaml
+++ b/releasenotes/notes/remove_obsolete_docker_container-e446de73b02080c0.yaml
@@ -1,0 +1,4 @@
+---
+deprecations:
+  - |
+    The following Windows Agent container versions are removed: 1909, 2004 and 20H2.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Remove the Windows 1909, Windows 2004, and Windows 20H2 docker build jobs, and update the container release jobs to not push the 1909, 2004 and 20H2 images.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
https://datadoghq.atlassian.net/browse/WA-87
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
