### PR TITLE
Convert jmx subcommand to an app

### DIFF
--- a/cmd/agent/subcommands/check/command.go
+++ b/cmd/agent/subcommands/check/command.go
@@ -114,7 +114,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				// we'll search for a config file named `datadog-cluster.yaml`
 				configName = "datadog-cluster"
 			}
-			resolvedLogLevel, warnings, err := standalone.SetupCLI(config.CoreLoggerName, globalParams.ConfFilePath, configName, "", logLevel, "off")
+			resolvedLogLevel, warnings, err := setupCLI(config.CoreLoggerName, globalParams.ConfFilePath, configName, "", logLevel, "off")
 			if err != nil {
 				fmt.Printf("Cannot initialize command: %v\n", err)
 				return err

--- a/cmd/agent/subcommands/check/setup.go
+++ b/cmd/agent/subcommands/check/setup.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package standalone
+package check
 
 import (
 	"fmt"
@@ -12,11 +12,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
-// SetupCLI sets up the shared utilities for a standalone CLI command:
+// setupCLI sets up the shared utilities for a standalone CLI command:
 // - config, with defaults to avoid conflicting with an agent process running in parallel
 // - logger
 // and returns the log level resolved from cliLogLevel and defaultLogLevel
-func SetupCLI(loggerName config.LoggerName, confFilePath, configName string, cliLogFile string, cliLogLevel string, defaultLogLevel string) (string, *config.Warnings, error) {
+func setupCLI(loggerName config.LoggerName, confFilePath, configName string, cliLogFile string, cliLogLevel string, defaultLogLevel string) (string, *config.Warnings, error) {
 	var resolvedLogLevel string
 
 	if cliLogLevel != "" {

--- a/cmd/agent/subcommands/jmx/command.go
+++ b/cmd/agent/subcommands/jmx/command.go
@@ -12,55 +12,74 @@ package jmx
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
+	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/command"
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/cmd/internal/standalone"
+	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
-var (
-	cliSelectedChecks = []string{}
-	jmxLogLevel       string
-	saveFlare         bool
-)
+type cliParams struct {
+	*command.GlobalParams
 
-var (
-	discoveryTimeout       uint
-	discoveryRetryInterval uint
-	discoveryMinInstances  uint
-)
+	// command is the jmx console command to run
+	command string
+
+	cliSelectedChecks     []string
+	logFile               string // calculated in makeCoreBundleParams
+	jmxLogLevel           string
+	saveFlare             bool
+	discoveryTimeout      uint
+	discoveryMinInstances uint
+}
 
 // Commands returns a slice of subcommands for the 'agent' command.
 func Commands(globalParams *command.GlobalParams) []*cobra.Command {
+	var discoveryRetryInterval uint // unused command-line flag
+	cliParams := &cliParams{
+		GlobalParams: globalParams,
+	}
+
 	jmxCmd := &cobra.Command{
 		Use:   "jmx",
 		Short: "Run troubleshooting commands on JMXFetch integrations",
 		Long:  ``,
 	}
-	jmxCmd.PersistentFlags().StringVarP(&jmxLogLevel, "log-level", "l", "", "set the log level (default 'debug') (deprecated, use the env var DD_LOG_LEVEL instead)")
-	jmxCmd.PersistentFlags().UintVarP(&discoveryTimeout, "discovery-timeout", "", 5, "max retry duration until Autodiscovery resolves the check template (in seconds)")
+	jmxCmd.PersistentFlags().StringVarP(&cliParams.jmxLogLevel, "log-level", "l", "", "set the log level (default 'debug') (deprecated, use the env var DD_LOG_LEVEL instead)")
+	jmxCmd.PersistentFlags().UintVarP(&cliParams.discoveryTimeout, "discovery-timeout", "", 5, "max retry duration until Autodiscovery resolves the check template (in seconds)")
 	jmxCmd.PersistentFlags().UintVarP(&discoveryRetryInterval, "discovery-retry-interval", "", 1, "(unused)")
-	jmxCmd.PersistentFlags().UintVarP(&discoveryMinInstances, "discovery-min-instances", "", 1, "minimum number of config instances to be discovered before running the check(s)")
+	jmxCmd.PersistentFlags().UintVarP(&cliParams.discoveryMinInstances, "discovery-min-instances", "", 1, "minimum number of config instances to be discovered before running the check(s)")
 
 	jmxCollectCmd := &cobra.Command{
 		Use:   "collect",
 		Short: "Start the collection of metrics based on your current configuration and display them in the console.",
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runJmxCommandConsole(globalParams, "collect")
+			cliParams.command = "collect"
+			disableCmdPort()
+			return fxutil.OneShot(runJmxCommandConsole,
+				fx.Supply(cliParams),
+				fx.Supply(makeCoreBundleParams(globalParams, cliParams)),
+				core.Bundle,
+			)
 		},
 	}
-	jmxCollectCmd.PersistentFlags().StringSliceVar(&cliSelectedChecks, "checks", []string{}, "JMX checks (ex: jmx,tomcat)")
-	jmxCollectCmd.PersistentFlags().BoolVarP(&saveFlare, "flare", "", false, "save jmx list results to the log dir so it may be reported in a flare")
+	jmxCollectCmd.PersistentFlags().StringSliceVar(&cliParams.cliSelectedChecks, "checks", []string{}, "JMX checks (ex: jmx,tomcat)")
+	jmxCollectCmd.PersistentFlags().BoolVarP(&cliParams.saveFlare, "flare", "", false, "save jmx list results to the log dir so it may be reported in a flare")
 	jmxCmd.AddCommand(jmxCollectCmd)
 
 	jmxListEverythingCmd := &cobra.Command{
@@ -68,7 +87,13 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		Short: "List every attributes available that has a type supported by JMXFetch.",
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runJmxCommandConsole(globalParams, "list_everything")
+			cliParams.command = "list_everything"
+			disableCmdPort()
+			return fxutil.OneShot(runJmxCommandConsole,
+				fx.Supply(cliParams),
+				fx.Supply(makeCoreBundleParams(globalParams, cliParams)),
+				core.Bundle,
+			)
 		},
 	}
 
@@ -77,7 +102,13 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		Short: "List attributes that match at least one of your instances configuration.",
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runJmxCommandConsole(globalParams, "list_matching_attributes")
+			cliParams.command = "list_matching_attributes"
+			disableCmdPort()
+			return fxutil.OneShot(runJmxCommandConsole,
+				fx.Supply(cliParams),
+				fx.Supply(makeCoreBundleParams(globalParams, cliParams)),
+				core.Bundle,
+			)
 		},
 	}
 
@@ -86,7 +117,13 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		Short: "List attributes and metrics data that match at least one of your instances configuration.",
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runJmxCommandConsole(globalParams, "list_with_metrics")
+			cliParams.command = "list_with_metrics"
+			disableCmdPort()
+			return fxutil.OneShot(runJmxCommandConsole,
+				fx.Supply(cliParams),
+				fx.Supply(makeCoreBundleParams(globalParams, cliParams)),
+				core.Bundle,
+			)
 		},
 	}
 
