### PR TITLE
[RCM] Add an unverified repository and client for remote config

### DIFF
--- a/pkg/config/remote/client.go
+++ b/pkg/config/remote/client.go
@@ -83,16 +83,12 @@ func newClient(agentName string, doTufVerification bool, agentVersion string, pr
 
 	if doTufVerification {
 		repository, err = state.NewRepository(meta.RootsDirector().Last())
-		if err != nil {
-			close()
-			return nil, err
-		}
 	} else {
 		repository, err = state.NewUnverifiedRepository()
-		if err != nil {
-			close()
-			return nil, err
-		}
+	}
+	if err != nil {
+	    close()
+		return nil, err
 	}
 
 	// A backoff is calculated as a range from which a random value will be selected. The formula is as follows.

--- a/pkg/config/remote/client.go
+++ b/pkg/config/remote/client.go
@@ -87,7 +87,7 @@ func newClient(agentName string, doTufVerification bool, agentVersion string, pr
 		repository, err = state.NewUnverifiedRepository()
 	}
 	if err != nil {
-	    close()
+		close()
 		return nil, err
 	}
 

--- a/pkg/remoteconfig/state/testingutils_test.go
+++ b/pkg/remoteconfig/state/testingutils_test.go
@@ -26,11 +26,12 @@ var (
 )
 
 type testArtifacts struct {
-	key            keys.Signer
-	signedBaseRoot []byte
-	root           *data.Root
-	targets        *data.Targets
-	repository     *Repository
+	key                  keys.Signer
+	signedBaseRoot       []byte
+	root                 *data.Root
+	targets              *data.Targets
+	repository           *Repository
+	unverifiedRepository *Repository
 }
 
 func newTestKey() keys.Signer {
@@ -85,6 +86,11 @@ func newTestArtifacts() testArtifacts {
 		panic(err)
 	}
 
+	unverifiedRepository, err := NewUnverifiedRepository()
+	if err != nil {
+		panic(err)
+	}
+
 	state := struct {
 		State []byte `json:"opaque_backend_state"`
 	}{[]byte(testOpaqueBackendStateContents)}
@@ -100,11 +106,12 @@ func newTestArtifacts() testArtifacts {
 	targets.Custom = &rm
 
 	return testArtifacts{
-		key:            key,
-		signedBaseRoot: signedBaseRoot,
-		root:           root,
-		targets:        targets,
-		repository:     repository,
+		key:                  key,
+		signedBaseRoot:       signedBaseRoot,
+		root:                 root,
+		targets:              targets,
+		repository:           repository,
+		unverifiedRepository: unverifiedRepository,
 	}
 }
 

--- a/pkg/remoteconfig/state/tuf.go
+++ b/pkg/remoteconfig/state/tuf.go
@@ -209,3 +209,26 @@ func unsafeUnmarshalRoot(raw []byte) (*data.Root, error) {
 	}
 	return &root, err
 }
+
+func unsafeUnmarshalTargets(raw []byte) (*data.Targets, error) {
+	var signedTargets data.Signed
+	err := json.Unmarshal(raw, &signedTargets)
+	if err != nil {
+		return nil, err
+	}
+	var targets data.Targets
+	err = json.Unmarshal(signedTargets.Signed, &targets)
+	if err != nil {
+		return nil, err
+	}
+	return &targets, err
+}
+
+func extractRootVersion(raw []byte) (int64, error) {
+	root, err := unsafeUnmarshalRoot(raw)
+	if err != nil {
+		return 0, err
+	}
+
+	return root.Version, nil
+}


### PR DESCRIPTION
Ideally the agent clients perform some basic TUF verification of their own, however, since the core agent is doing full verification, if we trust the connection between the clients and the agent we can forego verification. This simplifies things on the client side, as they don't need to have the base root file embedded into their binary in order to create a Repository.

This is primarily for the Go tracer, which utilizes the Repository structure for storage of its state as well. Until root rotations are fully off the ground, this prevents us from having to publish a new root file and requiring end users to either reconfigure or rebuild their applications if we need to publish a new root in the interim.

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
