### PR TITLE
[netflow] Avoid tracking ports when it is not needed

### DIFF
--- a/pkg/netflow/portrollup/portrollup.go
+++ b/pkg/netflow/portrollup/portrollup.go
@@ -70,13 +70,15 @@ func NewEndpointPairPortRollupStore(portRollupThreshold int) *EndpointPairPortRo
 func (prs *EndpointPairPortRollupStore) Add(sourceAddr []byte, destAddr []byte, sourcePort uint16, destPort uint16) {
 	srcToDestKey := buildStoreKey(sourceAddr, destAddr, isSourceEndpoint, sourcePort)
 	destToSrcKey := buildStoreKey(sourceAddr, destAddr, isDestinationEndpoint, destPort)
-	prs.AddToStore(prs.curStore, srcToDestKey, destToSrcKey, sourceAddr, destAddr, sourcePort, destPort)
-	prs.AddToStore(prs.newStore, srcToDestKey, destToSrcKey, sourceAddr, destAddr, sourcePort, destPort)
+
+	prs.AddToStore(prs.curStore, srcToDestKey, destToSrcKey, sourceAddr, destAddr, sourcePort, destPort, NoEphemeralPort)
+
+	// We pass isEphemeralStatus here to avoid writing to newStore if a port is known to be ephemeral already in curStore
+	prs.AddToStore(prs.newStore, srcToDestKey, destToSrcKey, sourceAddr, destAddr, sourcePort, destPort, prs.IsEphemeralFromKeys(srcToDestKey, destToSrcKey))
 }
 
 // AddToStore will add ports to store
