### PR TITLE
[Orchestrator] Buffer manifest payloads

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/manifest_buffer.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/manifest_buffer.go
@@ -1,0 +1,133 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver && orchestrator
+// +build kubeapiserver,orchestrator
+
+package orchestrator
+
+import (
+	"time"
+
+	"go.uber.org/atomic"
+
+	model "github.com/DataDog/agent-payload/v5/process"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
+	"github.com/DataDog/datadog-agent/pkg/orchestrator/config"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// ManifestBufferConfig contains information about buffering manifests.
+type ManifestBufferConfig struct {
+	KubeClusterName             string
+	ClusterID                   string
+	MaxPerMessage               int
+	MaxWeightPerMessageBytes    int
+	MsgGroupRef                 *atomic.Int32
+	BufferedManifestEnabled     bool
+	MaxBufferedManifests        int
+	ManifestBufferFlushInterval time.Duration
+}
+
+// ManifestBuffer is a buffer of manifest sent from all collectors
+// It has a slice bufferedManifests used to buffer manifest and stop channel
+// ManifestBuffer is started as a dedicated thread each time CollectorBundle runs a check
+// and gets stopped after the check is done.
+type ManifestBuffer struct {
+	Cfg               *ManifestBufferConfig
+	ManifestChan      chan interface{}
+	bufferedManifests []interface{}
+	stopCh            chan struct{}
+}
+
+// NewManifestBuffer returns a new ManifestBuffer
+func NewManifestBuffer(chk *OrchestratorCheck) *ManifestBuffer {
+	manifestBuffer := &ManifestBuffer{
+		Cfg: &ManifestBufferConfig{
+			ClusterID:                   chk.clusterID,
+			KubeClusterName:             chk.orchestratorConfig.KubeClusterName,
+			MsgGroupRef:                 chk.groupID,
+			MaxPerMessage:               chk.orchestratorConfig.MaxPerMessage,
+			MaxWeightPerMessageBytes:    chk.orchestratorConfig.MaxWeightPerMessageBytes,
+			BufferedManifestEnabled:     chk.orchestratorConfig.BufferedManifestEnabled,
+			MaxBufferedManifests:        chk.orchestratorConfig.MaxPerMessage,
+			ManifestBufferFlushInterval: chk.orchestratorConfig.ManifestBufferFlushInterval,
+		},
+		ManifestChan: make(chan interface{}),
+		stopCh:       make(chan struct{}),
+	}
+	manifestBuffer.bufferedManifests = make([]interface{}, 0, manifestBuffer.Cfg.MaxBufferedManifests)
+
+	return manifestBuffer
+}
+
+// flushManifest flushes manifests by chunking them first then sending them to the sender
+func (cb *ManifestBuffer) flushManifest(sender aggregator.Sender) {
+	manifests := cb.bufferedManifests
+	cb.bufferedManifests = cb.bufferedManifests[:0]
+	ctx := &processors.ProcessorContext{
+		ClusterID:  cb.Cfg.ClusterID,
+		MsgGroupID: cb.Cfg.MsgGroupRef.Inc(),
+		Cfg: &config.OrchestratorConfig{
+			KubeClusterName:          cb.Cfg.KubeClusterName,
+			MaxPerMessage:            cb.Cfg.MaxPerMessage,
+			MaxWeightPerMessageBytes: cb.Cfg.MaxWeightPerMessageBytes,
+		},
+	}
+	manifestMessages := processors.ChunkManifest(ctx, manifests)
+	sender.OrchestratorManifest(manifestMessages, cb.Cfg.ClusterID)
+
+}
+
+// appendManifest appends manifest into the buffer
+// If buffer is full, it will flush the buffer first then append the manifest
+func (cb *ManifestBuffer) appendManifest(m interface{}, sender aggregator.Sender) {
+	if len(cb.bufferedManifests) >= cb.Cfg.MaxBufferedManifests {
+		cb.flushManifest(sender)
+	}
+
+	cb.bufferedManifests = append(cb.bufferedManifests, m)
+}
+
+// Start is to start a thread to buffer manifest and send them
+// It flushes manifests every defaultFlushManifestTime
+func (cb *ManifestBuffer) Start(sender aggregator.Sender) {
+	ticker := time.NewTicker(cb.Cfg.ManifestBufferFlushInterval)
+	go func() {
+	loop:
+		for {
+			select {
+			case msg, ok := <-cb.ManifestChan:
+				if !ok {
+					log.Warnf("Fail to read orchestrator manifest from channel")
+					continue
+				}
+				cb.appendManifest(msg, sender)
+			case <-ticker.C:
+				cb.flushManifest(sender)
+			case <-cb.stopCh:
+				cb.flushManifest(sender)
+				break loop
+			}
+		}
+	}()
+}
+
+// Stop is to kill the thread collecting manifest
+func (cb *ManifestBuffer) Stop() {
+	cb.stopCh <- struct{}{}
+}
+
+// BufferManifestProcessResult is to add process result to the buffer
+func BufferManifestProcessResult(messages []model.MessageBody, buffer *ManifestBuffer) {
+	for _, message := range messages {
+		m := message.(*model.CollectorManifest)
+		for _, manifest := range m.Manifests {
+			buffer.ManifestChan <- manifest
+		}
+	}
+}

--- a/pkg/collector/corechecks/cluster/orchestrator/manifest_buffer_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/manifest_buffer_test.go
@@ -1,0 +1,171 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver && orchestrator
+// +build kubeapiserver,orchestrator
+
+package orchestrator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"gotest.tools/assert"
+
+	model "github.com/DataDog/agent-payload/v5/process"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/serializer"
+)
+
+// TestOrchestratorManifestBuffer tests manifest buffer
+// This test sets maximum beffer size to 2 and we have 5 manifests in total
+// The maximum manifests per message is 100 by default
+// Therefore we should have 3 messages to send
+// message 1 contains manifest 1 and 2
+// message 2 contains manifest 3 and 4
+// message 3 contains manifest 5
+func TestOrchestratorManifestBuffer(t *testing.T) {
+	orchCheck := OrchestratorFactory().(*OrchestratorCheck)
+	mb := NewManifestBuffer(orchCheck)
+	mb.Cfg.MaxBufferedManifests = 2
+	mb.Cfg.ManifestBufferFlushInterval = 3 * time.Second
+
+	noopSender := noopSender{}
+	mb.Start(&noopSender)
+
+	// Send 5 manifests to the buffer
+	for i := 1; i <= 5; i++ {
+		mb.ManifestChan <- &model.Manifest{
+			Type: int32(i),
+		}
+	}
+
+	mb.Stop()
+
+	// The buffer should be flushed 3 times
+	require.Len(t, noopSender.OrchestratorManifestOut, 3)
+
+	i := int32(1)
+	for _, collectorManifests := range noopSender.OrchestratorManifestOut {
+		// The maximum manifests per message is 100 by default, therefore we should only have one message created by each flush
+		require.Len(t, collectorManifests, 1)
+		collectorManifest := collectorManifests[0].(*model.CollectorManifest)
+		for _, m := range collectorManifest.Manifests {
+			assert.Equal(t, i, m.Type)
+			i++
+		}
+	}
+
+}
+
+type noopSender struct {
+	OrchestratorManifestOut [][]model.MessageBody
+}
+
+var _ aggregator.Sender = &noopSender{}
+
+func (s *noopSender) OrchestratorManifest(msgs []serializer.ProcessMessageBody, clusterID string) {
+	s.OrchestratorManifestOut = append(s.OrchestratorManifestOut, msgs)
+}
+
+func (s *noopSender) DisableDefaultHostname(_ bool) {
+	panic("implement me ")
+}
+
+func (s *noopSender) SetCheckCustomTags(_ []string) {
+	panic("implement me ")
+}
+
+func (s *noopSender) SetCheckService(_ string) {
+	panic("implement me ")
+}
+
+func (s *noopSender) FinalizeCheckServiceTag() {
+	panic("implement me ")
+}
+
+func (s *noopSender) Commit() {
+	panic("implement me ")
+}
+
+func (s *noopSender) GetSenderStats() (metricStats check.SenderStats) {
+	panic("implement me ")
+}
+
+func (s *noopSender) cyclemetricStats() {
+	panic("implement me ")
+}
+
+func (s *noopSender) SendRawMetricSample(sample *metrics.MetricSample) {
+	panic("implement me ")
+}
+
+func (s *noopSender) Gauge(_ string, _ float64, _ string, _ []string) {
+	panic("implement me ")
+}
+
+func (s *noopSender) GaugeNoIndex(_ string, _ float64, _ string, _ []string) {
+	panic("implement me ")
+}
+
+func (s *noopSender) Rate(_ string, _ float64, _ string, _ []string) {
+	panic("implement me ")
+}
+
+func (s *noopSender) Count(_ string, _ float64, _ string, _ []string) {
+	panic("implement me ")
+}
+
+func (s *noopSender) MonotonicCount(_ string, _ float64, _ string, _ []string) {
+	panic("implement me ")
+}
+
+func (s *noopSender) MonotonicCountWithFlushFirstValue(_ string, _ float64, _ string, _ []string, _ bool) {
+	panic("implement me ")
+}
+
+func (s *noopSender) Counter(_ string, _ float64, _ string, _ []string) {
+	panic("implement me ")
+}
+
+func (s *noopSender) Histogram(_ string, _ float64, _ string, _ []string) {
+	panic("implement me ")
+}
+
+func (s *noopSender) HistogramBucket(_ string, _ int64, _, _ float64, _ bool, _ string, _ []string, _ bool) {
+	panic("implement me ")
+}
+
+func (s *noopSender) Historate(_ string, _ float64, _ string, _ []string) {
+	panic("implement me ")
+}
+
+func (s *noopSender) SendRawServiceCheck(_ *metrics.ServiceCheck) {
+	panic("implement me ")
+}
+
+func (s *noopSender) ServiceCheck(_ string, _ metrics.ServiceCheckStatus, _ string, _ []string, _ string) {
+	panic("implement me ")
+}
+
+func (s *noopSender) Event(_ metrics.Event) {
+	panic("implement me ")
+}
+
+func (s *noopSender) EventPlatformEvent(_ string, _ string) {
+	panic("implement me ")
+}
+
+func (s *noopSender) OrchestratorMetadata(_ []serializer.ProcessMessageBody, _ string, _ int) {
+	panic("implement me ")
+}
+
+func (s *noopSender) ContainerLifecycleEvent(_ []serializer.ContainerLifecycleMessage) {
+	panic("implement me ")
+}

