### PR TITLE
Fix entity uniqueness in AD kubecontainer provider

### DIFF
--- a/releasenotes/notes/fix-ad-statefulset-ae77cc549e9a7cd0.yaml
+++ b/releasenotes/notes/fix-ad-statefulset-ae77cc549e9a7cd0.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    Fix a bug in Autodiscovery preventing the Agent to correctly schedule checks or logs configurations on newly created PODs during a StatefulSet rollout.
+    Fix a bug in Autodiscovery that prevents the Agent from correctly scheduling checks or log configurations on newly created pods during a StatefulSet rollout.

--- a/releasenotes/notes/fix-ad-statefulset-ae77cc549e9a7cd0.yaml
+++ b/releasenotes/notes/fix-ad-statefulset-ae77cc549e9a7cd0.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix a bug in Autodiscovery preventing the Agent to correctly schedule checks or logs configurations on newly created PODs during a StatefulSet rollout.


### PR DESCRIPTION
### What does this PR do?

Fix a bug in Autodiscovery preventing the Agent to correctly schedule checks or logs configurations on newly created PODs during a StatefulSet rollout.

### Motivation

Bugfix.

### Additional Notes

### Possible Drawbacks / Trade-offs

It could have been cleaner to separate the stored id and the display name, although this will increase code complexity and incur a small performance penalty.
I believe it's easier to understand this way.

### Describe how to test/QA your changes

The original bug is difficult to reproduce as it depends on the sequence of events in the Kubelet+containerd collectors.
The actual validation requires extra logs to make sure what was scheduled/unscheduled (which I've done).
Flagging is PR as `skip-qa` due to this as manual validation won't bring added value.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
