### PR TITLE
Fix panic in when a service tailed by the agent is deleted

### DIFF
--- a/pkg/logs/service/services.go
+++ b/pkg/logs/service/services.go
@@ -49,11 +49,13 @@ func (s *Services) RemoveService(service *Service) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	for i, svc := range s.services {
-		if svc.Type == service.Type && svc.Identifier == service.Identifier {
-			s.services = append(s.services[:i], s.services[i+1:]...)
+	remainingServices := s.services[:0]
+	for _, svc := range s.services {
+		if svc.Type != service.Type || svc.Identifier != service.Identifier {
+			remainingServices = append(remainingServices, svc)
 		}
 	}
+	s.services = remainingServices
 
 	removed, _ := s.removedPerType[service.Type]
 	for _, ch := range append(removed, s.allRemoved...) {

--- a/releasenotes/notes/fix-log-panic-removing-service-b36fee43555852db.yaml
+++ b/releasenotes/notes/fix-log-panic-removing-service-b36fee43555852db.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix potential panic when removing a service that the log agent is currently tailing.


### PR DESCRIPTION
### What does this PR do?

This panic could be triggered when deleting a pod that was currently being tailed by the log agent.

By using a slice with a same underlying array we can remove item without triggering "panic slice bounds out of range".

### Describe how to test/QA your changes

Enable collecting logs from all containers in the agent, and check that the stopping a container service is capture by the agent.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
