### PR TITLE
usm: tls: Solve slow start TLS capturing issue

### DIFF
--- a/pkg/ebpf/bytecode/runtime/http.go
+++ b/pkg/ebpf/bytecode/runtime/http.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Http = NewAsset("http.c", "0518c075f400ad4a462e5a39b6fd31e7a4afaa99cd652a6848e3b2f18334051a")
+var Http = NewAsset("http.c", "18fe06329fd9837f268b64f0b8cc23d482757a4c2e0e1ef971fc89ec941ead9a")

--- a/pkg/network/ebpf/c/http-types.h
+++ b/pkg/network/ebpf/c/http-types.h
@@ -116,7 +116,7 @@ typedef struct {
     __u32 fd;
 } ssl_sock_t;
 
- #define LIB_PATH_MAX_SIZE 120
+#define LIB_PATH_MAX_SIZE 120
 
 typedef struct {
     __u32 pid;

--- a/pkg/network/ebpf/c/https.h
+++ b/pkg/network/ebpf/c/https.h
@@ -103,7 +103,7 @@ static __always_inline void init_ssl_sock_from_do_handshake(struct sock *skp) {
 
     // copy map value to stack. required for older kernels
     void *ssl_ctx = *ssl_ctx_map_val;
-    bpf_map_update_with_telemetry(ssl_sock_by_ctx, &ssl_ctx , &ssl_sock, BPF_ANY);
+    bpf_map_update_with_telemetry(ssl_sock_by_ctx, &ssl_ctx, &ssl_sock, BPF_ANY);
 }
 
 #endif

--- a/pkg/network/ebpf/c/prebuilt/http.c
+++ b/pkg/network/ebpf/c/prebuilt/http.c
@@ -57,6 +57,14 @@ int kprobe__tcp_sendmsg(struct pt_regs* ctx) {
     return 0;
 }
 
+SEC("kprobe/tcp_recvmsg")
+int kprobe__tcp_recvmsg(struct pt_regs *ctx) {
+    log_debug("kprobe/tcp_recvmsg: sk=%llx\n", PT_REGS_PARM1(ctx));
+    init_ssl_sock_from_do_handshake((struct sock *)PT_REGS_PARM1(ctx));
+
+    return 0;
+}
+
 SEC("tracepoint/net/netif_receive_skb")
 int tracepoint__net__netif_receive_skb(struct pt_regs* ctx) {
     log_debug("tracepoint/net/netif_receive_skb\n");
@@ -162,6 +170,12 @@ int uprobe__SSL_read(struct pt_regs* ctx) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     log_debug("uprobe/SSL_read: pid_tgid=%llx ctx=%llx\n", pid_tgid, args.ctx);
     bpf_map_update_with_telemetry(ssl_read_args, &pid_tgid, &args, BPF_ANY);
+
+    conn_tuple_t *t = tup_from_ssl_ctx(args.ctx, pid_tgid);
+    if (t == NULL) {
+        log_debug("uprobe/SSL_read: no conn tuple, activating lazy loading %d %p\n", pid_tgid, args.ctx);
+        bpf_map_update_elem(&ssl_ctx_by_pid_tgid, &pid_tgid, &args.ctx, BPF_ANY);
+    }
     return 0;
 }
 
@@ -190,6 +204,7 @@ int uretprobe__SSL_read(struct pt_regs* ctx) {
     https_process(t, args->buf, len, LIBSSL);
 cleanup:
     bpf_map_delete_elem(&ssl_read_args, &pid_tgid);
+    bpf_map_delete_elem(&ssl_ctx_by_pid_tgid, &pid_tgid);
     return 0;
 }
 
@@ -201,6 +216,11 @@ int uprobe__SSL_write(struct pt_regs* ctx) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     log_debug("uprobe/SSL_write: pid_tgid=%llx ctx=%llx\n", pid_tgid, args.ctx);
     bpf_map_update_with_telemetry(ssl_write_args, &pid_tgid, &args, BPF_ANY);
+    conn_tuple_t *t = tup_from_ssl_ctx(args.ctx, pid_tgid);
+    if (t == NULL) {
+        log_debug("uprobe/SSL_write: no conn tuple, activating lazy loading %d %p\n", pid_tgid, args.ctx);
+        bpf_map_update_elem(&ssl_ctx_by_pid_tgid, &pid_tgid, &args.ctx, BPF_ANY);
+    }
     return 0;
 }
 
