### PR TITLE
Fix KSM core `labels_as_tags` when a label must be turned into different tags depending on the resource kind

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -95,6 +95,15 @@ type KSMConfig struct {
 	//   namespace: kube_namespace
 	LabelsMapper map[string]string `yaml:"labels_mapper"`
 
+	// LabelsMapperByResourceKind can be used to translate kube-state-metrics labels to other tags, depending on the resource kind.
+	// Example: Adding kube_pod_namespace tag instead of namespace for pods and kube_deployment_namespace for deployments.
+	// labels_mapper:
+	//   pod:
+	//     namespace: kube_pod_namespace
+	//   deployment:
+	//     namespace: kube_deployment_namespace
+	labelsMapperByResourceKind map[string]map[string]string
+
 	// Tags contains the list of tags to attach to every metric, event and service check emitted by this integration.
 	// Example:
 	// tags:
@@ -196,6 +205,8 @@ func (k *KSMCheck) Configure(config, initConfig integration.Data, source string)
 
 	labelJoins := defaultLabelJoins()
 	k.mergeLabelJoins(labelJoins)
+
+	k.instance.labelsMapperByResourceKind = defaultLabelsMapperByResourceKind()
 
 	k.processLabelsAsTags()
 
@@ -471,7 +482,7 @@ func (k *KSMCheck) processMetrics(sender aggregator.Sender, metrics map[string][
 				// So, let’s continue the processing.
 			}
 			if transform, found := k.metricTransformers[metricFamily.Name]; found {
-				lMapperOverride := labelsMapperOverride(metricFamily.Name)
+				lMapperOverride := k.labelsMapperOverride(metricFamily.Name)
 				for _, m := range metricFamily.ListMetrics {
 					hostname, tags := k.hostnameAndTags(m.Labels, labelJoiner, lMapperOverride)
 					transform(sender, metricFamily.Name, m, hostname, tags, now)
@@ -479,7 +490,7 @@ func (k *KSMCheck) processMetrics(sender aggregator.Sender, metrics map[string][
 				continue
 			}
 			if ddname, found := k.metricNamesMapper[metricFamily.Name]; found {
-				lMapperOverride := labelsMapperOverride(metricFamily.Name)
+				lMapperOverride := k.labelsMapperOverride(metricFamily.Name)
 				for _, m := range metricFamily.ListMetrics {
 					hostname, tags := k.hostnameAndTags(m.Labels, labelJoiner, lMapperOverride)
 					sender.Gauge(ksmMetricPrefix+ddname, m.Val, hostname, tags)
@@ -631,8 +642,12 @@ func (k *KSMCheck) processLabelsAsTags() {
 		labels := make([]string, 0, len(labelsMapper))
 		for label, tag := range labelsMapper {
 			label = "label_" + labelRegexp.ReplaceAllString(label, "_")
-			if _, ok := k.instance.LabelsMapper[label]; !ok {
-				k.instance.LabelsMapper[label] = tag
+			if _, ok := k.instance.labelsMapperByResourceKind[resourceKind]; !ok {
+				k.instance.labelsMapperByResourceKind[resourceKind] = map[string]string{
+					label: tag,
+				}
+			} else {
+				k.instance.labelsMapperByResourceKind[resourceKind][label] = tag
 			}
 			labels = append(labels, label)
 		}
@@ -859,19 +874,12 @@ func ownerTags(kind, name string) []string {
 //   - `phase` tag should be mapped to `pod_phase` on pod metrics only.
 //   - Ingress metrics have generic tag names (host/path/service_name/service_port).
 //     It's important to have them in a dedicated mapper override for ingresses.
-func labelsMapperOverride(metricName string) map[string]string {
-	if strings.HasPrefix(metricName, "kube_pod") {
-		return map[string]string{"phase": "pod_phase"}
+func (k *KSMCheck) labelsMapperOverride(metricName string) map[string]string {
+	tok := strings.SplitN(metricName, "_", 3)
+	if len(tok) < 2 {
+		return nil
 	}
+	resourceKind := tok[1]
 
-	if strings.HasPrefix(metricName, "kube_ingress") {
-		return map[string]string{
-			"host":         "kube_ingress_host",
-			"path":         "kube_ingress_path",
-			"service_name": "kube_service",
-			"service_port": "kube_service_port",
-		}
-	}
-
-	return nil
+	return k.instance.labelsMapperByResourceKind[resourceKind]
 }

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -875,6 +875,9 @@ func ownerTags(kind, name string) []string {
 //   - Ingress metrics have generic tag names (host/path/service_name/service_port).
 //     It's important to have them in a dedicated mapper override for ingresses.
 func (k *KSMCheck) labelsMapperOverride(metricName string) map[string]string {
+	// KSM metrics are named, `kube_<RESOURCE_KIND>_<METRIC_NAME>` like for ex.:
+	// kube_pod_info, kube_pod_status_ready, or kube_pod_container_resource_requests_memory_bytes
+	// Splitting by underscores and getting the second token returns the resource kind.
 	tok := strings.SplitN(metricName, "_", 3)
 	if len(tok) < 2 {
 		return nil

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators.go
@@ -188,7 +188,7 @@ func (a *counterAggregator) flush(sender aggregator.Sender, k *KSMCheck, labelJo
 			labels[allowedLabel] = labelValues[i]
 		}
 
-		hostname, tags := k.hostnameAndTags(labels, labelJoiner, labelsMapperOverride(a.ksmMetricName))
+		hostname, tags := k.hostnameAndTags(labels, labelJoiner, k.labelsMapperOverride(a.ksmMetricName))
 
 		sender.Gauge(ksmMetricPrefix+a.ddMetricName, count, hostname, tags)
 	}

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
@@ -129,6 +129,21 @@ func defaultLabelsMapper() map[string]string {
 	}
 }
 
+// defaultLabelsMapperByResourceKind returns a map that contains the default labels to tag names by resource kind mapping
+func defaultLabelsMapperByResourceKind() map[string]map[string]string {
+	return map[string]map[string]string{
+		"pod": {
+			"phase": "pod_phase",
+		},
+		"ingress": {
+			"host":         "kube_ingress_host",
+			"path":         "kube_ingress_path",
+			"service_name": "kube_service",
+			"service_port": "kube_service_port",
+		},
+	}
+}
+
 // defaultLabelJoins returns a map that contains the default label joins configuration
 func defaultLabelJoins() map[string]*JoinsConfig {
 	defaultStandardLabels := []string{

--- a/releasenotes/notes/fix_ksm_labels_as_tags-682bc54024f9c1fc.yaml
+++ b/releasenotes/notes/fix_ksm_labels_as_tags-682bc54024f9c1fc.yaml
@@ -1,0 +1,17 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    In ``kubernetes_state_core`` check, fix the `labels_as_tags` feature when the same kubernetes label must be turned into different datadog tag, depending on the resource kind like with::
+
+       labels_as_tags:
+         daemonset:
+           first_owner: kube_daemonset_label_first_owner
+         deployment:
+           first_owner: kube_deployment_label_first_owner

--- a/releasenotes/notes/fix_ksm_labels_as_tags-682bc54024f9c1fc.yaml
+++ b/releasenotes/notes/fix_ksm_labels_as_tags-682bc54024f9c1fc.yaml
@@ -8,7 +8,7 @@
 ---
 fixes:
   - |
-    In ``kubernetes_state_core`` check, fix the `labels_as_tags` feature when the same kubernetes label must be turned into different datadog tag, depending on the resource kind like with::
+    In ``kubernetes_state_core`` check, fix the `labels_as_tags` feature when the same Kubernetes label must be turned into different Datadog tags, depending on the resource:
 
        labels_as_tags:
          daemonset:


### PR DESCRIPTION
### What does this PR do?

The `labels_as_tags` parameter of the `kubernetes_state_core` check was designed to ease the use of `label_joins` combined with `labels_mapper`.

The syntax of `labels_as_tags` allows to specify different datadog tags for the same kubernetes label, depending on the resource kind like:

```yaml
labels_as_tags:
  daemonset:
    first_owner: kube_daemonset_label_first_owner
  deployment:
    first_owner: kube_deployment_label_first_owner
```

Under the hood, it was leveraging the `labels_mapper` feature. And the `labels_mapper` feature didn’t allow to have different mappings depending on the resource kind.

This led to unexpected behavior with the above settings for `labels_as_tags`.

### Describe how to test/QA your changes

Configure the `kubernetes_state_core` check with the above piece of configuration.

Create a `DeamonSet` with:

```yaml
labels:
  app: sleep-daemonset
  first_owner: sleep-daemonset
```

Create a `Deployment` with:

```yaml
labels:
  app: sleep-deploy
  first_owner: sleep-deploy
```

**Before** this patch, the `first_owner` k8s label was always transformed into a `kube_daemonset_label_first_owner` tag, whatever the original resource kind, even `Deployment`:

```
$ kubectl --namespace datadog-agent-helm exec pod/datadog-agent-linux-cluster-agent-67b69fc58f-qknmb -- agent check -r kubernetes_state_core --table | grep -E 'kubernetes_state\.(daemonset\.|deployment\.replicas_)desired .* kube_namespace:workload-sleep' | sed 's/ *$//'
  kubernetes_state.daemonset.desired                         gauge  1666283667  2             kube_cluster_name:gke-lenaic, kube_daemon_set:sleep-daemonset, kube_deployment_label_first_owner:sleep-daemonset, kube_namespace:workload-sleep
  kubernetes_state.daemonset.desired                         gauge  1666283668  2             kube_cluster_name:gke-lenaic, kube_daemon_set:sleep-daemonset, kube_deployment_label_first_owner:sleep-daemonset, kube_namespace:workload-sleep
  kubernetes_state.deployment.replicas_desired               gauge  1666283667  1             kube_cluster_name:gke-lenaic, kube_deployment:sleep-deploy, kube_deployment_label_first_owner:sleep-deploy, kube_namespace:workload-sleep
  kubernetes_state.deployment.replicas_desired               gauge  1666283668  1             kube_cluster_name:gke-lenaic, kube_deployment:sleep-deploy, kube_deployment_label_first_owner:sleep-deploy, kube_namespace:workload-sleep
```

Note that, in this output, the `DaemonSet` related metric `kubernetes_state.daemonset.desired` is tagged with `kube_deployment_label_first_owner:sleep-daemonset`.
Whereas the tag value is the correct one. The tag name isn’t the one we could expect given the `labels_as_tags` setting.

**With** this patch, the `first_owner` k8s label is transformed into a different tag, depending on the resource kind:

```
$ kubectl --namespace datadog-agent-helm exec pod/datadog-agent-linux-cluster-agent-5f9c6bc8cf-cxm7g -- agent check -r kubernetes_state_core --table | grep -E 'kubernetes_state\.(daemonset\.|deployment\.replicas_)desired .* kube_namespace:workload-sleep' | sed 's/ *$//'
  kubernetes_state.daemonset.desired                         gauge  1666283403  2             kube_cluster_name:gke-lenaic, kube_daemon_set:sleep-daemonset, kube_daemonset_label_first_owner:sleep-daemonset, kube_namespace:workload-sleep
  kubernetes_state.daemonset.desired                         gauge  1666283404  2             kube_cluster_name:gke-lenaic, kube_daemon_set:sleep-daemonset, kube_daemonset_label_first_owner:sleep-daemonset, kube_namespace:workload-sleep
  kubernetes_state.deployment.replicas_desired               gauge  1666283403  1             kube_cluster_name:gke-lenaic, kube_deployment:sleep-deploy, kube_deployment_label_first_owner:sleep-deploy, kube_namespace:workload-sleep
  kubernetes_state.deployment.replicas_desired               gauge  1666283404  1             kube_cluster_name:gke-lenaic, kube_deployment:sleep-deploy, kube_deployment_label_first_owner:sleep-deploy, kube_namespace:workload-sleep
```

Now, the `kubernetes_state.daemonset.desired` metric is tagged with `kube_daemonset_label_first_owner:sleep-daemonset`.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
