### PR TITLE
[netflow] Increase aggregator buffer size

### DIFF
--- a/pkg/netflow/common/constants.go
+++ b/pkg/netflow/common/constants.go
@@ -13,7 +13,7 @@ const (
 	DefaultAggregatorFlushInterval = 300 // 5min
 
 	// DefaultAggregatorBufferSize is the default aggregator buffer size interval
-	DefaultAggregatorBufferSize = 100
+	DefaultAggregatorBufferSize = 10000
 
 	// DefaultAggregatorPortRollupThreshold is the default aggregator port rollup threshold
 	DefaultAggregatorPortRollupThreshold = 10

--- a/pkg/netflow/config/config_test.go
+++ b/pkg/netflow/config/config_test.go
@@ -84,7 +84,7 @@ network_devices:
 `,
 			expectedConfig: NetflowConfig{
 				StopTimeout:                            5,
-				AggregatorBufferSize:                   100,
+				AggregatorBufferSize:                   10000,
 				AggregatorFlushInterval:                300,
 				AggregatorFlowContextTTL:               300,
 				AggregatorPortRollupThreshold:          10,
@@ -112,7 +112,7 @@ network_devices:
 `,
 			expectedConfig: NetflowConfig{
 				StopTimeout:                            5,
-				AggregatorBufferSize:                   100,
+				AggregatorBufferSize:                   10000,
 				AggregatorFlushInterval:                50,
 				AggregatorFlowContextTTL:               50,
 				AggregatorPortRollupThreshold:          10,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

[netflow] Increase aggregator buffer size

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Increasing aggregator buffer size will help continue receiving payloads even if the `flowAccumulator.add` is not able to add them fast enough (`flowAccumulator.add` and `portRollup.Add` use mutex).

When testing with 50k flows per sec, we casually have aggregator input chan spiking at 1k-5k.

![image](https://user-images.githubusercontent.com/49917914/194278848-1bd80e9a-dbac-4c76-bf53-a195f03d7708.png)


<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

Increasing to 10k can increase memory usage, but additional 10k flows in memory is quite low compared to aggregation flows context that can reach multiple millions.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
