### PR TITLE
forwarder: Use TLS 1.2 by default

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -363,8 +363,8 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("server_timeout", 30)
 
 	// Configuration for TLS for outgoing connections
-	config.BindEnvAndSetDefault("force_tls_12", false) // deprecated
-	config.BindEnvAndSetDefault("min_tls_version", "") // default depends on force_tls_12
+	config.BindEnvAndSetDefault("force_tls_12", false)        // deprecated
+	config.BindEnvAndSetDefault("min_tls_version", "tlsv1.2") // default depends on force_tls_12
 
 	// Defaults to safe YAML methods in base and custom checks.
 	config.BindEnvAndSetDefault("disable_unsafe_yaml", true)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -363,8 +363,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("server_timeout", 30)
 
 	// Configuration for TLS for outgoing connections
-	config.BindEnvAndSetDefault("force_tls_12", false)        // deprecated
-	config.BindEnvAndSetDefault("min_tls_version", "tlsv1.2") // default depends on force_tls_12
+	config.BindEnvAndSetDefault("min_tls_version", "tlsv1.2")
 
 	// Defaults to safe YAML methods in base and custom checks.
 	config.BindEnvAndSetDefault("disable_unsafe_yaml", true)

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -73,15 +73,6 @@ api_key:
 #
 # min_tls_version: "tlsv1.2"
 
-## Deprecated - use `min_tls_version` instead
-## @param force_tls_12 - boolean - optional - default: false
-## @env DD_FORCE_TLS_12 - boolean - optional - default: false
-## Setting this option to "true" forces the Agent to only use TLS 1.2 when
-## pushing data to the Datadog intake specified in "site" or "dd_url".
-## This parameter is deprecated in favor of `min_tls_version`.
-#
-# force_tls_12: false
-
 ## @param hostname - string - optional - default: auto-detected
 ## @env DD_HOSTNAME - string - optional - default: auto-detected
 ## Force the hostname name.

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -67,17 +67,18 @@ api_key:
 ## @env DD_MIN_TLS_VERSION - string - optional - default: "tlsv1.0"
 ## This option defines the minimum TLS version that will be used when
 ## submitting data to the Datadog intake specified in "site" or "dd_url".
-## This parameter defaults to "tlsv1.0" (but see `force_tls_12`, below).
+## This parameter defaults to "tlsv1.2".
 ## Possible values are: tlsv1.0, tlsv1.1, tlsv1.2, tlsv1.3; values are case-
 ## insensitive.
 #
-# min_tls_version: "tlsv1.0"
+# min_tls_version: "tlsv1.2"
 
+## Deprecated - use `min_tls_version` instead
 ## @param force_tls_12 - boolean - optional - default: false
 ## @env DD_FORCE_TLS_12 - boolean - optional - default: false
-## Setting this option to "true" is equivalent to setting the default for
-## `min_tls_version` to `tlsv1.2`.  This parameter is deprecated in favor of
-## `min_tls_version`.
+## Setting this option to "true" forces the Agent to only use TLS 1.2 when
+## pushing data to the Datadog intake specified in "site" or "dd_url".
+## This parameter is deprecated in favor of `min_tls_version`.
 #
 # force_tls_12: false
 

