### PR TITLE
[CWS][SEC-4682] Add the possibility to change max_dump_size parameter at runtime

### DIFF
--- a/cmd/system-probe/app/config.go
+++ b/cmd/system-probe/app/config.go
@@ -54,5 +54,15 @@ func getSettingsClient(cmd *cobra.Command, _ []string) (settings.Client, error) 
 // initRuntimeSettings builds the map of runtime settings configurable at runtime.
 func initRuntimeSettings() error {
 	// Runtime-editable settings must be registered here to dynamically populate command-line information
-	return settings.RegisterRuntimeSetting(settings.LogLevelRuntimeSetting{ConfigKey: config.Namespace + ".log_level"})
+	err := settings.RegisterRuntimeSetting(settings.LogLevelRuntimeSetting{ConfigKey: config.Namespace + ".log_level"})
+	if err != nil {
+		return err
+	}
+
+	err = settings.RegisterRuntimeSetting(settings.ActivityDumpRuntimeSetting{ConfigKey: settings.MaxDumpSizeConfKey})
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/config/settings/runtime_setting_activity_dump.go
+++ b/pkg/config/settings/runtime_setting_activity_dump.go
@@ -1,0 +1,68 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package settings
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/metadata/inventories"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const (
+	// MaxDumpSizeConfKey defines the full config key for rate_limiter
+	MaxDumpSizeConfKey = "runtime_security_config.activity_dump.max_dump_size"
+)
+
+// ActivityDumpRuntimeSetting wraps operations to change activity dumps settings at runtime
+type ActivityDumpRuntimeSetting struct {
+	ConfigKey string
+}
+
+// Description returns the runtime setting's description
+func (l ActivityDumpRuntimeSetting) Description() string {
+	return "Set/get the corresponding field."
+}
+
+// Hidden returns whether or not this setting is hidden from the list of runtime settings
+func (l ActivityDumpRuntimeSetting) Hidden() bool {
+	return false
+}
+
+// Name returns the name of the runtime setting
+func (l ActivityDumpRuntimeSetting) Name() string {
+	return l.ConfigKey
+}
+
+// Get returns the current value of the runtime setting
+func (l ActivityDumpRuntimeSetting) Get() (interface{}, error) {
+	val := config.Datadog.Get(l.ConfigKey)
+	return val, nil
+}
+
+func (l ActivityDumpRuntimeSetting) setMaxDumpSize(v interface{}) {
+	intVar, _ := strconv.Atoi(v.(string))
+	config.Datadog.Set(l.ConfigKey, intVar)
+}
+
+// Set changes the value of the runtime setting
+func (l ActivityDumpRuntimeSetting) Set(v interface{}) error {
+	val := v.(string)
+	log.Infof("ActivityDumpRuntimeSetting Set %s = %s\n", l.ConfigKey, val)
+
+	switch l.ConfigKey {
+	case MaxDumpSizeConfKey:
+		l.setMaxDumpSize(v)
+	default:
+		return fmt.Errorf("Field %s does not exist", l.ConfigKey)
+	}
+
+	// we trigger a new inventory metadata payload since the configuration was updated by the user.
+	inventories.Refresh()
+	return nil
+}

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -22,6 +22,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
 