@@ -95,7 +132,13 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		Short: "List attributes and metrics data that match at least one of your instances configuration, including rates and counters.",
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runJmxCommandConsole(globalParams, "list_with_rate_metrics")
+			cliParams.command = "list_with_rate_metrics"
+			disableCmdPort()
+			return fxutil.OneShot(runJmxCommandConsole,
+				fx.Supply(cliParams),
+				fx.Supply(makeCoreBundleParams(globalParams, cliParams)),
+				core.Bundle,
+			)
 		},
 	}
 
@@ -104,7 +147,13 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		Short: "List attributes that do match one of your instances configuration but that are not being collected because it would exceed the number of metrics that can be collected.",
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runJmxCommandConsole(globalParams, "list_limited_attributes")
+			cliParams.command = "list_limited_attributes"
+			disableCmdPort()
+			return fxutil.OneShot(runJmxCommandConsole,
+				fx.Supply(cliParams),
+				fx.Supply(makeCoreBundleParams(globalParams, cliParams)),
+				core.Bundle,
+			)
 		},
 	}
 
@@ -113,7 +162,13 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		Short: "List attributes that will actually be collected by your current instances configuration.",
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runJmxCommandConsole(globalParams, "list_collected_attributes")
+			cliParams.command = "list_collected_attributes"
+			disableCmdPort()
+			return fxutil.OneShot(runJmxCommandConsole,
+				fx.Supply(cliParams),
+				fx.Supply(makeCoreBundleParams(globalParams, cliParams)),
+				core.Bundle,
+			)
 		},
 	}
 