@@ -226,6 +246,7 @@ int uretprobe__SSL_write(struct pt_regs* ctx) {
     https_process(t, args->buf, write_len, LIBSSL);
 cleanup:
     bpf_map_delete_elem(&ssl_write_args, &pid_tgid);
+    bpf_map_delete_elem(&ssl_ctx_by_pid_tgid, &pid_tgid);
     return 0;
 }
 
@@ -238,6 +259,11 @@ int uprobe__SSL_read_ex(struct pt_regs* ctx) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     log_debug("uprobe/SSL_read_ex: pid_tgid=%llx ctx=%llx\n", pid_tgid, args.ctx);
     bpf_map_update_elem(&ssl_read_ex_args, &pid_tgid, &args, BPF_ANY);
+    conn_tuple_t *t = tup_from_ssl_ctx(args.ctx, pid_tgid);
+    if (t == NULL) {
+        log_debug("uprobe/SSL_read_ex: no conn tuple, activating lazy loading %d %p\n", pid_tgid, args.ctx);
+        bpf_map_update_elem(&ssl_ctx_by_pid_tgid, &pid_tgid, &args.ctx, BPF_ANY);
+    }
     return 0;
 }
 
@@ -278,6 +304,7 @@ int uretprobe__SSL_read_ex(struct pt_regs* ctx) {
     https_process(conn_tuple, args->buf, bytes_count, LIBSSL);
 cleanup:
     bpf_map_delete_elem(&ssl_read_ex_args, &pid_tgid);
+    bpf_map_delete_elem(&ssl_ctx_by_pid_tgid, &pid_tgid);
     return 0;
 }
 
@@ -290,6 +317,11 @@ int uprobe__SSL_write_ex(struct pt_regs* ctx) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     log_debug("uprobe/SSL_write_ex: pid_tgid=%llx ctx=%llx\n", pid_tgid, args.ctx);
     bpf_map_update_elem(&ssl_write_ex_args, &pid_tgid, &args, BPF_ANY);
+    conn_tuple_t *t = tup_from_ssl_ctx(args.ctx, pid_tgid);
+    if (t == NULL) {
+        log_debug("uprobe/SSL_write_ex: no conn tuple, activating lazy loading %d %p\n", pid_tgid, args.ctx);
+        bpf_map_update_elem(&ssl_ctx_by_pid_tgid, &pid_tgid, &args.ctx, BPF_ANY);
+    }
     return 0;
 }
 
@@ -327,6 +359,7 @@ int uretprobe__SSL_write_ex(struct pt_regs* ctx) {
     https_process(conn_tuple, args->buf, bytes_count, LIBSSL);
 cleanup:
     bpf_map_delete_elem(&ssl_write_ex_args, &pid_tgid);
+    bpf_map_delete_elem(&ssl_ctx_by_pid_tgid, &pid_tgid);
     return 0;
 }
 
@@ -417,8 +450,14 @@ int uprobe__gnutls_record_recv(struct pt_regs *ctx) {
         .buf = data,
     };
     u64 pid_tgid = bpf_get_current_pid_tgid();
-    log_debug("gnutls_record_recv: pid=%llu ctx=%llx\n", pid_tgid, ssl_session);
+    log_debug("uprobe/gnutls_record_recv: pid=%llu ctx=%llx\n", pid_tgid, ssl_session);
     bpf_map_update_with_telemetry(ssl_read_args, &pid_tgid, &args, BPF_ANY);
+
+    conn_tuple_t *t = tup_from_ssl_ctx(args.ctx, pid_tgid);
+    if (t == NULL) {
+        log_debug("uprobe/gnutls_record_recv: no conn tuple, activating lazy loading %d %p\n", pid_tgid, args.ctx);
+        bpf_map_update_elem(&ssl_ctx_by_pid_tgid, &pid_tgid, &args.ctx, BPF_ANY);
+    }
     return 0;
 }
 
@@ -438,7 +477,7 @@ int uretprobe__gnutls_record_recv(struct pt_regs *ctx) {
     }
 
     void *ssl_session = args->ctx;
