### PR TITLE
Convert tagger-list and workload-list commands to apps

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -102,6 +102,8 @@
 /cmd/agent/subcommands/integrations     @DataDog/software-integrity-and-trust @DataDog/agent-integrations @DataDog/agent-shared-components
 /cmd/agent/subcommands/remoteconfig     @Datadog/remote-config
 /cmd/agent/subcommands/snmp             @DataDog/network-device-monitoring
+/cmd/agent/subcommands/taggerlist       @DataDog/container-integrations
+/cmd/agent/subcommands/workloadlist     @DataDog/container-integrations
 /cmd/agent/subcommands/run/internal/clcrunnerapi/       @DataDog/container-integrations @DataDog/agent-shared-components
 /cmd/agent/dist/conf.d/jetson.d         @DataDog/agent-platform
 /cmd/agent/dist/conf.d/snmp.d/          @DataDog/network-device-monitoring

--- a/cmd/agent/subcommands/taggerlist/command.go
+++ b/cmd/agent/subcommands/taggerlist/command.go
@@ -9,56 +9,69 @@ package taggerlist
 import (
 	"fmt"
 
+	"go.uber.org/fx"
+
 	"github.com/DataDog/datadog-agent/cmd/agent/command"
-	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	tagger_api "github.com/DataDog/datadog-agent/pkg/tagger/api"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
 
+// cliParams are the command-line arguments for this subcommand
+type cliParams struct {
+	*command.GlobalParams
+}
+
 // Commands returns a slice of subcommands for the 'agent' command.
 func Commands(globalParams *command.GlobalParams) []*cobra.Command {
+	cliParams := &cliParams{
+		GlobalParams: globalParams,
+	}
 	taggerListCommand := &cobra.Command{
 		Use:   "tagger-list",
 		Short: "Print the tagger content of a running agent",
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := common.SetupConfigWithoutSecrets(globalParams.ConfFilePath, "")
-			if err != nil {
-				return fmt.Errorf("unable to set up global agent configuration: %v", err)
-			}
-
-			err = config.SetupLogger(config.CoreLoggerName, config.GetEnvDefault("DD_LOG_LEVEL", "off"), "", "", false, true, false)
-			if err != nil {
-				fmt.Printf("Cannot setup logger, exiting: %v\n", err)
-				return err
-			}
-
-			// Set session token
-			if err := util.SetAuthToken(); err != nil {
-				return err
-			}
-
-			url, err := getTaggerURL()
-			if err != nil {
-				return err
-			}
-
-			return tagger_api.GetTaggerList(color.Output, url)
+			return fxutil.OneShot(taggerList,
+				fx.Supply(cliParams),
+				fx.Supply(core.BundleParams{
+					ConfFilePath:      globalParams.ConfFilePath,
+					ConfigLoadSecrets: false,
+				}.LogForOneShot("CORE", "off", true)),
+				core.Bundle,
+			)
 		},
 	}
 
 	return []*cobra.Command{taggerListCommand}
 }
 
