### PR TITLE
Backport: [APM] Add v2 of the evp_proxy endpoint (#13825)

### DIFF
--- a/pkg/trace/api/endpoints.go
+++ b/pkg/trace/api/endpoints.go
@@ -117,6 +117,10 @@ var endpoints = []Endpoint{
 		Handler: func(r *HTTPReceiver) http.Handler { return r.evpProxyHandler() },
 	},
 	{
+		Pattern: "/evp_proxy/v2/",
+		Handler: func(r *HTTPReceiver) http.Handler { return r.evpProxyHandler() },
+	},
+	{
 		Pattern: "/debugger/v1/input",
 		Handler: func(r *HTTPReceiver) http.Handler { return r.debuggerProxyHandler() },
 	},

--- a/pkg/trace/api/info_test.go
+++ b/pkg/trace/api/info_test.go
@@ -131,6 +131,7 @@ func TestInfoHandler(t *testing.T) {
 		"/v0.1/pipeline_stats",
 		"/appsec/proxy/",
 		"/evp_proxy/v1/",
+		"/evp_proxy/v2/",
 		"/debugger/v1/input"
 		"/dogstatsd/v1/proxy"
 	],
@@ -191,6 +192,7 @@ func TestInfoHandler(t *testing.T) {
 		"/v0.1/pipeline_stats",
 		"/appsec/proxy/",
 		"/evp_proxy/v1/",
+		"/evp_proxy/v2/",
 		"/debugger/v1/input"
 		"/dogstatsd/v1/proxy"
 	],


### PR DESCRIPTION
### What does this PR do?

Backport: [APM] Add v2 of the evp_proxy endpoint (#13825)

### Motivation

We can't use the feature introduced in 7.40 without an API version bump.
