### PR TITLE
Disable the API server in `agent check`

### DIFF
--- a/cmd/agent/subcommands/check/command.go
+++ b/cmd/agent/subcommands/check/command.go
@@ -619,7 +619,7 @@ func populateMemoryProfileConfig(cliParams *cliParams, initConfig map[string]int
 // server starts up, it does not do so on the same port as a running agent.
 //
 // Ideally, the server wouldn't start up at all, but this workaround has been
-// in place for some times.
+// in place for some time.
 func disableCmdPort() {
 	os.Setenv("DD_CMD_PORT", "0") // 0 indicates the OS should pick an unused port
 }

--- a/cmd/agent/subcommands/check/command.go
+++ b/cmd/agent/subcommands/check/command.go
@@ -98,6 +98,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			}
 			cliParams.cmd = cmd
 			cliParams.args = args
+			disableCmdPort()
 			return fxutil.OneShot(run,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
@@ -612,4 +613,13 @@ func populateMemoryProfileConfig(cliParams *cliParams, initConfig map[string]int
 	}
 
 	return nil
+}
+
+// disableCmdPort overrrides the `cmd_port` configuration so that when the
+// server starts up, it does not do so on the same port as a running agent.
+//
+// Ideally, the server wouldn't start up at all, but this workaround has been
+// in place for some times.
+func disableCmdPort() {
+	os.Setenv("DD_CMD_PORT", "0") // 0 indicates the OS should pick an unused port
 }


### PR DESCRIPTION
This hack was accidentally removed in #13725.  It is the same hack used in the jmx command, in #13722.


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Run `agent check hazelcast --check-rate --json` for the previous version and this version and observe they both work.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
