### PR TITLE
[corechecks/containerd] Respect `exclude_pause_container` option when emitting events

### DIFF
--- a/pkg/collector/corechecks/containers/containerd/check.go
+++ b/pkg/collector/corechecks/containers/containerd/check.go
@@ -88,7 +88,7 @@ func (c *ContainerdCheck) Configure(config, initConfig integration.Data, source 
 
 	c.processor = generic.NewProcessor(metrics.GetProvider(), generic.MetadataContainerAccessor{}, metricsAdapter{}, getProcessorFilter(c.containerFilter))
 	c.processor.RegisterExtension("containerd-custom-metrics", &containerdCustomMetricsExtension{})
-	c.subscriber = createEventSubscriber("ContainerdCheck", cutil.FiltersWithNamespaces(c.instance.ContainerdFilters))
+	c.subscriber = createEventSubscriber("ContainerdCheck", c.client, cutil.FiltersWithNamespaces(c.instance.ContainerdFilters))
 
 	return nil
 }
@@ -172,7 +172,7 @@ func (c *ContainerdCheck) collectEvents(sender aggregator.Sender) {
 
 	if !c.subscriber.isRunning() {
 		// Keep track of the health of the Containerd socket.
-		c.subscriber.CheckEvents(c.client)
+		c.subscriber.CheckEvents()
 	}
 	events := c.subscriber.Flush(time.Now().Unix())
 	// Process events

--- a/pkg/collector/corechecks/containers/containerd/events.go
+++ b/pkg/collector/corechecks/containers/containerd/events.go
@@ -15,12 +15,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/api/events"
 	containerdevents "github.com/containerd/containerd/events"
 	"github.com/gogo/protobuf/proto"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
@@ -29,7 +29,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// compute events converts Containerd events into Datadog events
+// computeEvents converts Containerd events into Datadog events
 func computeEvents(events []containerdEvent, sender aggregator.Sender, fil *containers.Filter) {
 	for _, e := range events {
 		split := strings.Split(e.Topic, "/")
@@ -112,30 +112,89 @@ type subscriber struct {
 	Events              []containerdEvent
 	CollectionTimestamp int64
 	running             bool
+	client              ctrUtil.ContainerdItf
 }
 
-func createEventSubscriber(name string, f []string) *subscriber {
+func createEventSubscriber(name string, client ctrUtil.ContainerdItf, f []string) *subscriber {
 	return &subscriber{
 		Name:                name,
 		CollectionTimestamp: time.Now().Unix(),
 		Filters:             f,
+		client:              client,
 	}
 }
 
-func (s *subscriber) CheckEvents(ctrItf ctrUtil.ContainerdItf) {
+type setPauseContainers struct {
+	// map indexed by namespace and container ID
+	containers map[string]map[string]struct{}
+}
+
+func newSetPauseContainers() setPauseContainers {
+	return setPauseContainers{
+		containers: make(map[string]map[string]struct{}),
+	}
+}
+
+func (set *setPauseContainers) add(namespace string, containerID string) {
+	if _, namespaceHasPauseCtns := set.containers[namespace]; !namespaceHasPauseCtns {
+		set.containers[namespace] = make(map[string]struct{})
+	}
+
+	set.containers[namespace][containerID] = struct{}{}
+}
+
+func (set *setPauseContainers) delete(namespace string, containerID string) {
+	if _, namespaceHasPauseCtns := set.containers[namespace]; namespaceHasPauseCtns {
+		delete(set.containers[namespace], containerID)
+		if len(set.containers[namespace]) == 0 {
+			delete(set.containers, namespace)
+		}
+	}
+}
+
+func (set *setPauseContainers) isPause(namespace string, containerID string) bool {
+	if _, namespaceHasPauseCtns := set.containers[namespace]; !namespaceHasPauseCtns {
+		return false
+	}
+
+	_, isPause := set.containers[namespace][containerID]
+	return isPause
+}
+
+func (s *subscriber) CheckEvents() {
 	ctx := context.Background()
-	ev := ctrItf.GetEvents()
 	log.Info("Starting routine to collect Containerd events ...")
-	go s.run(ctx, ev) //nolint:errcheck
+	go s.run(ctx) //nolint:errcheck
 }
 
 // Run should only be called once, at start time
-func (s *subscriber) run(ctx context.Context, ev containerd.EventService) error {
+func (s *subscriber) run(ctx context.Context) error {
 	s.Lock()
 	if s.running {
 		s.Unlock()
 		return fmt.Errorf("subscriber is already running the event listener routine")
 	}
+
+	excludePauseContainers := config.Datadog.GetBool("exclude_pause_container")
+
+	// Only used when excludePauseContainers is true
+	var pauseContainers setPauseContainers
+
+	if excludePauseContainers {
+		// We want to ignore events related with "pause" containers.
+		// Delete events don't contain an image ID or the container labels. This
+		// means that, by looking only at the event, we can't know if it belongs to
+		// a "pause" container. When a container is created, we check if it's a
+		// "pause" one, and in that case, we store its ID in this set so when a
+		// delete event arrives we know if it corresponds to a "pause" container.
+		var err error
+		pauseContainers, err = pauseContainersIDs(s.client)
+		if err != nil {
+			return fmt.Errorf("can't get pause containers: %v", err)
+		}
+	}
+
+	ev := s.client.GetEvents()
 	stream, errC := ev.Subscribe(ctx, s.Filters...)
 	s.running = true
 	s.Unlock()
@@ -150,18 +209,47 @@ func (s *subscriber) run(ctx context.Context, ev containerd.EventService) error 
 					log.Errorf("Could not process create event from Containerd: %v", err)
 					continue
 				}
+
+				if excludePauseContainers {
+					// If there's an error, and we don't know if the container is a
+					// sandbox, we'll assume it's not. It's better to send an event
+					// that we should have ignored rather than not sending an event
+					// that shouldn't have been ignored.
+					isSandbox := false
+					container, err := s.client.Container(message.Namespace, create.ID)
+					if err != nil {
+						log.Warnf("error getting container: %v", err)
+					} else {
+						isSandbox, err = s.client.IsSandbox(message.Namespace, container)
+						if err != nil {
+							log.Warnf("error checking if container is sandbox: %v", err)
+						}
+					}
+
+					if isSandbox {
+						pauseContainers.add(message.Namespace, create.ID)
+						continue
+					}
+				}
+
 				event := processMessage(create.ID, message)
 				event.Message = fmt.Sprintf("Container %s started, running the image %s", create.ID, create.Image)
 				s.addEvents(event)
 			case "/containers/delete":
-				delete := &events.ContainerDelete{}
-				err := proto.Unmarshal(message.Event.Value, delete)
+				ctnDelete := &events.ContainerDelete{}
+				err := proto.Unmarshal(message.Event.Value, ctnDelete)
 				if err != nil {
 					log.Errorf("Could not process delete event from Containerd: %v", err)
 					continue
 				}
-				event := processMessage(delete.ID, message)
-				event.Message = fmt.Sprintf("Container %s deleted", delete.ID)
+
+				if excludePauseContainers && pauseContainers.isPause(message.Namespace, ctnDelete.ID) {
+					pauseContainers.delete(message.Namespace, ctnDelete.ID)
+					continue
+				}
+
+				event := processMessage(ctnDelete.ID, message)
+				event.Message = fmt.Sprintf("Container %s deleted", ctnDelete.ID)
 				s.addEvents(event)
 			case "/containers/update":
 				updated := &events.ContainerUpdate{}
@@ -170,6 +258,11 @@ func (s *subscriber) run(ctx context.Context, ev containerd.EventService) error 
 					log.Errorf("Could not process update event from Containerd: %v", err)
 					continue
 				}
+
+				if excludePauseContainers && pauseContainers.isPause(message.Namespace, updated.ID) {
+					continue
+				}
+
 				event := processMessage(updated.ID, message)
 				event.Message = fmt.Sprintf("Container %s updated, running image %s. Snapshot key: %s", updated.ID, updated.Image, updated.SnapshotKey)
 				event.Extra = updated.Labels
@@ -214,6 +307,11 @@ func (s *subscriber) run(ctx context.Context, ev containerd.EventService) error 
 					log.Errorf("Could not process create event from Containerd: %v", err)
 					continue
 				}
+
+				if excludePauseContainers && pauseContainers.isPause(message.Namespace, created.ContainerID) {
+					continue
+				}
+
 				event := processMessage(created.ContainerID, message)
 				event.Message = fmt.Sprintf("Task %s created with PID %d", created.ContainerID, created.Pid)
 				s.addEvents(event)
@@ -224,6 +322,11 @@ func (s *subscriber) run(ctx context.Context, ev containerd.EventService) error 
 					log.Errorf("Could not process delete event from Containerd: %v", err)
 					continue
 				}
+
+				if excludePauseContainers && pauseContainers.isPause(message.Namespace, deleted.ContainerID) {
+					continue
+				}
+
 				event := processMessage(deleted.ContainerID, message)
 				event.Message = fmt.Sprintf("Task %s deleted with exit code %d", deleted.ContainerID, deleted.ExitStatus)
 				s.addEvents(event)
@@ -232,6 +335,10 @@ func (s *subscriber) run(ctx context.Context, ev containerd.EventService) error 
 				err := proto.Unmarshal(message.Event.Value, exited)
 				if err != nil {
 					log.Errorf("Could not process exit event from Containerd: %v", err)
+					continue
+				}
+
+				if excludePauseContainers && pauseContainers.isPause(message.Namespace, exited.ContainerID) {
 					continue
 				}
 
@@ -245,6 +352,11 @@ func (s *subscriber) run(ctx context.Context, ev containerd.EventService) error 
 					log.Errorf("Could not process create event from Containerd: %v", err)
 					continue
 				}
+
+				if excludePauseContainers && pauseContainers.isPause(message.Namespace, oomed.ContainerID) {
+					continue
+				}
+
 				event := processMessage(oomed.ContainerID, message)
 				event.Message = fmt.Sprintf("Task %s ran out of memory", oomed.ContainerID)
 				s.addEvents(event)
@@ -253,6 +365,10 @@ func (s *subscriber) run(ctx context.Context, ev containerd.EventService) error 
 				err := proto.Unmarshal(message.Event.Value, paused)
 				if err != nil {
 					log.Errorf("Could not process create event from Containerd: %v", err)
+					continue
+				}
+
+				if excludePauseContainers && pauseContainers.isPause(message.Namespace, paused.ContainerID) {
 					continue
 				}
 
@@ -266,6 +382,11 @@ func (s *subscriber) run(ctx context.Context, ev containerd.EventService) error 
 					log.Errorf("Could not process create event from Containerd: %v", err)
 					continue
 				}
+
+				if excludePauseContainers && pauseContainers.isPause(message.Namespace, resumed.ContainerID) {
+					continue
+				}
+
 				event := processMessage(resumed.ContainerID, message)
 				event.Message = fmt.Sprintf("Task %s was resumed", resumed.ContainerID)
 				s.addEvents(event)
@@ -339,4 +460,33 @@ func getEventType(topic string) string {
 	}
 
 	return t
+}
+
+// Returns a set indexed by namespace and containerID
+func pauseContainersIDs(client ctrUtil.ContainerdItf) (setPauseContainers, error) {
+	pauseContainers := newSetPauseContainers()
+
+	namespaces, err := ctrUtil.NamespacesToWatch(context.TODO(), client)
+	if err != nil {
+		return setPauseContainers{}, err
+	}
+
+	for _, namespace := range namespaces {
+		containersInNamespace, err := client.Containers(namespace)
+		if err != nil {
+			return setPauseContainers{}, err
+		}
+
+		for _, container := range containersInNamespace {
+			isSandbox, err := client.IsSandbox(namespace, container)
+
+			// If there's an error, the container could have been deleted. When
+			// there's an error assume that the container is not sandbox.
+			if err == nil && isSandbox {
+				pauseContainers.add(namespace, container.ID())
+			}
+		}
+	}
+
+	return pauseContainers, nil
 }

