### PR TITLE
Convert 'agent run' command to app

### DIFF
--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -21,6 +21,7 @@ import (
 	_ "net/http/pprof" // Blank import used because this isn't directly used in this file
 
 	"github.com/spf13/cobra"
+	"go.uber.org/fx"
 	"gopkg.in/DataDog/dd-trace-go.v1/profiler"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/api"
@@ -31,12 +32,15 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/agent/gui"
 	"github.com/DataDog/datadog-agent/cmd/agent/subcommands/run/internal/clcrunnerapi"
 	"github.com/DataDog/datadog-agent/cmd/manager"
+	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/api/healthprobe"
 	"github.com/DataDog/datadog-agent/pkg/cloudfoundry/containertagger"
 	"github.com/DataDog/datadog-agent/pkg/collector"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/embed/jmx"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	remoteconfig "github.com/DataDog/datadog-agent/pkg/config/remote/service"
 	"github.com/DataDog/datadog-agent/pkg/dogstatsd"
 	"github.com/DataDog/datadog-agent/pkg/forwarder"
@@ -53,8 +57,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
+	pkglog "github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
 
 	// runtime init routines
@@ -89,45 +94,58 @@ import (
 	_ "github.com/DataDog/datadog-agent/pkg/metadata"
 )
 
-var (
-	// flags variables
+// demux is shared between StartAgent and StopAgent.
+var demux *aggregator.AgentDemultiplexer
+
+type cliParams struct {
+	*command.GlobalParams
+
+	// pidfilePath contains the value of the --pidfile flag.
 	pidfilePath string
-
-	configService *remoteconfig.Service
-
-	demux *aggregator.AgentDemultiplexer
-)
+}
 
 // Commands returns a slice of subcommands for the 'agent' command.
 func Commands(globalParams *command.GlobalParams) []*cobra.Command {
+	cliParams := &cliParams{
+		GlobalParams: globalParams,
+	}
+	runE := func(*cobra.Command, []string) error {
+		// TODO: once the agent is represented as a component, and not a function (run),
+		// this will use `fxutil.Run` instead of `fxutil.OneShot`.
+		return fxutil.OneShot(run,
+			fx.Supply(cliParams),
+			fx.Supply(core.BundleParams{
+				ConfFilePath:      globalParams.ConfFilePath,
+				ConfigLoadSecrets: true,
+			}.LogForDaemon("CORE", "log_file", common.DefaultLogFile)),
+			core.Bundle,
+		)
+	}
+
 	runCmd := &cobra.Command{
 		Use:   "run",
 		Short: "Run the Agent",
 		Long:  `Runs the agent in the foreground`,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return Run(globalParams, cmd, args)
-		},
+		RunE:  runE,
 	}
-	runCmd.Flags().StringVarP(&pidfilePath, "pidfile", "p", "", "path to the pidfile")
+	runCmd.Flags().StringVarP(&cliParams.pidfilePath, "pidfile", "p", "", "path to the pidfile")
 
 	startCmd := &cobra.Command{
 		Use:        "start",
 		Deprecated: "Use \"run\" instead to start the Agent",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return Run(globalParams, cmd, args)
-		},
+		RunE:       runE,
 	}
-	startCmd.Flags().StringVarP(&pidfilePath, "pidfile", "p", "", "path to the pidfile")
+	startCmd.Flags().StringVarP(&cliParams.pidfilePath, "pidfile", "p", "", "path to the pidfile")
 
 	return []*cobra.Command{startCmd, runCmd}
 }
 
-// Run starts the main loop.
+// run starts the main loop.
 //
 // This is exported because it also used from the deprecated `agent start` command.
-func Run(globalParams *command.GlobalParams, cmd *cobra.Command, args []string) error {
+func run(log log.Component, config config.Component, cliParams *cliParams) error {
 	defer func() {
-		stopAgent()
+		stopAgent(cliParams)
 	}()
 
 	// prepare go runtime
@@ -147,7 +165,7 @@ func Run(globalParams *command.GlobalParams, cmd *cobra.Command, args []string) 
 			log.Info("Received stop command, shutting down...")
 			stopCh <- nil
 		case <-signals.ErrorStopper:
-			log.Critical("The Agent has encountered an error, shutting down...")
+			_ = log.Critical("The Agent has encountered an error, shutting down...")
 			stopCh <- fmt.Errorf("shutting down because of an error")
 		case sig := <-signalCh:
 			log.Infof("Received signal '%s', shutting down...", sig)
@@ -166,7 +184,7 @@ func Run(globalParams *command.GlobalParams, cmd *cobra.Command, args []string) 
 		}
 	}()
 
