### PR TITLE
Re-introduce parent cgroup CPU limit parsing (used on ECS)

### DIFF
--- a/pkg/util/containers/metrics/system/collector_linux.go
+++ b/pkg/util/containers/metrics/system/collector_linux.go
@@ -9,6 +9,7 @@
 package system
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -18,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/cgroups"
 	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics/provider"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 	systemutils "github.com/DataDog/datadog-agent/pkg/util/system"
 )
 
@@ -163,10 +165,22 @@ func (c *systemCollector) buildContainerMetrics(cg cgroups.Cgroup, cacheValidity
 		return nil, fmt.Errorf("cgroup parsing failed, incomplete data for containerID: %s, err: %w", cg.Identifier(), err)
 	}
 
+	parentCPUStatRetriever := func(parentCPUStats *cgroups.CPUStats) error {
+		parentCg, err := cg.GetParent()
+		if err != nil {
+			return err
+		}
+		if parentCg == nil {
+			return errors.New("no parent cgroup")
+		}
+
+		return parentCg.GetCPUStats(parentCPUStats)
+	}
+
 	cs := &provider.ContainerStats{
 		Timestamp: time.Now(),
 		Memory:    buildMemoryStats(stats.Memory),
-		CPU:       buildCPUStats(stats.CPU),
+		CPU:       buildCPUStats(stats.CPU, parentCPUStatRetriever),
 		IO:        buildIOStats(c.procPath, stats.IO),
 		PID:       buildPIDStats(stats.PID),
 	}
@@ -204,7 +218,7 @@ func buildMemoryStats(cgs *cgroups.MemoryStats) *provider.ContainerMemStats {
 	return cs
 }
 
-func buildCPUStats(cgs *cgroups.CPUStats) *provider.ContainerCPUStats {
+func buildCPUStats(cgs *cgroups.CPUStats, parentCPUStatsRetriever func(parentCPUStats *cgroups.CPUStats) error) *provider.ContainerCPUStats {
 	if cgs == nil {
 		return nil
 	}
@@ -220,12 +234,32 @@ func buildCPUStats(cgs *cgroups.CPUStats) *provider.ContainerCPUStats {
 	convertField(cgs.ThrottledTime, &cs.ThrottledTime)
 
 	// Compute complex fields
-	cs.Limit = computeCPULimitPct(cgs)
+	cs.Limit = computeCPULimitPct(cgs, parentCPUStatsRetriever)
 
 	return cs
 }
 
-func computeCPULimitPct(cgs *cgroups.CPUStats) *float64 {
+func computeCPULimitPct(cgs *cgroups.CPUStats, parentCPUStatsRetriever func(parentCPUStats *cgroups.CPUStats) error) *float64 {
+	limitPct := computeCgroupCPULimitPct(cgs)
+
+	// Check parent cgroup as it's used on ECS
+	if limitPct == nil {
+		parentCPUStats := &cgroups.CPUStats{}
+		if err := parentCPUStatsRetriever(parentCPUStats); err == nil {
+			limitPct = computeCgroupCPULimitPct(parentCPUStats)
+		}
+	}
+
+	// If no limit is available, setting the limit to number of CPUs.
+	// Always reporting a limit allows to compute CPU % accurately.
+	if limitPct == nil {
+		limitPct = pointer.Float64Ptr(float64(systemutils.HostCPUCount() * 100))
+	}
+
+	return limitPct
+}
+
+func computeCgroupCPULimitPct(cgs *cgroups.CPUStats) *float64 {
 	// Limit is computed using min(CPUSet, CFS CPU Quota)
 	var limitPct float64
 	if cgs.CPUCount != nil {
@@ -237,12 +271,11 @@ func computeCPULimitPct(cgs *cgroups.CPUStats) *float64 {
 			limitPct = quotaLimitPct
 		}
 	}
-	// If no limit is available, setting the limit to number of CPUs.
-	// Always reporting a limit allows to compute CPU % accurately.
-	if limitPct == 0 {
-		limitPct = float64(systemutils.HostCPUCount()) * 100
+
+	if limitPct != 0 {
+		return &limitPct
 	}
-	return &limitPct
+	return nil
 }
 
 func buildPIDStats(cgs *cgroups.PIDStats) *provider.ContainerPIDStats {

--- a/pkg/util/containers/metrics/system/collector_linux_test.go
+++ b/pkg/util/containers/metrics/system/collector_linux_test.go
@@ -141,6 +141,23 @@ func TestBuildContainerMetrics(t *testing.T) {
 				PID: &provider.ContainerPIDStats{},
 			},
 		},
+		{
+			name: "limit cpu count on parent",
+			cg: &cgroups.MockCgroup{
+				CPU: &cgroups.CPUStats{},
+				Parent: &cgroups.MockCgroup{
+					CPU: &cgroups.CPUStats{
+						CPUCount: pointer.UInt64Ptr(10),
+					},
+				},
+			},
+			want: &provider.ContainerStats{
+				CPU: &provider.ContainerCPUStats{
+					Limit: pointer.Float64Ptr(1000),
+				},
+				PID: &provider.ContainerPIDStats{},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/releasenotes/notes/fix-ecs-parent-limit-2bcf000a0e895503.yaml
+++ b/releasenotes/notes/fix-ecs-parent-limit-2bcf000a0e895503.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    Container CPU limit reported by `docker` and `container` checks on ECS was not defaulting to task limit when no CPU limit is set at container level
+    The container CPU limit that is reported by `docker` and `container` checks on ECS was not defaulting to the task limit when no CPU limit is set at container level.

--- a/releasenotes/notes/fix-ecs-parent-limit-2bcf000a0e895503.yaml
+++ b/releasenotes/notes/fix-ecs-parent-limit-2bcf000a0e895503.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Container CPU limit reported by `docker` and `container` checks on ECS was not defaulting to task limit when no CPU limit is set at container level


### PR DESCRIPTION
### What does this PR do?

Re-add parsing of cgroup parent for CPU Limit. It's used on ECS to default to task limit when no container limit is set.

### Motivation

Bugfix. Feature was working in 7.34.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Deploy the Agent on ECS. Deploy an ECS Task with task CPU limit but no container CPU limit (use a container that consumes a fixed amount of CPU, like `stress-ng` to ease verification).
The CPU Limit reported by `docker.cpu.limit` should be the task CPU limit, not the number of CPU on the host (so host has to be bigger than task CPU limit)

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