--- a/pkg/collector/corechecks/containers/containerd/events_test.go
+++ b/pkg/collector/corechecks/containers/containerd/events_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	containerdutil "github.com/DataDog/datadog-agent/pkg/util/containerd"
 	"github.com/DataDog/datadog-agent/pkg/util/containerd/fake"
@@ -40,8 +41,18 @@ func (m *mockEvt) Subscribe(ctx context.Context, filters ...string) (ch <-chan *
 	return m.mockSubscribe(ctx)
 }
 
+type mockedContainer struct {
+	containerd.Container
+	mockID func() string
+}
+
+func (m *mockedContainer) ID() string {
+	return m.mockID()
+}
+
 // TestCheckEvent is an integration test as the underlying logic that we test is the listener for events.
 func TestCheckEvents(t *testing.T) {
+	testNamespace := "test_namespace"
 	cha := make(chan *events.Envelope)
 	errorsCh := make(chan error)
 	me := &mockEvt{
@@ -53,10 +64,16 @@ func TestCheckEvents(t *testing.T) {
 		MockEvents: func() containerd.EventService {
 			return containerd.EventService(me)
 		},
+		MockNamespaces: func(ctx context.Context) ([]string, error) {
+			return []string{testNamespace}, nil
+		},
+		MockContainers: func(namespace string) ([]containerd.Container, error) {
+			return nil, nil
+		},
 	}
 	// Test the basic listener
-	sub := createEventSubscriber("subscriberTest1", nil)
-	sub.CheckEvents(containerdutil.ContainerdItf(itf))
+	sub := createEventSubscriber("subscriberTest1", containerdutil.ContainerdItf(itf), nil)
+	sub.CheckEvents()
 
 	tp := containerdevents.TaskPaused{
 		ContainerID: "42",
@@ -112,8 +129,8 @@ func TestCheckEvents(t *testing.T) {
 	}
 
 	// Test the multiple events one unsupported
-	sub = createEventSubscriber("subscriberTest2", nil)
-	sub.CheckEvents(containerdutil.ContainerdItf(itf))
+	sub = createEventSubscriber("subscriberTest2", containerdutil.ContainerdItf(itf), nil)
+	sub.CheckEvents()
 
 	tk := containerdevents.TaskOOM{
 		ContainerID: "42",
@@ -165,6 +182,147 @@ func TestCheckEvents(t *testing.T) {
 	fmt.Printf("\n\n 2/ Flush %v\n\n", ev2)
 	assert.Len(t, ev2, 1)
 	assert.Equal(t, ev2[0].Topic, "/tasks/oom")
+}
+
+func TestCheckEvents_PauseContainers(t *testing.T) {
+	testNamespace := "test_namespace"
+	existingPauseContainerID := "existing_pause"
+	existingNonPauseContainerID := "existing_non_pause"
+	newPauseContainerID := "new_container"
+
+	testTimeout := 1 * time.Second
+	testTicker := 5 * time.Millisecond
+
+	cha := make(chan *events.Envelope)
+	errorsCh := make(chan error)
+	me := &mockEvt{
+		mockSubscribe: func(ctx context.Context, filter ...string) (ch <-chan *events.Envelope, errs <-chan error) {
+			return cha, errorsCh
+		},
+	}
+
+	// Define a mocked containerd client. There are 2 containers deployed, one
+	// is a pause one and the other is not.
+	itf := &fake.MockedContainerdClient{
+		MockEvents: func() containerd.EventService {
+			return containerd.EventService(me)
+		},
+		MockNamespaces: func(ctx context.Context) ([]string, error) {
+			return []string{testNamespace}, nil
+		},
+		MockContainers: func(namespace string) ([]containerd.Container, error) {
+			if namespace == testNamespace {
+				return []containerd.Container{
+					&mockedContainer{
+						mockID: func() string {
+							return existingPauseContainerID
+						},
+					},
+					&mockedContainer{
+						mockID: func() string {
+							return existingNonPauseContainerID
+						},
+					},
+				}, nil
+			}
+
+			return nil, nil
+		},
+		MockContainer: func(namespace string, id string) (containerd.Container, error) {
+			if namespace == testNamespace && id == newPauseContainerID {
+				return &mockedContainer{
+					mockID: func() string {
+						return newPauseContainerID
+					},
+				}, nil
+			}
+
+			return nil, nil
+		},
+		MockIsSandbox: func(namespace string, ctn containerd.Container) (bool, error) {
+			return namespace == testNamespace && (ctn.ID() == existingPauseContainerID || ctn.ID() == newPauseContainerID), nil
+		},
+	}
+
+	sub := createEventSubscriber("subscriberTestPauseContainers", containerdutil.ContainerdItf(itf), nil)
+	sub.CheckEvents()
+	assert.Eventually(t, sub.isRunning, testTimeout, testTicker) // Wait until it's processing events
+
+	tests := []struct {
+		name                   string
+		containerID            string
+		excludePauseContainers bool
+		expectsEvents          bool
+		generateCreateEvent    bool
+	}{
+		{
+			name:                   "existing pause container",
+			containerID:            existingPauseContainerID,
+			excludePauseContainers: true,
+			expectsEvents:          false,
+			generateCreateEvent:    false, // existing container
+		},
+		{
+			name:                   "existing non-pause container",
+			containerID:            existingNonPauseContainerID,
+			excludePauseContainers: true,
+			expectsEvents:          true,
+			generateCreateEvent:    false, // existing container
+		},
+		{
+			name:                   "new pause container",
+			containerID:            newPauseContainerID,
+			excludePauseContainers: true,
+			expectsEvents:          false,
+			generateCreateEvent:    true,
+		},
+		{
+			name:                   "pause container, but pause containers are not excluded",
+			containerID:            existingPauseContainerID,
+			excludePauseContainers: false,
+			expectsEvents:          true,
+			generateCreateEvent:    false, // existing container
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			defaultExcludePauseContainers := config.Datadog.GetBool("exclude_pause_container")
+			config.Datadog.Set("exclude_pause_container", test.excludePauseContainers)
+
+			if test.generateCreateEvent {
+				eventCreateContainer, err := createContainerEvent(testNamespace, test.containerID)
+				assert.NoError(t, err)
+				cha <- &eventCreateContainer
+			}
+
+			eventDeleteTask, err := deleteTaskEvent(testNamespace, test.containerID)
+			assert.NoError(t, err)
+			cha <- &eventDeleteTask
+
+			eventContainerDelete, err := deleteContainerEvent(testNamespace, test.containerID)
+			assert.NoError(t, err)
+			cha <- &eventContainerDelete
+
+			if test.expectsEvents {
+				var flushed []containerdEvent
+				assert.Eventually(t, func() bool {
+					flushed = sub.Flush(time.Now().Unix())
+					if test.generateCreateEvent {
+						return len(flushed) == 3 // create container + delete task + delete container
+					} else {
+						return len(flushed) == 2 // delete task + delete container
+					}
+				}, testTimeout, testTicker)
+			} else {
+				assert.Empty(t, sub.Flush(time.Now().Unix()))
+			}
+
+			config.Datadog.Set("exclude_pause_container", defaultExcludePauseContainers)
+		})
+	}
+
+	errorsCh <- fmt.Errorf("stop subscriber")
 }
 
 // TestComputeEvents checks the conversion of Containerd events to Datadog events
@@ -265,4 +423,61 @@ func TestComputeEvents(t *testing.T) {
 			mocked.ResetCalls()
 		})
 	}
+}
+
+func createContainerEvent(namespace string, containerID string) (events.Envelope, error) {
+	containerCreate := containerdevents.ContainerCreate{
+		ID: containerID,
+	}
+	containerCreateMarshal, err := containerCreate.Marshal()
+	if err != nil {
+		return events.Envelope{}, err
+	}
+
+	return events.Envelope{
+		Namespace: namespace,
+		Timestamp: time.Now(),
+		Topic:     "/containers/create",
+		Event: &prototypes.Any{
+			Value: containerCreateMarshal,
+		},
+	}, nil
+}
+
+func deleteTaskEvent(namespace string, containerID string) (events.Envelope, error) {
+	taskDelete := containerdevents.TaskDelete{
+		ContainerID: containerID,
+	}
+	taskDeleteMarshal, err := taskDelete.Marshal()
+	if err != nil {
+		return events.Envelope{}, err
+	}
+
+	return events.Envelope{
+		Namespace: namespace,
+		Timestamp: time.Now(),
+		Topic:     "/tasks/delete",
+		Event: &prototypes.Any{
+			Value: taskDeleteMarshal,
+		},
+	}, nil
+}
+
+func deleteContainerEvent(namespace string, containerID string) (events.Envelope, error) {
+	containerDelete := containerdevents.ContainerDelete{
+		ID: containerID,
+	}
+	containerDeleteMarshal, err := containerDelete.Marshal()
+	if err != nil {
+		return events.Envelope{}, err
+	}
+
+	return events.Envelope{
+		Namespace: namespace,
+		Timestamp: time.Now(),
+		Topic:     "/containers/delete",
+		Event: &prototypes.Any{
+			Value: containerDeleteMarshal,
+		},
+	}, nil
 }

--- a/releasenotes/notes/containerd-ignore-pause-container-events-10866a6a2fc41c9f.yaml
+++ b/releasenotes/notes/containerd-ignore-pause-container-events-10866a6a2fc41c9f.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    The containerd check no longer emits events related with pause containers when `exclude_pause_container` is set to `true`.


### PR DESCRIPTION

### What does this PR do?

Fixes a bug in the containerd check. It was emitting events for pause containers even when the `exclude_pause_container` option is set to true, which is the default value.


### Describe how to test/QA your changes

Deploy with `exclude_pause_container` set to true (default), deploy some pods, delete them, etc. and check that you don't see any events for pause containers in the "Events Explorer" section.

Also make sure that you don't get events when you delete pods that were already running before the agent was deployed.

Set `exclude_pause_container` to false and check that pause container events are not excluded.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
