### PR TITLE
[corechecks/containerlifecycle] Add telemetry

### DIFF
--- a/pkg/collector/corechecks/containerlifecycle/telemetry.go
+++ b/pkg/collector/corechecks/containerlifecycle/telemetry.go
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package containerlifecycle
+
+import "github.com/DataDog/datadog-agent/pkg/telemetry"
+
+var emittedEvents = telemetry.NewCounterWithOpts(
+	checkName,
+	"emitted_events",
+	[]string{"event_type", "object_kind"},
+	"Number of events emitted by the check",
+	telemetry.Options{NoDoubleUnderscoreSep: true},
+)

--- a/releasenotes/notes/container_lifecycle-telemetry-65e5af2bf12dde7f.yaml
+++ b/releasenotes/notes/container_lifecycle-telemetry-65e5af2bf12dde7f.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Added telemetry for the "container-lifecycle" check.


### PR DESCRIPTION
### What does this PR do?

Adds telemetry for the container_lifecycle check:

```
# HELP container_lifecycle_emitted_events Number of events emitted by the check
# TYPE container_lifecycle_emitted_events counter
container_lifecycle_emitted_events{event_type="delete",object_kind="container"} 1
container_lifecycle_emitted_events{event_type="delete",object_kind="pod"} 1
```

### Describe how to test/QA your changes

- Deploy the agent with the `container_lifecycle` check enabled. Also enable telemetry (`DD_TELEMETRY_ENABLED=true`).
- Delete some containers or pods.
- In the agent container, `curl http://localhost:6000/telemetry`. You should see the `container_lifecycle_emitted_events` metric in the output.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
