### PR TITLE
[orchestration] refactor by addition of a base handler

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/base.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/base.go
@@ -1,0 +1,55 @@
+package k8s
+
+import (
+	model "github.com/DataDog/agent-payload/v5/process"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type BaseHandler struct{}
+
+func (BaseHandler) AfterMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}, yaml []byte) (skip bool) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (BaseHandler) BeforeCacheCheck(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
+	return
+}
+
+func (BaseHandler) BeforeMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
+	return
+}
+
+func (BaseHandler) BuildMessageBody(ctx *processors.ProcessorContext, resourceModels []interface{}, groupSize int) model.MessageBody {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (BaseHandler) ExtractResource(ctx *processors.ProcessorContext, resource interface{}) (resourceModel interface{}) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (BaseHandler) ResourceList(ctx *processors.ProcessorContext, list interface{}) (resources []interface{}) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (BaseHandler) ResourceUID(ctx *processors.ProcessorContext, resource, resourceModel interface{}) types.UID {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (BaseHandler) ResourceVersion(ctx *processors.ProcessorContext, resource, resourceModel interface{}) string {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (BaseHandler) ScrubBeforeExtraction(ctx *processors.ProcessorContext, resource interface{}) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (BaseHandler) ScrubBeforeMarshalling(ctx *processors.ProcessorContext, resource interface{}) {
+}

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/base.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/base.go
@@ -1,3 +1,11 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build orchestrator
+// +build orchestrator
+
 package k8s
 
 import (

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/base.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/base.go
@@ -1,17 +1,10 @@
 package k8s
 
 import (
-	model "github.com/DataDog/agent-payload/v5/process"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 type BaseHandler struct{}
-
-func (BaseHandler) AfterMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}, yaml []byte) (skip bool) {
-	//TODO implement me
-	panic("implement me")
-}
 
 func (BaseHandler) BeforeCacheCheck(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	return
@@ -19,36 +12,6 @@ func (BaseHandler) BeforeCacheCheck(ctx *processors.ProcessorContext, resource, 
 
 func (BaseHandler) BeforeMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	return
-}
-
-func (BaseHandler) BuildMessageBody(ctx *processors.ProcessorContext, resourceModels []interface{}, groupSize int) model.MessageBody {
-	//TODO implement me
-	panic("implement me")
-}
-
-func (BaseHandler) ExtractResource(ctx *processors.ProcessorContext, resource interface{}) (resourceModel interface{}) {
-	//TODO implement me
-	panic("implement me")
-}
-
-func (BaseHandler) ResourceList(ctx *processors.ProcessorContext, list interface{}) (resources []interface{}) {
-	//TODO implement me
-	panic("implement me")
-}
-
-func (BaseHandler) ResourceUID(ctx *processors.ProcessorContext, resource, resourceModel interface{}) types.UID {
-	//TODO implement me
-	panic("implement me")
-}
-
-func (BaseHandler) ResourceVersion(ctx *processors.ProcessorContext, resource, resourceModel interface{}) string {
-	//TODO implement me
-	panic("implement me")
-}
-
-func (BaseHandler) ScrubBeforeExtraction(ctx *processors.ProcessorContext, resource interface{}) {
-	//TODO implement me
-	panic("implement me")
 }
 
 func (BaseHandler) ScrubBeforeMarshalling(ctx *processors.ProcessorContext, resource interface{}) {

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/base.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/base.go
@@ -12,15 +12,15 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
 )
 
-type BaseHandler struct{}
+type BaseHandlers struct{}
 
-func (BaseHandler) BeforeCacheCheck(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
+func (BaseHandlers) BeforeCacheCheck(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	return
 }
 
-func (BaseHandler) BeforeMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
+func (BaseHandlers) BeforeMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	return
 }
 
-func (BaseHandler) ScrubBeforeMarshalling(ctx *processors.ProcessorContext, resource interface{}) {
+func (BaseHandlers) ScrubBeforeMarshalling(ctx *processors.ProcessorContext, resource interface{}) {
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/clusterrole.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/clusterrole.go
@@ -20,22 +20,14 @@ import (
 )
 
 // ClusterRoleHandlers implements the Handlers interface for Kubernetes ClusterRoles.
-type ClusterRoleHandlers struct{}
+type ClusterRoleHandlers struct {
+	BaseHandler
+}
 
 // AfterMarshalling is a handler called after resource marshalling.
 func (h *ClusterRoleHandlers) AfterMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}, yaml []byte) (skip bool) {
 	m := resourceModel.(*model.ClusterRole)
 	m.Yaml = yaml
-	return
-}
-
-// BeforeCacheCheck is a handler called before cache lookup.
-func (h *ClusterRoleHandlers) BeforeCacheCheck(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
-	return
-}
-
-// BeforeMarshalling is a handler called before resource marshalling.
-func (h *ClusterRoleHandlers) BeforeMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	return
 }
 
@@ -92,9 +84,4 @@ func (h *ClusterRoleHandlers) ResourceVersion(ctx *processors.ProcessorContext, 
 func (h *ClusterRoleHandlers) ScrubBeforeExtraction(ctx *processors.ProcessorContext, resource interface{}) {
 	r := resource.(*rbacv1.ClusterRole)
 	redact.RemoveLastAppliedConfigurationAnnotation(r.Annotations)
-}
-
-// ScrubBeforeMarshalling is a handler called to redact the raw resource before
-// it is marshalled to generate a manifest.
-func (h *ClusterRoleHandlers) ScrubBeforeMarshalling(ctx *processors.ProcessorContext, resource interface{}) {
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/clusterrole.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/clusterrole.go
@@ -21,7 +21,7 @@ import (
 
 // ClusterRoleHandlers implements the Handlers interface for Kubernetes ClusterRoles.
 type ClusterRoleHandlers struct {
-	BaseHandler
+	BaseHandlers
 }
 
 // AfterMarshalling is a handler called after resource marshalling.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/clusterrolebinding.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/clusterrolebinding.go
@@ -21,7 +21,7 @@ import (
 
 // ClusterRoleBindingHandlers implements the Handlers interface for Kubernetes ClusteRoleBindings.
 type ClusterRoleBindingHandlers struct {
-	BaseHandler
+	BaseHandlers
 }
 
 // AfterMarshalling is a handler called after resource marshalling.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/clusterrolebinding.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/clusterrolebinding.go
@@ -20,22 +20,14 @@ import (
 )
 
 // ClusterRoleBindingHandlers implements the Handlers interface for Kubernetes ClusteRoleBindings.
-type ClusterRoleBindingHandlers struct{}
+type ClusterRoleBindingHandlers struct {
+	BaseHandler
+}
 
 // AfterMarshalling is a handler called after resource marshalling.
 func (h *ClusterRoleBindingHandlers) AfterMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}, yaml []byte) (skip bool) {
 	m := resourceModel.(*model.ClusterRoleBinding)
 	m.Yaml = yaml
-	return
-}
-
-// BeforeCacheCheck is a handler called before cache lookup.
-func (h *ClusterRoleBindingHandlers) BeforeCacheCheck(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
-	return
-}
-
-// BeforeMarshalling is a handler called before resource marshalling.
-func (h *ClusterRoleBindingHandlers) BeforeMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	return
 }
 
@@ -92,9 +84,4 @@ func (h *ClusterRoleBindingHandlers) ResourceVersion(ctx *processors.ProcessorCo
 func (h *ClusterRoleBindingHandlers) ScrubBeforeExtraction(ctx *processors.ProcessorContext, resource interface{}) {
 	r := resource.(*rbacv1.ClusterRoleBinding)
 	redact.RemoveLastAppliedConfigurationAnnotation(r.Annotations)
-}
-
-// ScrubBeforeMarshalling is a handler called to redact the raw resource before
-// it is marshalled to generate a manifest.
-func (h *ClusterRoleBindingHandlers) ScrubBeforeMarshalling(ctx *processors.ProcessorContext, resource interface{}) {
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1.go
@@ -19,22 +19,14 @@ import (
 )
 
 // CronJobV1Handlers implements the Handlers interface for Kubernetes CronJobs.
-type CronJobV1Handlers struct{}
+type CronJobV1Handlers struct {
+	BaseHandler
+}
 
 // AfterMarshalling is a handler called after resource marshalling.
 func (h *CronJobV1Handlers) AfterMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}, yaml []byte) (skip bool) {
 	m := resourceModel.(*model.CronJob)
 	m.Yaml = yaml
-	return
-}
-
-// BeforeCacheCheck is a handler called before cache lookup.
-func (h *CronJobV1Handlers) BeforeCacheCheck(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
-	return
-}
-
-// BeforeMarshalling is a handler called before resource marshalling.
-func (h *CronJobV1Handlers) BeforeMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	return
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1.go
@@ -20,7 +20,7 @@ import (
 
 // CronJobV1Handlers implements the Handlers interface for Kubernetes CronJobs.
 type CronJobV1Handlers struct {
-	BaseHandler
+	BaseHandlers
 }
 
 // AfterMarshalling is a handler called after resource marshalling.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1beta1.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1beta1.go
@@ -20,22 +20,14 @@ import (
 )
 
 // CronJobV1Beta1Handlers implements the Handlers interface for Kubernetes CronJobs.
-type CronJobV1Beta1Handlers struct{}
+type CronJobV1Beta1Handlers struct {
+	BaseHandler
+}
 
 // AfterMarshalling is a handler called after resource marshalling.
 func (h *CronJobV1Beta1Handlers) AfterMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}, yaml []byte) (skip bool) {
 	m := resourceModel.(*model.CronJob)
 	m.Yaml = yaml
-	return
-}
-
-// BeforeCacheCheck is a handler called before cache lookup.
-func (h *CronJobV1Beta1Handlers) BeforeCacheCheck(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
-	return
-}
-
-// BeforeMarshalling is a handler called before resource marshalling.
-func (h *CronJobV1Beta1Handlers) BeforeMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	return
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1beta1.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1beta1.go
@@ -21,7 +21,7 @@ import (
 
 // CronJobV1Beta1Handlers implements the Handlers interface for Kubernetes CronJobs.
 type CronJobV1Beta1Handlers struct {
-	BaseHandler
+	BaseHandlers
 }
 
 // AfterMarshalling is a handler called after resource marshalling.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/daemonset.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/daemonset.go
@@ -20,22 +20,14 @@ import (
 )
 
 // DaemonSetHandlers implements the Handlers interface for Kubernetes DaemonSets.
-type DaemonSetHandlers struct{}
+type DaemonSetHandlers struct {
+	BaseHandler
+}
 
 // AfterMarshalling is a handler called after resource marshalling.
 func (h *DaemonSetHandlers) AfterMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}, yaml []byte) (skip bool) {
 	m := resourceModel.(*model.DaemonSet)
 	m.Yaml = yaml
-	return
-}
-
-// BeforeCacheCheck is a handler called before cache lookup.
-func (h *DaemonSetHandlers) BeforeCacheCheck(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
-	return
-}
-
-// BeforeMarshalling is a handler called before resource marshalling.
-func (h *DaemonSetHandlers) BeforeMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	return
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/daemonset.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/daemonset.go
@@ -21,7 +21,7 @@ import (
 
 // DaemonSetHandlers implements the Handlers interface for Kubernetes DaemonSets.
 type DaemonSetHandlers struct {
-	BaseHandler
+	BaseHandlers
 }
 
 // AfterMarshalling is a handler called after resource marshalling.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/deployment.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/deployment.go
@@ -20,22 +20,14 @@ import (
 )
 
 // DeploymentHandlers implements the Handlers interface for Kubernetes Deployments.
-type DeploymentHandlers struct{}
+type DeploymentHandlers struct {
+	BaseHandler
+}
 
 // AfterMarshalling is a handler called after resource marshalling.
 func (h *DeploymentHandlers) AfterMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}, yaml []byte) (skip bool) {
 	m := resourceModel.(*model.Deployment)
 	m.Yaml = yaml
-	return
-}
-
-// BeforeCacheCheck is a handler called before cache lookup.
-func (h *DeploymentHandlers) BeforeCacheCheck(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
-	return
-}
-
-// BeforeMarshalling is a handler called before resource marshalling.
-func (h *DeploymentHandlers) BeforeMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	return
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/deployment.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/deployment.go
@@ -21,7 +21,7 @@ import (
 
 // DeploymentHandlers implements the Handlers interface for Kubernetes Deployments.
 type DeploymentHandlers struct {
-	BaseHandler
+	BaseHandlers
 }
 
 // AfterMarshalling is a handler called after resource marshalling.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/ingress.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/ingress.go
@@ -20,22 +20,14 @@ import (
 )
 
 // IngressHandlers implements the Handlers interface for Kubernetes Ingresss.
-type IngressHandlers struct{}
+type IngressHandlers struct {
+	BaseHandler
+}
 
 // AfterMarshalling is a handler called after resource marshalling.
 func (h *IngressHandlers) AfterMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}, yaml []byte) (skip bool) {
 	m := resourceModel.(*model.Ingress)
 	m.Yaml = yaml
-	return
-}
-
-// BeforeCacheCheck is a handler called before cache lookup.
-func (h *IngressHandlers) BeforeCacheCheck(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
-	return
-}
-
-// BeforeMarshalling is a handler called before resource marshalling.
-func (h *IngressHandlers) BeforeMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	return
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/ingress.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/ingress.go
@@ -21,7 +21,7 @@ import (
 
 // IngressHandlers implements the Handlers interface for Kubernetes Ingresss.
 type IngressHandlers struct {
-	BaseHandler
+	BaseHandlers
 }
 
 // AfterMarshalling is a handler called after resource marshalling.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/job.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/job.go
@@ -21,7 +21,7 @@ import (
 
 // JobHandlers implements the Handlers interface for Kubernetes Jobs.
 type JobHandlers struct {
-	BaseHandler
+	BaseHandlers
 }
 
 // AfterMarshalling is a handler called after resource marshalling.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/job.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/job.go
@@ -20,22 +20,14 @@ import (
 )
 
 // JobHandlers implements the Handlers interface for Kubernetes Jobs.
-type JobHandlers struct{}
+type JobHandlers struct {
+	BaseHandler
+}
 
 // AfterMarshalling is a handler called after resource marshalling.
 func (h *JobHandlers) AfterMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}, yaml []byte) (skip bool) {
 	m := resourceModel.(*model.Job)
 	m.Yaml = yaml
-	return
-}
-
-// BeforeCacheCheck is a handler called before cache lookup.
-func (h *JobHandlers) BeforeCacheCheck(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
-	return
-}
-
-// BeforeMarshalling is a handler called before resource marshalling.
-func (h *JobHandlers) BeforeMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	return
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/node.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/node.go
@@ -21,7 +21,7 @@ import (
 
 // NodeHandlers implements the Handlers interface for Kubernetes Nodes.
 type NodeHandlers struct {
-	BaseHandler
+	BaseHandlers
 }
 
 // AfterMarshalling is a handler called after resource marshalling.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/node.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/node.go
@@ -20,22 +20,14 @@ import (
 )
 
 // NodeHandlers implements the Handlers interface for Kubernetes Nodes.
-type NodeHandlers struct{}
+type NodeHandlers struct {
+	BaseHandler
+}
 
 // AfterMarshalling is a handler called after resource marshalling.
 func (h *NodeHandlers) AfterMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}, yaml []byte) (skip bool) {
 	m := resourceModel.(*model.Node)
 	m.Yaml = yaml
-	return
-}
-
-// BeforeCacheCheck is a handler called before cache lookup.
-func (h *NodeHandlers) BeforeCacheCheck(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
-	return
-}
-
-// BeforeMarshalling is a handler called before resource marshalling.
-func (h *NodeHandlers) BeforeMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	return
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/persistentvolume.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/persistentvolume.go
@@ -20,7 +20,9 @@ import (
 )
 
 // PersistentVolumeHandlers implements the Handlers interface for Kubernetes PersistentVolumes.
