### PR TITLE
Fix sockets lingering

### DIFF
--- a/pkg/network/http/monitor.go
+++ b/pkg/network/http/monitor.go
@@ -68,6 +68,7 @@ func NewMonitor(c *config.Config, offsets []manager.ConstantEditor, sockFD *ebpf
 
 	batchMap, _, err := mgr.GetMap(httpBatchesMap)
 	if err != nil {
+		closeFilterFn()
 		return nil, err
 	}
 
@@ -76,6 +77,7 @@ func NewMonitor(c *config.Config, offsets []manager.ConstantEditor, sockFD *ebpf
 
 	telemetry, err := newTelemetry()
 	if err != nil {
+		closeFilterFn()
 		return nil, err
 	}
 	statkeeper := newHTTPStatkeeper(c, telemetry)
@@ -88,6 +90,7 @@ func NewMonitor(c *config.Config, offsets []manager.ConstantEditor, sockFD *ebpf
 
 	batchManager, err := newBatchManager(batchMap, numCPUs)
 	if err != nil {
+		closeFilterFn()
 		return nil, fmt.Errorf("couldn't instantiate batch manager: %w", err)
 	}
 

--- a/pkg/network/netlink/conntracker.go
+++ b/pkg/network/netlink/conntracker.go
@@ -243,6 +243,7 @@ func (ctr *realConntracker) IsSampling() bool {
 func (ctr *realConntracker) Close() {
 	ctr.consumer.Stop()
 	ctr.compactTicker.Stop()
+	ctr.cache.Purge()
 }
 
 func (ctr *realConntracker) loadInitialState(events <-chan Event) {
@@ -365,6 +366,11 @@ func (cc *conntrackCache) Get(k connKey) (*translationEntry, bool) {
 
 func (cc *conntrackCache) Remove(k connKey) bool {
 	return cc.cache.Remove(k)
+}
+
+func (cc *conntrackCache) Purge() {
+	cc.cache.Purge()
+	cc.orphans.Init()
 }
 
 func (cc *conntrackCache) Add(c Con, orphan bool) (evicts int) {

--- a/pkg/network/netlink/consumer.go
+++ b/pkg/network/netlink/consumer.go
@@ -306,6 +306,7 @@ func (c *Consumer) dumpTable(family uint8, output chan Event, ns netns.NsHandle)
 
 		defer func() {
 			_ = conn.Close()
+			c.socket = nil
 		}()
 
 		req := netlink.Message{
@@ -407,6 +408,7 @@ func (c *Consumer) dumpAndDiscardTable(family uint8, ns netns.NsHandle) error {
 
 		defer func() {
 			_ = conn.Close()
+			c.socket = nil
 		}()
 
 		req := netlink.Message{
@@ -447,6 +449,7 @@ func (c *Consumer) GetStats() map[string]int64 {
 func (c *Consumer) Stop() {
 	if c.conn != nil {
 		c.conn.Close()
+		c.socket = nil
 	}
 	c.breaker.Stop()
 	c.rootNetNs.Close()
@@ -615,6 +618,7 @@ func (c *Consumer) throttle(numMessages int) error {
 	// Close current socket
 	c.conn.Close()
 	c.conn = nil
+	c.socket = nil
 
 	if pre315Kernel {
 		// we cannot recreate the socket and set a bpf filter on

--- a/pkg/network/route_cache.go
+++ b/pkg/network/route_cache.go
@@ -97,6 +97,10 @@ func newRouteCache(size int, router Router, ttl time.Duration) *routeCache {
 }
 
 func (c *routeCache) Close() {
+	c.Lock()
+	defer c.Unlock()
+
+	c.cache.Clear()
 	c.router.Close()
 }
 
@@ -225,6 +229,7 @@ func NewNetlinkRouter(cfg *config.Config) (Router, error) {
 }
 
 func (n *netlinkRouter) Close() {
+	n.ifcache.Clear()
 	unix.Close(n.ioctlFD)
 	n.nlHandle.Close()
 }

--- a/pkg/network/tracer/gateway_lookup.go
+++ b/pkg/network/tracer/gateway_lookup.go
@@ -192,6 +192,12 @@ func (g *gatewayLookup) GetStats() map[string]interface{} {
 	return report
 }
 
+func (g *gatewayLookup) Close() {
+	g.rootNetNs.Close()
+	g.routeCache.Close()
+	g.purge()
+}
+
 func (g *gatewayLookup) purge() {
 	g.subnetCache.Purge()
 	g.subnetCacheSize.Store(0)

--- a/pkg/network/tracer/offsetguess.go
+++ b/pkg/network/tracer/offsetguess.go
@@ -767,39 +767,46 @@ type eventGenerator struct {
 }
 
 func newEventGenerator(ipv6 bool) (*eventGenerator, error) {
+	eg := &eventGenerator{}
+
 	// port 0 means we let the kernel choose a free port
+	var err error
 	addr := fmt.Sprintf("%s:0", listenIPv4)
-	l, err := net.Listen("tcp4", addr)
+	eg.listener, err = net.Listen("tcp4", addr)
 	if err != nil {
 		return nil, err
 	}
 
-	go acceptHandler(l)
+	go acceptHandler(eg.listener)
 
 	// Spin up UDP server
-	udpAddr, udpDone, err := newUDPServer(addr)
+	var udpAddr string
+	udpAddr, eg.udpDone, err = newUDPServer(addr)
 	if err != nil {
+		eg.Close()
 		return nil, err
 	}
 
 	// Establish connection that will be used in the offset guessing
-	c, err := net.Dial(l.Addr().Network(), l.Addr().String())
+	eg.conn, err = net.Dial(eg.listener.Addr().Network(), eg.listener.Addr().String())
 	if err != nil {
-		_ = l.Close()
+		eg.Close()
 		return nil, err
 	}
 
-	udpConn, err := net.Dial("udp", udpAddr)
+	eg.udpConn, err = net.Dial("udp", udpAddr)
 	if err != nil {
+		eg.Close()
 		return nil, err
 	}
 
-	udp6Conn, err := getUDP6Conn(ipv6)
+	eg.udp6Conn, err = getUDP6Conn(ipv6)
 	if err != nil {
+		eg.Close()
 		return nil, err
 	}
 
-	return &eventGenerator{listener: l, conn: c, udpConn: udpConn, udp6Conn: udp6Conn, udpDone: udpDone}, nil
+	return eg, nil
 }
 
 func getUDP6Conn(ipv6 bool) (*net.UDPConn, error) {
@@ -903,7 +910,9 @@ func (e *eventGenerator) Close() {
 		e.conn.Close()
 	}
 
-	_ = e.listener.Close()
+	if e.listener != nil {
+		_ = e.listener.Close()
+	}
 
 	if e.udpConn != nil {
 		_ = e.udpConn.Close()
@@ -926,6 +935,9 @@ func acceptHandler(l net.Listener) {
 		}
 
 		_, _ = io.Copy(ioutil.Discard, conn)
+		if tcpc, ok := conn.(*net.TCPConn); ok {
+			tcpc.SetLinger(0)
+		}
 		conn.Close()
 	}
 }
@@ -938,22 +950,24 @@ func acceptHandler(l net.Listener) {
 func tcpGetInfo(conn net.Conn) (*unix.TCPInfo, error) {
 	tcpConn, ok := conn.(*net.TCPConn)
 	if !ok {
-		return nil, errors.New("not a TCPConn")
+		return nil, fmt.Errorf("not a TCPConn")
 	}
 
-	file, err := tcpConn.File()
+	sysc, err := tcpConn.SyscallConn()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error getting syscall connection: %w", err)
 	}
-	defer func() {
-		_ = file.Close()
-	}()
 
-	tcpInfo, err := unix.GetsockoptTCPInfo(int(file.Fd()), syscall.SOL_TCP, syscall.TCP_INFO)
+	var tcpInfo *unix.TCPInfo
+	ctrlErr := sysc.Control(func(fd uintptr) {
+		tcpInfo, err = unix.GetsockoptTCPInfo(int(fd), syscall.SOL_TCP, syscall.TCP_INFO)
+	})
 	if err != nil {
-		return nil, errors.Wrap(err, "error calling syscall.SYS_GETSOCKOPT")
+		return nil, fmt.Errorf("error calling syscall.SYS_GETSOCKOPT: %w", err)
 	}
-
+	if ctrlErr != nil {
+		return nil, fmt.Errorf("error controlling TCP connection: %w", ctrlErr)
+	}
 	return tcpInfo, nil
 }
 

--- a/pkg/network/tracer/offsetguess.go
+++ b/pkg/network/tracer/offsetguess.go
@@ -936,7 +936,7 @@ func acceptHandler(l net.Listener) {
 
 		_, _ = io.Copy(ioutil.Discard, conn)
 		if tcpc, ok := conn.(*net.TCPConn); ok {
-			tcpc.SetLinger(0)
+			_ = tcpc.SetLinger(0)
 		}
 		conn.Close()
 	}

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -334,6 +334,9 @@ func (t *Tracer) storeClosedConnections(connections []network.ConnectionStats) {
 
 // Stop stops the tracer
 func (t *Tracer) Stop() {
+	if t.gwLookup != nil {
+		t.gwLookup.Close()
+	}
 	t.reverseDNS.Close()
 	t.ebpfTracer.Stop()
 	t.httpMonitor.Stop()

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -13,10 +13,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	netlink "github.com/DataDog/datadog-agent/pkg/network/netlink/testutil"
-	"github.com/DataDog/datadog-agent/pkg/network/tracer/connection/kprobe"
-	"github.com/DataDog/datadog-agent/pkg/network/tracer/testutil/grpc"
-	"golang.org/x/sys/unix"
 	"io"
 	"io/ioutil"
 	"math"
@@ -32,28 +28,26 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	vnetns "github.com/vishvananda/netns"
+	"golang.org/x/sys/unix"
+
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/config/sysctl"
 	"github.com/DataDog/datadog-agent/pkg/network/http"
+	netlink "github.com/DataDog/datadog-agent/pkg/network/netlink/testutil"
 	"github.com/DataDog/datadog-agent/pkg/network/testutil"
+	"github.com/DataDog/datadog-agent/pkg/network/tracer/connection/kprobe"
 	tracertest "github.com/DataDog/datadog-agent/pkg/network/tracer/testutil"
+	"github.com/DataDog/datadog-agent/pkg/network/tracer/testutil/grpc"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
-	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	vnetns "github.com/vishvananda/netns"
 )
-
-func init() {
-	unix.Setrlimit(unix.RLIMIT_NOFILE, &unix.Rlimit{
-		Cur: 4096,
-		Max: 4096,
-	})
-}
 
 func httpSupported(t *testing.T) bool {
 	currKernelVersion, err := kernel.HostVersion()

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -1956,6 +1956,7 @@ func testProtocolClassificationMapCleanup(t *testing.T, cfg *config.Config, clie
 		initTracerState(t, tr)
 		require.NoError(t, err)
 		done := make(chan struct{})
+		defer close(done)
 		server := NewTCPServerOnAddress(serverHost, func(c net.Conn) {
 			r := bufio.NewReader(c)
 			input, err := r.ReadBytes(byte('\n'))
@@ -2017,7 +2018,7 @@ func waitForConnectionsWithProtocol(t *testing.T, tr *Tracer, targetAddr, server
 			}
 		}
 		for _, conn := range incomingConns {
-			t.Logf("Found incmoing connection %v", conn)
+			t.Logf("Found incoming connection %v", conn)
 			if conn.Protocol == expectedProtocol {
 				foundIncomingWithProtocol = true
 				break

--- a/pkg/process/util/netns.go
+++ b/pkg/process/util/netns.go
@@ -44,6 +44,7 @@ func WithNS(procRoot string, ns netns.NsHandle, fn func() error) error {
 	if err != nil {
 		return err
 	}
+	defer prevNS.Close()
 
 	if ns.Equal(prevNS) {
 		return fn()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fixes a couple sources of "leaked" sockets during test runs:
- Fixes offset guessing to immediately close the TCP socket when done.
- Fixes `WithNS()` helper to close the `prevNS` handle (this was the big one)
- Ensures the `protocol_cleanup` test of `TestProtocolClassification` closes the `done` channel, to close the running servers.
- Does some additional work to cleanup sockets in the face of errors.

### Motivation

@guyarb noticed a socket "leak" during test runs. Since most tests each run offset guessing, there was an accumulation of sockets in the lingering stage.

### Additional Notes

This also fixes the cleanup of offset guessing, should an error occur during initialization.
It also improves the `TestConnectionClobber` test to not lose track of sockets.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
