### PR TITLE
Use builtins adapted from cilium

### DIFF
--- a/pkg/ebpf/bytecode/runtime/conntrack.go
+++ b/pkg/ebpf/bytecode/runtime/conntrack.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Conntrack = NewAsset("conntrack.c", "8c5cb1e5943fb49c4d7424e1f0ff254ea576b4a8c19eb4d50a15b1fc36f210f5")
+var Conntrack = newAsset("conntrack.c", "8c5cb1e5943fb49c4d7424e1f0ff254ea576b4a8c19eb4d50a15b1fc36f210f5")

--- a/pkg/ebpf/bytecode/runtime/conntrack.go
+++ b/pkg/ebpf/bytecode/runtime/conntrack.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Conntrack = newAsset("conntrack.c", "8c5cb1e5943fb49c4d7424e1f0ff254ea576b4a8c19eb4d50a15b1fc36f210f5")
+var Conntrack = newAsset("conntrack.c", "82d6966d75ac284c00a01e66def784399c01d0c2c97cd108b33e6ab3f4b4eaa8")

--- a/pkg/ebpf/bytecode/runtime/conntrack.go
+++ b/pkg/ebpf/bytecode/runtime/conntrack.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Conntrack = NewAsset("conntrack.c", "2f3d70deee3ae9b823009d258d2bfcddd2d59eaa013c99d5d7e34acda5015fc4")
+var Conntrack = NewAsset("conntrack.c", "c99d88e4cf3d6d50702fb8068afec76bfc90089c54a14176913378daac872105")

--- a/pkg/ebpf/bytecode/runtime/conntrack.go
+++ b/pkg/ebpf/bytecode/runtime/conntrack.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Conntrack = newAsset("conntrack.c", "01a1afac5b8ee50172f2380f7cd0dcf2ba2c1b9416f1e3b352a323b23351688a")
+var Conntrack = NewAsset("conntrack.c", "4d19898f9c9c252ff705f6805f3dca80010eb64e34d748c6b109c2f6d199cd75")

--- a/pkg/ebpf/bytecode/runtime/conntrack.go
+++ b/pkg/ebpf/bytecode/runtime/conntrack.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Conntrack = NewAsset("conntrack.c", "4d19898f9c9c252ff705f6805f3dca80010eb64e34d748c6b109c2f6d199cd75")
+var Conntrack = NewAsset("conntrack.c", "2f3d70deee3ae9b823009d258d2bfcddd2d59eaa013c99d5d7e34acda5015fc4")

--- a/pkg/ebpf/bytecode/runtime/conntrack.go
+++ b/pkg/ebpf/bytecode/runtime/conntrack.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Conntrack = NewAsset("conntrack.c", "c99d88e4cf3d6d50702fb8068afec76bfc90089c54a14176913378daac872105")
+var Conntrack = NewAsset("conntrack.c", "8c5cb1e5943fb49c4d7424e1f0ff254ea576b4a8c19eb4d50a15b1fc36f210f5")

--- a/pkg/ebpf/bytecode/runtime/http.go
+++ b/pkg/ebpf/bytecode/runtime/http.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Http = NewAsset("http.c", "00eb12407732d3a37f74a26dfbc69f88184ae8ca6203f3cdcf758ebf509e0279")
+var Http = newAsset("http.c", "00eb12407732d3a37f74a26dfbc69f88184ae8ca6203f3cdcf758ebf509e0279")

--- a/pkg/ebpf/bytecode/runtime/http.go
+++ b/pkg/ebpf/bytecode/runtime/http.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Http = newAsset("http.c", "0518c075f400ad4a462e5a39b6fd31e7a4afaa99cd652a6848e3b2f18334051a")
+var Http = NewAsset("http.c", "e03a0df55e97945b2d92b199cb9fa3103045308a679aee370bde5d1f42eee199")

--- a/pkg/ebpf/bytecode/runtime/http.go
+++ b/pkg/ebpf/bytecode/runtime/http.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Http = NewAsset("http.c", "e03a0df55e97945b2d92b199cb9fa3103045308a679aee370bde5d1f42eee199")
+var Http = NewAsset("http.c", "d227076957e29267f95cba6075c71337fad5221a73a25dfd90e4e7ee1a803ccd")

--- a/pkg/ebpf/bytecode/runtime/http.go
+++ b/pkg/ebpf/bytecode/runtime/http.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Http = NewAsset("http.c", "d227076957e29267f95cba6075c71337fad5221a73a25dfd90e4e7ee1a803ccd")
+var Http = NewAsset("http.c", "00eb12407732d3a37f74a26dfbc69f88184ae8ca6203f3cdcf758ebf509e0279")

--- a/pkg/ebpf/bytecode/runtime/tracer.go
+++ b/pkg/ebpf/bytecode/runtime/tracer.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Tracer = NewAsset("tracer.c", "fef2e9aa632503828a6b7b33bf9cd084d0e0ff352ad7ba06896c69d67eea248d")
+var Tracer = NewAsset("tracer.c", "1c203f8117833635e3620440da27f750dac2073d882fe46273900fc9906a5528")

--- a/pkg/ebpf/bytecode/runtime/tracer.go
+++ b/pkg/ebpf/bytecode/runtime/tracer.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Tracer = NewAsset("tracer.c", "571dfe39b242208f5af2a855fe7dc0135b4a03937a3b0275ba3e33bb681654f4")
+var Tracer = NewAsset("tracer.c", "103cb9937e9277c5aab73e8fe10e3cec2584da6edc1c936beba832fb7e99e07a")

--- a/pkg/ebpf/bytecode/runtime/tracer.go
+++ b/pkg/ebpf/bytecode/runtime/tracer.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Tracer = NewAsset("tracer.c", "1c203f8117833635e3620440da27f750dac2073d882fe46273900fc9906a5528")
+var Tracer = newAsset("tracer.c", "1c203f8117833635e3620440da27f750dac2073d882fe46273900fc9906a5528")

--- a/pkg/ebpf/bytecode/runtime/tracer.go
+++ b/pkg/ebpf/bytecode/runtime/tracer.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Tracer = newAsset("tracer.c", "9d798d82c6e212ae8154336649b01ae4f4f5138a48a5278a9725522de1d3a0ee")
+var Tracer = NewAsset("tracer.c", "571dfe39b242208f5af2a855fe7dc0135b4a03937a3b0275ba3e33bb681654f4")

--- a/pkg/ebpf/bytecode/runtime/tracer.go
+++ b/pkg/ebpf/bytecode/runtime/tracer.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Tracer = NewAsset("tracer.c", "103cb9937e9277c5aab73e8fe10e3cec2584da6edc1c936beba832fb7e99e07a")
+var Tracer = NewAsset("tracer.c", "fef2e9aa632503828a6b7b33bf9cd084d0e0ff352ad7ba06896c69d67eea248d")

