### PR TITLE
Convert windows subcommands to apps

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -102,7 +102,11 @@
 /cmd/agent/subcommands/integrations     @DataDog/software-integrity-and-trust @DataDog/agent-integrations @DataDog/agent-shared-components
 /cmd/agent/subcommands/remoteconfig     @Datadog/remote-config
 /cmd/agent/subcommands/snmp             @DataDog/network-device-monitoring
+/cmd/agent/subcommands/installsvc       @DataDog/windows-agent
+/cmd/agent/subcommands/removesvc        @DataDog/windows-agent
+/cmd/agent/subcommands/controlsvc       @DataDog/windows-agent
 /cmd/agent/subcommands/run/internal/clcrunnerapi/       @DataDog/container-integrations @DataDog/agent-shared-components
+/cmd/agent/windows                      @DataDog/windows-agent
 /cmd/agent/dist/conf.d/jetson.d         @DataDog/agent-platform
 /cmd/agent/dist/conf.d/snmp.d/          @DataDog/network-device-monitoring
 /cmd/agent/*.manifest                   @DataDog/agent-platform

--- a/cmd/agent/subcommands/controlsvc/command.go
+++ b/cmd/agent/subcommands/controlsvc/command.go
@@ -11,22 +11,11 @@
 package controlsvc
 
 import (
-	"bytes"
-	"encoding/binary"
-	"fmt"
-	"time"
-	"unsafe"
-
 	"github.com/spf13/cobra"
-	"golang.org/x/sys/windows"
-	"golang.org/x/sys/windows/svc"
-	"golang.org/x/sys/windows/svc/mgr"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/command"
-	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/util/winutil"
-
-	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/cmd/agent/windows/controlsvc"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
 // Commands returns a slice of subcommands for the 'agent' command.
@@ -36,236 +25,25 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			Use:   "start-service",
 			Short: "starts the agent within the service control manager",
 			Long:  ``,
-			RunE:  StartService,
+			RunE: func(cmd *cobra.Command, args []string) error {
+				return fxutil.OneShot(controlsvc.StartService)
+			},
 		},
 		{
 			Use:   "stopservice",
 			Short: "stops the agent within the service control manager",
 			Long:  ``,
-			RunE:  stopService,
+			RunE: func(cmd *cobra.Command, args []string) error {
+				return fxutil.OneShot(controlsvc.StopService)
+			},
 		},
 		{
 			Use:   "restart-service",
 			Short: "restarts the agent within the service control manager",
 			Long:  ``,
-			RunE:  restartService,
+			RunE: func(cmd *cobra.Command, args []string) error {
+				return fxutil.OneShot(controlsvc.RestartService)
+			},
 		},
 	}
-}
-
-var (
-	modadvapi32 = windows.NewLazyDLL("advapi32.dll")
-
-	procEnumDependentServices = modadvapi32.NewProc("EnumDependentServicesW")
-)
-
-type enumServiceState uint32
-
-const (
-	enumServiceActive = enumServiceState(0x1) // START_PENDING, STOP_PENDING, RUNNING
-	// continue_pending, pause_pending, paused
-	enumServiceInactive = enumServiceState(0x02) // STOPPED
-	enumServiceAll      = enumServiceState(0x03) // all of the above
-)
-
-// StartService starts the agent service via the Service Control Manager
-func StartService(cmd *cobra.Command, args []string) error {
-	/*
-	 * default go impolementations of mgr.Connect and mgr.OpenService use way too
-	 * open permissions by default.  Use those structures so the other methods
-	 * work properly, but initialize them here using restrictive enough permissions
-	 * that we can actually open/start the service when running as non-root.
-	 */
-	h, err := windows.OpenSCManager(nil, nil, windows.SC_MANAGER_CONNECT)
-	if err != nil {
-		log.Warnf("Failed to connect to scm %v", err)
-		return err
-	}
-	m := &mgr.Mgr{Handle: h}
-	defer m.Disconnect()
-
-	hSvc, err := windows.OpenService(m.Handle, windows.StringToUTF16Ptr(config.ServiceName),
-		windows.SERVICE_START|windows.SERVICE_STOP)
-	if err != nil {
-		log.Warnf("Failed to open service %v", err)
-		return fmt.Errorf("could not access service: %v", err)
-	}
-	scm := &mgr.Service{Name: config.ServiceName, Handle: hSvc}
-	defer scm.Close()
-	err = scm.Start("is", "manual-started")
-	if err != nil {
-		log.Warnf("Failed to start service %v", err)
-		return fmt.Errorf("could not start service: %v", err)
-	}
-	return nil
-}
-
-func stopService(cmd *cobra.Command, args []string) error {
-	return StopService(config.ServiceName, true)
-}
-
-func restartService(cmd *cobra.Command, args []string) error {
-	var err error
-	if err = StopService(config.ServiceName, true); err == nil {
-		err = StartService(cmd, args)
-	}
-	return err
-}
-
-// StopService stops the agent service via the Service Control Manager
-func StopService(serviceName string, withDeps bool) error {
-	/*
-	 * default go impolementations of mgr.Connect and mgr.OpenService use way too
-	 * open permissions by default.  Use those structures so the other methods
-	 * work properly, but initialize them here using restrictive enough permissions
-	 * that we can actually open/start the service when running as non-root.
-	 */
-	h, err := windows.OpenSCManager(nil, nil, windows.SC_MANAGER_CONNECT)
-	if err != nil {
-		log.Warnf("Failed to connect to scm %v", err)
-		return err
-	}
-	m := &mgr.Mgr{Handle: h}
-	defer m.Disconnect()
-
-	hSvc, err := windows.OpenService(m.Handle, windows.StringToUTF16Ptr(serviceName),
-		windows.SERVICE_START|windows.SERVICE_STOP|windows.SERVICE_QUERY_STATUS|windows.SERVICE_ENUMERATE_DEPENDENTS)
-	if err != nil {
-		log.Warnf("Failed to open service %v", err)
-		return fmt.Errorf("could not access service: %v", err)
-	}
-	s := &mgr.Service{Name: serviceName, Handle: hSvc}
-	defer s.Close()
-	if withDeps {
-		deps, err := enumDependentServices(s.Handle, enumServiceActive)
-		if err != nil {
-			log.Warnf("Failed to enumerate dependencies; skipping %v", err)
-		} else {
-			for _, dep := range deps {
-				log.Debugf("Stopping service %s", dep.serviceName)
-				StopService(dep.serviceName, false)
-			}
-		}
-	}
-	status, err := s.Control(svc.Stop)
-	if err != nil {
-		return fmt.Errorf("could not send control=%d: %v", svc.Stop, err)
-	}
-	timeout := time.Now().Add(10 * time.Second)
-	for status.State != svc.Stopped {
-		if timeout.Before(time.Now()) {
-			return fmt.Errorf("timeout waiting for service to go to state=%d", svc.Stopped)
-		}
-		time.Sleep(300 * time.Millisecond)
-		status, err = s.Query()
-		if err != nil {
-			return fmt.Errorf("could not retrieve service status: %v", err)
-		}
-	}
-	return nil
-}
-
-// ControlService sets the service state via the Service Control Manager
-func ControlService(serviceName string, c svc.Cmd, to svc.State) error {
-	m, err := mgr.Connect()
-	if err != nil {
-		return err
-	}
-	defer m.Disconnect()
-	s, err := m.OpenService(serviceName)
-	if err != nil {
-		return fmt.Errorf("could not access service: %v", err)
-	}
-	defer s.Close()
-	status, err := s.Control(c)
-	if err != nil {
-		return fmt.Errorf("could not send control=%d: %v", c, err)
-	}
-	timeout := time.Now().Add(10 * time.Second)
-	for status.State != to {
-		if timeout.Before(time.Now()) {
-			return fmt.Errorf("timeout waiting for service to go to state=%d", to)
-		}
-		time.Sleep(300 * time.Millisecond)
-		status, err = s.Query()
-		if err != nil {
-			return fmt.Errorf("could not retrieve service status: %v", err)
-		}
-	}
-	return nil
-}
-
-// ServiceStatus reports information pertaining to enumerated services
-// only exported so binary.Read works
-type ServiceStatus struct {
-	DwServiceType             uint32
-	DwCurrentState            uint32
-	DwControlsAccepted        uint32
-	DwWin32ExitCode           uint32
-	DwServiceSpecificExitCode uint32
-	DwCheckPoint              uint32
-	DwWaitHint                uint32
-}
-
-// EnumServiceStatus complete enumerated service information
-// only exported so binary.Read works
-type EnumServiceStatus struct {
-	serviceName string
-	displayName string
-	status      ServiceStatus
-}
-
-type internalEnumServiceStatus struct {
-	ServiceName uint64 // offset from beginning of buffer
-	DisplayName uint64 // offset from beginning of buffer.
-	Status      ServiceStatus
-	Padding     uint32 // structure is qword aligned.
-
-}
-
-func enumDependentServices(h windows.Handle, state enumServiceState) (services []EnumServiceStatus, err error) {
-	services = make([]EnumServiceStatus, 0)
-	var bufsz uint32
-	var count uint32
-	_, _, err = procEnumDependentServices.Call(uintptr(h),
-		uintptr(state),
-		uintptr(0),
-		uintptr(0), // current buffer size is zero
-		uintptr(unsafe.Pointer(&bufsz)),
-		uintptr(unsafe.Pointer(&count)))
-
-	if err != error(windows.ERROR_MORE_DATA) {
-		log.Warnf("Error getting buffer %v", err)
-		return
-	}
-	servicearray := make([]uint8, bufsz)
-	ret, _, err := procEnumDependentServices.Call(uintptr(h),
-		uintptr(state),
-		uintptr(unsafe.Pointer(&servicearray[0])),
-		uintptr(bufsz),
-		uintptr(unsafe.Pointer(&bufsz)),
-		uintptr(unsafe.Pointer(&count)))
-	if ret == 0 {
-		log.Warnf("Error getting deps %d %v", int(ret), err)
-		return
-	}
-	// now get to parse out the C structure into go.
-	var ess internalEnumServiceStatus
-	baseptr := uintptr(unsafe.Pointer(&servicearray[0]))
-	buf := bytes.NewReader(servicearray)
-	for i := uint32(0); i < count; i++ {
-
-		err = binary.Read(buf, binary.LittleEndian, &ess)
-		if err != nil {
-			break
-		}
-
-		ess.ServiceName = ess.ServiceName - uint64(baseptr)
-		ess.DisplayName = ess.DisplayName - uint64(baseptr)
-		ss := EnumServiceStatus{serviceName: winutil.ConvertWindowsString(servicearray[ess.ServiceName:]),
-			displayName: winutil.ConvertWindowsString(servicearray[ess.DisplayName:]),
-			status:      ess.Status}
-		services = append(services, ss)
-	}
-	return
 }

