### PR TITLE
[dca] Introduce the Cluster Tagger

### DIFF
--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -241,7 +241,7 @@ func runAgent(ctx context.Context, cliParams *cliParams, config config.Component
 
 	// container tagging initialisation if origin detection is on
 	if config.GetBool("dogstatsd_origin_detection") {
-		store := workloadmeta.GetGlobalStore()
+		store := workloadmeta.CreateGlobalStore(workloadmeta.NodeAgentCatalog)
 		store.Start(ctx)
 
 		tagger.SetDefaultTagger(local.NewTagger(store))

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -178,16 +178,22 @@ func runAgent(exit chan struct{}) {
 	misconfig.ToLog(misconfig.ProcessAgent)
 
 	// Start workload metadata store before tagger (used for containerCollection)
-	store := workloadmeta.GetGlobalStore()
+	store := workloadmeta.CreateGlobalStore(workloadmeta.NodeAgentCatalog)
 	store.Start(mainCtx)
 
 	// Tagger must be initialized after agent config has been setup
 	var t tagger.Tagger
 	if ddconfig.Datadog.GetBool("process_config.remote_tagger") {
-		t = remote.NewTagger()
+		options, err := remote.NodeAgentOptions()
+		if err != nil {
+			log.Errorf("unable to configure the remote tagger: %s", err)
+		} else {
+			t = remote.NewTagger(options)
+		}
 	} else {
 		t = local.NewTagger(store)
 	}
+
 	tagger.SetDefaultTagger(t)
 	err = tagger.Init(mainCtx)
 	if err != nil {

--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -231,15 +231,20 @@ func RunAgent(ctx context.Context, pidfilePath string) (err error) {
 
 	// Initialize the remote tagger
 	if coreconfig.Datadog.GetBool("security_agent.remote_tagger") {
-		tagger.SetDefaultTagger(remote.NewTagger())
-		err := tagger.Init(ctx)
+		options, err := remote.NodeAgentOptions()
 		if err != nil {
-			log.Errorf("failed to start the tagger: %s", err)
+			log.Errorf("unable to configure the remote tagger: %s", err)
+		} else {
+			tagger.SetDefaultTagger(remote.NewTagger(options))
+			err := tagger.Init(ctx)
+			if err != nil {
+				log.Errorf("failed to start the tagger: %s", err)
+			}
 		}
 	}
 
 	// Start workloadmeta store
-	store := workloadmeta.GetGlobalStore()
+	store := workloadmeta.CreateGlobalStore(workloadmeta.NodeAgentCatalog)
 	store.Start(ctx)
 
 	complianceAgent, err := compliance.StartCompliance(hostnameDetected, stopper, statsdClient)

--- a/cmd/trace-agent/run.go
+++ b/cmd/trace-agent/run.go
@@ -155,17 +155,23 @@ func Run(ctx context.Context) {
 
 	remoteTagger := coreconfig.Datadog.GetBool("apm_config.remote_tagger")
 	if remoteTagger {
-		tagger.SetDefaultTagger(remote.NewTagger())
-		if err := tagger.Init(ctx); err != nil {
-			log.Infof("starting remote tagger failed. falling back to local tagger: %s", err)
+		options, err := remote.NodeAgentOptions()
+		if err != nil {
+			log.Errorf("unable to configure the remote tagger: %s", err)
 			remoteTagger = false
+		} else {
+			tagger.SetDefaultTagger(remote.NewTagger(options))
+			if err := tagger.Init(ctx); err != nil {
+				log.Infof("starting remote tagger failed. falling back to local tagger: %s", err)
+				remoteTagger = false
+			}
 		}
 	}
 
 	// starts the local tagger if apm_config says so, or if starting the
 	// remote tagger has failed.
 	if !remoteTagger {
-		store := workloadmeta.GetGlobalStore()
+		store := workloadmeta.CreateGlobalStore(workloadmeta.NodeAgentCatalog)
 		store.Start(ctx)
 
 		tagger.SetDefaultTagger(local.NewTagger(store))

--- a/cmd/trace-agent/run.go
+++ b/cmd/trace-agent/run.go
@@ -157,12 +157,12 @@ func Run(ctx context.Context) {
 	if remoteTagger {
 		options, err := remote.NodeAgentOptions()
 		if err != nil {
-			log.Errorf("unable to configure the remote tagger: %s", err)
+			log.Errorf("Unable to configure the remote tagger: %s", err)
 			remoteTagger = false
 		} else {
 			tagger.SetDefaultTagger(remote.NewTagger(options))
 			if err := tagger.Init(ctx); err != nil {
-				log.Infof("starting remote tagger failed. falling back to local tagger: %s", err)
+				log.Infof("Starting remote tagger failed. Falling back to local tagger: %s", err)
 				remoteTagger = false
 			}
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -713,6 +713,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("cluster_agent.token_name", "datadogtoken")
 	config.BindEnvAndSetDefault("cluster_agent.max_leader_connections", 100)
 	config.BindEnvAndSetDefault("cluster_agent.client_reconnect_period_seconds", 1200)
+	config.BindEnvAndSetDefault("cluster_agent.collect_kubernetes_tags", false)
 	config.BindEnvAndSetDefault("metrics_port", "5000")
 
 	// Metadata endpoints

--- a/pkg/logs/internal/launchers/docker/launcher_test.go
+++ b/pkg/logs/internal/launchers/docker/launcher_test.go
@@ -18,9 +18,14 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/status"
 	"github.com/DataDog/datadog-agent/pkg/logs/service"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 
 	"github.com/docker/docker/api/types"
 )
+
+func init() {
+	workloadmeta.CreateGlobalStore(nil)
+}
 
 func TestOverrideSourceServiceNameOrder(t *testing.T) {
 	tests := []struct {

--- a/pkg/security/probe/resolvers/tags_resolver.go
+++ b/pkg/security/probe/resolvers/tags_resolver.go
@@ -83,14 +83,18 @@ func (t *TagsResolver) Stop() error {
 
 // NewTagsResolver returns a new tags resolver
 func NewTagsResolver(config *config.Config) *TagsResolver {
-	var tagger Tagger
 	if config.RemoteTaggerEnabled {
-		tagger = remote.NewTagger()
-	} else {
-		tagger = &nullTagger{}
+		options, err := remote.NodeAgentOptions()
+		if err != nil {
+			log.Errorf("unable to configure the remote tagger: %s", err)
+		} else {
+			return &TagsResolver{
+				tagger: remote.NewTagger(options),
+			}
+		}
 	}
 
 	return &TagsResolver{
-		tagger: tagger,
+		tagger: &nullTagger{},
 	}
 }

--- a/pkg/tagger/collectors/workloadmeta_extract.go
+++ b/pkg/tagger/collectors/workloadmeta_extract.go
@@ -454,11 +454,6 @@ func (c *WorkloadMetaCollector) extractTagsFromPodOwner(pod *workloadmeta.Kubern
 			tags.AddLow(kubernetes.DeploymentTagName, deployment)
 		}
 		tags.AddLow(kubernetes.ReplicaSetTagName, owner.Name)
-
-	case "":
-
-	default:
-		log.Debugf("unknown owner kind %q for pod %q", owner.Kind, pod.Name)
 	}
 }
 

--- a/pkg/tagger/global.go
+++ b/pkg/tagger/global.go
@@ -7,6 +7,7 @@ package tagger
 
 import (
 	"context"
+	"errors"
 	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -76,8 +77,8 @@ func Init(ctx context.Context) error {
 			DogstatsdCardinality = collectors.LowCardinality
 		}
 
-		if config.IsCLCRunner() {
-			log.Infof("Tagger not started on CLC")
+		if defaultTagger == nil {
+			initErr = errors.New("tagger has not been set")
 			return
 		}
 

--- a/pkg/tagger/local/tagger_test.go
+++ b/pkg/tagger/local/tagger_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestTagBuilder(t *testing.T) {
-	tagger := NewTagger(workloadmeta.GetGlobalStore())
+	tagger := NewTagger(workloadmeta.NewStore(nil))
 	tagger.Init(context.Background())
 	defer tagger.Stop()
 

--- a/pkg/util/clusteragent/clusteragent.go
+++ b/pkg/util/clusteragent/clusteragent.go
@@ -104,7 +104,7 @@ func GetClusterAgentClient() (DCAClientInterface, error) {
 func (c *DCAClient) init() error {
 	var err error
 
-	c.clusterAgentAPIEndpoint, err = getClusterAgentEndpoint()
+	c.clusterAgentAPIEndpoint, err = GetClusterAgentEndpoint()
 	if err != nil {
 		return err
 	}
@@ -199,12 +199,12 @@ func (c *DCAClient) initLeaderClient() {
 	c.leaderClient = newLeaderClient(c.clusterAgentAPIClient, c.clusterAgentAPIEndpoint)
 }
 
-// getClusterAgentEndpoint provides a validated https endpoint from configuration keys in datadog.yaml:
+// GetClusterAgentEndpoint provides a validated https endpoint from configuration keys in datadog.yaml:
 // 1st. configuration key "cluster_agent.url" (or the DD_CLUSTER_AGENT_URL environment variable),
 //      add the https prefix if the scheme isn't specified
 // 2nd. environment variables associated with "cluster_agent.kubernetes_service_name"
 //      ${dcaServiceName}_SERVICE_HOST and ${dcaServiceName}_SERVICE_PORT
-func getClusterAgentEndpoint() (string, error) {
+func GetClusterAgentEndpoint() (string, error) {
 	const configDcaURL = "cluster_agent.url"
 	const configDcaSvcName = "cluster_agent.kubernetes_service_name"
 

--- a/pkg/util/clusteragent/clusteragent_test.go
+++ b/pkg/util/clusteragent/clusteragent_test.go
@@ -300,7 +300,7 @@ func (suite *clusterAgentSuite) TestGetClusterAgentEndpointEmpty() {
 	mockConfig.Set("cluster_agent.url", "")
 	mockConfig.Set("cluster_agent.kubernetes_service_name", "")
 
-	_, err := getClusterAgentEndpoint()
+	_, err := GetClusterAgentEndpoint()
 	require.NotNil(suite.T(), err)
 }
 
@@ -364,20 +364,20 @@ func (suite *clusterAgentSuite) TestGetClusterAgentAuthTokenTooShort() {
 func (suite *clusterAgentSuite) TestGetClusterAgentEndpointFromUrl() {
 	mockConfig.Set("cluster_agent.url", "https://127.0.0.1:8080")
 	mockConfig.Set("cluster_agent.kubernetes_service_name", "")
-	_, err := getClusterAgentEndpoint()
+	_, err := GetClusterAgentEndpoint()
 	require.Nil(suite.T(), err, fmt.Sprintf("%v", err))
 
 	mockConfig.Set("cluster_agent.url", "https://127.0.0.1")
-	_, err = getClusterAgentEndpoint()
+	_, err = GetClusterAgentEndpoint()
 	require.Nil(suite.T(), err, fmt.Sprintf("%v", err))
 
 	mockConfig.Set("cluster_agent.url", "127.0.0.1")
-	endpoint, err := getClusterAgentEndpoint()
+	endpoint, err := GetClusterAgentEndpoint()
 	require.Nil(suite.T(), err, fmt.Sprintf("%v", err))
 	assert.Equal(suite.T(), "https://127.0.0.1", endpoint)
 
 	mockConfig.Set("cluster_agent.url", "127.0.0.1:1234")
-	endpoint, err = getClusterAgentEndpoint()
+	endpoint, err = GetClusterAgentEndpoint()
 	require.Nil(suite.T(), err, fmt.Sprintf("%v", err))
 	assert.Equal(suite.T(), "https://127.0.0.1:1234", endpoint)
 }
@@ -385,11 +385,11 @@ func (suite *clusterAgentSuite) TestGetClusterAgentEndpointFromUrl() {
 func (suite *clusterAgentSuite) TestGetClusterAgentEndpointFromUrlInvalid() {
 	mockConfig.Set("cluster_agent.url", "http://127.0.0.1:8080")
 	mockConfig.Set("cluster_agent.kubernetes_service_name", "")
-	_, err := getClusterAgentEndpoint()
+	_, err := GetClusterAgentEndpoint()
 	require.NotNil(suite.T(), err)
 
 	mockConfig.Set("cluster_agent.url", "tcp://127.0.0.1:8080")
-	_, err = getClusterAgentEndpoint()
+	_, err = GetClusterAgentEndpoint()
 	require.NotNil(suite.T(), err)
 }
 
@@ -399,7 +399,7 @@ func (suite *clusterAgentSuite) TestGetClusterAgentEndpointFromKubernetesSvc() {
 	suite.T().Setenv(clusterAgentServiceHost, "127.0.0.1")
 	suite.T().Setenv(clusterAgentServicePort, "443")
 
-	endpoint, err := getClusterAgentEndpoint()
+	endpoint, err := GetClusterAgentEndpoint()
 	require.Nil(suite.T(), err, fmt.Sprintf("%v", err))
 	assert.Equal(suite.T(), "https://127.0.0.1:443", endpoint)
 }
@@ -410,12 +410,12 @@ func (suite *clusterAgentSuite) TestGetClusterAgentEndpointFromKubernetesSvcEmpt
 	suite.T().Setenv(clusterAgentServiceHost, "127.0.0.1")
 	suite.T().Setenv(clusterAgentServicePort, "")
 
-	_, err := getClusterAgentEndpoint()
+	_, err := GetClusterAgentEndpoint()
 	require.NotNil(suite.T(), err, fmt.Sprintf("%v", err))
 
 	suite.T().Setenv(clusterAgentServiceHost, "")
 	suite.T().Setenv(clusterAgentServicePort, "443")
-	_, err = getClusterAgentEndpoint()
+	_, err = GetClusterAgentEndpoint()
 	require.NotNil(suite.T(), err, fmt.Sprintf("%v", err))
 }
 

--- a/pkg/workloadmeta/collectors.go
+++ b/pkg/workloadmeta/collectors.go
@@ -20,12 +20,30 @@ type Collector interface {
 	Pull(context.Context) error
 }
 
+type CollectorCatalog map[string]collectorFactory
+
 type collectorFactory func() Collector
 
-var collectorCatalog = make(map[string]collectorFactory)
+var (
+	// NodeAgentCatalog is a catalog of collectors that runs in the node
+	// agents
+	NodeAgentCatalog = make(CollectorCatalog)
 
-// RegisterCollector registers a new collector, identified by an id for logging
-// and telemetry purposes, to be used by the store.
+	// ClusterAgentCatalog is a catalog of collectors that runs in the
+	// cluster agent, and the cluster checks runner agents
+	ClusterAgentCatalog = make(CollectorCatalog)
+)
+
+// RegisterCollector registers a new collector in the NodeAgentCatalog,
+// identified by an id for logging and telemetry purposes, to be used by the
+// store.
 func RegisterCollector(id string, c collectorFactory) {
-	collectorCatalog[id] = c
+	NodeAgentCatalog[id] = c
+}
+
+// RegisterClusterCollector registers a new collector in the
+// ClusterAgentCatalog, identified by an id for logging and telemetry purposes,
+// to be used by the store.
+func RegisterClusterCollector(id string, c collectorFactory) {
+	ClusterAgentCatalog[id] = c
 }

--- a/pkg/workloadmeta/collectors/collectors.go
+++ b/pkg/workloadmeta/collectors/collectors.go
@@ -16,6 +16,7 @@ import (
 	_ "github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors/internal/docker"
 	_ "github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors/internal/ecs"
 	_ "github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors/internal/ecsfargate"
+	_ "github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors/internal/kubeapiserver"
 	_ "github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors/internal/kubelet"
 	_ "github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors/internal/kubemetadata"
 	_ "github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors/internal/podman"

--- a/pkg/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
+++ b/pkg/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
@@ -1,0 +1,78 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+// +build kubeapiserver
+
+package kubeapiserver
+
+import (
+	"context"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/errors"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
+)
+
+const (
+	collectorID   = "kubeapiserver"
+	componentName = "workloadmeta-kubeapiserver"
+	noResync      = time.Duration(0)
+)
+
+type collector struct{}
+
+func init() {
+	workloadmeta.RegisterClusterCollector(collectorID, func() workloadmeta.Collector {
+		return &collector{}
+	})
+}
+
+func (c *collector) Start(ctx context.Context, wlmetaStore workloadmeta.Store) error {
+	if !config.Datadog.GetBool("cluster_agent.collect_kubernetes_tags") {
+		return errors.NewDisabled(componentName, "Cluster Agent tag collection is disabled, disabling kubeapiserver collector")
+	}
+
+	apiserverClient, err := apiserver.GetAPIClient()
+	if err != nil {
+		return err
+	}
+
+	client := apiserverClient.Cl
+	namespace := metav1.NamespaceAll
+
+	listerWatcher := &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			return client.CoreV1().Pods(namespace).List(ctx, options)
+		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			return client.CoreV1().Pods(namespace).Watch(ctx, options)
+		},
+	}
+
+	reflector := cache.NewNamedReflector(
+		componentName,
+		listerWatcher,
+		&corev1.Pod{},
+		newReflectorStore(wlmetaStore),
+		noResync,
+	)
+
+	go reflector.Run(ctx.Done())
+
+	return nil
+}
+
+func (c *collector) Pull(_ context.Context) error {
+	return nil
+}

--- a/pkg/workloadmeta/collectors/internal/kubeapiserver/reflector_store.go
+++ b/pkg/workloadmeta/collectors/internal/kubeapiserver/reflector_store.go
@@ -1,0 +1,211 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+// +build kubeapiserver
+
+package kubeapiserver
+
+import (
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
+)
+
+type reflectorStore struct {
+	wlmetaStore workloadmeta.Store
+
+	mu   sync.Mutex
+	seen map[string]workloadmeta.EntityID
+}
+
+func newReflectorStore(wlmetaStore workloadmeta.Store) cache.Store {
+	return &reflectorStore{
+		wlmetaStore: wlmetaStore,
+		seen:        make(map[string]workloadmeta.EntityID),
+	}
+}
+
+// Add notifies the workloadmeta store with  an EventTypeSet for the given
+// object.
+func (r *reflectorStore) Add(obj interface{}) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	pod := obj.(*corev1.Pod)
+	entity := parsePod(pod)
+
+	r.seen[string(pod.UID)] = entity.EntityID
+
+	r.wlmetaStore.Notify([]workloadmeta.CollectorEvent{
+		{
+			Type:   workloadmeta.EventTypeSet,
+			Source: collectorID,
+			Entity: entity,
+		},
+	})
+
+	return nil
+}
+
+// Update notifies the workloadmeta store with  an EventTypeSet for the given
+// object.
+func (r *reflectorStore) Update(obj interface{}) error {
+	return r.Add(obj)
+}
+
+// Delete notifies the workloadmeta store with  an EventTypeUnset for the given
+// object.
+func (r *reflectorStore) Delete(obj interface{}) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	pod := obj.(*corev1.Pod)
+
+	delete(r.seen, string(pod.UID))
+
+	r.wlmetaStore.Notify([]workloadmeta.CollectorEvent{
+		{
+			Type:   workloadmeta.EventTypeUnset,
+			Source: collectorID,
+			Entity: &workloadmeta.KubernetesPod{
+				EntityID: workloadmeta.EntityID{
+					Kind: workloadmeta.KindKubernetesPod,
+					ID:   string(pod.UID),
+				},
+			},
+		},
+	})
+
+	return nil
+}
+
+// Replace diffs the given list with the contents of the workloadmeta store
+// (through r.seen), and updates and deletes the necessary objects.
+func (r *reflectorStore) Replace(list []interface{}, _ string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	var events []workloadmeta.CollectorEvent
+
+	seenNow := make(map[string]workloadmeta.EntityID)
+	seenBefore := r.seen
+
+	for _, obj := range list {
+		pod := obj.(*corev1.Pod)
+		podUID := string(pod.UID)
+		entity := parsePod(pod)
+
+		events = append(events, workloadmeta.CollectorEvent{
+			Type:   workloadmeta.EventTypeSet,
+			Source: collectorID,
+			Entity: entity,
+		})
+
+		if _, ok := seenBefore[podUID]; ok {
+			delete(seenBefore, podUID)
+		}
+
+		seenNow[podUID] = entity.EntityID
+	}
+
+	for _, entityID := range seenBefore {
+		events = append(events, workloadmeta.CollectorEvent{
+			Type:   workloadmeta.EventTypeUnset,
+			Source: collectorID,
+			Entity: &workloadmeta.KubernetesPod{
+				EntityID: entityID,
+			},
+		})
+	}
+
+	r.wlmetaStore.Notify(events)
+
+	r.seen = seenNow
+
+	return nil
+}
+
+// List is not implemented
+func (r *reflectorStore) List() []interface{} {
+	panic("not implemented")
+}
+
+// ListKeys is not implemented
+func (r *reflectorStore) ListKeys() []string {
+	panic("not implemented")
+}
+
+// Get is not implemented
+func (r *reflectorStore) Get(obj interface{}) (item interface{}, exists bool, err error) {
+	panic("not implemented")
+}
+
+// GetByKey is not implemented
+func (r *reflectorStore) GetByKey(key string) (item interface{}, exists bool, err error) {
+	panic("not implemented")
+}
+
+// Resync is not implemented
+func (r *reflectorStore) Resync() error {
+	panic("not implemented")
+}
+
+func parsePod(pod *corev1.Pod) *workloadmeta.KubernetesPod {
+	owners := make([]workloadmeta.KubernetesPodOwner, 0, len(pod.OwnerReferences))
+	for _, o := range pod.OwnerReferences {
+		owners = append(owners, workloadmeta.KubernetesPodOwner{
+			Kind: o.Kind,
+			Name: o.Name,
+			ID:   string(o.UID),
+		})
+	}
+
+	var ready bool
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodReady {
+			if condition.Status == corev1.ConditionTrue {
+				ready = true
+			}
+			break
+		}
+	}
+
+	var pvcNames []string
+	for _, volume := range pod.Spec.Volumes {
+		if volume.PersistentVolumeClaim != nil {
+			pvcNames = append(pvcNames, volume.PersistentVolumeClaim.ClaimName)
+		}
+	}
+
+	return &workloadmeta.KubernetesPod{
+		EntityID: workloadmeta.EntityID{
+			Kind: workloadmeta.KindKubernetesPod,
+			ID:   string(pod.UID),
+		},
+		EntityMeta: workloadmeta.EntityMeta{
+			Name:        pod.Name,
+			Namespace:   pod.Namespace,
+			Annotations: pod.Annotations,
+			Labels:      pod.Labels,
+		},
+		Phase:                      string(pod.Status.Phase),
+		Owners:                     owners,
+		PersistentVolumeClaimNames: pvcNames,
+		Ready:                      ready,
+		IP:                         pod.Status.PodIP,
+		PriorityClass:              pod.Spec.PriorityClassName,
+		QOSClass:                   string(pod.Status.QOSClass),
+
+		// Containers could be generated by this collector, but
+		// currently it's not to save on memory, since this is supposed
+		// to run in the Cluster Agent, and the total amount of
+		// containers can be quite significant
+		// Containers:                 []workloadmeta.OrchestratorContainer{},
+	}
+}

--- a/pkg/workloadmeta/collectors/internal/kubeapiserver/stub.go
+++ b/pkg/workloadmeta/collectors/internal/kubeapiserver/stub.go
@@ -1,0 +1,6 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package kubeapiserver

--- a/pkg/workloadmeta/store_example_test.go
+++ b/pkg/workloadmeta/store_example_test.go
@@ -7,6 +7,12 @@ package workloadmeta
 
 import "fmt"
 
+func init() {
+	// CreateGlobalStore is usually called by the main cmd in the existing
+	// agents, so there's no need to call it yourself
+	CreateGlobalStore(nil)
+}
+
 func ExampleStore_Subscribe() {
 	filter := NewFilter([]Kind{KindContainer}, SourceRuntime, EventTypeAll)
 	ch := GetGlobalStore().Subscribe("test", NormalPriority, filter)

--- a/test/integration/corechecks/docker/main_test.go
+++ b/test/integration/corechecks/docker/main_test.go
@@ -106,7 +106,7 @@ func setup() error {
 	}
 	config.DetectFeatures()
 
-	store := workloadmeta.GetGlobalStore()
+	store := workloadmeta.CreateGlobalStore(workloadmeta.NodeAgentCatalog)
 	store.Start(context.Background())
 
 	// Setup tagger

--- a/test/integration/listeners/docker/docker_listener_test.go
+++ b/test/integration/listeners/docker/docker_listener_test.go
@@ -57,7 +57,7 @@ func (suite *DockerListenerTestSuite) SetupSuite() {
 		false,
 	)
 
-	store := workloadmeta.GetGlobalStore()
+	store := workloadmeta.CreateGlobalStore(workloadmeta.NodeAgentCatalog)
 	store.Start(context.Background())
 
 	tagger.SetDefaultTagger(local.NewTagger(store))


### PR DESCRIPTION
### What does this PR do?

The Cluster Tagger is just a fancy name for a collection of components we already have, now available also in the Cluster Agent. Here's what's included in this PR:

* It enables the workloadmeta to run in the DCA. A few supporting changes were made: `workloadmeta.GetGlobalStore` no longer creates a store by itself, and `workloadmeta.CreateGlobalStore` takes up that responsibility. It takes a catalog of collectors to run, instead of defaulting to all available collectors. We also have two catalogs available: `workloadmeta.NodeAgentCatalog` and `workloadmeta.ClusterAgentCatalog`.
* It introduces a new workloadmeta collector, `kubeapiserver`, responsible for fetching data about pods and storing them as our well known `workloadmeta.KubernetesPod` already in use everywhere. The most effective way we found to do this was to use a [Reflector](https://pkg.go.dev/k8s.io/client-go/tools/cache#Reflector), which is a funny name for a component that lists then watches a resource.
* Enables our good old tagger in the DCA, with zero changes 😄 
* Changes the remote tagger to be able to point to a different endpoint. This is needed so the Cluster Checks Workers can point the remote tagger to the DCA. Enabling the tagger server in the DCA is added in #13844. This touches basically all agent binaries unfortunately, and is basically what teams other than Container Integrations need to review. I'm hoping that the components work will reduce the need for this types of changes in the future, since other components will just get an initialized instance automagically injected in, instead of having to know anything about `remote.Options`.

Since these are all reusable components, data flows with very little effort. The `kubeapiserver` collector uses known types, so as soon as the tagger is enabled, it can start collecting pod tags immediately. Since we're using our standard tagger, it can be very easily exposed via gRPC in the DCA with the same server code we use in the node agents as well. Since that's a known interface, cluster check runners can just point the remote taggers there, and all of a sudden we have pod tags replicated to all components, ready to be used with a simple `tagger.Tag`.

### Motivation

Beyond general availability of pod tags in the Cluster Agent and Cluster Workers, the Cluster Tagger is meant to initially power two specific use cases (not part of this PR): tagging of events generated by the `kubernetes_apiserver` check, and metrics generated by the `kubernetes_state_core` check. Those two are among of the most requested features in container-land.

### Additional Notes

Note for reviewers: this PR also includes the two commits from #13844, where we enabled the remote tagger in the cluster check workers. I'll rebase this PR on that once it's merged.

A few other implementations were considered for this feature. They're detailed below, together with the reasons for not choosing them over the one put forward in this PR.

#### Using a Pod Informer

The most obvious way to consume pod information from the API server is to use an [informer](https://pkg.go.dev/k8s.io/client-go/informers). It watches all changes to the pod objects, storing the full objects into its own internal storage, and allowing event handlers to be attached to changes in those objects.

Its main advantage is that it's a popular way of doing things, requires very little setup, and Just Works(tm). The main problem is memory usage. Below is a benchmark showing memory usage of the DCA running in a cluster with ~2.5k pods:

![DCA_ Memory Usage](https://user-images.githubusercontent.com/58992/196382347-b48c57aa-06f5-44cd-95ce-1502b256b668.png)

Compared to the implementation proposed in this PR, it uses about ~100MB more, just from the data living inside the informer alone. Even if we were to assume that this increase is acceptable, it does not show the cost of the full solution. Being able to have tags extracted from the informer would also entail either of the two following paths:

1. Implement a workloadmeta collector to store the data coming from the informer events, so we can reuse `pkg/tagger/local.Tagger` with no changes. This would cause a further ~150MB increase for this particular cluster due to the duplicated data, and is prohibitive in bigger clusters.

2. Implement a completely new tagger collector that is able to consume `k8s.io/api/core/v1.Pod` objects. While this does not incur a large memory penalty beyond the tags themselves, is a good bit of code to write and maintain, especially since it's supposed to be an exact duplicate of the existing collector in the tagger.

#### Using a Pod Lister

Since the biggest issue with using a pod informer is either the duplication or excessive data being held in memory, a natural solution is to use a pod lister, periodically calling the API Server for a list of all pods, and storing them in workloadmeta. Its only advantage is being relatively simple ("just" a method call in a loop), but in the end this was only briefly considered and discarded due to the following reasons:

* We'd need to diff the current pods in workloadmeta vs. the list coming from the API server. While that's somewhat trivial, it is a loss compared to using an informer, where we only need to handle events.
* While less data would be kept in memory (the full pod data only for the duration of the workloadmeta pull, and the extracted data afterwards), it would require much more data to travel over the network since we'd get the full working set on every pull, which can easily be several megabytes.
* Any pods that started and finished between pulls (aka short-lived pods) would be completely invisible to workloadmeta, and therefore would have no tags associated to them.

These issues could be fixed by careful use of `resourceVersion` parameters and watches, and that's the thought process that led us to use the `Reflector` that does exactly that. There are some [relevant docs](https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes) that state as much.

#### Getting tags or pods directly from node agents

This was our first idea on how to implement this. We had planned to benchmark pull from agents vs. push to DCA, but several disadvantages made us discard the whole idea on principle. I can't think of a clear advantage to this approach, and the list of downsides is large.

* In a big cluster, that's a lot of network traffic going all over the place. Pushing to the DCA means being able to support thousands of requests, and pulling from the node agents is probably more efficient but means exposing them to the cluster, which is not something we currently do and has security implications.
* There are a lot more potential points of failure. An agent might fail to push its data, or the DCA might not be able to reach the agent for any amount of time, for all kinds of random reasons.
* Similar to the pod lister solution, this one has the potential to miss short-lived pods. It's possible to store updates and consolidate them into batches instead of consuming lists directly, but that's a feature that does not exist in workloadmeta nor the tagger. Those batches also need to be pruned in failure scenarios (DCA failing to pull, or unreachable from the agent) to prevent runaway memory usage.
* Dealing with several DCA replicas requires a lot more thinking. Does each agent push to all DCAs? Just the leader? How does the leader replicate data to the replica? Or does it even have to?

### Possible Drawbacks / Trade-offs

1. Since the cluster tagger needs to collect information from all pods in the cluster, big clusters will of course consume a lot of memory. In a cluster with ~15k pods, we saw an increase of about 500MB in memory consumption. This is also heavily dependent on labels and annotations on top of those pods, since that's data that we have to collect for the complete set of tags to work, and they may be relatively large string blobs. Due to this, the cluster tagger sits behind a feature flag that's disabled by default for now.

2. In clusters with a lot of pod churn, there is also a small but noticeable increase in CPU usage as well. During testing, we noticed that this increase is higher with the workloadmeta+reflector solution we're going with compared to using an informer, which suggests possible optimizations to be made in workloadmeta. Given that the increase was small, we're not considering it a blocker for this PR. The graph below shows CPU usage and has the same DCA instances as the one I showed earlier in this PR:

![DCA_ CPU Usage](https://user-images.githubusercontent.com/58992/196402832-de2d301d-273f-40b5-ad2e-a4279807beac.png)

3. Each DCA replica will have its own full copy of workloadmeta and tagger data, regardless of leadership status. This results in some waste, but does simplify implementation by a lot, since we don't have to fill or purge data when leadership status changes. It also simplifies clients, since they don't have to be redirected to the leader, or restarting the remote tagger when leadership status changes. Load-balancing is not terribly important due the usual small number of cluster check runner replicas, but is taken care of by the Kubernetes Service in front of the DCA replicas anyway.

4. To save memory, we do not store any data about containers. We also have a single use case for container-level tags in a cluster context in KSM, but those metrics are also available from the kubelet check coming from the node agents, so we find this to be an acceptable omission. This is very easy to change should we ever need it in the future.

### Describe how to test/QA your changes

The DCA binary currently does not have a `tagger-list` or `workload-list` command, which is due to be implemented soon, so it's hard to QA this directly. But since it propagates tags (which are the bits we actually care about in the context of this PR) to the cluster check runners, running `agent tagger-list` on them is a good way to ensure that tags for all pods in the cluster are present. Just remember to set `cluster_agent.collect_kubernetes_tags` to true in the cluster agent first!

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
