### PR TITLE
[CWS][SEC-5583] remove extra merge config calls

### DIFF
--- a/cmd/cluster-agent/app/compliance_cmd.go
+++ b/cmd/cluster-agent/app/compliance_cmd.go
@@ -9,10 +9,13 @@
 package app
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
+	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/cmd/security-agent/app"
-	"github.com/DataDog/datadog-agent/cmd/security-agent/common"
+	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
 var (
@@ -25,8 +28,13 @@ var (
 func init() {
 	checkCmd := app.CheckCmd()
 	checkCmd.PreRunE = func(cmd *cobra.Command, args []string) error {
-		// Read configuration files received from the command line arguments '-c'
-		return common.MergeConfigurationFiles("datadog-cluster", []string{confPath}, cmd.Flags().Lookup("cfgpath").Changed)
+		// we'll search for a config file named `datadog-cluster.yaml`
+		config.Datadog.SetConfigName("datadog-cluster")
+		err := common.SetupConfig(confPath)
+		if err != nil {
+			return fmt.Errorf("unable to set up global cluster agent configuration: %w", err)
+		}
+		return nil
 	}
 
 	complianceCmd.AddCommand(checkCmd)

--- a/cmd/cluster-agent/app/compliance_cmd.go
+++ b/cmd/cluster-agent/app/compliance_cmd.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/DataDog/datadog-agent/cmd/security-agent/app"
+	"github.com/DataDog/datadog-agent/cmd/security-agent/common"
 )
 
 var (
@@ -22,8 +23,12 @@ var (
 )
 
 func init() {
-	complianceCmd.AddCommand(app.CheckCmd(func() []string {
-		return []string{confPath}
-	}))
+	checkCmd := app.CheckCmd()
+	checkCmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+		// Read configuration files received from the command line arguments '-c'
+		return common.MergeConfigurationFiles("datadog-cluster", []string{confPath}, cmd.Flags().Lookup("cfgpath").Changed)
+	}
+
+	complianceCmd.AddCommand(checkCmd)
 	ClusterAgentCmd.AddCommand(complianceCmd)
 }

--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -67,6 +67,10 @@ var (
 Datadog Security Agent takes care of running compliance and security checks.`,
 		SilenceUsage: true, // don't print usage on errors
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if flagNoColor {
+				color.NoColor = true
+			}
+
 			return common.MergeConfigurationFiles("datadog", confPathArray, cmd.Flags().Lookup("cfgpath").Changed)
 		},
 	}
@@ -83,9 +87,6 @@ Datadog Security Agent takes care of running compliance and security checks.`,
 		Short: "Print the version info",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			if flagNoColor {
-				color.NoColor = true
-			}
 			av, _ := version.Agent()
 			meta := ""
 			if av.Meta != "" {

--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -92,14 +92,12 @@ Datadog Security Agent takes care of running compliance and security checks.`,
 			if av.Meta != "" {
 				meta = fmt.Sprintf("- Meta: %s ", color.YellowString(av.Meta))
 			}
-			fmt.Fprintln(
-				color.Output,
-				fmt.Sprintf("Security agent %s %s- Commit: '%s' - Serialization version: %s",
-					color.BlueString(av.GetNumberAndPre()),
-					meta,
-					color.GreenString(version.Commit),
-					color.MagentaString(serializer.AgentPayloadVersion),
-				),
+
+			fmt.Fprintf(color.Output, "Security agent %s %s- Commit: '%s' - Serialization version: %s\n",
+				color.BlueString(av.GetNumberAndPre()),
+				meta,
+				color.GreenString(version.Commit),
+				color.MagentaString(serializer.AgentPayloadVersion),
 			)
 		},
 	}

--- a/cmd/security-agent/app/compliance.go
+++ b/cmd/security-agent/app/compliance.go
@@ -14,7 +14,6 @@ import (
 
 	ddgostatsd "github.com/DataDog/datadog-go/v5/statsd"
 
-	secagentcommon "github.com/DataDog/datadog-agent/cmd/security-agent/common"
 	"github.com/DataDog/datadog-agent/pkg/collector/runner"
 	"github.com/DataDog/datadog-agent/pkg/collector/scheduler"
 	"github.com/DataDog/datadog-agent/pkg/compliance/agent"
@@ -66,11 +65,6 @@ func newLogContextCompliance() (*config.Endpoints, *client.DestinationsContext, 
 }
 
 func eventRun(cmd *cobra.Command, args []string) error {
-	// Read configuration files received from the command line arguments '-c'
-	if err := secagentcommon.MergeConfigurationFiles("datadog", confPathArray, cmd.Flags().Lookup("cfgpath").Changed); err != nil {
-		return err
-	}
-
 	stopper := startstop.NewSerialStopper()
 	defer stopper.Stop()
 

--- a/cmd/security-agent/app/config.go
+++ b/cmd/security-agent/app/config.go
@@ -15,7 +15,6 @@ import (
 	"github.com/spf13/cobra"
 
 	cmdconfig "github.com/DataDog/datadog-agent/cmd/security-agent/commands/config"
-	"github.com/DataDog/datadog-agent/cmd/security-agent/common"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/settings"
@@ -31,24 +30,13 @@ func setupConfig(cmd *cobra.Command) error {
 		color.NoColor = true
 	}
 
-	// Read configuration files received from the command line arguments '-c'
-	err := common.MergeConfigurationFiles("datadog", confPathArray, cmd.Flags().Lookup("cfgpath").Changed)
-	if err != nil {
-		return err
-	}
-
-	err = config.SetupLogger(loggerName, config.GetEnvDefault("DD_LOG_LEVEL", "off"), "", "", false, true, false)
+	err := config.SetupLogger(loggerName, config.GetEnvDefault("DD_LOG_LEVEL", "off"), "", "", false, true, false)
 	if err != nil {
 		fmt.Printf("Cannot setup logger, exiting: %v\n", err)
 		return err
 	}
 
-	err = util.SetAuthToken()
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return util.SetAuthToken()
 }
 
 func getSettingsClient(cmd *cobra.Command, _ []string) (settings.Client, error) {

--- a/cmd/security-agent/app/config.go
+++ b/cmd/security-agent/app/config.go
@@ -11,7 +11,6 @@ package app
 import (
 	"fmt"
 
-	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
 	cmdconfig "github.com/DataDog/datadog-agent/cmd/security-agent/commands/config"
@@ -26,10 +25,6 @@ func init() {
 }
 
 func setupConfig(cmd *cobra.Command) error {
-	if flagNoColor {
-		color.NoColor = true
-	}
-
 	err := config.SetupLogger(loggerName, config.GetEnvDefault("DD_LOG_LEVEL", "off"), "", "", false, true, false)
 	if err != nil {
 		fmt.Printf("Cannot setup logger, exiting: %v\n", err)

--- a/cmd/security-agent/app/flare.go
+++ b/cmd/security-agent/app/flare.go
@@ -76,10 +76,11 @@ func requestFlare(caseID string) error {
 	}
 
 	r, e := util.DoPost(c, urlstr, "application/json", bytes.NewBuffer([]byte{}))
+	sr := string(r)
 	var filePath string
 	if e != nil {
-		if r != nil && string(r) != "" {
-			fmt.Fprintln(color.Output, fmt.Sprintf("The agent ran into an error while making the flare: %s", color.RedString(string(r))))
+		if r != nil && sr != "" {
+			fmt.Fprintf(color.Output, "The agent ran into an error while making the flare: %s\n", color.RedString(sr))
 		} else {
 			fmt.Fprintln(color.Output, color.RedString("The agent was unable to make a full flare: %s.", e.Error()))
 		}
@@ -90,14 +91,14 @@ func requestFlare(caseID string) error {
 			return e
 		}
 	} else {
-		filePath = string(r)
+		filePath = sr
 	}
 
-	fmt.Fprintln(color.Output, fmt.Sprintf("%s is going to be uploaded to Datadog", color.YellowString(filePath)))
+	fmt.Fprintf(color.Output, "%s is going to be uploaded to Datadog\n", color.YellowString(filePath))
 	if !autoconfirm {
 		confirmation := input.AskForConfirmation("Are you sure you want to upload a flare? [y/N]")
 		if !confirmation {
-			fmt.Fprintln(color.Output, fmt.Sprintf("Aborting. (You can still use %s)", color.YellowString(filePath)))
+			fmt.Fprintf(color.Output, "Aborting. (You can still use %s)\n", color.YellowString(filePath))
 			return nil
 		}
 	}

--- a/cmd/security-agent/app/flare.go
+++ b/cmd/security-agent/app/flare.go
@@ -36,11 +36,6 @@ var flareCmd = &cobra.Command{
 	Short: "Collect a flare and send it to Datadog",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
-
-		if flagNoColor {
-			color.NoColor = true
-		}
-
 		// The flare command should not log anything, all errors should be reported directly to the console without the log format
 		err := config.SetupLogger(loggerName, "off", "", "", false, true, false)
 		if err != nil {

--- a/cmd/security-agent/app/flare.go
+++ b/cmd/security-agent/app/flare.go
@@ -12,7 +12,6 @@ import (
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
-	secagentcommon "github.com/DataDog/datadog-agent/cmd/security-agent/common"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/flare"
@@ -42,14 +41,8 @@ var flareCmd = &cobra.Command{
 			color.NoColor = true
 		}
 
-		// Read configuration files received from the command line arguments '-c'
-		err := secagentcommon.MergeConfigurationFiles("datadog", confPathArray, cmd.Flags().Lookup("cfgpath").Changed)
-		if err != nil {
-			return err
-		}
-
 		// The flare command should not log anything, all errors should be reported directly to the console without the log format
-		err = config.SetupLogger(loggerName, "off", "", "", false, true, false)
+		err := config.SetupLogger(loggerName, "off", "", "", false, true, false)
 		if err != nil {
 			fmt.Printf("Cannot setup logger, exiting: %v\n", err)
 			return err

--- a/cmd/security-agent/app/runtime.go
+++ b/cmd/security-agent/app/runtime.go
@@ -23,7 +23,6 @@ import (
 	ddgostatsd "github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/spf13/cobra"
 
-	"github.com/DataDog/datadog-agent/cmd/security-agent/common"
 	"github.com/DataDog/datadog-agent/pkg/compliance/event"
 	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
@@ -362,11 +361,6 @@ func init() {
 }
 
 func dumpProcessCache(cmd *cobra.Command, args []string) error {
-	// Read configuration files received from the command line arguments '-c'
-	if err := common.MergeConfigurationFiles("datadog", confPathArray, cmd.Flags().Lookup("cfgpath").Changed); err != nil {
-		return err
-	}
-
 	client, err := secagent.NewRuntimeSecurityClient()
 	if err != nil {
 		return fmt.Errorf("unable to create a runtime security client instance: %w", err)
@@ -384,11 +378,6 @@ func dumpProcessCache(cmd *cobra.Command, args []string) error {
 }
 
 func dumpNetworkNamespace(cmd *cobra.Command, args []string) error {
-	// Read configuration files received from the command line arguments '-c'
-	if err := common.MergeConfigurationFiles("datadog", confPathArray, cmd.Flags().Lookup("cfgpath").Changed); err != nil {
-		return err
-	}
-
 	client, err := secagent.NewRuntimeSecurityClient()
 	if err != nil {
 		return fmt.Errorf("unable to create a runtime security client instance: %w", err)
@@ -460,11 +449,6 @@ func parseStorageRequest() (*api.StorageRequestParams, error) {
 }
 
 func generateActivityDump(cmd *cobra.Command, args []string) error {
-	// Read configuration files received from the command line arguments '-c'
-	if err := common.MergeConfigurationFiles("datadog", confPathArray, cmd.Flags().Lookup("cfgpath").Changed); err != nil {
-		return err
-	}
-
 	client, err := secagent.NewRuntimeSecurityClient()
 	if err != nil {
 		return fmt.Errorf("unable to create a runtime security client instance: %w", err)
@@ -494,11 +478,6 @@ func generateActivityDump(cmd *cobra.Command, args []string) error {
 }
 
 func listActivityDumps(cmd *cobra.Command, args []string) error {
-	// Read configuration files received from the command line arguments '-c'
-	if err := common.MergeConfigurationFiles("datadog", confPathArray, cmd.Flags().Lookup("cfgpath").Changed); err != nil {
-		return err
-	}
-
 	client, err := secagent.NewRuntimeSecurityClient()
 	if err != nil {
 		return fmt.Errorf("unable to create a runtime security client instance: %w", err)
@@ -526,11 +505,6 @@ func listActivityDumps(cmd *cobra.Command, args []string) error {
 }
 
 func stopActivityDump(cmd *cobra.Command, args []string) error {
-	// Read configuration files received from the command line arguments '-c'
-	if err := common.MergeConfigurationFiles("datadog", confPathArray, cmd.Flags().Lookup("cfgpath").Changed); err != nil {
-		return err
-	}
-
 	client, err := secagent.NewRuntimeSecurityClient()
 	if err != nil {
 		return fmt.Errorf("unable to create a runtime security client instance: %w", err)
@@ -550,10 +524,6 @@ func stopActivityDump(cmd *cobra.Command, args []string) error {
 }
 
 func generateEncodingFromActivityDump(cmd *cobra.Command, args []string) error {
-	// Read configuration files received from the command line arguments '-c'
-	if err := common.MergeConfigurationFiles("datadog", confPathArray, cmd.Flags().Lookup("cfgpath").Changed); err != nil {
-		return err
-	}
 	var output *api.TranscodingRequestMessage
 
 	if activityDumpArgs.remoteRequest {

--- a/cmd/security-agent/app/status.go
+++ b/cmd/security-agent/app/status.go
@@ -14,7 +14,6 @@ import (
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
-	"github.com/DataDog/datadog-agent/cmd/security-agent/common"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/status"
@@ -48,13 +47,7 @@ func runStatus(cmd *cobra.Command, args []string) error {
 		color.NoColor = true
 	}
 
-	// Read configuration files received from the command line arguments '-c'
-	err := common.MergeConfigurationFiles("datadog", confPathArray, cmd.Flags().Lookup("cfgpath").Changed)
-	if err != nil {
-		return err
-	}
-
-	err = config.SetupLogger(loggerName, config.GetEnvDefault("DD_LOG_LEVEL", "off"), "", "", false, true, false)
+	err := config.SetupLogger(loggerName, config.GetEnvDefault("DD_LOG_LEVEL", "off"), "", "", false, true, false)
 	if err != nil {
 		return log.Errorf("Cannot setup logger, exiting: %v", err)
 	}

--- a/cmd/security-agent/app/status.go
+++ b/cmd/security-agent/app/status.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
 	"github.com/DataDog/datadog-agent/pkg/api/util"
@@ -43,10 +42,6 @@ func init() {
 }
 
 func runStatus(cmd *cobra.Command, args []string) error {
-	if flagNoColor {
-		color.NoColor = true
-	}
-
 	err := config.SetupLogger(loggerName, config.GetEnvDefault("DD_LOG_LEVEL", "off"), "", "", false, true, false)
 	if err != nil {
 		return log.Errorf("Cannot setup logger, exiting: %v", err)

--- a/cmd/security-agent/common/config.go
+++ b/cmd/security-agent/common/config.go
@@ -15,6 +15,7 @@ import (
 
 // MergeConfigurationFiles reads an array of configuration filenames and attempts to merge them. The userDefined value is used to specify that configurationFilesArray contains filenames defined on the command line
 func MergeConfigurationFiles(configName string, configurationFilesArray []string, userDefined bool) error {
+	fmt.Printf("configName=%s, configFilesArray=%v, userDefined=%v\n", configName, configurationFilesArray, userDefined)
 	// we'll search for a config file named `datadog.yaml`
 	coreconfig.Datadog.SetConfigName(configName)
 

--- a/cmd/security-agent/common/config.go
+++ b/cmd/security-agent/common/config.go
@@ -15,7 +15,6 @@ import (
 
 // MergeConfigurationFiles reads an array of configuration filenames and attempts to merge them. The userDefined value is used to specify that configurationFilesArray contains filenames defined on the command line
 func MergeConfigurationFiles(configName string, configurationFilesArray []string, userDefined bool) error {
-	fmt.Printf("configName=%s, configFilesArray=%v, userDefined=%v\n", configName, configurationFilesArray, userDefined)
 	// we'll search for a config file named `datadog.yaml`
 	coreconfig.Datadog.SetConfigName(configName)
 


### PR DESCRIPTION
### What does this PR do?

With the goal of moving the security-agent to fx, we first need to cleanup the different global states.
The "complicated" config merge of the security agent is the first one that needs to be cleaned up.

This PR:
- removes the extra call to merge (when the merge is already done in the persistent pre run call)
- cleans up a few warnings about colored input
- disables the color output as soon as possible

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
