### PR TITLE
Use rv "0" when polling Kubernetes endpoint list

### DIFF
--- a/pkg/util/kubernetes/apiserver/apiserver_kubelet.go
+++ b/pkg/util/kubernetes/apiserver/apiserver_kubelet.go
@@ -23,7 +23,7 @@ import (
 // node to the cache
 // Only called when the node agent computes the metadata mapper locally and does not rely on the DCA.
 func (c *APIClient) NodeMetadataMapping(nodeName string, pods []*kubelet.Pod) error {
-	endpointList, err := c.Cl.CoreV1().Endpoints("").List(context.TODO(), metav1.ListOptions{TimeoutSeconds: &c.timeoutSeconds})
+	endpointList, err := c.Cl.CoreV1().Endpoints("").List(context.TODO(), metav1.ListOptions{TimeoutSeconds: &c.timeoutSeconds, ResourceVersion: "0"})
 	if err != nil {
 		log.Errorf("Could not collect endpoints from the API Server: %q", err.Error())
 		return err


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This makes the endpoint polling use the watch cache instead of hitting etcd every time.

### Motivation

Since this code path polls the endpoint list endpoint once every 60s by default to update the internal stat in the agent, we don't really need the consistency guarantees we implicitly get from the unset resource version.

When the resource version is unset, the api-server needs to fetch all endpoints from etcd, causing a costly round-trip that can potentially result in a lot of data traffic. When setting resource version "0", all requests are handled by the watch cache, meaning they will be much more efficient and less costly. On large cluster, the difference will be very noticeable in terms of etcd range scan load. 


As a side note; deploying the cluster agent will make this code path not be hit, so deploying that is also an option. 

The semantics are described in detail here;
https://kubernetes.io/docs/reference/using-api/api-concepts/#semantics-for-get-and-list
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

For the most part, the actual returned data will be the same, but in some cases where the API-servers are having a bad time, the data might be a bit stall; but that is not very common. In that case, getting data from the watch cache instead of not being able to list at all is preferable.

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Compiled a binary myself and tested on a k8s cluster. The number of kubernetes endpoint list calls hitting etcd plummeted (~25 nodes in the cluster), and the number of similar requests hitting the watch cache increased. Everything else seems fine.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
