### PR TITLE
[CWS] split host and docker functests

### DIFF
--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -34,19 +34,29 @@ kitchen_test_security_agent_x64:
   parallel:
     matrix:
       - KITCHEN_PLATFORM: "centos"
-        KITCHEN_OSVERS: "centos-77,rhel-85"
+        KITCHEN_OSVERS: "centos-77"
+        KITCHEN_CWS_PLATFORM: [host, docker]
+      - KITCHEN_PLATFORM: "rhel"
+        KITCHEN_OSVERS: "rhel-85"
+        KITCHEN_CWS_PLATFORM: [host]
       - KITCHEN_PLATFORM: "ubuntu"
         KITCHEN_OSVERS: "ubuntu-18-04-0,ubuntu-18-04,ubuntu-18-04-3"
+        KITCHEN_CWS_PLATFORM: [host, docker]
       - KITCHEN_PLATFORM: "ubuntu"
         KITCHEN_OSVERS: "ubuntu-20-04,ubuntu-20-04-2,ubuntu-22-04"
+        KITCHEN_CWS_PLATFORM: [host, docker]
       - KITCHEN_PLATFORM: "suse"
         KITCHEN_OSVERS: "sles-12,sles-15"
+        KITCHEN_CWS_PLATFORM: [host]
       - KITCHEN_PLATFORM: "suse"
         KITCHEN_OSVERS: "opensuse-15-3"
+        KITCHEN_CWS_PLATFORM: [host]
       - KITCHEN_PLATFORM: "debian"
         KITCHEN_OSVERS: "debian-10,debian-11"
+        KITCHEN_CWS_PLATFORM: [host, docker]
       - KITCHEN_PLATFORM: "oracle"
         KITCHEN_OSVERS: "oracle-7-9"
+        KITCHEN_CWS_PLATFORM: [host, docker]
 
 kitchen_test_security_agent_arm64:
   extends:

--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -76,6 +76,7 @@ kitchen_test_security_agent_arm64:
     matrix:
       - KITCHEN_PLATFORM: "ubuntu"
         KITCHEN_OSVERS: "ubuntu-20-04-2,ubuntu-22-04"
+        KITCHEN_CWS_PLATFORM: [host, docker]
 
 kitchen_test_security_agent_amazonlinux_x64:
   extends:
@@ -95,6 +96,7 @@ kitchen_test_security_agent_amazonlinux_x64:
     matrix:
       - KITCHEN_PLATFORM: "amazonlinux"
         KITCHEN_OSVERS: "amazonlinux2-4-14,amazonlinux2-5-10,amazonlinux2022-5-15"
+        KITCHEN_CWS_PLATFORM: [host, docker]
 
 kitchen_stress_security_agent:
   extends:

--- a/test/kitchen/drivers/azure-driver.yml
+++ b/test/kitchen/drivers/azure-driver.yml
@@ -128,6 +128,9 @@ platforms:
 - name: <%= platform_name %>
   attributes:
     color_idx: <%= idx %>
+    <% if ENV["KITCHEN_CWS_PLATFORM"] %>
+    cws_platform: ENV["KITCHEN_CWS_PLATFORM"]
+    <% end %>
   driver_config:
     machine_size: <%= size %>
     <% if platform[1] == "urn" %>

--- a/test/kitchen/drivers/azure-driver.yml
+++ b/test/kitchen/drivers/azure-driver.yml
@@ -129,7 +129,7 @@ platforms:
   attributes:
     color_idx: <%= idx %>
     <% if ENV["KITCHEN_CWS_PLATFORM"] %>
-    cws_platform: ENV["KITCHEN_CWS_PLATFORM"]
+    cws_platform: <%= ENV["KITCHEN_CWS_PLATFORM"] %>
     <% end %>
   driver_config:
     machine_size: <%= size %>

--- a/test/kitchen/drivers/ec2-driver.yml
+++ b/test/kitchen/drivers/ec2-driver.yml
@@ -84,6 +84,9 @@ platforms:
 - name: <%= platform_name %>
   attributes:
     color_idx: <%= idx %>
+    <% if ENV["KITCHEN_CWS_PLATFORM"] %>
+    cws_platform: ENV["KITCHEN_CWS_PLATFORM"]
+    <% end %>
   driver:
     <% if windows %>
     connection_timeout: 20

--- a/test/kitchen/drivers/ec2-driver.yml
+++ b/test/kitchen/drivers/ec2-driver.yml
@@ -85,7 +85,7 @@ platforms:
   attributes:
     color_idx: <%= idx %>
     <% if ENV["KITCHEN_CWS_PLATFORM"] %>
-    cws_platform: ENV["KITCHEN_CWS_PLATFORM"]
+    cws_platform: <%= ENV["KITCHEN_CWS_PLATFORM"] %>
     <% end %>
   driver:
     <% if windows %>

--- a/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
@@ -8,6 +8,10 @@
 if node['platform_family'] != 'windows'
   wrk_dir = '/tmp/security-agent'
 
+  directory wrk_dir do
+    recursive true
+  end
+
   file "#{wrk_dir}/cws_platform" do
     content node[:cws_platform].to_s || ""
     mode 644

