### PR TITLE
Convert integrations subcommand to an app

### DIFF
--- a/cmd/agent/subcommands/integrations/command.go
+++ b/cmd/agent/subcommands/integrations/command.go
@@ -23,10 +23,14 @@ import (
 	"regexp"
 	"strings"
 
+	"go.uber.org/fx"
+
 	"github.com/DataDog/datadog-agent/cmd/agent/command"
-	"github.com/DataDog/datadog-agent/cmd/agent/common"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/executable"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 
 	"github.com/coreos/go-semver/semver"
 	"github.com/fatih/color"
@@ -56,30 +60,44 @@ var (
 	versionSpecifiersRe   = regexp.MustCompile("([><=!]{1,2})([0-9.]*)")                                                                         // Matches version specifiers defined in https://packaging.python.org/specifications/core-metadata/#requires-dist-multiple-use
 	pep440VersionStringRe = regexp.MustCompile("^(?P<release>\\d+\\.\\d+\\.\\d+)(?:(?P<preReleaseType>[a-zA-Z]+)(?P<preReleaseNumber>\\d+)?)?$") // e.g. 1.3.4b1, simplified form of: https://www.python.org/dev/peps/pep-0440
 
-	allowRoot           bool
-	verbose             int
-	useSysPython        bool
-	versionOnly         bool
-	localWheel          bool
-	thirdParty          bool
 	rootDir             string
-	pythonMajorVersion  string
 	pythonMinorVersion  string
 	reqAgentReleasePath string
 	constraintsPath     string
 )
 
+// cliParams are the command-line arguments for the sub-subcommands.
+//
+// Note that not all params are present for all sub-subcommands.
+type cliParams struct {
+	*command.GlobalParams
+
+	// args are the positional command-line arguments
+	args []string
+
+	allowRoot          bool
+	verbose            int
+	useSysPython       bool
+	versionOnly        bool
+	localWheel         bool
+	thirdParty         bool
+	pythonMajorVersion string
+}
+
 // Commands returns a slice of subcommands for the 'agent' command.
 func Commands(globalParams *command.GlobalParams) []*cobra.Command {
+	cliParams := &cliParams{}
+
 	integrationCmd := &cobra.Command{
 		Use:   "integration [command]",
 		Short: "Datadog integration manager",
 		Long:  ``,
 	}
-	integrationCmd.PersistentFlags().CountVarP(&verbose, "verbose", "v", "enable verbose logging")
-	integrationCmd.PersistentFlags().BoolVarP(&allowRoot, "allow-root", "r", false, "flag to enable root to install packages")
-	integrationCmd.PersistentFlags().BoolVarP(&useSysPython, "use-sys-python", "p", false, "use system python instead [dev flag]")
-	integrationCmd.PersistentFlags().StringVarP(&pythonMajorVersion, "python", "", "", "the version of Python to act upon (2 or 3). defaults to the python_version setting in datadog.yaml")
+
+	integrationCmd.PersistentFlags().CountVarP(&cliParams.verbose, "verbose", "v", "enable verbose logging")
+	integrationCmd.PersistentFlags().BoolVarP(&cliParams.allowRoot, "allow-root", "r", false, "flag to enable root to install packages")
+	integrationCmd.PersistentFlags().BoolVarP(&cliParams.useSysPython, "use-sys-python", "p", false, "use system python instead [dev flag]")
+	integrationCmd.PersistentFlags().StringVarP(&cliParams.pythonMajorVersion, "python", "", "", "the version of Python to act upon (2 or 3). defaults to the python_version setting in datadog.yaml")
 
 	// Power user flags - mark as hidden
 	integrationCmd.PersistentFlags().MarkHidden("use-sys-python") //nolint:errcheck
@@ -92,14 +110,23 @@ You must specify a version of the package to install using the syntax: <package>
  - <package> of the form datadog-<integration-name>
  - <version> of the form x.y.z`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return install(globalParams, cmd, args)
+			cliParams.args = args
+			return fxutil.OneShot(install,
+				fx.Supply(cliParams),
+				fx.Supply(core.BundleParams{
+					ConfFilePath:      globalParams.ConfFilePath,
+					ConfigLoadSecrets: false,
+					ConfigMissingOK:   true,
+				}),
+				core.Bundle,
+			)
 		},
 	}
 	installCmd.Flags().BoolVarP(
-		&localWheel, "local-wheel", "w", false, fmt.Sprintf("install an agent check from a locally available wheel file. %s", disclaimer),
+		&cliParams.localWheel, "local-wheel", "w", false, fmt.Sprintf("install an agent check from a locally available wheel file. %s", disclaimer),
 	)
 	installCmd.Flags().BoolVarP(
-		&thirdParty, "third-party", "t", false, "install a community or vendor-contributed integration",
+		&cliParams.thirdParty, "third-party", "t", false, "install a community or vendor-contributed integration",
 	)
 	integrationCmd.AddCommand(installCmd)
 
@@ -108,7 +135,16 @@ You must specify a version of the package to install using the syntax: <package>
 		Short: "Remove Datadog integration core/extra packages",
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return remove(globalParams, cmd, args)
+			cliParams.args = args
+			return fxutil.OneShot(remove,
+				fx.Supply(cliParams),
+				fx.Supply(core.BundleParams{
+					ConfFilePath:      globalParams.ConfFilePath,
+					ConfigLoadSecrets: false,
+					ConfigMissingOK:   true,
+				}),
+				core.Bundle,
+			)
 		},
 	}
 	integrationCmd.AddCommand(removeCmd)
@@ -118,7 +154,16 @@ You must specify a version of the package to install using the syntax: <package>
 		Short: "Print the list of installed packages in the agent's python environment",
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return list(globalParams, cmd, args)
+			cliParams.args = args
+			return fxutil.OneShot(list,
+				fx.Supply(cliParams),
+				fx.Supply(core.BundleParams{
+					ConfFilePath:      globalParams.ConfFilePath,
+					ConfigLoadSecrets: false,
+					ConfigMissingOK:   true,
+				}),
+				core.Bundle,
+			)
 		},
 	}
 	integrationCmd.AddCommand(freezeCmd)
@@ -129,16 +174,25 @@ You must specify a version of the package to install using the syntax: <package>
 		Args:  cobra.ExactArgs(1),
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return show(globalParams, cmd, args)
+			cliParams.args = args
+			return fxutil.OneShot(show,
+				fx.Supply(cliParams),
+				fx.Supply(core.BundleParams{
+					ConfFilePath:      globalParams.ConfFilePath,
+					ConfigLoadSecrets: false,
+					ConfigMissingOK:   true,
+				}),
+				core.Bundle,
+			)
 		},
 	}
-	showCmd.Flags().BoolVarP(&versionOnly, "show-version-only", "q", false, "only display version information")
+	showCmd.Flags().BoolVarP(&cliParams.versionOnly, "show-version-only", "q", false, "only display version information")
 	integrationCmd.AddCommand(showCmd)
 
 	return []*cobra.Command{integrationCmd}
 }
 
-func loadPythonInfo(globalParams *command.GlobalParams) error {
+func loadPythonInfo(config config.Component, cliParams *cliParams) error {
 	rootDir, _ = executable.Folder()
 	for {
 		agentReleaseFile := filepath.Join(rootDir, reqAgentReleaseFile)
@@ -155,16 +209,11 @@ func loadPythonInfo(globalParams *command.GlobalParams) error {
 		rootDir = parentDir
 	}
 
-	if err := common.SetupConfigIfExist(globalParams.ConfFilePath); err != nil {
-		fmt.Printf("Cannot setup config, exiting: %v\n", err)
-		return err
+	if cliParams.pythonMajorVersion == "" {
+		cliParams.pythonMajorVersion = config.GetString("python_version")
 	}
 
-	if pythonMajorVersion == "" {
-		pythonMajorVersion = config.Datadog.GetString("python_version")
-	}
-
-	constraintsPath = filepath.Join(rootDir, fmt.Sprintf("final_constraints-py%s.txt", pythonMajorVersion))
+	constraintsPath = filepath.Join(rootDir, fmt.Sprintf("final_constraints-py%s.txt", cliParams.pythonMajorVersion))
 	if _, err := os.Lstat(constraintsPath); err != nil {
 		return err
 	}
@@ -172,9 +221,9 @@ func loadPythonInfo(globalParams *command.GlobalParams) error {
 	return nil
 }
 
-func detectPythonMinorVersion() error {
+func detectPythonMinorVersion(cliParams *cliParams) error {
 	if pythonMinorVersion == "" {
-		pythonPath, err := getCommandPython()
+		pythonPath, err := getCommandPython(cliParams)
 		if err != nil {
 			return err
 		}
@@ -256,12 +305,12 @@ func PEP440ToSemver(pep440 string) (*semver.Version, error) {
 	return semver.NewVersion(versionString)
 }
 
-func getCommandPython() (string, error) {
-	if useSysPython {
+func getCommandPython(cliParams *cliParams) (string, error) {
+	if cliParams.useSysPython {
 		return pythonBin, nil
 	}
 
-	pyPath := filepath.Join(rootDir, getRelPyPath())
+	pyPath := filepath.Join(rootDir, getRelPyPath(cliParams))
 
 	if _, err := os.Stat(pyPath); err != nil {
 		if os.IsNotExist(err) {
@@ -297,8 +346,8 @@ func validateArgs(args []string, local bool) error {
 	return nil
 }
 
-func pip(globalParams *command.GlobalParams, args []string, stdout io.Writer, stderr io.Writer) error {
-	pythonPath, err := getCommandPython()
+func pip(cliParams *cliParams, args []string, stdout io.Writer, stderr io.Writer) error {
+	pythonPath, err := getCommandPython(cliParams)
 	if err != nil {
 		return err
 	}
@@ -308,8 +357,8 @@ func pip(globalParams *command.GlobalParams, args []string, stdout io.Writer, st
 	implicitFlags = append(implicitFlags, "--disable-pip-version-check")
 	args = append([]string{"-mpip"}, cmd)
 
-	if verbose > 0 {
-		args = append(args, fmt.Sprintf("-%s", strings.Repeat("v", verbose)))
+	if cliParams.verbose > 0 {
+		args = append(args, fmt.Sprintf("-%s", strings.Repeat("v", cliParams.verbose)))
 	}
 
 	// Append implicit flags to the *pip* command
@@ -349,17 +398,17 @@ func pip(globalParams *command.GlobalParams, args []string, stdout io.Writer, st
 	return nil
 }
 
-func install(globalParams *command.GlobalParams, cmd *cobra.Command, args []string) error {
-	if err := loadPythonInfo(globalParams); err != nil {
+func install(config config.Component, cliParams *cliParams) error {
+	if err := loadPythonInfo(config, cliParams); err != nil {
 		return err
 	}
 
-	err := validateUser(allowRoot)
+	err := validateUser(cliParams.allowRoot)
 	if err != nil {
 		return err
 	}
 
-	if err := validateArgs(args, localWheel); err != nil {
+	if err := validateArgs(cliParams.args, cliParams.localWheel); err != nil {
 		return err
 	}
 
@@ -375,11 +424,11 @@ func install(globalParams *command.GlobalParams, cmd *cobra.Command, args []stri
 		"--no-deps",
 	}
 
-	if localWheel {
+	if cliParams.localWheel {
 		// Specific case when installing from locally available wheel
 		// No compatibility verifications are performed, just install the wheel (with --no-deps still)
 		// Verify that the wheel depends on `datadog-checks-base` to decide if it's an agent check or not
-		wheelPath := args[0]
+		wheelPath := cliParams.args[0]
 
 		fmt.Println(disclaimer)
 		if ok, err := validateBaseDependency(wheelPath, nil); err != nil {
@@ -396,12 +445,12 @@ func install(globalParams *command.GlobalParams, cmd *cobra.Command, args []stri
 		integration = normalizePackageName(strings.TrimSpace(integration))
 
 		// Install the wheel
-		if err := pip(globalParams, append(pipArgs, wheelPath), os.Stdout, os.Stderr); err != nil {
+		if err := pip(cliParams, append(pipArgs, wheelPath), os.Stdout, os.Stderr); err != nil {
 			return fmt.Errorf("error installing wheel %s: %v", wheelPath, err)
 		}
 
 		// Move configuration files
-		if err := moveConfigurationFilesOf(integration); err != nil {
+		if err := moveConfigurationFilesOf(cliParams, integration); err != nil {
 			fmt.Printf("Installed %s from %s\n", integration, wheelPath)
 			return fmt.Errorf("Some errors prevented moving %s configuration files: %v", integration, err)
 		}
@@ -414,11 +463,11 @@ func install(globalParams *command.GlobalParams, cmd *cobra.Command, args []stri
 	}
 
 	// Additional verification for installation
-	if len(strings.Split(args[0], "==")) != 2 {
+	if len(strings.Split(cliParams.args[0], "==")) != 2 {
 		return fmt.Errorf("you must specify a version to install with <package>==<version>")
 	}
 
-	intVer := strings.Split(args[0], "==")
+	intVer := strings.Split(cliParams.args[0], "==")
 	integration := normalizePackageName(strings.TrimSpace(intVer[0]))
 	if integration == "datadog-checks-base" {
 		return fmt.Errorf("this command does not allow installing datadog-checks-base")
@@ -427,7 +476,7 @@ func install(globalParams *command.GlobalParams, cmd *cobra.Command, args []stri
 	if err != nil || versionToInstall == nil {
 		return fmt.Errorf("unable to get version of %s to install: %v", integration, err)
 	}
-	currentVersion, found, err := installedVersion(integration)
+	currentVersion, found, err := installedVersion(cliParams, integration)
 	if err != nil {
 		return fmt.Errorf("could not get current version of %s: %v", integration, err)
 	}
@@ -448,18 +497,18 @@ func install(globalParams *command.GlobalParams, cmd *cobra.Command, args []stri
 	}
 
 	rootLayoutType := "core"
-	if thirdParty {
+	if cliParams.thirdParty {
 		rootLayoutType = "extras"
 	}
 
 	// Download the wheel
-	wheelPath, err := downloadWheel(integration, semverToPEP440(versionToInstall), rootLayoutType)
+	wheelPath, err := downloadWheel(cliParams, integration, semverToPEP440(versionToInstall), rootLayoutType)
 	if err != nil {
 		return fmt.Errorf("error when downloading the wheel for %s %s: %v", integration, versionToInstall, err)
 	}
 
 	// Verify datadog-checks-base is compatible with the requirements
-	shippedBaseVersion, found, err := installedVersion("datadog-checks-base")
+	shippedBaseVersion, found, err := installedVersion(cliParams, "datadog-checks-base")
 	if err != nil {
 		return fmt.Errorf("unable to get the version of datadog-checks-base: %v", err)
 	}
@@ -473,12 +522,12 @@ func install(globalParams *command.GlobalParams, cmd *cobra.Command, args []stri
 	}
 
 	// Install the wheel
-	if err := pip(globalParams, append(pipArgs, wheelPath), os.Stdout, os.Stderr); err != nil {
+	if err := pip(cliParams, append(pipArgs, wheelPath), os.Stdout, os.Stderr); err != nil {
 		return fmt.Errorf("error installing wheel %s: %v", wheelPath, err)
 	}
 
 	// Move configuration files
-	if err := moveConfigurationFilesOf(integration); err != nil {
+	if err := moveConfigurationFilesOf(cliParams, integration); err != nil {
 		fmt.Printf("Installed %s %s", integration, versionToInstall)
 		return fmt.Errorf("Some errors prevented moving %s configuration files: %v", integration, err)
 	}
@@ -489,8 +538,8 @@ func install(globalParams *command.GlobalParams, cmd *cobra.Command, args []stri
 	return nil
 }
 
-func downloadWheel(integration, version, rootLayoutType string) (string, error) {
-	pyPath, err := getCommandPython()
+func downloadWheel(cliParams *cliParams, integration, version, rootLayoutType string) (string, error) {
+	pyPath, err := getCommandPython(cliParams)
 	if err != nil {
 		return "", err
 	}
@@ -501,8 +550,8 @@ func downloadWheel(integration, version, rootLayoutType string) (string, error) 
 		"--version", version,
 		"--type", rootLayoutType,
 	}
-	if verbose > 0 {
-		args = append(args, fmt.Sprintf("-%s", strings.Repeat("v", verbose)))
+	if cliParams.verbose > 0 {
+		args = append(args, fmt.Sprintf("-%s", strings.Repeat("v", cliParams.verbose)))
 	}
 
 	downloaderCmd := exec.Command(pyPath, args...)
@@ -532,7 +581,7 @@ func downloadWheel(integration, version, rootLayoutType string) (string, error) 
 	downloaderCmd.Env = environ
 
 	// Proxy support
-	proxies := config.GetProxies()
+	proxies := pkgconfig.GetProxies()
 	if proxies != nil {
 		downloaderCmd.Env = append(downloaderCmd.Env,
 			fmt.Sprintf("HTTP_PROXY=%s", proxies.HTTP),
@@ -703,8 +752,8 @@ func minAllowedVersion(integration string) (*semver.Version, bool, error) {
 }
 
 // Return the version of an installed integration and whether or not it was found
-func installedVersion(integration string) (*semver.Version, bool, error) {
-	pythonPath, err := getCommandPython()
+func installedVersion(cliParams *cliParams, integration string) (*semver.Version, bool, error) {
+	pythonPath, err := getCommandPython(cliParams)
 	if err != nil {
 		return nil, false, err
 	}
@@ -768,15 +817,15 @@ func getVersionFromReqLine(integration string, lines string) (*semver.Version, b
 	return version, true, nil
 }
 
-func moveConfigurationFilesOf(integration string) error {
-	confFolder := config.Datadog.GetString("confd_path")
+func moveConfigurationFilesOf(cliParams *cliParams, integration string) error {
+	confFolder := pkgconfig.Datadog.GetString("confd_path")
 	check := getIntegrationName(integration)
 	confFileDest := filepath.Join(confFolder, fmt.Sprintf("%s.d", check))
 	if err := os.MkdirAll(confFileDest, os.ModeDir|0755); err != nil {
 		return err
 	}
 
-	relChecksPath, err := getRelChecksPath()
+	relChecksPath, err := getRelChecksPath(cliParams)
 	if err != nil {
 		return err
 	}
@@ -836,17 +885,17 @@ func moveConfigurationFiles(srcFolder string, dstFolder string) error {
 	return nil
 }
 
-func remove(globalParams *command.GlobalParams, cmd *cobra.Command, args []string) error {
-	if err := loadPythonInfo(globalParams); err != nil {
+func remove(config config.Component, cliParams *cliParams) error {
+	if err := loadPythonInfo(config, cliParams); err != nil {
 		return err
 	}
 
-	err := validateUser(allowRoot)
+	err := validateUser(cliParams.allowRoot)
 	if err != nil {
 		return err
 	}
 
-	if err := validateArgs(args, false); err != nil {
+	if err := validateArgs(cliParams.args, false); err != nil {
 		return err
 	}
 
@@ -854,14 +903,14 @@ func remove(globalParams *command.GlobalParams, cmd *cobra.Command, args []strin
 		"uninstall",
 		"--no-cache-dir",
 	}
-	pipArgs = append(pipArgs, args...)
+	pipArgs = append(pipArgs, cliParams.args...)
 	pipArgs = append(pipArgs, "-y")
 
-	return pip(globalParams, pipArgs, os.Stdout, os.Stderr)
+	return pip(cliParams, pipArgs, os.Stdout, os.Stderr)
 }
 
-func list(globalParams *command.GlobalParams, cmd *cobra.Command, args []string) error {
-	if err := loadPythonInfo(globalParams); err != nil {
+func list(config config.Component, cliParams *cliParams) error {
+	if err := loadPythonInfo(config, cliParams); err != nil {
 		return err
 	}
 
@@ -871,7 +920,7 @@ func list(globalParams *command.GlobalParams, cmd *cobra.Command, args []string)
 	}
 
 	pipStdo := bytes.NewBuffer(nil)
-	err := pip(globalParams, pipArgs, io.Writer(pipStdo), os.Stderr)
+	err := pip(cliParams, pipArgs, io.Writer(pipStdo), os.Stderr)
 	if err != nil {
 		return err
 	}
@@ -887,17 +936,17 @@ func list(globalParams *command.GlobalParams, cmd *cobra.Command, args []string)
 	return nil
 }
 
-func show(globalParams *command.GlobalParams, cmd *cobra.Command, args []string) error {
-	if err := loadPythonInfo(globalParams); err != nil {
+func show(config config.Component, cliParams *cliParams) error {
+	if err := loadPythonInfo(config, cliParams); err != nil {
 		return err
 	}
 
-	if err := validateArgs(args, false); err != nil {
+	if err := validateArgs(cliParams.args, false); err != nil {
 		return err
 	}
-	packageName := normalizePackageName(args[0])
+	packageName := normalizePackageName(cliParams.args[0])
 
-	version, found, err := installedVersion(packageName)
+	version, found, err := installedVersion(cliParams, packageName)
 	if err != nil {
 		return fmt.Errorf("could not get current version of %s: %v", packageName, err)
 	} else if !found {
@@ -909,7 +958,7 @@ func show(globalParams *command.GlobalParams, cmd *cobra.Command, args []string)
 		return nil
 	}
 
-	if versionOnly {
+	if cliParams.versionOnly {
 		// Print only the version for easier parsing
 		fmt.Println(version)
 	} else {

--- a/cmd/agent/subcommands/integrations/command.go
+++ b/cmd/agent/subcommands/integrations/command.go
@@ -102,6 +102,19 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	// Power user flags - mark as hidden
 	integrationCmd.PersistentFlags().MarkHidden("use-sys-python") //nolint:errcheck
 
+	// all subcommands use the same provided components, with a different oneShot callback
+	runOneShot := func(callback interface{}) error {
+		return fxutil.OneShot(callback,
+			fx.Supply(cliParams),
+			fx.Supply(core.BundleParams{
+				ConfFilePath:      globalParams.ConfFilePath,
+				ConfigLoadSecrets: false,
+				ConfigMissingOK:   true,
+			}),
+			core.Bundle,
+		)
+	}
+
 	installCmd := &cobra.Command{
 		Use:   "install [package==version]",
 		Short: "Install Datadog integration core/extra packages",
@@ -111,15 +124,7 @@ You must specify a version of the package to install using the syntax: <package>
  - <version> of the form x.y.z`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliParams.args = args
-			return fxutil.OneShot(install,
-				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					ConfFilePath:      globalParams.ConfFilePath,
-					ConfigLoadSecrets: false,
-					ConfigMissingOK:   true,
-				}),
-				core.Bundle,
-			)
+			return runOneShot(install)
 		},
 	}
 	installCmd.Flags().BoolVarP(
@@ -136,15 +141,7 @@ You must specify a version of the package to install using the syntax: <package>
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliParams.args = args
-			return fxutil.OneShot(remove,
-				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					ConfFilePath:      globalParams.ConfFilePath,
-					ConfigLoadSecrets: false,
-					ConfigMissingOK:   true,
-				}),
-				core.Bundle,
-			)
+			return runOneShot(remove)
 		},
 	}
 	integrationCmd.AddCommand(removeCmd)
