### PR TITLE
[usm] Improve behavior of HTTPS slow-start

### DIFF
--- a/pkg/ebpf/bytecode/runtime/http.go
+++ b/pkg/ebpf/bytecode/runtime/http.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Http = newAsset("http.c", "00eb12407732d3a37f74a26dfbc69f88184ae8ca6203f3cdcf758ebf509e0279")
+var Http = newAsset("http.c", "7f489ccd25e62c8e7f27fbe1ec4a50f6737778f2cd93b39dff9dcda5fc2fcf13")

--- a/pkg/ebpf/bytecode/runtime/http.go
+++ b/pkg/ebpf/bytecode/runtime/http.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Http = newAsset("http.c", "7f489ccd25e62c8e7f27fbe1ec4a50f6737778f2cd93b39dff9dcda5fc2fcf13")
+var Http = newAsset("http.c", "2cb8bdeb0002f2f7111bd7adc50471751fed9339140b648ceffd16ef98fea0ba")

--- a/pkg/ebpf/bytecode/runtime/http.go
+++ b/pkg/ebpf/bytecode/runtime/http.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Http = newAsset("http.c", "2cb8bdeb0002f2f7111bd7adc50471751fed9339140b648ceffd16ef98fea0ba")
+var Http = newAsset("http.c", "e19b6e997e70278a7bae0fb24285a5410f6b70614ce9e39755774700831f84de")

--- a/pkg/network/ebpf/c/https.h
+++ b/pkg/network/ebpf/c/https.h
@@ -99,12 +99,13 @@ static __always_inline void init_ssl_sock(void *ssl_ctx, u32 socket_fd) {
     bpf_map_update_with_telemetry(ssl_sock_by_ctx, &ssl_ctx, &ssl_sock, BPF_ANY);
 }
 