--- a/pkg/collector/corechecks/cluster/orchestrator/manifest_buffer_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/manifest_buffer_test.go
@@ -98,10 +98,6 @@ func (s *noopSender) GetSenderStats() (metricStats check.SenderStats) {
 	panic("implement me ")
 }
 
-func (s *noopSender) cyclemetricStats() {
-	panic("implement me ")
-}
-
 func (s *noopSender) SendRawMetricSample(sample *metrics.MetricSample) {
 	panic("implement me ")
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/manifest_buffer_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/manifest_buffer_test.go
@@ -12,156 +12,94 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"gotest.tools/assert"
+	"go.uber.org/atomic"
 
 	model "github.com/DataDog/agent-payload/v5/process"
 
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
-	"github.com/DataDog/datadog-agent/pkg/metrics"
-	"github.com/DataDog/datadog-agent/pkg/serializer"
 )
 
-// TestOrchestratorManifestBuffer tests manifest buffer
-// This test sets maximum beffer size to 2 and we have 5 manifests in total
-// The maximum manifests per message is 100 by default
-// Therefore we should have 3 messages to send
-// message 1 contains manifest 1 and 2
-// message 2 contains manifest 3 and 4
-// message 3 contains manifest 5
+var manifestToSend []*model.CollectorManifest
+
 func TestOrchestratorManifestBuffer(t *testing.T) {
-	orchCheck := OrchestratorFactory().(*OrchestratorCheck)
-	mb := NewManifestBuffer(orchCheck)
-	mb.Cfg.MaxBufferedManifests = 2
-	mb.Cfg.ManifestBufferFlushInterval = 3 * time.Second
+	mb := getManifestBuffer()
+	mb.Start(getSender(t))
 
-	noopSender := noopSender{}
-	mb.Start(&noopSender)
-
-	// Send 5 manifests to the buffer
-	for i := 1; i <= 5; i++ {
-		mb.ManifestChan <- &model.Manifest{
-			Type: int32(i),
-		}
+	b := []*model.Manifest{
+		{
+			Type: int32(1),
+		},
+		{
+			Type: int32(2),
+		},
+		{
+			Type: int32(3),
+		},
+		{
+			Type: int32(4),
+		},
+		{
+			Type: int32(5),
+		},
+	}
+	for _, m := range b {
+		mb.ManifestChan <- m
 	}
 
 	mb.Stop()
 
-	// The buffer should be flushed 3 times
-	require.Len(t, noopSender.OrchestratorManifestOut, 3)
+	// Buffer size is 2, as we have 5 manifests, the buffer needs to be flushed 3 times
+	require.Len(t, manifestToSend, 3)
 
-	i := int32(1)
-	for _, collectorManifests := range noopSender.OrchestratorManifestOut {
-		// The maximum manifests per message is 100 by default, therefore we should only have one message created by each flush
-		require.Len(t, collectorManifests, 1)
-		collectorManifest := collectorManifests[0].(*model.CollectorManifest)
-		for _, m := range collectorManifest.Manifests {
-			assert.Equal(t, i, m.Type)
-			i++
-		}
-	}
+	assert.EqualValues(t, []*model.Manifest{
+		{
+			Type: int32(1),
+		},
+		{
+			Type: int32(2),
+		},
+	}, manifestToSend[0].Manifests)
+
+	assert.EqualValues(t, []*model.Manifest{
+		{
+			Type: int32(3),
+		},
+		{
+			Type: int32(4),
+		},
+	}, manifestToSend[1].Manifests)
+
+	assert.EqualValues(t, []*model.Manifest{
+		{
+			Type: int32(5),
+		},
+	}, manifestToSend[2].Manifests)
 
 }
 
-type noopSender struct {
-	OrchestratorManifestOut [][]model.MessageBody
+// getSender returns a mock Sender
+// When calling OrchestratorManifest, it adds the messges to a global var manifestToSend
+func getSender(t *testing.T) *mocksender.MockSender {
+	sender := mocksender.NewMockSender(check.ID(rune(1)))
+	sender.On("OrchestratorManifest", mock.Anything, mock.Anything).Return().Run(func(args mock.Arguments) {
+		arg := args.Get(0).([]model.MessageBody)
+		require.Equal(t, 1, len(arg))
+		a := arg[0].(*model.CollectorManifest)
+		manifestToSend = append(manifestToSend, a)
+	})
+	return sender
 }
 
-var _ aggregator.Sender = &noopSender{}
-
-func (s *noopSender) OrchestratorManifest(msgs []serializer.ProcessMessageBody, clusterID string) {
-	s.OrchestratorManifestOut = append(s.OrchestratorManifestOut, msgs)
-}
-
-func (s *noopSender) DisableDefaultHostname(_ bool) {
-	panic("implement me ")
-}
-
-func (s *noopSender) SetCheckCustomTags(_ []string) {
-	panic("implement me ")
-}
-
-func (s *noopSender) SetCheckService(_ string) {
-	panic("implement me ")
-}
-
-func (s *noopSender) FinalizeCheckServiceTag() {
-	panic("implement me ")
-}
-
-func (s *noopSender) Commit() {
-	panic("implement me ")
-}
-
-func (s *noopSender) GetSenderStats() (metricStats check.SenderStats) {
-	panic("implement me ")
-}
-
-func (s *noopSender) SendRawMetricSample(sample *metrics.MetricSample) {
-	panic("implement me ")
-}
-
-func (s *noopSender) Gauge(_ string, _ float64, _ string, _ []string) {
-	panic("implement me ")
-}
-
-func (s *noopSender) GaugeNoIndex(_ string, _ float64, _ string, _ []string) {
-	panic("implement me ")
-}
-
-func (s *noopSender) Rate(_ string, _ float64, _ string, _ []string) {
-	panic("implement me ")
-}
-
-func (s *noopSender) Count(_ string, _ float64, _ string, _ []string) {
-	panic("implement me ")
-}
-
-func (s *noopSender) MonotonicCount(_ string, _ float64, _ string, _ []string) {
-	panic("implement me ")
-}
-
-func (s *noopSender) MonotonicCountWithFlushFirstValue(_ string, _ float64, _ string, _ []string, _ bool) {
-	panic("implement me ")
-}
-
-func (s *noopSender) Counter(_ string, _ float64, _ string, _ []string) {
-	panic("implement me ")
-}
-
-func (s *noopSender) Histogram(_ string, _ float64, _ string, _ []string) {
-	panic("implement me ")
-}
-
-func (s *noopSender) HistogramBucket(_ string, _ int64, _, _ float64, _ bool, _ string, _ []string, _ bool) {
-	panic("implement me ")
-}
-
-func (s *noopSender) Historate(_ string, _ float64, _ string, _ []string) {
-	panic("implement me ")
-}
-
-func (s *noopSender) SendRawServiceCheck(_ *metrics.ServiceCheck) {
-	panic("implement me ")
-}
-
-func (s *noopSender) ServiceCheck(_ string, _ metrics.ServiceCheckStatus, _ string, _ []string, _ string) {
-	panic("implement me ")
-}
-
-func (s *noopSender) Event(_ metrics.Event) {
-	panic("implement me ")
-}
-
-func (s *noopSender) EventPlatformEvent(_ string, _ string) {
-	panic("implement me ")
-}
-
-func (s *noopSender) OrchestratorMetadata(_ []serializer.ProcessMessageBody, _ string, _ int) {
-	panic("implement me ")
-}
-
-func (s *noopSender) ContainerLifecycleEvent(_ []serializer.ContainerLifecycleMessage) {
-	panic("implement me ")
+// getManifestBuffer returns a manifest buffer for test with buffer size = 2
+func getManifestBuffer() *ManifestBuffer {
+	orchCheck := OrchestratorFactory().(*OrchestratorCheck)
+	mb := NewManifestBuffer(orchCheck)
+	mb.Cfg.MaxBufferedManifests = 2
+	mb.Cfg.ManifestBufferFlushInterval = 3 * time.Second
+	mb.Cfg.MsgGroupRef = atomic.NewInt32(0)
+	return mb
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1037,6 +1037,8 @@ func InitConfig(config Config) {
 	config.BindEnv("orchestrator_explorer.orchestrator_additional_endpoints")
 	config.BindEnv("orchestrator_explorer.use_legacy_endpoint")
 	config.BindEnvAndSetDefault("orchestrator_explorer.manifest_collection.enabled", false)
+	config.BindEnvAndSetDefault("orchestrator_explorer.manifest_collection.buffer_manifest", true)
+	config.BindEnvAndSetDefault("orchestrator_explorer.manifest_collection.buffer_flush_interval", 20*time.Second)
 
 	// Container lifecycle configuration
 	config.BindEnvAndSetDefault("container_lifecycle.enabled", false)

--- a/pkg/orchestrator/config/config.go
+++ b/pkg/orchestrator/config/config.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/resolver"
@@ -44,6 +45,8 @@ type OrchestratorConfig struct {
 	PodQueueBytes                  int // The total number of bytes that can be enqueued for delivery to the orchestrator endpoint
 	ExtraTags                      []string
 	IsManifestCollectionEnabled    bool
+	BufferedManifestEnabled        bool
+	ManifestBufferFlushInterval    time.Duration
 }
 
 // NewDefaultOrchestratorConfig returns an NewDefaultOrchestratorConfig using a configuration file. It can be nil
@@ -115,6 +118,8 @@ func (oc *OrchestratorConfig) Load() error {
 	oc.IsScrubbingEnabled = config.Datadog.GetBool(key(orchestratorNS, "container_scrubbing.enabled"))
 	oc.ExtraTags = config.Datadog.GetStringSlice(key(orchestratorNS, "extra_tags"))
 	oc.IsManifestCollectionEnabled = config.Datadog.GetBool(key(orchestratorNS, "manifest_collection.enabled"))
+	oc.BufferedManifestEnabled = config.Datadog.GetBool(key(orchestratorNS, "manifest_collection.buffer_manifest"))
+	oc.ManifestBufferFlushInterval = config.Datadog.GetDuration(key(orchestratorNS, "manifest_collection.buffer_flush_interval"))
 
 	return nil
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR allows us to buffer manifest payloads when orchestrator check runs and flush payloads when

- the buffer is full
- every X seconds
- the check is done and the thread buffering manifest should be killed 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
