### PR TITLE
[Serverless] Fix flaky tests.

### DIFF
--- a/cmd/trace-agent/config/config.go
+++ b/cmd/trace-agent/config/config.go
@@ -574,7 +574,7 @@ func validate(c *config.AgentConfig) error {
 	if c.DDAgentBin == "" {
 		return errors.New("agent binary path not set")
 	}
-	if c.Hostname == "" {
+	if c.Hostname == "" && !coreconfig.Datadog.GetBool("serverless.enabled") {
 		// no user-set hostname, try to acquire
 		if err := acquireHostname(c); err != nil {
 			log.Debugf("Could not get hostname via gRPC: %v. Falling back to other methods.", err)

--- a/cmd/trace-agent/config/config_test.go
+++ b/cmd/trace-agent/config/config_test.go
@@ -264,6 +264,15 @@ func TestConfigHostname(t *testing.T) {
 		assert.Equal("envoverride", cfg.Hostname)
 	})
 
+	t.Run("serverless", func(t *testing.T) {
+		defer cleanConfig()()
+		coreconfig.Datadog.Set("serverless.enabled", true)
+		assert := assert.New(t)
+		cfg, err := LoadConfigFile("./testdata/site_default.yaml")
+		assert.NoError(err)
+		assert.Equal("", cfg.Hostname)
+	})
+
 	t.Run("external", func(t *testing.T) {
 		body, err := ioutil.ReadFile("testdata/stringcode.go.tmpl")
 		if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1138,6 +1138,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("runtime_security_config.envs_with_value", []string{"LD_PRELOAD", "LD_LIBRARY_PATH", "PATH", "HISTSIZE", "HISTFILESIZE"})
 
 	// Serverless Agent
+	config.SetDefault("serverless.enabled", false)
 	config.BindEnvAndSetDefault("serverless.logs_enabled", true)
 	config.BindEnvAndSetDefault("enhanced_metrics", true)
 	config.BindEnvAndSetDefault("capture_lambda_payload", false)

--- a/pkg/serverless/registration/extension_api_test.go
+++ b/pkg/serverless/registration/extension_api_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const registerExtensionTimeout = 10 * time.Millisecond
+const registerExtensionTimeout = 100 * time.Millisecond
 
 func TestCreateRegistrationPayload(t *testing.T) {
 	payload := createRegistrationPayload()

--- a/pkg/serverless/registration/logs_api_test.go
+++ b/pkg/serverless/registration/logs_api_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const registerLogsTimeout = 10 * time.Millisecond
+const registerLogsTimeout = 100 * time.Millisecond
 
 func TestBuildLogRegistrationPayload(t *testing.T) {
 	payload := buildLogRegistrationPayload("myUri", "platform function", 10, 100, 1000)
@@ -80,7 +80,6 @@ func TestSubscribeLogsSuccess(t *testing.T) {
 		w.WriteHeader(200)
 	}))
 	defer ts.Close()
-	time.Sleep(100 * time.Millisecond)
 	err := subscribeLogs("myId", ts.URL, registerLogsTimeout, payload)
 	assert.Nil(t, err)
 }

--- a/pkg/serverless/trace/span_modifer_test.go
+++ b/pkg/serverless/trace/span_modifer_test.go
@@ -34,7 +34,9 @@ func TestServerlessServiceRewrite(t *testing.T) {
 	agnt.ModifySpan = spanModifier.ModifySpan
 	defer cancel()
 
-	tp := testutil.TracerPayloadWithChunk(testutil.RandomTraceChunk(1, 1))
+	tc := testutil.RandomTraceChunk(1, 1)
+	tc.Priority += 1 // ensure trace is never sampled out
+	tp := testutil.TracerPayloadWithChunk(tc)
 	tp.Chunks[0].Spans[0].Service = "aws.lambda"
 	go agnt.Process(&api.Payload{
 		TracerPayload: tp,
@@ -63,7 +65,9 @@ func TestInferredSpanFunctionTagFiltering(t *testing.T) {
 	agnt.ModifySpan = spanModifier.ModifySpan
 	defer cancel()
 
-	tp := testutil.TracerPayloadWithChunk(testutil.RandomTraceChunk(2, 1))
+	tc := testutil.RandomTraceChunk(2, 1)
+	tc.Priority += 1 // ensure trace is never sampled out
+	tp := testutil.TracerPayloadWithChunk(tc)
 	tp.Chunks[0].Spans[0].Meta["_inferred_span.tag_source"] = "self"
 	tp.Chunks[0].Spans[1].Meta["_dd_origin"] = "lambda"
 	go agnt.Process(&api.Payload{

--- a/pkg/serverless/trace/span_modifer_test.go
+++ b/pkg/serverless/trace/span_modifer_test.go
@@ -35,7 +35,7 @@ func TestServerlessServiceRewrite(t *testing.T) {
 	defer cancel()
 
 	tc := testutil.RandomTraceChunk(1, 1)
-	tc.Priority += 1 // ensure trace is never sampled out
+	tc.Priority = 1 // ensure trace is never sampled out
 	tp := testutil.TracerPayloadWithChunk(tc)
 	tp.Chunks[0].Spans[0].Service = "aws.lambda"
 	go agnt.Process(&api.Payload{
@@ -66,7 +66,7 @@ func TestInferredSpanFunctionTagFiltering(t *testing.T) {
 	defer cancel()
 
 	tc := testutil.RandomTraceChunk(2, 1)
-	tc.Priority += 1 // ensure trace is never sampled out
+	tc.Priority = 1 // ensure trace is never sampled out
 	tp := testutil.TracerPayloadWithChunk(tc)
 	tp.Chunks[0].Spans[0].Meta["_inferred_span.tag_source"] = "self"
 	tp.Chunks[0].Spans[1].Meta["_dd_origin"] = "lambda"

--- a/pkg/serverless/trace/trace.go
+++ b/pkg/serverless/trace/trace.go
@@ -56,10 +56,10 @@ func (l *LoadConfig) Load() (*config.AgentConfig, error) {
 // Start starts the agent
 func (s *ServerlessTraceAgent) Start(enabled bool, loadConfig Load) {
 	if enabled {
-		// during hostname resolution the first step is to make a GRPC call which is timeboxed to a 2 seconds deadline
-		// in the serverless mode, we don't start the GRPC server so this call will fail and cause a 2 seconds delay
-		// by setting cmd_port to -1, this will cause the GRPC client to fail instantly
-		ddConfig.Datadog.Set("cmd_port", "-1")
+		// Set the serverless config option which will be used to determine if
+		// hostname should be resolved. Skipping hostname resolution saves >1s
+		// in load time between gRPC calls and agent commands.
+		ddConfig.Datadog.Set("serverless.enabled", true)
 
 		tc, confErr := loadConfig.Load()
 		if confErr != nil {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Fixes some of the serverless team's most flaky tests.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Flaky tests are annoying.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

I've left comments in the code for each fix.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

None.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Run the tests a bunch of times and make sure there are no failures.  
`go test ./pkg/serverless/... -count=10 -failfast`

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
