### PR TITLE
Separate config interface into parts

### DIFF
--- a/comp/core/config/component.go
+++ b/comp/core/config/component.go
@@ -16,8 +16,6 @@
 package config
 
 import (
-	"time"
-
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -28,86 +26,7 @@ import (
 
 // Component is the component type.
 type Component interface {
-	// IsSet determines whether the given config parameter is set.
-	//
-	// This includes values set in the config file, by environment variables, or with
-	// a default value.
-	IsSet(key string) bool
-
-	// Get gets the underlying value of a config parameter, without conversion.
-	Get(key string) interface{}
-
-	// GetString gets a string-typed config parameter value.
-	GetString(key string) string
-
-	// GetBool gets an integer-typed config parameter value.
-	GetBool(key string) bool
-
-	// GetInt gets an integer-typed config parameter value.
-	GetInt(key string) int
-
-	// GetInt32 gets an int32 config parameter value.
-	GetInt32(key string) int32
-
-	// GetInt64 gets an int64 config parameter value.
-	GetInt64(key string) int64
-
-	// GetFloat64 gets an float64 config parameter value.
-	GetFloat64(key string) float64
-
-	// GetTime gets a time as a config parameter value.
-	GetTime(key string) time.Time
-
-	// GetDuration gets a duration as a config parameter value, parsing common suffixes.
-	// Bare integers are treated as nanoseconds.
-	GetDuration(key string) time.Duration
-
-	// GetStringSlice gets a slice of strings (represented as a list in the source YAML)
-	GetStringSlice(key string) []string
-
-	// GetFloat64SliceE gets a slice of floats (represented as a list in the source
-	// YAML) as a config parameter value, returning an error if any of the
-	// values cannot be parsed
-	GetFloat64SliceE(key string) ([]float64, error)
-
-	// GetStringMap gets a map (represented as an object in the source YAML) as
-	// a config parameter value.
-	GetStringMap(key string) map[string]interface{}
-
-	// GetStringMapString gets a map (represented as an object in the source
-	// YAML) as a config parameter value, treating each value as a string.
-	GetStringMapString(key string) map[string]string
-
-	// GetStringMapStringSlice gets a map (represented as an object in the source
-	// YAML) as a config parameter value, treating each value as a string slice
-	// (represented as an array in the source YAML).
-	GetStringMapStringSlice(key string) map[string][]string
-
-	// GetSizeInBytes gets a size as a config parameter value, parsing common suffixes.
-	GetSizeInBytes(key string) uint
-
-	// AllSettings merges all settings and returns them as a map[string]interface{}.
-	AllSettings() map[string]interface{}
-
-	// AllSettingsWithoutDefault is like AllSettings but omits configuration that was
-	// applied based on defaults.
-	AllSettingsWithoutDefault() map[string]interface{}
-
-	// AllKeys returns all keys holding a value, regardless of where they are
-	// set. Nested keys are returned with a v.keyDelim separator
-	AllKeys() []string
-
-	// GetKnownKeys returns all the keys that meet at least one of these criteria:
-	// 1) have a default, 2) have an environment variable binded, 3) are an alias or 4) have been SetKnown()
-	GetKnownKeys() map[string]interface{}
-
-	// GetEnvVars returns a list of the env vars that the config supports.
-	// These have had the EnvPrefix applied, as well as the EnvKeyReplacer.
-	GetEnvVars() []string
-
-	// IsSectionSet checks if a given section is set by checking if any of
-	// its subkeys is set.
-	IsSectionSet(section string) bool
+	config.ConfigReader
 
 	// Warnings returns config warnings collected during setup.
 	Warnings() *config.Warnings
@@ -116,9 +35,7 @@ type Component interface {
 // Mock implements mock-specific methods.
 type Mock interface {
 	Component
-
-	// Set sets the given config value
-	Set(key string, value interface{})
+	config.ConfigWriter
 }
 
 // Module defines the fx options for this component.

--- a/comp/core/config/config.go
+++ b/comp/core/config/config.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"go.uber.org/fx"
 
@@ -21,6 +20,7 @@ import (
 type cfg struct {
 	// this component is currently implementing a thin wrapper around pkg/config,
 	// and uses globals in that package.
+	config.ConfigReader
 
 	// warnings are the warnings generated during setup
 	warnings *config.Warnings
@@ -42,81 +42,9 @@ func newConfig(deps dependencies) (Component, error) {
 		return nil, err
 	}
 
-	return &cfg{warnings}, nil
+	return &cfg{config.Datadog, warnings}, nil
 }
 
-func (c *cfg) ConfigFileUsed() string {
-	return config.Datadog.ConfigFileUsed()
-}
-func (c *cfg) IsKnown(key string) bool {
-	return config.Datadog.IsKnown(key)
-}
-func (c *cfg) IsSet(key string) bool {
-	return config.Datadog.IsSet(key)
-}
-func (c *cfg) Get(key string) interface{} {
-	return config.Datadog.Get(key)
-}
-func (c *cfg) GetString(key string) string {
-	return config.Datadog.GetString(key)
-}
-func (c *cfg) GetBool(key string) bool {
-	return config.Datadog.GetBool(key)
-}
-func (c *cfg) GetInt(key string) int {
-	return config.Datadog.GetInt(key)
-}
-func (c *cfg) GetInt32(key string) int32 {
-	return config.Datadog.GetInt32(key)
-}
-func (c *cfg) GetInt64(key string) int64 {
-	return config.Datadog.GetInt64(key)
-}
-func (c *cfg) GetFloat64(key string) float64 {
-	return config.Datadog.GetFloat64(key)
-}
-func (c *cfg) GetTime(key string) time.Time {
-	return config.Datadog.GetTime(key)
-}
-func (c *cfg) GetDuration(key string) time.Duration {
-	return config.Datadog.GetDuration(key)
-}
-func (c *cfg) GetStringSlice(key string) []string {
-	return config.Datadog.GetStringSlice(key)
-}
-func (c *cfg) GetFloat64SliceE(key string) ([]float64, error) {
-	return config.Datadog.GetFloat64SliceE(key)
-}
-func (c *cfg) GetStringMap(key string) map[string]interface{} {
-	return config.Datadog.GetStringMap(key)
-}
-func (c *cfg) GetStringMapString(key string) map[string]string {
-	return config.Datadog.GetStringMapString(key)
-}
-func (c *cfg) GetStringMapStringSlice(key string) map[string][]string {
-	return config.Datadog.GetStringMapStringSlice(key)
-}
-func (c *cfg) GetSizeInBytes(key string) uint {
-	return config.Datadog.GetSizeInBytes(key)
-}
-func (c *cfg) AllSettings() map[string]interface{} {
-	return config.Datadog.AllSettings()
-}
-func (c *cfg) AllSettingsWithoutDefault() map[string]interface{} {
-	return config.Datadog.AllSettingsWithoutDefault()
-}
-func (c *cfg) AllKeys() []string {
-	return config.Datadog.AllKeys()
-}
-func (c *cfg) GetKnownKeys() map[string]interface{} {
-	return config.Datadog.GetKnownKeys()
-}
-func (c *cfg) GetEnvVars() []string {
-	return config.Datadog.GetEnvVars()
-}
-func (c *cfg) IsSectionSet(section string) bool {
-	return config.Datadog.IsSectionSet(section)
-}
 func (c *cfg) Warnings() *config.Warnings {
 	return c.warnings
 }

--- a/comp/core/config/config.go
+++ b/comp/core/config/config.go
@@ -45,6 +45,12 @@ func newConfig(deps dependencies) (Component, error) {
 	return &cfg{warnings}, nil
 }
 
+func (c *cfg) ConfigFileUsed() string {
+	return config.Datadog.ConfigFileUsed()
+}
+func (c *cfg) IsKnown(key string) bool {
+	return config.Datadog.IsKnown(key)
+}
 func (c *cfg) IsSet(key string) bool {
 	return config.Datadog.IsSet(key)
 }

--- a/comp/core/sysprobeconfig/component.go
+++ b/comp/core/sysprobeconfig/component.go
@@ -16,8 +16,6 @@
 package sysprobeconfig
 
 import (
-	"time"
-
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -28,97 +26,12 @@ import (
 
 // Component is the component type.
 type Component interface {
-	// IsSet determines whether the given config parameter is set.
-	//
-	// This includes values set in the config file, by environment variables, or with
-	// a default value.
-	IsSet(key string) bool
-
-	// Get gets the underlying value of a config parameter, without conversion.
-	Get(key string) interface{}
-
-	// GetString gets a string-typed config parameter value.
-	GetString(key string) string
-
-	// GetBool gets an integer-typed config parameter value.
-	GetBool(key string) bool
-
-	// GetInt gets an integer-typed config parameter value.
-	GetInt(key string) int
-
-	// GetInt32 gets an int32 config parameter value.
-	GetInt32(key string) int32
-
-	// GetInt64 gets an int64 config parameter value.
-	GetInt64(key string) int64
-
-	// GetFloat64 gets an float64 config parameter value.
-	GetFloat64(key string) float64
-
-	// GetTime gets a time as a config parameter value.
-	GetTime(key string) time.Time
-
-	// GetDuration gets a duration as a config parameter value, parsing common suffixes.
-	// Bare integers are treated as nanoseconds.
-	GetDuration(key string) time.Duration
-
-	// GetStringSlice gets a slice of strings (represented as a list in the source YAML)
-	GetStringSlice(key string) []string
-
-	// GetFloat64SliceE gets a slice of floats (represented as a list in the source
-	// YAML) as a config parameter value, returning an error if any of the
-	// values cannot be parsed
-	GetFloat64SliceE(key string) ([]float64, error)
-
-	// GetStringMap gets a map (represented as an object in the source YAML) as
-	// a config parameter value.
-	GetStringMap(key string) map[string]interface{}
-
-	// GetStringMapString gets a map (represented as an object in the source
-	// YAML) as a config parameter value, treating each value as a string.
-	GetStringMapString(key string) map[string]string
-
-	// GetStringMapStringSlice gets a map (represented as an object in the source
-	// YAML) as a config parameter value, treating each value as a string slice
-	// (represented as an array in the source YAML).
-	GetStringMapStringSlice(key string) map[string][]string
-
-	// GetSizeInBytes gets a size as a config parameter value, parsing common suffixes.
-	GetSizeInBytes(key string) uint
-
-	// AllSettings merges all settings and returns them as a map[string]interface{}.
-	AllSettings() map[string]interface{}
-
-	// AllSettingsWithoutDefault is like AllSettings but omits configuration that was
-	// applied based on defaults.
-	AllSettingsWithoutDefault() map[string]interface{}
-
-	// AllKeys returns all keys holding a value, regardless of where they are
-	// set. Nested keys are returned with a v.keyDelim separator
-	AllKeys() []string
-
-	// GetKnownKeys returns all the keys that meet at least one of these criteria:
-	// 1) have a default, 2) have an environment variable binded, 3) are an alias or 4) have been SetKnown()
-	GetKnownKeys() map[string]interface{}
-
-	// GetEnvVars returns a list of the env vars that the config supports.
-	// These have had the EnvPrefix applied, as well as the EnvKeyReplacer.
-	GetEnvVars() []string
-
-	// IsSectionSet checks if a given section is set by checking if any of
-	// its sub-keys is set.
-	IsSectionSet(section string) bool
-
-	// Warnings returns config warnings collected during setup.
-	Warnings() *config.Warnings
+	config.ConfigReaderWriter
 }
 
 // Mock implements mock-specific methods.
 type Mock interface {
 	Component
-
-	// Set sets the given config value
-	Set(key string, value interface{})
 }
 
 // Module defines the fx options for this component.

--- a/comp/core/sysprobeconfig/config.go
+++ b/comp/core/sysprobeconfig/config.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"go.uber.org/fx"
 
@@ -21,6 +20,7 @@ import (
 type cfg struct {
 	// this component is currently implementing a thin wrapper around pkg/config,
 	// and uses globals in that package.
+	config.ConfigReader
 
 	// warnings are the warnings generated during setup
 	warnings *config.Warnings
@@ -40,81 +40,9 @@ func newConfig(deps dependencies) (Component, error) {
 		return nil, err
 	}
 
-	return &cfg{warnings}, nil
+	return &cfg{config.SystemProbe, warnings}, nil
 }
 
-func (c *cfg) ConfigFileUsed() string {
-	return config.SystemProbe.ConfigFileUsed()
-}
-func (c *cfg) IsKnown(key string) bool {
-	return config.SystemProbe.IsKnown(key)
-}
-func (c *cfg) IsSet(key string) bool {
-	return config.SystemProbe.IsSet(key)
-}
-func (c *cfg) Get(key string) interface{} {
-	return config.SystemProbe.Get(key)
-}
-func (c *cfg) GetString(key string) string {
-	return config.SystemProbe.GetString(key)
-}
-func (c *cfg) GetBool(key string) bool {
-	return config.SystemProbe.GetBool(key)
-}
-func (c *cfg) GetInt(key string) int {
-	return config.SystemProbe.GetInt(key)
-}
-func (c *cfg) GetInt32(key string) int32 {
-	return config.SystemProbe.GetInt32(key)
-}
-func (c *cfg) GetInt64(key string) int64 {
-	return config.SystemProbe.GetInt64(key)
-}
-func (c *cfg) GetFloat64(key string) float64 {
-	return config.SystemProbe.GetFloat64(key)
-}
-func (c *cfg) GetTime(key string) time.Time {
-	return config.SystemProbe.GetTime(key)
-}
-func (c *cfg) GetDuration(key string) time.Duration {
-	return config.SystemProbe.GetDuration(key)
-}
-func (c *cfg) GetStringSlice(key string) []string {
-	return config.SystemProbe.GetStringSlice(key)
-}
-func (c *cfg) GetFloat64SliceE(key string) ([]float64, error) {
-	return config.SystemProbe.GetFloat64SliceE(key)
-}
-func (c *cfg) GetStringMap(key string) map[string]interface{} {
-	return config.SystemProbe.GetStringMap(key)
-}
-func (c *cfg) GetStringMapString(key string) map[string]string {
-	return config.SystemProbe.GetStringMapString(key)
-}
-func (c *cfg) GetStringMapStringSlice(key string) map[string][]string {
-	return config.SystemProbe.GetStringMapStringSlice(key)
-}
-func (c *cfg) GetSizeInBytes(key string) uint {
-	return config.SystemProbe.GetSizeInBytes(key)
-}
-func (c *cfg) AllSettings() map[string]interface{} {
-	return config.SystemProbe.AllSettings()
-}
-func (c *cfg) AllSettingsWithoutDefault() map[string]interface{} {
-	return config.SystemProbe.AllSettingsWithoutDefault()
-}
-func (c *cfg) AllKeys() []string {
-	return config.SystemProbe.AllKeys()
-}
-func (c *cfg) GetKnownKeys() map[string]interface{} {
-	return config.SystemProbe.GetKnownKeys()
-}
-func (c *cfg) GetEnvVars() []string {
-	return config.SystemProbe.GetEnvVars()
-}
-func (c *cfg) IsSectionSet(section string) bool {
-	return config.SystemProbe.IsSectionSet(section)
-}
 func (c *cfg) Warnings() *config.Warnings {
 	return c.warnings
 }

--- a/comp/core/sysprobeconfig/config.go
+++ b/comp/core/sysprobeconfig/config.go
@@ -43,6 +43,12 @@ func newConfig(deps dependencies) (Component, error) {
 	return &cfg{warnings}, nil
 }
 
+func (c *cfg) ConfigFileUsed() string {
+	return config.SystemProbe.ConfigFileUsed()
+}
+func (c *cfg) IsKnown(key string) bool {
+	return config.SystemProbe.IsKnown(key)
+}
 func (c *cfg) IsSet(key string) bool {
 	return config.SystemProbe.IsSet(key)
 }

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -15,21 +15,8 @@ import (
 	"github.com/spf13/pflag"
 )
 
-// Config represents an object that can load and store configuration parameters
-// coming from different kind of sources:
-// - defaults
-// - files
-// - environment variables
-// - flags
-type Config interface {
-
-	// API implemented by viper.Viper
-
-	Set(key string, value interface{})
-	SetDefault(key string, value interface{})
-	SetFs(fs afero.Fs)
-	IsSet(key string) bool
-
+// ConfigReader is a subset of Config that only allows reading of configuration
+type ConfigReader interface {
 	Get(key string) interface{}
 	GetString(key string) string
 	GetBool(key string) bool
@@ -46,6 +33,45 @@ type Config interface {
 	GetStringMapStringSlice(key string) map[string][]string
 	GetSizeInBytes(key string) uint
 
+	ConfigFileUsed() string
+
+	AllSettings() map[string]interface{}
+	AllSettingsWithoutDefault() map[string]interface{}
+	AllKeys() []string
+
+	IsSet(key string) bool
+
+	// IsKnown returns whether this key is known
+	IsKnown(key string) bool
+
+	// GetKnownKeys returns all the keys that meet at least one of these criteria:
+	// 1) have a default, 2) have an environment variable binded, 3) are an alias or 4) have been SetKnown()
+	GetKnownKeys() map[string]interface{}
+
+	// GetEnvVars returns a list of the env vars that the config supports.
+	// These have had the EnvPrefix applied, as well as the EnvKeyReplacer.
+	GetEnvVars() []string
+
+	// IsSectionSet checks if a given section is set by checking if any of
+	// its subkeys is set.
+	IsSectionSet(section string) bool
+}
+
+type ConfigWriter interface {
+	Set(key string, value interface{})
+}
+
+type ConfigReaderWriter interface {
+	ConfigReader
+	ConfigWriter
+}
+
+type ConfigLoader interface {
+	// API implemented by viper.Viper
+
+	SetDefault(key string, value interface{})
+	SetFs(fs afero.Fs)
+
 	SetEnvPrefix(in string)
 	BindEnv(input ...string)
 	SetEnvKeyReplacer(r *strings.Replacer)
@@ -60,25 +86,15 @@ type Config interface {
 	MergeConfig(in io.Reader) error
 	MergeConfigOverride(in io.Reader) error
 
-	AllSettings() map[string]interface{}
-	AllSettingsWithoutDefault() map[string]interface{}
-	AllKeys() []string
-
 	AddConfigPath(in string)
 	SetConfigName(in string)
 	SetConfigFile(in string)
 	SetConfigType(in string)
-	ConfigFileUsed() string
 
 	BindPFlag(key string, flag *pflag.Flag) error
 
 	// SetKnown adds a key to the set of known valid config keys
 	SetKnown(key string)
-	// IsKnown returns whether this key is known
-	IsKnown(key string) bool
-	// GetKnownKeys returns all the keys that meet at least one of these criteria:
-	// 1) have a default, 2) have an environment variable binded, 3) are an alias or 4) have been SetKnown()
-	GetKnownKeys() map[string]interface{}
 
 	// API not implemented by viper.Viper and that have proven useful for our config usage
 
@@ -88,12 +104,15 @@ type Config interface {
 	// If env is provided, it will override the name of the environment variable used for this
 	// config key
 	BindEnvAndSetDefault(key string, val interface{}, env ...string)
+}
 
-	// GetEnvVars returns a list of the env vars that the config supports.
-	// These have had the EnvPrefix applied, as well as the EnvKeyReplacer.
-	GetEnvVars() []string
-
-	// IsSectionSet checks if a given section is set by checking if any of
-	// its subkeys is set.
-	IsSectionSet(section string) bool
+// Config represents an object that can load and store configuration parameters
+// coming from different kind of sources:
+// - defaults
+// - files
+// - environment variables
+// - flags
+type Config interface {
+	ConfigReaderWriter
+	ConfigLoader
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Separates the config interface into three parts: reader, writer, and loader

### Motivation

Simplifies the interface definition for the config/sysprobeconfig components

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
