### PR TITLE
[APM] Add v2 of the evp_proxy endpoint

### DIFF
--- a/pkg/trace/api/endpoints.go
+++ b/pkg/trace/api/endpoints.go
@@ -117,6 +117,10 @@ var endpoints = []Endpoint{
 		Handler: func(r *HTTPReceiver) http.Handler { return r.evpProxyHandler() },
 	},
 	{
+		Pattern: "/evp_proxy/v2/",
+		Handler: func(r *HTTPReceiver) http.Handler { return r.evpProxyHandler() },
+	},
+	{
 		Pattern: "/debugger/v1/input",
 		Handler: func(r *HTTPReceiver) http.Handler { return r.debuggerProxyHandler() },
 	},

--- a/pkg/trace/api/info_test.go
+++ b/pkg/trace/api/info_test.go
@@ -131,6 +131,7 @@ func TestInfoHandler(t *testing.T) {
 		"/v0.1/pipeline_stats",
 		"/appsec/proxy/",
 		"/evp_proxy/v1/",
+		"/evp_proxy/v2/",
 		"/debugger/v1/input"
 		"/dogstatsd/v1/proxy"
 	],
@@ -191,6 +192,7 @@ func TestInfoHandler(t *testing.T) {
 		"/v0.1/pipeline_stats",
 		"/appsec/proxy/",
 		"/evp_proxy/v1/",
+		"/evp_proxy/v2/",
 		"/debugger/v1/input"
 		"/dogstatsd/v1/proxy"
 	],


### PR DESCRIPTION
### What does this PR do?

In #13212 we added a new feature to the EVP Proxy. However, there was no way for tracers to know if the new feature is available or not in the Agent, since we didn't bump the version.

Although this feature is also supported in the `v1` API (since it's not a breaking change for `v1`), we want to add a way to tell our tracers that this version of the Agent supports the new feature by adding a `v2` API.