### PR TITLE
[tagger] Expose a gRPC tagger service in the DCA

### DIFF
--- a/cmd/agent/api/grpc.go
+++ b/cmd/agent/api/grpc.go
@@ -17,27 +17,19 @@ import (
 	"time"
 
 	workloadmetaServer "github.com/DataDog/datadog-agent/pkg/workloadmeta/server"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	remoteconfig "github.com/DataDog/datadog-agent/pkg/config/remote/service"
 	dsdReplay "github.com/DataDog/datadog-agent/pkg/dogstatsd/replay"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo"
-	pbutils "github.com/DataDog/datadog-agent/pkg/proto/utils"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/tagger/replay"
-	"github.com/DataDog/datadog-agent/pkg/tagger/telemetry"
+	taggerserver "github.com/DataDog/datadog-agent/pkg/tagger/server"
 	"github.com/DataDog/datadog-agent/pkg/util/grpc"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-)
-
-const (
-	taggerStreamSendTimeout = 1 * time.Minute
-	streamKeepAliveInterval = 9 * time.Minute
 )
 
 type server struct {
@@ -46,6 +38,7 @@ type server struct {
 
 type serverSecure struct {
 	pb.UnimplementedAgentSecureServer
+	taggerServer       *taggerserver.Server
 	workloadmetaServer *workloadmetaServer.Server
 	configService      *remoteconfig.Service
 }
@@ -64,6 +57,14 @@ func (s *server) GetHostname(ctx context.Context, in *pb.HostnameRequest) (*pb.H
 // see: https://godoc.org/github.com/grpc-ecosystem/go-grpc-middleware/auth#ServiceAuthFuncOverride
 func (s *server) AuthFuncOverride(ctx context.Context, fullMethodName string) (context.Context, error) {
 	return ctx, nil
+}
+
+func (s *serverSecure) TaggerStreamEntities(req *pb.StreamTagsRequest, srv pb.AgentSecure_TaggerStreamEntitiesServer) error {
+	return s.taggerServer.TaggerStreamEntities(req, srv)
+}
+
+func (s *serverSecure) TaggerFetchEntity(ctx context.Context, req *pb.FetchEntityRequest) (*pb.FetchEntityResponse, error) {
+	return s.taggerServer.TaggerFetchEntity(ctx, req)
 }
 
 // DogstatsdCaptureTrigger triggers a dogstatsd traffic capture for the
@@ -120,102 +121,6 @@ func (s *serverSecure) DogstatsdSetTaggerState(ctx context.Context, req *pb.Tagg
 	log.Debugf("API: loaded state successfully")
 
 	return &pb.TaggerStateResponse{Loaded: true}, nil
-}
-
-// TaggerStreamEntities subscribes to added, removed, or changed entities in the Tagger
-// and streams them to clients as pb.StreamTagsResponse events. Filtering is as
-// of yet not implemented.
-func (s *serverSecure) TaggerStreamEntities(in *pb.StreamTagsRequest, out pb.AgentSecure_TaggerStreamEntitiesServer) error {
-	cardinality, err := pbutils.Pb2TaggerCardinality(in.Cardinality)
-	if err != nil {
-		return err
-	}
-
-	// NOTE: StreamTagsRequest can specify filters, but they cannot be
-	// implemented since the tagger has no concept of container metadata.
-	// these filters will be introduced when we implement a container
-	// metadata service that can receive them as is from the tagger.
-
-	t := tagger.GetDefaultTagger()
-	eventCh := t.Subscribe(cardinality)
-	defer t.Unsubscribe(eventCh)
-
-	ticker := time.NewTicker(streamKeepAliveInterval)
-	defer ticker.Stop()
-	for {
-		select {
-		case events := <-eventCh:
-			ticker.Reset(streamKeepAliveInterval)
-
-			responseEvents := make([]*pb.StreamTagsEvent, 0, len(events))
-			for _, event := range events {
-				e, err := pbutils.Tagger2PbEntityEvent(event)
-				if err != nil {
-					log.Warnf("can't convert tagger entity to protobuf: %s", err)
-					continue
-				}
-
-				responseEvents = append(responseEvents, e)
-			}
-
-			err = grpc.DoWithTimeout(func() error {
-				return out.Send(&pb.StreamTagsResponse{
-					Events: responseEvents,
-				})
-			}, taggerStreamSendTimeout)
-
-			if err != nil {
-				log.Warnf("error sending tagger event: %s", err)
-				telemetry.ServerStreamErrors.Inc()
-				return err
-			}
-
-		case <-out.Context().Done():
-			return nil
-
-		// The remote tagger client has a timeout that closes the connection after 10 minutes of inactivity
-		// (implemented in pkg/tagger/remote/tagger.go)
-		// In order to avoid closing the connection and having to open it again, the server will send an empty
-		// message after 9 minutes of inactivity.
-		// The goal is only to keep the connection alive without losing the protection against “half” closed connections brought by the timeout.
-		case <-ticker.C:
-			err = grpc.DoWithTimeout(func() error {
-				return out.Send(&pb.StreamTagsResponse{
-					Events: []*pb.StreamTagsEvent{},
-				})
-			}, taggerStreamSendTimeout)
-
-			if err != nil {
-				log.Warnf("error sending tagger keep-alive: %s", err)
-				telemetry.ServerStreamErrors.Inc()
-				return err
-			}
-		}
-	}
-}
-
-// TaggerFetchEntity fetches an entity from the Tagger with the desired cardinality tags.
-func (s *serverSecure) TaggerFetchEntity(ctx context.Context, in *pb.FetchEntityRequest) (*pb.FetchEntityResponse, error) {
-	if in.Id == nil {
-		return nil, status.Errorf(codes.InvalidArgument, `missing "id" parameter`)
-	}
-
-	entityID := fmt.Sprintf("%s://%s", in.Id.Prefix, in.Id.Uid)
-	cardinality, err := pbutils.Pb2TaggerCardinality(in.Cardinality)
-	if err != nil {
-		return nil, err
-	}
-
-	tags, err := tagger.Tag(entityID, cardinality)
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "%s", err)
-	}
-
-	return &pb.FetchEntityResponse{
-		Id:          in.Id,
-		Cardinality: in.Cardinality,
-		Tags:        tags,
-	}, nil
 }
 
 func (s *serverSecure) ClientGetConfigs(ctx context.Context, in *pb.ClientGetConfigsRequest) (*pb.ClientGetConfigsResponse, error) {

--- a/cmd/agent/api/server.go
+++ b/cmd/agent/api/server.go
@@ -113,6 +113,7 @@ func StartServer(configService *remoteconfig.Service) error {
 	logWriter, _ := config.NewLogWriter(5, seelog.ErrorLvl)
 
 	srv := grpcutil.NewMuxedGRPCServer(
+		tlsAddr,
 		&tls.Config{
 			Certificates: []tls.Certificate{*tlsKeyPair},
 			NextProtos:   []string{"h2"},
@@ -122,7 +123,6 @@ func StartServer(configService *remoteconfig.Service) error {
 		grpcutil.TimeoutHandlerFunc(mux, time.Duration(config.Datadog.GetInt64("server_timeout"))*time.Second),
 	)
 
-	srv.Addr = tlsAddr
 	srv.ErrorLog = stdLog.New(logWriter, "Error from the agent http API server: ", 0) // log errors to seelog
 
 	tlsListener := tls.NewListener(listener, srv.TLSConfig)

--- a/cmd/agent/api/server.go
+++ b/cmd/agent/api/server.go
@@ -17,7 +17,6 @@ import (
 	stdLog "log"
 	"net"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
@@ -35,35 +34,12 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 	remoteconfig "github.com/DataDog/datadog-agent/pkg/config/remote/service"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo"
+	"github.com/DataDog/datadog-agent/pkg/tagger"
+	taggerserver "github.com/DataDog/datadog-agent/pkg/tagger/server"
+	grpcutil "github.com/DataDog/datadog-agent/pkg/util/grpc"
 )
 
 var listener net.Listener
-
-// grpcHandlerFunc returns an http.Handler that delegates to grpcServer on incoming gRPC
-// connections or otherHandler otherwise. Copied from cockroachdb.
-func grpcHandlerFunc(grpcServer *grpc.Server, otherHandler http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// This is a partial recreation of gRPC's internal checks https://github.com/grpc/grpc-go/pull/514/files#diff-95e9a25b738459a2d3030e1e6fa2a718R61
-		if r.ProtoMajor == 2 && strings.Contains(r.Header.Get("Content-Type"), "application/grpc") {
-			grpcServer.ServeHTTP(w, r)
-		} else {
-			otherHandler.ServeHTTP(w, r)
-		}
-	})
-}
-
-// timeoutHandler limits requests to the enclosed handler to the value
-// configured in `server_timeout`.
-func timeoutHandlerFunc(otherHandler http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		deadline := time.Now().Add(time.Duration(config.Datadog.GetInt64("server_timeout")) * time.Second)
-
-		conn := agent.GetConnection(r)
-		_ = conn.SetWriteDeadline(deadline)
-
-		otherHandler.ServeHTTP(w, r)
-	})
-}
 
 // StartServer creates the router and starts the HTTP server
 func StartServer(configService *remoteconfig.Service) error {
@@ -84,17 +60,18 @@ func StartServer(configService *remoteconfig.Service) error {
 	}
 
 	// gRPC server
-	mux := http.NewServeMux()
+	authInterceptor := grpcutil.AuthInterceptor(parseToken)
 	opts := []grpc.ServerOption{
 		grpc.Creds(credentials.NewClientTLSFromCert(tlsCertPool, tlsAddr)),
-		grpc.StreamInterceptor(grpc_auth.StreamServerInterceptor(grpcAuth)),
-		grpc.UnaryInterceptor(grpc_auth.UnaryServerInterceptor(grpcAuth)),
+		grpc.StreamInterceptor(grpc_auth.StreamServerInterceptor(authInterceptor)),
+		grpc.UnaryInterceptor(grpc_auth.UnaryServerInterceptor(authInterceptor)),
 	}
 
 	s := grpc.NewServer(opts...)
 	pb.RegisterAgentServer(s, &server{})
 	pb.RegisterAgentSecureServer(s, &serverSecure{
 		configService:      configService,
+		taggerServer:       taggerserver.NewServer(tagger.GetDefaultTagger()),
 		workloadmetaServer: workloadmetaServer.NewServer(workloadmeta.GetGlobalStore()),
 	})
 
@@ -127,32 +104,26 @@ func StartServer(configService *remoteconfig.Service) error {
 	agentMux.Use(validateToken)
 	checkMux.Use(validateToken)
 
+	mux := http.NewServeMux()
 	mux.Handle("/agent/", http.StripPrefix("/agent", agent.SetupHandlers(agentMux)))
 	mux.Handle("/check/", http.StripPrefix("/check", check.SetupHandlers(checkMux)))
 	mux.Handle("/", gwmux)
 
-	// apply server_timeout to all handlers in the mux (with a few exceptions
-	// such as streaming logs, which reset the deadlines back to zero)
-	handler := timeoutHandlerFunc(mux)
-
 	// Use a stack depth of 4 on top of the default one to get a relevant filename in the stdlib
 	logWriter, _ := config.NewLogWriter(5, seelog.ErrorLvl)
 
-	srv := &http.Server{
-		Addr: tlsAddr,
-		// handle grpc calls directly, falling back to `handler` for non-grpc reqs
-		Handler: grpcHandlerFunc(s, handler),
-		TLSConfig: &tls.Config{
+	srv := grpcutil.NewMuxedGRPCServer(
+		&tls.Config{
 			Certificates: []tls.Certificate{*tlsKeyPair},
 			NextProtos:   []string{"h2"},
 			MinVersion:   tls.VersionTLS12,
 		},
-		ErrorLog: stdLog.New(logWriter, "Error from the agent http API server: ", 0), // log errors to seelog,
-		ConnContext: func(ctx context.Context, c net.Conn) context.Context {
-			// Store the connection in the context so requests can reference it if needed
-			return context.WithValue(ctx, agent.ConnContextKey, c)
-		},
-	}
+		s,
+		grpcutil.TimeoutHandlerFunc(mux, time.Duration(config.Datadog.GetInt64("server_timeout"))*time.Second),
+	)
+
+	srv.Addr = tlsAddr
+	srv.ErrorLog = stdLog.New(logWriter, "Error from the agent http API server: ", 0) // log errors to seelog
 
 	tlsListener := tls.NewListener(listener, srv.TLSConfig)
 

--- a/cmd/cluster-agent/api/grpc.go
+++ b/cmd/cluster-agent/api/grpc.go
@@ -1,0 +1,28 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package api
+
+import (
+	"context"
+
+	"github.com/DataDog/datadog-agent/pkg/proto/pbgo"
+
+	taggerserver "github.com/DataDog/datadog-agent/pkg/tagger/server"
+)
+
+type serverSecure struct {
+	pbgo.UnimplementedAgentSecureServer
+
+	taggerServer *taggerserver.Server
+}
+
+func (s *serverSecure) TaggerStreamEntities(req *pbgo.StreamTagsRequest, srv pbgo.AgentSecure_TaggerStreamEntitiesServer) error {
+	return s.taggerServer.TaggerStreamEntities(req, srv)
+}
+
+func (s *serverSecure) TaggerFetchEntity(ctx context.Context, req *pbgo.FetchEntityRequest) (*pbgo.FetchEntityResponse, error) {
+	return s.taggerServer.TaggerFetchEntity(ctx, req)
+}

--- a/cmd/cluster-agent/api/server.go
+++ b/cmd/cluster-agent/api/server.go
@@ -14,6 +14,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	stdLog "log"
 	"net"
@@ -23,12 +24,18 @@ import (
 
 	"github.com/cihub/seelog"
 	"github.com/gorilla/mux"
+	grpc_auth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
+	"google.golang.org/grpc"
 
 	"github.com/DataDog/datadog-agent/cmd/cluster-agent/api/agent"
 	v1 "github.com/DataDog/datadog-agent/cmd/cluster-agent/api/v1"
 	"github.com/DataDog/datadog-agent/pkg/api/security"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo"
+	"github.com/DataDog/datadog-agent/pkg/tagger"
+	taggerserver "github.com/DataDog/datadog-agent/pkg/tagger/server"
+	grpcutil "github.com/DataDog/datadog-agent/pkg/util/grpc"
 )
 
 var (
@@ -84,7 +91,7 @@ func StartServer() error {
 		return fmt.Errorf("invalid key pair: %v", err)
 	}
 
-	tlsConfig := tls.Config{
+	tlsConfig := &tls.Config{
 		Certificates: []tls.Certificate{rootTLSCert},
 		MinVersion:   tls.VersionTLS13,
 	}
@@ -96,16 +103,29 @@ func StartServer() error {
 	// Use a stack depth of 4 on top of the default one to get a relevant filename in the stdlib
 	logWriter, _ := config.NewLogWriter(4, seelog.WarnLvl)
 
-	srv := &http.Server{
-		Handler:      router,
-		ErrorLog:     stdLog.New(logWriter, "Error from the agent http API server: ", 0), // log errors to seelog,
-		TLSConfig:    &tlsConfig,
-		ReadTimeout:  config.Datadog.GetDuration("cluster_agent.server.read_timeout_seconds") * time.Second,
-		WriteTimeout: config.Datadog.GetDuration("cluster_agent.server.write_timeout_seconds") * time.Second,
-		IdleTimeout:  config.Datadog.GetDuration("cluster_agent.server.idle_timeout_seconds") * time.Second,
+	authInterceptor := grpcutil.AuthInterceptor(func(token string) (interface{}, error) {
+		if token != util.GetDCAAuthToken() {
+			return struct{}{}, errors.New("Invalid session token")
+		}
+
+		return struct{}{}, nil
+	})
+
+	opts := []grpc.ServerOption{
+		grpc.StreamInterceptor(grpc_auth.StreamServerInterceptor(authInterceptor)),
+		grpc.UnaryInterceptor(grpc_auth.UnaryServerInterceptor(authInterceptor)),
 	}
 
-	tlsListener := tls.NewListener(listener, &tlsConfig)
+	grpcSrv := grpc.NewServer(opts...)
+	pb.RegisterAgentSecureServer(grpcSrv, &serverSecure{
+		taggerServer: taggerserver.NewServer(tagger.GetDefaultTagger()),
+	})
+
+	timeout := config.Datadog.GetDuration("cluster_agent.server.idle_timeout_seconds") * time.Second
+	srv := grpcutil.NewMuxedGRPCServer(tlsConfig, grpcSrv, grpcutil.TimeoutHandlerFunc(router, timeout))
+	srv.ErrorLog = stdLog.New(logWriter, "Error from the agent http API server: ", 0) // log errors to seelog
+
+	tlsListener := tls.NewListener(listener, srv.TLSConfig)
 
 	go srv.Serve(tlsListener) //nolint:errcheck
 	return nil

--- a/cmd/cluster-agent/api/server.go
+++ b/cmd/cluster-agent/api/server.go
@@ -122,7 +122,12 @@ func StartServer() error {
 	})
 
 	timeout := config.Datadog.GetDuration("cluster_agent.server.idle_timeout_seconds") * time.Second
-	srv := grpcutil.NewMuxedGRPCServer(tlsConfig, grpcSrv, grpcutil.TimeoutHandlerFunc(router, timeout))
+	srv := grpcutil.NewMuxedGRPCServer(
+		listener.Addr().String(),
+		tlsConfig,
+		grpcSrv,
+		grpcutil.TimeoutHandlerFunc(router, timeout),
+	)
 	srv.ErrorLog = stdLog.New(logWriter, "Error from the agent http API server: ", 0) // log errors to seelog
 
 	tlsListener := tls.NewListener(listener, srv.TLSConfig)

--- a/pkg/tagger/server/server.go
+++ b/pkg/tagger/server/server.go
@@ -1,0 +1,136 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package server
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo"
+	pbutils "github.com/DataDog/datadog-agent/pkg/proto/utils"
+	"github.com/DataDog/datadog-agent/pkg/tagger"
+	"github.com/DataDog/datadog-agent/pkg/tagger/telemetry"
+	"github.com/DataDog/datadog-agent/pkg/util/grpc"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const (
+	taggerStreamSendTimeout = 1 * time.Minute
+	streamKeepAliveInterval = 9 * time.Minute
+)
+
+func NewServer(t tagger.Tagger) *Server {
+	return &Server{
+		tagger: t,
+	}
+}
+
+type Server struct {
+	tagger tagger.Tagger
+}
+
+// TaggerStreamEntities subscribes to added, removed, or changed entities in the Tagger
+// and streams them to clients as pb.StreamTagsResponse events. Filtering is as
+// of yet not implemented.
+func (s *Server) TaggerStreamEntities(in *pb.StreamTagsRequest, out pb.AgentSecure_TaggerStreamEntitiesServer) error {
+	cardinality, err := pbutils.Pb2TaggerCardinality(in.Cardinality)
+	if err != nil {
+		return err
+	}
+
+	// NOTE: StreamTagsRequest can specify filters, but they cannot be
+	// implemented since the tagger has no concept of container metadata.
+	// these filters will be introduced when we implement a container
+	// metadata service that can receive them as is from the tagger.
+
+	t := tagger.GetDefaultTagger()
+	eventCh := t.Subscribe(cardinality)
+	defer t.Unsubscribe(eventCh)
+
+	ticker := time.NewTicker(streamKeepAliveInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case events := <-eventCh:
+			ticker.Reset(streamKeepAliveInterval)
+
+			responseEvents := make([]*pb.StreamTagsEvent, 0, len(events))
+			for _, event := range events {
+				e, err := pbutils.Tagger2PbEntityEvent(event)
+				if err != nil {
+					log.Warnf("can't convert tagger entity to protobuf: %s", err)
+					continue
+				}
+
+				responseEvents = append(responseEvents, e)
+			}
+
+			err = grpc.DoWithTimeout(func() error {
+				return out.Send(&pb.StreamTagsResponse{
+					Events: responseEvents,
+				})
+			}, taggerStreamSendTimeout)
+
+			if err != nil {
+				log.Warnf("error sending tagger event: %s", err)
+				telemetry.ServerStreamErrors.Inc()
+				return err
+			}
+
+		case <-out.Context().Done():
+			return nil
+
+		// The remote tagger client has a timeout that closes the
+		// connection after 10 minutes of inactivity (implemented in
+		// pkg/tagger/remote/tagger.go) In order to avoid closing the
+		// connection and having to open it again, the server will send
+		// an empty message after 9 minutes of inactivity. The goal is
+		// only to keep the connection alive without losing the
+		// protection against “half” closed connections brought by the
+		// timeout.
+		case <-ticker.C:
+			err = grpc.DoWithTimeout(func() error {
+				return out.Send(&pb.StreamTagsResponse{
+					Events: []*pb.StreamTagsEvent{},
+				})
+			}, taggerStreamSendTimeout)
+
+			if err != nil {
+				log.Warnf("error sending tagger keep-alive: %s", err)
+				telemetry.ServerStreamErrors.Inc()
+				return err
+			}
+		}
+	}
+}
+
+// TaggerFetchEntity fetches an entity from the Tagger with the desired cardinality tags.
+func (s *Server) TaggerFetchEntity(ctx context.Context, in *pb.FetchEntityRequest) (*pb.FetchEntityResponse, error) {
+	if in.Id == nil {
+		return nil, status.Errorf(codes.InvalidArgument, `missing "id" parameter`)
+	}
+
+	entityID := fmt.Sprintf("%s://%s", in.Id.Prefix, in.Id.Uid)
+	cardinality, err := pbutils.Pb2TaggerCardinality(in.Cardinality)
+	if err != nil {
+		return nil, err
+	}
+
+	tags, err := tagger.Tag(entityID, cardinality)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "%s", err)
+	}
+
+	return &pb.FetchEntityResponse{
+		Id:          in.Id,
+		Cardinality: in.Cardinality,
+		Tags:        tags,
+	}, nil
+}

--- a/pkg/tagger/server/server.go
+++ b/pkg/tagger/server/server.go
@@ -26,14 +26,14 @@ const (
 	streamKeepAliveInterval = 9 * time.Minute
 )
 
+type Server struct {
+	tagger tagger.Tagger
+}
+
 func NewServer(t tagger.Tagger) *Server {
 	return &Server{
 		tagger: t,
 	}
-}
-
-type Server struct {
-	tagger tagger.Tagger
 }
 
 // TaggerStreamEntities subscribes to added, removed, or changed entities in the Tagger

--- a/pkg/util/grpc/auth.go
+++ b/pkg/util/grpc/auth.go
@@ -1,0 +1,39 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package grpc
+
+import (
+	"context"
+
+	grpc_auth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+var contextKeyTokenInfoID = &contextKey{"token-info-id"}
+
+// verifierFunc receives the token passed in the request headers, and returns
+// arbitrary information about the token to be stored in the request context,
+// or an error if the token is not valid.
+type verifierFunc func(string) (interface{}, error)
+
+// AuthInterceptor is a gRPC interceptor that extracts an auth token from the
+// request headers, and validates it using the provided func.
+func AuthInterceptor(verifier verifierFunc) grpc_auth.AuthFunc {
+	return func(ctx context.Context) (context.Context, error) {
+		token, err := grpc_auth.AuthFromMD(ctx, "Bearer")
+		if err != nil {
+			return nil, err
+		}
+
+		tokenInfo, err := verifier(token)
+		if err != nil {
+			return nil, status.Errorf(codes.Unauthenticated, "invalid auth token: %v", err)
+		}
+
+		return context.WithValue(ctx, contextKeyTokenInfoID, tokenInfo), nil
+	}
+}

--- a/pkg/util/grpc/server.go
+++ b/pkg/util/grpc/server.go
@@ -1,0 +1,69 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package grpc
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"google.golang.org/grpc"
+)
+
+type contextKey struct {
+	key string
+}
+
+var connContextKey = &contextKey{"http-connection"}
+
+// NewMuxedGRPCServer returns an http.Server that multiplexes connections
+// between a gRPC server and an HTTP handler.
+func NewMuxedGRPCServer(tlsConfig *tls.Config, grpcServer *grpc.Server, httpHandler http.Handler) *http.Server {
+	// our gRPC clients do not handle protocol negotiation, so we need to force
+	// HTTP/2
+	tlsConfig.NextProtos = []string{"h2"}
+
+	return &http.Server{
+		Handler:   handlerWithFallback(grpcServer, httpHandler),
+		TLSConfig: tlsConfig,
+		ConnContext: func(ctx context.Context, c net.Conn) context.Context {
+			// Store the connection in the context so requests can reference it if needed
+			return context.WithValue(ctx, connContextKey, c)
+		},
+	}
+}
+
+// TimeoutHandlerFunc returns an HTTP handler that times out after a duration.
+// This is useful for muxed gRPC servers where http.Server cannot have a
+// timeout when handling streaming, long running connections.
+func TimeoutHandlerFunc(httpHandler http.Handler, timeout time.Duration) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		deadline := time.Now().Add(timeout)
+
+		conn := r.Context().Value(connContextKey).(net.Conn)
+		_ = conn.SetWriteDeadline(deadline)
+
+		httpHandler.ServeHTTP(w, r)
+	})
+}
+
+// handlerWithFallback returns an http.Handler that delegates to grpcServer on
+// incoming gRPC connections or httpServer otherwise. Copied from
+// cockroachdb.
+func handlerWithFallback(grpcServer *grpc.Server, httpServer http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// This is a partial recreation of gRPC's internal checks
+		// https://github.com/grpc/grpc-go/pull/514/files#diff-95e9a25b738459a2d3030e1e6fa2a718R61
+		if r.ProtoMajor == 2 && strings.Contains(r.Header.Get("Content-Type"), "application/grpc") {
+			grpcServer.ServeHTTP(w, r)
+		} else {
+			httpServer.ServeHTTP(w, r)
+		}
+	})
+}