--- a/cmd/agent/subcommands/controlsvc/command_test.go
+++ b/cmd/agent/subcommands/controlsvc/command_test.go
@@ -1,0 +1,41 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build windows
+// +build windows
+
+package controlsvc
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/command"
+	"github.com/DataDog/datadog-agent/cmd/agent/windows/controlsvc"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+func TestStartServiceCommand(t *testing.T) {
+	fxutil.TestOneShotSubcommand(t,
+		Commands(&command.GlobalParams{}),
+		[]string{"start-service"},
+		controlsvc.StartService,
+		func() {})
+}
+
+func TestStopServiceCommand(t *testing.T) {
+	fxutil.TestOneShotSubcommand(t,
+		Commands(&command.GlobalParams{}),
+		[]string{"stopservice"},
+		controlsvc.StopService,
+		func() {})
+}
+
+func TestRestartServiceCommand(t *testing.T) {
+	fxutil.TestOneShotSubcommand(t,
+		Commands(&command.GlobalParams{}),
+		[]string{"restart-service"},
+		controlsvc.RestartService,
+		func() {})
+}

--- a/cmd/agent/subcommands/installsvc/command.go
+++ b/cmd/agent/subcommands/installsvc/command.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/agent/command"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
 // Commands returns a slice of subcommands for the 'agent' command.
