### PR TITLE
[backport][corechecks/helm] Add missing nil checks in getValue()

### DIFF
--- a/pkg/collector/corechecks/cluster/helm/map_utils.go
+++ b/pkg/collector/corechecks/cluster/helm/map_utils.go
@@ -31,11 +31,15 @@ import (
 // "agents.image.tag" and "agents.image.pullPolicy" are valid keys, but
 // "agents.image" is not.
 func getValue(m map[string]interface{}, dotSeparatedKey string) (string, error) {
+	if dotSeparatedKey == "" {
+		return "", fmt.Errorf("not found")
+	}
+
 	keys := strings.Split(dotSeparatedKey, ".")
 	var obj interface{} = m
 
 	for _, key := range keys {
-		if reflect.TypeOf(obj).Kind() != reflect.Map {
+		if obj == nil || reflect.TypeOf(obj).Kind() != reflect.Map {
 			return "", fmt.Errorf("not found")
 		}
 
@@ -50,7 +54,7 @@ func getValue(m map[string]interface{}, dotSeparatedKey string) (string, error) 
 		obj = objValue.Interface()
 	}
 
-	if reflect.TypeOf(obj).Kind() == reflect.Map {
+	if obj == nil || reflect.TypeOf(obj).Kind() == reflect.Map {
 		return "", fmt.Errorf("not found")
 	}
 

--- a/pkg/collector/corechecks/cluster/helm/map_utils_test.go
+++ b/pkg/collector/corechecks/cluster/helm/map_utils_test.go
@@ -98,6 +98,40 @@ func TestGetValue(t *testing.T) {
 			dotSeparatedKey: "agents.image.abc",
 			expectsError:    true,
 		},
+		{
+			name: "nil value for final part of the key",
+			inputMap: map[string]interface{}{
+				"agents": map[string]interface{}{
+					"image": map[string]interface{}{
+						"tag": nil,
+					},
+				},
+			},
+			dotSeparatedKey: "agents.image.tag",
+			expectsError:    true,
+		},
+		{
+			name: "nil value for middle part of the key",
+			inputMap: map[string]interface{}{
+				"agents": map[string]interface{}{
+					"image": nil,
+				},
+			},
+			dotSeparatedKey: "agents.image.tag",
+			expectsError:    true,
+		},
+		{
+			name: "empty key",
+			inputMap: map[string]interface{}{
+				"agents": map[string]interface{}{
+					"image": map[string]string{
+						"tag": "7.39.0",
+					},
+				},
+			},
+			dotSeparatedKey: "",
+			expectsError:    true,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION

### What does this PR do?

Backport of https://github.com/DataDog/datadog-agent/pull/13815 to 7.40.x.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
