### PR TITLE
pkg/trace/api: add /dogstatsd/v2/proxy that splits on newlines

### DIFF
--- a/pkg/trace/api/dogstatsd_test.go
+++ b/pkg/trace/api/dogstatsd_test.go
@@ -110,12 +110,15 @@ func TestDogStatsDReverseProxyEndToEndUDP(t *testing.T) {
 	// Check that both payloads were sent over (without a newline).
 	ln.SetReadDeadline(time.Now().Add(2 * time.Second))
 	buf := make([]byte, len(msg)-len(sep))
-	_, _, err = ln.ReadFrom(buf)
+	n, _, err := ln.ReadFrom(buf)
 	require.NoError(t, err)
-	_, _, err = ln.ReadFrom(buf[len(payloads[0]):])
+	if got, want := buf[:n], payloads[0]; !bytes.Equal(got, want) {
+		t.Errorf("got first payload: %q\nwant first payload: %q", got, want)
+	}
+	_, _, err = ln.ReadFrom(buf[n:])
 	require.NoError(t, err)
-	if got, want := buf, bytes.Join(payloads, nil); !bytes.Equal(got, want) {
-		t.Errorf("got: %q\nwant: %q", got, want)
+	if got, want := buf[n:], payloads[1]; !bytes.Equal(got, want) {
+		t.Errorf("got second payload: %q\nwant second payload: %q", got, want)
 	}
 }
 

--- a/pkg/trace/api/dogstatsd_test.go
+++ b/pkg/trace/api/dogstatsd_test.go
@@ -100,7 +100,7 @@ func TestDogStatsDReverseProxyEndToEndUDP(t *testing.T) {
 	rec := httptest.NewRecorder()
 
 	// Send two payloads separated by a newline.
-	payloads := [][]byte{[]byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2"), []byte("_sc|agent.up|0|m:this is fine")}
+	payloads := [][]byte{[]byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2"), []byte("_e{21,36}:An exception occurred|Cannot parse CSV file from\\n10.0.0.17|t:warning|#err_type:bad_file")}
 	sep := []byte("\n")
 	msg := bytes.Join(payloads, sep)
 	body := ioutil.NopCloser(bytes.NewBuffer(msg))

--- a/pkg/trace/api/dogstatsd_test.go
+++ b/pkg/trace/api/dogstatsd_test.go
@@ -108,7 +108,7 @@ func TestDogStatsDReverseProxyEndToEndUDP(t *testing.T) {
 	require.Equal(t, http.StatusOK, rec.Code)
 
 	// Check that both payloads were sent over (without a newline).
-	ln.SetReadDeadline(time.Now().Add(2 * time.Second))
+	ln.SetReadDeadline(time.Now().Add(30 * time.Second))
 	buf := make([]byte, len(msg)-len(sep))
 	n, _, err := ln.ReadFrom(buf)
 	require.NoError(t, err)

--- a/pkg/trace/api/endpoints.go
+++ b/pkg/trace/api/endpoints.go
@@ -125,7 +125,11 @@ var endpoints = []Endpoint{
 		Handler: func(r *HTTPReceiver) http.Handler { return r.debuggerProxyHandler() },
 	},
 	{
-		Pattern: "/dogstatsd/v1/proxy",
+		Pattern: "/dogstatsd/v1/proxy", // deprecated
+		Handler: func(r *HTTPReceiver) http.Handler { return r.dogstatsdProxyHandler() },
+	},
+	{
+		Pattern: "/dogstatsd/v2/proxy",
 		Handler: func(r *HTTPReceiver) http.Handler { return r.dogstatsdProxyHandler() },
 	},
 }

--- a/releasenotes/notes/apm-fix-statsd-endpoint.yaml
+++ b/releasenotes/notes/apm-fix-statsd-endpoint.yaml
@@ -9,6 +9,6 @@
 fixes:
   - |
     APM: DogStatsD data can now be proxied through the "/dogstatsd/v1/proxy" endpoint
-    and the new "/dogstatsd/v2/proxy" endpoint over UDS or UDP, with multiple payloads
+    and the new "/dogstatsd/v2/proxy" endpoint over UDS, with multiple payloads
     separated by newlines in a single request body.
     See https://docs.datadoghq.com/developers/dogstatsd#setup for configuration details.

--- a/releasenotes/notes/apm-fix-statsd-endpoint.yaml
+++ b/releasenotes/notes/apm-fix-statsd-endpoint.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fix:
+  - |
+    APM: DogStatsD data can now be proxied through the "/dogstatsd/v1/proxy" endpoint
+    and the new "/dogstatsd/v2/proxy" endpoint over UDS or UDP, with multiple payloads
+    separated by newlines in a single request body.
+    See https://docs.datadoghq.com/developers/dogstatsd#setup for configuration details.

--- a/releasenotes/notes/apm-fix-statsd-endpoint.yaml
+++ b/releasenotes/notes/apm-fix-statsd-endpoint.yaml
@@ -6,7 +6,7 @@
 #
 # Each section note must be formatted as reStructuredText.
 ---
-fix:
+fixes:
   - |
     APM: DogStatsD data can now be proxied through the "/dogstatsd/v1/proxy" endpoint
     and the new "/dogstatsd/v2/proxy" endpoint over UDS or UDP, with multiple payloads


### PR DESCRIPTION
### What does this PR do?

Adds a v2 endpoint for the DogStatsD proxy through the Trace Agent which splits payloads by newline. The `/dogstatsd/v1/proxy` endpoint has also been changed to parse requests in this way, since the risk is negligible that someone is relying on the previous behavior.

### Motivation

Previously, clients would have to send a request for every single stats payload that they wanted to send over to the proxy. Now, they can send a large request with several stats requests separated by newlines to this endpoint, lowering the load on the tracer side.

An alternative would be to simply change the v1 endpoint to separate by newlines and not create a v2 endpoint. We can't do this since a current Agent release contains this v1 endpoint. The issue would arise if the NodeJS tracer is released with their logic hitting the v1 endpoint. There would be no way for the NodeJS tracer to guarantee that a customer is using the "newer" version of the v1 endpoint in the agent, instead of the "older" version that doesn't split by newlines. In that case, it could be sending over large payloads separated by newlines that are not currently split or processed in the Core Agent, and the status code of OK from this endpoint would make it look like everything was working as expected. Creating a v2 endpoint and having the NodeJS tracer send payloads over to this prevents this versioning issue in the agent.

This builds on top of https://github.com/DataDog/datadog-agent/pull/13393

### Possible Drawbacks / Trade-offs

If a customer is currently relying on the `/dogstatsd/v1/proxy` endpoint *not* splitting on newlines, this will be a breaking change for them. But this is an endpoint that would only ever be used by Datadog's tracers, which none of them are today, so no customers should be affected by this.

### Describe how to test/QA your changes

There are unit tests covering this use case, and there are manual tests that can run this end-to-end with the NodeJS tracer.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