@@ -28,13 +29,15 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		Use:   "installservice",
 		Short: "Installs the agent within the service control manager",
 		Long:  ``,
-		RunE:  installService,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return fxutil.OneShot(installService)
+		},
 	}
 
 	return []*cobra.Command{cmd}
 }
 
-func installService(cmd *cobra.Command, args []string) error {
+func installService() error {
 	exepath, err := exePath()
 	if err != nil {
 		return err

--- a/cmd/agent/subcommands/installsvc/command_test.go
+++ b/cmd/agent/subcommands/installsvc/command_test.go
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build windows
+// +build windows
+
+package installsvc
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/command"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+func TestCommand(t *testing.T) {
+	fxutil.TestOneShotSubcommand(t,
+		Commands(&command.GlobalParams{}),
+		[]string{"installservice"},
+		installService,
+		func() {})
+}

--- a/cmd/agent/subcommands/removesvc/command.go
+++ b/cmd/agent/subcommands/removesvc/command.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/agent/command"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
 // Commands returns a slice of subcommands for the 'agent' command.
@@ -26,12 +27,14 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		Use:   "remove-service",
 		Short: "Removes the agent from the service control manager",
 		Long:  ``,
-		RunE:  removeService,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return fxutil.OneShot(removeService)
+		},
 	}
 	return []*cobra.Command{cmd}
 }
 
