### PR TITLE
[CWS] rework kernel version cache

### DIFF
--- a/pkg/security/ebpf/probes/syscall_helpers.go
+++ b/pkg/security/ebpf/probes/syscall_helpers.go
@@ -10,7 +10,6 @@ package probes
 
 import (
 	"bytes"
-	"errors"
 	"strings"
 
 	manager "github.com/DataDog/ebpf-manager"
@@ -37,18 +36,6 @@ func resolveRuntimeArch() {
 	default:
 		RuntimeArch = "ia32"
 	}
-}
-
-// currentKernelVersion is the current kernel version
-var currentKernelVersion *kernel.Version
-
-func resolveCurrentKernelVersion() error {
-	var err error
-	currentKernelVersion, err = kernel.NewKernelVersion()
-	if err != nil {
-		return errors.New("couldn't resolve kernel version")
-	}
-	return nil
 }
 
 // cache of the syscall prefix depending on kernel version
@@ -88,6 +75,11 @@ func getCompatSyscallFnName(name string) string {
 // ShouldUseSyscallExitTracepoints returns true if the kernel version is old and we need to use tracepoints to handle syscall exits
 // instead of kretprobes
 func ShouldUseSyscallExitTracepoints() bool {
+	currentKernelVersion, err := kernel.NewKernelVersion()
+	if err != nil || currentKernelVersion == nil {
+		return false
+	}
+
 	return currentKernelVersion != nil && (currentKernelVersion.Code < kernel.Kernel4_12 || currentKernelVersion.IsRH7Kernel())
 }
 
@@ -159,10 +151,6 @@ func ExpandSyscallProbes(probe *manager.Probe, flag int, compat ...bool) []*mana
 		resolveRuntimeArch()
 	}
 
-	if currentKernelVersion == nil {
-		_ = resolveCurrentKernelVersion()
-	}
-
 	if flag&ExpandTime32 == ExpandTime32 {
 		// check if _time32 should be expanded
 		if getSyscallPrefix() == "sys_" {
@@ -187,10 +175,6 @@ func ExpandSyscallProbesSelector(id manager.ProbeIdentificationPair, flag int, c
 
 	if len(RuntimeArch) == 0 {
 		resolveRuntimeArch()
-	}
-
-	if currentKernelVersion == nil {
-		_ = resolveCurrentKernelVersion()
 	}
 
 	if flag&ExpandTime32 == ExpandTime32 {


### PR DESCRIPTION
### What does this PR do?

This PR removes the second cache on the kernel version, and makes use of a RWMutex to protect this cache (instead of a classical Mutex)

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
