### PR TITLE
[WIP] Auto set trace-agent cpu limit based on any k8s limit

### DIFF
--- a/Dockerfiles/agent/datadog-kubernetes.yaml
+++ b/Dockerfiles/agent/datadog-kubernetes.yaml
@@ -4,7 +4,6 @@
 apm_config:
   apm_non_local_traffic: true
   max_memory: 0
-  max_cpu_percent: 0
 
 # Use java container support
 jmx_use_container_support: true

--- a/Dockerfiles/agent/datadog-kubernetes.yaml
+++ b/Dockerfiles/agent/datadog-kubernetes.yaml
@@ -3,8 +3,7 @@
 
 apm_config:
   apm_non_local_traffic: true
-  max_memory: 500000000
-  max_cpu_percent: 45
+  max_memory: 0
 
 # Use java container support
 jmx_use_container_support: true

--- a/Dockerfiles/agent/datadog-kubernetes.yaml
+++ b/Dockerfiles/agent/datadog-kubernetes.yaml
@@ -3,7 +3,8 @@
 
 apm_config:
   apm_non_local_traffic: true
-  max_memory: 0
+  max_memory: 500000000
+  max_cpu_percent: 45
 
 # Use java container support
 jmx_use_container_support: true

--- a/cmd/trace-agent/config/config.go
+++ b/cmd/trace-agent/config/config.go
@@ -339,7 +339,7 @@ func applyDatadogConfig(c *config.AgentConfig) error {
 	if coreconfig.Datadog.IsSet("apm_config.max_cpu_percent") {
 		log.Infof("Found configured CPU value")
 		c.MaxCPU = coreconfig.Datadog.GetFloat64("apm_config.max_cpu_percent") / 100
-	} else if cgLim, err := getCgroupCPULimit(); err != nil {
+	} else if cgLim, err := getCgroupCPULimit(); err == nil {
 		if cgLim > 0 {
 			c.MaxCPU = cgLim * 0.9
 			log.Infof("Cgroups CPU limit detected, setting max_cpu_percent to 90%% of %d cpu: %f", cgLim, c.MaxCPU)

--- a/cmd/trace-agent/config/config.go
+++ b/cmd/trace-agent/config/config.go
@@ -335,10 +335,14 @@ func applyDatadogConfig(c *config.AgentConfig) error {
 		}
 	}
 
-	// undocumented
 	if coreconfig.Datadog.IsSet("apm_config.max_cpu_percent") {
 		c.MaxCPU = coreconfig.Datadog.GetFloat64("apm_config.max_cpu_percent") / 100
+	} else if coreconfig.Datadog.IsSet("apm_config.k8s_max_milli_cpu") {
+		mc := coreconfig.Datadog.GetInt("apm_config.k8s_max_milli_cpu")
+		log.Debugf("Kubernetes CPU limit detected, setting max_cpu_percent to 90% of %d milli-cpu.", mc)
+		c.MaxCPU = float64(mc) / 1000.0 * 0.9
 	}
+
 	if coreconfig.Datadog.IsSet("apm_config.max_memory") {
 		c.MaxMemory = coreconfig.Datadog.GetFloat64("apm_config.max_memory")
 	}

--- a/cmd/trace-agent/config/config.go
+++ b/cmd/trace-agent/config/config.go
@@ -335,12 +335,16 @@ func applyDatadogConfig(c *config.AgentConfig) error {
 		}
 	}
 
+	log.Infof("DOING CPU DETECTION NOW")
 	if coreconfig.Datadog.IsSet("apm_config.max_cpu_percent") {
+		log.Infof("Found configured CPU value")
 		c.MaxCPU = coreconfig.Datadog.GetFloat64("apm_config.max_cpu_percent") / 100
 	} else if cgLim, err := getCgroupCPULimit(); err != nil {
 		if cgLim > 0 {
 			c.MaxCPU = cgLim * 0.9
 			log.Infof("Cgroups CPU limit detected, setting max_cpu_percent to 90%% of %d cpu: %f", cgLim, c.MaxCPU)
+		} else {
+			log.Infof("CPU saw a limit of %f ignoring", cgLim)
 		}
 	} else {
 		log.Infof("No CPU limit set for trace-agent err: %v", err)

--- a/cmd/trace-agent/config/config.go
+++ b/cmd/trace-agent/config/config.go
@@ -335,7 +335,6 @@ func applyDatadogConfig(c *config.AgentConfig) error {
 		}
 	}
 
-	log.Infof("DOING CPU DETECTION NOW")
 	if coreconfig.Datadog.IsSet("apm_config.max_cpu_percent") {
 		log.Infof("Found configured CPU value")
 		c.MaxCPU = coreconfig.Datadog.GetFloat64("apm_config.max_cpu_percent") / 100
@@ -347,7 +346,7 @@ func applyDatadogConfig(c *config.AgentConfig) error {
 			log.Infof("CPU saw a limit of %f ignoring", cgLim)
 		}
 	} else {
-		log.Infof("No CPU limit set for trace-agent err: %v", err)
+		log.Infof("No auto CPU limit set for trace-agent err: %v", err)
 	}
 
 	if coreconfig.Datadog.IsSet("apm_config.max_memory") {

--- a/cmd/trace-agent/config/config.go
+++ b/cmd/trace-agent/config/config.go
@@ -342,6 +342,8 @@ func applyDatadogConfig(c *config.AgentConfig) error {
 			c.MaxCPU = cgLim * 0.9
 			log.Infof("Cgroups CPU limit detected, setting max_cpu_percent to 90%% of %d cpu: %f", cgLim, c.MaxCPU)
 		}
+	} else {
+		log.Infof("No CPU limit set for trace-agent err: %v", err)
 	}
 
 	if coreconfig.Datadog.IsSet("apm_config.max_memory") {

--- a/cmd/trace-agent/config/config.go
+++ b/cmd/trace-agent/config/config.go
@@ -341,7 +341,7 @@ func applyDatadogConfig(c *config.AgentConfig) error {
 	} else if cgLim, err := getCgroupCPULimit(); err == nil {
 		if cgLim > 0 {
 			c.MaxCPU = cgLim * 0.9
-			log.Infof("Cgroups CPU limit detected, setting max_cpu_percent to 90%% of %f cpu: %f", cgLim, c.MaxCPU)
+			log.Infof("Cgroups CPU limit detected, setting max_cpu_percent to 90%% of %f%% cpu: %f%%", cgLim, c.MaxCPU)
 		} else {
 			log.Infof("CPU saw a limit of %f ignoring", cgLim)
 		}

--- a/cmd/trace-agent/config/config.go
+++ b/cmd/trace-agent/config/config.go
@@ -339,7 +339,7 @@ func applyDatadogConfig(c *config.AgentConfig) error {
 		c.MaxCPU = coreconfig.Datadog.GetFloat64("apm_config.max_cpu_percent") / 100
 	} else if coreconfig.Datadog.IsSet("apm_config.k8s_max_milli_cpu") {
 		mc := coreconfig.Datadog.GetInt("apm_config.k8s_max_milli_cpu")
-		log.Debugf("Kubernetes CPU limit detected, setting max_cpu_percent to 90% of %d milli-cpu.", mc)
+		log.Debugf("Kubernetes CPU limit detected, setting max_cpu_percent to 90%% of %d milli-cpu.", mc)
 		c.MaxCPU = float64(mc) / 1000.0 * 0.9
 	}
 

--- a/cmd/trace-agent/config/config.go
+++ b/cmd/trace-agent/config/config.go
@@ -337,10 +337,10 @@ func applyDatadogConfig(c *config.AgentConfig) error {
 
 	if coreconfig.Datadog.IsSet("apm_config.max_cpu_percent") {
 		c.MaxCPU = coreconfig.Datadog.GetFloat64("apm_config.max_cpu_percent") / 100
-	} else if coreconfig.Datadog.IsSet("apm_config.k8s_max_milli_cpu") {
-		if mc := coreconfig.Datadog.GetInt("apm_config.k8s_max_milli_cpu"); mc > 0 {
-			c.MaxCPU = float64(mc) / 1000.0 * 0.8
-			log.Infof("Kubernetes CPU limit detected, setting max_cpu_percent to 80%% of %d milli-cpu: %f", mc, c.MaxCPU)
+	} else if cgLim, err := getCgroupCPULimit(); err != nil {
+		if cgLim > 0 {
+			c.MaxCPU = cgLim * 0.9
+			log.Infof("Cgroups CPU limit detected, setting max_cpu_percent to 90%% of %d cpu: %f", cgLim, c.MaxCPU)
 		}
 	}
 

--- a/cmd/trace-agent/config/config.go
+++ b/cmd/trace-agent/config/config.go
@@ -338,9 +338,10 @@ func applyDatadogConfig(c *config.AgentConfig) error {
 	if coreconfig.Datadog.IsSet("apm_config.max_cpu_percent") {
 		c.MaxCPU = coreconfig.Datadog.GetFloat64("apm_config.max_cpu_percent") / 100
 	} else if coreconfig.Datadog.IsSet("apm_config.k8s_max_milli_cpu") {
-		mc := coreconfig.Datadog.GetInt("apm_config.k8s_max_milli_cpu")
-		log.Debugf("Kubernetes CPU limit detected, setting max_cpu_percent to 90%% of %d milli-cpu.", mc)
-		c.MaxCPU = float64(mc) / 1000.0 * 0.9
+		if mc := coreconfig.Datadog.GetInt("apm_config.k8s_max_milli_cpu"); mc > 0 {
+			c.MaxCPU = float64(mc) / 1000.0 * 0.8
+			log.Infof("Kubernetes CPU limit detected, setting max_cpu_percent to 80%% of %d milli-cpu: %f", mc, c.MaxCPU)
+		}
 	}
 
 	if coreconfig.Datadog.IsSet("apm_config.max_memory") {

--- a/cmd/trace-agent/config/config.go
+++ b/cmd/trace-agent/config/config.go
@@ -342,7 +342,7 @@ func applyDatadogConfig(c *config.AgentConfig) error {
 	} else if cgLim, err := getCgroupCPULimit(); err == nil {
 		if cgLim > 0 {
 			c.MaxCPU = cgLim * 0.9
-			log.Infof("Cgroups CPU limit detected, setting max_cpu_percent to 90%% of %d cpu: %f", cgLim, c.MaxCPU)
+			log.Infof("Cgroups CPU limit detected, setting max_cpu_percent to 90%% of %f cpu: %f", cgLim, c.MaxCPU)
 		} else {
 			log.Infof("CPU saw a limit of %f ignoring", cgLim)
 		}

--- a/cmd/trace-agent/config/config_linux.go
+++ b/cmd/trace-agent/config/config_linux.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
 //go:build linux
 // +build linux
 

--- a/cmd/trace-agent/config/config_linux.go
+++ b/cmd/trace-agent/config/config_linux.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/cgroups"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 	systemutils "github.com/DataDog/datadog-agent/pkg/util/system"
 )
@@ -34,10 +35,12 @@ func getCgroupCPULimit() (float64, error) {
 	// Limit is computed using min(CPUSet, CFS CPU Quota)
 	var limitPct *float64
 
+	log.Infof("calculating cpu limit, hostcpuCount %d cgs stats %d", systemutils.HostCPUCount(), cgs.CPUCount)
 	if cgs.CPUCount != nil && *cgs.CPUCount != uint64(systemutils.HostCPUCount()) {
 		limitPct = pointer.UIntToFloatPtr(*cgs.CPUCount * 100)
 	}
 	if cgs.SchedulerQuota != nil && cgs.SchedulerPeriod != nil {
+		log.Infof("Found scheduler quota %d and period %d", cgs.SchedulerQuota, cgs.SchedulerPeriod)
 		quotaLimitPct := 100 * (float64(*cgs.SchedulerQuota) / float64(*cgs.SchedulerPeriod))
 		if limitPct == nil || quotaLimitPct < *limitPct {
 			limitPct = &quotaLimitPct

--- a/cmd/trace-agent/config/config_linux.go
+++ b/cmd/trace-agent/config/config_linux.go
@@ -1,0 +1,42 @@
+//go:build linux
+// +build linux
+
+package config
+
+import (
+	"errors"
+
+	"github.com/DataDog/datadog-agent/pkg/util/cgroups"
+	"github.com/DataDog/datadog-agent/pkg/util/pointer"
+	systemutils "github.com/DataDog/datadog-agent/pkg/util/system"
+)
+
+func getCgroupCPULimit() (float64, error) {
+	reader, err := cgroups.NewSelfReader("/proc", true)
+	if err != nil {
+		return 0, err
+	}
+	cg := reader.GetCgroup(cgroups.SelfCgroupIdentifier)
+	if cg == nil {
+		return 0, errors.New("cannot get self cgroup")
+	}
+	var cgs cgroups.CPUStats
+	err = cg.GetCPUStats(&cgs)
+	if err != nil {
+		return 0, err
+	}
+	// Limit is computed using min(CPUSet, CFS CPU Quota)
+	var limitPct *float64
+
+	if cgs.CPUCount != nil && *cgs.CPUCount != uint64(systemutils.HostCPUCount()) {
+		limitPct = pointer.UIntToFloatPtr(*cgs.CPUCount * 100)
+	}
+	if cgs.SchedulerQuota != nil && cgs.SchedulerPeriod != nil {
+		quotaLimitPct := 100 * (float64(*cgs.SchedulerQuota) / float64(*cgs.SchedulerPeriod))
+		if limitPct == nil || quotaLimitPct < *limitPct {
+			limitPct = &quotaLimitPct
+		}
+	}
+
+	return *limitPct, nil
+}

--- a/cmd/trace-agent/config/config_linux.go
+++ b/cmd/trace-agent/config/config_linux.go
@@ -6,13 +6,14 @@ package config
 import (
 	"errors"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/cgroups"
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 	systemutils "github.com/DataDog/datadog-agent/pkg/util/system"
 )
 
 func getCgroupCPULimit() (float64, error) {
-	reader, err := cgroups.NewSelfReader("/proc", true)
+	reader, err := cgroups.NewSelfReader("/proc", config.IsContainerized())
 	if err != nil {
 		return 0, err
 	}

--- a/cmd/trace-agent/config/config_notlinux.go
+++ b/cmd/trace-agent/config/config_notlinux.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
 //go:build !linux
 // +build !linux
 

--- a/cmd/trace-agent/config/config_notlinux.go
+++ b/cmd/trace-agent/config/config_notlinux.go
@@ -1,0 +1,10 @@
+//go:build !linux
+// +build !linux
+
+package config
+
+import "errors"
+
+func getCgroupCPULimit() (float64, error) {
+	return 0, errors.New("cgroup cpu limit not support outside linux environments")
+}

--- a/pkg/config/apm.go
+++ b/pkg/config/apm.go
@@ -81,6 +81,7 @@ func setupAPM(config Config) {
 
 	config.BindEnv("apm_config.max_memory", "DD_APM_MAX_MEMORY")
 	config.BindEnv("apm_config.max_cpu_percent", "DD_APM_MAX_CPU_PERCENT")
+	config.BindEnv("apm_config.k8s_max_milli_cpu", "DD_K8S_MAX_CPU")
 	config.BindEnv("apm_config.env", "DD_APM_ENV")
 	config.BindEnv("apm_config.apm_non_local_traffic", "DD_APM_NON_LOCAL_TRAFFIC")
 	config.BindEnv("apm_config.apm_dd_url", "DD_APM_DD_URL")

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -713,6 +713,7 @@ var killProcess = func(format string, a ...interface{}) {
 // the configuration MaxMemory and MaxCPU. If these values are 0, all limits are disabled and the rate
 // limiter will accept everything.
 func (r *HTTPReceiver) watchdog(now time.Time) {
+	log.Infof("Watchdog called")
 	cpu, cpuErr := watchdog.CPU(now)
 	wi := watchdog.Info{
 		Mem: watchdog.Mem(),

--- a/pkg/trace/api/ratelimiter.go
+++ b/pkg/trace/api/ratelimiter.go
@@ -116,7 +116,7 @@ func (ps *rateLimiter) Active() bool {
 	return active
 }
 
-// Stats returns a copy of the currrent rate limiter's stats.
+// Stats returns a copy of the current rate limiter's stats.
 func (ps *rateLimiter) Stats() *info.RateLimiterStats {
 	ps.mu.RLock()
 	stats := ps.stats

--- a/pkg/trace/watchdog/info.go
+++ b/pkg/trace/watchdog/info.go
@@ -96,10 +96,13 @@ func (pi *CurrentInfo) CPU(now time.Time) (CPUInfo, error) {
 
 	dua := userTime - pi.lastCPUUser
 	pi.lastCPUUser = userTime
+	log.Infof("Calculating CPU usage now. ut %f lcpu %f, pid %d", userTime, pi.lastCPUUser, pi.pid)
 	if dua <= 0 {
+		log.Infof("Time was negative for cpu calc????")
 		pi.lastCPU.UserAvg = 0 // shouldn't happen, but make sure result is always > 0
 	} else {
 		pi.lastCPU.UserAvg = float64(time.Second) * dua / float64(dt)
+		log.Infof("Delete me: Setting UserAvg cpu %f", pi.lastCPU.UserAvg)
 		pi.lastCPUUser = userTime
 	}
 

--- a/pkg/trace/writer/sender.go
+++ b/pkg/trace/writer/sender.go
@@ -104,7 +104,7 @@ type eventData struct {
 	// connectionFill specifies the percentage of allowed connections used.
 	// At 100% (1.0) the writer will become blocking.
 	connectionFill float64
-	// queueFill specifies how flul the queue is. It's a floating point number ranging
+	// queueFill specifies how full the queue is. It's a floating point number ranging
 	// between 0 (0%) and 1 (100%).
 	queueFill float64
 }

--- a/pkg/trace/writer/sender.go
+++ b/pkg/trace/writer/sender.go
@@ -32,7 +32,7 @@ func newSenders(cfg *config.AgentConfig, r eventRecorder, path string, climit, q
 	if e := cfg.Endpoints; len(e) == 0 || e[0].Host == "" || e[0].APIKey == "" {
 		panic(errors.New("config was not properly validated"))
 	}
-	// spread out the the maximum connection limit (climit) between senders
+	// spread out the maximum connection limit (climit) between senders
 	maxConns := math.Max(1, float64(climit/len(cfg.Endpoints)))
 	senders := make([]*sender, len(cfg.Endpoints))
 	for i, endpoint := range cfg.Endpoints {

--- a/pkg/util/cgroups/stats.go
+++ b/pkg/util/cgroups/stats.go
@@ -61,7 +61,7 @@ type MemoryStats struct {
 	PSIFull PSIStats
 }
 
-// CPUStats - all metrics are in nanoseconds execept if otherwise specified
+// CPUStats - all metrics are in nanoseconds except if otherwise specified
 // cgroupv1: cpu/cpuacct/cpuset
 // cgroupv2: cpu/cpuset
 type CPUStats struct {

--- a/releasenotes/notes/traceAgentK8sLimit-165e630cca46f6a0.yaml
+++ b/releasenotes/notes/traceAgentK8sLimit-165e630cca46f6a0.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    APM: Trace-Agent will now set internal CPU rate limiter based on detected Kubernetes CPU Limit. To continue ONLY using the K8S cpu limit you must set `apm_config.max_cpu_percent` or `DD_APM_MAX_CPU_PERCENT` to 0.

--- a/releasenotes/notes/traceAgentK8sLimit-165e630cca46f6a0.yaml
+++ b/releasenotes/notes/traceAgentK8sLimit-165e630cca46f6a0.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    APM: Trace-Agent will now set internal CPU rate limiter based on detected Kubernetes CPU Limit. To continue ONLY using the K8S cpu limit you must set `apm_config.max_cpu_percent` or `DD_APM_MAX_CPU_PERCENT` to 0.
+    APM: Trace-Agent now sets the internal CPU rate limiter based on the detected Kubernetes CPU limit. To continue using only the K8S CPU limit, you must set `apm_config.max_cpu_percent` or `DD_APM_MAX_CPU_PERCENT` to 0.


### PR DESCRIPTION
**This PR should wait until https://github.com/DataDog/helm-charts/pull/794 is merged to avoid a situation where new installs of the agent get the default 50% cpu limit instead of the new behavior or the old behavior**

### What does this PR do?
This PR sets the trace-agent's internal CPU limit to 80% of the configured K8S CPU limit. Note this is set in this PR here: https://github.com/DataDog/helm-charts/pull/794. Note that the Trace-Agent limit, does NOT function like the Kubernetes limit. The trace-agent limiter is a soft-limit that kicks in only AFTER the total cpu usage of the trace-agent exceeds the configured limit. 

### Motivation
Currently in K8s environments the trace-agent only relies on the container runtime / k8s for cpu throttling. This means that the trace-agent can become overwhelmed with traffic but not report this to the backend leading to customers being unaware their trace-agents need more resources (or less traffic). Using the k8s limit in the trace-agent will allow it to rate limit (read: drop) traffic when it starts to be overwhelmed, and indicate to the backend (via tags) that the trace-agent has insufficient resources.

### Possible Drawbacks / Trade-offs
This is a behavior change from the current "no limit except for k8s container limit". For customers who have very consistent traffic and sit between 80-100% of their utilization this change will cause some of their traffic to be dropped / rate limited as the trace-agent tries to get to 80% usage. However, customers can continue to see the same behavior by just disabling the cpu limiter as it was disabled in k8s by default before by setting `apm_config.max_cpu_percent` to 0.  

### Describe how to test/QA your changes
I installed the datadog agent using my branch of the helm chart to my local minikube cluster. I configured a CPU limit on the container resources and verified that the trace-agent both:
1. Logged that it was using the K8S limit
2. Began to throttle traffic once the limit was reached.
Running this same test on any RC builds should be sufficient here.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
