### PR TITLE
evp_proxy: fix v2 not stripping the right prefix

### DIFF
--- a/pkg/trace/api/endpoints.go
+++ b/pkg/trace/api/endpoints.go
@@ -114,11 +114,11 @@ var endpoints = []Endpoint{
 	},
 	{
 		Pattern: "/evp_proxy/v1/",
-		Handler: func(r *HTTPReceiver) http.Handler { return r.evpProxyHandler() },
+		Handler: func(r *HTTPReceiver) http.Handler { return r.evpProxyHandler(1) },
 	},
 	{
 		Pattern: "/evp_proxy/v2/",
-		Handler: func(r *HTTPReceiver) http.Handler { return r.evpProxyHandler() },
+		Handler: func(r *HTTPReceiver) http.Handler { return r.evpProxyHandler(2) },
 	},
 	{
 		Pattern: "/debugger/v1/input",

--- a/pkg/trace/api/evp_proxy.go
+++ b/pkg/trace/api/evp_proxy.go
@@ -50,12 +50,12 @@ func evpProxyEndpointsFromConfig(conf *config.AgentConfig) []config.Endpoint {
 	return endpoints
 }
 
-func (r *HTTPReceiver) evpProxyHandler() http.Handler {
+func (r *HTTPReceiver) evpProxyHandler(apiVersion int) http.Handler {
 	if !r.conf.EVPProxy.Enabled {
 		return evpProxyErrorHandler("Has been disabled in config")
 	}
 	handler := evpProxyForwarder(r.conf)
-	return http.StripPrefix("/evp_proxy/v1", handler)
+	return http.StripPrefix(fmt.Sprintf("/evp_proxy/v%v", apiVersion), handler)
 }
 
 // evpProxyErrorHandler returns an HTTP handler that will always return

--- a/pkg/trace/api/evp_proxy.go
+++ b/pkg/trace/api/evp_proxy.go
@@ -55,7 +55,7 @@ func (r *HTTPReceiver) evpProxyHandler(apiVersion int) http.Handler {
 		return evpProxyErrorHandler("Has been disabled in config")
 	}
 	handler := evpProxyForwarder(r.conf)
-	return http.StripPrefix(fmt.Sprintf("/evp_proxy/v%v", apiVersion), handler)
+	return http.StripPrefix(fmt.Sprintf("/evp_proxy/v%d", apiVersion), handler)
 }
 
 // evpProxyErrorHandler returns an HTTP handler that will always return

--- a/pkg/trace/api/evp_proxy_test.go
+++ b/pkg/trace/api/evp_proxy_test.go
@@ -372,7 +372,7 @@ func TestEVPProxyHandler(t *testing.T) {
 	t.Run("enabled", func(t *testing.T) {
 		cfg := config.New()
 		receiver := &HTTPReceiver{conf: cfg}
-		handler := receiver.evpProxyHandler()
+		handler := receiver.evpProxyHandler(2)
 		require.NotNil(t, handler)
 	})
 
@@ -380,11 +380,11 @@ func TestEVPProxyHandler(t *testing.T) {
 		cfg := config.New()
 		cfg.EVPProxy.Enabled = false
 		receiver := &HTTPReceiver{conf: cfg}
-		handler := receiver.evpProxyHandler()
+		handler := receiver.evpProxyHandler(2)
 		require.NotNil(t, handler)
 
 		rec := httptest.NewRecorder()
-		req := httptest.NewRequest("POST", "/evp_proxy/v1/mypath", nil)
+		req := httptest.NewRequest("POST", "/evp_proxy/v2/mypath", nil)
 		req.Header.Set("X-Datadog-EVP-Subdomain", "my.subdomain")
 		handler.ServeHTTP(rec, req)
 		require.Equal(t, http.StatusMethodNotAllowed, rec.Code)


### PR DESCRIPTION
### What does this PR do?

Fixes the `StripPrefix` handler still assuming all urls had `v1` in them :(

### Motivation

Fixes #13825
