### PR TITLE
[CWS] fix envs truncation resolution

### DIFF
--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -950,7 +950,7 @@ func (p *ProcessResolver) GetProcessEnvs(pr *model.Process) ([]string, bool) {
 
 	keys, truncated := pr.EnvsEntry.FilterEnvs(p.opts.envsWithValue)
 
-	return keys, pr.ArgsTruncated || truncated
+	return keys, pr.EnvsTruncated || truncated
 }
 
 // GetProcessEnvp returns the envs of the event with their values
@@ -961,7 +961,7 @@ func (p *ProcessResolver) GetProcessEnvp(pr *model.Process) ([]string, bool) {
 
 	envp, truncated := pr.EnvsEntry.ToArray()
 
-	return envp, pr.ArgsTruncated || truncated
+	return envp, pr.EnvsTruncated || truncated
 }
 
 // SetProcessTTY resolves TTY and cache the result

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -9,6 +9,7 @@
 package tests
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -484,10 +485,19 @@ func TestProcessContext(t *testing.T) {
 		for i := 0; i != 1024; i++ {
 			long += "a"
 		}
+		long += "="
 		envs = append(envs, long)
 
+		if kind == dockerWrapperType {
+			args = []string{"-u", "PATH", "-u", "HOSTNAME", "-u", "HOME", "ls", "-al"}
+		}
+
 		test.WaitSignal(t, func() error {
-			cmd := cmdFunc("ls", args, envs)
+			bin := "ls"
+			if kind == dockerWrapperType {
+				bin = "env"
+			}
+			cmd := cmdFunc(bin, args, envs)
 			return cmd.Run()
 		}, validateExecEvent(t, kind, func(event *sprobe.Event, rule *rules.Rule) {
 			execEnvp, err := event.GetFieldValue("exec.envp")
@@ -521,12 +531,24 @@ func TestProcessContext(t *testing.T) {
 
 		// number of envs overflow
 		nEnvs, envs := 1024, []string{"LD_LIBRARY_PATH=/tmp/lib"}
+		var buf bytes.Buffer
+		buf.Grow(50)
 		for i := 0; i != nEnvs; i++ {
-			envs = append(envs, eval.RandString(50))
+			buf.Reset()
+			fmt.Fprintf(&buf, "%s=%s", eval.RandString(19), eval.RandString(30))
+			envs = append(envs, buf.String())
+		}
+
+		if kind == dockerWrapperType {
+			args = []string{"-u", "PATH", "-u", "HOSTNAME", "-u", "HOME", "ls", "-al"}
 		}
 
 		test.WaitSignal(t, func() error {
-			cmd := cmdFunc("ls", args, envs)
+			bin := "ls"
+			if kind == dockerWrapperType {
+				bin = "env"
+			}
+			cmd := cmdFunc(bin, args, envs)
 			return cmd.Run()
 		}, validateExecEvent(t, kind, func(event *sprobe.Event, rule *rules.Rule) {
 			execEnvp, err := event.GetFieldValue("exec.envp")
@@ -560,12 +582,24 @@ func TestProcessContext(t *testing.T) {
 
 		// number of envs overflow
 		nEnvs, envs := 1024, []string{"LD_LIBRARY_PATH=/tmp/lib"}
+		var buf bytes.Buffer
+		buf.Grow(500)
 		for i := 0; i != nEnvs; i++ {
-			envs = append(envs, eval.RandString(500))
+			buf.Reset()
+			fmt.Fprintf(&buf, "%s=%s", eval.RandString(199), eval.RandString(300))
+			envs = append(envs, buf.String())
+		}
+
+		if kind == dockerWrapperType {
+			args = []string{"-u", "PATH", "-u", "HOSTNAME", "-u", "HOME", "ls", "-al"}
 		}
 
 		test.WaitSignal(t, func() error {
-			cmd := cmdFunc("ls", args, envs)
+			bin := "ls"
+			if kind == dockerWrapperType {
+				bin = "env"
+			}
+			cmd := cmdFunc(bin, args, envs)
 			return cmd.Run()
 		}, validateExecEvent(t, kind, func(event *sprobe.Event, rule *rules.Rule) {
 			execEnvp, err := event.GetFieldValue("exec.envp")


### PR DESCRIPTION
This PR fixes the environment variables truncation resolution and adds relevant functional tests to detect future regressions.

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
