### PR TITLE
[netflow] Note on optimisation of ephemeral port rollup mem usage

### DIFF
--- a/pkg/netflow/portrollup/portrollup.go
+++ b/pkg/netflow/portrollup/portrollup.go
@@ -42,6 +42,16 @@ const (
 type EndpointPairPortRollupStore struct {
 	portRollupThreshold int
 
+	// If there is a need to optimize storage used for ephemeral port rollup, a possible solution is to use
+	// a 64bits or 128bits hash. See benchmark below:
+	// Benchmark/Stats for 20 millions keys
+	// Type of key               | Mem used | % less compared| collision probably
+	//                           |          | to string key  | for 20M keys
+	// ---------------------------------------------------------------
+	// String (current)          | 1883 MB  |                | none
+	// Hash 128bits/16bytes key  | 1633 MB  | -250 MB / -13% | near 0 / ridiculously small
+	// Hash 64bits/8bytes key    | 1450 MB  | -433 MB / -22% | ~0.00001 (1 in 100k)
+
 	// We might also use map[uint16]struct to store ports, but using []uint16 takes less mem.
 	// - Empty map is about 128 bytes
 	// - Empty list is about 24 bytes


### PR DESCRIPTION
…torage

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

[netflow] Note on optimisation of ephemeral port rollup mem usage

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Note for future

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
