### PR TITLE
Update 7.40 release with latest driver

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,37 @@
 Release Notes
 =============
 
+.. _Release Notes_7.39.1:
+
+7.39.1 / 6.39.1
+======
+
+.. _Release Notes_7.39.1_Prelude:
+
+Prelude
+-------
+
+Release on: 2022-09-27
+
+
+.. _Release Notes_7.39.1_Security Notes:
+
+Security Notes
+--------------
+
+- Bump ``github.com/open-policy-agent/opa`` to `v0.43.1 <https://github.com/open-policy-agent/opa/releases/tag/v0.43.1>`_ to patch CVE-2022-36085.
+
+
+.. _Release Notes_7.39.1_Other Notes:
+
+Other Notes
+-----------
+
+- Bump embedded Python3 to `3.8.14`.
+
+- Deactivated support of HTTP/2 in all non localhost endpoint used by Datadog Agent and Cluster Agent. (except endpoints)
+
+
 .. _Release Notes_7.39.0:
 
 7.39.0 / 6.39.0

--- a/go.mod
+++ b/go.mod
@@ -45,15 +45,15 @@ require (
 	code.cloudfoundry.org/lager v2.0.0+incompatible
 	github.com/DataDog/agent-payload/v5 v5.0.29
 	github.com/DataDog/btf-internals v0.0.0-20220424171854-ebe6bce9afb0
-	github.com/DataDog/datadog-agent/pkg/obfuscate v0.40.0-rc.2
-	github.com/DataDog/datadog-agent/pkg/otlp/model v0.40.0-rc.2
-	github.com/DataDog/datadog-agent/pkg/quantile v0.40.0-rc.2
-	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.40.0-rc.2
-	github.com/DataDog/datadog-agent/pkg/security/secl v0.40.0-rc.2
-	github.com/DataDog/datadog-agent/pkg/trace v0.40.0-rc.2
-	github.com/DataDog/datadog-agent/pkg/util/cgroups v0.40.0-rc.2
-	github.com/DataDog/datadog-agent/pkg/util/log v0.40.0-rc.2
-	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.40.0-rc.2
+	github.com/DataDog/datadog-agent/pkg/obfuscate v0.40.0-rc.3
+	github.com/DataDog/datadog-agent/pkg/otlp/model v0.40.0-rc.3
+	github.com/DataDog/datadog-agent/pkg/quantile v0.40.0-rc.3
+	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.40.0-rc.3
+	github.com/DataDog/datadog-agent/pkg/security/secl v0.40.0-rc.3
+	github.com/DataDog/datadog-agent/pkg/trace v0.40.0-rc.3
+	github.com/DataDog/datadog-agent/pkg/util/cgroups v0.40.0-rc.3
+	github.com/DataDog/datadog-agent/pkg/util/log v0.40.0-rc.3
+	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.40.0-rc.3
 	github.com/DataDog/datadog-go/v5 v5.1.1
 	github.com/DataDog/datadog-operator v0.7.1-0.20220602134901-4f6af09bf54f
 	github.com/DataDog/ebpf-manager v0.0.0-20220916102325-8091ed929797

--- a/pkg/forwarder/internal/retry/transaction_retry_queue.go
+++ b/pkg/forwarder/internal/retry/transaction_retry_queue.go
@@ -110,7 +110,7 @@ func (tc *TransactionRetryQueue) Add(t transaction.Transaction) (int, error) {
 				diskErr = multierror.Append(diskErr, err)
 				// Assuming all payloads failed during serialization
 				for _, payload := range payloads {
-					tc.telemetry.addTransactionsDroppedCount(payload.GetPointCount())
+					tc.telemetry.addPointDroppedCount(payload.GetPointCount())
 				}
 			}
 		}

