### PR TITLE
Provide clearer messages to users when Fx initialization fails

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -9,11 +9,13 @@
 package main
 
 import (
+	"os"
+
 	"github.com/DataDog/datadog-agent/cmd/agent/command"
 	"github.com/DataDog/datadog-agent/cmd/agent/subcommands"
 	"github.com/DataDog/datadog-agent/cmd/internal/runcmd"
 )
 
 func main() {
-	runcmd.Run(command.MakeCommand(subcommands.AgentSubcommands()))
+	os.Exit(runcmd.Run(command.MakeCommand(subcommands.AgentSubcommands())))
 }

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -9,14 +9,11 @@
 package main
 
 import (
-	"os"
-
 	"github.com/DataDog/datadog-agent/cmd/agent/command"
 	"github.com/DataDog/datadog-agent/cmd/agent/subcommands"
+	"github.com/DataDog/datadog-agent/cmd/internal/runcmd"
 )
 
 func main() {
-	if err := command.MakeCommand(subcommands.AgentSubcommands()).Execute(); err != nil {
-		os.Exit(-1)
-	}
+	runcmd.Run(command.MakeCommand(subcommands.AgentSubcommands()))
 }

--- a/cmd/agent/main_windows.go
+++ b/cmd/agent/main_windows.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/cmd/agent/subcommands"
 	"github.com/DataDog/datadog-agent/cmd/agent/windows/service"
+	"github.com/DataDog/datadog-agent/cmd/internal/runcmd"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -38,8 +39,5 @@ func main() {
 	}
 	defer log.Flush()
 
-	if err := command.MakeCommand(subcommands.AgentSubcommands()).Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(-1)
-	}
+	runcmd.Run(command.MakeCommand(subcommands.AgentSubcommands()))
 }

--- a/cmd/internal/runcmd/runcmd.go
+++ b/cmd/internal/runcmd/runcmd.go
@@ -1,0 +1,31 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package runcmd provides support for running Cobra commands in main functions.
+package runcmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// Run executes a cobra command and handles the results.  It is intended
+// for use in `main` functions, supplying the necessary error-handling and
+// exiting the process with an appropriate status.
+//
+// This function does not return.
+func Run(cmd *cobra.Command) {
+	// always silence errors, since they are handled here
+	cmd.SilenceErrors = true
+
+	err := cmd.Execute()
+	if err != nil {
+		fmt.Fprintln(cmd.ErrOrStderr(), "Error:", err.Error())
+		os.Exit(-1)
+	}
+	os.Exit(0)
+}

