### PR TITLE
De-duplicate post-symlink header directories

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -961,6 +961,7 @@ core,golang.org/x/crypto/pbkdf2,BSD-3-Clause,Copyright (c) 2009 The Go Authors. 
 core,golang.org/x/crypto/salsa20/salsa,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
 core,golang.org/x/crypto/scrypt,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
 core,golang.org/x/exp/constraints,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/exp/maps,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
 core,golang.org/x/exp/slices,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
 core,golang.org/x/net/bpf,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
 core,golang.org/x/net/context,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved

--- a/pkg/util/kernel/find_headers.go
+++ b/pkg/util/kernel/find_headers.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/mholt/archiver/v3"
+	"golang.org/x/exp/maps"
 
 	model "github.com/DataDog/agent-payload/v5/process"
 	"github.com/DataDog/datadog-go/v5/statsd"
@@ -226,9 +227,18 @@ func (h *headerProvider) downloadHeaders(hv Version) ([]string, headerFetchResul
 // validateHeaderDirs checks all the given directories and returns the directories containing kernel
 // headers matching the kernel version of the running host
 func validateHeaderDirs(hv Version, dirs []string, checkForCriticalHeaders bool) []string {
-	var valid []string
-	for _, d := range dirs {
-		if _, err := os.Stat(d); errors.Is(err, fs.ErrNotExist) {
+	valid := make(map[string]struct{})
+	for _, rd := range dirs {
+		if _, err := os.Stat(rd); errors.Is(err, fs.ErrNotExist) {
+			continue
+		}
+
+		d, err := filepath.EvalSymlinks(rd)
+		if err != nil {
+			log.Debugf("unable to eval symlink for %s: %s", rd, err)
+			continue
+		}
+		if _, ok := valid[d]; ok {
 			continue
 		}
 
@@ -238,7 +248,7 @@ func validateHeaderDirs(hv Version, dirs []string, checkForCriticalHeaders bool)
 				// version.h is not found in this directory; we'll consider it valid, in case
 				// it contains necessary files
 				log.Debugf("found non-versioned kernel headers at %s", d)
-				valid = append(valid, d)
+				valid[d] = struct{}{}
 				continue
 			}
 			log.Debugf("error validating %s: error validating headers version: %v", d, err)
@@ -250,15 +260,15 @@ func validateHeaderDirs(hv Version, dirs []string, checkForCriticalHeaders bool)
 			continue
 		}
 		log.Debugf("found valid kernel headers at %s", d)
-		valid = append(valid, d)
+		valid[d] = struct{}{}
 	}
 
-	if checkForCriticalHeaders && len(valid) != 0 && !containsCriticalHeaders(valid) {
-		log.Debugf("error validating %s: missing critical headers", valid)
+	dirlist := maps.Keys(valid)
+	if checkForCriticalHeaders && len(dirlist) != 0 && !containsCriticalHeaders(dirlist) {
+		log.Debugf("error validating %s: missing critical headers", dirlist)
 		return nil
 	}
-
-	return valid
+	return dirlist
 }
 
 func containsCriticalHeaders(dirs []string) bool {

--- a/pkg/util/kernel/find_headers.go
+++ b/pkg/util/kernel/find_headers.go
@@ -43,7 +43,6 @@ const kernelModulesPath = "/lib/modules/%s/build"
 const debKernelModulesPath = "/lib/modules/%s/source"
 const cosKernelModulesPath = "/usr/src/linux-headers-%s"
 const centosKernelModulesPath = "/usr/src/kernels/%s"
-const fedoraKernelModulesPath = "/usr"
 
 var versionCodeRegexp = regexp.MustCompile(`^#define[\t ]+LINUX_VERSION_CODE[\t ]+(\d+)$`)
 
@@ -360,7 +359,6 @@ func getDefaultHeaderDirs() []string {
 		fmt.Sprintf(debKernelModulesPath, hi.KernelVersion),
 		fmt.Sprintf(cosKernelModulesPath, hi.KernelVersion),
 		fmt.Sprintf(centosKernelModulesPath, hi.KernelVersion),
-		fedoraKernelModulesPath,
 	}
 	return dirs
 }

--- a/pkg/util/kernel/find_headers.go
+++ b/pkg/util/kernel/find_headers.go
@@ -238,6 +238,7 @@ func validateHeaderDirs(hv Version, dirs []string, checkForCriticalHeaders bool)
 			log.Debugf("unable to eval symlink for %s: %s", rd, err)
 			continue
 		}
+		log.Debugf("resolved header dir %s to %s", rd, d)
 		if _, ok := valid[d]; ok {
 			continue
 		}

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -757,10 +757,6 @@ def get_linux_header_dirs(kernel_release=None, minimal_kernel_release=None):
         else:
             linux_headers = [os.path.join(src_dir, d) for d in os.listdir(src_dir) if d.startswith("linux-")]
 
-    # fallback to /usr as a last report
-    if len(linux_headers) == 0:
-        linux_headers = ["/usr"]
-
     # deduplicate
     linux_headers = list(dict.fromkeys(linux_headers))
     arch = get_kernel_arch()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Evaluates symlinks for header directories, and de-duplicates them afterwards.

### Motivation

Our defaults include multiple directories that may end up pointing to the same place.

### Additional Notes

This removes the `/usr` directory from consideration for kernel headers. It will never have the kernel types necessary to compile eBPF code. I have verified that fedora `kernel-devel` packages always use `/usr/src/kernels` for the kernel headers they install.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