--- a/pkg/ebpf/c/bpf_builtins.h
+++ b/pkg/ebpf/c/bpf_builtins.h
@@ -320,7 +320,7 @@ __bpf_no_builtin_memset(void *d __maybe_unused, __u8 c __maybe_unused,
 /* Redirect any direct use in our code to throw an error. */
 #define __builtin_memset	__bpf_no_builtin_memset
 
-static __always_inline __nobuiltin("memset") void bpf_memset(void *d, int c,
+static __always_inline __maybe_unused __nobuiltin("memset") void bpf_memset(void *d, int c,
 							 __u64 len)
 {
 	if (__builtin_constant_p(len) && __builtin_constant_p(c) && c == 0)
@@ -636,7 +636,7 @@ __bpf_no_builtin_memcpy(void *d __maybe_unused, const void *s __maybe_unused,
 /* Redirect any direct use in our code to throw an error. */
 #define __builtin_memcpy	__bpf_no_builtin_memcpy
 
-static __always_inline __nobuiltin("memcpy") void bpf_memcpy(void *d, const void *s,
+static __always_inline __maybe_unused __nobuiltin("memcpy") void bpf_memcpy(void *d, const void *s,
 							 __u64 len)
 {
 	return __bpf_memcpy(d, s, len);
@@ -961,7 +961,7 @@ __bpf_no_builtin_memcmp(const void *x __maybe_unused,
 /* Modified for our needs in that we only return either zero (x and y
  * are equal) or non-zero (x and y are non-equal).
  */
-static __always_inline __nobuiltin("memcmp") __u64 bpf_memcmp(const void *x,
+static __always_inline __maybe_unused __nobuiltin("memcmp") __u64 bpf_memcmp(const void *x,
 							  const void *y,
 							  __u64 len)
 {
@@ -1290,7 +1290,7 @@ static __always_inline void __bpf_memmove(void *d, const void *s, __u64 len)
 		return __bpf_memmove_bwd(d, s, len);
 }
 
-static __always_inline __nobuiltin("memmove") void bpf_memmove(void *d,
+static __always_inline __maybe_unused __nobuiltin("memmove") void bpf_memmove(void *d,
 							   const void *s,
 							   __u64 len)
 {

--- a/pkg/ebpf/c/bpf_builtins.h
+++ b/pkg/ebpf/c/bpf_builtins.h
@@ -1,0 +1,1300 @@
+#ifndef __BPF_BUILTINS__
+#define __BPF_BUILTINS__
+
+#include "compiler.h"
+
+/* Memory iterators used below. */
+#define __it_bwd(x, op) (x -= sizeof(__u##op))
+#define __it_fwd(x, op) (x += sizeof(__u##op))
+
+/* Memory operators used below. */
+#define __it_set(a, op) (*(__u##op *)__it_bwd(a, op)) = 0
+#define __it_xor(a, b, r, op) r |= (*(__u##op *)__it_bwd(a, op)) ^ (*(__u##op *)__it_bwd(b, op))
+#define __it_mob(a, b, op) (*(__u##op *)__it_bwd(a, op)) = (*(__u##op *)__it_bwd(b, op))
+#define __it_mof(a, b, op)				\
+	do {						\
+		*(__u##op *)a = *(__u##op *)b;		\
+		__it_fwd(a, op); __it_fwd(b, op);	\
+	} while (0)
+
+static __always_inline __maybe_unused void
+__bpf_memset_builtin(void *d, __u8 c, __u64 len)
+{
+	/* Everything non-zero or non-const (currently unsupported) as c
+	 * gets handled here.
+	 */
+	__builtin_memset(d, c, len);
+}
+
+static __always_inline void __bpf_memzero(void *d, __u64 len)
+{
+#if __clang_major__ >= 10
+	if (!__builtin_constant_p(len))
+		__throw_build_bug();
+
+	d += len;
+
+	switch (len) {
+    case 512:          __it_set(d, 64);
+    case 504: jmp_504: __it_set(d, 64);
+    case 496: jmp_496: __it_set(d, 64);
+    case 488: jmp_488: __it_set(d, 64);
+    case 480: jmp_480: __it_set(d, 64);
+    case 472: jmp_472: __it_set(d, 64);
+    case 464: jmp_464: __it_set(d, 64);
+    case 456: jmp_456: __it_set(d, 64);
+    case 448: jmp_448: __it_set(d, 64);
+    case 440: jmp_440: __it_set(d, 64);
+    case 432: jmp_432: __it_set(d, 64);
+    case 424: jmp_424: __it_set(d, 64);
+    case 416: jmp_416: __it_set(d, 64);
+    case 408: jmp_408: __it_set(d, 64);
+    case 400: jmp_400: __it_set(d, 64);
+    case 392: jmp_392: __it_set(d, 64);
+    case 384: jmp_384: __it_set(d, 64);
+    case 376: jmp_376: __it_set(d, 64);
+    case 368: jmp_368: __it_set(d, 64);
+    case 360: jmp_360: __it_set(d, 64);
+    case 352: jmp_352: __it_set(d, 64);
+    case 344: jmp_344: __it_set(d, 64);
+    case 336: jmp_336: __it_set(d, 64);
+    case 328: jmp_328: __it_set(d, 64);
+    case 320: jmp_320: __it_set(d, 64);
+    case 312: jmp_312: __it_set(d, 64);
+    case 304: jmp_304: __it_set(d, 64);
+    case 296: jmp_296: __it_set(d, 64);
+    case 288: jmp_288: __it_set(d, 64);
+    case 280: jmp_280: __it_set(d, 64);
+    case 272: jmp_272: __it_set(d, 64);
+    case 264: jmp_264: __it_set(d, 64);
+    case 256: jmp_256: __it_set(d, 64);
+    case 248: jmp_248: __it_set(d, 64);
+    case 240: jmp_240: __it_set(d, 64);
+    case 232: jmp_232: __it_set(d, 64);
+    case 224: jmp_224: __it_set(d, 64);
+    case 216: jmp_216: __it_set(d, 64);
+    case 208: jmp_208: __it_set(d, 64);
+    case 200: jmp_200: __it_set(d, 64);
+    case 192: jmp_192: __it_set(d, 64);
+    case 184: jmp_184: __it_set(d, 64);
+    case 176: jmp_176: __it_set(d, 64);
+    case 168: jmp_168: __it_set(d, 64);
+    case 160: jmp_160: __it_set(d, 64);
+    case 152: jmp_152: __it_set(d, 64);
+    case 144: jmp_144: __it_set(d, 64);
+    case 136: jmp_136: __it_set(d, 64);
+    case 128: jmp_128: __it_set(d, 64);
+    case 120: jmp_120: __it_set(d, 64);
+    case 112: jmp_112: __it_set(d, 64);
+    case 104: jmp_104: __it_set(d, 64);
+    case 96: jmp_96: __it_set(d, 64);
+    case 88: jmp_88: __it_set(d, 64);
+    case 80: jmp_80: __it_set(d, 64);
+    case 72: jmp_72: __it_set(d, 64);
+    case 64: jmp_64: __it_set(d, 64);
+    case 56: jmp_56: __it_set(d, 64);
+    case 48: jmp_48: __it_set(d, 64);
+    case 40: jmp_40: __it_set(d, 64);
+    case 32: jmp_32: __it_set(d, 64);
+    case 24: jmp_24: __it_set(d, 64);
+    case 16: jmp_16: __it_set(d, 64);
+    case 8: jmp_8: __it_set(d, 64); break;
+    
+    case 510: __it_set(d, 16); __it_set(d, 32); goto jmp_504;
+    case 502: __it_set(d, 16); __it_set(d, 32); goto jmp_496;
+    case 494: __it_set(d, 16); __it_set(d, 32); goto jmp_488;
+    case 486: __it_set(d, 16); __it_set(d, 32); goto jmp_480;
+    case 478: __it_set(d, 16); __it_set(d, 32); goto jmp_472;
+    case 470: __it_set(d, 16); __it_set(d, 32); goto jmp_464;
+    case 462: __it_set(d, 16); __it_set(d, 32); goto jmp_456;
+    case 454: __it_set(d, 16); __it_set(d, 32); goto jmp_448;
+    case 446: __it_set(d, 16); __it_set(d, 32); goto jmp_440;
+    case 438: __it_set(d, 16); __it_set(d, 32); goto jmp_432;
+    case 430: __it_set(d, 16); __it_set(d, 32); goto jmp_424;
+    case 422: __it_set(d, 16); __it_set(d, 32); goto jmp_416;
+    case 414: __it_set(d, 16); __it_set(d, 32); goto jmp_408;
+    case 406: __it_set(d, 16); __it_set(d, 32); goto jmp_400;
+    case 398: __it_set(d, 16); __it_set(d, 32); goto jmp_392;
+    case 390: __it_set(d, 16); __it_set(d, 32); goto jmp_384;
+    case 382: __it_set(d, 16); __it_set(d, 32); goto jmp_376;
+    case 374: __it_set(d, 16); __it_set(d, 32); goto jmp_368;
+    case 366: __it_set(d, 16); __it_set(d, 32); goto jmp_360;
+    case 358: __it_set(d, 16); __it_set(d, 32); goto jmp_352;
+    case 350: __it_set(d, 16); __it_set(d, 32); goto jmp_344;
+    case 342: __it_set(d, 16); __it_set(d, 32); goto jmp_336;
+    case 334: __it_set(d, 16); __it_set(d, 32); goto jmp_328;
+    case 326: __it_set(d, 16); __it_set(d, 32); goto jmp_320;
+    case 318: __it_set(d, 16); __it_set(d, 32); goto jmp_312;
+    case 310: __it_set(d, 16); __it_set(d, 32); goto jmp_304;
+    case 302: __it_set(d, 16); __it_set(d, 32); goto jmp_296;
+    case 294: __it_set(d, 16); __it_set(d, 32); goto jmp_288;
+    case 286: __it_set(d, 16); __it_set(d, 32); goto jmp_280;
+    case 278: __it_set(d, 16); __it_set(d, 32); goto jmp_272;
+    case 270: __it_set(d, 16); __it_set(d, 32); goto jmp_264;
+    case 262: __it_set(d, 16); __it_set(d, 32); goto jmp_256;
+    case 254: __it_set(d, 16); __it_set(d, 32); goto jmp_248;
+    case 246: __it_set(d, 16); __it_set(d, 32); goto jmp_240;
+    case 238: __it_set(d, 16); __it_set(d, 32); goto jmp_232;
+    case 230: __it_set(d, 16); __it_set(d, 32); goto jmp_224;
+    case 222: __it_set(d, 16); __it_set(d, 32); goto jmp_216;
+    case 214: __it_set(d, 16); __it_set(d, 32); goto jmp_208;
+    case 206: __it_set(d, 16); __it_set(d, 32); goto jmp_200;
+    case 198: __it_set(d, 16); __it_set(d, 32); goto jmp_192;
+    case 190: __it_set(d, 16); __it_set(d, 32); goto jmp_184;
+    case 182: __it_set(d, 16); __it_set(d, 32); goto jmp_176;
+    case 174: __it_set(d, 16); __it_set(d, 32); goto jmp_168;
+    case 166: __it_set(d, 16); __it_set(d, 32); goto jmp_160;
+    case 158: __it_set(d, 16); __it_set(d, 32); goto jmp_152;
+    case 150: __it_set(d, 16); __it_set(d, 32); goto jmp_144;
+    case 142: __it_set(d, 16); __it_set(d, 32); goto jmp_136;
+    case 134: __it_set(d, 16); __it_set(d, 32); goto jmp_128;
+    case 126: __it_set(d, 16); __it_set(d, 32); goto jmp_120;
+    case 118: __it_set(d, 16); __it_set(d, 32); goto jmp_112;
+    case 110: __it_set(d, 16); __it_set(d, 32); goto jmp_104;
+    case 102: __it_set(d, 16); __it_set(d, 32); goto jmp_96;
+    case 94: __it_set(d, 16); __it_set(d, 32); goto jmp_88;
+    case 86: __it_set(d, 16); __it_set(d, 32); goto jmp_80;
+    case 78: __it_set(d, 16); __it_set(d, 32); goto jmp_72;
+    case 70: __it_set(d, 16); __it_set(d, 32); goto jmp_64;
+    case 62: __it_set(d, 16); __it_set(d, 32); goto jmp_56;
+    case 54: __it_set(d, 16); __it_set(d, 32); goto jmp_48;
+    case 46: __it_set(d, 16); __it_set(d, 32); goto jmp_40;
+    case 38: __it_set(d, 16); __it_set(d, 32); goto jmp_32;
+    case 30: __it_set(d, 16); __it_set(d, 32); goto jmp_24;
+    case 22: __it_set(d, 16); __it_set(d, 32); goto jmp_16;
+    case 14: __it_set(d, 16); __it_set(d, 32); goto jmp_8;
+    case 6: __it_set(d, 16); __it_set(d, 32); break;
+    
+    case 508: __it_set(d, 32); goto jmp_504;
+    case 500: __it_set(d, 32); goto jmp_496;
+    case 492: __it_set(d, 32); goto jmp_488;
+    case 484: __it_set(d, 32); goto jmp_480;
+    case 476: __it_set(d, 32); goto jmp_472;
+    case 468: __it_set(d, 32); goto jmp_464;
+    case 460: __it_set(d, 32); goto jmp_456;
+    case 452: __it_set(d, 32); goto jmp_448;
+    case 444: __it_set(d, 32); goto jmp_440;
+    case 436: __it_set(d, 32); goto jmp_432;
+    case 428: __it_set(d, 32); goto jmp_424;
+    case 420: __it_set(d, 32); goto jmp_416;
+    case 412: __it_set(d, 32); goto jmp_408;
+    case 404: __it_set(d, 32); goto jmp_400;
+    case 396: __it_set(d, 32); goto jmp_392;
+    case 388: __it_set(d, 32); goto jmp_384;
+    case 380: __it_set(d, 32); goto jmp_376;
+    case 372: __it_set(d, 32); goto jmp_368;
+    case 364: __it_set(d, 32); goto jmp_360;
+    case 356: __it_set(d, 32); goto jmp_352;
+    case 348: __it_set(d, 32); goto jmp_344;
+    case 340: __it_set(d, 32); goto jmp_336;
+    case 332: __it_set(d, 32); goto jmp_328;
+    case 324: __it_set(d, 32); goto jmp_320;
+    case 316: __it_set(d, 32); goto jmp_312;
+    case 308: __it_set(d, 32); goto jmp_304;
+    case 300: __it_set(d, 32); goto jmp_296;
+    case 292: __it_set(d, 32); goto jmp_288;
+    case 284: __it_set(d, 32); goto jmp_280;
+    case 276: __it_set(d, 32); goto jmp_272;
+    case 268: __it_set(d, 32); goto jmp_264;
+    case 260: __it_set(d, 32); goto jmp_256;
+    case 252: __it_set(d, 32); goto jmp_248;
+    case 244: __it_set(d, 32); goto jmp_240;
+    case 236: __it_set(d, 32); goto jmp_232;
+    case 228: __it_set(d, 32); goto jmp_224;
+    case 220: __it_set(d, 32); goto jmp_216;
+    case 212: __it_set(d, 32); goto jmp_208;
+    case 204: __it_set(d, 32); goto jmp_200;
+    case 196: __it_set(d, 32); goto jmp_192;
+    case 188: __it_set(d, 32); goto jmp_184;
+    case 180: __it_set(d, 32); goto jmp_176;
+    case 172: __it_set(d, 32); goto jmp_168;
+    case 164: __it_set(d, 32); goto jmp_160;
+    case 156: __it_set(d, 32); goto jmp_152;
+    case 148: __it_set(d, 32); goto jmp_144;
+    case 140: __it_set(d, 32); goto jmp_136;
+    case 132: __it_set(d, 32); goto jmp_128;
+    case 124: __it_set(d, 32); goto jmp_120;
+    case 116: __it_set(d, 32); goto jmp_112;
+    case 108: __it_set(d, 32); goto jmp_104;
+    case 100: __it_set(d, 32); goto jmp_96;
+    case 92: __it_set(d, 32); goto jmp_88;
+    case 84: __it_set(d, 32); goto jmp_80;
+    case 76: __it_set(d, 32); goto jmp_72;
+    case 68: __it_set(d, 32); goto jmp_64;
+    case 60: __it_set(d, 32); goto jmp_56;
+    case 52: __it_set(d, 32); goto jmp_48;
+    case 44: __it_set(d, 32); goto jmp_40;
+    case 36: __it_set(d, 32); goto jmp_32;
+    case 28: __it_set(d, 32); goto jmp_24;
+    case 20: __it_set(d, 32); goto jmp_16;
+    case 12: __it_set(d, 32); goto jmp_8;
+    case 4: __it_set(d, 32); break;
+    
+    case 506: __it_set(d, 16); goto jmp_504;
+    case 498: __it_set(d, 16); goto jmp_496;
+    case 490: __it_set(d, 16); goto jmp_488;
+    case 482: __it_set(d, 16); goto jmp_480;
+    case 474: __it_set(d, 16); goto jmp_472;
+    case 466: __it_set(d, 16); goto jmp_464;
+    case 458: __it_set(d, 16); goto jmp_456;
+    case 450: __it_set(d, 16); goto jmp_448;
+    case 442: __it_set(d, 16); goto jmp_440;
+    case 434: __it_set(d, 16); goto jmp_432;
+    case 426: __it_set(d, 16); goto jmp_424;
+    case 418: __it_set(d, 16); goto jmp_416;
+    case 410: __it_set(d, 16); goto jmp_408;
+    case 402: __it_set(d, 16); goto jmp_400;
+    case 394: __it_set(d, 16); goto jmp_392;
+    case 386: __it_set(d, 16); goto jmp_384;
+    case 378: __it_set(d, 16); goto jmp_376;
+    case 370: __it_set(d, 16); goto jmp_368;
+    case 362: __it_set(d, 16); goto jmp_360;
+    case 354: __it_set(d, 16); goto jmp_352;
+    case 346: __it_set(d, 16); goto jmp_344;
+    case 338: __it_set(d, 16); goto jmp_336;
+    case 330: __it_set(d, 16); goto jmp_328;
+    case 322: __it_set(d, 16); goto jmp_320;
+    case 314: __it_set(d, 16); goto jmp_312;
+    case 306: __it_set(d, 16); goto jmp_304;
+    case 298: __it_set(d, 16); goto jmp_296;
+    case 290: __it_set(d, 16); goto jmp_288;
+    case 282: __it_set(d, 16); goto jmp_280;
+    case 274: __it_set(d, 16); goto jmp_272;
+    case 266: __it_set(d, 16); goto jmp_264;
+    case 258: __it_set(d, 16); goto jmp_256;
+    case 250: __it_set(d, 16); goto jmp_248;
+    case 242: __it_set(d, 16); goto jmp_240;
+    case 234: __it_set(d, 16); goto jmp_232;
+    case 226: __it_set(d, 16); goto jmp_224;
+    case 218: __it_set(d, 16); goto jmp_216;
+    case 210: __it_set(d, 16); goto jmp_208;
+    case 202: __it_set(d, 16); goto jmp_200;
+    case 194: __it_set(d, 16); goto jmp_192;
+    case 186: __it_set(d, 16); goto jmp_184;
+    case 178: __it_set(d, 16); goto jmp_176;
+    case 170: __it_set(d, 16); goto jmp_168;
+    case 162: __it_set(d, 16); goto jmp_160;
+    case 154: __it_set(d, 16); goto jmp_152;
+    case 146: __it_set(d, 16); goto jmp_144;
+    case 138: __it_set(d, 16); goto jmp_136;
+    case 130: __it_set(d, 16); goto jmp_128;
+    case 122: __it_set(d, 16); goto jmp_120;
+    case 114: __it_set(d, 16); goto jmp_112;
+    case 106: __it_set(d, 16); goto jmp_104;
+    case 98: __it_set(d, 16); goto jmp_96;
+    case 90: __it_set(d, 16); goto jmp_88;
+    case 82: __it_set(d, 16); goto jmp_80;
+    case 74: __it_set(d, 16); goto jmp_72;
+    case 66: __it_set(d, 16); goto jmp_64;
+    case 58: __it_set(d, 16); goto jmp_56;
+    case 50: __it_set(d, 16); goto jmp_48;
+    case 42: __it_set(d, 16); goto jmp_40;
+    case 34: __it_set(d, 16); goto jmp_32;
+    case 26: __it_set(d, 16); goto jmp_24;
+    case 18: __it_set(d, 16); goto jmp_16;
+    case 10: __it_set(d, 16); goto jmp_8;
+    case 2: __it_set(d, 16); break;
+    
+    case 1: __it_set(d, 8); break;
+
+   	default:
+		/* __builtin_memset() is crappy slow since it cannot
+		 * make any assumptions about alignment & underlying
+		 * efficient unaligned access on the target we're
+		 * running.
+		 */
+		__throw_build_bug();
+	}
+#else
+	__bpf_memset_builtin(d, 0, len);
+#endif
+}
+
+static __always_inline __maybe_unused void*
+__bpf_no_builtin_memset(void *d __maybe_unused, __u8 c __maybe_unused,
+			__u64 len __maybe_unused)
+{
+	__throw_build_bug();
+}
+
+/* Redirect any direct use in our code to throw an error. */
+#define __builtin_memset	__bpf_no_builtin_memset
+
+static __always_inline __nobuiltin("memset") void bpf_memset(void *d, int c,
+							 __u64 len)
+{
+	if (__builtin_constant_p(len) && __builtin_constant_p(c) && c == 0)
+		__bpf_memzero(d, len);
+	else
+		__bpf_memset_builtin(d, (__u8)c, len);
+}
+
+static __always_inline __maybe_unused void
+__bpf_memcpy_builtin(void *d, const void *s, __u64 len)
+{
+	/* Explicit opt-in for __builtin_memcpy(). */
+	__builtin_memcpy(d, s, len);
+}
+
+static __always_inline void __bpf_memcpy(void *d, const void *s, __u64 len)
+{
+#if __clang_major__ >= 10
+	if (!__builtin_constant_p(len))
+		__throw_build_bug();
+
+	d += len;
+	s += len;
+
+	if (len > 1 && len % 2 == 1) {
+		__it_mob(d, s, 8);
+		len -= 1;
+	}
+
+	switch (len) {
+    case 512:          __it_mob(d, s, 64);
+    case 504: jmp_504: __it_mob(d, s, 64);
+    case 496: jmp_496: __it_mob(d, s, 64);
+    case 488: jmp_488: __it_mob(d, s, 64);
+    case 480: jmp_480: __it_mob(d, s, 64);
+    case 472: jmp_472: __it_mob(d, s, 64);
+    case 464: jmp_464: __it_mob(d, s, 64);
+    case 456: jmp_456: __it_mob(d, s, 64);
+    case 448: jmp_448: __it_mob(d, s, 64);
+    case 440: jmp_440: __it_mob(d, s, 64);
+    case 432: jmp_432: __it_mob(d, s, 64);
+    case 424: jmp_424: __it_mob(d, s, 64);
+    case 416: jmp_416: __it_mob(d, s, 64);
+    case 408: jmp_408: __it_mob(d, s, 64);
+    case 400: jmp_400: __it_mob(d, s, 64);
+    case 392: jmp_392: __it_mob(d, s, 64);
+    case 384: jmp_384: __it_mob(d, s, 64);
+    case 376: jmp_376: __it_mob(d, s, 64);
+    case 368: jmp_368: __it_mob(d, s, 64);
+    case 360: jmp_360: __it_mob(d, s, 64);
+    case 352: jmp_352: __it_mob(d, s, 64);
+    case 344: jmp_344: __it_mob(d, s, 64);
+    case 336: jmp_336: __it_mob(d, s, 64);
+    case 328: jmp_328: __it_mob(d, s, 64);
+    case 320: jmp_320: __it_mob(d, s, 64);
+    case 312: jmp_312: __it_mob(d, s, 64);
+    case 304: jmp_304: __it_mob(d, s, 64);
+    case 296: jmp_296: __it_mob(d, s, 64);
+    case 288: jmp_288: __it_mob(d, s, 64);
+    case 280: jmp_280: __it_mob(d, s, 64);
+    case 272: jmp_272: __it_mob(d, s, 64);
+    case 264: jmp_264: __it_mob(d, s, 64);
+    case 256: jmp_256: __it_mob(d, s, 64);
+    case 248: jmp_248: __it_mob(d, s, 64);
+    case 240: jmp_240: __it_mob(d, s, 64);
+    case 232: jmp_232: __it_mob(d, s, 64);
+    case 224: jmp_224: __it_mob(d, s, 64);
+    case 216: jmp_216: __it_mob(d, s, 64);
+    case 208: jmp_208: __it_mob(d, s, 64);
+    case 200: jmp_200: __it_mob(d, s, 64);
+    case 192: jmp_192: __it_mob(d, s, 64);
+    case 184: jmp_184: __it_mob(d, s, 64);
+    case 176: jmp_176: __it_mob(d, s, 64);
+    case 168: jmp_168: __it_mob(d, s, 64);
+    case 160: jmp_160: __it_mob(d, s, 64);
+    case 152: jmp_152: __it_mob(d, s, 64);
+    case 144: jmp_144: __it_mob(d, s, 64);
+    case 136: jmp_136: __it_mob(d, s, 64);
+    case 128: jmp_128: __it_mob(d, s, 64);
+    case 120: jmp_120: __it_mob(d, s, 64);
+    case 112: jmp_112: __it_mob(d, s, 64);
+    case 104: jmp_104: __it_mob(d, s, 64);
+    case 96: jmp_96: __it_mob(d, s, 64);
+    case 88: jmp_88: __it_mob(d, s, 64);
+    case 80: jmp_80: __it_mob(d, s, 64);
+    case 72: jmp_72: __it_mob(d, s, 64);
+    case 64: jmp_64: __it_mob(d, s, 64);
+    case 56: jmp_56: __it_mob(d, s, 64);
+    case 48: jmp_48: __it_mob(d, s, 64);
+    case 40: jmp_40: __it_mob(d, s, 64);
+    case 32: jmp_32: __it_mob(d, s, 64);
+    case 24: jmp_24: __it_mob(d, s, 64);
+    case 16: jmp_16: __it_mob(d, s, 64);
+    case 8: jmp_8: __it_mob(d, s, 64); break;
+    
+    case 510: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_504;
+    case 502: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_496;
+    case 494: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_488;
+    case 486: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_480;
+    case 478: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_472;
+    case 470: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_464;
+    case 462: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_456;
+    case 454: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_448;
+    case 446: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_440;
+    case 438: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_432;
+    case 430: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_424;
+    case 422: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_416;
+    case 414: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_408;
+    case 406: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_400;
+    case 398: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_392;
+    case 390: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_384;
+    case 382: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_376;
+    case 374: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_368;
+    case 366: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_360;
+    case 358: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_352;
+    case 350: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_344;
+    case 342: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_336;
+    case 334: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_328;
+    case 326: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_320;
+    case 318: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_312;
+    case 310: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_304;
+    case 302: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_296;
+    case 294: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_288;
+    case 286: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_280;
+    case 278: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_272;
+    case 270: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_264;
+    case 262: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_256;
+    case 254: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_248;
+    case 246: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_240;
+    case 238: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_232;
+    case 230: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_224;
+    case 222: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_216;
+    case 214: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_208;
+    case 206: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_200;
+    case 198: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_192;
+    case 190: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_184;
+    case 182: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_176;
+    case 174: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_168;
+    case 166: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_160;
+    case 158: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_152;
+    case 150: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_144;
+    case 142: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_136;
+    case 134: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_128;
+    case 126: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_120;
+    case 118: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_112;
+    case 110: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_104;
+    case 102: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_96;
+    case 94: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_88;
+    case 86: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_80;
+    case 78: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_72;
+    case 70: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_64;
+    case 62: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_56;
+    case 54: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_48;
+    case 46: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_40;
+    case 38: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_32;
+    case 30: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_24;
+    case 22: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_16;
+    case 14: __it_mob(d, s, 16); __it_mob(d, s, 32); goto jmp_8;
+    case 6: __it_mob(d, s, 16); __it_mob(d, s, 32); break;
+    
+    case 508: __it_mob(d, s, 32); goto jmp_504;
+    case 500: __it_mob(d, s, 32); goto jmp_496;
+    case 492: __it_mob(d, s, 32); goto jmp_488;
+    case 484: __it_mob(d, s, 32); goto jmp_480;
+    case 476: __it_mob(d, s, 32); goto jmp_472;
+    case 468: __it_mob(d, s, 32); goto jmp_464;
+    case 460: __it_mob(d, s, 32); goto jmp_456;
+    case 452: __it_mob(d, s, 32); goto jmp_448;
+    case 444: __it_mob(d, s, 32); goto jmp_440;
+    case 436: __it_mob(d, s, 32); goto jmp_432;
+    case 428: __it_mob(d, s, 32); goto jmp_424;
+    case 420: __it_mob(d, s, 32); goto jmp_416;
+    case 412: __it_mob(d, s, 32); goto jmp_408;
+    case 404: __it_mob(d, s, 32); goto jmp_400;
+    case 396: __it_mob(d, s, 32); goto jmp_392;
+    case 388: __it_mob(d, s, 32); goto jmp_384;
+    case 380: __it_mob(d, s, 32); goto jmp_376;
+    case 372: __it_mob(d, s, 32); goto jmp_368;
+    case 364: __it_mob(d, s, 32); goto jmp_360;
+    case 356: __it_mob(d, s, 32); goto jmp_352;
+    case 348: __it_mob(d, s, 32); goto jmp_344;
+    case 340: __it_mob(d, s, 32); goto jmp_336;
+    case 332: __it_mob(d, s, 32); goto jmp_328;
+    case 324: __it_mob(d, s, 32); goto jmp_320;
+    case 316: __it_mob(d, s, 32); goto jmp_312;
+    case 308: __it_mob(d, s, 32); goto jmp_304;
+    case 300: __it_mob(d, s, 32); goto jmp_296;
+    case 292: __it_mob(d, s, 32); goto jmp_288;
+    case 284: __it_mob(d, s, 32); goto jmp_280;
+    case 276: __it_mob(d, s, 32); goto jmp_272;
+    case 268: __it_mob(d, s, 32); goto jmp_264;
+    case 260: __it_mob(d, s, 32); goto jmp_256;
+    case 252: __it_mob(d, s, 32); goto jmp_248;
+    case 244: __it_mob(d, s, 32); goto jmp_240;
+    case 236: __it_mob(d, s, 32); goto jmp_232;
+    case 228: __it_mob(d, s, 32); goto jmp_224;
+    case 220: __it_mob(d, s, 32); goto jmp_216;
+    case 212: __it_mob(d, s, 32); goto jmp_208;
+    case 204: __it_mob(d, s, 32); goto jmp_200;
+    case 196: __it_mob(d, s, 32); goto jmp_192;
+    case 188: __it_mob(d, s, 32); goto jmp_184;
+    case 180: __it_mob(d, s, 32); goto jmp_176;
+    case 172: __it_mob(d, s, 32); goto jmp_168;
+    case 164: __it_mob(d, s, 32); goto jmp_160;
+    case 156: __it_mob(d, s, 32); goto jmp_152;
+    case 148: __it_mob(d, s, 32); goto jmp_144;
+    case 140: __it_mob(d, s, 32); goto jmp_136;
+    case 132: __it_mob(d, s, 32); goto jmp_128;
+    case 124: __it_mob(d, s, 32); goto jmp_120;
+    case 116: __it_mob(d, s, 32); goto jmp_112;
+    case 108: __it_mob(d, s, 32); goto jmp_104;
+    case 100: __it_mob(d, s, 32); goto jmp_96;
+    case 92: __it_mob(d, s, 32); goto jmp_88;
+    case 84: __it_mob(d, s, 32); goto jmp_80;
+    case 76: __it_mob(d, s, 32); goto jmp_72;
+    case 68: __it_mob(d, s, 32); goto jmp_64;
+    case 60: __it_mob(d, s, 32); goto jmp_56;
+    case 52: __it_mob(d, s, 32); goto jmp_48;
+    case 44: __it_mob(d, s, 32); goto jmp_40;
+    case 36: __it_mob(d, s, 32); goto jmp_32;
+    case 28: __it_mob(d, s, 32); goto jmp_24;
+    case 20: __it_mob(d, s, 32); goto jmp_16;
+    case 12: __it_mob(d, s, 32); goto jmp_8;
+    case 4: __it_mob(d, s, 32); break;
+    
+    case 506: __it_mob(d, s, 16); goto jmp_504;
+    case 498: __it_mob(d, s, 16); goto jmp_496;
+    case 490: __it_mob(d, s, 16); goto jmp_488;
+    case 482: __it_mob(d, s, 16); goto jmp_480;
+    case 474: __it_mob(d, s, 16); goto jmp_472;
+    case 466: __it_mob(d, s, 16); goto jmp_464;
+    case 458: __it_mob(d, s, 16); goto jmp_456;
+    case 450: __it_mob(d, s, 16); goto jmp_448;
+    case 442: __it_mob(d, s, 16); goto jmp_440;
+    case 434: __it_mob(d, s, 16); goto jmp_432;
+    case 426: __it_mob(d, s, 16); goto jmp_424;
+    case 418: __it_mob(d, s, 16); goto jmp_416;
+    case 410: __it_mob(d, s, 16); goto jmp_408;
+    case 402: __it_mob(d, s, 16); goto jmp_400;
+    case 394: __it_mob(d, s, 16); goto jmp_392;
+    case 386: __it_mob(d, s, 16); goto jmp_384;
+    case 378: __it_mob(d, s, 16); goto jmp_376;
+    case 370: __it_mob(d, s, 16); goto jmp_368;
+    case 362: __it_mob(d, s, 16); goto jmp_360;
+    case 354: __it_mob(d, s, 16); goto jmp_352;
+    case 346: __it_mob(d, s, 16); goto jmp_344;
+    case 338: __it_mob(d, s, 16); goto jmp_336;
+    case 330: __it_mob(d, s, 16); goto jmp_328;
+    case 322: __it_mob(d, s, 16); goto jmp_320;
+    case 314: __it_mob(d, s, 16); goto jmp_312;
+    case 306: __it_mob(d, s, 16); goto jmp_304;
+    case 298: __it_mob(d, s, 16); goto jmp_296;
+    case 290: __it_mob(d, s, 16); goto jmp_288;
+    case 282: __it_mob(d, s, 16); goto jmp_280;
+    case 274: __it_mob(d, s, 16); goto jmp_272;
+    case 266: __it_mob(d, s, 16); goto jmp_264;
+    case 258: __it_mob(d, s, 16); goto jmp_256;
+    case 250: __it_mob(d, s, 16); goto jmp_248;
+    case 242: __it_mob(d, s, 16); goto jmp_240;
+    case 234: __it_mob(d, s, 16); goto jmp_232;
+    case 226: __it_mob(d, s, 16); goto jmp_224;
+    case 218: __it_mob(d, s, 16); goto jmp_216;
+    case 210: __it_mob(d, s, 16); goto jmp_208;
+    case 202: __it_mob(d, s, 16); goto jmp_200;
+    case 194: __it_mob(d, s, 16); goto jmp_192;
+    case 186: __it_mob(d, s, 16); goto jmp_184;
+    case 178: __it_mob(d, s, 16); goto jmp_176;
+    case 170: __it_mob(d, s, 16); goto jmp_168;
+    case 162: __it_mob(d, s, 16); goto jmp_160;
+    case 154: __it_mob(d, s, 16); goto jmp_152;
+    case 146: __it_mob(d, s, 16); goto jmp_144;
+    case 138: __it_mob(d, s, 16); goto jmp_136;
+    case 130: __it_mob(d, s, 16); goto jmp_128;
+    case 122: __it_mob(d, s, 16); goto jmp_120;
+    case 114: __it_mob(d, s, 16); goto jmp_112;
+    case 106: __it_mob(d, s, 16); goto jmp_104;
+    case 98: __it_mob(d, s, 16); goto jmp_96;
+    case 90: __it_mob(d, s, 16); goto jmp_88;
+    case 82: __it_mob(d, s, 16); goto jmp_80;
+    case 74: __it_mob(d, s, 16); goto jmp_72;
+    case 66: __it_mob(d, s, 16); goto jmp_64;
+    case 58: __it_mob(d, s, 16); goto jmp_56;
+    case 50: __it_mob(d, s, 16); goto jmp_48;
+    case 42: __it_mob(d, s, 16); goto jmp_40;
+    case 34: __it_mob(d, s, 16); goto jmp_32;
+    case 26: __it_mob(d, s, 16); goto jmp_24;
+    case 18: __it_mob(d, s, 16); goto jmp_16;
+    case 10: __it_mob(d, s, 16); goto jmp_8;
+    case 2: __it_mob(d, s, 16); break;
+    
+    case 1: __it_mob(d, s, 8); break;
+
+	default:
+		/* __builtin_memcpy() is crappy slow since it cannot
+		 * make any assumptions about alignment & underlying
+		 * efficient unaligned access on the target we're
+		 * running.
+		 */
+		__throw_build_bug();
+	}
+#else
+	__bpf_memcpy_builtin(d, s, len);
+#endif
+}
+
+static __always_inline __maybe_unused void*
+__bpf_no_builtin_memcpy(void *d __maybe_unused, const void *s __maybe_unused,
+			__u64 len __maybe_unused)
+{
+	__throw_build_bug();
+}
+
+/* Redirect any direct use in our code to throw an error. */
+#define __builtin_memcpy	__bpf_no_builtin_memcpy
+
+static __always_inline __nobuiltin("memcpy") void bpf_memcpy(void *d, const void *s,
+							 __u64 len)
+{
+	return __bpf_memcpy(d, s, len);
+}
+
+static __always_inline __maybe_unused __u64
+__bpf_memcmp_builtin(const void *x, const void *y, __u64 len)
+{
+	/* Explicit opt-in for __builtin_memcmp(). We use the bcmp builtin
+	 * here for two reasons: i) we only need to know equal or non-equal
+	 * similar as in __bpf_memcmp(), and ii) if __bpf_memcmp() ends up
+	 * selecting __bpf_memcmp_builtin(), clang generats a memcmp loop.
+	 * That is, (*) -> __bpf_memcmp() -> __bpf_memcmp_builtin() ->
+	 * __builtin_memcmp() -> memcmp() -> (*), meaning it will end up
+	 * selecting our memcmp() from here. Remapping to __builtin_bcmp()
+	 * breaks this loop and resolves both needs at once.
+	 */
+	return __builtin_bcmp(x, y, len);
+}
+
+static __always_inline __u64 __bpf_memcmp(const void *x, const void *y,
+					  __u64 len)
+{
+#if __clang_major__ >= 10
+	__u64 r = 0;
+
+	if (!__builtin_constant_p(len))
+		__throw_build_bug();
+
+	x += len;
+	y += len;
+
+	if (len > 1 && len % 2 == 1) {
+		__it_xor(x, y, r, 8);
+		len -= 1;
+	}
+
+	switch (len) {
+    case 512:          __it_xor(x, y, r, 64);
+    case 504: jmp_504: __it_xor(x, y, r, 64);
+    case 496: jmp_496: __it_xor(x, y, r, 64);
+    case 488: jmp_488: __it_xor(x, y, r, 64);
+    case 480: jmp_480: __it_xor(x, y, r, 64);
+    case 472: jmp_472: __it_xor(x, y, r, 64);
+    case 464: jmp_464: __it_xor(x, y, r, 64);
+    case 456: jmp_456: __it_xor(x, y, r, 64);
+    case 448: jmp_448: __it_xor(x, y, r, 64);
+    case 440: jmp_440: __it_xor(x, y, r, 64);
+    case 432: jmp_432: __it_xor(x, y, r, 64);
+    case 424: jmp_424: __it_xor(x, y, r, 64);
+    case 416: jmp_416: __it_xor(x, y, r, 64);
+    case 408: jmp_408: __it_xor(x, y, r, 64);
+    case 400: jmp_400: __it_xor(x, y, r, 64);
+    case 392: jmp_392: __it_xor(x, y, r, 64);
+    case 384: jmp_384: __it_xor(x, y, r, 64);
+    case 376: jmp_376: __it_xor(x, y, r, 64);
+    case 368: jmp_368: __it_xor(x, y, r, 64);
+    case 360: jmp_360: __it_xor(x, y, r, 64);
+    case 352: jmp_352: __it_xor(x, y, r, 64);
+    case 344: jmp_344: __it_xor(x, y, r, 64);
+    case 336: jmp_336: __it_xor(x, y, r, 64);
+    case 328: jmp_328: __it_xor(x, y, r, 64);
+    case 320: jmp_320: __it_xor(x, y, r, 64);
+    case 312: jmp_312: __it_xor(x, y, r, 64);
+    case 304: jmp_304: __it_xor(x, y, r, 64);
+    case 296: jmp_296: __it_xor(x, y, r, 64);
+    case 288: jmp_288: __it_xor(x, y, r, 64);
+    case 280: jmp_280: __it_xor(x, y, r, 64);
+    case 272: jmp_272: __it_xor(x, y, r, 64);
+    case 264: jmp_264: __it_xor(x, y, r, 64);
+    case 256: jmp_256: __it_xor(x, y, r, 64);
+    case 248: jmp_248: __it_xor(x, y, r, 64);
+    case 240: jmp_240: __it_xor(x, y, r, 64);
+    case 232: jmp_232: __it_xor(x, y, r, 64);
+    case 224: jmp_224: __it_xor(x, y, r, 64);
+    case 216: jmp_216: __it_xor(x, y, r, 64);
+    case 208: jmp_208: __it_xor(x, y, r, 64);
+    case 200: jmp_200: __it_xor(x, y, r, 64);
+    case 192: jmp_192: __it_xor(x, y, r, 64);
+    case 184: jmp_184: __it_xor(x, y, r, 64);
+    case 176: jmp_176: __it_xor(x, y, r, 64);
+    case 168: jmp_168: __it_xor(x, y, r, 64);
+    case 160: jmp_160: __it_xor(x, y, r, 64);
+    case 152: jmp_152: __it_xor(x, y, r, 64);
+    case 144: jmp_144: __it_xor(x, y, r, 64);
+    case 136: jmp_136: __it_xor(x, y, r, 64);
+    case 128: jmp_128: __it_xor(x, y, r, 64);
+    case 120: jmp_120: __it_xor(x, y, r, 64);
+    case 112: jmp_112: __it_xor(x, y, r, 64);
+    case 104: jmp_104: __it_xor(x, y, r, 64);
+    case 96: jmp_96: __it_xor(x, y, r, 64);
+    case 88: jmp_88: __it_xor(x, y, r, 64);
+    case 80: jmp_80: __it_xor(x, y, r, 64);
+    case 72: jmp_72: __it_xor(x, y, r, 64);
+    case 64: jmp_64: __it_xor(x, y, r, 64);
+    case 56: jmp_56: __it_xor(x, y, r, 64);
+    case 48: jmp_48: __it_xor(x, y, r, 64);
+    case 40: jmp_40: __it_xor(x, y, r, 64);
+    case 32: jmp_32: __it_xor(x, y, r, 64);
+    case 24: jmp_24: __it_xor(x, y, r, 64);
+    case 16: jmp_16: __it_xor(x, y, r, 64);
+    case 8: jmp_8: __it_xor(x, y, r, 64); break;
+    
+    case 510: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_504;
+    case 502: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_496;
+    case 494: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_488;
+    case 486: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_480;
+    case 478: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_472;
+    case 470: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_464;
+    case 462: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_456;
+    case 454: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_448;
+    case 446: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_440;
+    case 438: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_432;
+    case 430: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_424;
+    case 422: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_416;
+    case 414: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_408;
+    case 406: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_400;
+    case 398: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_392;
+    case 390: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_384;
+    case 382: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_376;
+    case 374: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_368;
+    case 366: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_360;
+    case 358: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_352;
+    case 350: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_344;
+    case 342: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_336;
+    case 334: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_328;
+    case 326: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_320;
+    case 318: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_312;
+    case 310: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_304;
+    case 302: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_296;
+    case 294: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_288;
+    case 286: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_280;
+    case 278: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_272;
+    case 270: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_264;
+    case 262: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_256;
+    case 254: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_248;
+    case 246: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_240;
+    case 238: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_232;
+    case 230: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_224;
+    case 222: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_216;
+    case 214: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_208;
+    case 206: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_200;
+    case 198: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_192;
+    case 190: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_184;
+    case 182: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_176;
+    case 174: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_168;
+    case 166: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_160;
+    case 158: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_152;
+    case 150: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_144;
+    case 142: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_136;
+    case 134: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_128;
+    case 126: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_120;
+    case 118: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_112;
+    case 110: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_104;
+    case 102: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_96;
+    case 94: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_88;
+    case 86: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_80;
+    case 78: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_72;
+    case 70: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_64;
+    case 62: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_56;
+    case 54: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_48;
+    case 46: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_40;
+    case 38: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_32;
+    case 30: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_24;
+    case 22: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_16;
+    case 14: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_8;
+    case 6: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); break;
+    
+    case 508: __it_xor(x, y, r, 32); goto jmp_504;
+    case 500: __it_xor(x, y, r, 32); goto jmp_496;
+    case 492: __it_xor(x, y, r, 32); goto jmp_488;
+    case 484: __it_xor(x, y, r, 32); goto jmp_480;
+    case 476: __it_xor(x, y, r, 32); goto jmp_472;
+    case 468: __it_xor(x, y, r, 32); goto jmp_464;
+    case 460: __it_xor(x, y, r, 32); goto jmp_456;
+    case 452: __it_xor(x, y, r, 32); goto jmp_448;
+    case 444: __it_xor(x, y, r, 32); goto jmp_440;
+    case 436: __it_xor(x, y, r, 32); goto jmp_432;
+    case 428: __it_xor(x, y, r, 32); goto jmp_424;
+    case 420: __it_xor(x, y, r, 32); goto jmp_416;
+    case 412: __it_xor(x, y, r, 32); goto jmp_408;
+    case 404: __it_xor(x, y, r, 32); goto jmp_400;
+    case 396: __it_xor(x, y, r, 32); goto jmp_392;
+    case 388: __it_xor(x, y, r, 32); goto jmp_384;
+    case 380: __it_xor(x, y, r, 32); goto jmp_376;
+    case 372: __it_xor(x, y, r, 32); goto jmp_368;
+    case 364: __it_xor(x, y, r, 32); goto jmp_360;
+    case 356: __it_xor(x, y, r, 32); goto jmp_352;
+    case 348: __it_xor(x, y, r, 32); goto jmp_344;
+    case 340: __it_xor(x, y, r, 32); goto jmp_336;
+    case 332: __it_xor(x, y, r, 32); goto jmp_328;
+    case 324: __it_xor(x, y, r, 32); goto jmp_320;
+    case 316: __it_xor(x, y, r, 32); goto jmp_312;
+    case 308: __it_xor(x, y, r, 32); goto jmp_304;
+    case 300: __it_xor(x, y, r, 32); goto jmp_296;
+    case 292: __it_xor(x, y, r, 32); goto jmp_288;
+    case 284: __it_xor(x, y, r, 32); goto jmp_280;
+    case 276: __it_xor(x, y, r, 32); goto jmp_272;
+    case 268: __it_xor(x, y, r, 32); goto jmp_264;
+    case 260: __it_xor(x, y, r, 32); goto jmp_256;
+    case 252: __it_xor(x, y, r, 32); goto jmp_248;
+    case 244: __it_xor(x, y, r, 32); goto jmp_240;
+    case 236: __it_xor(x, y, r, 32); goto jmp_232;
+    case 228: __it_xor(x, y, r, 32); goto jmp_224;
+    case 220: __it_xor(x, y, r, 32); goto jmp_216;
+    case 212: __it_xor(x, y, r, 32); goto jmp_208;
+    case 204: __it_xor(x, y, r, 32); goto jmp_200;
+    case 196: __it_xor(x, y, r, 32); goto jmp_192;
+    case 188: __it_xor(x, y, r, 32); goto jmp_184;
+    case 180: __it_xor(x, y, r, 32); goto jmp_176;
+    case 172: __it_xor(x, y, r, 32); goto jmp_168;
+    case 164: __it_xor(x, y, r, 32); goto jmp_160;
+    case 156: __it_xor(x, y, r, 32); goto jmp_152;
+    case 148: __it_xor(x, y, r, 32); goto jmp_144;
+    case 140: __it_xor(x, y, r, 32); goto jmp_136;
+    case 132: __it_xor(x, y, r, 32); goto jmp_128;
+    case 124: __it_xor(x, y, r, 32); goto jmp_120;
+    case 116: __it_xor(x, y, r, 32); goto jmp_112;
+    case 108: __it_xor(x, y, r, 32); goto jmp_104;
+    case 100: __it_xor(x, y, r, 32); goto jmp_96;
+    case 92: __it_xor(x, y, r, 32); goto jmp_88;
+    case 84: __it_xor(x, y, r, 32); goto jmp_80;
+    case 76: __it_xor(x, y, r, 32); goto jmp_72;
+    case 68: __it_xor(x, y, r, 32); goto jmp_64;
+    case 60: __it_xor(x, y, r, 32); goto jmp_56;
+    case 52: __it_xor(x, y, r, 32); goto jmp_48;
+    case 44: __it_xor(x, y, r, 32); goto jmp_40;
+    case 36: __it_xor(x, y, r, 32); goto jmp_32;
+    case 28: __it_xor(x, y, r, 32); goto jmp_24;
+    case 20: __it_xor(x, y, r, 32); goto jmp_16;
+    case 12: __it_xor(x, y, r, 32); goto jmp_8;
+    case 4: __it_xor(x, y, r, 32); break;
+    
+    case 506: __it_xor(x, y, r, 16); goto jmp_504;
+    case 498: __it_xor(x, y, r, 16); goto jmp_496;
+    case 490: __it_xor(x, y, r, 16); goto jmp_488;
+    case 482: __it_xor(x, y, r, 16); goto jmp_480;
+    case 474: __it_xor(x, y, r, 16); goto jmp_472;
+    case 466: __it_xor(x, y, r, 16); goto jmp_464;
+    case 458: __it_xor(x, y, r, 16); goto jmp_456;
+    case 450: __it_xor(x, y, r, 16); goto jmp_448;
+    case 442: __it_xor(x, y, r, 16); goto jmp_440;
+    case 434: __it_xor(x, y, r, 16); goto jmp_432;
+    case 426: __it_xor(x, y, r, 16); goto jmp_424;
+    case 418: __it_xor(x, y, r, 16); goto jmp_416;
+    case 410: __it_xor(x, y, r, 16); goto jmp_408;
+    case 402: __it_xor(x, y, r, 16); goto jmp_400;
+    case 394: __it_xor(x, y, r, 16); goto jmp_392;
+    case 386: __it_xor(x, y, r, 16); goto jmp_384;
+    case 378: __it_xor(x, y, r, 16); goto jmp_376;
+    case 370: __it_xor(x, y, r, 16); goto jmp_368;
+    case 362: __it_xor(x, y, r, 16); goto jmp_360;
+    case 354: __it_xor(x, y, r, 16); goto jmp_352;
+    case 346: __it_xor(x, y, r, 16); goto jmp_344;
+    case 338: __it_xor(x, y, r, 16); goto jmp_336;
+    case 330: __it_xor(x, y, r, 16); goto jmp_328;
+    case 322: __it_xor(x, y, r, 16); goto jmp_320;
+    case 314: __it_xor(x, y, r, 16); goto jmp_312;
+    case 306: __it_xor(x, y, r, 16); goto jmp_304;
+    case 298: __it_xor(x, y, r, 16); goto jmp_296;
+    case 290: __it_xor(x, y, r, 16); goto jmp_288;
+    case 282: __it_xor(x, y, r, 16); goto jmp_280;
+    case 274: __it_xor(x, y, r, 16); goto jmp_272;
+    case 266: __it_xor(x, y, r, 16); goto jmp_264;
+    case 258: __it_xor(x, y, r, 16); goto jmp_256;
+    case 250: __it_xor(x, y, r, 16); goto jmp_248;
+    case 242: __it_xor(x, y, r, 16); goto jmp_240;
+    case 234: __it_xor(x, y, r, 16); goto jmp_232;
+    case 226: __it_xor(x, y, r, 16); goto jmp_224;
+    case 218: __it_xor(x, y, r, 16); goto jmp_216;
+    case 210: __it_xor(x, y, r, 16); goto jmp_208;
+    case 202: __it_xor(x, y, r, 16); goto jmp_200;
+    case 194: __it_xor(x, y, r, 16); goto jmp_192;
+    case 186: __it_xor(x, y, r, 16); goto jmp_184;
+    case 178: __it_xor(x, y, r, 16); goto jmp_176;
+    case 170: __it_xor(x, y, r, 16); goto jmp_168;
+    case 162: __it_xor(x, y, r, 16); goto jmp_160;
+    case 154: __it_xor(x, y, r, 16); goto jmp_152;
+    case 146: __it_xor(x, y, r, 16); goto jmp_144;
+    case 138: __it_xor(x, y, r, 16); goto jmp_136;
+    case 130: __it_xor(x, y, r, 16); goto jmp_128;
+    case 122: __it_xor(x, y, r, 16); goto jmp_120;
+    case 114: __it_xor(x, y, r, 16); goto jmp_112;
+    case 106: __it_xor(x, y, r, 16); goto jmp_104;
+    case 98: __it_xor(x, y, r, 16); goto jmp_96;
+    case 90: __it_xor(x, y, r, 16); goto jmp_88;
+    case 82: __it_xor(x, y, r, 16); goto jmp_80;
+    case 74: __it_xor(x, y, r, 16); goto jmp_72;
+    case 66: __it_xor(x, y, r, 16); goto jmp_64;
+    case 58: __it_xor(x, y, r, 16); goto jmp_56;
+    case 50: __it_xor(x, y, r, 16); goto jmp_48;
+    case 42: __it_xor(x, y, r, 16); goto jmp_40;
+    case 34: __it_xor(x, y, r, 16); goto jmp_32;
+    case 26: __it_xor(x, y, r, 16); goto jmp_24;
+    case 18: __it_xor(x, y, r, 16); goto jmp_16;
+    case 10: __it_xor(x, y, r, 16); goto jmp_8;
+    case 2: __it_xor(x, y, r, 16); break;
+    
+    case 1: __it_xor(x, y, r, 8); break;
+
+	default:
+		__throw_build_bug();
+	}
+
+	return r;
+#else
+	return __bpf_memcmp_builtin(x, y, len);
+#endif
+}
+
+static __always_inline __maybe_unused __u64
+__bpf_no_builtin_memcmp(const void *x __maybe_unused,
+			const void *y __maybe_unused, __u64 len __maybe_unused)
+{
+	__throw_build_bug();
+	return 0;
+}
+
+/* Redirect any direct use in our code to throw an error. */
+#define __builtin_memcmp	__bpf_no_builtin_memcmp
+
+/* Modified for our needs in that we only return either zero (x and y
+ * are equal) or non-zero (x and y are non-equal).
+ */
+static __always_inline __nobuiltin("memcmp") __u64 bpf_memcmp(const void *x,
+							  const void *y,
+							  __u64 len)
+{
+	return __bpf_memcmp(x, y, len);
+}
+
+static __always_inline __maybe_unused void
+__bpf_memmove_builtin(void *d, const void *s, __u64 len)
+{
+	/* Explicit opt-in for __builtin_memmove(). */
+	__builtin_memmove(d, s, len);
+}
+
+static __always_inline void __bpf_memmove_bwd(void *d, const void *s, __u64 len)
+{
+	/* Our internal memcpy implementation walks backwards by default. */
+	__bpf_memcpy(d, s, len);
+}
+
+static __always_inline void __bpf_memmove_fwd(void *d, const void *s, __u64 len)
+{
+#if __clang_major__ >= 10
+	if (!__builtin_constant_p(len))
+		__throw_build_bug();
+
+	switch (len) {
+    case 512:          __it_mof(d, s, 64);
+    case 504: jmp_504: __it_mof(d, s, 64);
+    case 496: jmp_496: __it_mof(d, s, 64);
+    case 488: jmp_488: __it_mof(d, s, 64);
+    case 480: jmp_480: __it_mof(d, s, 64);
+    case 472: jmp_472: __it_mof(d, s, 64);
+    case 464: jmp_464: __it_mof(d, s, 64);
+    case 456: jmp_456: __it_mof(d, s, 64);
+    case 448: jmp_448: __it_mof(d, s, 64);
+    case 440: jmp_440: __it_mof(d, s, 64);
+    case 432: jmp_432: __it_mof(d, s, 64);
+    case 424: jmp_424: __it_mof(d, s, 64);
+    case 416: jmp_416: __it_mof(d, s, 64);
+    case 408: jmp_408: __it_mof(d, s, 64);
+    case 400: jmp_400: __it_mof(d, s, 64);
+    case 392: jmp_392: __it_mof(d, s, 64);
+    case 384: jmp_384: __it_mof(d, s, 64);
+    case 376: jmp_376: __it_mof(d, s, 64);
+    case 368: jmp_368: __it_mof(d, s, 64);
+    case 360: jmp_360: __it_mof(d, s, 64);
+    case 352: jmp_352: __it_mof(d, s, 64);
+    case 344: jmp_344: __it_mof(d, s, 64);
+    case 336: jmp_336: __it_mof(d, s, 64);
+    case 328: jmp_328: __it_mof(d, s, 64);
+    case 320: jmp_320: __it_mof(d, s, 64);
+    case 312: jmp_312: __it_mof(d, s, 64);
+    case 304: jmp_304: __it_mof(d, s, 64);
+    case 296: jmp_296: __it_mof(d, s, 64);
+    case 288: jmp_288: __it_mof(d, s, 64);
+    case 280: jmp_280: __it_mof(d, s, 64);
+    case 272: jmp_272: __it_mof(d, s, 64);
+    case 264: jmp_264: __it_mof(d, s, 64);
+    case 256: jmp_256: __it_mof(d, s, 64);
+    case 248: jmp_248: __it_mof(d, s, 64);
+    case 240: jmp_240: __it_mof(d, s, 64);
+    case 232: jmp_232: __it_mof(d, s, 64);
+    case 224: jmp_224: __it_mof(d, s, 64);
+    case 216: jmp_216: __it_mof(d, s, 64);
+    case 208: jmp_208: __it_mof(d, s, 64);
+    case 200: jmp_200: __it_mof(d, s, 64);
+    case 192: jmp_192: __it_mof(d, s, 64);
+    case 184: jmp_184: __it_mof(d, s, 64);
+    case 176: jmp_176: __it_mof(d, s, 64);
+    case 168: jmp_168: __it_mof(d, s, 64);
+    case 160: jmp_160: __it_mof(d, s, 64);
+    case 152: jmp_152: __it_mof(d, s, 64);
+    case 144: jmp_144: __it_mof(d, s, 64);
+    case 136: jmp_136: __it_mof(d, s, 64);
+    case 128: jmp_128: __it_mof(d, s, 64);
+    case 120: jmp_120: __it_mof(d, s, 64);
+    case 112: jmp_112: __it_mof(d, s, 64);
+    case 104: jmp_104: __it_mof(d, s, 64);
+    case 96: jmp_96: __it_mof(d, s, 64);
+    case 88: jmp_88: __it_mof(d, s, 64);
+    case 80: jmp_80: __it_mof(d, s, 64);
+    case 72: jmp_72: __it_mof(d, s, 64);
+    case 64: jmp_64: __it_mof(d, s, 64);
+    case 56: jmp_56: __it_mof(d, s, 64);
+    case 48: jmp_48: __it_mof(d, s, 64);
+    case 40: jmp_40: __it_mof(d, s, 64);
+    case 32: jmp_32: __it_mof(d, s, 64);
+    case 24: jmp_24: __it_mof(d, s, 64);
+    case 16: jmp_16: __it_mof(d, s, 64);
+    case 8: jmp_8: __it_mof(d, s, 64); break;
+    
+    case 510: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_504;
+    case 502: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_496;
+    case 494: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_488;
+    case 486: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_480;
+    case 478: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_472;
+    case 470: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_464;
+    case 462: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_456;
+    case 454: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_448;
+    case 446: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_440;
+    case 438: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_432;
+    case 430: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_424;
+    case 422: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_416;
+    case 414: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_408;
+    case 406: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_400;
+    case 398: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_392;
+    case 390: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_384;
+    case 382: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_376;
+    case 374: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_368;
+    case 366: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_360;
+    case 358: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_352;
+    case 350: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_344;
+    case 342: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_336;
+    case 334: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_328;
+    case 326: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_320;
+    case 318: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_312;
+    case 310: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_304;
+    case 302: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_296;
+    case 294: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_288;
+    case 286: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_280;
+    case 278: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_272;
+    case 270: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_264;
+    case 262: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_256;
+    case 254: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_248;
+    case 246: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_240;
+    case 238: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_232;
+    case 230: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_224;
+    case 222: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_216;
+    case 214: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_208;
+    case 206: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_200;
+    case 198: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_192;
+    case 190: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_184;
+    case 182: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_176;
+    case 174: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_168;
+    case 166: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_160;
+    case 158: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_152;
+    case 150: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_144;
+    case 142: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_136;
+    case 134: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_128;
+    case 126: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_120;
+    case 118: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_112;
+    case 110: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_104;
+    case 102: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_96;
+    case 94: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_88;
+    case 86: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_80;
+    case 78: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_72;
+    case 70: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_64;
+    case 62: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_56;
+    case 54: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_48;
+    case 46: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_40;
+    case 38: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_32;
+    case 30: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_24;
+    case 22: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_16;
+    case 14: __it_mof(d, s, 16); __it_mof(d, s, 32); goto jmp_8;
+    case 6: __it_mof(d, s, 16); __it_mof(d, s, 32); break;
+    
+    case 508: __it_mof(d, s, 32); goto jmp_504;
+    case 500: __it_mof(d, s, 32); goto jmp_496;
+    case 492: __it_mof(d, s, 32); goto jmp_488;
+    case 484: __it_mof(d, s, 32); goto jmp_480;
+    case 476: __it_mof(d, s, 32); goto jmp_472;
+    case 468: __it_mof(d, s, 32); goto jmp_464;
+    case 460: __it_mof(d, s, 32); goto jmp_456;
+    case 452: __it_mof(d, s, 32); goto jmp_448;
+    case 444: __it_mof(d, s, 32); goto jmp_440;
+    case 436: __it_mof(d, s, 32); goto jmp_432;
+    case 428: __it_mof(d, s, 32); goto jmp_424;
+    case 420: __it_mof(d, s, 32); goto jmp_416;
+    case 412: __it_mof(d, s, 32); goto jmp_408;
+    case 404: __it_mof(d, s, 32); goto jmp_400;
+    case 396: __it_mof(d, s, 32); goto jmp_392;
+    case 388: __it_mof(d, s, 32); goto jmp_384;
+    case 380: __it_mof(d, s, 32); goto jmp_376;
+    case 372: __it_mof(d, s, 32); goto jmp_368;
+    case 364: __it_mof(d, s, 32); goto jmp_360;
+    case 356: __it_mof(d, s, 32); goto jmp_352;
+    case 348: __it_mof(d, s, 32); goto jmp_344;
+    case 340: __it_mof(d, s, 32); goto jmp_336;
+    case 332: __it_mof(d, s, 32); goto jmp_328;
+    case 324: __it_mof(d, s, 32); goto jmp_320;
+    case 316: __it_mof(d, s, 32); goto jmp_312;
+    case 308: __it_mof(d, s, 32); goto jmp_304;
+    case 300: __it_mof(d, s, 32); goto jmp_296;
+    case 292: __it_mof(d, s, 32); goto jmp_288;
+    case 284: __it_mof(d, s, 32); goto jmp_280;
+    case 276: __it_mof(d, s, 32); goto jmp_272;
+    case 268: __it_mof(d, s, 32); goto jmp_264;
+    case 260: __it_mof(d, s, 32); goto jmp_256;
+    case 252: __it_mof(d, s, 32); goto jmp_248;
+    case 244: __it_mof(d, s, 32); goto jmp_240;
+    case 236: __it_mof(d, s, 32); goto jmp_232;
+    case 228: __it_mof(d, s, 32); goto jmp_224;
+    case 220: __it_mof(d, s, 32); goto jmp_216;
+    case 212: __it_mof(d, s, 32); goto jmp_208;
+    case 204: __it_mof(d, s, 32); goto jmp_200;
+    case 196: __it_mof(d, s, 32); goto jmp_192;
+    case 188: __it_mof(d, s, 32); goto jmp_184;
+    case 180: __it_mof(d, s, 32); goto jmp_176;
+    case 172: __it_mof(d, s, 32); goto jmp_168;
+    case 164: __it_mof(d, s, 32); goto jmp_160;
+    case 156: __it_mof(d, s, 32); goto jmp_152;
+    case 148: __it_mof(d, s, 32); goto jmp_144;
+    case 140: __it_mof(d, s, 32); goto jmp_136;
+    case 132: __it_mof(d, s, 32); goto jmp_128;
+    case 124: __it_mof(d, s, 32); goto jmp_120;
+    case 116: __it_mof(d, s, 32); goto jmp_112;
+    case 108: __it_mof(d, s, 32); goto jmp_104;
+    case 100: __it_mof(d, s, 32); goto jmp_96;
+    case 92: __it_mof(d, s, 32); goto jmp_88;
+    case 84: __it_mof(d, s, 32); goto jmp_80;
+    case 76: __it_mof(d, s, 32); goto jmp_72;
+    case 68: __it_mof(d, s, 32); goto jmp_64;
+    case 60: __it_mof(d, s, 32); goto jmp_56;
+    case 52: __it_mof(d, s, 32); goto jmp_48;
+    case 44: __it_mof(d, s, 32); goto jmp_40;
+    case 36: __it_mof(d, s, 32); goto jmp_32;
+    case 28: __it_mof(d, s, 32); goto jmp_24;
+    case 20: __it_mof(d, s, 32); goto jmp_16;
+    case 12: __it_mof(d, s, 32); goto jmp_8;
+    case 4: __it_mof(d, s, 32); break;
+    
+    case 506: __it_mof(d, s, 16); goto jmp_504;
+    case 498: __it_mof(d, s, 16); goto jmp_496;
+    case 490: __it_mof(d, s, 16); goto jmp_488;
+    case 482: __it_mof(d, s, 16); goto jmp_480;
+    case 474: __it_mof(d, s, 16); goto jmp_472;
+    case 466: __it_mof(d, s, 16); goto jmp_464;
+    case 458: __it_mof(d, s, 16); goto jmp_456;
+    case 450: __it_mof(d, s, 16); goto jmp_448;
+    case 442: __it_mof(d, s, 16); goto jmp_440;
+    case 434: __it_mof(d, s, 16); goto jmp_432;
+    case 426: __it_mof(d, s, 16); goto jmp_424;
+    case 418: __it_mof(d, s, 16); goto jmp_416;
+    case 410: __it_mof(d, s, 16); goto jmp_408;
+    case 402: __it_mof(d, s, 16); goto jmp_400;
+    case 394: __it_mof(d, s, 16); goto jmp_392;
+    case 386: __it_mof(d, s, 16); goto jmp_384;
+    case 378: __it_mof(d, s, 16); goto jmp_376;
+    case 370: __it_mof(d, s, 16); goto jmp_368;
+    case 362: __it_mof(d, s, 16); goto jmp_360;
+    case 354: __it_mof(d, s, 16); goto jmp_352;
+    case 346: __it_mof(d, s, 16); goto jmp_344;
+    case 338: __it_mof(d, s, 16); goto jmp_336;
+    case 330: __it_mof(d, s, 16); goto jmp_328;
+    case 322: __it_mof(d, s, 16); goto jmp_320;
+    case 314: __it_mof(d, s, 16); goto jmp_312;
+    case 306: __it_mof(d, s, 16); goto jmp_304;
+    case 298: __it_mof(d, s, 16); goto jmp_296;
+    case 290: __it_mof(d, s, 16); goto jmp_288;
+    case 282: __it_mof(d, s, 16); goto jmp_280;
+    case 274: __it_mof(d, s, 16); goto jmp_272;
+    case 266: __it_mof(d, s, 16); goto jmp_264;
+    case 258: __it_mof(d, s, 16); goto jmp_256;
+    case 250: __it_mof(d, s, 16); goto jmp_248;
+    case 242: __it_mof(d, s, 16); goto jmp_240;
+    case 234: __it_mof(d, s, 16); goto jmp_232;
+    case 226: __it_mof(d, s, 16); goto jmp_224;
+    case 218: __it_mof(d, s, 16); goto jmp_216;
+    case 210: __it_mof(d, s, 16); goto jmp_208;
+    case 202: __it_mof(d, s, 16); goto jmp_200;
+    case 194: __it_mof(d, s, 16); goto jmp_192;
+    case 186: __it_mof(d, s, 16); goto jmp_184;
+    case 178: __it_mof(d, s, 16); goto jmp_176;
+    case 170: __it_mof(d, s, 16); goto jmp_168;
+    case 162: __it_mof(d, s, 16); goto jmp_160;
+    case 154: __it_mof(d, s, 16); goto jmp_152;
+    case 146: __it_mof(d, s, 16); goto jmp_144;
+    case 138: __it_mof(d, s, 16); goto jmp_136;
+    case 130: __it_mof(d, s, 16); goto jmp_128;
+    case 122: __it_mof(d, s, 16); goto jmp_120;
+    case 114: __it_mof(d, s, 16); goto jmp_112;
+    case 106: __it_mof(d, s, 16); goto jmp_104;
+    case 98: __it_mof(d, s, 16); goto jmp_96;
+    case 90: __it_mof(d, s, 16); goto jmp_88;
+    case 82: __it_mof(d, s, 16); goto jmp_80;
+    case 74: __it_mof(d, s, 16); goto jmp_72;
+    case 66: __it_mof(d, s, 16); goto jmp_64;
+    case 58: __it_mof(d, s, 16); goto jmp_56;
+    case 50: __it_mof(d, s, 16); goto jmp_48;
+    case 42: __it_mof(d, s, 16); goto jmp_40;
+    case 34: __it_mof(d, s, 16); goto jmp_32;
+    case 26: __it_mof(d, s, 16); goto jmp_24;
+    case 18: __it_mof(d, s, 16); goto jmp_16;
+    case 10: __it_mof(d, s, 16); goto jmp_8;
+    case 2: __it_mof(d, s, 16); break;
+    
+    case 1: __it_mof(d, s, 8); break;
+
+	default:
+		/* __builtin_memmove() is crappy slow since it cannot
+		 * make any assumptions about alignment & underlying
+		 * efficient unaligned access on the target we're
+		 * running.
+		 */
+		__throw_build_bug();
+	}
+#else
+	__bpf_memmove_builtin(d, s, len);
+#endif
+}
+
+static __always_inline __maybe_unused void*
+__bpf_no_builtin_memmove(void *d __maybe_unused, const void *s __maybe_unused,
+			 __u64 len __maybe_unused)
+{
+	__throw_build_bug();
+}
+
+/* Redirect any direct use in our code to throw an error. */
+#define __builtin_memmove	__bpf_no_builtin_memmove
+
+static __always_inline void __bpf_memmove(void *d, const void *s, __u64 len)
+{
+	/* Note, the forward walking memmove() might not work with on-stack data
+	 * since we'll end up walking the memory unaligned even when __align_stack_8
+	 * is set. Should not matter much since we'll use memmove() mostly or only
+	 * on pkt data.
+	 *
+	 * Example with d, s, len = 12 bytes:
+	 *   * __bpf_memmove_fwd() emits: mov_32 d[0],s[0]; mov_64 d[4],s[4]
+	 *   * __bpf_memmove_bwd() emits: mov_32 d[8],s[8]; mov_64 d[0],s[0]
+	 */
+	if (d <= s)
+		return __bpf_memmove_fwd(d, s, len);
+	else
+		return __bpf_memmove_bwd(d, s, len);
+}
+
+static __always_inline __nobuiltin("memmove") void bpf_memmove(void *d,
+							   const void *s,
+							   __u64 len)
+{
+	return __bpf_memmove(d, s, len);
+}
+
+#endif /* __BPF_BUILTINS__ */

--- a/pkg/ebpf/c/bpf_builtins.h
+++ b/pkg/ebpf/c/bpf_builtins.h
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
 #ifndef __BPF_BUILTINS__
 #define __BPF_BUILTINS__
 

--- a/pkg/ebpf/c/compiler.h
+++ b/pkg/ebpf/c/compiler.h
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
 #ifndef __BPF_COMPILER_H_
 #define __BPF_COMPILER_H_
 

--- a/pkg/ebpf/c/compiler.h
+++ b/pkg/ebpf/c/compiler.h
@@ -1,0 +1,37 @@
+#ifndef __BPF_COMPILER_H_
+#define __BPF_COMPILER_H_
+
+#ifndef __maybe_unused
+# define __maybe_unused		__attribute__((__unused__))
+#endif
+
+#ifndef __nobuiltin
+# if __clang_major__ >= 10
+#  define __nobuiltin(X)	__attribute__((no_builtin(X)))
+# else
+#  define __nobuiltin(X)
+# endif
+#endif
+
+#ifndef __throw_build_bug
+# define __throw_build_bug()	__builtin_trap()
+#endif
+
+#ifndef barrier
+# define barrier()		asm volatile("": : :"memory")
+#endif
+
+#ifndef barrier_data
+# define barrier_data(ptr)	asm volatile("": :"r"(ptr) :"memory")
+#endif
+
+static __always_inline void bpf_barrier(void)
+{
+	/* Workaround to avoid verifier complaint:
+	 * "dereference of modified ctx ptr R5 off=48+0, ctx+const is allowed,
+	 *        ctx+const+const is not"
+	 */
+	barrier();
+}
+
+#endif /* __BPF_COMPILER_H_ */

--- a/pkg/ebpf/c/compiler.h
+++ b/pkg/ebpf/c/compiler.h
@@ -25,13 +25,4 @@
 # define barrier_data(ptr)	asm volatile("": :"r"(ptr) :"memory")
 #endif
 
-static __always_inline void bpf_barrier(void)
-{
-	/* Workaround to avoid verifier complaint:
-	 * "dereference of modified ctx ptr R5 off=48+0, ctx+const is allowed,
-	 *        ctx+const+const is not"
-	 */
-	barrier();
-}
-
 #endif /* __BPF_COMPILER_H_ */

--- a/pkg/network/ebpf/c/conntrack.h
+++ b/pkg/network/ebpf/c/conntrack.h
@@ -40,7 +40,7 @@ static __always_inline void print_translation(const conntrack_tuple_t *t) {
 }
 
 static __always_inline int nf_conntrack_tuple_to_conntrack_tuple(conntrack_tuple_t *t, const struct nf_conntrack_tuple *ct) {
-    __builtin_memset(t, 0, sizeof(conntrack_tuple_t));
+    bpf_memset(t, 0, sizeof(conntrack_tuple_t));
 
     switch (ct->dst.protonum) {
     case IPPROTO_TCP:
@@ -108,7 +108,7 @@ static __always_inline void increment_telemetry_registers_count() {
 
 static __always_inline int nf_conn_to_conntrack_tuples(struct nf_conn* ct, conntrack_tuple_t* orig, conntrack_tuple_t* reply) {
     struct nf_conntrack_tuple_hash tuplehash[IP_CT_DIR_MAX];
-    __builtin_memset(tuplehash, 0, sizeof(tuplehash));
+    bpf_memset(tuplehash, 0, sizeof(tuplehash));
     bpf_probe_read_kernel_with_telemetry(&tuplehash, sizeof(tuplehash), &ct->tuplehash);
 
     struct nf_conntrack_tuple orig_tup = tuplehash[IP_CT_DIR_ORIGINAL].tuple;

--- a/pkg/network/ebpf/c/conntrack.h
+++ b/pkg/network/ebpf/c/conntrack.h
@@ -4,6 +4,7 @@
 #include <net/netfilter/nf_conntrack.h>
 #include <linux/types.h>
 #include <linux/sched.h>
+#include "bpf_builtins.h"
 #include "tracer.h"
 #include "conntrack-types.h"
 #include "conntrack-maps.h"

--- a/pkg/network/ebpf/c/http-buffer.h
+++ b/pkg/network/ebpf/c/http-buffer.h
@@ -10,7 +10,7 @@
 //
 // This function is used for the uprobe-based HTTPS monitoring (eg. OpenSSL, GnuTLS etc)
 static __always_inline void read_into_buffer(char *buffer, char *data, size_t data_size) {
-    __builtin_memset(buffer, 0, HTTP_BUFFER_SIZE);
+    bpf_memset(buffer, 0, HTTP_BUFFER_SIZE);
 
     // we read HTTP_BUFFER_SIZE-1 bytes to ensure that the string is always null terminated
     if (bpf_probe_read_user_with_telemetry(buffer, HTTP_BUFFER_SIZE - 1, data) < 0) {

--- a/pkg/network/ebpf/c/http-buffer.h
+++ b/pkg/network/ebpf/c/http-buffer.h
@@ -2,6 +2,7 @@
 #define __HTTP_BUFFER_H
 
 #include <linux/err.h>
+#include "bpf_builtins.h"
 #include "http-types.h"
 
 // This function reads a constant number of bytes into the fragment buffer of the http

--- a/pkg/network/ebpf/c/http.h
+++ b/pkg/network/ebpf/c/http.h
@@ -71,7 +71,7 @@ static __always_inline void http_enqueue(http_transaction_t *http) {
         return;
     }
 
-    __builtin_memcpy(&batch->txs[batch->pos], http, sizeof(http_transaction_t));
+    bpf_memcpy(&batch->txs[batch->pos], http, sizeof(http_transaction_t));
     log_debug("http_enqueue: htx=%llx path=%s\n", http, http->request_fragment);
     log_debug("http transaction enqueued: cpu: %d batch_idx: %d pos: %d\n", key.cpu, batch_state->idx, batch->pos);
     batch->pos++;
@@ -89,7 +89,7 @@ static __always_inline void http_begin_request(http_transaction_t *http, http_me
     http->request_started = bpf_ktime_get_ns();
     http->response_last_seen = 0;
     http->response_status_code = 0;
-    __builtin_memcpy(&http->request_fragment, buffer, HTTP_BUFFER_SIZE);
+    bpf_memcpy(&http->request_fragment, buffer, HTTP_BUFFER_SIZE);
     log_debug("http_begin_request: htx=%llx method=%d start=%llx\n", http, http->request_method, http->request_started);
 }
 
@@ -196,7 +196,7 @@ static __always_inline int http_process(http_transaction_t *http_stack, skb_info
 
     if (http_should_flush_previous_state(http, packet_type)) {
         http_enqueue(http);
-        __builtin_memcpy(http, http_stack, sizeof(http_transaction_t));
+        bpf_memcpy(http, http_stack, sizeof(http_transaction_t));
     }
 
     log_debug("http_process: type=%d method=%d\n", packet_type, method);

--- a/pkg/network/ebpf/c/http.h
+++ b/pkg/network/ebpf/c/http.h
@@ -1,6 +1,7 @@
 #ifndef __HTTP_H
 #define __HTTP_H
 
+#include "bpf_builtins.h"
 #include "tracer.h"
 #include "http-types.h"
 #include "http-maps.h"

--- a/pkg/network/ebpf/c/https.h
+++ b/pkg/network/ebpf/c/https.h
@@ -1,6 +1,7 @@
 #ifndef __HTTPS_H
 #define __HTTPS_H
 
+#include "bpf_builtins.h"
 #include "http-buffer.h"
 #include "http-types.h"
 #include "http-maps.h"

--- a/pkg/network/ebpf/c/https.h
+++ b/pkg/network/ebpf/c/https.h
@@ -17,8 +17,8 @@ static __always_inline int http_process(http_transaction_t *http_stack, skb_info
 
 static __always_inline void https_process(conn_tuple_t *t, void *buffer, size_t len, __u64 tags) {
     http_transaction_t http;
-    __builtin_memset(&http, 0, sizeof(http));
-    __builtin_memcpy(&http.tup, t, sizeof(conn_tuple_t));
+    bpf_memset(&http, 0, sizeof(http));
+    bpf_memcpy(&http.tup, t, sizeof(conn_tuple_t));
     read_into_buffer(http.request_fragment, buffer, len);
     http.owned_by_src_port = http.tup.sport;
     log_debug("https_process: htx=%llx sport=%d\n", &http, http.owned_by_src_port);
@@ -27,8 +27,8 @@ static __always_inline void https_process(conn_tuple_t *t, void *buffer, size_t 
 
 static __always_inline void https_finish(conn_tuple_t *t) {
     http_transaction_t http;
-    __builtin_memset(&http, 0, sizeof(http));
-    __builtin_memcpy(&http.tup, t, sizeof(conn_tuple_t));
+    bpf_memset(&http, 0, sizeof(http));
+    bpf_memcpy(&http.tup, t, sizeof(conn_tuple_t));
     http.owned_by_src_port = http.tup.sport;
 
     skb_info_t skb_info = {0};
@@ -71,7 +71,7 @@ static __always_inline conn_tuple_t* tup_from_ssl_ctx(void *ssl_ctx, u64 pid_tgi
     t.netns = 0;
     t.pid = 0;
 
-    __builtin_memcpy(&ssl_sock->tup, &t, sizeof(conn_tuple_t));
+    bpf_memcpy(&ssl_sock->tup, &t, sizeof(conn_tuple_t));
 
     if (!is_ephemeral_port(ssl_sock->tup.sport)) {
         flip_tuple(&ssl_sock->tup);

--- a/pkg/network/ebpf/c/ip.h
+++ b/pkg/network/ebpf/c/ip.h
@@ -53,7 +53,7 @@ static __always_inline void read_ipv4_skb(struct __sk_buff *skb, __u64 off, __u6
 // On older kernels, clang can generate Wunused-function warnings on static inline functions defined in 
 // header files, even if they are later used in source files. __maybe_unused prevents that issue
 __maybe_unused static __always_inline __u64 read_conn_tuple_skb(struct __sk_buff *skb, skb_info_t *info, conn_tuple_t *tup) {
-    __builtin_memset(info, 0, sizeof(skb_info_t));
+    bpf_memset(info, 0, sizeof(skb_info_t));
     info->data_off = ETH_HLEN;
 
     __u16 l3_proto = load_half(skb, offsetof(struct ethhdr, h_proto));

--- a/pkg/network/ebpf/c/ip.h
+++ b/pkg/network/ebpf/c/ip.h
@@ -3,6 +3,7 @@
 
 #include "kconfig.h"
 #include "bpf_helpers.h"
+#include "bpf_builtins.h"
 #include "bpf_endian.h"
 
 #include <uapi/linux/if_ether.h>

--- a/pkg/network/ebpf/c/prebuilt/dns.c
+++ b/pkg/network/ebpf/c/prebuilt/dns.c
@@ -1,5 +1,6 @@
 #include "tracer.h"
 #include "bpf_helpers.h"
+#include "bpf_builtins.h"
 #include "ip.h"
 #include "defs.h"
 
@@ -16,7 +17,7 @@ SEC("socket/dns_filter")
 int socket__dns_filter(struct __sk_buff* skb) {
     skb_info_t skb_info;
     conn_tuple_t tup;
-    __builtin_memset(&tup, 0, sizeof(conn_tuple_t));
+    bpf_memset(&tup, 0, sizeof(conn_tuple_t));
     if (!read_conn_tuple_skb(skb, &skb_info, &tup)) {
         return 0;
     }

--- a/pkg/network/ebpf/c/prebuilt/http.c
+++ b/pkg/network/ebpf/c/prebuilt/http.c
@@ -1,6 +1,7 @@
 #include "kconfig.h"
 #include "tracer.h"
 #include "bpf_telemetry.h"
+#include "bpf_builtins.h"
 #include "ip.h"
 #include "ipv6.h"
 #include "http.h"
@@ -29,7 +30,7 @@ SEC("socket/http_filter")
 int socket__http_filter(struct __sk_buff* skb) {
     skb_info_t skb_info;
     http_transaction_t http;
-    __builtin_memset(&http, 0, sizeof(http));
+    bpf_memset(&http, 0, sizeof(http));
 
     if (!read_conn_tuple_skb(skb, &skb_info, &http.tup)) {
         return 0;
@@ -594,7 +595,7 @@ static __always_inline int do_sys_open_helper_exit(struct pt_regs* ctx) {
 
     // Copy map value into eBPF stack
     lib_path_t lib_path;
-    __builtin_memcpy(&lib_path, path, sizeof(lib_path));
+    bpf_memcpy(&lib_path, path, sizeof(lib_path));
 
     u32 cpu = bpf_get_smp_processor_id();
     bpf_perf_event_output(ctx, &shared_libraries, cpu, &lib_path, sizeof(lib_path));

--- a/pkg/network/ebpf/c/prebuilt/offset-guess.c
+++ b/pkg/network/ebpf/c/prebuilt/offset-guess.c
@@ -1,6 +1,7 @@
 #include "kconfig.h"
 #include "offset-guess.h"
 #include "bpf_helpers.h"
+#include "bpf_builtins.h"
 #include "map-defs.h"
 
 #include <net/net_namespace.h>

--- a/pkg/network/ebpf/c/prebuilt/offset-guess.c
+++ b/pkg/network/ebpf/c/prebuilt/offset-guess.c
@@ -1,7 +1,6 @@
 #include "kconfig.h"
 #include "offset-guess.h"
 #include "bpf_helpers.h"
-#include "bpf_builtins.h"
 #include "map-defs.h"
 
 #include <net/net_namespace.h>

--- a/pkg/network/ebpf/c/prebuilt/sock.h
+++ b/pkg/network/ebpf/c/prebuilt/sock.h
@@ -258,7 +258,7 @@ static __always_inline int read_conn_tuple_partial(conn_tuple_t * t, struct sock
  * Reads values into a `conn_tuple_t` from a `sock`. Initializes all values in conn_tuple_t to `0`. Returns 1 success, 0 otherwise.
  */
 static __always_inline int read_conn_tuple(conn_tuple_t* t, struct sock* skp, u64 pid_tgid, metadata_mask_t type) {
-    __builtin_memset(t, 0, sizeof(conn_tuple_t));
+    bpf_memset(t, 0, sizeof(conn_tuple_t));
     return read_conn_tuple_partial(t, skp, pid_tgid, type);
 }
 

--- a/pkg/network/ebpf/c/prebuilt/sock.h
+++ b/pkg/network/ebpf/c/prebuilt/sock.h
@@ -2,6 +2,7 @@
 #define __SOCK_H
 
 #include "kconfig.h"
+#include "bpf_builtins.h"
 #include "defs.h"
 
 // source include/linux/socket.h

--- a/pkg/network/ebpf/c/prebuilt/tracer.c
+++ b/pkg/network/ebpf/c/prebuilt/tracer.c
@@ -1,5 +1,6 @@
 #include "kconfig.h"
 #include "bpf_telemetry.h"
+#include "bpf_builtins.h"
 #include "tracer.h"
 
 #include "tracer-events.h"
@@ -414,7 +415,7 @@ static __always_inline int handle_ret_udp_recvmsg(int copied, void *udp_sock_map
     log_debug("kretprobe/udp_recvmsg: ret=%d\n", copied);
 
     conn_tuple_t t = {};
-    __builtin_memset(&t, 0, sizeof(conn_tuple_t));
+    bpf_memset(&t, 0, sizeof(conn_tuple_t));
     if (st->msg) {
         struct sockaddr *sap = NULL;
         bpf_probe_read_kernel_with_telemetry(&sap, sizeof(sap), &(st->msg->msg_name));

--- a/pkg/network/ebpf/c/runtime/conn-tuple.h
+++ b/pkg/network/ebpf/c/runtime/conn-tuple.h
@@ -106,7 +106,7 @@ static __always_inline int read_conn_tuple_partial(conn_tuple_t* t, struct sock*
  * Reads values into a `conn_tuple_t` from a `sock`. Initializes all values in conn_tuple_t to `0`. Returns 1 success, 0 otherwise.
  */
 static __always_inline int read_conn_tuple(conn_tuple_t* t, struct sock* skp, u64 pid_tgid, metadata_mask_t type) {
-    __builtin_memset(t, 0, sizeof(conn_tuple_t));
+    bpf_memset(t, 0, sizeof(conn_tuple_t));
     return read_conn_tuple_partial(t, skp, pid_tgid, type);
 }
 

--- a/pkg/network/ebpf/c/runtime/conn-tuple.h
+++ b/pkg/network/ebpf/c/runtime/conn-tuple.h
@@ -1,6 +1,7 @@
 #ifndef __CONN_TUPLE_H
 #define __CONN_TUPLE_H
 
+#include "bpf_builtins.h"
 #include "netns.h"
 
 #ifdef FEATURE_IPV6_ENABLED

--- a/pkg/network/ebpf/c/runtime/conntrack.c
+++ b/pkg/network/ebpf/c/runtime/conntrack.c
@@ -3,6 +3,7 @@
 
 #include "bpf_telemetry.h"
 #include "bpf_endian.h"
+#include "bpf_builtins.h"
 #include "conntrack.h"
 #include "conntrack-maps.h"
 #include "netns.h"

--- a/pkg/network/ebpf/c/runtime/conntrack.c
+++ b/pkg/network/ebpf/c/runtime/conntrack.c
@@ -3,7 +3,6 @@
 
 #include "bpf_telemetry.h"
 #include "bpf_endian.h"
-#include "bpf_builtins.h"
 #include "conntrack.h"
 #include "conntrack-maps.h"
 #include "netns.h"

--- a/pkg/network/ebpf/c/runtime/http.c
+++ b/pkg/network/ebpf/c/runtime/http.c
@@ -1,6 +1,7 @@
 #include <linux/kconfig.h>
 #include "tracer.h"
 #include "bpf_telemetry.h"
+#include "bpf_builtins.h"
 #include "ip.h"
 #include "ipv6.h"
 #include "http.h"
@@ -29,7 +30,7 @@ SEC("socket/http_filter")
 int socket__http_filter(struct __sk_buff *skb) {
     skb_info_t skb_info;
     http_transaction_t http;
-    __builtin_memset(&http, 0, sizeof(http));
+    bpf_memset(&http, 0, sizeof(http));
 
     if (!read_conn_tuple_skb(skb, &skb_info, &http.tup)) {
         return 0;
@@ -595,7 +596,7 @@ static __always_inline int do_sys_open_helper_exit(struct pt_regs *ctx) {
 
     // Copy map value into eBPF stack
     lib_path_t lib_path;
-    __builtin_memcpy(&lib_path, path, sizeof(lib_path));
+    bpf_memcpy(&lib_path, path, sizeof(lib_path));
 
     u32 cpu = bpf_get_smp_processor_id();
     bpf_perf_event_output(ctx, &shared_libraries, cpu, &lib_path, sizeof(lib_path));

--- a/pkg/network/ebpf/c/runtime/skb.h
+++ b/pkg/network/ebpf/c/runtime/skb.h
@@ -29,7 +29,7 @@ static __always_inline int sk_buff_to_tuple(struct sk_buff *skb, conn_tuple_t *t
     }
 
     struct iphdr iph;
-    __builtin_memset(&iph, 0, sizeof(struct iphdr));
+    bpf_memset(&iph, 0, sizeof(struct iphdr));
     ret = bpf_probe_read_kernel_with_telemetry(&iph, sizeof(iph), (struct iphdr *)(head + net_head));
     if (ret) {
         log_debug("ERR reading iphdr\n");
@@ -57,7 +57,7 @@ static __always_inline int sk_buff_to_tuple(struct sk_buff *skb, conn_tuple_t *t
 #ifdef FEATURE_IPV6_ENABLED
     else if (iph.version == 6) {
         struct ipv6hdr ip6h;
-        __builtin_memset(&ip6h, 0, sizeof(struct ipv6hdr));
+        bpf_memset(&ip6h, 0, sizeof(struct ipv6hdr));
         ret = bpf_probe_read_kernel_with_telemetry(&ip6h, sizeof(ip6h), (struct ipv6hdr *)(head + net_head));
         if (ret) {
             log_debug("ERR reading ipv6 hdr\n");
@@ -96,7 +96,7 @@ static __always_inline int sk_buff_to_tuple(struct sk_buff *skb, conn_tuple_t *t
     int proto = get_proto(tup);
     if (proto == CONN_TYPE_UDP) {
         struct udphdr udph;
-        __builtin_memset(&udph, 0, sizeof(struct udphdr));
+        bpf_memset(&udph, 0, sizeof(struct udphdr));
         ret = bpf_probe_read_kernel_with_telemetry(&udph, sizeof(udph), (struct udphdr *)(head + trans_head));
         if (ret) {
             log_debug("ERR reading udphdr\n");
@@ -111,7 +111,7 @@ static __always_inline int sk_buff_to_tuple(struct sk_buff *skb, conn_tuple_t *t
 
     if (proto == CONN_TYPE_TCP) {
         struct tcphdr tcph;
-        __builtin_memset(&tcph, 0, sizeof(struct tcphdr));
+        bpf_memset(&tcph, 0, sizeof(struct tcphdr));
         ret = bpf_probe_read_kernel_with_telemetry(&tcph, sizeof(tcph), (struct tcphdr *)(head + trans_head));
         if (ret) {
             log_debug("ERR reading tcphdr\n");

--- a/pkg/network/ebpf/c/runtime/skb.h
+++ b/pkg/network/ebpf/c/runtime/skb.h
@@ -11,6 +11,7 @@
 #include "tracer.h"
 #include "bpf_helpers.h"
 #include "bpf_endian.h"
+#include "bpf_builtins.h"
 #include "ipv6.h"
 
 // returns the data length of the skb or a negative value in case of an error

--- a/pkg/network/ebpf/c/runtime/tracer.c
+++ b/pkg/network/ebpf/c/runtime/tracer.c
@@ -315,7 +315,7 @@ static __always_inline void handle_skb_consume_udp(struct sock *sk, struct sk_bu
         return;
     }
     conn_tuple_t t;
-    __builtin_memset(&t, 0, sizeof(conn_tuple_t));
+    bpf_memset(&t, 0, sizeof(conn_tuple_t));
     int data_len = sk_buff_to_tuple(skb, &t);
     if (data_len <= 0) {
         log_debug("ERR(skb_consume_udp): error reading tuple ret=%d\n", data_len);

--- a/pkg/network/ebpf/c/runtime/tracer.c
+++ b/pkg/network/ebpf/c/runtime/tracer.c
@@ -1,5 +1,6 @@
 #include "kconfig.h"
 #include "bpf_telemetry.h"
+#include "bpf_builtins.h"
 #include "tracer.h"
 
 #include "tracer-events.h"

--- a/pkg/network/ebpf/c/sockfd.h
+++ b/pkg/network/ebpf/c/sockfd.h
@@ -1,6 +1,7 @@
 #ifndef __SOCKFD_H
 #define __SOCKFD_H
 
+#include "bpf_builtins.h"
 #include "tracer.h"
 #include <linux/types.h>
 

--- a/pkg/network/ebpf/c/sockfd.h
+++ b/pkg/network/ebpf/c/sockfd.h
@@ -28,7 +28,7 @@ __maybe_unused static __always_inline void clear_sockfd_maps(struct sock* sock) 
 
     // Copy map value to stack before re-using it (needed for Kernel 4.4)
     pid_fd_t pid_fd_copy = {};
-    __builtin_memcpy(&pid_fd_copy, pid_fd, sizeof(pid_fd_t));
+    bpf_memcpy(&pid_fd_copy, pid_fd, sizeof(pid_fd_t));
     pid_fd = &pid_fd_copy;
 
     bpf_map_delete_elem(&sock_by_pid_fd, pid_fd);

--- a/pkg/network/ebpf/c/tracer-events.h
+++ b/pkg/network/ebpf/c/tracer-events.h
@@ -92,7 +92,7 @@ static __always_inline void flush_conn_close_if_full(struct pt_regs *ctx) {
         // This is necessary for older Kernel versions only (we validated this behavior on 4.4.0),
         // since you can't directly write a map entry to the perf buffer.
         batch_t batch_copy = {};
-        __builtin_memcpy(&batch_copy, batch_ptr, sizeof(batch_copy));
+        bpf_memcpy(&batch_copy, batch_ptr, sizeof(batch_copy));
         batch_ptr->len = 0;
         batch_ptr->id++;
         bpf_perf_event_output(ctx, &conn_close_event, cpu, &batch_copy, sizeof(batch_copy));

--- a/pkg/network/ebpf/c/tracer-events.h
+++ b/pkg/network/ebpf/c/tracer-events.h
@@ -8,6 +8,7 @@
 #include "tcp_states.h"
 
 #include "bpf_helpers.h"
+#include "bpf_builtins.h"
 
 static __always_inline int get_proto(conn_tuple_t *t) {
     return (t->metadata & CONN_TYPE_TCP) ? CONN_TYPE_TCP : CONN_TYPE_UDP;

--- a/pkg/network/ebpf/c/tracer-stats.h
+++ b/pkg/network/ebpf/c/tracer-stats.h
@@ -15,7 +15,7 @@ static __always_inline u32 get_sk_cookie(struct sock *sk) {
 static __always_inline conn_stats_ts_t *get_conn_stats(conn_tuple_t *t, struct sock *sk) {
     // initialize-if-no-exist the connection stat, and load it
     conn_stats_ts_t empty = {};
-    __builtin_memset(&empty, 0, sizeof(conn_stats_ts_t));
+    bpf_memset(&empty, 0, sizeof(conn_stats_ts_t));
     empty.cookie = get_sk_cookie(sk);
     bpf_map_update_with_telemetry(conn_stats, t, &empty, BPF_NOEXIST);
     return bpf_map_lookup_elem(&conn_stats, t);

--- a/pkg/network/ebpf/c/tracer-stats.h
+++ b/pkg/network/ebpf/c/tracer-stats.h
@@ -1,6 +1,7 @@
 #ifndef __TRACER_STATS_H
 #define __TRACER_STATS_H
 
+#include "bpf_builtins.h"
 #include "tracer.h"
 #include "tracer-maps.h"
 #include "tracer-telemetry.h"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR adds builtins which take advantage of the fact that map values and context pointers, etc, are guaranteed to be aligned, to generate efficient bytecode.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Assuming r0 points to some memory location, and r2 points to a stack variable, when using `__builtin_memcpy` to copy data the compiler generates the following bytecode:
```
......
// Copy r0[30] to r2[0]
r1 = *(u8 *)(r0 + 30)
*(u8 *)(r2 + 30) = r1
......
// Copy r0[0] to r2[0]
r1 = *(u8 *)(r0 + 0)
*(u8 *)(r2 + 0) = r1
```
This bytecode copies the memory from r0 to r2, byte by byte.

For an object for 247 bytes, copying to stack requires 494 instructions. 1 million executions of a socket filter would result in 247 million memory read and 247 million memory write operations when using `__builtin_memcpy`.

The optimized `bpf_memcpy` introduced in this PR, [taken from the cilium project](https://github.com/cilium/cilium/blob/master/bpf/include/bpf/builtins.h#L152), makes assumptions about memory alignment enforced by the [verifier](https://elixir.bootlin.com/linux/v5.15/source/kernel/bpf/verifier.c#L3567), to generate optimized bytecode for copying. For any read of `x` bytes, the worst case scenario is when `x % 8 == 7`. In this case the number of instructions for copying the memory is given by the formula:
```
 2 ( 3 + ((x-7)/8) )
 |   |      |_ (x-7)/8 8-byte copies remain.
 |   |_ Three copies of size 8, 16 and 32, to align on qword boundary
 |_ Each copy of upto 64 bytes will generate two instructions.
```
The optimized `bpf_memcpy` will do enough copies to align on 8 byte boundary, and then copy 8 bytes at a time.
For the same object of size 247 bytes. Copying using the optimized helper will take 33 memory reads and 33 memory writes for a total of 66 instructions. Over 1 million invocations this reduces the instructions executed to 66 million, a reduction of more than 87%.
 
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
For the cases where we are copying a stack value to a memory location, the compiler is smarter and generates efficient bytecode even when using `__builtin_memcpy`

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
