### PR TITLE
Add CO-RE flavour of kitchen tests

### DIFF
--- a/.gitlab/functional_test/system_probe.yml
+++ b/.gitlab/functional_test/system_probe.yml
@@ -21,8 +21,8 @@
 
 
 .retrieve_minimized_btfs:
-  - $S3_CP_CMD $S3_ARTIFACTS_URI/minimized-btfs-${ARCH}.tar.gz /tmp/minimized-btfs.tar.gz
-  - cp /tmp/minimized-btfs.tar.gz $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/minimized-btfs.tar.gz
+  - $S3_CP_CMD $S3_ARTIFACTS_URI/minimized-btfs-${ARCH}.tar.xz /tmp/minimized-btfs.tar.xz
+  - cp /tmp/minimized-btfs.tar.xz $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/minimized-btfs.tar.xz
 
 
 kitchen_test_system_probe_linux_x64:

--- a/.gitlab/functional_test/system_probe.yml
+++ b/.gitlab/functional_test/system_probe.yml
@@ -19,16 +19,24 @@
   script:
     - bash -l tasks/run-test-kitchen.sh system-probe-test $AGENT_MAJOR_VERSION
 
+
+.retrieve_minimized_btfs:
+  - $S3_CP_CMD $S3_ARTIFACTS_URI/minimized-btfs-${ARCH}.tar.gz /tmp/minimized-btfs.tar.gz
+  - cp /tmp/minimized-btfs.tar.gz $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/minimized-btfs.tar.gz
+
+
 kitchen_test_system_probe_linux_x64:
   extends:
     - .kitchen_test_system_probe
     - .kitchen_azure_x64
     - .kitchen_azure_location_north_central_us
-  needs: [ "tests_ebpf_x64" ]
+  needs: [ "tests_ebpf_x64", "generate_minimized_btfs_x64" ]
   variables:
+    ARCH: amd64
     KITCHEN_ARCH: x86_64
     KITCHEN_IMAGE_SIZE: Standard_D2_v2
   before_script:
+    - !reference [.retrieve_minimized_btfs]
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh
   parallel:
@@ -46,11 +54,13 @@ kitchen_test_system_probe_linux_x64_ec2:
     - .kitchen_test_system_probe
     - .kitchen_ec2_location_us_east_1
     - .kitchen_ec2
-  needs: [ "tests_ebpf_x64" ]
+  needs: [ "tests_ebpf_x64", "generate_minimized_btfs_x64" ]
   variables:
+    ARCH: amd64
     KITCHEN_ARCH: x86_64
     KITCHEN_EC2_INSTANCE_TYPE: "t2.xlarge"
   before_script:
+    - !reference [.retrieve_minimized_btfs]
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh
   parallel:
@@ -64,11 +74,13 @@ kitchen_test_system_probe_linux_arm64:
     - .kitchen_test_system_probe
     - .kitchen_ec2_location_us_east_1
     - .kitchen_ec2_spot_instances
-  needs: [ "tests_ebpf_arm64" ]
+  needs: [ "tests_ebpf_arm64", "generate_minimized_btfs_arm64" ]
   variables:
+    ARCH: arm64
     KITCHEN_ARCH: arm64
     KITCHEN_EC2_INSTANCE_TYPE: "t4g.xlarge"
   before_script:
