### PR TITLE
Make windows service commands consistently dashed

### DIFF
--- a/cmd/agent/subcommands/controlsvc/command.go
+++ b/cmd/agent/subcommands/controlsvc/command.go
@@ -22,25 +22,28 @@ import (
 func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	return []*cobra.Command{
 		{
-			Use:   "start-service",
-			Short: "starts the agent within the service control manager",
-			Long:  ``,
+			Use:     "start-service",
+			Aliases: []string{"startservice"},
+			Short:   "starts the agent within the service control manager",
+			Long:    ``,
 			RunE: func(cmd *cobra.Command, args []string) error {
 				return fxutil.OneShot(controlsvc.StartService)
 			},
 		},
 		{
-			Use:   "stopservice",
-			Short: "stops the agent within the service control manager",
-			Long:  ``,
+			Use:     "stop-service",
+			Aliases: []string{"stopservice"},
+			Short:   "stops the agent within the service control manager",
+			Long:    ``,
 			RunE: func(cmd *cobra.Command, args []string) error {
 				return fxutil.OneShot(controlsvc.StopService)
 			},
 		},
 		{
-			Use:   "restart-service",
-			Short: "restarts the agent within the service control manager",
-			Long:  ``,
+			Use:     "restart-service",
+			Aliases: []string{"restartservice"},
+			Short:   "restarts the agent within the service control manager",
+			Long:    ``,
 			RunE: func(cmd *cobra.Command, args []string) error {
 				return fxutil.OneShot(controlsvc.RestartService)
 			},

--- a/cmd/agent/subcommands/installsvc/command.go
+++ b/cmd/agent/subcommands/installsvc/command.go
@@ -26,9 +26,10 @@ import (
 // Commands returns a slice of subcommands for the 'agent' command.
 func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "installservice",
-		Short: "Installs the agent within the service control manager",
-		Long:  ``,
+		Use:     "install-service",
+		Aliases: []string{"installservice"},
+		Short:   "Installs the agent within the service control manager",
+		Long:    ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(installService)
 		},

--- a/cmd/agent/subcommands/removesvc/command.go
+++ b/cmd/agent/subcommands/removesvc/command.go
@@ -24,9 +24,10 @@ import (
 // Commands returns a slice of subcommands for the 'agent' command.
 func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "remove-service",
-		Short: "Removes the agent from the service control manager",
-		Long:  ``,
+		Use:     "remove-service",
+		Aliases: []string{"removeservice"},
+		Short:   "Removes the agent from the service control manager",
+		Long:    ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(removeService)
 		},

--- a/releasenotes/notes/service-command-consistent-d7d8040e43798785.yaml
+++ b/releasenotes/notes/service-command-consistent-d7d8040e43798785.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The ``agent`` CLI subcommands related to Windows services are now
+    consistent in use of dashes in the command names (``install-service``,
+    ``start-service``, etc.).  The names without dashes are supported as
+    aliases.

--- a/releasenotes/notes/service-command-consistent-d7d8040e43798785.yaml
+++ b/releasenotes/notes/service-command-consistent-d7d8040e43798785.yaml
@@ -10,5 +10,5 @@ enhancements:
   - |
     The ``agent`` CLI subcommands related to Windows services are now
     consistent in use of dashes in the command names (``install-service``,
-    ``start-service``, etc.).  The names without dashes are supported as
+    ``start-service``, and so on). The names without dashes are supported as
     aliases.


### PR DESCRIPTION
### What does this PR do?

Fixes this inconsistency:
```
  installservice    Installs the agent within the service control manager
  start-service     starts the agent within the service control manager
  stopservice       stops the agent within the service control manager
  remove-service    Removes the agent from the service control manager
  restart-service   restarts the agent within the service control manager
```

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

QA for other 7.41 changes will cover this.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
