### PR TITLE
Use an fx app even when starting core agent as a service

### DIFF
--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -196,7 +196,16 @@ func run(log log.Component, config config.Component, cliParams *cliParams) error
 
 // StartAgentWithDefaults is a temporary way for other packages to use startAgent.
 func StartAgentWithDefaults() error {
-	return startAgent(&cliParams{GlobalParams: &command.GlobalParams{}})
+	// run startAgent in an app, so that the log and config components get initialized
+	return fxutil.OneShot(func(log log.Component, config config.Component) error {
+		return startAgent(&cliParams{GlobalParams: &command.GlobalParams{}})
+	},
+		fx.Supply(core.BundleParams{
+			ConfFilePath:      "", // no config file path specification in this situation
+			ConfigLoadSecrets: true,
+		}.LogForDaemon("CORE", "log_file", common.DefaultLogFile)),
+		core.Bundle,
+	)
 }
 
 // startAgent Initializes the agent process

--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -210,25 +210,13 @@ func StartAgentWithDefaults() error {
 
 // startAgent Initializes the agent process
 func startAgent(cliParams *cliParams) error {
-	var (
-		err            error
-		configSetupErr error
-		loggerSetupErr error
-	)
+	var err error
 
 	// Main context passed to components
 	common.MainCtx, common.MainCtxCancel = context.WithCancel(context.Background())
 
-	// Global Agent configuration
-	configSetupErr = common.SetupConfig(cliParams.GlobalParams.ConfFilePath)
-
 	// Setup logger
 	syslogURI := pkgconfig.GetSyslogURI()
-	logFile := pkgconfig.Datadog.GetString("log_file")
-	if logFile == "" {
-		logFile = common.DefaultLogFile
-	}
-
 	jmxLogFile := pkgconfig.Datadog.GetString("jmx_log_file")
 	if jmxLogFile == "" {
 		jmxLogFile = common.DefaultJmxLogFile
@@ -236,38 +224,20 @@ func startAgent(cliParams *cliParams) error {
 
 	if pkgconfig.Datadog.GetBool("disable_file_logging") {
 		// this will prevent any logging on file
-		logFile = ""
 		jmxLogFile = ""
 	}
 
-	loggerSetupErr = pkgconfig.SetupLogger(
-		pkgconfig.CoreLoggerName,
-		pkgconfig.Datadog.GetString("log_level"),
-		logFile,
+	// Setup JMX logger
+	jmxLoggerSetupErr := pkgconfig.SetupJMXLogger(
+		jmxLogFile,
 		syslogURI,
 		pkgconfig.Datadog.GetBool("syslog_rfc"),
 		pkgconfig.Datadog.GetBool("log_to_console"),
 		pkgconfig.Datadog.GetBool("log_format_json"),
 	)
 
-	// Setup JMX logger
-	if loggerSetupErr == nil {
-		loggerSetupErr = pkgconfig.SetupJMXLogger(
-			jmxLogFile,
-			syslogURI,
-			pkgconfig.Datadog.GetBool("syslog_rfc"),
-			pkgconfig.Datadog.GetBool("log_to_console"),
-			pkgconfig.Datadog.GetBool("log_format_json"),
-		)
-	}
-
-	if configSetupErr != nil {
-		pkglog.Errorf("Failed to setup config %v", configSetupErr)
-		return fmt.Errorf("unable to set up global agent configuration: %v", configSetupErr)
-	}
-
-	if loggerSetupErr != nil {
-		return fmt.Errorf("Error while setting up logging, exiting: %v", loggerSetupErr)
+	if jmxLoggerSetupErr != nil {
+		return fmt.Errorf("Error while setting up logging, exiting: %v", jmxLoggerSetupErr)
 	}
 
 	if flavor.GetFlavor() == flavor.IotAgent {


### PR DESCRIPTION
### What does this PR do?

Initializes the comp/core/{config,log} components when using StartAgentWithDefaults (which is used within the Windows service).

Prior to this PR, *nix builds were performing redundant initialization of config and logging (but not JMX logging).

### Motivation

There is no behavioral bug to be fixed in `main`, but this simplifies things and avoids redundant initializations.

Thanks to @brycekahle for letting me know.

### Additional Notes

This is a temporary arrangement until we sort out implementing the agent daemon as a component, which is coming soon -- but maybe not for 7.41.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
