### PR TITLE
[process-agent] Set SysprobeProcessModuleEnabled in check command

### DIFF
--- a/cmd/process-agent/app/check.go
+++ b/cmd/process-agent/app/check.go
@@ -23,6 +23,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/metadata/host"
 	"github.com/DataDog/datadog-agent/pkg/process/checks"
 	"github.com/DataDog/datadog-agent/pkg/process/config"
+	"github.com/DataDog/datadog-agent/pkg/process/net"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/tagger/local"
 	"github.com/DataDog/datadog-agent/pkg/tagger/remote"
@@ -132,6 +133,14 @@ func runCheckCmd(cmd *cobra.Command, args []string) error {
 			c()
 		}
 	}()
+
+	// If the sysprobe module is enabled, the process check can call out to the sysprobe for privileged stats
+	_, checks.Process.SysprobeProcessModuleEnabled = syscfg.EnabledModules[sysconfig.ProcessModule]
+
+	if checks.Process.SysprobeProcessModuleEnabled {
+		net.SetSystemProbePath(cfg.SystemProbeAddress)
+	}
+
 	// Connections check requires process-check to have occurred first (for process creation ts),
 	if check == checks.Connections.Name() {
 		// use a different client ID to prevent destructive querying of connections data


### PR DESCRIPTION
### What does this PR do?

Ensures that `SysprobeProcessModuleEnabled` is set in the `process-agent check` command.

### Motivation

Currently we are not using the process module when we run the `check process`.

### Describe how to test/QA your changes

Run the `process-agent check process`, make sure we are able to collect privileged stats.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
