### PR TITLE
[CSPM] fix expected finding in e2e tests

### DIFF
--- a/test/e2e/cws-tests/tests/test_e2e_cspm_kubernetes.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cspm_kubernetes.py
@@ -150,11 +150,6 @@ class TestE2EKubernetes(unittest.TestCase):
                 "result": "error",
             }
         ],
-        "cis-kubernetes-1.5.1-4.2.10": [
-            {
-                "result": "failed",
-            }
-        ],
         "cis-kubernetes-1.5.1-4.2.12": [
             {
                 "result": "failed",

--- a/test/e2e/cws-tests/tests/test_e2e_cspm_kubernetes.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cspm_kubernetes.py
@@ -155,31 +155,6 @@ class TestE2EKubernetes(unittest.TestCase):
                 "result": "error",
             }
         ],
-        "cis-kubernetes-1.5.1-4.2.5": [
-            {
-                "result": "error",
-            }
-        ],
-        "cis-kubernetes-1.5.1-4.2.6": [
-            {
-                "result": "error",
-            }
-        ],
-        "cis-kubernetes-1.5.1-4.2.7": [
-            {
-                "result": "error",
-            }
-        ],
-        "cis-kubernetes-1.5.1-4.2.8": [
-            {
-                "result": "error",
-            }
-        ],
-        "cis-kubernetes-1.5.1-4.2.9": [
-            {
-                "result": "error",
-            }
-        ],
     }
     hostname = "k8s-e2e-tests-control-plane"
 

--- a/test/e2e/cws-tests/tests/test_e2e_cspm_kubernetes.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cspm_kubernetes.py
@@ -150,6 +150,11 @@ class TestE2EKubernetes(unittest.TestCase):
                 "result": "error",
             }
         ],
+        "cis-kubernetes-1.5.1-4.2.2": [
+            {
+                "result": "error",
+            }
+        ],
         "cis-kubernetes-1.5.1-4.2.3": [
             {
                 "result": "error",

--- a/test/e2e/cws-tests/tests/test_e2e_cspm_kubernetes.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cspm_kubernetes.py
@@ -155,11 +155,6 @@ class TestE2EKubernetes(unittest.TestCase):
                 "result": "error",
             }
         ],
-        "cis-kubernetes-1.5.1-4.2.4": [
-            {
-                "result": "error",
-            }
-        ],
         "cis-kubernetes-1.5.1-4.2.5": [
             {
                 "result": "error",

--- a/test/e2e/cws-tests/tests/test_e2e_cspm_kubernetes.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cspm_kubernetes.py
@@ -115,14 +115,6 @@ class TestE2EKubernetes(unittest.TestCase):
         ],
     }
     expectedFindingsWorkerNode = {
-        "cis-kubernetes-1.5.1-4.2.6": [
-            {
-                "agent_rule_id": "cis-kubernetes-1.5.1-4.2.6",
-                "agent_framework_id": "cis-kubernetes",
-                "result": "failed",
-                "resource_type": "kubernetes_worker_node",
-            }
-        ],
         "cis-kubernetes-1.5.1-4.1.1": [
             {
                 "result": "error",
@@ -179,26 +171,6 @@ class TestE2EKubernetes(unittest.TestCase):
             }
         ],
         "cis-kubernetes-1.5.1-4.2.5": [
-            {
-                "result": "failed",
-            }
-        ],
-        "cis-kubernetes-1.5.1-4.2.6": [
-            {
-                "result": "failed",
-            }
-        ],
-        "cis-kubernetes-1.5.1-4.2.7": [
-            {
-                "result": "failed",
-            }
-        ],
-        "cis-kubernetes-1.5.1-4.2.8": [
-            {
-                "result": "failed",
-            }
-        ],
-        "cis-kubernetes-1.5.1-4.2.9": [
             {
                 "result": "failed",
             }

--- a/test/e2e/cws-tests/tests/test_e2e_cspm_kubernetes.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cspm_kubernetes.py
@@ -75,7 +75,7 @@ class TestE2EKubernetes(unittest.TestCase):
         ],
         "cis-kubernetes-1.5.1-1.3.2": [
             {
-                "result": "error",
+                "result": "failed",
             }
         ],
         "cis-kubernetes-1.5.1-1.3.3": [

--- a/test/e2e/cws-tests/tests/test_e2e_cspm_kubernetes.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cspm_kubernetes.py
@@ -183,6 +183,26 @@ class TestE2EKubernetes(unittest.TestCase):
                 "result": "failed",
             }
         ],
