### PR TITLE
Adding cloud provider identifiers for ec2

### DIFF
--- a/pkg/metadata/inventories/README.md
+++ b/pkg/metadata/inventories/README.md
@@ -127,6 +127,10 @@ The payload is a JSON dict with the following fields
   - `mac_address` - **string**: the MAC address for the host.
   - `agent_version` - **string**: the version of the Agent that sent this payload.
   - `cloud_provider` - **string**: the name of the cloud provider detected by the Agent.
+  - `cloud_identifiers` - **dict of string to string**: The different identifiers found for the current cloud providers.
+    Those can vary depending on cloud providers, agent setup, instance type, ... Those identifiers can be used by the
+    backend to link an agent to instance. This is useful when we can determine with certainty wether we're running on a
+    cloud provider or not (metadata API not available, agent running in a container, ...).
 
 ("scrubbed" indicates that secrets are removed from the field value just as they are in logs)
 
@@ -253,7 +257,11 @@ Here an example of an inventory payload:
         "ipv6_address": "fe80::1ff:fe23:4567:890a",
         "mac_address": "01:23:45:67:89:AB",
         "agent_version": "7.37.0-devel+git.198.68a5b69",
-        "cloud_provider": "AWS"
+        "cloud_provider": "AWS",
+        "cloud_identifiers": {
+            "ec2-product_uuid": "ec2d024c-6b4c-46a1-ba8b-d058c272dd99",
+            "ec2-instance_id": "i-abcdef"
+        }
     },
     "hostname": "my-host",
     "timestamp": 1631281754507358895

--- a/pkg/metadata/inventories/host_metadata.go
+++ b/pkg/metadata/inventories/host_metadata.go
@@ -52,9 +52,10 @@ type HostMetadata struct {
 	MacAddress  string `json:"mac_address"`
 
 	// from the agent itself
-	AgentVersion  string `json:"agent_version"`
-	CloudProvider string `json:"cloud_provider"`
-	OsVersion     string `json:"os_version"`
+	AgentVersion     string            `json:"agent_version"`
+	CloudProvider    string            `json:"cloud_provider"`
+	CloudIdentifiers map[string]string `json:"cloud_identifiers"`
+	OsVersion        string            `json:"os_version"`
 }
 
 // For now we simply logs warnings from gohai.
@@ -139,6 +140,14 @@ func getHostMetadata() *HostMetadata {
 		}
 	} else {
 		logErrorf("OS version not found in agent metadata cache") //nolint:errcheck
+	}
+
+	if value, ok := hostMetadata[string(HostCloudIdentifiers)]; ok {
+		if mapValue, ok := value.(map[string]string); ok {
+			metadata.CloudIdentifiers = mapValue
+		} else {
+			logErrorf("Cloud identifiers are not a map[string]string in host metadata cache") //nolint:errcheck
+		}
 	}
 	return metadata
 }

--- a/pkg/metadata/inventories/host_metadata_test.go
+++ b/pkg/metadata/inventories/host_metadata_test.go
@@ -41,6 +41,7 @@ var (
 		MacAddress:           "00:0c:29:b6:d2:32",
 		AgentVersion:         version.AgentVersion,
 		CloudProvider:        "some_cloud_provider",
+		CloudIdentifiers:     map[string]string{"cloud-test": "some_identifier"},
 		OsVersion:            "testOS",
 	}
 )