-type PersistentVolumeHandlers struct{}
+type PersistentVolumeHandlers struct {
+	BaseHandler
+}
 
 // AfterMarshalling is a handler called after resource marshalling.
 func (h *PersistentVolumeHandlers) AfterMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}, yaml []byte) (skip bool) {
@@ -82,9 +84,4 @@ func (h *PersistentVolumeHandlers) ResourceVersion(ctx *processors.ProcessorCont
 func (h *PersistentVolumeHandlers) ScrubBeforeExtraction(ctx *processors.ProcessorContext, resource interface{}) {
 	r := resource.(*corev1.PersistentVolume)
 	redact.RemoveLastAppliedConfigurationAnnotation(r.Annotations)
-}
-
-// ScrubBeforeMarshalling is a handler called to redact the raw resource before
-// it is marshalled to generate a manifest.
-func (h *PersistentVolumeHandlers) ScrubBeforeMarshalling(ctx *processors.ProcessorContext, resource interface{}) {
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/persistentvolume.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/persistentvolume.go
@@ -29,16 +29,6 @@ func (h *PersistentVolumeHandlers) AfterMarshalling(ctx *processors.ProcessorCon
 	return
 }
 
-// BeforeCacheCheck is a handler called before cache lookup.
-func (h *PersistentVolumeHandlers) BeforeCacheCheck(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
-	return
-}
-
-// BeforeMarshalling is a handler called before resource marshalling.
-func (h *PersistentVolumeHandlers) BeforeMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
-	return
-}
-
 // BuildMessageBody is a handler called to build a message body out of a list of
 // extracted resources.
 func (h *PersistentVolumeHandlers) BuildMessageBody(ctx *processors.ProcessorContext, resourceModels []interface{}, groupSize int) model.MessageBody {

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/persistentvolume.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/persistentvolume.go
@@ -21,7 +21,7 @@ import (
 
 // PersistentVolumeHandlers implements the Handlers interface for Kubernetes PersistentVolumes.
 type PersistentVolumeHandlers struct {
-	BaseHandler
+	BaseHandlers
 }
 
 // AfterMarshalling is a handler called after resource marshalling.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/persistentvolumeclaim.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/persistentvolumeclaim.go
@@ -20,7 +20,9 @@ import (
 )
 
 // PersistentVolumeClaimHandlers implements the Handlers interface for Kubernetes PersistentVolumeClaims.
-type PersistentVolumeClaimHandlers struct{}
+type PersistentVolumeClaimHandlers struct {
+	BaseHandler
+}
 
 // AfterMarshalling is a handler called after resource marshalling.
 func (h *PersistentVolumeClaimHandlers) AfterMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}, yaml []byte) (skip bool) {
@@ -82,9 +84,4 @@ func (h *PersistentVolumeClaimHandlers) ResourceVersion(ctx *processors.Processo
 func (h *PersistentVolumeClaimHandlers) ScrubBeforeExtraction(ctx *processors.ProcessorContext, resource interface{}) {
 	r := resource.(*corev1.PersistentVolumeClaim)
 	redact.RemoveLastAppliedConfigurationAnnotation(r.Annotations)
-}
-
-// ScrubBeforeMarshalling is a handler called to redact the raw resource before
-// it is marshalled to generate a manifest.
-func (h *PersistentVolumeClaimHandlers) ScrubBeforeMarshalling(ctx *processors.ProcessorContext, resource interface{}) {
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/persistentvolumeclaim.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/persistentvolumeclaim.go
@@ -29,16 +29,6 @@ func (h *PersistentVolumeClaimHandlers) AfterMarshalling(ctx *processors.Process
 	return
 }
 
-// BeforeCacheCheck is a handler called before cache lookup.
-func (h *PersistentVolumeClaimHandlers) BeforeCacheCheck(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
-	return
-}
-
-// BeforeMarshalling is a handler called before resource marshalling.
-func (h *PersistentVolumeClaimHandlers) BeforeMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
-	return
-}
-
 // BuildMessageBody is a handler called to build a message body out of a list of
 // extracted resources.
 func (h *PersistentVolumeClaimHandlers) BuildMessageBody(ctx *processors.ProcessorContext, resourceModels []interface{}, groupSize int) model.MessageBody {

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/persistentvolumeclaim.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/persistentvolumeclaim.go
@@ -21,7 +21,7 @@ import (
 
 // PersistentVolumeClaimHandlers implements the Handlers interface for Kubernetes PersistentVolumeClaims.
 type PersistentVolumeClaimHandlers struct {
-	BaseHandler
+	BaseHandlers
 }
 
 // AfterMarshalling is a handler called after resource marshalling.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/pod.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/pod.go
@@ -29,7 +29,9 @@ import (
 )
 
 // PodHandlers implements the Handlers interface for Kubernetes Pods.
-type PodHandlers struct{}
+type PodHandlers struct {
+	BaseHandler
+}
 
 // AfterMarshalling is a handler called after resource marshalling.
 func (h *PodHandlers) AfterMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}, yaml []byte) (skip bool) {
@@ -81,11 +83,6 @@ func (h *PodHandlers) BeforeCacheCheck(ctx *processors.ProcessorContext, resourc
 		return
 	}
 
-	return
-}
-
-// BeforeMarshalling is a handler called before resource marshalling.
-func (h *PodHandlers) BeforeMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	return
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/pod.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/pod.go
@@ -30,7 +30,7 @@ import (
 
 // PodHandlers implements the Handlers interface for Kubernetes Pods.
 type PodHandlers struct {
-	BaseHandler
+	BaseHandlers
 }
 
 // AfterMarshalling is a handler called after resource marshalling.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/replicaset.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/replicaset.go
@@ -20,22 +20,14 @@ import (
 )
 
 // ReplicaSetHandlers implements the Handlers interface for Kubernetes ReplicaSets.
-type ReplicaSetHandlers struct{}
+type ReplicaSetHandlers struct {
+	BaseHandler
+}
 
 // AfterMarshalling is a handler called after resource marshalling.
 func (h *ReplicaSetHandlers) AfterMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}, yaml []byte) (skip bool) {
 	m := resourceModel.(*model.ReplicaSet)
 	m.Yaml = yaml
-	return
-}
-
-// BeforeCacheCheck is a handler called before cache lookup.
-func (h *ReplicaSetHandlers) BeforeCacheCheck(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
-	return
-}
-
-// BeforeMarshalling is a handler called before resource marshalling.
-func (h *ReplicaSetHandlers) BeforeMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	return
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/replicaset.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/replicaset.go
@@ -21,7 +21,7 @@ import (
 
 // ReplicaSetHandlers implements the Handlers interface for Kubernetes ReplicaSets.
 type ReplicaSetHandlers struct {
-	BaseHandler
+	BaseHandlers
 }
 
 // AfterMarshalling is a handler called after resource marshalling.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/role.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/role.go
@@ -20,22 +20,14 @@ import (
 )
 
 // RoleHandlers implements the Handlers interface for Kubernetes Roles.
-type RoleHandlers struct{}
+type RoleHandlers struct {
+	BaseHandler
+}
 
 // AfterMarshalling is a handler called after resource marshalling.
 func (h *RoleHandlers) AfterMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}, yaml []byte) (skip bool) {
 	m := resourceModel.(*model.Role)
 	m.Yaml = yaml
-	return
-}
-
-// BeforeCacheCheck is a handler called before cache lookup.
-func (h *RoleHandlers) BeforeCacheCheck(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
-	return
-}
-
-// BeforeMarshalling is a handler called before resource marshalling.
-func (h *RoleHandlers) BeforeMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	return
 }
 
@@ -92,9 +84,4 @@ func (h *RoleHandlers) ResourceVersion(ctx *processors.ProcessorContext, resourc
 func (h *RoleHandlers) ScrubBeforeExtraction(ctx *processors.ProcessorContext, resource interface{}) {
 	r := resource.(*rbacv1.Role)
 	redact.RemoveLastAppliedConfigurationAnnotation(r.Annotations)
-}
-
-// ScrubBeforeMarshalling is a handler called to redact the raw resource before
-// it is marshalled to generate a manifest.
-func (h *RoleHandlers) ScrubBeforeMarshalling(ctx *processors.ProcessorContext, resource interface{}) {
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/role.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/role.go
@@ -21,7 +21,7 @@ import (
 
 // RoleHandlers implements the Handlers interface for Kubernetes Roles.
 type RoleHandlers struct {
-	BaseHandler
+	BaseHandlers
 }
 
 // AfterMarshalling is a handler called after resource marshalling.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/rolebinding.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/rolebinding.go
@@ -21,7 +21,7 @@ import (
 
 // RoleBindingHandlers implements the Handlers interface for Kubernetes RoleBindings.
 type RoleBindingHandlers struct {
-	BaseHandler
+	BaseHandlers
 }
 
 // AfterMarshalling is a handler called after resource marshalling.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/rolebinding.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/rolebinding.go
@@ -20,22 +20,14 @@ import (
 )
 
 // RoleBindingHandlers implements the Handlers interface for Kubernetes RoleBindings.
-type RoleBindingHandlers struct{}
+type RoleBindingHandlers struct {
+	BaseHandler
+}
 
 // AfterMarshalling is a handler called after resource marshalling.
 func (h *RoleBindingHandlers) AfterMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}, yaml []byte) (skip bool) {
 	m := resourceModel.(*model.RoleBinding)
 	m.Yaml = yaml
-	return
-}
-
-// BeforeCacheCheck is a handler called before cache lookup.
-func (h *RoleBindingHandlers) BeforeCacheCheck(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
-	return
-}
-
-// BeforeMarshalling is a handler called before resource marshalling.
-func (h *RoleBindingHandlers) BeforeMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	return
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/rolebinding.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/rolebinding.go
@@ -85,8 +85,3 @@ func (h *RoleBindingHandlers) ScrubBeforeExtraction(ctx *processors.ProcessorCon
 	r := resource.(*rbacv1.RoleBinding)
 	redact.RemoveLastAppliedConfigurationAnnotation(r.Annotations)
 }
-
-// ScrubBeforeMarshalling is a handler called to redact the raw resource before
-// it is marshalled to generate a manifest.
-func (h *RoleBindingHandlers) ScrubBeforeMarshalling(ctx *processors.ProcessorContext, resource interface{}) {
-}

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/service.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/service.go
@@ -20,22 +20,14 @@ import (
 )
 
 // ServiceHandlers implements the Handlers interface for Kubernetes Services.
-type ServiceHandlers struct{}
+type ServiceHandlers struct {
+	BaseHandler
+}
 
 // AfterMarshalling is a handler called after resource marshalling.
 func (h *ServiceHandlers) AfterMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}, yaml []byte) (skip bool) {
 	m := resourceModel.(*model.Service)
 	m.Yaml = yaml
-	return
-}
-
-// BeforeCacheCheck is a handler called before cache lookup.
-func (h *ServiceHandlers) BeforeCacheCheck(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
-	return
-}
-
-// BeforeMarshalling is a handler called before resource marshalling.
-func (h *ServiceHandlers) BeforeMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	return
 }
 