-    log_debug("uret/gnutls_record_recv: pid=%llu ctx=%llx\n", pid_tgid, ssl_session);
+    log_debug("uretprobe/gnutls_record_recv: pid=%llu ctx=%llx\n", pid_tgid, ssl_session);
     conn_tuple_t *t = tup_from_ssl_ctx(ssl_session, pid_tgid);
     if (t == NULL) {
         goto cleanup;
@@ -447,6 +486,7 @@ int uretprobe__gnutls_record_recv(struct pt_regs *ctx) {
     https_process(t, args->buf, read_len, LIBGNUTLS);
 cleanup:
     bpf_map_delete_elem(&ssl_read_args, &pid_tgid);
+    bpf_map_delete_elem(&ssl_ctx_by_pid_tgid, &pid_tgid);
     return 0;
 }
 
@@ -459,6 +499,11 @@ int uprobe__gnutls_record_send(struct pt_regs *ctx) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     log_debug("uprobe/gnutls_record_send: pid=%llu ctx=%llx\n", pid_tgid, args.ctx);
     bpf_map_update_with_telemetry(ssl_write_args, &pid_tgid, &args, BPF_ANY);
+    conn_tuple_t *t = tup_from_ssl_ctx(args.ctx, pid_tgid);
+    if (t == NULL) {
+        log_debug("uprobe/gnutls_record_send: no conn tuple, activating lazy loading %d %p\n", pid_tgid, args.ctx);
+        bpf_map_update_elem(&ssl_ctx_by_pid_tgid, &pid_tgid, &args.ctx, BPF_ANY);
+    }
     return 0;
 }
 
@@ -484,6 +529,7 @@ int uretprobe__gnutls_record_send(struct pt_regs *ctx) {
     https_process(t, args->buf, write_len, LIBGNUTLS);
 cleanup:
     bpf_map_delete_elem(&ssl_write_args, &pid_tgid);
+    bpf_map_delete_elem(&ssl_ctx_by_pid_tgid, &pid_tgid);
     return 0;
 }
 

--- a/pkg/network/http/ebpf_main.go
+++ b/pkg/network/http/ebpf_main.go
@@ -39,6 +39,9 @@ const (
 	httpSocketFilter     = "socket/http_filter"
 	httpProgsMap         = "http_progs"
 
+	tcpRecvMsgProbe = "kprobe/tcp_recvmsg"
+	tcpRecvMsgHook  = "kprobe__tcp_recvmsg"
+
 	// maxActive configures the maximum number of instances of the
 	// kretprobe-probed functions handled simultaneously.  This value should be
 	// enough for typical workloads (e.g. some amount of processes blocked on
@@ -122,6 +125,15 @@ func newEBPFProgram(c *config.Config, offsets []manager.ConstantEditor, sockFD *
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
 					EBPFSection:  string(probes.TCPSendMsg),
 					EBPFFuncName: "kprobe__tcp_sendmsg",
+					UID:          probeUID,
+				},
+				KProbeMaxActive:    maxActive,
+				KprobeAttachMethod: kprobeAttachMethod,
+			},
+			{
+				ProbeIdentificationPair: manager.ProbeIdentificationPair{
+					EBPFSection:  tcpRecvMsgProbe,
+					EBPFFuncName: tcpRecvMsgHook,
 					UID:          probeUID,
 				},
 				KProbeMaxActive:    maxActive,
@@ -220,6 +232,13 @@ func (e *ebpfProgram) Init() error {
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
 					EBPFSection:  string(probes.TCPSendMsg),
 					EBPFFuncName: "kprobe__tcp_sendmsg",
+					UID:          probeUID,
+				},
+			},
+			&manager.ProbeSelector{
+				ProbeIdentificationPair: manager.ProbeIdentificationPair{
+					EBPFSection:  tcpRecvMsgProbe,
+					EBPFFuncName: tcpRecvMsgHook,
 					UID:          probeUID,
 				},
 			},

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -12,6 +12,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -1948,6 +1949,95 @@ func TestOpenSSLVersions(t *testing.T) {
 	}, 3*time.Second, time.Second, "connection not found")
 }
 