-func removeService(cmd *cobra.Command, args []string) error {
+func removeService() error {
 	m, err := mgr.Connect()
 	if err != nil {
 		return err

--- a/cmd/agent/subcommands/removesvc/command_test.go
+++ b/cmd/agent/subcommands/removesvc/command_test.go
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build windows
+// +build windows
+
+package removesvc
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/command"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+func TestCommand(t *testing.T) {
+	fxutil.TestOneShotSubcommand(t,
+		Commands(&command.GlobalParams{}),
+		[]string{"remove-service"},
+		removeService,
+		func() {})
+}

--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -127,7 +127,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 // This is exported because it also used from the deprecated `agent start` command.
 func Run(globalParams *command.GlobalParams, cmd *cobra.Command, args []string) error {
 	defer func() {
-		StopAgent()
+		stopAgent()
 	}()
 
 	// prepare go runtime
@@ -166,7 +166,7 @@ func Run(globalParams *command.GlobalParams, cmd *cobra.Command, args []string) 
 		}
 	}()
 
-	if err := StartAgent(globalParams); err != nil {
+	if err := startAgent(globalParams); err != nil {
 		return err
 	}
 
@@ -176,8 +176,13 @@ func Run(globalParams *command.GlobalParams, cmd *cobra.Command, args []string) 
 	}
 }
 
