### PR TITLE
protocol-classification: Added HTTP/2 tests and fixed classification …

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -646,6 +646,7 @@ core,github.com/opencontainers/selinux/go-selinux/label,Apache-2.0,Copyright (c)
 core,github.com/opencontainers/selinux/pkg/pwalk,Apache-2.0,Copyright (c) 2017 The Authors
 core,github.com/opencontainers/selinux/pkg/pwalkdir,Apache-2.0,Copyright (c) 2017 The Authors
 core,github.com/openshift/api/quota/v1,Apache-2.0,"Copyright 2020 Red Hat, Inc."
+core,github.com/pahanini/go-grpc-bidirectional-streaming-example/src/proto,MIT,Copyright (c) 2017 Pavel Tetyaev
 core,github.com/patrickmn/go-cache,MIT,Alex Edwards <ajmedwards@gmail.com> | Copyright (c) 2012-2017 Patrick Mylund Nielsen and the go-cache contributors | Dustin Sallings <dustin@spy.net> | Jason Mooberry <jasonmoo@me.com> | Sergey Shepelev <temotor@gmail.com>
 core,github.com/pborman/uuid,BSD-3-Clause,"Copyright (c) 2009,2014 Google Inc. All rights reserved | Paul Borman <borman@google.com>"
 core,github.com/pelletier/go-toml,MIT,"Copyright (c) 2013 - 2021 Thomas Pelletier, Eric Anderton"
@@ -1084,6 +1085,7 @@ core,google.golang.org/grpc/credentials/oauth,Apache-2.0,Copyright 2014 gRPC aut
 core,google.golang.org/grpc/encoding,Apache-2.0,Copyright 2014 gRPC authors.
 core,google.golang.org/grpc/encoding/gzip,Apache-2.0,Copyright 2014 gRPC authors.
 core,google.golang.org/grpc/encoding/proto,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/examples/helloworld/helloworld,Apache-2.0,Copyright 2014 gRPC authors.
 core,google.golang.org/grpc/grpclog,Apache-2.0,Copyright 2014 gRPC authors.
 core,google.golang.org/grpc/health/grpc_health_v1,Apache-2.0,Copyright 2014 gRPC authors.
 core,google.golang.org/grpc/internal,Apache-2.0,Copyright 2014 gRPC authors.

--- a/go.mod
+++ b/go.mod
@@ -415,6 +415,12 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
+require google.golang.org/grpc/examples v0.0.0-20221020162917-9127159caf5a
+
+require github.com/pahanini/go-grpc-bidirectional-streaming-example v0.0.0-20211027164128-cc6111af44be
+
+replace github.com/pahanini/go-grpc-bidirectional-streaming-example v0.0.0-20211027164128-cc6111af44be => github.com/DataDog/go-grpc-bidirectional-streaming-example v0.0.0-20221024060302-b9cf785c02fe
+
 // Fixing a CVE on a transitive dep of k8s/etcd, should be cleaned-up once k8s.io/apiserver dep is removed (but double-check with `go mod why` that no other dep pulls it)
 replace github.com/dgrijalva/jwt-go => github.com/golang-jwt/jwt v3.2.1+incompatible
 

--- a/go.sum
+++ b/go.sum
@@ -143,6 +143,8 @@ github.com/DataDog/ebpf-manager v0.0.0-20221012225856-cd406734ee52 h1:xNo7KJXnD5
 github.com/DataDog/ebpf-manager v0.0.0-20221012225856-cd406734ee52/go.mod h1:oUCSIP1dv/SGMlSzJ8ZII3nCHdUqFQOjXD5QvQcdk+8=
 github.com/DataDog/extendeddaemonset v0.7.1-0.20220530183123-9c60ea5abbc6 h1:XDD6SEIEpe5CAa7esIWlgdXLQgLKN4hvPw+Wd8pJQFU=
 github.com/DataDog/extendeddaemonset v0.7.1-0.20220530183123-9c60ea5abbc6/go.mod h1:YxkO6rhI37nstfxBAdk4fVi5kheKJRMk9AtqDdl/mSQ=
