### PR TITLE
add support for components implementing the actor pattern

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -148,6 +148,7 @@
 /Dockerfiles/agent/windows/              @DataDog/container-integrations @DataDog/windows-agent
 
 /docs/                                  @DataDog/documentation @DataDog/agent-platform
+/docs/components/                       @DataDog/documentation @DataDog/agent-shared-components
 /docs/agent/                            @DataDog/documentation @DataDog/agent-shared-components
 /docs/components/                       @DataDog/documentation @DataDog/agent-shared-components
 /docs/dogstatsd/                        @DataDog/documentation @DataDog/agent-metrics-logs
@@ -263,6 +264,7 @@
 /pkg/util/retry/                        @DataDog/container-integrations
 /pkg/util/intern/                       @DataDog/ebpf-platform
 /pkg/util/winutil/                      @DataDog/windows-agent
+/pkg/util/actor/                        @DataDog/agent-shared-components
 /pkg/logs/                              @DataDog/agent-metrics-logs
 /pkg/process/                           @DataDog/processes
 /pkg/process/util/address*.go           @DataDog/Networks

--- a/docs/components/README.md
+++ b/docs/components/README.md
@@ -9,3 +9,4 @@
    * [Defining Apps and Binaries](./defining-apps.md)
    * [Registrations](./registrations.md)
    * [Subscriptions](./subscriptions.md)
+   * [Actors](./actors.md)