@@ -155,15 +152,7 @@ You must specify a version of the package to install using the syntax: <package>
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliParams.args = args
-			return fxutil.OneShot(list,
-				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					ConfFilePath:      globalParams.ConfFilePath,
-					ConfigLoadSecrets: false,
-					ConfigMissingOK:   true,
-				}),
-				core.Bundle,
-			)
+			return runOneShot(list)
 		},
 	}
 	integrationCmd.AddCommand(freezeCmd)
@@ -175,15 +164,7 @@ You must specify a version of the package to install using the syntax: <package>
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliParams.args = args
-			return fxutil.OneShot(show,
-				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					ConfFilePath:      globalParams.ConfFilePath,
-					ConfigLoadSecrets: false,
-					ConfigMissingOK:   true,
-				}),
-				core.Bundle,
-			)
+			return runOneShot(show)
 		},
 	}
 	showCmd.Flags().BoolVarP(&cliParams.versionOnly, "show-version-only", "q", false, "only display version information")

--- a/cmd/agent/subcommands/integrations/command_test.go
+++ b/cmd/agent/subcommands/integrations/command_test.go
@@ -1,0 +1,71 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build python
+// +build python
+
+package integrations
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/command"
+	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+func TestInstallCommand(t *testing.T) {
+	fxutil.TestOneShotSubcommand(t,
+		Commands(&command.GlobalParams{}),
+		[]string{"integration", "install", "foo==1.0", "-v"},
+		install,
+		func(cliParams *cliParams, coreParams core.BundleParams) {
+			require.Equal(t, []string{"foo==1.0"}, cliParams.args)
+			require.Equal(t, 1, cliParams.verbose)
+			require.Equal(t, false, coreParams.ConfigLoadSecrets)
+			require.Equal(t, true, coreParams.ConfigMissingOK)
+		})
+}
+
+func TestRemoveCommand(t *testing.T) {
+	fxutil.TestOneShotSubcommand(t,
+		Commands(&command.GlobalParams{}),
+		[]string{"integration", "remove", "foo"},
+		remove,
+		func(cliParams *cliParams, coreParams core.BundleParams) {
+			require.Equal(t, []string{"foo"}, cliParams.args)
+			require.Equal(t, 0, cliParams.verbose)
+			require.Equal(t, false, coreParams.ConfigLoadSecrets)
+			require.Equal(t, true, coreParams.ConfigMissingOK)
+		})
+}
+
+func TestFreezeCommand(t *testing.T) {
+	fxutil.TestOneShotSubcommand(t,
+		Commands(&command.GlobalParams{}),
+		[]string{"integration", "freeze"},
+		list,
+		func(cliParams *cliParams, coreParams core.BundleParams) {
+			require.Equal(t, []string{}, cliParams.args)
+			require.Equal(t, 0, cliParams.verbose)
+			require.Equal(t, false, coreParams.ConfigLoadSecrets)
+			require.Equal(t, true, coreParams.ConfigMissingOK)
+		})
+}
+
+func TestShowCommand(t *testing.T) {
+	fxutil.TestOneShotSubcommand(t,
+		Commands(&command.GlobalParams{}),
+		[]string{"integration", "show", "foo"},
+		show,
+		func(cliParams *cliParams, coreParams core.BundleParams) {
+			require.Equal(t, []string{"foo"}, cliParams.args)
+			require.Equal(t, 0, cliParams.verbose)
+			require.Equal(t, false, coreParams.ConfigLoadSecrets)
+			require.Equal(t, true, coreParams.ConfigMissingOK)
+		})
+}

