### PR TITLE
[SNMP] Use agent snmp configuration (network addresses) for the integrated snmpwalk 

### DIFF
--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -113,9 +113,9 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				//We check the ip address configuration in the agent runtime and we use it for the snmpwalk
 				deviceIP = address
 				//Allow the possibility to pass the config file as an argument to the command
-				erre := common.SetupConfig(globalParams.ConfFilePath)
-				if erre != nil {
-					fmt.Printf("The config file provided is invalid : %v \n", erre)
+				err := common.SetupConfig(globalParams.ConfFilePath)
+				if err != nil {
+					fmt.Printf("The config file provided is invalid : %v \n", err)
 				}
 				snmpConfigList, err := parse.GetConfigCheckSnmp()
 				instance := parse.GetIPConfig(deviceIP, snmpConfigList)

--- a/pkg/snmp/snmpparse/config_snmp.go
+++ b/pkg/snmp/snmpparse/config_snmp.go
@@ -39,7 +39,8 @@ type SNMPConfig struct {
 	PrivProtocol string `yaml:"privProtocol"`
 	PrivKey      string `yaml:"privKey"`
 	Context      string `yaml:"context_name"`
-	NetAddress   string `yaml:"network_address"`
+	//network
+	NetAddress string `yaml:"network_address"`
 }
 
 func ParseConfigSnmp(c integration.Config) []SNMPConfig {

--- a/pkg/snmp/snmpparse/config_snmp.go
+++ b/pkg/snmp/snmpparse/config_snmp.go
@@ -98,7 +98,7 @@ func GetIPConfig(ip_address string, SnmpConfigList []SNMPConfig) SNMPConfig {
 	ipAddressConfigs := []SNMPConfig{}
 	netAddressConfigs := []SNMPConfig{}
 
-	//split the SnmpConfigList to get the IP addresses seperated from
+	//split the SnmpConfigList to get the IP addresses separated from
 	//the network addresses
 	for _, snmpconfig := range SnmpConfigList {
 		if snmpconfig.IPAddress != "" {
@@ -109,7 +109,7 @@ func GetIPConfig(ip_address string, SnmpConfigList []SNMPConfig) SNMPConfig {
 		}
 	}
 
-	//check if the ip address is explictly mentioned
+	//check if the ip address is explicitly mentioned
 	for _, snmpIPconfig := range ipAddressConfigs {
 		if snmpIPconfig.IPAddress == ip_address {
 			return snmpIPconfig

--- a/pkg/snmp/snmpparse/config_snmp.go
+++ b/pkg/snmp/snmpparse/config_snmp.go
@@ -113,7 +113,6 @@ func GetIPConfig(ip_address string, SnmpConfigList []SNMPConfig) SNMPConfig {
 	for _, snmpIPconfig := range ipAddressConfigs {
 		if snmpIPconfig.IPAddress == ip_address {
 			return snmpIPconfig
-			//this works but need to find a better way to do the same work in one loop
 		}
 	}
 	//check if the ip address is a part of a network/subnet

--- a/pkg/snmp/snmpparse/config_snmp_test.go
+++ b/pkg/snmp/snmpparse/config_snmp_test.go
@@ -108,6 +108,89 @@ func TestGetSNMPConfig(t *testing.T) {
 
 }
 
+func TestGetSNMPConfigNetwork(t *testing.T) {
+	IPList := []SNMPConfig{
+		{
+			Version:         "2",
+			CommunityString: "password",
+			NetAddress:      "192.168.5.0/24",
+			Port:            161,
+			Timeout:         60,
+			Retries:         3,
+		},
+		{
+			Version:         "2",
+			CommunityString: "drowssap",
+			IPAddress:       "98.6.18.159",
+			Port:            162,
+			Timeout:         30,
+			Retries:         5,
+		},
+		{
+			Version:         "3",
+			CommunityString: "drowssap",
+			IPAddress:       "98.6.18.160",
+			Port:            172,
+			Timeout:         30,
+			Retries:         5,
+		},
+	}
+	input := "192.168.5.3"
+	Exoutput := SNMPConfig{
+		Version:         "2",
+		CommunityString: "password",
+		IPAddress:       "192.168.5.3",
+		NetAddress:      "192.168.5.0/24",
+		Port:            161,
+		Timeout:         60,
+		Retries:         3,
+	}
+	assertIP(t, input, IPList, Exoutput)
+
+}
+
+func TestGetSNMPConfigNet(t *testing.T) {
+	//if the ip address is a part of network but alos is defined indivudualy
+	// the ip_address field should be the one that works
+	IPList := []SNMPConfig{
+		{
+			Version:         "2",
+			CommunityString: "password",
+			NetAddress:      "192.168.5.0/24",
+			Port:            161,
+			Timeout:         60,
+			Retries:         3,
+		},
+		{
+			Version:         "2",
+			CommunityString: "drowssap",
+			IPAddress:       "98.6.18.159",
+			Port:            162,
+			Timeout:         30,
+			Retries:         5,
+		},
+		{
+			Version:         "2",
+			CommunityString: "password",
+			IPAddress:       "192.168.5.1",
+			Port:            161,
+			Timeout:         60,
+			Retries:         3,
+		},
+	}
+	input := "192.168.5.1"
+	Exoutput := SNMPConfig{
+		Version:         "2",
+		CommunityString: "password",
+		IPAddress:       "192.168.5.1",
+		Port:            161,
+		Timeout:         60,
+		Retries:         3,
+	}
+	assertIP(t, input, IPList, Exoutput)
+
+}
+
 func assertIP(t *testing.T, input string, snmpConfigList []SNMPConfig, expectedOutput SNMPConfig) {
 	output := GetIPConfig(input, snmpConfigList)
 	assert.Equal(t, expectedOutput, output)

--- a/pkg/snmp/snmpparse/config_snmp_test.go
+++ b/pkg/snmp/snmpparse/config_snmp_test.go
@@ -191,6 +191,48 @@ func TestGetSNMPConfigNet(t *testing.T) {
 
 }
 
+func TestGetSNMPConfigNoAddress(t *testing.T) {
+	//if the ip address doesn't match anything
+	IPList := []SNMPConfig{
+		{
+			Version:         "2",
+			CommunityString: "password",
+			NetAddress:      "192.168.5.0/24",
+			Port:            161,
+			Timeout:         60,
+			Retries:         3,
+		},
+		{
+			Version:         "2",
+			CommunityString: "drowssap",
+			IPAddress:       "98.6.18.159",
+			Port:            162,
+			Timeout:         30,
+			Retries:         5,
+		},
+		{
+			Version:         "2",
+			CommunityString: "password",
+			IPAddress:       "192.168.5.1",
+			Port:            161,
+			Timeout:         60,
+			Retries:         3,
+		},
+	}
+	input := "192.168.6.1"
+	Exoutput := SNMPConfig{}
+	assertIP(t, input, IPList, Exoutput)
+
+}
+func TestGetSNMPConfigEmpty(t *testing.T) {
+	//if the snmp configuration is empty
+	IPList := []SNMPConfig{}
+	input := "192.168.6.1"
+	Exoutput := SNMPConfig{}
+	assertIP(t, input, IPList, Exoutput)
+
+}
+
 func assertIP(t *testing.T, input string, snmpConfigList []SNMPConfig, expectedOutput SNMPConfig) {
 	output := GetIPConfig(input, snmpConfigList)
 	assert.Equal(t, expectedOutput, output)


### PR DESCRIPTION
### What does this PR do?

The current behaviour of the integrated snmpwalk command only recognizes IP addresses explicitly mentioned under the integration file, if the IP address is a part of a network/subnet under the Integration file, the integrated snmpwalk won't be able to load its configuration and pass it along as options. The customer would still have to manually insert the IP address and all options required to have the output.
The purpose of this PR is to make the integrated snmpwalk command load any IP addresses that are a part of network addresses (only if defined under the integration file).

### Motivation

This is the continuation of this PR: https://github.com/DataDog/datadog-agent/pull/13779


### Additional Notes

Nothing for now.


### Possible Drawbacks / Trade-offs

<!--
-->

### Describe how to test/QA your changes

<!--

-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
