### PR TITLE
[Serverless] Small readability updates and other nitpicks.

### DIFF
--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -214,8 +214,7 @@ func runAgent(stopCh chan struct{}) (serverlessDaemon *daemon.Daemon, err error)
 	serverlessDaemon.SetupLogCollectionHandler(logsAPICollectionRoute, logChannel, config.Datadog.GetBool("serverless.logs_enabled"), config.Datadog.GetBool("enhanced_metrics"))
 
 	wg := sync.WaitGroup{}
-	wg.Add(1)
-	wg.Add(1)
+	wg.Add(2)
 
 	// starts trace agent
 	go func() {

--- a/pkg/serverless/invocationlifecycle/lifecycle.go
+++ b/pkg/serverless/invocationlifecycle/lifecycle.go
@@ -69,7 +69,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 
 	payloadBytes := []byte(lambdaPayloadString)
 	region, account, resource, arnParseErr := trigger.ParseArn(startDetails.InvokedFunctionARN)
-	if err != nil {
+	if arnParseErr != nil {
 		log.Debugf("[lifecycle] Error parsing ARN: %v", err)
 	}
 

--- a/pkg/serverless/logs/testdata/platform_extension.json
+++ b/pkg/serverless/logs/testdata/platform_extension.json
@@ -1,0 +1,12 @@
+{
+    "time": "2020-08-20T12:31:32.123Z",
+    "type": "platform.extension",
+    "record": {
+        "name": "datadog-agent",
+        "state": "Ready",
+        "events": [
+            "INVOKE",
+            "SHUTDOWN"
+        ]
+    }
+}

--- a/pkg/serverless/logs/testdata/platform_fault.json
+++ b/pkg/serverless/logs/testdata/platform_fault.json
@@ -1,0 +1,5 @@
+{
+    "time": "2020-08-20T12:31:32.123Z",
+    "type": "platform.fault",
+    "record": "sample fault log"
+}

--- a/pkg/serverless/metrics/enhanced_metrics.go
+++ b/pkg/serverless/metrics/enhanced_metrics.go
@@ -53,7 +53,7 @@ func getOutOfMemorySubstrings() []string {
 }
 
 // GenerateRuntimeDurationMetric generates the runtime duration metric
-func GenerateRuntimeDurationMetric(start time.Time, end time.Time, status string, tags []string, demux aggregator.Demultiplexer) {
+func GenerateRuntimeDurationMetric(start time.Time, end time.Time, tags []string, demux aggregator.Demultiplexer) {
 	// first check if both date are set
 	if start.IsZero() || end.IsZero() {
 		log.Debug("Impossible to compute aws.lambda.enhanced.runtime_duration due to an invalid interval")

--- a/pkg/serverless/metrics/enhanced_metrics_test.go
+++ b/pkg/serverless/metrics/enhanced_metrics_test.go
@@ -328,7 +328,7 @@ func TestGenerateRuntimeDurationMetricNoStartDate(t *testing.T) {
 	tags := []string{"functionname:test-function"}
 	startTime := time.Time{}
 	endTime := time.Now()
-	go GenerateRuntimeDurationMetric(startTime, endTime, "myStatus", tags, demux)
+	go GenerateRuntimeDurationMetric(startTime, endTime, tags, demux)
 	generatedMetrics, timedMetrics := demux.WaitForSamples(100 * time.Millisecond)
 	assert.Len(t, generatedMetrics, 0, "no metrics should have been generated")
 	assert.Len(t, timedMetrics, 0)
@@ -340,7 +340,7 @@ func TestGenerateRuntimeDurationMetricNoEndDate(t *testing.T) {
 	tags := []string{"functionname:test-function"}
 	startTime := time.Now()
 	endTime := time.Time{}
-	go GenerateRuntimeDurationMetric(startTime, endTime, "myStatus", tags, demux)
+	go GenerateRuntimeDurationMetric(startTime, endTime, tags, demux)
 	generatedMetrics, timedMetrics := demux.WaitForSamples(100 * time.Millisecond)
 	assert.Len(t, generatedMetrics, 0, "no metrics should have been generated")
 	assert.Len(t, timedMetrics, 0)
@@ -352,7 +352,7 @@ func TestGenerateRuntimeDurationMetricOK(t *testing.T) {
 	tags := []string{"functionname:test-function"}
 	startTime := time.Date(2020, 01, 01, 01, 01, 01, 500000000, time.UTC)
 	endTime := time.Date(2020, 01, 01, 01, 01, 01, 653000000, time.UTC) //153 ms later
-	go GenerateRuntimeDurationMetric(startTime, endTime, "myStatus", tags, demux)
+	go GenerateRuntimeDurationMetric(startTime, endTime, tags, demux)
 	generatedMetrics, timedMetrics := demux.WaitForSamples(100 * time.Millisecond)
 	assert.Equal(t, generatedMetrics[:1], []metrics.MetricSample{{
 		Name:       runtimeDurationMetric,

--- a/pkg/serverless/trace/trace.go
+++ b/pkg/serverless/trace/trace.go
@@ -73,9 +73,7 @@ func (s *ServerlessTraceAgent) Start(enabled bool, loadConfig Load) {
 			s.ta.ModifySpan = s.spanModifier.ModifySpan
 			s.ta.DiscardSpan = filterSpanFromLambdaLibraryOrRuntime
 			s.cancel = cancel
-			go func() {
-				s.ta.Run()
-			}()
+			go s.ta.Run()
 		}
 	}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR is a set of small nitpick changes I've collected over the last couple months. I will comment in the code on each change directly, but in general these changes offer some slight performance improvements and maintainability improvements.

The only functionality changed with this PR is to fix a couple of small bugs that were preventing debug logging in certain cases.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

I believe these changes improve readability and maintainability for the extension as well as offer a few small performance improvements.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Running the unit tests and integration tests should suffice. You should also consider testing a deployed lambda function that triggers the following logs api events as their logic has changed:
+ `platform.fault`: when a handler raises an exception, we do nothing with the logs api event
+ `platform.extension`: when the extension is registered with the extensions api, we do nothing with the logs api event
+ `platform.logsSubscription`: when the extension registers with the logs api, we do nothing with the logs api event
+ `platform.logsDropped`: when a function produces too many logs, the extension will process the `platform.logsDropped` event and log a debug message

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
