### PR TITLE
[CWS][SEC-5503] handle exec in threads

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewAsset("runtime-security.c", "ef74758f5875c48ae4312dd9575e5e3daf0d96dbc2203b236e128a2b4d0f4e1d")
+var RuntimeSecurity = NewAsset("runtime-security.c", "44f81214de5620fa5ed36fe1507c26fd6fb3611348439e8f882e62f2c6d02710")

--- a/pkg/security/ebpf/c/exec.h
+++ b/pkg/security/ebpf/c/exec.h
@@ -133,12 +133,21 @@ struct bpf_map_def SEC("maps/exec_count_bb") exec_count_bb = {
     .namespace = "",
 };
 
-struct bpf_map_def SEC("maps/task_in_coredump") tasks_in_coredump = {
+struct bpf_map_def SEC("maps/tasks_in_coredump") tasks_in_coredump = {
     .type = BPF_MAP_TYPE_LRU_HASH,
     .key_size = sizeof(u64),
     .value_size = sizeof(u8),
     .max_entries = 64,
     .map_flags = BPF_F_NO_COMMON_LRU,
+    .pinning = 0,
+    .namespace = "",
+};
+
+struct bpf_map_def SEC("maps/exec_pid_transfer") exec_pid_transfer = {
+    .type = BPF_MAP_TYPE_LRU_HASH,
+    .key_size = sizeof(u32),
+    .value_size = sizeof(u64),
+    .max_entries = 512,
     .pinning = 0,
     .namespace = "",
 };
@@ -261,6 +270,18 @@ int __attribute__((always_inline)) trace__sys_execveat(struct pt_regs *ctx, cons
         }
     };
     cache_syscall(&syscall);
+
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    u32 tgid = pid_tgid >> 32;
+    u32 pid = pid_tgid;
+    // exec is called from a non leader thread:
+    //   - we need to remember that this thread will change its pid to the thread group leader's in the flush_old_exec kernel function,
+    //     before sending the event to userspace
+    //   - because the "real" thread leader will be terminated during this exec syscall, we also need to make sure to not send
+    //     the corresponding exit event
+    if (tgid != pid) {
+        bpf_map_update_elem(&exec_pid_transfer, &tgid, &pid_tgid, BPF_ANY);
+    }
 
     return 0;
 }