+github.com/DataDog/go-grpc-bidirectional-streaming-example v0.0.0-20221024060302-b9cf785c02fe h1:RO40ywnX/vZLi4Pb4jRuFGgQQBYGIIoQ6u+P2MIgFOA=
+github.com/DataDog/go-grpc-bidirectional-streaming-example v0.0.0-20221024060302-b9cf785c02fe/go.mod h1:90sqV0j7E8wYCyqIp5d9HmYWLTFQttqPFFtNYDyAybQ=
 github.com/DataDog/go-tuf v0.3.0--fix-localmeta h1:lM/fRQNIaJpsnLU7edjV3jYHylCym0Ah+kvoJWRTzsk=
 github.com/DataDog/go-tuf v0.3.0--fix-localmeta/go.mod h1:E5XP0wXitrFUHe4b8cUcAAdxBW4LbfnqF4WXXGLgWNo=
 github.com/DataDog/gohai v0.0.0-20221011094921-fcc1e3d5ddda h1:0xPsvJrSNeob7C1fvh0i47XBX76HedF3LOFKsY/cqUM=
@@ -2425,6 +2427,7 @@ google.golang.org/genproto v0.0.0-20200618031413-b414f8b61790/go.mod h1:jDfRM7Fc
 google.golang.org/genproto v0.0.0-20200726014623-da3ae01ef02d/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200729003335-053ba62fc06f/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200804131852-c06518451d9c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20200806141610-86f49bd18e98/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200825200019-8632dd797987/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201019141844-1ed22bb0c154/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
@@ -2500,11 +2503,14 @@ google.golang.org/grpc v1.39.0/go.mod h1:PImNr+rS9TWYb2O4/emRugxiyHZ5JyHW5F+RPnD
 google.golang.org/grpc v1.39.1/go.mod h1:PImNr+rS9TWYb2O4/emRugxiyHZ5JyHW5F+RPnDzfrE=
 google.golang.org/grpc v1.40.0/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
 google.golang.org/grpc v1.40.1/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
+google.golang.org/grpc v1.41.0/go.mod h1:U3l9uK9J0sini8mHphKoXyaqDA/8VyGnDee1zzIUK6k=
 google.golang.org/grpc v1.42.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
 google.golang.org/grpc v1.44.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
 google.golang.org/grpc v1.50.1 h1:DS/BukOZWp8s6p4Dt/tOaJaTQyPyOoCcrjroHuCeLzY=
 google.golang.org/grpc v1.50.1/go.mod h1:ZgQEeidpAuNRZ8iRrlBKXZQP1ghovWIVhdJRyCDK+GI=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
+google.golang.org/grpc/examples v0.0.0-20221020162917-9127159caf5a h1:p51n6zkL483uumoZhCSGtHCem9kDeU05G5jX/wYI9gw=
+google.golang.org/grpc/examples v0.0.0-20221020162917-9127159caf5a/go.mod h1:gxndsbNG1n4TZcHGgsYEfVGnTxqfEdfiDv6/DADXX9o=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/pkg/ebpf/bytecode/runtime/tracer.go
+++ b/pkg/ebpf/bytecode/runtime/tracer.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Tracer = newAsset("tracer.c", "49dbeee5b03cc413824a57e0e361e355c3014b398111d288b037a7e037ba07ac")
+var Tracer = newAsset("tracer.c", "7671e640af04ab62d7c35531531f4d56767af27f63b9bea848f9acf2bd60ade4")

--- a/pkg/network/ebpf/c/prebuilt/tracer.c
+++ b/pkg/network/ebpf/c/prebuilt/tracer.c
@@ -910,7 +910,14 @@ int tracepoint__net__net_dev_queue(struct net_dev_queue_ctx* ctx) {
         return 0;
     }
 
-    bpf_map_update_elem(&conn_tuple_to_socket_map, &skb_tup, &sk, BPF_ANY);
+    conn_tuple_t sock_tup;
+    bpf_memset(&sock_tup, 0, sizeof(conn_tuple_t));
+    if (!read_conn_tuple(&sock_tup, sk, 0, CONN_TYPE_TCP)) {
+        return 0;
+    }
+    sock_tup.netns = 0;
+
+    bpf_map_update_elem(&skb_conn_tuple_to_socket_conn_tuple, &skb_tup, &sock_tup, BPF_ANY);
 
     return 0;
 }

