### PR TITLE
[CWS][SEC-5608] add a schema for the ruleset_loaded event

### DIFF
--- a/pkg/security/module/module.go
+++ b/pkg/security/module/module.go
@@ -437,10 +437,9 @@ func (m *Module) LoadPolicies(policyProviders []rules.PolicyProvider, sendLoaded
 	if sendLoadedReport {
 		// report that a new policy was loaded
 		monitor := m.probe.GetMonitor()
-		ruleSetLoadedReport := monitor.PrepareRuleSetLoadedReport(ruleSet, loadApproversErrs)
-		monitor.ReportRuleSetLoaded(ruleSetLoadedReport)
+		monitor.ReportRuleSetLoaded(ruleSet, loadApproversErrs)
 
-		m.policyMonitor.AddPolicies(ruleSet.GetPolicies(), loadErrs)
+		m.policyMonitor.AddPolicies(ruleSet.GetPolicies(), loadApproversErrs)
 	}
 
 	return nil

--- a/pkg/security/module/module.go
+++ b/pkg/security/module/module.go
@@ -447,6 +447,7 @@ func (m *Module) LoadPolicies(policyProviders []rules.PolicyProvider, sendLoaded
 
 // Close the module
 func (m *Module) Close() {
+	signal.Stop(m.sigupChan)
 	close(m.sigupChan)
 
 	for _, provider := range m.policyProviders {

--- a/pkg/security/probe/custom_events_easyjson.go
+++ b/pkg/security/probe/custom_events_easyjson.go
@@ -179,65 +179,30 @@ func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe1(in *jle
 		case "policies":
 			if in.IsNull() {
 				in.Skip()
-				out.PoliciesLoaded = nil
+				out.Policies = nil
 			} else {
 				in.Delim('[')
-				if out.PoliciesLoaded == nil {
+				if out.Policies == nil {
 					if !in.IsDelim(']') {
-						out.PoliciesLoaded = make([]*PolicyLoaded, 0, 8)
+						out.Policies = make([]*PolicyState, 0, 8)
 					} else {
-						out.PoliciesLoaded = []*PolicyLoaded{}
+						out.Policies = []*PolicyState{}
 					}
 				} else {
-					out.PoliciesLoaded = (out.PoliciesLoaded)[:0]
+					out.Policies = (out.Policies)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v7 *PolicyLoaded
+					var v7 *PolicyState
 					if in.IsNull() {
 						in.Skip()
 						v7 = nil
 					} else {
 						if v7 == nil {
-							v7 = new(PolicyLoaded)
+							v7 = new(PolicyState)
 						}
 						(*v7).UnmarshalEasyJSON(in)
 					}
-					out.PoliciesLoaded = append(out.PoliciesLoaded, v7)
-					in.WantComma()
-				}
-				in.Delim(']')
-			}
-		case "policies_ignored":
-			if in.IsNull() {
-				in.Skip()
-				out.PoliciesIgnored = nil
-			} else {
-				if out.PoliciesIgnored == nil {
-					out.PoliciesIgnored = new(PoliciesIgnored)
-				}
-				if data := in.Raw(); in.Ok() {
-					in.AddError((*out.PoliciesIgnored).UnmarshalJSON(data))
-				}
-			}
-		case "macros_loaded":
-			if in.IsNull() {
-				in.Skip()
-				out.MacrosLoaded = nil
-			} else {
-				in.Delim('[')
-				if out.MacrosLoaded == nil {
-					if !in.IsDelim(']') {
-						out.MacrosLoaded = make([]string, 0, 4)
-					} else {
-						out.MacrosLoaded = []string{}
-					}
-				} else {
-					out.MacrosLoaded = (out.MacrosLoaded)[:0]
-				}
-				for !in.IsDelim(']') {
-					var v8 string
-					v8 = string(in.String())
-					out.MacrosLoaded = append(out.MacrosLoaded, v8)
+					out.Policies = append(out.Policies, v7)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -264,40 +229,19 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe1(out *jw
 	{
 		const prefix string = ",\"policies\":"
 		out.RawString(prefix)
-		if in.PoliciesLoaded == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+		if in.Policies == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v9, v10 := range in.PoliciesLoaded {
-				if v9 > 0 {
+			for v8, v9 := range in.Policies {
+				if v8 > 0 {
 					out.RawByte(',')
 				}
-				if v10 == nil {
+				if v9 == nil {
 					out.RawString("null")
 				} else {
-					(*v10).MarshalEasyJSON(out)
+					(*v9).MarshalEasyJSON(out)
 				}
-			}
-			out.RawByte(']')
-		}
-	}
-	if in.PoliciesIgnored != nil {
-		const prefix string = ",\"policies_ignored\":"
-		out.RawString(prefix)
-		out.Raw((*in.PoliciesIgnored).MarshalJSON())
-	}
-	{
-		const prefix string = ",\"macros_loaded\":"
-		out.RawString(prefix)
-		if in.MacrosLoaded == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
-			out.RawString("null")
-		} else {
-			out.RawByte('[')
-			for v11, v12 := range in.MacrosLoaded {
-				if v11 > 0 {
-					out.RawByte(',')
-				}
-				out.String(string(v12))
 			}
 			out.RawByte(']')
 		}
@@ -314,7 +258,7 @@ func (v RulesetLoadedEvent) MarshalEasyJSON(w *jwriter.Writer) {
 func (v *RulesetLoadedEvent) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe1(l, v)
 }
-func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe2(in *jlexer.Lexer, out *RuleLoaded) {
+func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe2(in *jlexer.Lexer, out *RuleState) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -339,6 +283,10 @@ func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe2(in *jle
 			out.Version = string(in.String())
 		case "expression":
 			out.Expression = string(in.String())
+		case "status":
+			out.Status = string(in.String())
+		case "message":
+			out.Message = string(in.String())
 		default:
 			in.SkipRecursive()
 		}
@@ -349,7 +297,7 @@ func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe2(in *jle
 		in.Consumed()
 	}
 }
-func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe2(out *jwriter.Writer, in RuleLoaded) {
+func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe2(out *jwriter.Writer, in RuleState) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -368,19 +316,29 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe2(out *jw
 		out.RawString(prefix)
 		out.String(string(in.Expression))
 	}
+	{
+		const prefix string = ",\"status\":"
+		out.RawString(prefix)
+		out.String(string(in.Status))
+	}
+	if in.Message != "" {
+		const prefix string = ",\"message\":"
+		out.RawString(prefix)
+		out.String(string(in.Message))
+	}
 	out.RawByte('}')
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v RuleLoaded) MarshalEasyJSON(w *jwriter.Writer) {
+func (v RuleState) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe2(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *RuleLoaded) UnmarshalEasyJSON(l *jlexer.Lexer) {
+func (v *RuleState) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe2(l, v)
 }
-func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe3(in *jlexer.Lexer, out *RuleIgnored) {
+func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe3(in *jlexer.Lexer, out *PolicyState) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -399,14 +357,43 @@ func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe3(in *jle
 			continue
 		}
 		switch key {
-		case "id":
-			out.ID = string(in.String())
+		case "name":
+			out.Name = string(in.String())
 		case "version":
 			out.Version = string(in.String())
-		case "expression":
-			out.Expression = string(in.String())
-		case "reason":
-			out.Reason = string(in.String())
+		case "source":
+			out.Source = string(in.String())
+		case "rules":
+			if in.IsNull() {
+				in.Skip()
+				out.Rules = nil
+			} else {
+				in.Delim('[')
+				if out.Rules == nil {
+					if !in.IsDelim(']') {
+						out.Rules = make([]*RuleState, 0, 8)
+					} else {
+						out.Rules = []*RuleState{}
+					}
+				} else {
+					out.Rules = (out.Rules)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v10 *RuleState
+					if in.IsNull() {
+						in.Skip()
+						v10 = nil
+					} else {
+						if v10 == nil {
+							v10 = new(RuleState)
+						}
+						(*v10).UnmarshalEasyJSON(in)
+					}
+					out.Rules = append(out.Rules, v10)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
 		default:
 			in.SkipRecursive()
 		}
@@ -417,184 +404,40 @@ func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe3(in *jle
 		in.Consumed()
 	}
 }
-func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe3(out *jwriter.Writer, in RuleIgnored) {
+func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe3(out *jwriter.Writer, in PolicyState) {
 	out.RawByte('{')
 	first := true
 	_ = first
 	{
-		const prefix string = ",\"id\":"
+		const prefix string = ",\"name\":"
 		out.RawString(prefix[1:])
-		out.String(string(in.ID))
+		out.String(string(in.Name))
 	}
-	if in.Version != "" {
+	{
 		const prefix string = ",\"version\":"
 		out.RawString(prefix)
 		out.String(string(in.Version))
 	}
 	{
-		const prefix string = ",\"expression\":"
-		out.RawString(prefix)
-		out.String(string(in.Expression))
-	}
-	{
-		const prefix string = ",\"reason\":"
-		out.RawString(prefix)
-		out.String(string(in.Reason))
-	}
-	out.RawByte('}')
-}
-
-// MarshalEasyJSON supports easyjson.Marshaler interface
-func (v RuleIgnored) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe3(w, v)
-}
-
-// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *RuleIgnored) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe3(l, v)
-}
-func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe4(in *jlexer.Lexer, out *PolicyLoaded) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "Version":
-			out.Version = string(in.String())
-		case "Source":
-			out.Source = string(in.String())
-		case "rules_loaded":
-			if in.IsNull() {
-				in.Skip()
-				out.RulesLoaded = nil
-			} else {
-				in.Delim('[')
-				if out.RulesLoaded == nil {
-					if !in.IsDelim(']') {
-						out.RulesLoaded = make([]*RuleLoaded, 0, 8)
-					} else {
-						out.RulesLoaded = []*RuleLoaded{}
-					}
-				} else {
-					out.RulesLoaded = (out.RulesLoaded)[:0]
-				}
-				for !in.IsDelim(']') {
-					var v13 *RuleLoaded
-					if in.IsNull() {
-						in.Skip()
-						v13 = nil
-					} else {
-						if v13 == nil {
-							v13 = new(RuleLoaded)
-						}
-						(*v13).UnmarshalEasyJSON(in)
-					}
-					out.RulesLoaded = append(out.RulesLoaded, v13)
-					in.WantComma()
-				}
-				in.Delim(']')
-			}
-		case "rules_ignored":
-			if in.IsNull() {
-				in.Skip()
-				out.RulesIgnored = nil
-			} else {
-				in.Delim('[')
-				if out.RulesIgnored == nil {
-					if !in.IsDelim(']') {
-						out.RulesIgnored = make([]*RuleIgnored, 0, 8)
-					} else {
-						out.RulesIgnored = []*RuleIgnored{}
-					}
-				} else {
-					out.RulesIgnored = (out.RulesIgnored)[:0]
-				}
-				for !in.IsDelim(']') {
-					var v14 *RuleIgnored
-					if in.IsNull() {
-						in.Skip()
-						v14 = nil
-					} else {
-						if v14 == nil {
-							v14 = new(RuleIgnored)
-						}
-						(*v14).UnmarshalEasyJSON(in)
-					}
-					out.RulesIgnored = append(out.RulesIgnored, v14)
-					in.WantComma()
-				}
-				in.Delim(']')
-			}
-		default:
-			in.SkipRecursive()
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe4(out *jwriter.Writer, in PolicyLoaded) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	{
-		const prefix string = ",\"Version\":"
-		out.RawString(prefix[1:])
-		out.String(string(in.Version))
-	}
-	{
-		const prefix string = ",\"Source\":"
+		const prefix string = ",\"source\":"
 		out.RawString(prefix)
 		out.String(string(in.Source))
 	}
 	{
-		const prefix string = ",\"rules_loaded\":"
+		const prefix string = ",\"rules\":"
 		out.RawString(prefix)
-		if in.RulesLoaded == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+		if in.Rules == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v15, v16 := range in.RulesLoaded {
-				if v15 > 0 {
+			for v11, v12 := range in.Rules {
+				if v11 > 0 {
 					out.RawByte(',')
 				}
-				if v16 == nil {
+				if v12 == nil {
 					out.RawString("null")
 				} else {
-					(*v16).MarshalEasyJSON(out)
-				}
-			}
-			out.RawByte(']')
-		}
-	}
-	if len(in.RulesIgnored) != 0 {
-		const prefix string = ",\"rules_ignored\":"
-		out.RawString(prefix)
-		{
-			out.RawByte('[')
-			for v17, v18 := range in.RulesIgnored {
-				if v17 > 0 {
-					out.RawByte(',')
-				}
-				if v18 == nil {
-					out.RawString("null")
-				} else {
-					(*v18).MarshalEasyJSON(out)
+					(*v12).MarshalEasyJSON(out)
 				}
 			}
 			out.RawByte(']')
@@ -604,15 +447,15 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe4(out *jw
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v PolicyLoaded) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe4(w, v)
+func (v PolicyState) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe3(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *PolicyLoaded) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe4(l, v)
+func (v *PolicyState) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe3(l, v)
 }
-func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe5(in *jlexer.Lexer, out *NoisyProcessEvent) {
+func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe4(in *jlexer.Lexer, out *NoisyProcessEvent) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -659,7 +502,7 @@ func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe5(in *jle
 		in.Consumed()
 	}
 }
-func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe5(out *jwriter.Writer, in NoisyProcessEvent) {
+func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe4(out *jwriter.Writer, in NoisyProcessEvent) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -703,14 +546,14 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe5(out *jw
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v NoisyProcessEvent) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe5(w, v)
+	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe4(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *NoisyProcessEvent) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe5(l, v)
+	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe4(l, v)
 }
-func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe6(in *jlexer.Lexer, out *EventLostWrite) {
+func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe5(in *jlexer.Lexer, out *EventLostWrite) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -744,9 +587,9 @@ func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe6(in *jle
 				for !in.IsDelim('}') {
 					key := string(in.String())
 					in.WantColon()
-					var v19 uint64
-					v19 = uint64(in.Uint64())
-					(out.Lost)[key] = v19
+					var v13 uint64
+					v13 = uint64(in.Uint64())
+					(out.Lost)[key] = v13
 					in.WantComma()
 				}
 				in.Delim('}')
@@ -761,7 +604,7 @@ func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe6(in *jle
 		in.Consumed()
 	}
 }
-func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe6(out *jwriter.Writer, in EventLostWrite) {
+func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe5(out *jwriter.Writer, in EventLostWrite) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -782,16 +625,16 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe6(out *jw
 			out.RawString(`null`)
 		} else {
 			out.RawByte('{')
-			v20First := true
-			for v20Name, v20Value := range in.Lost {
-				if v20First {
-					v20First = false
+			v14First := true
+			for v14Name, v14Value := range in.Lost {
+				if v14First {
+					v14First = false
 				} else {
 					out.RawByte(',')
 				}
-				out.String(string(v20Name))
+				out.String(string(v14Name))
 				out.RawByte(':')
-				out.Uint64(uint64(v20Value))
+				out.Uint64(uint64(v14Value))
 			}
 			out.RawByte('}')
 		}
@@ -801,14 +644,14 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe6(out *jw
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v EventLostWrite) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe6(w, v)
+	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe5(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *EventLostWrite) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe6(l, v)
+	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe5(l, v)
 }
-func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe7(in *jlexer.Lexer, out *EventLostRead) {
+func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe6(in *jlexer.Lexer, out *EventLostRead) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -845,7 +688,7 @@ func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe7(in *jle
 		in.Consumed()
 	}
 }
-func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe7(out *jwriter.Writer, in EventLostRead) {
+func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe6(out *jwriter.Writer, in EventLostRead) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -869,14 +712,14 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe7(out *jw
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v EventLostRead) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe7(w, v)
+	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe6(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *EventLostRead) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe7(l, v)
+	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe6(l, v)
 }
-func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe8(in *jlexer.Lexer, out *AbnormalPathEvent) {
+func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe7(in *jlexer.Lexer, out *AbnormalPathEvent) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -921,7 +764,7 @@ func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe8(in *jle
 		in.Consumed()
 	}
 }
-func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe8(out *jwriter.Writer, in AbnormalPathEvent) {
+func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe7(out *jwriter.Writer, in AbnormalPathEvent) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -949,10 +792,10 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe8(out *jw
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v AbnormalPathEvent) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe8(w, v)
+	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe7(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *AbnormalPathEvent) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe8(l, v)
+	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe7(l, v)
 }

--- a/pkg/security/probe/probe_monitor.go
+++ b/pkg/security/probe/probe_monitor.go
@@ -168,14 +168,11 @@ type RuleSetLoadedReport struct {
 	Event *CustomEvent
 }
 
-// PrepareRuleSetLoadedReport prepares a report of new loaded ruleset
-func (m *Monitor) PrepareRuleSetLoadedReport(ruleSet *rules.RuleSet, err *multierror.Error) RuleSetLoadedReport {
-	r, ev := NewRuleSetLoadedEvent(ruleSet, err)
-	return RuleSetLoadedReport{Rule: r, Event: ev}
-}
-
 // ReportRuleSetLoaded reports to Datadog that new ruleset was loaded
-func (m *Monitor) ReportRuleSetLoaded(report RuleSetLoadedReport) {
+func (m *Monitor) ReportRuleSetLoaded(ruleSet *rules.RuleSet, err *multierror.Error) {
+	r, ev := NewRuleSetLoadedEvent(ruleSet, err)
+	report := RuleSetLoadedReport{Rule: r, Event: ev}
+
 	if err := m.probe.statsdClient.Count(metrics.MetricRuleSetLoaded, 1, []string{}, 1.0); err != nil {
 		log.Error(fmt.Errorf("failed to send ruleset_loaded metric: %w", err))
 	}

--- a/pkg/security/secl/rules/errors.go
+++ b/pkg/security/secl/rules/errors.go
@@ -12,6 +12,15 @@ import (
 )
 
 var (
+	// ErrRuleWithoutID is returned when there is no ID
+	ErrRuleWithoutID = errors.New("no rule ID")
+
+	// ErrRuleWithoutExpression is returned when there is no expression
+	ErrRuleWithoutExpression = errors.New("no rule expression")
+
+	// ErrRuleWithoutExpression is returned when there is no expression
+	ErrRuleIDPattern = errors.New("rule ID pattern error")
+
 	// ErrRuleWithoutEvent is returned when no event type was inferred from the rule
 	ErrRuleWithoutEvent = errors.New("no event in the rule definition")
 
@@ -29,6 +38,9 @@ var (
 
 	// ErrCannotMergeExpression is returned when trying to merge SECL expression
 	ErrCannotMergeExpression = errors.New("cannot merge expression")
+
+	// ErrRuleAgentVersion is returned when there is an agent version error
+	ErrRuleAgentVersion = errors.New("agent version incompatible")
 )
 
 // ErrFieldTypeUnknown is returned when a field has an unknown type
@@ -104,5 +116,46 @@ type ErrRuleLoad struct {
 }
 
 func (e ErrRuleLoad) Error() string {
-	return fmt.Sprintf("rule `%s` definition error: %s", e.Definition.ID, e.Err)
+	return fmt.Sprintf("rule `%s` error: %s", e.Definition.ID, e.Err)
+}
+
+// RuleLoadErrType defines an rule error type
+type RuleLoadErrType string
+
+const (
+	// AgentVersionErrType agent version incompatible
+	AgentVersionErrType RuleLoadErrType = "agent_version_error"
+	// EventTypeNotEnabledErrType event type not enabled
+	EventTypeNotEnabledErrType RuleLoadErrType = "event_type_disabled"
+	// SyntaxErrType syntax error
+	SyntaxErrType RuleLoadErrType = "syntax_error"
+	// UnknownErrType undefined error
+	UnknownErrType RuleLoadErrType = "error"
+)
+
+// Type return the type of the error
+func (e ErrRuleLoad) Type() RuleLoadErrType {
+	switch e.Err {
+	case ErrRuleAgentVersion:
+		return AgentVersionErrType
+	case ErrEventTypeNotEnabled:
+		return EventTypeNotEnabledErrType
+	}
+
+	switch e.Err.(type) {
+	case *ErrFieldTypeUnknown, *ErrValueTypeUnknown, *ErrRuleSyntax:
+		return SyntaxErrType
+	}
+
+	return UnknownErrType
+
+}
+
+// ErrRuleSyntax is returned when there is a syntax error
+type ErrRuleSyntax struct {
+	Err error
+}
+
+func (e *ErrRuleSyntax) Error() string {
+	return fmt.Sprintf("syntax error `%v`", e.Err)
 }

--- a/pkg/security/secl/rules/policy_test.go
+++ b/pkg/security/secl/rules/policy_test.go
@@ -464,8 +464,8 @@ func TestRuleErrorLoading(t *testing.T) {
 	rs, err := loadPolicy(t, testPolicy, PolicyLoaderOpts{})
 	assert.NotNil(t, err)
 	assert.Len(t, err.Errors, 2)
-	assert.ErrorContains(t, err.Errors[0], "rule `testA` definition error: multiple definition with the same ID")
-	assert.ErrorContains(t, err.Errors[1], "rule `testB` definition error: syntax error: 1:16: unexpected token")
+	assert.ErrorContains(t, err.Errors[0], "rule `testA` error: multiple definition with the same ID")
+	assert.ErrorContains(t, err.Errors[1], "rule `testB` error: syntax error `1:16: unexpected token \"-\" (expected \"~\")`")
 
 	assert.Contains(t, rs.rules, "testA")
 	assert.NotContains(t, rs.rules, "testB")
@@ -600,7 +600,13 @@ func TestRuleAgentConstraint(t *testing.T) {
 	}
 
 	rs, err := loadPolicy(t, testPolicy, policyOpts)
-	assert.Nil(t, err)
+	for _, err := range err.(*multierror.Error).Errors {
+		if rerr, ok := err.(*ErrRuleLoad); ok {
+			if rerr.Definition.ID != "basic" && rerr.Definition.ID != "range_not" {
+				t.Errorf("unexpected error: %v", rerr)
+			}
+		}
+	}
 
 	for _, exp := range expected {
 		t.Run(exp.ruleID, func(t *testing.T) {
@@ -608,14 +614,6 @@ func TestRuleAgentConstraint(t *testing.T) {
 				assert.Contains(t, rs.rules, exp.ruleID)
 			} else {
 				assert.NotContains(t, rs.rules, exp.ruleID)
-
-				var present bool
-				for _, skipped := range rs.policies[0].RuleSkipped {
-					if skipped.ID == exp.ruleID {
-						present = true
-					}
-				}
-				assert.True(t, present)
 			}
 		})
 	}

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -318,7 +318,7 @@ func (rs *RuleSet) AddRule(ruleDef *RuleDefinition) (*eval.Rule, error) {
 	}
 
 	if err := rule.Parse(); err != nil {
-		return nil, &ErrRuleLoad{Definition: ruleDef, Err: fmt.Errorf("syntax error: %w", err)}
+		return nil, &ErrRuleLoad{Definition: ruleDef, Err: &ErrRuleSyntax{Err: err}}
 	}
 
 	if err := rule.GenEvaluator(rs.model, rs.replCtx()); err != nil {

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -566,7 +566,7 @@ func validateExecEvent(tb *testing.T, kind wrapperType, validate func(event *spr
 }
 
 func setTestPolicy(dir string, macros []*rules.MacroDefinition, rules []*rules.RuleDefinition) (string, error) {
-	testPolicyFile, err := os.CreateTemp(dir, "secagent-policy.*.policy")
+	testPolicyFile, err := os.Create(path.Join(dir, "secagent-policy.policy"))
 	if err != nil {
 		return "", err
 	}
@@ -706,11 +706,9 @@ func newTestModule(t testing.TB, macroDefs []*rules.MacroDefinition, ruleDefs []
 		return nil, err
 	}
 
-	cfgFilename, err := setTestPolicy(st.root, macroDefs, ruleDefs)
-	if err != nil {
+	if _, err = setTestPolicy(st.root, macroDefs, ruleDefs); err != nil {
 		return nil, err
 	}
-	defer os.Remove(cfgFilename)
 
 	var cmdWrapper cmdWrapper
 	if testEnvironment == DockerEnvironment {

--- a/pkg/security/tests/schemas.go
+++ b/pkg/security/tests/schemas.go
@@ -81,9 +81,9 @@ func validateEventSchema(t *testing.T, event *sprobe.Event, path string) bool {
 }
 
 //nolint:deadcode,unused
-func validateStringSchema(t *testing.T, ad string, path string) bool {
+func validateStringSchema(t *testing.T, event string, path string) bool {
 	t.Helper()
-	return validateSchema(t, ad, path)
+	return validateSchema(t, event, path)
 }
 
 //nolint:deadcode,unused
@@ -210,4 +210,10 @@ func validateBindSchema(t *testing.T, event *sprobe.Event) bool {
 func validateActivityDumpProtoSchema(t *testing.T, ad string) bool {
 	t.Helper()
 	return validateStringSchema(t, ad, "file:///schemas/activity_dump_proto.schema.json")
+}
+
+//nolint:deadcode,unused
+func validateRuleSetLoadedSchema(t *testing.T, event *sprobe.CustomEvent) bool {
+	t.Helper()
+	return validateStringSchema(t, event.String(), "file:///schemas/ruleset_loaded.schema.json")
 }

--- a/pkg/security/tests/schemas/ruleset_loaded.schema.json
+++ b/pkg/security/tests/schemas/ruleset_loaded.schema.json
@@ -1,0 +1,80 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$id": "ruleset_loaded.json",
+    "type": "object",
+    "properties": {
+        "policies": {
+            "type": "array",
+            "items": {
+                "$ref": "#/$defs/policy"
+            }
+        },
+        "date": {
+            "$ref": "/schemas/datetime.json"
+        }
+    },
+    "required": [
+        "policies",
+        "date"
+    ],
+    "$defs": {
+        "policy": {
+            "type": "object",
+            "properties": {
+                "source": {
+                    "type": "string",
+                    "enum": [
+                        "file",
+                        "remote_config"
+                    ]
+                },
+                "name": {
+                    "type": "string"
+                },
+                "version": {
+                    "type": "string"
+                },
+                "rules": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/rule"
+                    }
+                }
+            },
+            "required": [
+                "source",
+                "name",
+                "version",
+                "rules"
+            ]
+        },
+        "rule": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "version": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string",
+                    "enum": [
+                        "loaded",
+                        "agent_version_error",
+                        "event_type_disabled",
+                        "syntax_error",
+                        "error"
+                    ]
+                },
+                "message": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "id",
+                "status"
+            ]
+        }
+    }
+}

--- a/pkg/security/tests/schemas/ruleset_loaded.schema.json
+++ b/pkg/security/tests/schemas/ruleset_loaded.schema.json
@@ -57,6 +57,9 @@
                 "version": {
                     "type": "string"
                 },
+                "expression": {
+                    "type": "string"
+                },
                 "status": {
                     "type": "string",
                     "enum": [
@@ -73,7 +76,8 @@
             },
             "required": [
                 "id",
-                "status"
+                "status",
+                "expression"
             ]
         }
     }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Change the rulseset_loaded event in order to add the reason of a rule loading failure and a message explaining the error. It also add a json schema. A follow-up PR will introduce regular ruleset summary events.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
