### PR TITLE
[CSPM][SEC-5435] add normalization step for finding status

### DIFF
--- a/pkg/compliance/checks/rego_check.go
+++ b/pkg/compliance/checks/rego_check.go
@@ -460,7 +460,7 @@ func parseFindings(regoData interface{}) ([]regoFinding, error) {
 			return nil, err
 		}
 
-		if err := checkFindingStatus(&finding); err != nil {
+		if err := finding.normalizeStatus(); err != nil {
 			return nil, err
 		}
 
@@ -470,13 +470,23 @@ func parseFindings(regoData interface{}) ([]regoFinding, error) {
 	return res, nil
 }
 
-func checkFindingStatus(finding *regoFinding) error {
-	switch finding.Status {
-	case "passed", "failing", "error":
-		return nil
-	default:
+var statusMapping = map[string]string{
+	"passed":  "passed",
+	"pass":    "passed",
+	"failing": "failing",
+	"fail":    "failing",
+	"error":   "error",
+	"err":     "error",
+}
+
+func (finding *regoFinding) normalizeStatus() error {
+	mapped, ok := statusMapping[finding.Status]
+	if !ok {
 		return fmt.Errorf("unknown finding status: %s", finding.Status)
 	}
+
+	finding.Status = mapped
+	return nil
 }
 
 func checkFindingRequiredFields(metadata *mapstructure.Metadata) error {


### PR DESCRIPTION
### What does this PR do?

This PR implements a normalization step for rego findings status in order to accept "pass"/"fail" in addition to "passing"/"failing" to stay in sync with new rego syntax from cloud configuration CSPM.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
