### PR TITLE
[7.40] Fix parent limit was not working in all combination of CPUSets/Limits

### DIFF
--- a/pkg/util/containers/metrics/system/collector_linux_test.go
+++ b/pkg/util/containers/metrics/system/collector_linux_test.go
@@ -144,16 +144,20 @@ func TestBuildContainerMetrics(t *testing.T) {
 		{
 			name: "limit cpu count on parent",
 			cg: &cgroups.MockCgroup{
-				CPU: &cgroups.CPUStats{},
+				CPU: &cgroups.CPUStats{
+					CPUCount: pointer.UInt64Ptr(uint64(utilsystem.HostCPUCount())),
+				},
 				Parent: &cgroups.MockCgroup{
 					CPU: &cgroups.CPUStats{
-						CPUCount: pointer.UInt64Ptr(10),
+						CPUCount:        pointer.UInt64Ptr(uint64(utilsystem.HostCPUCount())),
+						SchedulerPeriod: pointer.UInt64Ptr(100),
+						SchedulerQuota:  pointer.UInt64Ptr(10),
 					},
 				},
 			},
 			want: &provider.ContainerStats{
 				CPU: &provider.ContainerCPUStats{
-					Limit: pointer.Float64Ptr(1000),
+					Limit: pointer.Float64Ptr(10),
 				},
 				PID: &provider.ContainerPIDStats{},
 			},


### PR DESCRIPTION
### What does this PR do?

Backport #13892

### Motivation

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

See #13794

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
