### PR TITLE
(rcm) fix database cleanup on empty state

### DIFF
--- a/pkg/config/remote/service/util.go
+++ b/pkg/config/remote/service/util.go
@@ -32,13 +32,19 @@ type AgentMetadata struct {
 
 func recreate(path string) (*bbolt.DB, error) {
 	log.Infof("Clear remote configuration database")
-	err := os.Remove(path)
-	if err != nil {
-		log.Debugf("failed to remove rc db: %v", err)
+	_, err := os.Stat(path)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("could not check if rc db exists: (%s): %v", path, err)
+	}
+	if err == nil {
+		err := os.Remove(path)
+		if err != nil {
+			return nil, fmt.Errorf("could not remote existing rc db (%s): %v", path, err)
+		}
 	}
 	err = os.MkdirAll(filepath.Dir(path), 0700)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create rc db dir: %v", err)
+		return nil, fmt.Errorf("failed to create rc db dir: (%s): %v", path, err)
 	}
 	db, err := bbolt.Open(path, 0600, &bbolt.Options{})
 	if err != nil {

--- a/pkg/config/remote/service/util.go
+++ b/pkg/config/remote/service/util.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"go.etcd.io/bbolt"
@@ -31,8 +32,13 @@ type AgentMetadata struct {
 
 func recreate(path string) (*bbolt.DB, error) {
 	log.Infof("Clear remote configuration database")
-	if err := os.Remove(path); err != nil {
-		return nil, fmt.Errorf("failed to remove corrupted database: %w", err)
+	err := os.Remove(path)
+	if err != nil {
+		log.Debugf("failed to remove rc db: %v", err)
+	}
+	err = os.MkdirAll(filepath.Dir(path), 0700)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create rc db dir: %v", err)
 	}
 	db, err := bbolt.Open(path, 0600, &bbolt.Options{})
 	if err != nil {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fixes a bug in https://github.com/DataDog/datadog-agent/pull/13469 preventing RC from starting up on installs that were missing the `/opt/datadog-agent/run` directory.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
