### PR TITLE
[workloadmeta/store] Don't send initial `set` events if filter type is `EvenTypeUnset`

### DIFF
--- a/pkg/workloadmeta/store_test.go
+++ b/pkg/workloadmeta/store_test.go
@@ -148,6 +148,22 @@ func TestSubscribe(t *testing.T) {
 			},
 		},
 		{
+			// if the filter has type "EventTypeUnset", it does not receive
+			// events for entities that are currently in the store.
+			name:   "do not receive events for entities in the store pre-subscription if filter type is EventTypeUnset",
+			filter: NewFilter(nil, fooSource, EventTypeUnset),
+			preEvents: []CollectorEvent{
+				{
+					Type:   EventTypeSet,
+					Source: fooSource,
+					Entity: fooContainer,
+				},
+			},
+			expected: []EventBundle{
+				{},
+			},
+		},
+		{
 			// will receive events for entities that are currently
 			// in the store, and match a filter by source. entities
 			// that don't match the filter at all should not

--- a/releasenotes/notes/fix-workloadmeta-initial-events-unset-filter-77408d14e2fe5d90.yaml
+++ b/releasenotes/notes/fix-workloadmeta-initial-events-unset-filter-77408d14e2fe5d90.yaml
@@ -8,7 +8,7 @@
 ---
 fixes:
   - |
-    Fixed a bug in the workloadmeta store. Subscribers that specified to receive
-    only `unset` events mistakenly got `set` events on first subscription for
+    Fixed a bug in the workloadmeta store. Subscribers that asked to receive
+    only `unset` events mistakenly got `set` events on the first subscription for
     all the entities present in the store. This only affects the
     `container_lifecycle` check.

--- a/releasenotes/notes/fix-workloadmeta-initial-events-unset-filter-77408d14e2fe5d90.yaml
+++ b/releasenotes/notes/fix-workloadmeta-initial-events-unset-filter-77408d14e2fe5d90.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed a bug in the workloadmeta store. Subscribers that specified to receive
+    only `unset` events mistakenly got `set` events on first subscription for
+    all the entities present in the store. This only affects the
+    `container_lifecycle` check.


### PR DESCRIPTION

### What does this PR do?

Fixed a bug in the workloadmeta store. Subscribers that specified to receive only `unset` events mistakenly got `set` events on first subscription for all the entities present in the store. This only affects the `container_lifecycle` check.

### Describe how to test/QA your changes

Deploy the agent with the `container_lifecycle` check enable. When it starts, verify that it doesn't get "set" events for all the pods and containers running on the node.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
