### PR TITLE
Add back nat key collision test

### DIFF
--- a/pkg/network/state_test.go
+++ b/pkg/network/state_test.go
@@ -1660,6 +1660,146 @@ func TestDetermineConnectionIntraHost(t *testing.T) {
 	}
 }
 
+func TestClosedMergingWithAddressColision(t *testing.T) {
+	const client = "foo"
+
+	c1 := ConnectionStats{
+		Pid:    123,
+		Type:   TCP,
+		Family: AFINET,
+		Source: util.AddressFromString("127.0.0.1"),
+		Dest:   util.AddressFromString("127.0.0.1"),
+		SPort:  1000,
+		DPort:  8080,
+		Monotonic: StatCountersByCookie{
+			{
+				StatCounters: StatCounters{
+					SentBytes: 100,
+				},
+				Cookie: 1,
+			},
+		},
+		IPTranslation: &IPTranslation{
+			ReplSrcIP:   util.AddressFromString("1.1.1.1"),
+			ReplDstIP:   util.AddressFromString("2.2.2.2"),
+			ReplSrcPort: 123,
+			ReplDstPort: 456,
+		},
+	}
+	c2 := ConnectionStats{
+		Pid:    123,
+		Type:   TCP,
+		Family: AFINET,
+		Source: util.AddressFromString("127.0.0.1"),
+		Dest:   util.AddressFromString("127.0.0.1"),
+		SPort:  1000,
+		DPort:  8080,
+		Monotonic: StatCountersByCookie{
+			{
+				StatCounters: StatCounters{
+					SentBytes: 150,
+				},
+				Cookie: 2,
+			},
+		},
+		IPTranslation: &IPTranslation{
+			ReplSrcIP:   util.AddressFromString("3.3.3.3"),
+			ReplDstIP:   util.AddressFromString("4.4.4.4"),
+			ReplSrcPort: 123,
+			ReplDstPort: 456,
+		},
+	}
+
+	t.Run("ephemeral connections", func(t *testing.T) {
+		// tests the state aggregation of *ephemeral* connections that share the
+		// same source/destination addresses but that differ in their NAT
+		// translations. this tends to happen in high-load scenarios with a lot
+		// of connection churn.
+		// note that by *ephemeral* we mean connections whose entire lifecycle
+		// (eg. TCP_ESTABLISHED to TCP_CLOSE) happens whithin two consecutive
+		// connection checks.
+
+		state := newDefaultState()
+		state.RegisterClient(client)
+
+		state.StoreClosedConnections([]ConnectionStats{c1})
+		state.StoreClosedConnections([]ConnectionStats{c2})
+
+		active := ConnectionStats{
+			Pid:    123,
+			Type:   TCP,
+			Family: AFINET,
+			Source: util.AddressFromString("127.0.0.1"),
+			Dest:   util.AddressFromString("127.0.0.1"),
+			SPort:  1000,
+			DPort:  8080,
+			Monotonic: StatCountersByCookie{
+				{
+					StatCounters: StatCounters{
+						SentBytes: 150,
+					},
+					Cookie: 3,
+				},
+			},
+			IPTranslation: &IPTranslation{
+				ReplSrcIP:   util.AddressFromString("5.5.5.5"),
+				ReplDstIP:   util.AddressFromString("6.6.6.6"),
+				ReplSrcPort: 123,
+				ReplDstPort: 456,
+			},
+		}
+
+		// these two connections will be treated as distinct and won't be aggregated.
+		// also pass in an active connection with the same (non-nat) tuple; this
+		// should aggregated into the first closed connection c1 only
+		delta := state.GetDelta(client, latestEpochTime(), []ConnectionStats{active}, nil, nil)
+		connections := delta.Conns
+
+		assert.Len(t, delta.Conns, 2)
+		assert.Condition(t, func() bool {
+			// assert c1 is present
+			for _, c := range connections {
+				if c.IPTranslation != nil && c.IPTranslation.ReplSrcIP == util.AddressFromString("1.1.1.1") {
+					return c.Last.SentBytes == 250 // 100 + 150, c1 + active
+				}
+			}
+			return false
+		})
+
+		assert.Condition(t, func() bool {
+			// assert c2 is present
+			for _, c := range connections {
+				if c.IPTranslation != nil && c.IPTranslation.ReplSrcIP == util.AddressFromString("3.3.3.3") {
+					return c.Last.SentBytes == 150 // only c2
+				}
+			}
+			return false
+		})
+	})
+
+	t.Run("long-lived connection", func(t *testing.T) {
+		state := newDefaultState()
+		state.RegisterClient(client)
+
+		// despite having different NAT translations these 2 connections will be
+		// interpreted as one. we do this because over the lifecycle of a long-lived
+		// connection the conntrack entry is looked up multiple times and may change
+		// (usually from a nil to a non-nil value). this behavior stems from a
+		// *limitation* in our connection tracking code and should be revisited
+		// once we find a way to reliably get the NAT translation the *first*
+		// time a connection is seen
+		_ = state.GetDelta(client, latestEpochTime(), []ConnectionStats{c1}, nil, nil)
+		c2.Monotonic[0].Cookie = c1.Monotonic[0].Cookie
+		state.StoreClosedConnections([]ConnectionStats{c2})
+
+		// assert that the value returned by the second call to `GetDelta` represents c2 - c1
+		delta := state.GetDelta(client, latestEpochTime(), nil, nil, nil)
+		assert.Len(t, delta.Conns, 1)
+		assert.Equal(t, uint64(50), delta.Conns[0].Last.SentBytes)
+	})
+
+}
+
 func generateRandConnections(n int) []ConnectionStats {
 	cs := make([]ConnectionStats, 0, n)
 	for i := 0; i < n; i++ {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Adds back a test that was inadvertently taken out as part of #12648 , with test changes for changes in that PR

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