-	if err := startAgent(globalParams); err != nil {
+	if err := startAgent(cliParams); err != nil {
 		return err
 	}
 
@@ -178,11 +196,11 @@ func Run(globalParams *command.GlobalParams, cmd *cobra.Command, args []string) 
 
 // StartAgentWithDefaults is a temporary way for other packages to use startAgent.
 func StartAgentWithDefaults() error {
-	return startAgent(&command.GlobalParams{})
+	return startAgent(&cliParams{GlobalParams: &command.GlobalParams{}})
 }
 
 // startAgent Initializes the agent process
-func startAgent(globalParams *command.GlobalParams) error {
+func startAgent(cliParams *cliParams) error {
 	var (
 		err            error
 		configSetupErr error
@@ -193,49 +211,49 @@ func startAgent(globalParams *command.GlobalParams) error {
 	common.MainCtx, common.MainCtxCancel = context.WithCancel(context.Background())
 
 	// Global Agent configuration
-	configSetupErr = common.SetupConfig(globalParams.ConfFilePath)
+	configSetupErr = common.SetupConfig(cliParams.GlobalParams.ConfFilePath)
 
 	// Setup logger
-	syslogURI := config.GetSyslogURI()
-	logFile := config.Datadog.GetString("log_file")
+	syslogURI := pkgconfig.GetSyslogURI()
+	logFile := pkgconfig.Datadog.GetString("log_file")
 	if logFile == "" {
 		logFile = common.DefaultLogFile
 	}
 
-	jmxLogFile := config.Datadog.GetString("jmx_log_file")
+	jmxLogFile := pkgconfig.Datadog.GetString("jmx_log_file")
 	if jmxLogFile == "" {
 		jmxLogFile = common.DefaultJmxLogFile
 	}
 
-	if config.Datadog.GetBool("disable_file_logging") {
+	if pkgconfig.Datadog.GetBool("disable_file_logging") {
 		// this will prevent any logging on file
 		logFile = ""
 		jmxLogFile = ""
 	}
 
-	loggerSetupErr = config.SetupLogger(
-		config.CoreLoggerName,
-		config.Datadog.GetString("log_level"),
+	loggerSetupErr = pkgconfig.SetupLogger(
+		pkgconfig.CoreLoggerName,
+		pkgconfig.Datadog.GetString("log_level"),
 		logFile,
 		syslogURI,
-		config.Datadog.GetBool("syslog_rfc"),
-		config.Datadog.GetBool("log_to_console"),
-		config.Datadog.GetBool("log_format_json"),
+		pkgconfig.Datadog.GetBool("syslog_rfc"),
+		pkgconfig.Datadog.GetBool("log_to_console"),
+		pkgconfig.Datadog.GetBool("log_format_json"),
 	)
 
 	// Setup JMX logger
 	if loggerSetupErr == nil {
-		loggerSetupErr = config.SetupJMXLogger(
+		loggerSetupErr = pkgconfig.SetupJMXLogger(
 			jmxLogFile,
 			syslogURI,
-			config.Datadog.GetBool("syslog_rfc"),
-			config.Datadog.GetBool("log_to_console"),
-			config.Datadog.GetBool("log_format_json"),
+			pkgconfig.Datadog.GetBool("syslog_rfc"),
+			pkgconfig.Datadog.GetBool("log_to_console"),
+			pkgconfig.Datadog.GetBool("log_format_json"),
 		)
 	}
 
 	if configSetupErr != nil {
-		log.Errorf("Failed to setup config %v", configSetupErr)
+		pkglog.Errorf("Failed to setup config %v", configSetupErr)
 		return fmt.Errorf("unable to set up global agent configuration: %v", configSetupErr)
 	}
 
@@ -244,23 +262,23 @@ func startAgent(globalParams *command.GlobalParams) error {
 	}
 
 	if flavor.GetFlavor() == flavor.IotAgent {
-		log.Infof("Starting Datadog IoT Agent v%v", version.AgentVersion)
+		pkglog.Infof("Starting Datadog IoT Agent v%v", version.AgentVersion)
 	} else {
-		log.Infof("Starting Datadog Agent v%v", version.AgentVersion)
+		pkglog.Infof("Starting Datadog Agent v%v", version.AgentVersion)
 	}
 
 	if err := util.SetupCoreDump(); err != nil {
-		log.Warnf("Can't setup core dumps: %v, core dumps might not be available after a crash", err)
+		pkglog.Warnf("Can't setup core dumps: %v, core dumps might not be available after a crash", err)
 	}
 
-	if v := config.Datadog.GetBool("internal_profiling.capture_all_allocations"); v {
+	if v := pkgconfig.Datadog.GetBool("internal_profiling.capture_all_allocations"); v {
 		runtime.MemProfileRate = 1
-		log.Infof("MemProfileRate set to 1, capturing every single memory allocation!")
+		pkglog.Infof("MemProfileRate set to 1, capturing every single memory allocation!")
 	}
 
 	// init settings that can be changed at runtime
 	if err := initRuntimeSettings(); err != nil {
-		log.Warnf("Can't initiliaze the runtime settings: %v", err)
+		pkglog.Warnf("Can't initiliaze the runtime settings: %v", err)
 	}
 
 	// Setup Internal Profiling
@@ -268,8 +286,8 @@ func startAgent(globalParams *command.GlobalParams) error {
 
 	// Setup expvar server
 	telemetryHandler := telemetry.Handler()
-	expvarPort := config.Datadog.GetString("expvar_port")
-	if config.Datadog.GetBool("telemetry.enabled") {
+	expvarPort := pkgconfig.Datadog.GetString("expvar_port")
+	if pkgconfig.Datadog.GetBool("telemetry.enabled") {
 		http.Handle("/telemetry", telemetryHandler)
 	}
 	go func() {
@@ -278,64 +296,65 @@ func startAgent(globalParams *command.GlobalParams) error {
 			Handler: http.DefaultServeMux,
 		}
 		if err := common.ExpvarServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			log.Errorf("Error creating expvar server on %v: %v", common.ExpvarServer.Addr, err)
+			pkglog.Errorf("Error creating expvar server on %v: %v", common.ExpvarServer.Addr, err)
 		}
 	}()
 
 	// Setup healthcheck port
-	healthPort := config.Datadog.GetInt("health_port")
+	healthPort := pkgconfig.Datadog.GetInt("health_port")
 	if healthPort > 0 {
 		err := healthprobe.Serve(common.MainCtx, healthPort)
 		if err != nil {
-			return log.Errorf("Error starting health port, exiting: %v", err)
+			return pkglog.Errorf("Error starting health port, exiting: %v", err)
 		}
-		log.Debugf("Health check listening on port %d", healthPort)
+		pkglog.Debugf("Health check listening on port %d", healthPort)
 	}
 
-	if pidfilePath != "" {
-		err = pidfile.WritePID(pidfilePath)
+	if cliParams.pidfilePath != "" {
+		err = pidfile.WritePID(cliParams.pidfilePath)
 		if err != nil {
-			return log.Errorf("Error while writing PID file, exiting: %v", err)
+			return pkglog.Errorf("Error while writing PID file, exiting: %v", err)
 		}
-		log.Infof("pid '%d' written to pid file '%s'", os.Getpid(), pidfilePath)
+		pkglog.Infof("pid '%d' written to pid file '%s'", os.Getpid(), cliParams.pidfilePath)
 	}
 
 	err = manager.ConfigureAutoExit(common.MainCtx)
 	if err != nil {
-		return log.Errorf("Unable to configure auto-exit, err: %v", err)
+		return pkglog.Errorf("Unable to configure auto-exit, err: %v", err)
 	}
 
 	hostnameDetected, err := hostname.Get(context.TODO())
 	if err != nil {
-		return log.Errorf("Error while getting hostname, exiting: %v", err)
+		return pkglog.Errorf("Error while getting hostname, exiting: %v", err)
 	}
-	log.Infof("Hostname is: %s", hostnameDetected)
+	pkglog.Infof("Hostname is: %s", hostnameDetected)
 
 	// HACK: init host metadata module (CPU) early to avoid any
 	//       COM threading model conflict with the python checks
 	err = host.InitHostMetadata()
 	if err != nil {
-		log.Errorf("Unable to initialize host metadata: %v", err)
+		pkglog.Errorf("Unable to initialize host metadata: %v", err)
 	}
 
 	// start remote configuration management
-	if config.Datadog.GetBool("remote_configuration.enabled") {
+	var configService *remoteconfig.Service
+	if pkgconfig.Datadog.GetBool("remote_configuration.enabled") {
 		configService, err = remoteconfig.NewService()
 		if err != nil {
-			log.Errorf("Failed to initialize config management service: %s", err)
+			pkglog.Errorf("Failed to initialize config management service: %s", err)
 		} else if err := configService.Start(context.Background()); err != nil {
-			log.Errorf("Failed to start config management service: %s", err)
+			pkglog.Errorf("Failed to start config management service: %s", err)
 		}
 	}
 
 	// create and setup the Autoconfig instance
-	common.LoadComponents(common.MainCtx, config.Datadog.GetString("confd_path"))
+	common.LoadComponents(common.MainCtx, pkgconfig.Datadog.GetString("confd_path"))
 
 	// start the cloudfoundry container tagger
-	if config.IsFeaturePresent(config.CloudFoundry) && !config.Datadog.GetBool("cloud_foundry_buildpack") {
+	if pkgconfig.IsFeaturePresent(pkgconfig.CloudFoundry) && !pkgconfig.Datadog.GetBool("cloud_foundry_buildpack") {
 		containerTagger, err := containertagger.NewContainerTagger()
 		if err != nil {
-			log.Errorf("Failed to create Cloud Foundry container tagger: %v", err)
+			pkglog.Errorf("Failed to create Cloud Foundry container tagger: %v", err)
 		} else {
 			containerTagger.Start(common.MainCtx)
 		}
@@ -343,39 +362,39 @@ func startAgent(globalParams *command.GlobalParams) error {
 
 	// start the cmd HTTP server
 	if err = api.StartServer(configService); err != nil {
-		return log.Errorf("Error while starting api server, exiting: %v", err)
+		return pkglog.Errorf("Error while starting api server, exiting: %v", err)
 	}
 
 	// start clc runner server
 	// only start when the cluster agent is enabled and a cluster check runner host is enabled
-	if config.Datadog.GetBool("cluster_agent.enabled") && config.Datadog.GetBool("clc_runner_enabled") {
+	if pkgconfig.Datadog.GetBool("cluster_agent.enabled") && pkgconfig.Datadog.GetBool("clc_runner_enabled") {
 		if err = clcrunnerapi.StartCLCRunnerServer(map[string]http.Handler{
 			"/telemetry": telemetryHandler,
 		}); err != nil {
-			return log.Errorf("Error while starting clc runner api server, exiting: %v", err)
+			return pkglog.Errorf("Error while starting clc runner api server, exiting: %v", err)
 		}
 	}
 
 	// start the GUI server
-	guiPort := config.Datadog.GetString("GUI_port")
+	guiPort := pkgconfig.Datadog.GetString("GUI_port")
 	if guiPort == "-1" {
-		log.Infof("GUI server port -1 specified: not starting the GUI.")
+		pkglog.Infof("GUI server port -1 specified: not starting the GUI.")
 	} else if err = gui.StartGUIServer(guiPort); err != nil {
-		log.Errorf("Error while starting GUI: %v", err)
+		pkglog.Errorf("Error while starting GUI: %v", err)
 	}
 
 	// setup the forwarder
-	keysPerDomain, err := config.GetMultipleEndpoints()
+	keysPerDomain, err := pkgconfig.GetMultipleEndpoints()
 	if err != nil {
-		log.Error("Misconfiguration of agent endpoints: ", err)
+		pkglog.Error("Misconfiguration of agent endpoints: ", err)
 	}
 
 	forwarderOpts := forwarder.NewOptions(keysPerDomain)
 	// Enable core agent specific features like persistence-to-disk
 	forwarderOpts.EnabledFeatures = forwarder.SetFeature(forwarderOpts.EnabledFeatures, forwarder.CoreFeatures)
 	opts := aggregator.DefaultAgentDemultiplexerOptions(forwarderOpts)
-	opts.EnableNoAggregationPipeline = config.Datadog.GetBool("dogstatsd_no_aggregation_pipeline")
-	opts.UseContainerLifecycleForwarder = config.Datadog.GetBool("container_lifecycle.enabled")
+	opts.EnableNoAggregationPipeline = pkgconfig.Datadog.GetBool("dogstatsd_no_aggregation_pipeline")
+	opts.UseContainerLifecycleForwarder = pkgconfig.Datadog.GetBool("container_lifecycle.enabled")
 	demux = aggregator.InitAndStartAgentDemultiplexer(opts, hostnameDetected)
 
 	// Setup stats telemetry handler
@@ -384,15 +403,15 @@ func startAgent(globalParams *command.GlobalParams) error {
 	}
 
 	// Start OTLP intake
-	otlpEnabled := otlp.IsEnabled(config.Datadog)
+	otlpEnabled := otlp.IsEnabled(pkgconfig.Datadog)
 	inventories.SetAgentMetadata(inventories.AgentOTLPEnabled, otlpEnabled)
 	if otlpEnabled {
 		var err error
-		common.OTLP, err = otlp.BuildAndStart(common.MainCtx, config.Datadog, demux.Serializer())
+		common.OTLP, err = otlp.BuildAndStart(common.MainCtx, pkgconfig.Datadog, demux.Serializer())
 		if err != nil {
-			log.Errorf("Could not start OTLP: %s", err)
+			pkglog.Errorf("Could not start OTLP: %s", err)
 		} else {
-			log.Debug("OTLP pipeline started")
+			pkglog.Debug("OTLP pipeline started")
 		}
 	}
 
@@ -400,12 +419,12 @@ func startAgent(globalParams *command.GlobalParams) error {
 	if traps.IsEnabled() {
 		err = traps.StartServer(hostnameDetected, demux)
 		if err != nil {
-			log.Errorf("Failed to start snmp-traps server: %s", err)
+			pkglog.Errorf("Failed to start snmp-traps server: %s", err)
 		}
 	}
 
-	if err = common.SetupSystemProbeConfig(globalParams.SysProbeConfFilePath); err != nil {
-		log.Infof("System probe config not found, disabling pulling system probe info in the status page: %v", err)
+	if err = common.SetupSystemProbeConfig(cliParams.GlobalParams.SysProbeConfFilePath); err != nil {
+		pkglog.Infof("System probe config not found, disabling pulling system probe info in the status page: %v", err)
 	}
 
 	// Detect Cloud Provider
@@ -421,26 +440,26 @@ func startAgent(globalParams *command.GlobalParams) error {
 	demux.AddAgentStartupTelemetry(version.AgentVersion)
 
 	// start dogstatsd
-	if config.Datadog.GetBool("use_dogstatsd") {
+	if pkgconfig.Datadog.GetBool("use_dogstatsd") {
 		var err error
 		common.DSD, err = dogstatsd.NewServer(demux, false)
 		if err != nil {
-			log.Errorf("Could not start dogstatsd: %s", err)
+			pkglog.Errorf("Could not start dogstatsd: %s", err)
 		} else {
-			log.Debugf("dogstatsd started")
+			pkglog.Debugf("dogstatsd started")
 		}
 	}
 
 	// start logs-agent.  This must happen after AutoConfig is set up (via common.LoadComponents)
-	if config.Datadog.GetBool("logs_enabled") || config.Datadog.GetBool("log_enabled") {
-		if config.Datadog.GetBool("log_enabled") {
-			log.Warn(`"log_enabled" is deprecated, use "logs_enabled" instead`)
+	if pkgconfig.Datadog.GetBool("logs_enabled") || pkgconfig.Datadog.GetBool("log_enabled") {
+		if pkgconfig.Datadog.GetBool("log_enabled") {
+			pkglog.Warn(`"log_enabled" is deprecated, use "logs_enabled" instead`)
 		}
 		if _, err := logs.Start(common.AC); err != nil {
-			log.Error("Could not start logs-agent: ", err)
+			pkglog.Error("Could not start logs-agent: ", err)
 		}
 	} else {
-		log.Info("logs-agent disabled")
+		pkglog.Info("logs-agent disabled")
 	}
 
 	// Start NetFlow server
@@ -449,11 +468,11 @@ func startAgent(globalParams *command.GlobalParams) error {
 	if netflow.IsEnabled() {
 		sender, err := demux.GetDefaultSender()
 		if err != nil {
-			log.Errorf("Failed to get default sender for NetFlow server: %s", err)
+			pkglog.Errorf("Failed to get default sender for NetFlow server: %s", err)
 		} else {
 			err = netflow.StartServer(sender)
 			if err != nil {
-				log.Errorf("Failed to start NetFlow server: %s", err)
+				pkglog.Errorf("Failed to start NetFlow server: %s", err)
 			}
 		}
 	}
@@ -482,23 +501,23 @@ func startAgent(globalParams *command.GlobalParams) error {
 
 // StopAgentWithDefaults is a temporary way for other packages to use stopAgent.
 func StopAgentWithDefaults() {
-	stopAgent()
+	stopAgent(&cliParams{GlobalParams: &command.GlobalParams{}})
 }
 
 // stopAgent Tears down the agent process
-func stopAgent() {
+func stopAgent(cliParams *cliParams) {
 	// retrieve the agent health before stopping the components
 	// GetReadyNonBlocking has a 100ms timeout to avoid blocking
 	health, err := health.GetReadyNonBlocking()
 	if err != nil {
-		log.Warnf("Agent health unknown: %s", err)
+		pkglog.Warnf("Agent health unknown: %s", err)
 	} else if len(health.Unhealthy) > 0 {
-		log.Warnf("Some components were unhealthy: %v", health.Unhealthy)
+		pkglog.Warnf("Some components were unhealthy: %v", health.Unhealthy)
 	}
 
 	if common.ExpvarServer != nil {
 		if err := common.ExpvarServer.Shutdown(context.Background()); err != nil {
-			log.Errorf("Error shutting down expvar server: %v", err)
+			pkglog.Errorf("Error shutting down expvar server: %v", err)
 		}
 	}
 	if common.DSD != nil {
@@ -527,11 +546,11 @@ func stopAgent() {
 	gui.StopGUIServer()
 	profiler.Stop()
 
-	os.Remove(pidfilePath)
+	os.Remove(cliParams.pidfilePath)
 
 	// gracefully shut down any component
 	common.MainCtxCancel()
 
-	log.Info("See ya!")
-	log.Flush()
+	pkglog.Info("See ya!")
+	pkglog.Flush()
 }

--- a/cmd/agent/subcommands/run/command_test.go
+++ b/cmd/agent/subcommands/run/command_test.go
@@ -1,0 +1,37 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package run
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/command"
+	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+func TestCommand(t *testing.T) {
+	fxutil.TestOneShotSubcommand(t,
+		Commands(&command.GlobalParams{}),
+		[]string{"run"},
+		run,
+		func(cliParams *cliParams, coreParams core.BundleParams) {
+			require.Equal(t, true, coreParams.ConfigLoadSecrets)
+		})
+}
+
+func TestCommandPidfile(t *testing.T) {
+	fxutil.TestOneShotSubcommand(t,
+		Commands(&command.GlobalParams{}),
+		[]string{"run", "--pidfile", "/pid/file"},
+		run,
+		func(cliParams *cliParams, coreParams core.BundleParams) {
+			require.Equal(t, "/pid/file", cliParams.pidfilePath)
+			require.Equal(t, true, coreParams.ConfigLoadSecrets)
+		})
+}


### PR DESCRIPTION
### What does this PR do?

Converts the `agent run` command to an Fx App.

### Motivation

Top-down approach to componentization.  I apologize for the late PR -- this got lost in rebasing my topic branch!

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Confirm that an agent containing this PR has the same overall behavior as one not containing this PR, in both

* `agent run`
* `agent run --pidfile /tmp/pid` -- pidfile should be created, and deleted on stop

Pay particular attention to:
 * logging output
 * stop behavior (`agent stop` and ctrl-c, at least)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
