### PR TITLE
pkg/snmp/traps/listener.go: fix logger

### DIFF
--- a/pkg/snmp/traps/listener.go
+++ b/pkg/snmp/traps/listener.go
@@ -78,7 +78,7 @@ func (t *TrapListener) Stop() {
 
 func (t *TrapListener) receiveTrap(p *gosnmp.SnmpPacket, u *net.UDPAddr) {
 	if err := validatePacket(p, t.config); err != nil {
-		log.Warnf("Invalid credentials from %s on listener %s, dropping traps", u.String(), t.config.Addr())
+		log.Debugf("Invalid credentials from %s on listener %s, dropping traps", u.String(), t.config.Addr())
 		trapsPacketsAuthErrors.Add(1)
 		return
 	}

--- a/pkg/snmp/traps/listener.go
+++ b/pkg/snmp/traps/listener.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/gosnmp/gosnmp"
 
-	"github.com/DataDog/datadog-agent/pkg/trace/log"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // TrapListener opens an UDP socket and put all received traps in a channel
@@ -21,7 +21,6 @@ type TrapListener struct {
 	packets       PacketsChannel
 	listener      *gosnmp.TrapListener
 	errorsChannel chan error
-	errorLogger   *log.ThrottledLogger
 }
 
 // NewTrapListener creates a simple TrapListener instance but does not start it
@@ -38,7 +37,6 @@ func NewTrapListener(config Config, packets PacketsChannel) (*TrapListener, erro
 		packets:       packets,
 		listener:      gosnmpListener,
 		errorsChannel: errorsChan,
-		errorLogger:   log.NewThrottled(5, 10*time.Second),
 	}
 
 	gosnmpListener.OnNewTrap = trapListener.receiveTrap
@@ -80,7 +78,7 @@ func (t *TrapListener) Stop() {
 
 func (t *TrapListener) receiveTrap(p *gosnmp.SnmpPacket, u *net.UDPAddr) {
 	if err := validatePacket(p, t.config); err != nil {
-		t.errorLogger.Warn("Invalid credentials from %s on listener %s, dropping traps", u.String(), t.config.Addr())
+		log.Warnf("Invalid credentials from %s on listener %s, dropping traps", u.String(), t.config.Addr())
 		trapsPacketsAuthErrors.Add(1)
 		return
 	}

--- a/releasenotes/notes/fix-logger-snmp-linstener-6e48554510c08b49.yaml
+++ b/releasenotes/notes/fix-logger-snmp-linstener-6e48554510c08b49.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Make Agent write logs when snmp trap listener starts and Agent
+    receives invalid packets.

--- a/releasenotes/notes/fix-logger-snmp-linstener-6e48554510c08b49.yaml
+++ b/releasenotes/notes/fix-logger-snmp-linstener-6e48554510c08b49.yaml
@@ -8,5 +8,5 @@
 ---
 fixes:
   - |
-    Make Agent write logs when snmp trap listener starts and Agent
+    Make Agent write logs when SNMP trap listener starts and Agent
     receives invalid packets.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Use `github.com/DataDog/datadog-agent/pkg/util/log` instead of `github.com/DataDog/datadog-agent/pkg/trace/log` in `pkg/snmp/traps/listener.go`.

### Motivation

Currently, Agent doesn't write logs on the following line because  `pkg/snmp/traps/listener.go` uses [NoopLogger](https://github.com/DataDog/datadog-agent/blob/151aba22811eba4d2af35b828345e23173330785/pkg/trace/log/logger.go#L14) in `pkg/trace/log/logger.go`. 
It makes `snmp trap` debug difficult.

- https://github.com/DataDog/datadog-agent/blob/151aba22811eba4d2af35b828345e23173330785/pkg/snmp/traps/listener.go#L50
- https://github.com/DataDog/datadog-agent/blob/151aba22811eba4d2af35b828345e23173330785/pkg/snmp/traps/listener.go#L83


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

#### Before this change

We can confirm that Agent doesn't write logs above.

```shell
ubuntu@ip-172-31-29-109:~/go/src/github.com/DataDog/datadog-agent$ git log -n 1
commit a563ae282e3b2f8c11cec5f43e23b3cc4f121d76 (HEAD -> main, origin/main, origin/HEAD, snmp-listener)
Author: Paul <paul.coignet@datadoghq.com>
Date:   Thu Oct 20 15:16:08 2022 +0200

    [RCM] Fix tracer predicates logic (#13926)

    * Fix tracer predicates logic

    * Retrigger CI build manually
ubuntu@ip-172-31-29-109:~/go/src/github.com/DataDog/datadog-agent$ date
Fri Oct 21 00:04:04 UTC 2022
ubuntu@ip-172-31-29-109:~/go/src/github.com/DataDog/datadog-agent$ sudo ./bin/agent/agent run -c /etc/datadog-agent/datadog.yaml > /dev/null 2>&1 &
[1] 20524
ubuntu@ip-172-31-29-109:~/go/src/github.com/DataDog/datadog-agent$ snmptrap -c public -v 2c 0.0.0.0:9162 "" 1.3.6.1.2.1.43.18.2.0.1
ubuntu@ip-172-31-29-109:~/go/src/github.com/DataDog/datadog-agent$ snmptrap -c public -v 2c 0.0.0.0:9162 "" 1.3.6.1.2.1.43.18.2.0.1
ubuntu@ip-172-31-29-109:~/go/src/github.com/DataDog/datadog-agent$ snmptrap -c public -v 2c 0.0.0.0:9162 "" 1.3.6.1.2.1.43.18.2.0.1
ubuntu@ip-172-31-29-109:~/go/src/github.com/DataDog/datadog-agent$ sudo ./bin/agent/agent status | grep Packet
  Event Packets: 0
  Metric Packets: 0
  Service Check Packets: 0
  Udp Packet Reading Errors: 0
  Udp Packets: 0
  Uds Packet Reading Errors: 0
  Uds Packets: 0
  Packets: 0
  Packets Auth Errors: 3
ubuntu@ip-172-31-29-109:~/go/src/github.com/DataDog/datadog-agent$ fg
sudo ./bin/agent/agent run -c /etc/datadog-agent/datadog.yaml > /dev/null 2>&1
^Cubuntu@ip-172-31-29-109:~/go/src/github.com/DataDog/datadog-agenttail -n 100 /var/log/datadog/agent.log | grep snmp
2022-10-21 00:04:10 UTC | CORE | INFO | (pkg/snmp/traps/forwarder.go:37 in Start) | Starting TrapForwarder
2022-10-21 00:04:45 UTC | CORE | INFO | (pkg/snmp/traps/server.go:127 in func1) | Stop listening on 0.0.0.0:9162
2022-10-21 00:04:45 UTC | CORE | INFO | (pkg/snmp/traps/forwarder.go:50 in run) | Stopped TrapForwarder
```

#### After this change

There are expected logs in `/var/log/datadog/agent.log`.

```shell
ubuntu@ip-172-31-29-109:~/go/src/github.com/DataDog/datadog-agent$ git switch keisku/snmp-listener
Switched to branch 'keisku/snmp-listener'
ubuntu@ip-172-31-29-109:~/go/src/github.com/DataDog/datadog-agent$ git log -n 1
commit 653ddbbe780650e7ecfc06e7ea34da20cedb733b (HEAD -> keisku/snmp-listener, origin/keisku/snmp-listener)
Author: keisku <keisuke.umegaki.630@gmail.com>
Date:   Thu Oct 20 23:48:52 2022 +0000

    fix logger
ubuntu@ip-172-31-29-109:~/go/src/github.com/DataDog/datadog-agent$ python3 -m invoke -e agent.build --build-exclude=systemd
...
ubuntu@ip-172-31-29-109:~/go/src/github.com/DataDog/datadog-agent$ date
Fri Oct 21 00:08:29 UTC 2022
ubuntu@ip-172-31-29-109:~/go/src/github.com/DataDog/datadog-agent$ sudo ./bin/agent/agent run -c /etc/datadog-agent/datadog.yaml > /dev/null 2>&1 &
[1] 20840
ubuntu@ip-172-31-29-109:~/go/src/github.com/DataDog/datadog-agent$ snmptrap -c public -v 2c 0.0.0.0:9162 "" 1.3.6.1.2.1.43.18.2.0.1
ubuntu@ip-172-31-29-109:~/go/src/github.com/DataDog/datadog-agent$ snmptrap -c public -v 2c 0.0.0.0:9162 "" 1.3.6.1.2.1.43.18.2.0.1
ubuntu@ip-172-31-29-109:~/go/src/github.com/DataDog/datadog-agent$ snmptrap -c public -v 2c 0.0.0.0:9162 "" 1.3.6.1.2.1.43.18.2.0.1
ubuntu@ip-172-31-29-109:~/go/src/github.com/DataDog/datadog-agent$ sudo ./bin/agent/agent status | grep Packet
  Event Packets: 0
  Metric Packets: 0
  Service Check Packets: 0
  Udp Packet Reading Errors: 0
  Udp Packets: 0
  Uds Packet Reading Errors: 0
  Uds Packets: 0
  Packets: 0
  Packets Auth Errors: 3
ubuntu@ip-172-31-29-109:~/go/src/github.com/DataDog/datadog-agent$ fg
sudo ./bin/agent/agent run -c /etc/datadog-agent/datadog.yaml > /dev/null 2>&1
^Cubuntu@ip-172-31-29-109:~/go/src/github.com/DataDog/datadog-agent$
ubuntu@ip-172-31-29-109:~/go/src/github.com/DataDog/datadog-agent$ tail -n 100 /var/log/datadog/agent.log | grep snmp
2022-10-21 00:08:34 UTC | CORE | INFO | (pkg/snmp/traps/listener.go:48 in Start) | Start listening for traps on 0.0.0.0:9162
2022-10-21 00:08:34 UTC | CORE | INFO | (pkg/snmp/traps/forwarder.go:37 in Start) | Starting TrapForwarder
2022-10-21 00:08:49 UTC | CORE | WARN | (pkg/snmp/traps/listener.go:81 in receiveTrap) | Invalid credentials from 127.0.0.1:43002 on listener 0.0.0.0:9162, dropping traps
2022-10-21 00:08:50 UTC | CORE | WARN | (pkg/snmp/traps/listener.go:81 in receiveTrap) | Invalid credentials from 127.0.0.1:51986 on listener 0.0.0.0:9162, dropping traps
2022-10-21 00:08:51 UTC | CORE | WARN | (pkg/snmp/traps/listener.go:81 in receiveTrap) | Invalid credentials from 127.0.0.1:51632 on listener 0.0.0.0:9162, dropping traps
2022-10-21 00:09:03 UTC | CORE | INFO | (pkg/snmp/traps/server.go:127 in func1) | Stop listening on 0.0.0.0:9162
2022-10-21 00:09:03 UTC | CORE | INFO | (pkg/snmp/traps/forwarder.go:50 in run) | Stopped TrapForwarder
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
