### PR TITLE
Replace hardcoded PDH_REFRESH_INTERVAL with configurable value

### DIFF
--- a/releasenotes/notes/go-pdhutil-configurable-refresh-limit-1010228fe8a9d537.yaml
+++ b/releasenotes/notes/go-pdhutil-configurable-refresh-limit-1010228fe8a9d537.yaml
@@ -1,0 +1,7 @@
+---
+enhancements:
+  - |
+    Use the `windows_counter_refresh_interval` configuration option to limit
+    how frequently the PDH object cache can be refreshed during counter
+    intialization in golang. This replaces the previously hardcoded limit
+    of 60 seconds.

--- a/releasenotes/notes/go-pdhutil-configurable-refresh-limit-1010228fe8a9d537.yaml
+++ b/releasenotes/notes/go-pdhutil-configurable-refresh-limit-1010228fe8a9d537.yaml
@@ -3,5 +3,5 @@ enhancements:
   - |
     Use the `windows_counter_refresh_interval` configuration option to limit
     how frequently the PDH object cache can be refreshed during counter
-    intialization in golang. This replaces the previously hardcoded limit
+    initialization in golang. This replaces the previously hardcoded limit
     of 60 seconds.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Replaces the hardcoded PDH_REFRESH_INTERVAL value with the `windows_counter_refresh_interval` configuration option

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
https://datadoghq.atlassian.net/browse/WA-72

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
1. Install the agent on a Windows OS
2. Use the following powershell to create the registry values that disable the performance counters needed by the `winproc`, `memory`, `file_handle`, and `io` checks.
   ```powershell
   New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\PerfDisk\Performance" -Name "Disable Performance Counters" -PropertyType "DWORD" -Force -Value 1
   New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\PerfOS\Performance" -Name "Disable Performance Counters" -PropertyType "DWORD" -Force -Value 1
   New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\PerfProc\Performance" -Name "Disable Performance Counters" -PropertyType "DWORD" -Force -Value 1
   ```
3. Set `windows_counter_refresh_interval: 30` in `datadog.yaml`
4. Restart the agent
5. Ensure the log line "Refreshing performance counters" from `pdhhelper.go` does not appear more frequently than 30 seconds.
6. Set `windows_counter_refresh_interval: 0` in `datadog.yaml`
7. Restart the agent
8.  Ensure the log line "Refreshing performance counters" from `pdhhelper.go` does not appear

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