@@ -122,7 +177,13 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		Short: "List attributes that don’t match any of your instances configuration.",
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runJmxCommandConsole(globalParams, "list_not_matching_attributes")
+			cliParams.command = "list_not_matching_attributes"
+			disableCmdPort()
+			return fxutil.OneShot(runJmxCommandConsole,
+				fx.Supply(cliParams),
+				fx.Supply(makeCoreBundleParams(globalParams, cliParams)),
+				core.Bundle,
+			)
 		},
 	}
 
@@ -131,39 +192,74 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		Short: "List attributes matched by JMXFetch.",
 		Long:  ``,
 	}
-	jmxListCmd.AddCommand(jmxListEverythingCmd, jmxListMatchingCmd, jmxListLimitedCmd, jmxListCollectedCmd, jmxListNotMatchingCmd, jmxListWithMetricsCmd, jmxListWithRateMetricsCmd)
+	jmxListCmd.AddCommand(
+		jmxListEverythingCmd,
+		jmxListMatchingCmd,
+		jmxListLimitedCmd,
+		jmxListCollectedCmd,
+		jmxListNotMatchingCmd,
+		jmxListWithMetricsCmd,
+		jmxListWithRateMetricsCmd,
+	)
 
-	jmxListCmd.PersistentFlags().StringSliceVar(&cliSelectedChecks, "checks", []string{}, "JMX checks (ex: jmx,tomcat)")
-	jmxListCmd.PersistentFlags().BoolVarP(&saveFlare, "flare", "", false, "save jmx list results to the log dir so it may be reported in a flare")
+	jmxListCmd.PersistentFlags().StringSliceVar(&cliParams.cliSelectedChecks, "checks", []string{}, "JMX checks (ex: jmx,tomcat)")
+	jmxListCmd.PersistentFlags().BoolVarP(&cliParams.saveFlare, "flare", "", false, "save jmx list results to the log dir so it may be reported in a flare")
 	jmxCmd.AddCommand(jmxListCmd)
 
 	// attach the command to the root
 	return []*cobra.Command{jmxCmd}
 }
 
