### PR TITLE
[CWS][SEC-5820] add tracepoint fallback to send init module event on rhel7-based kernels

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = newAsset("runtime-security.c", "609b09e7f1de2bd1d7af44243c78696c8e963399a280408b55324ca2ee635062")
+var RuntimeSecurity = newAsset("runtime-security.c", "2d960e61e737dc029b5f6f94e1ae926fc7e0d4e71e78b53ed155240a112d15f1")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = newAsset("runtime-security.c", "2d960e61e737dc029b5f6f94e1ae926fc7e0d4e71e78b53ed155240a112d15f1")
+var RuntimeSecurity = newAsset("runtime-security.c", "005e4a6c0c1a7c23425705e1ed3bcf1f390cadac98fc2243a3837dbd33eb1512")

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -540,6 +540,9 @@ func GetSelectorsPerEventType() map[eval.EventType][]manager.ProbesSelector {
 				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
 					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "finit_module"}, EntryAndExit),
 				},
+				&manager.BestEffort{Selectors: []manager.ProbesSelector{
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "tracepoint/module/module_load", EBPFFuncName: "module_load"}},
+				}},
 			},
 
 			// List of probes required to capture kernel unload_module events

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -11,7 +11,6 @@ package probes
 import (
 	manager "github.com/DataDog/ebpf-manager"
 
-	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 )
 
@@ -591,8 +590,7 @@ func GetSelectorsPerEventType() map[eval.EventType][]manager.ProbesSelector {
 		}
 	}
 
-	kv, err := kernel.NewKernelVersion()
-	if err == nil && kv.IsRH7Kernel() { // the condition may need to be fine-tuned based on the kernel version
+	if ShouldUseModuleLoadTracepoint() {
 		selectorsPerEventTypeStore["load_module"] = append(selectorsPerEventTypeStore["load_module"], &manager.BestEffort{Selectors: []manager.ProbesSelector{
 			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "tracepoint/module/module_load", EBPFFuncName: "module_load"}},
 		}})

--- a/pkg/security/ebpf/probes/module.go
+++ b/pkg/security/ebpf/probes/module.go
@@ -40,6 +40,13 @@ var moduleProbes = []*manager.Probe{
 			EBPFFuncName: "kprobe_module_put",
 		},
 	},
+	{
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "tracepoint/module/module_load",
+			EBPFFuncName: "module_load",
+		},
+	},
 }
 
 func getModuleProbes() []*manager.Probe {

--- a/pkg/security/ebpf/probes/syscall_helpers.go
+++ b/pkg/security/ebpf/probes/syscall_helpers.go
@@ -84,12 +84,9 @@ func ShouldUseSyscallExitTracepoints() bool {
 }
 
 func ShouldUseModuleLoadTracepoint() bool {
-	if currentKernelVersion == nil {
-		_ = resolveCurrentKernelVersion()
-	}
-
+	currentKernelVersion, err := kernel.NewKernelVersion()
 	// the condition may need to be fine-tuned based on the kernel version
-	return currentKernelVersion != nil && currentKernelVersion.IsRH7Kernel()
+	return err == nil && currentKernelVersion != nil && currentKernelVersion.IsRH7Kernel()
 }
 
 func expandKprobe(hookpoint string, flag int) []string {

--- a/pkg/security/ebpf/probes/syscall_helpers.go
+++ b/pkg/security/ebpf/probes/syscall_helpers.go
@@ -83,6 +83,15 @@ func ShouldUseSyscallExitTracepoints() bool {
 	return currentKernelVersion != nil && (currentKernelVersion.Code < kernel.Kernel4_12 || currentKernelVersion.IsRH7Kernel())
 }
 
+func ShouldUseModuleLoadTracepoint() bool {
+	if currentKernelVersion == nil {
+		_ = resolveCurrentKernelVersion()
+	}
+
+	// the condition may need to be fine-tuned based on the kernel version
+	return currentKernelVersion != nil && currentKernelVersion.IsRH7Kernel()
+}
+
 func expandKprobe(hookpoint string, flag int) []string {
 	var sections []string
 	if flag&Entry == Entry {

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -1527,6 +1527,10 @@ func NewProbe(config *config.Config, statsdClient statsd.ClientInterface) (*Prob
 			Name:  "setup_new_exec_is_last",
 			Value: utils.BoolTouint64(!p.kernelVersion.IsRH7Kernel() && p.kernelVersion.Code >= kernel.Kernel5_5), // the setup_new_exec kprobe is after security_bprm_committed_creds in kernels that are not RH7, and additionally, have a kernel version of at least 5.5
 		},
+		manager.ConstantEditor{
+			Name:  "tracepoint_module_load_sends_event",
+			Value: utils.BoolTouint64(p.kernelVersion.IsRH7Kernel()), // the condition may need to be fine-tuned based on the kernel version
+		},
 	)
 
 	p.managerOptions.ConstantEditors = append(p.managerOptions.ConstantEditors, DiscarderConstants...)

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -1527,10 +1527,6 @@ func NewProbe(config *config.Config, statsdClient statsd.ClientInterface) (*Prob
 			Name:  "setup_new_exec_is_last",
 			Value: utils.BoolTouint64(!p.kernelVersion.IsRH7Kernel() && p.kernelVersion.Code >= kernel.Kernel5_5), // the setup_new_exec kprobe is after security_bprm_committed_creds in kernels that are not RH7, and additionally, have a kernel version of at least 5.5
 		},
-		manager.ConstantEditor{
-			Name:  "tracepoint_module_load_sends_event",
-			Value: utils.BoolTouint64(p.kernelVersion.IsRH7Kernel()), // the condition may need to be fine-tuned based on the kernel version
-		},
 	)
 
 	p.managerOptions.ConstantEditors = append(p.managerOptions.ConstantEditors, DiscarderConstants...)


### PR DESCRIPTION
This PR uses the `module/module_load` tracepoint on rhel7-based kernels to send the init module event if the module is loaded by a kworker.

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
