### PR TITLE
pkg/remoteconfig/state: add apply status to configs for RCTE2

### DIFF
--- a/pkg/remoteconfig/state/configs.go
+++ b/pkg/remoteconfig/state/configs.go
@@ -210,14 +210,34 @@ func (r *Repository) ASMFeaturesConfigs() map[string]ASMFeaturesConfig {
 	return typedConfigs
 }
 
+// ApplyState represents the status of a configuration application by a remote configuration client
+// Clients need to either ack the correct application of received configurations, or communicate that
+// they haven't applied it yet, or communicate any error that may have happened while doing so
+type ApplyState uint64
+
+const (
+	ApplyStateUnknown ApplyState = iota
+	ApplyStateUnacknowledged
+	ApplyStateAcknowledged
+	ApplyStateError
+)
+
+// ApplyStatus is the processing status for a given configuration.
+// It basically represents whether a config was successfully processed and apply, or if an error occurred
+type ApplyStatus struct {
+	State ApplyState
+	Error string
+}
+
 // Metadata stores remote config metadata for a given configuration
 type Metadata struct {
-	Product   string
-	ID        string
-	Name      string
-	Version   uint64
-	RawLength uint64
-	Hashes    map[string][]byte
+	Product     string
+	ID          string
+	Name        string
+	Version     uint64
+	RawLength   uint64
+	Hashes      map[string][]byte
+	ApplyStatus ApplyStatus
 }
 
 func newConfigMetadata(parsedPath configPath, tfm data.TargetFileMeta) (Metadata, error) {

--- a/pkg/remoteconfig/state/repository.go
+++ b/pkg/remoteconfig/state/repository.go
@@ -33,9 +33,10 @@ type RepositoryState struct {
 
 // ConfigState describes an applied config by the agent client.
 type ConfigState struct {
-	Product string
-	ID      string
-	Version uint64
+	Product     string
+	ID          string
+	Version     uint64
+	ApplyStatus ApplyStatus
 }
 
 // CachedFile describes a cached file stored by the agent client
@@ -253,6 +254,15 @@ func (r *Repository) Update(update Update) ([]string, error) {
 	return changedProducts, nil
 }
 
+// UpdateApplyStatus updates the config's metadata to reflect its processing state
+// Can be used after a call to Update() in order to tell the repository which config was acked, which
+// wasn't and which errors occurred while processing.
+func (r *Repository) UpdateApplyStatus(cfgPath string, status ApplyStatus) {
+	if m, ok := r.metadata[cfgPath]; ok {
+		m.ApplyStatus = status
+	}
+}
+
 func (r *Repository) getConfigs(product string) map[string]interface{} {
 	configs, ok := r.configs[product]
 	if !ok {
@@ -360,9 +370,10 @@ func (ur updateResult) isEmpty() bool {
 
 func configStateFromMetadata(m Metadata) ConfigState {
 	return ConfigState{
-		Product: m.Product,
-		ID:      m.ID,
-		Version: m.Version,
+		Product:     m.Product,
+		ID:          m.ID,
+		Version:     m.Version,
+		ApplyStatus: m.ApplyStatus,
 	}
 }
 

--- a/pkg/remoteconfig/state/repository.go
+++ b/pkg/remoteconfig/state/repository.go
@@ -257,6 +257,8 @@ func (r *Repository) Update(update Update) ([]string, error) {
 // UpdateApplyStatus updates the config's metadata to reflect its processing state
 // Can be used after a call to Update() in order to tell the repository which config was acked, which
 // wasn't and which errors occurred while processing.
+// Note: it is the responsibility of the caller to ensure that no new Update() call was made between
+// the first Update() call and the call to UpdateApplyStatus() so as to keep the repository state accurate.
 func (r *Repository) UpdateApplyStatus(cfgPath string, status ApplyStatus) {
 	if m, ok := r.metadata[cfgPath]; ok {
 		m.ApplyStatus = status


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Implement [RCTE2](https://docs.google.com/document/d/1bUVtEpXNTkIGvLxzkNYCxQzP2X9EK9HMBLHWXr_5KLM/edit?usp=chrome_omnibox&ouid=101259864799886662149) for remote configuration.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
This is needed in order to maintain an accurate state of the configurations. If an error occurs while processing a configuraiton
we need to be able to inform all parties so that actions can be taken upon it (re-sending a config, for example).
This is also a requirement for the ASM Go library to enable 1-click activation of its product through remote configuration (as well as future for use cases of remote config).
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
