### PR TITLE
(rcm) add scoped API keys support

### DIFF
--- a/pkg/config/remote/api/http.go
+++ b/pkg/config/remote/api/http.go
@@ -29,6 +29,12 @@ type API interface {
 	Fetch(context.Context, *pbgo.LatestConfigsRequest) (*pbgo.LatestConfigsResponse, error)
 }
 
+type Auth struct {
+	ApiKey    string
+	AppKey    string
+	UseAppKey bool
+}
+
 // HTTPClient fetches configurations using HTTP requests
 type HTTPClient struct {
 	baseURL string
@@ -37,12 +43,13 @@ type HTTPClient struct {
 }
 
 // NewHTTPClient returns a new HTTP configuration client
-func NewHTTPClient(authHeaders map[string]string) *HTTPClient {
+func NewHTTPClient(auth Auth) *HTTPClient {
 	header := http.Header{
 		"Content-Type": []string{"application/x-protobuf"},
+		"DD-Api-Key":   []string{auth.ApiKey},
 	}
-	for k, v := range authHeaders {
-		header[k] = []string{v}
+	if auth.UseAppKey {
+		header["DD-Application-Key"] = []string{auth.AppKey}
 	}
 	httpClient := &http.Client{
 		Transport: httputils.CreateHTTPTransport(),

--- a/pkg/config/remote/api/http.go
+++ b/pkg/config/remote/api/http.go
@@ -37,13 +37,13 @@ type HTTPClient struct {
 }
 
 // NewHTTPClient returns a new HTTP configuration client
-func NewHTTPClient(apiKey, appKey string) *HTTPClient {
+func NewHTTPClient(authHeaders map[string]string) *HTTPClient {
 	header := http.Header{
-		"DD-Api-Key":         []string{apiKey},
-		"DD-Application-Key": []string{appKey},
-		"Content-Type":       []string{"application/x-protobuf"},
+		"Content-Type": []string{"application/x-protobuf"},
 	}
-
+	for k, v := range authHeaders {
+		header[k] = []string{v}
+	}
 	httpClient := &http.Client{
 		Transport: httputils.CreateHTTPTransport(),
 	}

--- a/pkg/config/remote/service/service.go
+++ b/pkg/config/remote/service/service.go
@@ -141,7 +141,7 @@ func NewService() (*Service, error) {
 	if err != nil {
 		return nil, err
 	}
-	http := api.NewHTTPClient(authKeys.httpHeaders())
+	http := api.NewHTTPClient(authKeys.apiAuth())
 	hname, err := hostname.Get(context.Background())
 	if err != nil {
 		return nil, err

--- a/pkg/config/remote/service/util.go
+++ b/pkg/config/remote/service/util.go
@@ -14,6 +14,7 @@ import (
 
 	"go.etcd.io/bbolt"
 
+	"github.com/DataDog/datadog-agent/pkg/config/remote/api"
 	"github.com/DataDog/datadog-agent/pkg/config/remote/data"
 	"github.com/DataDog/datadog-agent/pkg/config/remote/uptane"
 	"github.com/DataDog/datadog-agent/pkg/proto/msgpgo"
@@ -103,14 +104,15 @@ type remoteConfigAuthKeys struct {
 	rcKey    *msgpgo.RemoteConfigKey
 }
 
-func (k *remoteConfigAuthKeys) httpHeaders() map[string]string {
-	headers := map[string]string{
-		"DD-Api-Key": k.apiKey,
+func (k *remoteConfigAuthKeys) apiAuth() api.Auth {
+	auth := api.Auth{
+		ApiKey: k.apiKey,
 	}
 	if k.rcKeySet {
-		headers["DD-Application-Key"] = k.rcKey.AppKey
+		auth.UseAppKey = true
+		auth.AppKey = k.rcKey.AppKey
 	}
-	return headers
+	return auth
 }
 
 func getRemoteConfigAuthKeys(apiKey string, rcKey string) (remoteConfigAuthKeys, error) {

--- a/pkg/config/remote/service/util_test.go
+++ b/pkg/config/remote/service/util_test.go
@@ -22,20 +22,29 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
-func TestRemoteConfigKey(t *testing.T) {
+func TestAuthKeys(t *testing.T) {
 	tests := []struct {
-		input  string
+		rcKey  string
+		apiKey string
 		err    bool
-		output *msgpgo.RemoteConfigKey
+		output remoteConfigAuthKeys
 	}{
-		{input: generateKey(t, 2, "datadoghq.com", "58d58c60b8ac337293ce2ca6b28b19eb"), output: &msgpgo.RemoteConfigKey{AppKey: "58d58c60b8ac337293ce2ca6b28b19eb", OrgID: 2, Datacenter: "datadoghq.com"}},
-		{input: generateKey(t, 2, "datadoghq.com", ""), err: true},
-		{input: generateKey(t, 2, "", "app_Key"), err: true},
-		{input: generateKey(t, 0, "datadoghq.com", "app_Key"), err: true},
+		{apiKey: "37d58c60b8ac337293ce2ca6b28b19eb", rcKey: generateKey(t, 2, "datadoghq.com", "58d58c60b8ac337293ce2ca6b28b19eb"), output: remoteConfigAuthKeys{
+			apiKey:   "37d58c60b8ac337293ce2ca6b28b19eb",
+			rcKeySet: true,
+			rcKey:    &msgpgo.RemoteConfigKey{AppKey: "58d58c60b8ac337293ce2ca6b28b19eb", OrgID: 2, Datacenter: "datadoghq.com"},
+		}},
+		{apiKey: "37d58c60b8ac337293ce2ca6b28b19eb", rcKey: "", output: remoteConfigAuthKeys{
+			apiKey:   "37d58c60b8ac337293ce2ca6b28b19eb",
+			rcKeySet: false,
+		}},
+		{rcKey: generateKey(t, 2, "datadoghq.com", ""), err: true},
+		{rcKey: generateKey(t, 2, "", "app_Key"), err: true},
+		{rcKey: generateKey(t, 0, "datadoghq.com", "app_Key"), err: true},
 	}
 	for _, test := range tests {
-		t.Run(test.input, func(tt *testing.T) {
-			output, err := parseRemoteConfigKey(test.input)
+		t.Run(fmt.Sprintf("%s|%s", test.apiKey, test.rcKey), func(tt *testing.T) {
+			output, err := getRemoteConfigAuthKeys(test.apiKey, test.rcKey)
 			if test.err {
 				assert.Error(tt, err)
 			} else {

--- a/pkg/config/remote/uptane/client_test.go
+++ b/pkg/config/remote/uptane/client_test.go
@@ -28,7 +28,7 @@ func TestClientState(t *testing.T) {
 	config.Datadog.Set("remote_configuration.config_root", testRepository1.configRoot)
 
 	db := getTestDB(t)
-	client1, err := NewClient(db, "testcachekey", 2)
+	client1, err := NewClient(db, "testcachekey", WithOrgIDCheck(2))
 	assert.NoError(t, err)
 
 	// Testing default state
@@ -53,7 +53,7 @@ func TestClientState(t *testing.T) {
 	assert.Equal(t, string(testRepository1.directorTargets), string(targets1))
 
 	// Testing state is maintained between runs
-	client2, err := NewClient(db, "testcachekey", 2)
+	client2, err := NewClient(db, "testcachekey", WithOrgIDCheck(2))
 	assert.NoError(t, err)
 	clientState, err = client2.State()
 	assert.NoError(t, err)
@@ -66,7 +66,7 @@ func TestClientState(t *testing.T) {
 	assert.Equal(t, string(testRepository1.directorTargets), string(targets1))
 
 	// Testing state is isolated by cache key
-	client3, err := NewClient(db, "testcachekey2", 2)
+	client3, err := NewClient(db, "testcachekey2", WithOrgIDCheck(2))
 	assert.NoError(t, err)
 	clientState, err = client3.State()
 	assert.NoError(t, err)
@@ -92,7 +92,7 @@ func TestClientFullState(t *testing.T) {
 
 	// Prepare
 	db := getTestDB(t)
-	client, err := NewClient(db, "testcachekey", 2)
+	client, err := NewClient(db, "testcachekey", WithOrgIDCheck(2))
 	assert.NoError(t, err)
 	err = client.Update(testRepository.toUpdate())
 	assert.NoError(t, err)
@@ -131,14 +131,14 @@ func TestClientVerifyTUF(t *testing.T) {
 	db := getTestDB(t)
 
 	previousConfigTargets := testRepository1.configTargets
-	client1, err := NewClient(db, "testcachekey1", 2)
+	client1, err := NewClient(db, "testcachekey1", WithOrgIDCheck(2))
 	assert.NoError(t, err)
 	testRepository1.configTargets = generateTargets(generateKey(), testRepository1.configTargetsVersion, nil)
 	err = client1.Update(testRepository1.toUpdate())
 	assert.Error(t, err)
 
 	testRepository1.configTargets = previousConfigTargets
-	client2, err := NewClient(db, "testcachekey2", 2)
+	client2, err := NewClient(db, "testcachekey2", WithOrgIDCheck(2))
 	assert.NoError(t, err)
 	testRepository1.directorTargets = generateTargets(generateKey(), testRepository1.directorTargetsVersion, nil)
 	err = client2.Update(testRepository1.toUpdate())
@@ -178,7 +178,7 @@ func TestClientVerifyUptane(t *testing.T) {
 
 	config.Datadog.Set("remote_configuration.director_root", testRepositoryValid.directorRoot)
 	config.Datadog.Set("remote_configuration.config_root", testRepositoryValid.configRoot)
-	client1, err := NewClient(db, "testcachekey1", 2)
+	client1, err := NewClient(db, "testcachekey1", WithOrgIDCheck(2))
 	assert.NoError(t, err)
 	err = client1.Update(testRepositoryValid.toUpdate())
 	assert.NoError(t, err)
@@ -188,7 +188,7 @@ func TestClientVerifyUptane(t *testing.T) {
 
 	config.Datadog.Set("remote_configuration.director_root", testRepositoryInvalid1.directorRoot)
 	config.Datadog.Set("remote_configuration.config_root", testRepositoryInvalid1.configRoot)
-	client2, err := NewClient(db, "testcachekey2", 2)
+	client2, err := NewClient(db, "testcachekey2", WithOrgIDCheck(2))
 	assert.NoError(t, err)
 	err = client2.Update(testRepositoryInvalid1.toUpdate())
 	assert.Error(t, err)
@@ -197,7 +197,7 @@ func TestClientVerifyUptane(t *testing.T) {
 
 	config.Datadog.Set("remote_configuration.director_root", testRepositoryInvalid2.directorRoot)
 	config.Datadog.Set("remote_configuration.config_root", testRepositoryInvalid2.configRoot)
-	client3, err := NewClient(db, "testcachekey3", 2)
+	client3, err := NewClient(db, "testcachekey3", WithOrgIDCheck(2))
 	assert.NoError(t, err)
 	err = client3.Update(testRepositoryInvalid2.toUpdate())
 	assert.Error(t, err)
@@ -229,14 +229,14 @@ func TestClientVerifyOrgID(t *testing.T) {
 
 	config.Datadog.Set("remote_configuration.director_root", testRepositoryValid.directorRoot)
 	config.Datadog.Set("remote_configuration.config_root", testRepositoryValid.configRoot)
-	client1, err := NewClient(db, "testcachekey1", 2)
+	client1, err := NewClient(db, "testcachekey1", WithOrgIDCheck(2))
 	assert.NoError(t, err)
 	err = client1.Update(testRepositoryValid.toUpdate())
 	assert.NoError(t, err)
 
 	config.Datadog.Set("remote_configuration.director_root", testRepositoryInvalid.directorRoot)
 	config.Datadog.Set("remote_configuration.config_root", testRepositoryInvalid.configRoot)
-	client2, err := NewClient(db, "testcachekey2", 2)
+	client2, err := NewClient(db, "testcachekey2", WithOrgIDCheck(2))
 	assert.NoError(t, err)
 	err = client2.Update(testRepositoryInvalid.toUpdate())
 	assert.Error(t, err)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR adds support for API key-only authentication while keeping RC key + API key auth. Note that the back-end to support this does not exist yet.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

We are replacing RC keys by scoped API key.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
