### PR TITLE
https: sowatcher scan process ended

### DIFF
--- a/pkg/network/protocols/http/shared_libraries.go
+++ b/pkg/network/protocols/http/shared_libraries.go
@@ -183,6 +183,7 @@ func (w *soWatcher) sync() {
 				for _, pidPath := range lib.PidsPath {
 					pid, err := extractPID(pidPath)
 					if err != nil {
+						log.Errorf("extractPID '%s' failed : %s", pidPath, err)
 						continue
 					}
 					w.registry.register(path, pid, r)

--- a/pkg/network/protocols/http/shared_libraries.go
+++ b/pkg/network/protocols/http/shared_libraries.go
@@ -229,7 +229,7 @@ func (w *soWatcher) checkProcessDone() (updated bool) {
 		}
 	}
 
-	for libpath := range w.registry.byPath {
+	for libpath := range pathsToBeRemoved {
 		w.registry.unregister(libpath)
 	}
 


### PR DESCRIPTION
### What does this PR do?

Scan ended pids every 10 sec and unregister library if process doesn't exist anymore.

### Motivation

The main issue is when in host propagation HostToContainer, with uprobe the kernel lock the ELF file and runc seems to wait on a free filesystem to unmount the overlay.

### Describe how to test/QA your changes

* on a k8s cluster
* edit the daemonset : kubectl edit ds
   * in system-probe section

```
        - mountPath: /host/root
          mountPropagation: HostToContainer
          name: hostroot
          readOnly: true

```
* change the image to the docker build

* kubectl get pods -o wide
* kubectl logs -f datadog-sysprobe-pod-that-run-on-the-same-node-than-haproxy  -c system-probe
* kubectl delete pod/haproxy

output logs

```
2022-10-07 21:03:53 UTC | SYS-PROBE | DEBUG | (pkg/network/http/shared_libraries.go:213 in checkProcessDone) | process /host/proc/2933421 doesn't exist anymore, unregister /host/root/run/containerd/io.containerd.runtime.v2.task/k8s.io/d48eb1059ba90ef6e1ec00b2756120a0239f3da5bbc97deeda4d36992481255f/rootfs/usr/lib/x86_64-linux-gnu/libcrypto.so.1.1
2022-10-07 21:03:53 UTC | SYS-PROBE | DEBUG | (pkg/network/http/shared_libraries.go:292 in unregister) | unregistering library=/host/root/run/containerd/io.containerd.runtime.v2.task/k8s.io/d48eb1059ba90ef6e1ec00b2756120a0239f3da5bbc97deeda4d36992481255f/rootfs/usr/lib/x86_64-linux-gnu/libcrypto.so.1.1

```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
