### PR TITLE
[CWS][SEC-5583] move GlobalParams to common package

### DIFF
--- a/cmd/security-agent/app/activity_dump.go
+++ b/cmd/security-agent/app/activity_dump.go
@@ -11,6 +11,7 @@ package app
 import (
 	"fmt"
 
+	"github.com/DataDog/datadog-agent/cmd/security-agent/app/common"
 	secagent "github.com/DataDog/datadog-agent/pkg/security/agent"
 	"github.com/DataDog/datadog-agent/pkg/security/api"
 	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
@@ -19,7 +20,7 @@ import (
 )
 
 type activityDumpCliParams struct {
-	*GlobalParams
+	*common.GlobalParams
 
 	comm                     string
 	file                     string
@@ -33,7 +34,7 @@ type activityDumpCliParams struct {
 	remoteRequest            bool
 }
 
-func activityDumpCommands(globalParams *GlobalParams) []*cobra.Command {
+func activityDumpCommands(globalParams *common.GlobalParams) []*cobra.Command {
 	activityDumpCmd := &cobra.Command{
 		Use:   "activity-dump",
 		Short: "activity dump command",
@@ -46,7 +47,7 @@ func activityDumpCommands(globalParams *GlobalParams) []*cobra.Command {
 	return []*cobra.Command{activityDumpCmd}
 }
 
-func listCommands(globalParams *GlobalParams) []*cobra.Command {
+func listCommands(globalParams *common.GlobalParams) []*cobra.Command {
 	activityDumpListCmd := &cobra.Command{
 		Use:   "list",
 		Short: "get the list of running activity dumps",
@@ -58,7 +59,7 @@ func listCommands(globalParams *GlobalParams) []*cobra.Command {
 	return []*cobra.Command{activityDumpListCmd}
 }
 
-func stopCommands(globalParams *GlobalParams) []*cobra.Command {
+func stopCommands(globalParams *common.GlobalParams) []*cobra.Command {
 	cliParams := activityDumpCliParams{
 		GlobalParams: globalParams,
 	}
@@ -81,7 +82,7 @@ func stopCommands(globalParams *GlobalParams) []*cobra.Command {
 	return []*cobra.Command{activityDumpStopCmd}
 }
 
-func generateCommands(globalParams *GlobalParams) []*cobra.Command {
+func generateCommands(globalParams *common.GlobalParams) []*cobra.Command {
 	activityDumpGenerateCmd := &cobra.Command{
 		Use:   "generate",
 		Short: "generate command for activity dumps",
@@ -93,7 +94,7 @@ func generateCommands(globalParams *GlobalParams) []*cobra.Command {
 	return []*cobra.Command{activityDumpGenerateCmd}
 }
 
-func generateDumpCommands(globalParams *GlobalParams) []*cobra.Command {
+func generateDumpCommands(globalParams *common.GlobalParams) []*cobra.Command {
 	cliParams := activityDumpCliParams{
 		GlobalParams: globalParams,
 	}
@@ -158,7 +159,7 @@ func generateDumpCommands(globalParams *GlobalParams) []*cobra.Command {
 	return []*cobra.Command{activityDumpGenerateDumpCmd}
 }
 
-func generateEncodingCommands(globalParams *GlobalParams) []*cobra.Command {
+func generateEncodingCommands(globalParams *common.GlobalParams) []*cobra.Command {
 	cliParams := activityDumpCliParams{
 		GlobalParams: globalParams,
 	}

--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -28,7 +28,8 @@ import (
 	commonagent "github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/cmd/manager"
 	"github.com/DataDog/datadog-agent/cmd/security-agent/api"
-	"github.com/DataDog/datadog-agent/cmd/security-agent/common"
+	"github.com/DataDog/datadog-agent/cmd/security-agent/app/common"
+	secagentcommon "github.com/DataDog/datadog-agent/cmd/security-agent/common"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/config/resolver"
 	"github.com/DataDog/datadog-agent/pkg/config/settings"
@@ -63,14 +64,8 @@ var (
 	stopper      startstop.Stopper
 )
 
-type GlobalParams struct {
-	confPathArray []string
-}
-
-type SubcommandFactory func(*GlobalParams) []*cobra.Command
-
 func CreateSecurityAgentCmd() *cobra.Command {
-	globalParams := GlobalParams{}
+	globalParams := common.GlobalParams{}
 	var flagNoColor bool
 
 	SecurityAgentCmd := &cobra.Command{
@@ -84,7 +79,7 @@ Datadog Security Agent takes care of running compliance and security checks.`,
 				color.NoColor = true
 			}
 
-			return common.MergeConfigurationFiles("datadog", globalParams.confPathArray, cmd.Flags().Lookup("cfgpath").Changed)
+			return secagentcommon.MergeConfigurationFiles("datadog", globalParams.ConfPathArray, cmd.Flags().Lookup("cfgpath").Changed)
 		},
 	}
 
@@ -92,10 +87,10 @@ Datadog Security Agent takes care of running compliance and security checks.`,
 		path.Join(commonagent.DefaultConfPath, "datadog.yaml"),
 		path.Join(commonagent.DefaultConfPath, "security-agent.yaml"),
 	}
-	SecurityAgentCmd.PersistentFlags().StringArrayVarP(&globalParams.confPathArray, "cfgpath", "c", defaultConfPathArray, "path to a yaml configuration file")
+	SecurityAgentCmd.PersistentFlags().StringArrayVarP(&globalParams.ConfPathArray, "cfgpath", "c", defaultConfPathArray, "path to a yaml configuration file")
 	SecurityAgentCmd.PersistentFlags().BoolVarP(&flagNoColor, "no-color", "n", false, "disable color output")
 
-	factories := []SubcommandFactory{
+	factories := []common.SubcommandFactory{
 		StatusCommands,
 		FlareCommands,
 		ConfigCommands,

--- a/cmd/security-agent/app/check.go
+++ b/cmd/security-agent/app/check.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cihub/seelog"
 	"github.com/spf13/cobra"
 
+	"github.com/DataDog/datadog-agent/cmd/security-agent/app/common"
 	"github.com/DataDog/datadog-agent/pkg/compliance/agent"
 	"github.com/DataDog/datadog-agent/pkg/compliance/checks"
 	"github.com/DataDog/datadog-agent/pkg/compliance/event"
@@ -31,7 +32,7 @@ import (
 )
 
 type checkCliParams struct {
-	*GlobalParams
+	*common.GlobalParams
 
 	args []string
 
@@ -47,11 +48,11 @@ type checkCliParams struct {
 
 // TODO: fix this, this is currently a stub for the cluster-agent
 func CheckCmd() *cobra.Command {
-	return CheckCommands(&GlobalParams{})[0]
+	return CheckCommands(&common.GlobalParams{})[0]
 }
 
 // CheckCommands returns a cobra command to run security agent checks
-func CheckCommands(globalParams *GlobalParams) []*cobra.Command {
+func CheckCommands(globalParams *common.GlobalParams) []*cobra.Command {
 	checkArgs := checkCliParams{
 		GlobalParams: globalParams,
 	}

--- a/cmd/security-agent/app/common/common.go
+++ b/cmd/security-agent/app/common/common.go
@@ -3,16 +3,12 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build windows || !kubeapiserver
+package common
 
-package app
+import "github.com/spf13/cobra"
 
-import (
-	"github.com/spf13/cobra"
-
-	"github.com/DataDog/datadog-agent/cmd/security-agent/app/common"
-)
-
-func CheckCommands(globalParams *common.GlobalParams) []*cobra.Command {
-	return nil
+type GlobalParams struct {
+	ConfPathArray []string
 }
+
+type SubcommandFactory func(*GlobalParams) []*cobra.Command

--- a/cmd/security-agent/app/compliance_cmds.go
+++ b/cmd/security-agent/app/compliance_cmds.go
@@ -8,10 +8,11 @@ package app
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/DataDog/datadog-agent/cmd/security-agent/app/common"
 	"github.com/DataDog/datadog-agent/pkg/compliance/event"
 )
 
-func ComplianceCommands(globalParams *GlobalParams) []*cobra.Command {
+func ComplianceCommands(globalParams *common.GlobalParams) []*cobra.Command {
 	complianceCmd := &cobra.Command{
 		Use:   "compliance",
 		Short: "Compliance Agent utility commands",
@@ -24,7 +25,7 @@ func ComplianceCommands(globalParams *GlobalParams) []*cobra.Command {
 }
 
 type eventCliParams struct {
-	*GlobalParams
+	*common.GlobalParams
 
 	sourceName string
 	sourceType string
@@ -32,7 +33,7 @@ type eventCliParams struct {
 	data       []string
 }
 
-func complianceEventCommand(globalParams *GlobalParams) *cobra.Command {
+func complianceEventCommand(globalParams *common.GlobalParams) *cobra.Command {
 	eventArgs := eventCliParams{
 		GlobalParams: globalParams,
 	}

--- a/cmd/security-agent/app/config.go
+++ b/cmd/security-agent/app/config.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/DataDog/datadog-agent/cmd/security-agent/app/common"
 	cmdconfig "github.com/DataDog/datadog-agent/cmd/security-agent/commands/config"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -20,7 +21,7 @@ import (
 	settingshttp "github.com/DataDog/datadog-agent/pkg/config/settings/http"
 )
 
-func ConfigCommands(globalParams *GlobalParams) []*cobra.Command {
+func ConfigCommands(globalParams *common.GlobalParams) []*cobra.Command {
 	cmd := cmdconfig.Config(getSettingsClient)
 	return []*cobra.Command{cmd}
 }

--- a/cmd/security-agent/app/config_unsupported.go
+++ b/cmd/security-agent/app/config_unsupported.go
@@ -10,8 +10,10 @@ package app
 
 import (
 	"github.com/spf13/cobra"
+
+	"github.com/DataDog/datadog-agent/cmd/security-agent/app/common"
 )
 
-func ConfigCommands(globalParams *GlobalParams) []*cobra.Command {
+func ConfigCommands(globalParams *common.GlobalParams) []*cobra.Command {
 	return nil
 }

--- a/cmd/security-agent/app/flare.go
+++ b/cmd/security-agent/app/flare.go
@@ -12,6 +12,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
+	"github.com/DataDog/datadog-agent/cmd/security-agent/app/common"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/flare"
@@ -19,13 +20,13 @@ import (
 )
 
 type flareCliParams struct {
-	*GlobalParams
+	*common.GlobalParams
 
 	customerEmail string
 	autoconfirm   bool
 }
 
-func FlareCommands(globalParams *GlobalParams) []*cobra.Command {
+func FlareCommands(globalParams *common.GlobalParams) []*cobra.Command {
 	cliParams := flareCliParams{
 		GlobalParams: globalParams,
 	}

--- a/cmd/security-agent/app/runtime.go
+++ b/cmd/security-agent/app/runtime.go
@@ -23,6 +23,7 @@ import (
 	ddgostatsd "github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/spf13/cobra"
 
+	"github.com/DataDog/datadog-agent/cmd/security-agent/app/common"
 	"github.com/DataDog/datadog-agent/pkg/compliance/event"
 	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
@@ -51,7 +52,7 @@ const (
 	cwsIntakeOrigin config.IntakeOrigin = "cloud-workload-security"
 )
 
-func RuntimeCommands(globalParams *GlobalParams) []*cobra.Command {
+func RuntimeCommands(globalParams *common.GlobalParams) []*cobra.Command {
 	runtimeCmd := &cobra.Command{
 		Use:   "runtime",
 		Short: "runtime Agent utility commands",
@@ -70,12 +71,12 @@ func RuntimeCommands(globalParams *GlobalParams) []*cobra.Command {
 }
 
 type checkPoliciesCliParams struct {
-	*GlobalParams
+	*common.GlobalParams
 
 	dir string
 }
 
-func checkPoliciesCommands(globalParams *GlobalParams) []*cobra.Command {
+func checkPoliciesCommands(globalParams *common.GlobalParams) []*cobra.Command {
 	cliParams := checkPoliciesCliParams{
 		GlobalParams: globalParams,
 	}
@@ -94,7 +95,7 @@ func checkPoliciesCommands(globalParams *GlobalParams) []*cobra.Command {
 	return []*cobra.Command{checkPoliciesCmd}
 }
 
-func reloadPoliciesCommands(globalParams *GlobalParams) []*cobra.Command {
+func reloadPoliciesCommands(globalParams *common.GlobalParams) []*cobra.Command {
 	reloadPoliciesCmd := &cobra.Command{
 		Use:   "reload",
 		Short: "Reload policies",
@@ -106,7 +107,7 @@ func reloadPoliciesCommands(globalParams *GlobalParams) []*cobra.Command {
 	return []*cobra.Command{reloadPoliciesCmd}
 }
 
-func commonPolicyCommands(globalParams *GlobalParams) []*cobra.Command {
+func commonPolicyCommands(globalParams *common.GlobalParams) []*cobra.Command {
 	commonPolicyCmd := &cobra.Command{
 		Use:   "policy",
 		Short: "Policy related commands",
@@ -121,7 +122,7 @@ func commonPolicyCommands(globalParams *GlobalParams) []*cobra.Command {
 }
 
 type evalCliParams struct {
-	*GlobalParams
+	*common.GlobalParams
 
 	dir       string
 	ruleID    string
@@ -129,7 +130,7 @@ type evalCliParams struct {
 	debug     bool
 }
 
-func evalCommands(globalParams *GlobalParams) []*cobra.Command {
+func evalCommands(globalParams *common.GlobalParams) []*cobra.Command {
 	evalArgs := evalCliParams{
 		GlobalParams: globalParams,
 	}
@@ -152,7 +153,7 @@ func evalCommands(globalParams *GlobalParams) []*cobra.Command {
 	return []*cobra.Command{evalCmd}
 }
 
-func commonCheckPoliciesCommands(globalParams *GlobalParams) []*cobra.Command {
+func commonCheckPoliciesCommands(globalParams *common.GlobalParams) []*cobra.Command {
 	cliParams := checkPoliciesCliParams{
 		GlobalParams: globalParams,
 	}
@@ -170,7 +171,7 @@ func commonCheckPoliciesCommands(globalParams *GlobalParams) []*cobra.Command {
 	return []*cobra.Command{commonCheckPoliciesCmd}
 }
 
-func commonReloadPoliciesCommands(globalParams *GlobalParams) []*cobra.Command {
+func commonReloadPoliciesCommands(globalParams *common.GlobalParams) []*cobra.Command {
 	commonReloadPoliciesCmd := &cobra.Command{
 		Use:   "reload",
 		Short: "Reload policies",
@@ -181,7 +182,7 @@ func commonReloadPoliciesCommands(globalParams *GlobalParams) []*cobra.Command {
 	return []*cobra.Command{commonReloadPoliciesCmd}
 }
 
-func selfTestCommands(globalParams *GlobalParams) []*cobra.Command {
+func selfTestCommands(globalParams *common.GlobalParams) []*cobra.Command {
 	selfTestCmd := &cobra.Command{
 		Use:   "self-test",
 		Short: "Run runtime self test",
@@ -194,13 +195,13 @@ func selfTestCommands(globalParams *GlobalParams) []*cobra.Command {
 }
 
 type downloadPolicyCliParams struct {
-	*GlobalParams
+	*common.GlobalParams
 
 	check      bool
 	outputPath string
 }
 
-func downloadPolicyCommands(globalParams *GlobalParams) []*cobra.Command {
+func downloadPolicyCommands(globalParams *common.GlobalParams) []*cobra.Command {
 	downloadPolicyArgs := downloadPolicyCliParams{
 		GlobalParams: globalParams,
 	}
@@ -220,12 +221,12 @@ func downloadPolicyCommands(globalParams *GlobalParams) []*cobra.Command {
 }
 
 type processCacheDumpCliParams struct {
-	*GlobalParams
+	*common.GlobalParams
 
 	withArgs bool
 }
 
-func processCacheCommands(globalParams *GlobalParams) []*cobra.Command {
+func processCacheCommands(globalParams *common.GlobalParams) []*cobra.Command {
 	cliParams := processCacheDumpCliParams{
 		GlobalParams: globalParams,
 	}
@@ -249,12 +250,12 @@ func processCacheCommands(globalParams *GlobalParams) []*cobra.Command {
 }
 
 type dumpNetworkNamespaceCliParams struct {
-	*GlobalParams
+	*common.GlobalParams
 
 	snapshotInterfaces bool
 }
 
-func networkNamespaceCommands(globalParams *GlobalParams) []*cobra.Command {
+func networkNamespaceCommands(globalParams *common.GlobalParams) []*cobra.Command {
 	cliParams := dumpNetworkNamespaceCliParams{
 		GlobalParams: globalParams,
 	}
@@ -277,7 +278,7 @@ func networkNamespaceCommands(globalParams *GlobalParams) []*cobra.Command {
 	return []*cobra.Command{networkNamespaceCmd}
 }
 
-func discardersCommands(globalParams *GlobalParams) []*cobra.Command {
+func discardersCommands(globalParams *common.GlobalParams) []*cobra.Command {
 
 	dumpDiscardersCmd := &cobra.Command{
 		Use:   "dump",

--- a/cmd/security-agent/app/runtime_unsupported.go
+++ b/cmd/security-agent/app/runtime_unsupported.go
@@ -20,13 +20,14 @@ import (
 
 	ddgostatsd "github.com/DataDog/datadog-go/v5/statsd"
 
+	"github.com/DataDog/datadog-agent/cmd/security-agent/app/common"
 	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
 	secagent "github.com/DataDog/datadog-agent/pkg/security/agent"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/startstop"
 )
 
-func RuntimeCommands(globalParams *GlobalParams) []*cobra.Command {
+func RuntimeCommands(globalParams *common.GlobalParams) []*cobra.Command {
 	return nil
 }
 

--- a/cmd/security-agent/app/start.go
+++ b/cmd/security-agent/app/start.go
@@ -9,16 +9,17 @@ import (
 	"context"
 	"errors"
 
+	"github.com/DataDog/datadog-agent/cmd/security-agent/app/common"
 	"github.com/spf13/cobra"
 )
 
 type startCliParams struct {
-	*GlobalParams
+	*common.GlobalParams
 
 	pidfilePath string
 }
 
-func StartCommands(globalParams *GlobalParams) []*cobra.Command {
+func StartCommands(globalParams *common.GlobalParams) []*cobra.Command {
 	cliParams := startCliParams{
 		GlobalParams: globalParams,
 	}

--- a/cmd/security-agent/app/status.go
+++ b/cmd/security-agent/app/status.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/DataDog/datadog-agent/cmd/security-agent/app/common"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/status"
@@ -20,14 +21,14 @@ import (
 )
 
 type statusCliParams struct {
-	*GlobalParams
+	*common.GlobalParams
 
 	json            bool
 	prettyPrintJSON bool
 	file            string
 }
 
-func StatusCommands(globalParams *GlobalParams) []*cobra.Command {
+func StatusCommands(globalParams *common.GlobalParams) []*cobra.Command {
 	cliParams := &statusCliParams{
 		GlobalParams: globalParams,
 	}

--- a/cmd/security-agent/app/version.go
+++ b/cmd/security-agent/app/version.go
@@ -8,13 +8,14 @@ package app
 import (
 	"fmt"
 
+	"github.com/DataDog/datadog-agent/cmd/security-agent/app/common"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/version"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
 
-func VersionCommands(globalParams *GlobalParams) []*cobra.Command {
+func VersionCommands(globalParams *common.GlobalParams) []*cobra.Command {
 	versionCmd := &cobra.Command{
 		Use:   "version",
 		Short: "Print the version info",


### PR DESCRIPTION
### What does this PR do?

This PR creates a new package with common types and value. The goal is that this package can be imported both from old-school commands in the `cmd/security-agent/app` package and new `cmd/security-agent/app/subcommands`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