--- a/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
@@ -5,143 +5,143 @@
 # Copyright (C) 2020-present Datadog
 #
 
-if node['platform_family'] != 'windows'
-  wrk_dir = '/tmp/security-agent'
+wrk_dir = '/tmp/security-agent'
 
-  directory wrk_dir do
-    recursive true
-  end
+directory wrk_dir do
+  recursive true
+end
 
-  file "#{wrk_dir}/cws_platform" do
-    content node[:cws_platform].to_s || ""
-    mode 644
-  end
+file "#{wrk_dir}/cws_platform" do
+  content node[:cws_platform].to_s || ""
+  mode 644
+end
 
-  remote_directory "#{wrk_dir}/ebpf_bytecode" do
-    source 'ebpf_bytecode'
-    sensitive true
-    files_owner 'root'
-    owner 'root'
-  end
+remote_directory "#{wrk_dir}/ebpf_bytecode" do
+  source 'ebpf_bytecode'
+  sensitive true
+  files_owner 'root'
+  owner 'root'
+end
 
-  cookbook_file "#{wrk_dir}/testsuite" do
-    source "testsuite"
-    mode '755'
-  end
+cookbook_file "#{wrk_dir}/testsuite" do
+  source "testsuite"
+  mode '755'
+end
 
-  directory "/opt/datadog-agent/embedded/bin" do
-    recursive true
-  end
+directory "/opt/datadog-agent/embedded/bin" do
+  recursive true
+end
 
-  cookbook_file "/opt/datadog-agent/embedded/bin/clang-bpf" do
-    source "clang-bpf"
-    mode '0744'
-    action :create
-  end
+cookbook_file "/opt/datadog-agent/embedded/bin/clang-bpf" do
+  source "clang-bpf"
+  mode '0744'
+  action :create
+end
 
-  cookbook_file "#{wrk_dir}/clang-bpf" do
-    source "clang-bpf"
-    mode '0744'
-    action :create
-  end
+cookbook_file "#{wrk_dir}/clang-bpf" do
+  source "clang-bpf"
+  mode '0744'
+  action :create
+end
 
-  cookbook_file "/opt/datadog-agent/embedded/bin/llc-bpf" do
-    source "llc-bpf"
-    mode '0744'
-    action :create
-  end
+cookbook_file "/opt/datadog-agent/embedded/bin/llc-bpf" do
+  source "llc-bpf"
+  mode '0744'
+  action :create
+end
 
-  cookbook_file "#{wrk_dir}/llc-bpf" do
-    source "llc-bpf"
-    mode '0744'
-    action :create
-  end
+cookbook_file "#{wrk_dir}/llc-bpf" do
+  source "llc-bpf"
+  mode '0744'
+  action :create
+end
 
-  cookbook_file "#{wrk_dir}/nikos.tar.gz" do
-    source "nikos.tar.gz"
-    mode '755'
-  end
+cookbook_file "#{wrk_dir}/nikos.tar.gz" do
+  source "nikos.tar.gz"
+  mode '755'
+end
 
-  if node[:platform] == "amazon" and node[:platform_version] == "2022"
-    execute "increase /tmp size" do
-      command "mount -o remount,size=5G /tmp/"
-      live_stream true
-      action :run
-    end
-  end
-
-  execute "Extract nikos.tar.gz" do
-    command "mkdir -p /opt/datadog-agent/embedded/nikos/embedded/ && tar -xzvf #{wrk_dir}/nikos.tar.gz -C /opt/datadog-agent/embedded/nikos/embedded/"
+if node[:platform] == "amazon" and node[:platform_version] == "2022"
+  execute "increase /tmp size" do
+    command "mount -o remount,size=5G /tmp/"
+    live_stream true
     action :run
   end
+end
 
-  # `/swapfile` doesn't work on Oracle Linux, so we use `/mnt/swapfile`
-  swap_file '/mnt/swapfile' do
-    size 2048
+execute "Extract nikos.tar.gz" do
+  command "mkdir -p /opt/datadog-agent/embedded/nikos/embedded/ && tar -xzvf #{wrk_dir}/nikos.tar.gz -C /opt/datadog-agent/embedded/nikos/embedded/"
+  action :run
+end
+
+# `/swapfile` doesn't work on Oracle Linux, so we use `/mnt/swapfile`
+swap_file '/mnt/swapfile' do
+  size 2048
+end
+
+kernel_module 'loop' do
+  action :load
+end
+
+kernel_module 'veth' do
+  action :load
+end
+
+# Some functional tests, TestProcessIdentifyInterpreter for example, require python and perl
+# Re: the container tests: Python comes with the Dockerfile, Perl needs to be installed manually
+package 'python3'
+package 'perl'
+
+if not ['redhat', 'suse', 'opensuseleap'].include?(node[:platform])
+  if ['ubuntu', 'debian'].include?(node[:platform])
+    apt_update
+
+    package 'gnupg'
+
+    package 'unattended-upgrades' do
+      action :remove
+    end
   end
 
