### PR TITLE
[backport] [aggregator] move a verbose debug log into trace log level.

### DIFF
--- a/pkg/aggregator/no_aggregation_stream_worker.go
+++ b/pkg/aggregator/no_aggregation_stream_worker.go
@@ -172,7 +172,7 @@ func (w *noAggregationStreamWorker) run() {
 
 					// receiving samples
 					case samples := <-w.samplesChan:
-						log.Debugf("Streaming %d metrics from the no-aggregation pipeline", len(samples))
+						log.Tracef("Streaming %d metrics from the no-aggregation pipeline", len(samples))
 						countProcessed := 0
 						countUnsupportedType := 0
 


### PR DESCRIPTION
### What does this PR do?

Move a verbose debug log of the no-aggregation pipeline to the trace level.

### Reviewer's Checklist


- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