-// StartAgent Initializes the agent process
-func StartAgent(globalParams *command.GlobalParams) error {
+// StartAgentWithDefaults is a temporary way for other packages to use startAgent.
+func StartAgentWithDefaults() error {
+	return startAgent(&command.GlobalParams{})
+}
+
+// startAgent Initializes the agent process
+func startAgent(globalParams *command.GlobalParams) error {
 	var (
 		err            error
 		configSetupErr error
@@ -501,8 +506,13 @@ func StartAgent(globalParams *command.GlobalParams) error {
 	return nil
 }
 
-// StopAgent Tears down the agent process
-func StopAgent() {
+// StopAgentWithDefaults is a temporary way for other packages to use stopAgent.
+func StopAgentWithDefaults() {
+	stopAgent()
+}
+
+// stopAgent Tears down the agent process
+func stopAgent() {
 	// retrieve the agent health before stopping the components
 	// GetReadyNonBlocking has a 100ms timeout to avoid blocking
 	health, err := health.GetReadyNonBlocking()

--- a/cmd/agent/windows/controlsvc/controlsvc.go
+++ b/cmd/agent/windows/controlsvc/controlsvc.go
@@ -1,0 +1,218 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build windows
+// +build windows
+
+// Package controlsvc contains shared code for controlling the Windows agent service.
+package controlsvc
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/svc"
+	"golang.org/x/sys/windows/svc/mgr"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/winutil"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+var (
+	modadvapi32 = windows.NewLazyDLL("advapi32.dll")
+
+	procEnumDependentServices = modadvapi32.NewProc("EnumDependentServicesW")
+)
+
+type enumServiceState uint32
+
+const (
+	enumServiceActive = enumServiceState(0x1) // START_PENDING, STOP_PENDING, RUNNING
+	// continue_pending, pause_pending, paused
+	enumServiceInactive = enumServiceState(0x02) // STOPPED
+	enumServiceAll      = enumServiceState(0x03) // all of the above
+)
+
+// StartService starts the agent service via the Service Control Manager
+func StartService() error {
+	/*
+	 * default go implementations of mgr.Connect and mgr.OpenService use way too
+	 * open permissions by default.  Use those structures so the other methods
+	 * work properly, but initialize them here using restrictive enough permissions
+	 * that we can actually open/start the service when running as non-root.
+	 */
+	h, err := windows.OpenSCManager(nil, nil, windows.SC_MANAGER_CONNECT)
+	if err != nil {
+		log.Warnf("Failed to connect to scm %v", err)
+		return err
+	}
+	m := &mgr.Mgr{Handle: h}
+	defer m.Disconnect()
+
+	hSvc, err := windows.OpenService(m.Handle, windows.StringToUTF16Ptr(config.ServiceName),
+		windows.SERVICE_START|windows.SERVICE_STOP)
+	if err != nil {
+		log.Warnf("Failed to open service %v", err)
+		return fmt.Errorf("could not access service: %v", err)
+	}
+	scm := &mgr.Service{Name: config.ServiceName, Handle: hSvc}
+	defer scm.Close()
+	err = scm.Start("is", "manual-started")
+	if err != nil {
+		log.Warnf("Failed to start service %v", err)
+		return fmt.Errorf("could not start service: %v", err)
+	}
+	return nil
+}
+
+// RestartService restarts the agent service by calling StopService and StartService.
+func RestartService() error {
+	var err error
+	if err = StopService(); err == nil {
+		err = StartService()
+	}
+	return err
+}
+
+// StopService stops the agent service via the Service Control Manager
+func StopService() error {
+	return stopService(config.ServiceName, true)
+}
+
+// stopService stops the named service.
+//
+// If withDeps is true, then dependents of this service are stopped as well.
+func stopService(serviceName string, withDeps bool) error {
+	/*
+	 * default go impolementations of mgr.Connect and mgr.OpenService use way too
+	 * open permissions by default.  Use those structures so the other methods
+	 * work properly, but initialize them here using restrictive enough permissions
+	 * that we can actually open/start the service when running as non-root.
+	 */
+	h, err := windows.OpenSCManager(nil, nil, windows.SC_MANAGER_CONNECT)
+	if err != nil {
+		log.Warnf("Failed to connect to scm %v", err)
+		return err
+	}
+	m := &mgr.Mgr{Handle: h}
+	defer m.Disconnect()
+
+	hSvc, err := windows.OpenService(m.Handle, windows.StringToUTF16Ptr(serviceName),
+		windows.SERVICE_START|windows.SERVICE_STOP|windows.SERVICE_QUERY_STATUS|windows.SERVICE_ENUMERATE_DEPENDENTS)
+	if err != nil {
+		log.Warnf("Failed to open service %v", err)
+		return fmt.Errorf("could not access service: %v", err)
+	}
+	s := &mgr.Service{Name: serviceName, Handle: hSvc}
+	defer s.Close()
+	if withDeps {
+		deps, err := enumDependentServices(s.Handle, enumServiceActive)
+		if err != nil {
+			log.Warnf("Failed to enumerate dependencies; skipping %v", err)
+		} else {
+			for _, dep := range deps {
+				log.Debugf("Stopping service %s", dep.serviceName)
+				StopService()
+			}
+		}
+	}
+	status, err := s.Control(svc.Stop)
+	if err != nil {
+		return fmt.Errorf("could not send control=%d: %v", svc.Stop, err)
+	}
+	timeout := time.Now().Add(10 * time.Second)
+	for status.State != svc.Stopped {
+		if timeout.Before(time.Now()) {
+			return fmt.Errorf("timeout waiting for service to go to state=%d", svc.Stopped)
+		}
+		time.Sleep(300 * time.Millisecond)
+		status, err = s.Query()
+		if err != nil {
+			return fmt.Errorf("could not retrieve service status: %v", err)
+		}
+	}
+	return nil
+}
+
+// ServiceStatus reports information pertaining to enumerated services
+// only exported so binary.Read works
+type ServiceStatus struct {
+	DwServiceType             uint32
+	DwCurrentState            uint32
+	DwControlsAccepted        uint32
+	DwWin32ExitCode           uint32
+	DwServiceSpecificExitCode uint32
+	DwCheckPoint              uint32
+	DwWaitHint                uint32
+}
+
+// EnumServiceStatus complete enumerated service information
+// only exported so binary.Read works
+type EnumServiceStatus struct {
+	serviceName string
+	displayName string
+	status      ServiceStatus
+}
+
+type internalEnumServiceStatus struct {
+	ServiceName uint64 // offset from beginning of buffer
+	DisplayName uint64 // offset from beginning of buffer.
+	Status      ServiceStatus
+	Padding     uint32 // structure is qword aligned.
+
+}
+
+func enumDependentServices(h windows.Handle, state enumServiceState) (services []EnumServiceStatus, err error) {
+	services = make([]EnumServiceStatus, 0)
+	var bufsz uint32
+	var count uint32
+	_, _, err = procEnumDependentServices.Call(uintptr(h),
+		uintptr(state),
+		uintptr(0),
+		uintptr(0), // current buffer size is zero
+		uintptr(unsafe.Pointer(&bufsz)),
+		uintptr(unsafe.Pointer(&count)))
+
+	if err != error(windows.ERROR_MORE_DATA) {
+		log.Warnf("Error getting buffer %v", err)
+		return
+	}
+	servicearray := make([]uint8, bufsz)
+	ret, _, err := procEnumDependentServices.Call(uintptr(h),
+		uintptr(state),
+		uintptr(unsafe.Pointer(&servicearray[0])),
+		uintptr(bufsz),
+		uintptr(unsafe.Pointer(&bufsz)),
+		uintptr(unsafe.Pointer(&count)))
+	if ret == 0 {
+		log.Warnf("Error getting deps %d %v", int(ret), err)
+		return
+	}
+	// now get to parse out the C structure into go.
+	var ess internalEnumServiceStatus
+	baseptr := uintptr(unsafe.Pointer(&servicearray[0]))
+	buf := bytes.NewReader(servicearray)
+	for i := uint32(0); i < count; i++ {
+
+		err = binary.Read(buf, binary.LittleEndian, &ess)
+		if err != nil {
+			break
+		}
+
+		ess.ServiceName = ess.ServiceName - uint64(baseptr)
+		ess.DisplayName = ess.DisplayName - uint64(baseptr)
+		ss := EnumServiceStatus{serviceName: winutil.ConvertWindowsString(servicearray[ess.ServiceName:]),
+			displayName: winutil.ConvertWindowsString(servicearray[ess.DisplayName:]),
+			status:      ess.Status}
+		services = append(services, ss)
+	}
+	return
+}

--- a/cmd/agent/windows/service/service.go
+++ b/cmd/agent/windows/service/service.go
@@ -16,7 +16,6 @@ import (
 	"golang.org/x/sys/windows/svc/debug"
 	"golang.org/x/sys/windows/svc/eventlog"
 
-	"github.com/DataDog/datadog-agent/cmd/agent/command"
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
 	runcmd "github.com/DataDog/datadog-agent/cmd/agent/subcommands/run"
@@ -37,7 +36,7 @@ func (m *agentWindowsService) Execute(args []string, r <-chan svc.ChangeRequest,
 		elog.Warning(0x80000002, err.Error())
 		// continue running with what we have.
 	}
-	if err := runcmd.StartAgent(&command.GlobalParams{}); err != nil {
+	if err := runcmd.StartAgentWithDefaults(); err != nil {
 		log.Errorf("Failed to start agent %v", err)
 		elog.Error(0xc000000B, err.Error())
 		errno = 1 // indicates non-successful return from handler.
@@ -81,7 +80,7 @@ loop:
 	elog.Info(0x4000000d, config.ServiceName)
 	log.Infof("Initiating service shutdown")
 	changes <- svc.Status{State: svc.StopPending}
-	runcmd.StopAgent()
+	runcmd.StopAgentWithDefaults()
 	changes <- svc.Status{State: svc.Stopped}
 	return
 }

--- a/cmd/systray/doservicecontrol.go
+++ b/cmd/systray/doservicecontrol.go
@@ -2,32 +2,32 @@
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
+
 //go:build windows
 // +build windows
 
 package main
 
 import (
-	controlservicecmd "github.com/DataDog/datadog-agent/cmd/agent/subcommands/controlsvc"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/cmd/agent/windows/controlsvc"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 func onRestart() {
-	if err := controlservicecmd.StopService(config.ServiceName, true); err == nil {
-		controlservicecmd.StartService(nil, nil)
+	if err := controlsvc.RestartService(); err != nil {
+		log.Warnf("Failed to restart datadog service %v", err)
 	}
 
 }
 func onStart() {
-	if err := controlservicecmd.StartService(nil, nil); err != nil {
+	if err := controlsvc.StartService(); err != nil {
 		log.Warnf("Failed to start datadog service %v", err)
 	}
 
 }
 
 func onStop() {
-	if err := controlservicecmd.StopService(config.ServiceName, true); err != nil {
+	if err := controlsvc.StopService(); err != nil {
 		log.Warnf("Failed to stop datadog service %v", err)
 	}
 


### PR DESCRIPTION
### What does this PR do?

Converts the windows-service-related commands to an Fx App.

This also moves the service-controlling code out to `cmd/agent/windows/controlsvc` for better isolation.

### Motivation

Top-down approach to componentization.

### Additional Notes

This PR is against a base branch containing #13699 and #13662.  Once those are merged, I'll change the base of this PR to `main` and rebase, but it can be reviewed in the interim.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Run the various service-related commands and verify they still work.

Compare behavior of the following commands, using the services MMC to view the status of the service.

 * `agent stopservice`
 * `agent start-service`
 * `agent restart-service`
 * `agent installservice`
 * `agent remove-service`

Note that `agent remove-service` only removes the "core" DatadogAgent service, and not the dependent services defined by the installer.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