--- a/pkg/util/grpc/server.go
+++ b/pkg/util/grpc/server.go
@@ -24,12 +24,13 @@ var connContextKey = &contextKey{"http-connection"}
 
 // NewMuxedGRPCServer returns an http.Server that multiplexes connections
 // between a gRPC server and an HTTP handler.
-func NewMuxedGRPCServer(tlsConfig *tls.Config, grpcServer *grpc.Server, httpHandler http.Handler) *http.Server {
+func NewMuxedGRPCServer(addr string, tlsConfig *tls.Config, grpcServer *grpc.Server, httpHandler http.Handler) *http.Server {
 	// our gRPC clients do not handle protocol negotiation, so we need to force
 	// HTTP/2
 	tlsConfig.NextProtos = []string{"h2"}
 
 	return &http.Server{
+		Addr:      addr,
 		Handler:   handlerWithFallback(grpcServer, httpHandler),
 		TLSConfig: tlsConfig,
 		ConnContext: func(ctx context.Context, c net.Conn) context.Context {


### PR DESCRIPTION
### What does this PR do?

This is a small refactoring of the gRPC tagger server in the core agent, to be able to also expose it in the DCA. Future clients of this service will be the remote taggers running on the cluster checks runners, in order to be able to take advantage of cluster level tags.

### Describe how to test/QA your changes

I'm adding the `skip-qa` on this one, as the core agent tagger is touched by everything and basically QA'd by everything else, and the DCA tagger is currently empty, so there's nothing to QA there yet, upcoming PRs will take care of that.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