+        "cis-kubernetes-1.5.1-4.2.6": [
+            {
+                "result": "failed",
+            }
+        ],
+        "cis-kubernetes-1.5.1-4.2.7": [
+            {
+                "result": "failed",
+            }
+        ],
+        "cis-kubernetes-1.5.1-4.2.8": [
+            {
+                "result": "failed",
+            }
+        ],
+        "cis-kubernetes-1.5.1-4.2.9": [
+            {
+                "result": "failed",
+            }
+        ],
     }
     hostname = "k8s-e2e-tests-control-plane"
 

--- a/test/e2e/cws-tests/tests/test_e2e_cspm_kubernetes.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cspm_kubernetes.py
@@ -80,27 +80,27 @@ class TestE2EKubernetes(unittest.TestCase):
         ],
         "cis-kubernetes-1.5.1-1.3.3": [
             {
-                "result": "error",
+                "result": "passed",
             }
         ],
         "cis-kubernetes-1.5.1-1.3.4": [
             {
-                "result": "error",
+                "result": "passed",
             }
         ],
         "cis-kubernetes-1.5.1-1.3.5": [
             {
-                "result": "error",
+                "result": "passed",
             }
         ],
         "cis-kubernetes-1.5.1-1.3.6": [
             {
-                "result": "error",
+                "result": "failed",
             }
         ],
         "cis-kubernetes-1.5.1-1.3.7": [
             {
-                "result": "error",
+                "result": "passed",
             }
         ],
         "cis-kubernetes-1.5.1-1.4.1": [

--- a/test/e2e/cws-tests/tests/test_e2e_cspm_kubernetes.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cspm_kubernetes.py
@@ -155,6 +155,11 @@ class TestE2EKubernetes(unittest.TestCase):
                 "result": "error",
             }
         ],
+        "cis-kubernetes-1.5.1-4.2.12": [
+            {
+                "result": "error",
+            }
+        ],
     }
     hostname = "k8s-e2e-tests-control-plane"
 

--- a/test/e2e/cws-tests/tests/test_e2e_cspm_kubernetes.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cspm_kubernetes.py
@@ -147,7 +147,7 @@ class TestE2EKubernetes(unittest.TestCase):
         ],
         "cis-kubernetes-1.5.1-4.2.1": [
             {
-                "result": "failed",
+                "result": "error",
             }
         ],
         "cis-kubernetes-1.5.1-4.2.10": [

--- a/test/e2e/cws-tests/tests/test_e2e_cspm_kubernetes.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cspm_kubernetes.py
@@ -152,17 +152,37 @@ class TestE2EKubernetes(unittest.TestCase):
         ],
         "cis-kubernetes-1.5.1-4.2.3": [
             {
-                "result": "failed",
+                "result": "error",
             }
         ],
         "cis-kubernetes-1.5.1-4.2.4": [
             {
-                "result": "failed",
+                "result": "error",
             }
         ],
         "cis-kubernetes-1.5.1-4.2.5": [
             {
-                "result": "failed",
+                "result": "error",
+            }
+        ],
+        "cis-kubernetes-1.5.1-4.2.6": [
+            {
+                "result": "error",
+            }
+        ],
+        "cis-kubernetes-1.5.1-4.2.7": [
+            {
+                "result": "error",
+            }
+        ],
+        "cis-kubernetes-1.5.1-4.2.8": [
+            {
+                "result": "error",
+            }
+        ],
+        "cis-kubernetes-1.5.1-4.2.9": [
+            {
+                "result": "error",
             }
         ],
     }

--- a/test/e2e/cws-tests/tests/test_e2e_cspm_kubernetes.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cspm_kubernetes.py
@@ -150,11 +150,6 @@ class TestE2EKubernetes(unittest.TestCase):
                 "result": "error",
             }
         ],
-        "cis-kubernetes-1.5.1-4.2.12": [
-            {
-                "result": "failed",
-            }
-        ],
         "cis-kubernetes-1.5.1-4.2.3": [
             {
                 "result": "failed",


### PR DESCRIPTION
### What does this PR do?

The configuration recently changed a bit and broke the CSPM e2e. This PR fixes those tests by syncing expected findings.

This was confirmed to be the thing to change because I tested:
- latest agent stable + old expected => same failure
- latest agent stable + new expected => success
this means that it actually is a k8s configuration change and not a bug in the agent

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
