### PR TITLE
[SNMP] : Use datadog agent SNMP configuration as options for the integrated snmpwalk

### DIFF
--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -112,7 +112,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				//if the customer provides only 1 argument : the ip_address
 				//We check the ip address configuration in the agent runtime and we use it for the snmpwalk
 				snmpConfigList, _ := parse.GetConfigCheckSnmp()
-				instance, _ := parse.GetIPConfig(deviceIP, snmpConfigList)
+				instance := parse.GetIPConfig(deviceIP, snmpConfigList)
 				if instance.IPAddress != "" {
 					snmpVersion = instance.Version
 					port = instance.Port
@@ -132,6 +132,9 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 					retries = instance.Retries
 					timeout = instance.Timeout
 
+				} else {
+					deviceIP = address
+					port = defaultPort
 				}
 			}
 

--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -143,7 +143,6 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 					}
 
 				} else {
-					deviceIP = address
 					port = defaultPort
 				}
 			}

--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -113,7 +113,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				//We check the ip address configuration in the agent runtime and we use it for the snmpwalk
 				deviceIP = address
 				//Allow the possibility to pass the config file as an argument to the command
-				erre := common.SetupConfig(globalArgs.ConfFilePath)
+				erre := common.SetupConfig(globalParams.ConfFilePath)
 				if erre != nil {
 					fmt.Printf("The config file provided is invalid : %v \n", erre)
 				}

--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -109,9 +109,10 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 					port = defaultPort
 				}
 			} else {
-				deviceIP = address
-				//if the customer provides only 1 argument : the ip_address
+				//If the customer provides only 1 argument : the ip_address
 				//We check the ip address configuration in the agent runtime and we use it for the snmpwalk
+				deviceIP = address
+				//Allow the possibility to pass the config file as an argument to the command
 				err := common.SetupConfig(globalArgs.ConfFilePath)
 				if err != nil {
 					fmt.Printf("The config file provided is invalid : %v \n", err)

--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -113,9 +113,9 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				//We check the ip address configuration in the agent runtime and we use it for the snmpwalk
 				deviceIP = address
 				//Allow the possibility to pass the config file as an argument to the command
-				err := common.SetupConfig(globalArgs.ConfFilePath)
-				if err != nil {
-					fmt.Printf("The config file provided is invalid : %v \n", err)
+				erre := common.SetupConfig(globalArgs.ConfFilePath)
+				if erre != nil {
+					fmt.Printf("The config file provided is invalid : %v \n", erre)
 				}
 				snmpConfigList, err := parse.GetConfigCheckSnmp()
 				instance := parse.GetIPConfig(deviceIP, snmpConfigList)

--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -110,27 +110,29 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			} else {
 				deviceIP = address
 				//if the customer provides only 1 argument : the ip_address
-				//We check the ip address configuration in the agent runtime and we use it for the snmwalk
-				ip_list, _ := parse.GetConfigCheckSnmp()
-				instance := parse.GetIPConfig(deviceIP, ip_list)
-				snmpVersion = instance.SnmpVersion
-				port = instance.SnmpPort
+				//We check the ip address configuration in the agent runtime and we use it for the snmpwalk
+				snmpConfigList, _ := parse.GetConfigCheckSnmp()
+				instance, _ := parse.GetIPConfig(deviceIP, snmpConfigList)
+				if instance.IPAddress != "" {
+					snmpVersion = instance.Version
+					port = instance.Port
 
-				// v1 & v2c
-				communityString = instance.SnmpCommunityString
+					// v1 & v2c
+					communityString = instance.CommunityString
 
-				// v3
-				user = instance.SnmpUsername
-				authProt = instance.SnmpAuthProtocol
-				authKey = instance.SnmpAuthKey
-				privProt = instance.SnmpPrivProtocol
-				privKey = instance.SnmpPrivKey
-				snmpContext = instance.SnmpContext
+					// v3
+					user = instance.Username
+					authProt = instance.AuthProtocol
+					authKey = instance.AuthKey
+					privProt = instance.PrivProtocol
+					privKey = instance.PrivKey
+					snmpContext = instance.Context
 
-				// communication
-				retries = instance.SnmpRetries
-				timeout = instance.SnmpTimeout
+					// communication
+					retries = instance.Retries
+					timeout = instance.Timeout
 
+				}
 			}
 
 			// Communication options check

--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/agent/command"
 	utilFunc "github.com/DataDog/datadog-agent/pkg/snmp/gosnmplib"
+	parse "github.com/DataDog/datadog-agent/pkg/snmp/snmpparse"
 )
 
 const (
@@ -108,7 +109,28 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				}
 			} else {
 				deviceIP = address
-				port = defaultPort
+				//if the customer provides only 1 argument : the ip_address
+				//We check the ip address configuration in the agent runtime and we use it for the snmwalk
+				ip_list, _ := parse.GetConfigCheckSnmp()
+				instance := parse.GetIPConfig(deviceIP, ip_list)
+				snmpVersion = instance.SnmpVersion
+				port = instance.SnmpPort
+
+				// v1 & v2c
+				communityString = instance.SnmpCommunityString
+
+				// v3
+				user = instance.SnmpUsername
+				authProt = instance.SnmpAuthProtocol
+				authKey = instance.SnmpAuthKey
+				privProt = instance.SnmpPrivProtocol
+				privKey = instance.SnmpPrivKey
+				snmpContext = instance.SnmpContext
+
+				// communication
+				retries = instance.SnmpRetries
+				timeout = instance.SnmpTimeout
+
 			}
 
 			// Communication options check

