### PR TITLE
Adding unit test to service deletion

### DIFF
--- a/pkg/logs/service/services_test.go
+++ b/pkg/logs/service/services_test.go
@@ -61,3 +61,31 @@ func TestRemoveService(t *testing.T) {
 	assert.Equal(t, <-removed, service)
 	assert.Equal(t, <-all, service)
 }
+
+func TestRemoveMultipleService(t *testing.T) {
+	services := NewServices()
+	service1 := NewService("foo", "1")
+	service2 := NewService("foo", "2")
+	service3 := NewService("foo", "3")
+
+	removed := services.GetRemovedServicesForType("foo")
+	assert.NotNil(t, removed)
+	assert.Equal(t, 0, len(removed))
+
+	services.AddService(service1)
+	services.AddService(service2)
+	services.AddService(service3)
+	services.AddService(service1)
+
+	assert.Len(t, services.services, 4)
+
+	go func() { services.RemoveService(service1) }()
+	assert.Equal(t, <-removed, service1)
+
+	assert.Len(t, services.services, 2)
+
+	go func() { services.RemoveService(service1) }()
+	assert.Equal(t, <-removed, service1)
+
+	assert.Len(t, services.services, 2)
+}


### PR DESCRIPTION
### What does this PR do?

The old test only deleted from an empty list. We had a panic in the deletion logic when deleted multiple services at once. This new unit test now test the actual deletion.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
