### PR TITLE
[CWS] copy []string when encoding/decoding protobufs

### DIFF
--- a/pkg/security/probe/activity_dump_proto_dec_v1.go
+++ b/pkg/security/probe/activity_dump_proto_dec_v1.go
@@ -26,7 +26,8 @@ func protoToActivityDump(dest *ActivityDump, ad *adproto.ActivityDump) {
 	dest.Source = ad.Source
 	dest.DumpMetadata = protoMetadataToDumpMetadata(ad.Metadata)
 
-	dest.Tags = ad.Tags
+	dest.Tags = make([]string, len(ad.Tags))
+	copy(dest.Tags, ad.Tags)
 	dest.ProcessActivityTree = make([]*ProcessActivityNode, 0, len(ad.Tree))
 	dest.StorageRequests = make(map[dump.StorageFormat][]dump.StorageRequest)
 
@@ -107,7 +108,7 @@ func protoDecodeProcessNode(p *adproto.ProcessInfo) model.Process {
 		return model.Process{}
 	}
 
-	return model.Process{
+	mp := model.Process{
 		PIDContext: model.PIDContext{
 			Pid: p.Pid,
 			Tid: p.Tid,
@@ -128,13 +129,17 @@ func protoDecodeProcessNode(p *adproto.ProcessInfo) model.Process {
 
 		Credentials: protoDecodeCredentials(p.Credentials),
 
-		ScrubbedArgv:  p.Args,
+		ScrubbedArgv:  make([]string, len(p.Args)),
 		Argv0:         p.Argv0,
 		ArgsTruncated: p.ArgsTruncated,
 
-		Envs:          p.Envs,
+		Envs:          make([]string, len(p.Envs)),
 		EnvsTruncated: p.EnvsTruncated,
 	}
+
+	copy(mp.ScrubbedArgv, p.Args)
+	copy(mp.Envs, p.Envs)
+	return mp
 }
 
 func protoDecodeCredentials(creds *adproto.Credentials) model.Credentials {

--- a/pkg/security/probe/activity_dump_proto_enc_v1.go
+++ b/pkg/security/probe/activity_dump_proto_enc_v1.go
@@ -28,9 +28,11 @@ func activityDumpToProto(ad *ActivityDump) *adproto.ActivityDump {
 
 		Metadata: adMetadataToProto(&ad.DumpMetadata),
 
-		Tags: ad.Tags,
+		Tags: make([]string, len(ad.Tags)),
 		Tree: make([]*adproto.ProcessActivityNode, 0, len(ad.ProcessActivityTree)),
 	}
+
+	copy(pad.Tags, ad.Tags)
 
 	for _, tree := range ad.ProcessActivityTree {
 		pad.Tree = append(pad.Tree, processActivityNodeToProto(tree))
@@ -129,15 +131,16 @@ func processNodeToProto(p *model.Process) *adproto.ProcessInfo {
 
 		Credentials: credentialsToProto(&p.Credentials),
 
+		Args:          make([]string, len(p.ScrubbedArgv)),
 		Argv0:         p.Argv0,
 		ArgsTruncated: p.ArgsTruncated,
 
-		Envs:          p.Envs,
+		Envs:          make([]string, len(p.Envs)),
 		EnvsTruncated: p.EnvsTruncated,
 	}
 
-	ppi.Args = make([]string, len(p.ScrubbedArgv))
 	copy(ppi.Args, p.ScrubbedArgv)
+	copy(ppi.Envs, p.Envs)
 
 	return ppi
 }

--- a/pkg/security/probe/activity_dump_proto_enc_v1.go
+++ b/pkg/security/probe/activity_dump_proto_enc_v1.go
@@ -129,13 +129,15 @@ func processNodeToProto(p *model.Process) *adproto.ProcessInfo {
 
 		Credentials: credentialsToProto(&p.Credentials),
 
-		Args:          p.ScrubbedArgv,
 		Argv0:         p.Argv0,
 		ArgsTruncated: p.ArgsTruncated,
 
 		Envs:          p.Envs,
 		EnvsTruncated: p.EnvsTruncated,
 	}
+
+	ppi.Args = make([]string, len(p.ScrubbedArgv))
+	copy(ppi.Args, p.ScrubbedArgv)
 
 	return ppi
 }


### PR DESCRIPTION
### What does this PR do?

This PR fixes a race with the reusing of Args between VT pools and ArgsEntry pools

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
