### PR TITLE
Convert dogstatsd and stream-logs commands to apps

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -102,6 +102,8 @@
 /cmd/agent/subcommands/integrations     @DataDog/software-integrity-and-trust @DataDog/agent-integrations @DataDog/agent-shared-components
 /cmd/agent/subcommands/remoteconfig     @Datadog/remote-config
 /cmd/agent/subcommands/snmp             @DataDog/network-device-monitoring
+/cmd/agent/subcommands/dogstatsd*       @DataDog/agent-metrics-logs
+/cmd/agent/subcommands/streamlogs       @DataDog/agent-metrics-logs
 /cmd/agent/subcommands/run/internal/clcrunnerapi/       @DataDog/container-integrations @DataDog/agent-shared-components
 /cmd/agent/dist/conf.d/jetson.d         @DataDog/agent-platform
 /cmd/agent/dist/conf.d/snmp.d/          @DataDog/network-device-monitoring

--- a/cmd/agent/subcommands/dogstatsdcapture/command.go
+++ b/cmd/agent/subcommands/dogstatsdcapture/command.go
@@ -13,11 +13,16 @@ import (
 	"io/ioutil"
 	"time"
 
+	"go.uber.org/fx"
+
 	"github.com/DataDog/datadog-agent/cmd/agent/command"
-	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/pkg/api/security"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 
 	"github.com/spf13/cobra"
 
@@ -27,42 +32,44 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-var (
-	dsdCaptureDuration   time.Duration
-	dsdCaptureFilePath   string
-	dsdCaptureCompressed bool
-)
-
 const (
 	defaultCaptureDuration = time.Duration(1) * time.Minute
 )
 
+// cliParams are the command-line arguments for this subcommand
+type cliParams struct {
+	*command.GlobalParams
+
+	dsdCaptureDuration   time.Duration
+	dsdCaptureFilePath   string
+	dsdCaptureCompressed bool
+}
+
 // Commands returns a slice of subcommands for the 'agent' command.
 func Commands(globalParams *command.GlobalParams) []*cobra.Command {
+	cliParams := &cliParams{
+		GlobalParams: globalParams,
+	}
+
 	dogstatsdCaptureCmd := &cobra.Command{
 		Use:   "dogstatsd-capture",
 		Short: "Start a dogstatsd UDS traffic capture",
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
-
-			err := common.SetupConfigWithoutSecrets(globalParams.ConfFilePath, "")
-			if err != nil {
-				return fmt.Errorf("unable to set up global agent configuration: %v", err)
-			}
-
-			err = config.SetupLogger(config.CoreLoggerName, config.GetEnvDefault("DD_LOG_LEVEL", "off"), "", "", false, true, false)
-			if err != nil {
-				fmt.Printf("Cannot setup logger, exiting: %v\n", err)
-				return err
-			}
-
-			return dogstatsdCapture()
+			return fxutil.OneShot(dogstatsdCapture,
+				fx.Supply(cliParams),
+				fx.Supply(core.BundleParams{
+					ConfFilePath:      globalParams.ConfFilePath,
+					ConfigLoadSecrets: false,
+				}.LogForOneShot("CORE", "off", true)),
+				core.Bundle,
+			)
 		},
 	}
 
-	dogstatsdCaptureCmd.Flags().DurationVarP(&dsdCaptureDuration, "duration", "d", defaultCaptureDuration, "Duration traffic capture should span.")
-	dogstatsdCaptureCmd.Flags().StringVarP(&dsdCaptureFilePath, "path", "p", "", "Directory path to write the capture to.")
-	dogstatsdCaptureCmd.Flags().BoolVarP(&dsdCaptureCompressed, "compressed", "z", true, "Should capture be zstd compressed.")
+	dogstatsdCaptureCmd.Flags().DurationVarP(&cliParams.dsdCaptureDuration, "duration", "d", defaultCaptureDuration, "Duration traffic capture should span.")
+	dogstatsdCaptureCmd.Flags().StringVarP(&cliParams.dsdCaptureFilePath, "path", "p", "", "Directory path to write the capture to.")
+	dogstatsdCaptureCmd.Flags().BoolVarP(&cliParams.dsdCaptureCompressed, "compressed", "z", true, "Should capture be zstd compressed.")
 
 	// shut up grpc client!
 	grpclog.SetLoggerV2(grpclog.NewLoggerV2(ioutil.Discard, ioutil.Discard, ioutil.Discard))
@@ -70,7 +77,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	return []*cobra.Command{dogstatsdCaptureCmd}
 }
 