--- a/pkg/util/http/transport.go
+++ b/pkg/util/http/transport.go
@@ -73,11 +73,8 @@ func minTLSVersionFromConfig(cfg config.Config) uint16 {
 	case "tlsv1.3":
 		min = tls.VersionTLS13
 	default:
-		if cfg.GetBool("force_tls_12") {
-			min = tls.VersionTLS12
-		} else {
-			min = tls.VersionTLS10
-		}
+		min = tls.VersionTLS12
+
 		if minTLSVersion != "" {
 			log.Warnf("Invalid `min_tls_version` %#v; using default", minTLSVersion)
 		}

--- a/pkg/util/http/transport.go
+++ b/pkg/util/http/transport.go
@@ -74,7 +74,6 @@ func minTLSVersionFromConfig(cfg config.Config) uint16 {
 		min = tls.VersionTLS13
 	default:
 		min = tls.VersionTLS12
-
 		if minTLSVersion != "" {
 			log.Warnf("Invalid `min_tls_version` %#v; using default", minTLSVersion)
 		}

--- a/pkg/util/http/transport_test.go
+++ b/pkg/util/http/transport_test.go
@@ -153,12 +153,9 @@ func TestCreateHTTPTransport(t *testing.T) {
 	mockConfig := config.Mock(t)
 
 	skipSSL := config.Datadog.GetBool("skip_ssl_validation")
-	forceTLS := config.Datadog.GetBool("force_tls_12")
 	defer mockConfig.Set("skip_ssl_validation", skipSSL)
-	defer mockConfig.Set("force_tls_12", forceTLS)
 
 	mockConfig.Set("skip_ssl_validation", false)
-	mockConfig.Set("force_tls_12", false)
 	transport := CreateHTTPTransport()
 	assert.False(t, transport.TLSClientConfig.InsecureSkipVerify)
 	assert.Equal(t, transport.TLSClientConfig.MinVersion, uint16(tls.VersionTLS12))
@@ -168,7 +165,6 @@ func TestCreateHTTPTransport(t *testing.T) {
 	assert.True(t, transport.TLSClientConfig.InsecureSkipVerify)
 	assert.Equal(t, transport.TLSClientConfig.MinVersion, uint16(tls.VersionTLS12))
 
-	mockConfig.Set("force_tls_12", true)
 	transport = CreateHTTPTransport()
 	assert.True(t, transport.TLSClientConfig.InsecureSkipVerify)
 	assert.Equal(t, transport.TLSClientConfig.MinVersion, uint16(tls.VersionTLS12))
@@ -194,39 +190,33 @@ func TestNoProxyWarningMap(t *testing.T) {
 func TestMinTLSVersionFromConfig(t *testing.T) {
 	tests := []struct {
 		minTLSVersion string
-		forceTLS12    bool
 		expect        uint16
 	}{
-		{"tlsv1.0", false, tls.VersionTLS10},
-		{"tlsv1.0", true, tls.VersionTLS10},
-		{"tlsv1.1", false, tls.VersionTLS11},
-		{"tlsv1.1", true, tls.VersionTLS11},
-		{"tlsv1.2", false, tls.VersionTLS12},
-		{"tlsv1.2", true, tls.VersionTLS12},
-		{"tlsv1.3", false, tls.VersionTLS13},
-		{"tlsv1.3", true, tls.VersionTLS13},
+		{"tlsv1.0", tls.VersionTLS10},
+		{"tlsv1.1", tls.VersionTLS11},
+		{"tlsv1.2", tls.VersionTLS12},
+		{"tlsv1.3", tls.VersionTLS13},
 		// case-insensitive
-		{"TlSv1.0", false, tls.VersionTLS10},
-		{"TlSv1.3", true, tls.VersionTLS13},
+		{"TlSv1.0", tls.VersionTLS10},
+		{"TlSv1.3", tls.VersionTLS13},
 		// defaults
-		{"", false, tls.VersionTLS12},
-		{"", true, tls.VersionTLS12},
+		{"", tls.VersionTLS12},
+		{"", tls.VersionTLS12},
 		// invalid values
-		{"tlsv1.9", false, tls.VersionTLS12},
-		{"tlsv1.9", true, tls.VersionTLS12},
-		{"blergh", false, tls.VersionTLS12},
-		{"blergh", true, tls.VersionTLS12},
+		{"tlsv1.9", tls.VersionTLS12},
+		{"tlsv1.9", tls.VersionTLS12},
+		{"blergh", tls.VersionTLS12},
+		{"blergh", tls.VersionTLS12},
 	}
 
 	for _, test := range tests {
 		t.Run(
-			fmt.Sprintf("min_tls_version=%s/force_tls_12=%t", test.minTLSVersion, test.forceTLS12),
+			fmt.Sprintf("min_tls_version=%s", test.minTLSVersion),
 			func(t *testing.T) {
 				cfg := config.Mock(t)
 				if test.minTLSVersion != "" {
 					cfg.Set("min_tls_version", test.minTLSVersion)
 				}
-				cfg.Set("force_tls_12", test.forceTLS12)
 				got := minTLSVersionFromConfig(cfg)
 				require.Equal(t, test.expect, got)
 			})

--- a/pkg/util/http/transport_test.go
+++ b/pkg/util/http/transport_test.go
@@ -161,12 +161,12 @@ func TestCreateHTTPTransport(t *testing.T) {
 	mockConfig.Set("force_tls_12", false)
 	transport := CreateHTTPTransport()
 	assert.False(t, transport.TLSClientConfig.InsecureSkipVerify)
-	assert.Equal(t, transport.TLSClientConfig.MinVersion, uint16(tls.VersionTLS10))
+	assert.Equal(t, transport.TLSClientConfig.MinVersion, uint16(tls.VersionTLS12))
 
 	mockConfig.Set("skip_ssl_validation", true)
 	transport = CreateHTTPTransport()
 	assert.True(t, transport.TLSClientConfig.InsecureSkipVerify)
-	assert.Equal(t, transport.TLSClientConfig.MinVersion, uint16(tls.VersionTLS10))
+	assert.Equal(t, transport.TLSClientConfig.MinVersion, uint16(tls.VersionTLS12))
 
 	mockConfig.Set("force_tls_12", true)
 	transport = CreateHTTPTransport()
@@ -209,12 +209,12 @@ func TestMinTLSVersionFromConfig(t *testing.T) {
 		{"TlSv1.0", false, tls.VersionTLS10},
 		{"TlSv1.3", true, tls.VersionTLS13},
 		// defaults
-		{"", false, tls.VersionTLS10},
+		{"", false, tls.VersionTLS12},
 		{"", true, tls.VersionTLS12},
 		// invalid values
-		{"tlsv1.9", false, tls.VersionTLS10},
+		{"tlsv1.9", false, tls.VersionTLS12},
 		{"tlsv1.9", true, tls.VersionTLS12},
-		{"blergh", false, tls.VersionTLS10},
+		{"blergh", false, tls.VersionTLS12},
 		{"blergh", true, tls.VersionTLS12},
 	}
 

--- a/releasenotes/notes/use-tls-1.2-by-default-e2983c21056c3359.yaml
+++ b/releasenotes/notes/use-tls-1.2-by-default-e2983c21056c3359.yaml
@@ -1,5 +1,6 @@
 ---
 upgrade:
-    The ``force_tls_12` configuration parameter is removed in favor of ``min_tls_version``.
-    The ``min_tls_version`` configuration parameter now defaults to `tlsv1.2` instead of ``tlsv1.0``.
-    Set ``min_tls_version`` value to `tlsv1.0` or `tlsv1.1` to allow a lower TLS version.
+    The Agent now defaults to TLS 1.2 instead of TLS 1.0. The ``force_tls_12`` configuration parameter has been
+    removed since it's now the default behavior.
+    To continue using TLS 1.0 or 1.1, you must set the ``min_tls_version`` configuration parameter to either
+    `tlsv1.0` or `tlsv1.1`.

--- a/releasenotes/notes/use-tls-1.2-by-default-e2983c21056c3359.yaml
+++ b/releasenotes/notes/use-tls-1.2-by-default-e2983c21056c3359.yaml
@@ -1,10 +1,9 @@
 ---
 enhancements:
   - |
-    The ``min_tls_version`` configuration parameter is defined to `tlsv1.2` by
-    default. Set its value to `tlsv1.0` or `tlsv1.1` if a lower version is needed.
+    The ``min_tls_version`` configuration parameter now default to `tlsv1.2` instead of `tlsv1.0`.
+    Set its value to `tlsv1.0` or `tlsv1.1` if a lower version is needed.
    
 deprecations:
   - |
-    The deprecated ``force_tls_12`` configuration parameter is ignored even if
-    ``min_tls_version`` is not given.
+    The deprecated ``force_tls_12`` configuration parameter has been removed in favor of ``min_tls_version`` which default to TLS 1.2.

--- a/releasenotes/notes/use-tls-1.2-by-default-e2983c21056c3359.yaml
+++ b/releasenotes/notes/use-tls-1.2-by-default-e2983c21056c3359.yaml
@@ -1,9 +1,9 @@
 ---
 enhancements:
   - |
-    The ``min_tls_version`` configuration parameter now default to `tlsv1.2` instead of `tlsv1.0`.
+    The ``min_tls_version`` configuration parameter now defaults to ``tlsv1.2`` instead of ``tlsv1.0``.
     Set its value to `tlsv1.0` or `tlsv1.1` if a lower version is needed.
    
 deprecations:
   - |
-    The deprecated ``force_tls_12`` configuration parameter has been removed in favor of ``min_tls_version`` which default to TLS 1.2.
+    The deprecated ``force_tls_12`` configuration parameter has been removed in favor of ``min_tls_version`` which defaults to TLS v1.2.

--- a/releasenotes/notes/use-tls-1.2-by-default-e2983c21056c3359.yaml
+++ b/releasenotes/notes/use-tls-1.2-by-default-e2983c21056c3359.yaml
@@ -1,9 +1,5 @@
 ---
-enhancements:
-  - |
-    The ``min_tls_version`` configuration parameter now defaults to ``tlsv1.2`` instead of ``tlsv1.0``.
-    Set its value to `tlsv1.0` or `tlsv1.1` if a lower version is needed.
-   
-deprecations:
-  - |
-    The deprecated ``force_tls_12`` configuration parameter has been removed in favor of ``min_tls_version`` which defaults to TLS v1.2.
+upgrade:
+    The ``force_tls_12` configuration parameter is removed in favor of ``min_tls_version``.
+    The ``min_tls_version`` configuration parameter now defaults to `tlsv1.2` instead of ``tlsv1.0``.
+    Set ``min_tls_version`` value to `tlsv1.0` or `tlsv1.1` to allow a lower TLS version.

--- a/releasenotes/notes/use-tls-1.2-by-default-e2983c21056c3359.yaml
+++ b/releasenotes/notes/use-tls-1.2-by-default-e2983c21056c3359.yaml
@@ -1,6 +1,6 @@
 ---
 upgrade:
-    The Agent now defaults to TLS 1.2 instead of TLS 1.0. The ``force_tls_12`` configuration parameter has been
+    The Agent now defaults to TLS 1.2 instead of TLS 1.0. The `force_tls_12` configuration parameter has been
     removed since it's now the default behavior.
-    To continue using TLS 1.0 or 1.1, you must set the ``min_tls_version`` configuration parameter to either
+    To continue using TLS 1.0 or 1.1, you must set the `min_tls_version` configuration parameter to either
     `tlsv1.0` or `tlsv1.1`.

--- a/releasenotes/notes/use-tls-1.2-by-default-e2983c21056c3359.yaml
+++ b/releasenotes/notes/use-tls-1.2-by-default-e2983c21056c3359.yaml
@@ -1,0 +1,10 @@
+---
+enhancements:
+  - |
+    The ``min_tls_version`` configuration parameter is defined to `tlsv1.2` by
+    default. Set its value to `tlsv1.0` or `tlsv1.1` if a lower version is needed.
+   
+deprecations:
+  - |
+    The deprecated ``force_tls_12`` configuration parameter is ignored even if
+    ``min_tls_version`` is not given.

--- a/releasenotes/notes/use-tls-1.2-by-default-e2983c21056c3359.yaml
+++ b/releasenotes/notes/use-tls-1.2-by-default-e2983c21056c3359.yaml
@@ -1,6 +1,6 @@
 ---
 upgrade:
-    The Agent now defaults to TLS 1.2 instead of TLS 1.0. The `force_tls_12` configuration parameter has been
+    The Agent now defaults to TLS 1.2 instead of TLS 1.0. The ``force_tls_12`` configuration parameter has been
     removed since it's now the default behavior.
-    To continue using TLS 1.0 or 1.1, you must set the `min_tls_version` configuration parameter to either
+    To continue using TLS 1.0 or 1.1, you must set the ``min_tls_version`` configuration parameter to either
     `tlsv1.0` or `tlsv1.1`.


### PR DESCRIPTION
### What does this PR do?

This PR sets the default value of `min_tls_version` to `tlsv1.2` and completely removes `force_tls_12` from the code logic.

### Motivation

TLS 1.0 and 1.1 are insecure so we should use TLS 1.2 by default. Customers still can use TLS 1.0 and 1.1 by setting `min_tls_version`

### Additional Notes

Can we confirm that we are depreciating the `force_tls_v12` option ? If yes, can I just remove all the references to `force_tls_v12` in the code. (by removing this line `config.BindEnvAndSetDefault("force_tls_12", false)`) ?


### Possible Drawbacks / Trade-offs

That might breaks some customers' configuration if they are sending data to a proxy / non Datadog endpoint which do not support TLS 1.2

### Describe how to test/QA your changes

Changes are unit tested but it is still worth to check if `min_tls_version` is correctly setup.


#### Python script

This scripts creates  several fake TLS servers with different TLS version starting from TLS 1.0 to TLS 1.2. The servers will refuse a connection if the client (Agent in this case) is using a version above the one used by the server.

For instance, if the Agent can connect to a TLS 1.0 server, it means that `min_tls_server` is set to `tlsv1.0` because it would have failed if the `min_tls_server` was `tlsv1.1`.

```python3
# ssl_server.py
import socket
import ssl

def test_conn_tls_version(protocol):

    # This function simply creates a listening socket with a given tls protocol version
    # and waits for a connection. Then it outputs if the connection was successful or not
    # so it's possible to know if the client (Agent in our case) is using the same tls version
    # or above.
    context = ssl.SSLContext(protocol)
    context.load_cert_chain(certfile='cert.pem', keyfile='private.key')

    with socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0) as sock:
        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
        sock.bind(('127.0.0.1', 8443))
        sock.listen(5)

        with context.wrap_socket(sock, server_side=True) as ssock:
            try:
                print("Waiting for connection ...")
                conn, addr = ssock.accept()
                print('Used tls version: ', conn.version())
                conn.close()
                return True
            except ssl.SSLError as e:
                print(f"Agent cannot communicate with the server using {str(protocol)}")
            except Exception:
                pass
    print("==============================================================================\n")
    return False


# Testing connection establishment with tls version starting from 1.0 to 1.2.
# The first successful connection is actually the value of min_tls_version in the Agent
tls_versions =  [(ssl.PROTOCOL_TLSv1, 'tlsv1.0'), (ssl.PROTOCOL_TLSv1_1, 'tlsv1.1'), (ssl.PROTOCOL_TLSv1_2, 'tlsv1.2')]
for tls_version, version_str in tls_versions:
    if test_conn_tls_version(tls_version):
        print(f"Agent min_tls_version is set to {version_str}")
        break
```

#### Agent configuration

Technically we want the following behavior : 

```
if min_tls_version is set and valid:
     min = min_tls_version
else
     min = TLSv1.2
```

If we want to be exhaustive we need to test all the combinations  of : 
- `min_tls_version`: not set, invalid, `tlsv1.0`, `tlsv1.1`, `tlsv1.2`, `tlsv1.3`
- `force_tls_12`: not set, `true`, `false`

To make the testing less cumbersome we can set `force_tls_12: true` and test only the different values for `min_tls_version`. (Technically `force_tls_12` is not used anymore in the code so we should have a warning because the key is unknown, but we're never to sure)

Steps to follow : 
- Stop the Agent
- Set DD_DD_URL to `https://localhost:8443` and `min_tls_version` to the tested value 
- Launch the python script with `python3 ssl_server.py`
- Start the Agent
- Verify the output of the script : the last line should be `Agent min_tls_version is set to tlsv<x.y>`


Here are the values that need to be tested and the expected python output :

- [ ] `min_tls_version: "hello"` -> `tlsv1.2`
- [ ] `min_tls_version: ""` -> `tlsv1.2`
- [ ] `min_tls_version: "tlsv1.0"` -> `tlsv1.0`
- [ ] `min_tls_version: "tlsv1.1"` ->  `tlsv1.1`
- [ ] `min_tls_version: "tlsv1.2"` -> `tlsv1.2`
- [ ] `min_tls_version: "tlsv1.3"` -> Agent is not able to communicate with servers


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
