### PR TITLE
Remove support for Android (comp/core changes)

### DIFF
--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -191,66 +191,42 @@ func StartAgent(globalParams *command.GlobalParams) error {
 	configSetupErr = common.SetupConfig(globalParams.ConfFilePath)
 
 	// Setup logger
-	if runtime.GOOS != "android" {
-		syslogURI := config.GetSyslogURI()
-		logFile := config.Datadog.GetString("log_file")
-		if logFile == "" {
-			logFile = common.DefaultLogFile
-		}
+	syslogURI := config.GetSyslogURI()
+	logFile := config.Datadog.GetString("log_file")
+	if logFile == "" {
+		logFile = common.DefaultLogFile
+	}
 
-		jmxLogFile := config.Datadog.GetString("jmx_log_file")
-		if jmxLogFile == "" {
-			jmxLogFile = common.DefaultJmxLogFile
-		}
+	jmxLogFile := config.Datadog.GetString("jmx_log_file")
+	if jmxLogFile == "" {
+		jmxLogFile = common.DefaultJmxLogFile
+	}
 
-		if config.Datadog.GetBool("disable_file_logging") {
-			// this will prevent any logging on file
-			logFile = ""
-			jmxLogFile = ""
-		}
+	if config.Datadog.GetBool("disable_file_logging") {
+		// this will prevent any logging on file
+		logFile = ""
+		jmxLogFile = ""
+	}
 
-		loggerSetupErr = config.SetupLogger(
-			config.CoreLoggerName,
-			config.Datadog.GetString("log_level"),
-			logFile,
+	loggerSetupErr = config.SetupLogger(
+		config.CoreLoggerName,
+		config.Datadog.GetString("log_level"),
+		logFile,
+		syslogURI,
+		config.Datadog.GetBool("syslog_rfc"),
+		config.Datadog.GetBool("log_to_console"),
+		config.Datadog.GetBool("log_format_json"),
+	)
+
+	// Setup JMX logger
+	if loggerSetupErr == nil {
+		loggerSetupErr = config.SetupJMXLogger(
+			jmxLogFile,
 			syslogURI,
 			config.Datadog.GetBool("syslog_rfc"),
 			config.Datadog.GetBool("log_to_console"),
 			config.Datadog.GetBool("log_format_json"),
 		)
-
-		// Setup JMX logger
-		if loggerSetupErr == nil {
-			loggerSetupErr = config.SetupJMXLogger(
-				jmxLogFile,
-				syslogURI,
-				config.Datadog.GetBool("syslog_rfc"),
-				config.Datadog.GetBool("log_to_console"),
-				config.Datadog.GetBool("log_format_json"),
-			)
-		}
-
-	} else {
-		loggerSetupErr = config.SetupLogger(
-			config.CoreLoggerName,
-			config.Datadog.GetString("log_level"),
-			"", // no log file on android
-			"", // no syslog on android,
-			false,
-			true,  // always log to console
-			false, // not in json
-		)
-
-		// Setup JMX logger
-		if loggerSetupErr == nil {
-			loggerSetupErr = config.SetupJMXLogger(
-				"", // no log file on android
-				"", // no syslog on android,
-				false,
-				true,  // always log to console
-				false, // not in json
-			)
-		}
 	}
 
 	if configSetupErr != nil {
@@ -361,10 +337,8 @@ func StartAgent(globalParams *command.GlobalParams) error {
 	}
 
 	// start the cmd HTTP server
-	if runtime.GOOS != "android" {
-		if err = api.StartServer(configService); err != nil {
-			return log.Errorf("Error while starting api server, exiting: %v", err)
-		}
+	if err = api.StartServer(configService); err != nil {
+		return log.Errorf("Error while starting api server, exiting: %v", err)
 	}
 
 	// start clc runner server

--- a/comp/core/internal/params.go
+++ b/comp/core/internal/params.go
@@ -107,9 +107,6 @@ func (params BundleParams) LogForOneShot(loggerName, level string, overrideFromE
 // The log file is set based on the logFileConfig config parameter,
 // or disabled if `disable_file_logging` is set.
 //
-// On Android, the configuration is much like a one-shot app, except that
-// the log level is set based on the `log_level` config param.
-//
 // On platforms which support it, syslog is enabled if `log_to_syslog` is set,
 // using `syslog_uri` or defaulting to "unixgram:///dev/log" if that is empty.
 // The `syslog_rfc` config parameter determines whether this produces 5424-compliant
@@ -119,46 +116,43 @@ func (params BundleParams) LogForOneShot(loggerName, level string, overrideFromE
 // as JSON if `log_format_json` is set.
 func (params BundleParams) LogForDaemon(loggerName, logFileConfig, defaultLogFile string) BundleParams {
 	params.LoggerName = loggerName
-	if runtime.GOOS == "android" {
-		// no log file or syslog on android, and always log to console, not in JSON
-		params.LogLevelFn = func(g configGetter) string { return g.GetString("log_level") }
-		params.LogFileFn = func(configGetter) string { return "" }
-		params.LogSyslogURIFn = func(configGetter) string { return "" }
-		params.LogSyslogRFCFn = func(configGetter) bool { return false }
-		params.LogToConsoleFn = func(configGetter) bool { return true }
-		params.LogFormatJSONFn = func(configGetter) bool { return false }
-	} else {
-		params.LogLevelFn = func(g configGetter) string { return g.GetString("log_level") }
-		params.LogFileFn = func(g configGetter) string {
-			if g.GetBool("disable_file_logging") {
-				return ""
-			}
-			logFile := g.GetString(logFileConfig)
-			if logFile == "" {
-				logFile = defaultLogFile
-			}
-			return logFile
+	params.LogLevelFn = func(g configGetter) string { return g.GetString("log_level") }
+	params.LogFileFn = func(g configGetter) string {
+		if g.GetBool("disable_file_logging") {
+			return ""
 		}
-		params.LogSyslogURIFn = func(g configGetter) string {
-			if runtime.GOOS == "windows" {
-				return "" // syslog not supported on Windows
-			}
-			enabled := g.GetBool("log_to_syslog")
-			uri := g.GetString("syslog_uri")
-
-			if !enabled {
-				return ""
-			}
-
-			if uri == "" {
-				return "unixgram:///dev/log"
-			}
-
-			return uri
+		logFile := g.GetString(logFileConfig)
+		if logFile == "" {
+			logFile = defaultLogFile
 		}
-		params.LogSyslogRFCFn = func(g configGetter) bool { return g.GetBool("syslog_rfc") }
-		params.LogToConsoleFn = func(g configGetter) bool { return g.GetBool("log_to_console") }
-		params.LogFormatJSONFn = func(g configGetter) bool { return g.GetBool("log_format_json") }
+		return logFile
 	}
+	params.LogSyslogURIFn = func(g configGetter) string {
+		if runtime.GOOS == "windows" {
+			return "" // syslog not supported on Windows
+		}
+		enabled := g.GetBool("log_to_syslog")
+		uri := g.GetString("syslog_uri")
+
+		if !enabled {
+			return ""
+		}
+
+		if uri == "" {
+			return "unixgram:///dev/log"
+		}
+
+		return uri
+	}
+	params.LogSyslogRFCFn = func(g configGetter) bool { return g.GetBool("syslog_rfc") }
+	params.LogToConsoleFn = func(g configGetter) bool { return g.GetBool("log_to_console") }
+	params.LogFormatJSONFn = func(g configGetter) bool { return g.GetBool("log_format_json") }
+	return params
+}
+
+// LogToFile modifies the parameters to set the destination log file, overriding any
+// previous logfile parameter.
+func (params BundleParams) LogToFile(logFile string) BundleParams {
+	params.LogFileFn = func(configGetter) string { return logFile }
 	return params
 }

--- a/comp/core/internal/params_test.go
+++ b/comp/core/internal/params_test.go
@@ -53,26 +53,6 @@ func TestLogForOneShot_override(t *testing.T) {
 	require.Equal(t, false, params.LogFormatJSONFn(g))
 }
 
-func TestLogForDaemon_android(t *testing.T) {
-	if runtime.GOOS != "android" {
-		t.Skip()
-	}
-	params := BundleParams{}.LogForDaemon("TEST", "unused", "unused")
-	g := &getter{
-		strs: map[string]string{
-			"log_level": "trace",
-		},
-	}
-
-	require.Equal(t, "TEST", params.LoggerName)
-	require.Equal(t, "trace", params.LogLevelFn(g))
-	require.Equal(t, "", params.LogFileFn(g))
-	require.Equal(t, "", params.LogSyslogURIFn(g))
-	require.Equal(t, false, params.LogSyslogRFCFn(g))
-	require.Equal(t, true, params.LogToConsoleFn(g))
-	require.Equal(t, false, params.LogFormatJSONFn(g))
-}
-
 func TestLogForDaemon_windows(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip()
@@ -182,4 +162,11 @@ func TestLogForDaemon_linux(t *testing.T) {
 		require.Equal(t, false, params.LogToConsoleFn(g))
 		require.Equal(t, true, params.LogFormatJSONFn(g))
 	})
+}
+
+func TestLogToFile(t *testing.T) {
+	params := BundleParams{}.LogForOneShot("TEST", "trace", true).LogToFile("/some/file")
+	g := &getter{}
+
+	require.Equal(t, "/some/file", params.LogFileFn(g))
 }


### PR DESCRIPTION
### What does this PR do?

This is a followup to #13699 that removes support for Android in the code in #13662, which is still pending review.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

I'll rebase this PR against main once #13662 lands.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Same as #13622.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
