### PR TITLE
[snmp] Move NormalizeNamespace to `pkg/snmp`

### DIFF
--- a/pkg/collector/corechecks/snmp/common/utils.go
+++ b/pkg/collector/corechecks/snmp/common/utils.go
@@ -6,7 +6,6 @@
 package common
 
 import (
-	"bytes"
 	"fmt"
 
 	"github.com/DataDog/datadog-agent/pkg/version"
@@ -42,37 +41,4 @@ func CopyStrings(tags []string) []string {
 // GetAgentVersionTag returns agent version tag
 func GetAgentVersionTag() string {
 	return "agent_version:" + version.AgentVersion
-}
-
-// NormalizeNamespace applies policy according to hostname rule
-func NormalizeNamespace(namespace string) (string, error) {
-	var buf bytes.Buffer
-
-	// namespace longer than 100 characters are illegal
-	if len(namespace) > 100 {
-		return "", fmt.Errorf("namespace is too long, should contain less than 100 characters")
-	}
-
-	for _, r := range namespace {
-		switch r {
-		// has null rune just toss the whole thing
-		case '\x00':
-			return "", fmt.Errorf("namespace cannot contain null character")
-		// drop these characters entirely
-		case '\n', '\r', '\t':
-			continue
-		// replace characters that are generally used for xss with '-'
-		case '>', '<':
-			buf.WriteByte('-')
-		default:
-			buf.WriteRune(r)
-		}
-	}
-
-	normalizedNamespace := buf.String()
-	if normalizedNamespace == "" {
-		return "", fmt.Errorf("namespace cannot be empty")
-	}
-
-	return normalizedNamespace, nil
 }

--- a/pkg/collector/corechecks/snmp/common/utils_test.go
+++ b/pkg/collector/corechecks/snmp/common/utils_test.go
@@ -7,7 +7,6 @@ package common
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -106,28 +105,4 @@ func Test_CopyStrings(t *testing.T) {
 	assert.Equal(t, tags, newTags)
 	assert.NotEqual(t, fmt.Sprintf("%p", tags), fmt.Sprintf("%p", newTags))
 	assert.NotEqual(t, fmt.Sprintf("%p", &tags[0]), fmt.Sprintf("%p", &newTags[0]))
-}
-
-func TestValidateNamespace(t *testing.T) {
-	assert := assert.New(t)
-	long := strings.Repeat("a", 105)
-	_, err := NormalizeNamespace(long)
-	assert.NotNil(err, "namespace should not be too long")
-
-	namespace, err := NormalizeNamespace("a<b")
-	assert.Nil(err, "namespace with symbols should be normalized")
-	assert.Equal("a-b", namespace, "namespace should not contain symbols")
-
-	namespace, err = NormalizeNamespace("a\nb")
-	assert.Nil(err, "namespace with symbols should be normalized")
-	assert.Equal("ab", namespace, "namespace should not contain symbols")
-
-	// Invalid namespace as bytes that would look like this: 9cbef2d1-8c20-4bf2-97a5-7d70��
-	b := []byte{
-		57, 99, 98, 101, 102, 50, 100, 49, 45, 56, 99, 50, 48, 45,
-		52, 98, 102, 50, 45, 57, 55, 97, 53, 45, 55, 100, 55, 48,
-		0, 0, 0, 0, 239, 191, 189, 239, 191, 189, 1, // these are bad bytes
-	}
-	_, err = NormalizeNamespace(string(b))
-	assert.NotNil(err, "namespace should not contain bad bytes")
 }

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/common"
 	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/snmp/utils"
 )
 
 // Using high oid batch size might lead to snmp calls timing out.
@@ -415,7 +416,7 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 		c.Namespace = coreconfig.Datadog.GetString("network_devices.namespace")
 	}
 
-	c.Namespace, err = common.NormalizeNamespace(c.Namespace)
+	c.Namespace, err = utils.NormalizeNamespace(c.Namespace)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/netflow/config/config.go
+++ b/pkg/netflow/config/config.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/netflow/common"
+
+	"github.com/DataDog/datadog-agent/pkg/snmp/utils"
 )
 
 // NetflowConfig contains configuration for NetFlow collector.
@@ -63,6 +65,11 @@ func ReadConfig() (*NetflowConfig, error) {
 		}
 		if listenerConfig.Namespace == "" {
 			listenerConfig.Namespace = coreconfig.Datadog.GetString("network_devices.namespace")
+		}
+		listenerConfig.Namespace, err = utils.NormalizeNamespace(listenerConfig.Namespace)
+		// TODO: testme
+		if err != nil {
+			return nil, fmt.Errorf("invalid namespace `%s` error: %s", listenerConfig.Namespace, err)
 		}
 	}
 

