### PR TITLE
[netflow] lower port rollup tracker refresh interval to reduce memory usage

### DIFF
--- a/pkg/netflow/common/constants.go
+++ b/pkg/netflow/common/constants.go
@@ -19,7 +19,7 @@ const (
 	DefaultAggregatorPortRollupThreshold = 10
 
 	// DefaultAggregatorRollupTrackerRefreshInterval is the default aggregator rollup tracker refresh interval
-	DefaultAggregatorRollupTrackerRefreshInterval = 3600 // 1h
+	DefaultAggregatorRollupTrackerRefreshInterval = 300 // 5min
 
 	// DefaultBindHost is the default bind host used for flow listeners
 	DefaultBindHost = "0.0.0.0"

--- a/pkg/netflow/config/config_test.go
+++ b/pkg/netflow/config/config_test.go
@@ -92,7 +92,7 @@ network_devices:
 				AggregatorFlushInterval:                300,
 				AggregatorFlowContextTTL:               300,
 				AggregatorPortRollupThreshold:          10,
-				AggregatorRollupTrackerRefreshInterval: 3600,
+				AggregatorRollupTrackerRefreshInterval: 300,
 				Listeners: []ListenerConfig{
 					{
 						FlowType:  common.TypeNetFlow9,
@@ -120,7 +120,7 @@ network_devices:
 				AggregatorFlushInterval:                50,
 				AggregatorFlowContextTTL:               50,
 				AggregatorPortRollupThreshold:          10,
-				AggregatorRollupTrackerRefreshInterval: 3600,
+				AggregatorRollupTrackerRefreshInterval: 300,
 				Listeners: []ListenerConfig{
 					{
 						FlowType:  common.TypeNetFlow9,


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

[netflow] lower port rollup tracker refresh interval to reduce memory usage

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

lower mem usage

This means that, if during a window of 10min (2x5min due to double write to current store and new store), instead of prev 1h, a port is changes a lot a reaches the threshold of 10 (default) it will be considered as ephemeral.

Reducing from 1h to 5min can lead to lower cases considered as ephemeral, but I think it's not an issue in practice.
=> If a port is not ephemeral with 5min interval, but ephemeral with 1h interval, it means that it's not a high volume traffic case (traffic with same src/dst IP, one fixed port and the other port ephemeral)
=> is a port is ephemeral, there is a good chance it's handle by 5min interval too

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
