### PR TITLE
Fix manifest payload submission

### DIFF
--- a/cmd/process-agent/collector.go
+++ b/cmd/process-agent/collector.go
@@ -785,7 +785,7 @@ func readResponseStatuses(checkName string, responses <-chan forwarder.Response)
 
 func ignoreResponseBody(checkName string) bool {
 	switch checkName {
-	case checks.Pod.Name(), checks.ProcessEvents.Name():
+	case checks.Pod.Name(), config.PodCheckManifestName, checks.ProcessEvents.Name():
 		return true
 	default:
 		return false

--- a/cmd/process-agent/collector.go
+++ b/cmd/process-agent/collector.go
@@ -187,7 +187,7 @@ func (l *Collector) runCheck(c checks.Check, results *api.WeightedQueue) {
 	}
 
 	if c.Name() == config.PodCheckName {
-		handlePodChecks(l, start, c.Name(), messages, results)
+		handlePodChecks(l, start, messages, results)
 	} else {
 		l.messagesToResultsQueue(start, c.Name(), messages, results)
 	}
@@ -287,11 +287,6 @@ func (l *Collector) messagesToCheckResult(start time.Time, name string, messages
 			}
 			extraHeaders.Set(headers.EVPOriginHeader, "process-agent")
 			extraHeaders.Set(headers.EVPOriginVersionHeader, version.AgentVersion)
-
-			switch m.(type) {
-			case *model.CollectorManifest:
-				extraHeaders.Set(headers.ContentEncodingHeader, headers.ZSTDContentEncoding)
-			}
 		}
 
 		if name == checks.ProcessEvents.Name() {
@@ -627,16 +622,14 @@ func (l *Collector) consumePayloads(results *api.WeightedQueue, fwd forwarder.Fo
 				responses, err = fwd.SubmitRTContainerChecks(forwarderPayload, payload.headers)
 			case checks.Connections.Name():
 				responses, err = fwd.SubmitConnectionChecks(forwarderPayload, payload.headers)
+			// Pod check metadata
 			case checks.Pod.Name():
-				// Orchestrator intake response does not change RT checks enablement or interval
 				updateRTStatus = false
-				// Pod check contains two parts: metadata and manifest.
-				// The manifest payload header has Content-Encoding:zstd allowing us to decompress payload in the intake
-				if payload.headers.Get(headers.ContentEncodingHeader) == headers.ZSTDContentEncoding {
-					responses, err = fwd.SubmitOrchestratorManifests(forwarderPayload, payload.headers)
-				} else {
-					responses, err = fwd.SubmitOrchestratorChecks(forwarderPayload, payload.headers, int(orchestrator.K8sPod))
-				}
+				responses, err = fwd.SubmitOrchestratorChecks(forwarderPayload, payload.headers, int(orchestrator.K8sPod))
+			// Pod check manifest data
+			case config.PodCheckManifestName:
+				updateRTStatus = false
+				responses, err = fwd.SubmitOrchestratorManifests(forwarderPayload, payload.headers)
 			case checks.ProcessDiscovery.Name():
 				// A Process Discovery check does not change the RT mode
 				updateRTStatus = false
@@ -802,9 +795,9 @@ func ignoreResponseBody(checkName string) bool {
 // Pod check returns a list of messages can be divided into two parts : pod payloads and manifest payloads
 // By default we only send pod payloads containing pod metadata and pod manifests (yaml)
 // Manifest payloads is a copy of pod manifests, we only send manifest payloads when feature flag is true
-func handlePodChecks(l *Collector, start time.Time, name string, messages []model.MessageBody, results *api.WeightedQueue) {
-	l.messagesToResultsQueue(start, name, messages[:len(messages)/2], results)
+func handlePodChecks(l *Collector, start time.Time, messages []model.MessageBody, results *api.WeightedQueue) {
+	l.messagesToResultsQueue(start, config.PodCheckName, messages[:len(messages)/2], results)
 	if l.cfg.Orchestrator.IsManifestCollectionEnabled {
-		l.messagesToResultsQueue(start, name, messages[len(messages)/2:], results)
+		l.messagesToResultsQueue(start, config.PodCheckManifestName, messages[len(messages)/2:], results)
 	}
 }

--- a/cmd/process-agent/collector_api_test.go
+++ b/cmd/process-agent/collector_api_test.go
@@ -23,7 +23,6 @@ import (
 	apicfg "github.com/DataDog/datadog-agent/pkg/process/util/api/config"
 	"github.com/DataDog/datadog-agent/pkg/process/util/api/headers"
 	"github.com/DataDog/datadog-agent/pkg/version"
-	"github.com/DataDog/zstd_0"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/assert"
@@ -422,14 +421,13 @@ func testPodMessageManifest(t *testing.T, clusterID string, cfg *config.AgentCon
 	assert.NotEmpty(t, req.headers.Get(headers.TimestampHeader))
 	assert.Equal(t, headers.ZSTDContentEncoding, req.headers.Get(headers.ContentEncodingHeader))
 
-	d, err := zstd_0.Decompress(nil, req.body)
+	reqBody, err := process.DecodeMessage(req.body)
 	require.NoError(t, err)
 
-	x := &process.CollectorManifest{}
-	err = proto.Unmarshal(d, x)
-	require.NoError(t, err)
+	cm, ok := reqBody.Body.(*process.CollectorManifest)
+	require.True(t, ok)
 
-	assert.Equal(t, clusterID, x.ClusterId)
+	assert.Equal(t, clusterID, cm.ClusterId)
 }
 
 func TestQueueSpaceNotAvailable(t *testing.T) {

--- a/cmd/process-agent/collector_api_test.go
+++ b/cmd/process-agent/collector_api_test.go
@@ -419,7 +419,6 @@ func testPodMessageManifest(t *testing.T, clusterID string, cfg *config.AgentCon
 	assert.Equal(t, "0", req.headers.Get(headers.ContainerCountHeader))
 	assert.Equal(t, "1", req.headers.Get("X-DD-Agent-Attempts"))
 	assert.NotEmpty(t, req.headers.Get(headers.TimestampHeader))
-	assert.Equal(t, headers.ZSTDContentEncoding, req.headers.Get(headers.ContentEncodingHeader))
 
 	reqBody, err := process.DecodeMessage(req.body)
 	require.NoError(t, err)

--- a/cmd/process-agent/collector_test.go
+++ b/cmd/process-agent/collector_test.go
@@ -10,9 +10,10 @@ import (
 	"testing"
 	"time"
 
-	model "github.com/DataDog/agent-payload/v5/process"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+
+	model "github.com/DataDog/agent-payload/v5/process"
 
 	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
@@ -343,6 +344,7 @@ func TestIgnoreResponseBody(t *testing.T) {
 		{checkName: checks.Container.Name(), ignore: false},
 		{checkName: checks.RTContainer.Name(), ignore: false},
 		{checkName: checks.Pod.Name(), ignore: true},
+		{checkName: config.PodCheckManifestName, ignore: true},
 		{checkName: checks.Connections.Name(), ignore: false},
 		{checkName: checks.ProcessEvents.Name(), ignore: true},
 	} {

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	code.cloudfoundry.org/bbs v0.0.0-20200403215808-d7bc971db0db
 	code.cloudfoundry.org/garden v0.0.0-20210208153517-580cadd489d2
 	code.cloudfoundry.org/lager v2.0.0+incompatible
-	github.com/DataDog/agent-payload/v5 v5.0.29
+	github.com/DataDog/agent-payload/v5 v5.0.31
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.40.0-rc.2
 	github.com/DataDog/datadog-agent/pkg/otlp/model v0.40.0-rc.2
 	github.com/DataDog/datadog-agent/pkg/quantile v0.40.0-rc.2

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	code.cloudfoundry.org/bbs v0.0.0-20200403215808-d7bc971db0db
 	code.cloudfoundry.org/garden v0.0.0-20210208153517-580cadd489d2
 	code.cloudfoundry.org/lager v2.0.0+incompatible
-	github.com/DataDog/agent-payload/v5 v5.0.31
+	github.com/DataDog/agent-payload/v5 v5.0.32
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.40.0-rc.2
 	github.com/DataDog/datadog-agent/pkg/otlp/model v0.40.0-rc.2
 	github.com/DataDog/datadog-agent/pkg/quantile v0.40.0-rc.2

--- a/go.sum
+++ b/go.sum
@@ -129,8 +129,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.1.0 h1:ksErzDEI1khOiGPgpwuI7x2ebx/uXQNw7xJpn9Eq1+I=
 github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/DataDog/agent-payload/v5 v5.0.31 h1:N/qgBofevxU/CL55LvaXBzz5YgWPM/cAXTnNe2mBqgI=
-github.com/DataDog/agent-payload/v5 v5.0.31/go.mod h1:2gapp8p4Vd548JI+axD8kCExklNvVI6AMF5/+IfN/4g=
+github.com/DataDog/agent-payload/v5 v5.0.32 h1:zfa5gXGfjzBza9klKWFoxM8qUBmvQfzoseI9odQHc0g=
+github.com/DataDog/agent-payload/v5 v5.0.32/go.mod h1:2gapp8p4Vd548JI+axD8kCExklNvVI6AMF5/+IfN/4g=
 github.com/DataDog/aptly v1.5.0 h1:Oy6JVRC9iDgnmpeVYa4diXwP/exU7wJ/U1kuI4Zacxg=
 github.com/DataDog/aptly v1.5.0/go.mod h1:KVyvkYXGcFugxadGFZ+u5Fc3M6q/EfzFZyeTD9HVbkY=
 github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3 h1:SobA9WYm4K/MUtWlbKaomWTmnuYp1KhIm8Wlx3vmpsg=

--- a/go.sum
+++ b/go.sum
@@ -129,8 +129,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.1.0 h1:ksErzDEI1khOiGPgpwuI7x2ebx/uXQNw7xJpn9Eq1+I=
 github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/DataDog/agent-payload/v5 v5.0.29 h1:Cxklf+ALD/0tenmo/6EdYPJqESaBnXO+HA9WtBn7fAc=
-github.com/DataDog/agent-payload/v5 v5.0.29/go.mod h1:2gapp8p4Vd548JI+axD8kCExklNvVI6AMF5/+IfN/4g=
+github.com/DataDog/agent-payload/v5 v5.0.31 h1:N/qgBofevxU/CL55LvaXBzz5YgWPM/cAXTnNe2mBqgI=
+github.com/DataDog/agent-payload/v5 v5.0.31/go.mod h1:2gapp8p4Vd548JI+axD8kCExklNvVI6AMF5/+IfN/4g=
 github.com/DataDog/aptly v1.5.0 h1:Oy6JVRC9iDgnmpeVYa4diXwP/exU7wJ/U1kuI4Zacxg=
 github.com/DataDog/aptly v1.5.0/go.mod h1:KVyvkYXGcFugxadGFZ+u5Fc3M6q/EfzFZyeTD9HVbkY=
 github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3 h1:SobA9WYm4K/MUtWlbKaomWTmnuYp1KhIm8Wlx3vmpsg=

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/processor.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/processor.go
@@ -179,7 +179,7 @@ func (p *Processor) Process(ctx *ProcessorContext, list interface{}) (processRes
 
 	for i := 0; i < chunkCount; i++ {
 		metadataMessages = append(metadataMessages, p.h.BuildMessageBody(ctx, metadataChunker.collectorOrchestratorList[i], chunkCount))
-		manifestMessages = append(manifestMessages, buildManifestMessageBody(ctx.Cfg.KubeClusterName, ctx.ClusterID, ctx.MsgGroupID, manifestChunker.collectorOrchestratorList[i], chunkCount))
+		manifestMessages = append(manifestMessages, buildManifestMessageBody(ctx, manifestChunker.collectorOrchestratorList[i], chunkCount))
 	}
 
 	processResult = ProcessResult{
@@ -191,7 +191,7 @@ func (p *Processor) Process(ctx *ProcessorContext, list interface{}) (processRes
 }
 
 // build orchestrator manifest message
-func buildManifestMessageBody(kubeClusterName, clusterID string, msgGroupID int32, resourceManifests []interface{}, groupSize int) model.MessageBody {
+func buildManifestMessageBody(ctx *ProcessorContext, resourceManifests []interface{}, groupSize int) model.MessageBody {
 	manifests := make([]*model.Manifest, 0, len(resourceManifests))
 
 	for _, m := range resourceManifests {
@@ -199,10 +199,10 @@ func buildManifestMessageBody(kubeClusterName, clusterID string, msgGroupID int3
 	}
 
 	return &model.CollectorManifest{
-		ClusterName: kubeClusterName,
-		ClusterId:   clusterID,
+		ClusterName: ctx.Cfg.KubeClusterName,
+		ClusterId:   ctx.ClusterID,
 		Manifests:   manifests,
-		GroupId:     msgGroupID,
+		GroupId:     ctx.MsgGroupID,
 		GroupSize:   int32(groupSize),
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1014,6 +1014,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("orchestrator_explorer.custom_sensitive_words", []string{})
 	config.BindEnvAndSetDefault("orchestrator_explorer.collector_discovery.enabled", true)
 	config.BindEnv("orchestrator_explorer.max_per_message")
+	config.BindEnv("orchestrator_explorer.max_message_bytes")
 	config.BindEnv("orchestrator_explorer.orchestrator_dd_url")
 	config.BindEnv("orchestrator_explorer.orchestrator_additional_endpoints")
 	config.BindEnv("orchestrator_explorer.use_legacy_endpoint")

--- a/pkg/orchestrator/config/config.go
+++ b/pkg/orchestrator/config/config.go
@@ -27,6 +27,7 @@ const (
 	processNS       = "process_config"
 	defaultEndpoint = "https://orchestrator.datadoghq.com"
 	maxMessageBatch = 100
+	maxMessageSize  = 50 * 1e6 // 50 MB
 )
 
 // OrchestratorConfig is the global config for the Orchestrator related packages. This information
@@ -89,16 +90,10 @@ func (oc *OrchestratorConfig) Load() error {
 		oc.Scrubber.AddCustomSensitiveWords(config.Datadog.GetStringSlice(k))
 	}
 
-	// The maximum number of pods, nodes, replicaSets, deployments and services per message. Note: Only change if the defaults are causing issues.
-	if k := key(orchestratorNS, "max_per_message"); config.Datadog.IsSet(k) {
-		if maxPerMessage := config.Datadog.GetInt(k); maxPerMessage <= 0 {
-			log.Warn("Invalid item count per message (<= 0), ignoring...")
-		} else if maxPerMessage <= maxMessageBatch {
-			oc.MaxPerMessage = maxPerMessage
-		} else if maxPerMessage > 0 {
-			log.Warn("Overriding the configured item count per message limit because it exceeds maximum")
-		}
-	}
+	// The maximum number of resources per message and the maximum message size.
+	// Note: Only change if the defaults are causing issues.
+	hanlePositiveIntValueWithMax(key(orchestratorNS, "max_per_message"), maxMessageBatch, func(v int) { oc.MaxPerMessage = v })
+	hanlePositiveIntValueWithMax(key(orchestratorNS, "max_message_bytes"), maxMessageSize, func(v int) { oc.MaxWeightPerMessageBytes = v })
 
 	if k := key(processNS, "pod_queue_bytes"); config.Datadog.IsSet(k) {
 		if queueBytes := config.Datadog.GetInt(k); queueBytes > 0 {
@@ -182,4 +177,23 @@ func NewOrchestratorForwarder() forwarder.Forwarder {
 	orchestratorForwarderOpts.DisableAPIKeyChecking = true
 
 	return forwarder.NewDefaultForwarder(orchestratorForwarderOpts)
+}
+
+func hanlePositiveIntValueWithMax(configKey string, maxValue int, setter func(v int)) {
+	if !config.Datadog.IsSet(configKey) {
+		return
+	}
+
+	val := config.Datadog.GetInt(configKey)
+
+	if val <= 0 {
+		log.Warn("Ignoring invalid value for setting %s (<=0)", configKey)
+		return
+	}
+	if val > maxValue {
+		log.Warn("Ignoring invalid value for setting %s (exceeds maximum allowed value)", configKey)
+		return
+	}
+
+	setter(val)
 }

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -47,6 +47,7 @@ const (
 	RTContainerCheckName   = "rtcontainer"
 	ConnectionsCheckName   = "connections"
 	PodCheckName           = "pod"
+	PodCheckManifestName   = "pod_manifest"
 	DiscoveryCheckName     = "process_discovery"
 	ProcessEventsCheckName = "process_events"
 

--- a/pkg/process/util/api/payload.go
+++ b/pkg/process/util/api/payload.go
@@ -8,10 +8,9 @@ package api
 import (
 	"fmt"
 
-	model "github.com/DataDog/agent-payload/v5/process"
-	"github.com/DataDog/zstd_0"
 	"github.com/gogo/protobuf/proto"
 
+	model "github.com/DataDog/agent-payload/v5/process"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 )
 
@@ -35,8 +34,6 @@ func EncodePayload(m model.MessageBody) ([]byte, error) {
 	var encoded []byte
 	if msgType == model.TypeCollectorProcEvent {
 		encoded, err = proto.Marshal(m)
-	} else if msgType == model.TypeCollectorManifest {
-		encoded, err = encodeManifestPayload(m)
 	} else {
 		encoding := model.MessageEncodingZstdPB
 		if msgType == model.TypeCollectorConnections {
@@ -52,15 +49,5 @@ func EncodePayload(m model.MessageBody) ([]byte, error) {
 
 	tlmBytesOut.Add(float64(len(encoded)), typeTag)
 
-	return encoded, err
-}
-
-func encodeManifestPayload(m model.MessageBody) ([]byte, error) {
-	pb, err := proto.Marshal(m)
-	if err != nil {
-		return pb, err
-	}
-
-	encoded, err := zstd_0.Compress(nil, pb)
 	return encoded, err
 }

--- a/pkg/process/util/api/payload.go
+++ b/pkg/process/util/api/payload.go
@@ -8,9 +8,9 @@ package api
 import (
 	"fmt"
 
+	model "github.com/DataDog/agent-payload/v5/process"
 	"github.com/gogo/protobuf/proto"
 
-	model "github.com/DataDog/agent-payload/v5/process"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 )
 

--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -435,7 +435,7 @@ func (s *Serializer) SendOrchestratorMetadata(msgs []ProcessMessageBody, hostNam
 		return errors.New("orchestrator forwarder is not setup")
 	}
 	for _, m := range msgs {
-		payloads, extraHeaders, err := makeOrchestratorPayloads(m, hostName, clusterID, false)
+		payloads, extraHeaders, err := makeOrchestratorPayloads(m, hostName, clusterID)
 		if err != nil {
 			return log.Errorf("Unable to encode message: %s", err)
 		}
@@ -486,7 +486,7 @@ func (s *Serializer) SendOrchestratorManifests(msgs []ProcessMessageBody, hostNa
 		return errors.New("orchestrator forwarder is not setup")
 	}
 	for _, m := range msgs {
-		payloads, extraHeaders, err := makeOrchestratorPayloads(m, hostName, clusterID, true)
+		payloads, extraHeaders, err := makeOrchestratorPayloads(m, hostName, clusterID)
 		if err != nil {
 			log.Errorf("Unable to encode message: %s", err)
 			continue
@@ -506,7 +506,7 @@ func (s *Serializer) SendOrchestratorManifests(msgs []ProcessMessageBody, hostNa
 	return nil
 }
 
-func makeOrchestratorPayloads(msg ProcessMessageBody, hostName, clusterID string, isManifest bool) (transaction.BytesPayloads, http.Header, error) {
+func makeOrchestratorPayloads(msg ProcessMessageBody, hostName, clusterID string) (transaction.BytesPayloads, http.Header, error) {
 	extraHeaders := make(http.Header)
 	extraHeaders.Set(headers.HostHeader, hostName)
 	extraHeaders.Set(headers.ClusterIDHeader, clusterID)
@@ -514,9 +514,6 @@ func makeOrchestratorPayloads(msg ProcessMessageBody, hostName, clusterID string
 	extraHeaders.Set(headers.EVPOriginHeader, "agent")
 	extraHeaders.Set(headers.EVPOriginVersionHeader, version.AgentVersion)
 	extraHeaders.Set(headers.ContentTypeHeader, headers.ProtobufContentType)
-	if isManifest {
-		extraHeaders.Set(headers.ContentEncodingHeader, headers.ZSTDContentEncoding)
-	}
 
 	body, err := processPayloadEncoder(msg)
 	if err != nil {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

- Make the payload size configurable (<= 50 MB)
- Drop the zstd header that triggers a different backend processing
- Use the same encoding/decoding as other orchestrator payloads


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