--- a/pkg/otlp/model/go.mod
+++ b/pkg/otlp/model/go.mod
@@ -5,7 +5,7 @@ go 1.18
 replace github.com/DataDog/datadog-agent/pkg/quantile => ../../quantile
 
 require (
-	github.com/DataDog/datadog-agent/pkg/quantile v0.40.0-rc.2
+	github.com/DataDog/datadog-agent/pkg/quantile v0.40.0-rc.3
 	github.com/DataDog/sketches-go v1.4.1
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/stretchr/testify v1.8.0

--- a/pkg/trace/go.mod
+++ b/pkg/trace/go.mod
@@ -10,11 +10,11 @@ go 1.18
 replace github.com/docker/distribution => github.com/docker/distribution v2.8.1+incompatible
 
 require (
-	github.com/DataDog/datadog-agent/pkg/obfuscate v0.40.0-rc.2
-	github.com/DataDog/datadog-agent/pkg/otlp/model v0.40.0-rc.2
-	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.40.0-rc.2
-	github.com/DataDog/datadog-agent/pkg/util/cgroups v0.40.0-rc.2
-	github.com/DataDog/datadog-agent/pkg/util/log v0.40.0-rc.2
+	github.com/DataDog/datadog-agent/pkg/obfuscate v0.40.0-rc.3
+	github.com/DataDog/datadog-agent/pkg/otlp/model v0.40.0-rc.3
+	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.40.0-rc.3
+	github.com/DataDog/datadog-agent/pkg/util/cgroups v0.40.0-rc.3
+	github.com/DataDog/datadog-agent/pkg/util/log v0.40.0-rc.3
 	github.com/DataDog/datadog-go/v5 v5.1.1
 	github.com/DataDog/sketches-go v1.4.1
 	github.com/Microsoft/go-winio v0.5.2
@@ -36,7 +36,7 @@ require (
 )
 
 require (
-	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.40.0-rc.2 // indirect
+	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.40.0-rc.3 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 // indirect
 	github.com/containerd/cgroups v1.0.4 // indirect

--- a/pkg/util/cgroups/go.mod
+++ b/pkg/util/cgroups/go.mod
@@ -8,7 +8,7 @@ replace (
 )
 
 require (
-	github.com/DataDog/datadog-agent/pkg/util/log v0.40.0-rc.2
+	github.com/DataDog/datadog-agent/pkg/util/log v0.40.0-rc.3
 	github.com/containerd/cgroups v1.0.4
 	github.com/google/go-cmp v0.5.8
 	github.com/karrick/godirwalk v1.17.0
@@ -16,7 +16,7 @@ require (
 )
 
 require (
-	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.40.0-rc.2 // indirect
+	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.40.0-rc.3 // indirect
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 // indirect
 	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/pkg/util/log/go.mod
+++ b/pkg/util/log/go.mod
@@ -5,7 +5,7 @@ go 1.18
 replace github.com/DataDog/datadog-agent/pkg/util/scrubber => ../scrubber
 
 require (
-	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.40.0-rc.2
+	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.40.0-rc.3
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575
 	github.com/stretchr/testify v1.8.0
 	go.uber.org/zap v1.22.0

--- a/pkg/workloadmeta/collectors/internal/kubemetadata/kubemetadata.go
+++ b/pkg/workloadmeta/collectors/internal/kubemetadata/kubemetadata.go
@@ -222,7 +222,13 @@ func (c *collector) parsePods(
 		seen[entityID] = struct{}{}
 
 		entity := &workloadmeta.KubernetesPod{
-			EntityID:        entityID,
+			EntityID: entityID,
+			EntityMeta: workloadmeta.EntityMeta{
+				Name:        pod.Metadata.Name,
+				Namespace:   pod.Metadata.Namespace,
+				Annotations: pod.Metadata.Annotations,
+				Labels:      pod.Metadata.Labels,
+			},
 			KubeServices:    services,
 			NamespaceLabels: nsLabels,
 		}

--- a/pkg/workloadmeta/collectors/internal/kubemetadata/kubemetadata_test.go
+++ b/pkg/workloadmeta/collectors/internal/kubemetadata/kubemetadata_test.go
@@ -469,6 +469,10 @@ func TestKubeMetadataCollector_parsePods(t *testing.T) {
 							Kind: workloadmeta.KindKubernetesPod,
 							ID:   "foouid",
 						},
+						EntityMeta: workloadmeta.EntityMeta{
+							Name:      "foo",
+							Namespace: "default",
+						},
 						KubeServices: []string{"svc1", "svc2"},
 						NamespaceLabels: map[string]string{
 							"label": "value",
@@ -507,6 +511,10 @@ func TestKubeMetadataCollector_parsePods(t *testing.T) {
 							Kind: workloadmeta.KindKubernetesPod,
 							ID:   "foouid",
 						},
+						EntityMeta: workloadmeta.EntityMeta{
+							Name:      "foo",
+							Namespace: "default",
+						},
 						KubeServices: []string{"svc1", "svc2"},
 					},
 				},
@@ -531,6 +539,10 @@ func TestKubeMetadataCollector_parsePods(t *testing.T) {
 						EntityID: workloadmeta.EntityID{
 							Kind: workloadmeta.KindKubernetesPod,
 							ID:   "foouid",
+						},
+						EntityMeta: workloadmeta.EntityMeta{
+							Name:      "foo",
+							Namespace: "default",
 						},
 						KubeServices: []string{},
 					},

--- a/release.json
+++ b/release.json
@@ -12,8 +12,8 @@
         "JMXFETCH_HASH": "4cbbff73abfa0e6baaa1e3cad57497abcbb0e1570a022eecb7828dce3a14a3d9",
         "MACOS_BUILD_VERSION": "7.40.x",
         "WINDOWS_DDNPM_DRIVER": "release-signed",
-        "WINDOWS_DDNPM_VERSION": "2.0.3",
-        "WINDOWS_DDNPM_SHASUM": "cd953f8e663cd77b2a9ad1b299e0bbb89082a3a37d2ab3a4cf85e97ac53265b8",
+        "WINDOWS_DDNPM_VERSION": "2.0.5",
+        "WINDOWS_DDNPM_SHASUM": "2df99754d1fb1bd1d7d33c125a9303faf9d35423545123589985e186d499d9dd",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "nightly-a7": {
@@ -24,8 +24,8 @@
         "JMXFETCH_HASH": "4cbbff73abfa0e6baaa1e3cad57497abcbb0e1570a022eecb7828dce3a14a3d9",
         "MACOS_BUILD_VERSION": "7.40.x",
         "WINDOWS_DDNPM_DRIVER": "release-signed",
-        "WINDOWS_DDNPM_VERSION": "2.0.3",
-        "WINDOWS_DDNPM_SHASUM": "cd953f8e663cd77b2a9ad1b299e0bbb89082a3a37d2ab3a4cf85e97ac53265b8",
+        "WINDOWS_DDNPM_VERSION": "2.0.5",
+        "WINDOWS_DDNPM_SHASUM": "2df99754d1fb1bd1d7d33c125a9303faf9d35423545123589985e186d499d9dd",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "release-a6": {
@@ -37,8 +37,8 @@
         "SECURITY_AGENT_POLICIES_VERSION": "v0.29.0",
         "MACOS_BUILD_VERSION": "6.40.0-rc.1",
         "WINDOWS_DDNPM_DRIVER": "release-signed",
-        "WINDOWS_DDNPM_VERSION": "2.0.3",
-        "WINDOWS_DDNPM_SHASUM": "cd953f8e663cd77b2a9ad1b299e0bbb89082a3a37d2ab3a4cf85e97ac53265b8"
+        "WINDOWS_DDNPM_VERSION": "2.0.5",
+        "WINDOWS_DDNPM_SHASUM": "2df99754d1fb1bd1d7d33c125a9303faf9d35423545123589985e186d499d9dd"
     },
     "release-a7": {
         "INTEGRATIONS_CORE_VERSION": "7.40.0-rc.3",
@@ -49,8 +49,8 @@
         "SECURITY_AGENT_POLICIES_VERSION": "v0.29.0",
         "MACOS_BUILD_VERSION": "7.40.0-rc.1",
         "WINDOWS_DDNPM_DRIVER": "release-signed",
-        "WINDOWS_DDNPM_VERSION": "2.0.3",
-        "WINDOWS_DDNPM_SHASUM": "cd953f8e663cd77b2a9ad1b299e0bbb89082a3a37d2ab3a4cf85e97ac53265b8"
+        "WINDOWS_DDNPM_VERSION": "2.0.5",
+        "WINDOWS_DDNPM_SHASUM": "2df99754d1fb1bd1d7d33c125a9303faf9d35423545123589985e186d499d9dd"
     },
     "dca-1.17.0": {
         "SECURITY_AGENT_POLICIES_VERSION": "v0.18.6"

--- a/release.json
+++ b/release.json
@@ -1,28 +1,28 @@
 {
     "base_branch": "main",
     "last_stable": {
-        "6": "6.39.0",
-        "7": "7.39.0"
+        "6": "6.39.1",
+        "7": "7.39.1"
     },
     "nightly": {
-        "INTEGRATIONS_CORE_VERSION": "master",
-        "OMNIBUS_SOFTWARE_VERSION": "master",
-        "OMNIBUS_RUBY_VERSION": "datadog-5.5.0",
+        "INTEGRATIONS_CORE_VERSION": "7.40.x",
+        "OMNIBUS_SOFTWARE_VERSION": "7.40.x",
+        "OMNIBUS_RUBY_VERSION": "7.40.x",
         "JMXFETCH_VERSION": "0.47.1",
         "JMXFETCH_HASH": "4cbbff73abfa0e6baaa1e3cad57497abcbb0e1570a022eecb7828dce3a14a3d9",
-        "MACOS_BUILD_VERSION": "master",
+        "MACOS_BUILD_VERSION": "7.40.x",
         "WINDOWS_DDNPM_DRIVER": "release-signed",
         "WINDOWS_DDNPM_VERSION": "2.0.3",
         "WINDOWS_DDNPM_SHASUM": "cd953f8e663cd77b2a9ad1b299e0bbb89082a3a37d2ab3a4cf85e97ac53265b8",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "nightly-a7": {
-        "INTEGRATIONS_CORE_VERSION": "master",
-        "OMNIBUS_SOFTWARE_VERSION": "master",
-        "OMNIBUS_RUBY_VERSION": "datadog-5.5.0",
+        "INTEGRATIONS_CORE_VERSION": "7.40.x",
+        "OMNIBUS_SOFTWARE_VERSION": "7.40.x",
+        "OMNIBUS_RUBY_VERSION": "7.40.x",
         "JMXFETCH_VERSION": "0.47.1",
         "JMXFETCH_HASH": "4cbbff73abfa0e6baaa1e3cad57497abcbb0e1570a022eecb7828dce3a14a3d9",
-        "MACOS_BUILD_VERSION": "master",
+        "MACOS_BUILD_VERSION": "7.40.x",
         "WINDOWS_DDNPM_DRIVER": "release-signed",
         "WINDOWS_DDNPM_VERSION": "2.0.3",
         "WINDOWS_DDNPM_SHASUM": "cd953f8e663cd77b2a9ad1b299e0bbb89082a3a37d2ab3a4cf85e97ac53265b8",

--- a/release.json
+++ b/release.json
@@ -29,7 +29,7 @@
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "release-a6": {
-        "INTEGRATIONS_CORE_VERSION": "7.40.0-rc.2",
+        "INTEGRATIONS_CORE_VERSION": "7.40.0-rc.3",
         "OMNIBUS_SOFTWARE_VERSION": "7.40.0-rc.1",
         "OMNIBUS_RUBY_VERSION": "7.40.0-rc.1",
         "JMXFETCH_VERSION": "0.47.1",
@@ -41,7 +41,7 @@
         "WINDOWS_DDNPM_SHASUM": "cd953f8e663cd77b2a9ad1b299e0bbb89082a3a37d2ab3a4cf85e97ac53265b8"
     },
     "release-a7": {
-        "INTEGRATIONS_CORE_VERSION": "7.40.0-rc.2",
+        "INTEGRATIONS_CORE_VERSION": "7.40.0-rc.3",
         "OMNIBUS_SOFTWARE_VERSION": "7.40.0-rc.1",
         "OMNIBUS_RUBY_VERSION": "7.40.0-rc.1",
         "JMXFETCH_VERSION": "0.47.1",


### PR DESCRIPTION
### What does this PR do?

Contains driver fixes for 7.40


### Additional Notes

### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes
Install previous version. Run fairly high load (vegeta at 1500 conns/sec will do it). Wait. sooner or later the machine will hang.

Install this version. Same instructions. Won't hang (or shouldn't)

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
