### PR TITLE
tooling: Add invoke vscode devcontainer cmd

### DIFF
--- a/docs/dev/agent_dev_env.md
+++ b/docs/dev/agent_dev_env.md
@@ -219,10 +219,25 @@ pre-commit run flake8 --all-files  # run flake8 on all files
 
 See `pre-commit run --help` for further options.
 
-# Setting up your Windows development environment
+## Setting up your Windows development environment
 
-## Code editor
+### Code editor
 
 [Microsoft Visual Studio Code](https://code.visualstudio.com/download) is recommended as it's lightweight and versatile.
 
 Building on Windows would require multiple 3rd-party softwares to be installed. To avoid the complexity, it is recommended to make the code change in VS Code then do the build in Docker image. For complete information, see [Build the Agent packages](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/agent_omnibus.md)
+
+## Setting up Visual Studio Code Dev Container
+
+[Microsoft Visual Studio Code](https://code.visualstudio.com/download) with the [devcontainer plugin](https://code.visualstudio.com/docs/remote/containers) allow to use a container as remote development environment in vscode. It simplify and isolate
+the dependencies needed to develop in this repository.
+
+To configure the vscode editor to use a container as remote development environment you need to:
+
+- Install the [devcontainer plugin](https://code.visualstudio.com/docs/remote/containers) and the [golang language plugin](https://code.visualstudio.com/docs/languages/go).
+- Run the following invoke command `invoke vscode.devcontainer --image "<image name>"`.
+  This command will create the devcontainer configuration file `./devcontainer/devcontainer.json`.
+- Start or restart your vscode editor.
+- A pop-up should show-up to propose to "reopen in container" your workspace.
+- The first start, it might propose you to install the golang plugin dependencies/tooling.
+

--- a/docs/dev/agent_dev_env.md
+++ b/docs/dev/agent_dev_env.md
@@ -235,7 +235,7 @@ the dependencies needed to develop in this repository.
 To configure the vscode editor to use a container as remote development environment you need to:
 
 - Install the [devcontainer plugin](https://code.visualstudio.com/docs/remote/containers) and the [golang language plugin](https://code.visualstudio.com/docs/languages/go).
-- Run the following invoke command `invoke vscode.devcontainer --image "<image name>"`.
+- Run the following invoke command `invoke vscode.setup-devcontainer --image "<image name>"`.
   This command will create the devcontainer configuration file `./devcontainer/devcontainer.json`.
 - Start or restart your vscode editor.
 - A pop-up should show-up to propose to "reopen in container" your workspace.

--- a/tasks/vscode.py
+++ b/tasks/vscode.py
@@ -14,6 +14,8 @@ from .flavor import AgentFlavor
 
 VSCODE_DIR = ".vscode"
 VSCODE_FILE = "settings.json"
+VSCODE_DEVCONTAINER_DIR = ".devcontainer"
+VSCODE_DEVCONTAINER_FILE = "devcontainer.json"
 
 
 @task
@@ -56,3 +58,73 @@ def set_buildtags(
 
     with open(fullpath, "w") as sf:
         json.dump(settings, sf, indent=4, sort_keys=False, separators=(',', ': '))
+
+
+@task
+def setup_devcontainer(
+    _,
+    target="agent",
+    build_include=None,
+    build_exclude=None,
+    flavor=AgentFlavor.base.name,
+    arch='x64',
+    image='',
+):
+    """
+    Generate or Modify devcontainer settings file for this project.
+    """
+    flavor = AgentFlavor[flavor]
+    if target not in build_tags[flavor].keys():
+        print("Must choose a valid target.  Valid targets are: \n")
+        print(f'{", ".join(build_tags[flavor].keys())} \n')
+        return
+
+    build_include = (
+        get_default_build_tags(build=target, arch=arch, flavor=flavor)
+        if build_include is None
+        else filter_incompatible_tags(build_include.split(","), arch=arch)
+    )
+    build_exclude = [] if build_exclude is None else build_exclude.split(",")
+    use_tags = get_build_tags(build_include, build_exclude)
+
+    if not os.path.exists(VSCODE_DEVCONTAINER_DIR):
+        os.makedirs(VSCODE_DEVCONTAINER_DIR)
+
+    devcontainer = {}
+    fullpath = os.path.join(VSCODE_DEVCONTAINER_DIR, VSCODE_DEVCONTAINER_FILE)
+    if os.path.exists(fullpath):
+        with open(fullpath, "r") as sf:
+            devcontainer = json.load(sf, object_pairs_hook=OrderedDict)
+
+    local_build_tags = ",".join(use_tags)
+
+    devcontainer["name"] = "Datadog-Agent-DevEnv"
+    if image:
+        devcontainer["image"] = image
+        if devcontainer.get("build"):
+            del devcontainer["build"]
+    else:
+        devcontainer["build"] = {
+            "dockerfile": "Dockerfile",
+            "args": {},
+        }
+        if devcontainer.get("image"):
+            del devcontainer["image"]
+    devcontainer["runArgs"] = ["--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"]
+    devcontainer["remoteUser"] = "datadog"
+    devcontainer["customizations"] = {
+        "vscode": {
+            "settings": {
+                "go.toolsManagement.checkForUpdates": "local",
+                "go.useLanguageServer": True,
+                "go.gopath": "/home/datadog/go",
+                "go.goroot": "/usr/local/go",
+                "go.buildTags": local_build_tags,
+                "go.testTags": local_build_tags,
+            },
+            "extensions": ["golang.Go"],
+        }
+    }
+
+    with open(fullpath, "w") as sf:
+        json.dump(devcontainer, sf, indent=4, sort_keys=False, separators=(',', ': '))


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Add a new "invoke" command to configure "devcontainer" plugin in VS code

the new command is `invoke vscode.setup-devcontainer --image "my-agent-devenv:latest"`
This command will bootstrap the `/devcontainer/devcontainer.json` use by the `devcontainer` plugin to use a container as remote development environment more information in the [devcontainer plugin documentation](https://code.visualstudio.com/docs/remote/containers)

### Motivation

Improve datadog-agent developer experience by simplifying the configuration of its development environment.

### Additional Notes


### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Run the command `invoke vscode.setup-devcontainer --image "my-agent-devenv:latest"`, it should create the file `.devcontainer/devcontainer.json`

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