@@ -92,9 +84,4 @@ func (h *ServiceHandlers) ResourceVersion(ctx *processors.ProcessorContext, reso
 func (h *ServiceHandlers) ScrubBeforeExtraction(ctx *processors.ProcessorContext, resource interface{}) {
 	r := resource.(*corev1.Service)
 	redact.RemoveLastAppliedConfigurationAnnotation(r.Annotations)
-}
-
-// ScrubBeforeMarshalling is a handler called to redact the raw resource before
-// it is marshalled to generate a manifest.
-func (h *ServiceHandlers) ScrubBeforeMarshalling(ctx *processors.ProcessorContext, resource interface{}) {
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/service.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/service.go
@@ -21,7 +21,7 @@ import (
 
 // ServiceHandlers implements the Handlers interface for Kubernetes Services.
 type ServiceHandlers struct {
-	BaseHandler
+	BaseHandlers
 }
 
 // AfterMarshalling is a handler called after resource marshalling.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/serviceaccount.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/serviceaccount.go
@@ -21,7 +21,7 @@ import (
 
 // ServiceAccountHandlers implements the Handlers interface for Kubernetes ServiceAccounts.
 type ServiceAccountHandlers struct {
-	BaseHandler
+	BaseHandlers
 }
 
 // AfterMarshalling is a handler called after resource marshalling.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/serviceaccount.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/serviceaccount.go
@@ -20,22 +20,14 @@ import (
 )
 
 // ServiceAccountHandlers implements the Handlers interface for Kubernetes ServiceAccounts.
-type ServiceAccountHandlers struct{}
+type ServiceAccountHandlers struct {
+	BaseHandler
+}
 
 // AfterMarshalling is a handler called after resource marshalling.
 func (h *ServiceAccountHandlers) AfterMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}, yaml []byte) (skip bool) {
 	m := resourceModel.(*model.ServiceAccount)
 	m.Yaml = yaml
-	return
-}
-
-// BeforeCacheCheck is a handler called before cache lookup.
-func (h *ServiceAccountHandlers) BeforeCacheCheck(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
-	return
-}
-
-// BeforeMarshalling is a handler called before resource marshalling.
-func (h *ServiceAccountHandlers) BeforeMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	return
 }
 
@@ -92,9 +84,4 @@ func (h *ServiceAccountHandlers) ResourceVersion(ctx *processors.ProcessorContex
 func (h *ServiceAccountHandlers) ScrubBeforeExtraction(ctx *processors.ProcessorContext, resource interface{}) {
 	r := resource.(*corev1.ServiceAccount)
 	redact.RemoveLastAppliedConfigurationAnnotation(r.Annotations)
-}
-
-// ScrubBeforeMarshalling is a handler called to redact the raw resource before
-// it is marshalled to generate a manifest.
-func (h *ServiceAccountHandlers) ScrubBeforeMarshalling(ctx *processors.ProcessorContext, resource interface{}) {
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/statefulset.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/statefulset.go
@@ -20,22 +20,14 @@ import (
 )
 
 // StatefulSetHandlers implements the Handlers interface for Kubernetes StatefulSets.
-type StatefulSetHandlers struct{}
+type StatefulSetHandlers struct {
+	BaseHandler
+}
 
 // AfterMarshalling is a handler called after resource marshalling.
 func (h *StatefulSetHandlers) AfterMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}, yaml []byte) (skip bool) {
 	m := resourceModel.(*model.StatefulSet)
 	m.Yaml = yaml
-	return
-}
-
-// BeforeCacheCheck is a handler called before cache lookup.
-func (h *StatefulSetHandlers) BeforeCacheCheck(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
-	return
-}
-
-// BeforeMarshalling is a handler called before resource marshalling.
-func (h *StatefulSetHandlers) BeforeMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	return
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/statefulset.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/statefulset.go
@@ -21,7 +21,7 @@ import (
 
 // StatefulSetHandlers implements the Handlers interface for Kubernetes StatefulSets.
 type StatefulSetHandlers struct {
-	BaseHandler
+	BaseHandlers
 }
 
 // AfterMarshalling is a handler called after resource marshalling.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

- adds a baseHandler for all handlers for methods that are usually only modified for single interface implementation for practicability 

### Motivation

- easier adding methods which are only intended for a few sub resources. I guess a proper way would be the introduction of multiple interfaces. But that would be a larger refactor
- Note: there might be a future we collect more orchestrators, which would lead to different base handlers. We might even split that up into a handler for workloads and one not. But that is something for the future and independent of this PR

### Describe how to test/QA your changes

- deploy to a cluster
- make sure that orchestrator resources are collected as usual and we do not panic
- my cluster log output:

```
2:10:41 UTC | CLUSTER | INFO | (pkg/collector/worker/check_logger.go:57 in CheckFinished) | check:orchestrator | Done running check
2022-10-21 12:10:44 UTC | CLUSTER | INFO | (pkg/collector/worker/check_logger.go:38 in CheckStarted) | check:orchestrator | Running check...
2022-10-21 12:10:44 UTC | CLUSTER | DEBUG | (pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go:175 in EnsureLeaderElectionRuns) | Currently Leader: true. Leader identity: "agent-dev-ubuntu-20"
2022-10-21 12:10:44 UTC | CLUSTER | DEBUG | (pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go:232 in Run) | Collector apps/v1/replicasets run stats: listed=2 processed=0 messages=0 duration=79.467µs
2022-10-21 12:10:44 UTC | CLUSTER | DEBUG | (pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go:232 in Run) | Collector apps/v1/deployments run stats: listed=1 processed=0 messages=0 duration=89.213µs
2022-10-21 12:10:44 UTC | CLUSTER | INFO | (pkg/collector/worker/check_logger.go:57 in CheckFinished) | check:orchestrator | Done running check
2022-10-21 12:10:44 UTC | CLUSTER | DEBUG | (pkg/aggregator/demultiplexer.go:144 in sendIterableSeries) | Demultiplexer: sendIterableSeries: start sending iterable series to the serializer
2022-10-21 12:10:44 UTC | CLUSTER | DEBUG | (pkg/aggregator/aggregator.go:619 in sendServiceChecks) | Flushing 4 service checks to the forwarder
2022-10-21 12:10:44 UTC | CLUSTER | DEBUG | (pkg/aggregator/demultiplexer.go:150 in sendIterableSeries) | Demultiplexer: sendIterableSeries: stop routine
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
