### PR TITLE
pkg/remoteconfig: add ASM_DATA product

### DIFF
--- a/pkg/remoteconfig/state/configs.go
+++ b/pkg/remoteconfig/state/configs.go
@@ -24,7 +24,7 @@ import (
 	4. Add a method on the `Repository` to retrieved typed configs for the product.
 */
 
-var allProducts = []string{ProductAPMSampling, ProductCWSDD, ProductASMFeatures, ProductASMDD}
+var allProducts = []string{ProductAPMSampling, ProductCWSDD, ProductASMFeatures, ProductASMDD, ProductASMData}
 
 const (
 	// ProductAPMSampling is the apm sampling product
@@ -35,6 +35,8 @@ const (
 	ProductASMFeatures = "ASM_FEATURES"
 	// ProductASMDD is the application security monitoring product managed by datadog employees
 	ProductASMDD = "ASM_DD"
+	// ProductASMData is the ASM product used to configure WAF rules data
+	ProductASMData = "ASM_DATA"
 )
 
 // ErrNoConfigVersion occurs when a target file's custom meta is missing the config version
@@ -52,6 +54,8 @@ func parseConfig(product string, raw []byte, metadata Metadata) (interface{}, er
 		c, err = parseConfigCWSDD(raw, metadata)
 	case ProductASMDD:
 		c, err = parseConfigASMDD(raw, metadata)
+	case ProductASMData:
+		c, err = parseConfigASMData(raw, metadata)
 	default:
 		return nil, fmt.Errorf("unknown product - %s", product)
 	}
@@ -227,6 +231,50 @@ const (
 type ApplyStatus struct {
 	State ApplyState
 	Error string
+}
+
+// ASMDataConfig is a deserialized configuration file that holds rules data that can be used
+// by the ASM WAF for specific features (example: ip blocking).
+type ASMDataConfig struct {
+	Config   ASMDataRulesData
+	Metadata Metadata
+}
+
+// ASMDataRulesData is a serializable array of rules data entries
+type ASMDataRulesData struct {
+	RulesData []ASMDataRuleData `json:"rules_data"`
+}
+
+// ASMDataRuleData is an entry in the rules data list held by an ASMData configuration
+type ASMDataRuleData struct {
+	ID   string        `json:"id"`
+	Type string        `json:"type"`
+	Data []interface{} `json:"data"`
+}
+
+func parseConfigASMData(data []byte, metadata Metadata) (ASMDataConfig, error) {
+	cfg := ASMDataConfig{
+		Metadata: metadata,
+	}
+	err := json.Unmarshal(data, &cfg.Config)
+	return cfg, err
+}
+
+// ASMDataConfigs returns the currently active ASMData configs
+func (r *Repository) ASMDataConfigs() map[string]ASMDataConfig {
+	typedConfigs := make(map[string]ASMDataConfig)
+	configs := r.getConfigs(ProductASMData)
+
+	for path, cfg := range configs {
+		// We control this, so if this has gone wrong something has gone horribly wrong
+		typed, ok := cfg.(ASMDataConfig)
+		if !ok {
+			panic("unexpected config stored as ASMDataConfig")
+		}
+		typedConfigs[path] = typed
+	}
+
+	return typedConfigs
 }
 
 // Metadata stores remote config metadata for a given configuration

--- a/pkg/remoteconfig/state/configs_test.go
+++ b/pkg/remoteconfig/state/configs_test.go
@@ -1,0 +1,131 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
+package state
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestASMData(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cfg  ASMDataConfig
+		raw  []byte
+	}{
+		{
+			name: "null",
+			cfg:  ASMDataConfig{},
+			raw:  []byte(`{"rules_data":null}`),
+		},
+		{
+			name: "empty",
+			cfg:  ASMDataConfig{Config: ASMDataRulesData{RulesData: []ASMDataRuleData{}}},
+			raw:  []byte(`{"rules_data":[]}`),
+		},
+		{
+			name: "single-entry-float",
+			cfg: ASMDataConfig{
+				Config: ASMDataRulesData{
+					RulesData: []ASMDataRuleData{
+						{
+							ID:   "1",
+							Type: "test1",
+							Data: []interface{}{float64(1)},
+						},
+					},
+				},
+			},
+			raw: []byte(`{"rules_data":[{"id":"1","type":"test1","data":[1]}]}`),
+		},
+		{
+			name: "single-entry-string",
+			cfg: ASMDataConfig{
+				Config: ASMDataRulesData{
+					RulesData: []ASMDataRuleData{
+						{
+							ID:   "1",
+							Type: "test1",
+							Data: []interface{}{"1"},
+						},
+					},
+				},
+			},
+			raw: []byte(`{"rules_data":[{"id":"1","type":"test1","data":["1"]}]}`),
+		},
+		{
+			name: "multiple-entries-float",
+			cfg: ASMDataConfig{
+				Config: ASMDataRulesData{
+					RulesData: []ASMDataRuleData{
+						{
+							ID:   "empty",
+							Type: "",
+							Data: []interface{}{},
+						},
+						{
+							ID:   "1",
+							Type: "test1",
+							Data: []interface{}{float64(1)},
+						},
+						{
+							ID:   "2",
+							Type: "test2",
+							Data: []interface{}{float64(1), float64(2), float64(3)},
+						},
+					},
+				},
+			},
+			raw: []byte(`{"rules_data":[{"id":"empty","type":"","data":[]},{"id":"1","type":"test1","data":[1]},{"id":"2","type":"test2","data":[1,2,3]}]}`),
+		},
+		{
+			name: "multiple-entries-string",
+			cfg: ASMDataConfig{
+				Config: ASMDataRulesData{
+					RulesData: []ASMDataRuleData{
+						{
+							ID:   "empty",
+							Type: "",
+							Data: []interface{}{},
+						},
+						{
+							ID:   "1",
+							Type: "test1",
+							Data: []interface{}{"1"},
+						},
+						{
+							ID:   "2",
+							Type: "test2",
+							Data: []interface{}{"1", "2", "3"},
+						},
+					},
+				},
+			},
+			raw: []byte(`{"rules_data":[{"id":"empty","type":"","data":[]},{"id":"1","type":"test1","data":["1"]},{"id":"2","type":"test2","data":["1","2","3"]}]}`),
+		},
+	} {
+		t.Run("marshall-"+tc.name, func(t *testing.T) {
+			raw, err := json.Marshal(tc.cfg.Config)
+			require.NoError(t, err)
+			require.Equal(t, tc.raw, raw)
+		})
+
+		t.Run("unmarshall-"+tc.name, func(t *testing.T) {
+			var cfg ASMDataConfig
+			err := json.Unmarshal(tc.raw, &cfg.Config)
+			require.NoError(t, err)
+			require.Equal(t, tc.cfg, cfg)
+		})
+
+		t.Run("parse-"+tc.name, func(t *testing.T) {
+			cfg, err := parseConfigASMData(tc.raw, Metadata{})
+			require.NoError(t, err)
+			require.Equal(t, tc.cfg, cfg)
+		})
+	}
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Add support for a new product - ASM_DATA - in pkg/remoteconfig/state
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
ASM_DATA is used by ASM to configure WAF rules data that can be used during rules matching by the WAF.
For example, the configuration can hold an entry that is a list of ips for which ASM will block HTTP requests.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
