### PR TITLE
[CSPM] improve error management from gopsutil to match Datadog's

### DIFF
--- a/pkg/compliance/checks/builder.go
+++ b/pkg/compliance/checks/builder.go
@@ -960,11 +960,7 @@ func valueFromProcessFlag(name string, flag string) (interface{}, error) {
 
 	matchedProcesses := processes.findProcessesByName(name)
 	if len(matchedProcesses) != 0 {
-		cmdLine, err := matchedProcesses[0].CmdlineSlice()
-		if err != nil {
-			return "", fmt.Errorf("unable to fetch command line: %w", err)
-		}
-
+		cmdLine := matchedProcesses[0].CmdlineSlice()
 		flagValues := parseProcessCmdLine(cmdLine)
 		return flagValues[flag], nil
 	}

--- a/pkg/compliance/checks/process_check.go
+++ b/pkg/compliance/checks/process_check.go
@@ -47,24 +47,9 @@ func resolveProcess(_ context.Context, e env.Env, id string, res compliance.Reso
 
 	var instances []resolvedInstance
 	for _, mp := range matchedProcesses {
-		name, err := mp.Name()
-		if err != nil {
-			log.Errorf("%s: Unable to fetch process name: %v", id, err)
-			continue
-		}
-
-		exe, err := mp.Exe()
-		if err != nil {
-			log.Errorf("%s: Unable to fetch process exe: %v", id, err)
-			continue
-		}
-
-		cmdLine, err := mp.CmdlineSlice()
-		if err != nil {
-			log.Errorf("%s: Unable to parse cmd line: %v", id, err)
-			continue
-		}
-
+		name := mp.Name()
+		exe := mp.Exe()
+		cmdLine := mp.CmdlineSlice()
 		flagValues := parseProcessCmdLine(cmdLine)
 
 		instance := eval.NewInstance(

--- a/pkg/compliance/checks/process_utils.go
+++ b/pkg/compliance/checks/process_utils.go
@@ -50,45 +50,48 @@ func (p *CheckedProcess) Pid() int32 {
 }
 
 // Name returns the name stored in this checked process
-func (p *CheckedProcess) Name() (string, error) {
+func (p *CheckedProcess) Name() string {
 	if p.name != "" || p.inner == nil {
-		return p.name, nil
+		return p.name
 	}
 
 	innerName, err := p.inner.Name()
 	if err != nil {
-		return "", err
+		log.Errorf("failed to fetch process (pid=%d) name: %v", p.pid, err)
+		return ""
 	}
 	p.name = innerName
-	return innerName, nil
+	return innerName
 }
 
 // Exe returns the executable path stored in this checked process
-func (p *CheckedProcess) Exe() (string, error) {
+func (p *CheckedProcess) Exe() string {
 	if p.exe != "" || p.inner == nil {
-		return p.exe, nil
+		return p.exe
 	}
 
 	innerExe, err := p.inner.Exe()
 	if err != nil {
-		return "", err
+		log.Errorf("failed to fetch process (pid=%d) exe: %v", p.pid, err)
+		return ""
 	}
 	p.exe = innerExe
-	return innerExe, nil
+	return innerExe
 }
 
 // CmdlineSlice returns the cmd line slice stored in this checked process
-func (p *CheckedProcess) CmdlineSlice() ([]string, error) {
+func (p *CheckedProcess) CmdlineSlice() []string {
 	if p.cmdLineSlice != nil || p.inner == nil {
-		return p.cmdLineSlice, nil
+		return p.cmdLineSlice
 	}
 
 	innerCmdLine, err := p.inner.CmdlineSlice()
 	if err != nil {
-		return nil, err
+		log.Errorf("failed to fetch process (pid=%d) cmdline: %v", p.pid, err)
+		return nil
 	}
 	p.cmdLineSlice = innerCmdLine
-	return innerCmdLine, nil
+	return innerCmdLine
 }
 
 type processes []*CheckedProcess
@@ -103,11 +106,7 @@ var (
 
 func (p processes) findProcessesByName(name string) []*CheckedProcess {
 	return p.findProcesses(func(p *CheckedProcess) bool {
-		pname, err := p.Name()
-		if err != nil {
-			return false
-		}
-		return pname == name
+		return p.Name() == name
 	})
 }
 

--- a/test/e2e/cws-tests/tests/test_e2e_cspm_kubernetes.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cspm_kubernetes.py
@@ -165,6 +165,11 @@ class TestE2EKubernetes(unittest.TestCase):
                 "result": "failed",
             }
         ],
+        "cis-kubernetes-1.5.1-4.2.6": [
+            {
+                "result": "failed",
+            }
+        ],
         "cis-kubernetes-1.5.1-4.2.10": [
             {
                 "result": "failed",

--- a/test/e2e/cws-tests/tests/test_e2e_cspm_kubernetes.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cspm_kubernetes.py
@@ -147,22 +147,32 @@ class TestE2EKubernetes(unittest.TestCase):
         ],
         "cis-kubernetes-1.5.1-4.2.1": [
             {
-                "result": "error",
-            }
-        ],
-        "cis-kubernetes-1.5.1-4.2.2": [
-            {
-                "result": "error",
+                "result": "failed",
             }
         ],
         "cis-kubernetes-1.5.1-4.2.3": [
             {
-                "result": "error",
+                "result": "failed",
+            }
+        ],
+        "cis-kubernetes-1.5.1-4.2.4": [
+            {
+                "result": "failed",
+            }
+        ],
+        "cis-kubernetes-1.5.1-4.2.5": [
+            {
+                "result": "failed",
+            }
+        ],
+        "cis-kubernetes-1.5.1-4.2.10": [
+            {
+                "result": "failed",
             }
         ],
         "cis-kubernetes-1.5.1-4.2.12": [
             {
-                "result": "error",
+                "result": "failed",
             }
         ],
     }


### PR DESCRIPTION
### What does this PR do?

This PR improves the error management of gopsutil process fetching to return default values instead of errors when fetching the value from `/host/proc` fails. This matches the behavior of `Datadog/gopsutil` (the previously used lib) and allows for better error handling when matching multiple processes at once.

This PR also reverts a part of expected findings changed erroneously in https://github.com/DataDog/datadog-agent/pull/13774

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
