### PR TITLE
Container check: ignore aberrant values for `container.memory.rss`

### DIFF
--- a/pkg/collector/corechecks/containers/generic/processor.go
+++ b/pkg/collector/corechecks/containers/generic/processor.go
@@ -160,7 +160,10 @@ func (p *Processor) processContainer(sender aggregator.Sender, tags []string, co
 		p.sendMetric(sender.Gauge, "container.memory.kernel", containerStats.Memory.KernelMemory, tags)
 		p.sendMetric(sender.Gauge, "container.memory.limit", containerStats.Memory.Limit, tags)
 		p.sendMetric(sender.Gauge, "container.memory.soft_limit", containerStats.Memory.Softlimit, tags)
-		p.sendMetric(sender.Gauge, "container.memory.rss", containerStats.Memory.RSS, tags)
+		// Filter out aberant values
+		if *containerStats.Memory.RSS < 1<<63 {
+			p.sendMetric(sender.Gauge, "container.memory.rss", containerStats.Memory.RSS, tags)
+		}
 		p.sendMetric(sender.Gauge, "container.memory.cache", containerStats.Memory.Cache, tags)
 		p.sendMetric(sender.Gauge, "container.memory.swap", containerStats.Memory.Swap, tags)
 		p.sendMetric(sender.Gauge, "container.memory.oom_events", containerStats.Memory.OOMEvents, tags)

--- a/pkg/collector/corechecks/containers/generic/processor.go
+++ b/pkg/collector/corechecks/containers/generic/processor.go
@@ -160,10 +160,7 @@ func (p *Processor) processContainer(sender aggregator.Sender, tags []string, co
 		p.sendMetric(sender.Gauge, "container.memory.kernel", containerStats.Memory.KernelMemory, tags)
 		p.sendMetric(sender.Gauge, "container.memory.limit", containerStats.Memory.Limit, tags)
 		p.sendMetric(sender.Gauge, "container.memory.soft_limit", containerStats.Memory.Softlimit, tags)
-		// Filter out aberant values
-		if *containerStats.Memory.RSS < 1<<63 {
-			p.sendMetric(sender.Gauge, "container.memory.rss", containerStats.Memory.RSS, tags)
-		}
+		p.sendMetric(sender.Gauge, "container.memory.rss", containerStats.Memory.RSS, tags)
 		p.sendMetric(sender.Gauge, "container.memory.cache", containerStats.Memory.Cache, tags)
 		p.sendMetric(sender.Gauge, "container.memory.swap", containerStats.Memory.Swap, tags)
 		p.sendMetric(sender.Gauge, "container.memory.oom_events", containerStats.Memory.OOMEvents, tags)

--- a/pkg/util/cgroups/cgroupv1_memory.go
+++ b/pkg/util/cgroups/cgroupv1_memory.go
@@ -41,7 +41,10 @@ func (c *cgroupV1) GetMemoryStats(stats *MemoryStats) error {
 		case "total_swap":
 			stats.Swap = &intVal
 		case "total_rss":
-			stats.RSS = &intVal
+			// Filter out aberant values
+			if intVal < 1<<63 {
+				stats.RSS = &intVal
+			}
 		case "total_rss_huge":
 			stats.RSSHuge = &intVal
 		case "total_mapped_file":

--- a/pkg/util/cgroups/cgroupv1_memory.go
+++ b/pkg/util/cgroups/cgroupv1_memory.go
@@ -41,7 +41,7 @@ func (c *cgroupV1) GetMemoryStats(stats *MemoryStats) error {
 		case "total_swap":
 			stats.Swap = &intVal
 		case "total_rss":
-			// Filter out aberant values
+			// Filter out aberrant values
 			if intVal < 1<<63 {
 				stats.RSS = &intVal
 			}

--- a/releasenotes/notes/filter-out-aberrant-rss-value-64be20e1a66c0a4e.yaml
+++ b/releasenotes/notes/filter-out-aberrant-rss-value-64be20e1a66c0a4e.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Discard aberrant values (close to 18 EiB) in the ``container.memory.rss`` metric.


### PR DESCRIPTION
### What does this PR do?

Ignore aberrant values (close to 18 EiB) for `container.memory.rss`.

### Motivation

Under some circumstances, the `memory.stat` cgroup file shows super high value for `total_rss` like for ex.:

```
/host/sys/fs/cgroup/memory/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod1cbe9fde_6ee9_445f_8f59_7298e66618f5.slice/cri-containerd-38fe097c37a933d8d2f5d3fe50e751bb64d3001e07217529349a9446a2944946.scope/memory.stat
```
```
cache 1622016
rss 1409024
rss_huge 0
shmem 0
mapped_file 159744
dirty 0
writeback 0
swap 0
pgpgin 231327950
pgpgout 231327210
pgfault 347344261
pgmajfault 75
inactive_anon 1404928
active_anon 4096
inactive_file 204800
active_file 1417216
unevictable 0
hierarchical_memory_limit 268435456
hierarchical_memsw_limit 9223372036854771712
total_cache 1622016
total_rss 18446744073706844160
total_rss_huge 0
total_shmem 0
total_mapped_file 159744
total_dirty 0
total_writeback 0
total_swap 0
total_pgpgin 231326246
total_pgpgout 231326507
total_pgfault 347341748
total_pgmajfault 75
total_inactive_anon 18446744073706860544
total_active_anon 0
total_inactive_file 204800
total_active_file 1417216
total_unevictable 0
```

In this case, the RSS value must be ignored to avoid triggering some “high memory” monitors.

### Additional Notes

* DataDog/integrations-core#13076

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Load the agent on a big cluster and look for spikes in `max:container.memory.rss{$datacenter,$kube_cluster_name,$host} by {datacenter,kube_cluster_name,host}.fill(null)`
While the metric should still be there, the spikes should disappear with an agent having this change.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