--- a/pkg/netflow/config/config.go
+++ b/pkg/netflow/config/config.go
@@ -9,8 +9,6 @@ import (
 	"fmt"
 	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/netflow/common"
-
-	"github.com/DataDog/datadog-agent/pkg/snmp/utils"
 )
 
 // NetflowConfig contains configuration for NetFlow collector.
@@ -65,11 +63,6 @@ func ReadConfig() (*NetflowConfig, error) {
 		}
 		if listenerConfig.Namespace == "" {
 			listenerConfig.Namespace = coreconfig.Datadog.GetString("network_devices.namespace")
-		}
-		listenerConfig.Namespace, err = utils.NormalizeNamespace(listenerConfig.Namespace)
-		// TODO: testme
-		if err != nil {
-			return nil, fmt.Errorf("invalid namespace `%s` error: %s", listenerConfig.Namespace, err)
 		}
 	}
 

--- a/pkg/snmp/traps/config.go
+++ b/pkg/snmp/traps/config.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/gosnmp/gosnmp"
 
-	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/common"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/snmp/gosnmplib"
+	"github.com/DataDog/datadog-agent/pkg/snmp/utils"
 )
 
 // IsEnabled returns whether SNMP trap collection is enabled in the Agent configuration.
@@ -90,7 +90,7 @@ func ReadConfig(agentHostname string) (*Config, error) {
 	if c.Namespace == "" {
 		c.Namespace = config.Datadog.GetString("network_devices.namespace")
 	}
-	c.Namespace, err = common.NormalizeNamespace(c.Namespace)
+	c.Namespace, err = utils.NormalizeNamespace(c.Namespace)
 	if err != nil {
 		return nil, fmt.Errorf("unable to load config: %w", err)
 	}

--- a/pkg/snmp/utils/utils.go
+++ b/pkg/snmp/utils/utils.go
@@ -1,0 +1,44 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
+package utils
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// NormalizeNamespace applies policy according to hostname rule
+func NormalizeNamespace(namespace string) (string, error) {
+	var buf bytes.Buffer
+
+	// namespace longer than 100 characters are illegal
+	if len(namespace) > 100 {
+		return "", fmt.Errorf("namespace is too long, should contain less than 100 characters")
+	}
+
+	for _, r := range namespace {
+		switch r {
+		// has null rune just toss the whole thing
+		case '\x00':
+			return "", fmt.Errorf("namespace cannot contain null character")
+		// drop these characters entirely
+		case '\n', '\r', '\t':
+			continue
+		// replace characters that are generally used for xss with '-'
+		case '>', '<':
+			buf.WriteByte('-')
+		default:
+			buf.WriteRune(r)
+		}
+	}
+
+	normalizedNamespace := buf.String()
+	if normalizedNamespace == "" {
+		return "", fmt.Errorf("namespace cannot be empty")
+	}
+
+	return normalizedNamespace, nil
+}

--- a/pkg/snmp/utils/utils_test.go
+++ b/pkg/snmp/utils/utils_test.go
@@ -1,0 +1,36 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
+package utils
+
+import (
+	"github.com/stretchr/testify/assert"
+	"strings"
+	"testing"
+)
+
+func TestValidateNamespace(t *testing.T) {
+	assert := assert.New(t)
+	long := strings.Repeat("a", 105)
+	_, err := NormalizeNamespace(long)
+	assert.NotNil(err, "namespace should not be too long")
+
+	namespace, err := NormalizeNamespace("a<b")
+	assert.Nil(err, "namespace with symbols should be normalized")
+	assert.Equal("a-b", namespace, "namespace should not contain symbols")
+
+	namespace, err = NormalizeNamespace("a\nb")
+	assert.Nil(err, "namespace with symbols should be normalized")
+	assert.Equal("ab", namespace, "namespace should not contain symbols")
+
+	// Invalid namespace as bytes that would look like this: 9cbef2d1-8c20-4bf2-97a5-7d70��
+	b := []byte{
+		57, 99, 98, 101, 102, 50, 100, 49, 45, 56, 99, 50, 48, 45,
+		52, 98, 102, 50, 45, 57, 55, 97, 53, 45, 55, 100, 55, 48,
+		0, 0, 0, 0, 239, 191, 189, 239, 191, 189, 1, // these are bad bytes
+	}
+	_, err = NormalizeNamespace(string(b))
+	assert.NotNil(err, "namespace should not contain bad bytes")
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

[snmp] Move NormalizeNamespace to `pkg/snmp`

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Move NormalizeNamespace to `pkg/snmp` to make it available for snmp corecheck, traps, netflow

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
