### PR TITLE
Adding fips doc to the config template

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -497,6 +497,56 @@ api_key:
   #
   # validation_period: 60
 
+
+## @param fips - custom object - optional
+## [BETA] Enter specific configurations for using the FIPS proxy.
+## Uncomment this parameter and the one below to enable them.
+#
+# fips:
+
+  ## @param enabled - boolean - optional - default: false
+  ## @env DD_FIPS_ENABLED - boolean - optional - default: false
+  ## This feature is in BETA.
+  ##
+  ## Enable the use of the FIPS proxy to send data to the DataDog backend. Enabling this will force all outgoing traffic
+  ## from the Agent to the local proxy.
+  ## It's important to note that enabling this will not make the Datadog Agent FIPS compliant, but will force all outgoing
+  ## traffic to a local FIPS compliant proxy. The FIPS proxy need to be installed locally in addition to the agent.
+  ##
+  ## When setting this to true the following settings would be overridden, ignoring the values from the
+  ## configuration:
+  ## - dd_url
+  ## - apm_config.apm_dd_url
+  ## - apm_config.profiling_dd_url
+  ## - apm_config.telemetry.dd_url
+  ## - process_config.process_dd_url
+  ## - logs_config.use_http
+  ## - logs_config.logs_no_ssl
+  ## - logs_config.logs_dd_url
+  ## - database_monitoring.metrics.dd_url
+  ## - database_monitoring.activity.dd_url
+  ## - database_monitoring.samples.dd_url
+  ## - network_devices.metadata.dd_url
+  #
+  ## The agent will also ignore 'proxy.*' settings and environment variables related to proxy (HTTP_PROXY, HTTPS_PROXY,
+  ## DD_PROXY_HTTP and DD_PROXY_HTTPS).
+  #
+  # enabled: false
+
+  ## @param local_address - string - optional - default: localhost
+  ## @env DD_FIPS_LOCAL_ADDRESS - string - optional - default: localhost
+  ## The local address that the FIPS proxy will bind ports on.
+  #
+  # local_address: localhost
+
+  ## @param port_range_start - integer - optional - default: 3833
+  ## @env DD_FIPS_LOCAL_PORT_RANGE_START - integer - optional - default: 3833
+  ## The FIPS proxy will bind a range of consecutive ports, each dedicated to a specific product (Metrics, Logs, APM.
+  ## Database monitoring, ...). 'port_range_start' is the first port in this range. The Agent will automatically assign
+  ## the right port to the right product based on this information.
+  #
+  # port_range_start: 3833
+
 {{ end }}
 {{- if .Agent }}
 {{- if .Python }}


### PR DESCRIPTION
### What does this PR do?

This is a follow-up on https://github.com/DataDog/datadog-agent/pull/13972 to add the documentation to the config template about the FIPS proxy,