-func dogstatsdCapture() error {
+func dogstatsdCapture(log log.Component, config config.Component, cliParams *cliParams) error {
 	fmt.Printf("Starting a dogstatsd traffic capture session...\n\n")
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -97,7 +104,7 @@ func dogstatsdCapture() error {
 
 	conn, err := grpc.DialContext(
 		ctx,
-		fmt.Sprintf(":%v", config.Datadog.GetInt("cmd_port")),
+		fmt.Sprintf(":%v", pkgconfig.Datadog.GetInt("cmd_port")),
 		grpc.WithTransportCredentials(creds),
 	)
 	if err != nil {
@@ -107,9 +114,9 @@ func dogstatsdCapture() error {
 	cli := pb.NewAgentSecureClient(conn)
 
 	resp, err := cli.DogstatsdCaptureTrigger(ctx, &pb.CaptureTriggerRequest{
-		Duration:   dsdCaptureDuration.String(),
-		Path:       dsdCaptureFilePath,
-		Compressed: dsdCaptureCompressed,
+		Duration:   cliParams.dsdCaptureDuration.String(),
+		Path:       cliParams.dsdCaptureFilePath,
+		Compressed: cliParams.dsdCaptureCompressed,
 	})
 	if err != nil {
 		return err

--- a/cmd/agent/subcommands/dogstatsdcapture/command_test.go
+++ b/cmd/agent/subcommands/dogstatsdcapture/command_test.go
@@ -1,0 +1,29 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package dogstatsdcapture
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/command"
+	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+func TestCommand(t *testing.T) {
+	fxutil.TestOneShotSubcommand(t,
+		Commands(&command.GlobalParams{}),
+		[]string{"dogstatsd-capture", "-d", "10s", "-z"},
+		dogstatsdCapture,
+		func(cliParams *cliParams, coreParams core.BundleParams) {
+			require.Equal(t, 10*time.Second, cliParams.dsdCaptureDuration)
+			require.True(t, cliParams.dsdCaptureCompressed)
+			require.Equal(t, false, coreParams.ConfigLoadSecrets)
+		})
+}

--- a/cmd/agent/subcommands/dogstatsdreplay/command.go
+++ b/cmd/agent/subcommands/dogstatsdreplay/command.go
@@ -15,63 +15,70 @@ import (
 	"os/signal"
 	"syscall"
 
+	"go.uber.org/fx"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/command"
-	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/pkg/api/security"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/dogstatsd/replay"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 
 	"github.com/spf13/cobra"
-)
-
-var (
-	dsdReplayFilePath   string
-	dsdVerboseReplay    bool
-	dsdMmapReplay       bool
-	dsdReplayIterations int
 )
 
 const (
 	defaultIterations = 1
 )
 
+// cliParams are the command-line arguments for this subcommand
+type cliParams struct {
+	*command.GlobalParams
+
+	// subcommand-specific flags
+
+	dsdReplayFilePath   string
+	dsdVerboseReplay    bool
+	dsdMmapReplay       bool
+	dsdReplayIterations int
+}
+
 // Commands returns a slice of subcommands for the 'agent' command.
 func Commands(globalParams *command.GlobalParams) []*cobra.Command {
+	cliParams := &cliParams{
+		GlobalParams: globalParams,
+	}
+
 	dogstatsdReplayCmd := &cobra.Command{
 		Use:   "dogstatsd-replay",
 		Short: "Replay dogstatsd traffic",
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
-
-			err := common.SetupConfigWithoutSecrets(globalParams.ConfFilePath, "")
-			if err != nil {
-				return fmt.Errorf("unable to set up global agent configuration: %v", err)
-			}
-
-			err = config.SetupLogger(config.CoreLoggerName, config.GetEnvDefault("DD_LOG_LEVEL", "off"), "", "", false, true, false)
-			if err != nil {
-				fmt.Printf("Cannot setup logger, exiting: %v\n", err)
-				return err
-			}
-
-			return dogstatsdReplay()
+			return fxutil.OneShot(dogstatsdReplay,
+				fx.Supply(cliParams),
+				fx.Supply(core.BundleParams{
+					ConfFilePath:      globalParams.ConfFilePath,
+					ConfigLoadSecrets: false,
+				}.LogForOneShot("CORE", "off", true)),
+				core.Bundle,
+			)
 		},
 	}
-	dogstatsdReplayCmd.Flags().StringVarP(&dsdReplayFilePath, "file", "f", "", "Input file with traffic captured with dogstatsd-capture.")
-	dogstatsdReplayCmd.Flags().BoolVarP(&dsdVerboseReplay, "verbose", "v", false, "Verbose replay.")
-	dogstatsdReplayCmd.Flags().BoolVarP(&dsdMmapReplay, "mmap", "m", true, "Mmap file for replay. Set to false to load the entire file into memory instead")
-	dogstatsdReplayCmd.Flags().IntVarP(&dsdReplayIterations, "loops", "l", defaultIterations, "Number of iterations to replay.")
+	dogstatsdReplayCmd.Flags().StringVarP(&cliParams.dsdReplayFilePath, "file", "f", "", "Input file with traffic captured with dogstatsd-capture.")
+	dogstatsdReplayCmd.Flags().BoolVarP(&cliParams.dsdVerboseReplay, "verbose", "v", false, "Verbose replay.")
+	dogstatsdReplayCmd.Flags().BoolVarP(&cliParams.dsdMmapReplay, "mmap", "m", true, "Mmap file for replay. Set to false to load the entire file into memory instead")
+	dogstatsdReplayCmd.Flags().IntVarP(&cliParams.dsdReplayIterations, "loops", "l", defaultIterations, "Number of iterations to replay.")
 
 	return []*cobra.Command{dogstatsdReplayCmd}
 }
 
-func dogstatsdReplay() error {
-
+func dogstatsdReplay(log log.Component, config config.Component, cliParams *cliParams) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -108,7 +115,7 @@ func dogstatsdReplay() error {
 
 	apiconn, err := grpc.DialContext(
 		ctx,
-		fmt.Sprintf(":%v", config.Datadog.GetInt("cmd_port")),
+		fmt.Sprintf(":%v", pkgconfig.Datadog.GetInt("cmd_port")),
 		grpc.WithTransportCredentials(creds),
 	)
 	if err != nil {
@@ -118,17 +125,17 @@ func dogstatsdReplay() error {
 	cli := pb.NewAgentSecureClient(apiconn)
 
 	depth := 10
-	reader, err := replay.NewTrafficCaptureReader(dsdReplayFilePath, depth, dsdMmapReplay)
+	reader, err := replay.NewTrafficCaptureReader(cliParams.dsdReplayFilePath, depth, cliParams.dsdMmapReplay)
 	if reader != nil {
 		defer reader.Close()
 	}
 
 	if err != nil {
-		fmt.Printf("could not open: %s\n", dsdReplayFilePath)
+		fmt.Printf("could not open: %s\n", cliParams.dsdReplayFilePath)
 		return err
 	}
 
-	s := config.Datadog.GetString("dogstatsd_socket")
+	s := pkgconfig.Datadog.GetString("dogstatsd_socket")
 	if s == "" {
 		return fmt.Errorf("Dogstatsd UNIX socket disabled")
 	}
@@ -145,7 +152,7 @@ func dogstatsdReplay() error {
 	defer syscall.Close(sk)
 
 	err = syscall.SetsockoptInt(sk, syscall.SOL_SOCKET, syscall.SO_SNDBUF,
-		config.Datadog.GetInt("dogstatsd_buffer_size"))
+		pkgconfig.Datadog.GetInt("dogstatsd_buffer_size"))
 	if err != nil {
 		return err
 	}
@@ -171,7 +178,7 @@ func dogstatsdReplay() error {
 	}
 
 	breaker := false
-	for i := 0; (i < dsdReplayIterations || dsdReplayIterations == 0) && !breaker; i++ {
+	for i := 0; (i < cliParams.dsdReplayIterations || cliParams.dsdReplayIterations == 0) && !breaker; i++ {
 
 		// enable reading at natural rate
 		ready := make(chan struct{})
@@ -192,7 +199,7 @@ func dogstatsdReplay() error {
 					return err
 				}
 
-				if dsdVerboseReplay {
+				if cliParams.dsdVerboseReplay {
 					fmt.Printf("Sent Payload: %d bytes, and OOB: %d bytes\n", n, oobn)
 				}
 			case <-reader.Done:

--- a/cmd/agent/subcommands/dogstatsdreplay/command_test.go
+++ b/cmd/agent/subcommands/dogstatsdreplay/command_test.go
@@ -1,0 +1,27 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package dogstatsdreplay
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/command"
+	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+func TestCommand(t *testing.T) {
+	fxutil.TestOneShotSubcommand(t,
+		Commands(&command.GlobalParams{}),
+		[]string{"dogstatsd-replay", "-v"},
+		dogstatsdReplay,
+		func(cliParams *cliParams, coreParams core.BundleParams) {
+			require.True(t, cliParams.dsdVerboseReplay)
+			require.Equal(t, false, coreParams.ConfigLoadSecrets)
+		})
+}

--- a/cmd/agent/subcommands/dogstatsdstats/command.go
+++ b/cmd/agent/subcommands/dogstatsdstats/command.go
@@ -13,62 +13,71 @@ import (
 	"io/ioutil"
 	"os"
 
+	"go.uber.org/fx"
+
 	"github.com/DataDog/datadog-agent/cmd/agent/command"
-	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/dogstatsd"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/input"
 
 	"github.com/spf13/cobra"
 )
 
-var (
+// cliParams are the command-line arguments for this subcommand
+type cliParams struct {
+	*command.GlobalParams
+
+	// subcommand-specific flags
+
 	dsdStatsFilePath string
 	jsonStatus       bool
 	prettyPrintJSON  bool
-)
+}
 
 // Commands returns a slice of subcommands for the 'agent' command.
 func Commands(globalParams *command.GlobalParams) []*cobra.Command {
+	cliParams := &cliParams{
+		GlobalParams: globalParams,
+	}
+
 	dogstatsdStatsCmd := &cobra.Command{
 		Use:   "dogstatsd-stats",
 		Short: "Print basic statistics on the metrics processed by dogstatsd",
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
-
-			err := common.SetupConfigWithoutSecrets(globalParams.ConfFilePath, "")
-			if err != nil {
-				return fmt.Errorf("unable to set up global agent configuration: %v", err)
-			}
-
-			err = config.SetupLogger(config.CoreLoggerName, config.GetEnvDefault("DD_LOG_LEVEL", "off"), "", "", false, true, false)
-			if err != nil {
-				fmt.Printf("Cannot setup logger, exiting: %v\n", err)
-				return err
-			}
-
-			return requestDogstatsdStats()
+			return fxutil.OneShot(requestDogstatsdStats,
+				fx.Supply(cliParams),
+				fx.Supply(core.BundleParams{
+					ConfFilePath:      globalParams.ConfFilePath,
+					ConfigLoadSecrets: false,
+				}.LogForOneShot("CORE", "off", true)),
+				core.Bundle,
+			)
 		},
 	}
 
-	dogstatsdStatsCmd.Flags().BoolVarP(&jsonStatus, "json", "j", false, "print out raw json")
-	dogstatsdStatsCmd.Flags().BoolVarP(&prettyPrintJSON, "pretty-json", "p", false, "pretty print JSON")
-	dogstatsdStatsCmd.Flags().StringVarP(&dsdStatsFilePath, "file", "o", "", "Output the dogstatsd-stats command to a file")
+	dogstatsdStatsCmd.Flags().BoolVarP(&cliParams.jsonStatus, "json", "j", false, "print out raw json")
+	dogstatsdStatsCmd.Flags().BoolVarP(&cliParams.prettyPrintJSON, "pretty-json", "p", false, "pretty print JSON")
+	dogstatsdStatsCmd.Flags().StringVarP(&cliParams.dsdStatsFilePath, "file", "o", "", "Output the dogstatsd-stats command to a file")
 
 	return []*cobra.Command{dogstatsdStatsCmd}
 }
 
-func requestDogstatsdStats() error {
+func requestDogstatsdStats(log log.Component, config config.Component, cliParams *cliParams) error {
 	fmt.Printf("Getting the dogstatsd stats from the agent.\n\n")
 	var e error
 	var s string
 	c := util.GetClient(false) // FIX: get certificates right then make this true
-	ipcAddress, err := config.GetIPCAddress()
+	ipcAddress, err := pkgconfig.GetIPCAddress()
 	if err != nil {
 		return err
 	}
-	urlstr := fmt.Sprintf("https://%v:%v/agent/dogstatsd-stats", ipcAddress, config.Datadog.GetInt("cmd_port"))
+	urlstr := fmt.Sprintf("https://%v:%v/agent/dogstatsd-stats", ipcAddress, pkgconfig.Datadog.GetInt("cmd_port"))
 
 	// Set session token
 	e = util.SetAuthToken()
@@ -96,11 +105,11 @@ func requestDogstatsdStats() error {
 	}
 
 	// The rendering is done in the client so that the agent has less work to do
-	if prettyPrintJSON {
+	if cliParams.prettyPrintJSON {
 		var prettyJSON bytes.Buffer
 		json.Indent(&prettyJSON, r, "", "  ") //nolint:errcheck
 		s = prettyJSON.String()
-	} else if jsonStatus {
+	} else if cliParams.jsonStatus {
 		s = string(r)
 	} else {
 		s, e = dogstatsd.FormatDebugStats(r)
@@ -110,23 +119,23 @@ func requestDogstatsdStats() error {
 		}
 	}
 
-	if dsdStatsFilePath == "" {
+	if cliParams.dsdStatsFilePath == "" {
 		fmt.Println(s)
 		return nil
 	}
 
 	// if the file is already existing, ask for a confirmation.
-	if _, err := os.Stat(dsdStatsFilePath); err == nil {
-		if !input.AskForConfirmation(fmt.Sprintf("'%s' already exists, do you want to overwrite it? [y/N]", dsdStatsFilePath)) {
+	if _, err := os.Stat(cliParams.dsdStatsFilePath); err == nil {
+		if !input.AskForConfirmation(fmt.Sprintf("'%s' already exists, do you want to overwrite it? [y/N]", cliParams.dsdStatsFilePath)) {
 			fmt.Println("Canceling.")
 			return nil
 		}
 	}
 
-	if err := ioutil.WriteFile(dsdStatsFilePath, []byte(s), 0644); err != nil {
+	if err := ioutil.WriteFile(cliParams.dsdStatsFilePath, []byte(s), 0644); err != nil {
 		fmt.Println("Error while writing the file (is the location writable by the dd-agent user?):", err)
 	} else {
-		fmt.Println("Dogstatsd stats written in:", dsdStatsFilePath)
+		fmt.Println("Dogstatsd stats written in:", cliParams.dsdStatsFilePath)
 	}
 
 	return nil

--- a/cmd/agent/subcommands/dogstatsdstats/command_test.go
+++ b/cmd/agent/subcommands/dogstatsdstats/command_test.go
@@ -1,0 +1,27 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package dogstatsdstats
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/command"
+	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+func TestCommand(t *testing.T) {
+	fxutil.TestOneShotSubcommand(t,
+		Commands(&command.GlobalParams{}),
+		[]string{"dogstatsd-stats", "--json"},
+		requestDogstatsdStats,
+		func(cliParams *cliParams, coreParams core.BundleParams) {
+			require.True(t, cliParams.jsonStatus)
+			require.Equal(t, false, coreParams.ConfigLoadSecrets)
+		})
+}

--- a/cmd/agent/subcommands/streamlogs/command.go
+++ b/cmd/agent/subcommands/streamlogs/command.go
@@ -12,61 +12,68 @@ import (
 	"fmt"
 	"io"
 
+	"go.uber.org/fx"
+
 	"github.com/DataDog/datadog-agent/cmd/agent/command"
-	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/diagnostic"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 
 	"github.com/spf13/cobra"
 )
 
-var (
+// cliParams are the command-line arguments for this subcommand
+type cliParams struct {
+	*command.GlobalParams
+
 	filters diagnostic.Filters
-)
+}
 
 // Commands returns a slice of subcommands for the 'agent' command.
 func Commands(globalParams *command.GlobalParams) []*cobra.Command {
-	troubleshootLogsCmd := &cobra.Command{
+	cliParams := &cliParams{
+		GlobalParams: globalParams,
+	}
+	cmd := &cobra.Command{
 		Use:   "stream-logs",
 		Short: "Stream the logs being processed by a running agent",
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := common.SetupConfigWithoutSecrets(globalParams.ConfFilePath, "")
-			if err != nil {
-				return fmt.Errorf("unable to set up global agent configuration: %v", err)
-			}
-
-			err = config.SetupLogger(config.CoreLoggerName, config.GetEnvDefault("DD_LOG_LEVEL", "off"), "", "", false, true, false)
-			if err != nil {
-				fmt.Printf("Cannot setup logger, exiting: %v\n", err)
-				return err
-			}
-
-			return connectAndStream()
+			return fxutil.OneShot(streamLogs,
+				fx.Supply(cliParams),
+				fx.Supply(core.BundleParams{
+					ConfFilePath:      globalParams.ConfFilePath,
+					ConfigLoadSecrets: false,
+				}.LogForOneShot("CORE", "off", true)),
+				core.Bundle,
+			)
 		},
 	}
-	troubleshootLogsCmd.Flags().StringVar(&filters.Name, "name", "", "Filter by name")
-	troubleshootLogsCmd.Flags().StringVar(&filters.Type, "type", "", "Filter by type")
-	troubleshootLogsCmd.Flags().StringVar(&filters.Source, "source", "", "Filter by source")
-	troubleshootLogsCmd.Flags().StringVar(&filters.Service, "service", "", "Filter by service")
+	cmd.Flags().StringVar(&cliParams.filters.Name, "name", "", "Filter by name")
+	cmd.Flags().StringVar(&cliParams.filters.Type, "type", "", "Filter by type")
+	cmd.Flags().StringVar(&cliParams.filters.Source, "source", "", "Filter by source")
+	cmd.Flags().StringVar(&cliParams.filters.Service, "service", "", "Filter by service")
 
-	return []*cobra.Command{troubleshootLogsCmd}
+	return []*cobra.Command{cmd}
 }
 
-func connectAndStream() error {
-	ipcAddress, err := config.GetIPCAddress()
+func streamLogs(log log.Component, config config.Component, cliParams *cliParams) error {
+	ipcAddress, err := pkgconfig.GetIPCAddress()
 	if err != nil {
 		return err
 	}
 
-	body, err := json.Marshal(&filters)
+	body, err := json.Marshal(&cliParams.filters)
 
 	if err != nil {
 		return err
 	}
 
-	urlstr := fmt.Sprintf("https://%v:%v/agent/stream-logs", ipcAddress, config.Datadog.GetInt("cmd_port"))
+	urlstr := fmt.Sprintf("https://%v:%v/agent/stream-logs", ipcAddress, config.GetInt("cmd_port"))
 	return streamRequest(urlstr, body, func(chunk []byte) {
 		fmt.Print(string(chunk))
 	})

--- a/cmd/agent/subcommands/streamlogs/command_test.go
+++ b/cmd/agent/subcommands/streamlogs/command_test.go
@@ -1,0 +1,27 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package streamlogs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/command"
+	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+func TestCommand(t *testing.T) {
+	fxutil.TestOneShotSubcommand(t,
+		Commands(&command.GlobalParams{}),
+		[]string{"stream-logs", "--type", "foo"},
+		streamLogs,
+		func(cliParams *cliParams, coreParams core.BundleParams) {
+			require.Equal(t, false, coreParams.ConfigLoadSecrets)
+			require.Equal(t, "foo", cliParams.filters.Type)
+		})
+}


### PR DESCRIPTION
### What does this PR do?

Converts the `agent dogstats*` and `agent stream-logs` commands to Fx Apps.

### Motivation

Top-down approach to componentization.

### Additional Notes

This PR is against a base branch containing #13699 and #13662.  Once those are merged, I'll change the base of this PR to `main` and rebase, but it can be reviewed in the interim.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Compare the output of the following commands before and after the changes in https://github.com/DataDog/datadog-agent/pull/13463 and https://github.com/DataDog/datadog-agent/pull/13721 to ensure no significant changes have occurred.

#### stream-logs

Start an agent that will process a small volume of logs.  For example, start an agent with `logs_config.container_collect_all: true` and start a container with `docker run -ti --rm bash bash -c 'while true; do date; sleep 1; done'`. 
Run `agent stream-logs`.

The output should not have any color under any circumstances.

#### dogstatsd-stats

Start a running agent with
```
use_dogstatsd: true
dogstatsd_metrics_stats_enable: true
```

There's no need to have any actual stats - that code hasn't changed. Compare output for the following commands

 * `agent dogstatsd-stats -h`
 * `agent dogstatsd-stats`
 * `agent dogstatsd-stats -j`
 * `agent dogstatsd-stats -o somefile` (compare the file contents for old and new)

The output should not have any color under any circumstances.

#### dogstatsd-capture

Start a running agent with
```
use_dogstatsd: true
```

Compare output for the following commands

 * `agent dogstatsd-capture -h`
 * `agent dogstatsd-capture` (the filename will differ, that's fine)
 * `agent dogstatsd-capture -d 1s` (run twice less than 1m0s apart to verify that the 1s duration is adhered to) (verify the file is compressed with `file`)
 * `agent dogstatsd-capture --compress=false -d 1s` (verify the file is not compressed)
 * `agent dogstatsd-capture --compress=true -d 1s` (verify the file is compressed)

The output should not have any color under any circumstances.

#### dogstatsd-replay

Compare the output of the following commands before and after the changes in https://github.com/DataDog/datadog-agent/pull/13463 and https://github.com/DataDog/datadog-agent/pull/13721 to ensure no significant changes have occurred.

Start a running agent with
```
use_dogstatsd: true
dogstatsd_socket: /tmp/dsd
```

and use `dogstatsd-capture` to make a capture file.  It should have at least a little bit of data so that you can distinguish the number of loops.

Compare output for the following commands

 * `agent dogstatsd-replay` (fails with the same error message)
 * `agent dogstatsd-replay -h`
 * `agent dogstatsd-replay -f <capturefile>`
 * `agent dogstatsd-replay -v -f <capturefile>`
 * `agent dogstatsd-replay --mmap=false -f <capturefile>`
 * `agent dogstatsd-replay -l 10 -f <capturefile>` (verify in the app that this loops the captured data 10 times)

Note that no agent-side or command-side logging distinguishes the `--mmap` flag, so there's no way to tell if that worked.  

The output should not have any color under any circumstances.


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
