### PR TITLE
Adding fips option to connect to the FIPS proxy

### DIFF
--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -102,6 +102,17 @@
     </span>
   </div>
 
+  {{- if eq .config.fips_enabled "true" }}
+
+    <div class="stat">
+      <span class="stat_title">FIPS proxy</span>
+      <span class="stat_data">
+        FIPS proxy is enabled. All communication will be routed to a local FIPS proxy:<br>
+          - Local address: {{ .config.fips_local_address }}<br>
+          - Starting port range: {{ .config.fips_port_range_start }}<br>
+      </span>
+  {{- end }}
+
   {{- if .TransportWarnings }}
     <div class="stat">
       <span class="stat_title">Transport Proxy Warnings</span>

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -275,6 +276,11 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("allow_arbitrary_tags", false)
 	config.BindEnvAndSetDefault("use_proxy_for_cloud_metadata", false)
 	config.BindEnvAndSetDefault("remote_tagger_timeout_seconds", 30)
+
+	// Fips
+	config.BindEnvAndSetDefault("fips.enabled", false)
+	config.BindEnvAndSetDefault("fips.port_range_start", 3833)
+	config.BindEnvAndSetDefault("fips.local_address", "localhost")
 
 	// Remote config
 	config.BindEnvAndSetDefault("remote_configuration.enabled", false)
