### PR TITLE
[CWS] fix a race during the ad snapshot

### DIFF
--- a/pkg/security/probe/activity_dump.go
+++ b/pkg/security/probe/activity_dump.go
@@ -1086,7 +1086,14 @@ func extractFirstParent(path string) (string, int) {
 // InsertFileEventInProcess inserts the provided file event in the current node. This function returns true if a new entry was
 // added, false if the event was dropped.
 func (ad *ActivityDump) InsertFileEventInProcess(pan *ProcessActivityNode, fileEvent *model.FileEvent, event *Event, generationType NodeGenerationType) bool {
-	parent, nextParentIndex := extractFirstParent(event.ResolveFilePath(fileEvent))
+	var filePath string
+	if generationType != Snapshot {
+		filePath = event.ResolveFilePath(fileEvent)
+	} else {
+		filePath = fileEvent.PathnameStr
+	}
+
+	parent, nextParentIndex := extractFirstParent(filePath)
 	if nextParentIndex == 0 {
 		return false
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fix the following race : 
```
==================
WARNING: DATA RACE
Read at 0x00c00293a3c0 by goroutine 49:
  runtime.mapaccess2_fast32()
      /home/safchain/go/src/runtime/map_fast32.go:53 +0x0
  github.com/DataDog/datadog-agent/pkg/security/probe.(*DentryResolver).lookupInodeFromCache()
      /home/safchain/go-src/src/github.com/DataDog/datadog-agent/pkg/security/probe/dentry_resolver.go:265 +0x5d
  github.com/DataDog/datadog-agent/pkg/security/probe.(*DentryResolver).ResolveFromCache()
      /home/safchain/go-src/src/github.com/DataDog/datadog-agent/pkg/security/probe/dentry_resolver.go:406 +0x16a
  github.com/DataDog/datadog-agent/pkg/security/probe.(*DentryResolver).Resolve()
      /home/safchain/go-src/src/github.com/DataDog/datadog-agent/pkg/security/probe/dentry_resolver.go:721 +0x86
  github.com/DataDog/datadog-agent/pkg/security/probe.(*Resolvers).resolveFileFieldsPath()
      /home/safchain/go-src/src/github.com/DataDog/datadog-agent/pkg/security/probe/resolvers.go:93 +0x104
  github.com/DataDog/datadog-agent/pkg/security/probe.(*Event).ResolveFilePath()
      /home/safchain/go-src/src/github.com/DataDog/datadog-agent/pkg/security/probe/model.go:108 +0xa4
  github.com/DataDog/datadog-agent/pkg/security/probe.(*ActivityDump).InsertFileEventInProcess()
      /home/safchain/go-src/src/github.com/DataDog/datadog-agent/pkg/security/probe/activity_dump.go:1095 +0x6c
  github.com/DataDog/datadog-agent/pkg/security/probe.(*ProcessActivityNode).snapshotFiles()
      /home/safchain/go-src/src/github.com/DataDog/datadog-agent/pkg/security/probe/activity_dump.go:1314 +0x948
  github.com/DataDog/datadog-agent/pkg/security/probe.(*ActivityDump).snapshotProcess()
      /home/safchain/go-src/src/github.com/DataDog/datadog-agent/pkg/security/probe/activity_dump.go:1139 +0x237
  github.com/DataDog/datadog-agent/pkg/security/probe.(*ActivityDump).snapshotProcess()
      /home/safchain/go-src/src/github.com/DataDog/datadog-agent/pkg/security/probe/activity_dump.go:1122 +0xc4
  github.com/DataDog/datadog-agent/pkg/security/probe.(*ActivityDump).snapshotProcess()
      /home/safchain/go-src/src/github.com/DataDog/datadog-agent/pkg/security/probe/activity_dump.go:1122 +0xc4
  github.com/DataDog/datadog-agent/pkg/security/probe.(*ActivityDump).Snapshot()
      /home/safchain/go-src/src/github.com/DataDog/datadog-agent/pkg/security/probe/activity_dump.go:740 +0x166
  github.com/DataDog/datadog-agent/pkg/security/probe.(*ActivityDumpManager).Start()
      /home/safchain/go-src/src/github.com/DataDog/datadog-agent/pkg/security/probe/activity_dump_manager.go:81 +0x5b9
  github.com/DataDog/datadog-agent/pkg/security/probe.(*Monitor).Start.func2()
      /home/safchain/go-src/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe_monitor.go:95 +0x64

Previous write at 0x00c00293a3c0 by goroutine 53:
  runtime.mapassign_fast32()
      /home/safchain/go/src/runtime/map_fast32.go:93 +0x0
  github.com/DataDog/datadog-agent/pkg/security/probe.(*DentryResolver).cacheInode()
      /home/safchain/go-src/src/github.com/DataDog/datadog-agent/pkg/security/probe/dentry_resolver.go:296 +0x1ea
  github.com/DataDog/datadog-agent/pkg/security/probe.(*DentryResolver).cacheEntries()
      /home/safchain/go-src/src/github.com/DataDog/datadog-agent/pkg/security/probe/dentry_resolver.go:624 +0x18d
  github.com/DataDog/datadog-agent/pkg/security/probe.(*DentryResolver).ResolveFromERPC()
      /home/safchain/go-src/src/github.com/DataDog/datadog-agent/pkg/security/probe/dentry_resolver.go:703 +0xcd0
  github.com/DataDog/datadog-agent/pkg/security/probe.(*DentryResolver).Resolve()
      /home/safchain/go-src/src/github.com/DataDog/datadog-agent/pkg/security/probe/dentry_resolver.go:724 +0x137
  github.com/DataDog/datadog-agent/pkg/security/probe.(*Resolvers).resolveFileFieldsPath()
      /home/safchain/go-src/src/github.com/DataDog/datadog-agent/pkg/security/probe/resolvers.go:93 +0x104
  github.com/DataDog/datadog-agent/pkg/security/probe.(*Event).ResolveFilePath()
      /home/safchain/go-src/src/github.com/DataDog/datadog-agent/pkg/security/probe/model.go:108 +0xa4
  github.com/DataDog/datadog-agent/pkg/security/probe.(*Model).GetEvaluator.func311()
      /home/safchain/go-src/src/github.com/DataDog/datadog-agent/pkg/security/probe/accessors.go:2601 +0x90
  github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval.StringEquals.func5()
      /home/safchain/go-src/src/github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval/operators.go:363 +0x55
  github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval.And.func3()
      /home/safchain/go-src/src/github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval/operators.go:176 +0x5a
  github.com/DataDog/datadog-agent/pkg/security/secl/rules.(*RuleSet).Evaluate()
      /home/safchain/go-src/src/github.com/DataDog/datadog-agent/pkg/security/secl/rules/ruleset.go:544 +0x4ca
  github.com/DataDog/datadog-agent/pkg/security/module.(*Module).HandleEvent()
      /home/safchain/go-src/src/github.com/DataDog/datadog-agent/pkg/security/module/module.go:499 +0x98
  github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).DispatchEvent()
      /home/safchain/go-src/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe.go:349 +0x255
  github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).handleEvent()
      /home/safchain/go-src/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe.go:811 +0x6acd
  github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).handleEvent-fm()
      <autogenerated>:1 +0x6d
  github.com/DataDog/datadog-agent/pkg/security/probe.NewOrderedPerfMap.func1()
      /home/safchain/go-src/src/github.com/DataDog/datadog-agent/pkg/security/probe/perfmap.go:94 +0x103
  github.com/DataDog/datadog-agent/pkg/security/probe.(*reOrdererHeap).dequeue()
      /home/safchain/go-src/src/github.com/DataDog/datadog-agent/pkg/security/probe/reorderer.go:144 +0x701
  github.com/DataDog/datadog-agent/pkg/security/probe.(*ReOrderer).Start()
      /home/safchain/go-src/src/github.com/DataDog/datadog-agent/pkg/security/probe/reorderer.go:234 +0x672
  github.com/DataDog/datadog-agent/pkg/security/probe.(*OrderedPerfMap).Start.func2()
      /home/safchain/go-src/src/github.com/DataDog/datadog-agent/pkg/security/probe/perfmap.go:74 +0x47

```

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
