### PR TITLE
[gitlab] Cover new infra failure type

### DIFF
--- a/tasks/libs/pipeline_data.py
+++ b/tasks/libs/pipeline_data.py
@@ -69,6 +69,12 @@ infra_failure_logs = [
         ),
         FailedJobReason.DOCKER_RUNNER,
     ),
+    (
+        re.compile(
+            r'WARNING: Failed to pull image with policy "always":.*:.*\(.*\)'
+        ),
+        FailedJobReason.DOCKER_RUNNER,
+    ),
     # k8s Gitlab runner init failures
     (
         re.compile(

--- a/tasks/libs/pipeline_data.py
+++ b/tasks/libs/pipeline_data.py
@@ -70,9 +70,7 @@ infra_failure_logs = [
         FailedJobReason.DOCKER_RUNNER,
     ),
     (
-        re.compile(
-            r'WARNING: Failed to pull image with policy "always":.*:.*\(.*\)'
-        ),
+        re.compile(r'WARNING: Failed to pull image with policy "always":.*:.*\(.*\)'),
         FailedJobReason.DOCKER_RUNNER,
     ),
     # k8s Gitlab runner init failures


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Adds a new case for docker / docker-arm runner init failures, eg.:
```
WARNING: Failed to pull image with policy "always": error during connect: Post "http://%2Fvar%2Frun%2Fdocker.sock/v1.25/images/create?fromImage=registry.gitlab.com%2Fgitlab-org%2Fgitlab-runner%2Fgitlab-runner-helper&tag=arm64-f188edd7": EOF (manager.go:203:0s)
```

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Catch more kinds of infra failures.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

This regex might be a bit too generic, and catch real script errors?

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

`CI_PIPELINE_ID=10357550 inv pipeline.send-stats --print-to-stdout` should detect an infra failure.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
