### PR TITLE
[CWS] remove unused unsafe string pointer in testdrive path

### DIFF
--- a/pkg/security/tests/mount_test.go
+++ b/pkg/security/tests/mount_test.go
@@ -47,17 +47,11 @@ func TestMount(t *testing.T) {
 	}
 	defer test.Close()
 
-	mntPath, _, err := testDrive.Path("test-mount")
-	if err != nil {
-		t.Fatal(err)
-	}
+	mntPath := testDrive.Path("test-mount")
 	os.MkdirAll(mntPath, 0755)
 	defer os.RemoveAll(mntPath)
 
-	dstMntPath, _, err := testDrive.Path(dstMntBasename)
-	if err != nil {
-		t.Fatal(err)
-	}
+	dstMntPath := testDrive.Path(dstMntBasename)
 	os.MkdirAll(dstMntPath, 0755)
 	defer os.RemoveAll(dstMntPath)
 
@@ -90,10 +84,7 @@ func TestMount(t *testing.T) {
 	})
 
 	t.Run("mount_resolver", func(t *testing.T) {
-		file, _, err := testDrive.Path(path.Join(dstMntBasename, "test-mount"))
-		if err != nil {
-			t.Fatal(err)
-		}
+		file := testDrive.Path(path.Join(dstMntBasename, "test-mount"))
 
 		f, err := os.Create(file)
 		if err != nil {

--- a/pkg/security/tests/mount_test.go
+++ b/pkg/security/tests/mount_test.go
@@ -84,7 +84,7 @@ func TestMount(t *testing.T) {
 	})
 
 	t.Run("mount_resolver", func(t *testing.T) {
-		file := testDrive.Path(path.Join(dstMntBasename, "test-mount"))
+		file := testDrive.Path(dstMntBasename, "test-mount")
 
 		f, err := os.Create(file)
 		if err != nil {

--- a/pkg/security/tests/overlayfs_test.go
+++ b/pkg/security/tests/overlayfs_test.go
@@ -135,10 +135,7 @@ func TestOverlayFS(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mountPoint, _, err := testDrive.Path("bind")
-	if err != nil {
-		t.Fatal(err)
-	}
+	mountPoint := testDrive.Path("bind")
 	defer os.Remove(mountPoint)
 
 	if err := os.Mkdir(mountPoint, 0777); err != nil {

--- a/pkg/security/tests/testdrive.go
+++ b/pkg/security/tests/testdrive.go
@@ -14,9 +14,7 @@ import (
 	"os/exec"
 	"path"
 	"strings"
-	"syscall"
 	"testing"
-	"unsafe"
 
 	"github.com/avast/retry-go/v4"
 	"github.com/freddierice/go-losetup"
@@ -32,15 +30,11 @@ func (td *testDrive) Root() string {
 	return td.mountPoint
 }
 
-func (td *testDrive) Path(filename ...string) (string, unsafe.Pointer, error) {
+func (td *testDrive) Path(filename ...string) string {
 	components := []string{td.mountPoint}
 	components = append(components, filename...)
 	path := path.Join(components...)
-	filenamePtr, err := syscall.BytePtrFromString(path)
-	if err != nil {
-		return "", nil, err
-	}
-	return path, unsafe.Pointer(filenamePtr), nil
+	return path
 }
 
 func newTestDrive(tb testing.TB, fsType string, mountOpts []string, mountPoint string) (*testDrive, error) {


### PR DESCRIPTION
### What does this PR do?

The unsafe pointer is unused, this PR removes it

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
