### PR TITLE
feat: Get cluster-name from k8s Node label

### DIFF
--- a/pkg/compliance/agent/node_labels.go
+++ b/pkg/compliance/agent/node_labels.go
@@ -7,6 +7,7 @@ package agent
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"time"
 
@@ -43,9 +44,13 @@ type labelsFetcher struct {
 	nodeLabels map[string]string
 }
 
-func (f *labelsFetcher) fetch() (err error) {
-	f.nodeLabels, err = hostinfo.GetNodeLabels(context.TODO())
-	return
+func (f *labelsFetcher) fetch() error {
+	nodeInfo, err := hostinfo.NewNodeInfo()
+	if err != nil {
+		return fmt.Errorf("unable to instantiate NodeInfo, err: %w", err)
+	}
+	f.nodeLabels, err = nodeInfo.GetNodeLabels(context.TODO())
+	return err
 }
 
 func notifyFetchNodeLabels() backoff.Notify {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -587,6 +587,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("kubernetes_node_labels_as_tags", map[string]string{})
 	config.BindEnvAndSetDefault("kubernetes_node_annotations_as_tags", map[string]string{"cluster.k8s.io/machine": "kube_machine"})
 	config.BindEnvAndSetDefault("kubernetes_node_annotations_as_host_aliases", []string{"cluster.k8s.io/machine"})
+	config.BindEnvAndSetDefault("kubernetes_node_label_as_cluster_name", "")
 	config.BindEnvAndSetDefault("kubernetes_namespace_labels_as_tags", map[string]string{})
 	config.BindEnvAndSetDefault("container_cgroup_prefix", "")
 

--- a/pkg/util/kubernetes/clustername/clustername.go
+++ b/pkg/util/kubernetes/clustername/clustername.go
@@ -109,10 +109,17 @@ func getClusterName(ctx context.Context, data *clusterNameData, hostname string)
 		}
 
 		if data.clusterName == "" && config.IsFeaturePresent(config.Kubernetes) {
-			clusterName, err := hostinfo.GetNodeClusterNameLabel(ctx)
+			var clusterName string
+			nodeInfo, err := hostinfo.NewNodeInfo()
 			if err != nil {
 				log.Debugf("Unable to auto discover the cluster name from node label : %s", err)
 			} else {
+				clusterName, err = nodeInfo.GetNodeClusterNameLabel(ctx)
+				if err != nil {
+					log.Debugf("Unable to auto discover the cluster name from node label : %s", err)
+				}
+			}
+			if len(clusterName) > 0 {
 				data.clusterName = clusterName
 			}
 		}

--- a/pkg/util/kubernetes/clustername/clustername.go
+++ b/pkg/util/kubernetes/clustername/clustername.go
@@ -108,13 +108,13 @@ func getClusterName(ctx context.Context, data *clusterNameData, hostname string)
 			}
 		}
 