-// runJmxCommandConsole sets up the common utils necessary for JMX, and executes the command
-// with the Console reporter
-func runJmxCommandConsole(globalParams *command.GlobalParams, command string) error {
-	logFile := ""
-	if saveFlare {
+// disableCmdPort overrrides the `cmd_port` configuration so that when the
+// server starts up, it does not do so on the same port as a running agent.
+//
+// Ideally, the server wouldn't start up at all, but this workaround has been
+// in place for some times.
+func disableCmdPort() {
+	os.Setenv("DD_CMD_PORT", "0") // 0 indicates the OS should pick an unused port
+}
+
+// makeCoreBundleParams prepares the core.BundleParams for jmx subcommands.
+//
+// This involves a bit of logic that is needed for each subcommand, and collected here.
+func makeCoreBundleParams(globalParams *command.GlobalParams, cliParams *cliParams) core.BundleParams {
+	cliParams.logFile = ""
+
+	// if saving a flare, write a debug log within a directory that will be
+	// captured in the flare.
+	if cliParams.saveFlare {
 		// Windows cannot accept ":" in file names
 		filenameSafeTimeStamp := strings.ReplaceAll(time.Now().UTC().Format(time.RFC3339), ":", "-")
-		logFile = filepath.Join(common.DefaultJMXFlareDirectory, "jmx_"+command+"_"+filenameSafeTimeStamp+".log")
-		jmxLogLevel = "debug"
+		cliParams.logFile = filepath.Join(common.DefaultJMXFlareDirectory, "jmx_"+cliParams.command+"_"+filenameSafeTimeStamp+".log")
+		cliParams.jmxLogLevel = "debug"
 	}
 
-	logLevel, _, err := standalone.SetupCLI(config.CoreLoggerName, globalParams.ConfFilePath, "", logFile, jmxLogLevel, "debug")
-	if err != nil {
-		fmt.Printf("Cannot initialize command: %v\n", err)
-		return err
+	// default log level to "debug" if not given
+	if cliParams.jmxLogLevel == "" {
+		cliParams.jmxLogLevel = "debug"
 	}
 
-	err = config.SetupJMXLogger(logFile, "", false, true, false)
+	params := core.BundleParams{
+		ConfFilePath:      globalParams.ConfFilePath,
+		ConfigLoadSecrets: true,
+	}.LogForOneShot("CORE", cliParams.jmxLogLevel, false)
+
+	if cliParams.logFile != "" {
+		params = params.LogToFile(cliParams.logFile)
+	}
+
+	return params
+}
+
+// runJmxCommandConsole sets up the common utils necessary for JMX, and executes the command
+// with the Console reporter
+func runJmxCommandConsole(log log.Component, config config.Component, cliParams *cliParams) error {
+	err := pkgconfig.SetupJMXLogger(cliParams.logFile, "", false, true, false)
 	if err != nil {
 		return fmt.Errorf("Unable to set up JMX logger: %v", err)
 	}
 
-	common.LoadComponents(context.Background(), config.Datadog.GetString("confd_path"))
+	common.LoadComponents(context.Background(), config.GetString("confd_path"))
 	common.AC.LoadAndRun(context.Background())
 
 	// Create the CheckScheduler, but do not attach it to
@@ -173,16 +269,16 @@ func runJmxCommandConsole(globalParams *command.GlobalParams, command string) er
 	// if cliSelectedChecks is empty, then we want to fetch all check configs;
 	// otherwise, we fetch only the matching cehck configs.
 	waitCtx, cancelTimeout := context.WithTimeout(
-		context.Background(), time.Duration(discoveryTimeout)*time.Second)
+		context.Background(), time.Duration(cliParams.discoveryTimeout)*time.Second)
 	var allConfigs []integration.Config
-	if len(cliSelectedChecks) == 0 {
+	if len(cliParams.cliSelectedChecks) == 0 {
 		allConfigs = common.WaitForAllConfigsFromAD(waitCtx)
 	} else {
-		allConfigs = common.WaitForConfigsFromAD(waitCtx, cliSelectedChecks, int(discoveryMinInstances))
+		allConfigs = common.WaitForConfigsFromAD(waitCtx, cliParams.cliSelectedChecks, int(cliParams.discoveryMinInstances))
 	}
 	cancelTimeout()
 
-	err = standalone.ExecJMXCommandConsole(command, cliSelectedChecks, logLevel, allConfigs)
+	err = standalone.ExecJMXCommandConsole(cliParams.command, cliParams.cliSelectedChecks, cliParams.jmxLogLevel, allConfigs)
 
 	if runtime.GOOS == "windows" {
 		standalone.PrintWindowsUserWarning("jmx")

--- a/cmd/agent/subcommands/jmx/command_test.go
+++ b/cmd/agent/subcommands/jmx/command_test.go
@@ -1,0 +1,133 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build jmx
+// +build jmx
+
+package jmx
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/command"
+	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+func TestCollectCommand(t *testing.T) {
+	// this tests several permutations of options that have a complex
+	// relationship with the resulting params
+	t.Run("with no args", func(t *testing.T) {
+		fxutil.TestOneShotSubcommand(t,
+			Commands(&command.GlobalParams{}),
+			[]string{"jmx", "collect"},
+			runJmxCommandConsole,
+			func(cliParams *cliParams, coreParams core.BundleParams) {
+				require.Equal(t, "collect", cliParams.command)
+				require.Equal(t, "debug", cliParams.jmxLogLevel)
+				require.Equal(t, "debug", coreParams.LogLevelFn(nil))
+				require.Equal(t, "", cliParams.logFile)
+				require.Equal(t, "", coreParams.LogFileFn(nil))
+				require.Equal(t, "CORE", coreParams.LoggerName)
+				require.Equal(t, true, coreParams.ConfigLoadSecrets)
+			})
+	})
+
+	t.Run("with --log-level", func(t *testing.T) {
+		fxutil.TestOneShotSubcommand(t,
+			Commands(&command.GlobalParams{}),
+			[]string{"jmx", "collect", "--log-level", "info"},
+			runJmxCommandConsole,
+			func(cliParams *cliParams, coreParams core.BundleParams) {
+				require.Equal(t, "collect", cliParams.command)
+				require.Equal(t, "info", cliParams.jmxLogLevel)
+				require.Equal(t, "info", coreParams.LogLevelFn(nil))
+				require.Equal(t, "", cliParams.logFile)
+				require.Equal(t, "", coreParams.LogFileFn(nil))
+				require.Equal(t, "CORE", coreParams.LoggerName)
+				require.Equal(t, true, coreParams.ConfigLoadSecrets)
+			})
+	})
+
+	t.Run("with --flare", func(t *testing.T) {
+		fxutil.TestOneShotSubcommand(t,
+			Commands(&command.GlobalParams{}),
+			[]string{"jmx", "collect", "--flare", "--log-level", "info"},
+			runJmxCommandConsole,
+			func(cliParams *cliParams, coreParams core.BundleParams) {
+				require.Equal(t, "collect", cliParams.command)
+				require.Equal(t, "debug", cliParams.jmxLogLevel)      // overrides --log-level
+				require.Equal(t, "debug", coreParams.LogLevelFn(nil)) // overrides --log-level
+				require.True(t, strings.HasPrefix(cliParams.logFile, common.DefaultJMXFlareDirectory))
+				require.Equal(t, cliParams.logFile, coreParams.LogFileFn(nil))
+				require.Equal(t, "CORE", coreParams.LoggerName)
+				require.Equal(t, true, coreParams.ConfigLoadSecrets)
+			})
+	})
+}
+
+func TestListEverythingCommand(t *testing.T) {
+	fxutil.TestOneShotSubcommand(t,
+		Commands(&command.GlobalParams{}),
+		[]string{"jmx", "list", "everything"},
+		runJmxCommandConsole,
+		func(cliParams *cliParams, coreParams core.BundleParams) {
+			require.Equal(t, "list_everything", cliParams.command)
+		})
+}
+
+func TestListMatchingCommand(t *testing.T) {
+	fxutil.TestOneShotSubcommand(t,
+		Commands(&command.GlobalParams{}),
+		[]string{"jmx", "list", "matching"},
+		runJmxCommandConsole,
+		func(cliParams *cliParams, coreParams core.BundleParams) {
+			require.Equal(t, "list_matching_attributes", cliParams.command)
+		})
+}
+
+func TestListWithRateMetricsCommand(t *testing.T) {
+	fxutil.TestOneShotSubcommand(t,
+		Commands(&command.GlobalParams{}),
+		[]string{"jmx", "list", "with-rate-metrics"},
+		runJmxCommandConsole,
+		func(cliParams *cliParams, coreParams core.BundleParams) {
+			require.Equal(t, "list_with_rate_metrics", cliParams.command)
+		})
+}
+
+func TestListLimitedCommand(t *testing.T) {
+	fxutil.TestOneShotSubcommand(t,
+		Commands(&command.GlobalParams{}),
+		[]string{"jmx", "list", "limited"},
+		runJmxCommandConsole,
+		func(cliParams *cliParams, coreParams core.BundleParams) {
+			require.Equal(t, "list_limited_attributes", cliParams.command)
+		})
+}
+
+func TestListCollectedCommand(t *testing.T) {
+	fxutil.TestOneShotSubcommand(t,
+		Commands(&command.GlobalParams{}),
+		[]string{"jmx", "list", "collected"},
+		runJmxCommandConsole,
+		func(cliParams *cliParams, coreParams core.BundleParams) {
+			require.Equal(t, "list_collected_attributes", cliParams.command)
+		})
+}
+
+func TestListNotMatchingCommand(t *testing.T) {
+	fxutil.TestOneShotSubcommand(t,
+		Commands(&command.GlobalParams{}),
+		[]string{"jmx", "list", "not-matching"},
+		runJmxCommandConsole,
+		func(cliParams *cliParams, coreParams core.BundleParams) {
+			require.Equal(t, "list_not_matching_attributes", cliParams.command)
+		})
+}

--- a/cmd/cluster-agent/commands/check/check.go
+++ b/cmd/cluster-agent/commands/check/check.go
@@ -112,7 +112,7 @@ func Check(loggerName config.LoggerName, confFilePath *string, flagNoColor *bool
 				// we'll search for a config file named `datadog-cluster.yaml`
 				configName = "datadog-cluster"
 			}
-			resolvedLogLevel, warnings, err := standalone.SetupCLI(loggerName, *confFilePath, configName, "", logLevel, "off")
+			resolvedLogLevel, warnings, err := setupCLI(loggerName, *confFilePath, configName, "", logLevel, "off")
 			if err != nil {
 				fmt.Printf("Cannot initialize command: %v\n", err)
 				return err

--- a/cmd/cluster-agent/commands/check/setup.go
+++ b/cmd/cluster-agent/commands/check/setup.go
@@ -1,0 +1,47 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package check
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+// setupCLI sets up the shared utilities for a standalone CLI command:
+// - config, with defaults to avoid conflicting with an agent process running in parallel
+// - logger
+// and returns the log level resolved from cliLogLevel and defaultLogLevel
+func setupCLI(loggerName config.LoggerName, confFilePath, configName string, cliLogFile string, cliLogLevel string, defaultLogLevel string) (string, *config.Warnings, error) {
+	var resolvedLogLevel string
+
+	if cliLogLevel != "" {
+		// Honour the deprecated --log-level argument
+		overrides := make(map[string]interface{})
+		overrides["log_level"] = cliLogLevel
+		config.AddOverrides(overrides)
+		resolvedLogLevel = cliLogLevel
+	} else {
+		resolvedLogLevel = config.GetEnvDefault("DD_LOG_LEVEL", defaultLogLevel)
+	}
+
+	overrides := make(map[string]interface{})
+	overrides["cmd_port"] = 0 // let the OS assign an available port for the HTTP server
+	config.AddOverrides(overrides)
+
+	warnings, err := common.SetupConfigWithWarnings(confFilePath, configName)
+	if err != nil {
+		return resolvedLogLevel, warnings, fmt.Errorf("unable to set up global agent configuration: %v", err)
+	}
+
+	err = config.SetupLogger(loggerName, resolvedLogLevel, cliLogFile, "", false, true, false)
+	if err != nil {
+		return resolvedLogLevel, warnings, fmt.Errorf("unable to set up logger: %v", err)
+	}
+
+	return resolvedLogLevel, warnings, nil
+}


### PR DESCRIPTION
### What does this PR do?

Converts the `agent jmx` command to an Fx App.

### Motivation

Top-down approach to componentization.

### Additional Notes

This PR is against a base branch containing #13699 and #13662.  Once those are merged, I'll change the base of this PR to `main` and rebase, but it can be reviewed in the interim.

The only remaining use of SetupCLI is in `cmd/cluster-agent/commands/check`, so the function is moved to that package.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Set up an agent with a running JMX integration.

Compare output for the following commands, paying particular attention to log levels.

 * `agent jmx`
 * `agent jmx list`
 * `agent jmx list everything`
 * `agent jmx list collected`
 * `agent jmx list limited`
 * `agent jmx list matching`
 * `agent jmx list non-matching`
 * `agent jmx list with-metrics`
 * `agent jmx list with-rate-metrics`
 * `agent jmx list everything --flare` (verify the content of the created logfile is correct)
 * `agent jmx list everything --discovery-timeout=1` (verify it only waits 1s for discovery, not the default 5)
 * `agent jmx collect` (observe that it collects the same things)

Note that "JMXFetch is closing" is sometimes captured in the logs, and sometimes not -- this is a harmless race in shutdown.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
