### PR TITLE
Adds extra logging around the reason for a file rotation decision

### DIFF
--- a/pkg/logs/internal/tailers/file/rotate_nix.go
+++ b/pkg/logs/internal/tailers/file/rotate_nix.go
@@ -12,6 +12,7 @@ import (
 	"os"
 
 	"github.com/DataDog/datadog-agent/pkg/util/filesystem"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // DidRotate returns true if the file has been log-rotated.
@@ -37,8 +38,17 @@ func (t *Tailer) DidRotate() (bool, error) {
 		return true, nil
 	}
 
+	lastReadOffset := t.lastReadOffset.Load()
+	fileSize := fi1.Size()
+
 	recreated := !os.SameFile(fi1, fi2)
-	truncated := fi1.Size() < t.lastReadOffset.Load()
+	truncated := fileSize < lastReadOffset
+
+	if recreated {
+		log.Debugf("File rotation detected due to recreation, f1: %+v, f2: %+v", fi1, fi2)
+	} else if truncated {
+		log.Debugf("File rotation detected due to size change, lastReadOffset=%d, fileSize=%d", lastReadOffset, fileSize)
+	}
 
 	return recreated || truncated, nil
 }

--- a/pkg/logs/internal/tailers/file/rotate_windows.go
+++ b/pkg/logs/internal/tailers/file/rotate_windows.go
@@ -39,6 +39,7 @@ func (t *Tailer) DidRotate() (bool, error) {
 	offset := t.lastReadOffset.Load()
 
 	if sz < offset {
+		log.Debugf("File rotation detected due to size change, lastReadOffset=%d, fileSize=%d", offset, sz)
 		return true, nil
 	}
 


### PR DESCRIPTION
### What does this PR do?
When the logs agent detects a file rotation on *nix, it could be for 1 of 2 reasons. This adds explicit `DEBUG` level logs that show why the rotation was detected.

### Motivation
When investigating how the agent handles rotations, I encountered a case where it appeared that the underlying file did not actually rotate, however the agent said it did.

This log will provide extra information to help debug such a situation in the future.

### Additional Notes
n/a

### Possible Drawbacks / Trade-offs
n/a

### Describe how to test/QA your changes
n/a

### Reviewer's Checklist


- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