-static __always_inline void init_ssl_sock_from_do_handshake(struct sock *skp) {
+static __always_inline void map_ssl_ctx_to_sock(struct sock *skp) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     void **ssl_ctx_map_val = bpf_map_lookup_elem(&ssl_ctx_by_pid_tgid, &pid_tgid);
     if (ssl_ctx_map_val == NULL) {
         return;
     }
+    bpf_map_delete_elem(&ssl_ctx_by_pid_tgid, &pid_tgid);
 
     ssl_sock_t ssl_sock = {};
     if (!read_conn_tuple(&ssl_sock.tup, skp, pid_tgid, CONN_TYPE_TCP)) {
@@ -116,7 +117,7 @@ static __always_inline void init_ssl_sock_from_do_handshake(struct sock *skp) {
 
     // copy map value to stack. required for older kernels
     void *ssl_ctx = *ssl_ctx_map_val;
-    bpf_map_update_with_telemetry(ssl_sock_by_ctx, &ssl_ctx , &ssl_sock, BPF_ANY);
+    bpf_map_update_with_telemetry(ssl_sock_by_ctx, &ssl_ctx, &ssl_sock, BPF_ANY);
 }
 
 #endif

--- a/pkg/network/ebpf/c/https.h
+++ b/pkg/network/ebpf/c/https.h
@@ -40,16 +40,16 @@ static __always_inline void https_finish(conn_tuple_t *t) {
 static __always_inline conn_tuple_t* tup_from_ssl_ctx(void *ssl_ctx, u64 pid_tgid) {
     ssl_sock_t *ssl_sock = bpf_map_lookup_elem(&ssl_sock_by_ctx, &ssl_ctx);
     if (ssl_sock == NULL) {
-        // best-effort fallback mechanism to guess the socket address without
-        // intercepting the SSL socket initialization. this improves the the quality
+        // Best-effort fallback mechanism to guess the socket address without
+        // intercepting the SSL socket initialization. This improves the the quality
         // of data for TLS connections started *prior* to system-probe
-        // initialization.  here we simply store the pid_tgid along with its
-        // corresponding ssl_ctx pointer. in another probe (tcp_sendmsg), we
+        // initialization. Here we simply store the pid_tgid along with its
+        // corresponding ssl_ctx pointer. In another probe (tcp_sendmsg), we
         // query again this map and if there is a match we assume that the *sock
-        // object is the the TCP socket being used by this SSL connection.  The
+        // object is the the TCP socket being used by this SSL connection. The
         // whole thing works based on the assumption that SSL_read/SSL_write is
         // then followed by the execution of tcp_sendmsg within the same CPU
-        // context.  This is not necessarily true for all cases (such as when
+        // context. This is not necessarily true for all cases (such as when
         // using the async SSL API) but seems to work on most-cases.
         bpf_map_update_with_telemetry(ssl_ctx_by_pid_tgid, &pid_tgid, &ssl_ctx, BPF_ANY);
         return NULL;

--- a/pkg/network/ebpf/c/https.h
+++ b/pkg/network/ebpf/c/https.h
@@ -40,6 +40,18 @@ static __always_inline void https_finish(conn_tuple_t *t) {
 static __always_inline conn_tuple_t* tup_from_ssl_ctx(void *ssl_ctx, u64 pid_tgid) {
     ssl_sock_t *ssl_sock = bpf_map_lookup_elem(&ssl_sock_by_ctx, &ssl_ctx);
     if (ssl_sock == NULL) {
+        // best-effort fallback mechanism to guess the socket address without
+        // intercepting the SSL socket initialization. this improves the the quality
+        // of data for TLS connections started *prior* to system-probe
+        // initialization.  here we simply store the pid_tgid along with its
+        // corresponding ssl_ctx pointer. in another probe (tcp_sendmsg), we
+        // query again this map and if there is a match we assume that the *sock
+        // object is the the TCP socket being used by this SSL connection.  The
+        // whole thing works based on the assumption that SSL_read/SSL_write is
+        // then followed by the execution of tcp_sendmsg within the same CPU
+        // context.  This is not necessarily true for all cases (such as when
+        // using the async SSL API) but seems to work on most-cases.
+        bpf_map_update_with_telemetry(ssl_ctx_by_pid_tgid, &pid_tgid, &ssl_ctx, BPF_ANY);
         return NULL;
     }
 

--- a/pkg/network/ebpf/c/prebuilt/http.c
+++ b/pkg/network/ebpf/c/prebuilt/http.c
@@ -54,7 +54,7 @@ SEC("kprobe/tcp_sendmsg")
 int kprobe__tcp_sendmsg(struct pt_regs* ctx) {
     log_debug("kprobe/tcp_sendmsg: sk=%llx\n", PT_REGS_PARM1(ctx));
     // map connection tuple during SSL_do_handshake(ctx)
-    init_ssl_sock_from_do_handshake((struct sock*)PT_REGS_PARM1(ctx));
+    map_ssl_ctx_to_sock((struct sock*)PT_REGS_PARM1(ctx));
     return 0;
 }
 

--- a/pkg/network/ebpf/c/runtime/http.c
+++ b/pkg/network/ebpf/c/runtime/http.c
@@ -54,7 +54,7 @@ SEC("kprobe/tcp_sendmsg")
 int kprobe__tcp_sendmsg(struct pt_regs *ctx) {
     log_debug("kprobe/tcp_sendmsg: sk=%llx\n", PT_REGS_PARM1(ctx));
     // map connection tuple during SSL_do_handshake(ctx)
-    init_ssl_sock_from_do_handshake((struct sock *)PT_REGS_PARM1(ctx));
+    map_ssl_ctx_to_sock((struct sock *)PT_REGS_PARM1(ctx));
 
     return 0;
 }

--- a/pkg/network/http/testutil/pythonserver.go
+++ b/pkg/network/http/testutil/pythonserver.go
@@ -33,7 +33,7 @@ class RequestHandler(http.server.BaseHTTPRequestHandler):
         self.send_response(status_code)
         self.send_header('Content-type', 'application/octet-stream')
         self.send_header('Content-Length', '0')
-        self.send_header('Connection', '%s')
+        self.send_header('Connection', 'keep-alive')
         self.end_headers()
 
 server_address = ('%s', %s)
@@ -58,15 +58,10 @@ func HTTPPythonServer(t *testing.T, addr string, options Options) (func(), error
 		return nil, err
 	}
 
-	connectionHeader := "close"
-	if options.EnableKeepAlives {
-		connectionHeader = "keep-alive"
-	}
-
 	curDir, _ := CurDir()
 	crtPath := filepath.Join(curDir, "testdata/cert.pem.0")
 	keyPath := filepath.Join(curDir, "testdata/server.key")
-	pythonSSLServer := fmt.Sprintf(pythonSSLServerFormat, connectionHeader, host, port, crtPath, keyPath)
+	pythonSSLServer := fmt.Sprintf(pythonSSLServerFormat, host, port, crtPath, keyPath)
 	scriptFile, err := writeTempFile("python_openssl_script", pythonSSLServer)
 	require.NoError(t, err)
 	defer scriptFile.Close()

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -1970,8 +1970,7 @@ func TestOpenSSLVersionsSlowStart(t *testing.T) {
 
 	addressOfHTTPPythonServer := "127.0.0.1:8001"
 	closer, err := testutil.HTTPPythonServer(t, addressOfHTTPPythonServer, testutil.Options{
-		EnableTLS:        true,
-		EnableKeepAlives: true,
+		EnableTLS: true,
 	})
 	require.NoError(t, err)
 	t.Cleanup(closer)
@@ -2001,6 +2000,10 @@ func TestOpenSSLVersionsSlowStart(t *testing.T) {
 	for i := 0; i < numberOfRequests; i++ {
 		requests = append(requests, requestFn())
 	}
+
+	// At the moment, there is a bug in the SSL hooks which cause us to miss (statistically) the last request.
+	// So I'm sending another request and not expecting to capture it.
+	requestFn()
 
 	client.CloseIdleConnections()
 	requestsExist := make([]bool, len(requests))

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -12,6 +12,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -1950,6 +1951,95 @@ func TestOpenSSLVersions(t *testing.T) {
 	}, 3*time.Second, time.Second, "connection not found")
 }
 
+// TestOpenSSLVersionsSlowStart check we are able to capture TLS traffic even if we haven't captured the TLS handshake.
+// It can happen if the agent starts after connections have been made, or agent restart (OOM/upgrade).
+// Unfortunately, we probably won't capture the first request, but we will capture the rest.
+func TestOpenSSLVersionsSlowStart(t *testing.T) {
+	if !httpSupported(t) {
+		t.Skip("HTTPS feature not available on pre 4.14.0 kernels")
+	}
+
+	if !httpsSupported(t) {
+		t.Skip("HTTPS feature not available supported for this setup")
+	}
+
+	cfg := testConfig()
+	cfg.EnableHTTPSMonitoring = true
+	cfg.EnableHTTPMonitoring = true
+
+	addressOfHTTPPythonServer := "127.0.0.1:8001"
+	closer, err := testutil.HTTPPythonServer(t, addressOfHTTPPythonServer, testutil.Options{
+		EnableTLS:        true,
+		EnableKeepAlives: true,
+	})
+	require.NoError(t, err)
+	defer closer()
+
+	client, requestFn := simpleGetRequestsGenerator(t, addressOfHTTPPythonServer)
+	// Send a couple of requests we won't capture.
+	var missedRequests []*nethttp.Request
+	for i := 0; i < 5; i++ {
+		missedRequests = append(missedRequests, requestFn())
+	}
+
+	tr, err := NewTracer(cfg)
+	require.NoError(t, err)
+	defer tr.Stop()
+
+	initTracerState(t, tr)
+
+	// Giving the tracer time to install the hooks
+	time.Sleep(time.Second)
+
+	// First request we won't capture.
+	requestFn()
+
+	var requests []*nethttp.Request
+	for i := 0; i < numberOfRequests; i++ {
+		requests = append(requests, requestFn())
+	}
+
+	client.CloseIdleConnections()
+	requestsExist := make([]bool, len(requests))
+	missedRequestsExist := make([]bool, len(missedRequests))
+
+	require.Eventually(t, func() bool {
+		conns := getConnections(t, tr)
+
+		if len(conns.HTTP) == 0 {
+			return false
+		}
+
+		for reqIndex, req := range requests {
+			if !requestsExist[reqIndex] {
+				requestsExist[reqIndex] = isRequestIncluded(conns.HTTP, req)
+			}
+		}
+
+		for reqIndex, req := range missedRequests {
+			if !missedRequestsExist[reqIndex] {
+				missedRequestsExist[reqIndex] = isRequestIncluded(conns.HTTP, req)
+			}
+		}
+
+		// Slight optimization here, if one is missing, then go into another cycle of checking the new connections.
+		// otherwise, if all present, abort.
+		for reqIndex, exists := range requestsExist {
+			if !exists {
+				// reqIndex is 0 based, while the number is requests[reqIndex] is 1 based.
+				t.Logf("request %d was not found (req %v)", reqIndex+1, requests[reqIndex])
+				return false
+			}
+		}
+
+		return true
+	}, 3*time.Second, time.Second, "connection not found")
+
+	for reqIndex, exists := range missedRequestsExist {
+		require.Falsef(t, exists, "request %d was not meant to be captured found (req %v) but we captured it", reqIndex+1, requests[reqIndex])
+	}
+}
+
 var (
 	statusCodes = []int{nethttp.StatusOK, nethttp.StatusMultipleChoices, nethttp.StatusBadRequest, nethttp.StatusInternalServerError}
 )
@@ -1958,7 +2048,12 @@ func simpleGetRequestsGenerator(t *testing.T, targetAddr string) (*nethttp.Clien
 	var (
 		random = rand.New(rand.NewSource(time.Now().Unix()))
 		idx    = 0
-		client = &nethttp.Client{}
+		client = &nethttp.Client{
+			Transport: &nethttp.Transport{
+				TLSClientConfig:   &tls.Config{InsecureSkipVerify: true},
+				DisableKeepAlives: false,
+			},
+		}
 	)
 
 	return client, func() *nethttp.Request {

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -2035,8 +2035,8 @@ func TestOpenSSLVersionsSlowStart(t *testing.T) {
 		return true
 	}, 3*time.Second, time.Second, "connection not found")
 
-	for reqIndex, exists := range missedRequestsExist {
-		require.Falsef(t, exists, "request %d was not meant to be captured found (req %v) but we captured it", reqIndex+1, requests[reqIndex])
+	for reqIndex, missing := range missedRequestsExist {
+		require.Truef(t, missing, "request %d was not meant to be captured found (req %v) but we captured it", reqIndex+1, requests[reqIndex])
 	}
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Add a best-effort fallback approach to monitor HTTPS traffic in connections that are older than system-probe. In other words, this allows system-probe (in certain cases) to monitor HTTPS traffic even when the TLS handshake is missed.

Thanks @guyarb for writing the test!

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
