### PR TITLE
[CWS] replace `RWMutex` with `Mutex` in namespace resolver

### DIFF
--- a/pkg/security/probe/namespace_resolver.go
+++ b/pkg/security/probe/namespace_resolver.go
@@ -191,7 +191,7 @@ func (nn *NetworkNamespace) hasValidHandle() bool {
 
 // NamespaceResolver is used to store namespace handles
 type NamespaceResolver struct {
-	sync.RWMutex
+	sync.Mutex
 	state  *atomic.Int64
 	probe  *Probe
 	client statsd.ClientInterface
@@ -279,8 +279,8 @@ func (nr *NamespaceResolver) ResolveNetworkNamespace(nsID uint32) *NetworkNamesp
 		return nil
 	}
 
-	nr.RLock()
-	defer nr.RUnlock()
+	nr.Lock()
+	defer nr.Unlock()
 
 	if ns, found := nr.networkNamespaces.Get(nsID); found {
 		return ns.(*NetworkNamespace)
@@ -492,8 +492,8 @@ func (nr *NamespaceResolver) preventNetworkNamespaceDrift(probesCount map[uint32
 
 // SendStats sends metrics about the current state of the namespace resolver
 func (nr *NamespaceResolver) SendStats() error {
-	nr.RLock()
-	defer nr.RUnlock()
+	nr.Lock()
+	defer nr.Unlock()
 
 	networkNamespacesCount := float64(nr.networkNamespaces.Len())
 	if networkNamespacesCount > 0 {
@@ -553,8 +553,8 @@ type NetworkNamespaceDump struct {
 }
 
 func (nr *NamespaceResolver) dump(params *api.DumpNetworkNamespaceParams) []NetworkNamespaceDump {
-	nr.RLock()
-	defer nr.RUnlock()
+	nr.Lock()
+	defer nr.Unlock()
 
 	var handle *os.File
 	var ntl *manager.NetlinkSocket


### PR DESCRIPTION
### What does this PR do?

When using an LRU, the get operation is actually doing a write as well: updating the "recently used bookkeeping". This can cause races because a `RWMutex` is not enough to protect it. This PR replaces usage of `RWMutex` with a standard `Mutex` in the network resolver to solve a race caused by this issue.

### Motivation
https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/183046338:

```
WARNING: DATA RACE
Read at 0x00c000f1ec98 by goroutine 74:
container/list.(*Element).Prev()
/root/.gimme/versions/go1.18.7.linux.arm64/src/container/list/list.go:40 +0x2dc
github.com/hashicorp/golang-lru/simplelru.(*LRU).Keys()
/go/pkg/mod/github.com/hashicorp/golang-lru@v0.5.4/simplelru/lru.go:136 +0x19c
github.com/DataDog/datadog-agent/pkg/security/probe.(*NamespaceResolver).SendStats()
/go/src/github.com/3dJSsqPy/0/DataDog/datadog-agent/pkg/security/probe/namespace_resolver.go:506 +0x138
github.com/DataDog/datadog-agent/pkg/security/probe.(*Monitor).SendStats()
/go/src/github.com/3dJSsqPy/0/DataDog/datadog-agent/pkg/security/probe/probe_monitor.go:116 +0x1c4
github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).SendStats()
/go/src/github.com/3dJSsqPy/0/DataDog/datadog-agent/pkg/security/probe/probe.go:398 +0x48
github.com/DataDog/datadog-agent/pkg/security/module.(*Module).sendStats()
/go/src/github.com/3dJSsqPy/0/DataDog/datadog-agent/pkg/security/module/module.go:565 +0x40
github.com/DataDog/datadog-agent/pkg/security/module.(*Module).statsSender()
/go/src/github.com/3dJSsqPy/0/DataDog/datadog-agent/pkg/security/module/module.go:591 +0x2a0
github.com/DataDog/datadog-agent/pkg/security/module.(*Module).Start.func3()
/go/src/github.com/3dJSsqPy/0/DataDog/datadog-agent/pkg/security/module/module.go:220 +0x38

Previous write at 0x00c000f1ec98 by goroutine 12:
container/list.(*List).move()
/root/.gimme/versions/go1.18.7.linux.arm64/src/container/list/list.go:123 +0x194
container/list.(*List).MoveToFront()
/root/.gimme/versions/go1.18.7.linux.arm64/src/container/list/list.go:185 +0xf4
github.com/hashicorp/golang-lru/simplelru.(*LRU).Get()
/go/pkg/mod/github.com/hashicorp/golang-lru@v0.5.4/simplelru/lru.go:75 +0x8c
github.com/DataDog/datadog-agent/pkg/security/probe.(*NamespaceResolver).ResolveNetworkNamespace()
/go/src/github.com/3dJSsqPy/0/DataDog/datadog-agent/pkg/security/probe/namespace_resolver.go:285 +0xe4
github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).setupNewTCClassifier()
/go/src/github.com/3dJSsqPy/0/DataDog/datadog-agent/pkg/security/probe/probe.go:1277 +0x84
github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).handleEvent()
/go/src/github.com/3dJSsqPy/0/DataDog/datadog-agent/pkg/security/probe/probe.go:770 +0x1070
github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).handleEvent-fm()
<autogenerated>:1 +0x58
github.com/DataDog/datadog-agent/pkg/security/probe.NewOrderedPerfMap.func1()
/go/src/github.com/3dJSsqPy/0/DataDog/datadog-agent/pkg/security/probe/perfmap.go:94 +0xc4
github.com/DataDog/datadog-agent/pkg/security/probe.(*reOrdererHeap).dequeue()
/go/src/github.com/3dJSsqPy/0/DataDog/datadog-agent/pkg/security/probe/reorderer.go:144 +0x538
github.com/DataDog/datadog-agent/pkg/security/probe.(*ReOrderer).Start()
/go/src/github.com/3dJSsqPy/0/DataDog/datadog-agent/pkg/security/probe/reorderer.go:234 +0x48c
github.com/DataDog/datadog-agent/pkg/security/probe.(*OrderedPerfMap).Start.func2()
/go/src/github.com/3dJSsqPy/0/DataDog/datadog-agent/pkg/security/probe/perfmap.go:74 +0x44
```

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
