### PR TITLE
[netflow] Add disable port rollup config

### DIFF
--- a/pkg/netflow/config/config.go
+++ b/pkg/netflow/config/config.go
@@ -19,7 +19,7 @@ type NetflowConfig struct {
 	AggregatorFlushInterval       int              `mapstructure:"aggregator_flush_interval"`
 	AggregatorFlowContextTTL      int              `mapstructure:"aggregator_flow_context_ttl"`
 	AggregatorPortRollupThreshold int              `mapstructure:"aggregator_port_rollup_threshold"`
-	AggregatorPortRollupDisable   bool             `mapstructure:"aggregator_port_rollup_disable"`
+	AggregatorPortRollupDisabled  bool             `mapstructure:"aggregator_port_rollup_disabled"`
 
 	// AggregatorRollupTrackerRefreshInterval is useful to speed up testing to avoid wait for 1h default
 	AggregatorRollupTrackerRefreshInterval uint `mapstructure:"aggregator_rollup_tracker_refresh_interval"`

--- a/pkg/netflow/config/config.go
+++ b/pkg/netflow/config/config.go
@@ -19,6 +19,7 @@ type NetflowConfig struct {
 	AggregatorFlushInterval       int              `mapstructure:"aggregator_flush_interval"`
 	AggregatorFlowContextTTL      int              `mapstructure:"aggregator_flow_context_ttl"`
 	AggregatorPortRollupThreshold int              `mapstructure:"aggregator_port_rollup_threshold"`
+	AggregatorPortRollupDisable   bool             `mapstructure:"aggregator_port_rollup_disable"`
 
 	// AggregatorRollupTrackerRefreshInterval is useful to speed up testing to avoid wait for 1h default
 	AggregatorRollupTrackerRefreshInterval uint `mapstructure:"aggregator_rollup_tracker_refresh_interval"`

--- a/pkg/netflow/config/config_test.go
+++ b/pkg/netflow/config/config_test.go
@@ -36,7 +36,7 @@ network_devices:
     aggregator_port_rollup_threshold: 20
     aggregator_rollup_tracker_refresh_interval: 60
     log_payloads: true
-    aggregator_port_rollup_disable: true
+    aggregator_port_rollup_disabled: true
     listeners:
       - flow_type: netflow9
         bind_host: 127.0.0.1
@@ -56,7 +56,7 @@ network_devices:
 				AggregatorFlowContextTTL:               40,
 				AggregatorPortRollupThreshold:          20,
 				AggregatorRollupTrackerRefreshInterval: 60,
-				AggregatorPortRollupDisable:            true,
+				AggregatorPortRollupDisabled:           true,
 				Listeners: []ListenerConfig{
 					{
 						FlowType:  common.TypeNetFlow9,

--- a/pkg/netflow/config/config_test.go
+++ b/pkg/netflow/config/config_test.go
@@ -36,6 +36,7 @@ network_devices:
     aggregator_port_rollup_threshold: 20
     aggregator_rollup_tracker_refresh_interval: 60
     log_payloads: true
+    aggregator_port_rollup_disable: true
     listeners:
       - flow_type: netflow9
         bind_host: 127.0.0.1
@@ -55,6 +56,7 @@ network_devices:
 				AggregatorFlowContextTTL:               40,
 				AggregatorPortRollupThreshold:          20,
 				AggregatorRollupTrackerRefreshInterval: 60,
+				AggregatorPortRollupDisable:            true,
 				Listeners: []ListenerConfig{
 					{
 						FlowType:  common.TypeNetFlow9,

--- a/pkg/netflow/flowaggregator/aggregator.go
+++ b/pkg/netflow/flowaggregator/aggregator.go
@@ -32,6 +32,7 @@ type FlowAggregator struct {
 	receivedFlowCount            *atomic.Uint64
 	flushedFlowCount             *atomic.Uint64
 	hostname                     string
+	portRollupDisable            bool
 }
 
 // NewFlowAggregator returns a new FlowAggregator
@@ -41,7 +42,7 @@ func NewFlowAggregator(sender aggregator.Sender, config *config.NetflowConfig, h
 	rollupTrackerRefreshInterval := time.Duration(config.AggregatorRollupTrackerRefreshInterval) * time.Second
 	return &FlowAggregator{
 		flowIn:                       make(chan *common.Flow, config.AggregatorBufferSize),
-		flowAcc:                      newFlowAccumulator(flushInterval, flowContextTTL, config.AggregatorPortRollupThreshold),
+		flowAcc:                      newFlowAccumulator(flushInterval, flowContextTTL, config.AggregatorPortRollupThreshold, config.AggregatorPortRollupDisable),
 		flushInterval:                flowAggregatorFlushInterval,
 		rollupTrackerRefreshInterval: rollupTrackerRefreshInterval,
 		sender:                       sender,

--- a/pkg/netflow/flowaggregator/aggregator.go
+++ b/pkg/netflow/flowaggregator/aggregator.go
@@ -32,7 +32,6 @@ type FlowAggregator struct {
 	receivedFlowCount            *atomic.Uint64
 	flushedFlowCount             *atomic.Uint64
 	hostname                     string
-	portRollupDisable            bool
 }
 
 // NewFlowAggregator returns a new FlowAggregator

--- a/pkg/netflow/flowaggregator/aggregator.go
+++ b/pkg/netflow/flowaggregator/aggregator.go
@@ -41,7 +41,7 @@ func NewFlowAggregator(sender aggregator.Sender, config *config.NetflowConfig, h
 	rollupTrackerRefreshInterval := time.Duration(config.AggregatorRollupTrackerRefreshInterval) * time.Second
 	return &FlowAggregator{
 		flowIn:                       make(chan *common.Flow, config.AggregatorBufferSize),
-		flowAcc:                      newFlowAccumulator(flushInterval, flowContextTTL, config.AggregatorPortRollupThreshold, config.AggregatorPortRollupDisable),
+		flowAcc:                      newFlowAccumulator(flushInterval, flowContextTTL, config.AggregatorPortRollupThreshold, config.AggregatorPortRollupDisabled),
 		flushInterval:                flowAggregatorFlushInterval,
 		rollupTrackerRefreshInterval: rollupTrackerRefreshInterval,
 		sender:                       sender,

--- a/pkg/netflow/flowaggregator/flowaccumulator.go
+++ b/pkg/netflow/flowaggregator/flowaccumulator.go
@@ -36,7 +36,7 @@ type flowAccumulator struct {
 
 	portRollup          *portrollup.EndpointPairPortRollupStore
 	portRollupThreshold int
-	portRollupDisable   bool
+	portRollupDisabled  bool
 }
 
 func newFlowContext(flow *common.Flow) flowContext {
@@ -47,14 +47,14 @@ func newFlowContext(flow *common.Flow) flowContext {
 	}
 }
 
-func newFlowAccumulator(aggregatorFlushInterval time.Duration, aggregatorFlowContextTTL time.Duration, portRollupThreshold int, portRollupDisable bool) *flowAccumulator {
+func newFlowAccumulator(aggregatorFlushInterval time.Duration, aggregatorFlowContextTTL time.Duration, portRollupThreshold int, portRollupDisabled bool) *flowAccumulator {
 	return &flowAccumulator{
 		flows:               make(map[uint64]flowContext),
 		flowFlushInterval:   aggregatorFlushInterval,
 		flowContextTTL:      aggregatorFlowContextTTL,
 		portRollup:          portrollup.NewEndpointPairPortRollupStore(portRollupThreshold),
 		portRollupThreshold: portRollupThreshold,
-		portRollupDisable:   portRollupDisable,
+		portRollupDisabled:  portRollupDisabled,
 	}
 }
 
@@ -98,7 +98,7 @@ func (f *flowAccumulator) flush() []*common.Flow {
 func (f *flowAccumulator) add(flowToAdd *common.Flow) {
 	log.Tracef("Add new flow: %+v", flowToAdd)
 
-	if !f.portRollupDisable {
+	if !f.portRollupDisabled {
 		// Handle port rollup
 		f.portRollup.Add(flowToAdd.SrcAddr, flowToAdd.DstAddr, uint16(flowToAdd.SrcPort), uint16(flowToAdd.DstPort))
 		ephemeralStatus := f.portRollup.IsEphemeral(flowToAdd.SrcAddr, flowToAdd.DstAddr, uint16(flowToAdd.SrcPort), uint16(flowToAdd.DstPort))

--- a/pkg/netflow/flowaggregator/flowaccumulator.go
+++ b/pkg/netflow/flowaggregator/flowaccumulator.go
@@ -36,6 +36,7 @@ type flowAccumulator struct {
 
 	portRollup          *portrollup.EndpointPairPortRollupStore
 	portRollupThreshold int
+	portRollupDisable   bool
 }
 
 func newFlowContext(flow *common.Flow) flowContext {
@@ -46,13 +47,14 @@ func newFlowContext(flow *common.Flow) flowContext {
 	}
 }
 
-func newFlowAccumulator(aggregatorFlushInterval time.Duration, aggregatorFlowContextTTL time.Duration, portRollupThreshold int) *flowAccumulator {
+func newFlowAccumulator(aggregatorFlushInterval time.Duration, aggregatorFlowContextTTL time.Duration, portRollupThreshold int, portRollupDisable bool) *flowAccumulator {
 	return &flowAccumulator{
 		flows:               make(map[uint64]flowContext),
 		flowFlushInterval:   aggregatorFlushInterval,
 		flowContextTTL:      aggregatorFlowContextTTL,
 		portRollup:          portrollup.NewEndpointPairPortRollupStore(portRollupThreshold),
 		portRollupThreshold: portRollupThreshold,
+		portRollupDisable:   portRollupDisable,
 	}
 }
 
@@ -96,14 +98,16 @@ func (f *flowAccumulator) flush() []*common.Flow {
 func (f *flowAccumulator) add(flowToAdd *common.Flow) {
 	log.Tracef("Add new flow: %+v", flowToAdd)
 
-	// Handle port rollup
-	f.portRollup.Add(flowToAdd.SrcAddr, flowToAdd.DstAddr, uint16(flowToAdd.SrcPort), uint16(flowToAdd.DstPort))
-	ephemeralStatus := f.portRollup.IsEphemeral(flowToAdd.SrcAddr, flowToAdd.DstAddr, uint16(flowToAdd.SrcPort), uint16(flowToAdd.DstPort))
-	switch ephemeralStatus {
-	case portrollup.IsEphemeralSourcePort:
-		flowToAdd.SrcPort = portrollup.EphemeralPort
-	case portrollup.IsEphemeralDestPort:
-		flowToAdd.DstPort = portrollup.EphemeralPort
+	if !f.portRollupDisable {
+		// Handle port rollup
+		f.portRollup.Add(flowToAdd.SrcAddr, flowToAdd.DstAddr, uint16(flowToAdd.SrcPort), uint16(flowToAdd.DstPort))
+		ephemeralStatus := f.portRollup.IsEphemeral(flowToAdd.SrcAddr, flowToAdd.DstAddr, uint16(flowToAdd.SrcPort), uint16(flowToAdd.DstPort))
+		switch ephemeralStatus {
+		case portrollup.IsEphemeralSourcePort:
+			flowToAdd.SrcPort = portrollup.EphemeralPort
+		case portrollup.IsEphemeralDestPort:
+			flowToAdd.DstPort = portrollup.EphemeralPort
+		}
 	}
 
 	f.flowsMutex.Lock()

--- a/releasenotes/notes/netflow_disable_port_rollup_config-2092620e727edabe.yaml
+++ b/releasenotes/notes/netflow_disable_port_rollup_config-2092620e727edabe.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    [netflow] Add disable port rollup config.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

[netflow] Add disable port rollup config

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Can be useful in case user want to disable port rollup.
Option to disable port rollup is a better option than setting high port rollup threshold.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
