### PR TITLE
[CODEOWNERS] Add @DataDog/agent-shared-components to `/pkg/forwarder` owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -166,7 +166,7 @@
 /pkg/aggregator/                        @DataDog/agent-metrics-logs
 /pkg/collector/                         @DataDog/agent-metrics-logs
 /pkg/dogstatsd/                         @DataDog/agent-metrics-logs
-/pkg/forwarder/                         @DataDog/agent-metrics-logs
+/pkg/forwarder/                         @DataDog/agent-metrics-logs @DataDog/agent-shared-components
 /pkg/jmxfetch/                          @DataDog/agent-metrics-logs
 /pkg/metadata/                          @DataDog/agent-shared-components
 /pkg/metrics/                           @DataDog/agent-metrics-logs


### PR DESCRIPTION
### What does this PR do?

Adds @DataDog/agent-shared-components to `/pkg/forwarder` CODEOWNERS section

### Motivation

This package should be co-owned by @DataDog/agent-shared-components and @DataDog/agent-metrics-logs since the division is unclear between the teams.

### Additional Notes

N/A

### Possible Drawbacks / Trade-offs

N/A

### Describe how to test/QA your changes

N/A

### Reviewer's Checklist

N/A