-func (prs *EndpointPairPortRollupStore) AddToStore(store map[string][]uint16, srcToDestKey string, destToSrcKey string,
-	sourceAddr []byte, destAddr []byte, sourcePort uint16, destPort uint16) {
+func (prs *EndpointPairPortRollupStore) AddToStore(store map[string][]uint16, srcToDestKey string, destToSrcKey string, sourceAddr []byte, destAddr []byte, sourcePort uint16, destPort uint16, curStoreIsEphemeralStatus IsEphemeralStatus) {
 	prs.mu.Lock()
 	sourceToDestPorts := len(store[srcToDestKey])
 	destToSourcePorts := len(store[destToSrcKey])
@@ -86,21 +88,23 @@ func (prs *EndpointPairPortRollupStore) AddToStore(store map[string][]uint16, sr
 		prs.mu.Unlock()
 		return
 	}
-	if sourceToDestPorts+1 < prs.portRollupThreshold {
-		store[destToSrcKey] = appendPort(store[destToSrcKey], sourcePort)
-	}
-	// TODO: EXPLAIN
-	if len(store[destToSrcKey]) >= prs.portRollupThreshold {
-		for _, port := range store[destToSrcKey] {
-			delete(store, buildStoreKey(sourceAddr, destAddr, isSourceEndpoint, port))
-		}
-	}
-	if destToSourcePorts+1 < prs.portRollupThreshold {
+	if destToSourcePorts+1 < prs.portRollupThreshold && curStoreIsEphemeralStatus != IsEphemeralSourcePort {
 		store[srcToDestKey] = appendPort(store[srcToDestKey], destPort)
 	}
+	// if the destination port is ephemeral, we can delete the corresponding destToSrc entries
 	if len(store[srcToDestKey]) >= prs.portRollupThreshold {
 		for _, port := range store[srcToDestKey] {
 			delete(store, buildStoreKey(sourceAddr, destAddr, isDestinationEndpoint, port))
+		}
+	}
+
+	if sourceToDestPorts+1 < prs.portRollupThreshold && curStoreIsEphemeralStatus != IsEphemeralDestPort {
+		store[destToSrcKey] = appendPort(store[destToSrcKey], sourcePort)
+	}
+	// if the source port is ephemeral, we can delete the corresponding srcToDest entries
+	if len(store[destToSrcKey]) >= prs.portRollupThreshold {
+		for _, port := range store[destToSrcKey] {
+			delete(store, buildStoreKey(sourceAddr, destAddr, isSourceEndpoint, port))
 		}
 	}
 
@@ -118,11 +122,21 @@ func (prs *EndpointPairPortRollupStore) GetPortCount(sourceAddr []byte, destAddr
 
 // IsEphemeral checks if source port and destination port are ephemeral
 func (prs *EndpointPairPortRollupStore) IsEphemeral(sourceAddr []byte, destAddr []byte, sourcePort uint16, destPort uint16) IsEphemeralStatus {
-	sourceToDestPortCount := prs.GetSourceToDestPortCount(sourceAddr, destAddr, sourcePort)
-	destToSourcePortCount := prs.GetDestToSourcePortCount(sourceAddr, destAddr, destPort)
-	portCount := common.MaxUint16(sourceToDestPortCount, destToSourcePortCount)
+	srcToDestKey := buildStoreKey(sourceAddr, destAddr, isSourceEndpoint, sourcePort)
+	destToSrcKey := buildStoreKey(sourceAddr, destAddr, isDestinationEndpoint, destPort)
 
-	if int(portCount) < prs.portRollupThreshold {
+	return prs.IsEphemeralFromKeys(srcToDestKey, destToSrcKey)
+}
+
+func (prs *EndpointPairPortRollupStore) IsEphemeralFromKeys(srcToDestKey string, destToSrcKey string) IsEphemeralStatus {
+	sourceToDestPortCount := len(prs.curStore[srcToDestKey])
+	destToSourcePortCount := len(prs.curStore[destToSrcKey])
+	portCount := sourceToDestPortCount
+	if destToSourcePortCount > sourceToDestPortCount {
+		portCount = destToSourcePortCount
+	}
+
+	if portCount < prs.portRollupThreshold {
 		return NoEphemeralPort
 	}
 
@@ -177,7 +191,8 @@ func (prs *EndpointPairPortRollupStore) UseNewStoreAsCurrentStore() {
 func buildStoreKey(sourceAddr []byte, destAddr []byte, endpointT endpointType, port uint16) string {
 	var portPart1, portPart2 = uint8(port >> 8), uint8(port & 0xff)
 	return string(sourceAddr) + string(destAddr) + string([]byte{byte(endpointT)}) + string([]byte{portPart1, portPart2})
-
+	// FOR DEBUGGING: You can replace above line with the following one for debugging, it makes the key easier to read
+	// return common.IPBytesToString(sourceAddr) + "|" + common.IPBytesToString(destAddr) + "|" + fmt.Sprintf("%d", endpointT) + "|" + fmt.Sprintf("%d", port)
 }
 
 func appendPort(ports []uint16, newPort uint16) []uint16 {

--- a/pkg/netflow/portrollup/portrollup.go
+++ b/pkg/netflow/portrollup/portrollup.go
@@ -129,8 +129,11 @@ func (prs *EndpointPairPortRollupStore) IsEphemeral(sourceAddr []byte, destAddr 
 }
 
 func (prs *EndpointPairPortRollupStore) IsEphemeralFromKeys(srcToDestKey string, destToSrcKey string) IsEphemeralStatus {
+	prs.mu.Lock()
 	sourceToDestPortCount := len(prs.curStore[srcToDestKey])
 	destToSourcePortCount := len(prs.curStore[destToSrcKey])
+	prs.mu.Unlock()
+
 	portCount := sourceToDestPortCount
 	if destToSourcePortCount > sourceToDestPortCount {
 		portCount = destToSourcePortCount


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

[netflow] Avoid tracking ports when it is not needed

1/

If we get 3 flows like:
```
IP1:IP2 src_port:10001 dst_port:80
IP1:IP2 src_port:10002 dst_port:80
IP1:IP2 src_port:10003 dst_port:80
```

Before, port rollup tracker will store:
```
                 IP1:IP2:dst:80  => [10001, 10002, 10003]
                 IP1:IP2:dst:10001  => [80]
                 IP1:IP2:dst:10002  => [80]
                 IP1:IP2:dst:10003  => [80]
```

With this PR:
```
                 IP1:IP2:dst:80  => [10001, 10002, 10003]
```

2/

If a flow is know to be ephemeral in curStore (but not considered yet as ephemeral by newStore),
we will won't track the ports that are ephemeral in newStore.

For example, if curStore has with portRollupThreshold at 3:
```
                 IP1:IP2:dst:80  => [10001, 10002, 10003] <= is ephemeral
```
And newStore is empty.

If a new flow like `IP1:IP2 src_port:10004 dst_port:80` arrives, we will write: 
```
                 IP1:IP2:dst:80  => [10004]
```
to newStore, but we won't track `IP1:IP2:src:10004  => [80]` since we know that the source port `10004` is ephemeral for flow with IP1:IP2 + src_port:80.

#### Memory reduction

Before the change, the number of port rollup tracker entries where around 17M, there are now around 15M (11% reduction).

![image](https://user-images.githubusercontent.com/49917914/194590351-f6213be0-3cb2-4e4b-8c92-49bed69a73e0.png)

### Motivation

Use less heap mem.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