--- a/cmd/internal/runcmd/runcmd.go
+++ b/cmd/internal/runcmd/runcmd.go
@@ -37,6 +37,8 @@ func Run(cmd *cobra.Command) {
 // are first simplified to reduce user confusion.
 func displayError(err error, w io.Writer) {
 	_, traceFxSet := os.LookupEnv("TRACE_FX")
+	// RootCause returns the error it was given if it cannot find a "root cause",
+	// and otherwise returns the root cause, which is more useful to the user.
 	if rc := dig.RootCause(err); rc != err && !traceFxSet {
 		fmt.Fprintln(w, "Error:", rc.Error())
 		return

--- a/cmd/internal/runcmd/runcmd.go
+++ b/cmd/internal/runcmd/runcmd.go
@@ -19,17 +19,17 @@ import (
 // for use in `main` functions, supplying the necessary error-handling and
 // exiting the process with an appropriate status.
 //
-// This function does not return.
-func Run(cmd *cobra.Command) {
+// This function returns the appropriate exit status (0 or -1).
+func Run(cmd *cobra.Command) int {
 	// always silence errors, since they are handled here
 	cmd.SilenceErrors = true
 
 	err := cmd.Execute()
 	if err != nil {
 		displayError(err, cmd.ErrOrStderr())
-		os.Exit(-1)
+		return -1
 	}
-	os.Exit(0)
+	return 0
 }
 
 // displayError handles displaying errors from the running command.  Typically

--- a/cmd/internal/runcmd/runcmd_test.go
+++ b/cmd/internal/runcmd/runcmd_test.go
@@ -1,0 +1,52 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package runcmd
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+)
+
+func TestDisplayError_normalError(t *testing.T) {
+	var buf bytes.Buffer
+	displayError(errors.New("uhoh"), &buf)
+	require.Equal(t, "Error: uhoh\n", buf.String())
+}
+
+func makeFxError(t *testing.T) error {
+	app := fx.New(
+		fx.Provide(func() (string, error) {
+			return "", errors.New("uhoh")
+		}),
+		fx.Invoke(func(s string) {}),
+	)
+
+	// "could not build arguments for function .. uhoh"
+	return app.Err()
+}
+
+// fx errors are abbreviated to just the root cause by default
+func TestDisplayError_fxError(t *testing.T) {
+	var buf bytes.Buffer
+	t.Setenv("TRACE_FX", "") // get testing to reset this value for us
+	os.Unsetenv("TRACE_FX")  // but actually _unset_ the value
+	displayError(makeFxError(t), &buf)
+	require.Equal(t, "Error: uhoh\n", buf.String())
+}
+
+// entire error is included with TRACE_FX set
+func TestDisplayError_fxError_TRACE_FX(t *testing.T) {
+	var buf bytes.Buffer
+	t.Setenv("TRACE_FX", "1")
+	displayError(makeFxError(t), &buf)
+	require.Regexp(t, regexp.MustCompile("Error: could not build arguments for function .* uhoh"), buf.String())
+}

--- a/cmd/internal/runcmd/runcmd_test.go
+++ b/cmd/internal/runcmd/runcmd_test.go
@@ -12,14 +12,31 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
 )
 
-func TestDisplayError_normalError(t *testing.T) {
-	var buf bytes.Buffer
-	displayError(errors.New("uhoh"), &buf)
-	require.Equal(t, "Error: uhoh\n", buf.String())
+func TestRun_success(t *testing.T) {
+	cmd := &cobra.Command{
+		Use: "ok",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+	cmd.SetArgs([]string{"ok"})
+	require.Equal(t, 0, Run(cmd))
+}
+
+func TestRun_fail(t *testing.T) {
+	cmd := &cobra.Command{
+		Use: "bad",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("uhoh")
+		},
+	}
+	cmd.SetArgs([]string{"bad"})
+	require.Equal(t, -1, Run(cmd))
 }
 
 func makeFxError(t *testing.T) error {
@@ -32,6 +49,12 @@ func makeFxError(t *testing.T) error {
 
 	// "could not build arguments for function .. uhoh"
 	return app.Err()
+}
+
+func TestDisplayError_normalError(t *testing.T) {
+	var buf bytes.Buffer
+	displayError(errors.New("uhoh"), &buf)
+	require.Equal(t, "Error: uhoh\n", buf.String())
 }
 
 // fx errors are abbreviated to just the root cause by default

--- a/go.mod
+++ b/go.mod
@@ -389,7 +389,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.10.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v0.32.1 // indirect
 	go.opentelemetry.io/otel/trace v1.10.0 // indirect
-	go.uber.org/dig v1.15.0 // indirect
+	go.uber.org/dig v1.15.0
 	go.uber.org/fx v1.18.2
 	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Centralizes handling of errors from application startup, and adds special handling for fx errors to provide a simple error message by default.  If TRACE_FX=1, lots of Fx-related debugging information is provided, including the full error message.

### Motivation

Error messages like
```
./bin/agent/agent diagnose                           
Error: could not build arguments for function "reflect".makeFuncStub (/home/maxime/dev/src_go/src/reflect/asm_amd64.s:28): failed to build log.Component: could not build arguments for function "github.com/DataDog/datadog-agent/comp/core/log".newLogger (/home/maxime/dev/go/src/github.com/DataDog/datadog-agent/comp/core/log/logger.go:23): failed to build config.Component: received non-nil error from function "github.com/DataDog/datadog-agent/comp/core/config".newConfig (/home/maxime/dev/go/src/github.com/DataDog/datadog-agent/comp/core/config/config.go:36): unable to load Datadog config file: Config File "datadog" Not Found in "[/etc/datadog-agent]"
```

### Additional Notes

@ogaca-dd do you think we should include a line suggesting `TRACE_FX=1` here?  Would that ever be useful to customers?

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Handled as part of QA for agent command refactors.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
