### PR TITLE
Fix missing tags on the `kubernetes_state.cronjob.complete` service check

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators.go
@@ -208,8 +208,8 @@ func (a *lastCronJobAggregator) flush(sender aggregator.Sender, k *KSMCheck, lab
 	for cronjob, state := range a.accumulator {
 		hostname, tags := k.hostnameAndTags(
 			map[string]string{
-				"namespace":    cronjob.namespace,
-				"kube_cronjob": cronjob.name,
+				"namespace": cronjob.namespace,
+				"cronjob":   cronjob.name,
 			},
 			labelJoiner,
 			nil,

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators_test.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators_test.go
@@ -234,7 +234,7 @@ func Test_lastCronJobAggregator(t *testing.T) {
 			expected: &serviceCheck{
 				name:    "kubernetes_state.cronjob.complete",
 				status:  metrics.ServiceCheckOK,
-				tags:    []string{"namespace:foo", "kube_cronjob:bar"},
+				tags:    []string{"namespace:foo", "cronjob:bar"},
 				message: "",
 			},
 		},
@@ -271,7 +271,7 @@ func Test_lastCronJobAggregator(t *testing.T) {
 			expected: &serviceCheck{
 				name:    "kubernetes_state.cronjob.complete",
 				status:  metrics.ServiceCheckCritical,
-				tags:    []string{"namespace:foo", "kube_cronjob:bar"},
+				tags:    []string{"namespace:foo", "cronjob:bar"},
 				message: "",
 			},
 		},

--- a/releasenotes/notes/fix_ksm_cronjob_complete_tags-9998dce7461d933b.yaml
+++ b/releasenotes/notes/fix_ksm_cronjob_complete_tags-9998dce7461d933b.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Fix missing tags on the ``kubernetes_state.cronjob.complete`` service check
+    Fix missing tags on the ``kubernetes_state.cronjob.complete`` service check.

--- a/releasenotes/notes/fix_ksm_cronjob_complete_tags-9998dce7461d933b.yaml
+++ b/releasenotes/notes/fix_ksm_cronjob_complete_tags-9998dce7461d933b.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix missing tags on the ``kubernetes_state.cronjob.complete`` service check


### PR DESCRIPTION
### What does this PR do?

Fix missing tags on the `kubernetes_state.cronjob.complete` service check.

### Motivation

Fix bug.

### Additional Notes

Labels join was broken because we were using a wrong label key.

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Create a `CronJob` with [unified service tagging](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/?tab=kubernetes) and/or [recommended Kubernetes labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/).

Check that, before this patch, the corresponding tags were appearing on the `kubernetes_state.cronjob.on_schedule_check` service check but not on the `kubernetes_state.cronjob.complete` one.

With this patch, the corresponding tags must appear on both service checks.

### Reviewer's Checklist


- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