@@ -593,7 +614,10 @@ int kprobe_do_exit(struct pt_regs *ctx) {
     // delete netns entry
     bpf_map_delete_elem(&netns_cache, &pid);
 
-    if (tgid == pid) {
+    u64 *pid_tgid_execing = (u64 *)bpf_map_lookup_elem(&exec_pid_transfer, &tgid);
+
+    // only send the exit event if this is the thread group leader that isn't being killed by an execing thread
+    if (tgid == pid && pid_tgid_execing == NULL) {
         expire_pid_discarder(tgid);
 
         // update exit time
@@ -687,8 +711,52 @@ void __attribute__((always_inline)) fill_args_envs(struct exec_event_t *event, s
     event->envs_truncated = syscall->exec.envs.truncated;
 }
 
-int __attribute__((always_inline)) fetch_interpreter(struct pt_regs *ctx, struct linux_binprm *bprm) {
+struct syscall_cache_t *__attribute__((always_inline)) peek_current_or_impersonated_exec_syscall() {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_EXEC);
+    if (!syscall) {
+        u64 pid_tgid = bpf_get_current_pid_tgid();
+        u32 tgid = pid_tgid >> 32;
+        u32 pid = pid_tgid;
+        u64 *pid_tgid_execing_ptr = (u64 *)bpf_map_lookup_elem(&exec_pid_transfer, &tgid);
+        if (!pid_tgid_execing_ptr) {
+            return NULL;
+        }
+        u64 pid_tgid_execing = *pid_tgid_execing_ptr;
+        u32 tgid_execing = pid_tgid_execing >> 32;
+        u32 pid_execing = pid_tgid_execing;
+        if (tgid != tgid_execing || pid == pid_execing) {
+            return NULL;
+        }
+        // the current task is impersonating its thread group leader
+        syscall = peek_task_syscall(pid_tgid_execing, EVENT_EXEC);
+    }
+    return syscall;
+}
+
+struct syscall_cache_t *__attribute__((always_inline)) pop_current_or_impersonated_exec_syscall() {
+    struct syscall_cache_t *syscall = pop_syscall(EVENT_EXEC);
+    if (!syscall) {
+        u64 pid_tgid = bpf_get_current_pid_tgid();
+        u32 tgid = pid_tgid >> 32;
+        u32 pid = pid_tgid;
+        u64 *pid_tgid_execing_ptr = (u64 *)bpf_map_lookup_elem(&exec_pid_transfer, &tgid);
+        if (!pid_tgid_execing_ptr) {
+            return NULL;
+        }
+        u64 pid_tgid_execing = *pid_tgid_execing_ptr;
+        u32 tgid_execing = pid_tgid_execing >> 32;
+        u32 pid_execing = pid_tgid_execing;
+        if (tgid != tgid_execing || pid == pid_execing) {
+            return NULL;
+        }
+        // the current task is impersonating its thread group leader
+        syscall = pop_task_syscall(pid_tgid_execing, EVENT_EXEC);
+    }
+    return syscall;
+}
+
+int __attribute__((always_inline)) fetch_interpreter(struct pt_regs *ctx, struct linux_binprm *bprm) {
+    struct syscall_cache_t *syscall = peek_current_or_impersonated_exec_syscall();
     if (!syscall) {
         return 0;
     }
@@ -717,7 +785,7 @@ int __attribute__((always_inline)) fetch_interpreter(struct pt_regs *ctx, struct
 }
 
 int __attribute__((always_inline)) send_exec_event(struct pt_regs *ctx, struct linux_binprm *bprm) {
-    struct syscall_cache_t *syscall = pop_syscall(EVENT_EXEC);
+    struct syscall_cache_t *syscall = pop_current_or_impersonated_exec_syscall();
     if (!syscall) {
         return 0;
     }
@@ -726,6 +794,8 @@ int __attribute__((always_inline)) send_exec_event(struct pt_regs *ctx, struct l
     u64 pid_tgid = bpf_get_current_pid_tgid();
     u64 now = bpf_ktime_get_ns();
     u32 tgid = pid_tgid >> 32;
+
+    bpf_map_delete_elem(&exec_pid_transfer, &tgid);
 
     struct pid_cache_t *pid_entry = (struct pid_cache_t *) bpf_map_lookup_elem(&pid_cache, &tgid);
     if (pid_entry) {

--- a/pkg/security/tests/syscall_tester/c/syscall_tester.c
+++ b/pkg/security/tests/syscall_tester/c/syscall_tester.c
@@ -572,6 +572,34 @@ int test_wait_signal(int argc, char** argv) {
     return sigwait(&set, sigptr);
 }
 
+void *thread_exec(void *arg) {
+    char **argv = (char **) arg;
+    if (argv == NULL || argv[0] == NULL) {
+        return NULL;
+    }
+
+    char *path_cpy = strdup(argv[0]);
+    char *progname = basename(argv[0]);
+    argv[0] = progname;
+
+    execv(path_cpy, argv);
+    return NULL;
+}
+
+int test_exec_in_pthread(int argc, char **argv) {
+    if (argc <= 1) {
+        return EXIT_FAILURE;
+    }
+
+    pthread_t thread;
+    if (pthread_create(&thread, NULL, thread_exec, &argv[1]) < 0) {
+        return EXIT_FAILURE;
+    }
+    pthread_join(thread, NULL);
+
+    return EXIT_SUCCESS;
+}
+
 int main(int argc, char **argv) {
     if (argc <= 1) {
         fprintf(stderr, "Please pass a command\n");
@@ -633,6 +661,8 @@ int main(int argc, char **argv) {
             exit_code = test_open(sub_argc, sub_argv);
         } else if (strcmp(cmd, "unlink") == 0) {
             exit_code = test_unlink(sub_argc, sub_argv);
+        } else if (strcmp(cmd, "exec-in-pthread") == 0) {
+            exit_code = test_exec_in_pthread(sub_argc, sub_argv);
         } else {
             fprintf(stderr, "Unknown command `%s`\n", cmd);
             exit_code = EXIT_FAILURE;


### PR DESCRIPTION
This PR handles the case the exec syscall is called from a thread that isn't the thread group leader.
When a thread that isn't the thread group leader calls exec:
 - The thread group leader is terminated: this PR avoids sending the corresponding exit event to userspace to avoid removing the process from the agent process cache.
 - The thread that called exec changes its PID to its thread group leader's midway into the syscall to impersonate it: this PR uses the original PID to lookup the cached syscall once the PID change is effective. 


<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
