### PR TITLE
Generate and bundle minimized BTFs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,6 +3,7 @@ include:
   - /.gitlab/shared.yml
   - /.gitlab/maintenance_jobs.yml
   - /.gitlab/deps_build.yml
+  - /.gitlab/package_deps_build.yml
   - /.gitlab/deps_fetch.yml
   - /.gitlab/source_test.yml
   - /.gitlab/source_test_junit_upload.yml
@@ -58,6 +59,7 @@ stages:
   - source_test
   - source_test_junit_upload
   - binary_build
+  - package_deps_build
   - integration_test
   - package_build
   - internal_deploy
@@ -143,6 +145,7 @@ variables:
   DATADOG_AGENT_ARMBUILDIMAGES: v10726529-3c98072
   DATADOG_AGENT_SYSPROBE_BUILDIMAGES: v10726529-3c98072
   DATADOG_AGENT_NIKOS_BUILDIMAGES: v10726529-3c98072
+  DATADOG_AGENT_BTF_GEN_BUILDIMAGES: v10582792-c2b9fb7
   DATADOG_AGENT_EMBEDDED_PATH: /opt/datadog-agent/embedded
   NIKOS_INSTALL_DIR: /opt/datadog-agent/embedded/nikos
   NIKOS_EMBEDDED_PATH: /opt/datadog-agent/embedded/nikos/embedded

--- a/.gitlab/binary_build/system_probe.yml
+++ b/.gitlab/binary_build/system_probe.yml
@@ -44,8 +44,6 @@ build_system-probe-x64:
     ARCH: amd64
 
 build_system-probe-arm64:
-  rules:
-    !reference [.on_all_builds]
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_arm64:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
   needs: ["go_deps"]