--- a/cmd/agent/subcommands/integrations/integrations_darwin.go
+++ b/cmd/agent/subcommands/integrations/integrations_darwin.go
@@ -18,17 +18,17 @@ const (
 	pythonBin = "python"
 )
 
-func getRelPyPath() string {
-	return filepath.Join("embedded", "bin", fmt.Sprintf("%s%s", pythonBin, pythonMajorVersion))
+func getRelPyPath(cliParams *cliParams) string {
+	return filepath.Join("embedded", "bin", fmt.Sprintf("%s%s", pythonBin, cliParams.pythonMajorVersion))
 }
 
-func getRelChecksPath() (string, error) {
-	err := detectPythonMinorVersion()
+func getRelChecksPath(cliParams *cliParams) (string, error) {
+	err := detectPythonMinorVersion(cliParams)
 	if err != nil {
 		return "", err
 	}
 
-	pythonDir := fmt.Sprintf("%s%s.%s", pythonBin, pythonMajorVersion, pythonMinorVersion)
+	pythonDir := fmt.Sprintf("%s%s.%s", pythonBin, cliParams.pythonMajorVersion, pythonMinorVersion)
 	return filepath.Join("embedded", "lib", pythonDir, "site-packages", "datadog_checks"), nil
 }
 

--- a/cmd/agent/subcommands/integrations/integrations_nix.go
+++ b/cmd/agent/subcommands/integrations/integrations_nix.go
@@ -18,17 +18,17 @@ const (
 	pythonBin = "python"
 )
 
-func getRelPyPath() string {
-	return filepath.Join("embedded", "bin", fmt.Sprintf("%s%s", pythonBin, pythonMajorVersion))
+func getRelPyPath(cliParams *cliParams) string {
+	return filepath.Join("embedded", "bin", fmt.Sprintf("%s%s", pythonBin, cliParams.pythonMajorVersion))
 }
 
-func getRelChecksPath() (string, error) {
-	err := detectPythonMinorVersion()
+func getRelChecksPath(cliParams *cliParams) (string, error) {
+	err := detectPythonMinorVersion(cliParams)
 	if err != nil {
 		return "", err
 	}
 
-	pythonDir := fmt.Sprintf("%s%s.%s", pythonBin, pythonMajorVersion, pythonMinorVersion)
+	pythonDir := fmt.Sprintf("%s%s.%s", pythonBin, cliParams.pythonMajorVersion, pythonMinorVersion)
 	return filepath.Join("embedded", "lib", pythonDir, "site-packages", "datadog_checks"), nil
 }
 

--- a/cmd/agent/subcommands/integrations/integrations_windows.go
+++ b/cmd/agent/subcommands/integrations/integrations_windows.go
@@ -19,12 +19,12 @@ const (
 	pythonBin = "python.exe"
 )
 
-func getRelPyPath() string {
-	return filepath.Join(fmt.Sprintf("embedded%s", pythonMajorVersion), pythonBin)
+func getRelPyPath(cliParams *cliParams) string {
+	return filepath.Join(fmt.Sprintf("embedded%s", cliParams.pythonMajorVersion), pythonBin)
 }
 
-func getRelChecksPath() (string, error) {
-	return filepath.Join(fmt.Sprintf("embedded%s", pythonMajorVersion), "Lib", "site-packages", "datadog_checks"), nil
+func getRelChecksPath(cliParams *cliParams) (string, error) {
+	return filepath.Join(fmt.Sprintf("embedded%s", cliParams.pythonMajorVersion), "Lib", "site-packages", "datadog_checks"), nil
 }
 
 func validateUser(allowRoot bool) error {


### PR DESCRIPTION
### What does this PR do?

Converts the `agent integrations` command to an Fx App.

### Motivation

Top-down approach to componentization.

### Additional Notes

This PR is against a base branch containing #13699 and #13662.  Once those are merged, I'll change the base of this PR to `main` and rebase, but it can be reviewed in the interim.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Compare the output of the following commands before and after the changes in https://github.com/DataDog/datadog-agent/pull/13463 and https://github.com/DataDog/datadog-agent/pull/13718 to ensure no significant changes have occurred.

* `agent integration`
* `agent integration freeze` (packages will differ!)
* `agent integration install` (error)
* `agent integration install foo==1.2.3` (should error, but it parses the command)
* `agent integration remove datadog-voltdb` (should fail)
* `agent integration remove -r datadog-voltdb` (should fail)
* `agent integration show` (error)
* `agent integration show datadog-voltdb`
* `agent integration remove --python=2 datadog-voltdb` (should fail for Agent 7)
* `agent integration remove -r -v datadog-voltdb` (should have verbose output)

Finally, verify color output from the `agent integration install` command

* `docker run $image bash -c 'agent integration remove -r datadog-yarn && agent integration install -r datadog-yarn=4.2.0'` should output two "Successfully .." lines without color
* `docker run $image bash -c 'agent integration remove -r datadog-yarn && agent integration install -n -r datadog-yarn=4.2.0'` should output two "Successfully .." lines without color
* `docker run -ti $image bash -c 'agent integration remove -r datadog-yarn && agent integration install -r datadog-yarn=4.2.0'` should output two "Successfully .." lines with color
* `docker run -ti $image bash -c 'agent integration remove -r datadog-yarn && agent integration install -n -r datadog-yarn=4.2.0'` should output two "Successfully .." lines without color

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
