### PR TITLE
[CWS][SEC-5583] secagent subcommands refactor

### DIFF
--- a/cmd/cluster-agent/app/compliance_cmd.go
+++ b/cmd/cluster-agent/app/compliance_cmd.go
@@ -26,8 +26,7 @@ var (
 )
 
 func init() {
-	// TODO: improve this
-	checkCmd := app.CheckCommands(nil)[0]
+	checkCmd := app.CheckCmd()
 	checkCmd.PreRunE = func(cmd *cobra.Command, args []string) error {
 		// we'll search for a config file named `datadog-cluster.yaml`
 		config.Datadog.SetConfigName("datadog-cluster")

--- a/cmd/cluster-agent/app/compliance_cmd.go
+++ b/cmd/cluster-agent/app/compliance_cmd.go
@@ -26,7 +26,8 @@ var (
 )
 
 func init() {
-	checkCmd := app.CheckCmd()
+	// TODO: improve this
+	checkCmd := app.CheckCommands(nil)[0]
 	checkCmd.PreRunE = func(cmd *cobra.Command, args []string) error {
 		// we'll search for a config file named `datadog-cluster.yaml`
 		config.Datadog.SetConfigName("datadog-cluster")

--- a/cmd/security-agent/app/activity_dump.go
+++ b/cmd/security-agent/app/activity_dump.go
@@ -1,0 +1,388 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+// +build linux
+
+package app
+
+import (
+	"fmt"
+
+	secagent "github.com/DataDog/datadog-agent/pkg/security/agent"
+	"github.com/DataDog/datadog-agent/pkg/security/api"
+	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
+	"github.com/DataDog/datadog-agent/pkg/security/probe/dump"
+	"github.com/spf13/cobra"
+)
+
+type activityDumpCliParams struct {
+	*GlobalParams
+
+	comm                     string
+	file                     string
+	timeout                  int
+	differentiateArgs        bool
+	localStorageDirectory    string
+	localStorageFormats      []string
+	localStorageCompression  bool
+	remoteStorageFormats     []string
+	remoteStorageCompression bool
+	remoteRequest            bool
+}
+
+func activityDumpCommands(globalParams *GlobalParams) []*cobra.Command {
+	activityDumpCmd := &cobra.Command{
+		Use:   "activity-dump",
+		Short: "activity dump command",
+	}
+
+	activityDumpCmd.AddCommand(generateCommands(globalParams)...)
+	activityDumpCmd.AddCommand(listCommands(globalParams)...)
+	activityDumpCmd.AddCommand(stopCommands(globalParams)...)
+
+	return []*cobra.Command{activityDumpCmd}
+}
+
+func listCommands(globalParams *GlobalParams) []*cobra.Command {
+	activityDumpListCmd := &cobra.Command{
+		Use:   "list",
+		Short: "get the list of running activity dumps",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return listActivityDumps()
+		},
+	}
+
+	return []*cobra.Command{activityDumpListCmd}
+}
+
+func stopCommands(globalParams *GlobalParams) []*cobra.Command {
+	cliParams := activityDumpCliParams{
+		GlobalParams: globalParams,
+	}
+
+	activityDumpStopCmd := &cobra.Command{
+		Use:   "stop",
+		Short: "stops the first activity dump that matches the provided selector",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return stopActivityDump(&cliParams)
+		},
+	}
+
+	activityDumpStopCmd.Flags().StringVar(
+		&cliParams.comm,
+		"comm",
+		"",
+		"a process command can be used to filter the activity dump from a specific process.",
+	)
+
+	return []*cobra.Command{activityDumpStopCmd}
+}
+
+func generateCommands(globalParams *GlobalParams) []*cobra.Command {
+	activityDumpGenerateCmd := &cobra.Command{
+		Use:   "generate",
+		Short: "generate command for activity dumps",
+	}
+
+	activityDumpGenerateCmd.AddCommand(generateDumpCommands(globalParams)...)
+	activityDumpGenerateCmd.AddCommand(generateEncodingCommands(globalParams)...)
+
+	return []*cobra.Command{activityDumpGenerateCmd}
+}
+
+func generateDumpCommands(globalParams *GlobalParams) []*cobra.Command {
+	cliParams := activityDumpCliParams{
+		GlobalParams: globalParams,
+	}
+
+	activityDumpGenerateDumpCmd := &cobra.Command{
+		Use:   "dump",
+		Short: "generate an activity dump",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return generateActivityDump(&cliParams)
+		},
+	}
+
+	activityDumpGenerateDumpCmd.Flags().StringVar(
+		&cliParams.comm,
+		"comm",
+		"",
+		"a process command can be used to filter the activity dump from a specific process.",
+	)
+	activityDumpGenerateDumpCmd.Flags().IntVar(
+		&cliParams.timeout,
+		"timeout",
+		60,
+		"timeout for the activity dump in minutes",
+	)
+	activityDumpGenerateDumpCmd.Flags().BoolVar(
+		&cliParams.differentiateArgs,
+		"differentiate-args",
+		true,
+		"add the arguments in the process node merge algorithm",
+	)
+	activityDumpGenerateDumpCmd.Flags().StringVar(
+		&cliParams.localStorageDirectory,
+		"output",
+		"/tmp/activity_dumps/",
+		"local storage output directory",
+	)
+	activityDumpGenerateDumpCmd.Flags().BoolVar(
+		&cliParams.localStorageCompression,
+		"compression",
+		false,
+		"defines if the local storage output should be compressed before persisting the data to disk",
+	)
+	activityDumpGenerateDumpCmd.Flags().StringArrayVar(
+		&cliParams.localStorageFormats,
+		"format",
+		[]string{},
+		fmt.Sprintf("local storage output formats. Available options are %v.", dump.AllStorageFormats()),
+	)
+	activityDumpGenerateDumpCmd.Flags().BoolVar(
+		&cliParams.remoteStorageCompression,
+		"remote-compression",
+		true,
+		"defines if the remote storage output should be compressed before sending the data",
+	)
+	activityDumpGenerateDumpCmd.Flags().StringArrayVar(
+		&cliParams.remoteStorageFormats,
+		"remote-format",
+		[]string{},
+		fmt.Sprintf("remote storage output formats. Available options are %v.", dump.AllStorageFormats()),
+	)
+
+	return []*cobra.Command{activityDumpGenerateDumpCmd}
+}
+
+func generateEncodingCommands(globalParams *GlobalParams) []*cobra.Command {
+	cliParams := activityDumpCliParams{
+		GlobalParams: globalParams,
+	}
+
+	activityDumpGenerateEncodingCmd := &cobra.Command{
+		Use:   "encoding",
+		Short: "encode an activity dump to the requested formats",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return generateEncodingFromActivityDump(&cliParams)
+		},
+	}
+
+	activityDumpGenerateEncodingCmd.Flags().StringVar(
+		&cliParams.file,
+		"input",
+		"",
+		"path to the activity dump file",
+	)
+	_ = activityDumpGenerateEncodingCmd.MarkFlagRequired("input")
+	activityDumpGenerateEncodingCmd.Flags().StringVar(
+		&cliParams.localStorageDirectory,
+		"output",
+		"/tmp/activity_dumps/",
+		"local storage output directory",
+	)
+	activityDumpGenerateEncodingCmd.Flags().BoolVar(
+		&cliParams.localStorageCompression,
+		"compression",
+		false,
+		"defines if the local storage output should be compressed before persisting the data to disk",
+	)
+	activityDumpGenerateEncodingCmd.Flags().StringArrayVar(
+		&cliParams.localStorageFormats,
+		"format",
+		[]string{},
+		fmt.Sprintf("local storage output formats. Available options are %v.", dump.AllStorageFormats()),
+	)
+	activityDumpGenerateEncodingCmd.Flags().BoolVar(
+		&cliParams.remoteStorageCompression,
+		"remote-compression",
+		true,
+		"defines if the remote storage output should be compressed before sending the data",
+	)
+	activityDumpGenerateEncodingCmd.Flags().StringArrayVar(
+		&cliParams.remoteStorageFormats,
+		"remote-format",
+		[]string{},
+		fmt.Sprintf("remote storage output formats. Available options are %v.", dump.AllStorageFormats()),
+	)
+	activityDumpGenerateEncodingCmd.Flags().BoolVar(
+		&cliParams.remoteRequest,
+		"remote",
+		false,
+		"when set, the transcoding will be done by system-probe instead of the current security-agent instance",
+	)
+
+	return []*cobra.Command{activityDumpGenerateEncodingCmd}
+}
+
+func generateActivityDump(activityDumpArgs *activityDumpCliParams) error {
+	client, err := secagent.NewRuntimeSecurityClient()
+	if err != nil {
+		return fmt.Errorf("unable to create a runtime security client instance: %w", err)
+	}
+	defer client.Close()
+
+	storage, err := parseStorageRequest(activityDumpArgs)
+	if err != nil {
+		return err
+	}
+
+	output, err := client.GenerateActivityDump(&api.ActivityDumpParams{
+		Comm:              activityDumpArgs.comm,
+		Timeout:           int32(activityDumpArgs.timeout),
+		DifferentiateArgs: activityDumpArgs.differentiateArgs,
+		Storage:           storage,
+	})
+	if err != nil {
+		return fmt.Errorf("unable send request to system-probe: %w", err)
+	}
+	if len(output.Error) > 0 {
+		return fmt.Errorf("activity dump generation request failed: %s", output.Error)
+	}
+
+	printSecurityActivityDumpMessage("", output)
+	return nil
+}
+
+func generateEncodingFromActivityDump(activityDumpArgs *activityDumpCliParams) error {
+	var output *api.TranscodingRequestMessage
+
+	if activityDumpArgs.remoteRequest {
+		// send the encoding request to system-probe
+		client, err := secagent.NewRuntimeSecurityClient()
+		if err != nil {
+			return fmt.Errorf("encoding generation failed: %w", err)
+		}
+		defer client.Close()
+
+		// parse encoding request
+		storage, err := parseStorageRequest(activityDumpArgs)
+		if err != nil {
+			return err
+		}
+
+		output, err = client.GenerateEncoding(&api.TranscodingRequestParams{
+			ActivityDumpFile: activityDumpArgs.file,
+			Storage:          storage,
+		})
+		if err != nil {
+			return fmt.Errorf("couldn't send request to system-probe: %w", err)
+		}
+
+	} else {
+		// encoding request will be handled locally
+		ad := sprobe.NewEmptyActivityDump()
+
+		// open and parse input file
+		if err := ad.Decode(activityDumpArgs.file); err != nil {
+			return err
+		}
+		parsedRequests, err := parseStorageRequest(activityDumpArgs)
+		if err != nil {
+			return err
+		}
+
+		storageRequests, err := dump.ParseStorageRequests(parsedRequests)
+		if err != nil {
+			return fmt.Errorf("couldn't parse transcoding request for [%s]: %v", ad.GetSelectorStr(), err)
+		}
+		for _, request := range storageRequests {
+			ad.AddStorageRequest(request)
+		}
+
+		storage, err := sprobe.NewActivityDumpStorageManager(nil)
+		if err != nil {
+			return fmt.Errorf("couldn't instantiate storage manager: %w", err)
+		}
+
+		err = storage.Persist(ad)
+		if err != nil {
+			return fmt.Errorf("couldn't persist dump from %s: %w", activityDumpArgs.file, err)
+		}
+
+		output = ad.ToTranscodingRequestMessage()
+	}
+
+	if len(output.GetError()) > 0 {
+		return fmt.Errorf("encoding generation failed: %s", output.GetError())
+	}
+	if len(output.GetStorage()) > 0 {
+		fmt.Printf("encoding generation succeeded:\n")
+		for _, storage := range output.GetStorage() {
+			printStorageRequestMessage("\t", storage)
+		}
+	} else {
+		fmt.Println("encoding generation succeeded: empty output")
+	}
+	return nil
+}
+
+func listActivityDumps() error {
+	client, err := secagent.NewRuntimeSecurityClient()
+	if err != nil {
+		return fmt.Errorf("unable to create a runtime security client instance: %w", err)
+	}
+	defer client.Close()
+
+	output, err := client.ListActivityDumps()
+	if err != nil {
+		return fmt.Errorf("unable send request to system-probe: %w", err)
+	}
+	if len(output.Error) > 0 {
+		return fmt.Errorf("activity dump list request failed: %s", output.Error)
+	}
+
+	if len(output.Dumps) > 0 {
+		fmt.Println("active dumps:")
+		for _, d := range output.Dumps {
+			printSecurityActivityDumpMessage("\t", d)
+		}
+	} else {
+		fmt.Println("no active dumps found")
+	}
+
+	return nil
+}
+
+func parseStorageRequest(activityDumpArgs *activityDumpCliParams) (*api.StorageRequestParams, error) {
+	// parse local storage formats
+	_, err := dump.ParseStorageFormats(activityDumpArgs.localStorageFormats)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't parse local storage formats %v: %v", activityDumpArgs.localStorageFormats, err)
+	}
+
+	// parse remote storage formats
+	_, err = dump.ParseStorageFormats(activityDumpArgs.remoteStorageFormats)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't parse remote storage formats %v: %v", activityDumpArgs.remoteStorageFormats, err)
+	}
+	return &api.StorageRequestParams{
+		LocalStorageDirectory:    activityDumpArgs.localStorageDirectory,
+		LocalStorageCompression:  activityDumpArgs.localStorageCompression,
+		LocalStorageFormats:      activityDumpArgs.localStorageFormats,
+		RemoteStorageCompression: activityDumpArgs.remoteStorageCompression,
+		RemoteStorageFormats:     activityDumpArgs.remoteStorageFormats,
+	}, nil
+}
+
+func stopActivityDump(activityDumpArgs *activityDumpCliParams) error {
+	client, err := secagent.NewRuntimeSecurityClient()
+	if err != nil {
+		return fmt.Errorf("unable to create a runtime security client instance: %w", err)
+	}
+	defer client.Close()
+
+	output, err := client.StopActivityDump(activityDumpArgs.comm)
+	if err != nil {
+		return fmt.Errorf("unable send request to system-probe: %w", err)
+	}
+	if len(output.Error) > 0 {
+		return fmt.Errorf("activity dump stop request failed: %s", output.Error)
+	}
+
+	fmt.Println("done!")
+	return nil
+}

