### PR TITLE
Adds extra logging around file tailer behavior post-rotation

### DIFF
--- a/pkg/logs/internal/tailers/file/tailer.go
+++ b/pkg/logs/internal/tailers/file/tailer.go
@@ -214,8 +214,18 @@ func (t *Tailer) Stop() {
 // This is only used on UNIX.
 func (t *Tailer) StopAfterFileRotation() {
 	t.didFileRotate.Store(true)
+	bytesReadAtRotationTime := t.Source().BytesRead.Load()
 	go func() {
 		time.Sleep(t.closeTimeout)
+		if newBytesRead := t.Source().BytesRead.Load() - bytesReadAtRotationTime; newBytesRead > 0 {
+			log.Infof("After rotation close timeout (%ds), an additional %d bytes were read from file %q", t.closeTimeout, newBytesRead, t.file.Path)
+			fileStat, err := t.osFile.Stat()
+			if err != nil {
+				log.Warnf("During rotation close, unable to determine total file size for %q, err: %v", t.file.Path, err)
+			} else if remainingBytes := fileStat.Size() - t.lastReadOffset.Load(); remainingBytes > 0 {
+				log.Warnf("After rotation close timeout (%ds), there were %d bytes remaining unread for file %q. These unread logs are now lost. Consider increasing DD_LOGS_CONFIG_CLOSE_TIMEOUT", t.closeTimeout, remainingBytes, t.file.Path)
+			}
+		}
 		t.stopForward()
 		t.stop <- struct{}{}
 	}()

--- a/pkg/logs/internal/tailers/file/tailer.go
+++ b/pkg/logs/internal/tailers/file/tailer.go
@@ -46,11 +46,6 @@ type Tailer struct {
 	// ends.
 	decodedOffset *atomic.Int64
 
-	// bytesRead is the number of bytes successfully read from the file by this
-	// tailer.  This may be smaller than lastReadOffset if the tailer did not
-	// begin at the start of the file.
-	bytesRead int64
-
 	// file contains the logs configuration for the file to parse (path, source, ...)
 	// If you are looking for the os.file use to read on the FS, see osFile.
 	file *File
@@ -238,7 +233,7 @@ func (t *Tailer) readForever() {
 	defer func() {
 		t.osFile.Close()
 		t.decoder.Stop()
-		log.Info("Closed", t.file.Path, "for tailer key", t.file.GetScanKey(), "read", t.bytesRead, "bytes and", t.decoder.GetLineCount(), "lines")
+		log.Info("Closed", t.file.Path, "for tailer key", t.file.GetScanKey(), "read", t.Source().BytesRead.Load(), "bytes and", t.decoder.GetLineCount(), "lines")
 	}()
 
 	for {
@@ -325,7 +320,6 @@ func (t *Tailer) wait() {
 }
 
 func (t *Tailer) recordBytes(n int64) {
-	t.bytesRead += n
 	t.file.Source.RecordBytes(n)
 }
 


### PR DESCRIPTION
### What does this PR do?
Adds logging that will help determine how much data was read during the `closeTimeout` duration after a file rotation occurred.

### Motivation
If users need to tweak the `DD_LOGS_CONFIG_CLOSE_TIMEOUT` option, this data can help them fine-tune the value to best fit their use case.
The _lack_ of this log will indicate that during the `CLOSE_TIMEOUT` duration, no extra data was read.

This compliments the existing `warn` log [here](https://github.com/DataDog/datadog-agent/blob/276d660323f4d63c303c798e5033cd5a119db587/pkg/logs/internal/tailers/file/tailer.go#L248)

### Additional Notes
n/a

### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes
n/a

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