--- a/docs/components/actors.md
+++ b/docs/components/actors.md
@@ -1,0 +1,31 @@
+# Actors
+
+Many components use the [actor model](https://en.wikipedia.org/wiki/Actor_model) to structure their operations.
+Briefly, this is a "main loop" that reacts to events one-by-one, updating its internal state.
+This effectively serializes execution, removing the need for concurrency primitives and simplifying implementation.
+
+The `pkg/util/actor` package provides support for this model.
+It handles the particulars of starting and stopping an actor goroutine, and supports liveness monitoring.
+Use it like this:
+
+```go
+type listener struct {
+    actor Actor
+}
+
+func newTestComp(lc fx.Lifecycle) (*listener, health.Registration) {
+    c := &listener{}
+    c.actor.HookLifecycle(lc, c.run) // hook the actor into the Fx lifecycle
+    return c, reg
+}
+
+func (c *listener) run(ctx context.Context, alive <-chan struct{}) {
+    for {					// the main loop
+        select {
+        case <-alive: 		// consuming the message indicates the loop is healthy
+        case <-ctx.Done(): 	// actor stops when the context is complete
+            return
+        }
+    }
+}
+```

--- a/docs/components/actors.md
+++ b/docs/components/actors.md
@@ -10,20 +10,28 @@ Use it like this:
 
 ```go
 type listener struct {
+    // events are the things to which this component reacts
+    events chan event
+
+    // actor encapsulates this agent's "run loop"
     actor Actor
 }
 
-func newTestComp(lc fx.Lifecycle) (*listener, health.Registration) {
-    c := &listener{}
-    c.actor.HookLifecycle(lc, c.run) // hook the actor into the Fx lifecycle
-    return c, reg
+func newTestComp(lc fx.Lifecycle) (*listener) {
+    c := &listener{
+        events: ...,
+        actor: actor.New(lc, c.run),
+    }
+    return c
 }
 
 func (c *listener) run(ctx context.Context, alive <-chan struct{}) {
     for {					// the main loop
         select {
-        case <-alive: 		// consuming the message indicates the loop is healthy
-        case <-ctx.Done(): 	// actor stops when the context is complete
+        case <-c.events:
+            ...             // handle the event
+        case <-alive: 		// consuming an alive message indicates the loop is healthy
+        case <-ctx.Done(): 	// actor should stop when ctx is complete
             return
         }
     }

--- a/docs/components/guidelines.md
+++ b/docs/components/guidelines.md
@@ -13,3 +13,4 @@ If a situation arises that contradicts the guidelines, then we can update the gu
 * [Defining Apps](./defining-apps.md)
 * [Registrations](./registrations.md)
 * [Subscriptions](./subscriptions.md)
+* [Actors](./actors.md)

--- a/pkg/util/actor/actor.go
+++ b/pkg/util/actor/actor.go
@@ -1,0 +1,106 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package actor provides basic support for building actors for use in the Agent.
+//
+// Methods on this component are not re-entrant.  Components using this one
+// should _either_ call HookLifecycle once in their constructor or call Start
+// and Stop from their lifecycle hook.
+package actor
+
+import (
+	"context"
+
+	"go.uber.org/fx"
+)
+
+// NOTE: when a health component is introduced, this package should be updated
+// to automatically register with that component. See
+// https://github.com/DataDog/dd-agent-comp-experiments/tree/main/pkg/util/actor
+
+// Actor manages a component structured as an actor, supporting starting and
+// later stopping the goroutine.  This is one-shot: once started and stopped,
+// the goroutine cannot be started again.
+type Actor struct {
+	// started is true after the goroutine has been started, and remains true after
+	// it has stopped.
+	started bool
+
+	// cancel cancels the context passed to the `run` function, used to signal
+	// that it should stop
+	cancel context.CancelFunc
+
+	// stopped is closed once the run function returns.
+	stopped chan struct{}
+}
+
+// New creates a new actor.
+func New() *Actor {
+	return &Actor{}
+}
+
+// RunFunc defines the function implementing the actor's event loop.  It should
+// run until the passed context is cancelled.
+//
+// The loop should read from `alive`, discarding the results.  This is used to
+// monitor the actor's health, ensuring that the component is returning to
+// its main loop frequently.
+type RunFunc func(ctx context.Context, alive <-chan struct{})
+
+// HookLifecycle connects this actor to the given fx.Lifecycle, starting and
+// stopping it with the lifecycle.  Use this method _or_ the Start and Stop methods,
+// but not both.
+func (a *Actor) HookLifecycle(lc fx.Lifecycle, runFunc RunFunc) {
+	lc.Append(fx.Hook{
+		OnStart: func(context.Context) error {
+			a.Start(runFunc)
+			return nil
+		},
+		OnStop: a.Stop,
+	})
+}
+
+// Start starts run in a goroutine, setting up to stop it by cancelling the context
+// it receives.
+func (a *Actor) Start(runFunc RunFunc) {
+	if a.started {
+		panic("Goroutine has already been started")
+	}
+	a.started = true
+
+	ctx, cancel := context.WithCancel(context.Background())
+	a.cancel = cancel
+	a.stopped = make(chan struct{})
+
+	go a.run(ctx, runFunc)
+}
+
+// Stop stops the goroutine, waiting until it is complete, or the given context
+// is cancelled, before returning.  Returns the error from context if it is
+// cancelled.
+func (a *Actor) Stop(ctx context.Context) error {
+	if !a.started {
+		panic("Goroutine has not been started")
+	}
+	if a.cancel == nil {
+		panic("Goroutine has already been stopped")
+	}
+	a.cancel()
+	a.cancel = nil
+	select {
+	case <-a.stopped:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// run executes the given function, ensuring that the stopped channel is closed
+// when it finishes.  This method runs in a dedicated goroutine.
+func (a *Actor) run(ctx context.Context, runFunc RunFunc) {
+	defer close(a.stopped)
+	alive := make(chan struct{}, 1)
+	runFunc(ctx, alive)
+}

--- a/pkg/util/actor/actor_test.go
+++ b/pkg/util/actor/actor_test.go
@@ -1,0 +1,40 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package actor
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+func TestWithoutComponents(t *testing.T) {
+	actor := Actor{}
+	ch := make(chan int)
+
+	run := func(ctx context.Context, alive <-chan struct{}) {
+		for {
+			select {
+			case <-alive:
+			case v := <-ch:
+				fmt.Printf("GOT: %d\n", v)
+			case <-ctx.Done():
+				fmt.Println("Stopping")
+				return
+			}
+		}
+	}
+
+	actor.Start(run)
+	ch <- 1
+	ch <- 2
+	actor.Stop(context.Background())
+
+	// Output:
+	// GOT: 1
+	// GOT: 2
+	// Stopping
+}


### PR DESCRIPTION
### What does this PR do?

This adds a small supporting library for actor-shaped components.  This isn't used yet, but is likely to be useful in several components and it's easier to just get it in place first, rather than having those components "race" to see who introduces this support.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

This PR is against a base branch containing #13699 and #13662.  Once those are merged, I'll change the base of this PR to `main` and rebase, but it can be reviewed in the interim.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