--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -127,10 +127,6 @@ Datadog Security Agent takes care of running compliance and security checks.`,
 
 	SecurityAgentCmd.AddCommand(versionCmd)
 
-	if runtimeCmd != nil {
-		SecurityAgentCmd.AddCommand(runtimeCmd)
-	}
-
 	startCmd.Flags().StringVarP(&pidfilePath, "pidfile", "p", "", "path to the pidfile")
 	SecurityAgentCmd.AddCommand(startCmd)
 
@@ -139,6 +135,7 @@ Datadog Security Agent takes care of running compliance and security checks.`,
 		FlareCommands,
 		ConfigCommands,
 		ComplianceCommands,
+		RuntimeCommands,
 	}
 
 	for _, factory := range factories {

--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -100,7 +100,7 @@ type GlobalParams struct {
 
 type SubcommandFactory func(*GlobalParams) []*cobra.Command
 
-func init() {
+func CreateSecurityAgentCmd() *cobra.Command {
 	globalParams := GlobalParams{}
 
 	SecurityAgentCmd := &cobra.Command{
@@ -139,6 +139,7 @@ Datadog Security Agent takes care of running compliance and security checks.`,
 		StatusCommands,
 		FlareCommands,
 		CheckCommands,
+		ConfigCommands,
 	}
 
 	for _, factory := range factories {
@@ -146,6 +147,8 @@ Datadog Security Agent takes care of running compliance and security checks.`,
 			SecurityAgentCmd.AddCommand(subcmd)
 		}
 	}
+
+	return SecurityAgentCmd
 }
 
 func newLogContext(logsConfig *config.LogsConfigKeys, endpointPrefix string, intakeTrackType config.IntakeTrackType, intakeOrigin config.IntakeOrigin, intakeProtocol config.IntakeProtocol) (*config.Endpoints, *client.DestinationsContext, error) {

--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -138,6 +138,7 @@ Datadog Security Agent takes care of running compliance and security checks.`,
 	factories := []SubcommandFactory{
 		StatusCommands,
 		FlareCommands,
+		CheckCommands,
 	}
 
 	for _, factory := range factories {

--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -126,7 +126,6 @@ Datadog Security Agent takes care of running compliance and security checks.`,
 	SecurityAgentCmd.PersistentFlags().BoolVarP(&globalParams.flagNoColor, "no-color", "n", false, "disable color output")
 
 	SecurityAgentCmd.AddCommand(versionCmd)
-	SecurityAgentCmd.AddCommand(complianceCmd)
 
 	if runtimeCmd != nil {
 		SecurityAgentCmd.AddCommand(runtimeCmd)
@@ -138,8 +137,8 @@ Datadog Security Agent takes care of running compliance and security checks.`,
 	factories := []SubcommandFactory{
 		StatusCommands,
 		FlareCommands,
-		CheckCommands,
 		ConfigCommands,
+		ComplianceCommands,
 	}
 
 	for _, factory := range factories {

--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -65,13 +65,13 @@ var (
 
 type GlobalParams struct {
 	confPathArray []string
-	flagNoColor   bool
 }
 
 type SubcommandFactory func(*GlobalParams) []*cobra.Command
 
 func CreateSecurityAgentCmd() *cobra.Command {
 	globalParams := GlobalParams{}
+	var flagNoColor bool
 
 	SecurityAgentCmd := &cobra.Command{
 		Use:   "datadog-security-agent [command]",
@@ -80,7 +80,7 @@ func CreateSecurityAgentCmd() *cobra.Command {
 Datadog Security Agent takes care of running compliance and security checks.`,
 		SilenceUsage: true, // don't print usage on errors
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if globalParams.flagNoColor {
+			if flagNoColor {
 				color.NoColor = true
 			}
 
@@ -93,7 +93,7 @@ Datadog Security Agent takes care of running compliance and security checks.`,
 		path.Join(commonagent.DefaultConfPath, "security-agent.yaml"),
 	}
 	SecurityAgentCmd.PersistentFlags().StringArrayVarP(&globalParams.confPathArray, "cfgpath", "c", defaultConfPathArray, "path to a yaml configuration file")
-	SecurityAgentCmd.PersistentFlags().BoolVarP(&globalParams.flagNoColor, "no-color", "n", false, "disable color output")
+	SecurityAgentCmd.PersistentFlags().BoolVarP(&flagNoColor, "no-color", "n", false, "disable color output")
 
 	factories := []SubcommandFactory{
 		StatusCommands,

--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -106,7 +106,7 @@ Datadog Security Agent takes care of running compliance and security checks.`,
 	}
 
 	for _, factory := range factories {
-		for _, subcmd := range factory(nil) {
+		for _, subcmd := range factory(&globalParams) {
 			SecurityAgentCmd.AddCommand(subcmd)
 		}
 	}

--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -137,6 +137,7 @@ Datadog Security Agent takes care of running compliance and security checks.`,
 
 	factories := []SubcommandFactory{
 		StatusCommands,
+		FlareCommands,
 	}
 
 	for _, factory := range factories {

--- a/cmd/security-agent/app/check.go
+++ b/cmd/security-agent/app/check.go
@@ -45,6 +45,11 @@ type checkCliParams struct {
 	skipRegoEval      bool
 }
 
+// TODO: fix this, this is currently a stub for the cluster-agent
+func CheckCmd() *cobra.Command {
+	return CheckCommands(&GlobalParams{})[0]
+}
+
 // CheckCommands returns a cobra command to run security agent checks
 func CheckCommands(globalParams *GlobalParams) []*cobra.Command {
 	checkArgs := checkCliParams{

--- a/cmd/security-agent/app/check.go
+++ b/cmd/security-agent/app/check.go
@@ -45,7 +45,7 @@ type checkCliParams struct {
 	skipRegoEval      bool
 }
 
-// CheckCmd returns a cobra command to run security agent checks
+// CheckCommands returns a cobra command to run security agent checks
 func CheckCommands(globalParams *GlobalParams) []*cobra.Command {
 	checkArgs := checkCliParams{
 		GlobalParams: globalParams,

--- a/cmd/security-agent/app/check.go
+++ b/cmd/security-agent/app/check.go
@@ -210,7 +210,7 @@ func NewCheckReporter(stopper startstop.Stopper, report bool, dumpReportsPath st
 		}
 
 		runPath := coreconfig.Datadog.GetString("compliance_config.run_path")
-		reporter, err := event.NewLogReporter(stopper, eventArgs.sourceName, eventArgs.sourceType, runPath, endpoints, dstContext)
+		reporter, err := event.NewLogReporter(stopper, "compliance-agent", "compliance", runPath, endpoints, dstContext)
 		if err != nil {
 			return nil, fmt.Errorf("failed to set up compliance log reporter: %w", err)
 		}

--- a/cmd/security-agent/app/check.go
+++ b/cmd/security-agent/app/check.go
@@ -30,27 +30,34 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/startstop"
 )
 
-var (
-	checkArgs = struct {
-		framework         string
-		file              string
-		verbose           bool
-		report            bool
-		overrideRegoInput string
-		dumpRegoInput     string
-		dumpReports       string
-		skipRegoEval      bool
-	}{}
-)
+type checkCliParams struct {
+	*GlobalParams
+
+	args []string
+
+	framework         string
+	file              string
+	verbose           bool
+	report            bool
+	overrideRegoInput string
+	dumpRegoInput     string
+	dumpReports       string
+	skipRegoEval      bool
+}
 
 // CheckCmd returns a cobra command to run security agent checks
-func CheckCmd() *cobra.Command {
+func CheckCommands(globalParams *GlobalParams) []*cobra.Command {
+	checkArgs := checkCliParams{
+		GlobalParams: globalParams,
+	}
+
 	cmd := &cobra.Command{
 		Use:   "check",
 		Short: "Run compliance check(s)",
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runCheck(cmd, args)
+			checkArgs.args = args
+			return runCheck(&checkArgs)
 		},
 	}
 
@@ -63,11 +70,11 @@ func CheckCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&checkArgs.dumpReports, "dump-reports", "", "", "Path to file where to dump reports")
 	cmd.Flags().BoolVarP(&checkArgs.skipRegoEval, "skip-rego-eval", "", false, "Skip rego evaluation")
 
-	return cmd
+	return []*cobra.Command{cmd}
 }
 
-func runCheck(cmd *cobra.Command, args []string) error {
-	err := configureLogger()
+func runCheck(checkArgs *checkCliParams) error {
+	err := configureLogger(checkArgs)
 	if err != nil {
 		return err
 	}
@@ -106,8 +113,8 @@ func runCheck(cmd *cobra.Command, args []string) error {
 	}
 
 	var ruleID string
-	if len(args) != 0 {
-		ruleID = args[0]
+	if len(checkArgs.args) != 0 {
+		ruleID = checkArgs.args[0]
 	}
 
 	hname, err := hostname.Get(context.TODO())
@@ -166,7 +173,7 @@ func runCheck(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func configureLogger() error {
+func configureLogger(checkArgs *checkCliParams) error {
 	var (
 		logFormat = "%LEVEL | %Msg%n"
 		logLevel  = "info"
@@ -249,8 +256,4 @@ func (r *RunCheckReporter) dumpReports() error {
 		return os.WriteFile(r.dumpReportsPath, reportsJSON, 0644)
 	}
 	return nil
-}
-
-func init() {
-	complianceCmd.AddCommand(CheckCmd())
 }

--- a/cmd/security-agent/app/check_unsupported.go
+++ b/cmd/security-agent/app/check_unsupported.go
@@ -1,0 +1,12 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build windows || !kubeapiserver
+
+package app
+
+func CheckCommands(globalParams *GlobalParams) []*cobra.Command {
+	return nil
+}

--- a/cmd/security-agent/app/compliance.go
+++ b/cmd/security-agent/app/compliance.go
@@ -10,8 +10,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	ddgostatsd "github.com/DataDog/datadog-go/v5/statsd"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/runner"
@@ -26,52 +24,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/startstop"
 )
-
-func ComplianceCommands(globalParams *GlobalParams) []*cobra.Command {
-	complianceCmd := &cobra.Command{
-		Use:   "compliance",
-		Short: "Compliance Agent utility commands",
-	}
-
-	complianceCmd.AddCommand(complianceEventCommand(globalParams))
-	complianceCmd.AddCommand(CheckCommands(globalParams)...)
-
-	return []*cobra.Command{complianceCmd}
-}
-
-type eventCliParams struct {
-	*GlobalParams
-
-	sourceName string
-	sourceType string
-	event      event.Event
-	data       []string
-}
-
-func complianceEventCommand(globalParams *GlobalParams) *cobra.Command {
-	eventArgs := eventCliParams{
-		GlobalParams: globalParams,
-	}
-
-	eventCmd := &cobra.Command{
-		Use:   "event",
-		Short: "Issue logs to test Security Agent compliance events",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return eventRun(&eventArgs)
-		},
-		Hidden: true,
-	}
-
-	eventCmd.Flags().StringVarP(&eventArgs.sourceType, "source-type", "", "compliance", "Log source name")
-	eventCmd.Flags().StringVarP(&eventArgs.sourceName, "source-name", "", "compliance-agent", "Log source name")
-	eventCmd.Flags().StringVarP(&eventArgs.event.AgentRuleID, "rule-id", "", "", "Rule ID")
-	eventCmd.Flags().StringVarP(&eventArgs.event.ResourceID, "resource-id", "", "", "Resource ID")
-	eventCmd.Flags().StringVarP(&eventArgs.event.ResourceType, "resource-type", "", "", "Resource type")
-	eventCmd.Flags().StringSliceVarP(&eventArgs.event.Tags, "tags", "t", []string{"security:compliance"}, "Tags")
-	eventCmd.Flags().StringSliceVarP(&eventArgs.data, "data", "d", []string{}, "Data KV fields")
-
-	return eventCmd
-}
 
 func newLogContextCompliance() (*config.Endpoints, *client.DestinationsContext, error) {
 	logsConfigComplianceKeys := config.NewLogsConfigKeys("compliance_config.endpoints.", coreconfig.Datadog)

--- a/cmd/security-agent/app/compliance_cmds.go
+++ b/cmd/security-agent/app/compliance_cmds.go
@@ -1,0 +1,58 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package app
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/DataDog/datadog-agent/pkg/compliance/event"
+)
+
+func ComplianceCommands(globalParams *GlobalParams) []*cobra.Command {
+	complianceCmd := &cobra.Command{
+		Use:   "compliance",
+		Short: "Compliance Agent utility commands",
+	}
+
+	complianceCmd.AddCommand(complianceEventCommand(globalParams))
+	complianceCmd.AddCommand(CheckCommands(globalParams)...)
+
+	return []*cobra.Command{complianceCmd}
+}
+
+type eventCliParams struct {
+	*GlobalParams
+
+	sourceName string
+	sourceType string
+	event      event.Event
+	data       []string
+}
+
+func complianceEventCommand(globalParams *GlobalParams) *cobra.Command {
+	eventArgs := eventCliParams{
+		GlobalParams: globalParams,
+	}
+
+	eventCmd := &cobra.Command{
+		Use:   "event",
+		Short: "Issue logs to test Security Agent compliance events",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return eventRun(&eventArgs)
+		},
+		Hidden: true,
+	}
+
+	eventCmd.Flags().StringVarP(&eventArgs.sourceType, "source-type", "", "compliance", "Log source name")
+	eventCmd.Flags().StringVarP(&eventArgs.sourceName, "source-name", "", "compliance-agent", "Log source name")
+	eventCmd.Flags().StringVarP(&eventArgs.event.AgentRuleID, "rule-id", "", "", "Rule ID")
+	eventCmd.Flags().StringVarP(&eventArgs.event.ResourceID, "resource-id", "", "", "Resource ID")
+	eventCmd.Flags().StringVarP(&eventArgs.event.ResourceType, "resource-type", "", "", "Resource type")
+	eventCmd.Flags().StringSliceVarP(&eventArgs.event.Tags, "tags", "t", []string{"security:compliance"}, "Tags")
+	eventCmd.Flags().StringSliceVarP(&eventArgs.data, "data", "d", []string{}, "Data KV fields")
+
+	return eventCmd
+}

--- a/cmd/security-agent/app/config.go
+++ b/cmd/security-agent/app/config.go
@@ -20,8 +20,9 @@ import (
 	settingshttp "github.com/DataDog/datadog-agent/pkg/config/settings/http"
 )
 
-func init() {
-	SecurityAgentCmd.AddCommand(cmdconfig.Config(getSettingsClient))
+func ConfigCommands(globalParams *GlobalParams) []*cobra.Command {
+	cmd := cmdconfig.Config(getSettingsClient)
+	return []*cobra.Command{cmd}
 }
 
 func setupConfig(cmd *cobra.Command) error {

--- a/cmd/security-agent/app/config_unsupported.go
+++ b/cmd/security-agent/app/config_unsupported.go
@@ -3,7 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build windows || !kubeapiserver
+//go:build !kubeapiserver
+// +build !kubeapiserver
 
 package app
 
@@ -11,6 +12,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func CheckCommands(globalParams *GlobalParams) []*cobra.Command {
+func ConfigCommands(globalParams *GlobalParams) []*cobra.Command {
 	return nil
 }

--- a/cmd/security-agent/app/flare.go
+++ b/cmd/security-agent/app/flare.go
@@ -18,50 +18,56 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/input"
 )
 
-var (
+type flareCliParams struct {
+	*GlobalParams
+
 	customerEmail string
 	autoconfirm   bool
-)
-
-func init() {
-	SecurityAgentCmd.AddCommand(flareCmd)
-
-	flareCmd.Flags().StringVarP(&customerEmail, "email", "e", "", "Your email")
-	flareCmd.Flags().BoolVarP(&autoconfirm, "send", "s", false, "Automatically send flare (don't prompt for confirmation)")
-	flareCmd.SetArgs([]string{"caseID"})
 }
 
-var flareCmd = &cobra.Command{
-	Use:   "flare [caseID]",
-	Short: "Collect a flare and send it to Datadog",
-	Long:  ``,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		// The flare command should not log anything, all errors should be reported directly to the console without the log format
-		err := config.SetupLogger(loggerName, "off", "", "", false, true, false)
-		if err != nil {
-			fmt.Printf("Cannot setup logger, exiting: %v\n", err)
-			return err
-		}
+func FlareCommands(globalParams *GlobalParams) []*cobra.Command {
+	cliParams := flareCliParams{
+		GlobalParams: globalParams,
+	}
 
-		caseID := ""
-		if len(args) > 0 {
-			caseID = args[0]
-		}
-
-		if customerEmail == "" {
-			var err error
-			customerEmail, err = input.AskForEmail()
+	flareCmd := &cobra.Command{
+		Use:   "flare [caseID]",
+		Short: "Collect a flare and send it to Datadog",
+		Long:  ``,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// The flare command should not log anything, all errors should be reported directly to the console without the log format
+			err := config.SetupLogger(loggerName, "off", "", "", false, true, false)
 			if err != nil {
-				fmt.Println("Error reading email, please retry or contact support")
+				fmt.Printf("Cannot setup logger, exiting: %v\n", err)
 				return err
 			}
-		}
 
-		return requestFlare(caseID)
-	},
+			caseID := ""
+			if len(args) > 0 {
+				caseID = args[0]
+			}
+
+			if cliParams.customerEmail == "" {
+				var err error
+				cliParams.customerEmail, err = input.AskForEmail()
+				if err != nil {
+					fmt.Println("Error reading email, please retry or contact support")
+					return err
+				}
+			}
+
+			return requestFlare(caseID, &cliParams)
+		},
+	}
+
+	flareCmd.Flags().StringVarP(&cliParams.customerEmail, "email", "e", "", "Your email")
+	flareCmd.Flags().BoolVarP(&cliParams.autoconfirm, "send", "s", false, "Automatically send flare (don't prompt for confirmation)")
+	flareCmd.SetArgs([]string{"caseID"})
+
+	return []*cobra.Command{flareCmd}
 }
 
-func requestFlare(caseID string) error {
+func requestFlare(caseID string, params *flareCliParams) error {
 	fmt.Fprintln(color.Output, color.BlueString("Asking the Security Agent to build the flare archive."))
 	var e error
 	c := util.GetClient(false) // FIX: get certificates right then make this true
@@ -95,7 +101,7 @@ func requestFlare(caseID string) error {
 	}
 
 	fmt.Fprintf(color.Output, "%s is going to be uploaded to Datadog\n", color.YellowString(filePath))
-	if !autoconfirm {
+	if !params.autoconfirm {
 		confirmation := input.AskForConfirmation("Are you sure you want to upload a flare? [y/N]")
 		if !confirmation {
 			fmt.Fprintf(color.Output, "Aborting. (You can still use %s)\n", color.YellowString(filePath))
@@ -103,7 +109,7 @@ func requestFlare(caseID string) error {
 		}
 	}
 
-	response, e := flare.SendFlare(filePath, caseID, customerEmail)
+	response, e := flare.SendFlare(filePath, caseID, params.customerEmail)
 	fmt.Println(response)
 	if e != nil {
 		return e

--- a/cmd/security-agent/app/runtime.go
+++ b/cmd/security-agent/app/runtime.go
@@ -52,22 +52,36 @@ const (
 	cwsIntakeOrigin config.IntakeOrigin = "cloud-workload-security"
 )
 
+type checkPoliciesCliParams struct {
+	*GlobalParams
+
+	dir string
+}
+
+func CheckPoliciesCommands(globalParams *GlobalParams) []*cobra.Command {
+	cliParams := checkPoliciesCliParams{
+		GlobalParams: globalParams,
+	}
+
+	checkPoliciesCmd := &cobra.Command{
+		Use:   "check-policies",
+		Short: "check policies and return a report",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return checkPolicies(&cliParams)
+		},
+		Deprecated: "please use `security-agent runtime policy check` instead",
+	}
+
+	checkPoliciesCmd.Flags().StringVar(&cliParams.dir, "policies-dir", coreconfig.DefaultRuntimePoliciesDir, "Path to policies directory")
+
+	return []*cobra.Command{checkPoliciesCmd}
+}
+
 var (
 	runtimeCmd = &cobra.Command{
 		Use:   "runtime",
 		Short: "runtime Agent utility commands",
 	}
-
-	checkPoliciesCmd = &cobra.Command{
-		Use:        "check-policies",
-		Short:      "check policies and return a report",
-		RunE:       checkPolicies,
-		Deprecated: "please use `security-agent runtime policy check` instead",
-	}
-
-	checkPoliciesArgs = struct {
-		dir string
-	}{}
 
 	evalArgs = struct {
 		dir       string
@@ -328,7 +342,6 @@ func init() {
 	runtimeCmd.AddCommand(activityDumpCmd)
 
 	runtimeCmd.AddCommand(checkPoliciesCmd)
-	checkPoliciesCmd.Flags().StringVar(&checkPoliciesArgs.dir, "policies-dir", coreconfig.DefaultRuntimePoliciesDir, "Path to policies directory")
 
 	commonPolicyCmd.AddCommand(evalCmd)
 	evalCmd.Flags().StringVar(&evalArgs.dir, "policies-dir", coreconfig.DefaultRuntimePoliciesDir, "Path to policies directory")
@@ -683,8 +696,8 @@ func checkPoliciesInner(dir string) error {
 	return nil
 }
 
-func checkPolicies(cmd *cobra.Command, args []string) error {
-	return checkPoliciesInner(checkPoliciesArgs.dir)
+func checkPolicies(args *checkPoliciesCliParams) error {
+	return checkPoliciesInner(args.dir)
 }
 
 // EvalReport defines a report of an evaluation

--- a/cmd/security-agent/app/runtime.go
+++ b/cmd/security-agent/app/runtime.go
@@ -64,6 +64,7 @@ func RuntimeCommands(globalParams *GlobalParams) []*cobra.Command {
 	runtimeCmd.AddCommand(activityDumpCommands(globalParams)...)
 	runtimeCmd.AddCommand(processCacheCommands(globalParams)...)
 	runtimeCmd.AddCommand(networkNamespaceCommands(globalParams)...)
+	runtimeCmd.AddCommand(discardersCommands(globalParams)...)
 
 	return []*cobra.Command{runtimeCmd}
 }
@@ -218,21 +219,6 @@ func downloadPolicyCommands(globalParams *GlobalParams) []*cobra.Command {
 	return []*cobra.Command{downloadPolicyCmd}
 }
 
-var (
-
-	/*Discarders*/
-	discardersCmd = &cobra.Command{
-		Use:   "discarders",
-		Short: "discarders commands",
-	}
-
-	dumpDiscardersCmd = &cobra.Command{
-		Use:   "dump",
-		Short: "dump discarders",
-		RunE:  dumpDiscarders,
-	}
-)
-
 type processCacheDumpCliParams struct {
 	*GlobalParams
 
@@ -291,10 +277,23 @@ func networkNamespaceCommands(globalParams *GlobalParams) []*cobra.Command {
 	return []*cobra.Command{networkNamespaceCmd}
 }
 
-func init() {
-	/*Discarders*/
+func discardersCommands(globalParams *GlobalParams) []*cobra.Command {
+
+	dumpDiscardersCmd := &cobra.Command{
+		Use:   "dump",
+		Short: "dump discarders",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return dumpDiscarders()
+		},
+	}
+
+	discardersCmd := &cobra.Command{
+		Use:   "discarders",
+		Short: "discarders commands",
+	}
 	discardersCmd.AddCommand(dumpDiscardersCmd)
-	runtimeCmd.AddCommand(discardersCmd)
+
+	return []*cobra.Command{discardersCmd}
 }
 
 func dumpProcessCache(processCacheDumpArgs *processCacheDumpCliParams) error {
@@ -765,7 +764,7 @@ func downloadPolicy(downloadPolicyArgs *downloadPolicyCliParams) error {
 	return err
 }
 
-func dumpDiscarders(cmd *cobra.Command, args []string) error {
+func dumpDiscarders() error {
 	runtimeSecurityClient, err := secagent.NewRuntimeSecurityClient()
 	if err != nil {
 		return fmt.Errorf("unable to create a runtime security client instance: %w", err)

--- a/cmd/security-agent/app/runtime.go
+++ b/cmd/security-agent/app/runtime.go
@@ -185,8 +185,8 @@ func selfTestCommands(globalParams *GlobalParams) []*cobra.Command {
 	selfTestCmd := &cobra.Command{
 		Use:   "self-test",
 		Short: "Run runtime self test",
-		Run: func(cmd *cobra.Command, args []string) {
-			runRuntimeSelfTest()
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runRuntimeSelfTest()
 		},
 	}
 

--- a/cmd/security-agent/app/runtime.go
+++ b/cmd/security-agent/app/runtime.go
@@ -35,7 +35,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/api"
 	secconfig "github.com/DataDog/datadog-agent/pkg/security/config"
 	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
-	"github.com/DataDog/datadog-agent/pkg/security/probe/dump"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
@@ -61,6 +60,7 @@ func RuntimeCommands(globalParams *GlobalParams) []*cobra.Command {
 	runtimeCmd.AddCommand(checkPoliciesCommands(globalParams)...)
 	runtimeCmd.AddCommand(commonPolicyCommands(globalParams)...)
 	runtimeCmd.AddCommand(selfTestCommands(globalParams)...)
+	runtimeCmd.AddCommand(activityDumpCommands(globalParams)...)
 
 	return []*cobra.Command{runtimeCmd}
 }
@@ -222,53 +222,6 @@ var (
 		withArgs bool
 	}{}
 
-	activityDumpCmd = &cobra.Command{
-		Use:   "activity-dump",
-		Short: "activity dump command",
-	}
-
-	activityDumpArgs = struct {
-		comm                     string
-		file                     string
-		timeout                  int
-		differentiateArgs        bool
-		localStorageDirectory    string
-		localStorageFormats      []string
-		localStorageCompression  bool
-		remoteStorageFormats     []string
-		remoteStorageCompression bool
-		remoteRequest            bool
-	}{}
-
-	activityDumpGenerateCmd = &cobra.Command{
-		Use:   "generate",
-		Short: "generate command for activity dumps",
-	}
-
-	activityDumpGenerateDumpCmd = &cobra.Command{
-		Use:   "dump",
-		Short: "generate an activity dump",
-		RunE:  generateActivityDump,
-	}
-
-	activityDumpGenerateEncodingCmd = &cobra.Command{
-		Use:   "encoding",
-		Short: "encode an activity dump to the requested formats",
-		RunE:  generateEncodingFromActivityDump,
-	}
-
-	activityDumpStopCmd = &cobra.Command{
-		Use:   "stop",
-		Short: "stops the first activity dump that matches the provided selector",
-		RunE:  stopActivityDump,
-	}
-
-	activityDumpListCmd = &cobra.Command{
-		Use:   "list",
-		Short: "get the list of running activity dumps",
-		RunE:  listActivityDumps,
-	}
-
 	reloadPoliciesCmd = &cobra.Command{
 		Use:        "reload",
 		Short:      "Reload policies",
@@ -298,116 +251,8 @@ var (
 func init() {
 	processCacheDumpCmd.Flags().BoolVar(&processCacheDumpArgs.withArgs, "with-args", false, "add process arguments to the dump")
 
-	activityDumpGenerateDumpCmd.Flags().StringVar(
-		&activityDumpArgs.comm,
-		"comm",
-		"",
-		"a process command can be used to filter the activity dump from a specific process.",
-	)
-	activityDumpGenerateDumpCmd.Flags().IntVar(
-		&activityDumpArgs.timeout,
-		"timeout",
-		60,
-		"timeout for the activity dump in minutes",
-	)
-	activityDumpGenerateDumpCmd.Flags().BoolVar(
-		&activityDumpArgs.differentiateArgs,
-		"differentiate-args",
-		true,
-		"add the arguments in the process node merge algorithm",
-	)
-	activityDumpGenerateDumpCmd.Flags().StringVar(
-		&activityDumpArgs.localStorageDirectory,
-		"output",
-		"/tmp/activity_dumps/",
-		"local storage output directory",
-	)
-	activityDumpGenerateDumpCmd.Flags().BoolVar(
-		&activityDumpArgs.localStorageCompression,
-		"compression",
-		false,
-		"defines if the local storage output should be compressed before persisting the data to disk",
-	)
-	activityDumpGenerateDumpCmd.Flags().StringArrayVar(
-		&activityDumpArgs.localStorageFormats,
-		"format",
-		[]string{},
-		fmt.Sprintf("local storage output formats. Available options are %v.", dump.AllStorageFormats()),
-	)
-	activityDumpGenerateDumpCmd.Flags().BoolVar(
-		&activityDumpArgs.remoteStorageCompression,
-		"remote-compression",
-		true,
-		"defines if the remote storage output should be compressed before sending the data",
-	)
-	activityDumpGenerateDumpCmd.Flags().StringArrayVar(
-		&activityDumpArgs.remoteStorageFormats,
-		"remote-format",
-		[]string{},
-		fmt.Sprintf("remote storage output formats. Available options are %v.", dump.AllStorageFormats()),
-	)
-
-	activityDumpStopCmd.Flags().StringVar(
-		&activityDumpArgs.comm,
-		"comm",
-		"",
-		"a process command can be used to filter the activity dump from a specific process.",
-	)
-
-	activityDumpGenerateEncodingCmd.Flags().StringVar(
-		&activityDumpArgs.file,
-		"input",
-		"",
-		"path to the activity dump file",
-	)
-	_ = activityDumpGenerateEncodingCmd.MarkFlagRequired("input")
-	activityDumpGenerateEncodingCmd.Flags().StringVar(
-		&activityDumpArgs.localStorageDirectory,
-		"output",
-		"/tmp/activity_dumps/",
-		"local storage output directory",
-	)
-	activityDumpGenerateEncodingCmd.Flags().BoolVar(
-		&activityDumpArgs.localStorageCompression,
-		"compression",
-		false,
-		"defines if the local storage output should be compressed before persisting the data to disk",
-	)
-	activityDumpGenerateEncodingCmd.Flags().StringArrayVar(
-		&activityDumpArgs.localStorageFormats,
-		"format",
-		[]string{},
-		fmt.Sprintf("local storage output formats. Available options are %v.", dump.AllStorageFormats()),
-	)
-	activityDumpGenerateEncodingCmd.Flags().BoolVar(
-		&activityDumpArgs.remoteStorageCompression,
-		"remote-compression",
-		true,
-		"defines if the remote storage output should be compressed before sending the data",
-	)
-	activityDumpGenerateEncodingCmd.Flags().StringArrayVar(
-		&activityDumpArgs.remoteStorageFormats,
-		"remote-format",
-		[]string{},
-		fmt.Sprintf("remote storage output formats. Available options are %v.", dump.AllStorageFormats()),
-	)
-	activityDumpGenerateEncodingCmd.Flags().BoolVar(
-		&activityDumpArgs.remoteRequest,
-		"remote",
-		false,
-		"when set, the transcoding will be done by system-probe instead of the current security-agent instance",
-	)
-
 	processCacheCmd.AddCommand(processCacheDumpCmd)
 	runtimeCmd.AddCommand(processCacheCmd)
-
-	activityDumpGenerateCmd.AddCommand(activityDumpGenerateDumpCmd)
-	activityDumpGenerateCmd.AddCommand(activityDumpGenerateEncodingCmd)
-
-	activityDumpCmd.AddCommand(activityDumpGenerateCmd)
-	activityDumpCmd.AddCommand(activityDumpListCmd)
-	activityDumpCmd.AddCommand(activityDumpStopCmd)
-	runtimeCmd.AddCommand(activityDumpCmd)
 
 	runtimeCmd.AddCommand(reloadPoliciesCmd)
 
@@ -487,175 +332,6 @@ func printSecurityActivityDumpMessage(prefix string, msg *api.ActivityDumpMessag
 			printStorageRequestMessage(prefix+"\t", storage)
 		}
 	}
-}
-
-func parseStorageRequest() (*api.StorageRequestParams, error) {
-	// parse local storage formats
-	_, err := dump.ParseStorageFormats(activityDumpArgs.localStorageFormats)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't parse local storage formats %v: %v", activityDumpArgs.localStorageFormats, err)
-	}
-
-	// parse remote storage formats
-	_, err = dump.ParseStorageFormats(activityDumpArgs.remoteStorageFormats)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't parse remote storage formats %v: %v", activityDumpArgs.remoteStorageFormats, err)
-	}
-	return &api.StorageRequestParams{
-		LocalStorageDirectory:    activityDumpArgs.localStorageDirectory,
-		LocalStorageCompression:  activityDumpArgs.localStorageCompression,
-		LocalStorageFormats:      activityDumpArgs.localStorageFormats,
-		RemoteStorageCompression: activityDumpArgs.remoteStorageCompression,
-		RemoteStorageFormats:     activityDumpArgs.remoteStorageFormats,
-	}, nil
-}
-
-func generateActivityDump(cmd *cobra.Command, args []string) error {
-	client, err := secagent.NewRuntimeSecurityClient()
-	if err != nil {
-		return fmt.Errorf("unable to create a runtime security client instance: %w", err)
-	}
-	defer client.Close()
-
-	storage, err := parseStorageRequest()
-	if err != nil {
-		return err
-	}
-
-	output, err := client.GenerateActivityDump(&api.ActivityDumpParams{
-		Comm:              activityDumpArgs.comm,
-		Timeout:           int32(activityDumpArgs.timeout),
-		DifferentiateArgs: activityDumpArgs.differentiateArgs,
-		Storage:           storage,
-	})
-	if err != nil {
-		return fmt.Errorf("unable send request to system-probe: %w", err)
-	}
-	if len(output.Error) > 0 {
-		return fmt.Errorf("activity dump generation request failed: %s", output.Error)
-	}
-
-	printSecurityActivityDumpMessage("", output)
-	return nil
-}
-
-func listActivityDumps(cmd *cobra.Command, args []string) error {
-	client, err := secagent.NewRuntimeSecurityClient()
-	if err != nil {
-		return fmt.Errorf("unable to create a runtime security client instance: %w", err)
-	}
-	defer client.Close()
-
-	output, err := client.ListActivityDumps()
-	if err != nil {
-		return fmt.Errorf("unable send request to system-probe: %w", err)
-	}
-	if len(output.Error) > 0 {
-		return fmt.Errorf("activity dump list request failed: %s", output.Error)
-	}
-
-	if len(output.Dumps) > 0 {
-		fmt.Println("active dumps:")
-		for _, d := range output.Dumps {
-			printSecurityActivityDumpMessage("\t", d)
-		}
-	} else {
-		fmt.Println("no active dumps found")
-	}
-
-	return nil
-}
-
-func stopActivityDump(cmd *cobra.Command, args []string) error {
-	client, err := secagent.NewRuntimeSecurityClient()
-	if err != nil {
-		return fmt.Errorf("unable to create a runtime security client instance: %w", err)
-	}
-	defer client.Close()
-
-	output, err := client.StopActivityDump(activityDumpArgs.comm)
-	if err != nil {
-		return fmt.Errorf("unable send request to system-probe: %w", err)
-	}
-	if len(output.Error) > 0 {
-		return fmt.Errorf("activity dump stop request failed: %s", output.Error)
-	}
-
-	fmt.Println("done!")
-	return nil
-}
-
-func generateEncodingFromActivityDump(cmd *cobra.Command, args []string) error {
-	var output *api.TranscodingRequestMessage
-
-	if activityDumpArgs.remoteRequest {
-		// send the encoding request to system-probe
-		client, err := secagent.NewRuntimeSecurityClient()
-		if err != nil {
-			return fmt.Errorf("encoding generation failed: %w", err)
-		}
-		defer client.Close()
-
-		// parse encoding request
-		storage, err := parseStorageRequest()
-		if err != nil {
-			return err
-		}
-
-		output, err = client.GenerateEncoding(&api.TranscodingRequestParams{
-			ActivityDumpFile: activityDumpArgs.file,
-			Storage:          storage,
-		})
-		if err != nil {
-			return fmt.Errorf("couldn't send request to system-probe: %w", err)
-		}
-
-	} else {
-		// encoding request will be handled locally
-		ad := sprobe.NewEmptyActivityDump()
-
-		// open and parse input file
-		if err := ad.Decode(activityDumpArgs.file); err != nil {
-			return err
-		}
-		parsedRequests, err := parseStorageRequest()
-		if err != nil {
-			return err
-		}
-
-		storageRequests, err := dump.ParseStorageRequests(parsedRequests)
-		if err != nil {
-			return fmt.Errorf("couldn't parse transcoding request for [%s]: %v", ad.GetSelectorStr(), err)
-		}
-		for _, request := range storageRequests {
-			ad.AddStorageRequest(request)
-		}
-
-		storage, err := sprobe.NewActivityDumpStorageManager(nil)
-		if err != nil {
-			return fmt.Errorf("couldn't instantiate storage manager: %w", err)
-		}
-
-		err = storage.Persist(ad)
-		if err != nil {
-			return fmt.Errorf("couldn't persist dump from %s: %w", activityDumpArgs.file, err)
-		}
-
-		output = ad.ToTranscodingRequestMessage()
-	}
-
-	if len(output.GetError()) > 0 {
-		return fmt.Errorf("encoding generation failed: %s", output.GetError())
-	}
-	if len(output.GetStorage()) > 0 {
-		fmt.Printf("encoding generation succeeded:\n")
-		for _, storage := range output.GetStorage() {
-			printStorageRequestMessage("\t", storage)
-		}
-	} else {
-		fmt.Println("encoding generation succeeded: empty output")
-	}
-	return nil
 }
 
 func newAgentVersionFilter() (*rules.AgentVersionFilter, error) {

--- a/cmd/security-agent/app/runtime_unsupported.go
+++ b/cmd/security-agent/app/runtime_unsupported.go
@@ -26,7 +26,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/startstop"
 )
 
-var runtimeCmd *cobra.Command
+func RuntimeCommands(globalParams *GlobalParams) []*cobra.Command {
+	return nil
+}
 
 func startRuntimeSecurity(hostname string, stopper startstop.Stopper, statsdClient *ddgostatsd.Client) (*secagent.RuntimeSecurityAgent, error) {
 	enabled := coreconfig.Datadog.GetBool("runtime_security_config.enabled")

--- a/cmd/security-agent/app/start.go
+++ b/cmd/security-agent/app/start.go
@@ -1,0 +1,61 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package app
+
+import (
+	"context"
+	"errors"
+
+	"github.com/spf13/cobra"
+)
+
+type startCliParams struct {
+	*GlobalParams
+
+	pidfilePath string
+}
+
+func StartCommands(globalParams *GlobalParams) []*cobra.Command {
+	cliParams := startCliParams{
+		GlobalParams: globalParams,
+	}
+
+	startCmd := &cobra.Command{
+		Use:   "start",
+		Short: "Start the Security Agent",
+		Long:  `Runs Datadog Security agent in the foreground`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return start(&cliParams)
+		},
+	}
+
+	startCmd.Flags().StringVarP(&cliParams.pidfilePath, "pidfile", "p", "", "path to the pidfile")
+
+	return []*cobra.Command{startCmd}
+}
+
+func start(cliParams *startCliParams) error {
+	// Main context passed to components
+	ctx, cancel := context.WithCancel(context.Background())
+	defer StopAgent(cancel)
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	go handleSignals(stopCh)
+
+	err := RunAgent(ctx, cliParams.pidfilePath)
+	if errors.Is(err, errAllComponentsDisabled) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	// Block here until we receive a stop signal
+	<-stopCh
+
+	return nil
+}

--- a/cmd/security-agent/app/status.go
+++ b/cmd/security-agent/app/status.go
@@ -55,10 +55,6 @@ func runStatus(params *cliParams) error {
 		return log.Errorf("Cannot setup logger, exiting: %v", err)
 	}
 
-	return requestStatus(params)
-}
-
-func requestStatus(params *cliParams) error {
 	fmt.Printf("Getting the status from the agent.\n")
 	var e error
 	var s string

--- a/cmd/security-agent/app/status.go
+++ b/cmd/security-agent/app/status.go
@@ -19,7 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-type cliParams struct {
+type statusCliParams struct {
 	*GlobalParams
 
 	json            bool
@@ -28,7 +28,7 @@ type cliParams struct {
 }
 
 func StatusCommands(globalParams *GlobalParams) []*cobra.Command {
-	cliParams := &cliParams{
+	cliParams := &statusCliParams{
 		GlobalParams: globalParams,
 	}
 
@@ -48,7 +48,7 @@ func StatusCommands(globalParams *GlobalParams) []*cobra.Command {
 	return nil
 }
 
-func runStatus(params *cliParams) error {
+func runStatus(params *statusCliParams) error {
 	err := config.SetupLogger(loggerName, config.GetEnvDefault("DD_LOG_LEVEL", "off"), "", "", false, true, false)
 	if err != nil {
 		return log.Errorf("Cannot setup logger, exiting: %v", err)

--- a/cmd/security-agent/app/status.go
+++ b/cmd/security-agent/app/status.go
@@ -45,7 +45,7 @@ func StatusCommands(globalParams *GlobalParams) []*cobra.Command {
 	statusCmd.Flags().BoolVarP(&cliParams.prettyPrintJSON, "pretty-json", "p", false, "pretty print JSON")
 	statusCmd.Flags().StringVarP(&cliParams.file, "file", "o", "", "Output the status command to a file")
 
-	return nil
+	return []*cobra.Command{statusCmd}
 }
 
 func runStatus(params *statusCliParams) error {

--- a/cmd/security-agent/app/status.go
+++ b/cmd/security-agent/app/status.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/DataDog/datadog-agent/cmd/agent/command"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/status"
@@ -21,14 +20,14 @@ import (
 )
 
 type cliParams struct {
-	*command.GlobalParams
+	*GlobalParams
 
 	json            bool
 	prettyPrintJSON bool
 	file            string
 }
 
-func Commands(globalParams *command.GlobalParams) []*cobra.Command {
+func StatusCommands(globalParams *GlobalParams) []*cobra.Command {
 	cliParams := &cliParams{
 		GlobalParams: globalParams,
 	}

--- a/cmd/security-agent/app/version.go
+++ b/cmd/security-agent/app/version.go
@@ -1,0 +1,39 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package app
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/serializer"
+	"github.com/DataDog/datadog-agent/pkg/version"
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+func VersionCommands(globalParams *GlobalParams) []*cobra.Command {
+	versionCmd := &cobra.Command{
+		Use:   "version",
+		Short: "Print the version info",
+		Long:  ``,
+		Run: func(cmd *cobra.Command, args []string) {
+			av, _ := version.Agent()
+			meta := ""
+			if av.Meta != "" {
+				meta = fmt.Sprintf("- Meta: %s ", color.YellowString(av.Meta))
+			}
+
+			fmt.Fprintf(color.Output, "Security agent %s %s- Commit: '%s' - Serialization version: %s\n",
+				color.BlueString(av.GetNumberAndPre()),
+				meta,
+				color.GreenString(version.Commit),
+				color.MagentaString(serializer.AgentPayloadVersion),
+			)
+		},
+	}
+
+	return []*cobra.Command{versionCmd}
+}

--- a/cmd/security-agent/main_nix.go
+++ b/cmd/security-agent/main_nix.go
@@ -23,7 +23,7 @@ func main() {
 	// set the Agent flavor
 	flavor.SetFlavor(flavor.SecurityAgent)
 
-	if err := app.SecurityAgentCmd.Execute(); err != nil {
+	if err := app.CreateSecurityAgentCmd().Execute(); err != nil {
 		os.Exit(-1)
 	}
 }

--- a/cmd/security-agent/main_windows.go
+++ b/cmd/security-agent/main_windows.go
@@ -82,7 +82,7 @@ func (m *myservice) Execute(args []string, r <-chan svc.ChangeRequest, changes c
 	log.Infof("Service control function")
 
 	ctx, cancel := context.WithCancel(context.Background())
-	err := app.RunAgent(ctx)
+	err := app.RunAgent(ctx, "")
 
 	if err != nil {
 		log.Errorf("Failed to start agent %v", err)

--- a/cmd/security-agent/main_windows.go
+++ b/cmd/security-agent/main_windows.go
@@ -67,7 +67,7 @@ func main() {
 	}
 	defer log.Flush()
 
-	if err = app.SecurityAgentCmd.Execute(); err != nil {
+	if err = app.CreateSecurityAgentCmd().Execute(); err != nil {
 		log.Error(err)
 		os.Exit(-1)
 	}


### PR DESCRIPTION
### What does this PR do?

With the goal of moving to fx for the security agent process, we need to cleanup the init of subcommands. This PR is a step in this direction.

The `Commands` function is based on the core agent, see [cmd/agent/subcommands/status/command.go](https://github.com/DataDog/datadog-agent/blob/main/cmd/agent/subcommands/status/command.go) for more details.

Notes:
- globalParams are currently unused but will be when using fx for component initialization

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

All commands should be tested if possible, but the more critical are:
- flare
- status
- version

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
