### PR TITLE
config_template.yaml: Add "how to listen on the port under 1024"

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -3148,6 +3148,8 @@ api_key:
     ## @param port - integer - optional - default: 9162
     ## The UDP port to use when listening for incoming trap packets.
     ## Because the Datadog Agent does not run as root, the port cannot be below 1024.
+    ## However, if you run `sudo setcap 'cap_net_bind_service=+ep' /opt/datadog-agent/bin/agent/agent`,
+    ## the Datadog Agent is able to listen on the port under 1024.
     #
     # port: 9162
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -3149,7 +3149,7 @@ api_key:
     ## The UDP port to use when listening for incoming trap packets.
     ## Because the Datadog Agent does not run as root, the port cannot be below 1024.
     ## However, if you run `sudo setcap 'cap_net_bind_service=+ep' /opt/datadog-agent/bin/agent/agent`,
-    ## the Datadog Agent is able to listen on the port under 1024.
+    ## the Datadog Agent can listen on ports below 1024.
     #
     # port: 9162
 

--- a/releasenotes/notes/add-how-to-listen-on-ports-below-1024-9e65de4420d44d7d.yaml
+++ b/releasenotes/notes/add-how-to-listen-on-ports-below-1024-9e65de4420d44d7d.yaml
@@ -1,4 +1,0 @@
-other:
-  - |
-    Add the comment to explain how to listen on the port under
-    1024 in pkg/config/config_template.yaml.

--- a/releasenotes/notes/add-how-to-listen-on-ports-below-1024-9e65de4420d44d7d.yaml
+++ b/releasenotes/notes/add-how-to-listen-on-ports-below-1024-9e65de4420d44d7d.yaml
@@ -1,3 +1,4 @@
 other:
   - |
-    Add the comment to explain how to listen on the port under 1024.
+    Add the comment to explain how to listen on the port under
+    1024 in pkg/config/config_template.yaml.

--- a/releasenotes/notes/add-how-to-listen-on-ports-below-1024-9e65de4420d44d7d.yaml
+++ b/releasenotes/notes/add-how-to-listen-on-ports-below-1024-9e65de4420d44d7d.yaml
@@ -1,0 +1,3 @@
+other:
+  - |
+    Add the comment to explain how to listen on the port under 1024.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Add the explanation how to listen on the port under 1024.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Sometimes, customers want Datadog Agent to listen on 162 to use SNMP traps.

### Additional Notes

Agent doesn't have the capability.

```shell
vagrant@vagrant:~$ sudo getcap /opt/datadog-agent/bin/agent/agent
/opt/datadog-agent/bin/agent/agent =
```

Set `network_devices.snmp_traps.port: 162` and restart the Agent.

```yaml
network_devices:
  snmp_traps:
    enabled: true
    port: 162
```

Confirmed this error.

```
2022-10-24 22:22:05 UTC | CORE | ERROR | (cmd/agent/app/run.go:396 in StartAgent) | Failed to start snmp-traps server: error happened when listening for SNMP Traps: listen udp 0.0.0.0:162: bind: permission denied
```

No processes listening on 162.

```shell
vagrant@vagrant:~$ netstat -plan | grep '\:162'
```

Set the capability and restart the Agent.

```shell
vagrant@vagrant:~$ sudo setcap 'cap_net_bind_service=+ep' /opt/datadog-agent/bin/agent/agent
vagrant@vagrant:~$ sudo getcap /opt/datadog-agent/bin/agent/agent
/opt/datadog-agent/bin/agent/agent cap_net_bind_service=ep
vagrant@vagrant:~$ sudo systemctl restart datadog-agent
```

Confirmed that the Agent listens on 162.

```shell
vagrant@vagrant:~$ netstat -plan | grep '\:162'
udp6       0      0 :::162                  :::*                                -
```

Send the packet for a test.

```shell
vagrant@vagrant:~$ sudo snmptrap -v 2c -c public localhost '' 1.3.6.1.4.1.8072.2.3.0.1 1.3.6.1.4.1.8072.2.3.2.1 i 123456
```

Confirmed the Agent received the packet.

```shell
vagrant@vagrant:~$ sudo -u dd-agent datadog-agent status | grep Packets
  Event Packets: 0
  Metric Packets: 1,828
  Service Check Packets: 0
  Udp Packets: 1,049
  Uds Packets: 0
  Packets: 0
  Packets Auth Errors: 1
```

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