@@ -1193,6 +1199,12 @@ func LoadProxyFromEnv(config Config) {
 	// the conf files, overwrite them with the env variables and reset
 	// everything.
 
+	// When FIPS proxy is enabled we ignore proxy setting to force data to the local proxy
+	if config.GetBool("fips.enabled") {
+		log.Infof("'fips.enabled' has been set to true. Ignoring proxy setting.")
+		return
+	}
+
 	lookupEnvCaseInsensitive := func(key string) (string, bool) {
 		value, found := os.LookupEnv(key)
 		if !found {
@@ -1468,7 +1480,93 @@ func load(config Config, origin string, loadSecret bool) (*Warnings, error) {
 	// setTracemallocEnabled *must* be called before setNumWorkers
 	warnings.TraceMallocEnabledWithPy2 = setTracemallocEnabled(config)
 	setNumWorkers(config)
-	return &warnings, nil
+	return &warnings, setupFipsEndpoints(config)
+}
+
+// setupFipsEndpoints overwrites the Agent endpoint for outgoing data to be sent to the local FIPS proxy. The local FIPS
+// proxy will be in charge of forwarding data to the Datadog backend following FIPS standard. Starting from
+// fips.port_range_start we will assign a dedicated port per product (metrics, logs, traces, ...).
+func setupFipsEndpoints(config Config) error {
+	// Each port is dedicated to a specific data type:
+	//
+	// port_range_start: HAProxy stats
+	// port_range_start + 1:  metrics
+	// port_range_start + 2:  traces
+	// port_range_start + 3:  profiles
+	// port_range_start + 4:  processes
+	// port_range_start + 5:  logs
+	// port_range_start + 6:  databases monitoring metrics
+	// port_range_start + 7:  databases monitoring samples
+	// port_range_start + 8:  network devices metadata
+	// port_range_start + 9:  network devices snmp traps (unused)
+	// port_range_start + 10: instrumentation telemetry
+	// port_range_start + 11: appsec events (unused)
+
+	if !config.GetBool("fips.enabled") {
+		log.Debug("FIPS mode is disabled")
+		return nil
+	}
+
+	const (
+		proxyStats                 = 0
+		metrics                    = 1
+		traces                     = 2
+		profiles                   = 3
+		processes                  = 4
+		logs                       = 5
+		databasesMonitoringMetrics = 6
+		databasesMonitoringSamples = 7
+		networkDevicesMetadata     = 8
+		networkDevicesSnmpTraps    = 9
+		instrumentationTelemetry   = 10
+		appsecEvents               = 11
+	)
+
+	localAddress, err := isLocalAddress(config.GetString("fips.local_address"))
+	if err != nil {
+		return fmt.Errorf("fips.local_address: %s", err)
+	}
+
+	portRangeStart := config.GetInt("fips.port_range_start")
+	urlFor := func(port int) string { return net.JoinHostPort(localAddress, strconv.Itoa(portRangeStart+port)) }
+
+	log.Warnf("FIPS mode is enabled! All communication to DataDog will be routed to the local FIPS proxy on '%s' starting from port %d", localAddress, portRangeStart)
+
+	// Disabling proxy to make sure all data goes directly to the FIPS proxy
+	os.Unsetenv("HTTP_PROXY")
+	os.Unsetenv("HTTPS_PROXY")
+
+	// HTTP for now, will soon be updated to HTTPS
+	protocol := "http://"
+
+	// The following overwrites should be sync with the documentation for the fips.enabled config setting in the
+	// config_template.yaml
+
+	// Metrics
+	config.Set("dd_url", protocol+urlFor(metrics))
+
+	// APM
+	config.Set("apm_config.apm_dd_url", protocol+urlFor(traces))
+	config.Set("apm_config.profiling_dd_url", protocol+urlFor(profiles))
+	config.Set("apm_config.telemetry.dd_url", protocol+urlFor(instrumentationTelemetry))
+
+	// Processes
+	config.Set("process_config.process_dd_url", protocol+urlFor(processes))
+
+	// Logs
+	config.Set("logs_config.use_http", true)
+	config.Set("logs_config.logs_no_ssl", true)
+	config.Set("logs_config.logs_dd_url", urlFor(logs))
+
+	// Database monitoring
+	config.Set("database_monitoring.metrics.dd_url", urlFor(databasesMonitoringMetrics))
+	config.Set("database_monitoring.activity.dd_url", urlFor(databasesMonitoringMetrics))
+	config.Set("database_monitoring.samples.dd_url", urlFor(databasesMonitoringSamples))
+
+	// Network devices
+	config.Set("network_devices.metadata.dd_url", urlFor(networkDevicesMetadata))
+
+	return nil
 }
 
 // ResolveSecrets merges all the secret values from origin into config. Secret values
@@ -1729,15 +1827,13 @@ func FileUsedDir() string {
 	return filepath.Dir(Datadog.ConfigFileUsed())
 }
 
-// GetIPCAddress returns the IPC address or an error if the address is not local
-func GetIPCAddress() (string, error) {
-	address := Datadog.GetString("ipc_address")
+func isLocalAddress(address string) (string, error) {
 	if address == "localhost" {
 		return address, nil
 	}
 	ip := net.ParseIP(address)
 	if ip == nil {
-		return "", fmt.Errorf("ipc_address was set to an invalid IP address: %s", address)
+		return "", fmt.Errorf("address was set to an invalid IP address: %s", address)
 	}
 	for _, cidr := range []string{
 		"127.0.0.0/8", // IPv4 loopback
@@ -1751,7 +1847,16 @@ func GetIPCAddress() (string, error) {
 			return address, nil
 		}
 	}
-	return "", fmt.Errorf("ipc_address was set to a non-loopback IP address: %s", address)
+	return "", fmt.Errorf("address was set to a non-loopback IP address: %s", address)
+}
+
+// GetIPCAddress returns the IPC address or an error if the address is not local
+func GetIPCAddress() (string, error) {
+	address, err := isLocalAddress(Datadog.GetString("ipc_address"))
+	if err != nil {
+		return "", fmt.Errorf("ipc_address: %s", err)
+	}
+	return address, nil
 }
 
 // pathExists returns true if the given path exists

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -265,6 +265,11 @@ func getPartialConfig() map[string]string {
 	conf["log_level"] = config.Datadog.GetString("log_level")
 	conf["confd_path"] = config.Datadog.GetString("confd_path")
 	conf["additional_checksd"] = config.Datadog.GetString("additional_checksd")
+
+	conf["fips_enabled"] = config.Datadog.GetString("fips.enabled")
+	conf["fips_local_address"] = config.Datadog.GetString("fips.local_address")
+	conf["fips_port_range_start"] = config.Datadog.GetString("fips.port_range_start")
+
 	forwarderStorageMaxSizeInBytes := config.Datadog.GetInt("forwarder_storage_max_size_in_bytes")
 	if forwarderStorageMaxSizeInBytes > 0 {
 		conf["forwarder_storage_max_size_in_bytes"] = strconv.Itoa(forwarderStorageMaxSizeInBytes)

--- a/pkg/status/templates/header.tmpl
+++ b/pkg/status/templates/header.tmpl
@@ -86,6 +86,15 @@ NOTE: Changes made to this template should be reflected on the following templat
     {{ $key }}: {{ $value }}
   {{- end }}
 
+{{- if eq .config.fips_enabled true }}
+
+  FIPS proxy
+  ==========
+    FIPS proxy is enabled. All communication to Datadog is routed to a local FIPS proxy:
+      - Local address: {{ .config.fips_local_address }}
+      - Starting port: {{ .config.fips_port_range_start }}
+{{- end }}
+
 {{- if .TransportWarnings }}
 
   Transport Proxy Warnings


### PR DESCRIPTION
### What does this PR do?

We now have a single option to configure the FIPS proxy.

### Describe how to test/QA your changes

Enable the `fips.enabled` config and check that data flow to the proxy.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
