### PR TITLE
[kitchen] Detect infrastructure failures

### DIFF
--- a/tasks/libs/pipeline_data.py
+++ b/tasks/libs/pipeline_data.py
@@ -87,6 +87,13 @@ infra_failure_logs = [
         ),
         FailedJobReason.KITCHEN_AZURE,
     ),
+    # kitchen tests general infrastructure issues
+    (
+        re.compile(
+            r'ERROR: The kitchen tests failed due to infrastructure failures\.'
+        ),
+        FailedJobReason.KITCHEN,
+    )
 ]
 
 

--- a/tasks/libs/pipeline_data.py
+++ b/tasks/libs/pipeline_data.py
@@ -89,11 +89,9 @@ infra_failure_logs = [
     ),
     # kitchen tests general infrastructure issues
     (
-        re.compile(
-            r'ERROR: The kitchen tests failed due to infrastructure failures\.'
-        ),
+        re.compile(r'ERROR: The kitchen tests failed due to infrastructure failures\.'),
         FailedJobReason.KITCHEN,
-    )
+    ),
 ]
 
 

--- a/tasks/libs/types.py
+++ b/tasks/libs/types.py
@@ -48,7 +48,8 @@ class FailedJobReason(Enum):
     DOCKER_RUNNER = 2
     K8S_RUNNER = 3
     KITCHEN_AZURE = 4
-    FAILED_JOB_SCRIPT = 5
+    KITCHEN = 5
+    FAILED_JOB_SCRIPT = 6
 
 
 class SlackMessage:

--- a/test/kitchen/tasks/run-test-kitchen.sh
+++ b/test/kitchen/tasks/run-test-kitchen.sh
@@ -165,7 +165,7 @@ for attempt in $(seq 0 "${KITCHEN_INFRASTRUCTURE_FLAKES_RETRY:-2}"); do
 
   # If the destory operation fails, it is not safe to continue running kitchen
   # so we just exit with an infrastructure failure message.
-  if [ "$destroy_result" -eq 0 ]; then
+  if [ "$destroy_result" -ne 0 ]; then
     echo "Failure while destroying kitchen infrastructure, skipping retries"
     break
   fi

--- a/test/kitchen/tasks/run-test-kitchen.sh
+++ b/test/kitchen/tasks/run-test-kitchen.sh
@@ -179,4 +179,5 @@ done
 
 # if we ran out of attempts because of infrastructure/networking issues, exit with 1
 echo "Ran out of retry attempts"
+echo "ERROR: The kitchen tests failed due to infrastructure failures."
 exit 1

--- a/test/kitchen/tasks/run-test-kitchen.sh
+++ b/test/kitchen/tasks/run-test-kitchen.sh
@@ -157,7 +157,8 @@ for attempt in $(seq 0 "${KITCHEN_INFRASTRUCTURE_FLAKES_RETRY:-2}"); do
   failing_test_suites=$(bundle exec kitchen list --no-log-overwrite --json | jq -cr "[ .[] | select( .last_error != null ) ] | map( .instance ) | .[]")
 
   # Then, destroy the kitchen machines
-  bundle exec kitchen destroy "$test_suites" --no-log-overwrite
+  # Do not fail on kitchen destroy, it breaks the infra failures filter
+  bundle exec kitchen destroy "$test_suites" --no-log-overwrite || true
 
   if [ "$result" -eq 0 ]; then
       # if kitchen test succeeded, exit with 0


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Adds a specific log line when kitchen tests fail due to infrastructure issues, to filter them out of job notifications.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Reduce noise for teams that own kitchen tests: they shouldn't get pinged for failures they can't act on.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

n/a

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

n/a

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

n/a

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