--- a/pkg/network/ebpf/c/protocol-classification-maps.h
+++ b/pkg/network/ebpf/c/protocol-classification-maps.h
@@ -6,11 +6,12 @@
 
 // Maps a connection tuple to its classified protocol. Used to reduce redundant classification procedures on the same
 // connection. Assumption: each connection has a single protocol.
-BPF_HASH_MAP(connection_protocol, struct sock*, protocol_t, 1024)
+BPF_HASH_MAP(connection_protocol, conn_tuple_t, protocol_t, 1024)
 
-// Maps connection tuple before NAT resolving to the socket pointer.
+// Maps skb connection tuple to socket connection tuple.
+// On ingress, skb connection tuple is pre NAT, and socket connection tuple is post NAT, and on egress, the opposite.
 // We track the lifecycle of socket using tracepoint net/net_dev_queue.
-BPF_HASH_MAP(conn_tuple_to_socket_map, conn_tuple_t, struct sock*, 1024)
+BPF_HASH_MAP(skb_conn_tuple_to_socket_conn_tuple, conn_tuple_t, conn_tuple_t, 1024)
 
 // Maps a connection tuple to latest tcp segment we've processed. Helps to detect same packets that travels multiple
 // interfaces or retransmissions.

--- a/pkg/network/ebpf/c/runtime/tracer.c
+++ b/pkg/network/ebpf/c/runtime/tracer.c
@@ -871,7 +871,15 @@ int tracepoint__net__net_dev_queue(struct net_dev_queue_ctx* ctx) {
     if (!(skb_tup.metadata&CONN_TYPE_TCP)) {
         return 0;
     }
-    bpf_map_update_elem(&conn_tuple_to_socket_map, &skb_tup, &sk, BPF_ANY);
+
+    conn_tuple_t sock_tup;
+    bpf_memset(&sock_tup, 0, sizeof(conn_tuple_t));
+    if (!read_conn_tuple(&sock_tup, sk, 0, CONN_TYPE_TCP)) {
+        return 0;
+    }
+    sock_tup.netns = 0;
+
+    bpf_map_update_elem(&skb_conn_tuple_to_socket_conn_tuple, &skb_tup, &sock_tup, BPF_ANY);
 
     return 0;
 }

--- a/pkg/network/ebpf/c/tracer-stats.h
+++ b/pkg/network/ebpf/c/tracer-stats.h
@@ -53,28 +53,26 @@ static __always_inline void update_conn_stats(conn_tuple_t *t, size_t sent_bytes
     }
 
     protocol_t local_protocol = PROTOCOL_UNCLASSIFIED;
-    conn_tuple_t t2 = *t;
+    conn_tuple_t conn_tuple_copy = *t;
     // The classifier is a socket filter and there we are not accessible for pid and netns.
     // The key is based of the source & dest addresses and ports, and the metadata.
-    t2.netns = 0;
-    t2.pid = 0;
+    conn_tuple_copy.netns = 0;
+    conn_tuple_copy.pid = 0;
 
