### PR TITLE
[kitchen] Update integrations install tests

### DIFF
--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -707,14 +707,14 @@ shared_examples_for 'an Agent with integrations' do
 
   before do
     freeze_content = File.read(integrations_freeze_file)
-    freeze_content.gsub!(/datadog-cilium==.*/, 'datadog-cilium==1.5.3')
+    freeze_content.gsub!(/datadog-cilium==.*/, 'datadog-cilium==2.2.1')
     File.write(integrations_freeze_file, freeze_content)
 
     integration_remove('datadog-cilium')
   end
 
   it 'can uninstall an installed package' do
-    integration_install('datadog-cilium==1.5.3')
+    integration_install('datadog-cilium==2.2.1')
 
     expect do
       integration_remove('datadog-cilium')
@@ -725,32 +725,32 @@ shared_examples_for 'an Agent with integrations' do
     integration_remove('datadog-cilium')
 
     expect do
-      integration_install('datadog-cilium==1.5.3')
-    end.to change { integration_freeze.match?(%r{datadog-cilium==1\.5\.3}) }.from(false).to(true)
+      integration_install('datadog-cilium==2.2.1')
+    end.to change { integration_freeze.match?(%r{datadog-cilium==2\.2\.1}) }.from(false).to(true)
   end
 
   it 'can upgrade an installed package' do
     expect do
-      integration_install('datadog-cilium==1.6.0')
-    end.to change { integration_freeze.match?(%r{datadog-cilium==1\.6\.0}) }.from(false).to(true)
+      integration_install('datadog-cilium==2.3.0')
+    end.to change { integration_freeze.match?(%r{datadog-cilium==2\.3\.0}) }.from(false).to(true)
   end
 
   it 'can downgrade an installed package' do
     integration_remove('datadog-cilium')
-    integration_install('datadog-cilium==1.6.0')
+    integration_install('datadog-cilium==2.3.0')
 
     expect do
-      integration_install('datadog-cilium==1.5.3')
-    end.to change { integration_freeze.match?(%r{datadog-cilium==1\.5\.3}) }.from(false).to(true)
+      integration_install('datadog-cilium==2.2.1')
+    end.to change { integration_freeze.match?(%r{datadog-cilium==2\.2\.1}) }.from(false).to(true)
   end
 
   it 'cannot downgrade an installed package to a version older than the one shipped with the agent' do
     integration_remove('datadog-cilium')
-    integration_install('datadog-cilium==1.5.3')
+    integration_install('datadog-cilium==2.2.1')
 
     expect do
-      integration_install('datadog-cilium==1.5.2')
-    end.to raise_error(/Failed to install integrations package 'datadog-cilium==1\.5\.2'/)
+      integration_install('datadog-cilium==2.2.0')
+    end.to raise_error(/Failed to install integrations package 'datadog-cilium==2\.2\.0'/)
   end
 end
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Updates the versions used in the `datadog-agent integration install` tests.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Following [this change in the integrations downloader](https://github.com/DataDog/integrations-core/pull/13174), the old versions of the `datadog-cilium` integration we were using for these tests cannot be used anymore.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

n/a

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

n/a

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Kitchen tests pass.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
