### PR TITLE
Fix 0-value for config poller interval and file polling

### DIFF
--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -181,6 +181,10 @@ func (ac *AutoConfig) Stop() {
 // Agent lifetime.
 // If the config provider is polled, the routine is scheduled right away
 func (ac *AutoConfig) AddConfigProvider(provider providers.ConfigProvider, shouldPoll bool, pollInterval time.Duration) {
+	if shouldPoll && pollInterval <= 0 {
+		log.Warnf("Polling interval <= 0 for AD provider: %s, deactivating polling", provider.String())
+		shouldPoll = false
+	}
 	cp := newConfigPoller(provider, shouldPoll, pollInterval)
 
 	ac.m.Lock()

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2080,7 +2080,7 @@ api_key:
 ## @param autoconf_config_files_poll_interval - integer - optional - default: 60
 ## @env DD_AUTOCONF_CONFIG_FILES_POLL_INTERVAL - integer - optional - default: 60
 ## How frequently should the Agent check for new/updated integration configuration files (in seconds).
-## This value must be >= 1 (i.e. 1 second)
+## This value must be >= 1 (i.e. 1 second).
 ## WARNING: Only files containing checks configuration are supported (logs configuration are not supported).
 #
 # autoconf_config_files_poll_interval: 60

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2080,6 +2080,7 @@ api_key:
 ## @param autoconf_config_files_poll_interval - integer - optional - default: 60
 ## @env DD_AUTOCONF_CONFIG_FILES_POLL_INTERVAL - integer - optional - default: 60
 ## How frequently should the Agent check for new/updated integration configuration files (in seconds).
+## This value must be >= 1 (i.e. 1 second)
 ## WARNING: Only files containing checks configuration are supported (logs configuration are not supported).
 #
 # autoconf_config_files_poll_interval: 60


### PR DESCRIPTION
### What does this PR do?

Testing #13777 revealed that Config poller makes the Agent panic if polling interval is <=0.

### Motivation

Bugfix.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

#13777 Modified with QA instructions.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
