### PR TITLE
Fix missing config in system-probe for core dump and auto-exit

### DIFF
--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -319,7 +319,7 @@ func startAgent(cliParams *cliParams) error {
 		pkglog.Infof("pid '%d' written to pid file '%s'", os.Getpid(), cliParams.pidfilePath)
 	}
 
-	err = manager.ConfigureAutoExit(common.MainCtx)
+	err = manager.ConfigureAutoExit(common.MainCtx, pkgconfig.Datadog)
 	if err != nil {
 		return pkglog.Errorf("Unable to configure auto-exit, err: %v", err)
 	}

--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -268,7 +268,7 @@ func startAgent(cliParams *cliParams) error {
 		pkglog.Infof("Starting Datadog Agent v%v", version.AgentVersion)
 	}
 
-	if err := util.SetupCoreDump(); err != nil {
+	if err := util.SetupCoreDump(pkgconfig.Datadog); err != nil {
 		pkglog.Warnf("Can't setup core dumps: %v, core dumps might not be available after a crash", err)
 	}
 

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -150,7 +150,7 @@ func start(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	if err := util.SetupCoreDump(); err != nil {
+	if err := util.SetupCoreDump(config.Datadog); err != nil {
 		log.Warnf("Can't setup core dumps: %v, core dumps might not be available after a crash", err)
 	}
 

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -172,7 +172,7 @@ func runAgent(ctx context.Context) (err error) {
 		return
 	}
 
-	if err := util.SetupCoreDump(); err != nil {
+	if err := util.SetupCoreDump(config.Datadog); err != nil {
 		log.Warnf("Can't setup core dumps: %v, core dumps might not be available after a crash", err)
 	}
 

--- a/cmd/manager/auto_exit.go
+++ b/cmd/manager/auto_exit.go
@@ -6,14 +6,13 @@
 package manager
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-
-	"golang.org/x/net/context"
 )
 
 const (
@@ -26,12 +25,12 @@ type ExitDetector interface {
 }
 
 // ConfigureAutoExit starts automatic shutdown mechanism if necessary
-func ConfigureAutoExit(ctx context.Context) error {
+func ConfigureAutoExit(ctx context.Context, cfg config.Config) error {
 	var sd ExitDetector
 	var err error
 
-	if config.Datadog.GetBool("auto_exit.noprocess.enabled") {
-		sd, err = DefaultNoProcessExit()
+	if cfg.GetBool("auto_exit.noprocess.enabled") {
+		sd, err = DefaultNoProcessExit(cfg)
 	}
 
 	if err != nil {
@@ -42,7 +41,7 @@ func ConfigureAutoExit(ctx context.Context) error {
 		return nil
 	}
 
-	validationPeriod := time.Duration(config.Datadog.GetInt("auto_exit.validation_period")) * time.Second
+	validationPeriod := time.Duration(cfg.GetInt("auto_exit.validation_period")) * time.Second
 	return startAutoExit(ctx, sd, defaultExitTicker, validationPeriod)
 }
 

--- a/cmd/manager/auto_exit_noprocess.go
+++ b/cmd/manager/auto_exit_noprocess.go
@@ -38,11 +38,11 @@ func NoProcessExit(r []*regexp.Regexp) ExitDetector {
 }
 
 // DefaultNoProcessExit creates the default NoProcess shutdown detector
-func DefaultNoProcessExit() (ExitDetector, error) {
+func DefaultNoProcessExit(cfg config.Config) (ExitDetector, error) {
 	mergedRegexps := make([]*regexp.Regexp, len(defaultRegexps))
 	copy(mergedRegexps, defaultRegexps)
 
-	extraRegexps := config.Datadog.GetStringSlice("auto_exit.noprocess.excluded_processes")
+	extraRegexps := cfg.GetStringSlice("auto_exit.noprocess.excluded_processes")
 	for _, strRegexp := range extraRegexps {
 		r, err := regexp.Compile(strRegexp)
 		if err != nil {

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -108,7 +108,7 @@ Exiting.`
 )
 
 func runAgent(exit chan struct{}) {
-	if err := ddutil.SetupCoreDump(); err != nil {
+	if err := ddutil.SetupCoreDump(ddconfig.Datadog); err != nil {
 		log.Warnf("Can't setup core dumps: %v, core dumps might not be available after a crash", err)
 	}
 

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -148,7 +148,7 @@ func runAgent(exit chan struct{}) {
 
 	mainCtx, mainCancel := context.WithCancel(context.Background())
 	defer mainCancel()
-	err = manager.ConfigureAutoExit(mainCtx)
+	err = manager.ConfigureAutoExit(mainCtx, ddconfig.Datadog)
 	if err != nil {
 		log.Criticalf("Unable to configure auto-exit, err: %w", err)
 		cleanupAndExit(1)

--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -230,7 +230,7 @@ func RunAgent(ctx context.Context) (err error) {
 		return nil
 	}
 
-	err = manager.ConfigureAutoExit(ctx)
+	err = manager.ConfigureAutoExit(ctx, coreconfig.Datadog)
 	if err != nil {
 		log.Criticalf("Unable to configure auto-exit, err: %w", err)
 		return nil

--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -8,17 +8,15 @@ package app
 import (
 	"context"
 	"errors"
+	_ "expvar" // Blank import used because this isn't directly used in this file
 	"fmt"
 	"net/http"
+	_ "net/http/pprof" // Blank import used because this isn't directly used in this file
 	"os"
 	"os/signal"
 	"path"
 	"syscall"
 	"time"
-
-	_ "expvar" // Blank import used because this isn't directly used in this file
-
-	_ "net/http/pprof" // Blank import used because this isn't directly used in this file
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -203,7 +201,7 @@ func RunAgent(ctx context.Context) (err error) {
 		return nil
 	}
 
-	if err := util.SetupCoreDump(); err != nil {
+	if err := util.SetupCoreDump(coreconfig.Datadog); err != nil {
 		log.Warnf("Can't setup core dumps: %v, core dumps might not be available after a crash", err)
 	}
 

--- a/cmd/system-probe/app/run.go
+++ b/cmd/system-probe/app/run.go
@@ -149,7 +149,7 @@ func StartSystemProbe() error {
 	log.Infof("running system-probe with version: %s", versionString())
 	color.NoColor = false
 
-	if err := util.SetupCoreDump(); err != nil {
+	if err := util.SetupCoreDump(ddconfig.SystemProbe); err != nil {
 		log.Warnf("Can't setup core dumps: %v, core dumps might not be available after a crash", err)
 	}
 

--- a/cmd/system-probe/app/run.go
+++ b/cmd/system-probe/app/run.go
@@ -114,7 +114,7 @@ func run(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	err := manager.ConfigureAutoExit(mainCtx)
+	err := manager.ConfigureAutoExit(mainCtx, ddconfig.SystemProbe)
 	if err != nil {
 		return log.Criticalf("Unable to configure auto-exit, err: %w", err)
 	}

--- a/cmd/trace-agent/run.go
+++ b/cmd/trace-agent/run.go
@@ -136,7 +136,7 @@ func Run(ctx context.Context) {
 		log.Warnf("Can't setup core dumps: %v, core dumps might not be available after a crash", err)
 	}
 
-	err = manager.ConfigureAutoExit(ctx)
+	err = manager.ConfigureAutoExit(ctx, coreconfig.Datadog)
 	if err != nil {
 		osutil.Exitf("Unable to configure auto-exit, err: %v", err)
 		return

--- a/cmd/trace-agent/run.go
+++ b/cmd/trace-agent/run.go
@@ -132,7 +132,7 @@ func Run(ctx context.Context) {
 		defer os.Remove(flags.PIDFilePath)
 	}
 
-	if err := util.SetupCoreDump(); err != nil {
+	if err := util.SetupCoreDump(coreconfig.Datadog); err != nil {
 		log.Warnf("Can't setup core dumps: %v, core dumps might not be available after a crash", err)
 	}
 

--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -48,6 +48,11 @@ const (
 func InitSystemProbeConfig(cfg Config) {
 	cfg.BindEnvAndSetDefault("go_core_dump", false)
 
+	// Auto exit configuration
+	cfg.BindEnvAndSetDefault("auto_exit.validation_period", 60)
+	cfg.BindEnvAndSetDefault("auto_exit.noprocess.enabled", false)
+	cfg.BindEnvAndSetDefault("auto_exit.noprocess.excluded_processes", []string{})
+
 	// statsd
 	cfg.BindEnv("bind_host")
 	cfg.BindEnvAndSetDefault("dogstatsd_port", 8125)

--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -46,6 +46,8 @@ const (
 
 // InitSystemProbeConfig declares all the configuration values normally read from system-probe.yaml.
 func InitSystemProbeConfig(cfg Config) {
+	cfg.BindEnvAndSetDefault("go_core_dump", false)
+
 	// statsd
 	cfg.BindEnv("bind_host")
 	cfg.BindEnvAndSetDefault("dogstatsd_port", 8125)

--- a/pkg/util/core.go
+++ b/pkg/util/core.go
@@ -18,8 +18,8 @@ import (
 )
 
 // SetupCoreDump enables core dumps and sets the core dump size limit based on configuration
-func SetupCoreDump() error {
-	if config.Datadog.GetBool("go_core_dump") {
+func SetupCoreDump(cfg config.Config) error {
+	if cfg.GetBool("go_core_dump") {
 		debug.SetTraceback("crash")
 
 		err := unix.Setrlimit(unix.RLIMIT_CORE, &unix.Rlimit{

--- a/pkg/util/core_windows.go
+++ b/pkg/util/core_windows.go
@@ -12,8 +12,8 @@ import (
 )
 
 // SetupCoreDump enables core dumps and sets the core dump size limit based on configuration
-func SetupCoreDump() error {
-	if config.Datadog.GetBool("go_core_dump") {
+func SetupCoreDump(cfg config.Config) error {
+	if cfg.GetBool("go_core_dump") {
 		return fmt.Errorf("Not supported on Windows")
 	}
 	return nil


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fixes core dump and auto-exit functionality to be able to read from system-probe config.

### Motivation

Missing config for common functionality in system-probe

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