--- a/.gitlab/deps_build.yml
+++ b/.gitlab/deps_build.yml
@@ -127,3 +127,45 @@ build_vcpkg_deps:
     - if (Test-Path build-out) { remove-item -recurse -force build-out }
     - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e VCPKG_BINARY_SOURCES="clear;x-azblob,${vcpkgBlobSaSUrl},readwrite" 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/windows_1809_${ARCH}:${Env:DATADOG_AGENT_WINBUILDIMAGES} C:\mnt\tasks\winbuildscripts\build_vcpkg_deps.bat
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
+
+build_processed_btfhub_archive:
+  rules:
+    !reference [.manual]
+  stage: deps_build
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/btf-gen:$DATADOG_AGENT_BTF_GEN_BUILDIMAGES
+  tags: ["runner:main"]
+  script:
+    - git clone https://github.com/aquasecurity/btfhub-archive.git
+    - cd btfhub-archive
+    # Flatten btfhub-archive directories & separate arm/x64 btfs into separate directories
+    - dirs=("amzn/2" "centos/7" "centos/8" "debian/9" "debian/10" "fedora/29" "fedora/30" "fedora/31" "oracle-linux/ol7")
+    - |
+      for dir in ${dirs[@]}; do                                         \
+        platform=${dir%%/*}                                           &&\
+        mkdir -p "btfs-amd64/${platform}" "btfs-arm64/${platform}"    &&\
+        eval "mv ${dir}/x86_64/*.btf.tar.xz btfs-amd64/${platform}/"  &&\
+        eval "mv ${dir}/arm64/*.btf.tar.xz btfs-arm64/${platform}/";    \
+      done
+    # Handle the amzn/1 directory separately because it doesn't have an arm64 version
+    - mv amzn/1/x86_64/* btfs-amd64/amzn/
+    # Handle ubuntu separately because we want to keep the btfs separated by ubuntu version
+    - mkdir -p btfs-amd64/ubuntu/18.04 btfs-amd64/ubuntu/20.04 btfs-arm64/ubuntu/18.04 btfs-arm64/ubuntu/20.04
+    - mv ubuntu/18.04/x86_64/*.btf.tar.xz btfs-amd64/ubuntu/18.04/
+    - mv ubuntu/20.04/x86_64/*.btf.tar.xz btfs-amd64/ubuntu/20.04/
+    - mv ubuntu/18.04/arm64/*.btf.tar.xz btfs-arm64/ubuntu/18.04/
+    - mv ubuntu/20.04/arm64/*.btf.tar.xz btfs-arm64/ubuntu/20.04/
+    # Clean up platform names to match the names we get at runtime from gopsutil
+    - mv btfs-amd64/amzn btfs-amd64/amazon
+    - mv btfs-arm64/amzn btfs-arm64/amazon
+    - mv btfs-amd64/oracle-linux btfs-amd64/oracle
+    - mv btfs-arm64/oracle-linux btfs-arm64/oracle
+    # Store results in S3
+    - tar -czf btfs-arm64.tar.gz btfs-arm64
+    - tar -czf btfs-amd64.tar.gz btfs-amd64
+    - $S3_CP_CMD btfs-arm64.tar.gz $S3_PERMANENT_ARTIFACTS_URI/btfs-arm64.tar.gz
+    - $S3_CP_CMD btfs-amd64.tar.gz $S3_PERMANENT_ARTIFACTS_URI/btfs-amd64.tar.gz
+  artifacts:
+    expire_in: 2 weeks
+    paths:
+      - btfhub-archive/btfs-arm64.tar.gz
+      - btfhub-archive/btfs-amd64.tar.gz

--- a/.gitlab/package_build/deb.yml
+++ b/.gitlab/package_build/deb.yml
@@ -37,6 +37,7 @@
     - $S3_CP_CMD $S3_ARTIFACTS_URI/tcp-queue-length.c.${PACKAGE_ARCH} /tmp/system-probe/tcp-queue-length.c
     - $S3_CP_CMD $S3_PERMANENT_ARTIFACTS_URI/clang-$CLANG_LLVM_VER.${PACKAGE_ARCH} /tmp/system-probe/clang-bpf
     - $S3_CP_CMD $S3_PERMANENT_ARTIFACTS_URI/llc-$CLANG_LLVM_VER.${PACKAGE_ARCH} /tmp/system-probe/llc-bpf
+    - $S3_CP_CMD $S3_ARTIFACTS_URI/minimized-btfs-${PACKAGE_ARCH}.tar.gz /tmp/system-probe/minimized-btfs.tar.gz
     - chmod 0644 /tmp/system-probe/*.o
     - chmod 0744 /tmp/system-probe/system-probe /tmp/system-probe/clang-bpf /tmp/system-probe/llc-bpf
     - $S3_CP_CMD $S3_PERMANENT_ARTIFACTS_URI/nikos-${PACKAGE_ARCH}.tar.gz /tmp/nikos.tar.gz
@@ -59,7 +60,7 @@ agent_deb-x64-a6:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:main"]
-  needs: ["go_mod_tidy_check", "build_system-probe-x64", "go_deps"]
+  needs: ["go_mod_tidy_check", "build_system-probe-x64", "go_deps", "generate_minimized_btfs_x64"]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
     AGENT_MAJOR_VERSION: 6
@@ -78,7 +79,7 @@ agent_deb-x64-a7:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:main"]
-  needs: ["go_mod_tidy_check", "build_system-probe-x64", "go_deps"]
+  needs: ["go_mod_tidy_check", "build_system-probe-x64", "go_deps", "generate_minimized_btfs_x64"]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
     AGENT_MAJOR_VERSION: 7
@@ -97,7 +98,7 @@ agent_deb-arm64-a6:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
-  needs: ["go_mod_tidy_check", "build_system-probe-arm64", "go_deps"]
+  needs: ["go_mod_tidy_check", "build_system-probe-arm64", "go_deps", "generate_minimized_btfs_arm64"]
   variables:
     AGENT_MAJOR_VERSION: 6
     PYTHON_RUNTIMES: '2,3'
@@ -115,7 +116,7 @@ agent_deb-arm64-a7:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
-  needs: ["go_mod_tidy_check", "build_system-probe-arm64", "go_deps"]
+  needs: ["go_mod_tidy_check", "build_system-probe-arm64", "go_deps", "generate_minimized_btfs_arm64"]
   variables:
     AGENT_MAJOR_VERSION: 7
     PYTHON_RUNTIMES: '3'

--- a/.gitlab/package_build/deb.yml
+++ b/.gitlab/package_build/deb.yml
@@ -37,7 +37,7 @@
     - $S3_CP_CMD $S3_ARTIFACTS_URI/tcp-queue-length.c.${PACKAGE_ARCH} /tmp/system-probe/tcp-queue-length.c
     - $S3_CP_CMD $S3_PERMANENT_ARTIFACTS_URI/clang-$CLANG_LLVM_VER.${PACKAGE_ARCH} /tmp/system-probe/clang-bpf
     - $S3_CP_CMD $S3_PERMANENT_ARTIFACTS_URI/llc-$CLANG_LLVM_VER.${PACKAGE_ARCH} /tmp/system-probe/llc-bpf
-    - $S3_CP_CMD $S3_ARTIFACTS_URI/minimized-btfs-${PACKAGE_ARCH}.tar.gz /tmp/system-probe/minimized-btfs.tar.gz
+    - $S3_CP_CMD $S3_ARTIFACTS_URI/minimized-btfs-${PACKAGE_ARCH}.tar.xz /tmp/system-probe/minimized-btfs.tar.xz
     - chmod 0644 /tmp/system-probe/*.o
     - chmod 0744 /tmp/system-probe/system-probe /tmp/system-probe/clang-bpf /tmp/system-probe/llc-bpf
     - $S3_CP_CMD $S3_PERMANENT_ARTIFACTS_URI/nikos-${PACKAGE_ARCH}.tar.gz /tmp/nikos.tar.gz

--- a/.gitlab/package_build/rpm.yml
+++ b/.gitlab/package_build/rpm.yml
@@ -35,6 +35,7 @@
     - $S3_CP_CMD $S3_ARTIFACTS_URI/tcp-queue-length.c.${PACKAGE_ARCH} /tmp/system-probe/tcp-queue-length.c
     - $S3_CP_CMD $S3_PERMANENT_ARTIFACTS_URI/clang-$CLANG_LLVM_VER.${PACKAGE_ARCH} /tmp/system-probe/clang-bpf
     - $S3_CP_CMD $S3_PERMANENT_ARTIFACTS_URI/llc-$CLANG_LLVM_VER.${PACKAGE_ARCH} /tmp/system-probe/llc-bpf
+    - $S3_CP_CMD $S3_ARTIFACTS_URI/minimized-btfs-${PACKAGE_ARCH}.tar.gz /tmp/system-probe/minimized-btfs.tar.gz
     - chmod 0644 /tmp/system-probe/*.o
     - chmod 0744 /tmp/system-probe/system-probe /tmp/system-probe/clang-bpf /tmp/system-probe/llc-bpf
     - $S3_CP_CMD $S3_PERMANENT_ARTIFACTS_URI/nikos-${PACKAGE_ARCH}.tar.gz /tmp/nikos.tar.gz
@@ -56,7 +57,7 @@ agent_rpm-x64-a6:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:main"]
-  needs: ["go_mod_tidy_check", "build_system-probe-x64", "go_deps"]
+  needs: ["go_mod_tidy_check", "build_system-probe-x64", "go_deps", "generate_minimized_btfs_x64"]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
     AGENT_MAJOR_VERSION: 6
@@ -74,7 +75,7 @@ agent_rpm-x64-a7:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:main"]
-  needs: ["go_mod_tidy_check", "build_system-probe-x64", "go_deps"]
+  needs: ["go_mod_tidy_check", "build_system-probe-x64", "go_deps", "generate_minimized_btfs_x64"]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
     AGENT_MAJOR_VERSION: 7
@@ -92,7 +93,7 @@ agent_rpm-arm64-a6:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
-  needs: ["go_mod_tidy_check", "build_system-probe-arm64", "go_deps"]
+  needs: ["go_mod_tidy_check", "build_system-probe-arm64", "go_deps", "generate_minimized_btfs_arm64"]
   variables:
     AGENT_MAJOR_VERSION: 6
     PYTHON_RUNTIMES: '2,3'
@@ -109,7 +110,7 @@ agent_rpm-arm64-a7:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
-  needs: ["go_mod_tidy_check", "build_system-probe-arm64", "go_deps"]
+  needs: ["go_mod_tidy_check", "build_system-probe-arm64", "go_deps", "generate_minimized_btfs_arm64"]
   variables:
     AGENT_MAJOR_VERSION: 7
     PYTHON_RUNTIMES: '3'

--- a/.gitlab/package_build/rpm.yml
+++ b/.gitlab/package_build/rpm.yml
@@ -35,7 +35,7 @@
     - $S3_CP_CMD $S3_ARTIFACTS_URI/tcp-queue-length.c.${PACKAGE_ARCH} /tmp/system-probe/tcp-queue-length.c
     - $S3_CP_CMD $S3_PERMANENT_ARTIFACTS_URI/clang-$CLANG_LLVM_VER.${PACKAGE_ARCH} /tmp/system-probe/clang-bpf
     - $S3_CP_CMD $S3_PERMANENT_ARTIFACTS_URI/llc-$CLANG_LLVM_VER.${PACKAGE_ARCH} /tmp/system-probe/llc-bpf
-    - $S3_CP_CMD $S3_ARTIFACTS_URI/minimized-btfs-${PACKAGE_ARCH}.tar.gz /tmp/system-probe/minimized-btfs.tar.gz
+    - $S3_CP_CMD $S3_ARTIFACTS_URI/minimized-btfs-${PACKAGE_ARCH}.tar.xz /tmp/system-probe/minimized-btfs.tar.xz
     - chmod 0644 /tmp/system-probe/*.o
     - chmod 0744 /tmp/system-probe/system-probe /tmp/system-probe/clang-bpf /tmp/system-probe/llc-bpf
     - $S3_CP_CMD $S3_PERMANENT_ARTIFACTS_URI/nikos-${PACKAGE_ARCH}.tar.gz /tmp/nikos.tar.gz

--- a/.gitlab/package_build/suse_rpm.yml
+++ b/.gitlab/package_build/suse_rpm.yml
@@ -34,6 +34,7 @@
     - $S3_CP_CMD $S3_ARTIFACTS_URI/tcp-queue-length.c.${PACKAGE_ARCH} /tmp/system-probe/tcp-queue-length.c
     - $S3_CP_CMD $S3_PERMANENT_ARTIFACTS_URI/clang-$CLANG_LLVM_VER.${PACKAGE_ARCH} /tmp/system-probe/clang-bpf
     - $S3_CP_CMD $S3_PERMANENT_ARTIFACTS_URI/llc-$CLANG_LLVM_VER.${PACKAGE_ARCH} /tmp/system-probe/llc-bpf
+    - $S3_CP_CMD $S3_ARTIFACTS_URI/minimized-btfs-${PACKAGE_ARCH}.tar.gz /tmp/system-probe/minimized-btfs.tar.gz
     - chmod 0644 /tmp/system-probe/*.o
     - chmod 0744 /tmp/system-probe/system-probe /tmp/system-probe/clang-bpf /tmp/system-probe/llc-bpf
     - $S3_CP_CMD $S3_PERMANENT_ARTIFACTS_URI/nikos-${PACKAGE_ARCH}.tar.gz /tmp/nikos.tar.gz
@@ -58,7 +59,7 @@ agent_suse-x64-a6:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/suse_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:main"]
-  needs: ["go_mod_tidy_check", "build_system-probe-x64", "go_deps"]
+  needs: ["go_mod_tidy_check", "build_system-probe-x64", "go_deps", "generate_minimized_btfs_x64"]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
     AGENT_MAJOR_VERSION: 6
@@ -76,7 +77,7 @@ agent_suse-x64-a7:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/suse_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:main"]
-  needs: ["go_mod_tidy_check", "build_system-probe-x64", "go_deps"]
+  needs: ["go_mod_tidy_check", "build_system-probe-x64", "go_deps", "generate_minimized_btfs_x64"]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
     AGENT_MAJOR_VERSION: 7

--- a/.gitlab/package_build/suse_rpm.yml
+++ b/.gitlab/package_build/suse_rpm.yml
@@ -34,7 +34,7 @@
     - $S3_CP_CMD $S3_ARTIFACTS_URI/tcp-queue-length.c.${PACKAGE_ARCH} /tmp/system-probe/tcp-queue-length.c
     - $S3_CP_CMD $S3_PERMANENT_ARTIFACTS_URI/clang-$CLANG_LLVM_VER.${PACKAGE_ARCH} /tmp/system-probe/clang-bpf
     - $S3_CP_CMD $S3_PERMANENT_ARTIFACTS_URI/llc-$CLANG_LLVM_VER.${PACKAGE_ARCH} /tmp/system-probe/llc-bpf
-    - $S3_CP_CMD $S3_ARTIFACTS_URI/minimized-btfs-${PACKAGE_ARCH}.tar.gz /tmp/system-probe/minimized-btfs.tar.gz
+    - $S3_CP_CMD $S3_ARTIFACTS_URI/minimized-btfs-${PACKAGE_ARCH}.tar.xz /tmp/system-probe/minimized-btfs.tar.xz
     - chmod 0644 /tmp/system-probe/*.o
     - chmod 0744 /tmp/system-probe/system-probe /tmp/system-probe/clang-bpf /tmp/system-probe/llc-bpf
     - $S3_CP_CMD $S3_PERMANENT_ARTIFACTS_URI/nikos-${PACKAGE_ARCH}.tar.gz /tmp/nikos.tar.gz

--- a/.gitlab/package_deps_build.yml
+++ b/.gitlab/package_deps_build.yml
@@ -12,8 +12,8 @@
     - tar -xf btfs-$ARCH.tar.gz
     - inv -e system-probe.generate-minimized-btfs --source-dir "$CI_PROJECT_DIR/btfs-$ARCH" --output-dir "$CI_PROJECT_DIR/minimized-btfs" --input-bpf-programs ""
     - cd minimized-btfs
-    - tar -czf minimized-btfs.tar.gz *
-    - $S3_CP_CMD minimized-btfs.tar.gz $S3_ARTIFACTS_URI/minimized-btfs-$ARCH.tar.gz
+    - tar -cJf minimized-btfs.tar.xz *
+    - $S3_CP_CMD minimized-btfs.tar.xz $S3_ARTIFACTS_URI/minimized-btfs-$ARCH.tar.xz
 
 
 generate_minimized_btfs_x64:

--- a/.gitlab/package_deps_build.yml
+++ b/.gitlab/package_deps_build.yml
@@ -1,0 +1,30 @@
+---
+# package_deps_build stage
+# Contains jobs to build dependencies needed for datadog-agent packages
+
+.generate_minimized_btfs_common:
+  stage: package_deps_build
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/btf-gen:$DATADOG_AGENT_BTF_GEN_BUILDIMAGES
+  tags: ["runner:main"]
+  script:
+    - cd $CI_PROJECT_DIR
+    - $S3_CP_CMD $S3_PERMANENT_ARTIFACTS_URI/btfs-$ARCH.tar.gz .
+    - tar -xf btfs-$ARCH.tar.gz
+    - inv -e system-probe.generate-minimized-btfs --source-dir "$CI_PROJECT_DIR/btfs-$ARCH" --output-dir "$CI_PROJECT_DIR/minimized-btfs" --input-bpf-programs ""
+    - cd minimized-btfs
+    - tar -czf minimized-btfs.tar.gz *
+    - $S3_CP_CMD minimized-btfs.tar.gz $S3_ARTIFACTS_URI/minimized-btfs-$ARCH.tar.gz
+
+
+generate_minimized_btfs_x64:
+  needs: ["build_system-probe-x64"]
+  extends: .generate_minimized_btfs_common
+  variables:
+    ARCH: amd64
+
+
+generate_minimized_btfs_arm64:
+  needs: ["build_system-probe-arm64"]
+  extends: .generate_minimized_btfs_common
+  variables:
+    ARCH: arm64

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -40,7 +40,7 @@
   before_script:
     - !reference [.retrieve_linux_go_deps]
     - !reference [.retrieve_linux_go_tools_deps]
-    - mkdir -p $CI_PROJECT_DIR/.tmp/binary-ebpf
+    - mkdir -p $CI_PROJECT_DIR/.tmp/binary-ebpf/co-re
     - !reference [.retrieve_sysprobe_deps]
   script:
     - inv -e install-tools

--- a/omnibus/config/software/system-probe.rb
+++ b/omnibus/config/software/system-probe.rb
@@ -13,6 +13,8 @@ build do
 
   mkdir "#{install_dir}/embedded/share/system-probe/ebpf"
   mkdir "#{install_dir}/embedded/share/system-probe/ebpf/runtime"
+  mkdir "#{install_dir}/embedded/share/system-probe/ebpf/co-re"
+  mkdir "#{install_dir}/embedded/share/system-probe/ebpf/co-re/btf"
   mkdir "#{install_dir}/embedded/nikos/embedded/bin"
   mkdir "#{install_dir}/embedded/nikos/embedded/lib"
 
@@ -37,6 +39,7 @@ build do
     copy "#{ENV['SYSTEM_PROBE_BIN']}/tcp-queue-length.c", "#{install_dir}/embedded/share/system-probe/ebpf/runtime/"
     copy "#{ENV['SYSTEM_PROBE_BIN']}/clang-bpf", "#{install_dir}/embedded/bin/clang-bpf"
     copy "#{ENV['SYSTEM_PROBE_BIN']}/llc-bpf", "#{install_dir}/embedded/bin/llc-bpf"
+    command "tar -xf #{ENV['SYSTEM_PROBE_BIN']}/minimized-btfs.tar.gz -C #{install_dir}/embedded/share/system-probe/ebpf/co-re/btf/"
   end
 
   copy 'pkg/ebpf/c/COPYING', "#{install_dir}/embedded/share/system-probe/ebpf/"

--- a/omnibus/config/software/system-probe.rb
+++ b/omnibus/config/software/system-probe.rb
@@ -39,7 +39,7 @@ build do
     copy "#{ENV['SYSTEM_PROBE_BIN']}/tcp-queue-length.c", "#{install_dir}/embedded/share/system-probe/ebpf/runtime/"
     copy "#{ENV['SYSTEM_PROBE_BIN']}/clang-bpf", "#{install_dir}/embedded/bin/clang-bpf"
     copy "#{ENV['SYSTEM_PROBE_BIN']}/llc-bpf", "#{install_dir}/embedded/bin/llc-bpf"
-    command "tar -xf #{ENV['SYSTEM_PROBE_BIN']}/minimized-btfs.tar.gz -C #{install_dir}/embedded/share/system-probe/ebpf/co-re/btf/"
+    copy "#{ENV['SYSTEM_PROBE_BIN']}/minimized-btfs.tar.gz", "#{install_dir}/embedded/share/system-probe/ebpf/co-re/btf/minimized-btfs.tar.gz"
   end
 
   copy 'pkg/ebpf/c/COPYING', "#{install_dir}/embedded/share/system-probe/ebpf/"

--- a/omnibus/config/software/system-probe.rb
+++ b/omnibus/config/software/system-probe.rb
@@ -39,7 +39,7 @@ build do
     copy "#{ENV['SYSTEM_PROBE_BIN']}/tcp-queue-length.c", "#{install_dir}/embedded/share/system-probe/ebpf/runtime/"
     copy "#{ENV['SYSTEM_PROBE_BIN']}/clang-bpf", "#{install_dir}/embedded/bin/clang-bpf"
     copy "#{ENV['SYSTEM_PROBE_BIN']}/llc-bpf", "#{install_dir}/embedded/bin/llc-bpf"
-    copy "#{ENV['SYSTEM_PROBE_BIN']}/minimized-btfs.tar.gz", "#{install_dir}/embedded/share/system-probe/ebpf/co-re/btf/minimized-btfs.tar.gz"
+    copy "#{ENV['SYSTEM_PROBE_BIN']}/minimized-btfs.tar.xz", "#{install_dir}/embedded/share/system-probe/ebpf/co-re/btf/minimized-btfs.tar.xz"
   end
 
   copy 'pkg/ebpf/c/COPYING', "#{install_dir}/embedded/share/system-probe/ebpf/"

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -1016,7 +1016,7 @@ def generate_minimized_btfs(
 
     ctx.run(f"mkdir -p {output_dir}")
     for root, dirs, files in os.walk(source_dir):
-        path_from_root = root[len(source_dir) + 1 :]
+        path_from_root = os.path.relpath(root, source_dir)
 
         for dir in dirs:
             output_subdir = os.path.join(output_dir, path_from_root, dir)
@@ -1026,7 +1026,7 @@ def generate_minimized_btfs(
             if not file.endswith(".tar.xz"):
                 continue
 
-            btf_filename = file[: len(file) - 7]
+            btf_filename = file[: -len(".tar.xz")]
             compressed_source_btf_path = os.path.join(root, file)
             output_btf_path = os.path.join(output_dir, path_from_root, btf_filename)
             compressed_output_btf_path = output_btf_path + ".tar.xz"

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -1014,6 +1014,12 @@ def generate_minimized_btfs(
     bpf program(s).
     """
 
+    # If there are no input programs, we don't need to actually do anything; however, in order to
+    # prevent CI jobs from failing, we'll create a dummy output directory
+    if input_bpf_programs == "":
+        ctx.run(f"mkdir -p {output_dir}/dummy_data")
+        return
+
     ctx.run(f"mkdir -p {output_dir}")
     for root, dirs, files in os.walk(source_dir):
         path_from_root = os.path.relpath(root, source_dir)
@@ -1030,10 +1036,6 @@ def generate_minimized_btfs(
             compressed_source_btf_path = os.path.join(root, file)
             output_btf_path = os.path.join(output_dir, path_from_root, btf_filename)
             compressed_output_btf_path = output_btf_path + ".tar.xz"
-
-            if input_bpf_programs == "":
-                ctx.run(f"mv {compressed_source_btf_path} {compressed_output_btf_path}")
-                continue
 
             ctx.run(f"tar -xf {compressed_source_btf_path}")
             ctx.run(f"bpftool gen min_core_btf {btf_filename} {output_btf_path} {input_bpf_programs}")

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -1016,7 +1016,7 @@ def generate_minimized_btfs(
 
     ctx.run(f"mkdir -p {output_dir}")
     for root, dirs, files in os.walk(source_dir):
-        path_from_root = root[len(source_dir)+1:]
+        path_from_root = root[len(source_dir) + 1 :]
 
         for dir in dirs:
             output_subdir = os.path.join(output_dir, path_from_root, dir)
@@ -1026,7 +1026,7 @@ def generate_minimized_btfs(
             if not file.endswith(".tar.xz"):
                 continue
 
-            btf_filename = file[:len(file)-7]
+            btf_filename = file[: len(file) - 7]
             compressed_source_btf_path = os.path.join(root, file)
             output_btf_path = os.path.join(output_dir, path_from_root, btf_filename)
             compressed_output_btf_path = output_btf_path + ".tar.xz"
@@ -1041,4 +1041,3 @@ def generate_minimized_btfs(
             tar_working_directory = os.path.join(output_dir, path_from_root)
             ctx.run(f"tar -C {tar_working_directory} -cJf {compressed_output_btf_path} {btf_filename}")
             ctx.run(f"rm {output_btf_path}")
-


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Creates new CI jobs:
a) `build_processed_btfhub_archive`, which is responsible for fetching, processing and pushing to S3 a collection of BTF files for platforms/kernel versions which are known to not have BTF information by default.
b) `generate_minimized_btfs_x64`/`generate_minimized_btfs_arm`, which are responsible for downloading the stored BTF collections and generating collections of minimized BTFs which have been tailored to the given bpf CO-RE program(s). The minimized BTF collections are then bundled into the datadog-agent package.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