-    if (sk != NULL) {
-        log_debug("[update_conn_stats]: connection_protocol key: %p\n", sk);
-        protocol_t *protocol = bpf_map_lookup_elem(&connection_protocol, &sk);
-        if (protocol != NULL) {
-            local_protocol = *protocol;
-        }
+    protocol_t *cached_protocol_ptr = bpf_map_lookup_elem(&connection_protocol, &conn_tuple_copy);
 
-        // We update the protocol if the new protocol is known, and we don't already have a known protocol.
-        if (local_protocol != PROTOCOL_UNCLASSIFIED && val->protocol == PROTOCOL_UNCLASSIFIED) {
-            log_debug("[update_conn_stats]: A connection was classified with protocol %d\n", local_protocol);
-            val->protocol = local_protocol;
-        } else if (local_protocol != PROTOCOL_UNCLASSIFIED && val->protocol != PROTOCOL_UNKNOWN && val->protocol != local_protocol) {
-            // If the new protocol was classified, the current protocol is classified and it is known, then there is a possible error.
-            // If the current protocol is "unknown" and we managed to classify it to another protocol -> that's a reasonable and expected scenario.
-            log_debug("[update_conn_stats]: A classified connection (%d) has been re-classified with protocol %d\n", val->protocol, local_protocol);
-        }
+    if (cached_protocol_ptr != NULL) {
+        local_protocol = *cached_protocol_ptr;
+    }
+
+    // We update the protocol if the new protocol is known, and we don't already have a known protocol.
+    if (local_protocol != PROTOCOL_UNCLASSIFIED && val->protocol == PROTOCOL_UNCLASSIFIED) {
+        log_debug("[update_conn_stats]: A connection was classified with protocol %d\n", local_protocol);
+        val->protocol = local_protocol;
+    } else if (local_protocol != PROTOCOL_UNCLASSIFIED && val->protocol != PROTOCOL_UNKNOWN && val->protocol != local_protocol) {
+        // If the new protocol was classified, the current protocol is classified and it is known, then there is a possible error.
+        // If the current protocol is "unknown" and we managed to classify it to another protocol -> that's a reasonable and expected scenario.
+        log_debug("[update_conn_stats]: A classified connection (%d) has been re-classified with protocol %d\n", val->protocol, local_protocol);
     }
 
     // If already in our map, increment size in-place

--- a/pkg/network/tracer/testutil/grpc/client.go
+++ b/pkg/network/tracer/testutil/grpc/client.go
@@ -1,0 +1,139 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package grpc
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"math/rand"
+	"net"
+	"time"
+
+	pbStream "github.com/pahanini/go-grpc-bidirectional-streaming-example/src/proto"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	pb "google.golang.org/grpc/examples/helloworld/helloworld"
+)
+
+const (
+	defaultDialTimeout = 5 * time.Second
+)
+
+// HandleUnary performs a gRPC unary call to SayHello RPC of the greeter service.
+func (c *Client) HandleUnary(ctx context.Context, name string) error {
+	_, err := c.greeterClient.SayHello(ctx, &pb.HelloRequest{Name: name})
+	return err
+}
+
+// HandleStream performs a gRPC stream call to FetchResponse RPC of StreamService service.
+func (c *Client) HandleStream(ctx context.Context, numberOfMessages int32) error {
+	stream, err := c.streamClient.Max(ctx)
+	if err != nil {
+		return err
+	}
+
+	input := make([]int32, numberOfMessages)
+	for i := int32(0); i < numberOfMessages; i++ {
+		// The array is zero based, but we want the values to be 1 based.
+		input[i] = i + 1
+	}
+
+	rand.Seed(time.Now().UnixNano())
+	rand.Shuffle(len(input), func(i, j int) { input[i], input[j] = input[j], input[i] })
+
+	var max int32
+	var sendErr error
+	// A go routine to send input requests
+	go func() {
+		defer func() { _ = stream.CloseSend() }()
+		for _, elem := range input {
+			if err := stream.Send(&pbStream.Request{Num: elem}); err != nil {
+				sendErr = err
+				return
+			}
+			time.Sleep(time.Millisecond * 200)
+		}
+	}()
+
+	var receiveErr error
+	// A go routine to receive the requests and save the max number
+	go func() {
+		for {
+			resp, err := stream.Recv()
+			if err == io.EOF {
+				return
+			}
+			if err != nil {
+				receiveErr = err
+				return
+			}
+			max = resp.Result
+		}
+	}()
+
+	<-stream.Context().Done()
+
+	if sendErr != nil {
+		return sendErr
+	}
+
+	if receiveErr != nil {
+		return receiveErr
+	}
+	if max != numberOfMessages {
+		return fmt.Errorf("expected to have %d as max, but instead got %d", numberOfMessages, max)
+	}
+	return nil
+}
+
+// Client represents a single gRPC client that fits the gRPC server.
+type Client struct {
+	conn          *grpc.ClientConn
+	greeterClient pb.GreeterClient
+	streamClient  pbStream.MathClient
+}
+
+// Options allows to determine the behavior of the client.
+type Options struct {
+	// DialTimeout the timeout before giving up on a dialing to the server. Set as 0 for the default (currently 5 seconds).
+	DialTimeout time.Duration
+	// CustomDialer allows to modify the underlying dialer used by grpc package. Set nil for the default dialer.
+	CustomDialer *net.Dialer
+}
+
+// NewClient returns a new gRPC client
+func NewClient(addr string, options Options) (Client, error) {
+	gRPCOptions := []grpc.DialOption{
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	}
+	if options.CustomDialer != nil {
+		gRPCOptions = append(gRPCOptions, grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
+			return options.CustomDialer.DialContext(ctx, "tcp", addr)
+		}))
+	}
+
+	timeout := defaultDialTimeout
+	if options.DialTimeout != 0 {
+		timeout = options.DialTimeout
+	}
+	timedContext, cancel := context.WithTimeout(context.Background(), timeout)
+	conn, err := grpc.DialContext(timedContext, addr, gRPCOptions...)
+	cancel()
+	if err != nil {
+		return Client{}, err
+	}
+	return Client{
+		conn:          conn,
+		greeterClient: pb.NewGreeterClient(conn),
+		streamClient:  pbStream.NewMathClient(conn),
+	}, nil
+}
+
+// Close terminates the client connection.
+func (c *Client) Close() {
+	c.conn.Close()
+}