-		if data.clusterName == "" && config.IsFeaturePresent(config.Kubernetes) {
+		if config.IsFeaturePresent(config.Kubernetes) {
 			var clusterName string
 			nodeInfo, err := hostinfo.NewNodeInfo()
 			if err != nil {
 				log.Debugf("Unable to auto discover the cluster name from node label : %s", err)
 			} else {
-				clusterName, err = nodeInfo.GetNodeClusterNameLabel(ctx)
+				clusterName, err = nodeInfo.GetNodeClusterNameLabel(ctx, data.clusterName)
 				if err != nil {
 					log.Debugf("Unable to auto discover the cluster name from node label : %s", err)
 				}

--- a/pkg/util/kubernetes/hostinfo/no_node_labels.go
+++ b/pkg/util/kubernetes/hostinfo/no_node_labels.go
@@ -26,6 +26,6 @@ func (n *NodeInfo) GetNodeLabels(ctx context.Context) (map[string]string, error)
 }
 
 // GetNodeClusterNameLabel returns clustername by fetching a node label
-func (n *NodeInfo) GetNodeClusterNameLabel(ctx context.Context) (string, error) {
+func (n *NodeInfo) GetNodeClusterNameLabel(ctx context.Context, currentClusterName string) (string, error) {
 	return "", nil
 }

--- a/pkg/util/kubernetes/hostinfo/no_node_labels.go
+++ b/pkg/util/kubernetes/hostinfo/no_node_labels.go
@@ -10,12 +10,22 @@ package hostinfo
 
 import "context"
 
+// NodeInfo is use to get Kubernetes Node metadata information
+type NodeInfo struct {
+}
+
+// NewNodeInfo return a new NodeInfo instance
+// return an error if it fails to access the kubelet client.
+func NewNodeInfo() (*NodeInfo, error) {
+	return &NodeInfo{}, nil
+}
+
 // GetNodeLabels returns node labels for this host
-func GetNodeLabels(ctx context.Context) (map[string]string, error) {
+func (n *NodeInfo) GetNodeLabels(ctx context.Context) (map[string]string, error) {
 	return nil, nil
 }
 
 // GetNodeClusterNameLabel returns clustername by fetching a node label
-func GetNodeClusterNameLabel(ctx context.Context) (string, error) {
+func (n *NodeInfo) GetNodeClusterNameLabel(ctx context.Context) (string, error) {
 	return "", nil
 }

--- a/pkg/util/kubernetes/hostinfo/node_labels.go
+++ b/pkg/util/kubernetes/hostinfo/node_labels.go
@@ -16,37 +16,72 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 )
 
-// GetNodeLabels returns node labels for this host
-func GetNodeLabels(ctx context.Context) (map[string]string, error) {
+const (
+	eksClusterNameLabelKey       = "alpha.eksctl.io/cluster-name"
+	datadogADClusterNameLabelKey = "ad.datadoghq.com/cluster-name"
+)
+
+// NodeInfo is use to get Kubernetes Node metadata information
+type NodeInfo struct {
+	// client use to get NodeName from the "/pods" kubelet api.
+	client kubelet.KubeUtilInterface
+	// getClusterAgentFunc get Cluster-Agent client to get Node Labels with the Cluster-Agent api.
+	getClusterAgentFunc func() (clusteragent.DCAClientInterface, error)
+	// apiserverNodeLabelsFunc get Node Labels from the API server directly
+	apiserverNodeLabelsFunc func(ctx context.Context, nodeName string) (map[string]string, error)
+}
+
+// NewNodeInfo return a new NodeInfo instance
+// return an error if it fails to access the kubelet client.
+func NewNodeInfo() (*NodeInfo, error) {
 	ku, err := kubelet.GetKubeUtil()
 	if err != nil {
 		return nil, err
 	}
 
-	nodeName, err := ku.GetNodename(ctx)
+	nodeInfo := &NodeInfo{
+		client:                  ku,
+		getClusterAgentFunc:     clusteragent.GetClusterAgentClient,
+		apiserverNodeLabelsFunc: apiserverNodeLabels,
+	}
+
+	return nodeInfo, nil
+}
+
+// GetNodeLabels returns node labels for this host
+func (n *NodeInfo) GetNodeLabels(ctx context.Context) (map[string]string, error) {
+	nodeName, err := n.client.GetNodename(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	if config.Datadog.GetBool("cluster_agent.enabled") {
-		cl, err := clusteragent.GetClusterAgentClient()
+		cl, err := n.getClusterAgentFunc()
 		if err != nil {
 			return nil, err
 		}
 		return cl.GetNodeLabels(nodeName)
 	}
-	return apiserverNodeLabels(ctx, nodeName)
+	return n.apiserverNodeLabelsFunc(ctx, nodeName)
 }
 
 // GetNodeClusterNameLabel returns clustername by fetching a node label
-func GetNodeClusterNameLabel(ctx context.Context) (string, error) {
-	nodeLabels, err := GetNodeLabels(ctx)
+func (n *NodeInfo) GetNodeClusterNameLabel(ctx context.Context) (string, error) {
+	nodeLabels, err := n.GetNodeLabels(ctx)
 	if err != nil {
 		return "", err
 	}
 
-	clusterNameLabels := []string{
-		"alpha.eksctl.io/cluster-name", // EKS cluster-name label
+	var clusterNameLabels []string
+	// check if a node label has been added on the config
+	if customLabels := config.Datadog.GetString("kubernetes_node_label_as_cluster_name"); customLabels != "" {
+		clusterNameLabels = append(clusterNameLabels, customLabels)
+	} else {
+		// Use default configuration
+		clusterNameLabels = []string{
+			eksClusterNameLabelKey,       // EKS cluster-name label
+			datadogADClusterNameLabelKey, // Generic Datadog AD cluster-name label
+		}
 	}
 
 	for _, l := range clusterNameLabels {

--- a/pkg/util/kubernetes/hostinfo/node_labels_test.go
+++ b/pkg/util/kubernetes/hostinfo/node_labels_test.go
@@ -1,0 +1,128 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubelet
+// +build kubelet
+
+package hostinfo
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/clusteragent"
+	k "github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type kubeUtilMock struct {
+	k.KubeUtilInterface
+	mock.Mock
+}
+
+func (m *kubeUtilMock) GetNodename(ctx context.Context) (string, error) {
+	args := m.Called()
+	return args.String(0), args.Error(1)
+}
+
+func TestNodeInfo_GetNodeClusterNameLabel(t *testing.T) {
+	tests := []struct {
+		name           string
+		ctx            context.Context
+		mockClientFunc func(*kubeUtilMock)
+		mockConfFunc   func(conf *config.MockConfig)
+		nodeLabels     map[string]string
+		want           string
+		wantErr        bool
+	}{
+		{
+			name: "cluster-name not set",
+			mockClientFunc: func(ku *kubeUtilMock) {
+				ku.On("GetNodename").Return("node-name", nil)
+			},
+			nodeLabels: map[string]string{},
+			ctx:        context.Background(),
+			want:       "",
+			wantErr:    false,
+		},
+		{
+			name: "cluster-name label set",
+			mockClientFunc: func(ku *kubeUtilMock) {
+				ku.On("GetNodename").Return("node-name", nil)
+			},
+			nodeLabels: map[string]string{
+				"ad.datadoghq.com/cluster-name": "foo",
+			},
+			ctx:     context.Background(),
+			want:    "foo",
+			wantErr: false,
+		},
+		{
+			name: "cluster-name custom label set",
+			mockClientFunc: func(ku *kubeUtilMock) {
+				ku.On("GetNodename").Return("node-name", nil)
+			},
+			mockConfFunc: func(conf *config.MockConfig) {
+				conf.Set("kubernetes_node_label_as_cluster_name", "custom-label")
+			},
+			nodeLabels: map[string]string{
+				"custom-label": "bar",
+			},
+			ctx:     context.Background(),
+			want:    "bar",
+			wantErr: false,
+		},
+		{
+			name: "cluster-name if custom label set, not look at default labels",
+			mockClientFunc: func(ku *kubeUtilMock) {
+				ku.On("GetNodename").Return("node-name", nil)
+			},
+			mockConfFunc: func(conf *config.MockConfig) {
+				conf.Set("kubernetes_node_label_as_cluster_name", "custom-label")
+			},
+			nodeLabels: map[string]string{
+				"ad.datadoghq.com/cluster-name": "foo",
+				"custom-label":                  "bar",
+			},
+			ctx:     context.Background(),
+			want:    "bar",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ku := &kubeUtilMock{}
+			if tt.mockClientFunc != nil {
+				tt.mockClientFunc(ku)
+			}
+
+			mockConfig := config.Mock(t)
+			if tt.mockConfFunc != nil {
+				tt.mockConfFunc(mockConfig)
+			}
+
+			nodeInfo := &NodeInfo{
+				client:              ku,
+				getClusterAgentFunc: clusteragent.GetClusterAgentClient,
+				apiserverNodeLabelsFunc: func(ctx context.Context, nodeName string) (map[string]string, error) {
+					return tt.nodeLabels, nil
+				},
+			}
+
+			got, err := nodeInfo.GetNodeClusterNameLabel(tt.ctx)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NodeInfo.GetNodeClusterNameLabel() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("NodeInfo.GetNodeClusterNameLabel() = %v, want %v", got, tt.want)
+			}
+
+			ku.AssertExpectations(t)
+		})
+	}
+}

--- a/pkg/util/kubernetes/hostinfo/tags.go
+++ b/pkg/util/kubernetes/hostinfo/tags.go
@@ -22,10 +22,18 @@ func GetTags(ctx context.Context) (tags []string, err error) {
 	labelsToTags := getLabelsToTags()
 
 	if len(labelsToTags) > 0 {
-		nodeLabels, e := GetNodeLabels(ctx)
-		if e != nil {
+		var nodeLabels map[string]string
+		nodeInfo, e := NewNodeInfo()
+		if err != nil {
 			err = e
 		} else {
+			nodeLabels, e = nodeInfo.GetNodeLabels(ctx)
+			if e != nil {
+				err = e
+			}
+		}
+
+		if len(nodeLabels) > 0 {
 			tags = append(tags, extractTags(nodeLabels, labelsToTags)...)
 		}
 	}

--- a/releasenotes/notes/get-cluster-name-from-k8s-node-label-e2f022894a50b039.yaml
+++ b/releasenotes/notes/get-cluster-name-from-k8s-node-label-e2f022894a50b039.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    On Kubernetes, the "cluster name" can now be discovered by using
+    the Node label `ad.datadoghq.com/cluster-name` or any other label
+    key configured using to the configuration option:
+    `kubernetes_node_label_as_cluster_name`


### PR DESCRIPTION
### What does this PR do?

Enhance how the Agent can discover the "cluster-name" in Kubernetes. 

It is now possible to set the cluster-name on Node's label thanks to the label key: `ad.datadoghq.com/cluster-name`
or any other Node's label key configured with the option `kubernetes_node_labels_as_cluster_name`

### Motivation

Auto-discover more easy the cluster-name by introspecting the Kubernetes environment (Nodes). On some Kubernetes distribution it is not possible to detect the `cluster-name` with our current cloud-provider integration.

This new feature allows user to set the cluster-name as Node's metadata (labels) when they create the K8s cluster. So that the "cluster-name" doesn't need to be set inside the  Datadog Agent deployment configuration. Now, users can have a generic agent configuration for multiple clusters. 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

2 scenarios to test:
1. Create a kubernetes cluster (for example with kind). Add the `ad.datadoghq.com/cluster-name` label to every node of the cluster. The cluster name should appears in https://app.datadoghq.com/orchestration/overview/cluster
2. Create a kubernetes cluster (for example with kind). Add a random label key/value `my-cluster-name-key: my-test-cluster` on every Node. in the agent configuration add `kubernetes_node_labels_as_cluster_name: '["my-cluster-name-key"]'`. the cluster name should also appears in https://app.datadoghq.com/orchestration/overview/cluster

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
