### PR TITLE
Convert remoteconfig subcommand to an app

### DIFF
--- a/cmd/agent/subcommands/remoteconfig/command.go
+++ b/cmd/agent/subcommands/remoteconfig/command.go
@@ -14,34 +14,42 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
-	"google.golang.org/grpc"
+	"go.uber.org/fx"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/command"
-	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/pkg/api/security"
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/proto/pbgo"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	agentgrpc "github.com/DataDog/datadog-agent/pkg/util/grpc"
 )
 
+// cliParams are the command-line arguments for this subcommand
+type cliParams struct {
+	*command.GlobalParams
+}
+
 // Commands returns a slice of subcommands for the 'agent' command.
 func Commands(globalParams *command.GlobalParams) []*cobra.Command {
+	cliParams := &cliParams{
+		GlobalParams: globalParams,
+	}
 	remoteConfigCmd := &cobra.Command{
 		Use:   "remote-config",
 		Short: "Remote configuration state command",
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := common.SetupConfigWithoutSecrets(globalParams.ConfFilePath, "")
-			if err != nil {
-				return fmt.Errorf("Unable to set up global agent configuration: %v", err)
-			}
-
-			if !config.Datadog.GetBool("remote_configuration.enabled") {
-				return fmt.Errorf("Remote configuration is not enabled")
-			}
-			return state(cmd, args)
+			return fxutil.OneShot(state,
+				fx.Supply(cliParams),
+				fx.Supply(core.BundleParams{
+					ConfFilePath:      globalParams.ConfFilePath,
+					ConfigLoadSecrets: false,
+				}),
+				core.Bundle,
+			)
 		},
 		Hidden: true,
 	}
@@ -49,7 +57,10 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	return []*cobra.Command{remoteConfigCmd}
 }
 
-func state(cmd *cobra.Command, args []string, dialOpts ...grpc.DialOption) error {
+func state(config config.Component, cliParams *cliParams) error {
+	if !config.GetBool("remote_configuration.enabled") {
+		return fmt.Errorf("Remote configuration is not enabled")
+	}
 	fmt.Println("Fetching the configuration and director repos state..")
 	// Call GRPC endpoint returning state tree
 
@@ -64,7 +75,7 @@ func state(cmd *cobra.Command, args []string, dialOpts ...grpc.DialOption) error
 	}
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
-	cli, err := agentgrpc.GetDDAgentSecureClient(ctx, dialOpts...)
+	cli, err := agentgrpc.GetDDAgentSecureClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/agent/subcommands/remoteconfig/command.go
+++ b/cmd/agent/subcommands/remoteconfig/command.go
@@ -57,7 +57,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	return []*cobra.Command{remoteConfigCmd}
 }
 
-func state(config config.Component, cliParams *cliParams) error {
+func state(cliParams *cliParams, config config.Component) error {
 	if !config.GetBool("remote_configuration.enabled") {
 		return fmt.Errorf("Remote configuration is not enabled")
 	}

--- a/cmd/agent/subcommands/remoteconfig/command_test.go
+++ b/cmd/agent/subcommands/remoteconfig/command_test.go
@@ -1,0 +1,26 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package remoteconfig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/command"
+	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+func TestCommand(t *testing.T) {
+	fxutil.TestOneShotSubcommand(t,
+		Commands(&command.GlobalParams{}),
+		[]string{"remote-config"},
+		state,
+		func(cliParams *cliParams, coreParams core.BundleParams) {
+			require.Equal(t, false, coreParams.ConfigLoadSecrets)
+		})
+}


### PR DESCRIPTION
### What does this PR do?

Converts the `agent remote-config` command to an Fx App.

### Motivation

Top-down approach to componentization.

### Additional Notes

This PR is against a base branch containing #13699 and #13662.  Once those are merged, I'll change the base of this PR to `main` and rebase, but it can be reviewed in the interim.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

For each of 7.40.0 and a build of the main branch, do the following, and verify that the output is the same.

Configure an agent with remote config enabled (DD_REMOTE_CONFIG_ENABLED=true) and get a shell adjacent to it.  Run `agent remote-config` and see something like
```
Fetching the configuration and director repos state..
Error: Couldn't get the repositories state: rpc error: code = Unknown desc = remote configuration service not initialized
```

Run `agent remote-config show` and see the same output.  In no case should that output be colored.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
