### PR TITLE
DOCS-3949 CSM/CWS title updates

### DIFF
--- a/docs/cloud-workload-security/agent_expressions.md
+++ b/docs/cloud-workload-security/agent_expressions.md
@@ -1,5 +1,5 @@
 ---
-title: Agent Expressions
+title: Creating Custom Agent Rules
 kind: documentation
 description: "Agent expression attributes and operators for Cloud Workload Security Rules"
 disable_edit: true

--- a/docs/cloud-workload-security/backend.md
+++ b/docs/cloud-workload-security/backend.md
@@ -1,5 +1,5 @@
 ---
-title: Cloud Workload Security (CWS) Events
+title: Cloud Workload Security (CWS) Events Formats
 kind: documentation
 description: JSON schema documentation of the CWS backend event
 disable_edit: true

--- a/docs/cloud-workload-security/scripts/templates/agent_expressions.md
+++ b/docs/cloud-workload-security/scripts/templates/agent_expressions.md
@@ -1,5 +1,5 @@
 ---
-title: Agent Expressions
+title: Creating Custom Agent Rules
 kind: documentation
 description: "Agent expression attributes and operators for Cloud Workload Security Rules"
 disable_edit: true

--- a/docs/cloud-workload-security/scripts/templates/backend.md
+++ b/docs/cloud-workload-security/scripts/templates/backend.md
@@ -1,5 +1,5 @@
 ---
-title: Cloud Workload Security (CWS) Events
+title: Cloud Workload Security (CWS) Events Formats
 kind: documentation
 description: JSON schema documentation of the CWS backend event
 disable_edit: true


### PR DESCRIPTION

### What does this PR do?
Changes the H1s of two files used in documentation site to match navigation

Part of overall cloud security docs overhaul

### Motivation

DOCS-3949


- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
