### PR TITLE
pkg/trace: Log error when watchdog fails to lookup CPU

### DIFF
--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -736,7 +736,7 @@ func (r *HTTPReceiver) watchdog(now time.Time) {
 	rateCPU := 1.0
 	if r.conf.MaxCPU > 0 {
 		if cpuErr != nil {
-			log.Errorf("Unable to get CPU times: %v. Reusing previous value", cpuErr)
+			log.Errorf("Error retrieving current CPU usage: %v. Reusing previous value", cpuErr)
 		}
 		rateCPU = computeRateLimitingRate(r.conf.MaxCPU, wi.CPU.UserAvg, r.RateLimiter.RealRate())
 		if rateCPU < 1 {

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -713,9 +713,10 @@ var killProcess = func(format string, a ...interface{}) {
 // the configuration MaxMemory and MaxCPU. If these values are 0, all limits are disabled and the rate
 // limiter will accept everything.
 func (r *HTTPReceiver) watchdog(now time.Time) {
+	cpu, cpuErr := watchdog.CPU(now)
 	wi := watchdog.Info{
 		Mem: watchdog.Mem(),
-		CPU: watchdog.CPU(now),
+		CPU: cpu,
 	}
 	rateMem := 1.0
 	if r.conf.MaxMemory > 0 {
@@ -734,6 +735,9 @@ func (r *HTTPReceiver) watchdog(now time.Time) {
 	}
 	rateCPU := 1.0
 	if r.conf.MaxCPU > 0 {
+		if cpuErr != nil {
+			log.Errorf("Unable to get CPU times: %v. Reusing previous value", cpuErr)
+		}
 		rateCPU = computeRateLimitingRate(r.conf.MaxCPU, wi.CPU.UserAvg, r.RateLimiter.RealRate())
 		if rateCPU < 1 {
 			log.Warnf("CPU threshold exceeded (apm_config.max_cpu_percent: %.0f): %.0f", r.conf.MaxCPU*100, wi.CPU.UserAvg*100)

--- a/pkg/trace/watchdog/info_test.go
+++ b/pkg/trace/watchdog/info_test.go
@@ -22,10 +22,10 @@ func TestCPULow(t *testing.T) {
 	assert := assert.New(t)
 	runtime.GC()
 
-	_ = CPU(time.Now())
+	_, _ = CPU(time.Now())
 	globalCurrentInfo.cacheDelay = testDuration
 	time.Sleep(testDuration)
-	c := CPU(time.Now())
+	c, _ := CPU(time.Now())
 	t.Logf("CPU (sleep): %v", c)
 
 	// checking that CPU is low enough, this is theoretically flaky,
@@ -51,7 +51,7 @@ func TestCPUHigh(t *testing.T) {
 			runtime.GC()
 
 			done := make(chan struct{}, 1)
-			c := CPU(time.Now())
+			c, _ := CPU(time.Now())
 			globalCurrentInfo.cacheDelay = testDuration
 			for i := 0; i < tc.n; i++ {
 				go func() {
@@ -67,7 +67,7 @@ func TestCPUHigh(t *testing.T) {
 				}()
 			}
 			time.Sleep(testDuration)
-			c = CPU(time.Now())
+			c, _ = CPU(time.Now())
 			for i := 0; i < tc.n; i++ {
 				done <- struct{}{}
 			}
@@ -140,7 +140,7 @@ func BenchmarkCPU(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		_ = CPU(time.Now())
+		_, _ = CPU(time.Now())
 	}
 }
 

--- a/releasenotes/notes/LogCpuUsageLookupFailureAsError-f6bad1b421f2866e.yaml
+++ b/releasenotes/notes/LogCpuUsageLookupFailureAsError-f6bad1b421f2866e.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    APM: The trace-agent will log failures to lookup CPU usage at error level instead of debug.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Log an error when the Watchdog fails to lookup the cpu usage of the trace-agent process.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Previously this was only a debug log. The watchdog failing to lookup cpu values and reusing previous values can drastically affect trace ingestion by the agent. To make it easier for customers and support to spot issues with their trace-agent we should make it more obvious when the agent is using old CPU data. These sorts of issues can be difficult to recreate so logging them proactively instead of requiring the customer restart the trace-agent to get debug logs can assist in resolving these.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
This _may_ generate additional error log noise where there are infrequent failures to lookup cpu usage. However, the benefit of knowing about these failures (and maybe being able to do something) outweighs the downside here imho.
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
This change is very small, for a manual test it might be possible to delete the `proc/stat` file used by the trace-agent or run the container such that it's unable to see that file. Then the trace-agent should log this failure at error level.
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