-  kernel_module 'loop' do
-    action :load
+  if ['ubuntu', 'debian', 'centos'].include?(node[:platform])
+    package 'xfsprogs'
   end
 
-  kernel_module 'veth' do
-    action :load
+  if ['oracle'].include?(node[:platform])
+    docker_installation_package 'default' do
+      action :create
+      setup_docker_repo false
+      package_name 'docker-engine'
+      package_options %q|-y|
+    end
+
+    service 'docker' do
+      action [ :enable, :start ]
+    end
+  elsif ['amazon'].include?(node[:platform])
+    docker_installation_package 'default' do
+      action :create
+      setup_docker_repo false
+      package_name 'docker'
+      package_options %q|-y|
+    end
+
+    service 'docker' do
+      action [ :enable, :start ]
+    end
+  elsif ['ubuntu'].include?(node[:platform])
+    docker_installation_package 'default' do
+      action :create
+      setup_docker_repo false
+      package_name 'docker.io'
+    end
+  else
+    docker_service 'default' do
+      action [:create, :start]
+    end
   end
 
-  # Some functional tests, TestProcessIdentifyInterpreter for example, require python and perl
-  # Re: the container tests: Python comes with the Dockerfile, Perl needs to be installed manually
-  package 'python3'
-  package 'perl'
-
-  if not ['redhat', 'suse', 'opensuseleap'].include?(node[:platform])
-    if ['ubuntu', 'debian'].include?(node[:platform])
-      apt_update
-
-      package 'gnupg'
-
-      package 'unattended-upgrades' do
-        action :remove
-      end
-    end
-
-    if ['ubuntu', 'debian', 'centos'].include?(node[:platform])
-      package 'xfsprogs'
-    end
-
-    if ['oracle'].include?(node[:platform])
-      docker_installation_package 'default' do
-        action :create
-        setup_docker_repo false
-        package_name 'docker-engine'
-        package_options %q|-y|
-      end
-
-      service 'docker' do
-        action [ :enable, :start ]
-      end
-    elsif ['amazon'].include?(node[:platform])
-      docker_installation_package 'default' do
-        action :create
-        setup_docker_repo false
-        package_name 'docker'
-        package_options %q|-y|
-      end
-
-      service 'docker' do
-        action [ :enable, :start ]
-      end
-    elsif ['ubuntu'].include?(node[:platform])
-      docker_installation_package 'default' do
-        action :create
-        setup_docker_repo false
-        package_name 'docker.io'
-      end
-    else
-      docker_service 'default' do
-        action [:create, :start]
-      end
-    end
-
+  if node[:cws_platform] == "docker"
     # Please see https://github.com/paulcacheux/cws-buildimages/blob/main/Dockerfile
     # for the definition of this base image.
     # If this successfully helps in reducing the amount of rate limits, this should be moved
@@ -204,30 +204,30 @@ if node['platform_family'] != 'windows'
       end
     end
   end
+end
 
-  if platform_family?('centos', 'fedora', 'rhel')
-    selinux_state "SELinux Permissive" do
-      action :permissive
-    end
+if platform_family?('centos', 'fedora', 'rhel')
+  selinux_state "SELinux Permissive" do
+    action :permissive
   end
+end
 
-  if File.exists?('/sys/kernel/security/lockdown')
-    file '/sys/kernel/security/lockdown' do
-      action :create_if_missing
-      content "integrity"
-    end
+if File.exists?('/sys/kernel/security/lockdown')
+  file '/sys/kernel/security/lockdown' do
+    action :create_if_missing
+    content "integrity"
   end
+end
 
-  # system-probe common
+# system-probe common
 
-  system_probe_tests_folder = '/tmp/system-probe-tests'
+system_probe_tests_folder = '/tmp/system-probe-tests'
 
-  directory system_probe_tests_folder do
-    recursive true
-  end
+directory system_probe_tests_folder do
+  recursive true
+end
 
-  file "#{system_probe_tests_folder}/color_idx" do
-    content node[:color_idx].to_s
-    mode 644
-  end
+file "#{system_probe_tests_folder}/color_idx" do
+  content node[:color_idx].to_s
+  mode 644
 end

--- a/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
@@ -8,6 +8,11 @@
 if node['platform_family'] != 'windows'
   wrk_dir = '/tmp/security-agent'
 
+  file "#{wrk_dir}/cws_platform" do
+    content node[:cws_platform].to_s || ""
+    mode 644
+  end
+
   remote_directory "#{wrk_dir}/ebpf_bytecode" do
     source 'ebpf_bytecode'
     sensitive true


### PR DESCRIPTION
### What does this PR do?

This PR splits CWS functional tests into host and docker based runs. This has multiple goals:
- quicker test runs (since host and docker are run concurrently)
- better resilience to preemption (azure VMs are often pre-empted) since jobs are shorter (and preemption means that only a small part has to be restarted)
- quicker feedback loop (if you need to debug something that only happens in the CI in a docker test it will be faster)

To do this, the CWS platform (host or docker) is provided from the gitlab job description to the node via node attributes (like the color index) and then a file describing the platform is written to disk to be read by the test runner (again like the color index). 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