--- a/pkg/network/tracer/testutil/grpc/server.go
+++ b/pkg/network/tracer/testutil/grpc/server.go
@@ -1,0 +1,85 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package grpc
+
+import (
+	"context"
+	"io"
+	"log"
+	"net"
+
+	pbStream "github.com/pahanini/go-grpc-bidirectional-streaming-example/src/proto"
+	"google.golang.org/grpc"
+	pb "google.golang.org/grpc/examples/helloworld/helloworld"
+)
+
+// server is used to implement helloworld.GreeterServer.
+type server struct {
+	pb.UnimplementedGreeterServer
+	pbStream.UnimplementedMathServer
+}
+
+// SayHello implements helloworld.GreeterServer.
+func (server) SayHello(_ context.Context, in *pb.HelloRequest) (*pb.HelloReply, error) {
+	log.Printf("Received: %v", in.GetName())
+	return &pb.HelloReply{Message: "Hello " + in.GetName()}, nil
+}
+
+// FetchResponse implements StreamService.
+func (server) Max(srv pbStream.Math_MaxServer) error {
+	var max int32
+	for {
+		select {
+		case <-srv.Context().Done():
+			return srv.Context().Err()
+		default:
+		}
+
+		// receive data from stream
+		req, err := srv.Recv()
+		if err == io.EOF {
+			// return will close stream from server side
+			log.Println("exit")
+			return nil
+		}
+		if err != nil {
+			log.Printf("receive error %v", err)
+			continue
+		}
+
+		if req.Num <= max {
+			continue
+		}
+
+		// update max and send it to stream
+		max = req.Num
+		resp := pbStream.Response{Result: max}
+		if err := srv.Send(&resp); err != nil {
+			log.Printf("send error %v", err)
+		}
+	}
+}
+
+// Server returns a new instance of the gRPC server.
+func Server(addr string) (func(), error) {
+	lis, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+	s := grpc.NewServer()
+	pb.RegisterGreeterServer(s, &server{})
+	pbStream.RegisterMathServer(s, server{})
+
+	go func() {
+		if err := s.Serve(lis); err != nil {
+			log.Fatalf("failed to serve: %v", err)
+		}
+	}()
+
+	return func() {
+		s.Stop()
+	}, nil
+}


### PR DESCRIPTION
…problems with NAT and streams

When dealing with binary stream protocol like HTTP/2 it might be impossible to classify the protocol both on the request and response In HTTP/2 we can only identify the protocol by the first 24 bytes of the request.

When NAT is involved (like SNAT) there is a mismatch between the address the server is bind to (server address) and the address the client is communicating with (target address) thus we don't have classified protocol for the response.

The solution is to save the protocols for both the sock connection tupple and the inverse skb connection tuple.

Added a UT to test gRPC (HTTP/2) behavior

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
