### PR TITLE
Enable golangci-lint on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
+# Set go source line endings to LF on all platforms so gofmt can be used
+*.go text=auto eol=lf
 go.sum -diff -merge linguist-generated=true
 *.pb.go -diff -merge
 *.pb.go linguist-generated=true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -73,7 +73,8 @@ linters-settings:
       - sync/atomic: "Use go.uber.org/atomic instead; see docs/dev/atomics.md"
   errcheck:
     # Disable warnings for `fmt` and `log` packages. Also ignore `Write` functions from `net/http` package.
-    ignore: fmt:.*,github.com/DataDog/datadog-agent/pkg/util/log:.*,github.com/DataDog/datadog-agent/comp/core/log:.*,net/http:Write,github.com/DataDog/datadog-agent/pkg/trace/metrics:.*
+    # Disable warnings for select Windows functions
+    ignore: fmt:.*,github.com/DataDog/datadog-agent/pkg/util/log:.*,github.com/DataDog/datadog-agent/comp/core/log:.*,net/http:Write,github.com/DataDog/datadog-agent/pkg/trace/metrics:.*,github.com/DataDog/datadog-agent/pkg/collector/corechecks:Warnf?,golang.org/x/sys/windows:(CloseHandle|FreeSid|RegCloseKey|SetEvent),syscall:CloseHandle
   staticcheck:
     go: "1.17"
     checks: ["all",

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -74,7 +74,7 @@ linters-settings:
   errcheck:
     # Disable warnings for `fmt` and `log` packages. Also ignore `Write` functions from `net/http` package.
     # Disable warnings for select Windows functions
-    ignore: fmt:.*,github.com/DataDog/datadog-agent/pkg/util/log:.*,github.com/DataDog/datadog-agent/comp/core/log:.*,net/http:Write,github.com/DataDog/datadog-agent/pkg/trace/metrics:.*,github.com/DataDog/datadog-agent/pkg/collector/corechecks:Warnf?,golang.org/x/sys/windows:(CloseHandle|FreeSid|RegCloseKey|SetEvent),syscall:CloseHandle
+    ignore: fmt:.*,github.com/DataDog/datadog-agent/pkg/util/log:.*,github.com/DataDog/datadog-agent/comp/core/log:.*,net/http:Write,github.com/DataDog/datadog-agent/pkg/trace/metrics:.*,github.com/DataDog/datadog-agent/pkg/collector/corechecks:Warnf?,golang.org/x/sys/windows:(CloseHandle|FreeLibrary|FreeSid|RegCloseKey|SetEvent),syscall:CloseHandle,golang.org/x/sys/windows/svc/mgr:Disconnect,golang.org/x/sys/windows/svc/debug:(Close|Error|Info|Warning),github.com/lxn/walk:Dispose
   staticcheck:
     go: "1.17"
     checks: ["all",

--- a/cmd/agent/common/common_windows.go
+++ b/cmd/agent/common/common_windows.go
@@ -22,12 +22,7 @@ var (
 	PyChecksPath = filepath.Join(_here, "..", "checks.d")
 	distPath     string
 	// ViewsPath holds the path to the folder containing the GUI support files
-	viewsPath   string
-	enabledVals = map[string]bool{"yes": true, "true": true, "1": true,
-		"no": false, "false": false, "0": false}
-	subServices = map[string]string{"logs_enabled": "logs_enabled",
-		"apm_enabled":     "apm_config.enabled",
-		"process_enabled": "process_config.enabled"}
+	viewsPath string
 )
 
 var (

--- a/cmd/agent/subcommands/integrations/command.go
+++ b/cmd/agent/subcommands/integrations/command.go
@@ -43,7 +43,6 @@ const (
 	downloaderModule    = "datadog_checks.downloader"
 	disclaimer          = "For your security, only use this to install wheels containing an Agent integration " +
 		"and coming from a known source. The Agent cannot perform any verification on local wheels."
-	pythonMinorVersionScript = "import sys;print(sys.version_info[1])"
 	integrationVersionScript = `
 import pkg_resources
 try:
@@ -61,7 +60,6 @@ var (
 	pep440VersionStringRe = regexp.MustCompile("^(?P<release>\\d+\\.\\d+\\.\\d+)(?:(?P<preReleaseType>[a-zA-Z]+)(?P<preReleaseNumber>\\d+)?)?$") // e.g. 1.3.4b1, simplified form of: https://www.python.org/dev/peps/pep-0440
 
 	rootDir             string
-	pythonMinorVersion  string
 	reqAgentReleasePath string
 	constraintsPath     string
 )
@@ -197,25 +195,6 @@ func loadPythonInfo(config config.Component, cliParams *cliParams) error {
 	constraintsPath = filepath.Join(rootDir, fmt.Sprintf("final_constraints-py%s.txt", cliParams.pythonMajorVersion))
 	if _, err := os.Lstat(constraintsPath); err != nil {
 		return err
-	}
-
-	return nil
-}
-
-func detectPythonMinorVersion(cliParams *cliParams) error {
-	if pythonMinorVersion == "" {
-		pythonPath, err := getCommandPython(cliParams)
-		if err != nil {
-			return err
-		}
-
-		versionCmd := exec.Command(pythonPath, "-c", pythonMinorVersionScript)
-		minorVersion, err := versionCmd.Output()
-		if err != nil {
-			return err
-		}
-
-		pythonMinorVersion = strings.TrimSpace(string(minorVersion))
 	}
 
 	return nil

--- a/cmd/agent/subcommands/integrations/integrations_darwin.go
+++ b/cmd/agent/subcommands/integrations/integrations_darwin.go
@@ -11,26 +11,7 @@ package integrations
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 )
-
-const (
-	pythonBin = "python"
-)
-
-func getRelPyPath(cliParams *cliParams) string {
-	return filepath.Join("embedded", "bin", fmt.Sprintf("%s%s", pythonBin, cliParams.pythonMajorVersion))
-}
-
-func getRelChecksPath(cliParams *cliParams) (string, error) {
-	err := detectPythonMinorVersion(cliParams)
-	if err != nil {
-		return "", err
-	}
-
-	pythonDir := fmt.Sprintf("%s%s.%s", pythonBin, cliParams.pythonMajorVersion, pythonMinorVersion)
-	return filepath.Join("embedded", "lib", pythonDir, "site-packages", "datadog_checks"), nil
-}
 
 func validateUser(allowRoot bool) error {
 	if os.Geteuid() != 0 {

--- a/cmd/agent/subcommands/integrations/integrations_nix.go
+++ b/cmd/agent/subcommands/integrations/integrations_nix.go
@@ -11,26 +11,7 @@ package integrations
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 )
-
-const (
-	pythonBin = "python"
-)
-
-func getRelPyPath(cliParams *cliParams) string {
-	return filepath.Join("embedded", "bin", fmt.Sprintf("%s%s", pythonBin, cliParams.pythonMajorVersion))
-}
-
-func getRelChecksPath(cliParams *cliParams) (string, error) {
-	err := detectPythonMinorVersion(cliParams)
-	if err != nil {
-		return "", err
-	}
-
-	pythonDir := fmt.Sprintf("%s%s.%s", pythonBin, cliParams.pythonMajorVersion, pythonMinorVersion)
-	return filepath.Join("embedded", "lib", pythonDir, "site-packages", "datadog_checks"), nil
-}
 
 func validateUser(allowRoot bool) error {
 	if os.Geteuid() == 0 && !allowRoot {

--- a/cmd/agent/subcommands/integrations/integrations_nix_helpers.go
+++ b/cmd/agent/subcommands/integrations/integrations_nix_helpers.go
@@ -1,0 +1,58 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows && python
+// +build !windows,python
+
+package integrations
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	pythonBin                = "python"
+	pythonMinorVersionScript = "import sys;print(sys.version_info[1])"
+)
+
+var (
+	pythonMinorVersion string
+)
+
+func getRelPyPath(cliParams *cliParams) string {
+	return filepath.Join("embedded", "bin", fmt.Sprintf("%s%s", pythonBin, cliParams.pythonMajorVersion))
+}
+
+func getRelChecksPath(cliParams *cliParams) (string, error) {
+	err := detectPythonMinorVersion(cliParams)
+	if err != nil {
+		return "", err
+	}
+
+	pythonDir := fmt.Sprintf("%s%s.%s", pythonBin, cliParams.pythonMajorVersion, pythonMinorVersion)
+	return filepath.Join("embedded", "lib", pythonDir, "site-packages", "datadog_checks"), nil
+}
+
+func detectPythonMinorVersion(cliParams *cliParams) error {
+	if pythonMinorVersion == "" {
+		pythonPath, err := getCommandPython(cliParams)
+		if err != nil {
+			return err
+		}
+
+		versionCmd := exec.Command(pythonPath, "-c", pythonMinorVersionScript)
+		minorVersion, err := versionCmd.Output()
+		if err != nil {
+			return err
+		}
+
+		pythonMinorVersion = strings.TrimSpace(string(minorVersion))
+	}
+
+	return nil
+}

--- a/cmd/agent/windows/controlsvc/controlsvc.go
+++ b/cmd/agent/windows/controlsvc/controlsvc.go
@@ -34,6 +34,7 @@ var (
 
 type enumServiceState uint32
 
+//nolint:deadcode,unused
 const (
 	enumServiceActive = enumServiceState(0x1) // START_PENDING, STOP_PENDING, RUNNING
 	// continue_pending, pause_pending, paused
@@ -121,7 +122,11 @@ func stopService(serviceName string, withDeps bool) error {
 			for _, dep := range deps {
 				log.Debugf("Stopping service %s", dep.serviceName)
 				// recurse to this service, but only once
-				stopService(dep.serviceName, false)
+				err = stopService(dep.serviceName, false)
+				if err != nil {
+					log.Warnf("Failed to stop service %v: %v", dep.serviceName, err)
+					return fmt.Errorf("could not stop service %v: %v", dep.serviceName, err)
+				}
 			}
 		}
 	}

--- a/cmd/dogstatsd/main_windows.go
+++ b/cmd/dogstatsd/main_windows.go
@@ -31,12 +31,6 @@ var (
 
 	// DefaultConfPath points to the folder containing datadog.yaml
 	DefaultConfPath = "c:\\programdata\\datadog"
-
-	enabledVals = map[string]bool{"yes": true, "true": true, "1": true,
-		"no": false, "false": false, "0": false}
-	subServices = map[string]string{"logs_enabled": "logs_enabled",
-		"apm_enabled":     "apm_config.enabled",
-		"process_enabled": "process_config.enabled"}
 )
 
 func init() {

--- a/cmd/process-agent/main_windows.go
+++ b/cmd/process-agent/main_windows.go
@@ -33,13 +33,11 @@ const ServiceName = "datadog-process-agent"
 // opts are the command-line options
 var defaultConfigPath = flags.DefaultConfPath
 var defaultSysProbeConfigPath = flags.DefaultSysProbeConfPath
-var defaultConfdPath = flags.DefaultConfdPath
-var defaultLogFilePath = flags.DefaultLogFilePath
 
 var winopts struct {
-	startService     bool
-	stopService      bool
-	foreground       bool
+	startService bool
+	stopService  bool
+	foreground   bool
 }
 
 func init() {
@@ -47,8 +45,6 @@ func init() {
 	if err == nil {
 		defaultConfigPath = filepath.Join(pd, "datadog.yaml")
 		defaultSysProbeConfigPath = filepath.Join(pd, "system-probe.yaml")
-		defaultConfdPath = filepath.Join(pd, "conf.d")
-		defaultLogFilePath = filepath.Join(pd, "logs", "process-agent.log")
 	}
 }
 
@@ -201,14 +197,6 @@ func stopService() error {
 	return controlService(svc.Stop, svc.Stopped)
 }
 
-func restartService() error {
-	var err error
-	if err = stopService(); err == nil {
-		err = startService()
-	}
-	return err
-}
-
 func controlService(c svc.Cmd, to svc.State) error {
 	m, err := mgr.Connect()
 	if err != nil {
@@ -237,4 +225,3 @@ func controlService(c svc.Cmd, to svc.State) error {
 	}
 	return nil
 }
-

--- a/cmd/system-probe/config/config_windows.go
+++ b/cmd/system-probe/config/config_windows.go
@@ -11,7 +11,6 @@ package config
 import (
 	"fmt"
 	"net"
-	"path/filepath"
 
 	"github.com/DataDog/datadog-agent/pkg/util/winutil"
 )
@@ -25,15 +24,13 @@ const (
 )
 
 var (
-	defaultConfigDir              = "c:\\programdata\\datadog\\"
-	defaultSystemProbeLogFilePath = "c:\\programdata\\datadog\\logs\\system-probe.log"
+	defaultConfigDir = "c:\\programdata\\datadog\\"
 )
 
 func init() {
 	pd, err := winutil.GetProgramDataDir()
 	if err == nil {
 		defaultConfigDir = pd
-		defaultSystemProbeLogFilePath = filepath.Join(pd, "logs", "system-probe.log")
 	}
 }
 

--- a/cmd/system-probe/main_windows.go
+++ b/cmd/system-probe/main_windows.go
@@ -11,25 +11,12 @@ package main
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"golang.org/x/sys/windows/svc"
 
 	"github.com/DataDog/datadog-agent/cmd/system-probe/app"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/windows/service"
-	"github.com/DataDog/datadog-agent/pkg/util/winutil"
 )
-
-var (
-	defaultSysProbeConfigPath = "c:\\programdata\\datadog\\system-probe.yaml"
-)
-
-func init() {
-	pd, err := winutil.GetProgramDataDir()
-	if err == nil {
-		defaultSysProbeConfigPath = filepath.Join(pd, "system-probe.yaml")
-	}
-}
 
 func main() {
 	// if command line arguments are supplied, even in a non interactive session,

--- a/cmd/system-probe/modules/all_windows.go
+++ b/cmd/system-probe/modules/all_windows.go
@@ -32,5 +32,5 @@ func inactivityEventLog(duration time.Duration) {
 		return
 	}
 	defer elog.Close()
-	elog.Warning(msgSysprobeRestartInactivity, duration.String())
+	_ = elog.Warning(msgSysprobeRestartInactivity, duration.String())
 }

--- a/cmd/systray/doconfigure.go
+++ b/cmd/systray/doconfigure.go
@@ -61,7 +61,7 @@ func doConfigure() error {
 	csrfToken, err := util.DoGet(c, urlstr, util.LeaveConnectionOpen)
 	if err != nil {
 		var errMap = make(map[string]string)
-		json.Unmarshal(csrfToken, &errMap)
+		err = json.Unmarshal(csrfToken, &errMap)
 		if e, found := errMap["error"]; found {
 			err = fmt.Errorf(e)
 		}

--- a/cmd/systray/doflare.go
+++ b/cmd/systray/doflare.go
@@ -81,7 +81,10 @@ func dialogProc(hwnd win.HWND, msg uint32, wParam, lParam uintptr) (result uintp
 				r, _, _ = procGetWindowRect.Call(dt, uintptr(unsafe.Pointer(&wndrect)))
 				if r != 0 {
 					x, y, _, _ := calcPos(wndrect, dlgrect)
-					procSetWindowPos.Call(uintptr(hwnd), 0, uintptr(x), uintptr(y), uintptr(0), uintptr(0), uintptr(0x0041))
+					r, _, err = procSetWindowPos.Call(uintptr(hwnd), 0, uintptr(x), uintptr(y), uintptr(0), uintptr(0), uintptr(0x0041))
+					if r != 0 {
+						log.Debugf("failed to set window pos %v", err)
+					}
 				}
 			} else {
 				log.Debugf("failed to get pos %v", err)

--- a/cmd/systray/systray.go
+++ b/cmd/systray/systray.go
@@ -286,12 +286,20 @@ func main() {
 				log.Warnf("Failed to set text for item %s %v", item.label, err)
 				continue
 			}
-			action.SetEnabled(item.enabled)
+			err = action.SetEnabled(item.enabled)
+			if err != nil {
+				log.Warnf("Failed to set enabled for item %s %v", item.label, err)
+				continue
+			}
 			if item.handler != nil {
-				action.Triggered().Attach(item.handler)
+				_ = action.Triggered().Attach(item.handler)
 			}
 		}
-		ni.ContextMenu().Actions().Add(action)
+		err = ni.ContextMenu().Actions().Add(action)
+		if err != nil {
+			log.Warnf("Failed to add action for item %s to context menu %v", item.label, err)
+			continue
+		}
 	}
 
 	// The notify icon is hidden initially, so we have to make it visible.
@@ -332,6 +340,7 @@ func enableLoggingToFile() {
 	log.ReplaceLogger(logger)
 }
 
+//nolint:deadcode // for debugging
 func enableLoggingToConsole() {
 	seeConfig := `
 	<seelog minlevel="debug">

--- a/cmd/trace-agent/main_windows.go
+++ b/cmd/trace-agent/main_windows.go
@@ -168,14 +168,6 @@ func stopService() error {
 	return controlService(svc.Stop, svc.Stopped)
 }
 
-func restartService() error {
-	var err error
-	if err = stopService(); err == nil {
-		err = startService()
-	}
-	return err
-}
-
 func controlService(c svc.Cmd, to svc.State) error {
 	m, err := mgr.Connect()
 	if err != nil {
@@ -204,4 +196,3 @@ func controlService(c svc.Cmd, to svc.State) error {
 	}
 	return nil
 }
-

--- a/pkg/collector/collector_demux_test.go
+++ b/pkg/collector/collector_demux_test.go
@@ -3,6 +3,10 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build test
+// +build test
+
+
 package collector
 
 import (

--- a/pkg/collector/collector_test.go
+++ b/pkg/collector/collector_test.go
@@ -3,6 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build test
+// +build test
+
 package collector
 
 import (

--- a/pkg/collector/corechecks/system/cpu/cpu_ctx_switches.go
+++ b/pkg/collector/corechecks/system/cpu/cpu_ctx_switches.go
@@ -2,8 +2,8 @@
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
-//go:build !linux
-// +build !linux
+//go:build !linux && !windows
+// +build !linux,!windows
 
 package cpu
 

--- a/pkg/collector/corechecks/system/cpu/cpu_windows.go
+++ b/pkg/collector/corechecks/system/cpu/cpu_windows.go
@@ -17,18 +17,11 @@ import (
 	"strconv"
 
 	"github.com/DataDog/gohai/cpu"
-	"golang.org/x/sys/windows"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil/pdhutil"
-)
-
-var (
-	modkernel32 = windows.NewLazyDLL("kernel32.dll")
-
-	procGetSystemTimes = modkernel32.NewProc("GetSystemTimes")
 )
 
 const cpuCheckName = "cpu"
@@ -87,7 +80,7 @@ func (c *Check) Run() error {
 	if c.userCounter == nil {
 		c.userCounter, err = getProcessorPDHCounter("% User Time", "_Total")
 	}
-	if c.userCounter != nil{
+	if c.userCounter != nil {
 		val, err = c.userCounter.GetValue()
 	}
 	if err != nil {

--- a/pkg/collector/corechecks/system/disk/iostats_pdh_windows.go
+++ b/pkg/collector/corechecks/system/disk/iostats_pdh_windows.go
@@ -25,8 +25,7 @@ import (
 var (
 	modkernel32 = windows.NewLazyDLL("kernel32.dll")
 
-	procGetLogicalDriveStringsW = modkernel32.NewProc("GetLogicalDriveStringsW")
-	procGetDriveType            = modkernel32.NewProc("GetDriveTypeW")
+	procGetDriveType = modkernel32.NewProc("GetDriveTypeW")
 
 	driveLetterPattern    = regexp.MustCompile(`[A-Za-z]:`)
 	unmountedDrivePattern = regexp.MustCompile(`HarddiskVolume([0-9])+`)
@@ -141,7 +140,7 @@ func (c *IOCheck) Run() error {
 			}
 
 			if cname == "Disk Write Bytes/sec" || cname == "Disk Read Bytes/sec" {
-				val /= 1024
+				val /= kB
 			}
 			if cname == "Avg. Disk sec/Read" || cname == "Avg. Disk sec/Write" {
 				// r_await/w_await are in milliseconds, but the performance counter

--- a/pkg/collector/corechecks/system/disk/iostats_pdh_windows_test.go
+++ b/pkg/collector/corechecks/system/disk/iostats_pdh_windows_test.go
@@ -72,14 +72,14 @@ func TestIoCheckWindows(t *testing.T) {
 
 	mock := mocksender.NewMockSender(ioCheck.ID())
 
-	mock.On("Gauge", "system.io.wkb_s", 1.222/1024, "", []string{"device:C:"}).Return().Times(1)
-	mock.On("Gauge", "system.io.wkb_s", 1.333/1024, "", []string{"device:HarddiskVolume1", "device_name:HarddiskVolume1"}).Return().Times(1)
+	mock.On("Gauge", "system.io.wkb_s", 1.222/kB, "", []string{"device:C:"}).Return().Times(1)
+	mock.On("Gauge", "system.io.wkb_s", 1.333/kB, "", []string{"device:HarddiskVolume1", "device_name:HarddiskVolume1"}).Return().Times(1)
 
 	mock.On("Gauge", "system.io.w_s", 2.222, "", []string{"device:C:"}).Return().Times(1)
 	mock.On("Gauge", "system.io.w_s", 2.333, "", []string{"device:HarddiskVolume1", "device_name:HarddiskVolume1"}).Return().Times(1)
 
-	mock.On("Gauge", "system.io.rkb_s", 3.222/1024, "", []string{"device:C:"}).Return().Times(1)
-	mock.On("Gauge", "system.io.rkb_s", 3.333/1024, "", []string{"device:HarddiskVolume1", "device_name:HarddiskVolume1"}).Return().Times(1)
+	mock.On("Gauge", "system.io.rkb_s", 3.222/kB, "", []string{"device:C:"}).Return().Times(1)
+	mock.On("Gauge", "system.io.rkb_s", 3.333/kB, "", []string{"device:HarddiskVolume1", "device_name:HarddiskVolume1"}).Return().Times(1)
 
 	mock.On("Gauge", "system.io.r_s", 4.222, "", []string{"device:C:"}).Return().Times(1)
 	mock.On("Gauge", "system.io.r_s", 4.333, "", []string{"device:HarddiskVolume1", "device_name:HarddiskVolume1"}).Return().Times(1)
@@ -112,14 +112,14 @@ lowercase_device_tag: true
 
 	mock := mocksender.NewMockSender(ioCheck.ID())
 
-	mock.On("Gauge", "system.io.wkb_s", 1.222/1024, "", []string{"device:c:"}).Return().Times(1)
-	mock.On("Gauge", "system.io.wkb_s", 1.333/1024, "", []string{"device:harddiskvolume1", "device_name:harddiskvolume1"}).Return().Times(1)
+	mock.On("Gauge", "system.io.wkb_s", 1.222/kB, "", []string{"device:c:"}).Return().Times(1)
+	mock.On("Gauge", "system.io.wkb_s", 1.333/kB, "", []string{"device:harddiskvolume1", "device_name:harddiskvolume1"}).Return().Times(1)
 
 	mock.On("Gauge", "system.io.w_s", 2.222, "", []string{"device:c:"}).Return().Times(1)
 	mock.On("Gauge", "system.io.w_s", 2.333, "", []string{"device:harddiskvolume1", "device_name:harddiskvolume1"}).Return().Times(1)
 
-	mock.On("Gauge", "system.io.rkb_s", 3.222/1024, "", []string{"device:c:"}).Return().Times(1)
-	mock.On("Gauge", "system.io.rkb_s", 3.333/1024, "", []string{"device:harddiskvolume1", "device_name:harddiskvolume1"}).Return().Times(1)
+	mock.On("Gauge", "system.io.rkb_s", 3.222/kB, "", []string{"device:c:"}).Return().Times(1)
+	mock.On("Gauge", "system.io.rkb_s", 3.333/kB, "", []string{"device:harddiskvolume1", "device_name:harddiskvolume1"}).Return().Times(1)
 
 	mock.On("Gauge", "system.io.r_s", 4.222, "", []string{"device:c:"}).Return().Times(1)
 	mock.On("Gauge", "system.io.r_s", 4.333, "", []string{"device:harddiskvolume1", "device_name:harddiskvolume1"}).Return().Times(1)
@@ -154,14 +154,14 @@ func TestIoCheckInstanceAdded(t *testing.T) {
 
 	mock := mocksender.NewMockSender(ioCheck.ID())
 
-	mock.On("Gauge", "system.io.wkb_s", 1.222/1024, "", []string{"device:C:"}).Return().Times(2)
-	mock.On("Gauge", "system.io.wkb_s", 1.333/1024, "", []string{"device:HarddiskVolume1", "device_name:HarddiskVolume1"}).Return().Times(2)
+	mock.On("Gauge", "system.io.wkb_s", 1.222/kB, "", []string{"device:C:"}).Return().Times(2)
+	mock.On("Gauge", "system.io.wkb_s", 1.333/kB, "", []string{"device:HarddiskVolume1", "device_name:HarddiskVolume1"}).Return().Times(2)
 
 	mock.On("Gauge", "system.io.w_s", 2.222, "", []string{"device:C:"}).Return().Times(2)
 	mock.On("Gauge", "system.io.w_s", 2.333, "", []string{"device:HarddiskVolume1", "device_name:HarddiskVolume1"}).Return().Times(2)
 
-	mock.On("Gauge", "system.io.rkb_s", 3.222/1024, "", []string{"device:C:"}).Return().Times(2)
-	mock.On("Gauge", "system.io.rkb_s", 3.333/1024, "", []string{"device:HarddiskVolume1", "device_name:HarddiskVolume1"}).Return().Times(2)
+	mock.On("Gauge", "system.io.rkb_s", 3.222/kB, "", []string{"device:C:"}).Return().Times(2)
+	mock.On("Gauge", "system.io.rkb_s", 3.333/kB, "", []string{"device:HarddiskVolume1", "device_name:HarddiskVolume1"}).Return().Times(2)
 
 	mock.On("Gauge", "system.io.r_s", 4.222, "", []string{"device:C:"}).Return().Times(2)
 	mock.On("Gauge", "system.io.r_s", 4.333, "", []string{"device:HarddiskVolume1", "device_name:HarddiskVolume1"}).Return().Times(2)
@@ -170,14 +170,14 @@ func TestIoCheckInstanceAdded(t *testing.T) {
 	mock.On("Gauge", "system.io.avg_q_sz", 5.333, "", []string{"device:HarddiskVolume1", "device_name:HarddiskVolume1"}).Return().Times(2)
 
 	// and the checks for the added instance
-	mock.On("Gauge", "system.io.wkb_s", 1.444/1024, "", []string{"device:Y:"}).Return().Times(1)
-	mock.On("Gauge", "system.io.wkb_s", 1.555/1024, "", []string{"device:HarddiskVolume2", "device_name:HarddiskVolume2"}).Return().Times(1)
+	mock.On("Gauge", "system.io.wkb_s", 1.444/kB, "", []string{"device:Y:"}).Return().Times(1)
+	mock.On("Gauge", "system.io.wkb_s", 1.555/kB, "", []string{"device:HarddiskVolume2", "device_name:HarddiskVolume2"}).Return().Times(1)
 
 	mock.On("Gauge", "system.io.w_s", 2.444, "", []string{"device:Y:"}).Return().Times(1)
 	mock.On("Gauge", "system.io.w_s", 2.555, "", []string{"device:HarddiskVolume2", "device_name:HarddiskVolume2"}).Return().Times(1)
 
-	mock.On("Gauge", "system.io.rkb_s", 3.444/1024, "", []string{"device:Y:"}).Return().Times(1)
-	mock.On("Gauge", "system.io.rkb_s", 3.555/1024, "", []string{"device:HarddiskVolume2", "device_name:HarddiskVolume2"}).Return().Times(1)
+	mock.On("Gauge", "system.io.rkb_s", 3.444/kB, "", []string{"device:Y:"}).Return().Times(1)
+	mock.On("Gauge", "system.io.rkb_s", 3.555/kB, "", []string{"device:HarddiskVolume2", "device_name:HarddiskVolume2"}).Return().Times(1)
 
 	mock.On("Gauge", "system.io.r_s", 4.444, "", []string{"device:Y:"}).Return().Times(1)
 	mock.On("Gauge", "system.io.r_s", 4.555, "", []string{"device:HarddiskVolume2", "device_name:HarddiskVolume2"}).Return().Times(1)
@@ -213,14 +213,14 @@ func TestIoCheckInstanceRemoved(t *testing.T) {
 
 	mock := mocksender.NewMockSender(ioCheck.ID())
 
-	mock.On("Gauge", "system.io.wkb_s", 1.222/1024, "", []string{"device:C:"}).Return().Times(3)
-	mock.On("Gauge", "system.io.wkb_s", 1.333/1024, "", []string{"device:HarddiskVolume1", "device_name:HarddiskVolume1"}).Return().Times(3)
+	mock.On("Gauge", "system.io.wkb_s", 1.222/kB, "", []string{"device:C:"}).Return().Times(3)
+	mock.On("Gauge", "system.io.wkb_s", 1.333/kB, "", []string{"device:HarddiskVolume1", "device_name:HarddiskVolume1"}).Return().Times(3)
 
 	mock.On("Gauge", "system.io.w_s", 2.222, "", []string{"device:C:"}).Return().Times(3)
 	mock.On("Gauge", "system.io.w_s", 2.333, "", []string{"device:HarddiskVolume1", "device_name:HarddiskVolume1"}).Return().Times(3)
 
-	mock.On("Gauge", "system.io.rkb_s", 3.222/1024, "", []string{"device:C:"}).Return().Times(3)
-	mock.On("Gauge", "system.io.rkb_s", 3.333/1024, "", []string{"device:HarddiskVolume1", "device_name:HarddiskVolume1"}).Return().Times(3)
+	mock.On("Gauge", "system.io.rkb_s", 3.222/kB, "", []string{"device:C:"}).Return().Times(3)
+	mock.On("Gauge", "system.io.rkb_s", 3.333/kB, "", []string{"device:HarddiskVolume1", "device_name:HarddiskVolume1"}).Return().Times(3)
 
 	mock.On("Gauge", "system.io.r_s", 4.222, "", []string{"device:C:"}).Return().Times(3)
 	mock.On("Gauge", "system.io.r_s", 4.333, "", []string{"device:HarddiskVolume1", "device_name:HarddiskVolume1"}).Return().Times(3)
@@ -229,14 +229,14 @@ func TestIoCheckInstanceRemoved(t *testing.T) {
 	mock.On("Gauge", "system.io.avg_q_sz", 5.333, "", []string{"device:HarddiskVolume1", "device_name:HarddiskVolume1"}).Return().Times(3)
 
 	// and the checks for the added instance
-	mock.On("Gauge", "system.io.wkb_s", 1.444/1024, "", []string{"device:Y:"}).Return().Times(1)
-	mock.On("Gauge", "system.io.wkb_s", 1.555/1024, "", []string{"device:HarddiskVolume2", "device_name:HarddiskVolume2"}).Return().Times(1)
+	mock.On("Gauge", "system.io.wkb_s", 1.444/kB, "", []string{"device:Y:"}).Return().Times(1)
+	mock.On("Gauge", "system.io.wkb_s", 1.555/kB, "", []string{"device:HarddiskVolume2", "device_name:HarddiskVolume2"}).Return().Times(1)
 
 	mock.On("Gauge", "system.io.w_s", 2.444, "", []string{"device:Y:"}).Return().Times(1)
 	mock.On("Gauge", "system.io.w_s", 2.555, "", []string{"device:HarddiskVolume2", "device_name:HarddiskVolume2"}).Return().Times(1)
 
-	mock.On("Gauge", "system.io.rkb_s", 3.444/1024, "", []string{"device:Y:"}).Return().Times(1)
-	mock.On("Gauge", "system.io.rkb_s", 3.555/1024, "", []string{"device:HarddiskVolume2", "device_name:HarddiskVolume2"}).Return().Times(1)
+	mock.On("Gauge", "system.io.rkb_s", 3.444/kB, "", []string{"device:Y:"}).Return().Times(1)
+	mock.On("Gauge", "system.io.rkb_s", 3.555/kB, "", []string{"device:HarddiskVolume2", "device_name:HarddiskVolume2"}).Return().Times(1)
 
 	mock.On("Gauge", "system.io.r_s", 4.444, "", []string{"device:Y:"}).Return().Times(1)
 	mock.On("Gauge", "system.io.r_s", 4.555, "", []string{"device:HarddiskVolume2", "device_name:HarddiskVolume2"}).Return().Times(1)

--- a/pkg/collector/corechecks/system/memory/memory_windows.go
+++ b/pkg/collector/corechecks/system/memory/memory_windows.go
@@ -8,8 +8,6 @@
 package memory
 
 import (
-	"runtime"
-
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
@@ -21,7 +19,6 @@ import (
 var virtualMemory = winutil.VirtualMemory
 var swapMemory = winutil.SwapMemory
 var pageMemory = winutil.PagefileMemory
-var runtimeOS = runtime.GOOS
 
 // Check doesn't need additional fields
 type Check struct {
@@ -42,7 +39,6 @@ func (c *Check) Configure(data integration.Data, initConfig integration.Data, so
 
 	return err
 }
-
 
 // Run executes the check
 func (c *Check) Run() error {

--- a/pkg/collector/corechecks/system/winkmem/winkmem.go
+++ b/pkg/collector/corechecks/system/winkmem/winkmem.go
@@ -174,7 +174,7 @@ type systemPooltag struct {
 }
 type systemPooltagInformation struct {
 	count    uint32
-	padding  uint32
+	_        uint32 // padding
 	poolTags []systemPooltag
 }
 

--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -17,7 +17,6 @@ var (
 	defaultConfdPath            = "c:\\programdata\\datadog\\conf.d"
 	defaultAdditionalChecksPath = "c:\\programdata\\datadog\\checks.d"
 	defaultRunPath              = "c:\\programdata\\datadog\\run"
-	defaultSyslogURI            = ""
 	defaultGuiPort              = 5002
 	// defaultSecurityAgentLogFile points to the log file that will be used by the security-agent if not configured
 	defaultSecurityAgentLogFile = "c:\\programdata\\datadog\\logs\\security-agent.log"

--- a/pkg/dogstatsd/listeners/named_pipe_windows.go
+++ b/pkg/dogstatsd/listeners/named_pipe_windows.go
@@ -113,7 +113,7 @@ func (l *namedPipeConnections) handleConnections() {
 			}
 			for conn := range connections {
 				// Stop the current execution of net.Conn.Read() and exit listen loop.
-				conn.SetReadDeadline(time.Now())
+				_ = conn.SetReadDeadline(time.Now())
 			}
 
 		}

--- a/pkg/dogstatsd/listeners/named_pipe_windows_test.go
+++ b/pkg/dogstatsd/listeners/named_pipe_windows_test.go
@@ -119,7 +119,6 @@ func TestNamedPipeTooBigMessage(t *testing.T) {
 type namedPipeListenerTest struct {
 	*NamedPipeListener
 	packetOut chan packets.Packets
-	client    net.Conn
 }
 
 func newNamedPipeListenerTest(t *testing.T) namedPipeListenerTest {

--- a/pkg/dogstatsd/replay/reader_windows.go
+++ b/pkg/dogstatsd/replay/reader_windows.go
@@ -21,8 +21,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-const maxMapSize = 0xFFFFFFFFFFFF // 256TB
-
 type memoryMap []byte
 
 // keep track of handles

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -74,12 +74,6 @@ type SearchPaths map[string]string
 // The key is the filepath of the file.
 type permissionsInfos map[string]filePermsInfo
 
-type filePermsInfo struct {
-	mode  os.FileMode
-	owner string
-	group string
-}
-
 // ProfileData maps (pprof) profile names to the profile data.
 type ProfileData map[string][]byte
 

--- a/pkg/flare/archive_nix.go
+++ b/pkg/flare/archive_nix.go
@@ -40,6 +40,12 @@ func zipDatadogRegistry(tempDir, hostname string) error {
 	return nil
 }
 
+type filePermsInfo struct {
+	mode  os.FileMode
+	owner string
+	group string
+}
+
 // Add puts the given filepath in the map
 // of files to process later during the commit phase.
 func (p permissionsInfos) add(filePath string) {

--- a/pkg/flare/archive_win.go
+++ b/pkg/flare/archive_win.go
@@ -38,10 +38,7 @@ var (
 )
 
 const (
-	evtExportLogChannelPath         uint32 = 0x1
-	evtExportLogFilePath            uint32 = 0x2
-	evtExportLogTolerateQueryErrors uint32 = 0x1000
-	evtExportLogOverwrite           uint32 = 0x2000
+	evtExportLogChannelPath uint32 = 0x1
 )
 
 func zipCounterStrings(tempDir, hostname string) error {
@@ -82,10 +79,19 @@ func zipCounterStrings(tempDir, hostname string) error {
 	}
 	defer f.Close()
 	for i := 0; i < len(clist); i++ {
-		f.WriteString(clist[i])
-		f.WriteString("\r\n")
+		_, err = f.WriteString(clist[i])
+		if err != nil {
+			return err
+		}
+		_, err = f.WriteString("\r\n")
+		if err != nil {
+			return err
+		}
 	}
-	f.Sync()
+	err = f.Sync()
+	if err != nil {
+		return err
+	}
 	return nil
 
 }
@@ -208,6 +214,8 @@ func exportWindowsEventLog(eventLogChannel, eventLogQuery, destFileName, tempDir
 	return err
 }
 
+type filePermsInfo struct{}
+
 func (p permissionsInfos) add(filePath string) {}
 func (p permissionsInfos) commit(tempDir, hostname string, mode os.FileMode) error {
 	return nil
@@ -251,9 +259,9 @@ func zipServiceStatus(tempDir, hostname string) error {
 		pathtodriver := filepath.Join(ddroot, "bin", "agent", "driver", "ddnpm.sys")
 		fi, err := os.Stat(pathtodriver)
 		if err != nil {
-			fh.WriteString(fmt.Sprintf("Failed to stat file %v %v\n", pathtodriver, err))
+			_, _ = fh.WriteString(fmt.Sprintf("Failed to stat file %v %v\n", pathtodriver, err))
 		} else {
-			fh.WriteString(fmt.Sprintf("Driver last modification time : %v\n", fi.ModTime().Format(time.UnixDate)))
+			_, _ = fh.WriteString(fmt.Sprintf("Driver last modification time : %v\n", fi.ModTime().Format(time.UnixDate)))
 		}
 	} else {
 		return fmt.Errorf("Error getting path to datadog agent binaries %v", err)

--- a/pkg/forwarder/internal/retry/on_disk_retry_queue_test.go
+++ b/pkg/forwarder/internal/retry/on_disk_retry_queue_test.go
@@ -3,6 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build test
+// +build test
+
 package retry
 
 import (

--- a/pkg/forwarder/internal/retry/transaction_retry_queue.go
+++ b/pkg/forwarder/internal/retry/transaction_retry_queue.go
@@ -182,14 +182,6 @@ func (tc *TransactionRetryQueue) ExtractTransactions() ([]transaction.Transactio
 	return transactions, nil
 }
 
-// GetCurrentMemSizeInBytes gets the current memory usage in bytes
-func (tc *TransactionRetryQueue) getCurrentMemSizeInBytes() int {
-	tc.mutex.RLock()
-	defer tc.mutex.RUnlock()
-
-	return tc.currentMemSizeInBytes
-}
-
 // GetTransactionCount gets the number of transactions in the container
 func (tc *TransactionRetryQueue) GetTransactionCount() int {
 	tc.mutex.RLock()

--- a/pkg/forwarder/internal/retry/transaction_retry_queue_test.go
+++ b/pkg/forwarder/internal/retry/transaction_retry_queue_test.go
@@ -3,6 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build test
+// +build test
+
 package retry
 
 import (
@@ -14,6 +17,15 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/forwarder/transaction"
 	"github.com/DataDog/datadog-agent/pkg/util/filesystem"
 )
+
+// only used for testing
+// GetCurrentMemSizeInBytes gets the current memory usage in bytes
+func (tc *TransactionRetryQueue) getCurrentMemSizeInBytes() int {
+	tc.mutex.RLock()
+	defer tc.mutex.RUnlock()
+
+	return tc.currentMemSizeInBytes
+}
 
 func TestTransactionRetryQueueAdd(t *testing.T) {
 	a := assert.New(t)

--- a/pkg/jmxfetch/jmxfetch_windows.go
+++ b/pkg/jmxfetch/jmxfetch_windows.go
@@ -32,7 +32,7 @@ func (j *JMXFetch) Stop() error {
 		stopChan = make(chan struct{})
 
 		go func() {
-			j.Wait()
+			_ = j.Wait()
 			close(stopChan)
 		}()
 	}

--- a/pkg/logs/internal/launchers/listener/udp_default_test.go
+++ b/pkg/logs/internal/launchers/listener/udp_default_test.go
@@ -3,8 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !darwin && !linux
-// +build !darwin,!linux
+//go:build !darwin && !linux && !windows
+// +build !darwin,!linux,!windows
 
 package listener
 

--- a/pkg/logs/internal/launchers/windowsevent/launcher_windows.go
+++ b/pkg/logs/internal/launchers/windowsevent/launcher_windows.go
@@ -43,7 +43,7 @@ func EnumerateChannels() (chans []string, err error) {
 	if hEnum == evtEnumHandle(0) {
 		return
 	}
-	defer procEvtClose.Call(uintptr(hEnum))
+	defer procEvtClose.Call(uintptr(hEnum)) //nolint:errcheck
 
 	for {
 		var str string

--- a/pkg/logs/internal/tailers/file/tailer_windows.go
+++ b/pkg/logs/internal/tailers/file/tailer_windows.go
@@ -79,7 +79,11 @@ func (t *Tailer) readAvailable() (int, error) {
 				return bytes, io.EOF
 			}
 
-			f.Seek(offset, io.SeekStart)
+			_, err = f.Seek(offset, io.SeekStart)
+			if err != nil {
+				log.Debugf("Error seek()ing file %v", err)
+				return bytes, err
+			}
 		}
 
 		inBuf := make([]byte, 4096)

--- a/pkg/network/dns/driver_windows.go
+++ b/pkg/network/dns/driver_windows.go
@@ -3,6 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build windows && npm
+// +build windows,npm
+
 package dns
 
 /*

--- a/pkg/network/dns/parser.go
+++ b/pkg/network/dns/parser.go
@@ -3,8 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build windows || linux_bpf
-// +build windows linux_bpf
+//go:build (windows && npm) || linux_bpf
+// +build windows,npm linux_bpf
 
 package dns
 

--- a/pkg/network/dns/snooper.go
+++ b/pkg/network/dns/snooper.go
@@ -3,8 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build windows || linux_bpf
-// +build windows linux_bpf
+//go:build (windows && npm) || linux_bpf
+// +build windows,npm linux_bpf
 
 package dns
 

--- a/pkg/network/driver/driver_test.go
+++ b/pkg/network/driver/driver_test.go
@@ -17,14 +17,6 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-func dnsSupported(t *testing.T) bool {
-	return true
-}
-
-func httpSupported(t *testing.T) bool {
-	return false
-}
-
 func TestDriverRequiresPath(t *testing.T) {
 	p, err := windows.UTF16PtrFromString(deviceName)
 	assert.Nil(t, err)

--- a/pkg/network/driver_interface.go
+++ b/pkg/network/driver_interface.go
@@ -27,9 +27,9 @@ type DriverExpvar string
 
 const (
 	totalFlowStats  DriverExpvar = "driver_total_flow_stats"
-	flowHandleStats              = "driver_flow_handle_stats"
-	flowStats                    = "flows"
-	driverStats                  = "driver"
+	flowHandleStats DriverExpvar = "driver_flow_handle_stats"
+	flowStats       DriverExpvar = "flows"
+	driverStats     DriverExpvar = "driver"
 )
 
 const (

--- a/pkg/network/driver_interface.go
+++ b/pkg/network/driver_interface.go
@@ -213,6 +213,7 @@ func (di *DriverInterface) GetStats() (map[DriverExpvar]interface{}, error) {
 	}, nil
 }
 
+//nolint:deadcode,unused // debugging helper normally commented out
 func printClassification(fd *driver.PerFlowData) {
 	if fd.ClassificationStatus != driver.ClassificationUnclassified {
 		if fd.ClassifyRequest == driver.ClassificationRequestTLS || fd.ClassifyResponse == driver.ClassificationResponseTLS {

--- a/pkg/network/driver_interface_test.go
+++ b/pkg/network/driver_interface_test.go
@@ -20,10 +20,8 @@ import (
 type TestDriverHandleInfiniteLoop struct {
 	t *testing.T
 	// state variables
-	hasBeenCalled   bool
-	lastReturnBytes uint32
-	lastBufferSize  int
-	lastError       error
+	hasBeenCalled  bool
+	lastBufferSize int
 }
 
 func (tdh *TestDriverHandleInfiniteLoop) ReadFile(p []byte, bytesRead *uint32, ol *windows.Overlapped) error {
@@ -78,17 +76,4 @@ func TestConnectionStatsInfiniteLoop(t *testing.T) {
 		return true
 	})
 	require.NoError(t, err, "Failed to get connection stats")
-}
-
-type TestDriverHandleFiltersSuccess struct {
-	t *testing.T
-	// state variables
-	hasBeenCalled   bool
-	lastReturnBytes uint32
-	lastBufferSize  int
-	lastError       error
-}
-
-func (tdh *TestDriverHandleFiltersSuccess) ReadFile(p []byte, bytesRead *uint32, ol *windows.Overlapped) error {
-	return nil
 }

--- a/pkg/network/encoding/encoding_test.go
+++ b/pkg/network/encoding/encoding_test.go
@@ -235,6 +235,8 @@ func TestSerialization(t *testing.T) {
 			): &httpReqStats,
 		},
 	}
+	// ignore "declared but not used"
+	_ = httpReqStats
 
 	httpOut := &model.HTTPAggregations{
 		EndpointAggregations: []*model.HTTPStats{
@@ -481,6 +483,8 @@ func TestHTTPSerializationWithLocalhostTraffic(t *testing.T) {
 			): &httpReqStats,
 		},
 	}
+	// ignore "declared but not used"
+	_ = httpReqStats
 
 	httpOut := &model.HTTPAggregations{
 		EndpointAggregations: []*model.HTTPStats{

--- a/pkg/network/etw/etw-http-service.go
+++ b/pkg/network/etw/etw-http-service.go
@@ -84,7 +84,7 @@
 //
 //
 //	2. HTTP Req/Resp (the same ActivityID)
-//	   a. HTTPRequestTraceTaskRecvReq        1     [Correlated to Conncetion by builtin ActivityID<->ReleatedActivityID]
+//	   a. HTTPRequestTraceTaskRecvReq        1     [Correlated to Connection by builtin ActivityID<->ReleatedActivityID]
 //	      HTTPRequestTraceTaskParse          2     [verb, url]
 //	      HTTPRequestTraceTaskDeliver        3     [siteId, reqQueueName, url]
 //		  HTTPRequestTraceTaskFastResp       8     [statusCode, verb, headerLen, cachePolicy]
@@ -92,7 +92,7 @@
 //
 //		  or
 //
-//	   b. HTTPRequestTraceTaskRecvReq        1     [Correlated to Conncetion by builtin ActivityID<->ReleatedActivityID]
+//	   b. HTTPRequestTraceTaskRecvReq        1     [Correlated to Connection by builtin ActivityID<->ReleatedActivityID]
 //	      HTTPRequestTraceTaskParse          2     [verb, url]
 //	      HTTPRequestTraceTaskDeliver        3     [siteId, reqQueueName, url]
 //		  HTTPRequestTraceTaskFastResp       4     [statusCode, verb, headerLen, cachePolicy = 0]
@@ -100,7 +100,7 @@
 //
 //		  or
 //
-//	   c. HTTPRequestTraceTaskRecvReq        1     [Correlated to Conncetion by builtin ActivityID<->ReleatedActivityID]
+//	   c. HTTPRequestTraceTaskRecvReq        1     [Correlated to Connection by builtin ActivityID<->ReleatedActivityID]
 //	      HTTPRequestTraceTaskParse          2     [verb, url]
 //	      HTTPRequestTraceTaskDeliver        3     [siteId, reqQueueName, url]
 //		  HTTPRequestTraceTaskFastResp       4     [statusCode, verb, headerLen, cachePolicy=1]
@@ -109,7 +109,7 @@
 //
 //		  or
 //
-//	   d. HTTPRequestTraceTaskRecvReq        1     [Correlated to Conncetion by builtin ActivityID<->ReleatedActivityID]
+//	   d. HTTPRequestTraceTaskRecvReq        1     [Correlated to Connection by builtin ActivityID<->ReleatedActivityID]
 //	      HTTPRequestTraceTaskParse          2     [verb, url]
 //		  HTTPRequestTraceTaskSrvdFrmCache  16     [site, bytesSent]
 //
@@ -758,7 +758,7 @@ func httpCallbackOnHTTPRequestTraceTaskDeliver(eventInfo *C.DD_ETW_EVENT_INFO) {
 	if urlOffset > len(userData) {
 		parsingErrorCount++
 
-		log.Errorf("*** Error: ActivityId:%v. Connection ActivityId:%v. HTTPRequestTraceTaskDeliver could not find begining of Url\n\n",
+		log.Errorf("*** Error: ActivityId:%v. Connection ActivityId:%v. HTTPRequestTraceTaskDeliver could not find beginning of Url\n\n",
 			formatGuid(eventInfo.event.activityId), formatGuid(httpConnLink.connActivityId))
 
 		// If problem stop tracking this
@@ -1086,7 +1086,7 @@ func httpCallbackOnHttpSslConnEvent(eventInfo *C.DD_ETW_EVENT_INFO) {
 	if !captureHTTPS {
 
 		if HttpServiceLogVerbosity != HttpServiceLogVeryVerbose {
-			// Drop it immedeatly ...
+			// Drop it immediately ...
 			delete(connOpened, eventInfo.event.activityId)
 		} else {
 			// ... unless  if we want to track to the very end
@@ -1159,7 +1159,7 @@ func etwHttpServiceSummary() {
 
 func etwHttpServiceCallback(eventInfo *C.DD_ETW_EVENT_INFO) {
 
-	// Total number of bytes transfered to kernel from HTTP.sys driver. 0x68 is ETW header size
+	// Total number of bytes transferred to kernel from HTTP.sys driver. 0x68 is ETW header size
 	transferedETWBytesTotal += (uint64(eventInfo.event.userDataLength) + 0x68)
 	transferedETWBytesPayload += uint64(eventInfo.event.userDataLength)
 

--- a/pkg/network/etw/etw-utils.go
+++ b/pkg/network/etw/etw-utils.go
@@ -34,6 +34,7 @@ const EPOCH_DIFFERENCE_SECS uint64 = 116444736000000000
 
 // Copied from github.com\DataDog\datadog-agent\pkg\network\http\http_stats.go
 // Note: cannot refer to it due to package circularity
+//nolint:deadcode
 const (
 	methodUnknown uint32 = iota
 	methodGet
@@ -47,6 +48,7 @@ const (
 )
 
 // From HTTP_VERB enumeration (http.h)
+//nolint:deadcode
 const (
 	httpVerbUnparsed uint32 = iota
 	httpVerbUnknown
@@ -109,6 +111,7 @@ func verbToMethod(verb uint32) uint32 {
 	return verb2method[verb]
 }
 
+//nolint:deadcode
 func httpVerbToStr(httVerb uint32) string {
 	if httVerb >= httpVerbMaximum {
 		return "<UNKNOWN>"
@@ -271,6 +274,7 @@ func parseUnicodeString(data []byte, offset int) (val string, nextOffset int, va
 	return
 }
 
+//nolint:deadcode
 func parseAsciiString(data []byte, offset int) (val string, nextOffset int, valFound bool, foundTermZeroIdx int) {
 	singleZeroSlice := []byte{0}
 	termZeroIdx := bytes.Index(data[offset:], singleZeroSlice)
@@ -281,6 +285,7 @@ func parseAsciiString(data []byte, offset int) (val string, nextOffset int, valF
 	return string(data[offset : offset+termZeroIdx]), (offset + termZeroIdx + 1), true, (offset + termZeroIdx + 1)
 }
 
+//nolint:deadcode
 func skipAsciiString(data []byte, offset int) (nextOffset int, valFound bool, foundTermZeroIdx int) {
 	singleZeroSlice := []byte{0}
 	termZeroIdx := bytes.Index(data[offset:], singleZeroSlice)

--- a/pkg/network/event_windows_test.go
+++ b/pkg/network/event_windows_test.go
@@ -18,6 +18,7 @@ Protocol tcp Dynamic Port Range
 Start Port      : 49152
 Number of Ports : 16384`
 
+//nolint:misspell // misspell only handles english
 var frenchOut = `
 Plage de ports dynamique du protocole tcp
 ---------------------------------

--- a/pkg/network/protocols/http/driver_interface.go
+++ b/pkg/network/protocols/http/driver_interface.go
@@ -24,10 +24,6 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-const (
-	httpReadBufferCount = 100
-)
-
 type FullHttpTransaction struct {
 	Txn             driver.HttpTransactionType
 	RequestFragment []byte
@@ -84,7 +80,7 @@ func (di *httpDriverInterface) setupHTTPHandle(dh driver.Handle) error {
 	}
 	log.Infof("Enabled http in driver")
 
-	u16eventname, err := windows.UTF16PtrFromString("Global\\DDNPMHttpTxnReadyEvent")
+	u16eventname, _ := windows.UTF16PtrFromString("Global\\DDNPMHttpTxnReadyEvent")
 	di.driverEventHandle, err = windows.CreateEvent(nil, 1, 0, u16eventname)
 	if err != nil {
 		if err != windows.ERROR_ALREADY_EXISTS || di.driverEventHandle == windows.Handle(0) {
@@ -123,7 +119,7 @@ func (di *httpDriverInterface) startReadingBuffers() {
 		defer di.eventLoopWG.Done()
 
 		for {
-			windows.WaitForSingleObject(di.driverEventHandle, windows.INFINITE)
+			_, _ = windows.WaitForSingleObject(di.driverEventHandle, windows.INFINITE)
 			if di.closed {
 				break
 			}

--- a/pkg/network/protocols/http/etw_interface.go
+++ b/pkg/network/protocols/http/etw_interface.go
@@ -112,18 +112,6 @@ func (hei *httpEtwInterface) startReadingHttpFlows() {
 	}()
 }
 
-func (hei *httpEtwInterface) getHttpFlows() []etw.Http {
-	hei.eventLoopWG.Add(1)
-	defer hei.eventLoopWG.Done()
-
-	httpTxs, _ := etw.ReadHttpTx()
-	return httpTxs
-}
-
-func (hei *httpEtwInterface) getStats() (map[string]int64, error) {
-	return nil, nil
-}
-
 func (hei *httpEtwInterface) close() {
 	etw.StopEtw("ddnpm-httpservice")
 

--- a/pkg/network/protocols/http/monitor_windows.go
+++ b/pkg/network/protocols/http/monitor_windows.go
@@ -18,10 +18,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-const (
-	defaultMaxTrackedConnections = 65536
-)
-
 // Monitor is the interface to HTTP monitoring
 type Monitor interface {
 	Start()

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/miekg/dns"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	vnetns "github.com/vishvananda/netns"
@@ -44,6 +45,22 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
+
+func doDNSQuery(t *testing.T, domain string, serverIP string) (*net.UDPAddr, *net.UDPAddr) {
+	dnsServerAddr := &net.UDPAddr{IP: net.ParseIP(serverIP), Port: 53}
+	queryMsg := new(dns.Msg)
+	queryMsg.SetQuestion(dns.Fqdn(domain), dns.TypeA)
+	queryMsg.RecursionDesired = true
+	dnsClient := new(dns.Client)
+	dnsConn, err := dnsClient.Dial(dnsServerAddr.String())
+	require.NoError(t, err)
+	defer dnsConn.Close()
+	dnsClientAddr := dnsConn.LocalAddr().(*net.UDPAddr)
+	_, _, err = dnsClient.ExchangeWithConn(queryMsg, dnsConn)
+	require.NoError(t, err)
+
+	return dnsClientAddr, dnsServerAddr
+}
 
 func httpSupported(t *testing.T) bool {
 	currKernelVersion, err := kernel.HostVersion()

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -1863,22 +1863,6 @@ func testConfig() *config.Config {
 	return cfg
 }
 
-func doDNSQuery(t *testing.T, domain string, serverIP string) (*net.UDPAddr, *net.UDPAddr) {
-	dnsServerAddr := &net.UDPAddr{IP: net.ParseIP(serverIP), Port: 53}
-	queryMsg := new(dns.Msg)
-	queryMsg.SetQuestion(dns.Fqdn(domain), dns.TypeA)
-	queryMsg.RecursionDesired = true
-	dnsClient := new(dns.Client)
-	dnsConn, err := dnsClient.Dial(dnsServerAddr.String())
-	require.NoError(t, err)
-	defer dnsConn.Close()
-	dnsClientAddr := dnsConn.LocalAddr().(*net.UDPAddr)
-	_, _, err = dnsClient.ExchangeWithConn(queryMsg, dnsConn)
-	require.NoError(t, err)
-
-	return dnsClientAddr, dnsServerAddr
-}
-
 func skipIfWindows(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test unavailable on windows")

--- a/pkg/network/tracer/tracer_windows.go
+++ b/pkg/network/tracer/tracer_windows.go
@@ -47,10 +47,6 @@ type Tracer struct {
 
 	timerInterval int
 
-	// ticker for the polling interval for writing
-	inTicker            *time.Ticker
-	stopInTickerRoutine chan bool
-
 	// Connections for the tracer to exclude
 	sourceExcludes []*network.ConnectionFilter
 	destExcludes   []*network.ConnectionFilter
@@ -103,8 +99,8 @@ func NewTracer(config *config.Config) (*Tracer, error) {
 // Stop function stops running tracer
 func (t *Tracer) Stop() {
 	close(t.stopChan)
-	if t.httpMonitor != nil {
-		t.httpMonitor.Stop()
+	if t.httpMonitor != nil { //nolint
+		_ = t.httpMonitor.Stop()
 	}
 	t.reverseDNS.Close()
 	err := t.driverInterface.Close()
@@ -133,7 +129,7 @@ func (t *Tracer) GetActiveConnections(clientID string) (*network.Connections, er
 	t.state.StoreClosedConnections(closedConnStats)
 
 	var delta network.Delta
-	if t.httpMonitor != nil {
+	if t.httpMonitor != nil { //nolint
 		delta = t.state.GetDelta(clientID, uint64(time.Now().Nanosecond()), activeConnStats, t.reverseDNS.GetDNSStats(), t.httpMonitor.GetHTTPStats())
 	} else {
 		delta = t.state.GetDelta(clientID, uint64(time.Now().Nanosecond()), activeConnStats, t.reverseDNS.GetDNSStats(), nil)

--- a/pkg/network/tracer/tracer_windows_test.go
+++ b/pkg/network/tracer/tracer_windows_test.go
@@ -14,10 +14,6 @@ import (
 	"testing"
 )
 
-func dnsSupported(t *testing.T) bool {
-	return true
-}
-
 func httpSupported(t *testing.T) bool {
 	return false
 }

--- a/pkg/process/checks/process_common_test.go
+++ b/pkg/process/checks/process_common_test.go
@@ -20,12 +20,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 )
 
-func makeContainer(id string) *model.Container {
-	return &model.Container{
-		Id: id,
-	}
-}
-
 //nolint:deadcode,unused
 func procsToHash(procs []*procutil.Process) (procsByPid map[int32]*procutil.Process) {
 	procsByPid = make(map[int32]*procutil.Process)

--- a/pkg/process/checks/process_nix_test.go
+++ b/pkg/process/checks/process_nix_test.go
@@ -24,6 +24,12 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 )
 
+func makeContainer(id string) *model.Container {
+	return &model.Container{
+		Id: id,
+	}
+}
+
 // TestBasicProcessMessages tests basic cases for creating payloads by hard-coded scenarios
 func TestBasicProcessMessages(t *testing.T) {
 	const maxBatchBytes = 1000000

--- a/pkg/process/procutil/process_windows.go
+++ b/pkg/process/procutil/process_windows.go
@@ -468,7 +468,6 @@ func (p *probe) mapIOWriteBytesPerSec(instance string, v float64) {
 func getPIDs() ([]int32, error) {
 	var read uint32
 	var psSize uint32 = 1024
-	const dwordSize uint32 = 4
 
 	for {
 		buf := make([]uint32, psSize)

--- a/pkg/secrets/check_rights_windows.go
+++ b/pkg/secrets/check_rights_windows.go
@@ -18,10 +18,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/winutil"
 )
 
-var (
-	username = "ddagentuser"
-)
-
 // checkRights check that the given filename has access controls set only for
 // Administrator, Local System and the datadog user.
 func checkRights(filename string, allowGroupExec bool) error {

--- a/pkg/secrets/check_rights_windows_test.go
+++ b/pkg/secrets/check_rights_windows_test.go
@@ -32,7 +32,7 @@ func TestWrongPath(t *testing.T) {
 }
 
 func TestCheckRights(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "agent-collector-test")
+	_, err := ioutil.TempFile("", "agent-collector-test")
 	require.Nil(t, err)
 
 	// default options
@@ -42,7 +42,7 @@ func TestCheckRights(t *testing.T) {
 	require.NotNil(t, checkRights("/does not exists", allowGroupExec))
 
 	// missing current user
-	tmpfile, err = ioutil.TempFile("", "agent-collector-test")
+	tmpfile, err := ioutil.TempFile("", "agent-collector-test")
 	require.Nil(t, err)
 	defer os.Remove(tmpfile.Name())
 
@@ -52,7 +52,6 @@ func TestCheckRights(t *testing.T) {
 		"-removeAdmin", "0",
 		"-removeLocalSystem", "0",
 		"-addDDuser", "0").Run()
-	err = checkRights(tmpfile.Name(), allowGroupExec)
 	assert.NotNil(t, checkRights(tmpfile.Name(), allowGroupExec))
 
 	// missing localSystem

--- a/pkg/serializer/internal/metrics/events_test.go
+++ b/pkg/serializer/internal/metrics/events_test.go
@@ -3,8 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build zlib
-// +build zlib
+//go:build zlib && test
+// +build zlib,test
 
 package metrics
 

--- a/pkg/serializer/internal/metrics/iterable_series_test.go
+++ b/pkg/serializer/internal/metrics/iterable_series_test.go
@@ -3,6 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build test
+// +build test
+
 package metrics
 
 import (

--- a/pkg/serializer/internal/metrics/service_checks_test.go
+++ b/pkg/serializer/internal/metrics/service_checks_test.go
@@ -3,8 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build zlib
-// +build zlib
+//go:build zlib && test
+// +build zlib,test
 
 package metrics
 

--- a/pkg/serializer/internal/stream/compressor_test.go
+++ b/pkg/serializer/internal/stream/compressor_test.go
@@ -3,8 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2018-present Datadog, Inc.
 
-//go:build zlib
-// +build zlib
+//go:build zlib && test
+// +build zlib,test
 
 package stream
 

--- a/pkg/serializer/serializer_benchmark_test.go
+++ b/pkg/serializer/serializer_benchmark_test.go
@@ -3,8 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build zlib
-// +build zlib
+//go:build zlib && test
+// +build zlib,test
 
 package serializer
 

--- a/pkg/util/cloudproviders/cloudfoundry/cccache.go
+++ b/pkg/util/cloudproviders/cloudfoundry/cccache.go
@@ -727,20 +727,3 @@ func (ccc *CCCache) readData() {
 		close(ccc.updatedOnce)
 	}
 }
-
-// reset method is only used for testing
-func (ccc *CCCache) reset() {
-	ccc.Lock()
-	defer ccc.Unlock()
-	ccc.activeResources = make(map[string]chan interface{})
-	ccc.segmentBySpaceGUID = make(map[string]*cfclient.IsolationSegment)
-	ccc.segmentByOrgGUID = make(map[string]*cfclient.IsolationSegment)
-	ccc.sidecarsByAppGUID = make(map[string][]*CFSidecar)
-	ccc.appsByGUID = make(map[string]*cfclient.V3App)
-	ccc.spacesByGUID = make(map[string]*cfclient.V3Space)
-	ccc.orgsByGUID = make(map[string]*cfclient.V3Organization)
-	ccc.orgQuotasByGUID = make(map[string]*CFOrgQuota)
-	ccc.processesByAppGUID = make(map[string][]*cfclient.Process)
-	ccc.cfApplicationsByGUID = make(map[string]*CFApplication)
-	ccc.lastUpdated = time.Time{}
-}

--- a/pkg/util/cloudproviders/cloudfoundry/cccache_test.go
+++ b/pkg/util/cloudproviders/cloudfoundry/cccache_test.go
@@ -20,6 +20,23 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// reset method is only used for testing
+func (ccc *CCCache) reset() {
+	ccc.Lock()
+	defer ccc.Unlock()
+	ccc.activeResources = make(map[string]chan interface{})
+	ccc.segmentBySpaceGUID = make(map[string]*cfclient.IsolationSegment)
+	ccc.segmentByOrgGUID = make(map[string]*cfclient.IsolationSegment)
+	ccc.sidecarsByAppGUID = make(map[string][]*CFSidecar)
+	ccc.appsByGUID = make(map[string]*cfclient.V3App)
+	ccc.spacesByGUID = make(map[string]*cfclient.V3Space)
+	ccc.orgsByGUID = make(map[string]*cfclient.V3Organization)
+	ccc.orgQuotasByGUID = make(map[string]*CFOrgQuota)
+	ccc.processesByAppGUID = make(map[string][]*cfclient.Process)
+	ccc.cfApplicationsByGUID = make(map[string]*CFApplication)
+	ccc.lastUpdated = time.Time{}
+}
+
 type testCCClientCounter struct {
 	sync.RWMutex
 	hitsByMethod map[string]int

--- a/pkg/util/winutil/eventlog.go
+++ b/pkg/util/winutil/eventlog.go
@@ -25,13 +25,13 @@ func LogEventViewer(servicename string, msgnum uint32, arg string) {
 	switch msgnum & 0xF0000000 {
 	case 0x40000000:
 		// Info level message
-		elog.Info(msgnum, arg)
+		_ = elog.Info(msgnum, arg)
 	case 0x80000000:
 		// warning level message
-		elog.Warning(msgnum, arg)
+		_ = elog.Warning(msgnum, arg)
 	case 0xC0000000:
 		// error level message
-		elog.Error(msgnum, arg)
+		_ = elog.Error(msgnum, arg)
 	}
 
 }

--- a/pkg/util/winutil/iisconfig.go
+++ b/pkg/util/winutil/iisconfig.go
@@ -80,7 +80,7 @@ func (iiscfg *DynamicIISConfig) Start() error {
 			select {
 			case event := <-iiscfg.watcher.Events:
 				if event.Op&fsnotify.Write == fsnotify.Write {
-					iiscfg.readXmlConfig()
+					_ = iiscfg.readXmlConfig()
 				}
 			case err = <-iiscfg.watcher.Errors:
 				return

--- a/pkg/util/winutil/pdhutil/pdh_amd64.go
+++ b/pkg/util/winutil/pdhutil/pdh_amd64.go
@@ -21,7 +21,7 @@ type PDH_FMT_COUNTERVALUE_LARGE struct {
 
 // Union specialization for long values
 type PDH_FMT_COUNTERVALUE_LONG struct {
-	CStatus    uint32
-	intpadding uint32
-	LongValue  int32
+	CStatus   uint32
+	_         uint32 // intpadding
+	LongValue int32
 }

--- a/pkg/util/winutil/pdhutil/pdhcounter.go
+++ b/pkg/util/winutil/pdhutil/pdhcounter.go
@@ -18,7 +18,6 @@ var (
 	pfnPdhOpenQuery                     = PdhOpenQuery
 	pfnPdhAddEnglishCounter             = PdhAddEnglishCounter
 	pfnPdhCollectQueryData              = PdhCollectQueryData
-	pfnPdhRemoveCounter                 = PdhRemoveCounter
 	pfnPdhGetFormattedCounterValueFloat = pdhGetFormattedCounterValueFloat
 	pfnPdhGetFormattedCounterArray      = pdhGetFormattedCounterArray
 	pfnPdhCloseQuery                    = PdhCloseQuery
@@ -34,7 +33,7 @@ type CounterInstanceVerify func(string) bool
 type PdhCounterSet struct {
 	className string
 	query     PDH_HQUERY
-	counter PDH_HCOUNTER
+	counter   PDH_HCOUNTER
 
 	counterName string
 }
@@ -47,7 +46,7 @@ type PdhSingleInstanceCounterSet struct {
 // PdhMultiInstanceCounterSet is a specialization for a multiple instance counter
 type PdhMultiInstanceCounterSet struct {
 	PdhCounterSet
-	verifyfn             CounterInstanceVerify
+	verifyfn CounterInstanceVerify
 }
 
 // Initialize initializes a counter set object
@@ -172,4 +171,3 @@ func (p *PdhSingleInstanceCounterSet) GetValue() (val float64, err error) {
 func (p *PdhCounterSet) Close() {
 	pfnPdhCloseQuery(p.query)
 }
-

--- a/pkg/util/winutil/pdhutil/pdhcounter.go
+++ b/pkg/util/winutil/pdhutil/pdhcounter.go
@@ -54,7 +54,7 @@ type PdhMultiInstanceCounterSet struct {
 func (p *PdhCounterSet) Initialize(className string, counterName string) error {
 
 	// refresh PDH object cache (refresh will only occur periodically)
-	tryRefreshPdhObjectCache()
+	_, _ = tryRefreshPdhObjectCache()
 
 	p.className = className
 	p.counterName = counterName
@@ -170,6 +170,6 @@ func (p *PdhSingleInstanceCounterSet) GetValue() (val float64, err error) {
 
 // Close closes the query handle, freeing the underlying windows resources.
 func (p *PdhCounterSet) Close() {
-	PdhCloseQuery(p.query)
+	pfnPdhCloseQuery(p.query)
 }
 

--- a/pkg/util/winutil/pdhutil/pdhformatter.go
+++ b/pkg/util/winutil/pdhutil/pdhformatter.go
@@ -13,20 +13,19 @@ import (
 
 // PdhFormatter implements a formatter for PDH performance counters
 type PdhFormatter struct {
-	buf []uint8
 }
 
 // PdhCounterValue represents a counter value
 type PdhCounterValue struct {
-	CStatus    uint32
-	Double float64
-	Large  int64
-	Long   int32
+	CStatus uint32
+	Double  float64
+	Large   int64
+	Long    int32
 }
 
 type PdhCounterValueItem struct {
 	instance string
-	value PdhCounterValue
+	value    PdhCounterValue
 }
 
 // ValueEnumFunc implements a callback for counter enumeration

--- a/pkg/util/winutil/pdhutil/pdhhelper.go
+++ b/pkg/util/winutil/pdhutil/pdhhelper.go
@@ -20,15 +20,12 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/datadog-agent/pkg/util/winutil"
 )
 
 var (
 	modPdhDll = windows.NewLazyDLL("pdh.dll")
 
-	procPdhLookupPerfNameByIndex    = modPdhDll.NewProc("PdhLookupPerfNameByIndexW")
 	procPdhEnumObjects              = modPdhDll.NewProc("PdhEnumObjectsW")
-	procPdhEnumObjectItems          = modPdhDll.NewProc("PdhEnumObjectItemsW")
 	procPdhMakeCounterPath          = modPdhDll.NewProc("PdhMakeCounterPathW")
 	procPdhGetFormattedCounterValue = modPdhDll.NewProc("PdhGetFormattedCounterValue")
 	procPdhAddEnglishCounterW       = modPdhDll.NewProc("PdhAddEnglishCounterW")
@@ -46,32 +43,6 @@ const (
 	PERF_DETAIL_EXPERT   = 300 // For the expert user
 	PERF_DETAIL_WIZARD   = 400 // For the system designer
 )
-
-func pdhLookupPerfNameByIndex(ndx int) (string, error) {
-	var len uint32
-	var name string
-	r, _, _ := procPdhLookupPerfNameByIndex.Call(uintptr(0), // machine name, for now always local
-		uintptr(ndx),
-		uintptr(0),
-		uintptr(unsafe.Pointer(&len)))
-
-	if r != PDH_MORE_DATA {
-		log.Errorf("Failed to look up Windows performance counter (looking for index %d)", ndx)
-		log.Errorf("This error indicates that the Windows performance counter database may need to be rebuilt")
-		return name, fmt.Errorf("Failed to get buffer size (%#x)", r)
-	}
-	buf := make([]uint16, len)
-	r, _, _ = procPdhLookupPerfNameByIndex.Call(uintptr(0), // machine name, for now always local
-		uintptr(ndx),
-		uintptr(unsafe.Pointer(&buf[0])),
-		uintptr(unsafe.Pointer(&len)))
-
-	if r != ERROR_SUCCESS {
-		return name, fmt.Errorf("Error getting perf name for index %d (%#x)", ndx, r)
-	}
-	name = windows.UTF16ToString(buf)
-	return name, nil
-}
 
 // Lock enforces no more than once forceRefresh=false
 // is running concurrently
@@ -152,63 +123,6 @@ func tryRefreshPdhObjectCache() (didrefresh bool, err error) {
 	// may be skipped if cache was refreshed recently.
 	// see refreshPdhObjectCache() for details
 	return refreshPdhObjectCache(false)
-}
-
-func pdhEnumObjectItems(className string) (counters []string, instances []string, err error) {
-	var counterlen uint32
-	var instancelen uint32
-
-	if counterlen != 0 || instancelen != 0 {
-		log.Errorf("invalid parameter %v %v", counterlen, instancelen)
-		counterlen = 0
-		instancelen = 0
-	}
-	r, _, _ := procPdhEnumObjectItems.Call(
-		uintptr(0), // NULL data source, use computer in computername parameter
-		uintptr(0), // local computer
-		uintptr(unsafe.Pointer(windows.StringToUTF16Ptr(className))),
-		uintptr(0), // empty list, for now
-		uintptr(unsafe.Pointer(&counterlen)),
-		uintptr(0), // empty instance list
-		uintptr(unsafe.Pointer(&instancelen)),
-		uintptr(PERF_DETAIL_WIZARD),
-		uintptr(0))
-	if r != PDH_MORE_DATA {
-		log.Errorf("Failed to enumerate windows performance counters (%#x) (class %s)", r, className)
-		log.Errorf("This error indicates that the Windows performance counter database may need to be rebuilt")
-		if r == PDH_CSTATUS_NO_OBJECT {
-			return nil, nil, fmt.Errorf("Object not found (%#x) (class %v)", r, className)
-		} else {
-			return nil, nil, fmt.Errorf("Failed to get buffer size (%#x)", r)
-		}
-	}
-	counterbuf := make([]uint16, counterlen)
-	var instanceptr uintptr
-	var instancebuf []uint16
-
-	if instancelen != 0 {
-		instancebuf = make([]uint16, instancelen)
-		instanceptr = uintptr(unsafe.Pointer(&instancebuf[0]))
-	}
-	r, _, _ = procPdhEnumObjectItems.Call(
-		uintptr(0), // NULL data source, use computer in computername parameter
-		uintptr(0), // local computer
-		uintptr(unsafe.Pointer(windows.StringToUTF16Ptr(className))),
-		uintptr(unsafe.Pointer(&counterbuf[0])),
-		uintptr(unsafe.Pointer(&counterlen)),
-		instanceptr,
-		uintptr(unsafe.Pointer(&instancelen)),
-		uintptr(PERF_DETAIL_WIZARD),
-		uintptr(0))
-	if r != ERROR_SUCCESS {
-		err = fmt.Errorf("Error getting counter items (%#x)", r)
-		return
-	}
-	counters = winutil.ConvertWindowsStringList(counterbuf)
-	instances = winutil.ConvertWindowsStringList(instancebuf)
-	err = nil
-	return
-
 }
 
 type pdh_counter_path_elements struct {
@@ -298,7 +212,7 @@ func pdhGetFormattedCounterValueFloat(hCounter PDH_HCOUNTER) (val float64, err e
 //
 // Will append '#<INDEX>' to duplicate instance names to ensure their uniqueness.
 // Instance uniqueness is normally done by the PDH provider, except in the case of the Process class where it is NOT
-// handled in order to maintain backwards compatability.
+// handled in order to maintain backwards compatibility.
 // https://learn.microsoft.com/en-us/windows/win32/perfctrs/handling-duplicate-instance-names
 func pdhGetFormattedCounterArray(hCounter PDH_HCOUNTER, format uint32) (out_items []PdhCounterValueItem, err error) {
 	var buf []uint8
@@ -399,7 +313,7 @@ func pdhGetFormattedCounterArray(hCounter PDH_HCOUNTER, format uint32) (out_item
 
 		value_item := PdhCounterValueItem{
 			instance: instance,
-			value: value,
+			value:    value,
 		}
 		out_items = append(out_items, value_item)
 	}

--- a/pkg/util/winutil/pdhutil/pdhmocks_windows.go
+++ b/pkg/util/winutil/pdhutil/pdhmocks_windows.go
@@ -10,19 +10,18 @@ package pdhutil
 
 import (
 	"fmt"
-	"strings"
 	"regexp"
+	"strings"
 )
 
-var activeCounterStrings CounterStrings
 var activeAvailableCounters AvailableCounters
 
 type mockCounter struct {
-	path string
-	machine string
-	class string
+	path     string
+	machine  string
+	class    string
 	instance string
-	counter string
+	counter  string
 }
 
 type mockQuery struct {
@@ -43,11 +42,11 @@ func mockCounterFromString(path string) mockCounter {
 	r := regexp.MustCompile(`\\\\([^\\]+)\\([^\\\(]+)(?:\(([^\\\)]+)\))?\\(.+)`)
 	res := r.FindStringSubmatch(path)
 	return mockCounter{
-		path: path,
-		machine: res[1],
-		class: res[2],
+		path:     path,
+		machine:  res[1],
+		class:    res[2],
 		instance: res[3],
-		counter: res[4],
+		counter:  res[4],
 	}
 }
 
@@ -90,19 +89,7 @@ func mockPdhCloseQuery(hQuery PDH_HQUERY) uint32 {
 	return 0
 }
 
-func mockPdhRemoveCounter(hCounter PDH_HCOUNTER) uint32 {
-	counterIndex := int(hCounter)
-
-	for _, query := range openQueries {
-		if _, ok := query.counters[counterIndex]; ok {
-			delete(query.counters, counterIndex)
-			return 0
-		}
-	}
-	return PDH_INVALID_HANDLE
-}
-
-func mockCounterFromHandle(hCounter PDH_HCOUNTER) (mockCounter, error){
+func mockCounterFromHandle(hCounter PDH_HCOUNTER) (mockCounter, error) {
 	// check to see that it's a valid counter
 	ndx := int(hCounter)
 	var ctr mockCounter
@@ -125,14 +112,14 @@ func mockPdhGetFormattedCounterArray(hCounter PDH_HCOUNTER, format uint32) (out_
 	}
 	if classMap, ok := counterValues[ctr.class]; ok {
 		if instMap, ok := classMap[ctr.counter]; ok {
-			for inst,vals := range instMap {
+			for inst, vals := range instMap {
 				if len(vals) > 0 {
 					out_items = append(out_items,
 						PdhCounterValueItem{
 							instance: inst,
 							value: PdhCounterValue{
 								CStatus: PDH_CSTATUS_NEW_DATA,
-								Double: vals[0],
+								Double:  vals[0],
 							},
 						},
 					)
@@ -177,13 +164,11 @@ func mockpdhMakeCounterPath(machine string, object string, instance string, coun
 
 // SetupTesting initializes the PDH libarary with the mock functions rather than the real thing
 func SetupTesting(counterstringsfile, countersfile string) {
-	activeCounterStrings, _ = ReadCounterStrings(counterstringsfile)
 	activeAvailableCounters, _ = ReadCounters(countersfile)
 	// For testing
 	pfnPdhOpenQuery = mockPdhOpenQuery
 	pfnPdhAddEnglishCounter = mockPdhAddEnglishCounter
 	pfnPdhCollectQueryData = mockPdhCollectQueryData
-	pfnPdhRemoveCounter = mockPdhRemoveCounter
 	pfnPdhGetFormattedCounterValueFloat = mockpdhGetFormattedCounterValueFloat
 	pfnPdhGetFormattedCounterArray = mockPdhGetFormattedCounterArray
 	pfnPdhCloseQuery = mockPdhCloseQuery
@@ -210,7 +195,6 @@ func SetQueryReturnValue(counter string, val float64) {
 	// instance -> value list
 	instMap[mc.instance] = append(instMap[mc.instance], val)
 }
-
 
 // RemoveCounterInstance removes a specific instance from the table of available instances
 func RemoveCounterInstance(clss, inst string) {

--- a/pkg/util/winutil/process.go
+++ b/pkg/util/winutil/process.go
@@ -203,14 +203,18 @@ func readUnicodeString32(h windows.Handle, u unicodeString32) (string, error) {
 	if u.length > u.maxLength {
 		return "", fmt.Errorf("Invalid unicodeString32, maxLength %v < length %v", u.maxLength, u.length)
 	}
+	// length does not include null terminator, if it exists
+	// allocate two extra bytes so we can add it ourself
 	buf := make([]uint8, u.length+2)
-	read, err := ReadProcessMemory(h, uintptr(u.buffer), uintptr(unsafe.Pointer(&buf[0])), uint32(u.length+2))
+	read, err := ReadProcessMemory(h, uintptr(u.buffer), uintptr(unsafe.Pointer(&buf[0])), uint32(u.length))
 	if err != nil {
 		return "", err
 	}
-	if read != uint64(u.length+2) {
-		return "", fmt.Errorf("Wrong amount of bytes read (unicodeString32) %v != %v", read, u.length+2)
+	if read != uint64(u.length) {
+		return "", fmt.Errorf("Wrong amount of bytes read (unicodeString32) %v != %v", read, u.length)
 	}
+	// null terminate string
+	buf = append(buf, 0, 0)
 	return ConvertWindowsString(buf), nil
 }
 
@@ -301,14 +305,18 @@ func readUnicodeString(h windows.Handle, u unicodeString) (string, error) {
 	if u.length > u.maxLength {
 		return "", fmt.Errorf("Invalid unicodeString, maxLength %v < length %v", u.maxLength, u.length)
 	}
+	// length does not include null terminator, if it exists
+	// allocate two extra bytes so we can add it ourself
 	buf := make([]uint8, u.length+2)
-	read, err := ReadProcessMemory(h, uintptr(u.buffer), uintptr(unsafe.Pointer(&buf[0])), uint32(u.length+2))
+	read, err := ReadProcessMemory(h, uintptr(u.buffer), uintptr(unsafe.Pointer(&buf[0])), uint32(u.length))
 	if err != nil {
 		return "", err
 	}
-	if read != uint64(u.length+2) {
-		return "", fmt.Errorf("Wrong amount of bytes read (unicodeString) %v != %v", read, u.length+2)
+	if read != uint64(u.length) {
+		return "", fmt.Errorf("Wrong amount of bytes read (unicodeString) %v != %v", read, u.length)
 	}
+	// null terminate string
+	buf = append(buf, 0, 0)
 	return ConvertWindowsString(buf), nil
 }
 

--- a/pkg/util/winutil/process.go
+++ b/pkg/util/winutil/process.go
@@ -200,6 +200,9 @@ func getCommandParamsForProcess32(h windows.Handle, includeImagePath bool) (*Pro
 }
 
 func readUnicodeString32(h windows.Handle, u unicodeString32) (string, error) {
+	if u.length > u.maxLength {
+		return "", fmt.Errorf("Invalid unicodeString32, maxLength %v < length %v", u.maxLength, u.length)
+	}
 	buf := make([]uint8, u.length+2)
 	read, err := ReadProcessMemory(h, uintptr(u.buffer), uintptr(unsafe.Pointer(&buf[0])), uint32(u.length+2))
 	if err != nil {
@@ -295,6 +298,9 @@ func getCommandParamsForProcess64(h windows.Handle, includeImagePath bool) (*Pro
 }
 
 func readUnicodeString(h windows.Handle, u unicodeString) (string, error) {
+	if u.length > u.maxLength {
+		return "", fmt.Errorf("Invalid unicodeString, maxLength %v < length %v", u.maxLength, u.length)
+	}
 	buf := make([]uint8, u.length+2)
 	read, err := ReadProcessMemory(h, uintptr(u.buffer), uintptr(unsafe.Pointer(&buf[0])), uint32(u.length+2))
 	if err != nil {

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -40,7 +40,7 @@ def golangci_lint(ctx, targets, rtloader_root=None, build_tags=None, build="test
     for target in targets:
         print(f"running golangci on {target}")
         ctx.run(
-            f"golangci-lint run --timeout 15m0s --build-tags '{' '.join(tags)}' {target}/...",
+            f'golangci-lint run --timeout 15m0s --build-tags "{" ".join(tags)}" {target}/...',
             env=env,
         )
 

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -130,19 +130,17 @@ def lint_flavor(
     """
     Runs linters for given flavor, build tags, and modules.
     """
-    # For now we only run golangci_lint on Unix as the Windows env needs more work
-    if sys.platform != 'win32':
-        print(f"--- Flavor {flavor.name}: golangci_lint")
-        for module in modules:
-            print(f"----- Module '{module.full_path()}'")
-            if not module.condition():
-                print("----- Skipped")
-                continue
+    print(f"--- Flavor {flavor.name}: golangci_lint")
+    for module in modules:
+        print(f"----- Module '{module.full_path()}'")
+        if not module.condition():
+            print("----- Skipped")
+            continue
 
-            with ctx.cd(module.full_path()):
-                golangci_lint(
-                    ctx, targets=module.targets, rtloader_root=rtloader_root, build_tags=build_tags, arch=arch
-                )
+        with ctx.cd(module.full_path()):
+            golangci_lint(
+                ctx, targets=module.targets, rtloader_root=rtloader_root, build_tags=build_tags, arch=arch
+            )
 
 
 def test_flavor(

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -138,9 +138,7 @@ def lint_flavor(
             continue
 
         with ctx.cd(module.full_path()):
-            golangci_lint(
-                ctx, targets=module.targets, rtloader_root=rtloader_root, build_tags=build_tags, arch=arch
-            )
+            golangci_lint(ctx, targets=module.targets, rtloader_root=rtloader_root, build_tags=build_tags, arch=arch)
 
 
 def test_flavor(

--- a/tasks/winbuildscripts/sysprobe.bat
+++ b/tasks/winbuildscripts/sysprobe.bat
@@ -8,6 +8,7 @@ if not exist c:\mnt\ goto nomntdir
 if NOT DEFINED PY_RUNTIMES set PY_RUNTIMES=%~1
 
 call %~p0extract-modcache.bat
+call %~p0extract-tools-modcache.bat
 
 mkdir \dev\go\src\github.com\DataDog\datadog-agent
 if not exist \dev\go\src\github.com\DataDog\datadog-agent exit /b 2

--- a/tasks/winbuildscripts/sysprobe.ps1
+++ b/tasks/winbuildscripts/sysprobe.ps1
@@ -15,6 +15,7 @@ $Env:PATH="$Env:BUILD_ROOT\dev\lib;$Env:GOPATH\bin;$Env:Python2_ROOT_DIR;$Env:Py
 & $Env:Python3_ROOT_DIR\python.exe -m pip install PyYAML==5.3.1
 
 & inv -e deps
+& inv -e install-tools
 
 & inv -e golangci-lint --build system-probe .\pkg
 

--- a/tasks/winbuildscripts/sysprobe.ps1
+++ b/tasks/winbuildscripts/sysprobe.ps1
@@ -18,6 +18,11 @@ $Env:PATH="$Env:BUILD_ROOT\dev\lib;$Env:GOPATH\bin;$Env:Python2_ROOT_DIR;$Env:Py
 & inv -e install-tools
 
 & inv -e golangci-lint --build system-probe .\pkg
+$err = $LASTEXITCODE
+if ($err -ne 0) {
+    Write-Host -ForegroundColor Red "golangci-lint failed $err"
+    [Environment]::Exit($err)
+}
 
 & inv -e system-probe.kitchen-prepare
 

--- a/tasks/winbuildscripts/sysprobe.ps1
+++ b/tasks/winbuildscripts/sysprobe.ps1
@@ -17,6 +17,19 @@ $Env:PATH="$Env:BUILD_ROOT\dev\lib;$Env:GOPATH\bin;$Env:Python2_ROOT_DIR;$Env:Py
 & inv -e deps
 & inv -e install-tools
 
+# Must build the rtloader libs cgo depends on before running golangci-lint, which requires code to be compilable
+$archflag = "x64"
+if ($Env:TARGET_ARCH -eq "x86") {
+    $archflag = "x86"
+}
+& inv -e rtloader.make --python-runtimes="$Env:PY_RUNTIMES" --install-prefix=$Env:BUILD_ROOT\dev --cmake-options='-G \"Unix Makefiles\"' --arch $archflag
+$err = $LASTEXITCODE
+Write-Host Build result is $err
+if($err -ne 0){
+    Write-Host -ForegroundColor Red "rtloader make failed $err"
+    [Environment]::Exit($err)
+}
+
 & inv -e golangci-lint --build system-probe .\pkg
 $err = $LASTEXITCODE
 if ($err -ne 0) {

--- a/tasks/winbuildscripts/update-agent.ps1
+++ b/tasks/winbuildscripts/update-agent.ps1
@@ -1,4 +1,0 @@
-#Stop-Service -Name datadogagent -Force -Verbose
-#cp \\tsclient\C\Users\branden.clark\projects\datadog-agent-wsl\datadog-agent\bin\agent\agent.exe "$env:PROGRAMFILES\Datadog\Datadog Agent\bin\agent.exe"
-#Start-Service -Name datadogagent
-dir \\tsclient\C\Users

--- a/tasks/winbuildscripts/update-agent.ps1
+++ b/tasks/winbuildscripts/update-agent.ps1
@@ -1,0 +1,4 @@
+#Stop-Service -Name datadogagent -Force -Verbose
+#cp \\tsclient\C\Users\branden.clark\projects\datadog-agent-wsl\datadog-agent\bin\agent\agent.exe "$env:PROGRAMFILES\Datadog\Datadog Agent\bin\agent.exe"
+#Start-Service -Name datadogagent
+dir \\tsclient\C\Users


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Enables go linting on Windows and fixes linter errors.
* Forces all .go source files in the repo to have LF line endings on all platforms using `.gitattributes`. [gofmt only supports LF line endings](https://github.com/golang/go/issues/16355).
* Enables `golangci-lint` on Windows platforms via `tasks/test.py:lint_flavor()`, this is run in CI in `source_test/tests_windows-x64` via `unittests.bat`.
* Installs test tools (`golangci-lint`) in system-probe `source_test/test_windows_sysprobe_x64`, and checks return value of `golangci-lint`. (The `golangci-lint` command was already in the script but it wasn't installed.)
* Fixes lint errors
  * Fixes some errors by adding `errcheck` ignores to `.golangci-yml`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
These linters already run on the other platforms, it was only skipped for Windows. This meant that sometimes a Windows focused PR could cause Linux CI tests to fail because of modifications to a cross-platform go source file. Previously the only way to validate this was to also do a Linux build+test locally or to wait for the CI to fail. Now the linter can be run locally in the Windows build environment, and it is also validated in the CI.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->
For existing clones of the repo on dev machines with `core.autocrlf=true` (default on windows), git will not update the line endings automatically. Then running the linter locally will fail until the line endings are updated.

To check the `core.autocrlf` setting
```
git config -l
```

If `core.autocrlf=true` is true, after this changeset is merged run these commands **from a clean repo state** to re-checkout local files .
```
git switch main       # switch to main branch
git pull              # pull changes
git rm --cached -r .  # Remove every file from git's index.
git reset --hard      # Rewrite git's index to pick up all the new line endings.
```
Alternatively just re-clone the repo.

golangci-lint and other test tools are not installed by default in the `agent-buildimages-windows` container. To run the linter locally, first install the test tools by running
```
inv install-tools
```

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
