### PR TITLE
[netflow] Add metric and log to detect hash collision

### DIFF
--- a/pkg/netflow/common/flow.go
+++ b/pkg/netflow/common/flow.go
@@ -84,16 +84,16 @@ func (f *Flow) AggregationHash() uint64 {
 // IsEqualFlowContext check if the flow and another flow have equal values for all fields used in `AggregationHash`.
 // This method is used for hash collision detection.
 func IsEqualFlowContext(a Flow, b Flow) bool {
-	if a.Namespace != b.Namespace ||
-		bytes.Compare(a.DeviceAddr, b.DeviceAddr) != 0 ||
-		bytes.Compare(a.SrcAddr, b.SrcAddr) != 0 ||
-		bytes.Compare(a.DstAddr, b.DstAddr) != 0 ||
-		a.SrcPort != b.SrcPort ||
-		a.DstPort != b.DstPort ||
-		a.IPProtocol != b.IPProtocol ||
-		a.Tos != b.Tos ||
-		a.InputInterface != b.InputInterface {
-		return false
+	if a.Namespace == b.Namespace &&
+		bytes.Compare(a.DeviceAddr, b.DeviceAddr) == 0 &&
+		bytes.Compare(a.SrcAddr, b.SrcAddr) == 0 &&
+		bytes.Compare(a.DstAddr, b.DstAddr) == 0 &&
+		a.SrcPort == b.SrcPort &&
+		a.DstPort == b.DstPort &&
+		a.IPProtocol == b.IPProtocol &&
+		a.Tos == b.Tos &&
+		a.InputInterface == b.InputInterface {
+		return true
 	}
-	return true
+	return false
 }

--- a/pkg/netflow/common/flow.go
+++ b/pkg/netflow/common/flow.go
@@ -6,6 +6,7 @@
 package common
 
 import (
+	"bytes"
 	"encoding/binary"
 	"hash/fnv"
 )
@@ -78,4 +79,21 @@ func (f *Flow) AggregationHash() uint64 {
 	binary.Write(h, binary.LittleEndian, f.Tos)            //nolint:errcheck
 	binary.Write(h, binary.LittleEndian, f.InputInterface) //nolint:errcheck
 	return h.Sum64()
+}
+
+// IsEqualFlowContext check if the flow and another flow have equal values for all fields used in `AggregationHash`.
+// This method is used for hash collision detection.
+func IsEqualFlowContext(a Flow, b Flow) bool {
+	if a.Namespace != b.Namespace ||
+		bytes.Compare(a.DeviceAddr, b.DeviceAddr) != 0 ||
+		bytes.Compare(a.SrcAddr, b.SrcAddr) != 0 ||
+		bytes.Compare(a.DstAddr, b.DstAddr) != 0 ||
+		a.SrcPort != b.SrcPort ||
+		a.DstPort != b.DstPort ||
+		a.IPProtocol != b.IPProtocol ||
+		a.Tos != b.Tos ||
+		a.InputInterface != b.InputInterface {
+		return false
+	}
+	return true
 }

--- a/pkg/netflow/common/flow_test.go
+++ b/pkg/netflow/common/flow_test.go
@@ -88,3 +88,73 @@ func TestFlow_AggregationHash(t *testing.T) {
 	// Should contain expected number of different hashes
 	assert.Equal(t, 10, len(allHash))
 }
+
+func TestFlow_IsEqualFlowContext(t *testing.T) {
+	origFlow := Flow{
+		Namespace:      "default",
+		DeviceAddr:     []byte{127, 0, 0, 1},
+		SrcAddr:        []byte{1, 2, 3, 4},
+		DstAddr:        []byte{2, 3, 4, 5},
+		IPProtocol:     6,
+		SrcPort:        2000,
+		DstPort:        80,
+		InputInterface: 1,
+		Tos:            0,
+		Bytes:          5,
+	}
+
+	otherFlow := Flow{
+		Namespace:      "default",
+		DeviceAddr:     []byte{127, 0, 0, 1},
+		SrcAddr:        []byte{1, 2, 3, 4},
+		DstAddr:        []byte{2, 3, 4, 5},
+		IPProtocol:     6,
+		SrcPort:        2000,
+		DstPort:        80,
+		InputInterface: 1,
+		Tos:            0,
+		Bytes:          10,
+	}
+
+	assert.True(t, IsEqualFlowContext(origFlow, otherFlow))
+
+	flow := origFlow
+	flow.Namespace = "abc"
+	assert.False(t, IsEqualFlowContext(origFlow, flow))
+
+	flow = origFlow
+	flow.DeviceAddr = []byte{127, 0, 0, 2}
+	assert.False(t, IsEqualFlowContext(origFlow, flow))
+
+	flow = origFlow
+	flow.SrcAddr = []byte{1, 2, 3, 5}
+	assert.False(t, IsEqualFlowContext(origFlow, flow))
+
+	flow = origFlow
+	flow.DstAddr = []byte{2, 3, 4, 6}
+	assert.False(t, IsEqualFlowContext(origFlow, flow))
+
+	flow = origFlow
+	flow.IPProtocol = 7
+	assert.False(t, IsEqualFlowContext(origFlow, flow))
+
+	flow = origFlow
+	flow.SrcPort = 2001
+	assert.False(t, IsEqualFlowContext(origFlow, flow))
+
+	flow = origFlow
+	flow.DstPort = 81
+	assert.False(t, IsEqualFlowContext(origFlow, flow))
+
+	flow = origFlow
+	flow.InputInterface = 2
+	assert.False(t, IsEqualFlowContext(origFlow, flow))
+
+	flow = origFlow
+	flow.Tos = 1
+	assert.False(t, IsEqualFlowContext(origFlow, flow))
+
+	flow = origFlow
+	flow.Bytes = 999
+	assert.True(t, IsEqualFlowContext(origFlow, flow))
+}

--- a/pkg/netflow/flowaggregator/aggregator.go
+++ b/pkg/netflow/flowaggregator/aggregator.go
@@ -30,7 +30,6 @@ type FlowAggregator struct {
 	sender                       aggregator.Sender
 	stopChan                     chan struct{}
 	receivedFlowCount            *atomic.Uint64
-	hashCollisionFlowCount       *atomic.Uint64
 	flushedFlowCount             *atomic.Uint64
 	hostname                     string
 }
@@ -47,7 +46,6 @@ func NewFlowAggregator(sender aggregator.Sender, config *config.NetflowConfig, h
 		rollupTrackerRefreshInterval: rollupTrackerRefreshInterval,
 		sender:                       sender,
 		stopChan:                     make(chan struct{}),
-		hashCollisionFlowCount:       atomic.NewUint64(0),
 		receivedFlowCount:            atomic.NewUint64(0),
 		flushedFlowCount:             atomic.NewUint64(0),
 		hostname:                     hostname,
@@ -79,10 +77,7 @@ func (agg *FlowAggregator) run() {
 			return
 		case flow := <-agg.flowIn:
 			agg.receivedFlowCount.Inc()
-			hasHashCollision := agg.flowAcc.add(flow)
-			if hasHashCollision {
-				agg.hashCollisionFlowCount.Inc()
-			}
+			agg.flowAcc.add(flow)
 		}
 	}
 }
@@ -141,7 +136,7 @@ func (agg *FlowAggregator) flush() int {
 	}
 
 	agg.flushedFlowCount.Add(uint64(len(flowsToFlush)))
-	agg.sender.MonotonicCount("datadog.netflow.aggregator.hash_collisions", float64(agg.hashCollisionFlowCount.Load()), "", nil)
+	agg.sender.MonotonicCount("datadog.netflow.aggregator.hash_collisions", float64(agg.flowAcc.hashCollisionFlowCount.Load()), "", nil)
 	agg.sender.MonotonicCount("datadog.netflow.aggregator.flows_received", float64(agg.receivedFlowCount.Load()), "", nil)
 	agg.sender.MonotonicCount("datadog.netflow.aggregator.flows_flushed", float64(agg.flushedFlowCount.Load()), "", nil)
 	agg.sender.Gauge("datadog.netflow.aggregator.flows_contexts", float64(flowsContexts), "", nil)

--- a/pkg/netflow/flowaggregator/flowaccumulator.go
+++ b/pkg/netflow/flowaggregator/flowaccumulator.go
@@ -126,7 +126,9 @@ func (f *flowAccumulator) add(flowToAdd *common.Flow) (hasHashCollision bool) {
 	if aggFlow.flow == nil {
 		aggFlow.flow = flowToAdd
 	} else {
+		// use go routine for has collision detection to avoid blocking critical path
 		go f.detectHashCollision(*aggFlow.flow, *flowToAdd)
+
 		// accumulate flowToAdd with existing flow(s) with same hash
 		aggFlow.flow.Bytes += flowToAdd.Bytes
 		aggFlow.flow.Packets += flowToAdd.Packets

--- a/pkg/netflow/flowaggregator/flowaccumulator.go
+++ b/pkg/netflow/flowaggregator/flowaccumulator.go
@@ -149,7 +149,7 @@ func (f *flowAccumulator) getFlowContextCount() int {
 
 func (f *flowAccumulator) detectHashCollision(hash uint64, existingFlow common.Flow, flowToAdd common.Flow) {
 	if !common.IsEqualFlowContext(existingFlow, flowToAdd) {
-		log.Warnf("Hash collision for flows with hash `%s`: existingFlow=`%v` flowToAdd=`%v`", hash, existingFlow, flowToAdd)
+		log.Warnf("Hash collision for flows with hash `%s`: existingFlow=`%+v` flowToAdd=`%+v`", hash, existingFlow, flowToAdd)
 		f.hashCollisionFlowCount.Inc()
 	}
 }

--- a/pkg/netflow/flowaggregator/flowaccumulator.go
+++ b/pkg/netflow/flowaggregator/flowaccumulator.go
@@ -149,7 +149,7 @@ func (f *flowAccumulator) getFlowContextCount() int {
 
 func (f *flowAccumulator) detectHashCollision(hash uint64, existingFlow common.Flow, flowToAdd common.Flow) {
 	if !common.IsEqualFlowContext(existingFlow, flowToAdd) {
-		log.Warnf("Hash collision for flows with hash `%s`: existingFlow=`%+v` flowToAdd=`%+v`", hash, existingFlow, flowToAdd)
+		log.Warnf("Hash collision for flows with hash `%d`: existingFlow=`%+v` flowToAdd=`%+v`", hash, existingFlow, flowToAdd)
 		f.hashCollisionFlowCount.Inc()
 	}
 }

--- a/pkg/netflow/flowaggregator/flowaccumulator.go
+++ b/pkg/netflow/flowaggregator/flowaccumulator.go
@@ -99,7 +99,7 @@ func (f *flowAccumulator) flush() []*common.Flow {
 	return flowsToFlush
 }
 
-func (f *flowAccumulator) add(flowToAdd *common.Flow) (hasHashCollision bool) {
+func (f *flowAccumulator) add(flowToAdd *common.Flow) {
 	log.Tracef("Add new flow: %+v", flowToAdd)
 
 	if !f.portRollupDisabled {
@@ -121,7 +121,7 @@ func (f *flowAccumulator) add(flowToAdd *common.Flow) (hasHashCollision bool) {
 	aggFlow, ok := f.flows[aggHash]
 	if !ok {
 		f.flows[aggHash] = newFlowContext(flowToAdd)
-		return false
+		return
 	}
 	if aggFlow.flow == nil {
 		aggFlow.flow = flowToAdd
@@ -137,7 +137,6 @@ func (f *flowAccumulator) add(flowToAdd *common.Flow) (hasHashCollision bool) {
 		aggFlow.flow.TCPFlags |= flowToAdd.TCPFlags
 	}
 	f.flows[aggHash] = aggFlow
-	return false
 }
 
 func (f *flowAccumulator) getFlowContextCount() int {

--- a/pkg/netflow/flowaggregator/flowaccumulator.go
+++ b/pkg/netflow/flowaggregator/flowaccumulator.go
@@ -127,7 +127,7 @@ func (f *flowAccumulator) add(flowToAdd *common.Flow) (hasHashCollision bool) {
 		aggFlow.flow = flowToAdd
 	} else {
 		// use go routine for has collision detection to avoid blocking critical path
-		go f.detectHashCollision(*aggFlow.flow, *flowToAdd)
+		go f.detectHashCollision(aggHash, *aggFlow.flow, *flowToAdd)
 
 		// accumulate flowToAdd with existing flow(s) with same hash
 		aggFlow.flow.Bytes += flowToAdd.Bytes
@@ -147,9 +147,9 @@ func (f *flowAccumulator) getFlowContextCount() int {
 	return len(f.flows)
 }
 
-func (f *flowAccumulator) detectHashCollision(flowA common.Flow, flowB common.Flow) {
-	if !common.IsEqualFlowContext(flowA, flowB) {
-		log.Warnf("Hash collision for flows `%v` and `%v`", flowA, flowB)
+func (f *flowAccumulator) detectHashCollision(hash uint64, existingFlow common.Flow, flowToAdd common.Flow) {
+	if !common.IsEqualFlowContext(existingFlow, flowToAdd) {
+		log.Warnf("Hash collision for flows with hash `%s`: existingFlow=`%v` flowToAdd=`%v`", hash, existingFlow, flowToAdd)
 		f.hashCollisionFlowCount.Inc()
 	}
 }

--- a/pkg/netflow/flowaggregator/flowaccumulator.go
+++ b/pkg/netflow/flowaggregator/flowaccumulator.go
@@ -123,6 +123,7 @@ func (f *flowAccumulator) add(flowToAdd *common.Flow) (hasHashCollision bool) {
 		aggFlow.flow = flowToAdd
 	} else {
 		if !common.IsEqualFlowContext(*aggFlow.flow, *flowToAdd) {
+			log.Warnf("Hash collision for flows `%v` and `%v`", *aggFlow.flow, *flowToAdd)
 			return true
 		}
 		// accumulate flowToAdd with existing flow(s) with same hash


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

[netflow] Add metric and log to detect hash collision

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Will help monitor and detect hash collision.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Right, I didn't manage to have a real hash collision.

A way to simulate hash collision is to comment one of the fields of the hash like `DstPort` and send some flows with different values of this field.

https://github.com/DataDog/datadog-agent/blob/ccafa9e41618e617f0889a6a93457e8e07969cb9/pkg/netflow/common/flow.go#L77

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