+const (
+	// Minimum value for runtime_security_config.activity_dump.max_dump_size
+	MinMaxDumSize = 10
+)
+
 // Policy represents a policy file in the configuration file
 type Policy struct {
 	Name  string   `mapstructure:"name"`
@@ -264,7 +269,11 @@ func NewConfig(cfg *config.Config) (*Config, error) {
 		ActivityDumpSyscallMonitorPeriod:      time.Duration(coreconfig.Datadog.GetInt("runtime_security_config.activity_dump.syscall_monitor.period")) * time.Second,
 		// activity dump dynamic fields
 		ActivityDumpMaxDumpSize: func() int {
-			return coreconfig.Datadog.GetInt("runtime_security_config.activity_dump.max_dump_size") * (1 << 10)
+			mds := coreconfig.Datadog.GetInt("runtime_security_config.activity_dump.max_dump_size")
+			if mds < MinMaxDumSize {
+				mds = MinMaxDumSize
+			}
+			return mds * (1 << 10)
 		},
 	}
 

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -110,8 +110,6 @@ type Config struct {
 	ActivityDumpTagsResolutionPeriod time.Duration
 	// ActivityDumpLoadControlPeriod defines the period at which the activity dump manager should trigger the load controller
 	ActivityDumpLoadControlPeriod time.Duration
-	// ActivityDumpMaxDumpSize defines the maximum size of a dump
-	ActivityDumpMaxDumpSize int
 	// ActivityDumpPathMergeEnabled defines if path merge should be enabled
 	ActivityDumpPathMergeEnabled bool
 	// ActivityDumpTracedCgroupsCount defines the maximum count of cgroups that should be monitored concurrently. Leave this parameter to 0 to prevent the generation
@@ -147,6 +145,9 @@ type Config struct {
 	// ActivityDumpSyscallMonitorPeriod defines the minimum amount of time to wait between 2 syscalls event for the same
 	// process.
 	ActivityDumpSyscallMonitorPeriod time.Duration
+	// # Dynamic configuration fields:
+	// ActivityDumpMaxDumpSize defines the maximum size of a dump
+	ActivityDumpMaxDumpSize func() int
 
 	// RuntimeMonitor defines if the Go runtime and system monitor should be enabled
 	RuntimeMonitor bool
@@ -249,7 +250,6 @@ func NewConfig(cfg *config.Config) (*Config, error) {
 		ActivityDumpCleanupPeriod:             time.Duration(coreconfig.Datadog.GetInt("runtime_security_config.activity_dump.cleanup_period")) * time.Second,
 		ActivityDumpTagsResolutionPeriod:      time.Duration(coreconfig.Datadog.GetInt("runtime_security_config.activity_dump.tags_resolution_period")) * time.Second,
 		ActivityDumpLoadControlPeriod:         time.Duration(coreconfig.Datadog.GetInt("runtime_security_config.activity_dump.load_controller_period")) * time.Minute,
-		ActivityDumpMaxDumpSize:               coreconfig.Datadog.GetInt("runtime_security_config.activity_dump.max_dump_size") * (1 << 10),
 		ActivityDumpPathMergeEnabled:          coreconfig.Datadog.GetBool("runtime_security_config.activity_dump.path_merge.enabled"),
 		ActivityDumpTracedCgroupsCount:        coreconfig.Datadog.GetInt("runtime_security_config.activity_dump.traced_cgroups_count"),
 		ActivityDumpTracedEventTypes:          model.ParseEventTypeStringSlice(coreconfig.Datadog.GetStringSlice("runtime_security_config.activity_dump.traced_event_types")),
@@ -262,6 +262,10 @@ func NewConfig(cfg *config.Config) (*Config, error) {
 		ActivityDumpLocalStorageCompression:   coreconfig.Datadog.GetBool("runtime_security_config.activity_dump.local_storage.compression"),
 		ActivityDumpRemoteStorageCompression:  coreconfig.Datadog.GetBool("runtime_security_config.activity_dump.remote_storage.compression"),
 		ActivityDumpSyscallMonitorPeriod:      time.Duration(coreconfig.Datadog.GetInt("runtime_security_config.activity_dump.syscall_monitor.period")) * time.Second,
+		// activity dump dynamic fields
+		ActivityDumpMaxDumpSize: func() int {
+			return coreconfig.Datadog.GetInt("runtime_security_config.activity_dump.max_dump_size") * (1 << 10)
+		},
 	}
 
 	if err := c.sanitize(); err != nil {

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	// Minimum value for runtime_security_config.activity_dump.max_dump_size
-	MinMaxDumSize = 10
+	MinMaxDumSize = 100
 )
 
 // Policy represents a policy file in the configuration file

--- a/pkg/security/probe/activity_dump.go
+++ b/pkg/security/probe/activity_dump.go
@@ -288,7 +288,7 @@ func (ad *ActivityDump) AddStorageRequest(request dump.StorageRequest) {
 }
 
 func (ad *ActivityDump) checkInMemorySize() {
-	if ad.computeInMemorySize() < int64(ad.adm.probe.config.ActivityDumpMaxDumpSize) {
+	if ad.computeInMemorySize() < int64(ad.adm.probe.config.ActivityDumpMaxDumpSize()) {
 		return
 	}
 

--- a/pkg/security/probe/activity_dump_manager.go
+++ b/pkg/security/probe/activity_dump_manager.go
@@ -19,7 +19,6 @@ import (
 
 	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/security/api"
-	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/dump"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
@@ -27,10 +26,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 )
-
-func areCGroupADsEnabled(c *config.Config) bool {
-	return c.ActivityDumpTracedCgroupsCount > 0
-}
 
 // ActivityDumpManager is used to manage ActivityDumps
 type ActivityDumpManager struct {
@@ -608,7 +603,7 @@ func (adm *ActivityDumpManager) getOverweightDumps() []*ActivityDump {
 			seclog.Errorf("couldn't send %s metric: %v", metrics.MetricActivityDumpActiveDumpSizeInMemory, err)
 		}
 
-		if dumpSize >= int64(adm.probe.config.ActivityDumpMaxDumpSize) {
+		if dumpSize >= int64(adm.probe.config.ActivityDumpMaxDumpSize()) {
 			toDelete = append([]int{i}, toDelete...)
 			dumps = append(dumps, ad)
 			adm.ignoreFromSnapshot[ad.DumpMetadata.ContainerID] = true

--- a/pkg/security/probe/activity_dump_manager.go
+++ b/pkg/security/probe/activity_dump_manager.go
@@ -19,6 +19,7 @@ import (
 
 	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/security/api"
+	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/dump"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
@@ -26,6 +27,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 )
+
+func areCGroupADsEnabled(c *config.Config) bool {
+	return c.ActivityDumpTracedCgroupsCount > 0
+}
 
 // ActivityDumpManager is used to manage ActivityDumps
 type ActivityDumpManager struct {

--- a/pkg/security/probe/activity_dump_manager_test.go
+++ b/pkg/security/probe/activity_dump_manager_test.go
@@ -352,7 +352,9 @@ func TestActivityDumpManager_getOverweightDumps(t *testing.T) {
 				probe: &Probe{
 					statsdClient: mock.NewStatsdClient(),
 					config: &config.Config{
-						ActivityDumpMaxDumpSize: 2048,
+						ActivityDumpMaxDumpSize: func() int {
+							return 2048
+						},
 					},
 				},
 				ignoreFromSnapshot: make(map[string]bool),

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -1513,7 +1513,7 @@ func NewProbe(config *config.Config, statsdClient statsd.ClientInterface) (*Prob
 		},
 		manager.ConstantEditor{
 			Name:  "cgroup_activity_dumps_enabled",
-			Value: utils.BoolTouint64(config.ActivityDumpEnabled && areCGroupADsEnabled(config)),
+			Value: utils.BoolTouint64(config.ActivityDumpEnabled),
 		},
 		manager.ConstantEditor{
 			Name:  "net_struct_type",

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -1513,7 +1513,7 @@ func NewProbe(config *config.Config, statsdClient statsd.ClientInterface) (*Prob
 		},
 		manager.ConstantEditor{
 			Name:  "cgroup_activity_dumps_enabled",
-			Value: utils.BoolTouint64(config.ActivityDumpEnabled),
+			Value: utils.BoolTouint64(config.ActivityDumpEnabled && areCGroupADsEnabled(config)),
 		},
 		manager.ConstantEditor{
 			Name:  "net_struct_type",


### PR DESCRIPTION
### What does this PR do?

Add the possibility to set at runtime `runtime_security_config.activity_dump.max_dump_size` activity dumps configuration field


### Motivation

Being able to tweak at runtime some AD configs



### Additional Notes



### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes

First, you can list the new available runtime fields:

```
$ sudo ./bin/system-probe/system-probe config list-runtime
=== Settings that can be changed at runtime ===
log_level                      Set/get the log level, valid values are: trace, debug, info, warn, error, critical and off
runtime_security_config.activity_dump.max_dump_size Set/get the corresponding field.
```

Then, try to update it:
```
$ sudo ./bin/system-probe/system-probe config set runtime_security_config.activity_dump.max_dump_size 100
Configuration setting runtime_security_config.activity_dump.max_dump_size is now set to: 100
```


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