@@ -115,6 +116,7 @@ func setupHostMetadataMock() func() {
 	platformGet = platformMock
 
 	SetAgentMetadata(AgentCloudProvider, "some_cloud_provider")
+	SetHostMetadata(HostCloudIdentifiers, map[string]string{"cloud-test": "some_identifier"})
 	SetHostMetadata(HostOSVersion, "testOS")
 
 	return reset
@@ -145,6 +147,7 @@ func setupHostMetadataErrorMock() func() {
 	memoryGet = memoryErrorMock
 	networkGet = networkErrorMock
 	platformGet = platformErrorMock
+	hostMetadata = make(AgentMetadata)
 	return reset
 }
 

--- a/pkg/metadata/inventories/inventories.go
+++ b/pkg/metadata/inventories/inventories.go
@@ -101,7 +101,8 @@ const (
 	agentFullConf     AgentMetadataName = "full_configuration"
 
 	// key for the host metadata cache. See host_metadata.go
-	HostOSVersion AgentMetadataName = "os_version"
+	HostOSVersion        AgentMetadataName = "os_version"
+	HostCloudIdentifiers AgentMetadataName = "cloud_identifiers"
 )
 
 // Refresh signals that some data has been updated and a new payload should be sent (ex: when configuration is changed

--- a/pkg/metadata/inventories/inventories_test.go
+++ b/pkg/metadata/inventories/inventories_test.go
@@ -296,6 +296,7 @@ func TestGetPayload(t *testing.T) {
 			"mac_address": "00:0c:29:b6:d2:32",
 			"agent_version": "%v",
 			"cloud_provider": "some_cloud_provider",
+			"cloud_identifiers": {"cloud-test":"some_identifier"},
 			"os_version": "testOS"
 		}
 	}`

--- a/pkg/util/cloudproviders/cloudproviders.go
+++ b/pkg/util/cloudproviders/cloudproviders.go
@@ -33,6 +33,11 @@ type cloudProviderDetector struct {
 	callback func(context.Context) bool
 }
 
+type cloudProviderIdentifiersDetector struct {
+	name     string
+	callback func(context.Context) map[string]string
+}
+
 // DetectCloudProvider detects the cloud provider where the agent is running in order:
 func DetectCloudProvider(ctx context.Context) {
 	detectors := []cloudProviderDetector{
@@ -54,6 +59,30 @@ func DetectCloudProvider(ctx context.Context) {
 		}
 	}
 	log.Info("No cloud provider detected")
+
+	// At this point we haven't found any cloud provider. Some cloud provider aren't metadata endpoint aren't
+	// reliable and some customer setup prevent us from detecting cloud providers. This can prevent the backend from
+	// associating the hostname found by the agent to a known host in the backend.
+	//
+	// In those cases, we gather as much data, or hint, as possible on the cloud providers. This will help corrolate
+	// hosts in the backend.
+
+	// not all cloud providers provides hints yet.
+	identifiersDetectors := []cloudProviderIdentifiersDetector{
+		{name: ec2.CloudProviderName, callback: ec2.CollectIdentifiers},
+	}
+
+	cloudIdentifiers := map[string]string{}
+	for _, cloudDetector := range identifiersDetectors {
+		for identifier, value := range cloudDetector.callback(ctx) {
+			cloudIdentifiers[identifier] = value
+			log.Infof("Identifier for cloud provider %s detected: '%s' is '%s'", cloudDetector.name, identifier, value)
+		}
+	}
+
+	if len(cloudIdentifiers) != 0 {
+		inventories.SetHostMetadata(inventories.HostCloudIdentifiers, cloudIdentifiers)
+	}
 }
 
 type cloudProviderNTPDetector struct {

--- a/pkg/util/ec2/ec2_test.go
+++ b/pkg/util/ec2/ec2_test.go
@@ -12,6 +12,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -542,4 +544,29 @@ func TestGetNTPHosts(t *testing.T) {
 	actualHosts := GetNTPHosts(ctx)
 
 	assert.Equal(t, expectedHosts, actualHosts)
+}
+
+func TestCollectIdentifiers(t *testing.T) {
+	tempDir := t.TempDir()
+	defer func(sources []string) { identifiersUUIDSources = sources }(identifiersUUIDSources)
+	defer func(source string) { instanceIDSource = source }(instanceIDSource)
+
+	invalidPath := filepath.Join(tempDir, "invalid")
+	validPath := filepath.Join(tempDir, "valid")
+
+	identifiersUUIDSources = []string{
+		invalidPath,
+		filepath.Join(tempDir, "does-no-exists"),
+		validPath,
+	}
+	instanceIDSource = filepath.Join(tempDir, "board_asset_tag")
+
+	os.WriteFile(invalidPath, []byte("b40b8a96-4874-4d59-ba59-f6b07abf9920\n"), os.ModePerm)
+	os.WriteFile(validPath, []byte("ec2b8a96-4874-4d59-ba59-f6b07abf9920\n"), os.ModePerm)
+	os.WriteFile(instanceIDSource, []byte("i-something\n"), os.ModePerm)
+
+	assert.Equal(t, map[string]string{
+		"ec2-product-uuid": "ec2b8a96-4874-4d59-ba59-f6b07abf9920",
+		"ec2-instance-id":  "i-something",
+	}, CollectIdentifiers(context.TODO()))
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

In some setup the agent can't reliably detect if it's running on a cloud provider. Identifiers are hints for the backend to try to link Agent host to cloud providers resources.

For now only EC2 is supported, in a very minimal way.

### Describe how to test/QA your changes

Run the agent on EC2 instances and check the inventory paylaods.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