--- a/pkg/snmp/snmpparse/config_snmp.go
+++ b/pkg/snmp/snmpparse/config_snmp.go
@@ -18,44 +18,31 @@ import (
 
 var configCheckURLSnmp string
 
-type ShouldCloseConnectionSnmp int
-
-// DataSNMP contains all snmp instances YAML code
-type DataSNMP []SNMPConfig
-
 // SNMPConfig is a generic container for configuration data specific to the SNMP
 // integration.
-// The DataSNMP is an array of the SNMPConfig containers
 
 type SNMPConfig struct {
 
 	//General
-	SnmpIPAddress string `yaml:"ip_address"`
-	SnmpPort      uint16 `yaml:"port"`
-	SnmpVersion   string `yaml:"snmp_version"`
-	SnmpTimeout   int    `yaml:"timeout"`
-	SnmpRetries   int    `yaml:"retries"`
+	IPAddress string `yaml:"ip_address"`
+	Port      uint16 `yaml:"port"`
+	Version   string `yaml:"snmp_version"`
+	Timeout   int    `yaml:"timeout"`
+	Retries   int    `yaml:"retries"`
 	//v1 &2
-	SnmpCommunityString string `yaml:"community_string"`
+	CommunityString string `yaml:"community_string"`
 	//v3
-	SnmpUsername     string `yaml:"user"`
-	SnmpAuthProtocol string `yaml:"authProtocol"`
-	SnmpAuthKey      string `yaml:"authKey"`
-	SnmpPrivProtocol string `yaml:"privProtocol"`
-	SnmpPrivKey      string `yaml:"privKey"`
-	SnmpContext      string `yaml:"context_name"`
+	Username     string `yaml:"user"`
+	AuthProtocol string `yaml:"authProtocol"`
+	AuthKey      string `yaml:"authKey"`
+	PrivProtocol string `yaml:"privProtocol"`
+	PrivKey      string `yaml:"privKey"`
+	Context      string `yaml:"context_name"`
 }
 
-const (
-	// LeaveConnectionOpenSnmp keeps the underlying connection open after reading the request response
-	LeaveConnectionOpenSnmp ShouldCloseConnectionSnmp = iota
-	// CloseConnection closes the underlying connection after reading the request response
-	CloseConnectionSnmp
-)
-
-func ParseConfigSnmp(c integration.Config) DataSNMP {
+func ParseConfigSnmp(c integration.Config) []SNMPConfig {
 	//an array containing all the snmp instances
-	ws := DataSNMP{}
+	ws := []SNMPConfig{}
 
 	for _, inst := range c.Instances {
 		instance := SNMPConfig{}
@@ -70,8 +57,8 @@ func ParseConfigSnmp(c integration.Config) DataSNMP {
 	return ws
 }
 
-func GetConfigCheckSnmp() (DataSNMP, error) {
-	ws := DataSNMP{}
+func GetConfigCheckSnmp() ([]SNMPConfig, error) {
+	ws := []SNMPConfig{}
 
 	c := util.GetClient(false) // FIX: get certificates right then make this true
 
@@ -94,27 +81,25 @@ func GetConfigCheckSnmp() (DataSNMP, error) {
 	if err != nil {
 		return ws, err
 	}
-	//Store the SNMP config in the DataSNMP array (ws)
+	//Store the SNMP config in an array (ws)
 	//c is of type config while the cr is the config check response including the instances
 	for _, c := range cr.Configs {
 		if c.Name == "snmp" {
 			ws = ParseConfigSnmp(c)
-			//ParseConfigSnmp(c)
-
 		}
 	}
 
 	return ws, nil
 
 }
-func GetIPConfig(ip_address string, ip_list DataSNMP) SNMPConfig {
-	//How to unit test without providing the api key ?
-	//ip_list, _ = GetConfigCheckSnmp()
+func GetIPConfig(ip_address string, SnmpConfigList []SNMPConfig) (SNMPConfig, error) {
+
 	instance := SNMPConfig{}
-	for _, w := range ip_list {
-		if w.SnmpIPAddress == ip_address {
+	for _, w := range SnmpConfigList {
+		if w.IPAddress == ip_address {
 			instance = w
+			break
 		}
 	}
-	return instance
+	return instance, nil
 }

--- a/pkg/snmp/snmpparse/config_snmp.go
+++ b/pkg/snmp/snmpparse/config_snmp.go
@@ -91,14 +91,12 @@ func GetConfigCheckSnmp() ([]SNMPConfig, error) {
 	return nil, nil
 
 }
-func GetIPConfig(ip_address string, SnmpConfigList []SNMPConfig) (SNMPConfig, error) {
+func GetIPConfig(ip_address string, SnmpConfigList []SNMPConfig) SNMPConfig {
 
-	instance := SNMPConfig{}
-	for _, w := range SnmpConfigList {
-		if w.IPAddress == ip_address {
-			instance = w
-			return instance, nil
+	for _, snmpconfig := range SnmpConfigList {
+		if snmpconfig.IPAddress == ip_address {
+			return snmpconfig
 		}
 	}
-	return instance, nil
+	return SNMPConfig{}
 }

--- a/pkg/snmp/snmpparse/config_snmp.go
+++ b/pkg/snmp/snmpparse/config_snmp.go
@@ -42,7 +42,7 @@ type SNMPConfig struct {
 
 func ParseConfigSnmp(c integration.Config) []SNMPConfig {
 	//an array containing all the snmp instances
-	ws := []SNMPConfig{}
+	snmpconfigs := []SNMPConfig{}
 
 	for _, inst := range c.Instances {
 		instance := SNMPConfig{}
@@ -50,26 +50,26 @@ func ParseConfigSnmp(c integration.Config) []SNMPConfig {
 		if err != nil {
 			fmt.Printf("unable to get snmp config: %v", err)
 		}
-		// add the instance(type SNMPConfig) to the array ws
-		ws = append(ws, instance)
+		// add the instance(type SNMPConfig) to the array snmpconfigs
+		snmpconfigs = append(snmpconfigs, instance)
 	}
 
-	return ws
+	return snmpconfigs
 }
 
 func GetConfigCheckSnmp() ([]SNMPConfig, error) {
-	ws := []SNMPConfig{}
+	snmpconfigs := []SNMPConfig{}
 
 	c := util.GetClient(false) // FIX: get certificates right then make this true
 
 	// Set session token
 	err := util.SetAuthToken()
 	if err != nil {
-		return ws, err
+		return snmpconfigs, err
 	}
 	ipcAddress, err := config.GetIPCAddress()
 	if err != nil {
-		return ws, err
+		return snmpconfigs, err
 	}
 	//To Do: change the configCheckURLSnmp if the snmp check is a cluster check
 	if configCheckURLSnmp == "" {
@@ -79,17 +79,17 @@ func GetConfigCheckSnmp() ([]SNMPConfig, error) {
 	cr := response.ConfigCheckResponse{}
 	err = json.Unmarshal(r, &cr)
 	if err != nil {
-		return ws, err
+		return snmpconfigs, err
 	}
-	//Store the SNMP config in an array (ws)
+	//Store the SNMP config in an array (snmpconfigs)
 	//c is of type config while the cr is the config check response including the instances
 	for _, c := range cr.Configs {
 		if c.Name == "snmp" {
-			ws = ParseConfigSnmp(c)
+			snmpconfigs = ParseConfigSnmp(c)
 		}
 	}
 
-	return ws, nil
+	return snmpconfigs, nil
 
 }
 func GetIPConfig(ip_address string, SnmpConfigList []SNMPConfig) (SNMPConfig, error) {

--- a/pkg/snmp/snmpparse/config_snmp.go
+++ b/pkg/snmp/snmpparse/config_snmp.go
@@ -58,18 +58,17 @@ func ParseConfigSnmp(c integration.Config) []SNMPConfig {
 }
 
 func GetConfigCheckSnmp() ([]SNMPConfig, error) {
-	snmpconfigs := []SNMPConfig{}
 
 	c := util.GetClient(false) // FIX: get certificates right then make this true
 
 	// Set session token
 	err := util.SetAuthToken()
 	if err != nil {
-		return snmpconfigs, err
+		return nil, err
 	}
 	ipcAddress, err := config.GetIPCAddress()
 	if err != nil {
-		return snmpconfigs, err
+		return nil, err
 	}
 	//To Do: change the configCheckURLSnmp if the snmp check is a cluster check
 	if configCheckURLSnmp == "" {
@@ -79,17 +78,17 @@ func GetConfigCheckSnmp() ([]SNMPConfig, error) {
 	cr := response.ConfigCheckResponse{}
 	err = json.Unmarshal(r, &cr)
 	if err != nil {
-		return snmpconfigs, err
+		return nil, err
 	}
 	//Store the SNMP config in an array (snmpconfigs)
 	//c is of type config while the cr is the config check response including the instances
 	for _, c := range cr.Configs {
 		if c.Name == "snmp" {
-			snmpconfigs = ParseConfigSnmp(c)
+			return ParseConfigSnmp(c), nil
 		}
 	}
 
-	return snmpconfigs, nil
+	return nil, nil
 
 }
 func GetIPConfig(ip_address string, SnmpConfigList []SNMPConfig) (SNMPConfig, error) {
@@ -98,7 +97,7 @@ func GetIPConfig(ip_address string, SnmpConfigList []SNMPConfig) (SNMPConfig, er
 	for _, w := range SnmpConfigList {
 		if w.IPAddress == ip_address {
 			instance = w
-			break
+			return instance, nil
 		}
 	}
 	return instance, nil

--- a/pkg/snmp/snmpparse/config_snmp.go
+++ b/pkg/snmp/snmpparse/config_snmp.go
@@ -58,6 +58,7 @@ func ParseConfigSnmp(c integration.Config) DataSNMP {
 		err := yaml.Unmarshal(inst, &instance)
 		if err != nil {
 			fmt.Errorf("unable to get snmp config: %v", err)
+
 		}
 		// add the instance(type SNMPConfig) to the array ws
 		ws = append(ws, instance)
@@ -95,7 +96,7 @@ func GetConfigCheckSnmp(ws DataSNMP) error {
 	if configCheckURLSnmp == "" {
 		configCheckURLSnmp = fmt.Sprintf("https://%v:%v/agent/config-check", ipcAddress, config.Datadog.GetInt("cmd_port"))
 	}
-	r, err := util.DoGet(c, configCheckURLSnmp, util.LeaveConnectionOpen)
+	r, _ := util.DoGet(c, configCheckURLSnmp, util.LeaveConnectionOpen)
 	cr := response.ConfigCheckResponse{}
 	err = json.Unmarshal(r, &cr)
 	if err != nil {
@@ -105,7 +106,9 @@ func GetConfigCheckSnmp(ws DataSNMP) error {
 	//c is of type config while the cr is the config check response including the instances
 	for _, c := range cr.Configs {
 		if c.Name == "snmp" {
-			ws = ParseConfigSnmp(c)
+			//ws = ParseConfigSnmp(c)
+			ParseConfigSnmp(c)
+
 		}
 	}
 

--- a/pkg/snmp/snmpparse/config_snmp.go
+++ b/pkg/snmp/snmpparse/config_snmp.go
@@ -1,0 +1,114 @@
+package snmpparse
+
+import (
+	"encoding/json"
+	"fmt"
+
+	yaml "gopkg.in/yaml.v2"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/api/response"
+	"github.com/DataDog/datadog-agent/pkg/api/util"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+var configCheckURLSnmp string
+
+type ShouldCloseConnectionSnmp int
+
+// DataSNMP contains all snmp instances YAML code
+type DataSNMP []SNMPConfig
+
+// SNMPConfig is a generic container for configuration data specific to the SNMP
+// integration.
+// The DataSNMP is an array of the SNMPConfig containers
+
+type SNMPConfig struct {
+
+	//General
+	SnmpIPAddress string `yaml:"ip_address"`
+	SnmpPort      string `yaml:"port"`
+	SnmpVersion   string `yaml:"snmp_version"`
+	SnmpTimeout   string `yaml:"timeout"`
+	SnmpRetries   string `yaml:"retries"`
+	//v1 &2
+	SnmpCommunityString string `yaml:"community_string"`
+	//v3
+	SnmpUsername     string `yaml:"user"`
+	SnmpAuthProtocol string `yaml:"authProtocol"`
+	SnmpAuthKey      string `yaml:"authKey"`
+	SnmpPrivProtocol string `yaml:"privProtocol"`
+	SnmpPrivKey      string `yaml:"privKey"`
+	SnmpContext      string `yaml:"context_name"`
+}
+
+const (
+	// LeaveConnectionOpenSnmp keeps the underlying connection open after reading the request response
+	LeaveConnectionOpenSnmp ShouldCloseConnectionSnmp = iota
+	// CloseConnection closes the underlying connection after reading the request response
+	CloseConnectionSnmp
+)
+
+func ParseConfigSnmp(c integration.Config) DataSNMP {
+	//an array containing all the snmp instances
+	ws := DataSNMP{}
+
+	for _, inst := range c.Instances {
+		instance := SNMPConfig{}
+		err := yaml.Unmarshal(inst, &instance)
+		if err != nil {
+			fmt.Errorf("unable to get snmp config: %v", err)
+		}
+		// add the instance(type SNMPConfig) to the array ws
+		ws = append(ws, instance)
+	}
+
+	return ws
+}
+
+// This function gets the SNMP configuration from the main file
+// Go back to this when we try to implement the feature network address
+func GetMainFileSnmp() error {
+	c, err := yaml.Marshal(config.Datadog.AllSettings())
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(c))
+
+	return nil
+}
+
+func GetConfigCheckSnmp(ws DataSNMP) error {
+
+	c := util.GetClient(false) // FIX: get certificates right then make this true
+
+	// Set session token
+	err := util.SetAuthToken()
+	if err != nil {
+		return err
+	}
+	ipcAddress, err := config.GetIPCAddress()
+	if err != nil {
+		return err
+	}
+	//To Do: change the configCheckURLSnmp if the snmp check is a cluster check
+	if configCheckURLSnmp == "" {
+		configCheckURLSnmp = fmt.Sprintf("https://%v:%v/agent/config-check", ipcAddress, config.Datadog.GetInt("cmd_port"))
+	}
+	r, err := util.DoGet(c, configCheckURLSnmp, util.LeaveConnectionOpen)
+	cr := response.ConfigCheckResponse{}
+	err = json.Unmarshal(r, &cr)
+	if err != nil {
+		return err
+	}
+	//Store the SNMP config in the DataSNMP array (ws)
+	//c is of type config while the cr is the config check response including the instances
+	for _, c := range cr.Configs {
+		if c.Name == "snmp" {
+			ws = ParseConfigSnmp(c)
+		}
+	}
+
+	return nil
+
+}

--- a/pkg/snmp/snmpparse/config_snmp.go
+++ b/pkg/snmp/snmpparse/config_snmp.go
@@ -1,3 +1,7 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
 package snmpparse
 
 import (
@@ -57,8 +61,7 @@ func ParseConfigSnmp(c integration.Config) DataSNMP {
 		instance := SNMPConfig{}
 		err := yaml.Unmarshal(inst, &instance)
 		if err != nil {
-			fmt.Errorf("unable to get snmp config: %v", err)
-
+			fmt.Printf("unable to get snmp config: %v", err)
 		}
 		// add the instance(type SNMPConfig) to the array ws
 		ws = append(ws, instance)

--- a/pkg/snmp/snmpparse/config_snmp_test.go
+++ b/pkg/snmp/snmpparse/config_snmp_test.go
@@ -18,7 +18,7 @@ func TestOneInstance(t *testing.T) {
 	type Data = integration.Data
 	input := integration.Config{
 		Name:      "snmp",
-		Instances: []Data{Data("{\"ip_address\":\"98.6.18.158\",\"port\":\"161\",\"community_string\":\"password\",\"snmp_version\":\"2\",\"timeout\":\"60\",\"retries\":\"3\"}")},
+		Instances: []Data{Data("{\"ip_address\":\"98.6.18.158\",\"port\":161,\"community_string\":\"password\",\"snmp_version\":\"2\",\"timeout\":60,\"retries\":3}")},
 	}
 	//define the output
 	Exoutput := DataSNMP{
@@ -26,9 +26,9 @@ func TestOneInstance(t *testing.T) {
 			SnmpVersion:         "2",
 			SnmpCommunityString: "password",
 			SnmpIPAddress:       "98.6.18.158",
-			SnmpPort:            "161",
-			SnmpTimeout:         "60",
-			SnmpRetries:         "3",
+			SnmpPort:            161,
+			SnmpTimeout:         60,
+			SnmpRetries:         3,
 		},
 	}
 	assertSNMP(t, input, Exoutput)
@@ -38,8 +38,8 @@ func TestSeveralInstances(t *testing.T) {
 	type Data = integration.Data
 	input := integration.Config{
 		Name: "snmp",
-		Instances: []Data{Data("{\"ip_address\":\"98.6.18.158\",\"port\":\"161\",\"community_string\":\"password\",\"snmp_version\":\"2\",\"timeout\":\"60\",\"retries\":\"3\"}"),
-			Data("{\"ip_address\":\"98.6.18.159\",\"port\":\"162\",\"community_string\":\"drowssap\",\"snmp_version\":\"2\",\"timeout\":\"30\",\"retries\":\"5\"}")},
+		Instances: []Data{Data("{\"ip_address\":\"98.6.18.158\",\"port\":161,\"community_string\":\"password\",\"snmp_version\":\"2\",\"timeout\":60,\"retries\":3}"),
+			Data("{\"ip_address\":\"98.6.18.159\",\"port\":162,\"community_string\":\"drowssap\",\"snmp_version\":\"2\",\"timeout\":30,\"retries\":5}")},
 	}
 	//define the output
 	Exoutput := DataSNMP{
@@ -47,17 +47,17 @@ func TestSeveralInstances(t *testing.T) {
 			SnmpVersion:         "2",
 			SnmpCommunityString: "password",
 			SnmpIPAddress:       "98.6.18.158",
-			SnmpPort:            "161",
-			SnmpTimeout:         "60",
-			SnmpRetries:         "3",
+			SnmpPort:            161,
+			SnmpTimeout:         60,
+			SnmpRetries:         3,
 		},
 		{
 			SnmpVersion:         "2",
 			SnmpCommunityString: "drowssap",
 			SnmpIPAddress:       "98.6.18.159",
-			SnmpPort:            "162",
-			SnmpTimeout:         "30",
-			SnmpRetries:         "5",
+			SnmpPort:            162,
+			SnmpTimeout:         30,
+			SnmpRetries:         5,
 		},
 	}
 	assertSNMP(t, input, Exoutput)
@@ -65,5 +65,50 @@ func TestSeveralInstances(t *testing.T) {
 
 func assertSNMP(t *testing.T, input integration.Config, expectedOutput DataSNMP) {
 	output := ParseConfigSnmp(input)
+	assert.Equal(t, expectedOutput, output)
+}
+
+func TestGetSNMPConfig(t *testing.T) {
+	IPList := DataSNMP{
+		SNMPConfig{
+			SnmpVersion:         "2",
+			SnmpCommunityString: "password",
+			SnmpIPAddress:       "98.6.18.158",
+			SnmpPort:            161,
+			SnmpTimeout:         60,
+			SnmpRetries:         3,
+		},
+		{
+			SnmpVersion:         "2",
+			SnmpCommunityString: "drowssap",
+			SnmpIPAddress:       "98.6.18.159",
+			SnmpPort:            162,
+			SnmpTimeout:         30,
+			SnmpRetries:         5,
+		},
+		{
+			SnmpVersion:         "3",
+			SnmpCommunityString: "drowssap",
+			SnmpIPAddress:       "98.6.18.160",
+			SnmpPort:            172,
+			SnmpTimeout:         30,
+			SnmpRetries:         5,
+		},
+	}
+	input := "98.6.18.160"
+	Exoutput := SNMPConfig{
+		SnmpVersion:         "3",
+		SnmpCommunityString: "drowssap",
+		SnmpIPAddress:       "98.6.18.160",
+		SnmpPort:            172,
+		SnmpTimeout:         30,
+		SnmpRetries:         5,
+	}
+	assertIP(t, input, IPList, Exoutput)
+
+}
+
+func assertIP(t *testing.T, input string, input_ip_list DataSNMP, expectedOutput SNMPConfig) {
+	output := GetIPConfig(input, input_ip_list)
 	assert.Equal(t, expectedOutput, output)
 }

--- a/pkg/snmp/snmpparse/config_snmp_test.go
+++ b/pkg/snmp/snmpparse/config_snmp_test.go
@@ -109,6 +109,6 @@ func TestGetSNMPConfig(t *testing.T) {
 }
 
 func assertIP(t *testing.T, input string, snmpConfigList []SNMPConfig, expectedOutput SNMPConfig) {
-	output, _ := GetIPConfig(input, snmpConfigList)
+	output := GetIPConfig(input, snmpConfigList)
 	assert.Equal(t, expectedOutput, output)
 }

--- a/pkg/snmp/snmpparse/config_snmp_test.go
+++ b/pkg/snmp/snmpparse/config_snmp_test.go
@@ -1,0 +1,69 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package snmpparse
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+)
+
+func TestOneInstance(t *testing.T) {
+	//define the input
+	type Data = integration.Data
+	input := integration.Config{
+		Name:      "snmp",
+		Instances: []Data{Data("{\"ip_address\":\"98.6.18.158\",\"port\":\"161\",\"community_string\":\"password\",\"snmp_version\":\"2\",\"timeout\":\"60\",\"retries\":\"3\"}")},
+	}
+	//define the output
+	Exoutput := DataSNMP{
+		SNMPConfig{
+			SnmpVersion:         "2",
+			SnmpCommunityString: "password",
+			SnmpIPAddress:       "98.6.18.158",
+			SnmpPort:            "161",
+			SnmpTimeout:         "60",
+			SnmpRetries:         "3",
+		},
+	}
+	assertSNMP(t, input, Exoutput)
+}
+func TestSeveralInstances(t *testing.T) {
+	//define the input
+	type Data = integration.Data
+	input := integration.Config{
+		Name: "snmp",
+		Instances: []Data{Data("{\"ip_address\":\"98.6.18.158\",\"port\":\"161\",\"community_string\":\"password\",\"snmp_version\":\"2\",\"timeout\":\"60\",\"retries\":\"3\"}"),
+			Data("{\"ip_address\":\"98.6.18.159\",\"port\":\"162\",\"community_string\":\"drowssap\",\"snmp_version\":\"2\",\"timeout\":\"30\",\"retries\":\"5\"}")},
+	}
+	//define the output
+	Exoutput := DataSNMP{
+		SNMPConfig{
+			SnmpVersion:         "2",
+			SnmpCommunityString: "password",
+			SnmpIPAddress:       "98.6.18.158",
+			SnmpPort:            "161",
+			SnmpTimeout:         "60",
+			SnmpRetries:         "3",
+		},
+		{
+			SnmpVersion:         "2",
+			SnmpCommunityString: "drowssap",
+			SnmpIPAddress:       "98.6.18.159",
+			SnmpPort:            "162",
+			SnmpTimeout:         "30",
+			SnmpRetries:         "5",
+		},
+	}
+	assertSNMP(t, input, Exoutput)
+}
+
+func assertSNMP(t *testing.T, input integration.Config, expectedOutput DataSNMP) {
+	output := ParseConfigSnmp(input)
+	assert.Equal(t, expectedOutput, output)
+}

--- a/pkg/snmp/snmpparse/config_snmp_test.go
+++ b/pkg/snmp/snmpparse/config_snmp_test.go
@@ -13,6 +13,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 )
 
+func TestYamlParsing(t *testing.T) {
+
+}
+
 func TestOneInstance(t *testing.T) {
 	//define the input
 	type Data = integration.Data
@@ -21,14 +25,14 @@ func TestOneInstance(t *testing.T) {
 		Instances: []Data{Data("{\"ip_address\":\"98.6.18.158\",\"port\":161,\"community_string\":\"password\",\"snmp_version\":\"2\",\"timeout\":60,\"retries\":3}")},
 	}
 	//define the output
-	Exoutput := DataSNMP{
-		SNMPConfig{
-			SnmpVersion:         "2",
-			SnmpCommunityString: "password",
-			SnmpIPAddress:       "98.6.18.158",
-			SnmpPort:            161,
-			SnmpTimeout:         60,
-			SnmpRetries:         3,
+	Exoutput := []SNMPConfig{
+		{
+			Version:         "2",
+			CommunityString: "password",
+			IPAddress:       "98.6.18.158",
+			Port:            161,
+			Timeout:         60,
+			Retries:         3,
 		},
 	}
 	assertSNMP(t, input, Exoutput)
@@ -42,73 +46,73 @@ func TestSeveralInstances(t *testing.T) {
 			Data("{\"ip_address\":\"98.6.18.159\",\"port\":162,\"community_string\":\"drowssap\",\"snmp_version\":\"2\",\"timeout\":30,\"retries\":5}")},
 	}
 	//define the output
-	Exoutput := DataSNMP{
-		SNMPConfig{
-			SnmpVersion:         "2",
-			SnmpCommunityString: "password",
-			SnmpIPAddress:       "98.6.18.158",
-			SnmpPort:            161,
-			SnmpTimeout:         60,
-			SnmpRetries:         3,
+	Exoutput := []SNMPConfig{
+		{
+			Version:         "2",
+			CommunityString: "password",
+			IPAddress:       "98.6.18.158",
+			Port:            161,
+			Timeout:         60,
+			Retries:         3,
 		},
 		{
-			SnmpVersion:         "2",
-			SnmpCommunityString: "drowssap",
-			SnmpIPAddress:       "98.6.18.159",
-			SnmpPort:            162,
-			SnmpTimeout:         30,
-			SnmpRetries:         5,
+			Version:         "2",
+			CommunityString: "drowssap",
+			IPAddress:       "98.6.18.159",
+			Port:            162,
+			Timeout:         30,
+			Retries:         5,
 		},
 	}
 	assertSNMP(t, input, Exoutput)
 }
 
-func assertSNMP(t *testing.T, input integration.Config, expectedOutput DataSNMP) {
+func assertSNMP(t *testing.T, input integration.Config, expectedOutput []SNMPConfig) {
 	output := ParseConfigSnmp(input)
 	assert.Equal(t, expectedOutput, output)
 }
 
 func TestGetSNMPConfig(t *testing.T) {
-	IPList := DataSNMP{
-		SNMPConfig{
-			SnmpVersion:         "2",
-			SnmpCommunityString: "password",
-			SnmpIPAddress:       "98.6.18.158",
-			SnmpPort:            161,
-			SnmpTimeout:         60,
-			SnmpRetries:         3,
+	IPList := []SNMPConfig{
+		{
+			Version:         "2",
+			CommunityString: "password",
+			IPAddress:       "98.6.18.158",
+			Port:            161,
+			Timeout:         60,
+			Retries:         3,
 		},
 		{
-			SnmpVersion:         "2",
-			SnmpCommunityString: "drowssap",
-			SnmpIPAddress:       "98.6.18.159",
-			SnmpPort:            162,
-			SnmpTimeout:         30,
-			SnmpRetries:         5,
+			Version:         "2",
+			CommunityString: "drowssap",
+			IPAddress:       "98.6.18.159",
+			Port:            162,
+			Timeout:         30,
+			Retries:         5,
 		},
 		{
-			SnmpVersion:         "3",
-			SnmpCommunityString: "drowssap",
-			SnmpIPAddress:       "98.6.18.160",
-			SnmpPort:            172,
-			SnmpTimeout:         30,
-			SnmpRetries:         5,
+			Version:         "3",
+			CommunityString: "drowssap",
+			IPAddress:       "98.6.18.160",
+			Port:            172,
+			Timeout:         30,
+			Retries:         5,
 		},
 	}
 	input := "98.6.18.160"
 	Exoutput := SNMPConfig{
-		SnmpVersion:         "3",
-		SnmpCommunityString: "drowssap",
-		SnmpIPAddress:       "98.6.18.160",
-		SnmpPort:            172,
-		SnmpTimeout:         30,
-		SnmpRetries:         5,
+		Version:         "3",
+		CommunityString: "drowssap",
+		IPAddress:       "98.6.18.160",
+		Port:            172,
+		Timeout:         30,
+		Retries:         5,
 	}
 	assertIP(t, input, IPList, Exoutput)
 
 }
 
-func assertIP(t *testing.T, input string, input_ip_list DataSNMP, expectedOutput SNMPConfig) {
-	output := GetIPConfig(input, input_ip_list)
+func assertIP(t *testing.T, input string, snmpConfigList []SNMPConfig, expectedOutput SNMPConfig) {
+	output, _ := GetIPConfig(input, snmpConfigList)
 	assert.Equal(t, expectedOutput, output)
 }

--- a/pkg/snmp/snmpparse/config_snmp_test.go
+++ b/pkg/snmp/snmpparse/config_snmp_test.go
@@ -13,10 +13,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 )
 
-func TestYamlParsing(t *testing.T) {
-
-}
-
 func TestOneInstance(t *testing.T) {
 	//define the input
 	type Data = integration.Data

--- a/releasenotes/notes/parse-snmp-configuration-1aaeefbb06d07380.yaml
+++ b/releasenotes/notes/parse-snmp-configuration-1aaeefbb06d07380.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+
+features:
+  - |
+    parse the snmp configuration from the agent and pass it to the integrated snmpwalk command in case the customer only provides an ip address


### PR DESCRIPTION

### What does this PR do?
The goal behind this PR is to parse the customer SNMP configuration from the agent files (under snmp.d and eventually from the datadog.yaml) then use that snmp configuration to create an integrated snmpwalk command within the agent that only needs the IP address to run.
The new snmpwalk will use the IP address provided to search through the snmp configuration already provided within the agent, then run a classic snmpwalk command combining the IP address and the snmp options that were found in the agent.

### Motivation
When investigating snmp issues, we have to blindly trust the customer is using the same SNMP configuration within the agent as the ones passed to the snmpwalk command. 
Unfortunately, in many cases the custom makes typos or confuses different options, which leaves us with a lot of going back and forth just to fix simple configurations.
So parsing the agent snmp configuration and passing it as options to the snmpwalk integrated command will help us validate the customer configuration in a timely manner.
### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