-func getTaggerURL() (string, error) {
-	ipcAddress, err := config.GetIPCAddress()
+func taggerList(log log.Component, config config.Component, cliParams *cliParams) error {
+	// Set session token
+	if err := util.SetAuthToken(); err != nil {
+		return err
+	}
+
+	url, err := getTaggerURL(config)
+	if err != nil {
+		return err
+	}
+
+	return tagger_api.GetTaggerList(color.Output, url)
+}
+
+func getTaggerURL(config config.Component) (string, error) {
+	ipcAddress, err := pkgconfig.GetIPCAddress()
 	if err != nil {
 		return "", err
 	}
 
-	return fmt.Sprintf("https://%v:%v/agent/tagger-list", ipcAddress, config.Datadog.GetInt("cmd_port")), nil
+	return fmt.Sprintf("https://%v:%v/agent/tagger-list", ipcAddress, config.GetInt("cmd_port")), nil
 }

--- a/cmd/agent/subcommands/taggerlist/command_test.go
+++ b/cmd/agent/subcommands/taggerlist/command_test.go
@@ -1,0 +1,26 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package taggerlist
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/command"
+	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+func TestCommand(t *testing.T) {
+	fxutil.TestOneShotSubcommand(t,
+		Commands(&command.GlobalParams{}),
+		[]string{"tagger-list"},
+		taggerList,
+		func(cliParams *cliParams, coreParams core.BundleParams) {
+			require.Equal(t, false, coreParams.ConfigLoadSecrets)
+		})
+}

--- a/cmd/agent/subcommands/workloadlist/command.go
+++ b/cmd/agent/subcommands/workloadlist/command.go
@@ -10,71 +10,84 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"go.uber.org/fx"
+
 	"github.com/DataDog/datadog-agent/cmd/agent/command"
-	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
 
-var verboseList bool
+// cliParams are the command-line arguments for this subcommand
+type cliParams struct {
+	*command.GlobalParams
+
+	verboseList bool
+}
 
 // Commands returns a slice of subcommands for the 'agent' command.
 func Commands(globalParams *command.GlobalParams) []*cobra.Command {
+	cliParams := &cliParams{
+		GlobalParams: globalParams,
+	}
 	workloadListCommand := &cobra.Command{
 		Use:   "workload-list",
 		Short: "Print the workload content of a running agent",
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := common.SetupConfigWithoutSecrets(globalParams.ConfFilePath, "")
-			if err != nil {
-				return fmt.Errorf("unable to set up global agent configuration: %v", err)
-			}
-
-			err = config.SetupLogger(config.CoreLoggerName, config.GetEnvDefault("DD_LOG_LEVEL", "off"), "", "", false, true, false)
-			if err != nil {
-				fmt.Printf("Cannot setup logger, exiting: %v\n", err)
-				return err
-			}
-
-			c := util.GetClient(false) // FIX: get certificates right then make this true
-
-			// Set session token
-			err = util.SetAuthToken()
-			if err != nil {
-				return err
-			}
-			ipcAddress, err := config.GetIPCAddress()
-			if err != nil {
-				return err
-			}
-
-			r, err := util.DoGet(c, workloadURL(verboseList, ipcAddress, config.Datadog.GetInt("cmd_port")), util.LeaveConnectionOpen)
-			if err != nil {
-				if r != nil && string(r) != "" {
-					fmt.Fprintf(color.Output, "The agent ran into an error while getting the workload store information: %s\n", string(r))
-				} else {
-					fmt.Fprintf(color.Output, "Failed to query the agent (running?): %s\n", err)
-				}
-			}
-
-			workload := workloadmeta.WorkloadDumpResponse{}
-			err = json.Unmarshal(r, &workload)
-			if err != nil {
-				return err
-			}
-
-			workload.Write(color.Output)
-
-			return nil
+			return fxutil.OneShot(workloadList,
+				fx.Supply(cliParams),
+				fx.Supply(core.BundleParams{
+					ConfFilePath:      globalParams.ConfFilePath,
+					ConfigLoadSecrets: false,
+				}.LogForOneShot("CORE", "off", true)),
+				core.Bundle,
+			)
 		},
 	}
-	workloadListCommand.Flags().BoolVarP(&verboseList, "verbose", "v", false, "print out a full dump of the workload store")
+	workloadListCommand.Flags().BoolVarP(&cliParams.verboseList, "verbose", "v", false, "print out a full dump of the workload store")
 
 	return []*cobra.Command{workloadListCommand}
+}
+
+func workloadList(log log.Component, config config.Component, cliParams *cliParams) error {
+	c := util.GetClient(false) // FIX: get certificates right then make this true
+
+	// Set session token
+	err := util.SetAuthToken()
+	if err != nil {
+		return err
+	}
+	ipcAddress, err := pkgconfig.GetIPCAddress()
+	if err != nil {
+		return err
+	}
+
+	r, err := util.DoGet(c, workloadURL(cliParams.verboseList, ipcAddress, config.GetInt("cmd_port")), util.LeaveConnectionOpen)
+	if err != nil {
+		if r != nil && string(r) != "" {
+			fmt.Fprintf(color.Output, "The agent ran into an error while getting the workload store information: %s\n", string(r))
+		} else {
+			fmt.Fprintf(color.Output, "Failed to query the agent (running?): %s\n", err)
+		}
+	}
+
+	workload := workloadmeta.WorkloadDumpResponse{}
+	err = json.Unmarshal(r, &workload)
+	if err != nil {
+		return err
+	}
+
+	workload.Write(color.Output)
+
+	return nil
 }
 
 func workloadURL(verbose bool, address string, port int) string {

--- a/cmd/agent/subcommands/workloadlist/command_test.go
+++ b/cmd/agent/subcommands/workloadlist/command_test.go
@@ -1,0 +1,27 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package workloadlist
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/command"
+	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+func TestCommand(t *testing.T) {
+	fxutil.TestOneShotSubcommand(t,
+		Commands(&command.GlobalParams{}),
+		[]string{"workload-list", "-v"},
+		workloadList,
+		func(cliParams *cliParams, coreParams core.BundleParams) {
+			require.Equal(t, true, cliParams.verboseList)
+			require.Equal(t, false, coreParams.ConfigLoadSecrets)
+		})
+}


### PR DESCRIPTION
### What does this PR do?

Converts the `agent tagger-list` and `agent workload-list` commands to Fx Apps.

### Motivation

Top-down approach to componentization.

### Additional Notes

This PR is against a base branch containing #13699 and #13662.  Once those are merged, I'll change the base of this PR to `main` and rebase, but it can be reviewed in the interim.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Run an agent with some entities (containers) for WLM and Tagger to identify

* `agent tagger-list`
* `agent tagger-list -h`
* `agent tagger-list -n`
* `agent tagger-list | cat` (should not have colored output)
* `agent workload-list`
* `agent workload -h`
* `agent workload -n`
* `agent workload | cat` (should not have colored output)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