+    - !reference [.retrieve_minimized_btfs]
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh
   parallel:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1366,6 +1366,7 @@ func findUnknownEnvVars(config Config, environ []string) []string {
 		"DD_DOTNET_TRACER_HOME": {},
 		// these variables are used by system-probe, but not via the Config struct
 		"DD_TESTS_RUNTIME_COMPILED": {},
+		"DD_TESTS_CO_RE":            {},
 	}
 	for _, key := range config.GetEnvVars() {
 		knownVars[key] = struct{}{}

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -470,6 +470,7 @@ def test(
     bundle_ebpf=False,
     output_path=None,
     runtime_compiled=False,
+    co_re=False,
     skip_linters=False,
     skip_object_files=False,
     run=None,
@@ -520,6 +521,8 @@ def test(
     env['DD_SYSTEM_PROBE_BPF_DIR'] = EMBEDDED_SHARE_DIR
     if runtime_compiled:
         env['DD_TESTS_RUNTIME_COMPILED'] = "1"
+    if co_re:
+        env['DD_TESTS_CO_RE'] = "1"
 
     go_root = os.getenv("GOROOT")
     if go_root:

--- a/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
+++ b/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
@@ -100,6 +100,10 @@ directory "/opt/datadog-agent/embedded/include" do
   recursive true
 end
 
+directory "/tmp/system-probe-tests/pkg/ebpf/bytecode/build/co-re/btf" do
+  recursive true
+end
+
 cookbook_file "/opt/datadog-agent/embedded/bin/clang-bpf" do
   source "clang-bpf"
   mode '0744'
@@ -110,4 +114,14 @@ cookbook_file "/opt/datadog-agent/embedded/bin/llc-bpf" do
   source "llc-bpf"
   mode '0744'
   action :create
+end
+
+cookbook_file "minimized-btfs.tar.gz" do
+  source "minimized-btfs.tar.gz"
+  action :create
+end
+
+execute 'extract minimized btfs' do
+  command 'tar -xf minimized-btfs.tar.gz -C /tmp/system-probe-tests/pkg/ebpf/bytecode/build/co-re/btf/'
+  action :run
 end

--- a/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
+++ b/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
@@ -116,12 +116,7 @@ cookbook_file "/opt/datadog-agent/embedded/bin/llc-bpf" do
   action :create
 end
 
-cookbook_file "minimized-btfs.tar.gz" do
-  source "minimized-btfs.tar.gz"
+cookbook_file "/tmp/system-probe-tests/pkg/ebpf/bytecode/build/co-re/btf/minimized-btfs.tar.xz" do
+  source "minimized-btfs.tar.xz"
   action :create
-end
-
-execute 'extract minimized btfs' do
-  command 'tar -xf minimized-btfs.tar.gz -C /tmp/system-probe-tests/pkg/ebpf/bytecode/build/co-re/btf/'
-  action :run
 end

--- a/test/kitchen/test/integration/system-probe-test/rspec/system-probe-test_spec.rb
+++ b/test/kitchen/test/integration/system-probe-test/rspec/system-probe-test_spec.rb
@@ -31,6 +31,9 @@ print KernelOut.format(`uname -a`)
 Dir.glob('/tmp/system-probe-tests/pkg/ebpf/bytecode/build/*.o').each do |f|
   FileUtils.chmod 0644, f, :verbose => true
 end
+Dir.glob('/tmp/system-probe-tests/pkg/ebpf/bytecode/build/co-re/*.o').each do |f|
+  FileUtils.chmod 0644, f, :verbose => true
+end
 
 Dir.glob('/tmp/system-probe-tests/**/testsuite').each do |f|
   pkg = f.delete_prefix('/tmp/system-probe-tests').delete_suffix('/testsuite')
@@ -49,6 +52,17 @@ Dir.glob('/tmp/system-probe-tests/**/testsuite').each do |f|
     it 'successfully runs' do
       Dir.chdir(File.dirname(f)) do
         Open3.popen2e({"DD_TESTS_RUNTIME_COMPILED"=>"1", "DD_SYSTEM_PROBE_BPF_DIR"=>"/tmp/system-probe-tests/pkg/ebpf/bytecode/build"}, "sudo", "-E", f, "-test.v", "-test.count=1") do |_, output, wait_thr|
+          test_failures = check_output(output, wait_thr)
+          expect(test_failures).to be_empty, test_failures.join("\n")
+        end
+      end
+    end
+  end
+
+  describe "CO-RE system-probe tests for #{pkg}" do
+    it 'successfully runs' do
+      Dir.chdir(File.dirname(f)) do
+        Open3.popen2e({"DD_TESTS_CO_RE"=>"1", "DD_SYSTEM_PROBE_BPF_DIR"=>"/tmp/system-probe-tests/pkg/ebpf/bytecode/build"}, "sudo", "-E", f, "-test.v", "-test.count=1") do |_, output, wait_thr|
           test_failures = check_output(output, wait_thr)
           expect(test_failures).to be_empty, test_failures.join("\n")
         end

--- a/test/kitchen/test/integration/system-probe-test/rspec/system-probe-test_spec.rb
+++ b/test/kitchen/test/integration/system-probe-test/rspec/system-probe-test_spec.rb
@@ -4,6 +4,13 @@ require 'open3'
 
 GOLANG_TEST_FAILURE = /FAIL:/
 
+runtime_compiled_tests = Array.[](
+  "/pkg/network/tracer"
+)
+
+co_re_tests = Array.[](
+)
+
 def check_output(output, wait_thr)
   test_failures = []
 
@@ -48,23 +55,27 @@ Dir.glob('/tmp/system-probe-tests/**/testsuite').each do |f|
     end
   end
 
-  describe "runtime compiled system-probe tests for #{pkg}" do
-    it 'successfully runs' do
-      Dir.chdir(File.dirname(f)) do
-        Open3.popen2e({"DD_TESTS_RUNTIME_COMPILED"=>"1", "DD_SYSTEM_PROBE_BPF_DIR"=>"/tmp/system-probe-tests/pkg/ebpf/bytecode/build"}, "sudo", "-E", f, "-test.v", "-test.count=1") do |_, output, wait_thr|
-          test_failures = check_output(output, wait_thr)
-          expect(test_failures).to be_empty, test_failures.join("\n")
+  if runtime_compiled_tests.include? pkg
+    describe "runtime compiled system-probe tests for #{pkg}" do
+      it 'successfully runs' do
+        Dir.chdir(File.dirname(f)) do
+          Open3.popen2e({"DD_TESTS_RUNTIME_COMPILED"=>"1", "DD_SYSTEM_PROBE_BPF_DIR"=>"/tmp/system-probe-tests/pkg/ebpf/bytecode/build"}, "sudo", "-E", f, "-test.v", "-test.count=1") do |_, output, wait_thr|
+            test_failures = check_output(output, wait_thr)
+            expect(test_failures).to be_empty, test_failures.join("\n")
+          end
         end
       end
     end
   end
 
-  describe "CO-RE system-probe tests for #{pkg}" do
-    it 'successfully runs' do
-      Dir.chdir(File.dirname(f)) do
-        Open3.popen2e({"DD_TESTS_CO_RE"=>"1", "DD_SYSTEM_PROBE_BPF_DIR"=>"/tmp/system-probe-tests/pkg/ebpf/bytecode/build"}, "sudo", "-E", f, "-test.v", "-test.count=1") do |_, output, wait_thr|
-          test_failures = check_output(output, wait_thr)
-          expect(test_failures).to be_empty, test_failures.join("\n")
+  if co_re_tests.include? pkg
+    describe "CO-RE system-probe tests for #{pkg}" do
+      it 'successfully runs' do
+        Dir.chdir(File.dirname(f)) do
+          Open3.popen2e({"DD_TESTS_CO_RE"=>"1", "DD_SYSTEM_PROBE_BPF_DIR"=>"/tmp/system-probe-tests/pkg/ebpf/bytecode/build"}, "sudo", "-E", f, "-test.v", "-test.count=1") do |_, output, wait_thr|
+            test_failures = check_output(output, wait_thr)
+            expect(test_failures).to be_empty, test_failures.join("\n")
+          end
         end
       end
     end


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Enables CO-RE kitchen tests by 
a) copying minimized BTF collections to the kitchen test environments & 
b) running kitchen tests with `DD_TESTS_CO_RE` set to `true`.

In order to keep the kitchen test jobs as short as possible, CO-RE tests will only be run on packages specified in `test/kitchen/test/integration/system-probe-test/rspec/system-probe-test_spec.rb`. While I was at it, I made the same change for the runtime compilation tests. It turns out `/pkg/network/tracer` is the only package which actually utilizes the `DD_TESTS_RUNTIME_COMPILED` environment variable, so it's the only package where re-running the tests with that variable set is necessary.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
