### PR TITLE
[CWS] add btfhub support for oracle linux

### DIFF
--- a/pkg/security/probe/constantfetch/btfhub.go
+++ b/pkg/security/probe/constantfetch/btfhub.go
@@ -34,7 +34,7 @@ var idToDistribMapping = map[string]string{
 	"amzn":   "amzn",
 	"centos": "centos",
 	"fedora": "fedora",
-	"oracle": "oracle-linux",
+	"ol":     "oracle-linux",
 }
 
 var archMapping = map[string]string{

--- a/pkg/security/probe/constantfetch/btfhub.go
+++ b/pkg/security/probe/constantfetch/btfhub.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"errors"
 	"runtime"
+	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
 )
@@ -33,6 +34,7 @@ var idToDistribMapping = map[string]string{
 	"amzn":   "amzn",
 	"centos": "centos",
 	"fedora": "fedora",
+	"oracle": "oracle-linux",
 }
 
 var archMapping = map[string]string{
@@ -121,6 +123,15 @@ func newKernelInfos(kv *kernel.Version) (*kernelInfos, bool) {
 	version, ok := kv.OsRelease["VERSION_ID"]
 	if !ok {
 		return nil, false
+	}
+
+	// HACK: fix mapping of version for oracle-linux
+	if distribution == "oracle-linux" {
+		if strings.HasPrefix(version, "7.") {
+			version = "ol7"
+		} else {
+			return nil, false
+		}
 	}
 
 	arch, ok := archMapping[runtime.GOARCH]

--- a/pkg/security/probe/constantfetch/fallback.go
+++ b/pkg/security/probe/constantfetch/fallback.go
@@ -713,6 +713,8 @@ func getIoKcbCtxOffset(kv *kernel.Version) uint64 {
 	switch {
 	case kv.IsOracleUEKKernel() && kv.IsInRangeCloseOpen(kernel.Kernel5_4, kernel.Kernel5_5):
 		return 96
+	case kv.IsUbuntuKernel() && kv.IsInRangeCloseOpen(kernel.Kernel5_4, kernel.Kernel5_5):
+		return 96
 	default:
 		return 80
 	}

--- a/pkg/security/probe/constantfetch/fallback.go
+++ b/pkg/security/probe/constantfetch/fallback.go
@@ -647,6 +647,8 @@ func getFlowi4SAddrOffset(kv *kernel.Version) uint64 {
 		offset = 20
 	case kv.IsRH8Kernel():
 		offset = 56
+	case kv.IsOracleUEKKernel() && kv.IsInRangeCloseOpen(kernel.Kernel5_4, kernel.Kernel5_5):
+		offset = 56
 
 	case kv.IsInRangeCloseOpen(kernel.Kernel5_0, kernel.Kernel5_1):
 		offset = 32
@@ -708,5 +710,10 @@ func getBinPrmFileFieldOffset(kv *kernel.Version) uint64 {
 }
 
 func getIoKcbCtxOffset(kv *kernel.Version) uint64 {
-	return 80
+	switch {
+	case kv.IsOracleUEKKernel() && kv.IsInRangeCloseOpen(kernel.Kernel5_4, kernel.Kernel5_5):
+		return 96
+	default:
+		return 80
+	}
 }

--- a/pkg/security/tests/constants_test.go
+++ b/pkg/security/tests/constants_test.go
@@ -28,6 +28,10 @@ var RCVsFallbackPossiblyMissingConstants = []string{
 	constantfetch.OffsetNameIoKiocbStructCtx,
 }
 
+var BTFHubVsFallbackPossiblyMissingConstants = []string{
+	constantfetch.OffsetNameNFConnStructCTNet,
+}
+
 func TestOctogonConstants(t *testing.T) {
 	if err := initLogger(); err != nil {
 		t.Fatal(err)
@@ -97,7 +101,7 @@ func TestOctogonConstants(t *testing.T) {
 
 		fallbackFetcher := constantfetch.NewFallbackConstantFetcher(kv)
 
-		assertConstantsEqual(t, btfhubFetcher, fallbackFetcher, kv, nil)
+		assertConstantsEqual(t, btfhubFetcher, fallbackFetcher, kv, BTFHubVsFallbackPossiblyMissingConstants)
 	})
 
 	t.Run("btf-vs-fallback", func(t *testing.T) {

--- a/pkg/security/tests/constants_test.go
+++ b/pkg/security/tests/constants_test.go
@@ -86,6 +86,20 @@ func TestOctogonConstants(t *testing.T) {
 		assertConstantsEqual(t, rcFetcher, btfhubFetcher, kv, BTFHubVsRcPossiblyMissingConstants)
 	})
 
+	t.Run("btfhub-vs-fallback", func(t *testing.T) {
+		btfhubFetcher, err := constantfetch.NewBTFHubConstantFetcher(kv)
+		if err != nil {
+			t.Skipf("btfhub constant fetcher is not available: %v", err)
+		}
+		if !btfhubFetcher.HasConstantsInStore() {
+			t.Skip("btfhub has no constant for this OS")
+		}
+
+		fallbackFetcher := constantfetch.NewFallbackConstantFetcher(kv)
+
+		assertConstantsEqual(t, btfhubFetcher, fallbackFetcher, kv, nil)
+	})
+
 	t.Run("btf-vs-fallback", func(t *testing.T) {
 		btfFetcher, err := constantfetch.NewBTFConstantFetcherFromCurrentKernel()
 		if err != nil {


### PR DESCRIPTION
### What does this PR do?

The btfhub project recently started uploading btf files for oracle linux "ol7". This PR adds support for those constants by:
- improving the error management when a kernel is not supported (displaying more clearly the actual issue)
- adding distribution mapping to support oracle version and id
- adding a `btfhub vs fallback` octogon test. This is useful because we do not support kernel header downloading on oracle so we cannot use the `btfhub vs rc` to ensure that btfhub is working as expected

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