+// TestOpenSSLVersionsSlowStart check we are able to capture TLS traffic even if we haven't captured the TLS handshake.
+// It can happen if the agent starts after connections have been made, or agent restart (OOM/upgrade).
+// Unfortunately, we probably won't capture the first request, but we will capture the rest.
+func TestOpenSSLVersionsSlowStart(t *testing.T) {
+	if !httpSupported(t) {
+		t.Skip("HTTPS feature not available on pre 4.14.0 kernels")
+	}
+
+	if !httpsSupported(t) {
+		t.Skip("HTTPS feature not available supported for this setup")
+	}
+
+	cfg := testConfig()
+	cfg.EnableHTTPSMonitoring = true
+	cfg.EnableHTTPMonitoring = true
+
+	addressOfHTTPPythonServer := "127.0.0.1:8001"
+	closer, err := testutil.HTTPPythonServer(t, addressOfHTTPPythonServer, testutil.Options{
+		EnableTLS:        true,
+		EnableKeepAlives: true,
+	})
+	require.NoError(t, err)
+	defer closer()
+
+	client, requestFn := simpleGetRequestsGenerator(t, addressOfHTTPPythonServer)
+	// Send a couple of requests we won't capture.
+	var missedRequests []*nethttp.Request
+	for i := 0; i < 5; i++ {
+		missedRequests = append(missedRequests, requestFn())
+	}
+
+	tr, err := NewTracer(cfg)
+	require.NoError(t, err)
+	defer tr.Stop()
+
+	initTracerState(t, tr)
+
+	// Giving the tracer time to install the hooks
+	time.Sleep(time.Second)
+
+	// First request we won't capture.
+	requestFn()
+
+	var requests []*nethttp.Request
+	for i := 0; i < numberOfRequests; i++ {
+		requests = append(requests, requestFn())
+	}
+
+	client.CloseIdleConnections()
+	requestsExist := make([]bool, len(requests))
+	missedRequestsExist := make([]bool, len(missedRequests))
+
+	require.Eventually(t, func() bool {
+		conns := getConnections(t, tr)
+
+		if len(conns.HTTP) == 0 {
+			return false
+		}
+
+		for reqIndex, req := range requests {
+			if !requestsExist[reqIndex] {
+				requestsExist[reqIndex] = isRequestIncluded(conns.HTTP, req)
+			}
+		}
+
+		for reqIndex, req := range missedRequests {
+			if !missedRequestsExist[reqIndex] {
+				missedRequestsExist[reqIndex] = isRequestIncluded(conns.HTTP, req)
+			}
+		}
+
+		// Slight optimization here, if one is missing, then go into another cycle of checking the new connections.
+		// otherwise, if all present, abort.
+		for reqIndex, exists := range requestsExist {
+			if !exists {
+				// reqIndex is 0 based, while the number is requests[reqIndex] is 1 based.
+				t.Logf("request %d was not found (req %v)", reqIndex+1, requests[reqIndex])
+				return false
+			}
+		}
+
+		return true
+	}, 3*time.Second, time.Second, "connection not found")
+
+	for reqIndex, exists := range missedRequestsExist {
+		require.Falsef(t, exists, "request %d was not meant to be captured found (req %v) but we captured it", reqIndex+1, requests[reqIndex])
+	}
+}
+
 var (
 	statusCodes = []int{nethttp.StatusOK, nethttp.StatusMultipleChoices, nethttp.StatusBadRequest, nethttp.StatusInternalServerError}
 )
@@ -1956,7 +2046,12 @@ func simpleGetRequestsGenerator(t *testing.T, targetAddr string) (*nethttp.Clien
 	var (
 		random = rand.New(rand.NewSource(time.Now().Unix()))
 		idx    = 0
-		client = &nethttp.Client{}
+		client = &nethttp.Client{
+			Transport: &nethttp.Transport{
+				TLSClientConfig:   &tls.Config{InsecureSkipVerify: true},
+				DisableKeepAlives: false,
+			},
+		}
 	)
 
 	return client, func() *nethttp.Request {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Solves the slow issue accuracy issue for openssl & gnutls

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

If the agent starts (or restarts) and there is a HTTPs (openssl or gnutls based) connection then we are unable to capture its traffic as we don't have an association between the TLS context and the socket.

In the commit I've added the option to make a lazy association between the TLS ctx to the socket by marking for `tcp_sendmsg` and `tcp_recvmsg` to associate them.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
