### PR TITLE
Use English counters in go PDH checks

### DIFF
--- a/pkg/collector/corechecks/system/cpu/cpu_windows.go
+++ b/pkg/collector/corechecks/system/cpu/cpu_windows.go
@@ -123,11 +123,11 @@ func (c *Check) Run() error {
 // Note we use "processor information" instead of "processor" because on multi-processor machines the later only gives
 // you visibility about other applications running on the same processor as you
 func getProcessorPDHCounter(counterName, instance string) (*pdhutil.PdhSingleInstanceCounterSet, error) {
-	counter, err := pdhutil.GetUnlocalizedCounter("Processor Information", counterName, instance)
+	counter, err := pdhutil.GetEnglishCounterInstance("Processor Information", counterName, instance)
 	if err != nil {
-		counter, err = pdhutil.GetUnlocalizedCounter("Processor", counterName, instance)
+		counter, err = pdhutil.GetEnglishCounterInstance("Processor", counterName, instance)
 	}
-	return &counter, err
+	return counter, err
 }
 
 // Configure the CPU check doesn't need configuration

--- a/pkg/collector/corechecks/system/disk/iostats_pdh_windows.go
+++ b/pkg/collector/corechecks/system/disk/iostats_pdh_windows.go
@@ -104,7 +104,7 @@ func (c *IOCheck) Run() error {
 	// Try to initialize any nil counters
 	for name := range c.counternames {
 		if c.counters[name] == nil {
-			c.counters[name], err = pdhutil.GetMultiInstanceCounter("LogicalDisk", name, nil, isDrive)
+			c.counters[name], err = pdhutil.GetEnglishMultiInstanceCounter("LogicalDisk", name, isDrive)
 			if err != nil {
 				c.Warnf("io.Check: could not establish LogicalDisk '%v' counter: %v", name, err)
 			}

--- a/pkg/collector/corechecks/system/filehandles/file_handles_windows.go
+++ b/pkg/collector/corechecks/system/filehandles/file_handles_windows.go
@@ -19,7 +19,7 @@ const fileHandlesCheckName = "file_handle"
 
 type fhCheck struct {
 	core.CheckBase
-	counter *pdhutil.PdhMultiInstanceCounterSet
+	counter *pdhutil.PdhSingleInstanceCounterSet
 }
 
 // Run executes the check
@@ -30,19 +30,18 @@ func (c *fhCheck) Run() error {
 		return err
 	}
 
-	var vals map[string]float64
+	var val float64
 
 	// counter ("Process", "Handle count")
 	if c.counter == nil {
-		c.counter, err = pdhutil.GetMultiInstanceCounter("Process", "Handle Count", &[]string{"_Total"}, nil)
+		c.counter, err = pdhutil.GetEnglishCounterInstance("Process", "Handle Count", "_Total")
 	}
 	if c.counter != nil {
-		vals, err = c.counter.GetAllValues()
+		val, err = c.counter.GetValue()
 	}
 	if err != nil {
 		c.Warnf("file_handle.Check: Error getting process handle count: %v", err)
 	} else {
-		val := vals["_Total"]
 		log.Debugf("Submitting system.fs.file_handles_in_use %v", val)
 		sender.Gauge("system.fs.file_handles.in_use", float64(val), "", nil)
 	}

--- a/pkg/collector/corechecks/system/memory/memory_windows.go
+++ b/pkg/collector/corechecks/system/memory/memory_windows.go
@@ -55,7 +55,7 @@ func (c *Check) Run() error {
 
 	// counter ("Memory", "Cache Bytes")
 	if c.cacheBytes == nil {
-		c.cacheBytes, err = pdhutil.GetSingleInstanceCounter("Memory", "Cache Bytes")
+		c.cacheBytes, err = pdhutil.GetEnglishSingleInstanceCounter("Memory", "Cache Bytes")
 	}
 	if c.cacheBytes != nil {
 		val, err = c.cacheBytes.GetValue()
@@ -68,7 +68,7 @@ func (c *Check) Run() error {
 
 	// counter ("Memory", "Committed Bytes")
 	if c.committedBytes == nil {
-		c.committedBytes, err = pdhutil.GetSingleInstanceCounter("Memory", "Committed Bytes")
+		c.committedBytes, err = pdhutil.GetEnglishSingleInstanceCounter("Memory", "Committed Bytes")
 	}
 	if c.committedBytes != nil {
 		val, err = c.committedBytes.GetValue()
@@ -81,7 +81,7 @@ func (c *Check) Run() error {
 
 	// counter ("Memory", "Pool Paged Bytes")
 	if c.pagedBytes == nil {
-		c.pagedBytes, err = pdhutil.GetSingleInstanceCounter("Memory", "Pool Paged Bytes")
+		c.pagedBytes, err = pdhutil.GetEnglishSingleInstanceCounter("Memory", "Pool Paged Bytes")
 	}
 	if c.pagedBytes != nil {
 		val, err = c.pagedBytes.GetValue()
@@ -94,7 +94,7 @@ func (c *Check) Run() error {
 
 	// counter ("Memory", "Pool Nonpaged Bytes")
 	if c.nonpagedBytes == nil {
-		c.nonpagedBytes, err = pdhutil.GetSingleInstanceCounter("Memory", "Pool Nonpaged Bytes")
+		c.nonpagedBytes, err = pdhutil.GetEnglishSingleInstanceCounter("Memory", "Pool Nonpaged Bytes")
 	}
 	if c.nonpagedBytes != nil {
 		val, err = c.nonpagedBytes.GetValue()

--- a/pkg/collector/corechecks/system/winproc/winproc_windows.go
+++ b/pkg/collector/corechecks/system/winproc/winproc_windows.go
@@ -33,7 +33,7 @@ func (c *processChk) Run() error {
 
 	// counter ("System", "Processes")
 	if c.numprocs == nil {
-		c.numprocs, err = pdhutil.GetSingleInstanceCounter("System", "Processes")
+		c.numprocs, err = pdhutil.GetEnglishSingleInstanceCounter("System", "Processes")
 	}
 	if c.numprocs != nil {
 		val, err = c.numprocs.GetValue()
@@ -46,7 +46,7 @@ func (c *processChk) Run() error {
 
 	// counter ("System", "Processor Queue Length")
 	if c.pql == nil {
-		c.pql, err = pdhutil.GetSingleInstanceCounter("System", "Processor Queue Length")
+		c.pql, err = pdhutil.GetEnglishSingleInstanceCounter("System", "Processor Queue Length")
 	}
 	if c.pql != nil {
 		val, err = c.pql.GetValue()

--- a/pkg/util/winutil/pdhutil/pdh.go
+++ b/pkg/util/winutil/pdhutil/pdh.go
@@ -203,32 +203,6 @@ func PdhOpenQuery(szDataSource uintptr, dwUserData uintptr, phQuery *PDH_HQUERY)
 	return uint32(ret)
 }
 
-// PdhAddCounter adds the specified counter to the query
-/*
-Parameters
-hQuery [in]
-Handle to the query to which you want to add the counter. This handle is returned by the PdhOpenQuery function.
-
-szFullCounterPath [in]
-Null-terminated string that contains the counter path. For details on the format of a counter path, see Specifying a Counter Path. The maximum length of a counter path is PDH_MAX_COUNTER_PATH.
-
-dwUserData [in]
-User-defined value. This value becomes part of the counter information. To retrieve this value later, call the PdhGetCounterInfo function and access the dwUserData member of the PDH_COUNTER_INFO structure.
-
-phCounter [out]
-Handle to the counter that was added to the query. You may need to reference this handle in subsequent calls.
-*/
-func PdhAddCounter(hQuery PDH_HQUERY, szFullCounterPath string, dwUserData uintptr, phCounter *PDH_HCOUNTER) uint32 {
-	ptxt, _ := windows.UTF16PtrFromString(szFullCounterPath)
-	ret, _, _ := procPdhAddCounterW.Call(
-		uintptr(hQuery),
-		uintptr(unsafe.Pointer(ptxt)),
-		dwUserData,
-		uintptr(unsafe.Pointer(phCounter)))
-
-	return uint32(ret)
-}
-
 // PdhAddEnglishCounter adds the specified counter to the query
 /*
 Parameters

--- a/pkg/util/winutil/pdhutil/pdhcounter.go
+++ b/pkg/util/winutil/pdhutil/pdhcounter.go
@@ -15,15 +15,13 @@ import (
 
 // For testing
 var (
-	pfnMakeCounterSetInstances          = makeCounterSetIndexes
 	pfnPdhOpenQuery                     = PdhOpenQuery
 	pfnPdhAddCounter                    = PdhAddCounter
 	pfnPdhAddEnglishCounter             = PdhAddEnglishCounter
 	pfnPdhCollectQueryData              = PdhCollectQueryData
-	pfnPdhEnumObjectItems               = pdhEnumObjectItems
 	pfnPdhRemoveCounter                 = PdhRemoveCounter
-	pfnPdhLookupPerfNameByIndex         = pdhLookupPerfNameByIndex
 	pfnPdhGetFormattedCounterValueFloat = pdhGetFormattedCounterValueFloat
+	pfnPdhGetFormattedCounterArray      = pdhGetFormattedCounterArray
 	pfnPdhCloseQuery                    = PdhCloseQuery
 	pfnPdhMakeCounterPath               = pdhMakeCounterPath
 )
@@ -37,6 +35,7 @@ type CounterInstanceVerify func(string) bool
 type PdhCounterSet struct {
 	className string
 	query     PDH_HQUERY
+	counter PDH_HCOUNTER
 
 	counterName string
 }
@@ -44,299 +43,152 @@ type PdhCounterSet struct {
 // PdhSingleInstanceCounterSet is a specialization for single instance counters
 type PdhSingleInstanceCounterSet struct {
 	PdhCounterSet
-	singleCounter PDH_HCOUNTER
 }
 
 // PdhMultiInstanceCounterSet is a specialization for a multiple instance counter
 type PdhMultiInstanceCounterSet struct {
 	PdhCounterSet
-	requestedCounterName string
-	requestedInstances   map[string]bool
-	countermap           map[string]PDH_HCOUNTER // map instance name to counter handle
 	verifyfn             CounterInstanceVerify
 }
 
 // Initialize initializes a counter set object
-func (p *PdhCounterSet) Initialize(className string) error {
+func (p *PdhCounterSet) Initialize(className string, counterName string) error {
 
 	// refresh PDH object cache (refresh will only occur periodically)
 	tryRefreshPdhObjectCache()
 
-	// the counter index list may be > 1, but for class name, only take the first
-	// one.  If not present at all, try the english counter name
-	ndxlist, err := getCounterIndexList(className)
-	if err != nil {
-		return err
-	}
-	if ndxlist == nil || len(ndxlist) == 0 {
-		log.Warnf("Didn't find counter index for class %s, attempting english counter", className)
-		p.className = className
-	} else {
-		if len(ndxlist) > 1 {
-			log.Warnf("Class %s had multiple (%d) indices, using first", className, len(ndxlist))
-		}
-		ndx := ndxlist[0]
-		p.className, err = pfnPdhLookupPerfNameByIndex(ndx)
-		if err != nil {
-			return fmt.Errorf("Class name not found: %s", className)
-		}
-		log.Debugf("Found class name for %s %s", className, p.className)
-	}
+	p.className = className
+	p.counterName = counterName
 
 	winerror := pfnPdhOpenQuery(uintptr(0), uintptr(0), &p.query)
 	if ERROR_SUCCESS != winerror {
-		err = fmt.Errorf("Failed to open PDH query handle %d", winerror)
+		err := fmt.Errorf("Failed to open PDH query handle %#x", winerror)
 		return err
 	}
 	return nil
 }
 
-// GetUnlocalizedCounter wraps the PdhAddEnglishCounter call that takes unlocalized counter names (as opposed to the other functions which use PdhAddCounter)
-func GetUnlocalizedCounter(className, counterName, instance string) (PdhSingleInstanceCounterSet, error) {
-	// TODO (WA-52): Restructure GetUnlocalizedCounter / GetSingleInstanceCounter / GetMultiInstanceCounter
-	//               to make code more clear and deduplicate here and Initialize()
-
-	// refresh PDH object cache (refresh will only occur periodically)
-	tryRefreshPdhObjectCache()
+// GetEnglishCounterInstance returns a specific instance of the given counter
+// the className and counterName must be in English.
+// See PdhAddEnglishCounter docs for details
+// https://learn.microsoft.com/en-us/windows/win32/api/pdh/nf-pdh-pdhaddenglishcountera
+func GetEnglishCounterInstance(className string, counterName string, instance string) (*PdhSingleInstanceCounterSet, error) {
 
 	var p PdhSingleInstanceCounterSet
-	winerror := pfnPdhOpenQuery(uintptr(0), uintptr(0), &p.query)
-	if ERROR_SUCCESS != winerror {
-		return p, fmt.Errorf("Failed to open PDH query handle %d", winerror)
+	if err := p.Initialize(className, counterName); err != nil {
+		return nil, err
 	}
+
 	path, err := pfnPdhMakeCounterPath("", className, instance, counterName)
 	if err != nil {
-		return p, fmt.Errorf("Failed to make counter path %s: %v", counterName, err)
+		return nil, fmt.Errorf("Failed to make counter path %s: %v", counterName, err)
 	}
-	winerror = pfnPdhAddEnglishCounter(p.query, path, uintptr(0), &p.singleCounter)
+	winerror := pfnPdhAddEnglishCounter(p.query, path, uintptr(0), &p.counter)
 	if ERROR_SUCCESS != winerror {
-		return p, fmt.Errorf("Failed to add english counter %d", winerror)
+		return nil, fmt.Errorf("Failed to add english counter %#x", winerror)
 	}
 	winerror = pfnPdhCollectQueryData(p.query)
 	if ERROR_SUCCESS != winerror {
-		return p, fmt.Errorf("Failed to collect query data %d", winerror)
+		return nil, fmt.Errorf("Failed to collect query data %#x", winerror)
 	}
-	return p, nil
+	return &p, nil
 }
 
-// GetSingleInstanceCounter returns a single instance counter object for the given counter class
-// TODO: Replace usages of this with GetUnlocalizedCounter using an empty string as instance
-func GetSingleInstanceCounter(className, counterName string) (*PdhSingleInstanceCounterSet, error) {
+// GetEnglishSingleInstanceCounter returns a single instance counter object for the given counter class
+// the className and counterName must be in English.
+// See PdhAddEnglishCounter docs for details
+// https://learn.microsoft.com/en-us/windows/win32/api/pdh/nf-pdh-pdhaddenglishcountera
+func GetEnglishSingleInstanceCounter(className string, counterName string) (*PdhSingleInstanceCounterSet, error) {
+	return GetEnglishCounterInstance(className, counterName, "")
+}
+
+// GetLocalizedSingleInstanceCounter returns a single instance counter object for the given counter class
+// the className and counterName must be in the same localization as the system.
+func GetLocalizedSingleInstanceCounter(className string, counterName string) (*PdhSingleInstanceCounterSet, error) {
 	var p PdhSingleInstanceCounterSet
-	if err := p.Initialize(className); err != nil {
+	if err := p.Initialize(className, counterName); err != nil {
 		return nil, err
-	}
-	// check to make sure this is really a single instance counter
-	allcounters, instances, err := pfnPdhEnumObjectItems(p.className)
-	if err != nil {
-		return nil, err
-	}
-	if len(instances) > 0 {
-		return nil, fmt.Errorf("Requested counter is not single-instance: %s", p.className)
-	}
-	path, err := p.MakeCounterPath("", counterName, "", allcounters)
-	if err != nil {
-		log.Warnf("Failed to make counter path %v", err)
-		return nil, err
-	}
-	winerror := pfnPdhAddCounter(p.query, path, uintptr(0), &p.singleCounter)
-	if ERROR_SUCCESS != winerror {
-		return nil, fmt.Errorf("Failed to add single counter %d", winerror)
 	}
 
-	// do the initial collect now
-	pfnPdhCollectQueryData(p.query)
+	path, err := pfnPdhMakeCounterPath("", className, "", counterName)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to make counter path %s: %v", counterName, err)
+	}
+	winerror := pfnPdhAddCounter(p.query, path, uintptr(0), &p.counter)
+	if ERROR_SUCCESS != winerror {
+		return nil, fmt.Errorf("Failed to add localized counter %#x", winerror)
+	}
+	winerror = pfnPdhCollectQueryData(p.query)
+	if ERROR_SUCCESS != winerror {
+		return nil, fmt.Errorf("Failed to collect query data %#x", winerror)
+	}
 	return &p, nil
 }
 
 // GetMultiInstanceCounter returns a multi-instance counter object for the given counter class
-// TODO: Replace usages of this with a function similar to GetUnlocalizedCounter for multi-instance counters, that uses PdhAddEnglishCounter
-func GetMultiInstanceCounter(className, counterName string, requestedInstances *[]string, verifyfn CounterInstanceVerify) (*PdhMultiInstanceCounterSet, error) {
+func GetEnglishMultiInstanceCounter(className string, counterName string, verifyfn CounterInstanceVerify) (*PdhMultiInstanceCounterSet, error) {
 	var p PdhMultiInstanceCounterSet
-	if err := p.Initialize(className); err != nil {
+	if err := p.Initialize(className, counterName); err != nil {
 		return nil, err
 	}
-	p.countermap = make(map[string]PDH_HCOUNTER)
+
 	p.verifyfn = verifyfn
-	p.requestedCounterName = counterName
 
-	// check to make sure this is really a multi instance counter
-	_, instances, err := pfnPdhEnumObjectItems(p.className)
+	// Use the * wildcard to collect all instances
+	path, err := pfnPdhMakeCounterPath("", className, "*", counterName)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Failed to make counter path %s: %v", counterName, err)
 	}
-	if len(instances) <= 0 {
-		return nil, fmt.Errorf("Requested counter is a single-instance: %s", p.className)
+	winerror := pfnPdhAddEnglishCounter(p.query, path, uintptr(0), &p.counter)
+	if ERROR_SUCCESS != winerror {
+		return nil, fmt.Errorf("Failed to add english counter %#x", winerror)
 	}
-	// save the requested instances
-	if requestedInstances != nil && len(*requestedInstances) > 0 {
-		p.requestedInstances = make(map[string]bool)
-		for _, inst := range *requestedInstances {
-			p.requestedInstances[inst] = true
-		}
+	winerror = pfnPdhCollectQueryData(p.query)
+	if ERROR_SUCCESS != winerror {
+		return nil, fmt.Errorf("Failed to collect query data %#x", winerror)
 	}
-	if err := p.MakeInstanceList(); err != nil {
-		return nil, err
-	}
-	return &p, nil
 
+	return &p, nil
 }
 
-// MakeInstanceList walks the list of available instances, and adds new
-// instances that have appeared since the last check run
-func (p *PdhMultiInstanceCounterSet) MakeInstanceList() error {
-	allcounters, instances, err := pfnPdhEnumObjectItems(p.className)
+// GetAllValues returns the data associated with each instance in a query.
+// verifyfn is used to filter out instance names that are returned
+// instance:value pairs are not returned for items whose CStatus contains an error
+func (p *PdhMultiInstanceCounterSet) GetAllValues() (values map[string]float64, err error) {
+	// update data
+	pfnPdhCollectQueryData(p.query)
+	// fetch data
+	items, err := pfnPdhGetFormattedCounterArray(p.counter, PDH_FMT_DOUBLE)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	var instToMake []string
-	for _, actualInstance := range instances {
-		// if we have a list of requested instances, walk it, and make sure
-		// they're here.  If not, add them to the list of instances to make
-		if p.requestedInstances != nil {
-			// if it's not in the requestedInstances, don't bother
-			if !p.requestedInstances[actualInstance] {
-				continue
-			}
-			// ok.  it was requested.  If it's not in our map
-			// of counters, we have to add it
-			if p.countermap[actualInstance] == PDH_HCOUNTER(0) {
-				log.Debugf("Adding requested instance %s", actualInstance)
-				instToMake = append(instToMake, actualInstance)
-			}
-		} else {
-			// wanted all the instances.  Make sure all of the instances
-			// are present
-			if p.countermap[actualInstance] == PDH_HCOUNTER(0) {
-				instToMake = append(instToMake, actualInstance)
-			}
-		}
-	}
-	added := false
-	for _, inst := range instToMake {
+	values = make(map[string]float64)
+	for _, item := range items {
 		if p.verifyfn != nil {
-			if p.verifyfn(inst) == false {
+			if p.verifyfn(item.instance) == false {
 				// not interested, moving on
 				continue
 			}
 		}
-		path, err := p.MakeCounterPath("", p.requestedCounterName, inst, allcounters)
-		if err != nil {
-			log.Debugf("Failed to make counter path %s %s", p.counterName, inst)
+		if item.value.CStatus != PDH_CSTATUS_VALID_DATA &&
+			item.value.CStatus != PDH_CSTATUS_NEW_DATA {
+			// Does not necessarily indicate the problem, e.g. the process may have
+			// exited by the time the formatting of its counter values happened
+			log.Debugf("Counter value not valid for %s[%s]: %#x", p.counterName, item.instance, item.value.CStatus)
 			continue
 		}
-		var hc PDH_HCOUNTER
-		winerror := pfnPdhAddCounter(p.query, path, uintptr(0), &hc)
-		if ERROR_SUCCESS != winerror {
-			log.Debugf("Failed to add counter path %s", path)
-			continue
-		}
-		log.Debugf("Adding missing counter instance %s", inst)
-		p.countermap[inst] = hc
-		added = true
+		values[item.instance] = item.value.Double
 	}
-	if added {
-		// do the initial collect now
-		pfnPdhCollectQueryData(p.query)
-	}
-	return nil
-}
-
-//RemoveInvalidInstance removes an instance from the counter that is no longer valid
-func (p *PdhMultiInstanceCounterSet) RemoveInvalidInstance(badInstance string) {
-	hc := p.countermap[badInstance]
-	if hc != PDH_HCOUNTER(0) {
-		log.Debugf("Removing non-existent counter instance %s", badInstance)
-		pfnPdhRemoveCounter(hc)
-		delete(p.countermap, badInstance)
-	} else {
-		log.Debugf("Instance handle not found")
-	}
-}
-
-// MakeCounterPath creates a counter path from the counter instance and
-// counter name.  Tries all available translated counter indexes from
-// the english name
-func (p *PdhCounterSet) MakeCounterPath(machine, counterName, instanceName string, counters []string) (string, error) {
-	/*
-	   When handling non english versions, the counters don't work quite as documented.
-	   This is because strings like "Bytes Sent/sec" might appear multiple times in the
-	   english master, and might not have mappings for each index.
-
-	   Search each index, and make sure the requested counter name actually appears in
-	   the list of available counters; that's the counter we'll use.
-
-	   For more information, see README.md.
-	*/
-	idxList, err := getCounterIndexList(counterName)
-	if err != nil {
-		return "", err
-	}
-	for _, ndx := range idxList {
-		counter, e := pfnPdhLookupPerfNameByIndex(ndx)
-		if e != nil {
-			log.Debugf("Counter index %d not found, skipping", ndx)
-			continue
-		}
-		// see if the counter we got back is in the list of counters
-		if !stringInSlice(counter, counters) {
-			log.Debugf("counter %s not in counter list", counter)
-			continue
-		}
-		// check to see if we can create the counter
-		path, err := pfnPdhMakeCounterPath(machine, p.className, instanceName, counter)
-		if err == nil {
-			log.Debugf("Successfully created counter path %s", path)
-			p.counterName = counter
-			return path, nil
-		}
-		// else
-		log.Debugf("Unable to create path with %s, trying again", counter)
-	}
-	// if we get here, was never able to find a counter path or create a valid
-	// path.  Return failure.
-	log.Warnf("Unable to create counter path for %s %s", counterName, instanceName)
-	return "", fmt.Errorf("Unable to create counter path %s %s", counterName, instanceName)
-}
-
-// GetAllValues returns the data associated with each instance in a query.
-func (p *PdhMultiInstanceCounterSet) GetAllValues() (values map[string]float64, err error) {
-	values = make(map[string]float64)
-	err = nil
-	var removeList []string
-	pfnPdhCollectQueryData(p.query)
-	for inst, hcounter := range p.countermap {
-		var retval float64
-		retval, err = pfnPdhGetFormattedCounterValueFloat(hcounter)
-		if err != nil {
-			switch err.(type) {
-			case *ErrPdhInvalidInstance:
-				removeList = append(removeList, inst)
-				log.Debugf("Got invalid instance for %s %s", p.requestedCounterName, inst)
-				err = nil
-				continue
-			default:
-				log.Debugf("Other Error getting all values %s %s %v", p.requestedCounterName, inst, err)
-				return
-			}
-		}
-		values[inst] = retval
-	}
-	for _, inst := range removeList {
-		p.RemoveInvalidInstance(inst)
-	}
-	// check for newly found instances
-	p.MakeInstanceList()
-	return
+	return values, nil
 }
 
 // GetValue returns the data associated with a single-value counter
 func (p *PdhSingleInstanceCounterSet) GetValue() (val float64, err error) {
-	if p.singleCounter == PDH_HCOUNTER(0) {
+	if p.counter == PDH_HCOUNTER(0) {
 		return 0, fmt.Errorf("Not a single-value counter")
 	}
 	pfnPdhCollectQueryData(p.query)
-	return pfnPdhGetFormattedCounterValueFloat(p.singleCounter)
+	return pfnPdhGetFormattedCounterValueFloat(p.counter)
 
 }
 
@@ -345,25 +197,3 @@ func (p *PdhCounterSet) Close() {
 	PdhCloseQuery(p.query)
 }
 
-func getCounterIndexList(cname string) ([]int, error) {
-	if counterToIndex == nil || len(counterToIndex) == 0 {
-		if err := pfnMakeCounterSetInstances(); err != nil {
-			return []int{}, err
-		}
-	}
-
-	ndxlist, found := counterToIndex[cname]
-	if !found {
-		return []int{}, nil
-	}
-	return ndxlist, nil
-}
-
-func stringInSlice(a string, list []string) bool {
-	for _, b := range list {
-		if b == a {
-			return true
-		}
-	}
-	return false
-}

--- a/pkg/util/winutil/pdhutil/pdhcounter.go
+++ b/pkg/util/winutil/pdhutil/pdhcounter.go
@@ -59,9 +59,9 @@ func (p *PdhCounterSet) Initialize(className string, counterName string) error {
 	p.className = className
 	p.counterName = counterName
 
-	winerror := pfnPdhOpenQuery(uintptr(0), uintptr(0), &p.query)
-	if ERROR_SUCCESS != winerror {
-		err := fmt.Errorf("Failed to open PDH query handle %#x", winerror)
+	pdherror := pfnPdhOpenQuery(uintptr(0), uintptr(0), &p.query)
+	if ERROR_SUCCESS != pdherror {
+		err := fmt.Errorf("Failed to open PDH query handle %#x", pdherror)
 		return err
 	}
 	return nil
@@ -82,13 +82,13 @@ func GetEnglishCounterInstance(className string, counterName string, instance st
 	if err != nil {
 		return nil, fmt.Errorf("Failed to make counter path %s: %v", counterName, err)
 	}
-	winerror := pfnPdhAddEnglishCounter(p.query, path, uintptr(0), &p.counter)
-	if ERROR_SUCCESS != winerror {
-		return nil, fmt.Errorf("Failed to add english counter %#x", winerror)
+	pdherror := pfnPdhAddEnglishCounter(p.query, path, uintptr(0), &p.counter)
+	if ERROR_SUCCESS != pdherror {
+		return nil, fmt.Errorf("Failed to add english counter %#x", pdherror)
 	}
-	winerror = pfnPdhCollectQueryData(p.query)
-	if ERROR_SUCCESS != winerror {
-		return nil, fmt.Errorf("Failed to collect query data %#x", winerror)
+	pdherror = pfnPdhCollectQueryData(p.query)
+	if ERROR_SUCCESS != pdherror {
+		return nil, fmt.Errorf("Failed to collect query data %#x", pdherror)
 	}
 	return &p, nil
 }
@@ -115,13 +115,13 @@ func GetEnglishMultiInstanceCounter(className string, counterName string, verify
 	if err != nil {
 		return nil, fmt.Errorf("Failed to make counter path %s: %v", counterName, err)
 	}
-	winerror := pfnPdhAddEnglishCounter(p.query, path, uintptr(0), &p.counter)
-	if ERROR_SUCCESS != winerror {
-		return nil, fmt.Errorf("Failed to add english counter %#x", winerror)
+	pdherror := pfnPdhAddEnglishCounter(p.query, path, uintptr(0), &p.counter)
+	if ERROR_SUCCESS != pdherror {
+		return nil, fmt.Errorf("Failed to add english counter %#x", pdherror)
 	}
-	winerror = pfnPdhCollectQueryData(p.query)
-	if ERROR_SUCCESS != winerror {
-		return nil, fmt.Errorf("Failed to collect query data %#x", winerror)
+	pdherror = pfnPdhCollectQueryData(p.query)
+	if ERROR_SUCCESS != pdherror {
+		return nil, fmt.Errorf("Failed to collect query data %#x", pdherror)
 	}
 
 	return &p, nil

--- a/pkg/util/winutil/pdhutil/pdhcounter.go
+++ b/pkg/util/winutil/pdhutil/pdhcounter.go
@@ -16,7 +16,6 @@ import (
 // For testing
 var (
 	pfnPdhOpenQuery                     = PdhOpenQuery
-	pfnPdhAddCounter                    = PdhAddCounter
 	pfnPdhAddEnglishCounter             = PdhAddEnglishCounter
 	pfnPdhCollectQueryData              = PdhCollectQueryData
 	pfnPdhRemoveCounter                 = PdhRemoveCounter
@@ -100,29 +99,6 @@ func GetEnglishCounterInstance(className string, counterName string, instance st
 // https://learn.microsoft.com/en-us/windows/win32/api/pdh/nf-pdh-pdhaddenglishcountera
 func GetEnglishSingleInstanceCounter(className string, counterName string) (*PdhSingleInstanceCounterSet, error) {
 	return GetEnglishCounterInstance(className, counterName, "")
-}
-
-// GetLocalizedSingleInstanceCounter returns a single instance counter object for the given counter class
-// the className and counterName must be in the same localization as the system.
-func GetLocalizedSingleInstanceCounter(className string, counterName string) (*PdhSingleInstanceCounterSet, error) {
-	var p PdhSingleInstanceCounterSet
-	if err := p.Initialize(className, counterName); err != nil {
-		return nil, err
-	}
-
-	path, err := pfnPdhMakeCounterPath("", className, "", counterName)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to make counter path %s: %v", counterName, err)
-	}
-	winerror := pfnPdhAddCounter(p.query, path, uintptr(0), &p.counter)
-	if ERROR_SUCCESS != winerror {
-		return nil, fmt.Errorf("Failed to add localized counter %#x", winerror)
-	}
-	winerror = pfnPdhCollectQueryData(p.query)
-	if ERROR_SUCCESS != winerror {
-		return nil, fmt.Errorf("Failed to collect query data %#x", winerror)
-	}
-	return &p, nil
 }
 
 // GetMultiInstanceCounter returns a multi-instance counter object for the given counter class

--- a/pkg/util/winutil/pdhutil/pdhformatter.go
+++ b/pkg/util/winutil/pdhutil/pdhformatter.go
@@ -8,13 +8,6 @@
 package pdhutil
 
 import (
-	"fmt"
-	"reflect"
-	"strconv"
-	"unsafe"
-
-	"golang.org/x/sys/windows"
-
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -25,9 +18,15 @@ type PdhFormatter struct {
 
 // PdhCounterValue represents a counter value
 type PdhCounterValue struct {
+	CStatus    uint32
 	Double float64
 	Large  int64
 	Long   int32
+}
+
+type PdhCounterValueItem struct {
+	instance string
+	value PdhCounterValue
 }
 
 // ValueEnumFunc implements a callback for counter enumeration
@@ -35,121 +34,31 @@ type ValueEnumFunc func(s string, v PdhCounterValue)
 
 // Enum enumerates performance counter values for a wildcard instance counter (e.g. `\Process(*)\% Processor Time`)
 func (f *PdhFormatter) Enum(counterName string, hCounter PDH_HCOUNTER, format uint32, ignoreInstances []string, fn ValueEnumFunc) error {
-	var bufLen uint32
-	var itemCount uint32
-
-	if format == PDH_FMT_DOUBLE {
-		format |= PDH_FMT_NOCAP100
+	items, err := pdhGetFormattedCounterArray(hCounter, format)
+	if err != nil {
+		return err
 	}
-
-	r, _, _ := procPdhGetFormattedCounterArray.Call(
-		uintptr(hCounter),
-		uintptr(format),
-		uintptr(unsafe.Pointer(&bufLen)),
-		uintptr(unsafe.Pointer(&itemCount)),
-		uintptr(0),
-	)
-
-	if r != PDH_MORE_DATA {
-		return fmt.Errorf("Failed to get formatted counter array buffer size 0x%x", r)
-	}
-
-	if bufLen > uint32(len(f.buf)) {
-		f.buf = make([]uint8, bufLen)
-	}
-
-	buf := f.buf[:bufLen]
-
-	r, _, _ = procPdhGetFormattedCounterArray.Call(
-		uintptr(hCounter),
-		uintptr(format),
-		uintptr(unsafe.Pointer(&bufLen)),
-		uintptr(unsafe.Pointer(&itemCount)),
-		uintptr(unsafe.Pointer(&buf[0])),
-	)
-	if r != ERROR_SUCCESS {
-		return fmt.Errorf("Error getting formatted counter array 0x%x", r)
-	}
-
-	var items []PDH_FMT_COUNTERVALUE_ITEM_DOUBLE
-	// Accessing the `SliceHeader` to manipulate the `items` slice
-	// In the future we can use unsafe.Slice instead https://pkg.go.dev/unsafe@master#Slice
-	hdrItems := (*reflect.SliceHeader)(unsafe.Pointer(&items))
-	hdrItems.Data = uintptr(unsafe.Pointer(&buf[0]))
-	hdrItems.Len = int(itemCount)
-	hdrItems.Cap = int(itemCount)
-
-	var (
-		prevName    string
-		instanceIdx int
-	)
-
-	// Instance names are packed in the buffer following the items structs
-	strBufLen := int(bufLen - uint32(unsafe.Sizeof(PDH_FMT_COUNTERVALUE_ITEM_DOUBLE{}))*itemCount)
 	for _, item := range items {
-		var u []uint16
-
-		// Accessing the `SliceHeader` to manipulate the `u` slice
-		hdrU := (*reflect.SliceHeader)(unsafe.Pointer(&u))
-		hdrU.Data = uintptr(unsafe.Pointer(item.szName))
-		hdrU.Len = strBufLen / 2
-		hdrU.Cap = strBufLen / 2
-
-		// Scan for terminating NUL char
-		for i, v := range u {
-			if v == 0 {
-				u = u[:i]
-				// subtract from the instance names buffer space
-				strBufLen -= (i + 1) * 2 // in bytes including terminating NUL char
-				break
-			}
-		}
-
-		name := windows.UTF16ToString(u)
 		skip := false
 		for _, ignored := range ignoreInstances {
-			if name == ignored {
+			if item.instance == ignored {
 				skip = true
 			}
 		}
 		if skip {
 			continue
 		}
-		if name != prevName {
-			instanceIdx = 0
-			prevName = name
-		} else {
-			instanceIdx++
-		}
 
-		instance := name
-		if instanceIdx != 0 {
-			// To match same instance ID as in perfmon on Windows
-			instance += "#" + strconv.Itoa(instanceIdx)
-		}
 		if item.value.CStatus != PDH_CSTATUS_VALID_DATA &&
 			item.value.CStatus != PDH_CSTATUS_NEW_DATA {
 			// Does not necessarily indicate the problem, e.g. the process may have
 			// exited by the time the formatting of its counter values happened
-			log.Debugf("Counter value not valid for %s[%s]: 0x%x", counterName, instance, item.value.CStatus)
+			log.Debugf("Counter value not valid for %s[%s]: %#x", counterName, item.instance, item.value.CStatus)
 			continue
 		}
 
-		var value PdhCounterValue
-
-		switch format {
-		case PDH_FMT_DOUBLE:
-		case PDH_FMT_DOUBLE | PDH_FMT_NOCAP100:
-			value.Double = item.value.DoubleValue
-		case PDH_FMT_LONG:
-			from := (*PDH_FMT_COUNTERVALUE_ITEM_LONG)(unsafe.Pointer(&item))
-			value.Long = from.value.LongValue
-		case PDH_FMT_LARGE:
-			from := (*PDH_FMT_COUNTERVALUE_ITEM_LARGE)(unsafe.Pointer(&item))
-			value.Large = from.value.LargeValue
-		}
-
-		fn(instance, value)
+		fn(item.instance, item.value)
 	}
+
 	return nil
 }

--- a/pkg/util/winutil/pdhutil/pdhhelper.go
+++ b/pkg/util/winutil/pdhutil/pdhhelper.go
@@ -9,6 +9,7 @@ package pdhutil
 
 import (
 	"fmt"
+	"reflect"
 	"strconv"
 	"unsafe"
 	"time"
@@ -37,10 +38,6 @@ var (
 	procPdhOpenQuery                = modPdhDll.NewProc("PdhOpenQuery")
 	procPdhRemoveCounter            = modPdhDll.NewProc("PdhRemoveCounter")
 	procPdhGetFormattedCounterArray = modPdhDll.NewProc("PdhGetFormattedCounterArrayW")
-)
-
-var (
-	counterToIndex map[string][]int
 )
 
 const (
@@ -320,41 +317,114 @@ func pdhGetFormattedCounterValueFloat(hCounter PDH_HCOUNTER) (val float64, err e
 	return pValue.DoubleValue, nil
 }
 
-func makeCounterSetIndexes() error {
-	counterToIndex = make(map[string][]int)
+// Enum enumerates performance counter values for a wildcard instance counter (e.g. `\Process(*)\% Processor Time`)
+//
+// Will append '#<INDEX>' to duplicate instance names to ensure their uniqueness.
+// Instance uniqueness is normally done by the PDH provider, except in the case of the Process class where it is NOT
+// handled in order to maintain backwards compatability.
+// https://learn.microsoft.com/en-us/windows/win32/perfctrs/handling-duplicate-instance-names
+func pdhGetFormattedCounterArray(hCounter PDH_HCOUNTER, format uint32) (out_items []PdhCounterValueItem, err error) {
+	var buf []uint8
+	var bufLen uint32
+	var itemCount uint32
 
-	bufferIncrement := uint32(1024)
-	bufferSize := bufferIncrement
-	var counterlist []uint16
-	for {
-		var regtype uint32
-		counterlist = make([]uint16, bufferSize)
-		var sz uint32
-		sz = bufferSize
-		regerr := windows.RegQueryValueEx(windows.HKEY_PERFORMANCE_DATA,
-			windows.StringToUTF16Ptr("Counter 009"),
-			nil, // reserved
-			&regtype,
-			(*byte)(unsafe.Pointer(&counterlist[0])),
-			&sz)
-		if regerr == error(windows.ERROR_MORE_DATA) {
-			// buffer's not big enough
-			bufferSize += bufferIncrement
-			continue
-		} else if regerr != nil {
-			return regerr
+	if format == PDH_FMT_DOUBLE {
+		format |= PDH_FMT_NOCAP100
+	}
+
+	r, _, _ := procPdhGetFormattedCounterArray.Call(
+		uintptr(hCounter),
+		uintptr(format),
+		uintptr(unsafe.Pointer(&bufLen)),
+		uintptr(unsafe.Pointer(&itemCount)),
+		uintptr(0),
+	)
+
+	if r != PDH_MORE_DATA {
+		return nil, fmt.Errorf("Failed to get formatted counter array buffer size %#x", r)
+	}
+
+	buf = make([]uint8, bufLen)
+
+	r, _, _ = procPdhGetFormattedCounterArray.Call(
+		uintptr(hCounter),
+		uintptr(format),
+		uintptr(unsafe.Pointer(&bufLen)),
+		uintptr(unsafe.Pointer(&itemCount)),
+		uintptr(unsafe.Pointer(&buf[0])),
+	)
+	if r != ERROR_SUCCESS {
+		return nil, fmt.Errorf("Error getting formatted counter array %#x", r)
+	}
+
+	var items []PDH_FMT_COUNTERVALUE_ITEM_DOUBLE
+	// Accessing the `SliceHeader` to manipulate the `items` slice
+	// In the future we can use unsafe.Slice instead https://pkg.go.dev/unsafe@master#Slice
+	hdrItems := (*reflect.SliceHeader)(unsafe.Pointer(&items))
+	hdrItems.Data = uintptr(unsafe.Pointer(&buf[0]))
+	hdrItems.Len = int(itemCount)
+	hdrItems.Cap = int(itemCount)
+
+	var (
+		prevName    string
+		instanceIdx int
+	)
+
+	// Instance names are packed in the buffer following the items structs
+	strBufLen := int(bufLen - uint32(unsafe.Sizeof(PDH_FMT_COUNTERVALUE_ITEM_DOUBLE{}))*itemCount)
+	for _, item := range items {
+		var u []uint16
+
+		// Accessing the `SliceHeader` to manipulate the `u` slice
+		hdrU := (*reflect.SliceHeader)(unsafe.Pointer(&u))
+		hdrU.Data = uintptr(unsafe.Pointer(item.szName))
+		hdrU.Len = strBufLen / 2
+		hdrU.Cap = strBufLen / 2
+
+		// Scan for terminating NUL char
+		for i, v := range u {
+			if v == 0 {
+				u = u[:i]
+				// subtract from the instance names buffer space
+				strBufLen -= (i + 1) * 2 // in bytes including terminating NUL char
+				break
+			}
 		}
-		// must set the length of the slice to the actual amount of data
-		// sz is in bytes, but it's a slice of uint16s, so divide the returned
-		// buffer size by two.
 
-		counterlist = counterlist[:(sz / 2)]
-		break
+		name := windows.UTF16ToString(u)
+		if name != prevName {
+			instanceIdx = 0
+			prevName = name
+		} else {
+			instanceIdx++
+		}
+
+		instance := name
+		if instanceIdx != 0 {
+			// To match same instance ID as in perfmon on Windows
+			instance += "#" + strconv.Itoa(instanceIdx)
+		}
+
+		var value PdhCounterValue
+		value.CStatus = item.value.CStatus
+
+		switch format {
+		case PDH_FMT_DOUBLE:
+		case PDH_FMT_DOUBLE | PDH_FMT_NOCAP100:
+			value.Double = item.value.DoubleValue
+		case PDH_FMT_LONG:
+			from := (*PDH_FMT_COUNTERVALUE_ITEM_LONG)(unsafe.Pointer(&item))
+			value.Long = from.value.LongValue
+		case PDH_FMT_LARGE:
+			from := (*PDH_FMT_COUNTERVALUE_ITEM_LARGE)(unsafe.Pointer(&item))
+			value.Large = from.value.LargeValue
+		}
+
+		value_item := PdhCounterValueItem{
+			instance: instance,
+			value: value,
+		}
+		out_items = append(out_items, value_item)
 	}
-	clist := winutil.ConvertWindowsStringList(counterlist)
-	for i := 0; (i + 1) < len(clist); i += 2 {
-		ndx, _ := strconv.Atoi(clist[i])
-		counterToIndex[clist[i+1]] = append(counterToIndex[clist[i+1]], ndx)
-	}
-	return nil
+	return out_items, nil
 }

--- a/pkg/util/winutil/pdhutil/pdhhelper.go
+++ b/pkg/util/winutil/pdhutil/pdhhelper.go
@@ -31,7 +31,6 @@ var (
 	procPdhEnumObjectItems          = modPdhDll.NewProc("PdhEnumObjectItemsW")
 	procPdhMakeCounterPath          = modPdhDll.NewProc("PdhMakeCounterPathW")
 	procPdhGetFormattedCounterValue = modPdhDll.NewProc("PdhGetFormattedCounterValue")
-	procPdhAddCounterW              = modPdhDll.NewProc("PdhAddCounterW")
 	procPdhAddEnglishCounterW       = modPdhDll.NewProc("PdhAddEnglishCounterW")
 	procPdhCollectQueryData         = modPdhDll.NewProc("PdhCollectQueryData")
 	procPdhCloseQuery               = modPdhDll.NewProc("PdhCloseQuery")

--- a/pkg/util/winutil/pdhutil/pdhmocks_windows.go
+++ b/pkg/util/winutil/pdhutil/pdhmocks_windows.go
@@ -62,10 +62,6 @@ func mockPdhOpenQuery(szDataSource uintptr, dwUserData uintptr, phQuery *PDH_HQU
 }
 
 func mockPdhAddEnglishCounter(hQuery PDH_HQUERY, szFullCounterPath string, dwUserData uintptr, phCounter *PDH_HCOUNTER) uint32 {
-	return mockPdhAddCounter(hQuery, szFullCounterPath, dwUserData, phCounter)
-}
-
-func mockPdhAddCounter(hQuery PDH_HQUERY, szFullCounterPath string, dwUserData uintptr, phCounter *PDH_HCOUNTER) uint32 {
 	ndx := int(hQuery)
 	var thisQuery mockQuery
 	var ok bool
@@ -185,7 +181,6 @@ func SetupTesting(counterstringsfile, countersfile string) {
 	activeAvailableCounters, _ = ReadCounters(countersfile)
 	// For testing
 	pfnPdhOpenQuery = mockPdhOpenQuery
-	pfnPdhAddCounter = mockPdhAddCounter
 	pfnPdhAddEnglishCounter = mockPdhAddEnglishCounter
 	pfnPdhCollectQueryData = mockPdhCollectQueryData
 	pfnPdhRemoveCounter = mockPdhRemoveCounter

--- a/pkg/util/winutil/pdhutil/pdhmocks_windows.go
+++ b/pkg/util/winutil/pdhutil/pdhmocks_windows.go
@@ -11,24 +11,18 @@ package pdhutil
 import (
 	"fmt"
 	"strings"
+	"regexp"
 )
 
 var activeCounterStrings CounterStrings
 var activeAvailableCounters AvailableCounters
 
-func mockmakeCounterSetIndexes() error {
-	if !activeCounterStrings.initialized {
-		return fmt.Errorf("Counter strings not initialized")
-	}
-	counterToIndex = make(map[string][]int)
-	for k, v := range activeCounterStrings.counterIndex {
-		counterToIndex[v] = append(counterToIndex[v], k)
-	}
-	return nil
-}
-
 type mockCounter struct {
-	name string
+	path string
+	machine string
+	class string
+	instance string
+	counter string
 }
 
 type mockQuery struct {
@@ -40,7 +34,22 @@ var openQueriesIndex = 0
 var counterIndex = 0 // index of counter into the query must be global, because
 // RemoveCounter can be called on just a counter index
 
-var countervalues = make(map[string][]float64)
+// class -> counter -> instance -> values
+var counterValues = make(map[string]map[string]map[string][]float64)
+
+func mockCounterFromString(path string) mockCounter {
+	// Example: \\.\LogicalDisk(HarddiskVolume2)\Current Disk Queue Length
+	// Example: \\.\Memory\Available Bytes
+	r := regexp.MustCompile(`\\\\([^\\]+)\\([^\\\(]+)(?:\(([^\\\)]+)\))?\\(.+)`)
+	res := r.FindStringSubmatch(path)
+	return mockCounter{
+		path: path,
+		machine: res[1],
+		class: res[2],
+		instance: res[3],
+		counter: res[4],
+	}
+}
 
 func mockPdhOpenQuery(szDataSource uintptr, dwUserData uintptr, phQuery *PDH_HQUERY) uint32 {
 	var mq mockQuery
@@ -53,18 +62,7 @@ func mockPdhOpenQuery(szDataSource uintptr, dwUserData uintptr, phQuery *PDH_HQU
 }
 
 func mockPdhAddEnglishCounter(hQuery PDH_HQUERY, szFullCounterPath string, dwUserData uintptr, phCounter *PDH_HCOUNTER) uint32 {
-	ndx := int(hQuery)
-	var thisQuery mockQuery
-	var ok bool
-	if thisQuery, ok = openQueries[ndx]; ok == false {
-		return uint32(PDH_INVALID_PATH)
-	}
-	counterIndex++
-
-	thisQuery.counters[counterIndex] = mockCounter{name: szFullCounterPath}
-	*phCounter = PDH_HCOUNTER(uintptr(counterIndex))
-
-	return 0
+	return mockPdhAddCounter(hQuery, szFullCounterPath, dwUserData, phCounter)
 }
 
 func mockPdhAddCounter(hQuery PDH_HQUERY, szFullCounterPath string, dwUserData uintptr, phCounter *PDH_HCOUNTER) uint32 {
@@ -76,7 +74,8 @@ func mockPdhAddCounter(hQuery PDH_HQUERY, szFullCounterPath string, dwUserData u
 	}
 	counterIndex++
 
-	thisQuery.counters[counterIndex] = mockCounter{name: szFullCounterPath}
+	mc := mockCounterFromString(szFullCounterPath)
+	thisQuery.counters[counterIndex] = mc
 	*phCounter = PDH_HCOUNTER(uintptr(counterIndex))
 
 	return 0
@@ -107,17 +106,7 @@ func mockPdhRemoveCounter(hCounter PDH_HCOUNTER) uint32 {
 	return PDH_INVALID_HANDLE
 }
 
-func mockpdhLookupPerfNameByIndex(ndx int) (string, error) {
-	if !activeCounterStrings.initialized {
-		return "", fmt.Errorf("Counter strings not initialized")
-	}
-	if name, ok := activeCounterStrings.counterIndex[ndx]; ok {
-		return name, nil
-	}
-	return "", fmt.Errorf("Index not found")
-}
-
-func mockpdhGetFormattedCounterValueFloat(hCounter PDH_HCOUNTER) (val float64, err error) {
+func mockCounterFromHandle(hCounter PDH_HCOUNTER) (mockCounter, error){
 	// check to see that it's a valid counter
 	ndx := int(hCounter)
 	var ctr mockCounter
@@ -128,16 +117,56 @@ func mockpdhGetFormattedCounterValueFloat(hCounter PDH_HCOUNTER) (val float64, e
 		}
 	}
 	if !ok {
-		return 0, fmt.Errorf("Invalid handle")
+		return ctr, fmt.Errorf("Invalid handle")
 	}
-	if _, ok = countervalues[ctr.name]; ok {
-		if len(countervalues[ctr.name]) > 0 {
-			val, countervalues[ctr.name] = countervalues[ctr.name][0], countervalues[ctr.name][1:]
-			return val, nil
+	return ctr, nil
+
+}
+func mockPdhGetFormattedCounterArray(hCounter PDH_HCOUNTER, format uint32) (out_items []PdhCounterValueItem, err error) {
+	ctr, err := mockCounterFromHandle(hCounter)
+	if err != nil {
+		return nil, err
+	}
+	if classMap, ok := counterValues[ctr.class]; ok {
+		if instMap, ok := classMap[ctr.counter]; ok {
+			for inst,vals := range instMap {
+				if len(vals) > 0 {
+					out_items = append(out_items,
+						PdhCounterValueItem{
+							instance: inst,
+							value: PdhCounterValue{
+								CStatus: PDH_CSTATUS_NEW_DATA,
+								Double: vals[0],
+							},
+						},
+					)
+					instMap[inst] = vals[1:]
+				}
+			}
+			return out_items, nil
+		}
+	}
+	return nil, NewErrPdhInvalidInstance("Invalid counter instance")
+}
+
+func mockpdhGetFormattedCounterValueFloat(hCounter PDH_HCOUNTER) (val float64, err error) {
+	ctr, err := mockCounterFromHandle(hCounter)
+	if err != nil {
+		return 0, err
+	}
+	if classMap, ok := counterValues[ctr.class]; ok {
+		if instMap, ok := classMap[ctr.counter]; ok {
+			if vals, ok := instMap[ctr.instance]; ok {
+				if len(vals) > 0 {
+					val, instMap[ctr.instance] = vals[0], vals[1:]
+					return val, nil
+				}
+			}
 		}
 	}
 	return 0, NewErrPdhInvalidInstance("Invalid counter instance")
 }
+
 func mockpdhMakeCounterPath(machine string, object string, instance string, counter string) (path string, err error) {
 	var inst string
 	if len(instance) != 0 {
@@ -150,26 +179,18 @@ func mockpdhMakeCounterPath(machine string, object string, instance string, coun
 	return
 }
 
-func mockpdhEnumObjectItems(className string) (counters []string, instances []string, err error) {
-	counters = activeAvailableCounters.countersByClass[className]
-	instances = activeAvailableCounters.instancesByClass[className]
-	return
-}
-
 // SetupTesting initializes the PDH libarary with the mock functions rather than the real thing
 func SetupTesting(counterstringsfile, countersfile string) {
 	activeCounterStrings, _ = ReadCounterStrings(counterstringsfile)
 	activeAvailableCounters, _ = ReadCounters(countersfile)
 	// For testing
-	pfnMakeCounterSetInstances = mockmakeCounterSetIndexes
 	pfnPdhOpenQuery = mockPdhOpenQuery
 	pfnPdhAddCounter = mockPdhAddCounter
 	pfnPdhAddEnglishCounter = mockPdhAddEnglishCounter
 	pfnPdhCollectQueryData = mockPdhCollectQueryData
-	pfnPdhEnumObjectItems = mockpdhEnumObjectItems
 	pfnPdhRemoveCounter = mockPdhRemoveCounter
-	pfnPdhLookupPerfNameByIndex = mockpdhLookupPerfNameByIndex
 	pfnPdhGetFormattedCounterValueFloat = mockpdhGetFormattedCounterValueFloat
+	pfnPdhGetFormattedCounterArray = mockPdhGetFormattedCounterArray
 	pfnPdhCloseQuery = mockPdhCloseQuery
 	pfnPdhMakeCounterPath = mockpdhMakeCounterPath
 
@@ -178,9 +199,23 @@ func SetupTesting(counterstringsfile, countersfile string) {
 // SetQueryReturnValue provides an entry point for tests to set expected values for a
 // given counter
 func SetQueryReturnValue(counter string, val float64) {
-	countervalues[counter] = append(countervalues[counter], val)
-
+	mc := mockCounterFromString(counter)
+	// class -> counter
+	counterMap, ok := counterValues[mc.class]
+	if !ok {
+		counterMap = make(map[string]map[string][]float64)
+		counterValues[mc.class] = counterMap
+	}
+	// counter -> instance
+	instMap, ok := counterMap[mc.counter]
+	if !ok {
+		instMap = make(map[string][]float64)
+		counterMap[mc.counter] = instMap
+	}
+	// instance -> value list
+	instMap[mc.instance] = append(instMap[mc.instance], val)
 }
+
 
 // RemoveCounterInstance removes a specific instance from the table of available instances
 func RemoveCounterInstance(clss, inst string) {

--- a/releasenotes/notes/go-pdh-counter-localization-refactor-fc4072621c9e3ad1.yaml
+++ b/releasenotes/notes/go-pdh-counter-localization-refactor-fc4072621c9e3ad1.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Go PDH checks now all use the PdhAddEnglishCounter API to
+    ensure proper localization support.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Use PdhAddEnglishCounter for all PDH counters
Remove PdhEnumObjectItems calls

Use wildcards in multi-instance counters to replace PdhEnumObjectItems
- Removes per-instance counters, now single counter handle for
  multi-instance counters. No longer need to manage counters with instance life.

Refactor pdhmocks_windows.go to make instance iteration easier when mocking PdhGetFormattetCounterArray

Remove counter lang id mapping

### Motivation
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
https://datadoghq.atlassian.net/browse/WA-52

@iglendd's [detailed performance counter investigation](https://docs.google.com/document/d/1nu_Zsk-0iLfg6r5Fh-yFTn_v8ePh_oGc7dpFPLhPAck/edit)

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->


### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->
Now that multi-instance counters use a wildcard instead of PdhEnumObjectItems there is potential for performance loss (compared to an alternative solution) if a counter has a large number of instances (thousands) but a check is only interested in a handful of them. This is not the case for the disk check, which is currently the only check using multi-instance counters.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Ensure the following metrics are collected on an English and a non-English host (verify counters are localized in performance monitor utility)
- system.fs.file_handles.in_use
- system.io.wkb_s
- system.mem.nonpaged
- system.cpu.interrupt
- system.proc.count

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
