### PR TITLE
[CWS] remove `unsafe` in `SliceToArray`

### DIFF
--- a/pkg/security/secl/model/unmarshallers.go
+++ b/pkg/security/secl/model/unmarshallers.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"strings"
 	"time"
-	"unsafe"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 )
@@ -165,7 +164,7 @@ func (e *Process) UnmarshalProcEntryBinary(data []byte) (int, error) {
 	read += 8
 
 	var ttyRaw [64]byte
-	SliceToArray(data[read:read+64], unsafe.Pointer(&ttyRaw))
+	SliceToArray(data[read:read+64], ttyRaw[:])
 	ttyName, err := UnmarshalString(ttyRaw[:], 64)
 	if err != nil {
 		return 0, err
@@ -176,7 +175,7 @@ func (e *Process) UnmarshalProcEntryBinary(data []byte) (int, error) {
 	read += 64
 
 	var commRaw [16]byte
-	SliceToArray(data[read:read+16], unsafe.Pointer(&commRaw))
+	SliceToArray(data[read:read+16], commRaw[:])
 	e.Comm, err = UnmarshalString(commRaw[:], 16)
 	if err != nil {
 		return 0, err
@@ -312,7 +311,7 @@ func (e *ArgsEnvsEvent) UnmarshalBinary(data []byte) (int, error) {
 	if e.Size > MaxArgEnvSize {
 		e.Size = MaxArgEnvSize
 	}
-	SliceToArray(data[8:MaxArgEnvSize+8], unsafe.Pointer(&e.ValuesRaw))
+	SliceToArray(data[8:MaxArgEnvSize+8], e.ValuesRaw[:])
 
 	return MaxArgEnvSize + 8, nil
 }
@@ -395,7 +394,7 @@ func (e *MountEvent) UnmarshalBinary(data []byte) (int, error) {
 
 	// Notes: bytes 36 to 40 are used to pad the structure
 
-	SliceToArray(data[40:56], unsafe.Pointer(&e.FSTypeRaw))
+	SliceToArray(data[40:56], e.FSTypeRaw[:])
 	e.FSType, err = UnmarshalString(e.FSTypeRaw[:], 16)
 	if err != nil {
 		return 0, err
@@ -510,7 +509,7 @@ func (e *SetXAttrEvent) UnmarshalBinary(data []byte) (int, error) {
 	if len(data) < 200 {
 		return n, ErrNotEnoughData
 	}
-	SliceToArray(data[0:200], unsafe.Pointer(&e.NameRaw))
+	SliceToArray(data[0:200], e.NameRaw[:])
 
 	return n + 200, nil
 }
@@ -898,8 +897,8 @@ func (e *NetworkContext) UnmarshalBinary(data []byte) (int, error) {
 	}
 
 	var srcIP, dstIP [16]byte
-	SliceToArray(data[read:read+16], unsafe.Pointer(&srcIP))
-	SliceToArray(data[read+16:read+32], unsafe.Pointer(&dstIP))
+	SliceToArray(data[read:read+16], srcIP[:])
+	SliceToArray(data[read+16:read+32], dstIP[:])
 	e.Source.Port = binary.BigEndian.Uint16(data[read+32 : read+34])
 	e.Destination.Port = binary.BigEndian.Uint16(data[read+34 : read+36])
 	// padding 4 bytes
@@ -1008,7 +1007,7 @@ func (e *BindEvent) UnmarshalBinary(data []byte) (int, error) {
 	}
 
 	var ipRaw [16]byte
-	SliceToArray(data[read:read+16], unsafe.Pointer(&ipRaw))
+	SliceToArray(data[read:read+16], ipRaw[:])
 	e.AddrFamily = ByteOrder.Uint16(data[read+16 : read+18])
 	e.Addr.Port = binary.BigEndian.Uint16(data[read+18 : read+20])
 

--- a/pkg/security/secl/model/utils.go
+++ b/pkg/security/secl/model/utils.go
@@ -10,7 +10,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"regexp"
-	"unsafe"
 )
 
 // containerIDPattern is the pattern of a container ID
@@ -22,10 +21,12 @@ func FindContainerID(s string) string {
 }
 
 // SliceToArray copy src bytes to dst. Destination should have enough space
-func SliceToArray(src []byte, dst unsafe.Pointer) {
-	for i := range src {
-		*(*byte)(unsafe.Pointer(uintptr(dst) + uintptr(i))) = src[i]
+func SliceToArray(src []byte, dst []byte) {
+	if len(src) != len(dst) {
+		panic("different len in SliceToArray")
 	}
+
+	copy(dst, src)
 }
 
 // UnmarshalStringArray extract array of string for array of byte


### PR DESCRIPTION
### What does this PR do?

This PR removes an unsafe copy and replace it with a `copy` call

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
