### PR TITLE
[networks][backport] Fix HTTP keep-alive regression

### DIFF
--- a/pkg/ebpf/bytecode/runtime/http.go
+++ b/pkg/ebpf/bytecode/runtime/http.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Http = NewAsset("http.c", "9725a8188d39fba30e5d5f02ba30fd50b92e733f971aeeedc2dcd0ea66dc7ba0")
+var Http = NewAsset("http.c", "366ddb2f0379b975df44d58d332f2bb4c6b5162dcc95b251a8e3de327d2306a7")

--- a/pkg/network/http/monitor_test.go
+++ b/pkg/network/http/monitor_test.go
@@ -351,6 +351,74 @@ func TestRSTPacketRegression(t *testing.T) {
 	includesRequest(t, stats, &nethttp.Request{URL: url})
 }
 
+func TestKeepAliveWithIncompleteResponseRegression(t *testing.T) {
+	skipTestIfKernelNotSupported(t)
+
+	monitor, err := NewMonitor(config.New(), nil, nil, nil)
+	require.NoError(t, err)
+	err = monitor.Start()
+	require.NoError(t, err)
+	defer monitor.Stop()
+
+	const req = "GET /200/foobar HTTP/1.1\n"
+	const rsp = "HTTP/1.1 200 OK\n"
+	const serverAddr = "127.0.0.1:8080"
+
+	srvFn := func(c net.Conn) {
+		// emulates a half-transaction (beginning with a response)
+		n, err := c.Write([]byte(rsp))
+		require.NoError(t, err)
+		require.Equal(t, len(rsp), n)
+
+		// now we read the request from the client on the same connection
+		b := make([]byte, len(req))
+		n, err = c.Read(b)
+		require.NoError(t, err)
+		require.Equal(t, len(req), n)
+		require.Equal(t, string(b), req)
+
+		// and finally send the response completing a full HTTP transaction
+		n, err = c.Write([]byte(rsp))
+		require.NoError(t, err)
+		require.Equal(t, len(rsp), n)
+		c.Close()
+	}
+	srv := testutil.NewTCPServer(serverAddr, srvFn)
+	done := make(chan struct{})
+	srv.Run(done)
+	t.Cleanup(func() { close(done) })
+
+	c, err := net.DialTimeout("tcp", serverAddr, 5*time.Second)
+	require.NoError(t, err)
+
+	// ensure we're beginning the connection with a "headless" response from the
+	// server. this emulates the case where system-probe started in the middle of
+	// request/response cyle
+	b := make([]byte, len(rsp))
+	n, err := c.Read(b)
+	require.NoError(t, err)
+	require.Equal(t, len(rsp), n)
+	require.Equal(t, string(b), rsp)
+
+	// now perform a request
+	n, err = c.Write([]byte(req))
+	require.NoError(t, err)
+	require.Equal(t, len(req), n)
+
+	// and read the response completing a full transaction
+	n, err = c.Read(b)
+	require.NoError(t, err)
+	require.Equal(t, len(rsp), n)
+	require.Equal(t, string(b), rsp)
+
+	// after this response, request, response cycle we should ensure that
+	// we got a full HTTP transaction
+	stats := monitor.GetHTTPStats()
+	url, err := url.Parse("http://127.0.0.1:8080/200/foobar")
+	require.NoError(t, err)
+	includesRequest(t, stats, &nethttp.Request{URL: url, Method: "GET"})
+}
+
 func assertAllRequestsExists(t *testing.T, monitor *Monitor, requests []*nethttp.Request) {
 	requestsExist := make([]bool, len(requests))
 	for i := 0; i < 10; i++ {

--- a/pkg/network/http/testutil/tcp_server.go
+++ b/pkg/network/http/testutil/tcp_server.go
@@ -1,0 +1,45 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package testutil
+
+import "net"
+
+type TCPServer struct {
+	address   string
+	onMessage func(c net.Conn)
+}
+
+func NewTCPServer(addr string, onMessage func(c net.Conn)) *TCPServer {
+	return &TCPServer{
+		address:   addr,
+		onMessage: onMessage,
+	}
+}
+
+func (s *TCPServer) Run(done chan struct{}) error {
+	ln, err := net.Listen("tcp", s.address)
+	if err != nil {
+		return err
+	}
+	s.address = ln.Addr().String()
+
+	go func() {
+		<-done
+		ln.Close()
+	}()
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go s.onMessage(conn)
+		}
+	}()
+
+	return nil
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Backport #13765 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
