### PR TITLE
Poll agent integration configuration files for changes

### DIFF
--- a/cmd/agent/common/autodiscovery.go
+++ b/cmd/agent/common/autodiscovery.go
@@ -7,6 +7,7 @@ package common
 
 import (
 	"context"
+	"time"
 
 	"go.uber.org/atomic"
 

--- a/cmd/agent/common/autodiscovery.go
+++ b/cmd/agent/common/autodiscovery.go
@@ -36,7 +36,11 @@ var (
 func setupAutoDiscovery(confSearchPaths []string, metaScheduler *scheduler.MetaScheduler) *autodiscovery.AutoConfig {
 	ad := autodiscovery.NewAutoConfig(metaScheduler)
 	providers.InitConfigFilesReader(confSearchPaths)
-	ad.AddConfigProvider(providers.NewFileConfigProvider(), false, 0)
+	ad.AddConfigProvider(
+		providers.NewFileConfigProvider(),
+		config.Datadog.GetBool("autoconf_config_files_poll"),
+		config.Datadog.GetDuration("autoconf_config_files_poll_interval")*time.Second,
+	)
 
 	// Autodiscovery cannot easily use config.RegisterOverrideFunc() due to Unmarshalling
 	extraConfigProviders, extraConfigListeners := confad.DiscoverComponentsFromConfig()

--- a/cmd/agent/common/autodiscovery.go
+++ b/cmd/agent/common/autodiscovery.go
@@ -40,7 +40,7 @@ func setupAutoDiscovery(confSearchPaths []string, metaScheduler *scheduler.MetaS
 	ad.AddConfigProvider(
 		providers.NewFileConfigProvider(),
 		config.Datadog.GetBool("autoconf_config_files_poll"),
-		config.Datadog.GetDuration("autoconf_config_files_poll_interval")*time.Second,
+		time.Duration(config.Datadog.GetInt("autoconf_config_files_poll_interval"))*time.Second,
 	)
 
 	// Autodiscovery cannot easily use config.RegisterOverrideFunc() due to Unmarshalling

--- a/pkg/autodiscovery/providers/README.md
+++ b/pkg/autodiscovery/providers/README.md
@@ -18,7 +18,8 @@ for _, provider := range configProviders {
 
 ### `FileConfigProvider`
 
-The `FileConfigProvider` is a static config provider, it scans the check configs directory once at startup.
+The `FileConfigProvider` is a static config provider, it scans the check configs directory at startup. The files are cached
+in memory for five minutes.
 
 ### `KubeletConfigProvider`
 

--- a/pkg/autodiscovery/providers/README.md
+++ b/pkg/autodiscovery/providers/README.md
@@ -18,8 +18,7 @@ for _, provider := range configProviders {
 
 ### `FileConfigProvider`
 
-The `FileConfigProvider` is a static config provider, it scans the check configs directory at startup. The files are cached
-in memory for five minutes.
+The `FileConfigProvider` is a file-based config provider. By default it only scans files once at startup but can configured to poll regularly.
 
 ### `KubeletConfigProvider`
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -555,6 +555,8 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("statsd_metric_blocklist", []string{})
 	// Autoconfig
 	config.BindEnvAndSetDefault("autoconf_template_dir", "/datadog/check_configs")
+	config.BindEnvAndSetDefault("autoconf_config_files_poll", false)
+	config.BindEnvAndSetDefault("autoconf_config_files_poll_interval", 60)
 	config.BindEnvAndSetDefault("exclude_pause_container", true)
 	config.BindEnvAndSetDefault("ac_include", []string{})
 	config.BindEnvAndSetDefault("ac_exclude", []string{})

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2070,6 +2070,19 @@ api_key:
 #
 # autoconf_template_dir: /datadog/check_configs
 
+## @param autoconf_config_files_poll - boolean - optional - default: false
+## @env DD_AUTOCONF_CONFIG_FILES_POLL - boolean - optional - default: false
+## Should the we check for new/updated integration configuration files on disk.
+#
+# autoconf_config_files_poll: false
+
+## @param autoconf_config_files_poll_interval - integer - optional - default: 60
+## @env DD_AUTOCONF_CONFIG_FILES_POLL_INTERVAL - integer - optional - default: 60
+## How frequently should the Agent check for new/updated integration configuration files. WARNING: the configuration
+## provider caches reads from disk for 5 minutes.
+#
+# autoconf_config_files_poll_interval: 60
+
 ## @param config_providers - List of custom object - optional
 ## @env DD_CONFIG_PROVIDERS - List of custom object - optional
 ## The providers the Agent should call to collect checks configurations. Available providers are:

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2073,13 +2073,14 @@ api_key:
 ## @param autoconf_config_files_poll - boolean - optional - default: false
 ## @env DD_AUTOCONF_CONFIG_FILES_POLL - boolean - optional - default: false
 ## Should the we check for new/updated integration configuration files on disk.
+## WARNING: Only files containing checks configuration are supported (logs configuration are not supported).
 #
 # autoconf_config_files_poll: false
 
 ## @param autoconf_config_files_poll_interval - integer - optional - default: 60
 ## @env DD_AUTOCONF_CONFIG_FILES_POLL_INTERVAL - integer - optional - default: 60
-## How frequently should the Agent check for new/updated integration configuration files. WARNING: the configuration
-## provider caches reads from disk for 5 minutes.
+## How frequently should the Agent check for new/updated integration configuration files (in seconds).
+## WARNING: Only files containing checks configuration are supported (logs configuration are not supported).
 #
 # autoconf_config_files_poll_interval: 60
 

--- a/releasenotes/notes/agent-integration-config-polling-9e642c167a7e6033.yaml
+++ b/releasenotes/notes/agent-integration-config-polling-9e642c167a7e6033.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Optionally poll Agent integration configuration files for changes after startup. This allows the Agent to pick up new
+    integration configuration without a restart. This is enabled/disabled with the `autoconf_config_files_poll` boolean
+    configuration variable, and the polling interval is configured with the `autoconf_config_files_poll_interval`.
+    Warning- The ConfigFilesReader implementation will cache the files in memory regardless of any changes.

--- a/releasenotes/notes/agent-integration-config-polling-9e642c167a7e6033.yaml
+++ b/releasenotes/notes/agent-integration-config-polling-9e642c167a7e6033.yaml
@@ -1,14 +1,8 @@
-# Each section from every release note are combined when the
-# CHANGELOG.rst is rendered. So the text needs to be worded so that
-# it does not depend on any information only available in another
-# section. This may mean repeating some details, but each section
-# must be readable independently of the other.
-#
-# Each section note must be formatted as reStructuredText.
 ---
 enhancements:
   - |
-    Optionally poll Agent integration configuration files for changes after startup. This allows the Agent to pick up new
-    integration configuration without a restart. This is enabled/disabled with the `autoconf_config_files_poll` boolean
-    configuration variable, and the polling interval is configured with the `autoconf_config_files_poll_interval`.
-    Warning- The ConfigFilesReader implementation will cache the files in memory regardless of any changes.
+    Optionally poll Agent and Cluster Agent integration configuration files for changes after startup. This allows the Agent/Cluster Agent to pick up new
+    integration configuration without a restart.
+    This is enabled/disabled with the `autoconf_config_files_poll` boolean configuration variable.
+    The polling interval is configured with the `autoconf_config_files_poll_interval` (default 60s).
+    Note: Dynamic removal of logs configuration is currently not supported.


### PR DESCRIPTION
### What does this PR do?

Original contribution: PR#11162.

Allows the file AD provider to reload check configurations periodically

### Motivation

Allows to inject dynamically checks to the Agent or Cluster Agent
Can be useful in non-Kubernetes environments where Cluster Agent is not available to schedule service checks.

### Additional Notes

The feature is technically available in Agent and Cluster Agent, yet usage of [advanced_ad_identifiers](https://docs.datadoghq.com/containers/cluster_agent/clusterchecks/?tab=helm#example-http_check-on-a-kubernetes-service) should be preferred in the Cluster Agent.

### Possible Drawbacks / Trade-offs

Logs config do not always support being unscheduled.
Flagging this limitation in the changelog and in the config.

### Describe how to test/QA your changes

Deploy the Agent in any environment with `DD_AUTOCONF_CONFIG_FILES_POLL` set to true.
Add/remove configuration files in `/etc/datadog-agent/conf.d`, observe that the Agent loads and unloads **check** configs properly.

Run the Agent with `DD_AUTOCONF_CONFIG_FILES_POLL_INTERVAL` set to `1` and add a file in `conf.d`, it should be picked up right away.
Run the Agent with `DD_AUTOCONF_CONFIG_FILES_POLL_INTERVAL` set to `0`, polling should be disabled.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
