### PR TITLE
[CWS] remove `get_go_env` and `go_version` overrides

### DIFF
--- a/tasks/process_agent.py
+++ b/tasks/process_agent.py
@@ -12,7 +12,6 @@ from .utils import REPO_PATH, bin_name, get_build_flags, get_version_numeric_onl
 
 BIN_DIR = os.path.join(".", "bin", "process-agent")
 BIN_PATH = os.path.join(BIN_DIR, bin_name("process-agent"))
-GIMME_ENV_VARS = ['GOROOT', 'PATH']
 
 
 @task

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -36,30 +36,12 @@ from .utils import (
 
 BIN_DIR = os.path.join(".", "bin")
 BIN_PATH = os.path.join(BIN_DIR, "security-agent", bin_name("security-agent"))
-GIMME_ENV_VARS = ['GOROOT', 'PATH']
-
-
-def get_go_env(ctx, go_version):
-    goenv = {}
-    if go_version:
-        lines = ctx.run(f"gimme {go_version}").stdout.split("\n")
-        for line in lines:
-            for env_var in GIMME_ENV_VARS:
-                if env_var in line:
-                    goenv[env_var] = line[line.find(env_var) + len(env_var) + 1 : -1].strip('\'\"')
-
-    # extend PATH from gimme with the one from get_build_flags
-    if "PATH" in os.environ and "PATH" in goenv:
-        goenv["PATH"] += ":" + os.environ["PATH"]
-
-    return goenv
 
 
 @task
 def build(
     ctx,
     race=False,
-    go_version=None,
     incremental_build=True,
     major_version='7',
     # arch is never used here; we keep it to have a
@@ -94,13 +76,12 @@ def build(
     main = "main."
     ld_vars = {
         "Version": get_version(ctx, major_version=major_version),
-        "GoVersion": go_version if go_version else get_go_version(),
+        "GoVersion": get_go_version(),
         "GitBranch": get_git_branch_name(),
         "GitCommit": get_git_commit(),
         "BuildDate": datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
     }
 
-    env.update(get_go_env(ctx, go_version))
     ldflags += ' '.join([f"-X '{main + key}={value}'" for key, value in ld_vars.items()])
     build_tags = get_default_build_tags(
         build="security-agent"
@@ -310,7 +291,6 @@ def build_embed_syscall_tester(ctx, arch=CURRENT_ARCH, static=True):
 def build_functional_tests(
     ctx,
     output='pkg/security/tests/testsuite',
-    go_version=None,
     arch=CURRENT_ARCH,
     major_version='7',
     build_tags='functionaltests',
@@ -334,9 +314,6 @@ def build_functional_tests(
     ldflags, _, env = get_build_flags(
         ctx, major_version=major_version, nikos_embedded_path=nikos_embedded_path, static=static
     )
-
-    goenv = get_go_env(ctx, go_version)
-    env.update(goenv)
 
     env["CGO_ENABLED"] = "1"
     if arch == "x86":
@@ -380,7 +357,6 @@ def build_functional_tests(
 def build_stress_tests(
     ctx,
     output='pkg/security/tests/stresssuite',
-    go_version=None,
     arch=CURRENT_ARCH,
     major_version='7',
     bundle_ebpf=True,
@@ -391,7 +367,6 @@ def build_stress_tests(
     build_functional_tests(
         ctx,
         output=output,
-        go_version=go_version,
         arch=arch,
         major_version=major_version,
         build_tags='stresstests',
@@ -405,7 +380,6 @@ def build_stress_tests(
 def stress_tests(
     ctx,
     verbose=False,
-    go_version=None,
     arch=CURRENT_ARCH,
     major_version='7',
     output='pkg/security/tests/stresssuite',
@@ -416,7 +390,6 @@ def stress_tests(
 ):
     build_stress_tests(
         ctx,
-        go_version=go_version,
         arch=arch,
         major_version=major_version,
         output=output,
@@ -438,7 +411,6 @@ def functional_tests(
     ctx,
     verbose=False,
     race=False,
-    go_version=None,
     arch=CURRENT_ARCH,
     major_version='7',
     output='pkg/security/tests/testsuite',
@@ -449,7 +421,6 @@ def functional_tests(
 ):
     build_functional_tests(
         ctx,
-        go_version=go_version,
         arch=arch,
         major_version=major_version,
         output=output,
@@ -471,7 +442,6 @@ def functional_tests(
 def kitchen_functional_tests(
     ctx,
     verbose=False,
-    go_version=None,
     arch=CURRENT_ARCH,
     major_version='7',
     build_tests=False,
@@ -481,7 +451,6 @@ def kitchen_functional_tests(
         functional_tests(
             ctx,
             verbose=verbose,
-            go_version=go_version,
             arch=arch,
             major_version=major_version,
             output="test/kitchen/site-cookbooks/dd-security-agent-check/files/testsuite",
@@ -502,7 +471,6 @@ def docker_functional_tests(
     ctx,
     verbose=False,
     race=False,
-    go_version=None,
     arch=CURRENT_ARCH,
     major_version='7',
     testflags='',
@@ -512,7 +480,6 @@ def docker_functional_tests(
 ):
     build_functional_tests(
         ctx,
-        go_version=go_version,
         arch=arch,
         major_version=major_version,
         output="pkg/security/tests/testsuite",

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -23,7 +23,6 @@ BIN_PATH = os.path.join(BIN_DIR, bin_name("system-probe"))
 BPF_TAG = "linux_bpf"
 BUNDLE_TAG = "ebpf_bindata"
 NPM_TAG = "npm"
-GIMME_ENV_VARS = ['GOROOT', 'PATH']
 DNF_TAG = "dnf"
 
 CHECK_SOURCE_CMD = "grep -v '^//' {src_file} | if grep -q ' inline ' ; then echo -e '\u001b[7mPlease use __always_inline instead of inline in {src_file}\u001b[0m';exit 1;fi"


### PR DESCRIPTION
### What does this PR do?

This PR removes:
- the `get_go_env` function, since it's always called without `go_version` and thus always useless
- the `go_version` overrides. If you need to override the go_version you should just change your local go installation

This PR also removes multiple unused `GIMME_ENV_VARS` that were making `flake8` unhappy for some reasons.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
